### PR TITLE
test(patterns): tighten home-rehydration reload churn bounds to zero

### DIFF
--- a/packages/patterns/integration/home-rehydration-churn.test.ts
+++ b/packages/patterns/integration/home-rehydration-churn.test.ts
@@ -20,10 +20,10 @@ const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
 
 // One stable, machine-parseable line per churn measurement, logged before the
 // assertions so a run that exceeds a bound still records its value rather than
-// hiding it behind the failure. The reload bounds below are timing- and
-// hardware-sensitive, so the right value can only be read from the real
-// distribution across CI runs and runners. The `CHURN_METRIC` tag and
-// `key=value` shape are the stable contract — keep them greppable.
+// hiding it behind the failure. The reload bounds below are read from the real
+// distribution across CI runs and runners, which holds at zero. The
+// `CHURN_METRIC` tag and `key=value` shape are the stable contract — keep them
+// greppable.
 //
 // To pull the distribution from the most recent 100 CI runs (this test runs in
 // the "Deno Workflow" / deno.yml `package-integration-test` job; PRs land on
@@ -133,7 +133,7 @@ describe("home rehydration", () => {
     identity = await Identity.generate({ implementation: "noble" });
   });
 
-  it("reloading a populated home re-commits ~nothing already-durable", async () => {
+  it("reloading a populated home re-commits nothing already-durable", async () => {
     const page = shell.page();
 
     await gotoHome(shell, identity);
@@ -161,19 +161,17 @@ describe("home rehydration", () => {
     logChurnMetric("reload", reload.churn);
 
     const c = reload.churn;
-    // Read-mostly reload: re-commits stay near zero rather than scaling into a
+    // Read-mostly reload: re-commits stay at zero rather than scaling into a
     // storm. Resuming reads confirmed-loaded state before re-deriving — owned
     // cells are pre-synced, the manifest probe no longer reads not-yet-loaded
     // derived cells, and the list builtins defer their reconcile until the
-    // durable container lands instead of overwriting it with []. The residual
-    // is a small, bounded number of optimistic re-commits that lose a stale
-    // basis once and settle. The exact count is timing- and hardware-sensitive,
-    // so this bound is a regression sentinel with margin, not the measured
-    // floor — the values logged above are the basis for narrowing it. The
+    // durable container lands instead of overwriting it with []. Across the CI
+    // distribution these counters hold at zero, so the bound is zero: any
+    // conflict, revert, or schedule-run-error on reload is a regression. The
     // durability test below is the precise correctness gate.
-    expect(c.commitConflicts).toBeLessThanOrEqual(12);
-    expect(c.commitReverts).toBeLessThanOrEqual(12);
-    expect(c.scheduleRunErrors).toBeLessThanOrEqual(12);
+    expect(c.commitConflicts).toBeLessThanOrEqual(0);
+    expect(c.commitReverts).toBeLessThanOrEqual(0);
+    expect(c.scheduleRunErrors).toBeLessThanOrEqual(0);
   });
 
   it("a profile created in the post-reload window is durable", async () => {


### PR DESCRIPTION
The reload-health check in the home-rehydration integration test bounded three churn counters — commit conflicts, commit reverts, and schedule-run-errors — at 12 each. That ceiling was set as a regression sentinel with margin while the read-mostly-resume fix was landing, on the assumption that the residual count would be a small, timing- and hardware-sensitive number of optimistic re-commits.

The measured distribution disproves that assumption. Across every CI run that has carried the CHURN_METRIC line since it was introduced (122 runs, spanning main and many feature branches over multiple runners), the reload measurement reports exactly zero for all three counters, while actionRuns stays at 25-26 — so the runtime is doing real reactive work on reload and still committing nothing already-durable.

Tighten each bound from <= 12 to <= 0 so any single conflict, revert, or schedule-run-error on reload fails the test instead of being absorbed by slack. Update the surrounding comments to state the observed floor is zero rather than describing a margin, and drop the "~" from the test title now that the claim is exact. The CHURN_METRIC logging and the grep recipe are unchanged, so the distribution can still be re-checked if the floor ever moves off zero.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the reload churn bounds in the home‑rehydration test to zero so any conflict, revert, or schedule-run error on reload fails the test. Based on CI runs showing all three counters are always zero; updated comments and the test title, with CHURN_METRIC logging unchanged.

<sup>Written for commit bfc83c4063a7632e4fff4b62b74f9748871bc61f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

