### PR TITLE
Update memory audience docs

### DIFF
--- a/docs/development/federation-pr5-design.md
+++ b/docs/development/federation-pr5-design.md
@@ -1,5 +1,14 @@
 # Federation PR5 — audience-bound `session.open` + space lifecycle
 
+> Historical note: this document records an older PR design and is not the
+> current source of truth for memory WebSocket authentication. Current behavior
+> is documented in
+> [`docs/specs/memory-v2/04-protocol.md`](../specs/memory-v2/04-protocol.md).
+> In the current protocol, memory servers advertise `sessionOpen.audience` and a
+> one-time challenge in `hello.ok`; clients sign `aud`, `challenge`, `iat`, and
+> `exp` into `session.open`; and protected toolshed session opens require those
+> checks.
+
 Status: **Part A mechanism implemented; one decision needs Berni.** Last of the
 §14 federation arc (PR1–PR4 + site-table v0 landed). This is the *forcing
 function* for making the site table's host hints trustworthy: until the open

--- a/docs/specs/memory-v2/10-implementation-guidance.md
+++ b/docs/specs/memory-v2/10-implementation-guidance.md
@@ -18,11 +18,11 @@ target. In particular:
 - plain `transact` requests do not currently carry or persist per-commit
   `invocation` / `authorization` payloads; signed-write metadata remains
   deferred to a later pass
-- the toolshed v2 websocket currently authenticates `session.open` by
-  verifying a signature from the requested space DID against the requested
-  session descriptor
-- broader ACL / `Origin` enforcement, including non-owner read opens, remains
-  deferred; treat the current endpoint as trusted-only for now
+- the toolshed v2 websocket authenticates `session.open` by requiring the
+  signed invocation to match the requested space, session descriptor, server
+  audience, current connection challenge, and short validity window
+- the memory server ACL policy gates session opens and commands when enabled;
+  route-level `Origin` enforcement remains deferred
 - session resume still uses caller-provided `sessionId` values; principal
   binding and server-issued session ids remain deferred
 - one-shot `graph.query` now honors `branch` and `atSeq`
@@ -76,6 +76,12 @@ codebase. The target wire messages are:
 Do not switch this pass to full UCAN message framing. None of the current wire
 messages are transport-level signed UCAN invocations beyond the current
 `session.open` authentication step.
+
+The `hello.ok` response includes `sessionOpen.audience` and a one-time
+`sessionOpen.challenge`. The client signs both values into the next
+`session.open` invocation, along with `iat` and `exp`. The server rejects a
+missing, expired, reused, or mismatched challenge, and rejects a missing or
+mismatched audience.
 
 ## 4. Session Model
 

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -63,13 +63,22 @@ current (v2) protocol, authorization happens at **session open**
 (`packages/runner/src/storage/v2-remote-session.ts`,
 `packages/toolshed/routes/storage/memory.ts`):
 
-1. The client builds an invocation
-   `{ iss: <user did>, cmd: "session.open", sub: <space did>, args: {protocol, session} }`
-   and signs its hash with the user's key.
-2. The server verifies the signature against the issuer DID and that the
-   signed invocation matches *this exact* session-open request (no replay
-   onto other sessions).
-3. The issuer becomes the session's pinned **principal**: reopening the
+1. The client receives `sessionOpen.audience` and a one-time
+   `sessionOpen.challenge` from the server's `hello.ok`.
+2. The client builds a `session.open` invocation and signs its hash with the
+   user's key. The signed invocation includes:
+   - `iss`: the user DID
+   - `cmd`: `"session.open"`
+   - `sub`: the space DID
+   - `aud`: the server DID from `sessionOpen.audience`
+   - `challenge`: the challenge value from `sessionOpen.challenge`
+   - `iat` and `exp`: the signed time window
+   - `args.protocol` and `args.session`: the protocol and session descriptor
+3. The server verifies the signature against the issuer DID. It also verifies
+   that the signed invocation matches this session-open request, the advertised
+   audience, the current connection challenge, and the allowed time window.
+   That prevents replay onto another server or onto a later connection.
+4. The issuer becomes the session's pinned **principal**: reopening the
    session as someone else fails, a stolen stale token is revoked, and —
    importantly — the principal is what keys the `user:`/`session:` scope
    partitions from Chapter 9. `PerUser` isolation is cryptographic


### PR DESCRIPTION
The memory WebSocket session.open flow now requires audience binding and a server-issued challenge. Some guidance and tutorial prose still described the older shape, where the signed invocation only matched the space and session descriptor, and the old federation design note read like current status.

Refresh the memory v2 implementation guidance and identity tutorial so they describe hello.ok audience and challenge metadata, signed aud, challenge, iat, and exp fields, and server rejection of missing or mismatched values. Mark the old federation PR5 design document as historical and point readers to the current memory v2 protocol spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh memory v2 docs to match the audience‑bound WebSocket `session.open` flow with a server‑issued challenge: `hello.ok` advertises `sessionOpen.audience` and a one‑time `sessionOpen.challenge`; clients sign `aud`, `challenge`, `iat`, and `exp`, and servers enforce audience, challenge, and a short validity window, rejecting missing, mismatched, expired, or reused values. Mark the Federation PR5 design note as historical and point to `docs/specs/memory-v2/04-protocol.md`; update implementation guidance and the identity tutorial to include the audience/challenge steps and clarify that the memory server ACL gates session opens and commands while route‑level `Origin` checks remain deferred.

<sup>Written for commit a58ee5a7a4e3887ebd757cb573bfeaa8ecc988fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

