### PR TITLE
Add and adopt reactive auth readiness helper

### DIFF
--- a/docs/common/patterns/new-cells.md
+++ b/docs/common/patterns/new-cells.md
@@ -84,12 +84,12 @@ becomes a writable cell.
 This makes each state explicit. It also lets TypeScript narrow the value before
 code passes it to a handler or provider client.
 
-Provider pattern files can import `authIsReady` from
-`../auth/auth-types.ts`.
+Provider pattern files can import `authIsReady` from their relative path to
+`packages/patterns/auth/auth-types.ts`.
 
 ```typescript
 import { Writable } from "commonfabric";
-import { authIsReady } from "../auth/auth-types.ts";
+import { authIsReady } from "../../../packages/patterns/auth/auth-types.ts";
 
 type AuthData = { token: string };
 

--- a/docs/common/patterns/new-cells.md
+++ b/docs/common/patterns/new-cells.md
@@ -84,8 +84,12 @@ becomes a writable cell.
 This makes each state explicit. It also lets TypeScript narrow the value before
 code passes it to a handler or provider client.
 
+Provider pattern files can import `authIsReady` from
+`../auth/auth-types.ts`.
+
 ```typescript
 import { Writable } from "commonfabric";
+import { authIsReady } from "../auth/auth-types.ts";
 
 type AuthData = { token: string };
 
@@ -98,8 +102,20 @@ const availability: AuthAvailability = {
   auth: new Writable({ token: "token" }),
 };
 
+const authReady = authIsReady(availability);
 const auth = availability.state === "ready" ? availability.auth : null;
 ```
 
 This shape is useful for auth managers and follows the same state-machine style
 as `FetchState` in the program fetch cache.
+
+Use `authIsReady()` when code needs a shared boolean, such as a disabled state
+or a status panel. Provider clients still need the writable auth cell. Keep the
+`availability.state === "ready" ? availability.auth : null` selection next to
+the handler or component that uses it.
+
+Do not move the auth cell selection into a plain function. The function can run
+outside the reactive transform and hide the `state` read. Do not use `lift()` to
+return `Writable<AuthData> | null`. `lift()` receives a read-only view of cell
+input, so it is the right tool for the boolean readiness check and the wrong
+tool for exporting write access.

--- a/packages/patterns/airtable/core/airtable-auth.tsx
+++ b/packages/patterns/airtable/core/airtable-auth.tsx
@@ -161,9 +161,9 @@ export function createPreviewUI(
  *
  * CRITICAL: When consuming from another pattern, DO NOT use derive()!
  * Use direct property access: `airtableAuthPiece.auth`.
- * If selecting between auth sources, use a bare ternary such as
- * `availability.state === "ready" ? availability.auth : null`; this preserves
- * the underlying writable cell reference needed for token refresh.
+ * If auth comes through an auth manager, use `authIsReady(availability)` for
+ * shared readiness checks. Keep the writable auth cell access explicit at the
+ * call site that needs it.
  */
 export type AirtableAuth = {
   accessToken: Secret<string> | Default<"">;

--- a/packages/patterns/airtable/core/util/airtable-auth-manager.tsx
+++ b/packages/patterns/airtable/core/util/airtable-auth-manager.tsx
@@ -13,16 +13,22 @@
  *   requiredScopes: ["data.records:read", "schema.bases:read"],
  * });
  *
- * if (availability.state !== "ready") return;
- * const auth = availability.auth;
+ * const auth = availability.state === "ready" ? availability.auth : null;
+ * const providerUI = auth
+ *   ? <Importer auth={auth} />
+ *   : <div>Connect Airtable first.</div>;
  *
- * return { [UI]: <div>{fullUI}</div> };
+ * return { [UI]: <div>{fullUI}{providerUI}</div> };
  * ```
+ *
+ * Use authIsReady(availability) for shared boolean readiness checks.
+ * Keep the writable auth cell selection next to the code that uses it.
  */
 
 import { action, navigateTo, pattern, UI, Writable } from "commonfabric";
 import { AuthManagerBase } from "../../../auth/create-auth-manager.tsx";
 import type { AuthManagerDescriptor } from "../../../auth/auth-manager-descriptor.ts";
+import { authIsReady } from "../../../auth/auth-types.ts";
 import type { AuthManagerOutput } from "../../../auth/create-auth-manager.tsx";
 import AirtableAuth, {
   type AirtableAuth as AirtableAuthData,
@@ -140,7 +146,7 @@ export const AirtableAuthManager = pattern<
     auth: base.auth,
     availability: base.availability,
     authInfo: base.authInfo,
-    isReady: base.isReady,
+    isReady: authIsReady(base.availability),
     currentEmail: base.currentEmail,
     currentState: base.currentState,
     pickerUI: base.pickerUI,

--- a/packages/patterns/auth/auth-types.ts
+++ b/packages/patterns/auth/auth-types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for OAuth auth patterns and auth managers.
  */
-import type { VNode, Writable } from "commonfabric";
+import { lift, type VNode, type Writable } from "commonfabric";
 
 /**
  * Visual status of auth in preview/consumer UI components.
@@ -68,6 +68,11 @@ export type AuthAvailability<TAuth extends OAuthAuthData = OAuthAuthData> =
   }
   | { state: "token-expired"; auth: AuthCell<TAuth> }
   | { state: "ready"; auth: AuthCell<TAuth> };
+
+/** Reactive readiness check for auth-manager availability. */
+export const authIsReady = lift<AuthAvailability, boolean>(
+  (availability) => availability.state === "ready",
+);
 
 /** Complete auth info bundle returned by auth managers */
 export interface AuthInfo<TAuth extends OAuthAuthData = OAuthAuthData> {

--- a/packages/patterns/auth/ready-auth.test.tsx
+++ b/packages/patterns/auth/ready-auth.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Test Pattern: ready auth gate
+ *
+ * Exercises the shared readiness helper against an availability value that
+ * changes after the helper has been created.
+ *
+ * Run: deno task cf test packages/patterns/auth/ready-auth.test.tsx --verbose
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+import {
+  type AuthAvailability,
+  authIsReady,
+  type OAuthAuthData,
+} from "./auth-types.ts";
+
+interface TestAuth extends OAuthAuthData {
+  token: string;
+  scope: string[];
+  refreshToken: string;
+  user: {
+    email: string;
+    name: string;
+    picture: string;
+  };
+}
+
+export default pattern(() => {
+  const authState = new Writable<AuthAvailability<TestAuth>["state"]>(
+    "loading",
+  );
+  const authCell = new Writable<TestAuth>({
+    token: "initial",
+    scope: [],
+    refreshToken: "refresh",
+    user: {
+      email: "user@example.com",
+      name: "User Example",
+      picture: "",
+    },
+  });
+
+  const availability = computed((): AuthAvailability<TestAuth> => {
+    const state = authState.get();
+    if (state === "loading") {
+      return { state: "loading", auth: null };
+    }
+    if (state === "missing-scopes") {
+      return {
+        state: "missing-scopes",
+        auth: authCell,
+        missingScopes: ["gmail"],
+      };
+    }
+    return { state, auth: authCell };
+  });
+  const authReady = authIsReady(availability);
+  const mark_needs_login = action(() => {
+    authState.set("needs-login");
+  });
+  const mark_missing_scopes = action(() => {
+    authState.set("missing-scopes");
+  });
+  const mark_token_expired = action(() => {
+    authState.set("token-expired");
+  });
+  const mark_ready = action(() => {
+    authState.set("ready");
+  });
+
+  const refresh_through_ready_auth = action(() => {
+    if (availability.state !== "ready") return;
+    const currentAuth = availability.auth?.get?.();
+    if (!currentAuth) return;
+    availability.auth?.set?.({
+      ...currentAuth,
+      token: "refreshed",
+    });
+  });
+
+  const mark_loading = action(() => {
+    authState.set("loading");
+  });
+
+  const assert_auth_unavailable = authReady ? false : true;
+  const assert_auth_available = authReady ? true : false;
+  const assert_ready_reads_current_token = computed(() =>
+    availability.state === "ready" &&
+    availability.auth?.get?.()?.token === "initial"
+  );
+  const assert_refresh_writes_original_cell = computed(() =>
+    authCell.get().token === "refreshed" &&
+    availability.state === "ready" &&
+    availability.auth?.get?.()?.token === "refreshed"
+  );
+
+  return {
+    tests: [
+      { assertion: assert_auth_unavailable },
+      { action: mark_needs_login },
+      { assertion: assert_auth_unavailable },
+      { action: mark_missing_scopes },
+      { assertion: assert_auth_unavailable },
+      { action: mark_token_expired },
+      { assertion: assert_auth_unavailable },
+      { action: mark_ready },
+      { assertion: assert_auth_available },
+      { assertion: assert_ready_reads_current_token },
+      { action: refresh_through_ready_auth },
+      { assertion: assert_refresh_writes_original_cell },
+      { action: mark_loading },
+      { assertion: assert_auth_unavailable },
+    ],
+  };
+});

--- a/packages/patterns/google/core/gmail-importer.tsx
+++ b/packages/patterns/google/core/gmail-importer.tsx
@@ -38,8 +38,9 @@ type SyncableWritable<T> = Writable<T> & {
  * reference - do NOT copy it into a read-only projection. Token refresh
  * mutates the auth cell in place, so any consumer that reads a detached
  * snapshot will see refresh silently fail.
- * Use direct property access (piece.auth) or select it with a ternary
- * (which lowers to ifElse and preserves the underlying cell reference).
+ * Use direct property access (piece.auth). If auth comes through an auth
+ * manager, use `authIsReady(availability)` for readiness and keep writable auth
+ * cell access explicit at the call site that needs it.
  */
 export type Auth = {
   token: Secret<string> | Default<"">;

--- a/packages/patterns/google/core/google-auth.tsx
+++ b/packages/patterns/google/core/google-auth.tsx
@@ -218,9 +218,9 @@ export function createPreviewUI(
  *
  * ⚠️ CRITICAL: When consuming this auth from another pattern, DO NOT use derive()!
  * Use direct property access: `googleAuthPiece.auth`.
- * If selecting between auth sources, use a bare ternary such as
- * `availability.state === "ready" ? availability.auth : null`; this preserves
- * the underlying writable cell reference needed for token refresh.
+ * If auth comes through an auth manager, use `authIsReady(availability)` for
+ * shared readiness checks. Keep the writable auth cell access explicit at the
+ * call site that needs it.
  */
 export type Auth = {
   token: Secret<string> | Default<"">;

--- a/packages/patterns/google/core/util/google-auth-manager.tsx
+++ b/packages/patterns/google/core/util/google-auth-manager.tsx
@@ -13,12 +13,17 @@
  *   requiredScopes: ["gmail", "drive"],
  * });
  *
- * if (availability.state !== "ready") return;
- * const auth = availability.auth;
+ * const auth = availability.state === "ready" ? availability.auth : null;
+ * const providerUI = auth
+ *   ? <Importer auth={auth} />
+ *   : <div>Connect Google first.</div>;
  *
  * // In UI: {fullUI} handles all auth states
- * return { [UI]: <div>{fullUI}</div> };
+ * return { [UI]: <div>{fullUI}{providerUI}</div> };
  * ```
+ *
+ * Use authIsReady(availability) for shared boolean readiness checks.
+ * Keep the writable auth cell selection next to the code that uses it.
  *
  * Token refresh: Tokens auto-refresh via background-piece-service (when registered).
  * For fallback, a "Refresh Session" button is shown in the expired UI.
@@ -27,6 +32,7 @@
 import { action, navigateTo, pattern, UI, Writable } from "commonfabric";
 import { AuthManagerBase } from "../../../auth/create-auth-manager.tsx";
 import type { AuthManagerDescriptor } from "../../../auth/auth-manager-descriptor.ts";
+import { authIsReady } from "../../../auth/auth-types.ts";
 import GoogleAuth, { type Auth } from "../google-auth.tsx";
 
 // Re-export shared types for consumers
@@ -144,7 +150,7 @@ export const GoogleAuthManager = pattern<
     auth: base.auth,
     availability: base.availability,
     authInfo: base.authInfo,
-    isReady: base.isReady,
+    isReady: authIsReady(base.availability),
     currentEmail: base.currentEmail,
     currentState: base.currentState,
     pickerUI: base.pickerUI,

--- a/packages/patterns/google/extractors/email-notes.tsx
+++ b/packages/patterns/google/extractors/email-notes.tsx
@@ -37,6 +37,7 @@ import {
   createGoogleAuth,
   type ScopeKey,
 } from "../core/util/google-auth-manager.tsx";
+import { authIsReady } from "../../auth/auth-types.ts";
 import ProcessingStatus from "../core/processing-status.tsx";
 import type { Stream } from "commonfabric";
 
@@ -214,10 +215,10 @@ export default pattern<PatternInput, PatternOutput>(() => {
   const {
     availability,
     fullUI: authUI,
-    isReady,
   } = createGoogleAuth({
     requiredScopes: ["gmail", "gmailModify"] as ScopeKey[],
   });
+  const authReady = authIsReady(availability);
   const auth = availability.state === "ready" ? availability.auth : null;
 
   // NOTE: Auto-fetch labels was removed because having side effects (writes to
@@ -343,7 +344,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
             {authUI}
 
             {/* Connection status and refresh */}
-            {isReady
+            {authReady
               ? (
                 <div
                   style={{
@@ -436,7 +437,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
               : null}
 
             {/* Notes list */}
-            {!isReady
+            {!authReady
               ? (
                 <div
                   style={{

--- a/packages/patterns/google/extractors/expect-response-followup.tsx
+++ b/packages/patterns/google/extractors/expect-response-followup.tsx
@@ -39,6 +39,7 @@ import {
   createGoogleAuth,
   type ScopeKey,
 } from "../core/util/google-auth-manager.tsx";
+import { authIsReady } from "../../auth/auth-types.ts";
 import {
   type GmailLabel,
   GmailSendClient,
@@ -587,11 +588,11 @@ export default pattern<PatternInput, PatternOutput>(() => {
   const {
     availability,
     fullUI: authUI,
-    isReady,
     currentEmail,
   } = createGoogleAuth({
     requiredScopes: ["gmail", "gmailModify"] as ScopeKey[],
   });
+  const authReady = authIsReady(availability);
   const auth = availability.state === "ready" ? availability.auth : null;
 
   // ==========================================================================
@@ -898,7 +899,7 @@ Write only the email body, no subject line or greeting line (the greeting will b
             {authUI}
 
             {/* Refresh button when authenticated */}
-            {isReady
+            {authReady
               ? (
                 <div
                   style={{
@@ -983,7 +984,7 @@ Write only the email body, no subject line or greeting line (the greeting will b
               : null}
 
             {/* Threads list */}
-            {!isReady
+            {!authReady
               ? (
                 <div
                   style={{

--- a/packages/patterns/tools/importer-prompt.test.ts
+++ b/packages/patterns/tools/importer-prompt.test.ts
@@ -156,6 +156,14 @@ Deno.test("generateImporterPrompt includes auth availability and current JSX gui
   assertStringIncludes(instructions, "`auth ? mainContent : notReadyPanel`");
   assertStringIncludes(
     instructions,
+    "Use `authIsReady(availability)` only for boolean readiness checks",
+  );
+  assertStringIncludes(
+    instructions,
+    'Import `authIsReady` from `"../auth/auth-types.ts"`',
+  );
+  assertStringIncludes(
+    instructions,
     "Each provider call handler takes a non-null",
   );
   assertStringIncludes(

--- a/packages/patterns/tools/importer-prompt.ts
+++ b/packages/patterns/tools/importer-prompt.ts
@@ -219,9 +219,9 @@ export function createPreviewUI(
  *
  * CRITICAL: When consuming from another pattern, DO NOT use derive()!
  * Use direct property access: \`airtableAuthPiece.auth\`.
- * If selecting between auth sources, use a bare ternary such as
- * \`availability.state === "ready" ? availability.auth : null\`; this preserves
- * the underlying writable cell reference needed for token refresh.
+ * If auth comes through an auth manager, use \`authIsReady(availability)\` for
+ * shared readiness checks. Keep the writable auth cell access explicit at the
+ * call site that needs it.
  */
 export type AirtableAuth = {
   accessToken: Secret<string> | Default<"">;
@@ -1068,16 +1068,22 @@ const AIRTABLE_AUTH_MANAGER_SOURCE = `/**
  *   requiredScopes: ["data.records:read", "schema.bases:read"],
  * });
  *
- * if (availability.state !== "ready") return;
- * const auth = availability.auth;
+ * const auth = availability.state === "ready" ? availability.auth : null;
+ * const providerUI = auth
+ *   ? <Importer auth={auth} />
+ *   : <div>Connect Airtable first.</div>;
  *
- * return { [UI]: <div>{fullUI}</div> };
+ * return { [UI]: <div>{fullUI}{providerUI}</div> };
  * \`\`\`
+ *
+ * Use authIsReady(availability) for shared boolean readiness checks.
+ * Keep the writable auth cell selection next to the code that uses it.
  */
 
 import { action, navigateTo, pattern, UI, Writable } from "commonfabric";
 import { AuthManagerBase } from "../../../auth/create-auth-manager.tsx";
 import type { AuthManagerDescriptor } from "../../../auth/auth-manager-descriptor.ts";
+import { authIsReady } from "../../../auth/auth-types.ts";
 import type { AuthManagerOutput } from "../../../auth/create-auth-manager.tsx";
 import AirtableAuth, {
   type AirtableAuth as AirtableAuthData,
@@ -1195,7 +1201,7 @@ export const AirtableAuthManager = pattern<
     auth: base.auth,
     availability: base.availability,
     authInfo: base.authInfo,
-    isReady: base.isReady,
+    isReady: authIsReady(base.availability),
     currentEmail: base.currentEmail,
     currentState: base.currentState,
     pickerUI: base.pickerUI,
@@ -2597,6 +2603,7 @@ Main importer pattern. Follow the Airtable importer reference:
 - CTS transforms are enabled by default; do not add \`/// <cf-disable-transform />\`
 - Import from \`"commonfabric"\`: computed, Default, handler, NAME, pattern, UI, type VNode, Writable, safeDateNow, nonPrivateRandom (only when needed)
 - Import the auth manager and client
+- Import \`authIsReady\` from \`"../auth/auth-types.ts"\` if the importer needs a shared readiness boolean
 - Define module-scope \`handler()\` functions for each API call:
   - Each provider call handler takes a non-null \`auth\` cell and the relevant state cells (\`loading\`, \`error\`, result cells)
   - Each uses \`try/catch/finally\` with \`loading.set(true/false)\`
@@ -2608,6 +2615,7 @@ Main importer pattern. Follow the Airtable importer reference:
   4. Uses one terminal return statement; do not return early from the pattern body
   5. Renders \`auth ? mainContent : notReadyPanel\` so provider handlers are bound only in the authenticated branch where \`auth\` is non-null
   6. Returns [NAME], [UI], and data outputs. Type \`[UI]\` as \`VNode\` in the Output interface.
+- Keep the auth cell selection at the call site. Do not wrap it in a plain helper or \`lift()\`. Use \`authIsReady(availability)\` only for boolean readiness checks.
 - UI structure:
   1. Title header
   2. \`{authUI}\` for auth status/picker


### PR DESCRIPTION
Provider consumers need a shared way to ask whether AuthAvailability is ready without moving the writable auth cell behind a helper. A helper that returns the auth cell would either hide the reactive state read or return a read-only selected value, which would break the write access that token refresh depends on.

Add authIsReady as a lift-based boolean helper. Keep the ready auth cell selection explicit at provider call sites. Migrate the Google and Airtable auth manager wrappers, plus representative Google extractor UI checks, so existing code exercises the helper while provider handlers still receive the original writable auth cell.

Add a pattern test that walks every auth availability state, including non-ready states that still carry an auth cell, and verifies that ready auth writes still reach the original cell. Update provider auth guidance and importer prompt text so generated importers import the helper for shared readiness booleans and keep auth cell selection at the call site.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reactive `authIsReady` helper for `AuthAvailability` and adopts it across Google and Airtable patterns to simplify UI readiness checks while keeping writable auth cell access explicit for token refresh.

- **New Features**
  - Added `authIsReady` (lift-based boolean) in `auth-types.ts`.
  - Switched Google and Airtable auth managers and example extractors to use `authIsReady` for UI checks.
  - Added a pattern test for availability transitions; updated docs and importer prompt to import `authIsReady` and keep selection at the call site; fixed the docs example import path so the checker recognizes the helper.

- **Migration**
  - Use `authIsReady(availability)` for boolean readiness only.
  - Keep auth cell selection at the call site: `availability.state === "ready" ? availability.auth : null`.
  - Do not wrap the auth cell selection in a helper or return a cell from `lift()`; token refresh needs the original writable cell.

<sup>Written for commit a3cd521b8b9866c05c02768c96c6729b3b4c22b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

