### PR TITLE
perf(runner): memoize compiled-body parse in buildRecordsFromCompiled

### DIFF
--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -29,20 +29,26 @@ const TARGET = ts.ScriptTarget.ES2023;
 const logger = getLogger("module-record-compiler");
 
 /**
- * Content-addressed memo of the two pure derivations
- * {@link buildRecordsFromCompiled} extracts from a module's compiled body: its
- * direct export surface (names + `export *` target specifiers) and its runtime
- * `require()` specifiers. Keyed by the module's content-hash `identity`.
+ * Memo of the two pure derivations {@link buildRecordsFromCompiled} extracts
+ * from a module's compiled body: its direct export surface (names + `export *`
+ * target specifiers) and its runtime `require()` specifiers. **Keyed by the
+ * compiled body itself** — both derivations are pure functions of that body.
  *
  * At piece boot every system pattern loaded by identity rebuilds its record
  * graph from the SAME shared module closure, so `buildRecordsFromCompiled` runs
  * once per pattern over an identical module set and re-`createSourceFile`s every
- * body N times — the dominant cost of the warm boot path. Both derivations are
- * pure functions of the compiled body, and `identity` is that body's content
- * hash, so a parse is reusable across every call, closure, and space with no
- * staleness risk. This collapses the boot re-parse to one parse per distinct
- * module per worker. Cached arrays are treated as immutable; callers copy
- * before mutating or handing them to a consumer that might.
+ * body N times — the dominant cost of the warm boot path. This collapses that to
+ * one parse per distinct body per worker.
+ *
+ * Keying on the body (not the module's source `identity`) is deliberate: a
+ * content-hash identity is a hash of the *authored source*, and the same
+ * identity can map to *different* compiled bytes across compilation modes /
+ * runtime versions (cf. the `recordCache` note in `compileSourcesToRecords`,
+ * where a precompiled body and a bare-transpiled body share a content-hash key).
+ * An identity key could therefore serve one body's parse for another; the body
+ * fully determines the parse, so a body key is exact and cross-contamination is
+ * impossible. Cached arrays are treated as immutable; callers copy before
+ * mutating or handing them to a consumer that might.
  */
 const exportParseCache = new Map<
   string,
@@ -50,27 +56,23 @@ const exportParseCache = new Map<
 >();
 const importParseCache = new Map<string, readonly string[]>();
 
-function parseExportsByIdentity(
-  identity: string,
+function parseCompiledExports(
   code: string,
 ): { exportNames: readonly string[]; starTargetSpecs: readonly string[] } {
-  let hit = exportParseCache.get(identity);
+  let hit = exportParseCache.get(code);
   if (hit === undefined) {
     const { names, starTargetSpecs } = extractCompiledExports(code);
     hit = { exportNames: [...names], starTargetSpecs };
-    exportParseCache.set(identity, hit);
+    exportParseCache.set(code, hit);
   }
   return hit;
 }
 
-function parseImportsByIdentity(
-  identity: string,
-  code: string,
-): readonly string[] {
-  let hit = importParseCache.get(identity);
+function parseCompiledImports(code: string): readonly string[] {
+  let hit = importParseCache.get(code);
   if (hit === undefined) {
     hit = extractRuntimeImports(code);
-    importParseCache.set(identity, hit);
+    importParseCache.set(code, hit);
   }
   return hit;
 }
@@ -800,7 +802,7 @@ export function buildRecordsFromCompiled(
     { names: Set<string>; starTargets: string[] }
   >();
   for (const m of modules) {
-    const parsed = parseExportsByIdentity(m.identity, m.code);
+    const parsed = parseCompiledExports(m.code);
     const names = new Set<string>(parsed.exportNames);
     const starTargets: string[] = [];
     for (const spec of parsed.starTargetSpecs) {
@@ -848,7 +850,7 @@ export function buildRecordsFromCompiled(
     compiledBodies.set(specifier, m.code);
     if (m.sourceMap) moduleSourceMaps.set(specifier, m.sourceMap);
 
-    const importSpecs = [...parseImportsByIdentity(m.identity, m.code)];
+    const importSpecs = [...parseCompiledImports(m.code)];
     const resolutions: Record<string, string> = {};
     for (const spec of importSpecs) {
       const edge = m.imports.find((i) => i.specifier === spec);

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -38,7 +38,7 @@ const logger = getLogger("module-record-compiler");
  * graph from the SAME shared module closure, so `buildRecordsFromCompiled` runs
  * once per pattern over an identical module set and re-`createSourceFile`s every
  * body N times — the dominant cost of the warm boot path. This collapses that to
- * one parse per distinct body per worker.
+ * one parse per distinct body per process.
  *
  * Keying on the body (not the module's source `identity`) is deliberate: a
  * content-hash identity is a hash of the *authored source*, and the same
@@ -47,8 +47,17 @@ const logger = getLogger("module-record-compiler");
  * where a precompiled body and a bare-transpiled body share a content-hash key).
  * An identity key could therefore serve one body's parse for another; the body
  * fully determines the parse, so a body key is exact and cross-contamination is
- * impossible. Cached arrays are treated as immutable; callers copy before
- * mutating or handing them to a consumer that might.
+ * impossible.
+ *
+ * The two maps are process-global and unbounded by design: one small
+ * record-surface entry (export names + import specifiers) per distinct compiled
+ * body, retained for the process lifetime and keyed by the body string. Distinct
+ * bodies are bounded by the pattern universe a worker serves; a long-lived
+ * process that loaded an unbounded number of distinct bodies would want a hash
+ * key or a bounded cache instead (cf. `addressableByIdentity` in
+ * pattern-manager.ts, likewise session-lifetime and deliberately unbounded).
+ * Cached arrays are treated as immutable; callers copy before mutating or
+ * handing them to a consumer that might.
  */
 const exportParseCache = new Map<
   string,
@@ -62,7 +71,10 @@ function parseCompiledExports(
   let hit = exportParseCache.get(code);
   if (hit === undefined) {
     const { names, starTargetSpecs } = extractCompiledExports(code);
-    hit = { exportNames: [...names], starTargetSpecs };
+    // Copy both derived arrays into the cache entry so a cached parse can never
+    // be mutated through a reference the extractor might retain (symmetry with
+    // exportNames; the entry is handed out on every hit).
+    hit = { exportNames: [...names], starTargetSpecs: [...starTargetSpecs] };
     exportParseCache.set(code, hit);
   }
   return hit;

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -29,6 +29,53 @@ const TARGET = ts.ScriptTarget.ES2023;
 const logger = getLogger("module-record-compiler");
 
 /**
+ * Content-addressed memo of the two pure derivations
+ * {@link buildRecordsFromCompiled} extracts from a module's compiled body: its
+ * direct export surface (names + `export *` target specifiers) and its runtime
+ * `require()` specifiers. Keyed by the module's content-hash `identity`.
+ *
+ * At piece boot every system pattern loaded by identity rebuilds its record
+ * graph from the SAME shared module closure, so `buildRecordsFromCompiled` runs
+ * once per pattern over an identical module set and re-`createSourceFile`s every
+ * body N times — the dominant cost of the warm boot path. Both derivations are
+ * pure functions of the compiled body, and `identity` is that body's content
+ * hash, so a parse is reusable across every call, closure, and space with no
+ * staleness risk. This collapses the boot re-parse to one parse per distinct
+ * module per worker. Cached arrays are treated as immutable; callers copy
+ * before mutating or handing them to a consumer that might.
+ */
+const exportParseCache = new Map<
+  string,
+  { exportNames: readonly string[]; starTargetSpecs: readonly string[] }
+>();
+const importParseCache = new Map<string, readonly string[]>();
+
+function parseExportsByIdentity(
+  identity: string,
+  code: string,
+): { exportNames: readonly string[]; starTargetSpecs: readonly string[] } {
+  let hit = exportParseCache.get(identity);
+  if (hit === undefined) {
+    const { names, starTargetSpecs } = extractCompiledExports(code);
+    hit = { exportNames: [...names], starTargetSpecs };
+    exportParseCache.set(identity, hit);
+  }
+  return hit;
+}
+
+function parseImportsByIdentity(
+  identity: string,
+  code: string,
+): readonly string[] {
+  let hit = importParseCache.get(identity);
+  if (hit === undefined) {
+    hit = extractRuntimeImports(code);
+    importParseCache.set(identity, hit);
+  }
+  return hit;
+}
+
+/**
  * Create a write-once exports target for a module body. Re-assigning,
  * redefining, or deleting a property that already holds a real (non-`undefined`)
  * value throws. A `void 0` placeholder — the TS `exports.x = void 0;` forward
@@ -753,9 +800,10 @@ export function buildRecordsFromCompiled(
     { names: Set<string>; starTargets: string[] }
   >();
   for (const m of modules) {
-    const { names, starTargetSpecs } = extractCompiledExports(m.code);
+    const parsed = parseExportsByIdentity(m.identity, m.code);
+    const names = new Set<string>(parsed.exportNames);
     const starTargets: string[] = [];
-    for (const spec of starTargetSpecs) {
+    for (const spec of parsed.starTargetSpecs) {
       const edge = m.imports.find((i) => i.specifier === spec);
       if (edge) starTargets.push(edge.targetIdentity);
       else {for (const n of runtimeModules[spec] ?? []) {
@@ -800,7 +848,7 @@ export function buildRecordsFromCompiled(
     compiledBodies.set(specifier, m.code);
     if (m.sourceMap) moduleSourceMaps.set(specifier, m.sourceMap);
 
-    const importSpecs = extractRuntimeImports(m.code);
+    const importSpecs = [...parseImportsByIdentity(m.identity, m.code)];
     const resolutions: Record<string, string> = {};
     for (const spec of importSpecs) {
       const edge = m.imports.find((i) => i.specifier === spec);

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -143,3 +143,82 @@ describe("buildRecordsFromCompiled (resolve-free, source-free)", () => {
     );
   });
 });
+
+describe("buildRecordsFromCompiled parse memo (content-addressed)", () => {
+  // Two modules with unique content-hash identities and hand-written CJS bodies,
+  // so the process-global parse memo is cold for them at first sight. At piece
+  // boot the SAME system-app closure is rebuilt once per system pattern loaded
+  // by identity, so without the memo every module is re-parsed N times; these
+  // fixtures stand in for that shared closure.
+  const modA: CachedCompiledModule = {
+    identity: "memo-test-A-0000000000000000000000000000",
+    filename: "/memo-a.ts",
+    code: [
+      `Object.defineProperty(exports, "__esModule", { value: true });`,
+      `exports.a = void 0;`,
+      `exports.a = 1;`,
+    ].join("\n"),
+    imports: [],
+  };
+  const modB: CachedCompiledModule = {
+    identity: "memo-test-B-0000000000000000000000000000",
+    filename: "/memo-b.ts",
+    code: [
+      `Object.defineProperty(exports, "__esModule", { value: true });`,
+      `exports.b = void 0;`,
+      `exports.b = 2;`,
+    ].join("\n"),
+    imports: [],
+  };
+
+  // Records projected to a comparable, order-stable shape.
+  const exportsBySpecifier = (
+    g: ReturnType<typeof buildRecordsFromCompiled>,
+  ): [string, string[]][] =>
+    [...g.records]
+      .map(([specifier, r]): [string, string[]] => [
+        specifier,
+        [...r.exports].sort(),
+      ])
+      .sort(([a], [b]) => a.localeCompare(b));
+
+  it("is transparent: repeated builds of the same closure produce identical records", () => {
+    const first = buildRecordsFromCompiled([modA, modB]);
+    const second = buildRecordsFromCompiled([modA, modB]);
+    // Reusing a cached parse across calls must not corrupt output via shared
+    // mutable state — each record gets a fresh export Set and import array.
+    expect(exportsBySpecifier(second)).toEqual(exportsBySpecifier(first));
+  });
+
+  it("memoizes the parse by content-hash identity (equal identity ⇒ reused parse)", () => {
+    // The memo keys on `identity`, which is a content hash of the compiled body:
+    // a repeated identity is guaranteed to carry an identical body, so reusing
+    // the first parse is safe — and is exactly what elides the redundant boot
+    // re-parse of the shared system-app closure. Feeding a DIFFERENT body under
+    // an already-seen identity is not a real state (it violates the
+    // content-address invariant); it is used here only to make the reuse
+    // observable.
+    const id = "memo-reuse-identity-000000000000000000000000";
+    const spec = `cf:module/${id}`;
+    const exportsFor = (code: string): Set<string> => {
+      const g = buildRecordsFromCompiled([{
+        identity: id,
+        filename: "/reuse.ts",
+        code,
+        imports: [],
+      }]);
+      return new Set(g.records.get(spec)!.exports);
+    };
+    const seen = exportsFor(
+      `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+        `exports.first = void 0;\nexports.first = 1;`,
+    );
+    expect(seen).toEqual(new Set(["first", "__esModule"]));
+    // Same identity, different body → the memo returns the first parse.
+    const reused = exportsFor(
+      `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+        `exports.second = void 0;\nexports.second = 2;`,
+    );
+    expect(reused).toEqual(new Set(["first", "__esModule"]));
+  });
+});

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -220,4 +220,34 @@ describe("buildRecordsFromCompiled parse memo (content-addressed)", () => {
     );
     expect(second).toEqual(new Set(["second", "__esModule"]));
   });
+
+  it("keys the import memo on the compiled body too (no cross-contamination)", () => {
+    // Symmetric guard for parseCompiledImports: the runtime `require()`
+    // specifiers are also derived from — and memoized by — the compiled body.
+    // Feed two bodies that require() DIFFERENT specifiers under the SAME
+    // identity and assert each record's imports reflect ITS OWN body, proving
+    // the import memo is body-keyed (not identity-keyed) just like the exports.
+    const id = "memo-imports-identity-00000000000000000000";
+    const spec = `cf:module/${id}`;
+    const importsFor = (code: string): string[] => {
+      const g = buildRecordsFromCompiled([{
+        identity: id,
+        filename: "/imp.ts",
+        code,
+        imports: [],
+      }]);
+      return [...g.records.get(spec)!.imports];
+    };
+    const first = importsFor(
+      `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+        `const alpha = require("./alpha.ts");`,
+    );
+    expect(first).toEqual(["./alpha.ts"]);
+    // Same identity, DIFFERENT body → must reflect the second body's imports.
+    const second = importsFor(
+      `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+        `const beta = require("./beta.ts");`,
+    );
+    expect(second).toEqual(["./beta.ts"]);
+  });
 });

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -190,35 +190,34 @@ describe("buildRecordsFromCompiled parse memo (content-addressed)", () => {
     expect(exportsBySpecifier(second)).toEqual(exportsBySpecifier(first));
   });
 
-  it("memoizes the parse by content-hash identity (equal identity ⇒ reused parse)", () => {
-    // The memo keys on `identity`, which is a content hash of the compiled body:
-    // a repeated identity is guaranteed to carry an identical body, so reusing
-    // the first parse is safe — and is exactly what elides the redundant boot
-    // re-parse of the shared system-app closure. Feeding a DIFFERENT body under
-    // an already-seen identity is not a real state (it violates the
-    // content-address invariant); it is used here only to make the reuse
-    // observable.
-    const id = "memo-reuse-identity-000000000000000000000000";
+  it("keys the parse memo on the compiled body, not the source identity (no cross-contamination)", () => {
+    // The memo must key on the compiled body: the same source `identity` can map
+    // to different compiled bytes (different compilation modes / runtime
+    // versions), so serving one body's export surface for another would be a
+    // correctness bug. Feed two DIFFERENT bodies under the SAME identity and
+    // assert each record reflects ITS OWN body — proving the first body's parse
+    // is not reused for the second.
+    const id = "memo-key-identity-000000000000000000000000";
     const spec = `cf:module/${id}`;
     const exportsFor = (code: string): Set<string> => {
       const g = buildRecordsFromCompiled([{
         identity: id,
-        filename: "/reuse.ts",
+        filename: "/k.ts",
         code,
         imports: [],
       }]);
       return new Set(g.records.get(spec)!.exports);
     };
-    const seen = exportsFor(
+    const first = exportsFor(
       `Object.defineProperty(exports, "__esModule", { value: true });\n` +
         `exports.first = void 0;\nexports.first = 1;`,
     );
-    expect(seen).toEqual(new Set(["first", "__esModule"]));
-    // Same identity, different body → the memo returns the first parse.
-    const reused = exportsFor(
+    expect(first).toEqual(new Set(["first", "__esModule"]));
+    // Same identity, DIFFERENT body → must reflect the second body's exports.
+    const second = exportsFor(
       `Object.defineProperty(exports, "__esModule", { value: true });\n` +
         `exports.second = void 0;\nexports.second = 2;`,
     );
-    expect(reused).toEqual(new Set(["first", "__esModule"]));
+    expect(second).toEqual(new Set(["second", "__esModule"]));
   });
 });


### PR DESCRIPTION
## What

At piece boot the shared **system-app module closure** is rebuilt once per system
pattern loaded by identity, so `buildRecordsFromCompiled` re-parses every compiled
body to re-derive the same export/import record surface.

Measured on a trivial pattern's **cold** boot (isolated toolshed, current `main`),
the 9-module / 522 KB system-app closure is parsed **4×** — the 2nd–4th passes are
pure waste, since the derivation is a pure function of each module's compiled body:

| pass over the 9-module closure | before | after |
|---|---|---|
| 1st | 38.0 ms | 21.5 ms (the one real parse) |
| 2nd / 3rd / 4th | 19.7 / 18.6 / 18.2 ms | **0.0 / 0.0 / 0.0 ms** (memo hit) |
| **total** | **94.5 ms** | **21.5 ms** |

This is the 2nd-largest bucket of the ~640 ms generic per-piece cold-boot floor (a
trivial pattern pays the full system-app boot; the parse sits synchronously ahead
of first paint).

## Change

A memo (`exportParseCache` / `importParseCache`) in `module-record-compiler.ts`,
**keyed by the compiled body itself**. Both derivations — the export surface
(names + `export *` targets) and the runtime `require()` specifiers — are pure
functions of that body, so an equal body is guaranteed an equal parse. Each
distinct compiled body is parsed once per process → **~73 ms off the cold-boot
floor**, with byte-identical record output.

Keying on the body (not the module's source `identity`) is deliberate: a
content-hash `identity` hashes the *authored source*, and the same identity can
map to *different* compiled bytes across compilation modes / runtime versions (cf.
the `recordCache` guard in `compileSourcesToRecords`, where a precompiled body and
a bare-transpiled body share a content-hash key). A body key is exact, so
cross-contamination is impossible. The memo is process-global and unbounded by
design — one small record-surface entry per distinct body, session-lifetime.

<sub>(The table was measured on the initial identity-keyed prototype; the
parse-elision — and thus the wall-clock win — is identical under body-keying.)</sub>

## Why one parse and not zero

A SES virtual module record is `{ imports, exports, execute }`; the linker needs
the export names + import specifiers *before* `execute` runs. Modules are compiled
to CommonJS (no static export syntax) and the content-addressed cache stores the
compiled code but not the derived record surface, so it is reconstructed by parsing
on first sight. A follow-up persists the derived records at compile time to remove
the last parse entirely (0 on the critical path) — landing as a stacked PR on top
of this one.

## Tests / gate

- Regression tests in `build-from-compiled.test.ts`: transparency (repeated builds
  → identical records; guards shared-state corruption), plus cross-contamination
  guards for **both** the export and import memos (two different bodies under the
  same source `identity` each yield their own surface — proving the memo keys on
  the body, not the identity).
- Runner suite: **728 passed / 0 failed**.
- Integration `pattern-tests` (68) + `generated-patterns` (147): **green**.
- fmt / lint / check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoizes parsing in `buildRecordsFromCompiled`, keyed by the compiled body string. Collapses the shared system-app closure from 4× parses to 1×, saving ~73ms on cold boot (~94.5ms → ~21.5ms) with identical record output.

- **Refactors**
  - Adds process-global caches `exportParseCache` and `importParseCache`, keyed by compiled body (not source `identity`) to avoid cross-contamination across compile modes.
  - Introduces `parseCompiledExports` and `parseCompiledImports`; defensively copies cached arrays to prevent mutation on cache hits.
  - Adds tests for repeated-build transparency and body-keyed memoization for both exports and imports; all suites green.

<sup>Written for commit 562f01dc57baa48247f7d34e3c6d904a73c0dcfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

