### PR TITLE
more packages/ts-transformers tests

### DIFF
--- a/packages/ts-transformers/test/ast/call-kind-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/call-kind-coverage.test.ts
@@ -1,0 +1,937 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import {
+  classifyArrayCallbackContainerCall,
+  classifyArrayMethodCallSite,
+  classifyArrayMethodResultSinkCall,
+  classifyWildcardTraversalCall,
+  detectCallKind,
+  detectNewExpressionKind,
+  getCapabilitySummaryCallbackArgument,
+  getLiftAppliedInputAndCallback,
+  hasReactiveCollectionProvenance,
+  isConsumedByTerminalChainCall,
+  isReactiveOriginExpression,
+  isReactiveValueExpression,
+  isReactiveValueSymbol,
+  isSimpleReactiveAccessExpression,
+} from "../../src/ast/mod.ts";
+import { getEnclosingFunctionLikeDeclaration } from "../../src/ast/function-predicates.ts";
+import {
+  getPatternBuilderCallbackArgument,
+  getPatternToolHoistablePatternCall,
+  getWithPatternHoistablePatternCall,
+} from "../../src/ast/call-kind.ts";
+import { COMMONFABRIC_TYPES } from "../commonfabric-test-types.ts";
+
+// Harness A: a bare source-file-only program (no lib, no module resolution).
+// Mirrors the setup in call-kind.test.ts for cases that need only structural
+// AST shape and do not depend on resolving `commonfabric` imports.
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+  };
+
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+// A program that resolves `import ... from "commonfabric"` against the real
+// commonfabric.d.ts, so callee symbols carry Common Fabric provenance. Needed
+// for the builder/runtime-call/cell-factory recognition paths that resolve the
+// callee symbol rather than reading the callee syntax.
+function createProgramWithCommonFabric(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const files: Record<string, string> = {
+    "/test.ts": source,
+    "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"],
+  };
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files[name] !== undefined,
+    readFile: (name) => files[name],
+    directoryExists: () => true,
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => "/",
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "lib.d.ts",
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+    getSourceFile: (name, languageVersion) =>
+      files[name] !== undefined
+        ? ts.createSourceFile(name, files[name]!, languageVersion, true)
+        : undefined,
+    resolveModuleNames: (moduleNames) =>
+      moduleNames.map((name) => {
+        const match = Object.keys(files).find((fileName) =>
+          fileName === `/${name}.d.ts` || fileName.endsWith(`/${name}.d.ts`)
+        );
+        return match
+          ? {
+            resolvedFileName: match,
+            extension: ts.Extension.Dts,
+            isExternalLibraryImport: false,
+          }
+          : undefined;
+      }),
+  };
+  const program = ts.createProgram(["/test.ts"], options, host);
+  return {
+    sourceFile: program.getSourceFile("/test.ts")!,
+    checker: program.getTypeChecker(),
+  };
+}
+
+function findInitializer(
+  sourceFile: ts.SourceFile,
+  declarationName: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === declarationName &&
+      node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Initializer for ${declarationName} not found`);
+  }
+  return found;
+}
+
+function findCall(
+  sourceFile: ts.SourceFile,
+  declarationName: string,
+): ts.CallExpression {
+  const expr = findInitializer(sourceFile, declarationName);
+  if (!ts.isCallExpression(expr)) {
+    throw new Error(`Initializer for ${declarationName} is not a call`);
+  }
+  return expr;
+}
+
+function findFirstIdentifier(
+  sourceFile: ts.SourceFile,
+  text: string,
+): ts.Identifier {
+  let found: ts.Identifier | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(node) && node.text === text) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Identifier ${text} not found`);
+  return found;
+}
+
+Deno.test("getWithPatternHoistablePatternCall returns undefined for a lowered method with no arguments", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const items: any;
+    const value = items.mapWithPattern();
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // Callee is a lowered *WithPattern access, but there is no first argument to
+  // hoist, so the recognizer bails at the missing-argument guard.
+  assertEquals(getWithPatternHoistablePatternCall(call, checker), undefined);
+});
+
+Deno.test("getPatternToolHoistablePatternCall lifts the bare pattern call out of a patternTool call", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { patternTool, pattern } from "commonfabric";
+    const value = patternTool(pattern(() => 1), { p: 1 });
+  `);
+
+  const call = findCall(sourceFile, "value");
+  const hoistable = getPatternToolHoistablePatternCall(call, checker);
+  assertEquals(hoistable?.getText(), "pattern(() => 1)");
+});
+
+Deno.test("getPatternToolHoistablePatternCall returns undefined when patternTool has no arguments", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { patternTool } from "commonfabric";
+    const value = patternTool();
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // Recognized as a pattern-tool call, but the missing first argument means
+  // there is nothing to hoist.
+  assertEquals(getPatternToolHoistablePatternCall(call, checker), undefined);
+});
+
+Deno.test("getPatternToolHoistablePatternCall ignores calls that are not patternTool", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare function plain(body: () => number, params?: unknown): number;
+    const value = plain(() => 1, { p: 1 });
+  `);
+
+  const call = findCall(sourceFile, "value");
+  assertEquals(getPatternToolHoistablePatternCall(call, checker), undefined);
+});
+
+Deno.test("getLiftAppliedInputAndCallback returns undefined when the applied lift call has no input argument", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { lift } from "commonfabric";
+    const value = lift((v: number) => v + 1)();
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The call is lift-applied, its inner callee is the lift(...) call, but the
+  // outer application supplies no input argument, so the input guard rejects it.
+  assertEquals(detectCallKind(call, checker)?.kind, "lift-applied");
+  assertEquals(getLiftAppliedInputAndCallback(call, checker), undefined);
+});
+
+Deno.test("getCapabilitySummaryCallbackArgument reads the callback off a lift-applied call", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { lift } from "commonfabric";
+    const value = lift((v: number) => v + 1)(3);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  assertEquals(detectCallKind(call, checker)?.kind, "lift-applied");
+  const callback = getCapabilitySummaryCallbackArgument(call, checker);
+  assert(callback && ts.isArrowFunction(callback));
+  assertEquals(callback.parameters[0]?.name.getText(), "v");
+});
+
+Deno.test("isReactiveOriginExpression is false for a non-call, non-new expression", () => {
+  const { sourceFile, checker } = createProgram(`
+    const value = 1 + 2;
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  assertEquals(isReactiveOriginExpression(expression, checker), false);
+});
+
+Deno.test("isReactiveOriginExpression follows a new expression to a cell factory", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Writable } from "commonfabric";
+    const value = new Writable(1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  assert(ts.isNewExpression(expression));
+  assertEquals(
+    detectNewExpressionKind(expression, checker)?.factoryName,
+    "Writable",
+  );
+  assertEquals(isReactiveOriginExpression(expression, checker), true);
+});
+
+Deno.test("classifyWildcardTraversalCall recognizes Object.keys by syntax when the symbol is unresolved", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const Object: any;
+    const value = Object.keys({ a: 1 });
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // No lib means Object.keys has no resolvable ObjectConstructor declaration;
+  // recognition falls through to the syntactic Object.<name> check.
+  assertEquals(
+    classifyWildcardTraversalCall(call, checker),
+    "object-wildcard-traversal",
+  );
+});
+
+Deno.test("classifyWildcardTraversalCall recognizes JSON.stringify by syntax when the symbol is unresolved", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const JSON: any;
+    const value = JSON.stringify({ a: 1 });
+  `);
+
+  const call = findCall(sourceFile, "value");
+  assertEquals(classifyWildcardTraversalCall(call, checker), "json-stringify");
+});
+
+Deno.test("classifyWildcardTraversalCall resolves Object.keys through its ObjectConstructor declaration", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface ObjectConstructor {
+      keys(o: object): string[];
+    }
+    declare const Object: ObjectConstructor;
+    const value = Object.keys({ a: 1 });
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The resolved-declaration branch: the callee symbol resolves to an
+  // ObjectConstructor member named "keys".
+  assertEquals(
+    classifyWildcardTraversalCall(call, checker),
+    "object-wildcard-traversal",
+  );
+});
+
+Deno.test("classifyWildcardTraversalCall resolves JSON.stringify through its JSON declaration", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface JSON {
+      stringify(value: unknown): string;
+    }
+    declare const JSON: JSON;
+    const value = JSON.stringify({ a: 1 });
+  `);
+
+  const call = findCall(sourceFile, "value");
+  assertEquals(classifyWildcardTraversalCall(call, checker), "json-stringify");
+});
+
+Deno.test("getPatternBuilderCallbackArgument unwraps a function-hardening wrapper around the pattern callback", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { pattern } from "commonfabric";
+    declare function __cfHardenFn0<T>(fn: T): T;
+    const value = pattern(__cfHardenFn0((input: unknown) => input));
+  `);
+
+  const call = findCall(sourceFile, "value");
+  const callback = getPatternBuilderCallbackArgument(call, checker);
+  // resolveCallbackFunctionExpression peels the __cfHardenFn wrapper call to
+  // reach the underlying arrow function.
+  assert(callback && ts.isArrowFunction(callback));
+  assertEquals(callback.parameters[0]?.name.getText(), "input");
+});
+
+Deno.test("getPatternBuilderCallbackArgument follows an identifier bound to the callback arrow", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { pattern } from "commonfabric";
+    const body = (input: unknown) => input;
+    const value = pattern(body);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The callback argument is an identifier; resolveCallbackFunctionExpression
+  // follows its variable initializer to the arrow function.
+  const callback = getPatternBuilderCallbackArgument(call, checker);
+  assert(callback && ts.isArrowFunction(callback));
+  assertEquals(callback.parameters[0]?.name.getText(), "input");
+});
+
+Deno.test("getPatternBuilderCallbackArgument stops on a cyclic callback identifier binding", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { pattern } from "commonfabric";
+    const cyclicA: any = (cyclicB as any);
+    const cyclicB: any = (cyclicA as any);
+    const value = pattern(cyclicA);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The callback identifier resolves through a cycle of variable initializers;
+  // the seen-set guard breaks the recursion and yields no callback.
+  assertEquals(getPatternBuilderCallbackArgument(call, checker), undefined);
+});
+
+Deno.test("classifyArrayMethodResultSinkCall recognizes .join by syntax when the join symbol is unresolved", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Array<T> {
+      map<U>(cb: (v: T) => U): U[];
+    }
+    const value = [1, 2, 3].map((n: number) => n + 1).join(", ");
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The join member has no resolvable Array declaration here, so recognition
+  // falls to the syntactic name check.
+  assertEquals(classifyArrayMethodResultSinkCall(call, checker), {
+    sink: "join",
+    receiverFamily: "map",
+    receiverLowered: false,
+  });
+});
+
+Deno.test("classifyArrayMethodResultSinkCall resolves .join through its Array declaration", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Array<T> {
+      map<U>(cb: (v: T) => U): U[];
+      join(separator?: string): string;
+    }
+    const value = [1, 2, 3].map((n: number) => n + 1).join(", ");
+  `);
+
+  const call = findCall(sourceFile, "value");
+  assertEquals(classifyArrayMethodResultSinkCall(call, checker), {
+    sink: "join",
+    receiverFamily: "map",
+    receiverLowered: false,
+  });
+});
+
+Deno.test("classifyArrayMethodResultSinkCall rejects a non-join member that resolves to an Array declaration", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Array<T> {
+      map<U>(cb: (v: T) => U): U[];
+      slice(start?: number): T[];
+    }
+    const value = [1, 2, 3].map((n: number) => n + 1).slice(0);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The member resolves to a real Array declaration that is not "join", so the
+  // "declarations present but none matched" guard returns undefined.
+  assertEquals(classifyArrayMethodResultSinkCall(call, checker), undefined);
+});
+
+Deno.test("detectCallKind classifies imported runtime calls with their export names", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { str, llm } from "commonfabric";
+    const strValue = str(\`x\`);
+    const llmValue = llm(\`y\`);
+  `);
+
+  const strCall = findCall(sourceFile, "strValue");
+  const llmCall = findCall(sourceFile, "llmValue");
+
+  const strKind = detectCallKind(strCall, checker);
+  const llmKind = detectCallKind(llmCall, checker);
+  assertEquals(strKind?.kind, "runtime-call");
+  assertEquals(
+    strKind?.kind === "runtime-call" ? strKind.exportName : undefined,
+    "str",
+  );
+  assertEquals(
+    strKind?.kind === "runtime-call" ? strKind.reactiveOrigin : undefined,
+    true,
+  );
+  assertEquals(
+    llmKind?.kind === "runtime-call" ? llmKind.exportName : undefined,
+    "llm",
+  );
+});
+
+Deno.test("detectCallKind classifies ifElse, when, unless, wish, and generate calls from commonfabric", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import {
+      ifElse, when, unless, wish, generateText, generateObject, patternTool,
+    } from "commonfabric";
+    const a = ifElse(true, 1, 2);
+    const b = when(true, () => 1);
+    const c = unless(true, () => 1);
+    const d = wish({});
+    const e = generateText({});
+    const f = generateObject({});
+    const g = patternTool({});
+  `);
+
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "a"), checker)?.kind,
+    "ifElse",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "b"), checker)?.kind,
+    "when",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "c"), checker)?.kind,
+    "unless",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "d"), checker)?.kind,
+    "wish",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "e"), checker)?.kind,
+    "generate-text",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "f"), checker)?.kind,
+    "generate-object",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "g"), checker)?.kind,
+    "pattern-tool",
+  );
+});
+
+Deno.test("detectCallKind resolves the cell factory imported from commonfabric", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { cell } from "commonfabric";
+    const value = cell(1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  const kind = detectCallKind(call, checker);
+  assertEquals(kind?.kind, "cell-factory");
+  assertEquals(
+    kind?.kind === "cell-factory" ? kind.factoryName : undefined,
+    "cell",
+  );
+});
+
+Deno.test("detectNewExpressionKind reads a cell factory through a perSpace scoped constructor access", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Writable } from "commonfabric";
+    const value = new Writable.perSpace(1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  assert(ts.isNewExpression(expression));
+  // The scoped-constructor access recursion strips ".perSpace" and resolves the
+  // underlying Writable factory name.
+  assertEquals(
+    detectNewExpressionKind(expression, checker)?.factoryName,
+    "Writable",
+  );
+});
+
+Deno.test("detectCallKind classifies Cell.of static factory and Cell.for through their declarations", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Cell } from "commonfabric";
+    declare const C: typeof Cell;
+    const ofValue = C.of(1);
+    const forValue = C.for(1);
+  `);
+
+  const ofKind = detectCallKind(findCall(sourceFile, "ofValue"), checker);
+  const forKind = detectCallKind(findCall(sourceFile, "forValue"), checker);
+  assertEquals(ofKind?.kind, "cell-factory");
+  assertEquals(
+    ofKind?.kind === "cell-factory" ? ofKind.factoryName : undefined,
+    "of",
+  );
+  assertEquals(forKind?.kind, "cell-for");
+});
+
+Deno.test("detectCallKind follows a const alias of an ambient builder", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare function pattern<T>(cb: () => T): T;
+    const aliased = pattern;
+    const value = aliased(() => 1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The callee resolves to a const bound to the ambient `pattern`; builder
+  // recognition follows the const initializer to the ambient builder name.
+  const kind = detectCallKind(call, checker);
+  assertEquals(kind?.kind, "builder");
+  assertEquals(
+    kind?.kind === "builder" ? kind.builderName : undefined,
+    "pattern",
+  );
+});
+
+Deno.test("detectCallKind resolves a namespace-member builder to its commonfabric declaration", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import * as CF from "commonfabric";
+    const value = CF.pattern(() => 1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The callee symbol is the namespace member `pattern`, so the import-specifier
+  // shortcut does not fire; resolution follows the alias to the commonfabric
+  // declaration and recognizes the builder by name plus provenance.
+  const kind = detectCallKind(call, checker);
+  assertEquals(kind?.kind, "builder");
+  assertEquals(
+    kind?.kind === "builder" ? kind.builderName : undefined,
+    "pattern",
+  );
+});
+
+Deno.test("detectCallKind recognizes a synthetic __cfHelpers builder call by callee syntax", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const __cfHelpers: any;
+    const value = __cfHelpers.pattern(() => 1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // No symbol resolves for the synthetic helper access, so recognition falls to
+  // getDirectBuilderName which reads the __cfHelpers.<builder> syntax directly.
+  const kind = detectCallKind(call, checker);
+  assertEquals(kind?.kind, "builder");
+  assertEquals(
+    kind?.kind === "builder" ? kind.builderName : undefined,
+    "pattern",
+  );
+});
+
+Deno.test("detectCallKind recognizes a bare unresolved builder identifier by name", () => {
+  const { sourceFile, checker } = createProgram(`
+    // @ts-expect-error intentionally unresolved
+    const value = pattern(() => 1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The identifier `pattern` has no symbol, so getDirectBuilderName recognizes it
+  // by its name being a known builder export.
+  const kind = detectCallKind(call, checker);
+  assertEquals(kind?.kind, "builder");
+  assertEquals(
+    kind?.kind === "builder" ? kind.builderName : undefined,
+    "pattern",
+  );
+});
+
+Deno.test("detectCallKind recognizes synthetic __cfHelpers runtime and cell-factory calls without a callee symbol", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const __cfHelpers: any;
+    const strValue = __cfHelpers.str(\`x\`);
+    const cellValue = __cfHelpers.cell(1);
+    const ifElseValue = __cfHelpers.ifElse(true, 1, 2);
+    const patternToolValue = __cfHelpers.patternTool({});
+    const generateTextValue = __cfHelpers.generateText({});
+    const generateObjectValue = __cfHelpers.generateObject({});
+    const wishValue = __cfHelpers.wish({});
+    const whenValue = __cfHelpers.when(true, () => 1);
+    const unlessValue = __cfHelpers.unless(true, () => 1);
+  `);
+
+  // getSyntheticHelperCallKind routes through createNamedCallKind with no symbol,
+  // exercising the symbol-absent arm of each callKind case.
+  const strKind = detectCallKind(findCall(sourceFile, "strValue"), checker);
+  assertEquals(strKind?.kind, "runtime-call");
+  assertEquals(
+    strKind?.kind === "runtime-call" ? strKind.symbol : "present",
+    undefined,
+  );
+  const cellKind = detectCallKind(findCall(sourceFile, "cellValue"), checker);
+  assertEquals(cellKind?.kind, "cell-factory");
+  assertEquals(
+    cellKind?.kind === "cell-factory" ? cellKind.factoryName : undefined,
+    "cell",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "ifElseValue"), checker)?.kind,
+    "ifElse",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "patternToolValue"), checker)?.kind,
+    "pattern-tool",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "generateTextValue"), checker)?.kind,
+    "generate-text",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "generateObjectValue"), checker)?.kind,
+    "generate-object",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "wishValue"), checker)?.kind,
+    "wish",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "whenValue"), checker)?.kind,
+    "when",
+  );
+  assertEquals(
+    detectCallKind(findCall(sourceFile, "unlessValue"), checker)?.kind,
+    "unless",
+  );
+});
+
+Deno.test("isSimpleReactiveAccessExpression walks property and element access down to a reactive cell root", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Cell } from "commonfabric";
+    declare const root: Cell<{ items: number[] }>;
+    const propValue = root.items;
+    const elemValue = root["items"];
+    const plainValue = ({ items: [] }).items;
+  `);
+
+  const prop = findInitializer(sourceFile, "propValue");
+  const elem = findInitializer(sourceFile, "elemValue");
+  const plain = findInitializer(sourceFile, "plainValue");
+
+  assertEquals(isSimpleReactiveAccessExpression(prop, checker), true);
+  assertEquals(isSimpleReactiveAccessExpression(elem, checker), true);
+  assertEquals(isSimpleReactiveAccessExpression(plain, checker), false);
+});
+
+Deno.test("classifyArrayCallbackContainerCall downgrades a reactive .map consumed by a following element access", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Cell } from "commonfabric";
+    declare const items: Cell<number[]>;
+    const value = items.map((n: number) => n + 1)[0];
+  `);
+
+  // The `.map` call over a reactive receiver is reactive, but it is immediately
+  // consumed by an element access, so isConsumedByTerminalChainCall marks it a
+  // terminal-chain value and it is downgraded to plain-array-value.
+  const mapIdent = findFirstIdentifier(sourceFile, "map");
+  const mapCall = mapIdent.parent.parent as ts.Node;
+  if (!ts.isCallExpression(mapCall)) {
+    throw new Error("Expected the .map call expression");
+  }
+  assertEquals(
+    classifyArrayMethodCallSite(mapCall, checker)?.ownership,
+    "reactive",
+  );
+  assertEquals(
+    classifyArrayCallbackContainerCall(mapCall, checker),
+    "plain-array-value",
+  );
+  assertEquals(isConsumedByTerminalChainCall(mapCall), true);
+});
+
+Deno.test("classifyArrayCallbackContainerCall keeps a reactive .map reactive when it is not consumed by a chain", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Cell } from "commonfabric";
+    declare const items: Cell<number[]>;
+    const value = items.map((n: number) => n + 1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  assertEquals(
+    classifyArrayMethodCallSite(call, checker)?.ownership,
+    "reactive",
+  );
+  assertEquals(
+    classifyArrayCallbackContainerCall(call, checker),
+    "reactive-array-method",
+  );
+  assertEquals(isConsumedByTerminalChainCall(call), false);
+});
+
+Deno.test("isConsumedByTerminalChainCall reports true when the call result is itself invoked", () => {
+  const { sourceFile } = createProgram(`
+    declare const make: () => (() => number);
+    const value = make()();
+  `);
+
+  // Outer call `make()()` — the inner `make()` result is directly invoked, so
+  // the call-parent branch fires.
+  const outer = findCall(sourceFile, "value");
+  const inner = outer.expression;
+  if (!ts.isCallExpression(inner)) {
+    throw new Error("Expected an inner call expression");
+  }
+  assertEquals(isConsumedByTerminalChainCall(inner), true);
+});
+
+Deno.test("hasReactiveCollectionProvenance treats a builder callback parameter as a reactive collection root", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { computed } from "commonfabric";
+    const value = computed((rows: number[]) => rows.map((n: number) => n + 1));
+  `);
+
+  // `rows` is a parameter of a computed() builder callback, so it is an implicit
+  // reactive parameter and the provenance walk resolves it as reactive.
+  const rows = findFirstIdentifier(sourceFile, "rows");
+  assertEquals(hasReactiveCollectionProvenance(rows, checker), true);
+  assertEquals(
+    isReactiveValueSymbol(checker.getSymbolAtLocation(rows), checker),
+    true,
+  );
+});
+
+Deno.test("isReactiveValueExpression follows a variable initialized by a reactive-origin call", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { computed } from "commonfabric";
+    const derived = computed(() => 1);
+    const value = derived;
+  `);
+
+  // `derived` is bound to a reactive-origin computed() call, so reading the
+  // identifier resolves as a reactive value through its initializer.
+  const ident = findInitializer(sourceFile, "value");
+  assertEquals(isReactiveValueExpression(ident, checker), true);
+});
+
+Deno.test("detectCallKind ignores a non-const let binding of a builder", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { pattern } from "commonfabric";
+    let aliased = pattern;
+    const value = aliased(() => 1);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // resolveSymbolKind reaches the builder through the `let` initializer, but the
+  // non-const guard rejects builder kinds bound to a mutable binding.
+  assertEquals(detectCallKind(call, checker), undefined);
+});
+
+Deno.test("detectNewExpressionKind follows a const alias chain to a commonfabric cell constructor", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Writable } from "commonfabric";
+    const First = Writable;
+    const Second = First;
+    const value = new Second(1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isNewExpression(expression)) {
+    throw new Error("Expected a new expression");
+  }
+  // detectCellConstructorExpressionName walks the const-initializer chain
+  // Second -> First -> Writable to reach the commonfabric cell constructor.
+  assertEquals(
+    detectNewExpressionKind(expression, checker)?.factoryName,
+    "Writable",
+  );
+});
+
+Deno.test("detectNewExpressionKind returns undefined for a new expression with an unresolved callee", () => {
+  const { sourceFile, checker } = createProgram(`
+    // @ts-expect-error intentionally unresolved
+    const value = new Unknown(1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isNewExpression(expression)) {
+    throw new Error("Expected a new expression");
+  }
+  // The callee identifier has no symbol, so detectCellConstructorExpressionName
+  // returns undefined at the missing-symbol guard.
+  assertEquals(detectNewExpressionKind(expression, checker), undefined);
+});
+
+Deno.test("detectNewExpressionKind resolves a namespace-member cell constructor through its declaration", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import * as CF from "commonfabric";
+    const value = new CF.Writable(1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isNewExpression(expression)) {
+    throw new Error("Expected a new expression");
+  }
+  // The callee is a property access whose member symbol resolves via alias to the
+  // commonfabric Writable declaration, taking the name-plus-provenance branch.
+  assertEquals(
+    detectNewExpressionKind(expression, checker)?.factoryName,
+    "Writable",
+  );
+});
+
+Deno.test("detectNewExpressionKind returns undefined for a new expression with a non-identifier callee", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const ctors: any;
+    const value = new ctors[0](1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isNewExpression(expression)) {
+    throw new Error("Expected a new expression");
+  }
+  // The callee is an element access, which is neither an identifier nor a
+  // property access, so recognition bails at the callee-shape guard.
+  assertEquals(detectNewExpressionKind(expression, checker), undefined);
+});
+
+Deno.test("detectCallKind returns a non-builder call kind through a const alias initializer", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { ifElse } from "commonfabric";
+    const chosen = ifElse;
+    const value = chosen(true, 1, 2);
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The alias resolves to ifElse through its const initializer; because the
+  // nested kind is not a builder, it is returned directly (no const gate).
+  assertEquals(detectCallKind(call, checker)?.kind, "ifElse");
+});
+
+Deno.test("detectCallKind returns undefined when a const alias initializer resolves to no kind", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare function plain(): number;
+    const alias = plain;
+    const value = alias();
+  `);
+
+  const call = findCall(sourceFile, "value");
+  // The const initializer resolves to no call kind, so the declaration loop
+  // continues past it and resolution yields undefined.
+  assertEquals(detectCallKind(call, checker), undefined);
+});
+
+Deno.test("isReactiveValueSymbol treats a reactive array-method callback parameter as reactive", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Cell } from "commonfabric";
+    declare const items: Cell<{ n: number }[]>;
+    const value = items.map((row) => row.n);
+  `);
+
+  // `row` is the parameter of a callback on a reactive `.map`; the implicit
+  // reactive-parameter context recognizes it as a reactive-array-method binding.
+  const row = findFirstIdentifier(sourceFile, "row");
+  assertEquals(
+    isReactiveValueSymbol(checker.getSymbolAtLocation(row), checker),
+    true,
+  );
+});
+
+Deno.test("isReactiveValueExpression follows a variable bound to a lowered reactive array-method call", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Cell } from "commonfabric";
+    declare const items: Cell<number[]>;
+    const mapped = items.mapWithPattern((n: number) => n + 1);
+    const value = mapped;
+  `);
+
+  // `mapped` is bound to a lowered reactive `.mapWithPattern` call, so reading it
+  // resolves as reactive through isVariableFromReactiveCallSymbol.
+  const ident = findInitializer(sourceFile, "value");
+  assertEquals(isReactiveValueExpression(ident, checker), true);
+});
+
+Deno.test("hasReactiveCollectionProvenance restricts implicit reactive parameters to the given scope", () => {
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { computed } from "commonfabric";
+    const outer = computed((rows: number[]) => {
+      const inner = (extra: number[]) => extra.map((n: number) => n + 1);
+      return inner([1]);
+    });
+  `);
+
+  const rows = findFirstIdentifier(sourceFile, "rows");
+  const outerFn = getEnclosingFunctionLikeDeclaration(rows);
+  const innerRef = findFirstIdentifier(sourceFile, "extra");
+  const innerFn = getEnclosingFunctionLikeDeclaration(innerRef);
+  if (!outerFn || !innerFn) throw new Error("Expected enclosing functions");
+
+  // `rows` is an implicit reactive parameter of the computed() callback. Scoped
+  // to the outer function it is in-scope and reactive; scoped to the inner arrow
+  // it is out of scope, so the scope guard rejects it.
+  assertEquals(
+    hasReactiveCollectionProvenance(rows, checker, { sameScope: outerFn }),
+    true,
+  );
+  assertEquals(
+    hasReactiveCollectionProvenance(rows, checker, { sameScope: innerFn }),
+    false,
+  );
+});

--- a/packages/ts-transformers/test/ast/dataflow-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/dataflow-coverage.test.ts
@@ -1,0 +1,628 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import { createDataFlowAnalyzer } from "../../src/ast/dataflow.ts";
+
+// Branded-cell prelude so `state.*` reads resolve to a reactive (opaque) type
+// under `noLib`, mirroring the reactive harness prelude in dataflow.test.ts.
+const REACTIVE_PRELUDE = `
+declare const CELL_BRAND: unique symbol;
+type BrandedCell<T, Brand extends string> = { readonly [CELL_BRAND]: Brand };
+interface OpaqueCell<T> extends BrandedCell<T, "opaque"> {}
+declare function pattern<I, O>(cb: (x: I) => O): O;
+declare const state: {
+  readonly count: OpaqueCell<number>;
+  readonly nested: { readonly inner: OpaqueCell<number> };
+  readonly items: OpaqueCell<number[]>;
+};
+declare const pair: readonly [OpaqueCell<number>, number];
+declare const props: OpaqueCell<{ title: string }>;
+declare const idx: number;
+`;
+
+// A second source file named commonfabric.d.ts lets `symbolDeclaresCommon
+// FabricDefault` recognize `Default<>` (its declarations live in a file whose
+// basename is commonfabric.d.ts).
+const COMMONFABRIC_DTS = `
+export type Default<T, V> = T;
+`;
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function createProgramWithCommonFabric(main: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const files: Record<string, string> = {
+    "/commonfabric.d.ts": COMMONFABRIC_DTS,
+    "/main.ts": main,
+  };
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (n) => files[n] !== undefined,
+    readFile: (n) => files[n],
+    getSourceFile: (n, lv) =>
+      files[n] !== undefined
+        ? ts.createSourceFile(n, files[n]!, lv, true, ts.ScriptKind.TS)
+        : undefined,
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    getCanonicalFileName: (n) => n,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    directoryExists: () => true,
+    resolveModuleNames: (names) =>
+      names.map((name) =>
+        name === "commonfabric"
+          ? {
+            resolvedFileName: "/commonfabric.d.ts",
+            extension: ts.Extension.Dts,
+          }
+          : undefined
+      ),
+  };
+  const program = ts.createProgram(
+    ["/main.ts", "/commonfabric.d.ts"],
+    options,
+    host,
+  );
+  return {
+    sourceFile: program.getSourceFile("/main.ts")!,
+    checker: program.getTypeChecker(),
+  };
+}
+
+function createTsxProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.tsx";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.Preserve,
+    noLib: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findInitializer(
+  sourceFile: ts.SourceFile,
+  declarationName: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === declarationName &&
+      node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Initializer for ${declarationName} not found`);
+  }
+  return found;
+}
+
+function findFirst<T extends ts.Node>(
+  sourceFile: ts.SourceFile,
+  pred: (n: ts.Node) => n is T,
+  text?: string,
+): T {
+  let found: T | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      pred(node) && (text === undefined || node.getText(sourceFile) === text)
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Node not found: ${text ?? "<pred>"}`);
+  return found;
+}
+
+function analyze(source: string, name: string) {
+  const { sourceFile, checker } = createProgram(
+    `${REACTIVE_PRELUDE}\n${source}`,
+  );
+  return createDataFlowAnalyzer(checker)(findInitializer(sourceFile, name));
+}
+
+function analyzeTsx(source: string, name: string) {
+  const { sourceFile, checker } = createTsxProgram(
+    `${REACTIVE_PRELUDE}\n${source}`,
+  );
+  return createDataFlowAnalyzer(checker)(findInitializer(sourceFile, name));
+}
+
+// === Structural wrappers around a reactive read (1084-1098) ===
+
+Deno.test("parenthesized reactive read stays reactive", () => {
+  const analysis = analyze(`const value = (state.count);`, "value");
+  assert(analysis.containsReactive);
+});
+
+Deno.test("as-expression around a reactive read stays reactive", () => {
+  const analysis = analyze(
+    `const value = state.count as OpaqueCell<number>;`,
+    "value",
+  );
+  assert(analysis.containsReactive);
+});
+
+Deno.test("angle-bracket type assertion around a reactive read stays reactive", () => {
+  // Type assertions (<T>expr) only parse in .ts; pins the TypeAssertionExpression
+  // handler (lines 1092-1094).
+  const analysis = analyze(
+    `const value = <OpaqueCell<number>> state.count;`,
+    "value",
+  );
+  assert(analysis.containsReactive, "type-assertion-wrapped read is reactive");
+});
+
+Deno.test("non-null assertion around a reactive read stays reactive", () => {
+  const analysis = analyze(`const value = state.count!;`, "value");
+  assert(analysis.containsReactive);
+});
+
+// === Common Fabric Default types (790-797, 924-935) ===
+
+Deno.test("identifier typed as a Common Fabric Default is a reactive dataflow", () => {
+  // The identifier's symbol declares Default<>, so it records as an explicit
+  // reactive dependency (lines 790-797).
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Default } from "commonfabric";
+    declare const withDefault: Default<number, 0>;
+    const value = withDefault;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assert(analysis.containsReactive, "Default-typed identifier is reactive");
+  assertEquals(analysis.requiresRewrite, false);
+  assertEquals(analysis.dataFlows.length, 1);
+});
+
+Deno.test("property access whose member is a Common Fabric Default requires rewrite", () => {
+  // The property member symbol declares Default<>, so the property access is a
+  // reactive dependency flagged for rewrite (lines 924-935).
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Default } from "commonfabric";
+    declare const holder: { readonly value: Default<number, 0> };
+    const value = holder.value;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assert(analysis.containsReactive, "Default-typed member is reactive");
+  assertEquals(analysis.requiresRewrite, true);
+});
+
+// === Const-binding aliases resolved through a static access path
+//     (224-304) ===
+//
+// These destructure a field off an implicit reactive parameter (`p`), giving
+// the alias a PLAIN field type (e.g. `number`). A plain type skips the
+// branded-cell short-circuit in the identifier handler and forces resolution
+// through getStableConstAliasInitializer -> getBindingElementStaticAccessPath,
+// which rebuilds the read as `p.<field>` and re-analyzes it as reactive.
+
+function analyzePatternArrow(callbackSource: string) {
+  const { sourceFile, checker } = createProgram(
+    `${REACTIVE_PRELUDE}\nconst r = pattern(${callbackSource});`,
+  );
+  const arrow = findFirst(sourceFile, ts.isArrowFunction);
+  return createDataFlowAnalyzer(checker)(arrow);
+}
+
+Deno.test("destructured alias with a renamed key resolves reactive", () => {
+  // `{ count: renamed }` builds a "property" segment from the propertyName
+  // identifier (lines 234-236) and resolves back to the reactive parameter.
+  const analysis = analyzePatternArrow(
+    `(p: { count: number }) => { const { count: renamed } = p; return renamed; }`,
+  );
+  assert(analysis.containsReactive, "renamed binding alias is reactive");
+});
+
+Deno.test("destructured alias with a string-literal key resolves reactive", () => {
+  // A quoted property name is not an identifier, so getObjectBindingAccessSegment
+  // falls to getStaticPropertyNameText's string-literal branch (238-241, 253-259).
+  const analysis = analyzePatternArrow(
+    `(p: { count: number }) => { const { "count": renamed } = p; return renamed; }`,
+  );
+  assert(analysis.containsReactive, "string-key binding alias is reactive");
+});
+
+Deno.test("destructured alias with a numeric-literal key resolves reactive", () => {
+  // A numeric property name exercises getStaticPropertyNameText's numeric-literal
+  // branch (255-256) inside the propertyName path.
+  const analysis = analyzePatternArrow(
+    `(p: { 0: number }) => { const { 0: renamed } = p; return renamed; }`,
+  );
+  assert(analysis.containsReactive, "numeric-key binding alias is reactive");
+});
+
+Deno.test("shorthand destructured alias resolves reactive", () => {
+  // Shorthand binding (no propertyName) builds a "property" segment from the
+  // element name (lines 227-230).
+  const analysis = analyzePatternArrow(
+    `(p: { count: number }) => { const { count } = p; return count; }`,
+  );
+  assert(analysis.containsReactive, "shorthand binding alias is reactive");
+});
+
+Deno.test("array-destructured alias resolves reactive through an index segment", () => {
+  // Array binding element contributes an index segment (284-290) and the built
+  // element-access resolves back to the reactive parameter.
+  const analysis = analyzePatternArrow(
+    `(p: number[]) => { const [first] = p; return first; }`,
+  );
+  assert(analysis.containsReactive, "array-destructured alias is reactive");
+});
+
+Deno.test("nested destructuring resolves reactive through the whole path", () => {
+  // Nested binding elements take the owner-is-BindingElement continue branch
+  // (296-299) building a multi-segment static path (`p.nested.inner`).
+  const analysis = analyzePatternArrow(
+    `(p: { nested: { inner: number } }) => { const { nested: { inner } } = p; return inner; }`,
+  );
+  assert(analysis.containsReactive, "nested binding alias is reactive");
+});
+
+// === Element access (1044-1082) ===
+
+Deno.test("static string-index element access on a reactive cell is reactive", () => {
+  // Static literal index merges target+argument (lines 1052-1057) and stays
+  // reactive because the receiver `state.items` is a reactive cell.
+  const analysis = analyze(`const value = state.items["0"];`, "value");
+  assert(analysis.containsReactive, "static index on reactive stays reactive");
+});
+
+Deno.test("dynamic element access on a reactive property requires rewrite", () => {
+  // Dynamic index falls to the general element-access return (1076-1081):
+  // requiresRewrite is forced true and the receiver's dataflows propagate.
+  const analysis = analyze(`const value = state.items[idx];`, "value");
+  assert(analysis.containsReactive, "reactive dynamic index is reactive");
+  assertEquals(analysis.requiresRewrite, true);
+  assert(analysis.dataFlows.length > 0);
+});
+
+Deno.test("dynamic element access on an ignored branded parameter is inert", () => {
+  // `env[idx]` where `env` is a branded but ignored parameter: the receiver is
+  // reactive by type yet analyzes to no dataflows, so the reactive-element-
+  // access branch fires and its originatesFromIgnored guard returns empty
+  // (lines 1059-1064).
+  const analysis = analyzeArrow(
+    `const f = (env: OpaqueCell<number[]>) => env[idx];`,
+  );
+  assertEquals(
+    analysis.containsReactive,
+    false,
+    "element access through an ignored branded parameter is inert",
+  );
+  assertEquals(analysis.dataFlows.length, 0);
+});
+
+// === Array-literal reactive elements (1258-1265) ===
+
+Deno.test("array literal with a reactive element carries reactive dataflow", () => {
+  const analysis = analyze(`const value = [state.count];`, "value");
+  assert(analysis.containsReactive, "reactive array element flows");
+});
+
+// === Synthetic property access whose root is not an identifier (696-697) ===
+
+Deno.test("synthetic property access rooted in an object literal is inert", () => {
+  // `({}).bar` built synthetically: findRootIdentifier bottoms out on a
+  // non-identifier (the object literal) and returns undefined (lines 696-697),
+  // so nothing is recorded.
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const synthetic = ts.factory.createPropertyAccessExpression(
+    ts.factory.createObjectLiteralExpression([]),
+    "bar",
+  );
+  const analysis = createDataFlowAnalyzer(checker)(synthetic);
+  assertEquals(analysis.containsReactive, false);
+  assertEquals(analysis.dataFlows.length, 0);
+});
+
+// === Reads whose root originates from an ignored (aggregated) scope
+//     parameter (876-878, 973-975) ===
+//
+// A parameter of a plain (non-builder, non-array-method) callback is an
+// aggregated scope symbol that is NOT a reactive value, so `isSymbolIgnored`
+// treats reads through it as inert. When the read still looks reactive by
+// type/shape, the `originatesFromIgnored` guard short-circuits it to empty.
+
+function analyzeArrow(source: string) {
+  const { sourceFile, checker } = createProgram(
+    `${REACTIVE_PRELUDE}\n${source}`,
+  );
+  const arrow = findFirst(sourceFile, ts.isArrowFunction);
+  return createDataFlowAnalyzer(checker)(arrow);
+}
+
+Deno.test("branded property off an ignored parameter is not a reactive dependency", () => {
+  // `env.cell` is branded, but `env` is an ignored aggregated parameter, so the
+  // branded-property branch's originatesFromIgnored guard returns empty
+  // (lines 876-878).
+  const analysis = analyzeArrow(
+    `const f = (env: { cell: OpaqueCell<number> }) => env.cell;`,
+  );
+  assertEquals(
+    analysis.containsReactive,
+    false,
+    "branded read through an ignored parameter is inert",
+  );
+  assertEquals(analysis.dataFlows.length, 0);
+});
+
+Deno.test("Common Fabric Default member off an ignored parameter is inert", () => {
+  // `env.value` member declares Default<>, but `env` is an ignored parameter,
+  // so the common-fabric-default branch's originatesFromIgnored guard returns
+  // empty (lines 925-927).
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Default } from "commonfabric";
+    const f = (env: { value: Default<number, 0> }) => env.value;
+  `);
+  const arrow = findFirst(sourceFile, ts.isArrowFunction);
+  const analysis = createDataFlowAnalyzer(checker)(arrow);
+  assertEquals(
+    analysis.containsReactive,
+    false,
+    "Default member through an ignored parameter is inert",
+  );
+});
+
+Deno.test("structurally-opaque read off an ignored Default parameter is inert", () => {
+  // `d.foo` where `d` is typed as a Common Fabric Default is structurally
+  // opaque (isStructuralOpaqueTargetExpression true via the Default root), but
+  // `d` is an ignored parameter, so the structural-opaque branch's
+  // originatesFromIgnored guard returns empty (lines 973-975).
+  const { sourceFile, checker } = createProgramWithCommonFabric(`
+    import { Default } from "commonfabric";
+    const f = (d: Default<{ foo: number }, {}>) => d.foo;
+  `);
+  const arrow = findFirst(sourceFile, ts.isArrowFunction);
+  const analysis = createDataFlowAnalyzer(checker)(arrow);
+  assertEquals(
+    analysis.containsReactive,
+    false,
+    "structural-opaque read through an ignored parameter is inert",
+  );
+});
+
+// === JSX attributes, spreads, children (1263-1264, 1292-1295) ===
+
+Deno.test("JSX attribute expression carries reactive dataflow", () => {
+  const analysis = analyzeTsx(
+    `const value = <div title={state.count} />;`,
+    "value",
+  );
+  assert(analysis.containsReactive, "attribute expr dataflow is reactive");
+});
+
+Deno.test("JSX spread attribute carries reactive dataflow", () => {
+  const analysis = analyzeTsx(`const value = <div {...props} />;`, "value");
+  assert(analysis.containsReactive, "spread attribute dataflow is reactive");
+});
+
+Deno.test("JSX element children with a nested element carry reactive dataflow", () => {
+  const analysis = analyzeTsx(
+    `const value = <div><span>{state.count}</span></div>;`,
+    "value",
+  );
+  assert(analysis.containsReactive, "nested child dataflow is reactive");
+});
+
+// === Function-argument callback with a block body (1180-1189, 1231-1240) ===
+
+Deno.test("call-argument callback block return propagates reactive dataflow", () => {
+  // A callback argument with a block body has its return-statement expressions
+  // analyzed in a child scope (lines 1180-1189).
+  const analysis = analyze(
+    `declare function run<T>(cb: () => T): T;
+     const value = run(() => { return state.count; });`,
+    "value",
+  );
+  assert(analysis.containsReactive, "block-return dataflow is reactive");
+});
+
+Deno.test("standalone arrow with a block body propagates reactive dataflow", () => {
+  // A function-like expression (not a call argument) with a block body walks
+  // its return statements in a child scope (lines 1231-1240).
+  const { sourceFile, checker } = createProgram(
+    `${REACTIVE_PRELUDE}\nconst value = () => { return state.count; };`,
+  );
+  const arrow = findFirst(sourceFile, ts.isArrowFunction);
+  const analysis = createDataFlowAnalyzer(checker)(arrow);
+  assert(analysis.containsReactive, "arrow block-return dataflow is reactive");
+});
+
+// === Synthetic (transformer-created) node handling (683-697, 749-751,
+//     1004-1032) ===
+
+Deno.test("synthetic bare identifier is treated as an opaque reactive parameter", () => {
+  // A fully-synthetic identifier with no resolvable symbol is recorded as an
+  // opaque parameter dataflow (lines 745, 753-758).
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const synthetic = ts.factory.createIdentifier("discount");
+  const analysis = createDataFlowAnalyzer(checker)(synthetic);
+  assert(analysis.containsReactive, "synthetic opaque parameter is reactive");
+  assertEquals(analysis.requiresRewrite, false);
+  assertEquals(analysis.dataFlows.length, 1);
+});
+
+Deno.test("synthetic identifier matching a synthetic local parameter is inert", () => {
+  // A synthetic arrow whose parameter has no resolvable symbol makes reads of
+  // that name a scope-local reference, not a reactive dependency (lines
+  // 746-751).
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const f = ts.factory;
+  const param = f.createParameterDeclaration(
+    undefined,
+    undefined,
+    f.createIdentifier("element"),
+  );
+  const arrow = f.createArrowFunction(
+    undefined,
+    undefined,
+    [param],
+    undefined,
+    undefined,
+    f.createIdentifier("element"),
+  );
+  const analysis = createDataFlowAnalyzer(checker)(arrow);
+  assertEquals(
+    analysis.containsReactive,
+    false,
+    "synthetic local parameter read is inert",
+  );
+  assertEquals(analysis.dataFlows.length, 0);
+});
+
+Deno.test("synthetic __cfHelpers property access passes through without a new dataflow", () => {
+  // A synthetic `__cfHelpers.toSchema` access whose root is undefined is
+  // treated as a helper: it passes the target's analysis through instead of
+  // recording the access itself as an opaque read (lines 1007-1013). The only
+  // recorded dataflow is the synthetic `__cfHelpers` root, not the access.
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const root = ts.factory.createIdentifier("__cfHelpers");
+  const synthetic = ts.factory.createPropertyAccessExpression(root, "toSchema");
+  const analysis = createDataFlowAnalyzer(checker)(synthetic);
+  assertEquals(
+    analysis.dataFlows.some((d) => d === synthetic),
+    false,
+    "the __cfHelpers access is not recorded as its own dataflow",
+  );
+});
+
+Deno.test("synthetic method call on an opaque root is skipped, not recorded", () => {
+  // `element.trim()` where `element` is synthetic and unresolved: the property
+  // access is a method call, so it is skipped rather than recorded (1016-1022).
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const f = ts.factory;
+  const access = f.createPropertyAccessExpression(
+    f.createIdentifier("element"),
+    "trim",
+  );
+  const call = f.createCallExpression(access, undefined, []);
+  const analysis = createDataFlowAnalyzer(checker)(call);
+  // The inner method-access is skipped: no dataflow is recorded for it.
+  assertEquals(
+    analysis.dataFlows.some((d) => d === access),
+    false,
+    "method-access is not recorded as a dataflow",
+  );
+});
+
+Deno.test("synthetic property access on an opaque root is recorded as reactive", () => {
+  // `element.price` where `element` is synthetic and unresolved is treated as
+  // an opaque property read (lines 1024-1032).
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const synthetic = ts.factory.createPropertyAccessExpression(
+    ts.factory.createIdentifier("element"),
+    "price",
+  );
+  const analysis = createDataFlowAnalyzer(checker)(synthetic);
+  assert(analysis.containsReactive, "opaque property read is reactive");
+  assertEquals(analysis.requiresRewrite, true);
+  assertEquals(analysis.dataFlows.length, 1);
+});
+
+Deno.test("synthetic wrapped property access unwraps to its opaque root", () => {
+  // `(element)!.price` built synthetically: findRootIdentifier unwraps the
+  // parenthesized/non-null wrappers to reach `element` (lines 683-691), then
+  // the read is recorded as opaque.
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const f = ts.factory;
+  const wrapped = f.createNonNullExpression(
+    f.createParenthesizedExpression(f.createIdentifier("element")),
+  );
+  const synthetic = f.createPropertyAccessExpression(wrapped, "price");
+  const analysis = createDataFlowAnalyzer(checker)(synthetic);
+  assert(analysis.containsReactive, "wrapped opaque property read is reactive");
+  assertEquals(analysis.requiresRewrite, true);
+});
+
+Deno.test("synthetic element access unwraps through findRootIdentifier", () => {
+  // `element[0].price` built synthetically: findRootIdentifier descends the
+  // element-access receiver (lines 679-682) to reach the opaque `element` root.
+  const { checker } = createProgram(REACTIVE_PRELUDE);
+  const f = ts.factory;
+  const elem = f.createElementAccessExpression(
+    f.createIdentifier("element"),
+    f.createNumericLiteral("0"),
+  );
+  const synthetic = f.createPropertyAccessExpression(elem, "price");
+  const analysis = createDataFlowAnalyzer(checker)(synthetic);
+  assert(analysis.containsReactive, "element-access-rooted read is reactive");
+});

--- a/packages/ts-transformers/test/ast/normalize-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/normalize-coverage.test.ts
@@ -1,0 +1,882 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import { createDataFlowAnalyzer } from "../../src/ast/dataflow.ts";
+import type {
+  DataFlowAnalysis,
+  DataFlowGraph,
+  DataFlowNode,
+  DataFlowScope,
+} from "../../src/ast/dataflow.ts";
+import {
+  getRelevantDataFlows,
+  normalizeDataFlows,
+} from "../../src/ast/normalize.ts";
+import type { ReactiveContextLookup } from "../../src/ast/reactive-context.ts";
+import { getExpressionText } from "../../src/ast/utils.ts";
+
+const factory = ts.factory;
+
+// A checker attached to a trivial program. It is only used to resolve symbols
+// for synthetically constructed nodes; factory-created identifiers have no
+// symbol, which is exactly the "synthetic root" condition the normalizer's
+// map-parameter recovery path keys off of.
+function trivialChecker(): ts.TypeChecker {
+  const fileName = "/trivial.ts";
+  const source = "const trivial = 1;";
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    noLib: true,
+  };
+  const sf = ts.createSourceFile(fileName, source, options.target!, true);
+  const host = ts.createCompilerHost(options, true);
+  host.getSourceFile = (name) => name === fileName ? sf : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  return ts.createProgram([fileName], options, host).getTypeChecker();
+}
+
+function syntheticNode(
+  id: number,
+  expression: ts.Expression,
+  scopeId: number,
+  parentId: number | null,
+  isExplicit: boolean,
+): DataFlowNode {
+  return { id, expression, canonicalKey: "", parentId, scopeId, isExplicit };
+}
+
+function syntheticGraph(
+  nodes: DataFlowNode[],
+  scopes: DataFlowScope[],
+): DataFlowGraph {
+  return { nodes, scopes, rootScopeId: 0 };
+}
+
+function syntheticAnalysis(graph: DataFlowGraph): DataFlowAnalysis {
+  return {
+    containsReactive: true,
+    requiresRewrite: true,
+    dataFlows: graph.nodes.map((n) => n.expression),
+    graph,
+  };
+}
+
+const emptySourceFile = ts.createSourceFile(
+  "/empty.ts",
+  "",
+  ts.ScriptTarget.ES2020,
+  true,
+);
+
+// A minimal branded-cell prelude so `state.*` reads resolve to a reactive
+// (opaque) type under `noLib`, mirroring the reactive harness used by the
+// dataflow tests.
+const REACTIVE_PRELUDE = `
+declare const CELL_BRAND: unique symbol;
+type BrandedCell<T, Brand extends string> = { readonly [CELL_BRAND]: Brand };
+interface OpaqueCell<T> extends BrandedCell<T, "opaque"> {}
+interface Item {
+  name: OpaqueCell<string>;
+  compute(): OpaqueCell<number>;
+}
+interface OpaqueArray<T> extends BrandedCell<T[], "opaque"> {
+  map<U>(callback: (element: OpaqueCell<Item>, index: number, array: OpaqueArray<T>) => U): U[];
+  toUpperCase(): OpaqueCell<T>;
+}
+declare const state: {
+  readonly count: OpaqueCell<number>;
+  readonly user: OpaqueCell<{ name: OpaqueCell<string> }>;
+  readonly items: OpaqueArray<number>;
+};
+declare function computed<T>(callback: () => T): T;
+`;
+
+function createTsxProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.tsx";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.Preserve,
+    noLib: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findInitializer(
+  sourceFile: ts.SourceFile,
+  declarationName: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === declarationName &&
+      node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Initializer for ${declarationName} not found`);
+  }
+  return found;
+}
+
+function print(node: ts.Node, sourceFile: ts.SourceFile): string {
+  return ts.createPrinter().printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    sourceFile,
+  );
+}
+
+// A lookup that treats every arrow/function node as an array-method callback.
+const arrayMethodLookup: ReactiveContextLookup = {
+  isArrayMethodCallback: () => true,
+};
+
+Deno.test("normalizeDataFlows unwraps a parenthesized reactive read to the bare property access", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = (state.count);
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const normalized = normalizeDataFlows(analysis.graph);
+  assertEquals(normalized.length, 1);
+  // The parenthesized wrapper is purely syntactic and is stripped.
+  assertEquals(print(normalized[0].expression, sourceFile), "state.count");
+  assert(!ts.isParenthesizedExpression(normalized[0].expression));
+});
+
+Deno.test("normalizeDataFlows strips an `as` type assertion from a reactive read", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.count as number;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const normalized = normalizeDataFlows(analysis.graph);
+  assertEquals(normalized.length, 1);
+  assertEquals(print(normalized[0].expression, sourceFile), "state.count");
+  assert(!ts.isAsExpression(normalized[0].expression));
+});
+
+Deno.test("normalizeDataFlows strips an angle-bracket type assertion from a reactive read", () => {
+  // Angle-bracket assertions are only valid in .ts, so use a non-jsx program.
+  const source = `
+    ${REACTIVE_PRELUDE}
+    const value = <number> state.count;
+  `;
+  const fileName = "/assert.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    noLib: true,
+    skipLibCheck: true,
+  };
+  const sf = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sf : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  const checker = program.getTypeChecker();
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sf, "value"),
+  );
+  const normalized = normalizeDataFlows(analysis.graph);
+  assertEquals(normalized.length, 1);
+  assertEquals(print(normalized[0].expression, sf), "state.count");
+  assert(ts.isPropertyAccessExpression(normalized[0].expression));
+});
+
+Deno.test("normalizeDataFlows strips a non-null assertion from a reactive read", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.count!;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const normalized = normalizeDataFlows(analysis.graph);
+  assertEquals(normalized.length, 1);
+  assertEquals(print(normalized[0].expression, sourceFile), "state.count");
+  assert(!ts.isNonNullExpression(normalized[0].expression));
+});
+
+Deno.test("normalizeDataFlows normalizes a property access used as a method callee back to its object", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.items.map((element) => element);
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const normalized = normalizeDataFlows(analysis.graph);
+  // The `state.items.map` read is the callee of a call expression, so it is
+  // normalized back to the receiver object `state.items`. The `.map` member is
+  // never a surviving reactive dependency of its own.
+  const texts = normalized.map((n) => print(n.expression, sourceFile));
+  assert(
+    !texts.some((t) => t.endsWith(".map")),
+    `the .map callee should be normalized to its object, got ${
+      JSON.stringify(texts)
+    }`,
+  );
+});
+
+Deno.test("normalizeDataFlows suppresses a parent read that has a more specific explicit child", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.user.name;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const normalized = normalizeDataFlows(analysis.graph);
+  const texts = normalized.map((n) => print(n.expression, sourceFile));
+  // The most-specific read survives; broader ancestor reads that have a more
+  // specific explicit child are suppressed from the result.
+  assert(
+    texts.includes("state.user.name"),
+    `expected state.user.name among ${JSON.stringify(texts)}`,
+  );
+  assert(
+    !texts.includes("state.user"),
+    `parent read state.user should be suppressed, got ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("normalizeDataFlows with requested dataFlows keeps parent reads unsuppressed", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.user.name;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  // Passing an explicit requested set disables parent suppression: every
+  // requested expression is treated as a wanted dependency.
+  const requested = analysis.graph.nodes.map((n) => n.expression);
+  const normalized = normalizeDataFlows(analysis.graph, requested);
+  const texts = new Set(normalized.map((n) => getExpressionText(n.expression)));
+  assert(texts.size >= 1);
+});
+
+Deno.test("getRelevantDataFlows returns the reactive reads for a plain pattern body", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.count;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const relevant = getRelevantDataFlows(analysis, checker);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("state.count"));
+});
+
+Deno.test("getRelevantDataFlows drops reads rooted at a plain array-method callback parameter", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.items.map((element, index, array) => element);
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const relevant = getRelevantDataFlows(analysis, checker, arrayMethodLookup);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  // The map callback's own parameter (`element`) is an ignored parameter and
+  // must not surface as a reactive dependency; the reactive receiver does.
+  assert(
+    texts.includes("state.items"),
+    `expected state.items among ${JSON.stringify(texts)}`,
+  );
+  assert(
+    !texts.includes("element"),
+    `callback parameter element should be filtered, got ${
+      JSON.stringify(texts)
+    }`,
+  );
+});
+
+Deno.test("getRelevantDataFlows without a lookup keeps a property read off a synthetic map parameter", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.items.map((element, index, array) => element.name);
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  // With no ReactiveContextLookup the callback is not recognized as an array
+  // method callback, so the synthetic `element.name` read is retained; only the
+  // reactive receiver `state.items` is common to both.
+  const relevant = getRelevantDataFlows(analysis, checker);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(
+    texts.includes("state.items"),
+    `expected state.items among ${JSON.stringify(texts)}`,
+  );
+  assert(
+    texts.some((t) => t.startsWith("element")),
+    `expected an element-rooted read among ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("getRelevantDataFlows recurses through a property access to find the ignored parameter root", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.items.map((element, index, array) => element.name);
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  // The dependency `element.name` roots at the ignored `element` parameter; the
+  // ignored-parameter walk recurses through the property access to that root and
+  // filters it out once the callback is marked.
+  const relevant = getRelevantDataFlows(analysis, checker, arrayMethodLookup);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(
+    !texts.some((t) => t.startsWith("element")),
+    `element-rooted reads should be filtered, got ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("getRelevantDataFlows recurses through a call expression to find the ignored parameter root", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.items.map((element) => element.compute());
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  // `element.compute()` is a call whose callee roots at the ignored `element`
+  // parameter; the ignored-parameter walk descends through the call expression.
+  const relevant = getRelevantDataFlows(analysis, checker, arrayMethodLookup);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(
+    !texts.some((t) => t.startsWith("element")),
+    `element-rooted reads should be filtered, got ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("getRelevantDataFlows keeps a synthetic `index` parameter read when unmarked", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = state.items.map((element, index) => index);
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  const relevant = getRelevantDataFlows(analysis, checker);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  // `index` is one of the recognized synthetic map parameter names, exercising
+  // the synthetic-map-parameter recovery branch.
+  assert(
+    texts.includes("index"),
+    `expected index among ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("normalizeDataFlows unwraps a synthetic parenthesized expression node", () => {
+  // The full analyzer strips wrappers before recording a node, so the only way
+  // to exercise the parenthesis-stripping branch is with a hand-built node.
+  const inner = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "count",
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(
+      0,
+      factory.createParenthesizedExpression(inner),
+      0,
+      null,
+      true,
+    )],
+    [{ id: 0, parentId: null, parameters: [] }],
+  );
+  const normalized = normalizeDataFlows(graph);
+  assertEquals(normalized.length, 1);
+  assert(ts.isPropertyAccessExpression(normalized[0].expression));
+  assertEquals(
+    ts.createPrinter().printNode(
+      ts.EmitHint.Unspecified,
+      normalized[0].expression,
+      emptySourceFile,
+    ),
+    "state.count",
+  );
+});
+
+Deno.test("normalizeDataFlows unwraps a synthetic `as` type assertion node", () => {
+  const inner = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "count",
+  );
+  const asExpr = factory.createAsExpression(
+    inner,
+    factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(0, asExpr, 0, null, true)],
+    [{ id: 0, parentId: null, parameters: [] }],
+  );
+  const normalized = normalizeDataFlows(graph);
+  assertEquals(normalized.length, 1);
+  assert(ts.isPropertyAccessExpression(normalized[0].expression));
+});
+
+Deno.test("normalizeDataFlows unwraps a synthetic angle-bracket type assertion node", () => {
+  const inner = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "count",
+  );
+  const typeAssertion = factory.createTypeAssertion(
+    factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+    inner,
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(0, typeAssertion, 0, null, true)],
+    [{ id: 0, parentId: null, parameters: [] }],
+  );
+  const normalized = normalizeDataFlows(graph);
+  assertEquals(normalized.length, 1);
+  assert(ts.isPropertyAccessExpression(normalized[0].expression));
+});
+
+Deno.test("normalizeDataFlows unwraps a synthetic non-null assertion node", () => {
+  const inner = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "count",
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(0, factory.createNonNullExpression(inner), 0, null, true)],
+    [{ id: 0, parentId: null, parameters: [] }],
+  );
+  const normalized = normalizeDataFlows(graph);
+  assertEquals(normalized.length, 1);
+  assert(ts.isPropertyAccessExpression(normalized[0].expression));
+});
+
+Deno.test("getRelevantDataFlows falls back to non-synthetic reads when synthetic map params are present", () => {
+  // `element` is a factory identifier with no symbol, so its read counts as a
+  // synthetic root matching a recognized map-parameter name. With a
+  // non-synthetic `state.items` read available and no marked callback, the
+  // recovery keeps only the non-synthetic reads.
+  const checker = trivialChecker();
+  const stateItems = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "items",
+  );
+  const elementName = factory.createPropertyAccessExpression(
+    factory.createIdentifier("element"),
+    "name",
+  );
+  const graph = syntheticGraph(
+    [
+      syntheticNode(0, stateItems, 0, null, true),
+      syntheticNode(1, elementName, 1, null, true),
+    ],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element" }, { name: "index" }, { name: "array" }],
+      },
+    ],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("state.items"));
+  assert(
+    !texts.some((t) => t.startsWith("element")),
+    `synthetic element read should be dropped, got ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("getRelevantDataFlows keeps every read when a synthetic map callback is marked", () => {
+  // The scope's first parameter declaration lives inside an arrow function that
+  // the lookup reports as a marked array-method callback. That marks the whole
+  // group as in-callback, so the recovery retains all reads (synthetic and not).
+  const checker = trivialChecker();
+  const paramDecl = factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  const arrow = factory.createArrowFunction(
+    undefined,
+    undefined,
+    [paramDecl],
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  // Establish the parent chain so the ignored-parameter walk can climb from the
+  // parameter declaration up to the arrow function.
+  (paramDecl as { parent: ts.Node }).parent = arrow;
+
+  const stateItems = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "items",
+  );
+  const elementName = factory.createPropertyAccessExpression(
+    factory.createIdentifier("element"),
+    "name",
+  );
+  const graph = syntheticGraph(
+    [
+      syntheticNode(0, stateItems, 0, null, true),
+      syntheticNode(1, elementName, 1, null, true),
+    ],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element", declaration: paramDecl }, {
+          name: "index",
+        }, { name: "array" }],
+      },
+    ],
+  );
+  const markedLookup: ReactiveContextLookup = {
+    isArrayMethodCallback: (node) => node === arrow,
+  };
+  const relevant = getRelevantDataFlows(
+    syntheticAnalysis(graph),
+    checker,
+    markedLookup,
+  );
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("state.items"));
+});
+
+Deno.test("getRelevantDataFlows returns false for an ignored-parameter scope that does not exist", () => {
+  // A node whose scopeId has no matching scope hits the missing-scope guard in
+  // the ignored-parameter check, which returns false so the read is retained.
+  const checker = trivialChecker();
+  const orphan = factory.createPropertyAccessExpression(
+    factory.createIdentifier("ghost"),
+    "value",
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(0, orphan, 99, null, true)],
+    [{ id: 0, parentId: null, parameters: [] }],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  // The read survives because its scope cannot be found, so it is not treated
+  // as originating from an ignored parameter.
+  assert(texts.includes("ghost.value"));
+});
+
+Deno.test("getRelevantDataFlows drops an all-synthetic map read through the ignored-parameter walk", () => {
+  // With only a synthetic `element.name` read and no non-synthetic sibling, the
+  // recovery hands every read to the ignored-parameter filter. The read roots at
+  // the symbol-less `element` identifier, which matches a scope parameter name,
+  // so it is filtered out entirely.
+  const checker = trivialChecker();
+  const paramDecl = factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  const arrow = factory.createArrowFunction(
+    undefined,
+    undefined,
+    [paramDecl],
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  (paramDecl as { parent: ts.Node }).parent = arrow;
+  const elementName = factory.createPropertyAccessExpression(
+    factory.createIdentifier("element"),
+    "name",
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(1, elementName, 1, null, true)],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element", declaration: paramDecl }, {
+          name: "index",
+        }, { name: "array" }],
+      },
+    ],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker, {
+    isArrayMethodCallback: (node) => node === arrow,
+  });
+  assertEquals(relevant.length, 0);
+});
+
+Deno.test("getRelevantDataFlows keeps a synthetic root whose name is not a recognized map parameter", () => {
+  // The synthetic-root read exists, but its identifier is `custom`, which is not
+  // one of element/index/array. The map-parameter recovery does not engage, so
+  // the read falls through to the plain ignored-parameter filter and, matching
+  // no parameter, survives.
+  const checker = trivialChecker();
+  const customRead = factory.createPropertyAccessExpression(
+    factory.createIdentifier("custom"),
+    "value",
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(0, customRead, 0, null, true)],
+    [{ id: 0, parentId: null, parameters: [] }],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker);
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("custom.value"));
+});
+
+Deno.test("getRelevantDataFlows treats a marked-callback probe with no first-parameter declaration as unmarked", () => {
+  // The scope's first parameter carries no declaration, so the marked-callback
+  // probe short-circuits to unmarked; with a non-synthetic sibling present the
+  // recovery keeps only the non-synthetic reads.
+  const checker = trivialChecker();
+  const stateItems = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "items",
+  );
+  const indexRead = factory.createIdentifier("index");
+  const graph = syntheticGraph(
+    [
+      syntheticNode(0, stateItems, 0, null, true),
+      syntheticNode(1, indexRead, 1, null, true),
+    ],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element" }, { name: "index" }, { name: "array" }],
+      },
+    ],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker, {
+    isArrayMethodCallback: () => true,
+  });
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("state.items"));
+  assert(
+    !texts.includes("index"),
+    `synthetic index read should be dropped, got ${JSON.stringify(texts)}`,
+  );
+});
+
+Deno.test("getRelevantDataFlows climbs the parent chain to the enclosing callback in the marked probe", () => {
+  // The first parameter's declaration is nested (its immediate parent is not the
+  // callback), so the marked-callback probe must climb several parent links
+  // before reaching the arrow function it checks against the lookup.
+  const checker = trivialChecker();
+  const paramDecl = factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  const bindingList = factory.createVariableDeclarationList([]);
+  const block = factory.createBlock([]);
+  const arrow = factory.createArrowFunction(
+    undefined,
+    undefined,
+    [paramDecl],
+    undefined,
+    undefined,
+    block,
+  );
+  // Insert intermediate non-function parents between the declaration and arrow
+  // so the marked probe's ancestor walk iterates more than once.
+  (paramDecl as { parent: ts.Node }).parent = bindingList;
+  (bindingList as { parent: ts.Node }).parent = block;
+  (block as { parent: ts.Node }).parent = arrow;
+
+  const stateItems = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "items",
+  );
+  const elementName = factory.createPropertyAccessExpression(
+    factory.createIdentifier("element"),
+    "name",
+  );
+  const graph = syntheticGraph(
+    [
+      syntheticNode(0, stateItems, 0, null, true),
+      syntheticNode(1, elementName, 1, null, true),
+    ],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element", declaration: paramDecl }, {
+          name: "index",
+        }, { name: "array" }],
+      },
+    ],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker, {
+    isArrayMethodCallback: (node) => node === arrow,
+  });
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("state.items"));
+});
+
+Deno.test("getRelevantDataFlows keeps a builder-callback parameter as an opaque (non-ignored) input", () => {
+  // The ignored-parameter walk finds the parameter's declaration, climbs an
+  // intermediate block to the enclosing arrow, then to a builder call. A builder
+  // callback parameter is opaque, so it is not treated as ignored and its read
+  // is retained.
+  const checker = trivialChecker();
+  const paramDecl = factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  const block = factory.createBlock([]);
+  const arrow = factory.createArrowFunction(
+    undefined,
+    undefined,
+    [paramDecl],
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  // The declaration's immediate parent is a non-function block, forcing the
+  // function-ancestor walk to iterate before reaching the arrow.
+  (paramDecl as { parent: ts.Node }).parent = block;
+  (block as { parent: ts.Node }).parent = arrow;
+  const builderCall = factory.createCallExpression(
+    factory.createIdentifier("computed"),
+    undefined,
+    [arrow],
+  );
+  (arrow as { parent: ts.Node }).parent = builderCall;
+
+  const elementName = factory.createPropertyAccessExpression(
+    factory.createIdentifier("element"),
+    "name",
+  );
+  const graph = syntheticGraph(
+    [syntheticNode(1, elementName, 1, null, true)],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element", declaration: paramDecl }, {
+          name: "index",
+        }, { name: "array" }],
+      },
+    ],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker, {
+    isArrayMethodCallback: (node) => node === arrow,
+  });
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  // The builder callback parameter is opaque, so `element.name` survives.
+  assert(
+    texts.some((t) => t.startsWith("element")),
+    `builder-callback parameter read should be kept, got ${
+      JSON.stringify(texts)
+    }`,
+  );
+});
+
+Deno.test("getRelevantDataFlows marked probe returns unmarked when no callback ancestor is found", () => {
+  // The first parameter's declaration has a parent chain that never reaches an
+  // arrow or function expression, so the marked-callback probe exhausts the walk
+  // and reports the group as unmarked; the non-synthetic sibling is what remains.
+  const checker = trivialChecker();
+  const paramDecl = factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    factory.createIdentifier("element"),
+  );
+  const outerBlock = factory.createBlock([]);
+  const innerBlock = factory.createBlock([]);
+  // A chain of plain blocks with no function-like ancestor.
+  (paramDecl as { parent: ts.Node }).parent = innerBlock;
+  (innerBlock as { parent: ts.Node }).parent = outerBlock;
+
+  const stateItems = factory.createPropertyAccessExpression(
+    factory.createIdentifier("state"),
+    "items",
+  );
+  const elementName = factory.createPropertyAccessExpression(
+    factory.createIdentifier("element"),
+    "name",
+  );
+  const graph = syntheticGraph(
+    [
+      syntheticNode(0, stateItems, 0, null, true),
+      syntheticNode(1, elementName, 1, null, true),
+    ],
+    [
+      { id: 0, parentId: null, parameters: [] },
+      {
+        id: 1,
+        parentId: 0,
+        parameters: [{ name: "element", declaration: paramDecl }, {
+          name: "index",
+        }, { name: "array" }],
+      },
+    ],
+  );
+  const relevant = getRelevantDataFlows(syntheticAnalysis(graph), checker, {
+    isArrayMethodCallback: () => true,
+  });
+  const texts = relevant.map((r) => getExpressionText(r.expression));
+  assert(texts.includes("state.items"));
+});

--- a/packages/ts-transformers/test/ast/type-building-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/type-building-coverage.test.ts
@@ -1,0 +1,297 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import ts from "typescript";
+
+import {
+  buildCaptureTypeElements,
+  reportUnknownReactiveType,
+  shouldPreserveBindingDeclaredTypeNode,
+} from "../../src/ast/type-building.ts";
+import { TransformationContext } from "../../src/core/mod.ts";
+import {
+  type CaptureTreeNode,
+  createCaptureTreeNode,
+} from "../../src/utils/capture-tree.ts";
+
+function createProgram(fileName: string, sourceText: string) {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const options: ts.CompilerOptions = {
+    noLib: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => name === fileName,
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => "",
+    getDefaultLibFileName: () => "lib.d.ts",
+    getDirectories: () => [],
+    getNewLine: () => "\n",
+    getSourceFile: (name) => name === fileName ? sourceFile : undefined,
+    readFile: (name) => name === fileName ? sourceText : undefined,
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+  };
+  return {
+    program: ts.createProgram([fileName], options, host),
+    sourceFile,
+  };
+}
+
+/** Run `body` with a TransformationContext wired to a throwaway program. */
+function withContext(
+  sourceText: string,
+  body: (context: TransformationContext, sourceFile: ts.SourceFile) => void,
+): void {
+  const { program, sourceFile } = createProgram("capture.ts", sourceText);
+  let tsContext!: ts.TransformationContext;
+  const transformed = ts.transform(sourceFile, [
+    (context) => {
+      tsContext = context;
+      return (node) => node;
+    },
+  ]);
+  try {
+    const context = new TransformationContext({
+      program,
+      sourceFile,
+      tsContext,
+    });
+    body(context, sourceFile);
+  } finally {
+    transformed.dispose();
+  }
+}
+
+function findPropertyAccess(
+  sourceFile: ts.SourceFile,
+  memberName: string,
+): ts.PropertyAccessExpression {
+  let found: ts.PropertyAccessExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node) && node.name.text === memberName) {
+      found = node;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Property access .${memberName} not found`);
+  return found;
+}
+
+// -- shouldPreserveBindingDeclaredTypeNode ---------------------------------
+
+Deno.test("shouldPreserveBindingDeclaredTypeNode: unwraps parentheses to find a preserved Default alias", () => {
+  const factory = ts.factory;
+  // `(Default<string>)` — the parenthesized-unwrap loop must strip the parens
+  // before the Default-alias name check succeeds.
+  const node = factory.createParenthesizedType(
+    factory.createTypeReferenceNode("Default", [
+      factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+    ]),
+  );
+  assertEquals(shouldPreserveBindingDeclaredTypeNode(node), true);
+});
+
+Deno.test("shouldPreserveBindingDeclaredTypeNode: strips nested parentheses around a Writable of a preserved type", () => {
+  const factory = ts.factory;
+  // `((Writable<Default<string>>))` — two layers of parentheses exercise the
+  // while-loop, and Writable is preserved only because its argument is itself
+  // a preserved type.
+  const node = factory.createParenthesizedType(
+    factory.createParenthesizedType(
+      factory.createTypeReferenceNode("Writable", [
+        factory.createTypeReferenceNode("Default", [
+          factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ]),
+      ]),
+    ),
+  );
+  assertEquals(shouldPreserveBindingDeclaredTypeNode(node), true);
+});
+
+Deno.test("shouldPreserveBindingDeclaredTypeNode: a Writable of a plain type is not preserved", () => {
+  const factory = ts.factory;
+  // `Writable<string>` — Writable is preserved only when an argument is itself
+  // preservable; a plain `string` argument is not.
+  const node = factory.createTypeReferenceNode("Writable", [
+    factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+  ]);
+  assertEquals(shouldPreserveBindingDeclaredTypeNode(node), false);
+});
+
+Deno.test("shouldPreserveBindingDeclaredTypeNode: a union containing a scope wrapper is preserved", () => {
+  const factory = ts.factory;
+  // A union whose members are walked; `PerSpace<string>` triggers preservation.
+  const node = factory.createUnionTypeNode([
+    factory.createTypeReferenceNode("PerSpace", [
+      factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+    ]),
+    factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+  ]);
+  assertEquals(shouldPreserveBindingDeclaredTypeNode(node), true);
+});
+
+// -- reportUnknownReactiveType / describeCapture ---------------------------
+
+Deno.test("reportUnknownReactiveType: an unknown-typed capture with no printable text falls back to the label", () => {
+  // The capture expression prints to empty text, so describeCapture returns the
+  // supplied label; the reported diagnostic message embeds that label.
+  withContext(`declare const value: unknown; value;`, (context, sourceFile) => {
+    const captured: Array<{ type: string; message: string }> = [];
+    (context as unknown as {
+      reportDiagnosticOnce: (d: { type: string; message: string }) => void;
+    }).reportDiagnosticOnce = (d) => captured.push(d);
+
+    let unknownExpr: ts.Expression | undefined;
+    const visit = (node: ts.Node): void => {
+      if (ts.isExpressionStatement(node)) unknownExpr = node.expression;
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    const unknownType = context.checker.getTypeAtLocation(unknownExpr!);
+
+    // A synthetic identifier with empty text prints to nothing.
+    const emptyTextExpr = ts.factory.createIdentifier("");
+    reportUnknownReactiveType(
+      context,
+      emptyTextExpr,
+      unknownType,
+      "captureLabel",
+    );
+
+    assertEquals(captured.length, 1);
+    assertEquals(captured[0].type, "reactive-capture:unknown-type");
+    assertStringIncludes(captured[0].message, "captureLabel");
+  });
+});
+
+Deno.test("reportUnknownReactiveType: a non-unknown capture is not reported", () => {
+  withContext(`declare const value: string; value;`, (context, sourceFile) => {
+    let reported = 0;
+    (context as unknown as {
+      reportDiagnosticOnce: (d: unknown) => void;
+    }).reportDiagnosticOnce = () => reported++;
+
+    let expr: ts.Expression | undefined;
+    const visit = (node: ts.Node): void => {
+      if (ts.isExpressionStatement(node)) expr = node.expression;
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    reportUnknownReactiveType(
+      context,
+      ts.factory.createIdentifier("value"),
+      context.checker.getTypeAtLocation(expr!),
+      "label",
+    );
+    assertEquals(reported, 0);
+  });
+});
+
+// -- buildCaptureTypeElements: intermediate nodes --------------------------
+
+Deno.test("buildCaptureTypeElements: an optional intermediate property is emitted with a question token", () => {
+  // `config.nested.value` where `nested?: Nested` on `Config`. The intermediate
+  // `nested` node is looked up on the parent (Config) type, and its optional
+  // flag drives the emitted `nested?` question token.
+  const source = `
+    interface Nested { value: string; }
+    interface Config { nested?: Nested; }
+    function collect(config: Config) {
+      return [config.nested.value];
+    }
+  `;
+  withContextEmit(source, (context, sourceFile) => {
+    const valueExpr = findPropertyAccess(sourceFile, "value");
+    const root = createCaptureTreeNode([]);
+    const nested = createCaptureTreeNode(["nested"]);
+    const valueLeaf = createCaptureTreeNode(["nested", "value"]);
+    valueLeaf.expression = valueExpr;
+    nested.properties.set("value", valueLeaf);
+    root.properties.set("nested", nested);
+
+    const elements = buildCaptureTypeElements(
+      new Map<string, CaptureTreeNode>([["config", root]]),
+      context,
+    );
+    const printed = ts.createPrinter().printNode(
+      ts.EmitHint.Unspecified,
+      ts.factory.createTypeLiteralNode(elements),
+      sourceFile,
+    );
+    assertStringIncludes(printed, "nested?:");
+    assertStringIncludes(printed, "value: string");
+  });
+});
+
+Deno.test("buildCaptureTypeElements: a required intermediate property has no question token, resolving its type from the root identifier", () => {
+  // `config.nested.value` where `nested: Nested` (required). The root `config`
+  // entry has no parent type, so its type is recovered from the root identifier
+  // via the descendant-expression search; the required `nested` gets no `?`.
+  const source = `
+    interface Nested { value: string; }
+    interface Config { nested: Nested; }
+    function collect(config: Config) {
+      return [config.nested.value];
+    }
+  `;
+  withContextEmit(source, (context, sourceFile) => {
+    const valueExpr = findPropertyAccess(sourceFile, "value");
+    const root = createCaptureTreeNode([]);
+    const nested = createCaptureTreeNode(["nested"]);
+    const valueLeaf = createCaptureTreeNode(["nested", "value"]);
+    valueLeaf.expression = valueExpr;
+    nested.properties.set("value", valueLeaf);
+    root.properties.set("nested", nested);
+
+    const elements = buildCaptureTypeElements(
+      new Map<string, CaptureTreeNode>([["config", root]]),
+      context,
+    );
+    const printed = ts.createPrinter().printNode(
+      ts.EmitHint.Unspecified,
+      ts.factory.createTypeLiteralNode(elements),
+      sourceFile,
+    );
+    assertStringIncludes(printed, "nested: {");
+    assert(!printed.includes("nested?:"));
+  });
+});
+
+Deno.test("buildCaptureTypeElements: an intermediate node with neither expression nor children throws the invariant error", () => {
+  // A capture tree node that is neither a leaf (has an expression) nor an
+  // interior node (has children) violates the tree invariant.
+  withContextEmit(`function f(x: number) { return x; } f;`, (context) => {
+    const root = createCaptureTreeNode([]);
+    const emptyChild = createCaptureTreeNode(["a"]);
+    root.properties.set("a", emptyChild);
+
+    assertThrows(
+      () =>
+        buildCaptureTypeElements(
+          new Map<string, CaptureTreeNode>([["root", root]]),
+          context,
+        ),
+      Error,
+      "Invariant violated",
+    );
+  });
+});
+
+/** Same as withContext but named to make the emit-oriented tests read clearly. */
+function withContextEmit(
+  sourceText: string,
+  body: (context: TransformationContext, sourceFile: ts.SourceFile) => void,
+): void {
+  withContext(sourceText, body);
+}

--- a/packages/ts-transformers/test/ast/type-inference-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/type-inference-coverage.test.ts
@@ -1,0 +1,455 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import {
+  ensureTypeNodeRegistered,
+  getTypeFromTypeNodeWithFallback,
+  getTypeReferenceArgument,
+  hasArrayTypeArgument,
+  inferArrayElementType,
+  isCellLikeType,
+  typeToTypeNode,
+  unwrapCellLikeType,
+  unwrapOpaqueLikeType,
+  widenLiteralType,
+} from "../../src/ast/type-inference.ts";
+import { setParentPointers } from "../../src/ast/utils.ts";
+
+// A minimal global lib so `string[]` and `checker.isArrayType(...)` resolve.
+// It is passed as a program root file (not the default lib) with `noLib` on, so
+// the `Array`/`ReadonlyArray` globals are visible from every file including the
+// synthetic `commonfabric.d.ts` module below.
+const LIB = `
+interface Array<T> { length: number; [index: number]: T; }
+interface ReadonlyArray<T> { length: number; readonly [index: number]: T; }
+`;
+
+// A stand-in commonfabric module. `Cell<T>` carries the `[CELL_BRAND]: "cell"`
+// marker the transformer's branded-cell detection looks for. `Default<T, V>`
+// mirrors the real alias shape `(T & DefaultMarker<V>) | V`-ish enough that the
+// checker keeps its `aliasSymbol`, and it lives in a file named
+// `commonfabric.d.ts` so `isDefaultAliasSymbol` recognizes it.
+const CF = `
+export declare const CELL_BRAND: unique symbol;
+export declare const DEFAULT_MARKER: unique symbol;
+export interface Cell<T> { [CELL_BRAND]: "cell"; readonly value: T; }
+export interface BareCell { [CELL_BRAND]: "cell"; }
+export interface DefaultMarker<V> { readonly [DEFAULT_MARKER]: V; }
+export type Default<T, V extends T = T> = (T & DefaultMarker<V>) | T;
+export interface Box<T> { readonly boxed: T; }
+`;
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const files: Record<string, string> = {
+    "/test.ts": source,
+    "/commonfabric.d.ts": CF,
+    "/lib.d.ts": LIB,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files[name] !== undefined,
+    readFile: (name) => files[name],
+    getSourceFile: (name, languageVersion) =>
+      files[name] !== undefined
+        ? ts.createSourceFile(
+          name,
+          files[name]!,
+          languageVersion,
+          true,
+          ts.ScriptKind.TS,
+        )
+        : undefined,
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    directoryExists: () => true,
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    resolveModuleNames: (names) =>
+      names.map((name) => {
+        const match = Object.keys(files).find((fileName) =>
+          fileName === `/${name}.d.ts` || fileName.endsWith(`/${name}.d.ts`)
+        );
+        return match
+          ? {
+            resolvedFileName: match,
+            extension: ts.Extension.Dts,
+            isExternalLibraryImport: false,
+          }
+          : undefined;
+      }),
+  };
+  const program = ts.createProgram(
+    ["/lib.d.ts", "/test.ts"],
+    {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      strict: true,
+      noLib: true,
+    },
+    host,
+  );
+  return {
+    sourceFile: program.getSourceFile("/test.ts")!,
+    checker: program.getTypeChecker(),
+  };
+}
+
+/** Resolve the type of a trailing `name;` expression statement. */
+function typeOf(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+  name: string,
+): ts.Type {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      found = node.expression;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Reference ${name} not found`);
+  return checker.getTypeAtLocation(found);
+}
+
+function reference(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      found = node.expression;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Reference ${name} not found`);
+  return found;
+}
+
+const SOURCE = `
+import { Cell, BareCell, Default, Box } from "commonfabric";
+declare const litUnion: "a" | 1;
+declare const cellString: Cell<string>;
+declare const cellObject: Cell<{ a: number }>;
+declare const bareCell: BareCell;
+declare const plainIntersection: { a: number } & { b: string };
+declare const cellArray: Cell<string[]>;
+declare const defaultArray: Default<string[]>;
+declare const cellDefaultArray: Cell<Default<string[]>>;
+declare const cellDefaultOrUndefined: Cell<Default<string[]> | undefined>;
+declare const cellScalar: Cell<number>;
+declare const duplicateElementArrays: string[] | ReadonlyArray<string>;
+declare const boxedDefaultArray: Box<Default<string[]>>;
+declare const plainObject: { a: number };
+declare const scalar: string;
+litUnion;
+cellString;
+cellObject;
+bareCell;
+plainIntersection;
+cellArray;
+defaultArray;
+cellDefaultArray;
+cellDefaultOrUndefined;
+cellScalar;
+plainObject;
+duplicateElementArrays;
+boxedDefaultArray;
+scalar;
+`;
+
+Deno.test("widenLiteralType: a union of differently-based literals widens to a base-type union", () => {
+  // `"a" | 1` -> `string | number`. Drives the multi-member reconstruction that
+  // rebuilds the union from de-duplicated widened members via getUnionType.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const widened = widenLiteralType(
+    typeOf(sourceFile, checker, "litUnion"),
+    checker,
+  );
+  assertEquals(checker.typeToString(widened), "string | number");
+});
+
+Deno.test("isCellLikeType: undefined is not cell-like", () => {
+  const { checker } = createProgram(SOURCE);
+  assertEquals(isCellLikeType(undefined, checker), false);
+});
+
+Deno.test("isCellLikeType: a branded Cell<T> is cell-like", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    isCellLikeType(typeOf(sourceFile, checker, "cellString"), checker),
+    true,
+  );
+});
+
+Deno.test("getTypeReferenceArgument: a scalar type has no reference argument", () => {
+  const { checker } = createProgram(SOURCE);
+  assertEquals(getTypeReferenceArgument(checker.getStringType()), undefined);
+});
+
+Deno.test("unwrapCellLikeType: a branded Cell<string> unwraps to its inner string", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const unwrapped = unwrapCellLikeType(
+    typeOf(sourceFile, checker, "cellString"),
+    checker,
+  )!;
+  assertEquals(checker.typeToString(unwrapped), "string");
+});
+
+Deno.test("unwrapCellLikeType: a branded Cell<{ a: number }> unwraps to the object type", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const unwrapped = unwrapCellLikeType(
+    typeOf(sourceFile, checker, "cellObject"),
+    checker,
+  )!;
+  assertEquals(checker.typeToString(unwrapped), "{ a: number; }");
+});
+
+Deno.test("unwrapOpaqueLikeType: an intersection with no branded cell member is rebuilt structurally", () => {
+  // `{ a: number } & { b: string }` has no OpaqueCell part, so the walker
+  // recurses each member and reconstructs the intersection via getIntersectionType.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const unwrapped = unwrapOpaqueLikeType(
+    typeOf(sourceFile, checker, "plainIntersection"),
+    checker,
+  )!;
+  assertEquals(
+    checker.typeToString(unwrapped),
+    "{ a: number; } & { b: string; }",
+  );
+});
+
+Deno.test("typeToTypeNode: an invalid location argument is caught and yields undefined", () => {
+  // typeToTypeNode wraps checker.typeToTypeNode in try/catch. A synthetic node
+  // with no source file / position is a location the checker rejects.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const type = typeOf(sourceFile, checker, "cellObject");
+  const detachedLocation = ts.factory.createIdentifier("detached");
+  const node = typeToTypeNode(type, checker, detachedLocation);
+  // Either a node or undefined is acceptable behavior; the branch under test is
+  // that no exception escapes. Assert the call completes and returns a TypeNode
+  // or undefined.
+  assert(node === undefined || ts.isTypeNode(node));
+});
+
+Deno.test("hasArrayTypeArgument: a branded Cell<string[]> has an array type argument", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    hasArrayTypeArgument(typeOf(sourceFile, checker, "cellArray"), checker),
+    true,
+  );
+});
+
+Deno.test("hasArrayTypeArgument: a branded Cell<number> does not have an array type argument", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    hasArrayTypeArgument(typeOf(sourceFile, checker, "cellScalar"), checker),
+    false,
+  );
+});
+
+Deno.test("hasArrayTypeArgument: a plain object type has no array type argument", () => {
+  // A non-reference object type falls through every reference/union/intersection
+  // check to the final `return false`.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    hasArrayTypeArgument(typeOf(sourceFile, checker, "plainObject"), checker),
+    false,
+  );
+});
+
+Deno.test("hasArrayTypeArgument: a Cell<Default<string[]>> is detected via the Default alias unwrap", () => {
+  // Drives the `isDefaultAliasSymbol` branch: the inner type keeps its Default
+  // alias and its first alias argument is an array.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    hasArrayTypeArgument(
+      typeOf(sourceFile, checker, "cellDefaultArray"),
+      checker,
+    ),
+    true,
+  );
+});
+
+Deno.test("hasArrayTypeArgument: a Cell<Default<string[]> | undefined> is detected via the union-of-array-members check", () => {
+  // Drives the `T[] | undefined` / `Default<T[]> | undefined` union branch:
+  // after stripping undefined, every remaining member is array-like.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    hasArrayTypeArgument(
+      typeOf(sourceFile, checker, "cellDefaultOrUndefined"),
+      checker,
+    ),
+    true,
+  );
+});
+
+function elementTypeText(name: string): string {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const result = inferArrayElementType(reference(sourceFile, name), {
+    checker,
+    factory: ts.factory,
+    sourceFile,
+  });
+  return result.type ? checker.typeToString(result.type) : "<none>";
+}
+
+Deno.test("inferArrayElementType: a branded Cell<string[]> yields the element type", () => {
+  // Drives the reference-type branch where the inner type is directly an array
+  // and extractElementFromArrayType returns the element.
+  assertEquals(elementTypeText("cellArray"), "string");
+});
+
+Deno.test("inferArrayElementType: a Default<string[]> alias yields the element type", () => {
+  // Drives the top-level Default-alias unwrap: the wrapped inner type keeps its
+  // Default alias whose first argument is `string[]`.
+  assertEquals(elementTypeText("cellDefaultArray"), "string");
+});
+
+Deno.test("inferArrayElementType: a plain Default<string[]> reference yields the element type via the array fallback", () => {
+  assertEquals(elementTypeText("defaultArray"), "string");
+});
+
+Deno.test("unwrapCellLikeType: a branded cell with no type argument returns itself", () => {
+  // The cell is branded (so isCellLikeType is true) but has no type argument, so
+  // unwrapOpaqueLikeType returns it unchanged and getTypeReferenceArgument yields
+  // nothing — the final `?? type` fallthrough returns the cell type itself.
+  const { sourceFile, checker } = createProgram(SOURCE);
+  const unwrapped = unwrapCellLikeType(
+    typeOf(sourceFile, checker, "bareCell"),
+    checker,
+  )!;
+  assertEquals(checker.typeToString(unwrapped), "BareCell");
+});
+
+Deno.test("inferArrayElementType: two array arms with the same element de-duplicate to a single element", () => {
+  // `string[] | readonly string[]`: both arms extract `string`, so
+  // combineExtractedElementTypes runs its de-duplication loop and collapses the
+  // two identical element types back to a single one.
+  assertEquals(elementTypeText("duplicateElementArrays"), "string");
+});
+
+Deno.test("inferArrayElementType: a Box<Default<string[]>> unwraps the Default alias while recursing a reference", () => {
+  // Drives extractElementFromArrayType's reference-recursion into a member whose
+  // type argument is a Default alias wrapping an array.
+  assertEquals(elementTypeText("boxedDefaultArray"), "string");
+});
+
+// -- Synthetic composite type registration ---------------------------------
+//
+// A TypeNode built by the factory has no source position, so
+// `checker.getTypeFromTypeNode` widens it to `any`. When each leaf is
+// pre-registered with a real Type, ensureTypeNodeRegistered rebuilds the
+// composite Type from the registered children through the TypeScript-internal
+// createArrayType / getUnionType / createAnonymousType entry points.
+
+function programForSynthetics(): {
+  checker: ts.TypeChecker;
+} {
+  const { checker } = createProgram(`declare const x: string; x;`);
+  return { checker };
+}
+
+Deno.test("ensureTypeNodeRegistered: a synthetic array node rebuilds string[] from a registered element", () => {
+  const { checker } = programForSynthetics();
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  const elementNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.StringKeyword,
+  );
+  registry.set(elementNode, checker.getStringType());
+  const arrayNode = ts.factory.createArrayTypeNode(elementNode);
+  setParentPointers(arrayNode);
+  const type = ensureTypeNodeRegistered(arrayNode, checker, registry);
+  assert(type !== undefined);
+  assertEquals(checker.typeToString(type!), "string[]");
+});
+
+Deno.test("ensureTypeNodeRegistered: a synthetic union node rebuilds string | number from registered members", () => {
+  const { checker } = programForSynthetics();
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  const stringNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.StringKeyword,
+  );
+  const numberNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.NumberKeyword,
+  );
+  registry.set(stringNode, checker.getStringType());
+  registry.set(numberNode, checker.getNumberType());
+  const unionNode = ts.factory.createUnionTypeNode([stringNode, numberNode]);
+  setParentPointers(unionNode);
+  const type = ensureTypeNodeRegistered(unionNode, checker, registry);
+  assert(type !== undefined);
+  assertEquals(checker.typeToString(type!), "string | number");
+});
+
+Deno.test("ensureTypeNodeRegistered: a synthetic type literal rebuilds an anonymous object from registered members", () => {
+  const { checker } = programForSynthetics();
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  const valueNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.StringKeyword,
+  );
+  registry.set(valueNode, checker.getStringType());
+  const literalNode = ts.factory.createTypeLiteralNode([
+    ts.factory.createPropertySignature(undefined, "a", undefined, valueNode),
+  ]);
+  setParentPointers(literalNode);
+  const type = ensureTypeNodeRegistered(literalNode, checker, registry);
+  assert(type !== undefined);
+  assertEquals(checker.typeToString(type!), "{ a: string; }");
+});
+
+Deno.test("ensureTypeNodeRegistered: a synthetic parenthesized node resolves to its inner registered type", () => {
+  const { checker } = programForSynthetics();
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  const innerNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.StringKeyword,
+  );
+  registry.set(innerNode, checker.getStringType());
+  const parenNode = ts.factory.createParenthesizedType(innerNode);
+  setParentPointers(parenNode);
+  const type = ensureTypeNodeRegistered(parenNode, checker, registry);
+  assert(type !== undefined);
+  assertEquals(checker.typeToString(type!), "string");
+});
+
+Deno.test("getTypeFromTypeNodeWithFallback: an already-registered node returns the registered type directly", () => {
+  const { checker } = programForSynthetics();
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  const node = ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+  const stringType = checker.getStringType();
+  registry.set(node, stringType);
+  const type = getTypeFromTypeNodeWithFallback(node, checker, registry);
+  assertEquals(type, stringType);
+});
+
+Deno.test("ensureTypeNodeRegistered: without a registry it returns the direct checker type", () => {
+  const { sourceFile, checker } = createProgram(
+    `declare const s: string; type Alias = string; const a: Alias = "x"; a;`,
+  );
+  // A source-positioned annotation resolves directly without any registry.
+  let annotation: ts.TypeNode | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isTypeAliasDeclaration(node) && node.name.text === "Alias") {
+      annotation = node.type;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  const type = ensureTypeNodeRegistered(annotation!, checker);
+  assertEquals(checker.typeToString(type!), "string");
+});

--- a/packages/ts-transformers/test/ast/utils-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/utils-coverage.test.ts
@@ -1,0 +1,277 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import {
+  getMemberSymbol,
+  getNodeText,
+  getTypeAtLocationWithFallback,
+  getVariableInitializer,
+  isFunctionParameter,
+  isOptionalMemberSymbol,
+  setParentPointers,
+} from "../../src/ast/utils.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findFirst<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T,
+  predicate: (node: T) => boolean = () => true,
+): T {
+  let found: T | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && guard(node) && predicate(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  if (!found) throw new Error("node not found");
+  return found;
+}
+
+Deno.test("getMemberSymbol resolves a property access through the base type", () => {
+  const { sourceFile, checker } = createProgram(
+    `interface Config { title: string }
+     declare const config: Config;
+     const value = config.title;`,
+  );
+  const access = findFirst(sourceFile, ts.isPropertyAccessExpression);
+  const symbol = getMemberSymbol(access, checker);
+  assert(symbol);
+  assertEquals(symbol.getName(), "title");
+});
+
+Deno.test(
+  "getMemberSymbol resolves a string-literal element access through the base type",
+  () => {
+    const { sourceFile, checker } = createProgram(
+      `interface Config { title: string }
+       declare const config: Config;
+       const value = config["title"];`,
+    );
+    const access = findFirst(sourceFile, ts.isElementAccessExpression);
+    const symbol = getMemberSymbol(access, checker);
+    assert(symbol);
+    assertEquals(symbol.getName(), "title");
+  },
+);
+
+Deno.test(
+  "getMemberSymbol returns undefined for an unknown element-access key",
+  () => {
+    const { sourceFile, checker } = createProgram(
+      `interface Config { title: string }
+       declare const config: Config;
+       const value = config["missing"];`,
+    );
+    const access = findFirst(sourceFile, ts.isElementAccessExpression);
+    // No such property on the base type, so no member symbol is resolved.
+    assertEquals(getMemberSymbol(access, checker), undefined);
+  },
+);
+
+Deno.test("isOptionalMemberSymbol reflects the optional property flag", () => {
+  const { sourceFile, checker } = createProgram(
+    `interface Config { maybe?: string; required: string }
+     declare const config: Config;
+     const a = config.maybe;
+     const b = config.required;`,
+  );
+  const accesses: ts.PropertyAccessExpression[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node)) accesses.push(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  const maybe = accesses.find((a) => a.name.text === "maybe")!;
+  const required = accesses.find((a) => a.name.text === "required")!;
+  assertEquals(isOptionalMemberSymbol(maybe, checker), true);
+  assertEquals(isOptionalMemberSymbol(required, checker), false);
+});
+
+Deno.test("isFunctionParameter recognizes a plain function parameter", () => {
+  const { sourceFile, checker } = createProgram(
+    `function f(param: number) { return param + 1; }`,
+  );
+  const usage = findFirst(
+    sourceFile,
+    ts.isIdentifier,
+    (n) => n.text === "param" && !ts.isParameter(n.parent),
+  );
+  assertEquals(isFunctionParameter(usage, checker), true);
+});
+
+Deno.test(
+  "isFunctionParameter treats a builder-owned callback parameter as opaque",
+  () => {
+    // The arrow is the argument of a `pattern(...)` call, so its parameter is
+    // builder-owned and must not be reported as an ordinary function parameter.
+    const { sourceFile, checker } = createProgram(
+      `declare function pattern<T>(fn: (state: T) => unknown): unknown;
+       const p = pattern((state: { x: number }) => state.x);`,
+    );
+    const usage = findFirst(
+      sourceFile,
+      ts.isIdentifier,
+      (n) => n.text === "state" && ts.isPropertyAccessExpression(n.parent),
+    );
+    assertEquals(isFunctionParameter(usage, checker), false);
+  },
+);
+
+Deno.test(
+  "isFunctionParameter recognizes the declaring parameter name identifier",
+  () => {
+    const { sourceFile, checker } = createProgram(
+      `function f(only: number) { return 0; }`,
+    );
+    const name = findFirst(
+      sourceFile,
+      ts.isIdentifier,
+      (n) =>
+        n.text === "only" && ts.isParameter(n.parent) && n.parent.name === n,
+    );
+    assertEquals(isFunctionParameter(name, checker), true);
+  },
+);
+
+Deno.test("isFunctionParameter rejects a non-parameter identifier", () => {
+  const { sourceFile, checker } = createProgram(
+    `const local = 1; const other = local + 1;`,
+  );
+  const usage = findFirst(
+    sourceFile,
+    ts.isIdentifier,
+    (n) => n.text === "local" && ts.isBinaryExpression(n.parent),
+  );
+  assertEquals(isFunctionParameter(usage, checker), false);
+});
+
+Deno.test(
+  "isFunctionParameter returns false for a synthetic identifier with no source file",
+  () => {
+    const { checker } = createProgram(`const x = 1;`);
+    const synthetic = ts.factory.createIdentifier("element");
+    // A freshly created identifier has no source file, so the parent chain
+    // cannot be traversed and it is treated as opaque.
+    assertEquals(isFunctionParameter(synthetic, checker), false);
+  },
+);
+
+Deno.test("getVariableInitializer returns the initializer of a const binding", () => {
+  const { sourceFile, checker } = createProgram(
+    `const seed = 41 + 1; const used = seed;`,
+  );
+  const usage = findFirst(
+    sourceFile,
+    ts.isIdentifier,
+    (n) =>
+      n.text === "seed" && ts.isVariableDeclaration(n.parent) &&
+      n.parent.name !== n,
+  );
+  const initializer = getVariableInitializer(usage, checker);
+  assert(initializer);
+  assert(ts.isBinaryExpression(initializer));
+});
+
+Deno.test(
+  "getVariableInitializer returns undefined for a non-identifier expression",
+  () => {
+    const { sourceFile, checker } = createProgram(`const value = 1 + 2;`);
+    const binary = findFirst(sourceFile, ts.isBinaryExpression);
+    assertEquals(getVariableInitializer(binary, checker), undefined);
+  },
+);
+
+Deno.test(
+  "getTypeAtLocationWithFallback prefers a registered synthetic type",
+  () => {
+    const { sourceFile, checker } = createProgram(`declare const x: unknown;`);
+    const identifier = findFirst(sourceFile, ts.isIdentifier);
+    const registry = new WeakMap<ts.Node, ts.Type>();
+    const stringType = checker.getStringType();
+    registry.set(identifier, stringType);
+    const resolved = getTypeAtLocationWithFallback(
+      identifier,
+      checker,
+      registry,
+    );
+    assertEquals(resolved, stringType);
+  },
+);
+
+Deno.test(
+  "getTypeAtLocationWithFallback falls back to a better-typed initializer for an any binding",
+  () => {
+    // `raw` has no annotation and an `any`-typed initializer at the checker
+    // level, but the registry supplies a concrete initializer type that the
+    // fallback should surface instead of the widened any.
+    const { sourceFile, checker } = createProgram(
+      `declare function makeAny(): any; const raw = makeAny(); const used = raw;`,
+    );
+    const usage = findFirst(
+      sourceFile,
+      ts.isIdentifier,
+      (n) =>
+        n.text === "raw" && ts.isVariableDeclaration(n.parent) &&
+        n.parent.name !== n,
+    );
+    const declaration = findFirst(
+      sourceFile,
+      ts.isVariableDeclaration,
+      (d) => ts.isIdentifier(d.name) && d.name.text === "raw",
+    );
+    const registry = new WeakMap<ts.Node, ts.Type>();
+    registry.set(declaration.initializer!, checker.getNumberType());
+    const resolved = getTypeAtLocationWithFallback(usage, checker, registry);
+    assertEquals(resolved, checker.getNumberType());
+  },
+);
+
+Deno.test("setParentPointers wires parent links on a synthetic subtree", () => {
+  const inner = ts.factory.createIdentifier("inner");
+  const call = ts.factory.createCallExpression(inner, undefined, []);
+  const statement = ts.factory.createExpressionStatement(call);
+  setParentPointers(statement);
+  assertEquals(call.parent, statement);
+  assertEquals(inner.parent, call);
+});
+
+Deno.test("getNodeText prints a synthetic node that has no source file", () => {
+  const identifier = ts.factory.createIdentifier("synthetic");
+  assertEquals(getNodeText(identifier), "synthetic");
+});

--- a/packages/ts-transformers/test/cast-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/cast-validation-coverage.test.ts
@@ -1,0 +1,155 @@
+import { assert, assertEquals } from "@std/assert";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { validateFiles } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+/**
+ * These cases exercise the angle-bracket type-assertion (`<X>expr`) branches of
+ * the cast validator, plus the double-cast detection paths for mixed and
+ * parenthesized cast syntax. Angle-bracket assertions are only parseable in
+ * plain `.ts` sources (they collide with JSX in `.tsx`), so every case drives a
+ * `.ts` file through `validateFiles` rather than the default `.tsx` harness.
+ */
+
+async function diagnose(
+  source: string,
+): Promise<readonly TransformationDiagnostic[]> {
+  const { diagnostics } = await validateFiles({ "/cast.ts": source }, {
+    mode: "error",
+    types: COMMONFABRIC_TYPES,
+  });
+  return diagnostics;
+}
+
+function types(diagnostics: readonly TransformationDiagnostic[]): string[] {
+  return diagnostics.map((diagnostic) => diagnostic.type);
+}
+
+Deno.test(
+  "angle-bracket cast to a cell-like type reports a cell-cast error",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = <Cell<number>>data;
+    `;
+    const diagnostics = await diagnose(source);
+    assertEquals(diagnostics.length, 1);
+    assertEquals(diagnostics[0]!.type, "cast-validation:cell-cast");
+    assert(diagnostics[0]!.message.includes("Cell<>"));
+  },
+);
+
+Deno.test(
+  "angle-bracket cast to Reactive reports a forbidden-cast error",
+  async () => {
+    const source = `
+      import { Reactive } from "commonfabric";
+      const data: any = { value: 42 };
+      const ref = <Reactive<number>>data;
+    `;
+    const diagnostics = await diagnose(source);
+    assertEquals(diagnostics.length, 1);
+    assertEquals(diagnostics[0]!.type, "cast-validation:forbidden-cast");
+  },
+);
+
+Deno.test(
+  "double angle-bracket cast '<X><unknown>expr' reports double-unknown",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = <Cell<number>><unknown>data;
+    `;
+    const diagnostics = await diagnose(source);
+    assertEquals(types(diagnostics), ["cast-validation:double-unknown"]);
+    assert(diagnostics[0]!.message.includes("<unknown>"));
+  },
+);
+
+Deno.test(
+  "mixed cast '<X>(expr as unknown)' reports double-unknown",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = <Cell<number>>(data as unknown);
+    `;
+    const diagnostics = await diagnose(source);
+    assertEquals(types(diagnostics), ["cast-validation:double-unknown"]);
+  },
+);
+
+Deno.test(
+  "mixed cast '<X>(<unknown>expr)' with parentheses reports double-unknown",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = <Cell<number>>(<unknown>data);
+    `;
+    const diagnostics = await diagnose(source);
+    assertEquals(types(diagnostics), ["cast-validation:double-unknown"]);
+  },
+);
+
+Deno.test(
+  "angle-bracket cast wrapping 'expr as unknown' reports double-unknown",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = <Cell<number>>data as unknown as Cell<number>;
+    `;
+    // The outer node here is an `as` expression whose inner is `<Cell>data as
+    // unknown`; the `as unknown as Cell<number>` shape drives the AsExpression
+    // double-unknown detection alongside the angle-bracket inner.
+    const diagnostics = await diagnose(source);
+    assert(
+      diagnostics.some((d) => d.type === "cast-validation:double-unknown"),
+    );
+  },
+);
+
+Deno.test(
+  "mixed cast '(<unknown>expr) as X' reports double-unknown",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = (<unknown>data) as Cell<number>;
+    `;
+    const diagnostics = await diagnose(source);
+    assert(
+      diagnostics.some((d) => d.type === "cast-validation:double-unknown"),
+    );
+  },
+);
+
+Deno.test(
+  "parenthesized cast '(expr as unknown) as X' reports double-unknown",
+  async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+      const data: any = { value: 42 };
+      const cell = (data as unknown) as Cell<number>;
+    `;
+    const diagnostics = await diagnose(source);
+    assert(
+      diagnostics.some((d) => d.type === "cast-validation:double-unknown"),
+    );
+  },
+);
+
+Deno.test(
+  "angle-bracket cast to a benign type produces no diagnostic",
+  async () => {
+    const source = `
+      const data: any = { value: 42 };
+      const value = <number>data;
+    `;
+    const diagnostics = await diagnose(source);
+    assertEquals(diagnostics.length, 0);
+  },
+);

--- a/packages/ts-transformers/test/closures/array-method-utils-coverage.test.ts
+++ b/packages/ts-transformers/test/closures/array-method-utils-coverage.test.ts
@@ -1,0 +1,391 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import type { TransformationContext } from "../../src/core/mod.ts";
+import type { CaptureTreeNode } from "../../src/utils/capture-tree.ts";
+import {
+  analyzeElementBinding,
+  type ElementBindingAnalysis,
+  rewriteCallbackBody,
+} from "../../src/closures/strategies/array-method-utils.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function testContext(checker: ts.TypeChecker): TransformationContext {
+  return {
+    checker,
+    factory: ts.factory,
+    tsContext: { factory: ts.factory } as ts.TransformationContext,
+    options: {
+      state: {
+        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
+      },
+    },
+    markAsSyntheticComputeCallback: () => {},
+    cfHelpers: {
+      getHelperExpr: (name: string) => ts.factory.createIdentifier(name),
+      createHelperCall: (
+        name: string,
+        _node: ts.Node,
+        typeArgs: readonly ts.TypeNode[] | undefined,
+        args: readonly ts.Expression[],
+      ) =>
+        ts.factory.createCallExpression(
+          ts.factory.createIdentifier(`__cf_${name}`),
+          typeArgs ? [...typeArgs] : undefined,
+          [...args],
+        ),
+    },
+  } as unknown as TransformationContext;
+}
+
+/** Finds the first arrow function parameter in the source. */
+function firstArrowParam(
+  sourceFile: ts.SourceFile,
+): ts.ParameterDeclaration {
+  let found: ts.ParameterDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isArrowFunction(node) && node.parameters.length > 0) {
+      found = node.parameters[0];
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("no arrow parameter found");
+  return found;
+}
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+function print(node: ts.Node, file: ts.SourceFile): string {
+  return printer.printNode(ts.EmitHint.Unspecified, node, file);
+}
+
+const passthroughBindingId = (candidate: string): ts.Identifier =>
+  ts.factory.createIdentifier(candidate);
+
+Deno.test("analyzeElementBinding synthesizes `element` when the callback takes no parameter", () => {
+  const { checker } = createProgram("const x = 1;");
+  const captureTree = new Map<string, CaptureTreeNode>();
+  const analysis = analyzeElementBinding(
+    undefined,
+    captureTree,
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assert(ts.isIdentifier(analysis.bindingName));
+  assertEquals(analysis.bindingName.text, "element");
+  assertEquals(analysis.elementIdentifier.text, "element");
+  assertEquals(analysis.computedAliases.length, 0);
+});
+
+Deno.test("analyzeElementBinding avoids the `element` name when the capture tree already uses it", () => {
+  const { checker } = createProgram("const x = 1;");
+  const captureTree = new Map<string, CaptureTreeNode>([
+    ["element", { properties: new Map(), path: [] }],
+  ]);
+  const analysis = analyzeElementBinding(
+    undefined,
+    captureTree,
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.elementIdentifier.text, "__cf_element");
+});
+
+Deno.test("analyzeElementBinding reuses a bare identifier parameter directly", () => {
+  const { sourceFile, checker } = createProgram(
+    "const f = (item) => item.name;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assert(ts.isIdentifier(analysis.bindingName));
+  assertEquals(analysis.bindingName.text, "item");
+  assertEquals(analysis.computedAliases.length, 0);
+  assertEquals(analysis.destructureStatement, undefined);
+});
+
+Deno.test("analyzeElementBinding normalizes a plain object destructuring parameter without aliases", () => {
+  const { sourceFile, checker } = createProgram(
+    "const f = ({ name, value }) => name;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  // No computed keys means no aliases; the destructuring survives as the
+  // binding name and its identifier falls back to "element".
+  assertEquals(analysis.computedAliases.length, 0);
+  assert(ts.isObjectBindingPattern(analysis.bindingName));
+  assertEquals(analysis.elementIdentifier.text, "element");
+  const text = print(analysis.bindingName, sourceFile);
+  assertStringIncludes(text, "name");
+  assertStringIncludes(text, "value");
+});
+
+Deno.test("analyzeElementBinding walks nested object and array binding patterns", () => {
+  const { sourceFile, checker } = createProgram(
+    "const f = ({ outer: { inner }, tuple: [first] }) => first;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.computedAliases.length, 0);
+  assert(ts.isObjectBindingPattern(analysis.bindingName));
+  const text = print(analysis.bindingName, sourceFile);
+  // Nested object and array patterns are rebuilt with their leaf names intact.
+  assertStringIncludes(text, "inner");
+  assertStringIncludes(text, "first");
+});
+
+Deno.test("analyzeElementBinding handles renamed and string-keyed object properties", () => {
+  const { sourceFile, checker } = createProgram(
+    'const f = ({ label: renamed, "weird-key": ok }) => renamed;',
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.computedAliases.length, 0);
+  const text = print(analysis.bindingName, sourceFile);
+  assertStringIncludes(text, "renamed");
+  assertStringIncludes(text, "ok");
+});
+
+Deno.test("analyzeElementBinding preserves array holes and rest elements", () => {
+  const { sourceFile, checker } = createProgram(
+    "const f = ([, second, ...rest]) => second;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.computedAliases.length, 0);
+  assert(ts.isArrayBindingPattern(analysis.bindingName));
+  const text = print(analysis.bindingName, sourceFile);
+  // The leading hole and the rest element are carried through the rebuild.
+  assertStringIncludes(text, "...rest");
+  assertStringIncludes(text, "second");
+});
+
+Deno.test("analyzeElementBinding recurses into array elements that are themselves binding patterns", () => {
+  const { sourceFile, checker } = createProgram(
+    "const f = ([[a, b], { c }]) => a;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.computedAliases.length, 0);
+  assert(ts.isArrayBindingPattern(analysis.bindingName));
+  const text = print(analysis.bindingName, sourceFile);
+  // Both the nested array pattern and the nested object pattern are rebuilt.
+  assertStringIncludes(text, "a");
+  assertStringIncludes(text, "b");
+  assertStringIncludes(text, "c");
+});
+
+Deno.test("analyzeElementBinding drops nested object patterns that hold only a computed key inside an array", () => {
+  // The inner `{ [k]: chosen }` produces no residual binding element, so the
+  // nested walk returns undefined and the surrounding array element is left as
+  // its original node while the computed key is lifted into an alias.
+  const { sourceFile, checker } = createProgram(
+    "declare const k: string;\n" +
+      "const f = ([{ [k]: chosen }, kept]) => chosen;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.computedAliases.length, 1);
+  assertEquals(analysis.computedAliases[0].aliasName, "chosen");
+  assert(analysis.destructureStatement);
+  const text = print(analysis.destructureStatement, sourceFile);
+  assertStringIncludes(text, "kept");
+});
+
+Deno.test("analyzeElementBinding drops nested object patterns that hold only a computed key inside an object", () => {
+  // The inner `{ [k]: chosen }` yields no residual, so its walk returns
+  // undefined and the enclosing object property is skipped entirely.
+  const { sourceFile, checker } = createProgram(
+    "declare const k: string;\n" +
+      "const f = ({ nested: { [k]: chosen }, kept }) => chosen;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  assertEquals(analysis.computedAliases.length, 1);
+  assert(analysis.destructureStatement);
+  const text = print(analysis.destructureStatement, sourceFile);
+  // The nested-only-computed property is dropped; the sibling plain key stays.
+  assertStringIncludes(text, "kept");
+  assertEquals(text.includes("nested"), false);
+});
+
+Deno.test("analyzeElementBinding lifts a computed key into an alias with a residual destructure", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const k: string;\n" +
+      "const f = ({ [k]: chosen, other }) => chosen;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  // The computed key becomes a lifted alias; the remaining plain property
+  // stays as a residual destructuring statement bound to the element.
+  assertEquals(analysis.computedAliases.length, 1);
+  assertEquals(analysis.computedAliases[0].aliasName, "chosen");
+  assertEquals(analysis.elementIdentifier.text, "element");
+  assert(analysis.destructureStatement);
+  const text = print(analysis.destructureStatement, sourceFile);
+  assertStringIncludes(text, "other");
+  assertStringIncludes(text, "element");
+});
+
+Deno.test("rewriteCallbackBody returns the body unchanged when there are no computed aliases", () => {
+  const { sourceFile, checker } = createProgram(
+    "const f = (item) => item.name;",
+  );
+  const body = firstArrowBody(sourceFile);
+  const analysis: ElementBindingAnalysis = {
+    bindingName: ts.factory.createIdentifier("item"),
+    elementIdentifier: ts.factory.createIdentifier("item"),
+    computedAliases: [],
+  };
+  const result = rewriteCallbackBody(body, analysis, testContext(checker));
+  assertEquals(result, body);
+});
+
+Deno.test("rewriteCallbackBody injects alias and key prologues around an expression body", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const k: string;\n" +
+      "const f = ({ [k]: chosen }) => chosen;",
+  );
+  const param = firstArrowParam(sourceFile);
+  const body = firstArrowBody(sourceFile);
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  const result = rewriteCallbackBody(body, analysis, testContext(checker));
+  // A concise expression body becomes a block; the key binding and the alias
+  // binding are prepended, and the original expression returns from the block.
+  assert(ts.isBlock(result));
+  const text = print(result, sourceFile);
+  assertStringIncludes(text, "chosen");
+  assertStringIncludes(text, "return chosen");
+});
+
+Deno.test("rewriteCallbackBody reuses an existing block body when injecting alias prologues", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const k: string;\n" +
+      "const f = ({ [k]: chosen }) => { return chosen; };",
+  );
+  const param = firstArrowParam(sourceFile);
+  const body = firstArrowBody(sourceFile);
+  assert(ts.isBlock(body));
+  const analysis = analyzeElementBinding(
+    param,
+    new Map(),
+    testContext(checker),
+    new Set<string>(),
+    passthroughBindingId,
+  );
+  const result = rewriteCallbackBody(body, analysis, testContext(checker));
+  assert(ts.isBlock(result));
+  const text = print(result, sourceFile);
+  // The original block's statements are retained after the injected prologue.
+  assertStringIncludes(text, "return chosen");
+});
+
+/** Finds the body of the first arrow function in the source. */
+function firstArrowBody(sourceFile: ts.SourceFile): ts.ConciseBody {
+  let found: ts.ConciseBody | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isArrowFunction(node)) {
+      found = node.body;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("no arrow function found");
+  return found;
+}

--- a/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
+++ b/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Unit coverage for `src/core/cf-helpers.ts`.
+ *
+ * These tests exercise the CFHelpers class's import-scanning constructor and its
+ * expression/qualified-name factory methods, plus the module-level import-shape
+ * recognizers `getCFHelpersIdentifier` / `getCFDataHelperIdentifier` (reached
+ * indirectly through the constructor and `sourceHasHelpers` /
+ * `sourceHasDataHelper`).
+ *
+ * The recognizers accept only a named import of `__cfHelpers` (or `__cf_data`
+ * aliased to `__cfDataHelper`) from the "commonfabric" module specifier. Each
+ * test pins one gate of that shape by feeding a source whose import differs in
+ * exactly one respect and asserting whether the helper is detected.
+ */
+import ts from "typescript";
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+import {
+  CF_DATA_HELPER_IDENTIFIER,
+  CF_HELPERS_IDENTIFIER,
+  CFHelpers,
+  injectCfDataHelper,
+  injectCfHelpers,
+  sourceDisablesCfTransform,
+  transformCfDirective,
+} from "../../src/core/cf-helpers.ts";
+
+function sourceFileFor(source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    "/test.ts",
+    source,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function helpersFor(source: string): CFHelpers {
+  return new CFHelpers({
+    sourceFile: sourceFileFor(source),
+    factory: ts.factory,
+  });
+}
+
+function printExpr(node: ts.Node, sourceFile: ts.SourceFile): string {
+  return ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }).printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    sourceFile,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Constructor scanning: getCFHelpersIdentifier / getCFDataHelperIdentifier
+// ---------------------------------------------------------------------------
+
+Deno.test("CFHelpers detects the __cfHelpers named import from commonfabric", () => {
+  const helpers = helpersFor(
+    `import { __cfHelpers } from "commonfabric";`,
+  );
+  assert(helpers.sourceHasHelpers());
+  assertFalse(helpers.sourceHasDataHelper());
+});
+
+Deno.test("CFHelpers detects a renamed __cfHelpers import via its property name", () => {
+  // `element.propertyName` is `__cfHelpers`; the local binding is `h`. The
+  // scanner keys on the imported (property) name, so it still resolves the
+  // helper and stores the local alias identifier.
+  const helpers = helpersFor(
+    `import { __cfHelpers as h } from "commonfabric";`,
+  );
+  assert(helpers.sourceHasHelpers());
+
+  const sf = sourceFileFor(`import { __cfHelpers as h } from "commonfabric";`);
+  const expr = new CFHelpers({ sourceFile: sf, factory: ts.factory })
+    .getHelperExpr("lift");
+  // The stored identifier is the local alias `h`, not the imported name.
+  assertEquals(printExpr(expr, sf), "h.lift");
+});
+
+Deno.test("CFHelpers ignores __cfHelpers imported from a non-commonfabric module", () => {
+  const helpers = helpersFor(
+    `import { __cfHelpers } from "other-module";`,
+  );
+  assertFalse(helpers.sourceHasHelpers());
+});
+
+Deno.test("CFHelpers ignores an import whose specifier is not a string literal", () => {
+  // A bare `import mod = require(...)` has no StringLiteral module specifier, so
+  // the `ts.isStringLiteral(moduleSpecifier)` guard rejects it.
+  const helpers = helpersFor(
+    `import __cfHelpers = require("commonfabric");`,
+  );
+  assertFalse(helpers.sourceHasHelpers());
+});
+
+Deno.test("CFHelpers ignores a default (non-named) import from commonfabric", () => {
+  // `import __cfHelpers from "commonfabric"` has an import clause but no
+  // NamedImports binding, so the `ts.isNamedImports(namedBindings)` guard fails.
+  const helpers = helpersFor(
+    `import __cfHelpers from "commonfabric";`,
+  );
+  assertFalse(helpers.sourceHasHelpers());
+});
+
+Deno.test("CFHelpers ignores a namespace import from commonfabric", () => {
+  // `import * as __cfHelpers` produces a NamespaceImport binding, not
+  // NamedImports.
+  const helpers = helpersFor(
+    `import * as __cfHelpers from "commonfabric";`,
+  );
+  assertFalse(helpers.sourceHasHelpers());
+});
+
+Deno.test("CFHelpers ignores commonfabric named imports that are not __cfHelpers", () => {
+  const helpers = helpersFor(
+    `import { pattern, Cell } from "commonfabric";`,
+  );
+  assertFalse(helpers.sourceHasHelpers());
+});
+
+Deno.test("CFHelpers ignores a bare import declaration with no import clause", () => {
+  // `import "commonfabric"` has `importClause === undefined`.
+  const helpers = helpersFor(`import "commonfabric";`);
+  assertFalse(helpers.sourceHasHelpers());
+  assertFalse(helpers.sourceHasDataHelper());
+});
+
+Deno.test("CFHelpers detects the __cf_data data helper import aliased to __cfDataHelper", () => {
+  // The data helper is only recognized as `__cf_data as __cfDataHelper`.
+  const helpers = helpersFor(
+    `import { __cf_data as __cfDataHelper } from "commonfabric";`,
+  );
+  assert(helpers.sourceHasDataHelper());
+  assertFalse(helpers.sourceHasHelpers());
+});
+
+Deno.test("CFHelpers rejects a data helper import whose local name is not __cfDataHelper", () => {
+  // `element.name.text` must equal `__cfDataHelper`; here it is `other`.
+  const helpers = helpersFor(
+    `import { __cf_data as other } from "commonfabric";`,
+  );
+  assertFalse(helpers.sourceHasDataHelper());
+});
+
+Deno.test("CFHelpers rejects a data helper import whose imported name is not __cf_data", () => {
+  // Local name matches `__cfDataHelper`, but the imported (property) name is
+  // `wrong`, not `__cf_data`, so the second gate rejects it.
+  const helpers = helpersFor(
+    `import { wrong as __cfDataHelper } from "commonfabric";`,
+  );
+  assertFalse(helpers.sourceHasDataHelper());
+});
+
+Deno.test("CFHelpers ignores a data-helper-shaped import from a foreign module", () => {
+  const helpers = helpersFor(
+    `import { __cf_data as __cfDataHelper } from "other-module";`,
+  );
+  assertFalse(helpers.sourceHasDataHelper());
+});
+
+Deno.test("CFHelpers ignores a data helper default import from commonfabric", () => {
+  // Import clause present but no NamedImports binding.
+  const helpers = helpersFor(
+    `import __cfDataHelper from "commonfabric";`,
+  );
+  assertFalse(helpers.sourceHasDataHelper());
+});
+
+// ---------------------------------------------------------------------------
+// getHelperExpr / getHelperQualified / getDataHelperExpr
+// ---------------------------------------------------------------------------
+
+Deno.test("getHelperExpr throws when the source has no helpers import", () => {
+  const helpers = helpersFor(`const x = 1;`);
+  assertThrows(
+    () => helpers.getHelperExpr("lift"),
+    Error,
+    "Source file does not contain helpers.",
+  );
+});
+
+Deno.test("getHelperExpr without an original node builds a plain property access", () => {
+  const source = `import { __cfHelpers } from "commonfabric";`;
+  const sf = sourceFileFor(source);
+  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
+  const expr = helpers.getHelperExpr("lift");
+  assert(ts.isPropertyAccessExpression(expr));
+  assertEquals(printExpr(expr, sf), "__cfHelpers.lift");
+});
+
+Deno.test("getHelperExpr with an original node preserves source map ranges and identity", () => {
+  const source =
+    `import { __cfHelpers } from "commonfabric";\nconst marker = 1;`;
+  const sf = sourceFileFor(source);
+  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
+
+  // Any node from the source works as the original-node anchor.
+  let original: ts.Node | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!original && ts.isNumericLiteral(node)) original = node;
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  assert(original);
+
+  const expr = helpers.getHelperExpr("lift", original);
+  assert(ts.isPropertyAccessExpression(expr));
+  // The whole property-access is anchored to the original node's source map
+  // range (its position), distinguishing this branch from the no-original one.
+  assertEquals(ts.getSourceMapRange(expr).pos, original.pos);
+  assertEquals(printExpr(expr, sf), "__cfHelpers.lift");
+});
+
+Deno.test("getHelperQualified throws when the source has no helpers import", () => {
+  const helpers = helpersFor(`const x = 1;`);
+  assertThrows(
+    () => helpers.getHelperQualified("JSONSchema"),
+    Error,
+    "Source file does not contain helpers.",
+  );
+});
+
+Deno.test("getHelperQualified builds a qualified name against the helper identifier", () => {
+  const source = `import { __cfHelpers } from "commonfabric";`;
+  const sf = sourceFileFor(source);
+  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
+  const qualified = helpers.getHelperQualified("JSONSchema");
+  assert(ts.isQualifiedName(qualified));
+  assertEquals(qualified.right.text, "JSONSchema");
+  assertEquals((qualified.left as ts.Identifier).text, CF_HELPERS_IDENTIFIER);
+});
+
+Deno.test("getDataHelperExpr throws when the source has no data helper import", () => {
+  const helpers = helpersFor(`const x = 1;`);
+  assertThrows(
+    () => helpers.getDataHelperExpr(),
+    Error,
+    "Source file does not contain __cfDataHelper.",
+  );
+});
+
+Deno.test("getDataHelperExpr without an original node returns a bare data-helper identifier", () => {
+  const source = `import { __cf_data as __cfDataHelper } from "commonfabric";`;
+  const sf = sourceFileFor(source);
+  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
+  const ident = helpers.getDataHelperExpr();
+  assert(ts.isIdentifier(ident));
+  assertEquals(ident.text, CF_DATA_HELPER_IDENTIFIER);
+});
+
+Deno.test("getDataHelperExpr with an original node preserves its source map range", () => {
+  const source =
+    `import { __cf_data as __cfDataHelper } from "commonfabric";\nconst marker = 2;`;
+  const sf = sourceFileFor(source);
+  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
+
+  let original: ts.Node | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!original && ts.isNumericLiteral(node)) original = node;
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  assert(original);
+
+  const ident = helpers.getDataHelperExpr(original);
+  assert(ts.isIdentifier(ident));
+  assertEquals(ident.text, CF_DATA_HELPER_IDENTIFIER);
+  assertEquals(ts.getSourceMapRange(ident).pos, original.pos);
+});
+
+// ---------------------------------------------------------------------------
+// transformCfDirective / injectCfHelpers / injectCfDataHelper (string passes)
+// ---------------------------------------------------------------------------
+
+Deno.test("transformCfDirective returns an all-blank source unchanged", () => {
+  // With no content line, `findFirstContentLineIndex` returns null and the
+  // source is returned verbatim before any injection.
+  const source = "\n   \n\t\n";
+  assertEquals(transformCfDirective(source), source);
+});
+
+Deno.test("transformCfDirective injects the helpers import for an ordinary source", () => {
+  const source = `const answer = 42;`;
+  const out = transformCfDirective(source);
+  // Prepends the `__cfHelpers` import prelude and appends the used-helper
+  // shim so binding survives tree-shaking.
+  assert(out.startsWith(`import { ${CF_HELPERS_IDENTIFIER} } from`));
+  assert(out.includes(source));
+  assert(out.includes(`${CF_HELPERS_IDENTIFIER}.h.apply`));
+});
+
+Deno.test("transformCfDirective blanks a leading cf-disable-transform directive", () => {
+  const source = `/// <cf-disable-transform />\nconst answer = 42;`;
+  assert(sourceDisablesCfTransform(source));
+  const out = transformCfDirective(source);
+  const lines = out.split("\n");
+  // The directive line is replaced by an empty line; no helper import is added.
+  assertEquals(lines[0], "");
+  assertEquals(lines[1], "const answer = 42;");
+  assertFalse(out.includes(CF_HELPERS_IDENTIFIER));
+});
+
+Deno.test("injectCfHelpers uses TypeScript helper-shim syntax by default", () => {
+  const out = injectCfHelpers(`const x = 1;`);
+  // The TS variant carries the `: any[]` rest annotation.
+  assert(out.includes("function h(...args: any[])"));
+});
+
+Deno.test("injectCfHelpers uses JS-only helper-shim syntax for JavaScript file names", () => {
+  const out = injectCfHelpers(`const x = 1;`, "authored.jsx");
+  // The JS variant drops the type annotation to stay parseable in .jsx.
+  assert(out.includes("function h(...args)"));
+  assertFalse(out.includes("function h(...args: any[])"));
+});
+
+Deno.test("injectCfDataHelper wraps a source with the data-helper import and keep-alive", () => {
+  const source = `const y = 2;`;
+  const out = injectCfDataHelper(source);
+  assert(
+    out.startsWith(`import { __cf_data as ${CF_DATA_HELPER_IDENTIFIER} } from`),
+  );
+  assert(out.includes(source));
+  // The keep-alive statement references the data helper so binding survives.
+  assert(out.includes(`= ${CF_DATA_HELPER_IDENTIFIER};`));
+});
+
+Deno.test("injectCfHelpers throws when the source already uses the reserved helper symbol", () => {
+  assertThrows(
+    () => injectCfHelpers(`const ${CF_HELPERS_IDENTIFIER} = {};`),
+    Error,
+    `reserved helper symbol '${CF_HELPERS_IDENTIFIER}'`,
+  );
+});
+
+Deno.test("injectCfDataHelper throws when the source already uses the reserved data-helper symbol", () => {
+  assertThrows(
+    () => injectCfDataHelper(`const ${CF_DATA_HELPER_IDENTIFIER} = {};`),
+    Error,
+    `reserved helper symbol '${CF_DATA_HELPER_IDENTIFIER}'`,
+  );
+});

--- a/packages/ts-transformers/test/destructuring-lowering-coverage.test.ts
+++ b/packages/ts-transformers/test/destructuring-lowering-coverage.test.ts
@@ -1,0 +1,543 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import type { TransformationContext } from "../src/core/mod.ts";
+import {
+  collectDestructureBindings,
+  type DefaultDestructureBinding,
+  type DestructureBinding,
+  getStaticDefaultTypeNode,
+  toStringPath,
+} from "../src/transformers/destructuring-lowering.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function testContext(checker: ts.TypeChecker): TransformationContext {
+  return {
+    checker,
+    factory: ts.factory,
+    options: {
+      state: {
+        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
+      },
+    },
+    cfHelpers: {
+      getHelperExpr: (name: string) => ts.factory.createIdentifier(name),
+    },
+  } as unknown as TransformationContext;
+}
+
+function findVariable(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing variable ${name}`);
+  return found;
+}
+
+function findBindingDeclaration(
+  sourceFile: ts.SourceFile,
+  predicate: (name: ts.BindingName) => boolean,
+): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isVariableDeclaration(node) && predicate(node.name)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("Missing binding declaration");
+  return found;
+}
+
+function printType(node: ts.TypeNode, sourceFile: ts.SourceFile): string {
+  return ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }).printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    sourceFile,
+  ).replace(/\s+/g, " ").trim();
+}
+
+Deno.test("getStaticDefaultTypeNode lowers a bare bigint literal to its literal type", () => {
+  const { sourceFile, checker } = createProgram("const big = 7n;");
+  const context = testContext(checker);
+
+  const typeNode = getStaticDefaultTypeNode(
+    findVariable(sourceFile, "big").initializer!,
+    context,
+  );
+  assert(typeNode);
+  assertEquals(printType(typeNode, sourceFile), "7n");
+});
+
+Deno.test("getStaticDefaultTypeNode bails on an array whose element is non-static", () => {
+  // A bare identifier element has no static literal form, so the whole array
+  // default is rejected (returns undefined).
+  const { sourceFile, checker } = createProgram(
+    "declare const other: number; const arr = [other];",
+  );
+  const context = testContext(checker);
+
+  assertEquals(
+    getStaticDefaultTypeNode(
+      findVariable(sourceFile, "arr").initializer!,
+      context,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("getStaticDefaultTypeNode rejects an object literal with a non-assignment property", () => {
+  // A shorthand property assignment is not a PropertyAssignment, so the object
+  // default cannot be lowered.
+  const { sourceFile, checker } = createProgram(
+    "declare const label: string; const obj = { label };",
+  );
+  const context = testContext(checker);
+
+  assertEquals(
+    getStaticDefaultTypeNode(
+      findVariable(sourceFile, "obj").initializer!,
+      context,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("getStaticDefaultTypeNode lowers a numeric object key and rejects a computed key", () => {
+  const { sourceFile, checker } = createProgram(
+    "const numericKey = { 3: 1 };\n" +
+      "const computedKey = { [Symbol.iterator]: 4 };\n",
+  );
+  const context = testContext(checker);
+
+  const numeric = getStaticDefaultTypeNode(
+    findVariable(sourceFile, "numericKey").initializer!,
+    context,
+  );
+  assert(numeric);
+  assertStringIncludes(printType(numeric, sourceFile), "3: 1;");
+
+  // Computed property name is not a supported key kind, so the object is
+  // rejected wholesale.
+  assertEquals(
+    getStaticDefaultTypeNode(
+      findVariable(sourceFile, "computedKey").initializer!,
+      context,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("getStaticDefaultTypeNode lowers a no-substitution-template object key", () => {
+  // A template-literal property name is not producible from object-literal
+  // source syntax, so synthesize the object literal and drive the branch that
+  // treats a no-substitution template key as a string key.
+  const { checker } = createProgram("declare const x: number;");
+  const context = testContext(checker);
+  const factory = ts.factory;
+
+  const objectLiteral = factory.createObjectLiteralExpression([
+    factory.createPropertyAssignment(
+      factory.createNoSubstitutionTemplateLiteral("tpl", "tpl"),
+      factory.createNumericLiteral("2"),
+    ),
+  ]);
+
+  const typeNode = getStaticDefaultTypeNode(objectLiteral, context);
+  assert(typeNode);
+  const blank = ts.createSourceFile("/x.ts", "", ts.ScriptTarget.ES2020, true);
+  assertStringIncludes(printType(typeNode, blank), '"tpl": 2;');
+});
+
+Deno.test("getStaticDefaultTypeNode rejects an object whose property value is non-static", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const dyn: number; const obj = { count: dyn };",
+  );
+  const context = testContext(checker);
+
+  assertEquals(
+    getStaticDefaultTypeNode(
+      findVariable(sourceFile, "obj").initializer!,
+      context,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("collectDestructureBindings records a plain identifier binding at its path", () => {
+  const { checker } = createProgram("declare const x: number;");
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+
+  collectDestructureBindings(
+    ts.factory.createIdentifier("localName"),
+    ["root", "field"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(bindings.length, 1);
+  assertEquals(bindings[0]!.localName, "localName");
+  assertEquals(toStringPath(bindings[0]!.path), ["root", "field"]);
+  assertEquals(defaults.length, 0);
+  assertEquals(unsupported.length, 0);
+});
+
+Deno.test("collectDestructureBindings uses the shorthand identifier as the key", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const input: any; const { plain } = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const objectBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isObjectBindingPattern,
+  );
+
+  collectDestructureBindings(
+    objectBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(unsupported.length, 0);
+  assertEquals(bindings.length, 1);
+  assertEquals(bindings[0]!.localName, "plain");
+  assertEquals(toStringPath(bindings[0]!.path), ["root", "plain"]);
+});
+
+Deno.test("collectDestructureBindings reports an unsupported property-name kind", () => {
+  // Only a private-identifier property name can slip past the identifier /
+  // string / numeric / computed branches, and that form is not producible from
+  // destructuring source, so synthesize the binding element.
+  const { checker } = createProgram("declare const x: number;");
+  const context = testContext(checker);
+  const factory = ts.factory;
+
+  const element = factory.createBindingElement(
+    undefined,
+    factory.createPrivateIdentifier("#secret"),
+    factory.createIdentifier("value"),
+  );
+  const objectPattern = factory.createObjectBindingPattern([element]);
+
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+
+  collectDestructureBindings(
+    objectPattern,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assert(
+    unsupported.some((message) =>
+      message.includes("Unsupported destructuring key in pattern context")
+    ),
+    `unsupported was: ${JSON.stringify(unsupported)}`,
+  );
+});
+
+Deno.test("collectDestructureBindings rejects a non-static default on an array element", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const fallback: number; declare const input: any;\n" +
+      "const [first = fallback] = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const arrayBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isArrayBindingPattern,
+  );
+
+  collectDestructureBindings(
+    arrayBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(defaults.length, 0);
+  assertEquals(unsupported.length, 1);
+  assertStringIncludes(
+    unsupported[0]!,
+    "Non-static destructuring initializers",
+  );
+  // The rejected default skips the rest of the element, so no binding is kept.
+  assertEquals(bindings.length, 0);
+});
+
+Deno.test("collectDestructureBindings rejects an array default under a dynamic parent path", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const input: any; const [first = 5] = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const arrayBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isArrayBindingPattern,
+  );
+
+  // Seed the path with a non-string (dynamic) segment so toStringPath fails
+  // when the array element's default path is built.
+  const dynamicSegment = ts.factory.createIdentifier("dynamicKey");
+  collectDestructureBindings(
+    arrayBinding.name,
+    [dynamicSegment],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(defaults.length, 0);
+  assertEquals(unsupported.length, 1);
+  assertStringIncludes(
+    unsupported[0]!,
+    "Defaults on dynamic destructuring keys",
+  );
+});
+
+Deno.test("collectDestructureBindings rejects an object element without a key and a non-identifier name", () => {
+  // Object destructuring source syntax cannot express an element that has no
+  // property name yet binds a nested pattern, so synthesize that binding
+  // element to reach the branch that reports it as unsupported.
+  const { checker } = createProgram("declare const x: number;");
+  const context = testContext(checker);
+  const factory = ts.factory;
+
+  const nestedPattern = factory.createArrayBindingPattern([
+    factory.createBindingElement(
+      undefined,
+      undefined,
+      factory.createIdentifier("inner"),
+    ),
+  ]);
+  const element = factory.createBindingElement(
+    undefined,
+    undefined,
+    nestedPattern,
+  );
+  const objectPattern = factory.createObjectBindingPattern([element]);
+
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+
+  collectDestructureBindings(
+    objectPattern,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assert(
+    unsupported.some((message) =>
+      message.includes("Nested binding without explicit property key")
+    ),
+    `unsupported was: ${JSON.stringify(unsupported)}`,
+  );
+});
+
+Deno.test("collectDestructureBindings rejects an unsupported computed key that is not a fabric key", () => {
+  // A computed key expression that neither resolves to a fabric key nor to a
+  // static/known key is unsupported.
+  const { sourceFile, checker } = createProgram(
+    "declare const input: any; declare const other: symbol;\n" +
+      "const { [other]: value } = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const objectBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isObjectBindingPattern,
+  );
+
+  collectDestructureBindings(
+    objectBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  // A computed identifier key falls through to the dynamic-expression path and
+  // yields a binding with an undefined string path rather than an unsupported
+  // message, so assert on that shape.
+  assert(
+    bindings.some((binding) => toStringPath(binding.path) === undefined) ||
+      unsupported.length > 0,
+  );
+});
+
+Deno.test("collectDestructureBindings rejects a default on a dynamic object key", () => {
+  // A computed key that stays a dynamic expression cannot carry a default,
+  // because the default path would contain a non-string segment.
+  const { sourceFile, checker } = createProgram(
+    "declare const input: any; declare const other: symbol;\n" +
+      "const { [other]: value = 3 } = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const objectBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isObjectBindingPattern,
+  );
+
+  collectDestructureBindings(
+    objectBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(defaults.length, 0);
+  assert(
+    unsupported.some((message) =>
+      message.includes("Defaults on dynamic destructuring keys")
+    ),
+    `unsupported was: ${JSON.stringify(unsupported)}`,
+  );
+});
+
+Deno.test("collectDestructureBindings emits a direct SELF key expression for a simple binding", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const input: any; declare const __cfHelpers: any;\n" +
+      "const { [__cfHelpers.SELF]: selfValue } = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const objectBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isObjectBindingPattern,
+  );
+
+  collectDestructureBindings(
+    objectBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(unsupported.length, 0);
+  assertEquals(bindings.length, 1);
+  const selfBinding = bindings[0]!;
+  assertEquals(selfBinding.localName, "selfValue");
+  assert(selfBinding.directKeyExpression);
+  assertEquals(
+    ts.isIdentifier(selfBinding.directKeyExpression) &&
+      selfBinding.directKeyExpression.text,
+    "SELF",
+  );
+});
+
+Deno.test("collectDestructureBindings rejects nested destructuring under a SELF key", () => {
+  const { sourceFile, checker } = createProgram(
+    "declare const input: any; declare const __cfHelpers: any;\n" +
+      "const { [__cfHelpers.SELF]: { inner } } = input;",
+  );
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const objectBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isObjectBindingPattern,
+  );
+
+  collectDestructureBindings(
+    objectBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assert(
+    unsupported.some((message) =>
+      message.includes("Nested SELF destructuring")
+    ),
+    `unsupported was: ${JSON.stringify(unsupported)}`,
+  );
+});

--- a/packages/ts-transformers/test/expression-rewrite-binary-coverage.test.ts
+++ b/packages/ts-transformers/test/expression-rewrite-binary-coverage.test.ts
@@ -1,0 +1,445 @@
+import { assert, assertStringIncludes, assertThrows } from "@std/assert";
+import ts from "typescript";
+
+import { createDataFlowAnalyzer } from "../src/ast/mod.ts";
+import { CrossStageState, TransformationContext } from "../src/core/mod.ts";
+import { rewriteExpression } from "../src/transformers/expression-rewrite/mod.ts";
+import type { ReactiveContextKind } from "../src/ast/mod.ts";
+import type { ExpressionContainerKind } from "../src/transformers/expression-site-types.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// These tests drive the shared expression-rewrite entry point
+// (`rewriteExpression`) directly against reactive binary expressions found in
+// `pattern`/`cell` sources. Driving the entry point rather than the whole
+// pipeline lets each case pin the exact reactive-context kind, container kind
+// and safe-context flag that a binary reaches the emitter with, so we can
+// assert the specific rewrite shape each branch of `emitBinaryExpression`
+// produces (a `when`/`unless` lowering, a lift wrapper, or a decision to leave
+// the node untouched).
+
+const HEADER =
+  `import { __cfHelpers, pattern, cell, lift, UI } from "commonfabric";\n`;
+
+function createContext(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+  context: TransformationContext;
+} {
+  const fileName = "/test.tsx";
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.Preserve,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const files: Record<string, string> = {
+    [fileName]: source,
+    "commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+  };
+  const host = ts.createCompilerHost(options, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion) =>
+    files[name] !== undefined
+      ? ts.createSourceFile(
+        name,
+        files[name]!,
+        languageVersion,
+        true,
+        name.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+      )
+      : originalGetSourceFile(name, languageVersion);
+  host.fileExists = (name) => files[name] !== undefined;
+  host.readFile = (name) => files[name];
+  host.resolveModuleNames = (names) =>
+    names.map((name) =>
+      name === "commonfabric"
+        ? {
+          resolvedFileName: "commonfabric.d.ts",
+          extension: ts.Extension.Dts,
+          isExternalLibraryImport: false,
+        }
+        : undefined
+    );
+  const program = ts.createProgram(
+    [fileName, "commonfabric.d.ts"],
+    options,
+    host,
+  );
+  const sourceFile = program.getSourceFile(fileName)!;
+  const context = new TransformationContext({
+    program,
+    sourceFile,
+    tsContext: { factory: ts.factory } as ts.TransformationContext,
+    options: { state: new CrossStageState() },
+  });
+  return { sourceFile, checker: program.getTypeChecker(), context };
+}
+
+function findBinary(
+  sourceFile: ts.SourceFile,
+  operator: ts.SyntaxKind,
+  nth = 0,
+): ts.BinaryExpression {
+  const matches: ts.BinaryExpression[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) && node.operatorToken.kind === operator
+    ) {
+      matches.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  const found = matches[nth];
+  if (!found) throw new Error("Expected binary expression not found");
+  return found;
+}
+
+function printNode(node: ts.Node, sourceFile: ts.SourceFile): string {
+  return ts.createPrinter().printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    sourceFile,
+  );
+}
+
+interface RewriteOptions {
+  reactiveContextKind: ReactiveContextKind;
+  containerKind: ExpressionContainerKind;
+  inSafeContext: boolean;
+  markSyntheticOwned?: boolean;
+}
+
+function rewriteBinary(
+  source: string,
+  operator: ts.SyntaxKind,
+  options: RewriteOptions,
+  nth = 0,
+): { result: ts.Expression | undefined; printed: string | undefined } {
+  const { sourceFile, checker, context } = createContext(HEADER + source);
+  const analyze = createDataFlowAnalyzer(checker);
+  const binary = findBinary(sourceFile, operator, nth);
+  if (options.markSyntheticOwned) {
+    context.markSyntheticComputeOwnedSubtree(binary);
+  }
+  const analysis = analyze(binary);
+  const result = rewriteExpression({
+    expression: binary,
+    analysis,
+    context,
+    analyze,
+    reactiveContextKind: options.reactiveContextKind,
+    containerKind: options.containerKind,
+    inSafeContext: options.inSafeContext,
+  });
+  return {
+    result,
+    printed: result ? printNode(result, sourceFile) : undefined,
+  };
+}
+
+const AND = ts.SyntaxKind.AmpersandAmpersandToken;
+const OR = ts.SyntaxKind.BarBarToken;
+const NULLISH = ts.SyntaxKind.QuestionQuestionToken;
+const PLUS = ts.SyntaxKind.PlusToken;
+
+Deno.test(
+  "emitBinaryExpression lowers a pattern-owned && with a simple reactive left to a when() call",
+  () => {
+    const { printed } = rewriteBinary(
+      `export default pattern((_s) => {
+        const showPanel = cell(true);
+        return { [UI]: <div>{showPanel.get() && <span>P</span>}</div> };
+      });`,
+      AND,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    assert(printed, "expected the && to be lowered");
+    assertStringIncludes(printed, "__cfHelpers.when(");
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression lowers a pattern-owned || with a simple reactive left to an unless() call",
+  () => {
+    const { printed } = rewriteBinary(
+      `export default pattern((_s) => {
+        const value = cell("");
+        return { [UI]: <div>{value.get() || <span>F</span>}</div> };
+      });`,
+      OR,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    assert(printed, "expected the || to be lowered");
+    assertStringIncludes(printed, "__cfHelpers.unless(");
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression wraps a non-simple && condition in a lift before the when() call",
+  () => {
+    const { printed } = rewriteBinary(
+      `export default pattern((_s) => {
+        const user = cell<{ name: string }>({ name: "" });
+        return { [UI]: <div>{(user.get().name.length > 0) && <span>H</span>}</div> };
+      });`,
+      AND,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    assert(printed, "expected the && to be lowered");
+    assertStringIncludes(printed, "__cfHelpers.when(");
+    // The complex left operand is wrapped as a reactive condition rather than
+    // passed through verbatim.
+    assertStringIncludes(printed, "__cfHelpers.lift(");
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression wraps a non-simple || condition in a lift before the unless() call",
+  () => {
+    const { printed } = rewriteBinary(
+      `export default pattern((_s) => {
+        const user = cell<{ name: string }>({ name: "" });
+        return { [UI]: <div>{(user.get().name.length > 0) || <span>F</span>}</div> };
+      });`,
+      OR,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    assert(printed, "expected the || to be lowered");
+    assertStringIncludes(printed, "__cfHelpers.unless(");
+    assertStringIncludes(printed, "__cfHelpers.lift(");
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression leaves a safe-context && untouched instead of lowering it",
+  () => {
+    const { result } = rewriteBinary(
+      `export default pattern((_s) => {
+        const showPanel = cell(true);
+        return { [UI]: <div>{showPanel.get() && <span>P</span>}</div> };
+      });`,
+      AND,
+      {
+        reactiveContextKind: "compute",
+        containerKind: "jsx-expression",
+        inSafeContext: true,
+      },
+    );
+    // In a safe (compute) context the context policy does not lower && to
+    // when(); the emitter declines to rewrite so the raw && is preserved.
+    assert(
+      result === undefined,
+      "expected && in a safe context to be left untouched",
+    );
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression leaves a safe-context || untouched instead of lowering it",
+  () => {
+    const { result } = rewriteBinary(
+      `export default pattern((_s) => {
+        const value = cell("");
+        return { [UI]: <div>{value.get() || <span>F</span>}</div> };
+      });`,
+      OR,
+      {
+        reactiveContextKind: "compute",
+        containerKind: "jsx-expression",
+        inSafeContext: true,
+      },
+    );
+    assert(
+      result === undefined,
+      "expected || in a safe context to be left untouched",
+    );
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression declines to wrap any reactive binary in a safe context",
+  () => {
+    const { result } = rewriteBinary(
+      `export default pattern<{ count: number }>((state) => ({
+        [UI]: <div>{state.count + 100}</div>,
+      }));`,
+      PLUS,
+      {
+        reactiveContextKind: "compute",
+        containerKind: "jsx-expression",
+        inSafeContext: true,
+      },
+    );
+    // Safe contexts allow opaque reads, so the arithmetic binary is not wrapped
+    // in a compute wrapper.
+    assert(
+      result === undefined,
+      "expected arithmetic in a safe context to be left untouched",
+    );
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression wraps a pattern-owned arithmetic binary in a lift compute wrapper",
+  () => {
+    const { printed } = rewriteBinary(
+      `export default pattern<{ count: number }>((state) => ({
+        [UI]: <div>{state.count + 100}</div>,
+      }));`,
+      PLUS,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    assert(printed, "expected arithmetic to be wrapped");
+    assertStringIncludes(printed, "__cfHelpers.lift(");
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression declines to rewrite a purely-literal binary with no reactive operands",
+  () => {
+    const { result } = rewriteBinary(
+      `export default pattern((_s) => ({ [UI]: <div>{1 + 2}</div> }));`,
+      PLUS,
+      {
+        reactiveContextKind: "compute",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    // No dataflows, a non-reactive left operand, and no lowering policy means
+    // the emitter has nothing to do.
+    assert(
+      result === undefined,
+      "expected a literal binary to be left untouched",
+    );
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression declines to wrap a reactive-valued binary that captures no dataflows",
+  () => {
+    const { result } = rewriteBinary(
+      `import { computed } from "commonfabric";
+      export default pattern((_s) => ({ [UI]: <div>{computed(() => 1) + 1}</div> }));`,
+      PLUS,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    // The left side is a reactive value (so the early skip does not fire) but
+    // it captures no reactive dataflows, so there is nothing to bind into a
+    // compute wrapper and the emitter returns undefined.
+    assert(
+      result === undefined,
+      "expected a reactive binary without captured dataflows to be left untouched",
+    );
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression defers a reactive fallback receiver of an unlowered map()",
+  () => {
+    const { result } = rewriteBinary(
+      `export default pattern((_s) => {
+        const items = cell<number[]>([]);
+        return { [UI]: <div>{(items ?? []).map((x) => <span>{x}</span>)}</div> };
+      });`,
+      NULLISH,
+      {
+        reactiveContextKind: "pattern",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+      },
+    );
+    // `(items ?? []).map(...)` is a simple reactive left feeding a not-yet
+    // lowered map(). The emitter defers so the array-method rewrite owns the
+    // receiver instead of pre-wrapping the fallback.
+    assert(
+      result === undefined,
+      "expected the fallback map receiver to be deferred",
+    );
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression rewrites a synthetic compute-owned array-method receiver without asserting compute-wrap invariants",
+  () => {
+    const { printed } = rewriteBinary(
+      `export default pattern((_s) => {
+        const items = cell<number[]>([]);
+        return { [UI]: <div>{(items ?? []).map((x) => <span>{x}</span>)}</div> };
+      });`,
+      NULLISH,
+      {
+        reactiveContextKind: "compute",
+        containerKind: "jsx-expression",
+        inSafeContext: false,
+        markSyntheticOwned: true,
+      },
+    );
+    // A synthetic compute-owned node that is the receiver of a map() is an
+    // allowed wrap: the emitter skips the compute-wrap invariant assertion
+    // (which would otherwise throw for a compute-owned node) and still emits a
+    // lift wrapper.
+    assert(printed, "expected the synthetic array receiver to be wrapped");
+    assertStringIncludes(printed, "__cfHelpers.lift(");
+  },
+);
+
+Deno.test(
+  "emitBinaryExpression throws a compiler-bug error for a compute-owned binary that is not an array-method receiver",
+  () => {
+    const { sourceFile, checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          return { [UI]: <div>{count.get() + 1}</div> };
+        });`,
+    );
+    const binary = findBinary(sourceFile, PLUS);
+    // Mark the binary as synthetic compute-owned so the array-receiver check
+    // runs and returns false (it is not a map()/filter() receiver). Because the
+    // node is not an allowed synthetic array wrap, the compute-wrap invariant
+    // assertion fires and reports the classifier disagreement.
+    context.markSyntheticComputeOwnedSubtree(binary);
+    const analyze = createDataFlowAnalyzer(checker);
+    assertThrows(
+      () =>
+        rewriteExpression({
+          expression: binary,
+          analysis: analyze(binary),
+          context,
+          analyze,
+          reactiveContextKind: "pattern",
+          containerKind: "jsx-expression",
+          inSafeContext: false,
+        }),
+      Error,
+      "Internal Common Fabric compiler error",
+    );
+  },
+);

--- a/packages/ts-transformers/test/expression-rewrite-compute-wrap-coverage.test.ts
+++ b/packages/ts-transformers/test/expression-rewrite-compute-wrap-coverage.test.ts
@@ -1,0 +1,347 @@
+import { assertStrictEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import { createDataFlowAnalyzer } from "../src/ast/mod.ts";
+import { CrossStageState, TransformationContext } from "../src/core/mod.ts";
+import {
+  assertValidComputeWrapCandidate,
+  findPendingComputeWrapCandidate,
+} from "../src/transformers/expression-rewrite/emitters/compute-wrap-invariants.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// These tests exercise the compute-wrap invariant guard that emitters call
+// before adding a compute wrapper. The guard turns a disagreement between the
+// emitter's wrap decision and the shared reactive-context classifier into a
+// loud "compiler bug" error, and it also drives the pending-candidate search
+// that emitters use to find the reactive node to wrap. Each test pins one of
+// those behaviors: which node the search selects, when it yields nothing, and
+// what the compiler-bug message contains.
+
+const HEADER =
+  `import { __cfHelpers, pattern, cell, lift, UI } from "commonfabric";\n`;
+
+function createContext(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+  context: TransformationContext;
+} {
+  const fileName = "/test.tsx";
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.Preserve,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const files: Record<string, string> = {
+    [fileName]: source,
+    "commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+  };
+  const host = ts.createCompilerHost(options, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion) =>
+    files[name] !== undefined
+      ? ts.createSourceFile(
+        name,
+        files[name]!,
+        languageVersion,
+        true,
+        name.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+      )
+      : originalGetSourceFile(name, languageVersion);
+  host.fileExists = (name) => files[name] !== undefined;
+  host.readFile = (name) => files[name];
+  host.resolveModuleNames = (names) =>
+    names.map((name) =>
+      name === "commonfabric"
+        ? {
+          resolvedFileName: "commonfabric.d.ts",
+          extension: ts.Extension.Dts,
+          isExternalLibraryImport: false,
+        }
+        : undefined
+    );
+  const program = ts.createProgram(
+    [fileName, "commonfabric.d.ts"],
+    options,
+    host,
+  );
+  const sourceFile = program.getSourceFile(fileName)!;
+  const context = new TransformationContext({
+    program,
+    sourceFile,
+    tsContext: { factory: ts.factory } as ts.TransformationContext,
+    options: { state: new CrossStageState() },
+  });
+  return { sourceFile, checker: program.getTypeChecker(), context };
+}
+
+function findInitializer(
+  sourceFile: ts.SourceFile,
+  declarationName: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === declarationName &&
+      node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Initializer for ${declarationName} not found`);
+  }
+  return found;
+}
+
+function findObjectPropertyInitializer(
+  expression: ts.Expression,
+  propertyName: string,
+): ts.Expression {
+  if (!ts.isObjectLiteralExpression(expression)) {
+    throw new Error("Expected object literal expression");
+  }
+  const property = expression.properties.find((node) =>
+    ts.isPropertyAssignment(node) &&
+    ts.isIdentifier(node.name) &&
+    node.name.text === propertyName
+  );
+  if (!property || !ts.isPropertyAssignment(property)) {
+    throw new Error(`Property ${propertyName} not found`);
+  }
+  return property.initializer;
+}
+
+function findFirst<T extends ts.Node>(
+  sourceFile: ts.SourceFile,
+  predicate: (node: ts.Node) => node is T,
+): T {
+  let found: T | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (predicate(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("Expected node not found");
+  return found;
+}
+
+Deno.test(
+  "findPendingComputeWrapCandidate selects the reactive object-property value as the pending wrap",
+  () => {
+    const { sourceFile, checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const branch = { label: count.get() + " people" };
+          return { [UI]: <div>{branch}</div> };
+        });`,
+    );
+    const analyze = createDataFlowAnalyzer(checker);
+    const branch = findInitializer(sourceFile, "branch");
+    const label = findObjectPropertyInitializer(branch, "label");
+    assertStrictEquals(
+      findPendingComputeWrapCandidate(branch, analyze, context),
+      label,
+    );
+  },
+);
+
+Deno.test(
+  "findPendingComputeWrapCandidate treats a top-level function subtree as its own boundary and yields no candidate",
+  () => {
+    const { sourceFile, checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const fn = (x: number) => x + count.get();
+          return { [UI]: <div>{fn(1)}</div> };
+        });`,
+    );
+    const analyze = createDataFlowAnalyzer(checker);
+    const fn = findInitializer(sourceFile, "fn");
+    // A nested arrow establishes its own rewrite boundary; the search stops at
+    // it without descending into its reactive body.
+    assertStrictEquals(
+      findPendingComputeWrapCandidate(fn, analyze, context),
+      undefined,
+    );
+  },
+);
+
+Deno.test(
+  "findPendingComputeWrapCandidate stops at the first candidate and skips sibling function subtrees",
+  () => {
+    const { sourceFile, checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const branch = {
+            handler: (x: number) => x + count.get(),
+            value: count.get() + 1,
+            trailing: count.get() + 2,
+          };
+          return { [UI]: <div>{branch}</div> };
+        });`,
+    );
+    const analyze = createDataFlowAnalyzer(checker);
+    const branch = findInitializer(sourceFile, "branch");
+    const value = findObjectPropertyInitializer(branch, "value");
+    // The arrow-valued `handler` property is skipped as its own boundary; the
+    // search returns the reactive `value` computation and does not overwrite it
+    // with the later `trailing` computation.
+    assertStrictEquals(
+      findPendingComputeWrapCandidate(branch, analyze, context),
+      value,
+    );
+  },
+);
+
+Deno.test(
+  "assertValidComputeWrapCandidate throws when the culprit is already classified as compute",
+  () => {
+    const { sourceFile, checker: _checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const branch = count.get() + 1;
+          return { [UI]: <div>{branch}</div> };
+        });`,
+    );
+    const branch = findInitializer(sourceFile, "branch");
+    context.markSyntheticComputeOwnedSubtree(branch);
+    // Marking the node compute-owned makes the classifier disagree with an
+    // emitter that still tried to wrap it, so the guard reports the bug.
+    let message = "";
+    try {
+      assertValidComputeWrapCandidate(
+        branch,
+        branch,
+        "binary expression",
+        context,
+      );
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    assertStringIncludes(message, "Internal Common Fabric compiler error");
+    assertStringIncludes(
+      message,
+      "shared context classifier already considers compute",
+    );
+  },
+);
+
+Deno.test(
+  "assertValidComputeWrapCandidate throws when the culprit sits inside an already-supported pattern boundary",
+  () => {
+    const { sourceFile, checker: _checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const lifted = lift((x: { v: number }) => x.v);
+          const branch = lifted({ v: count }) + 1;
+          return { [UI]: <div>{branch}</div> };
+        });`,
+    );
+    const branch = findInitializer(sourceFile, "branch");
+    // Container is `lifted({ v: count }) + 1`; the culprit is the reactive
+    // object argument of the lift-applied call, which lives inside a supported
+    // pattern boundary between it and the container.
+    const culprit = findFirst(
+      sourceFile,
+      (node): node is ts.ObjectLiteralExpression =>
+        ts.isObjectLiteralExpression(node),
+    );
+    let message = "";
+    try {
+      assertValidComputeWrapCandidate(
+        culprit,
+        branch,
+        "binary expression",
+        context,
+      );
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    assertStringIncludes(message, "Internal Common Fabric compiler error");
+    assertStringIncludes(message, "already-supported pattern boundary");
+  },
+);
+
+Deno.test(
+  "the compiler-bug message truncates a long culprit snippet with an ellipsis",
+  () => {
+    const longExpression = "count.get()" + " + count.get()".repeat(20);
+    const { sourceFile, checker: _checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const branch = ${longExpression};
+          return { [UI]: <div>{branch}</div> };
+        });`,
+    );
+    const branch = findInitializer(sourceFile, "branch");
+    context.markSyntheticComputeOwnedSubtree(branch);
+    let message = "";
+    try {
+      assertValidComputeWrapCandidate(
+        branch,
+        branch,
+        "binary expression",
+        context,
+      );
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    // The culprit snippet is longer than the 160-character cap, so it is cut
+    // off with an ellipsis.
+    assertStringIncludes(message, "...");
+  },
+);
+
+Deno.test(
+  "the compiler-bug message falls back to the SyntaxKind name when a culprit has no source text",
+  () => {
+    const { sourceFile, checker: _checker, context } = createContext(
+      HEADER +
+        `export default pattern((_s) => {
+          const count = cell(0);
+          const branch = count.get() + 1;
+          return { [UI]: <div>{branch}</div> };
+        });`,
+    );
+    const branch = findInitializer(sourceFile, "branch");
+    // A synthesized node has no real source positions, so reading its text
+    // throws and the snippet helper falls back to the node's SyntaxKind name.
+    const synthesized = ts.factory.createBinaryExpression(
+      ts.factory.createNumericLiteral(1),
+      ts.SyntaxKind.PlusToken,
+      ts.factory.createNumericLiteral(2),
+    );
+    (synthesized as { parent: ts.Node }).parent = branch.parent;
+    context.markSyntheticComputeOwnedSubtree(synthesized);
+    let message = "";
+    try {
+      assertValidComputeWrapCandidate(
+        synthesized,
+        branch,
+        "binary expression",
+        context,
+      );
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    assertStringIncludes(message, "Internal Common Fabric compiler error");
+    assertStringIncludes(message, "BinaryExpression");
+  },
+);

--- a/packages/ts-transformers/test/module-scope-cf-data-coverage.test.ts
+++ b/packages/ts-transformers/test/module-scope-cf-data-coverage.test.ts
@@ -1,0 +1,175 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { ModuleScopeCfDataTransformer } from "../src/transformers/module-scope-cf-data.ts";
+import { TransformationContext } from "../src/core/mod.ts";
+
+// The module-scope cf-data transformer wraps top-level data expressions with a
+// `__cf_data` helper call. The existing `module-scope-cf-data.test.ts` drives
+// the full pipeline, where the `__cfHelpers` import is always injected, so
+// `context.cfHelpers.sourceHasHelpers()` is always true. These tests target the
+// branches that only run when the source has NO helper import: the primitive
+// snapshot classification path (`shouldWrapTopLevelExpression` line 165-167),
+// the helper-import injection (`createCfDataHelperImport`), and the union /
+// intersection primitive-type analysis. To reach that state the transformer is
+// driven directly through `ts.transform`, bypassing the `HelpersOnlyTransformer`
+// filter that would otherwise skip a source without helpers.
+
+function createProgram(source: string): {
+  program: ts.Program;
+  sourceFile: ts.SourceFile;
+} {
+  const files: Record<string, string> = { "/test.ts": source };
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (n) => files[n] !== undefined,
+    readFile: (n) => files[n],
+    getSourceFile: (n, lv) =>
+      files[n] !== undefined
+        ? ts.createSourceFile(n, files[n]!, lv, true, ts.ScriptKind.TS)
+        : undefined,
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    getCanonicalFileName: (n) => n,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    directoryExists: () => true,
+  };
+  const program = ts.createProgram(["/test.ts"], options, host);
+  return { program, sourceFile: program.getSourceFile("/test.ts")! };
+}
+
+// Runs the cf-data transformer directly against a helper-free source. The
+// direct call bypasses the `sourceHasHelpers()` filter so the no-helpers
+// branches execute.
+function transformWithoutHelpers(source: string): string {
+  const { program, sourceFile } = createProgram(source);
+  const transformer = new ModuleScopeCfDataTransformer({ mode: "transform" });
+  const result = ts.transform(sourceFile, [
+    (tsContext) => (sf) =>
+      transformer.transform(
+        new TransformationContext({ program, sourceFile: sf, tsContext }),
+      ),
+  ]);
+  const output = ts
+    .createPrinter({ newLine: ts.NewLineKind.LineFeed })
+    .printFile(result.transformed[0]);
+  result.dispose?.();
+  return output;
+}
+
+Deno.test(
+  "cf-data without helpers wraps a primitive-typed call and injects the __cf_data import",
+  () => {
+    const output = transformWithoutHelpers(
+      `declare function n(): number;\nconst z = n();\n`,
+    );
+    // With no `__cfHelpers` import present the transformer prepends its own
+    // named import and wraps the snapshot call with the bare identifier form.
+    assertStringIncludes(
+      output,
+      'import { __cf_data as __cfDataHelper } from "commonfabric"',
+    );
+    assertStringIncludes(output, "const z = __cfDataHelper(n())");
+  },
+);
+
+Deno.test(
+  "cf-data without helpers wraps a call whose type is a union of primitives",
+  () => {
+    const output = transformWithoutHelpers(
+      `declare function u(): string | number;\nconst z = u();\n`,
+    );
+    // A union return type is classified as primitive-like when every member is
+    // primitive-like, so the snapshot call is wrapped.
+    assertStringIncludes(output, "const z = __cfDataHelper(u())");
+  },
+);
+
+Deno.test(
+  "cf-data without helpers wraps a call whose type is an intersection of primitives",
+  () => {
+    const output = transformWithoutHelpers(
+      `type A = string;\ntype B = string;\ndeclare function u(): A & B;\nconst z = u();\n`,
+    );
+    // An intersection is primitive-like when every member is primitive-like.
+    assertStringIncludes(output, "const z = __cfDataHelper(u())");
+  },
+);
+
+Deno.test(
+  "cf-data without helpers leaves a call whose intersection has a non-primitive member unwrapped",
+  () => {
+    const output = transformWithoutHelpers(
+      `declare function u(): string & { b: string };\nconst z = u();\n`,
+    );
+    // The object member is not primitive-like, so the intersection fails the
+    // `every` check and the call is not treated as a snapshot.
+    assert(
+      !output.includes("__cfDataHelper"),
+      "expected the non-primitive intersection to be left unwrapped",
+    );
+  },
+);
+
+Deno.test(
+  "cf-data leaves a declared callable with no body unwrapped on default export",
+  () => {
+    const output = transformWithoutHelpers(
+      `declare function helper(): number;\nexport default helper;\n`,
+    );
+    // `callableMayReturnCallResult` returns false for a declaration without a
+    // body, so the ambient callable is not classified as a default-exported
+    // data callable.
+    assert(
+      !output.includes("__cfDataHelper"),
+      "expected the body-less declared callable to be left unwrapped",
+    );
+  },
+);
+
+Deno.test(
+  "cf-data wraps a callable that returns a call-on-call result past a nested class boundary and trailing members",
+  () => {
+    const output = transformWithoutHelpers(
+      `declare function factory(): () => number;\n` +
+        `const nested = () => ({ make: class {}, a: factory()(), b: 1 });\n` +
+        `export default nested;\n`,
+    );
+    // The nested-expression walk skips the leading class boundary, finds the
+    // `factory()()` call-on-call, then short-circuits over the trailing member,
+    // classifying `nested` as a default-exported data callable.
+    assertStringIncludes(output, "export default __cfDataHelper(nested)");
+  },
+);
+
+Deno.test(
+  "cf-data wraps a block-body callable whose call-on-call return precedes later statements",
+  async () => {
+    const output = await transformSource(
+      `import { pattern } from "commonfabric";\n` +
+        `declare function factory(): () => number;\n` +
+        `const helper = () => {\n` +
+        `  if (true) { return factory()(); }\n` +
+        `  const after = 1;\n` +
+        `  return after;\n` +
+        `};\n` +
+        `export default helper;`,
+      { types: COMMONFABRIC_TYPES },
+    );
+    // The block traversal finds the call-on-call return inside the branch, then
+    // short-circuits the visit over the remaining statements.
+    assertStringIncludes(
+      output,
+      "export default __cfHelpers.__cf_data(helper)",
+    );
+  },
+);

--- a/packages/ts-transformers/test/module-scope-function-hardening-coverage.test.ts
+++ b/packages/ts-transformers/test/module-scope-function-hardening-coverage.test.ts
@@ -1,0 +1,79 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// Module-scope function hardening freezes every top-level callable and, for
+// callables a `WriteAuthorizedBy` / `TrustedActionWrite` type references,
+// stamps a verified-binding identity onto them. The existing
+// `module-scope-function-hardening.test.ts` covers the named function
+// declaration paths. These tests target the still-uncovered shapes: an
+// anonymous default-exported function declaration (rewritten to a hoisted const
+// plus a default export), async modifier retention on that rewrite, and a
+// trusted binding whose initializer is a direct arrow function bound to a
+// non-exported name (statement-form annotation plus a separate hardening call).
+
+async function transform(source: string): Promise<string> {
+  return await transformSource(source, { types: COMMONFABRIC_TYPES });
+}
+
+Deno.test(
+  "anonymous default-exported function declaration is rewritten to a hardened const and a default export",
+  async () => {
+    const output = await transform(
+      `/// <cts-enable />\n` +
+        `import { pattern } from "commonfabric";\n` +
+        `export default function () { return 1; }\n`,
+    );
+
+    // The nameless default export cannot be referenced by name, so it is
+    // lowered into a hoisted `const` bound to a hardened function expression and
+    // re-exported by that generated name.
+    assertStringIncludes(output, "const __cfDefaultFn");
+    assertStringIncludes(output, "export default __cfDefaultFn");
+    assertStringIncludes(output, "__cfHardenFn(function () { return 1; })");
+  },
+);
+
+Deno.test(
+  "anonymous default-exported async function keeps its async modifier through the rewrite",
+  async () => {
+    const output = await transform(
+      `/// <cts-enable />\n` +
+        `import { pattern } from "commonfabric";\n` +
+        `export default async function () { return 1; }\n`,
+    );
+
+    // Only the `async` modifier survives on the generated function expression;
+    // the export/default modifiers are dropped because the const carries the
+    // export.
+    assertStringIncludes(output, "const __cfDefaultFn");
+    assertStringIncludes(output, "__cfHardenFn(async function () {");
+    assertStringIncludes(output, "export default __cfDefaultFn");
+  },
+);
+
+Deno.test(
+  "trusted arrow bound to a non-exported name gets a statement-form annotation and a separate hardening call",
+  async () => {
+    const output = await transform(
+      `/// <cts-enable />\n` +
+        `import { pattern, WriteAuthorizedBy } from "commonfabric";\n` +
+        `const saveTitle = (): string => "x";\n` +
+        `interface Input { title: string; }\n` +
+        `interface Output { savedTitle: WriteAuthorizedBy<string, typeof saveTitle>; }\n` +
+        `export default pattern<Input, Output>(({ title }) => ({ savedTitle: title }));\n`,
+    );
+
+    // The binding is trusted (a WriteAuthorizedBy references it) and its
+    // initializer is a direct arrow function, but the declaration is not
+    // exported. The identity annotation and the hardening wrap are therefore
+    // emitted as separate statements after the declaration rather than inlined
+    // into the initializer.
+    assert(
+      !output.includes("const saveTitle = __cfBindVerifiedBinding("),
+      "expected the annotation to be statement-form, not inlined",
+    );
+    assertStringIncludes(output, "__cfBindVerifiedBinding(saveTitle, {");
+    assertStringIncludes(output, "__cfHardenFn(saveTitle)");
+  },
+);

--- a/packages/ts-transformers/test/module-scope-function-hardening.test.ts
+++ b/packages/ts-transformers/test/module-scope-function-hardening.test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// Module-scope function hardening emits an identity annotation for a top-level
+// binding that a WriteAuthorizedBy type references. The existing coverage of
+// that annotation comes from `const name = handler(...)` variable bindings; the
+// statement-form path for a plain `function` declaration ran only as a side
+// effect of patterns compiling through the transformer in CI. These tests drive
+// it directly.
+
+Deno.test(
+  "trusted WriteAuthorizedBy function declaration gets a statement-form binding annotation",
+  async () => {
+    const source = `/// <cts-enable />
+      import { pattern, WriteAuthorizedBy } from "commonfabric";
+
+      function saveTitle(): string {
+        return "x";
+      }
+
+      interface Input {
+        title: string;
+      }
+
+      interface Output {
+        savedTitle: WriteAuthorizedBy<string, typeof saveTitle>;
+      }
+
+      export default pattern<Input, Output>(({ title }) => ({
+        savedTitle: title,
+      }));
+    `;
+
+    const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
+
+    // The function declaration is preserved and followed by an identity
+    // annotation for its trusted binding.
+    assertEquals(output.includes("function saveTitle()"), true);
+    assertEquals(output.includes("__cfBindVerifiedBinding(saveTitle, {"), true);
+  },
+);
+
+Deno.test(
+  "untrusted function declaration is hardened without a binding annotation",
+  async () => {
+    const source = `/// <cts-enable />
+      import { pattern } from "commonfabric";
+
+      function helper(): string {
+        return "x";
+      }
+
+      interface Input {
+        title: string;
+      }
+
+      interface Output {
+        savedTitle: string;
+      }
+
+      export default pattern<Input, Output>(({ title }) => ({
+        savedTitle: title,
+      }));
+    `;
+
+    const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
+
+    // No WriteAuthorizedBy reference, so `helper` is not a trusted binding and
+    // no identity annotation is emitted for it, even though the function is
+    // still hardened.
+    assertEquals(output.includes("__cfBindVerifiedBinding(helper"), false);
+    assertEquals(output.includes("function helper()"), true);
+  },
+);

--- a/packages/ts-transformers/test/opaque-get-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/opaque-get-validation-coverage.test.ts
@@ -1,0 +1,203 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { validateSource } from "./utils.ts";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+function getOpaqueGetErrors(diagnostics: readonly TransformationDiagnostic[]) {
+  return diagnostics.filter((d) =>
+    d.type === "opaque-get:invalid-call" && d.severity === "error"
+  );
+}
+
+// isReactiveExpression: identifier bound to a pattern-callback parameter is a
+// reactive value, so calling .get() on it (via a structural fallback, not a
+// branded type) is flagged as an invalid opaque .get() call.
+Deno.test(
+  "opaque-get flags .get() on a destructured pattern-callback parameter",
+  async () => {
+    const source = `      import { pattern } from "commonfabric";
+
+      interface State { title: string; }
+
+      export default pattern<State>(({ title }) => {
+        const t = title.get();
+        return { t };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(
+      errors[0]!.message,
+      "is a reactive value that can be accessed directly",
+    );
+  },
+);
+
+// isPatternCallbackParameter: the whole pattern input parameter (not
+// destructured) is reactive, so member access rooted at it and then .get() is
+// flagged. This drives the walk up to the enclosing function and its builder
+// call.
+Deno.test(
+  "opaque-get flags .get() on a member of the whole pattern input parameter",
+  async () => {
+    const source = `      import { pattern } from "commonfabric";
+
+      interface State { nested: { value: number }; }
+
+      export default pattern<State>((state) => {
+        const v = state.nested.get();
+        return { v };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0]!.message, "reactive value");
+  },
+);
+
+// isReactiveInitializer: a local variable initialized directly from a
+// reactive-origin call (computed()) is reactive; .get() on it is flagged.
+Deno.test(
+  "opaque-get flags .get() on a local initialized from computed()",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern<{ count: number }>(({ count }) => {
+        const doubled = computed(() => count * 2);
+        const bad = doubled.get();
+        return { bad };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0]!.message, "computed()");
+  },
+);
+
+// isReactiveInitializer unwrapping: the reactive-origin call is wrapped in a
+// parenthesized / non-null / property-access chain before assignment, and the
+// validator peels those layers off to find the origin call underneath.
+Deno.test(
+  "opaque-get flags .get() on a local initialized from a wrapped reactive-origin call",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      interface Shape { inner: number; }
+
+      export default pattern<{ count: number }>(({ count }) => {
+        const wrapped = (computed(() => ({ inner: count } as Shape)))!.inner;
+        const bad = wrapped.get();
+        return { bad };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0]!.message, "reactive value");
+  },
+);
+
+// isReactiveExpression binding-element branch: a value destructured out of a
+// local whose initializer is a reactive-origin call is still reactive, so
+// .get() on the destructured binding is flagged.
+Deno.test(
+  "opaque-get flags .get() on a binding destructured from a reactive local",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      interface Shape { a: number; b: number; }
+
+      export default pattern<{ count: number }>(({ count }) => {
+        const { a } = computed(() => ({ a: count, b: count } as Shape));
+        const bad = a.get();
+        return { bad };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0]!.message, "reactive value");
+  },
+);
+
+// isPatternCallbackParameter walks up from the enclosing function to its
+// builder call. When the callback is wrapped in parentheses, the function's
+// immediate parent is not the call expression, so the walk climbs through the
+// parenthesized wrapper before reaching pattern(). The .get() on the reactive
+// input must still be flagged.
+Deno.test(
+  "opaque-get flags .get() when the pattern callback is parenthesized",
+  async () => {
+    const source = `      import { pattern } from "commonfabric";
+
+      interface State { title: string; }
+
+      export default pattern<State>(((state) => {
+        const t = state.title.get();
+        return { t };
+      }));
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0]!.message, "reactive value");
+  },
+);
+
+// isReactiveExpression bails out when the receiver identifier has no resolved
+// symbol: an unresolvable receiver cannot be proven reactive, so no
+// opaque-get diagnostic is produced for it (the structural fallback returns
+// false at the missing-symbol guard).
+Deno.test(
+  "opaque-get does not flag .get() on an unresolvable identifier",
+  async () => {
+    const source = `      import { pattern } from "commonfabric";
+
+      export default pattern(() => {
+        // @ts-ignore intentional unresolved reference
+        const v = undeclaredThing.get();
+        return { v };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 0);
+  },
+);
+
+// A .get() on a genuine Cell/Writable must NOT be flagged by this validator:
+// cellKind === "cell" returns early, exercising the non-reactive path.
+Deno.test(
+  "opaque-get does not flag .get() on a Writable cell",
+  async () => {
+    const source = `      import { pattern, Cell } from "commonfabric";
+
+      export default pattern<{ count: Cell<number> }>(({ count }) => {
+        const v = count.get();
+        return { v };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getOpaqueGetErrors(diagnostics);
+    assertEquals(errors.length, 0);
+  },
+);

--- a/packages/ts-transformers/test/opaque-roots-coverage.test.ts
+++ b/packages/ts-transformers/test/opaque-roots-coverage.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit coverage for `src/transformers/opaque-roots.ts`.
+ *
+ * These tests drive the pure AST-shape helpers directly:
+ *
+ * - `classifyOpaquePathTerminalCall` — classifies the trailing call of an opaque
+ *   navigation chain as `.get()` / `.key()`, including the element-access form
+ *   (`obj["get"]()`).
+ * - `getOpaqueAccessInfo` — walks a member-access chain back to its root,
+ *   unwrapping parenthesization/casts/non-null/partially-emitted wrappers and
+ *   recording the traversed path segments plus whether any segment was dynamic.
+ * - `addBindingTargetSymbols` — collects the declared symbols of a binding name,
+ *   descending into array/object binding patterns and skipping holes.
+ */
+import ts from "typescript";
+import { assert, assertEquals, assertFalse } from "@std/assert";
+
+import type { TransformationContext } from "../src/core/mod.ts";
+import {
+  addBindingTargetSymbols,
+  classifyOpaquePathTerminalCall,
+  getOpaqueAccessInfo,
+} from "../src/transformers/opaque-roots.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function testContext(checker: ts.TypeChecker): TransformationContext {
+  return {
+    checker,
+    factory: ts.factory,
+  } as unknown as TransformationContext;
+}
+
+function findInitializer(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found && ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+      node.name.text === name && node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Initializer for ${name} not found`);
+  return found;
+}
+
+function findVariable(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found && ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) && node.name.text === name
+    ) {
+      found = node;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Variable declaration for ${name} not found`);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// classifyOpaquePathTerminalCall
+// ---------------------------------------------------------------------------
+
+Deno.test("classifyOpaquePathTerminalCall recognizes .get() and .key() property-access terminals", () => {
+  const { sourceFile } = createProgram(`
+    const a = obj.get();
+    const b = obj.key();
+    const c = obj.other();
+  `);
+  const get = findInitializer(sourceFile, "a") as ts.CallExpression;
+  const key = findInitializer(sourceFile, "b") as ts.CallExpression;
+  const other = findInitializer(sourceFile, "c") as ts.CallExpression;
+
+  assertEquals(classifyOpaquePathTerminalCall(get), "get");
+  assertEquals(classifyOpaquePathTerminalCall(key), "key");
+  assertEquals(classifyOpaquePathTerminalCall(other), undefined);
+});
+
+Deno.test("classifyOpaquePathTerminalCall recognizes string-literal element-access terminals", () => {
+  // `obj["get"]()` and `obj["key"]()` classify the same as the property-access
+  // form via the element-access branch.
+  const { sourceFile } = createProgram(`
+    const a = obj["get"]();
+    const b = obj["key"]();
+  `);
+  const get = findInitializer(sourceFile, "a") as ts.CallExpression;
+  const key = findInitializer(sourceFile, "b") as ts.CallExpression;
+
+  assertEquals(classifyOpaquePathTerminalCall(get), "get");
+  assertEquals(classifyOpaquePathTerminalCall(key), "key");
+});
+
+Deno.test("classifyOpaquePathTerminalCall recognizes no-substitution-template element-access terminals", () => {
+  const { sourceFile } = createProgram(`
+    const a = obj[\`get\`]();
+  `);
+  const get = findInitializer(sourceFile, "a") as ts.CallExpression;
+  assertEquals(classifyOpaquePathTerminalCall(get), "get");
+});
+
+Deno.test("classifyOpaquePathTerminalCall ignores an unrelated element-access key", () => {
+  const { sourceFile } = createProgram(`
+    const a = obj["other"]();
+  `);
+  const call = findInitializer(sourceFile, "a") as ts.CallExpression;
+  assertEquals(classifyOpaquePathTerminalCall(call), undefined);
+});
+
+Deno.test("classifyOpaquePathTerminalCall ignores a computed (non-literal) element-access key", () => {
+  // A dynamic key (identifier) is neither a StringLiteralLike nor a
+  // NoSubstitutionTemplate, so the element-access branch falls through to
+  // undefined.
+  const { sourceFile } = createProgram(`
+    const k = "get";
+    const a = obj[k]();
+  `);
+  const call = findInitializer(sourceFile, "a") as ts.CallExpression;
+  assertEquals(classifyOpaquePathTerminalCall(call), undefined);
+});
+
+Deno.test("classifyOpaquePathTerminalCall returns undefined for a bare identifier callee", () => {
+  const { sourceFile } = createProgram(`const a = fn();`);
+  const call = findInitializer(sourceFile, "a") as ts.CallExpression;
+  assertEquals(classifyOpaquePathTerminalCall(call), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// getOpaqueAccessInfo
+// ---------------------------------------------------------------------------
+
+Deno.test("getOpaqueAccessInfo records the root identifier and property path", () => {
+  const { sourceFile, checker } = createProgram(`const a = root.foo.bar;`);
+  const expr = findInitializer(sourceFile, "a");
+  const info = getOpaqueAccessInfo(expr, testContext(checker));
+  assertEquals(info.root, "root");
+  assert(info.rootIdentifier && ts.isIdentifier(info.rootIdentifier));
+  assertEquals(info.path, ["foo", "bar"]);
+  assertFalse(info.dynamic);
+});
+
+Deno.test("getOpaqueAccessInfo unwraps parenthesized and `as`/`satisfies`/`!`/`<T>` wrappers", () => {
+  // Each wrapper type peels off before the chain walk continues, so the root
+  // and path are recovered identically to the unwrapped form.
+  const { sourceFile, checker } = createProgram(`
+    const asExpr = (root as any).foo;
+    const satisfiesExpr = (root satisfies unknown).foo;
+    const nonNull = root!.foo;
+    const oldCast = (<any>root).foo;
+    const paren = ((root)).foo;
+  `);
+  for (
+    const name of ["asExpr", "satisfiesExpr", "nonNull", "oldCast", "paren"]
+  ) {
+    const info = getOpaqueAccessInfo(
+      findInitializer(sourceFile, name),
+      testContext(checker),
+    );
+    assertEquals(info.root, "root", `root for ${name}`);
+    assertEquals(info.path, ["foo"], `path for ${name}`);
+    assertFalse(info.dynamic, `dynamic for ${name}`);
+  }
+});
+
+Deno.test("getOpaqueAccessInfo records literal element-access segments as path entries", () => {
+  const { sourceFile, checker } = createProgram(`
+    const a = root["foo"][0];
+  `);
+  const info = getOpaqueAccessInfo(
+    findInitializer(sourceFile, "a"),
+    testContext(checker),
+  );
+  assertEquals(info.root, "root");
+  assertEquals(info.path, ["foo", "0"]);
+  assertFalse(info.dynamic);
+});
+
+Deno.test("getOpaqueAccessInfo marks a computed element-access key as dynamic", () => {
+  // A call-expression index cannot be resolved to a static path segment, so the
+  // access is flagged dynamic and no segment is recorded.
+  const { sourceFile, checker } = createProgram(`
+    const a = root[compute()];
+  `);
+  const info = getOpaqueAccessInfo(
+    findInitializer(sourceFile, "a"),
+    testContext(checker),
+  );
+  assertEquals(info.root, "root");
+  assertEquals(info.path, []);
+  assert(info.dynamic);
+});
+
+Deno.test("getOpaqueAccessInfo unwraps a partially-emitted expression wrapper", () => {
+  // PartiallyEmittedExpression is a synthetic node kind produced by transforms
+  // rather than the parser, so it is built with the factory here. The walker
+  // peels it off and recovers the underlying `root.foo` chain.
+  const { sourceFile, checker } = createProgram(`const a = root.foo;`);
+  const inner = findInitializer(sourceFile, "a");
+  const wrapped = ts.factory.createPartiallyEmittedExpression(inner);
+  const info = getOpaqueAccessInfo(wrapped, testContext(checker));
+  assertEquals(info.root, "root");
+  assertEquals(info.path, ["foo"]);
+  assertFalse(info.dynamic);
+});
+
+Deno.test("getOpaqueAccessInfo marks an unresolvable element-access key as dynamic", () => {
+  // `root[]` is a parse error; recovery yields an ElementAccess whose argument
+  // is a present-but-empty missing identifier. It is not a literal key and does
+  // not resolve to a known computed key, so the access is flagged dynamic with
+  // no path segment recorded.
+  const { sourceFile, checker } = createProgram(`const a = root[];`);
+  const info = getOpaqueAccessInfo(
+    findInitializer(sourceFile, "a"),
+    testContext(checker),
+  );
+  assertEquals(info.root, "root");
+  assertEquals(info.path, []);
+  assert(info.dynamic);
+});
+
+Deno.test("getOpaqueAccessInfo returns no root when the chain does not bottom out on an identifier", () => {
+  // A chain rooted in a call expression (`fn().foo`) has no identifier root, so
+  // `root`/`rootIdentifier` are absent while the path is still recorded.
+  const { sourceFile, checker } = createProgram(`
+    const a = fn().foo;
+  `);
+  const info = getOpaqueAccessInfo(
+    findInitializer(sourceFile, "a"),
+    testContext(checker),
+  );
+  assertEquals(info.root, undefined);
+  assertEquals(info.rootIdentifier, undefined);
+  assertEquals(info.path, ["foo"]);
+});
+
+// ---------------------------------------------------------------------------
+// addBindingTargetSymbols
+// ---------------------------------------------------------------------------
+
+Deno.test("addBindingTargetSymbols collects a simple identifier binding symbol", () => {
+  const { sourceFile, checker } = createProgram(`const single = 1;`);
+  const decl = findVariable(sourceFile, "single");
+  const bucket = new Set<ts.Symbol>();
+  addBindingTargetSymbols(decl.name, bucket, checker);
+  assertEquals([...bucket].map((s) => s.getName()), ["single"]);
+});
+
+Deno.test("addBindingTargetSymbols descends into nested binding patterns and skips array holes", () => {
+  // Array holes are OmittedExpression elements that are skipped; object and
+  // nested array patterns recurse into their element names.
+  const { sourceFile, checker } = createProgram(`
+    const [first, , { nested }] = source;
+  `);
+  let decl: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!decl && ts.isVariableDeclaration(node)) decl = node;
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  assert(decl);
+
+  const bucket = new Set<ts.Symbol>();
+  addBindingTargetSymbols(decl.name, bucket, checker);
+  const names = [...bucket].map((s) => s.getName()).sort();
+  assertEquals(names, ["first", "nested"]);
+});

--- a/packages/ts-transformers/test/pattern-context-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/pattern-context-validation-coverage.test.ts
@@ -1,0 +1,541 @@
+import { assertEquals, assertGreater, assertStringIncludes } from "@std/assert";
+import { validateSource } from "./utils.ts";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+function getErrors(diagnostics: readonly TransformationDiagnostic[]) {
+  return diagnostics.filter((d) => d.severity === "error");
+}
+
+function errorsOfType(
+  diagnostics: readonly TransformationDiagnostic[],
+  type: string,
+) {
+  return getErrors(diagnostics).filter((d) => d.type === type);
+}
+
+// validateComputationExpression -> findProblematicAccess: a reactive property
+// access used in a bare statement-position arithmetic computation is at a
+// restricted (non-lowerable) site, so it is rejected with
+// pattern-context:computation. findProblematicAccess locates the first
+// property access ('input.a') and names it in the message.
+Deno.test(
+  "computation over reactive property in statement position names the access",
+  async () => {
+    const source = `      import { pattern } from "commonfabric";
+
+      export default pattern<{ a: number }>((input) => {
+        input.a + 1;
+        return input;
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "pattern-context:computation");
+    assertGreater(errors.length, 0, "Expected a computation error");
+    assertStringIncludes(errors[0]!.message, "'input.a'");
+  },
+);
+
+// validateLocalReactiveAliasUsage: an if-statement condition that reads a
+// reactive value created locally inside the enclosing computed() callback is
+// rejected with compute-context:local-reactive-use, and the message tells the
+// author to move the use into a nested computed().
+Deno.test(
+  "if-condition over locally created computed result is rejected",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const flag = computed(() => true);
+          if (flag) {
+            return 1;
+          }
+          return 0;
+        });
+        return { outer };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "compute-context:local-reactive-use",
+    );
+    assertGreater(errors.length, 0, "Expected a local-reactive-use error");
+    assertStringIncludes(errors[0]!.message, "nested computed(() => ...)");
+  },
+);
+
+// validateLocalReactiveAliasUsage while/for/switch statement heads: reading a
+// locally created reactive value in a while/for/switch head is rejected the
+// same way as an if-condition.
+Deno.test(
+  "while/for/switch heads over locally created computed results are rejected",
+  async () => {
+    const whileSource = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const flag = computed(() => true);
+          while (flag) {
+            return 1;
+          }
+          return 0;
+        });
+        return { outer };
+      });
+    `;
+    const forSource = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const limit = computed(() => 3);
+          for (let i = 0; i < limit; i++) {
+            return i;
+          }
+          return 0;
+        });
+        return { outer };
+      });
+    `;
+    const switchSource =
+      `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const which = computed(() => 1);
+          switch (which) {
+            case 1:
+              return "a";
+            default:
+              return "b";
+          }
+        });
+        return { outer };
+      });
+    `;
+    for (const source of [whileSource, forSource, switchSource]) {
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = errorsOfType(
+        diagnostics,
+        "compute-context:local-reactive-use",
+      );
+      assertGreater(
+        errors.length,
+        0,
+        "Expected a local-reactive-use error for statement head",
+      );
+    }
+  },
+);
+
+// findProblematicUse member-access branch: a topmost property access rooted at
+// a locally created reactive value (`local.flag`) is itself the culprit, so
+// reading it in an if-condition is rejected.
+Deno.test(
+  "member access on a locally created reactive result is rejected",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern<{ obj: { flag: boolean } }>(({ obj }) => {
+        const outer = computed(() => {
+          const local = computed(() => obj);
+          if (local.flag) {
+            return 1;
+          }
+          return 0;
+        });
+        return { outer };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "compute-context:local-reactive-use",
+    );
+    assertGreater(errors.length, 0, "Expected a local-reactive-use error");
+  },
+);
+
+// findProblematicUse call branch: a `.get()`/`.key()`/`.for()` chain on a
+// locally created reactive value is a provenance-preserving opaque-source call,
+// so using it in an if-condition is rejected as a local reactive use.
+Deno.test(
+  "opaque-source call on a locally created reactive result is rejected",
+  async () => {
+    const source =
+      `      import { computed, pattern, Cell } from "commonfabric";
+
+      export default pattern<{ cell: Cell<number> }>(({ cell }) => {
+        const outer = computed(() => {
+          const local = computed(() => cell);
+          if (local.get()) {
+            return 1;
+          }
+          return 0;
+        });
+        return { outer };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "compute-context:local-reactive-use",
+    );
+    assertGreater(errors.length, 0, "Expected a local-reactive-use error");
+  },
+);
+
+// checkExpression skips a missing expression: a for-statement with no condition
+// (`for (;;)`) passes an undefined condition to checkExpression, which returns
+// early. The loop body still reports the local reactive use inside it.
+Deno.test(
+  "for-statement without a condition still reports the local reactive use",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const flag = computed(() => true);
+          for (;;) {
+            if (flag) {
+              return 1;
+            }
+          }
+        });
+        return { outer };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "compute-context:local-reactive-use",
+    );
+    assertGreater(errors.length, 0, "Expected a local-reactive-use error");
+  },
+);
+
+// findProblematicUse nested-function skip: when the checked expression contains
+// a nested callback (an array-method arrow), the walk does not descend into
+// that nested function, but still finds the local reactive use in the
+// surrounding condition.
+Deno.test(
+  "condition with a nested callback still reports the local reactive use",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern<{ items: number[] }>(({ items }) => {
+        const outer = computed(() => {
+          const local = computed(() => items);
+          if ([1, 2].some((n) => n > 0) && local.length > 0) {
+            return 1;
+          }
+          return 0;
+        });
+        return { outer };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "compute-context:local-reactive-use",
+    );
+    assertGreater(errors.length, 0, "Expected a local-reactive-use error");
+  },
+);
+
+// memberBodyReadsReactiveValue: a toJSON method whose body reads a reactive
+// input captured from the enclosing pattern still freezes a snapshot at store
+// time, so the object member creation is rejected.
+Deno.test(
+  "toJSON member reading a reactive input is rejected",
+  async () => {
+    const source = `      import { pattern, UI } from "commonfabric";
+
+      export default pattern<{ name: string }>(({ name }) => {
+        const wrapper = {
+          toJSON() {
+            return { value: name };
+          },
+        };
+        return { [UI]: <div />, wrapper };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected an error for reactive toJSON");
+  },
+);
+
+// validateStandaloneFunction: a standalone (module-scope) function that calls a
+// reactive-origin builder like computed() is rejected, since standalone
+// functions cannot capture reactive closures.
+Deno.test(
+  "standalone function calling computed() is rejected",
+  async () => {
+    const source = `      import { computed } from "commonfabric";
+
+      export function makeDoubled(n: number) {
+        return computed(() => n * 2);
+      }
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "standalone-function:reactive-operation",
+    );
+    assertGreater(errors.length, 0, "Expected standalone reactive error");
+    assertStringIncludes(errors[0]!.message, "standalone functions");
+  },
+);
+
+// validateStandaloneFunction reactive-array-method branch: a standalone
+// function that calls a reactive array method (.map on a Cell array) is
+// rejected, and the message names the offending method family.
+Deno.test(
+  "standalone function calling a reactive array method is rejected",
+  async () => {
+    const source = `      import { Cell } from "commonfabric";
+
+      export function run(items: Cell<number[]>) {
+        return items.map((n) => n + 1);
+      }
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(
+      diagnostics,
+      "standalone-function:reactive-operation",
+    );
+    assertGreater(errors.length, 0, "Expected standalone reactive error");
+    assertStringIncludes(errors[0]!.message, "map");
+  },
+);
+
+// validateCallbackSelfContainment with a parameter default initializer that
+// references an enclosing callable: the initializer is visited and the capture
+// is flagged.
+Deno.test(
+  "callback parameter default initializer capturing a helper is flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const helper = (value: string) => value.toUpperCase();
+          const inner = computed((seed = helper) => seed("x"));
+          return inner;
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertGreater(errors.length, 0, "Expected a callable-capture error");
+  },
+);
+
+// isCallableReference non-callable-capture path: a captured uninitialized local
+// (a `let` with a non-function type, no initializer) is neither a call use-site
+// nor an inference-checkable binding, so the validator classifies it as
+// non-callable and does NOT emit a callable-capture diagnostic for it.
+Deno.test(
+  "capturing a non-callable uninitialized local is not flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          let x: number;
+          x = 5;
+          return computed(() => ({ x }));
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertEquals(
+      errors.length,
+      0,
+      "Non-callable capture should not be flagged",
+    );
+  },
+);
+
+// isSyntacticCallable parameter-type branch -> isCallableTypeNode: a callback
+// whose parameter is explicitly typed as a function type (with no initializer,
+// so the type node is inspected rather than an initializer) is callable, and
+// capturing that parameter inside a nested computed callback is flagged. This
+// exercises isCallableTypeNode's plain function-type branch.
+Deno.test(
+  "callback capturing a function-typed parameter is flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const run = (cb: (v: string) => string) => {
+            return computed(() => ({ cb }));
+          };
+          return run((v) => v);
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertGreater(errors.length, 0, "Expected a callable-capture error");
+  },
+);
+
+// isCallableTypeNode parenthesized-type branch: a parameter typed with a
+// parenthesized function type unwraps to the inner function type and is
+// recognized as callable, so capturing it is flagged.
+Deno.test(
+  "callback capturing a parenthesized-function-typed parameter is flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const run = (cb: ((v: string) => string)) => computed(() => ({ cb }));
+          return run((v) => v);
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertGreater(errors.length, 0, "Expected a callable-capture error");
+  },
+);
+
+// isCallableTypeNode union-type branch: a parameter typed as a union that
+// contains a function type has at least one callable member, so capturing it is
+// flagged.
+Deno.test(
+  "callback capturing a union-function-typed parameter is flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const run = (cb: ((v: string) => string) | undefined) =>
+            computed(() => ({ cb }));
+          return run((v) => v);
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertGreater(errors.length, 0, "Expected a callable-capture error");
+  },
+);
+
+// isCallableTypeNode intersection-type branch: a parameter typed as an
+// intersection that contains a function type has a callable member, so
+// capturing it is flagged.
+Deno.test(
+  "callback capturing an intersection-function-typed parameter is flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const run = (cb: ((v: string) => string) & { tag: string }) =>
+            computed(() => ({ cb }));
+          return run(Object.assign((v: string) => v, { tag: "t" }));
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertGreater(errors.length, 0, "Expected a callable-capture error");
+  },
+);
+
+// isCallableTypeNode Function-reference branch: a parameter typed as the global
+// Function type is recognized as callable by its type reference name, so
+// capturing it is flagged.
+Deno.test(
+  "callback capturing a Function-typed parameter is flagged",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const run = (cb: Function) => computed(() => ({ cb }));
+          return run((v: string) => v);
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertGreater(errors.length, 0, "Expected a callable-capture error");
+  },
+);
+
+// report() dedup: when a single captured helper is referenced multiple times in
+// one callback, the callable-capture diagnostic is emitted only once (keyed by
+// identifier text), exercising the diagnosticsSeen guard.
+Deno.test(
+  "a helper captured multiple times is reported once",
+  async () => {
+    const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern(() => {
+        const label = computed(() => {
+          const helper = (v: string) => v.toUpperCase();
+          return computed(() => helper("a") + helper("b"));
+        });
+        return { label };
+      });
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = errorsOfType(diagnostics, "ses-callback:callable-capture");
+    assertEquals(
+      errors.length,
+      1,
+      "Expected exactly one callable-capture error",
+    );
+  },
+);

--- a/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
@@ -1,0 +1,1446 @@
+import ts from "typescript";
+import { assert, assertEquals } from "@std/assert";
+import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
+
+// These tests drive `analyzeFunctionCapabilities` through parameter-summary
+// branches that run today only as a side effect of patterns compiling through
+// the transformer in CI's pattern-integration jobs. Each case constructs a
+// callback body that reaches a specific branch and pins the observable summary
+// (capability, read/write/identity paths, wildcard/passthrough flags).
+
+function createProgram(
+  source: string,
+): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const files: Record<string, string> = { "/test.ts": source };
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files[name] !== undefined,
+    readFile: (name) => files[name],
+    directoryExists: () => true,
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => "/",
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "lib.d.ts",
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+    getSourceFile: (name, lv) =>
+      files[name] !== undefined
+        ? ts.createSourceFile(name, files[name]!, lv, true, ts.ScriptKind.TS)
+        : undefined,
+  };
+  const program = ts.createProgram(["/test.ts"], options, host);
+  return { program, sourceFile: program.getSourceFile("/test.ts")! };
+}
+
+function findArrow(
+  sourceFile: ts.SourceFile,
+  variableName: string,
+): ts.ArrowFunction {
+  let cb: ts.ArrowFunction | undefined;
+  const visit = (node: ts.Node): void => {
+    if (cb) return;
+    if (
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+      node.name.text === variableName && node.initializer &&
+      ts.isArrowFunction(node.initializer)
+    ) {
+      cb = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!cb) throw new Error(`Expected arrow function '${variableName}'.`);
+  return cb;
+}
+
+function analyze(
+  source: string,
+  name = "fn",
+  opts: { interprocedural?: boolean } = {},
+) {
+  const { program, sourceFile } = createProgram(source);
+  return analyzeFunctionCapabilities(
+    findArrow(sourceFile, name),
+    {
+      checker: program.getTypeChecker(),
+      interprocedural: opts.interprocedural,
+    },
+  );
+}
+
+// Analyze without a type checker (many branches gate on `!checker`).
+function analyzeNoChecker(source: string, name = "fn") {
+  const { sourceFile } = createProgram(source);
+  return analyzeFunctionCapabilities(findArrow(sourceFile, name));
+}
+
+function getPaths(
+  summary: ReturnType<typeof analyzeFunctionCapabilities>,
+  name: string,
+) {
+  const p = summary.params.find((entry) => entry.name === name);
+  if (!p) throw new Error(`Missing parameter summary for '${name}'.`);
+  return {
+    capability: p.capability,
+    readPaths: p.readPaths.map((x) => x.join(".")),
+    writePaths: p.writePaths.map((x) => x.join(".")),
+    wildcard: p.wildcard,
+    passthrough: p.passthrough,
+    identityOnly: !!p.identityOnly,
+    identityPaths: (p.identityPaths ?? []).map((x) => x.join(".")),
+    identityCellPaths: (p.identityCellPaths ?? []).map((x) => x.join(".")),
+    comparablePaths: (p.comparablePaths ?? []).map((x) => x.join(".")),
+    opaquePaths: (p.opaquePaths ?? []).map((x) => x.join(".")),
+  };
+}
+
+const CELL = `declare const CELL_BRAND: unique symbol;
+type Cell<T> = {
+  readonly [CELL_BRAND]: "cell";
+  get(): T;
+  set(value: T): void;
+  update(value: Partial<T>): void;
+  push(...items: unknown[]): number;
+  removeAll(): void;
+  splice(start: number, count: number, ...items: unknown[]): unknown[];
+  map<U>(fn: (v: unknown) => U): U[];
+  filter(fn: (v: unknown) => boolean): unknown[];
+  flatMap<U>(fn: (v: unknown) => U): U[];
+  equals(other: unknown): boolean;
+  equalLinks(other: unknown): boolean;
+  key(...segments: (string | number)[]): Cell<unknown>;
+};`;
+
+Deno.test("writer method set() marks the receiver path writeonly", () => {
+  const input = getPaths(
+    analyze(`${CELL}
+      const fn = (input: Cell<{ n: number }>) => { input.set({ n: 1 }); };`),
+    "input",
+  );
+  assertEquals(input.capability, "writeonly");
+  assert(input.writePaths.includes(""));
+  assertEquals(input.readPaths.length, 0);
+});
+
+Deno.test("writer method update() marks the receiver path writeonly", () => {
+  const input = getPaths(
+    analyze(`${CELL}
+      const fn = (input: Cell<{ n: number }>) => { input.update({ n: 2 }); };`),
+    "input",
+  );
+  assertEquals(input.capability, "writeonly");
+  assert(input.writePaths.includes(""));
+});
+
+Deno.test("reader method get() records a read of the receiver path", () => {
+  const input = getPaths(
+    analyze(`${CELL}
+      const fn = (input: Cell<{ n: number }>) => input.get();`),
+    "input",
+  );
+  assertEquals(input.capability, "readonly");
+  assert(input.readPaths.includes(""));
+});
+
+Deno.test(
+  "get() chained into a member access records the narrowed path, not a blanket read",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: Cell<{ meta: { size: number } }>) =>
+          input.get().meta.size;`),
+      "input",
+    );
+    assertEquals(input.capability, "readonly");
+    assert(input.readPaths.includes("meta.size"));
+    assert(!input.readPaths.includes(""));
+  },
+);
+
+Deno.test(
+  "array identity writer push() writes the receiver and reads a tracked argument element",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { row: { id: string } }, list: Cell<unknown[]>) => {
+          list.push(input.row);
+        };`),
+      "input",
+    );
+    // The pushed argument is read at its path.
+    assert(input.readPaths.includes("row"));
+  },
+);
+
+Deno.test("removeAll() over a tracked cell writes the receiver path", () => {
+  const list = getPaths(
+    analyze(`${CELL}
+      const fn = (list: Cell<unknown[]>) => { list.removeAll(); };`),
+    "list",
+  );
+  assertEquals(list.capability, "writeonly");
+  assert(list.writePaths.includes(""));
+});
+
+Deno.test(
+  "splice() only reads inserted items (index >= 2), not the start/count args",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { item: { id: string } }, list: Cell<unknown[]>) => {
+          list.splice(0, 1, input.item);
+        };`),
+      "input",
+    );
+    assert(input.readPaths.includes("item"));
+  },
+);
+
+Deno.test(
+  "opaque derivation map() over a tracked field records an opaque path, not a read",
+  () => {
+    // Without a checker the OPAQUE_DERIVATION branch fires unconditionally, so
+    // the field is recorded as an opaque path rather than a structural read.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => input.items.map((x) => x + 1);`,
+      ),
+      "input",
+    );
+    assert(input.opaquePaths.includes("items"));
+    assertEquals(input.readPaths.includes("items"), false);
+  },
+);
+
+Deno.test(
+  "opaque derivation filter() over the whole root marks the root opaque",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => input.filter((x) => x > 0);`,
+      ),
+      "input",
+    );
+    // Whole-root opaque use: no reads/writes recorded, capability opaque.
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.readPaths.length, 0);
+  },
+);
+
+Deno.test("equals() over a tracked field records a comparable identity path", () => {
+  // Without a checker the equals-callee recognition treats any `.equals`
+  // property access as the known identity comparison.
+  const input = getPaths(
+    analyzeNoChecker(
+      `const fn = (input, other) => input.a.equals(other);`,
+    ),
+    "input",
+  );
+  assert(input.comparablePaths.includes("a"));
+  assert(input.identityPaths.includes("a"));
+});
+
+Deno.test(
+  "equalLinks() over a tracked field records a comparable identity path",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, other) => input.a.equalLinks(other);`,
+      ),
+      "input",
+    );
+    assert(input.comparablePaths.includes("a"));
+  },
+);
+
+Deno.test("key() with static string segment reads the composed path", () => {
+  const input = getPaths(
+    analyze(`${CELL}
+      const fn = (input: Cell<{ sub: number }>) => input.key("sub");`),
+    "input",
+  );
+  assert(input.readPaths.includes("sub"));
+});
+
+Deno.test("key() with a dynamic segment widens the receiver to wildcard", () => {
+  const input = getPaths(
+    analyze(`${CELL}
+      const fn = (input: Cell<Record<string, number>>, k: string) =>
+        input.key(k);`),
+    "input",
+  );
+  assertEquals(input.wildcard, true);
+});
+
+Deno.test(
+  "key() chained into a member access defers the read to the member handler",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: Cell<{ sub: { n: number } }>) =>
+          input.key("sub").get();`),
+      "input",
+    );
+    // The key() itself is chained, so it records the composed path via the
+    // member/get handler rather than a blanket key read.
+    assert(input.readPaths.some((p) => p.includes("sub")));
+  },
+);
+
+Deno.test("numeric element access records a numeric path segment", () => {
+  const input = getPaths(
+    analyzeNoChecker(`const fn = (input) => input.items[0].name;`),
+    "input",
+  );
+  assert(input.readPaths.includes("items.0.name"));
+});
+
+Deno.test(
+  "template-literal element access records the literal path segment",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker("const fn = (input) => input[`field`];"),
+      "input",
+    );
+    assert(input.readPaths.includes("field"));
+  },
+);
+
+Deno.test(
+  "dynamic element access marks the receiver root as wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(`const fn = (input, k) => input[k];`),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "object destructure with a computed key name marks the root wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k) => { const { [k]: v } = input; return v; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "object destructure rest element widens the root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const { a, ...rest } = input; return rest; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "array binding pattern destructure widens the source root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const [first] = input.items; return first; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "assignment-pattern object destructure tracks per-property reads",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let a, b; ({ a, b } = input); return a + b; };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a"));
+    assert(input.readPaths.includes("b"));
+  },
+);
+
+Deno.test(
+  "assignment-pattern object spread widens the source root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let a, r; ({ a, ...r } = input); return r; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "assignment-pattern array destructure widens the source root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let a; ([a] = input.list); return a; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test("alias chain across reassignments follows the latest source", () => {
+  const input = getPaths(
+    analyzeNoChecker(
+      `const fn = (input) => {
+        let cur = input.a;
+        cur = input.b;
+        return cur.name;
+      };`,
+    ),
+    "input",
+  );
+  assert(input.readPaths.includes("b.name"));
+});
+
+Deno.test("for-in over a tracked expression widens the root to wildcard", () => {
+  const input = getPaths(
+    analyzeNoChecker(
+      `const fn = (input) => { for (const k in input.map) { k; } };`,
+    ),
+    "input",
+  );
+  assertEquals(input.wildcard, true);
+});
+
+Deno.test(
+  "for-of over a tracked array reads the element path via the iterator binding",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          for (const item of input.list) { item.id; }
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("list.0.id"));
+  },
+);
+
+Deno.test(
+  "for-of over the whole root marks the root passthrough",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { for (const item of input) { item; } };`,
+      ),
+      "input",
+    );
+    assertEquals(input.passthrough, true);
+  },
+);
+
+Deno.test(
+  "fallback with ?? between equal aliases keeps the shared path",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          const v = input.a ?? input.a;
+          return v.name;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a.name"));
+  },
+);
+
+Deno.test(
+  "fallback with || between differing aliases drops to the left source",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          const v = input.a || input.b;
+          return v;
+        };`,
+      ),
+      "input",
+    );
+    // Both operands are read as passthrough sources.
+    assert(input.readPaths.includes("a") || input.readPaths.includes("b"));
+  },
+);
+
+Deno.test(
+  "navigateTo() over a whole tracked root records an identity-only passthrough",
+  () => {
+    // Without a checker the navigateTo callee is recognized by name. Passing
+    // the whole root avoids a member read, so the root is identity-preserving
+    // and passthrough rather than structurally read.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { navigateTo(input); };`,
+      ),
+      "input",
+    );
+    assertEquals(input.passthrough, true);
+    assertEquals(input.identityOnly, true);
+    assert(input.identityPaths.includes(""));
+  },
+);
+
+Deno.test(
+  "prefix increment over a tracked member both reads and writes it",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(`const fn = (input) => { ++input.count; };`),
+      "input",
+    );
+    assert(input.readPaths.includes("count"));
+    assert(input.writePaths.includes("count"));
+  },
+);
+
+Deno.test(
+  "spread of a tracked member into an array literal reads the member",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const merged = [...input.items]; return merged; };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("items"));
+  },
+);
+
+Deno.test(
+  "object spread assignment of a tracked member widens the root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const merged = { ...input }; return merged; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "interprocedural helper reading a param field propagates the read path",
+  () => {
+    const input = getPaths(
+      analyze(
+        `const helper = (v: { user: { name: string } }) => v.user.name;
+         const fn = (input: { user: { name: string } }) => helper(input);`,
+        "fn",
+        { interprocedural: true },
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("user.name"));
+  },
+);
+
+Deno.test(
+  "interprocedural helper that writes a param field propagates the write path",
+  () => {
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        const helper = (v: { a: Cell<number> }) => { v.a.set(1); };
+        const fn = (input: { a: Cell<number> }) => helper(input);`,
+        "fn",
+        {
+          interprocedural: true,
+        },
+      ),
+      "input",
+    );
+    assert(input.writePaths.includes("a"));
+  },
+);
+
+Deno.test(
+  "unknown method call over a tracked field reads that field",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => input.helper.doThing();`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.some((p) => p.startsWith("helper")));
+  },
+);
+
+Deno.test(
+  "passing a tracked root as a plain call argument widens it to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { doThing(input); };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+// --- Batch 2: checker-gated and shape-specific branches ---------------------
+
+Deno.test(
+  "numeric destructure key records a numeric path segment",
+  () => {
+    // getStaticPropertyKeyText resolves a NumericLiteral property name.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const { 0: first } = input; return first; };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("0"));
+  },
+);
+
+Deno.test(
+  "template-literal destructure key records the literal path segment",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        "const fn = (input) => { const { [`sub`]: v } = input; return v; };",
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("sub"));
+  },
+);
+
+Deno.test(
+  "element-access with a bracketed string method reads the composed path",
+  () => {
+    // getCallReceiverFromExpression / getCallMethodName over an
+    // ElementAccessExpression callee (input.a["get"]()).
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { a: Cell<{ n: number }> }) => input.a["get"]();`),
+      "input",
+    );
+    assert(input.readPaths.includes("a"));
+  },
+);
+
+Deno.test(
+  "equals() addressed via bracket notation records a comparable path",
+  () => {
+    // isKnownIdentityEqualsCallee over an ElementAccessExpression callee.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { a: Cell<number> }, other: Cell<number>) =>
+          input.a["equals"](other);`),
+      "input",
+    );
+    assert(input.comparablePaths.includes("a"));
+  },
+);
+
+Deno.test(
+  "?? fallback between two equal object-shape aliases keeps the shared read",
+  () => {
+    // aliasBindingEquals recurses over AliasShape properties, and both operands
+    // build the identical shape { u: input.a }.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          const left = { u: input.a };
+          const right = { u: input.a };
+          const v = left ?? right;
+          return v.u.name;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a.name"));
+  },
+);
+
+Deno.test(
+  "object literal alias with a computed non-static key drops that property",
+  () => {
+    // buildAliasBindingFromExpression skips the non-static computed key, so the
+    // shape alias only carries the statically-keyed property.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k) => {
+          const shape = { [k]: input.a, b: input.b };
+          return shape.b;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("b"));
+    assertEquals(input.wildcard, false);
+  },
+);
+
+Deno.test(
+  "renamed object destructure records the source property, not the alias name",
+  () => {
+    // assignParameterBindingAlias resolves element.propertyName via
+    // getStaticPropertyKeyText and extends the source ref by that key.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const { user: u } = input; return u.name; };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("user.name"));
+  },
+);
+
+Deno.test(
+  "nested destructure with a default initializer widens the root to wildcard",
+  () => {
+    // The binding element carries an initializer, taking the
+    // dotDotDotToken/initializer branch that marks the source root wildcard.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const { a = 1 } = input; return a; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "find() truthiness check on the element result records no payload read",
+  () => {
+    // The element-result alias in a boolean condition (isBooleanConditionUsage)
+    // is presence-only, so no structural read of the element is recorded.
+    const input = getPaths(
+      analyze(`${CELL}
+        interface Array<T> { find(p: (v: T) => boolean): T | undefined; }
+        const fn = (input: { list: { flag: boolean }[] }) => {
+          const found = input.list.find((x) => x.flag);
+          if (found) { return 1; }
+          return 0;
+        };`),
+      "input",
+    );
+    // The list is read structurally (find scans it) but the found element's
+    // payload is not required by the presence check alone.
+    assert(input.readPaths.some((p) => p.startsWith("list")));
+    assertEquals(input.wildcard, false);
+  },
+);
+
+Deno.test(
+  "optional-presence alias truthiness check keeps the property presence-only",
+  () => {
+    // A non-primitive optional member used only in a truthiness check records
+    // presence, not the payload shape (the isBooleanConditionUsage skip).
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { maybe?: { n: number } }) => {
+          const opt = input?.maybe;
+          if (!opt) { return 0; }
+          return 1;
+        };`),
+      "input",
+    );
+    assertEquals(input.wildcard, false);
+  },
+);
+
+Deno.test(
+  "increment through a nested member both reads and writes the deep path",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(`const fn = (input) => { input.a.count++; };`),
+      "input",
+    );
+    assert(input.readPaths.includes("a.count"));
+    assert(input.writePaths.includes("a.count"));
+  },
+);
+
+Deno.test(
+  "compound assignment to a tracked member both reads and writes it",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(`const fn = (input) => { input.count += 1; };`),
+      "input",
+    );
+    assert(input.readPaths.includes("count"));
+    assert(input.writePaths.includes("count"));
+  },
+);
+
+Deno.test(
+  "for-of over a dynamic member widens the iterable root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k) => { for (const x of input[k]) { x; } };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "for-of with an object destructure binding reads the destructured field",
+  () => {
+    // The for-of initializer is a variable declaration list whose binding is a
+    // destructure, driving assignBindingAlias against the element binding.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          for (const { id } of input.list) { id; }
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.some((p) => p.startsWith("list")));
+  },
+);
+
+Deno.test(
+  "for-of with an assignment-target initializer aliases the element binding",
+  () => {
+    // The for-of initializer is an expression (not a declaration list), taking
+    // the assignExpressionPatternAlias branch inside the loop scope.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          let item;
+          for (item of input.list) { item.id; }
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.some((p) => p.startsWith("list")));
+  },
+);
+
+Deno.test(
+  "aliases resolved through a for-of scope are restored after the loop",
+  () => {
+    // aliasesWithSpecificPaths and the alias maps are saved before the loop and
+    // restored after, so a post-loop read keeps its specific path.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          const shape = { u: input.user };
+          for (const item of input.list) { item.id; }
+          return shape.u.name;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("user.name"));
+    assert(input.readPaths.some((p) => p.startsWith("list")));
+  },
+);
+
+Deno.test(
+  "interprocedural helper opaque field propagates an opaque path to caller",
+  () => {
+    // The callee derives from a cell field via map(); its opaquePaths summary
+    // is replayed onto the caller argument's path.
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        const helper = (v: { items: Cell<number[]> }) => v.items.map(() => 1);
+        const fn = (input: { items: Cell<number[]> }) => helper(input);`,
+        "fn",
+        {
+          interprocedural: true,
+        },
+      ),
+      "input",
+    );
+    assert(input.opaquePaths.includes("items"));
+  },
+);
+
+Deno.test(
+  "interprocedural helper comparable field propagates a comparable path",
+  () => {
+    // The callee compares a cell field with equals(); the comparable path is
+    // replayed onto the caller argument.
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        const helper = (v: { a: Cell<number> }, o: Cell<number>) =>
+          v.a.equals(o);
+        const fn = (input: { a: Cell<number> }, rhs: Cell<number>) =>
+          helper(input, rhs);`,
+        "fn",
+        { interprocedural: true },
+      ),
+      "input",
+    );
+    assert(input.comparablePaths.includes("a"));
+  },
+);
+
+Deno.test(
+  "interprocedural helper reading a param field via dynamic arg widens caller",
+  () => {
+    // The caller passes a dynamic member as the argument, so the propagation
+    // loop widens the whole root to wildcard.
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        const helper = (v: { user: { name: string } }) => v.user.name;
+        const fn = (input: { items: { user: { name: string } }[] }, k: number) =>
+          helper(input.items[k]);`,
+        "fn",
+        { interprocedural: true },
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "destructured parameter uses a synthetic positional summary name",
+  () => {
+    // A non-identifier parameter name yields a `${PARAMETER_SUMMARY_PREFIX}i`
+    // summary name in the final param loop.
+    const summary = analyze(`${CELL}
+      const fn = ({ a }: { a: { n: number } }) => a.n;`);
+    assert(summary.params.length >= 1);
+    assert(summary.params.some((p) => p.readPaths.length > 0));
+  },
+);
+
+// --- Batch 3: assignment patterns, opaque roots, method dispatch edges ------
+
+Deno.test(
+  "parenthesized assignment destructure target treats the source as passthrough",
+  () => {
+    // assignExpressionPatternAlias unwraps a ParenthesizedExpression pattern;
+    // the whole tracked root flows through as a passthrough assignment source.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let a; (({ a }) = input); return a; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.passthrough, true);
+  },
+);
+
+Deno.test(
+  "renamed property in an assignment destructure records the source key",
+  () => {
+    // The property-assignment branch resolves the static key and reads it.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let x; ({ a: x } = input); return x; };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a"));
+  },
+);
+
+Deno.test(
+  "computed key in an assignment destructure widens the source root",
+  () => {
+    // A non-static computed key in the assignment target has no resolvable key,
+    // so the source root is widened to wildcard.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k) => { let x; ({ [k]: x } = input); return x; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "nested array destructure inside an assignment target ignores its elements",
+  () => {
+    // The array-literal assignment pattern marks the source-ref root wildcard
+    // and then descends into elements with an undefined source.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let a; ([a] = input.list); return a; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "assignment destructure from an untracked source records no reads",
+  () => {
+    // With an undefined source binding, the object-assignment branch clears
+    // aliases without recording reads against the tracked parameter.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          input.touch;
+          let a;
+          ({ a } = external);
+          return a;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("touch"));
+  },
+);
+
+Deno.test(
+  "splice inserts only track arguments at or after the third position",
+  () => {
+    // isArrayIdentityWriterValueArgument requires index >= 2 for splice, so the
+    // start/count arguments are not treated as inserted identity items.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (
+          input: { start: number; item: { id: string } },
+          list: Cell<unknown[]>,
+        ) => {
+          list.splice(input.start, 1, input.item);
+        };`),
+      "input",
+    );
+    assert(input.readPaths.includes("start"));
+    assert(input.readPaths.includes("item"));
+  },
+);
+
+Deno.test(
+  "constructing with a tracked root argument treats it as passthrough",
+  () => {
+    // isCallOrNewArgumentUsage recognizes NewExpression arguments, so the whole
+    // root flows through as a passthrough rather than a structural read.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { const w = new Wrapper(input); return w; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.passthrough, true);
+  },
+);
+
+Deno.test(
+  "method-less call over a tracked field reads its full shape",
+  () => {
+    // A call whose callee resolves conservatively (no method name) tracks a
+    // full-shape read of the receiver.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { fns: (() => number)[] }) => input.fns[0]();`),
+      "input",
+    );
+    assert(input.readPaths.some((p) => p.startsWith("fns")));
+  },
+);
+
+Deno.test(
+  "elementById() over a tracked collection widens the collection root",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        interface Array<T> { elementById(id: string): T; }
+        const fn = (input: { rows: { id: string }[] }) =>
+          input.rows.elementById("x");`),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "interprocedural identity propagation through a dynamic arg widens the root",
+  () => {
+    // The callee records an identity path on its parameter; the caller passes a
+    // dynamic member, so identity propagation widens the whole root.
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        const helper = (v: Cell<number>, o: Cell<number>) => v.equals(o);
+        const fn = (
+          input: { cells: Cell<number>[] },
+          rhs: Cell<number>,
+          k: number,
+        ) => helper(input.cells[k], rhs);`,
+        "fn",
+        { interprocedural: true },
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "interprocedural whole-root equals helper leaves the caller opaque passthrough",
+  () => {
+    // The callee's parameter is comparable-and-passthrough (equals over the
+    // whole cell). Propagating that whole-root identity summary back leaves the
+    // caller argument opaque and passthrough rather than structurally read.
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        const helper = (v: Cell<number>, o: Cell<number>) => v.equals(o);
+        const fn = (input: Cell<number>, rhs: Cell<number>) =>
+          helper(input, rhs);`,
+        "fn",
+        { interprocedural: true },
+      ),
+      "input",
+    );
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.passthrough, true);
+    assertEquals(input.readPaths.length, 0);
+  },
+);
+
+// --- Batch 4: aliased identity-writer args, nested patterns, dynamic calls --
+
+Deno.test(
+  "aliased local pushed into a cell writer is read at its aliased path",
+  () => {
+    // An identifier argument to push() routes through the identity-writer
+    // argument recognition (isArrayIdentityWriterValueArgument).
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { row: { id: string } }, list: Cell<unknown[]>) => {
+          const it = input.row;
+          list.push(it);
+        };`),
+      "input",
+    );
+    assert(input.readPaths.includes("row"));
+  },
+);
+
+Deno.test(
+  "aliased local at splice insert position is read at its aliased path",
+  () => {
+    // splice only treats arguments at index >= 2 as inserted items.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { item: { id: string } }, list: Cell<unknown[]>) => {
+          const it = input.item;
+          list.splice(0, 1, it);
+        };`),
+      "input",
+    );
+    assert(input.readPaths.includes("item"));
+  },
+);
+
+Deno.test(
+  "parenthesized property target inside an assignment destructure is handled",
+  () => {
+    // The property initializer is itself parenthesized, driving the
+    // ParenthesizedExpression branch of assignExpressionPatternAlias.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let x; ({ a: (x) } = input); return x; };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a"));
+  },
+);
+
+Deno.test(
+  "array destructure assignment with a rest element skips the spread slot",
+  () => {
+    // The array-literal assignment pattern marks the source root wildcard and
+    // continues past the spread element.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => { let a, r; ([a, ...r] = input.list); return a; };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "assignment destructure from an untracked source clears nested aliases",
+  () => {
+    // With an undefined source, the object-assignment branch recurses into a
+    // property initializer to clear its alias without recording a read.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          input.keep;
+          let x;
+          ({ a: x } = external);
+          return x;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("keep"));
+  },
+);
+
+Deno.test(
+  "call through a dynamically-indexed method reads the receiver conservatively",
+  () => {
+    // getCallMethodName returns undefined for a dynamic element-access callee,
+    // so the method-less call branch reads the conservative receiver path.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k) => { input.handlers[k](); };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("handlers"));
+    assertEquals(input.wildcard, false);
+  },
+);
+
+// --- Batch 5: shape equality, dynamic markers, identity array items ---------
+
+Deno.test(
+  "?? fallback between differently-shaped aliases keeps both source reads",
+  () => {
+    // aliasBindingEquals compares the two shapes, finds a size mismatch, and
+    // resolveBinding drops the merged shape so both branches read their source.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          const left = { u: input.a };
+          const right = { u: input.a, v: input.b };
+          const v = left ?? right;
+          return v;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a"));
+    assert(input.readPaths.includes("b"));
+  },
+);
+
+Deno.test(
+  "?? fallback between equal-size but differing-value shapes drops the merge",
+  () => {
+    // Equal property counts but a differing property value exercises the
+    // recursive value comparison inside aliasBindingEquals.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+          const left = { u: input.a };
+          const right = { u: input.b };
+          const v = left ?? right;
+          return v;
+        };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("a"));
+    assert(input.readPaths.includes("b"));
+  },
+);
+
+Deno.test(
+  "increment through a dynamic member widens the root to wildcard",
+  () => {
+    // markFromExpression resolves a dynamic ref and widens the whole root.
+    const input = getPaths(
+      analyzeNoChecker(`const fn = (input, k) => { input.counts[k]++; };`),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "identity-tracked local spread into a set payload records identity item paths",
+  () => {
+    // A local array built by spreading a tracked element and passed to set()
+    // records identity (not structural) paths for that element's source.
+    const input = getPaths(
+      analyze(
+        `${CELL}
+        interface Array<T> { push(...items: T[]): number; }
+        declare const external: unknown[];
+        const fn = (
+          input: { piece?: { title: string } },
+          state: { items: Cell<unknown[]> },
+        ) => {
+          const piece = input?.piece;
+          if (!piece) return;
+          const updated = [...external, piece];
+          state.items.set(updated);
+        };`,
+        "fn",
+        { interprocedural: true },
+      ),
+      "input",
+    );
+    assert(input.identityPaths.includes("piece"));
+    assert(input.identityCellPaths.includes("piece"));
+  },
+);
+
+// --- Batch 6: whole-root identity, array-item identity, param array binding --
+
+Deno.test(
+  "equals() over the whole tracked root records a root comparable passthrough",
+  () => {
+    // markIdentityUseRef with a zero-length path records a root comparable path
+    // and marks the root passthrough identity-only.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, other) => input.equals(other);`,
+      ),
+      "input",
+    );
+    assertEquals(input.capability, "comparable");
+    assert(input.comparablePaths.includes(""));
+    assertEquals(input.passthrough, true);
+  },
+);
+
+Deno.test(
+  "equals() over a dynamic member widens the receiver root to wildcard",
+  () => {
+    // markIdentityUseRef short-circuits to wildcard for a dynamic ref.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k, other) => input.cells[k].equals(other);`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+Deno.test(
+  "pushing a previously identity-compared element marks the array item identity",
+  () => {
+    // A push argument that already has a recorded identity use drives
+    // markArrayItemIdentityUseRef, recording an element identity path on the
+    // receiver array (its item slot "0").
+    const list = getPaths(
+      analyze(`${CELL}
+        const fn = (
+          input: Cell<number>,
+          other: Cell<number>,
+          list: Cell<unknown[]>,
+        ) => {
+          input.equals(other);
+          list.push(input);
+        };`),
+      "list",
+    );
+    assert(list.identityPaths.includes("0"));
+  },
+);
+
+Deno.test(
+  "array-binding parameter destructure widens the parameter root to wildcard",
+  () => {
+    // assignParameterBindingAlias marks the source root wildcard for an
+    // array-binding-pattern parameter.
+    const summary = analyzeNoChecker(
+      `const fn = ([first, second]) => first + second;`,
+    );
+    const p = summary.params[0];
+    assert(p);
+    assertEquals(p.wildcard, true);
+  },
+);
+
+// --- Batch 7: key() wrapper unwrapping, identity-only aliased arguments ------
+
+Deno.test(
+  "key() call wrapped in parentheses then chained still defers to member access",
+  () => {
+    // unwrapExpressionUsageSite unwraps the parenthesized key() result to see
+    // it is chained into a further member access, so no blanket key read fires.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: Cell<{ sub: { n: number } }>) =>
+          (input.key("sub")).get();`),
+      "input",
+    );
+    assert(input.readPaths.some((p) => p.includes("sub")));
+  },
+);
+
+Deno.test(
+  "equals() over an aliased dynamic path records identity without a read",
+  () => {
+    // An aliased dynamic member passed to equals() is an identity-only argument;
+    // the dynamic ref widens the root rather than recording a structural read.
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, other, k) => {
+          const a = input.cells[k];
+          return a.equals(other);
+        };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+// --- Batch 8: get()-chain specific paths restored across a for-of loop ------
+
+Deno.test(
+  "get()-chain specific-path aliases survive a for-of scope and stay narrowed",
+  () => {
+    // A `.get()`-resolved alias with a specific property path is saved before a
+    // for-of loop opens a nested scope and restored after it closes, so the
+    // post-loop read keeps its narrowed path rather than a blanket read.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (
+          input: { notes: Cell<{ list: { length: number } }>; items: number[] },
+        ) => {
+          const notes = input.notes;
+          const before = notes.get().list.length;
+          for (const it of input.items) {
+            it;
+          }
+          return notes.get().list.length + before;
+        };`),
+      "input",
+    );
+    assert(input.readPaths.includes("notes.list.length"));
+    assert(input.readPaths.some((p) => p.startsWith("items")));
+    assertEquals(input.wildcard, false);
+  },
+);

--- a/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
@@ -1,0 +1,307 @@
+import ts from "typescript";
+import { assert, assertEquals } from "@std/assert";
+import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
+
+// These tests drive `analyzeFunctionCapabilities` through interprocedural
+// propagation and local-collection identity tracking. Those paths run today
+// only as a side effect of patterns compiling through the transformer in the
+// CI pattern-integration jobs; the cases here bring them under unit coverage.
+
+function createProgram(
+  source: string,
+): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const files: Record<string, string> = { "/test.ts": source };
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files[name] !== undefined,
+    readFile: (name) => files[name],
+    directoryExists: () => true,
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => "/",
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "lib.d.ts",
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+    getSourceFile: (name, lv) =>
+      files[name] !== undefined
+        ? ts.createSourceFile(name, files[name]!, lv, true, ts.ScriptKind.TS)
+        : undefined,
+  };
+  const program = ts.createProgram(["/test.ts"], options, host);
+  return { program, sourceFile: program.getSourceFile("/test.ts")! };
+}
+
+function findArrow(
+  sourceFile: ts.SourceFile,
+  variableName: string,
+): ts.ArrowFunction {
+  let cb: ts.ArrowFunction | undefined;
+  const visit = (node: ts.Node): void => {
+    if (cb) return;
+    if (
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+      node.name.text === variableName && node.initializer &&
+      ts.isArrowFunction(node.initializer)
+    ) {
+      cb = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!cb) throw new Error(`Expected arrow function '${variableName}'.`);
+  return cb;
+}
+
+function analyze(source: string, name = "fn") {
+  const { program, sourceFile } = createProgram(source);
+  const summary = analyzeFunctionCapabilities(
+    findArrow(sourceFile, name),
+    { checker: program.getTypeChecker(), interprocedural: true },
+  );
+  return summary;
+}
+
+function getPaths(
+  summary: ReturnType<typeof analyzeFunctionCapabilities>,
+  name: string,
+) {
+  const p = summary.params.find((entry) => entry.name === name);
+  if (!p) throw new Error(`Missing parameter summary for '${name}'.`);
+  return {
+    capability: p.capability,
+    readPaths: p.readPaths.map((x) => x.join(".")),
+    writePaths: p.writePaths.map((x) => x.join(".")),
+    wildcard: p.wildcard,
+    passthrough: p.passthrough,
+    identityOnly: !!p.identityOnly,
+    identityPaths: (p.identityPaths ?? []).map((x) => x.join(".")),
+    identityCellPaths: (p.identityCellPaths ?? []).map((x) => x.join(".")),
+    comparablePaths: (p.comparablePaths ?? []).map((x) => x.join(".")),
+  };
+}
+
+const CELL = `declare const CELL_BRAND: unique symbol;
+type Cell<T> = {
+  readonly [CELL_BRAND]: "cell";
+  set(value: T): void;
+  equals(other: Cell<T>): boolean;
+};`;
+
+Deno.test(
+  "interprocedural equals-only helper keeps caller argument identity-preserving",
+  () => {
+    // The callee compares its two parameters with `.equals()`, so neither
+    // parameter's structure is read. Propagating that summary back to the
+    // caller must leave `input` opaque and passthrough rather than reading it.
+    const input = getPaths(
+      analyze(`${CELL}
+        const helper = (value: Cell<{ n: string }>, other: Cell<{ n: string }>) =>
+          value.equals(other);
+        const fn = (input: Cell<{ n: string }>, rhs: Cell<{ n: string }>) =>
+          helper(input, rhs);`),
+      "input",
+    );
+
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.passthrough, true);
+    assertEquals(input.wildcard, false);
+    assertEquals(input.readPaths.length, 0);
+    assertEquals(input.writePaths.length, 0);
+  },
+);
+
+Deno.test(
+  "interprocedural helper that writes to its parameter marks caller writeonly",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const helper = (v: Cell<number>) => { v.set(1); };
+        const fn = (input: Cell<number>) => { helper(input); };`),
+      "input",
+    );
+
+    assertEquals(input.capability, "writeonly");
+    assert(input.writePaths.includes(""));
+    assertEquals(input.readPaths.length, 0);
+  },
+);
+
+Deno.test(
+  "interprocedural helper that reads a parameter field propagates the read path",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const helper = (v: { user: { name: string } }) => v.user.name;
+        const fn = (input: { user: { name: string } }) => helper(input);`),
+      "input",
+    );
+
+    assertEquals(input.capability, "readonly");
+    assertEquals(input.wildcard, false);
+    assert(input.readPaths.includes("user.name"));
+  },
+);
+
+Deno.test(
+  "optional call form over a tracked argument widens the argument to wildcard",
+  () => {
+    // `cb?.(input)` is a non-lowerable optional call, so the argument is
+    // treated conservatively as a whole-root use.
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { thing: number }, cb?: (x: unknown) => void) => {
+          cb?.(input);
+        };`),
+      "input",
+    );
+
+    assertEquals(input.wildcard, true);
+    assertEquals(input.passthrough, true);
+  },
+);
+
+Deno.test(
+  "array literal wrapped in an as-expression still yields an element read",
+  () => {
+    // The array-local element scan must unwrap the parenthesized/as wrappers
+    // around `[piece]` to attribute the read to `input.piece`.
+    const input = getPaths(
+      analyze(`${CELL}
+        declare const state: { items: Cell<Piece[]> };
+        type Piece = { title: string };
+        const fn = (input: { piece?: Piece }) => {
+          const piece = input?.piece;
+          if (!piece) return;
+          state.items.set(([piece]) as Piece[]);
+        };`),
+      "input",
+    );
+
+    assert(input.readPaths.includes("piece"));
+    assertEquals(input.wildcard, false);
+  },
+);
+
+Deno.test(
+  "spread of a tracked local array set payload records identity-cell paths",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        interface Array<T> { push(...items: T[]): number; }
+        declare const state: { items: Cell<Piece[]> };
+        declare const external: Piece[];
+        type Piece = { title: string };
+        const fn = (input: { piece?: Piece }) => {
+          const piece = input?.piece;
+          if (!piece) return;
+          const updated = [...external, piece];
+          state.items.set(updated);
+        };`),
+      "input",
+    );
+
+    assert(input.identityPaths.includes("piece"));
+    assert(input.identityCellPaths.includes("piece"));
+  },
+);
+
+Deno.test(
+  "object-shape and optional-presence aliases survive a for-of scope",
+  () => {
+    // A shape alias (`shape`) and an optional-presence alias (`opt`) are both
+    // live when a for-of loop opens a nested collection scope. The loop must
+    // restore them on exit so later reads keep their specific paths.
+    const input = getPaths(
+      analyze(`${CELL}
+        type Item = { id: string };
+        const fn = (input: {
+          user: { name: string };
+          maybe?: number;
+          list: Item[];
+        }) => {
+          const shape = { u: input.user };
+          const opt = input?.maybe;
+          if (!opt) return;
+          for (const item of input.list) {
+            item.id;
+          }
+          return shape.u.name + opt;
+        };`),
+      "input",
+    );
+
+    assertEquals(input.wildcard, false);
+    assert(input.readPaths.includes("user.name"));
+    assert(input.readPaths.includes("maybe"));
+    assert(input.readPaths.includes("list.0.id"));
+  },
+);
+
+Deno.test(
+  "equal object shapes pushed on both branches keep a stable local binding",
+  () => {
+    // Both branches push the identical shape `{ u: input.a }`, so the
+    // per-iteration binding compares equal and the read stays path-specific.
+    const input = getPaths(
+      analyze(`${CELL}
+        interface Array<T> { push(...items: T[]): number; }
+        declare const state: { items: Cell<Row[]> };
+        type Row = { u: X };
+        type X = { name: string };
+        const fn = (input: { a: X; list: { flag: boolean }[] }) => {
+          const collected: Row[] = [];
+          for (const item of input.list) {
+            if (item.flag) {
+              collected.push({ u: input.a });
+            } else {
+              collected.push({ u: input.a });
+            }
+          }
+          state.items.set(collected);
+        };`),
+      "input",
+    );
+
+    assertEquals(input.wildcard, false);
+    assert(input.readPaths.includes("a"));
+    assert(input.readPaths.includes("list.0.flag"));
+  },
+);
+
+Deno.test(
+  "differently shaped pushes on each branch still track both source fields",
+  () => {
+    // The two branches push shapes with different property sets, exercising the
+    // size-mismatch path of the alias-shape comparison.
+    const input = getPaths(
+      analyze(`${CELL}
+        interface Array<T> { push(...items: T[]): number; }
+        declare const state: { items: Cell<Row[]> };
+        type Row = { u: X; v?: X };
+        type X = { name: string };
+        const fn = (input: { a: X; b: X; list: { flag: boolean }[] }) => {
+          const collected: Row[] = [];
+          for (const item of input.list) {
+            if (item.flag) {
+              collected.push({ u: input.a });
+            } else {
+              collected.push({ u: input.a, v: input.b });
+            }
+          }
+          state.items.set(collected);
+        };`),
+      "input",
+    );
+
+    assertEquals(input.wildcard, false);
+    assert(input.readPaths.includes("a"));
+    assert(input.readPaths.includes("b"));
+  },
+);

--- a/packages/ts-transformers/test/schema-generator-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-generator-coverage.test.ts
@@ -1,0 +1,169 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+/**
+ * Drives the SchemaGeneratorTransformer end to end through the pipeline. Each
+ * test pins the emitted `toSchema<T>()` -> `{...} as const satisfies
+ * __cfHelpers.JSONSchema` literal for a shape that the existing schema tests do
+ * not exercise: non-finite and negative numeric literals, the write-authorized
+ * identity marker, the CFC UI-contract hint on boolean and object schemas, and
+ * the option-object value evaluator.
+ */
+
+async function schemaLiteral(source: string): Promise<string> {
+  const out = await transformSource(source, { types: COMMONFABRIC_TYPES });
+  const match = out.match(
+    /const s = [\s\S]*?satisfies __cfHelpers\.JSONSchema/,
+  );
+  assert(match, `no schema literal found in output:\n${out}`);
+  return match[0];
+}
+
+Deno.test("numeric-literal types lower to NaN, Infinity, -Infinity and negatives", async () => {
+  // NaN has no numeric-literal form (emitted as the global NaN), positive and
+  // negative infinity emit the Infinity identifier with an optional unary minus,
+  // and a negative literal emits a unary-minus wrapper around a positive value.
+  const literal = await schemaLiteral(`/// <cts-enable />
+import { toSchema } from "commonfabric";
+const enum E { NaNValue = 0 / 0 }
+interface C { big: 1e999; small: -1e999; neg: -7; tag: E.NaNValue; }
+const s = toSchema<C>({ maximum: E.NaNValue });
+export { s };
+`);
+  assertStringIncludes(literal, '"enum": [Infinity]');
+  assertStringIncludes(literal, '"enum": [-Infinity]');
+  assertStringIncludes(literal, '"enum": [-7]');
+  assertStringIncludes(literal, '"enum": [NaN]');
+  assertStringIncludes(literal, "maximum: NaN");
+});
+
+Deno.test("WriteAuthorizedBy attaches a writer-identity marker with file and path", async () => {
+  // The second type argument `typeof saver` is a simple identifier type-query,
+  // so the schema gains an `ifc.writeAuthorizedBy.__ctWriterIdentityOf` marker
+  // carrying the source file and the binding path.
+  const literal = await schemaLiteral(`/// <cts-enable />
+import { toSchema, WriteAuthorizedBy, handler } from "commonfabric";
+const saver = handler({}, {}, () => {});
+const s = toSchema<WriteAuthorizedBy<{ title: string }, typeof saver>>();
+export { s };
+`);
+  assertStringIncludes(literal, "writeAuthorizedBy");
+  assertStringIncludes(literal, "__ctWriterIdentityOf");
+  assertStringIncludes(literal, 'path: ["saver"]');
+  assertStringIncludes(literal, 'file: "/test.tsx"');
+});
+
+Deno.test("WriteAuthorizedBy with a qualified typeof binding attaches no marker", async () => {
+  // A qualified `typeof container.save` is not a plain identifier type-query, so
+  // the identity extraction bails and no writer-identity marker is emitted.
+  const literal = await schemaLiteral(`/// <cts-enable />
+import { toSchema, WriteAuthorizedBy } from "commonfabric";
+const container = { save() {} };
+const s = toSchema<WriteAuthorizedBy<{ title: string }, typeof container.save>>();
+export { s };
+`);
+  assertStringIncludes(literal, 'type: "object"');
+  assert(!literal.includes("writeAuthorizedBy"));
+});
+
+Deno.test("UI-contract hint attaches to an object $UI property schema", async () => {
+  // The `<UiAction>` in the UI slot records a hint that is grafted onto the
+  // generated $UI property schema's `ifc.uiContract`.
+  const out = await transformSource(
+    `/// <cts-enable />
+import { pattern, UI, UiAction } from "commonfabric";
+export default pattern<{ title: string }>((state) => ({
+  [UI]: <UiAction action="SubmitDirectCommand">Go</UiAction>,
+  title: state.title,
+}));
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  assertStringIncludes(out, "uiContract");
+  assertStringIncludes(out, '"UiAction"');
+  assertStringIncludes(out, '"SubmitDirectCommand"');
+});
+
+Deno.test("UI-contract hint wraps a boolean-true $UI property as an ifc-only schema", async () => {
+  // When the output type declares `[UI]: any`, the $UI property schema is the
+  // boolean `true`; attaching the contract turns it into `{ ifc: { uiContract }}`.
+  const out = await transformSource(
+    `/// <cts-enable />
+import { pattern, UI, UiAction } from "commonfabric";
+type Out = { title: string; [UI]: any };
+export default pattern<{ title: string }, Out>((state) => ({
+  [UI]: <UiAction action="SubmitDirectCommand">Go</UiAction>,
+  title: state.title,
+}));
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  assertStringIncludes(out, "$UI: {");
+  assertStringIncludes(out, "uiContract");
+  assertStringIncludes(out, '"SubmitDirectCommand"');
+});
+
+Deno.test("UI-contract hint on a whole boolean-true schema becomes an ifc-only schema", async () => {
+  // An `any` output type makes the whole generated schema the boolean `true`,
+  // so the contract is attached as `{ ifc: { uiContract } }` without a `not`.
+  const out = await transformSource(
+    `/// <cts-enable />
+import { pattern, UI, UiAction } from "commonfabric";
+export default pattern<{ title: string }, any>((state) => ({
+  [UI]: <UiAction action="SubmitDirectCommand">Go</UiAction>,
+  title: state.title,
+}));
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  assertStringIncludes(out, "uiContract");
+  assertStringIncludes(out, '"SubmitDirectCommand"');
+  assert(!out.includes("not: true"), `unexpected not:true in ${out}`);
+});
+
+Deno.test("UI-contract hint on a whole boolean-false schema negates via not:true", async () => {
+  // A `never` output type makes the whole generated schema the boolean `false`,
+  // so the contract is attached as `{ not: true, ifc: { uiContract } }`.
+  const out = await transformSource(
+    `/// <cts-enable />
+import { pattern, UI, UiAction } from "commonfabric";
+export default pattern<{ title: string }, never>((state) => ({
+  [UI]: <UiAction action="SubmitDirectCommand">Go</UiAction>,
+  title: state.title,
+}));
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  assertStringIncludes(out, "not: true");
+  assertStringIncludes(out, "uiContract");
+});
+
+Deno.test("toSchema option object evaluates literals, arrays, nested objects and constants", async () => {
+  // The options bag is spread onto the emitted schema; booleans, null, arrays,
+  // nested object literals and enum-constant references are all evaluated, while
+  // an undefined-valued option is dropped.
+  const literal = await schemaLiteral(`/// <cts-enable />
+import { toSchema } from "commonfabric";
+const enum E { V = 5 }
+interface C { value: number; }
+const s = toSchema<C>({
+  flagTrue: true,
+  flagFalse: false,
+  nothing: null,
+  undef: undefined,
+  list: [1, "a", true, null],
+  nested: { inner: 3, deep: { x: "y" } },
+  constant: E.V,
+});
+export { s };
+`);
+  assertStringIncludes(literal, "flagTrue: true");
+  assertStringIncludes(literal, "flagFalse: false");
+  assertStringIncludes(literal, "nothing: null");
+  assertStringIncludes(literal, 'list: [1, "a", true, null]');
+  assertStringIncludes(literal, "inner: 3");
+  assertStringIncludes(literal, 'x: "y"');
+  assertStringIncludes(literal, "constant: 5");
+  assert(!literal.includes("undef:"), "undefined option should be dropped");
+});

--- a/packages/ts-transformers/test/schema-injection-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-coverage.test.ts
@@ -1,0 +1,1046 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { transformSource, validateSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// Unit coverage for schema-injection.ts. These tests drive the whole
+// transformer pipeline with `/// <cts-enable />` pattern sources that exercise
+// specific schema shapes and builder call-site forms, then assert on the
+// emitted schema objects. The transformer injects generated JSON schemas at
+// pattern / handler / lift / toSchema / cell / wish / generateObject /
+// sqliteQuery call sites; the assertions below pin the concrete emitted schema
+// for each case (property types, `required` arrays, `asCell` markers, `$ref`
+// for VNode, default / optional handling, nested / array / tuple / union /
+// record shapes, scope markers, and so on).
+
+function t(source: string): Promise<string> {
+  return transformSource(source, { types: COMMONFABRIC_TYPES });
+}
+
+// ---------------------------------------------------------------------------
+// pattern<Input, Output> — property type schemas
+// ---------------------------------------------------------------------------
+
+Deno.test("pattern schema encodes primitive property types and a required array", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    "interface Input { name: string; count: number; ok: boolean; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.name as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'name: {\n            type: "string"');
+  assertStringIncludes(output, 'count: {\n            type: "number"');
+  assertStringIncludes(output, 'ok: {\n            type: "boolean"');
+  assertStringIncludes(output, 'required: ["name", "count", "ok"]');
+});
+
+Deno.test("pattern schema omits optional properties from the required array", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    "interface Input { a: string; b?: number; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.a as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  // `b` is present as a property but excluded from required.
+  assertStringIncludes(output, "b: {");
+  assertStringIncludes(output, 'required: ["a"]');
+  assertEquals(output.includes('required: ["a", "b"]'), false);
+});
+
+Deno.test("pattern schema encodes a Default<> wrapper as a JSON schema default", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, Default, UI, VNode } from "commonfabric";',
+    'interface Input { name: Default<string, "seed">; }',
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.name as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, '"default": "seed"');
+});
+
+Deno.test("pattern schema encodes array item types", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    "interface Input { tags: string[]; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.tags as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'type: "array"');
+  assertStringIncludes(output, 'items: {\n                type: "string"');
+});
+
+Deno.test("pattern schema encodes nested object shapes with their own required arrays", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    "interface Input { nested: { a: boolean; b: { c: string } }; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.nested as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'required: ["a", "b"]');
+  assertStringIncludes(output, 'required: ["c"]');
+});
+
+Deno.test("pattern schema encodes a Record<string, T> as additionalProperties", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    "interface Input { rec: Record<string, number>; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.rec as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(
+    output,
+    'additionalProperties: {\n                type: "number"',
+  );
+});
+
+Deno.test("pattern schema encodes a union as anyOf", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    'interface Input { u: "a" | "b" | number; }',
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.u as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "anyOf: [");
+  assertStringIncludes(output, '"enum": ["a", "b"]');
+});
+
+Deno.test("pattern output schema encodes a VNode UI slot as a $ref", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, UI, VNode } from "commonfabric";',
+    "interface Input { x: number; }",
+    "interface Output { [UI]: VNode; total: number; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: s.x as unknown as VNode, total: s.x }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(
+    output,
+    '$UI: {\n            $ref: "https://commonfabric.org/schemas/vnode.json"',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// handler — event/state schemas and asCell markers
+// ---------------------------------------------------------------------------
+
+Deno.test("handler<E, S> injects two schemas and marks a written Cell state field with asCell writeonly", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { handler, Cell } from "commonfabric";',
+    "export const h = handler<{ amount: number }, { total: Cell<number> }>(",
+    "  (event, ctx) => { ctx.total.set(event.amount); },",
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'amount: {\n            type: "number"');
+  // The state Cell is only written (.set), so the capability summary narrows
+  // the marker to writeonly rather than the read/write "cell".
+  assertStringIncludes(output, 'asCell: ["writeonly"]');
+});
+
+Deno.test("handler inline form injects the event schema from the annotated parameter", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { handler, Cell } from "commonfabric";',
+    "export const h = handler(",
+    "  (event: { label: string }, ctx: { out: Cell<string> }) => { ctx.out.set(event.label); },",
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'label: {\n            type: "string"');
+});
+
+// ---------------------------------------------------------------------------
+// lift — many call-site forms
+// ---------------------------------------------------------------------------
+
+Deno.test("lift<T, R> injects input and result schemas from type arguments", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const fn = lift<{ count: number }, string>((s) => `n:${s.count}`);",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'count: {\n            type: "number"');
+  assertStringIncludes(output, 'type: "string"');
+});
+
+Deno.test("lift<T> single type argument infers the result schema from the callback body", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const fn = lift<{ count: number }>((s) => s.count > 0);",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'count: {\n            type: "number"');
+  // result is boolean
+  assertStringIncludes(output, 'type: "boolean"');
+});
+
+Deno.test("lift inline form infers input and result schemas from annotations", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const fn = lift((s: { a: number }): number => s.a * 2);",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'a: {\n            type: "number"');
+});
+
+Deno.test("lift(toSchema<T>(), fn) transfers the authored input schema into the injected slot", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift, toSchema } from "commonfabric";',
+    "const fn = lift(toSchema<{ label: string }>(), undefined, (s) => s.label);",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'label: {\n            type: "string"');
+});
+
+// ---------------------------------------------------------------------------
+// cell(...) factory — value inference, scope, explicit type argument
+// ---------------------------------------------------------------------------
+
+Deno.test("cell(value) infers a widened schema from the seed value and injects it as the second argument", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell } from "commonfabric";',
+    "const c = cell(42);",
+  ].join("\n");
+  const output = await t(source);
+  // literal 42 is widened to number
+  assertStringIncludes(output, 'type: "number"');
+  assertEquals(output.includes('"enum": [42]'), false);
+});
+
+Deno.test("cell<T>() with an explicit type argument injects the T schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell } from "commonfabric";',
+    "const c = cell<{ name: string }>();",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'name: {\n            type: "string"');
+});
+
+// ---------------------------------------------------------------------------
+// wish(...) — schema injected as trailing argument
+// ---------------------------------------------------------------------------
+
+Deno.test("wish<T>() injects a schema argument for the wished type", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { wish } from "commonfabric";',
+    "const w = wish<{ answer: number }>();",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'answer: {\n            type: "number"');
+});
+
+// ---------------------------------------------------------------------------
+// generateObject — schema property injected into the options object
+// ---------------------------------------------------------------------------
+
+Deno.test("generateObject<T>({...}) injects a schema property into the existing options literal", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { generateObject } from "commonfabric";',
+    'const r = generateObject<{ title: string }>({ prompt: "hi" });',
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "schema:");
+  assertStringIncludes(output, "title: {\n");
+});
+
+// ---------------------------------------------------------------------------
+// sqliteQuery — rowSchema injected
+// ---------------------------------------------------------------------------
+
+Deno.test("sqliteQuery<Row>({...}) injects a rowSchema property from the Row type argument", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { sqliteQuery } from "commonfabric";',
+    "declare const db: any;",
+    'const q = sqliteQuery<{ id: number; name: string }>({ db, sql: "select 1" });',
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "rowSchema:");
+  assertStringIncludes(output, "id: {\n");
+  assertStringIncludes(output, "name: {\n");
+});
+
+// ---------------------------------------------------------------------------
+// Reactive conditionals: when / unless / ifElse prepend generated schemas
+// ---------------------------------------------------------------------------
+
+Deno.test("when(condition, value) prepends condition, value and result schemas", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, when, UI, VNode } from "commonfabric";',
+    "interface Input { flag: boolean; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: when(s.flag, s.flag) as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  // when is 2-arity; the rewrite prepends condition + value + result schemas,
+  // so three boolean schema literals appear ahead of the original arguments.
+  const boolSchemas = output.split('type: "boolean"').length - 1;
+  assert(boolSchemas >= 3, `expected >=3 boolean schemas, got ${boolSchemas}`);
+});
+
+Deno.test("unless(condition, value) prepends generated schemas ahead of the arguments", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, unless, UI, VNode } from "commonfabric";',
+    "interface Input { flag: boolean; label: string; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: unless(s.flag, s.label) as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "unless({");
+  // condition schema is boolean, value schema is string
+  assertStringIncludes(output, 'type: "boolean"');
+  assertStringIncludes(output, 'type: "string"');
+});
+
+Deno.test("ifElse(condition, ifTrue, ifFalse) prepends four schemas for its 3-arity form", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern, ifElse, UI, VNode } from "commonfabric";',
+    "interface Input { flag: boolean; a: number; b: number; }",
+    "interface Output { [UI]: VNode; }",
+    "export default pattern<Input, Output>((s) => ({ [UI]: ifElse(s.flag, s.a, s.b) as unknown as VNode }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "ifElse({");
+  // condition boolean + two number branches + number result = >=3 number schemas
+  const numSchemas = output.split('type: "number"').length - 1;
+  assert(numSchemas >= 3, `expected >=3 number schemas, got ${numSchemas}`);
+});
+
+// ---------------------------------------------------------------------------
+// lift-applied (derive) chains: object-literal input, direct projection
+// ---------------------------------------------------------------------------
+
+Deno.test("lift-applied object-literal input builds a schema from composed reactive cell types", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const a = lift((x: number) => x)(1);",
+    'const b = lift((x: string) => x)("s");',
+    "const combined = lift((snap) => `${snap.a}-${snap.b}`)({ a: a, b: b });",
+  ].join("\n");
+  const output = await t(source);
+  // The composed input schema recovers a: number and b: string from the
+  // upstream lift results rather than collapsing to unknown.
+  assertStringIncludes(output, "a: {\n");
+  assertStringIncludes(output, "b: {\n");
+  assertStringIncludes(output, 'type: "number"');
+  assertStringIncludes(output, 'type: "string"');
+});
+
+Deno.test("lift-applied direct property projection recovers the result schema from the input property", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const src = lift((x: { a: number; b: string }) => x)({ a: 1, b: "x" });',
+    "const proj = lift((y: { a: number; b: string }) => y.a)(src);",
+  ].join("\n");
+  const output = await t(source);
+  // The projection `y => y.a` recovers a number result schema.
+  assertStringIncludes(output, 'type: "number"');
+});
+
+Deno.test("lift-applied empty-object input lowers the no-capture placeholder to a false input schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const c = lift(() => "static")({});',
+  ].join("\n");
+  const output = await t(source);
+  // The single empty object literal is the no-capture placeholder, so the
+  // injected input schema is `false` (no input) rather than an object schema.
+  assertStringIncludes(output, "false");
+});
+
+// ---------------------------------------------------------------------------
+// pattern — single type argument (result inferred), one schema argument
+// ---------------------------------------------------------------------------
+
+Deno.test("pattern<Input> with a single type argument infers the result schema from the callback", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern } from "commonfabric";',
+    "interface Input { count: number; }",
+    "export default pattern<Input>((s) => ({ doubled: s.count * 2 }));",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'count: {\n            type: "number"');
+  // result schema carries the inferred `doubled: number`.
+  assertStringIncludes(output, "doubled: {");
+});
+
+Deno.test("pattern(fn, inputSchema) keeps the author input schema and appends an inferred result schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern } from "commonfabric";',
+    "export default pattern(",
+    "  (state: { count: number }) => ({ label: state }),",
+    '  { type: "object" } as const,',
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  // Author supplied one schema (input) verbatim; the transformer infers and
+  // appends the result schema (case 3a). The author input keeps its bare
+  // `{ type: "object" } as const` form while the appended result carries the
+  // `satisfies` marker and the inferred `label` property.
+  assertStringIncludes(output, '{ type: "object" } as const,');
+  assertStringIncludes(output, "label: {");
+  assertStringIncludes(output, "as const satisfies __cfHelpers.JSONSchema");
+});
+
+// ---------------------------------------------------------------------------
+// handler inline single-argument form — event/state inference
+// ---------------------------------------------------------------------------
+
+Deno.test("handler(fn) with no type args infers both event and state schemas from annotations", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { handler, Cell } from "commonfabric";',
+    "export const h = handler(",
+    "  (event: { delta: number }, ctx: { count: Cell<number> }) => {",
+    "    ctx.count.set(event.delta);",
+    "  },",
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'delta: {\n            type: "number"');
+  assertStringIncludes(output, "count: {");
+});
+
+Deno.test("handler(fn) with an underscore-prefixed unused event param yields a false event schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { handler, Cell } from "commonfabric";',
+    "export const h = handler(",
+    "  (_event, ctx: { count: Cell<number> }) => { ctx.count.set(1); },",
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  // Intentionally-unused `_event` collapses to a `never`/`false` event schema.
+  assertStringIncludes(
+    output,
+    "false as const satisfies __cfHelpers.JSONSchema",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// cell scope: call form cell.perSession(...), and PerSession contextual scope
+// ---------------------------------------------------------------------------
+
+Deno.test("new Writable.perUser(seed) reads the user scope and injects it into the schema", async () => {
+  const source = [
+    'import { Writable } from "commonfabric";',
+    "export default function T() {",
+    "  const v = new Writable.perUser(7);",
+    "  return { v };",
+    "}",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'scope: "user"');
+  assertStringIncludes(output, 'type: "number"');
+});
+
+Deno.test("new Writable.perSpace(seed) reads the space scope and injects it into the schema", async () => {
+  const source = [
+    'import { Writable } from "commonfabric";',
+    "export default function T() {",
+    "  const v = new Writable.perSpace(true);",
+    "  return { v };",
+    "}",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'scope: "space"');
+  assertStringIncludes(output, 'type: "boolean"');
+});
+
+// ---------------------------------------------------------------------------
+// lift result recovery: direct property / element-access projection
+// ---------------------------------------------------------------------------
+
+Deno.test("lift property projection recovers the result schema from the projected field type", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const f = lift((s: { a: number; b: string }) => s.a);",
+  ].join("\n");
+  const output = await t(source);
+  // The result schema is recovered as number from `s.a`. Capability shrinking
+  // narrows the input to the single accessed field `a`, dropping the unused `b`.
+  assertStringIncludes(output, 'a: {\n            type: "number"');
+  assertStringIncludes(
+    output,
+    'type: "number"\n} as const satisfies __cfHelpers.JSONSchema',
+  );
+});
+
+Deno.test("lift element-access projection recovers the result schema from the indexed field", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const f = lift((s: { title: string; other: number }) => s["title"]);',
+  ].join("\n");
+  const output = await t(source);
+  // `s["title"]` is a direct projection; the result schema recovers string.
+  assertStringIncludes(output, 'title: {\n            type: "string"');
+});
+
+// ---------------------------------------------------------------------------
+// pattern result diagnostics
+// ---------------------------------------------------------------------------
+
+Deno.test("pattern with an inferred any/unknown result reports pattern:any-result-schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern } from "commonfabric";',
+    "export default pattern((s: { x: number }) => s as any);",
+  ].join("\n");
+  const { diagnostics } = await validateSource(source, {
+    mode: "error",
+    types: COMMONFABRIC_TYPES,
+  });
+  assert(
+    diagnostics.some((d) => d.type === "pattern:any-result-schema"),
+    `expected pattern:any-result-schema, got: ${
+      diagnostics.map((d) => d.type).join(",")
+    }`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// handler<E, S> with only one usable type argument bails out
+// ---------------------------------------------------------------------------
+
+Deno.test("handler event schema encodes an optional field as not required", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { handler, Cell } from "commonfabric";',
+    "export const h = handler<{ amount?: number }, { total: Cell<number> }>(",
+    "  (event, ctx) => { ctx.total.set(event?.amount ?? 0); },",
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  // Optional event field is present but excluded from required.
+  assertStringIncludes(output, "amount: {");
+  assertEquals(output.includes('required: ["amount"]'), false);
+});
+
+// ---------------------------------------------------------------------------
+// generateObject — options variations
+// ---------------------------------------------------------------------------
+
+Deno.test("generateObject<T>() with no options builds a fresh options object carrying the schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { generateObject } from "commonfabric";',
+    "const r = generateObject<{ score: number }>();",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "schema:");
+  assertStringIncludes(output, "score: {");
+});
+
+Deno.test("generateObject<T>(spreadOptions) spreads a non-literal options expression and adds the schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { generateObject } from "commonfabric";',
+    "declare const opts: { prompt: string };",
+    "const r = generateObject<{ ok: boolean }>(opts);",
+  ].join("\n");
+  const output = await t(source);
+  // Non-literal options become { ...opts, schema: ... }.
+  assertStringIncludes(output, "...opts");
+  assertStringIncludes(output, "schema:");
+});
+
+// ---------------------------------------------------------------------------
+// sqliteQuery — method form and no-options form
+// ---------------------------------------------------------------------------
+
+Deno.test("sqliteQuery<Row>() with no options builds a fresh options object carrying rowSchema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { sqliteQuery } from "commonfabric";',
+    "const q = sqliteQuery<{ id: number; label: string }>();",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, "rowSchema:");
+  assertStringIncludes(output, "label: {");
+});
+
+Deno.test("untyped sqliteQuery(options) injects no rowSchema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { sqliteQuery } from "commonfabric";',
+    "declare const db: any;",
+    'const q = sqliteQuery({ db, sql: "select 1" });',
+  ].join("\n");
+  const output = await t(source);
+  // Untyped form must lower to no schema; runtime falls back to detection.
+  assertEquals(output.includes("rowSchema:"), false);
+});
+
+// ---------------------------------------------------------------------------
+// contextual cell scope from a Scoped<> / PerX<> annotation
+// ---------------------------------------------------------------------------
+
+Deno.test("cell(value) assigned to a PerSession<T> variable reads the session scope from the annotation", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, PerSession } from "commonfabric";',
+    "const c: PerSession<number> = cell(0);",
+  ].join("\n");
+  const output = await t(source);
+  // The scope brand is recovered from the `PerSession` alias on the contextual
+  // type rather than from any accessor on the call.
+  assertStringIncludes(output, 'scope: "session"');
+});
+
+Deno.test("cell(value) assigned to a PerUser<T> variable reads the user scope from the annotation", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, PerUser } from "commonfabric";',
+    'const c: PerUser<string> = cell("hi");',
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'scope: "user"');
+});
+
+Deno.test("cell(value) assigned to a PerSpace<T> variable reads the space scope from the annotation", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, PerSpace } from "commonfabric";',
+    "const c: PerSpace<boolean> = cell(true);",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'scope: "space"');
+});
+
+// ---------------------------------------------------------------------------
+// pattern result: inferred unknown output field reports pattern-result:unknown-type
+// ---------------------------------------------------------------------------
+
+Deno.test("pattern with an inferred unknown output field reports pattern-result:unknown-type", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern } from "commonfabric";',
+    "function opaque(): unknown { return 1; }",
+    "export default pattern((s: { x: number }) => ({ out: opaque() }));",
+  ].join("\n");
+  const { diagnostics } = await validateSource(source, {
+    mode: "error",
+    types: COMMONFABRIC_TYPES,
+  });
+  const paths = diagnostics.filter((d) =>
+    d.type === "pattern-result:unknown-type"
+  );
+  assert(
+    paths.length > 0,
+    `expected pattern-result:unknown-type, got: ${
+      diagnostics.map((d) => d.type).join(",")
+    }`,
+  );
+  // The message names the offending field path.
+  assertStringIncludes(paths[0]!.message, "out");
+});
+
+// ---------------------------------------------------------------------------
+// lift result shape: tuple, enum literal, and nested arrays
+// ---------------------------------------------------------------------------
+
+Deno.test("lift<T, R> encodes a tuple result as an array schema with a positional item type set", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const f = lift<{ a: number }, [string, number]>((s) => ["x", s.a]);',
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'type: "array"');
+  // tuple element union of the two positional types
+  assertStringIncludes(output, 'type: ["number", "string"]');
+});
+
+Deno.test("lift<T, R> encodes a string-literal-union result as an enum", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const f = lift<{ n: number }, "lo" | "hi">((s) => (s.n > 0 ? "hi" : "lo"));',
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, '"enum": ["lo", "hi"]');
+});
+
+Deno.test("lift<T, R> encodes a nested array-of-objects result schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const f = lift<{ n: number }, { id: number }[]>((s) => [{ id: s.n }]);",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'type: "array"');
+  assertStringIncludes(output, "id: {");
+});
+
+// ---------------------------------------------------------------------------
+// cell-for scope wrapping via .asSchema(...)
+// ---------------------------------------------------------------------------
+
+Deno.test("scoped cell-for value schema carries the scope marker", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, PerSession } from "commonfabric";',
+    "const base = cell<number>();",
+    "const scoped: PerSession<number> = base;",
+  ].join("\n");
+  const output = await t(source);
+  // The base cell schema is injected; assigning to PerSession keeps the schema.
+  assertStringIncludes(output, 'type: "number"');
+});
+
+// ---------------------------------------------------------------------------
+// new cell constructor: value inference, explicit type argument
+// ---------------------------------------------------------------------------
+
+Deno.test("new Writable(value) infers a widened schema from the seed and injects it as the second argument", async () => {
+  const source = [
+    'import { Writable } from "commonfabric";',
+    "export default function T() {",
+    "  const v = new Writable(5);",
+    "  return { v };",
+    "}",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'type: "number"');
+  // No scope accessor was used, so no scope marker is injected.
+  assertEquals(output.includes("scope:"), false);
+});
+
+Deno.test("new Writable<T>() with an explicit type argument and no value injects an undefined first argument", async () => {
+  const source = [
+    'import { Writable } from "commonfabric";',
+    "export default function T() {",
+    "  const v = new Writable<{ n: number }>();",
+    "  return { v };",
+    "}",
+  ].join("\n");
+  const output = await t(source);
+  // Schema is always the second argument, so `undefined` is inserted first.
+  assertStringIncludes(output, "new Writable<{");
+  assertStringIncludes(output, "undefined, {");
+  assertStringIncludes(output, "n: {");
+});
+
+// ---------------------------------------------------------------------------
+// contextual scope from a raw Scoped<T, scope> brand (no PerX alias)
+// ---------------------------------------------------------------------------
+
+Deno.test("cell(value) typed as raw Scoped<T, scope> reads the scope from the SCOPE_BRAND property", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, Scoped } from "commonfabric";',
+    'const c: Scoped<number, "session"> = cell(0);',
+  ].join("\n");
+  const output = await t(source);
+  // `Scoped` is not one of the PerX aliases, so the scope is recovered from the
+  // scope-brand property rather than the alias name.
+  assertStringIncludes(output, 'scope: "session"');
+});
+
+// ---------------------------------------------------------------------------
+// lift<T, R>(fn)(input): type arguments on the inner lift drive both schemas
+// ---------------------------------------------------------------------------
+
+Deno.test("lift<T, R>(fn)(input) reads the schemas from the inner lift type arguments", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const f = lift<{ a: number }, string>((s) => `${s.a}`)({ a: 1 });",
+  ].join("\n");
+  const output = await t(source);
+  assertStringIncludes(output, 'a: {\n            type: "number"');
+  assertStringIncludes(output, 'type: "string"');
+});
+
+// ---------------------------------------------------------------------------
+// chained lift-applied (derive) inputs: recover the upstream result type
+// ---------------------------------------------------------------------------
+
+Deno.test("chained lift-applied recovers the input schema from the upstream lift's inferred result", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const step1 = lift((x: { a: number }) => ({ a: x.a, b: x.a + 1 }))({ a: 1 });",
+    "const step2 = lift((y) => y.b)(step1);",
+  ].join("\n");
+  const output = await t(source);
+  // step2's callback param has no annotation; its type is recovered from
+  // step1's inferred `{ a, b }` result, and capability shrinking keeps only the
+  // accessed `b` field. The result schema is number.
+  const step2Def = output.slice(output.indexOf("__cfLift_2 = lift"));
+  assertStringIncludes(step2Def, "b: {");
+  assertStringIncludes(step2Def, 'type: "number"');
+});
+
+Deno.test("chained lift-applied whose upstream is a single-field object recovers a concrete input schema, not unknown", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const first = lift((x: { name: string }) => ({ name: x.name }))({ name: "n" });',
+    "const second = lift((v) => v.name.length)(first);",
+  ].join("\n");
+  const output = await t(source);
+  const secondDef = output.slice(output.indexOf("__cfLift_2 = lift"));
+  // The recovered input carries the concrete `name: string` field rather than a
+  // permissive `true`/unknown schema.
+  assertStringIncludes(secondDef, "name: {");
+  assertEquals(secondDef.slice(0, 200).includes("true as const"), false);
+});
+
+// ---------------------------------------------------------------------------
+// scope brand recovery when the scope is a union of literal scope values
+// ---------------------------------------------------------------------------
+
+Deno.test("cell typed as Scoped<T, union-of-scopes> recovers the first concrete scope from the brand union", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, Scoped } from "commonfabric";',
+    'const c: Scoped<number, "user" | "session"> = cell(0);',
+  ].join("\n");
+  const output = await t(source);
+  // The scope-brand type is a union; the recovery walks the members and returns
+  // the first concrete scope value.
+  assertStringIncludes(output, 'scope: "user"');
+});
+
+// ---------------------------------------------------------------------------
+// lift factory captured in a variable, then applied — recover the result type
+// through the factory's callback
+// ---------------------------------------------------------------------------
+
+Deno.test("applying a captured lift factory recovers the downstream input schema from the factory callback result", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    "const makeIt = lift((x: { a: number }) => ({ a: x.a, b: 2 }));",
+    "const applied = makeIt({ a: 1 });",
+    "const used = lift((y) => y.b)(applied);",
+  ].join("\n");
+  const output = await t(source);
+  // `used`'s callback param is untyped; its type is recovered from `applied`,
+  // whose type comes from the `makeIt` factory callback returning `{ a, b }`.
+  const usedDef = output.slice(output.lastIndexOf("= lift((y)"));
+  assertStringIncludes(usedDef, "b: {");
+  assertStringIncludes(usedDef, 'type: "number"');
+});
+
+// ---------------------------------------------------------------------------
+// pattern result: unknown paths are walked into nested objects and arrays
+// ---------------------------------------------------------------------------
+
+Deno.test("pattern result reports a nested unknown output field with a dotted path", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern } from "commonfabric";',
+    "function op(): unknown { return 1; }",
+    "export default pattern((s: { x: number }) => ({ nested: { deep: op() } }));",
+  ].join("\n");
+  const { diagnostics } = await validateSource(source, {
+    mode: "error",
+    types: COMMONFABRIC_TYPES,
+  });
+  const d = diagnostics.find((d) => d.type === "pattern-result:unknown-type");
+  assert(d, "expected pattern-result:unknown-type");
+  // The path walk descends into the nested object literal.
+  assertStringIncludes(d!.message, "nested.deep");
+});
+
+Deno.test("pattern result reports an unknown array element with an array path suffix", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { pattern } from "commonfabric";',
+    "function op(): unknown { return 1; }",
+    "export default pattern((s: { x: number }) => ({ items: [op()] }));",
+  ].join("\n");
+  const { diagnostics } = await validateSource(source, {
+    mode: "error",
+    types: COMMONFABRIC_TYPES,
+  });
+  const d = diagnostics.find((d) => d.type === "pattern-result:unknown-type");
+  assert(d, "expected pattern-result:unknown-type");
+  // The array element walk appends `[]` to the path.
+  assertStringIncludes(d!.message, "items[]");
+});
+
+// ---------------------------------------------------------------------------
+// idempotency / author-supplied skips: a builder that already carries its
+// schema is left untouched
+// ---------------------------------------------------------------------------
+
+Deno.test("new Writable(value, schema) with two arguments is left untouched", async () => {
+  const source = [
+    'import { Writable } from "commonfabric";',
+    "export default function T() {",
+    '  const v = new Writable(5, { type: "number" } as const);',
+    "  return { v };",
+    "}",
+  ].join("\n");
+  const output = await t(source);
+  // The schema slot is already filled, so no second schema is injected.
+  assertStringIncludes(output, 'new Writable(5, { type: "number" }');
+  assertEquals((output.match(/type: "number"/g) ?? []).length, 1);
+});
+
+Deno.test("wish(hint, schema) with an author-supplied schema is left untouched", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { wish } from "commonfabric";',
+    'const w = wish("hint", { type: "object" } as const);',
+  ].join("\n");
+  const output = await t(source);
+  // The two-argument wish already has its schema; the transformer does not add
+  // a satisfies-marked schema of its own.
+  assertStringIncludes(output, '{ type: "object" } as const');
+  assertEquals(
+    output.includes("as const satisfies __cfHelpers.JSONSchema"),
+    false,
+  );
+});
+
+Deno.test("generateObject({ schema }) already carrying a schema property is left untouched", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { generateObject } from "commonfabric";',
+    'const r = generateObject({ prompt: "hi", schema: { type: "object" } as const });',
+  ].join("\n");
+  const output = await t(source);
+  // Exactly the author's single schema property remains; none is injected.
+  assertEquals((output.match(/schema:/g) ?? []).length, 1);
+});
+
+Deno.test("untyped sqliteQuery already carrying a rowSchema is left untouched", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { sqliteQuery } from "commonfabric";',
+    "declare const db: any;",
+    'const q = sqliteQuery<{ id: number }>({ db, sql: "s", rowSchema: { type: "object" } as const });',
+  ].join("\n");
+  const output = await t(source);
+  // A rowSchema is already present, so the typed form does not inject a second.
+  assertEquals((output.match(/rowSchema:/g) ?? []).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// new scoped cell with no value: scope from accessor, value type from context
+// ---------------------------------------------------------------------------
+
+Deno.test("new Writable.perSession() with no value derives the value type from the contextual scope annotation", async () => {
+  const source = [
+    'import { Writable, PerSession } from "commonfabric";',
+    "export default function T() {",
+    "  const v: PerSession<number> = new Writable.perSession();",
+    "  return { v };",
+    "}",
+  ].join("\n");
+  const output = await t(source);
+  // No seed value, so the value type is recovered from the contextual
+  // PerSession<number> annotation and the accessor supplies the session scope.
+  assertStringIncludes(output, 'scope: "session"');
+  assertStringIncludes(output, 'type: "number"');
+  assertStringIncludes(output, "undefined, {");
+});
+
+// ---------------------------------------------------------------------------
+// lift-applied projection recovery: property-access and element-access forms
+// on a downstream callback whose parameter type is recovered from upstream
+// ---------------------------------------------------------------------------
+
+Deno.test("lift-applied element-access projection recovers the result schema from the indexed field", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const s1 = lift((x: { title: string; n: number }) => x)({ title: "t", n: 1 });',
+    'const s2 = lift((y) => y["title"])(s1);',
+  ].join("\n");
+  const output = await t(source);
+  // The downstream callback `y => y["title"]` has no annotation; its input is
+  // recovered from the upstream result and the string result schema is derived
+  // from the indexed `title` field.
+  const s2Def = output.slice(output.lastIndexOf("= lift((y)"));
+  assertStringIncludes(s2Def, "title: {");
+  assertStringIncludes(s2Def, 'type: "string"');
+});
+
+Deno.test("lift-applied property-access projection recovers the result schema from the accessed field", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { lift } from "commonfabric";',
+    'const s1 = lift((x: { count: number; other: string }) => x)({ count: 1, other: "o" });',
+    "const s2 = lift((y) => y.count)(s1);",
+  ].join("\n");
+  const output = await t(source);
+  const s2Def = output.slice(output.lastIndexOf("= lift((y)"));
+  assertStringIncludes(s2Def, "count: {");
+  assertStringIncludes(s2Def, 'type: "number"');
+});
+
+// ---------------------------------------------------------------------------
+// handler state Cell that is read marks the schema field asCell readonly
+// ---------------------------------------------------------------------------
+
+Deno.test("handler<E, S> marks a read-only Cell state field with asCell readonly", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { handler, Cell } from "commonfabric";',
+    "export const h = handler<{ q: number }, { total: Cell<number> }>(",
+    "  (event, ctx) => { const x = ctx.total.get(); void x; void event; },",
+    ");",
+  ].join("\n");
+  const output = await t(source);
+  // The state Cell is only read (.get), so the capability summary narrows the
+  // marker to readonly.
+  assertStringIncludes(output, 'asCell: ["readonly"]');
+});
+
+// ---------------------------------------------------------------------------
+// lift-applied whose untyped callback calls Cell methods on a Cell input:
+// the input schema is recovered from the cell-like fallback type and marked
+// asCell readonly
+// ---------------------------------------------------------------------------
+
+Deno.test("lift-applied untyped callback using Cell.get on a Cell input recovers a cell-like input schema", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { cell, lift } from "commonfabric";',
+    "const c = cell({ n: 5 });",
+    "const d = lift((x) => x.get().n)(c);",
+  ].join("\n");
+  const output = await t(source);
+  // The callback param has no annotation but calls `.get()`; because the input
+  // is a Cell, the input schema is recovered from the cell-like fallback type
+  // and carries the readonly asCell marker with the inner `{ n: number }` shape.
+  const liftDef = output.slice(output.indexOf("lift((x)"));
+  assertStringIncludes(liftDef, "n: {");
+  assertStringIncludes(liftDef, 'asCell: ["readonly"]');
+});

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -1,0 +1,1421 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import type {
+  CapabilityParamSummary,
+  TransformationContext,
+} from "../src/core/mod.ts";
+import {
+  applyCapabilityDefaultsToTypeNode,
+  applyShrinkAndWrap,
+  printTypeNode,
+} from "../src/transformers/type-shrinking.ts";
+
+// ---------------------------------------------------------------------------
+// Harness (mirrors test/type-shrinking.test.ts so cases stay comparable).
+// ---------------------------------------------------------------------------
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+  };
+
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findTypeAlias(
+  sourceFile: ts.SourceFile,
+  aliasName: string,
+): ts.TypeAliasDeclaration {
+  let found: ts.TypeAliasDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isTypeAliasDeclaration(node) && node.name.text === aliasName) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Type alias ${aliasName} not found`);
+  return found;
+}
+
+function createParamSummary(
+  summary: Partial<CapabilityParamSummary>,
+): CapabilityParamSummary {
+  return {
+    name: "input",
+    capability: "opaque",
+    readPaths: [],
+    writePaths: [],
+    opaquePaths: [],
+    passthrough: false,
+    wildcard: false,
+    identityOnly: false,
+    ...summary,
+  };
+}
+
+interface CollectedDiagnostic {
+  severity: string;
+  type: string;
+  message: string;
+}
+
+function createContext(sourceFile: ts.SourceFile): {
+  context: TransformationContext;
+  diagnostics: CollectedDiagnostic[];
+} {
+  const diagnostics: CollectedDiagnostic[] = [];
+  const context = {
+    sourceFile,
+    factory: ts.factory,
+    options: {
+      state: {
+        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
+      },
+    },
+    reportDiagnostic: (d: CollectedDiagnostic) => {
+      diagnostics.push({
+        severity: d.severity,
+        type: d.type,
+        message: d.message,
+      });
+    },
+  } as unknown as TransformationContext;
+  return { context, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Array element node building via type-driven shrinking (Array<T> reference).
+// Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
+// checker, element shrunk, array node rebuilt.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed fields", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Item = { id: string; title: string; unused: number };
+    type Input = Array<Item>;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["0", "title"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "title: string;");
+  // The `Array<Item>` reference is rebuilt with the shrunk element, staying an
+  // Array<...> reference rather than collapsing to a numeric-key object.
+  assertStringIncludes(printed, "Array<{");
+  assertEquals(printed.includes("unused"), false);
+  assertEquals(printed.includes("id"), false);
+});
+
+// ---------------------------------------------------------------------------
+// length-only access on an Array<T> reference emits unknown[] (array-root only
+// path). Exercises the `allNonItem` array branch in the node-driven path.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap collapses length-only Array<T> reads to unknown[]", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Item = { id: string; title: string };
+    type Input = Array<Item>;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["length"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  assertEquals(printTypeNode(result, sourceFile), "unknown[]");
+});
+
+// ---------------------------------------------------------------------------
+// Union of object shapes: shrink each non-nullish member; nullish member
+// preserved. Exercises the union branch in buildShrunkTypeNodeFromTypeNode
+// (lines ~1278-1301) via a source-authored union node.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input =
+      | { shared: string; onlyA: number }
+      | { shared: string; onlyB: boolean };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["shared"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "shared: string;");
+  assertEquals(printed.includes("onlyA"), false);
+  assertEquals(printed.includes("onlyB"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Union `T | undefined` where only one member holds the accessed property.
+// After shrinking the non-nullish member, a single member remains and the
+// union collapses to that member (line ~1299-1301 `all.length === 1`).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish member", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { keep: string; drop: number };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  // Author a union node whose only non-nullish member is the object literal.
+  const unionNode = ts.factory.createUnionTypeNode([
+    alias.type,
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+  ]);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["keep"]],
+    }),
+    unionNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: string;");
+  assertEquals(printed.includes("drop"), false);
+  // Single non-nullish member survived; undefined was dropped after collapse.
+  assertEquals(printed.includes("undefined"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Type-driven union nullish re-wrapping (buildShrunkTypeNodeFromType, ~856-895)
+// and line 888 (`nullishMembers.length === 0` short-circuit not taken).
+// Drive with a synthetic base node to force the type-driven path.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a nullable object", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Payload = { keep: string; drop: number };
+    type Input = Payload | undefined;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const syntheticBaseNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.UnknownKeyword,
+  );
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["keep"]],
+    }),
+    syntheticBaseNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: string;");
+  assertStringIncludes(printed, "undefined");
+  assertEquals(printed.includes("drop"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Nested primitive leaf on a type-driven shrink: `text.length` keeps the
+// string leaf intact instead of shrinking `text` to `{ length }`
+// (lines ~934-962 primitive-scalar branch through the type-driven path).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-driven shrinking", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { text: string; other: number };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const syntheticBaseNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.UnknownKeyword,
+  );
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["text", "length"]],
+    }),
+    syntheticBaseNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "text: string;");
+  assertEquals(printed.includes("length: number"), false);
+  assertEquals(printed.includes("other"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Index-signature access via type-driven shrinking: a numeric/string key that
+// is not a named property resolves through the index signature and the emitted
+// member is optional (lines ~913-936: `isOptional = true`, `984-989`).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap represents index-signature access as an optional member", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { [key: string]: { name: string; unused: number } };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const syntheticBaseNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.UnknownKeyword,
+  );
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["anyKey", "name"]],
+    }),
+    syntheticBaseNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "anyKey?:");
+  assertStringIncludes(printed, "name: string;");
+  assertEquals(printed.includes("unused"), false);
+});
+
+// ---------------------------------------------------------------------------
+// isUnchangedShrink: a TypeReference whose members are all accessed with no
+// nested change is kept as the original reference to preserve $ref/$defs
+// (lines ~1453-1474 return `node`).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccessed members", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Point { x: number; y: number; z: number; }
+    type Input = Point;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["x"], ["y"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  // The reference resolves to its declared members and the unaccessed `z` is
+  // dropped, so the shrink differs from the original (isUnchangedShrink false).
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "x: number;");
+  assertStringIncludes(printed, "y: number;");
+  assertEquals(printed.includes("z:"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Interface heritage merge: an interface extending a base contributes inherited
+// members that are merged and de-duplicated (mergeResolvedMembers, ~1416-1442;
+// resolveMembersFromDeclaration heritage branch ~1388-1414). An overriding
+// property in the derived interface wins.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap merges inherited interface members and honors overrides", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Base { shared: string; baseOnly: number; }
+    interface Derived extends Base { shared: string; derivedOnly: boolean; }
+    type Input = Derived;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["baseOnly"], ["derivedOnly"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "baseOnly: number;");
+  assertStringIncludes(printed, "derivedOnly: boolean;");
+  assertEquals(printed.includes("shared"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics: unknown base type with property access reports
+// schema:unknown-type-access (lines ~1876-1893). Driven through
+// applyShrinkAndWrap with a context + fnNode so validateShrinkCoverage runs.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap reports unknown-type-access for unknown base with reads", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = unknown;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+  const fnNode = alias;
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      name: "payload",
+      readPaths: [["missing"]],
+    }),
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    fnNode,
+  );
+
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0]!.type, "schema:unknown-type-access");
+  assertStringIncludes(diagnostics[0]!.message, "payload");
+  assertStringIncludes(diagnostics[0]!.message, "'.missing'");
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics: concrete type but an accessed path is absent reports
+// schema:path-not-in-type (lines ~1938-1954, and the missing filter 1939-1941).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { present: string };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      name: "row",
+      readPaths: [["present"], ["absent"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    alias,
+  );
+
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0]!.type, "schema:path-not-in-type");
+  assertStringIncludes(diagnostics[0]!.message, "'.absent'");
+  assertEquals(diagnostics[0]!.message.includes("'.present'"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics: concrete type with a property typed `unknown` reports
+// schema:unknown-type-access (case 2, lines ~1900-1935).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap reports unknown-typed property access", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { amounts: unknown };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      name: "input",
+      readPaths: [["amounts"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    alias,
+  );
+
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0]!.type, "schema:unknown-type-access");
+  assertStringIncludes(diagnostics[0]!.message, "'.amounts'");
+  assertStringIncludes(diagnostics[0]!.message, "typed as 'unknown'");
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics: `never` base type skips validation entirely (lines ~1857-1862).
+// A `never`-typed parameter with reads must produce no diagnostics.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap skips validation for a never base type", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = never;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["anything"]],
+    }),
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword),
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    alias,
+  );
+
+  assertEquals(diagnostics.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics: wildcard param typed `unknown` passed to an opaque function
+// reports the wildcard-specific unknown-type-access branch (lines ~1733-1750).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap reports unknown-type-access for an unknown wildcard param", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = unknown;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      name: "logged",
+      wildcard: true,
+    }),
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    alias,
+  );
+
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0]!.type, "schema:unknown-type-access");
+  assertStringIncludes(diagnostics[0]!.message, "logged");
+});
+
+// ---------------------------------------------------------------------------
+// Validation over an array base: item-level paths validate against the element
+// type. A missing item property reports through the array-element recursion
+// (lines ~1795-1833, getArrayElementTypeNode paths ~1656-1709).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap validates array item paths against the element type", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Row { id: string; }
+    type Input = Row[];
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      name: "rows",
+      readPaths: [["0", "id"], ["0", "missing"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    alias,
+  );
+
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0]!.type, "schema:path-not-in-type");
+  assertStringIncludes(diagnostics[0]!.message, "'.missing'");
+});
+
+// ---------------------------------------------------------------------------
+// defaults_only mode: a default nested under a path present in the base type
+// gets applied to the fallback shape when the direct node application misses.
+// Also exercises applyCapabilityDefaultsToTypeNode fallback (~2919-2945) and
+// buildDefaultsOnlyFallbackPaths leaf expansion (~2954-2956, 3001-3026).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base type shape", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { title: string; count: number };
+    type TitleDefault = "Untitled";
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const titleDefault = findTypeAlias(sourceFile, "TitleDefault");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      defaults: [{ path: ["title"], defaultType: titleDefault.type }],
+    }),
+    // A synthetic node that has no `title` member forces the fallback shape.
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "defaults_only",
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(
+    printed,
+    'title: __cfHelpers.Default<string, "Untitled">',
+  );
+  assertStringIncludes(printed, "count: number;");
+});
+
+// ---------------------------------------------------------------------------
+// applyCapabilityDefaultsToTypeNode: default applied directly through a tuple
+// index (applySingleDefaultToTypeNode tuple branch ~2825-2850).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple index", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = [{ name?: string }, number];
+    type NameDefault = "Anon";
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const nameDefault = findTypeAlias(sourceFile, "NameDefault");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyCapabilityDefaultsToTypeNode(
+    alias.type,
+    [{ path: ["0", "name"], defaultType: nameDefault.type }],
+    baseType,
+    [["0", "name"]],
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, 'name?: __cfHelpers.Default<string, "Anon">');
+});
+
+// ---------------------------------------------------------------------------
+// applyCapabilityDefaultsToTypeNode: out-of-range tuple index leaves the node
+// unchanged (tuple guard ~2827-2831). No __cfHelpers.Default wrapper appears.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = [{ name?: string }];
+    type NameDefault = "Anon";
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const nameDefault = findTypeAlias(sourceFile, "NameDefault");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyCapabilityDefaultsToTypeNode(
+    alias.type,
+    [{ path: ["5", "name"], defaultType: nameDefault.type }],
+    baseType,
+    [["5", "name"]],
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertEquals(printed.includes("__cfHelpers.Default"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Identity-only root on a union base: each union member is replaced with the
+// identity-only shape; nullish members are rebuilt as-is
+// (createIdentityOnlyRootTypeNode union branch ~2367-2400).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { a: string } | { b: number } | undefined;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityOnly: true,
+      passthrough: true,
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  // Each non-nullish member collapses to `unknown`; undefined is preserved.
+  assertStringIncludes(printed, "unknown");
+  assertStringIncludes(printed, "undefined");
+  assertEquals(printed.includes("a:"), false);
+  assertEquals(printed.includes("b:"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Identity-only root that is nullish (`undefined`): rebuilt via
+// createIdentityOnlyNullishTypeNode (lines ~2357-2365, 2311-2331).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap rebuilds an identity-only nullish root as undefined", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = undefined;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityOnly: true,
+      passthrough: true,
+    }),
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  assertEquals(printTypeNode(result, sourceFile), "undefined");
+});
+
+// ---------------------------------------------------------------------------
+// Identity paths descending through an array item interface reference resolved
+// via the checker (applyIdentityOnlyPathsToTypeNode Array<T> ref branch
+// ~2557-2583) using an Array<T> reference (not `T[]`).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> references", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    interface Item { keep: string; drop: number; }
+    type Input = Array<Item>;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["0", "keep"]],
+      identityCellPaths: [["0", "keep"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+});
+
+// ---------------------------------------------------------------------------
+// Identity paths through a union base node (applyIdentityOnlyPathsToTypeNode
+// union branch ~2728-2752): each union member is visited and changed members
+// force a rebuilt union.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap applies identity paths across union members", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    type Input =
+      | { item: { keep: string; drop: number } }
+      | { item: { keep: string; other: boolean } };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const unionNode = alias.type;
+  assert(ts.isUnionTypeNode(unionNode));
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["item", "keep"]],
+      identityCellPaths: [["item", "keep"]],
+    }),
+    unionNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+  assertStringIncludes(printed, "other: boolean");
+});
+
+// ---------------------------------------------------------------------------
+// Identity paths through a named interface reference that resolves to declared
+// members, where a nested member is left unchanged (no matching child path) so
+// the `!changed` early return keeps the reference
+// (applyIdentityOnlyPathsToTypeNode reference branch ~2669-2725, unchanged
+// return ~2721-2723).
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap keeps an interface reference when no identity path matches", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Outer { inner: { keep: string }; other: string; }
+    type Input = Outer;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      // Names a head that does not exist on Outer, so nothing changes.
+      identityPaths: [["nonexistent"]],
+      identityCellPaths: [["nonexistent"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  // No member matched, so the reference is returned unchanged.
+  assertEquals(printTypeNode(result, sourceFile), "Outer");
+});
+
+// ---------------------------------------------------------------------------
+// applyCellCapabilityPathsToTypeNode through a parenthesized type node
+// (~2181-2193) plus per-property cell capability selection where read+write
+// paths on the same leaf select `writable`.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized literals", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type Writable<T> = { readonly value?: T };
+      export type ReadonlyCell<T> = { readonly readonly?: T };
+    }
+    type Inner = { value: __cfHelpers.Writable<number> };
+    type Input = (Inner);
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      capability: "readonly",
+      readPaths: [["value"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "value: __cfHelpers.ReadonlyCell<number>");
+});
+
+// ---------------------------------------------------------------------------
+// Batch 2: "unchanged / no-match" arms of each identity-path node shape, plus
+// remaining array-element and default clusters.
+// ---------------------------------------------------------------------------
+
+// Identity item path on an Array<T> reference that names no member leaves the
+// whole array reference unchanged (Array<T> ref `updated === inner` ~2574-2576).
+Deno.test("applyShrinkAndWrap keeps Array<T> unchanged for an unresolved identity item path", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Item { keep: string; }
+    type Input = Array<Item>;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["0", "missing"]],
+      identityCellPaths: [["0", "missing"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  assertEquals(printTypeNode(result, sourceFile), "Array<Item>");
+});
+
+// Identity item path on a readonly array that names no member leaves the
+// readonly-array node unchanged (readonly-array `updated === elementType`
+// ~2546-2548).
+Deno.test("applyShrinkAndWrap keeps a readonly array unchanged for an unresolved identity item path", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Item { keep: string; }
+    type Input = readonly Item[];
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["0", "missing"]],
+      identityCellPaths: [["0", "missing"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  assertStringIncludes(printTypeNode(result, sourceFile), "readonly Item[]");
+});
+
+// Identity path through a parenthesized literal that DOES change a leaf: the
+// parenthesized wrapper is rebuilt around the updated inner
+// (createIdentityOnly paren branch ~2485-2498, change arm).
+Deno.test("applyShrinkAndWrap rebuilds a parenthesized identity root when a leaf changes", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    type Input = ({ item: { keep: string; drop: number } });
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  assert(ts.isParenthesizedTypeNode(alias.type));
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["item", "keep"]],
+      identityCellPaths: [["item", "keep"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+});
+
+// Identity path through a Cell-like wrapper reference descends into the inner
+// type argument (applyIdentityOnlyPathsToTypeNode cell-ref branch ~2642-2667).
+Deno.test("applyShrinkAndWrap descends identity paths through a Cell-like wrapper reference", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    type Cell<T> = { readonly cell?: T };
+    type Input = Cell<{ keep: string; drop: number }>;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["keep"]],
+      identityCellPaths: [["keep"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  // The Cell wrapper is retained; its inner `keep` leaf is wrapped in place.
+  assertStringIncludes(printed, "Cell<");
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+});
+
+// Node-driven array shrink where the base node is a type alias resolving to an
+// array (not `T[]`/`Array<T>` syntactically) exercises the checker-based array
+// detection (buildShrunkTypeNodeFromTypeNode ~1086-1096, 1185-1202). The alias
+// reference is recognized as array-shaped and preserved as a reference so
+// schema generation keeps its $ref.
+Deno.test("applyShrinkAndWrap recognizes an array type-alias reference as array-shaped", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Row { id: string; title: string; unused: number; }
+    type Rows = Row[];
+    type Input = Rows;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["0", "title"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  // The alias resolves to an array via the checker; the reference is kept.
+  assertEquals(printTypeNode(result, sourceFile), "Rows");
+});
+
+// Array-like TypeLiteral (numeric index + length) drives the
+// getArrayLikeTypeLiteralElementType path (~557-577) and element shrinking of a
+// literal element node (~565-567). Item field access shrinks the element.
+Deno.test("applyShrinkAndWrap shrinks array-like type literals with numeric index and length", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = {
+      length: number;
+      [n: number]: { id: string; title: string; unused: number };
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["length"], ["0", "title"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "title: string;");
+  assert(printed.endsWith("[]"), `expected array shape, got: ${printed}`);
+  assertEquals(printed.includes("unused"), false);
+});
+
+// findPropertySymbol resolves a property that lives only on one union
+// constituent (findPropertySymbol union recursion ~684-689) during type-driven
+// shrinking of a union base node.
+Deno.test("applyShrinkAndWrap resolves a union-only property during type-driven shrinking", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { common: string } & ({ onlyHere: number } | { alt: boolean });
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const syntheticBaseNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.UnknownKeyword,
+  );
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["common"]],
+    }),
+    syntheticBaseNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "common: string;");
+});
+
+// Type-driven shrink where a deeper path fails to materialise on a nested
+// property: the child is dropped rather than widened (buildShrunkTypeNodeFromType
+// `!shrunkChild && !hasDirectAccess` continue, ~978-989 region). Access a valid
+// head plus an invalid deep path on the same property.
+Deno.test("applyShrinkAndWrap drops an unresolved deep child during type-driven shrinking", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { data: { present: string }; other: number };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const syntheticBaseNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.UnknownKeyword,
+  );
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["data", "present"], ["other"]],
+    }),
+    syntheticBaseNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "present: string;");
+  assertStringIncludes(printed, "other: number;");
+});
+
+// applyCapabilityDefaultsToTypeNode applies a default through a union member
+// (applySingleDefaultToTypeNode union branch ~2852-2870).
+Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a union member", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { a?: string } | { b?: number };
+    type ADefault = "x";
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const aDefault = findTypeAlias(sourceFile, "ADefault");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyCapabilityDefaultsToTypeNode(
+    alias.type,
+    [{ path: ["a"], defaultType: aDefault.type }],
+    baseType,
+    [["a"]],
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, 'a?: __cfHelpers.Default<string, "x">');
+});
+
+// defaults-only fallback where a default is nested under a property: the
+// fallback path builder expands the child's leaves so the default lands
+// (buildDefaultsOnlyFallbackPaths nested-head expansion ~2954-2956, 3009-3026).
+Deno.test("applyShrinkAndWrap expands nested defaults-only fallback leaves", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { group: { title: string; note: string }; count: number };
+    type TitleDefault = "Untitled";
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const titleDefault = findTypeAlias(sourceFile, "TitleDefault");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      defaults: [{ path: ["group", "title"], defaultType: titleDefault.type }],
+    }),
+    // Synthetic base with no `group` member forces the fallback shape.
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "defaults_only",
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(
+    printed,
+    'title: __cfHelpers.Default<string, "Untitled">',
+  );
+  // Sibling leaf under the same parent is retained in the expanded fallback.
+  assertStringIncludes(printed, "note: string;");
+  assertStringIncludes(printed, "count: number;");
+});
+
+// Identity-only root whose resolved semantic type is undefined falls back to the
+// replacement type node (createIdentityOnlyRootTypeNode `!resolvedType` branch
+// ~2345-2354) — driven by a synthetic node with no base type.
+Deno.test("applyShrinkAndWrap replaces an identity-only root that has no resolvable type", () => {
+  const { sourceFile, checker } = createProgram(`type Marker = string;`);
+  // A synthetic reference to a name that resolves to nothing under noLib.
+  const syntheticNode = ts.factory.createTypeReferenceNode("Unresolvable");
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityOnly: true,
+      passthrough: true,
+    }),
+    syntheticNode,
+    undefined,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  // No base type and an unresolvable node → identity-only root collapses to
+  // `unknown`.
+  assertEquals(printTypeNode(result, sourceFile), "unknown");
+});
+
+// Cell-capability application over a plain object literal member whose value is
+// a cell wrapper (applyCellCapabilityPathsToTypeNode literal member branch
+// ~2199-2264): a read+write access selects the `writable` capability.
+Deno.test("applyShrinkAndWrap selects writable capability for read-and-write cell leaves", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type Writable<T> = { readonly value?: T };
+    }
+    type Input = { field: __cfHelpers.Writable<number>; untouched: string };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      capability: "writable",
+      readPaths: [["field"]],
+      writePaths: [["field"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "field: __cfHelpers.Writable<number>");
+  assertEquals(printed.includes("untouched"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Batch 3: array-union validation and remaining union collapse / defensive arms.
+// ---------------------------------------------------------------------------
+
+// Validation over a `Row[] | undefined` base with a valid item field reports no
+// diagnostic, exercising getArrayElementTypeNode's union branch (~1643-1657):
+// the nullish member is skipped and the array member yields the element type.
+Deno.test("applyShrinkAndWrap accepts item paths present on a nullable array union element", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Row { id: string; }
+    type Input = Row[] | undefined;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+
+  applyShrinkAndWrap(
+    createParamSummary({
+      name: "rows",
+      readPaths: [["0", "id"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+    "full",
+    "opaque",
+    context,
+    alias,
+  );
+
+  // `id` resolves on the array element, so no path-not-in-type is reported.
+  assertEquals(diagnostics.length, 0);
+});
+
+// A union node whose single non-nullish member shrinks collapses to that member
+// (buildShrunkTypeNodeFromTypeNode union `all.length === 1` ~1298-1301). A
+// one-element union node with one accessed property drives the collapse.
+Deno.test("applyShrinkAndWrap collapses a one-member union node to the shrunk member", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { keep: string; drop: number };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  // A union node with a single (object literal) member, no nullish members.
+  const unionNode = ts.factory.createUnionTypeNode([alias.type]);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["keep"]],
+    }),
+    unionNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: string;");
+  assertEquals(printed.includes("drop"), false);
+  // Collapsed to the single shrunk member, so no union `|` remains.
+  assertEquals(printed.includes("|"), false);
+});
+
+// A union node with only nullish members is returned unchanged
+// (buildShrunkTypeNodeFromTypeNode `nonNullish.length === 0` ~1278).
+Deno.test("applyShrinkAndWrap leaves an all-nullish union node unchanged", () => {
+  const { sourceFile, checker } = createProgram(`type Input = string;`);
+  const nullOnly = ts.factory.createUnionTypeNode([
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+    ts.factory.createLiteralTypeNode(ts.factory.createNull()),
+  ]);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["anything"]],
+    }),
+    nullOnly,
+    undefined,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "undefined");
+  assertStringIncludes(printed, "null");
+});
+
+// A valid tuple index whose nested default path does not resolve leaves the
+// tuple unchanged (applySingleDefaultToTypeNode tuple `!updatedChild.applied`
+// arm ~2841-2843).
+Deno.test("applyCapabilityDefaultsToTypeNode ignores a tuple default whose nested path is absent", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = [{ present?: string }];
+    type D = "x";
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const dDefault = findTypeAlias(sourceFile, "D");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyCapabilityDefaultsToTypeNode(
+    alias.type,
+    [{ path: ["0", "absent"], defaultType: dDefault.type }],
+    baseType,
+    [["0", "absent"]],
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  // The nested path names no member, so no default wrapper is applied.
+  assertEquals(
+    printTypeNode(result, sourceFile).includes("__cfHelpers.Default"),
+    false,
+  );
+});

--- a/packages/ts-transformers/test/utils/capture-tree-coverage.test.ts
+++ b/packages/ts-transformers/test/utils/capture-tree-coverage.test.ts
@@ -1,0 +1,278 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import {
+  buildCapturePropertyAssignments,
+  buildHierarchicalParamsValue,
+  type CaptureTreeNode,
+  createCaptureAccessExpression,
+  createCaptureTreeNode,
+  groupCapturesByRoot,
+  parseCaptureExpression,
+} from "../../src/utils/capture-tree.ts";
+
+const factory = ts.factory;
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+// Source-derived literal nodes read their text back from the source file they
+// were parsed from, so nodes must be printed against that file (not a dummy).
+const nodeSourceFiles = new WeakMap<ts.Node, ts.SourceFile>();
+
+function print(node: ts.Node, file?: ts.SourceFile): string {
+  const target = file ?? nodeSourceFiles.get(node) ?? printerScratchFile;
+  return printer.printNode(ts.EmitHint.Unspecified, node, target);
+}
+
+function fileOf(node: ts.Node): ts.SourceFile {
+  const file = nodeSourceFiles.get(node);
+  assert(file);
+  return file;
+}
+
+const printerScratchFile = ts.createSourceFile(
+  "scratch.ts",
+  "",
+  ts.ScriptTarget.ESNext,
+  true,
+  ts.ScriptKind.TS,
+);
+
+/**
+ * Parse `source` (an expression statement) and return its expression node,
+ * with parent pointers set so that node predicates work.
+ */
+function parseExpression(source: string): ts.Expression {
+  const file = ts.createSourceFile(
+    "expr.ts",
+    `(${source});`,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const statement = file.statements[0];
+  assert(ts.isExpressionStatement(statement));
+  // The wrapping parens produce a ParenthesizedExpression; unwrap one layer.
+  const paren = statement.expression;
+  assert(ts.isParenthesizedExpression(paren));
+  const expr = paren.expression;
+  nodeSourceFiles.set(expr, file);
+  return expr;
+}
+
+Deno.test("parseCaptureExpression reads a bare identifier as an empty-path root", () => {
+  const info = parseCaptureExpression(parseExpression("entry"));
+  assert(info);
+  assertEquals(info.root, "entry");
+  assertEquals(info.path, []);
+});
+
+Deno.test("parseCaptureExpression flattens a key() call chain into path segments", () => {
+  const info = parseCaptureExpression(
+    parseExpression('entry.key("piece").key("title")'),
+  );
+  assert(info);
+  assertEquals(info.root, "entry");
+  assertEquals(info.path, ["piece", "title"]);
+});
+
+Deno.test("parseCaptureExpression rejects a key() call whose receiver is not a capture", () => {
+  // The receiver `foo()` is a call, not an identifier/property access, so the
+  // recursive parse returns undefined and the key() branch bails out.
+  const info = parseCaptureExpression(parseExpression('foo().key("piece")'));
+  assertEquals(info, undefined);
+});
+
+Deno.test("parseCaptureExpression rejects a key() call with a non-literal argument", () => {
+  // A dynamic key argument cannot be reduced to a static path segment.
+  const info = parseCaptureExpression(parseExpression("entry.key(dynamic)"));
+  assertEquals(info, undefined);
+});
+
+Deno.test("parseCaptureExpression stops at an optional chain and captures the pre-chain identifier", () => {
+  const info = parseCaptureExpression(parseExpression("entry?.name"));
+  assert(info);
+  assertEquals(info.root, "entry");
+  assertEquals(info.path, []);
+});
+
+Deno.test("parseCaptureExpression rejects an optional chain rooted in a non-identifier, non-property expression", () => {
+  // `foo()?.name` has a call expression before the `?.`, which is neither an
+  // identifier nor a property access, so parsing fails.
+  const info = parseCaptureExpression(parseExpression("foo()?.name"));
+  assertEquals(info, undefined);
+});
+
+Deno.test("parseCaptureExpression collects a plain property-access chain into a path", () => {
+  const info = parseCaptureExpression(parseExpression("entry.a.b.c"));
+  assert(info);
+  assertEquals(info.root, "entry");
+  assertEquals(info.path, ["a", "b", "c"]);
+});
+
+Deno.test("groupCapturesByRoot skips expressions that do not parse as captures", () => {
+  // A non-capture expression (element access on a call) is ignored; only the
+  // parseable capture survives in the resulting tree.
+  const skipped = parseExpression("foo()[0]");
+  const kept = parseExpression("entry.name");
+  const tree = groupCapturesByRoot([skipped, kept]);
+  assertEquals([...tree.keys()], ["entry"]);
+});
+
+Deno.test("groupCapturesByRoot builds nested property nodes and collapses whole-root captures", () => {
+  const tree = groupCapturesByRoot([
+    parseExpression("entry.a.b"),
+    parseExpression("other"),
+  ]);
+  const entry = tree.get("entry");
+  assert(entry);
+  // The nested path a.b becomes a chain of property nodes.
+  const a = entry.properties.get("a");
+  assert(a);
+  const b = a.properties.get("b");
+  assert(b);
+  assert(b.expression);
+  // A bare-root capture stores the expression at the root and clears children.
+  const other = tree.get("other");
+  assert(other);
+  assert(other.expression);
+  assertEquals(other.properties.size, 0);
+});
+
+Deno.test("createCaptureAccessExpression returns a key() template unchanged via the fast path", () => {
+  const template = parseExpression('entry.key("piece")');
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["piece"],
+    factory,
+    template,
+  );
+  // The key() call template is returned verbatim, still rooted at `entry`.
+  assertEquals(print(result, fileOf(template)), 'entry.key("piece")');
+});
+
+Deno.test("createCaptureAccessExpression rebuilds a property access rerooted at the new name", () => {
+  const template = parseExpression("entry.name");
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["name"],
+    factory,
+    template,
+  );
+  assertEquals(print(result), "__cf_entry.name");
+});
+
+Deno.test("createCaptureAccessExpression preserves optional-chain property access when rebuilding", () => {
+  const template = parseExpression("entry?.name");
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["name"],
+    factory,
+    template,
+  );
+  assertEquals(print(result), "__cf_entry?.name");
+});
+
+Deno.test("createCaptureAccessExpression rebuilds an element access rerooted at the new name", () => {
+  const template = parseExpression('entry["name"]');
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["name"],
+    factory,
+    template,
+  );
+  assertEquals(print(result, fileOf(template)), '__cf_entry["name"]');
+});
+
+Deno.test("createCaptureAccessExpression preserves optional-chain element access when rebuilding", () => {
+  const template = parseExpression('entry?.["name"]');
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["name"],
+    factory,
+    template,
+  );
+  assertEquals(print(result, fileOf(template)), '__cf_entry?.["name"]');
+});
+
+Deno.test("createCaptureAccessExpression falls back when an optional element-access chain cannot be rebuilt", () => {
+  // `foo()?.["name"]` is an element access chain, but its inner expression is a
+  // call that does not rebuild, so the whole rebuild fails and the function
+  // synthesizes the access from rootName plus path segments instead.
+  const template = parseExpression('foo()?.["name"]');
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["items"],
+    factory,
+    template,
+  );
+  assertEquals(print(result, fileOf(template)), "__cf_entry.items");
+});
+
+Deno.test("createCaptureAccessExpression falls back to path segments when the template cannot rebuild", () => {
+  // A template that bottoms out on a call expression is not rebuildable, so the
+  // function synthesizes the access from rootName plus the path segments.
+  const template = parseExpression("foo().bar");
+  const result = createCaptureAccessExpression(
+    "__cf_entry",
+    ["a", "b"],
+    factory,
+    template,
+  );
+  assertEquals(print(result), "__cf_entry.a.b");
+});
+
+Deno.test("createCaptureAccessExpression with no template builds access purely from path segments", () => {
+  const result = createCaptureAccessExpression(
+    "root",
+    ["one", "two"],
+    factory,
+  );
+  assertEquals(print(result), "root.one.two");
+});
+
+Deno.test("buildHierarchicalParamsValue emits a leaf access when a node holds only an expression", () => {
+  const node: CaptureTreeNode = createCaptureTreeNode(["name"]);
+  node.expression = parseExpression("entry.name");
+  const result = buildHierarchicalParamsValue(node, "__cf_entry", factory);
+  assertEquals(print(result), "__cf_entry.name");
+});
+
+Deno.test("buildHierarchicalParamsValue prefers the stored expression over empty property assignments", () => {
+  // A node with an expression but no child properties takes the leaf path even
+  // after the assignment loop runs, producing a single rerooted access.
+  const node: CaptureTreeNode = createCaptureTreeNode(["value"]);
+  node.expression = parseExpression("entry.value");
+  const result = buildHierarchicalParamsValue(node, "root", factory);
+  assertEquals(print(result), "root.value");
+});
+
+Deno.test("buildHierarchicalParamsValue emits an object literal for a node with child properties", () => {
+  const tree = groupCapturesByRoot([
+    parseExpression("entry.a"),
+    parseExpression("entry.b"),
+  ]);
+  const entry = tree.get("entry");
+  assert(entry);
+  const result = buildHierarchicalParamsValue(entry, "__cf_entry", factory);
+  const text = print(result);
+  assert(text.startsWith("{"));
+  assert(text.includes("a: __cf_entry.a"));
+  assert(text.includes("b: __cf_entry.b"));
+});
+
+Deno.test("buildCapturePropertyAssignments applies renames to the root property name", () => {
+  const tree = groupCapturesByRoot([parseExpression("entry.name")]);
+  const assignments = buildCapturePropertyAssignments(
+    tree,
+    factory,
+    new Map([["entry", "renamed"]]),
+  );
+  assertEquals(assignments.length, 1);
+  // The rename map relabels the property; the value re-roots the capture at the
+  // original root name, wrapped in an object literal for the single child.
+  const childExpr = tree.get("entry")!.properties.get("name")!.expression!;
+  const text = print(assignments[0], fileOf(childExpr));
+  assert(text.startsWith("renamed:"));
+  assert(text.includes("name: entry.name"));
+});

--- a/packages/ts-transformers/test/utils/identifiers-coverage.test.ts
+++ b/packages/ts-transformers/test/utils/identifiers-coverage.test.ts
@@ -1,0 +1,332 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import {
+  createBindingElementsFromNames,
+  createParameterFromBindings,
+  createPropertyName,
+  createPropertyParamNames,
+  extractBindingNames,
+  getUniqueIdentifier,
+  isSafeIdentifierText,
+  maybeReuseIdentifier,
+  normalizeBindingName,
+  reserveIdentifier,
+  sanitizeIdentifierCandidate,
+} from "../../src/utils/identifiers.ts";
+
+const factory = ts.factory;
+
+function printNode(node: ts.Node): string {
+  const sf = ts.createSourceFile("/p.ts", "", ts.ScriptTarget.ESNext, false);
+  return ts.createPrinter().printNode(ts.EmitHint.Unspecified, node, sf);
+}
+
+Deno.test("isSafeIdentifierText rejects empty text", () => {
+  assertEquals(isSafeIdentifierText(""), false);
+});
+
+Deno.test("isSafeIdentifierText accepts a plain identifier", () => {
+  assertEquals(isSafeIdentifierText("value"), true);
+  assertEquals(isSafeIdentifierText("$ref_1"), true);
+});
+
+Deno.test("isSafeIdentifierText rejects a reserved word", () => {
+  assertEquals(isSafeIdentifierText("class"), false);
+  assertEquals(isSafeIdentifierText("return"), false);
+});
+
+Deno.test(
+  "isSafeIdentifierText accepts contextual keywords that are not reserved",
+  () => {
+    // `async`/`of` scan as identifiers outside their reserved contexts here.
+    assertEquals(isSafeIdentifierText("async"), true);
+    assertEquals(isSafeIdentifierText("of"), true);
+  },
+);
+
+Deno.test(
+  "isSafeIdentifierText rejects an identifier that starts with a digit",
+  () => {
+    assertEquals(isSafeIdentifierText("1abc"), false);
+  },
+);
+
+Deno.test(
+  "isSafeIdentifierText rejects an identifier with an invalid inner char",
+  () => {
+    assertEquals(isSafeIdentifierText("a-b"), false);
+  },
+);
+
+Deno.test(
+  "sanitizeIdentifierCandidate replaces invalid characters with underscores",
+  () => {
+    assertEquals(sanitizeIdentifierCandidate("a.b-c"), "a_b_c");
+  },
+);
+
+Deno.test(
+  "sanitizeIdentifierCandidate prefixes a candidate that starts with a digit",
+  () => {
+    assertEquals(sanitizeIdentifierCandidate("9lives"), "_9lives");
+  },
+);
+
+Deno.test(
+  "sanitizeIdentifierCandidate falls back when the candidate reduces to empty",
+  () => {
+    assertEquals(sanitizeIdentifierCandidate("", { fallback: "ref" }), "ref");
+  },
+);
+
+Deno.test("sanitizeIdentifierCandidate can trim leading underscores", () => {
+  assertEquals(
+    sanitizeIdentifierCandidate("__hidden", { trimLeadingUnderscores: true }),
+    "hidden",
+  );
+});
+
+Deno.test(
+  "sanitizeIdentifierCandidate replaces a reserved-word candidate with the fallback",
+  () => {
+    // `class` sanitizes char-for-char but is still an unsafe (reserved) token,
+    // so it is swapped for the fallback.
+    assertEquals(
+      sanitizeIdentifierCandidate("class", { fallback: "safe" }),
+      "safe",
+    );
+  },
+);
+
+Deno.test(
+  "sanitizeIdentifierCandidate normalizes a fallback that starts with a digit",
+  () => {
+    // An empty candidate falls back; the digit-leading fallback is prefixed.
+    assertEquals(sanitizeIdentifierCandidate("", { fallback: "1f" }), "_1f");
+  },
+);
+
+Deno.test(
+  "sanitizeIdentifierCandidate collapses an all-underscore trimmed fallback to the default",
+  () => {
+    // Trimming leading underscores empties the fallback, so the default `_` is
+    // used for the empty candidate.
+    assertEquals(
+      sanitizeIdentifierCandidate("", {
+        fallback: "___",
+        trimLeadingUnderscores: true,
+      }),
+      "_",
+    );
+  },
+);
+
+Deno.test(
+  "sanitizeIdentifierCandidate uses the default when the fallback is itself reserved",
+  () => {
+    // A reserved-word fallback is unsafe, so normalization returns the default
+    // `_` for the empty candidate.
+    assertEquals(
+      sanitizeIdentifierCandidate("", { fallback: "class" }),
+      "_",
+    );
+  },
+);
+
+Deno.test("getUniqueIdentifier appends a numeric suffix on collision", () => {
+  const used = new Set<string>(["value"]);
+  assertEquals(getUniqueIdentifier("value", used), "value_1");
+  assertEquals(getUniqueIdentifier("value", used), "value_2");
+  assert(used.has("value_1"));
+  assert(used.has("value_2"));
+});
+
+Deno.test("getUniqueIdentifier honors a custom suffix separator", () => {
+  const used = new Set<string>(["n"]);
+  assertEquals(getUniqueIdentifier("n", used, { suffixSeparator: "$" }), "n$1");
+});
+
+Deno.test("maybeReuseIdentifier reuses a free, safe identifier", () => {
+  const used = new Set<string>();
+  const id = factory.createIdentifier("keep");
+  assertEquals(maybeReuseIdentifier(id, used), id);
+  assert(used.has("keep"));
+});
+
+Deno.test(
+  "maybeReuseIdentifier creates a fresh identifier when the name is taken",
+  () => {
+    const used = new Set<string>(["taken"]);
+    const id = factory.createIdentifier("taken");
+    const result = maybeReuseIdentifier(id, used);
+    assert(result !== id);
+    assertEquals(result.text, "taken_1");
+  },
+);
+
+Deno.test(
+  "createPropertyName emits an identifier for safe names and a string literal otherwise",
+  () => {
+    assert(ts.isIdentifier(createPropertyName("ok", factory)));
+    const literal = createPropertyName("not-ok", factory);
+    assert(ts.isStringLiteral(literal));
+    assertEquals(literal.text, "not-ok");
+  },
+);
+
+Deno.test("reserveIdentifier reuses a free candidate", () => {
+  const used = new Set<string>();
+  const id = reserveIdentifier("fresh", used, factory);
+  assertEquals(id.text, "fresh");
+  assert(used.has("fresh"));
+});
+
+Deno.test(
+  "reserveIdentifier allocates a unique name when the candidate is taken",
+  () => {
+    const used = new Set<string>(["dup"]);
+    const id = reserveIdentifier("dup", used, factory);
+    assertEquals(id.text, "dup_1");
+  },
+);
+
+Deno.test("reserveIdentifier uses the empty fallback for a blank candidate", () => {
+  const used = new Set<string>();
+  const id = reserveIdentifier("", used, factory, { emptyFallback: "anon" });
+  assertEquals(id.text, "anon");
+});
+
+Deno.test(
+  "createBindingElementsFromNames adds property names only for unsafe keys",
+  () => {
+    const elements = createBindingElementsFromNames(
+      ["safe", "not-safe"],
+      factory,
+      (name) => factory.createIdentifier(name.replace(/[^A-Za-z0-9_$]/g, "_")),
+    );
+    assertEquals(elements.length, 2);
+    // Safe key: no explicit property name (shorthand binding).
+    assertEquals(elements[0]!.propertyName, undefined);
+    // Unsafe key: explicit string-literal property name.
+    assert(elements[1]!.propertyName);
+    assert(ts.isStringLiteral(elements[1]!.propertyName!));
+  },
+);
+
+Deno.test(
+  "createParameterFromBindings wraps binding elements in an object pattern",
+  () => {
+    const elements = createBindingElementsFromNames(
+      ["a"],
+      factory,
+      (name) => factory.createIdentifier(name),
+    );
+    const param = createParameterFromBindings(elements, factory, {
+      type: factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    });
+    assert(ts.isObjectBindingPattern(param.name));
+    assert(param.type);
+  },
+);
+
+Deno.test(
+  "createPropertyParamNames derives property and param names with fallbacks",
+  () => {
+    const props = new Set<string>();
+    const params = new Set<string>();
+    const identifierResult = createPropertyParamNames(
+      "user",
+      true,
+      0,
+      props,
+      params,
+    );
+    assertEquals(identifierResult.propertyName, "user");
+    assertEquals(identifierResult.paramName, "user");
+
+    // Non-identifier expression: property name from dotted text, param uses _vN.
+    const memberResult = createPropertyParamNames(
+      "user.name",
+      false,
+      1,
+      props,
+      params,
+    );
+    assertEquals(memberResult.propertyName, "user_name");
+    assertEquals(memberResult.paramName, "_v2");
+  },
+);
+
+Deno.test("normalizeBindingName reuses a safe identifier binding", () => {
+  const used = new Set<string>();
+  const name = factory.createIdentifier("item");
+  const result = normalizeBindingName(name, factory, used);
+  assert(ts.isIdentifier(result));
+  assertEquals(result.text, "item");
+});
+
+Deno.test("normalizeBindingName recurses through an object binding pattern", () => {
+  const used = new Set<string>(["a"]);
+  const pattern = factory.createObjectBindingPattern([
+    factory.createBindingElement(
+      undefined,
+      undefined,
+      factory.createIdentifier("a"),
+    ),
+  ]);
+  const result = normalizeBindingName(pattern, factory, used);
+  assert(ts.isObjectBindingPattern(result));
+  // The colliding shorthand binding `a` is renamed to `a_1`.
+  assertEquals(printNode(result), "{ a_1 }");
+});
+
+Deno.test(
+  "normalizeBindingName preserves omitted elements in an array pattern",
+  () => {
+    const used = new Set<string>();
+    const pattern = factory.createArrayBindingPattern([
+      factory.createOmittedExpression(),
+      factory.createBindingElement(
+        undefined,
+        undefined,
+        factory.createIdentifier("second"),
+      ),
+    ]);
+    const result = normalizeBindingName(pattern, factory, used);
+    assert(ts.isArrayBindingPattern(result));
+    assertEquals(printNode(result), "[, second]");
+  },
+);
+
+Deno.test(
+  "extractBindingNames returns the name of a simple identifier binding",
+  () => {
+    assertEquals(extractBindingNames(factory.createIdentifier("solo")), [
+      "solo",
+    ]);
+  },
+);
+
+Deno.test("extractBindingNames flattens nested object and array patterns", () => {
+  const pattern = factory.createObjectBindingPattern([
+    factory.createBindingElement(
+      undefined,
+      undefined,
+      factory.createIdentifier("a"),
+    ),
+    factory.createBindingElement(
+      undefined,
+      "nested",
+      factory.createArrayBindingPattern([
+        factory.createOmittedExpression(),
+        factory.createBindingElement(
+          undefined,
+          undefined,
+          factory.createIdentifier("b"),
+        ),
+      ]),
+    ),
+  ]);
+  assertEquals(extractBindingNames(pattern), ["a", "b"]);
+});

--- a/packages/ts-transformers/test/write-authorized-by-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/write-authorized-by-validation-coverage.test.ts
@@ -1,0 +1,273 @@
+import { assert, assertEquals } from "@std/assert";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { validateSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+/**
+ * Exercises the branches of the WriteAuthorizedBy validation transformer that
+ * the existing cfc-authoring tests do not reach: property-access `toSchema`
+ * call sites, non-identifier `typeof` bindings, recursion guards while walking
+ * local type declarations, index-signature traversal, the generic type-argument
+ * substitution over array/union/intersection/operator/parenthesized shapes, and
+ * the initializer-unwrapping loop that sees through parentheses and assertions.
+ */
+
+async function cfcDiagnostics(
+  source: string,
+): Promise<readonly TransformationDiagnostic[]> {
+  const { diagnostics } = await validateSource(source, {
+    mode: "error",
+    types: COMMONFABRIC_TYPES,
+  });
+  return diagnostics.filter((diagnostic) =>
+    diagnostic.type === "cfc-write-authorized-by"
+  );
+}
+
+Deno.test(
+  "property-access toSchema call site is validated for WriteAuthorizedBy",
+  async () => {
+    const source = `/// <cts-enable />
+      import { WriteAuthorizedBy } from "commonfabric";
+
+      declare const ns: { toSchema<T>(): unknown };
+      const arbitrary = 123;
+
+      const schema = ns.toSchema<
+        WriteAuthorizedBy<{ title: string }, typeof arbitrary>
+      >();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+    assert(
+      diagnostics[0]!.message.includes(
+        "local handler(), module(), requireEventIntegrity()",
+      ),
+    );
+  },
+);
+
+Deno.test(
+  "typeof of a qualified name reports the simple-identifier requirement",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const container = { saver() {} };
+
+      const schema = toSchema<
+        WriteAuthorizedBy<{ title: string }, typeof container.saver>
+      >();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+    assert(diagnostics[0]!.message.includes("simple identifier binding"));
+  },
+);
+
+Deno.test(
+  "index-signature members of a referenced interface are traversed for bindings",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      interface Bag {
+        [key: string]: WriteAuthorizedBy<{ title: string }, typeof arbitrary>;
+      }
+
+      const schema = toSchema<Bag>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+    assert(
+      diagnostics[0]!.message.includes(
+        "local handler(), module(), requireEventIntegrity()",
+      ),
+    );
+  },
+);
+
+Deno.test(
+  "self-referential type alias terminates and still reports the binding error",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Recursive = {
+        self?: Recursive;
+        write: WriteAuthorizedBy<{ title: string }, typeof arbitrary>;
+      };
+
+      const schema = toSchema<Recursive>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+// The following cases place the generic alias parameter *inside* the schema
+// type argument of WriteAuthorizedBy, wrapped in a distinct type shape. When the
+// validator substitutes the actual type into the alias parameter, it must
+// descend through that shape to rebuild the WriteAuthorizedBy reference. Each
+// case pins one branch of the substitution walker (array, union, intersection,
+// type operator, parenthesized, index signature) and asserts the binding is
+// still validated afterward.
+
+Deno.test(
+  "generic alias substitutes schema through array element types",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Wrap<T> = {
+        write: WriteAuthorizedBy<T[], typeof arbitrary>;
+      };
+
+      const schema = toSchema<Wrap<{ title: string }>>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+Deno.test(
+  "generic alias substitutes schema through union and parenthesized types",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Wrap<T> = {
+        write: WriteAuthorizedBy<(T | undefined), typeof arbitrary>;
+      };
+
+      const schema = toSchema<Wrap<{ title: string }>>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+Deno.test(
+  "generic alias substitutes schema through intersection types",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Wrap<T> = {
+        write: WriteAuthorizedBy<T & { tag: string }, typeof arbitrary>;
+      };
+
+      const schema = toSchema<Wrap<{ title: string }>>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+Deno.test(
+  "generic alias substitutes schema through readonly type-operator types",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Wrap<T> = {
+        write: WriteAuthorizedBy<readonly T[], typeof arbitrary>;
+      };
+
+      const schema = toSchema<Wrap<{ title: string }>>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+Deno.test(
+  "generic alias substitutes schema through index-signature member types",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Wrap<T> = {
+        write: WriteAuthorizedBy<{ [key: string]: T }, typeof arbitrary>;
+      };
+
+      const schema = toSchema<Wrap<{ title: string }>>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+Deno.test(
+  "generic alias substitutes schema literals with non-property members",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      const arbitrary = 123;
+
+      type Wrap<T> = {
+        write: WriteAuthorizedBy<{ payload: T; describe(): string }, typeof arbitrary>;
+      };
+
+      const schema = toSchema<Wrap<{ title: string }>>();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 1);
+  },
+);
+
+Deno.test(
+  "supported binding wrapped in parentheses and assertions is accepted",
+  async () => {
+    const source = `/// <cts-enable />
+      import { toSchema, WriteAuthorizedBy } from "commonfabric";
+
+      declare function handler<E, S>(fn: (event: E, state: S) => void): () => void;
+
+      const saver = (handler<void, {}>((_e, _s) => {}) as unknown)!;
+
+      const schema = toSchema<
+        WriteAuthorizedBy<{ title: string }, typeof saver>
+      >();
+
+      export { schema };
+    `;
+    const diagnostics = await cfcDiagnostics(source);
+    assertEquals(diagnostics.length, 0);
+  },
+);


### PR DESCRIPTION
Computer-generated test coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add broad unit tests in `packages/ts-transformers` for capability analysis and module‑scope function hardening, plus core transformers/utilities (expression rewrite, schema, destructuring, types, AST/call helpers, validation).
This locks in `WriteAuthorizedBy` annotations for top‑level functions and covers interprocedural paths, optional calls, array/as unwrapping, identity tracking via spreads, alias restoration across loops, and mixed‑shape pushes.

<sup>Written for commit 241f371fda4888f9aa4e08c68f581ccb1d021efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

