### PR TITLE
perf(runner): persist compiled record surface, skip the boot parse (Fix B)

### DIFF
--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -2,6 +2,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import { CFC_COMPILED_BY_ATOM } from "@commonfabric/api/cfc";
 import { computeModuleHashes } from "../harness/module-identity.ts";
+import { deriveModuleRecordFields } from "../sandbox/module-record-compiler.ts";
 import type { CacheableModule } from "../harness/types.ts";
 import type { MemorySpace, Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
@@ -75,6 +76,15 @@ export interface CompiledDoc extends ModuleDocBase {
   readonly kind: "compiled";
   /** Per-module source map, if any (registered for fn.src / CFC resolution). */
   readonly sourceMap?: unknown;
+  /**
+   * Precomputed record surface (Fix B): the direct export names, `export *`
+   * target specifiers, and runtime import specifiers derived from `code` at
+   * compile time. Lets the boot-time record build skip the in-worker TS parse.
+   * Absent on documents written before the field existed (→ parse fallback).
+   */
+  readonly exportNames?: readonly string[];
+  readonly starTargetSpecs?: readonly string[];
+  readonly importSpecs?: readonly string[];
 }
 
 /**
@@ -596,6 +606,9 @@ const compiledDocProperties = {
   code: { type: "string" },
   filename: { type: "string" },
   sourceMap: {},
+  exportNames: { type: "array", items: { type: "string" } },
+  starTargetSpecs: { type: "array", items: { type: "string" } },
+  importSpecs: { type: "array", items: { type: "string" } },
   imports: {
     type: "array",
     items: {
@@ -624,6 +637,9 @@ export const COMPILED_DOC_SCHEMA = {
         code: { type: "string" },
         filename: { type: "string" },
         sourceMap: {},
+        exportNames: { type: "array", items: { type: "string" } },
+        starTargetSpecs: { type: "array", items: { type: "string" } },
+        importSpecs: { type: "array", items: { type: "string" } },
         imports: {
           type: "array",
           items: {
@@ -658,6 +674,9 @@ interface StoredCompiledDoc {
   code: string;
   filename: string;
   sourceMap?: unknown;
+  exportNames?: readonly string[];
+  starTargetSpecs?: readonly string[];
+  importSpecs?: readonly string[];
   imports: { specifier: string; link: unknown }[];
 }
 
@@ -717,11 +736,17 @@ export function writeCompiledDocs(
         schema,
         tx,
       );
+      // Fix B: derive the record surface from the compiled body once, here, so
+      // the boot-time record build reads it instead of re-parsing per load.
+      const derived = deriveModuleRecordFields(module.js);
       cell.set({
         kind: "compiled",
         identity: module.identity,
         code: module.js,
         filename: module.filename,
+        exportNames: derived.exportNames,
+        starTargetSpecs: derived.starTargetSpecs,
+        importSpecs: derived.importSpecs,
         ...(module.sourceMap !== undefined
           ? { sourceMap: module.sourceMap }
           : {}),
@@ -819,6 +844,15 @@ export async function loadCompiledClosure(
       code: doc.code,
       filename: doc.filename,
       ...(doc.sourceMap !== undefined ? { sourceMap: doc.sourceMap } : {}),
+      ...(doc.exportNames !== undefined
+        ? { exportNames: doc.exportNames }
+        : {}),
+      ...(doc.starTargetSpecs !== undefined
+        ? { starTargetSpecs: doc.starTargetSpecs }
+        : {}),
+      ...(doc.importSpecs !== undefined
+        ? { importSpecs: doc.importSpecs }
+        : {}),
       imports,
     });
   }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -693,6 +693,17 @@ export class PatternManager {
         ...(doc.sourceMap !== undefined
           ? { sourceMap: doc.sourceMap as never }
           : {}),
+        // Fix B: carry the precomputed record surface so the boot record build
+        // skips the in-worker parse (absent on legacy docs → parse fallback).
+        ...(doc.exportNames !== undefined
+          ? { exportNames: doc.exportNames }
+          : {}),
+        ...(doc.starTargetSpecs !== undefined
+          ? { starTargetSpecs: doc.starTargetSpecs }
+          : {}),
+        ...(doc.importSpecs !== undefined
+          ? { importSpecs: doc.importSpecs }
+          : {}),
         // Drop the synthetic entry→root links (cfc.ts etc.); only real
         // require/export-* edges resolve module records.
         imports: doc.imports
@@ -799,6 +810,16 @@ export class PatternManager {
         code: doc.code,
         ...(doc.sourceMap !== undefined
           ? { sourceMap: doc.sourceMap as never }
+          : {}),
+        // Fix B: carry the precomputed record surface (parse fallback if absent).
+        ...(doc.exportNames !== undefined
+          ? { exportNames: doc.exportNames }
+          : {}),
+        ...(doc.starTargetSpecs !== undefined
+          ? { starTargetSpecs: doc.starTargetSpecs }
+          : {}),
+        ...(doc.importSpecs !== undefined
+          ? { importSpecs: doc.importSpecs }
           : {}),
         imports: doc.imports
           .filter((i) => !i.specifier.startsWith(ROOT_LINK_SPECIFIER))

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -90,6 +90,28 @@ function parseCompiledImports(code: string): readonly string[] {
 }
 
 /**
+ * Derive a compiled module's record surface — its direct export names,
+ * `export *` target specifiers, and runtime import specifiers — from its
+ * compiled body in one shot (unmemoized; called once per module at compile
+ * time). Fix B persists this on the compiled doc so
+ * {@link buildRecordsFromCompiled} can read it at boot instead of re-parsing.
+ * Uses the same scans as the boot-time parse, so a persisted value is
+ * byte-identical to what that parse would produce.
+ */
+export function deriveModuleRecordFields(code: string): {
+  exportNames: string[];
+  starTargetSpecs: string[];
+  importSpecs: string[];
+} {
+  const { names, starTargetSpecs } = extractCompiledExports(code);
+  return {
+    exportNames: [...names],
+    starTargetSpecs,
+    importSpecs: extractRuntimeImports(code),
+  };
+}
+
+/**
  * Create a write-once exports target for a module body. Re-assigning,
  * redefining, or deleting a property that already holds a real (non-`undefined`)
  * value throws. A `void 0` placeholder — the TS `exports.x = void 0;` forward
@@ -754,6 +776,16 @@ export interface CachedCompiledModule {
   imports: { specifier: string; targetIdentity: string }[];
   /** Per-module source map, if cached. */
   sourceMap?: SourceMap;
+  /**
+   * Precomputed record surface (Fix B), derived from `code` at compile time via
+   * {@link deriveModuleRecordFields} and persisted on the compiled doc: the
+   * module's direct export names, `export *` target specifiers, and runtime
+   * import specifiers. When present, {@link buildRecordsFromCompiled} reads them
+   * and skips the in-worker parse; absent on legacy docs → parse fallback.
+   */
+  exportNames?: readonly string[];
+  starTargetSpecs?: readonly string[];
+  importSpecs?: readonly string[];
 }
 
 /**
@@ -814,7 +846,11 @@ export function buildRecordsFromCompiled(
     { names: Set<string>; starTargets: string[] }
   >();
   for (const m of modules) {
-    const parsed = parseCompiledExports(m.code);
+    // Fix B: prefer the record surface persisted on the compiled doc; fall back
+    // to parsing the body only for legacy docs that predate the persisted field.
+    const parsed = m.exportNames !== undefined
+      ? { exportNames: m.exportNames, starTargetSpecs: m.starTargetSpecs ?? [] }
+      : parseCompiledExports(m.code);
     const names = new Set<string>(parsed.exportNames);
     const starTargets: string[] = [];
     for (const spec of parsed.starTargetSpecs) {
@@ -862,7 +898,9 @@ export function buildRecordsFromCompiled(
     compiledBodies.set(specifier, m.code);
     if (m.sourceMap) moduleSourceMaps.set(specifier, m.sourceMap);
 
-    const importSpecs = [...parseCompiledImports(m.code)];
+    const importSpecs = m.importSpecs !== undefined
+      ? [...m.importSpecs]
+      : [...parseCompiledImports(m.code)];
     const resolutions: Record<string, string> = {};
     for (const spec of importSpecs) {
       const edge = m.imports.find((i) => i.specifier === spec);

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -71,10 +71,10 @@ function parseCompiledExports(
   let hit = exportParseCache.get(code);
   if (hit === undefined) {
     const { names, starTargetSpecs } = extractCompiledExports(code);
-    // Copy both derived arrays into the cache entry so a cached parse can never
-    // be mutated through a reference the extractor might retain (symmetry with
-    // exportNames; the entry is handed out on every hit).
-    hit = { exportNames: [...names], starTargetSpecs: [...starTargetSpecs] };
+    // extractCompiledExports returns fresh `readonly` arrays, so store them
+    // directly: the readonly contract (not a defensive copy) is what keeps the
+    // shared cache entry safe across every call it is handed to.
+    hit = { exportNames: names, starTargetSpecs };
     exportParseCache.set(code, hit);
   }
   return hit;
@@ -99,13 +99,13 @@ function parseCompiledImports(code: string): readonly string[] {
  * byte-identical to what that parse would produce.
  */
 export function deriveModuleRecordFields(code: string): {
-  exportNames: string[];
-  starTargetSpecs: string[];
-  importSpecs: string[];
+  exportNames: readonly string[];
+  starTargetSpecs: readonly string[];
+  importSpecs: readonly string[];
 } {
   const { names, starTargetSpecs } = extractCompiledExports(code);
   return {
-    exportNames: [...names],
+    exportNames: names,
     starTargetSpecs,
     importSpecs: extractRuntimeImports(code),
   };
@@ -651,7 +651,9 @@ export function compileSourcesToRecords(
     // become record edges — unlike `collectImportSpecifiers`, which includes
     // them for module *identity*.
     compiledBodies.set(specifier, compiled);
-    const importSpecs = extractRuntimeImports(compiled);
+    // Copy the readonly extractor result into a mutable array the record owns
+    // (VirtualModuleRecord.imports is `string[]`); this is the cold compile path.
+    const importSpecs = [...extractRuntimeImports(compiled)];
     const resolutions: Record<string, string> = {};
     for (const spec of importSpecs) {
       const resolved = resolveImportSpecifier(spec, source);
@@ -780,8 +782,10 @@ export interface CachedCompiledModule {
    * Precomputed record surface (Fix B), derived from `code` at compile time via
    * {@link deriveModuleRecordFields} and persisted on the compiled doc: the
    * module's direct export names, `export *` target specifiers, and runtime
-   * import specifiers. When present, {@link buildRecordsFromCompiled} reads them
-   * and skips the in-worker parse; absent on legacy docs → parse fallback.
+   * import specifiers. Written all-or-nothing (all three present, or none).
+   * When present, {@link buildRecordsFromCompiled} reads them and skips the
+   * in-worker parse; absent only on the cold/recompile path (and in tests),
+   * which parses and writes the surface back for later warm loads.
    */
   exportNames?: readonly string[];
   starTargetSpecs?: readonly string[];
@@ -840,17 +844,40 @@ export function buildRecordsFromCompiled(
   const byIdentity = new Map(modules.map((m) => [m.identity, m]));
   const sourceNames = cachedModuleSourceNames(modules);
 
+  // Fix B: use the record surface persisted on the compiled doc; parse the body
+  // only when it wasn't precomputed. A module carries the full surface (a warm
+  // cache read) or none of it — the cold/recompile path builds modules without
+  // the fields and writes them back afterward (plus tests). This is NOT a stale
+  // "legacy" state: runtimeVersion is fingerprinted over the extractor, so a warm
+  // cache read always carries the fields and a fields-less doc is never read from
+  // cache. writeCompiledDocs persists the three fields all-or-nothing, so read
+  // them all-or-nothing here — the export and import surface are taken from the
+  // doc together, or both parsed, never a partial mix.
+  const persistedSurface = (
+    m: CachedCompiledModule,
+  ):
+    | {
+      exportNames: readonly string[];
+      starTargetSpecs: readonly string[];
+      importSpecs: readonly string[];
+    }
+    | undefined =>
+    m.exportNames !== undefined && m.starTargetSpecs !== undefined &&
+      m.importSpecs !== undefined
+      ? {
+        exportNames: m.exportNames,
+        starTargetSpecs: m.starTargetSpecs,
+        importSpecs: m.importSpecs,
+      }
+      : undefined;
+
   // Direct export names + `export *` edges (as dependency identities) per module.
   const direct = new Map<
     string,
     { names: Set<string>; starTargets: string[] }
   >();
   for (const m of modules) {
-    // Fix B: prefer the record surface persisted on the compiled doc; fall back
-    // to parsing the body only for legacy docs that predate the persisted field.
-    const parsed = m.exportNames !== undefined
-      ? { exportNames: m.exportNames, starTargetSpecs: m.starTargetSpecs ?? [] }
-      : parseCompiledExports(m.code);
+    const parsed = persistedSurface(m) ?? parseCompiledExports(m.code);
     const names = new Set<string>(parsed.exportNames);
     const starTargets: string[] = [];
     for (const spec of parsed.starTargetSpecs) {
@@ -898,8 +925,9 @@ export function buildRecordsFromCompiled(
     compiledBodies.set(specifier, m.code);
     if (m.sourceMap) moduleSourceMaps.set(specifier, m.sourceMap);
 
-    const importSpecs = m.importSpecs !== undefined
-      ? [...m.importSpecs]
+    const surface = persistedSurface(m);
+    const importSpecs = surface
+      ? [...surface.importSpecs]
       : [...parseCompiledImports(m.code)];
     const resolutions: Record<string, string> = {};
     for (const spec of importSpecs) {
@@ -971,7 +999,7 @@ export function buildRecordsFromCompiled(
  */
 export function extractCompiledExports(
   compiled: string,
-): { names: Set<string>; starTargetSpecs: string[] } {
+): { names: readonly string[]; starTargetSpecs: readonly string[] } {
   const sourceFile = ts.createSourceFile(
     "compiled.js",
     compiled,
@@ -1032,7 +1060,7 @@ export function extractCompiledExports(
     ts.forEachChild(node, visit);
   }
   visit(sourceFile);
-  return { names, starTargetSpecs: [...starTargetSpecs] };
+  return { names: [...names], starTargetSpecs: [...starTargetSpecs] };
 }
 
 /**
@@ -1045,7 +1073,7 @@ export function extractCompiledExports(
  * literal, template literal, or comment in the authored source is NOT mistaken
  * for a real dependency edge.
  */
-function extractRuntimeImports(compiled: string): string[] {
+function extractRuntimeImports(compiled: string): readonly string[] {
   const sourceFile = ts.createSourceFile(
     "compiled.js",
     compiled,

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -251,3 +251,29 @@ describe("buildRecordsFromCompiled parse memo (content-addressed)", () => {
     expect(second).toEqual(["./beta.ts"]);
   });
 });
+
+describe("buildRecordsFromCompiled precomputed record surface (Fix B)", () => {
+  it("reads the persisted export/import surface and skips the body parse", () => {
+    // With the precomputed fields present, buildRecordsFromCompiled must use
+    // them and NOT parse the body. Persist a surface that deliberately DISAGREES
+    // with the body (body exports `fromBody` and requires nothing; the doc
+    // claims export `fromDoc` and import `ghost:spec`). If the record reflects
+    // the persisted values, the parse was skipped.
+    const id = "fixb-persisted-000000000000000000000000";
+    const spec = `cf:module/${id}`;
+    const built = buildRecordsFromCompiled([{
+      identity: id,
+      filename: "/persisted.ts",
+      code: `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+        `exports.fromBody = void 0;\nexports.fromBody = 1;`,
+      imports: [],
+      exportNames: ["fromDoc"],
+      starTargetSpecs: [],
+      importSpecs: ["ghost:spec"],
+    }]);
+    const record = built.records.get(spec)!;
+    expect(new Set(record.exports)).toEqual(new Set(["fromDoc", "__esModule"]));
+    expect(record.exports).not.toContain("fromBody");
+    expect(record.imports).toEqual(["ghost:spec"]);
+  });
+});

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -30,7 +30,7 @@ describe("extractCompiledExports", () => {
     ].join("\n");
     const { names, starTargetSpecs } = extractCompiledExports(compiled);
     expect(new Set(names)).toEqual(new Set(["a", "b", "c"]));
-    expect(names.has("__esModule")).toBe(false);
+    expect(names).not.toContain("__esModule");
     expect(starTargetSpecs).toEqual([]);
   });
 

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -133,6 +133,50 @@ describe("ESM compile via content-addressed cell cache", () => {
     expect(await run(warm, 6)).toEqual({ result: 12 });
   });
 
+  it("persists the derived record surface and reads it back (Fix B round-trip)", async () => {
+    // Guards the Fix B perf win against a SILENT regression: because the parse
+    // fallback yields byte-identical records, a pattern still loads + runs
+    // correctly even if the surface never persisted — so "it runs" is not enough.
+    // Assert the fields actually survive writeCompiledDocs -> storage ->
+    // loadCompiledClosure, i.e. buildRecordsFromCompiled reads them instead of
+    // re-parsing the body at boot.
+    const pm = runtime.patternManager;
+    await pm.compilePattern(PROGRAM, { space, tx });
+    await pm.flushCompileCacheWrites();
+    await tx.commit();
+    tx = runtime.edit();
+
+    const { entryIdentity } = await (runtime.harness as Engine)
+      .compileToRecordGraph(PROGRAM);
+
+    const readTx = runtime.edit();
+    const closure = await loadCompiledClosure(
+      runtime,
+      space,
+      entryIdentity,
+      { runtimeVersion },
+      readTx,
+    );
+    readTx.abort?.("round-trip probe read complete");
+
+    expect(closure.size).toBeGreaterThan(0);
+    // Every loaded compiled doc must carry the persisted surface (never
+    // undefined), else the boot build would silently fall back to parsing.
+    for (const [identity, doc] of closure) {
+      expect(doc.exportNames, `exportNames missing for ${identity}`)
+        .toBeDefined();
+      expect(doc.starTargetSpecs, `starTargetSpecs missing for ${identity}`)
+        .toBeDefined();
+      expect(doc.importSpecs, `importSpecs missing for ${identity}`)
+        .toBeDefined();
+    }
+    // Spot-check the entry doc's surface matches the program: main.tsx exports
+    // `default` and requires ./util.ts.
+    const entry = closure.get(entryIdentity)!;
+    expect(new Set(entry.exportNames)).toEqual(new Set(["default"]));
+    expect(entry.importSpecs).toContain("./util.ts");
+  });
+
   it("surfaces cold writeback failure instead of returning an unloadable pattern", async () => {
     const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
     const failure = {


### PR DESCRIPTION
## What

Stacked on #4441 (Fix A). Removes the last in-worker TS parse of compiled bodies
at boot by persisting the derived record surface on the compiled document.

Fix A memoized the redundant re-parses (4×→1×). Fix B persists the derivation so
cached modules parse **0×** — the parse was only ever the cost of not having saved
the answer.

## Change

- `deriveModuleRecordFields(code)` derives the direct export names, `export *`
  target specifiers, and runtime import specifiers from the compiled body (same
  scans as the boot parse → byte-identical, incl. the `cfc.ts` ambient-exports
  edge case where source- and compiled-derived names diverge).
- `writeCompiledDocs` stamps them onto each `CompiledDoc`; the fields ride the
  existing compiler integrity atom (label-based, **not** value-hashed — the
  integrity gate is unchanged). `loadCompiledClosure` + `pattern-manager` thread
  them onto `CachedCompiledModule`.
- `buildRecordsFromCompiled` reads the persisted surface and parses only as a
  fallback for legacy docs that predate the field (Fix A stays the floor).

## Cache invalidation (no manual bump)

The compiled set is keyed by `(runtimeVersion, identity)`, and `runtimeVersion` is
the compiler fingerprint over `packages/runner/src/sandbox` (among others). Editing
`module-record-compiler.ts` moves the fingerprint, so the whole compiled set
recompiles once and every doc is rewritten with the fields. Forward/backward safe:
fields are optional — a new binary reading an old doc falls back to the parse; an
old binary reading a new doc ignores the extra fields.

## Measured

End-to-end on a trivial pattern's warm-cache cold boot (isolated toolshed): the
9-module system-app closure goes `parsed=9 → parsed=0` — every record surface read
from persisted fields.

## Tests / gate

- New test: a persisted surface that deliberately disagrees with the body wins
  (proof the parse is skipped).
- Runner suite **729/0**; integration `pattern-tests` (68) + `generated-patterns`
  (147) green; the compilation-cache tests cover the write/read roundtrip and the
  fingerprint check; fmt / lint / check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists each compiled module’s record surface (export names, export* targets, runtime imports) so boot no longer parses compiled code. Cached modules now load with 0 parses, improving cold boot time.

- **Performance**
  - Compute once via `deriveModuleRecordFields` and store on `CompiledDoc`; `buildRecordsFromCompiled` reads it and only parses on the cold/recompile fallback.
  - Thread fields through `writeCompiledDocs`, `loadCompiledClosure`, and `pattern-manager` into `CachedCompiledModule`; read the surface atomically (exports/imports together, never mixed with parsed values).
  - Extractors now return readonly arrays; dropped defensive copies in the parse memo.
  - No manual cache bump: compiled set is keyed by `runtimeVersion`; compiler changes rewrite docs. Forward/backward compatible.
  - Measured: 9-module warm-cache cold boot goes parsed=9 → parsed=0. New round-trip guard asserts fields survive write/read; persisted-surface-wins test; all suites green.

<sup>Written for commit fa42c7a5abe23c95f900757384e71c622e455e95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

