### PR TITLE
perf(runner): factory-build — O(1) partial-cause dedup + sanitize memo

### DIFF
--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -307,6 +307,44 @@ function factoryFromPattern<T, R>(
   };
 
   const assignedInternalPartialCauses = new Map<OpaqueCell<any>, JSONValue>();
+  // Canonical keys of the causes already assigned. Testing a candidate cause for
+  // collision is then an O(1) `Set` lookup instead of a `deepEqual` scan over
+  // every previously-assigned cause — the scan made this loop O(N²) in the number
+  // of internal cells (negligible for small patterns, but a scaling cliff for
+  // large ones, and it runs on every pattern instantiation, not just at boot).
+  const assignedCauseKeys = new Set<string>();
+  // Key-order-insensitive serialization, matching `deepEqual`'s order-insensitive
+  // record comparison, so `assignedCauseKeys.has(key)` is exactly the collision
+  // test the previous `deepEqual` scan performed. Causes are always JSON values
+  // with no `undefined`, so this is a faithful, collision-free key.
+  const causeKey = (cause: JSONValue): string => {
+    // `deepEqual` compares primitives with `Object.is` (so -0≠0, NaN=NaN) and is
+    // type- and key-order-insensitive for records. Encode with a per-type tag +
+    // Object.is-faithful numbers so `JSON.stringify`'s primitive collapses
+    // (-0→0, NaN/±Infinity→null, number 1 vs string "1") can't produce a false
+    // collision the previous `deepEqual` scan would not have.
+    const enc = (x: unknown): unknown => {
+      if (x === null) return " null";
+      switch (typeof x) {
+        case "string":
+          return " s" + x;
+        case "boolean":
+          return " b" + x;
+        case "number":
+          return " n" + (Object.is(x, -0) ? "-0" : String(x));
+        case "object":
+          if (Array.isArray(x)) return x.map(enc);
+          return Object.fromEntries(
+            Object.keys(x as Record<string, unknown>).sort().map(
+              (k) => [k, enc((x as Record<string, unknown>)[k])],
+            ),
+          );
+        default:
+          return " ?" + String(x);
+      }
+    };
+    return JSON.stringify(enc(cause));
+  };
   let anonymousPartialCauseCount = 0;
   const nextAnonymousPartialCause = (isStream: boolean): JSONObject => {
     const generated = { $generated: anonymousPartialCauseCount++ };
@@ -325,17 +363,16 @@ function factoryFromPattern<T, R>(
     let partialCause = name === undefined
       ? nextAnonymousPartialCause(isStream)
       : name as JSONValue;
-    while (
-      Array.from(assignedInternalPartialCauses.values()).some((used) =>
-        deepEqual(used, partialCause)
-      )
-    ) {
+    let key = causeKey(partialCause);
+    while (assignedCauseKeys.has(key)) {
       const generated = nextAnonymousPartialCause(isStream);
       partialCause = name === undefined
         ? generated
         : { name: name as JSONValue, ...generated };
+      key = causeKey(partialCause);
     }
     assignedInternalPartialCauses.set(top, partialCause);
+    assignedCauseKeys.add(key);
   });
 
   const cellReferenceForCell = (

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   type CellScope,
   type FactoryInput,
@@ -313,38 +314,13 @@ function factoryFromPattern<T, R>(
   // of internal cells (negligible for small patterns, but a scaling cliff for
   // large ones, and it runs on every pattern instantiation, not just at boot).
   const assignedCauseKeys = new Set<string>();
-  // Key-order-insensitive serialization, matching `deepEqual`'s order-insensitive
-  // record comparison, so `assignedCauseKeys.has(key)` is exactly the collision
-  // test the previous `deepEqual` scan performed. Causes are always JSON values
-  // with no `undefined`, so this is a faithful, collision-free key.
-  const causeKey = (cause: JSONValue): string => {
-    // `deepEqual` compares primitives with `Object.is` (so -0≠0, NaN=NaN) and is
-    // type- and key-order-insensitive for records. Encode with a per-type tag +
-    // Object.is-faithful numbers so `JSON.stringify`'s primitive collapses
-    // (-0→0, NaN/±Infinity→null, number 1 vs string "1") can't produce a false
-    // collision the previous `deepEqual` scan would not have.
-    const enc = (x: unknown): unknown => {
-      if (x === null) return " null";
-      switch (typeof x) {
-        case "string":
-          return " s" + x;
-        case "boolean":
-          return " b" + x;
-        case "number":
-          return " n" + (Object.is(x, -0) ? "-0" : String(x));
-        case "object":
-          if (Array.isArray(x)) return x.map(enc);
-          return Object.fromEntries(
-            Object.keys(x as Record<string, unknown>).sort().map(
-              (k) => [k, enc((x as Record<string, unknown>)[k])],
-            ),
-          );
-        default:
-          return " ?" + String(x);
-      }
-    };
-    return JSON.stringify(enc(cause));
-  };
+  // The canonical value hash is exactly the collision test the previous
+  // `deepEqual` scan performed: records hash key-order-insensitively (keys are
+  // fed in sorted UTF-8 byte order), numbers hash by their float64 bits with a
+  // dedicated `-0` cache entry, and `NaN` hashes canonically — i.e. `Object.is`
+  // primitive semantics and order-insensitive records, matching `deepEqual` on
+  // the JSON values causes are made of.
+  const causeKey = (cause: JSONValue): string => hashStringOf(cause);
   let anonymousPartialCauseCount = 0;
   const nextAnonymousPartialCause = (isStream: boolean): JSONObject => {
     const generated = { $generated: anonymousPartialCauseCount++ };

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,6 +1,7 @@
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   type AnyCell,
   type DerivedInternalCellDescriptor,
@@ -422,6 +423,12 @@ export enum KeepAsCell {
   All = "All",
 }
 
+// Identity-keyed memo for `sanitizeSchemaForLinks` (see the function body).
+const _sanitizeCache = new WeakMap<
+  object,
+  Map<KeepAsCell, JSONSchema | undefined>
+>();
+
 /**
  * Traverse schema and remove all asCell flags.
  * Also handles circular references by using JSON Schema $ref.
@@ -447,6 +454,22 @@ export function sanitizeSchemaForLinks(
     return schema;
   }
 
+  // Memoize by input identity: sanitize is a pure function of
+  // `(schema, keepAsCell)`, and at pattern-build time the same interned/frozen
+  // schema is sanitized repeatedly — measured ~46% of calls repeat a frozen
+  // input, carrying ~half of the total strip time. Only deep-frozen inputs are
+  // memoized (a mutable input's identity could go stale), matching the
+  // identity-keyed-memo guard `traverse.ts` uses; `isDeepFrozen` is O(1) for the
+  // already-frozen/cached inputs we hit here. Cached outputs are deep-frozen so a
+  // shared result cannot be mutated by a consumer (all consumers only spread it).
+  const memoizable = isDeepFrozen(schema);
+  if (memoizable) {
+    const byMode = _sanitizeCache.get(schema);
+    if (byMode !== undefined && byMode.has(keepAsCell)) {
+      return byMode.get(keepAsCell);
+    }
+  }
+
   // Collect existing $defs names to avoid collisions
   const existingDefNames = new Set<string>();
   if ("$defs" in schema) {
@@ -468,23 +491,28 @@ export function sanitizeSchemaForLinks(
     keepAsCell,
   };
 
-  const result = recursiveStripAsCellFromSchema(
-    schema,
-    context,
-    0,
-  );
+  const stripped = recursiveStripAsCellFromSchema(schema, context, 0);
 
-  // If we generated any $defs, add them to the root schema
-  if (Object.keys(context.defs).length > 0) {
-    // Merge with any existing $defs
-    const existingDefs = result?.$defs || {};
-    return {
-      ...result,
-      $defs: { ...existingDefs, ...context.defs },
-    };
+  // If we generated any $defs, add them to the root schema (merging existing).
+  const output = Object.keys(context.defs).length > 0
+    ? {
+      ...stripped,
+      $defs: { ...(stripped?.$defs || {}), ...context.defs },
+    }
+    : stripped;
+
+  if (memoizable) {
+    const frozen = deepFreeze(output);
+    let byMode = _sanitizeCache.get(schema);
+    if (byMode === undefined) {
+      byMode = new Map();
+      _sanitizeCache.set(schema, byMode);
+    }
+    byMode.set(keepAsCell, frozen);
+    return frozen;
   }
 
-  return result;
+  return output;
 }
 
 interface SanitizeContext {

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,7 +1,7 @@
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   type AnyCell,
   type DerivedInternalCellDescriptor,
@@ -424,9 +424,12 @@ export enum KeepAsCell {
 }
 
 // Identity-keyed memo for `sanitizeSchemaForLinks` (see the function body).
+// Values are always deep-frozen OBJECT schemas: boolean/undefined inputs take
+// the early return and never reach the memo, and outputs are frozen before
+// caching (their sub-trees are shared across callers).
 const _sanitizeCache = new WeakMap<
   object,
-  Map<KeepAsCell, JSONSchema | undefined>
+  Map<KeepAsCell, JSONSchema & object>
 >();
 
 /**
@@ -461,17 +464,15 @@ export function sanitizeSchemaForLinks(
   // memoized (a mutable input's identity could go stale), matching the
   // identity-keyed-memo guard `traverse.ts` uses; `isDeepFrozen` is O(1) for the
   // already-frozen/cached inputs we hit here. The cache holds the canonical strip
-  // result; every call returns a fresh SHALLOW CLONE of it. The clone matters:
+  // result, DEEP-FROZEN for share-safety (see the store site below); every call
+  // returns a fresh SHALLOW CLONE of it. The clone matters:
   // the reactive graph keys on the sanitized schema's top-level object identity
   // (returning a shared object changes recomputation), so each call needs its own
   // top — while still reusing the (expensive) stripped sub-tree from the cache.
   const memoizable = isDeepFrozen(schema);
   if (memoizable) {
-    const byMode = _sanitizeCache.get(schema);
-    if (byMode !== undefined && byMode.has(keepAsCell)) {
-      const hit = byMode.get(keepAsCell);
-      return hit !== null && typeof hit === "object" ? { ...hit } : hit;
-    }
+    const hit = _sanitizeCache.get(schema)?.get(keepAsCell);
+    if (hit !== undefined) return { ...hit };
   }
 
   // Collect existing $defs names to avoid collisions
@@ -511,10 +512,15 @@ export function sanitizeSchemaForLinks(
       byMode = new Map();
       _sanitizeCache.set(schema, byMode);
     }
-    byMode.set(keepAsCell, output);
-    return output !== null && typeof output === "object"
-      ? { ...output }
-      : output;
+    // Deep-freeze the cached result: every memo hit hands out a fresh top that
+    // SHARES this sub-tree across callers, so a consumer mutating a nested node
+    // would otherwise silently poison every later same-schema build — frozen,
+    // such a mutation throws loudly instead. Freezing only touches objects this
+    // call built: the strip rebuilds every node, and its depth-capped bail
+    // returns sub-trees of the input, which is deep-frozen on this path.
+    const frozen = deepFreeze(output) as JSONSchema & object;
+    byMode.set(keepAsCell, frozen);
+    return { ...frozen };
   }
 
   return output;

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,7 +1,7 @@
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
-import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   type AnyCell,
   type DerivedInternalCellDescriptor,
@@ -460,13 +460,17 @@ export function sanitizeSchemaForLinks(
   // input, carrying ~half of the total strip time. Only deep-frozen inputs are
   // memoized (a mutable input's identity could go stale), matching the
   // identity-keyed-memo guard `traverse.ts` uses; `isDeepFrozen` is O(1) for the
-  // already-frozen/cached inputs we hit here. Cached outputs are deep-frozen so a
-  // shared result cannot be mutated by a consumer (all consumers only spread it).
+  // already-frozen/cached inputs we hit here. The cache holds the canonical strip
+  // result; every call returns a fresh SHALLOW CLONE of it. The clone matters:
+  // the reactive graph keys on the sanitized schema's top-level object identity
+  // (returning a shared object changes recomputation), so each call needs its own
+  // top — while still reusing the (expensive) stripped sub-tree from the cache.
   const memoizable = isDeepFrozen(schema);
   if (memoizable) {
     const byMode = _sanitizeCache.get(schema);
     if (byMode !== undefined && byMode.has(keepAsCell)) {
-      return byMode.get(keepAsCell);
+      const hit = byMode.get(keepAsCell);
+      return hit !== null && typeof hit === "object" ? { ...hit } : hit;
     }
   }
 
@@ -502,14 +506,15 @@ export function sanitizeSchemaForLinks(
     : stripped;
 
   if (memoizable) {
-    const frozen = deepFreeze(output);
     let byMode = _sanitizeCache.get(schema);
     if (byMode === undefined) {
       byMode = new Map();
       _sanitizeCache.set(schema, byMode);
     }
-    byMode.set(keepAsCell, frozen);
-    return frozen;
+    byMode.set(keepAsCell, output);
+    return output !== null && typeof output === "object"
+      ? { ...output }
+      : output;
   }
 
   return output;

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -24,6 +24,7 @@ import { getJSONFromDataURI } from "../src/uri-utils.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -672,6 +673,41 @@ describe("link-utils", () => {
   });
 
   describe("stripAsCellAndStreamFromSchema", () => {
+    it("memoizes a frozen input per keepAsCell mode and freezes the shared result", () => {
+      // The memo only engages for deep-frozen inputs (a mutable input's identity
+      // could go stale), so it no-ops for the non-frozen literals other tests
+      // pass. A repeated frozen input must return the SAME object (served from
+      // the memo, not recomputed), and that shared object must be frozen so a
+      // consumer cannot corrupt it.
+      const schema = deepFreeze({
+        type: "object",
+        properties: { name: { type: "string", asCell: ["cell"] } },
+      }) as JSONSchema;
+
+      const noneA = sanitizeSchemaForLinks(schema, KeepAsCell.None);
+      const noneB = sanitizeSchemaForLinks(schema, KeepAsCell.None);
+      expect(noneB).toBe(noneA); // same reference ⇒ memo hit
+      expect(Object.isFrozen(noneA)).toBe(true);
+      expect((noneA as { properties: { name: JSONSchema } }).properties.name)
+        .toEqual({ type: "string" }); // asCell stripped
+
+      // A different keepAsCell mode is cached separately (asCell kept here).
+      const allA = sanitizeSchemaForLinks(schema, KeepAsCell.All);
+      expect(allA).not.toBe(noneA);
+      expect((allA as { properties: { name: JSONSchema } }).properties.name)
+        .toEqual({ type: "string", asCell: ["cell"] });
+    });
+
+    it("does not cross-contaminate different frozen inputs", () => {
+      const s1 = deepFreeze({ type: "string", asCell: ["cell"] }) as JSONSchema;
+      const s2 = deepFreeze({ type: "number", asCell: ["cell"] }) as JSONSchema;
+      const o1 = sanitizeSchemaForLinks(s1, KeepAsCell.None);
+      const o2 = sanitizeSchemaForLinks(s2, KeepAsCell.None);
+      expect(o1).not.toBe(o2);
+      expect(o1).toEqual({ type: "string" });
+      expect(o2).toEqual({ type: "number" });
+    });
+
     it("should remove asCell from simple schema", () => {
       const schema = {
         type: "object",

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -673,29 +673,36 @@ describe("link-utils", () => {
   });
 
   describe("stripAsCellAndStreamFromSchema", () => {
-    it("memoizes a frozen input per keepAsCell mode and freezes the shared result", () => {
+    it("memoizes a frozen input per keepAsCell mode, handing out a fresh top that shares the cached sub-tree", () => {
       // The memo only engages for deep-frozen inputs (a mutable input's identity
       // could go stale), so it no-ops for the non-frozen literals other tests
-      // pass. A repeated frozen input must return the SAME object (served from
-      // the memo, not recomputed), and that shared object must be frozen so a
-      // consumer cannot corrupt it.
+      // pass. On a repeat it must return a FRESH top-level object (the reactive
+      // graph keys on the sanitized schema's identity — a shared top changes
+      // recomputation), while reusing the cached stripped sub-tree (⇒ memo hit,
+      // no recompute).
       const schema = deepFreeze({
         type: "object",
         properties: { name: { type: "string", asCell: ["cell"] } },
       }) as JSONSchema;
 
-      const noneA = sanitizeSchemaForLinks(schema, KeepAsCell.None);
-      const noneB = sanitizeSchemaForLinks(schema, KeepAsCell.None);
-      expect(noneB).toBe(noneA); // same reference ⇒ memo hit
-      expect(Object.isFrozen(noneA)).toBe(true);
-      expect((noneA as { properties: { name: JSONSchema } }).properties.name)
-        .toEqual({ type: "string" }); // asCell stripped
+      const noneA = sanitizeSchemaForLinks(schema, KeepAsCell.None) as {
+        properties: Record<string, JSONSchema>;
+      };
+      const noneB = sanitizeSchemaForLinks(schema, KeepAsCell.None) as {
+        properties: Record<string, JSONSchema>;
+      };
+      expect(noneB).not.toBe(noneA); // fresh top-level object each call
+      expect(noneB.properties).toBe(noneA.properties); // cached sub-tree reused
+      expect(noneA.properties.name).toEqual({ type: "string" }); // asCell stripped
 
       // A different keepAsCell mode is cached separately (asCell kept here).
-      const allA = sanitizeSchemaForLinks(schema, KeepAsCell.All);
-      expect(allA).not.toBe(noneA);
-      expect((allA as { properties: { name: JSONSchema } }).properties.name)
-        .toEqual({ type: "string", asCell: ["cell"] });
+      const allA = sanitizeSchemaForLinks(schema, KeepAsCell.All) as {
+        properties: Record<string, JSONSchema>;
+      };
+      expect(allA.properties.name).toEqual({
+        type: "string",
+        asCell: ["cell"],
+      });
     });
 
     it("does not cross-contaminate different frozen inputs", () => {

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -695,6 +695,16 @@ describe("link-utils", () => {
       expect(noneB.properties).toBe(noneA.properties); // cached sub-tree reused
       expect(noneA.properties.name).toEqual({ type: "string" }); // asCell stripped
 
+      // The shared sub-tree is deep-frozen: a consumer mutating a nested node
+      // throws loudly instead of silently poisoning every later same-schema
+      // build. The handed-out top itself stays caller-mutable (fresh per call).
+      expect(Object.isFrozen(noneA.properties)).toBe(true);
+      expect(Object.isFrozen(noneA.properties.name)).toBe(true);
+      expect(() => {
+        (noneA.properties.name as { type?: string }).type = "mutated";
+      }).toThrow(TypeError);
+      expect(Object.isFrozen(noneB)).toBe(false);
+
       // A different keepAsCell mode is cached separately (asCell kept here).
       const allA = sanitizeSchemaForLinks(schema, KeepAsCell.All) as {
         properties: Record<string, JSONSchema>;


### PR DESCRIPTION
## What

Two small, independent, correctness-preserving perf fixes in the pattern-build
path (`factoryFromPattern`), found while profiling cold-load. Neither changes
behaviour for real inputs.

### 1. O(1) partial-cause dedup (was O(N²))
`factoryFromPattern` assigns a distinct "partial cause" to each internal cell,
deduping each candidate against **every** previously-assigned cause via a
`deepEqual` scan — O(N²) in the number of internal cells. Anonymous causes carry
a monotonic counter and are unique by construction, so that scan is pure waste;
and the quadratic bites on every instantiation of a *large* pattern, not just at
boot. Replaced with an O(1) `Set` of canonical cause keys — `hashStringOf`, the
canonical value hash, which is exactly `deepEqual`'s comparison on the JSON
domain: key-order-insensitive records (sorted UTF-8 key order) and
`Object.is` number semantics (`-0` ≠ `0`, `NaN` = `NaN`), pinned in
data-model's value-hash tests.

### 2. Memoize `sanitizeSchemaForLinks` by frozen input identity
`sanitizeSchemaForLinks` (strips `asCell`, de-cycles into `$defs`) is a pure
function of `(schema, keepAsCell)`, and at pattern-build time the same
interned/frozen schema is sanitized repeatedly. Memoized by input identity (per
`keepAsCell` mode), guarded to frozen inputs — the identity-keyed-memo pattern
`traverse.ts` already uses. Cached outputs are deep-frozen for share-safety
(a consumer mutating a nested node throws loudly instead of silently
poisoning every later same-schema build); each call hands out a fresh,
caller-mutable top-level clone that shares the frozen sub-tree; non-frozen
inputs bypass the memo unchanged.

## Measurement note (honest sizing)
- The **partial-cause** win is ~0 on a *trivial* pattern (tiny N) — it's a
  scaling fix for large patterns / repeated instantiation, plus it deletes
  provably-useless comparisons.
- The **sanitize memo**'s win (~4ms at boot) is below single-CPU-profile noise,
  so it was verified **deterministically**: measured on a trivial cold boot,
  2571 sanitize calls, 46% repeat a frozen input, and those repeats carry
  **~half (3.4 of 6.7ms) of the `recursiveStripAsCellFromSchema` time** — the
  memo's exact ceiling.

## Tests
- Frozen-share pins: the memoized sub-tree is deep-frozen (nested mutation
  throws), the handed-out top stays caller-mutable.
- New regression tests for the sanitize memo: a repeated frozen input returns the
  same frozen object (memo hit via reference-equality), keyed per `keepAsCell`
  mode, no cross-contamination between inputs.
- Partial-cause semantics covered by existing `rehydrate-internal-default` /
  `patterns-regressions` / `pattern` tests; full runner suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the pattern build by switching partial-cause dedup to O(1) via value hashing, and memoizes `sanitizeSchemaForLinks` for deep‑frozen inputs with deep‑frozen cached outputs while returning a fresh top‑level clone.

- **Refactors**
  - Partial-cause dedup: replace `deepEqual` scan with an O(1) `Set` keyed by `hashStringOf` (order‑insensitive, `Object.is`‑faithful), matching `deepEqual`.
  - `sanitizeSchemaForLinks`: identity-memoized for deep‑frozen inputs per `KeepAsCell`; cached strip is deep‑frozen and each call returns a fresh shallow top-level clone; mutable inputs bypass the cache.
  - Tests: add cases for memo hits, per-mode caching, fresh top with shared frozen sub-tree (mutation throws), and no cross-contamination across different frozen inputs.

<sup>Written for commit dd918997a99af10cbea6c110fc1b89f6de21dbcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

