### PR TITLE
OpenTelemetry for the runner/memory hot path: bridge existing telemetry to OTel, trace the write/fan-out path

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -100,10 +100,12 @@
     "npm:@opentelemetry/context-async-hooks@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/core@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/exporter-metrics-otlp-proto@0.46": "0.46.0_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/exporter-trace-otlp-http@0.46": "0.46.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/exporter-trace-otlp-proto@0.46": "0.46.0_@opentelemetry+api@1.9.0",
-    "npm:@opentelemetry/resources@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/resources@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/sdk-metrics@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
-    "npm:@opentelemetry/sdk-trace-base@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/sdk-trace-base@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/sdk-trace-web@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/semantic-conventions@^1.19.0": "1.38.0",
     "npm:@resvg/resvg-js@2.6.2": "2.6.2",
     "npm:@scalar/hono-api-reference@~0.5.165": "0.5.184_hono@4.10.5",
@@ -883,7 +885,7 @@
         "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/sdk-metrics"
       ]
     },
@@ -896,8 +898,19 @@
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-proto-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/sdk-metrics"
+      ]
+    },
+    "@opentelemetry/exporter-trace-otlp-http@0.46.0_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-vZ2pYOB+qrQ+jnKPY6Gnd58y1k/Ti//Ny6/XsSX7/jED0X77crtSVgC6N5UA0JiGJOh6QB2KE9gaH99010XHzg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
+        "@opentelemetry/otlp-exporter-base",
+        "@opentelemetry/otlp-transformer",
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
+        "@opentelemetry/sdk-trace-base@1.19.0_@opentelemetry+api@1.9.0"
       ]
     },
     "@opentelemetry/exporter-trace-otlp-proto@0.46.0_@opentelemetry+api@1.9.0": {
@@ -908,8 +921,8 @@
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-proto-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
-        "@opentelemetry/sdk-trace-base"
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
+        "@opentelemetry/sdk-trace-base@1.19.0_@opentelemetry+api@1.9.0"
       ]
     },
     "@opentelemetry/otlp-exporter-base@0.46.0_@opentelemetry+api@1.9.0": {
@@ -935,10 +948,10 @@
         "@opentelemetry/api",
         "@opentelemetry/api-logs",
         "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/sdk-logs",
         "@opentelemetry/sdk-metrics",
-        "@opentelemetry/sdk-trace-base"
+        "@opentelemetry/sdk-trace-base@1.19.0_@opentelemetry+api@1.9.0"
       ]
     },
     "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0": {
@@ -949,13 +962,21 @@
         "@opentelemetry/semantic-conventions@1.19.0"
       ]
     },
+    "@opentelemetry/resources@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/semantic-conventions@1.28.0"
+      ]
+    },
     "@opentelemetry/sdk-logs@0.46.0_@opentelemetry+api@1.9.0_@opentelemetry+api-logs@0.46.0": {
       "integrity": "sha512-Knlyk4+G72uEzNh6GRN1Fhmrj+/rkATI5/lOrevN7zRDLgp4kfyZBGGoWk7w+qQjlYvwhIIdPVxlIcipivdZIg==",
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/api-logs",
         "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
-        "@opentelemetry/resources"
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0"
       ]
     },
     "@opentelemetry/sdk-metrics@1.19.0_@opentelemetry+api@1.9.0": {
@@ -963,7 +984,7 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "lodash.merge"
       ]
     },
@@ -972,8 +993,26 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/semantic-conventions@1.19.0"
+      ]
+    },
+    "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/resources@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/semantic-conventions@1.28.0"
+      ]
+    },
+    "@opentelemetry/sdk-trace-web@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-AUo2e+1uyTGMB36VlbvBqnCogVzQhpC7dRcVVdCrt+cFHLpFRRJcd45J2obGTgs0XiAwNLyq5bhkW3JF2NZA+A==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/semantic-conventions@1.28.0"
       ]
     },
     "@opentelemetry/semantic-conventions@1.19.0": {
@@ -2087,7 +2126,11 @@
       "packages/shell": {
         "dependencies": [
           "npm:@lit/context@^1.1.5",
-          "npm:@lit/task@^1.0.2"
+          "npm:@lit/task@^1.0.2",
+          "npm:@opentelemetry/api@^1.7.0",
+          "npm:@opentelemetry/exporter-trace-otlp-http@0.46",
+          "npm:@opentelemetry/resources@^1.19.0",
+          "npm:@opentelemetry/sdk-trace-web@^1.19.0"
         ]
       },
       "packages/state-inspector": {

--- a/deno.lock
+++ b/deno.lock
@@ -99,8 +99,10 @@
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
     "npm:@opentelemetry/context-async-hooks@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/core@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/exporter-metrics-otlp-proto@0.46": "0.46.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/exporter-trace-otlp-proto@0.46": "0.46.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/resources@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/sdk-metrics@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/sdk-trace-base@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/semantic-conventions@^1.19.0": "1.38.0",
     "npm:@resvg/resvg-js@2.6.2": "2.6.2",
@@ -874,6 +876,30 @@
         "@opentelemetry/semantic-conventions@1.28.0"
       ]
     },
+    "@opentelemetry/exporter-metrics-otlp-http@0.46.0_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-7dyNATgM1LCKv4RGf3zsbHZMQNILQ6bxZ5/a56ptGDgg6Bz8Iz8jghonBx/K++A4QNMnu7Ppamm5qL2xlWEYjg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
+        "@opentelemetry/otlp-exporter-base",
+        "@opentelemetry/otlp-transformer",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-metrics"
+      ]
+    },
+    "@opentelemetry/exporter-metrics-otlp-proto@0.46.0_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-2nj4YoTMcx/PixfTp+Zj7G7uJm9twzlq50TVy9rCRLRC30qSuvNYcEXymNYI1GtOZmQT6FQB1AHE9+JZNetVNg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http",
+        "@opentelemetry/otlp-exporter-base",
+        "@opentelemetry/otlp-proto-exporter-base",
+        "@opentelemetry/otlp-transformer",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-metrics"
+      ]
+    },
     "@opentelemetry/exporter-trace-otlp-proto@0.46.0_@opentelemetry+api@1.9.0": {
       "integrity": "sha512-A7PftDM57w1TLiirrhi8ceAnCpYkpUBObELdn239IyYF67zwngImGfBLf5Yo3TTAOA2Oj1TL76L8zWVL8W+Suw==",
       "dependencies": [
@@ -903,7 +929,7 @@
       ],
       "deprecated": true
     },
-    "@opentelemetry/otlp-transformer@0.46.0_@opentelemetry+api@1.9.0_@opentelemetry+api-logs@0.46.0": {
+    "@opentelemetry/otlp-transformer@0.46.0_@opentelemetry+api@1.9.0": {
       "integrity": "sha512-Fj9hZwr6xuqgsaERn667Uf6kuDG884puWhyrai2Jen2Fq+bGf4/5BzEJp/8xvty0VSU4EfXOto/ys3KpSz2UHg==",
       "dependencies": [
         "@opentelemetry/api",
@@ -1888,6 +1914,7 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": true,
       "bin": true
     },
     "w3c-keyname@2.2.8": {
@@ -1983,8 +2010,10 @@
         "dependencies": [
           "npm:@opentelemetry/api@^1.7.0",
           "npm:@opentelemetry/context-async-hooks@^1.19.0",
+          "npm:@opentelemetry/exporter-metrics-otlp-proto@0.46",
           "npm:@opentelemetry/exporter-trace-otlp-proto@0.46",
           "npm:@opentelemetry/resources@^1.19.0",
+          "npm:@opentelemetry/sdk-metrics@^1.19.0",
           "npm:@opentelemetry/sdk-trace-base@^1.19.0"
         ]
       },
@@ -2045,6 +2074,7 @@
       },
       "packages/runner": {
         "dependencies": [
+          "npm:@opentelemetry/api@^1.7.0",
           "npm:ses@^1.15.0",
           "npm:typescript@*"
         ]

--- a/packages/background-piece-service/deno.jsonc
+++ b/packages/background-piece-service/deno.jsonc
@@ -12,7 +12,9 @@
   "imports": {
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.7.0",
     "@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@^1.19.0",
+    "@opentelemetry/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.19.0",
     "@opentelemetry/exporter-trace-otlp-proto": "npm:@opentelemetry/exporter-trace-otlp-proto@^0.46.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "npm:@opentelemetry/exporter-metrics-otlp-proto@^0.46.0",
     "@opentelemetry/resources": "npm:@opentelemetry/resources@^1.19.0",
     "@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@^1.19.0"
   },

--- a/packages/background-piece-service/src/otel.ts
+++ b/packages/background-piece-service/src/otel.ts
@@ -1,4 +1,10 @@
-import { context, trace, type Tracer } from "@opentelemetry/api";
+import {
+  context,
+  type Meter,
+  metrics,
+  trace,
+  type Tracer,
+} from "@opentelemetry/api";
 import { env, type EnvVars } from "./env.ts";
 
 /** The subset of env the tracer setup needs (injectable for tests). */
@@ -14,8 +20,18 @@ let _provider:
   | import("@opentelemetry/sdk-trace-base").BasicTracerProvider
   | undefined;
 
+// The registered metrics provider, mirroring `_provider` for traces. Undefined
+// when telemetry is off or has been shut down, so init/shutdown stay idempotent.
+let _meterProvider:
+  | import("@opentelemetry/sdk-metrics").MeterProvider
+  | undefined;
+
 export function getTracerProvider() {
   return _provider;
+}
+
+export function getMeterProvider() {
+  return _meterProvider;
 }
 
 /** Returns a tracer bound to the registered provider (or the no-op global one). */
@@ -25,26 +41,43 @@ export function getTracer(): Tracer {
     : trace.getTracer("bg-piece-service", "1.0.0");
 }
 
+/** Returns a meter bound to the registered provider (or the no-op global one). */
+export function getMeter(): Meter {
+  return _meterProvider
+    ? _meterProvider.getMeter("bg-piece-service", "1.0.0")
+    : metrics.getMeter("bg-piece-service", "1.0.0");
+}
+
 /**
  * Flush and shut down the tracer provider so buffered spans aren't dropped when
  * the process exits. No-op if telemetry was never initialized.
  */
 export async function shutdownOpenTelemetry(): Promise<void> {
-  if (!_provider) return;
-  // Clear the reference up front so a second call (or a span created after
-  // shutdown) is a no-op rather than touching a torn-down provider.
+  if (!_provider && !_meterProvider) return;
+  // Clear the references up front so a second call (or a span/metric created
+  // after shutdown) is a no-op rather than touching a torn-down provider.
   const provider = _provider;
+  const meterProvider = _meterProvider;
   _provider = undefined;
+  _meterProvider = undefined;
   try {
-    await provider.forceFlush();
-    await provider.shutdown();
+    if (provider) {
+      await provider.forceFlush();
+      await provider.shutdown();
+    }
+    if (meterProvider) {
+      await meterProvider.forceFlush();
+      await meterProvider.shutdown();
+    }
   } finally {
     // Reset the global API state too, so a later initOpenTelemetry() can register
-    // a fresh provider + context manager cleanly, and getTracer() falls back to
-    // the API no-op tracer until then. (We don't swallow flush/shutdown errors —
-    // the caller decides; see main.ts's shutdown handler.)
+    // fresh providers + context manager cleanly, and getTracer()/getMeter() fall
+    // back to the API no-op instruments until then. (We don't swallow
+    // flush/shutdown errors — the caller decides; see main.ts's shutdown
+    // handler.)
     trace.disable();
     context.disable();
+    metrics.disable();
   }
 }
 
@@ -104,6 +137,46 @@ export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
     console.log(
       `OpenTelemetry initialized successfully with endpoint: ${cfg.OTEL_EXPORTER_OTLP_ENDPOINT}`,
     );
+
+    // Metrics setup is independently fail-open: a MeterProvider error must not
+    // tear down the tracer that just registered successfully, so it gets its own
+    // try/catch nested inside the outer one.
+    try {
+      const { MeterProvider, PeriodicExportingMetricReader } = await import(
+        "@opentelemetry/sdk-metrics"
+      );
+      const { OTLPMetricExporter } = await import(
+        "@opentelemetry/exporter-metrics-otlp-proto"
+      );
+
+      const metricExporter = new OTLPMetricExporter({
+        url: `${cfg.OTEL_EXPORTER_OTLP_ENDPOINT.replace(/\/$/, "")}/v1/metrics`,
+      });
+      const meterProvider = new MeterProvider({
+        resource: new Resource({
+          "service.name": cfg.OTEL_SERVICE_NAME,
+          "service.version": "1.0.0",
+          "deployment.environment": cfg.ENV,
+        }),
+      });
+      // Periodically export metrics to the local OTLP collector, which forwards
+      // to SigNoz. (This SDK version registers readers post-construction.)
+      meterProvider.addMetricReader(
+        new PeriodicExportingMetricReader({ exporter: metricExporter }),
+      );
+
+      metrics.setGlobalMeterProvider(meterProvider);
+      _meterProvider = meterProvider;
+
+      console.log(
+        `OpenTelemetry metrics initialized successfully with endpoint: ${cfg.OTEL_EXPORTER_OTLP_ENDPOINT}`,
+      );
+    } catch (metricsError) {
+      console.error(
+        "Failed to initialize OpenTelemetry metrics:",
+        metricsError,
+      );
+    }
   } catch (error) {
     console.error("Failed to initialize OpenTelemetry:", error);
   }

--- a/packages/background-piece-service/src/otel.ts
+++ b/packages/background-piece-service/src/otel.ts
@@ -142,7 +142,11 @@ export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
     // tear down the tracer that just registered successfully, so it gets its own
     // try/catch nested inside the outer one.
     try {
-      const { MeterProvider, PeriodicExportingMetricReader } = await import(
+      const {
+        AggregationTemporality,
+        MeterProvider,
+        PeriodicExportingMetricReader,
+      } = await import(
         "@opentelemetry/sdk-metrics"
       );
       const { OTLPMetricExporter } = await import(
@@ -151,6 +155,10 @@ export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
 
       const metricExporter = new OTLPMetricExporter({
         url: `${cfg.OTEL_EXPORTER_OTLP_ENDPOINT.replace(/\/$/, "")}/v1/metrics`,
+        // Delta temporality: without it the exporter sends cumulative points
+        // that SigNoz records as "unspecified", which breaks rate()/increase()
+        // over our counters (only raw per-interval sums work).
+        temporalityPreference: AggregationTemporality.DELTA,
       });
       const meterProvider = new MeterProvider({
         resource: new Resource({

--- a/packages/background-piece-service/src/otel.ts
+++ b/packages/background-piece-service/src/otel.ts
@@ -60,14 +60,32 @@ export async function shutdownOpenTelemetry(): Promise<void> {
   const meterProvider = _meterProvider;
   _provider = undefined;
   _meterProvider = undefined;
+  // Flush/shutdown each provider independently: a failure tearing down traces
+  // must not silently skip the metrics flush (or vice versa). The first error
+  // is rethrown after both have been attempted — callers decide (see main.ts).
+  const errors: unknown[] = [];
   try {
     if (provider) {
-      await provider.forceFlush();
-      await provider.shutdown();
+      try {
+        await provider.forceFlush();
+        await provider.shutdown();
+      } catch (error) {
+        errors.push(error);
+      }
     }
     if (meterProvider) {
-      await meterProvider.forceFlush();
-      await meterProvider.shutdown();
+      try {
+        await meterProvider.forceFlush();
+        await meterProvider.shutdown();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      if (errors.length > 1) {
+        console.error("OpenTelemetry shutdown: additional error:", errors[1]);
+      }
+      throw errors[0];
     }
   } finally {
     // Reset the global API state too, so a later initOpenTelemetry() can register

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -1,6 +1,5 @@
 import { PieceManager } from "@commonfabric/piece";
 import {
-  attachRuntimeTelemetryOtelBridge,
   Cell,
   type ConsoleHandler,
   type ConsoleMessage,
@@ -11,6 +10,7 @@ import {
   Runtime,
   Stream,
 } from "@commonfabric/runner";
+import { attachRuntimeTelemetryOtelBridge } from "@commonfabric/runner/telemetry-otel-bridge";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { getMeter, getTracer } from "./otel.ts";
 

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -12,7 +12,13 @@ import {
 } from "@commonfabric/runner";
 import { attachRuntimeTelemetryOtelBridge } from "@commonfabric/runner/telemetry-otel-bridge";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { getMeter, getTracer } from "./otel.ts";
+import { env } from "./env.ts";
+import {
+  getMeter,
+  getTracer,
+  initOpenTelemetry,
+  shutdownOpenTelemetry,
+} from "./otel.ts";
 
 import {
   createSession,
@@ -169,6 +175,11 @@ export async function initialize(
     errorHandlers: [errorHandler],
     experimental,
   });
+  // Each worker is its own isolate: the provider main.ts registers doesn't
+  // exist here, so initialize OTel in-worker (idempotent, fail-open) or the
+  // bridge below would attach to no-op instruments.
+  await initOpenTelemetry();
+
   // Bridge the runtime's existing telemetry stream to OpenTelemetry. This is a
   // second, passive consumer of the same event bus the debug tooling uses; it
   // emits no-op instruments unless a provider is registered (see otel.ts).
@@ -179,6 +190,14 @@ export async function initialize(
       "ct.runtime": "bg-piece",
       "space.did": spaceId,
       "user.did": identity.did(),
+    },
+    // Metric datapoints don't inherit resource attributes in SigNoz, so stamp
+    // the scoping labels explicitly (metrics only — on spans these live on the
+    // resource, and duplicating them as span attributes makes the bare key
+    // ambiguous in queries).
+    metricAttributes: {
+      "service.name": env.OTEL_SERVICE_NAME,
+      "deployment.environment": env.ENV,
     },
   });
 
@@ -213,6 +232,14 @@ export async function cleanup(): Promise<void> {
     await runtime.storageManager.synced();
     await runtime.dispose();
     runtime = null;
+  }
+
+  // Flush buffered spans/metrics before the controller terminates this worker;
+  // fail-open — telemetry teardown must never block cleanup.
+  try {
+    await shutdownOpenTelemetry();
+  } catch (error) {
+    console.error("Failed to shut down OpenTelemetry:", error);
   }
 
   initialized = false;

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -1,5 +1,6 @@
 import { PieceManager } from "@commonfabric/piece";
 import {
+  attachRuntimeTelemetryOtelBridge,
   Cell,
   type ConsoleHandler,
   type ConsoleMessage,
@@ -11,6 +12,7 @@ import {
   Stream,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getMeter, getTracer } from "./otel.ts";
 
 import {
   createSession,
@@ -32,6 +34,10 @@ let latestError: Error | null = null;
 let currentSession: Session | null = null;
 let manager: PieceManager | null = null;
 let runtime: Runtime | null = null;
+// Detaches the OpenTelemetry bridge from the runtime's telemetry EventTarget.
+// Set when the runtime is created in initialize(), called on cleanup() so the
+// listener and any in-flight spans are torn down with the runtime.
+let detachOtelBridge: (() => void) | null = null;
 const loadedPieces = new Map<string, Cell<{ bgUpdater: Stream<unknown> }>>();
 let streamValidator = isStream;
 
@@ -127,6 +133,7 @@ export function resetWorkerStateForTesting(): void {
   currentSession = null;
   manager = null;
   runtime = null;
+  detachOtelBridge = null;
   loadedPieces.clear();
   streamValidator = isStream;
 }
@@ -162,6 +169,19 @@ export async function initialize(
     errorHandlers: [errorHandler],
     experimental,
   });
+  // Bridge the runtime's existing telemetry stream to OpenTelemetry. This is a
+  // second, passive consumer of the same event bus the debug tooling uses; it
+  // emits no-op instruments unless a provider is registered (see otel.ts).
+  detachOtelBridge = attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
+    tracer: getTracer(),
+    meter: getMeter(),
+    attributes: {
+      "ct.runtime": "bg-piece",
+      "space.did": spaceId,
+      "user.did": identity.did(),
+    },
+  });
+
   manager = new PieceManager(currentSession, runtime);
   await manager.ready;
 
@@ -180,6 +200,13 @@ export async function cleanup(): Promise<void> {
   loadedPieces.clear();
   currentSession = null;
   manager = null;
+
+  // Detach the OTel bridge before tearing down the runtime so its telemetry
+  // listener is removed and any in-flight storage spans are closed.
+  if (detachOtelBridge) {
+    detachOtelBridge();
+    detachOtelBridge = null;
+  }
 
   // Ensure storage is synced before cleanup
   if (runtime) {

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -220,18 +220,19 @@ export async function cleanup(): Promise<void> {
   currentSession = null;
   manager = null;
 
-  // Detach the OTel bridge before tearing down the runtime so its telemetry
-  // listener is removed and any in-flight storage spans are closed.
-  if (detachOtelBridge) {
-    detachOtelBridge();
-    detachOtelBridge = null;
-  }
-
   // Ensure storage is synced before cleanup
   if (runtime) {
     await runtime.storageManager.synced();
     await runtime.dispose();
     runtime = null;
+  }
+
+  // Detach the OTel bridge only after the runtime is fully torn down, so the
+  // final sync/dispose telemetry (storage completions, subscription removals)
+  // is still observed; detaching closes any spans left in flight.
+  if (detachOtelBridge) {
+    detachOtelBridge();
+    detachOtelBridge = null;
   }
 
   // Flush buffered spans/metrics before the controller terminates this worker;

--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -180,8 +180,12 @@ function otelBrowserPlatformPlugin(): esbuild.Plugin {
         const browserIndex = joinPath(platformDir, "browser", "index.js");
         try {
           Deno.statSync(browserIndex);
-        } catch {
-          return undefined; // no browser split in this package — default resolution
+        } catch (error) {
+          // Only "file doesn't exist" means "no browser split in this
+          // package"; a real I/O error must fail the build, not silently
+          // fall back to bundling the node platform path.
+          if (error instanceof Deno.errors.NotFound) return undefined;
+          throw error;
         }
         return { path: browserIndex };
       });

--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -1,6 +1,7 @@
 import * as esbuild from "esbuild";
 import { denoPlugin } from "@deno/esbuild-plugin";
 import { debounce } from "@std/async/debounce";
+import { join as joinPath, resolve as resolvePath } from "@std/path";
 import { ResolvedConfig } from "./interface.ts";
 import { blue, dim, green, red, yellow } from "@std/fmt/colors";
 
@@ -160,6 +161,34 @@ function textLoaderPlugin(): esbuild.Plugin {
   };
 }
 
+// The Deno resolver ignores npm packages' "browser" field. @opentelemetry
+// packages gate their node/browser split behind it: modules import
+// `./platform` (whose index re-exports `./node`), and the browser field remaps
+// that index file to `platform/browser/index.js`. Without the remap the node
+// platform build — `import "perf_hooks"`, `import "stream"` — lands in browser
+// bundles and breaks both the browser (unresolvable specifiers) and
+// `deno compile` of binaries that embed them. Reproduce exactly that file
+// mapping here, scoped to @opentelemetry packages.
+function otelBrowserPlatformPlugin(): esbuild.Plugin {
+  const OTEL_PKG = /[/\\]@opentelemetry[/\\][^/\\]+[/\\]/;
+  return {
+    name: "otel-browser-platform",
+    setup(build) {
+      build.onResolve({ filter: /^\.\.?[/\\]platform$/ }, (args) => {
+        if (!OTEL_PKG.test(args.importer)) return undefined;
+        const platformDir = resolvePath(args.resolveDir, args.path);
+        const browserIndex = joinPath(platformDir, "browser", "index.js");
+        try {
+          Deno.statSync(browserIndex);
+        } catch {
+          return undefined; // no browser split in this package — default resolution
+        }
+        return { path: browserIndex };
+      });
+    },
+  };
+}
+
 // Exposes `esbuild`'s build functionality, applying
 // default deno resolution plugins, browser platform,
 // and ESM bundling format.
@@ -167,7 +196,11 @@ export async function build(
   config: Parameters<typeof esbuild.build>[0],
 ): Promise<ReturnType<typeof esbuild.build>> {
   const fullConfig = Object.assign({}, config, {
-    plugins: [textLoaderPlugin(), denoPlugin({ noTranspile: true })],
+    plugins: [
+      textLoaderPlugin(),
+      otelBrowserPlatformPlugin(),
+      denoPlugin({ noTranspile: true }),
+    ],
     platform: "browser",
     bundle: true,
     format: "esm",

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -47,6 +47,18 @@ export type RuntimeInternalsCallbacks = {
   onError?: (event: RuntimeClientEvents["error"][0]) => void;
 };
 
+/**
+ * Optional telemetry sink for the client marker stream. When provided (browser
+ * OTel enabled), each marker is forwarded here IN ADDITION to the existing debug
+ * handling. Structurally matches the browser OTel bridge returned by
+ * packages/shell/src/lib/otel.ts, so this package pulls in no OTel code — the
+ * embedder owns SDK setup and passes the sink in. Absent = zero added work.
+ */
+export interface RuntimeTelemetrySink {
+  handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  shutdown(): void | Promise<void>;
+}
+
 export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   identity: Identity;
   apiUrl: URL;
@@ -66,6 +78,11 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   forwardWorkerConsole?: boolean;
   getBuildHash?: () => Promise<string | undefined>;
   workerUrl?: URL;
+  /**
+   * Optional telemetry sink (browser OTel bridge). Purely additive and gated by
+   * the embedder: when omitted, no telemetry work happens.
+   */
+  telemetry?: RuntimeTelemetrySink;
 };
 
 const NavigationEventName = "cf-navigate";
@@ -168,14 +185,18 @@ export class RuntimeInternals extends EventTarget {
   > = new Map();
   // TODO(runtime-worker-refactor)
   #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
+  // Optional OTel sink (browser telemetry enabled). Inert when undefined.
+  #telemetrySink?: RuntimeTelemetrySink;
 
   constructor(
     client: RuntimeClient,
     callbacks: RuntimeInternalsCallbacks = {},
+    telemetry?: RuntimeTelemetrySink,
   ) {
     super();
     this.#client = client;
     this.#callbacks = callbacks;
+    this.#telemetrySink = telemetry;
     this.#favorites = new FavoritesManager(client);
     this.#client.on("console", this.#onConsole);
     this.#client.on("navigaterequest", this.#onNavigateRequest);
@@ -350,6 +371,16 @@ export class RuntimeInternals extends EventTarget {
   async dispose(): Promise<void> {
     if (this.#disposed) return;
     this.#disposed = true;
+    // Flush + tear down telemetry first so buffered spans aren't dropped on
+    // runtime replacement/logout. Guarded — telemetry must never break disposal.
+    if (this.#telemetrySink) {
+      try {
+        await this.#telemetrySink.shutdown();
+      } catch (e) {
+        console.error("[RuntimeInternals] telemetry sink shutdown failed:", e);
+      }
+      this.#telemetrySink = undefined;
+    }
     await this.#client.dispose();
   }
 
@@ -456,6 +487,19 @@ export class RuntimeInternals extends EventTarget {
   #onTelemetry = (marker: RuntimeTelemetryMarkerResult) => {
     this.#telemetryMarkers.push(marker);
     this.dispatchEvent(new CustomEvent("telemetryupdate"));
+    // Additionally translate the marker into OTel spans/metrics when a sink is
+    // attached (browser telemetry enabled). Guarded so a bridge error never
+    // disrupts the existing debug telemetry pipeline.
+    if (this.#telemetrySink) {
+      try {
+        this.#telemetrySink.handleMarker(marker);
+      } catch (e) {
+        console.error(
+          "[RuntimeInternals] telemetry sink handleMarker failed:",
+          e,
+        );
+      }
+    }
   };
 
   #check() {
@@ -477,6 +521,7 @@ export class RuntimeInternals extends EventTarget {
     navigate,
     onConsole,
     onError,
+    telemetry,
   }: RuntimeInternalsCreateOptions): Promise<RuntimeInternals> {
     // One runtime per identity: the worker session is always the
     // identity's home session. Spaces — including derived named spaces —
@@ -522,6 +567,7 @@ export class RuntimeInternals extends EventTarget {
     return new RuntimeInternals(
       client,
       { navigate, onConsole, onError },
+      telemetry,
     );
   }
 }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1571,15 +1571,15 @@ export class Server {
     }
   }
 
-  async transact(
+  transact(
     message: TransactRequest,
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
     const session = this.#sessions.get(message.space, message.sessionId);
     if (session === null) {
-      return respondTypedError<Engine.AppliedCommit>(
+      return Promise.resolve(respondTypedError<Engine.AppliedCommit>(
         message.requestId,
         toError("SessionError", "Unknown session for space"),
-      );
+      ));
     }
 
     return tracer.startActiveSpan(
@@ -2206,7 +2206,7 @@ export class Server {
     };
   }
 
-  async syncSessionForConnection(
+  syncSessionForConnection(
     space: string,
     sessionId: string,
     dirtyIds?: ReadonlySet<string>,
@@ -2214,7 +2214,7 @@ export class Server {
   ): Promise<SessionEffectMessage | null> {
     const session = this.#sessions.get(space, sessionId);
     if (session === null) {
-      return null;
+      return Promise.resolve(null);
     }
     return tracer.startActiveSpan(
       "memory.subscriber.sync",

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2579,20 +2579,27 @@ export class Server {
         if (dirtyOrigins !== undefined) {
           this.#dirtyOriginsBySpace.delete(space);
         }
-        // Fan-out is a scheduled/batched timer decoupled from transact, so this
-        // is a separate root span (not parented under memory.transact).
-        await tracer.startActiveSpan("memory.fanout", async (span) => {
-          span.setAttribute("space.did", space);
-          span.setAttribute("subscriber.count", this.#connections.size);
-          span.setAttribute("dirty.count", dirtyIds?.size ?? 0);
-          try {
-            for (const connection of this.#connections.values()) {
-              await connection.refreshDirty(space, dirtyIds, dirtyOrigins);
+        // Fan-out is a scheduled/batched timer decoupled from transact, so it
+        // must be its own root span. `root: true` makes that explicit — the
+        // context manager propagates the active context into timer callbacks,
+        // so without it this span could parent under whichever memory.transact
+        // happened to schedule the refresh.
+        await tracer.startActiveSpan(
+          "memory.fanout",
+          { root: true },
+          async (span) => {
+            span.setAttribute("space.did", space);
+            span.setAttribute("subscriber.count", this.#connections.size);
+            span.setAttribute("dirty.count", dirtyIds?.size ?? 0);
+            try {
+              for (const connection of this.#connections.values()) {
+                await connection.refreshDirty(space, dirtyIds, dirtyOrigins);
+              }
+            } finally {
+              span.end();
             }
-          } finally {
-            span.end();
-          }
-        });
+          },
+        );
       }
 
       if (initial !== undefined) {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -86,8 +86,15 @@ import {
 } from "./server-sync.ts";
 import { SessionRegistry, type SessionState } from "./session-registry.ts";
 import { authorizationError } from "./session-open-auth.ts";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 
 export { SessionRegistry } from "./session-registry.ts";
+
+// Global OTel API tracer. Interface-only and inert when no provider is
+// registered, so this is a no-op unless the host process (toolshed) has an
+// OTLP SDK installed. Spans created here are purely additive observability and
+// do not affect write/fan-out behavior.
+const tracer = trace.getTracer("memory-server", "1.0.0");
 
 const SUBSCRIPTION_REFRESH_DELAY_MS = 5;
 const MIN_REFRESH_QUEUE_DRAIN_WAIT_MS = 500;
@@ -1575,141 +1582,188 @@ export class Server {
       );
     }
 
-    try {
-      const engine = await this.openEngine(message.space);
-      // ACL-document writes change who may access the space — OWNER only.
-      const aclTouched = commitTouchesAclDoc(
-        message.commit.operations,
-        message.space,
-      );
-      const deny = await this.#authorizeMessage(
-        message.space,
-        session.principal,
-        aclTouched ? "OWNER" : "WRITE",
-      );
-      if (deny) {
-        return respondTypedError<Engine.AppliedCommit>(message.requestId, deny);
-      }
-      const schedulerStateEnabled = getPersistentSchedulerStateConfig();
-      const commitPayload = schedulerStateEnabled ? message.commit : {
-        ...message.commit,
-        schedulerObservation: undefined,
-        schedulerObservationBatch: undefined,
-      };
-      const schedulerObservations = schedulerStateEnabled
-        ? schedulerObservationsFromCommit(commitPayload)
-        : [];
-      const previousReadSpaces = new Map<number, Set<string>>();
-      for (const { localSeq, observation } of schedulerObservations) {
-        previousReadSpaces.set(
-          localSeq,
-          this.schedulerObservationReadSpaces(
-            Engine.getLatestSchedulerActionSnapshot(engine, {
-              branch: message.commit.branch ?? "",
-              ownerSpace: message.space,
-              pieceId: observation.pieceId,
-              processGeneration: observation.processGeneration,
-              actionId: observation.actionId,
-            })?.observation,
-          ),
-        );
-      }
-      // Fold-in SQLite writes: ATTACH their cell-db(s) BEFORE applyCommit (ATTACH
-      // cannot run inside a transaction); the engine executes them inside the
-      // commit txn (atomic with cell ops). Detach in finally.
-      const sqliteAttachments = this.#attachCommitSqliteDbs(
-        engine,
-        message.space,
-        commitPayload.operations,
-        { principal: session.principal, sessionId: message.sessionId },
-      );
-      let commit: Engine.AppliedCommit;
-      try {
-        commit = Engine.applyCommit(engine, {
-          sessionId: message.sessionId,
-          space: message.space,
-          principal: session.principal,
-          commit: commitPayload,
-          sqliteAttachments,
-        });
-      } finally {
-        // Detach BEFORE any await. `engine.database` is shared per space, so
-        // holding a cell-db attached across the post-commit await would let a
-        // concurrent connection's commit attach a SECOND cell-db — breaking the
-        // ≤1-attached invariant that unqualified-name resolution relies on
-        // (B1). `applyCommit` is synchronous and is the only step that needs the
-        // attachments.
-        for (const alias of sqliteAttachments.values()) {
-          detachDatabase(engine.database, alias);
+    return tracer.startActiveSpan(
+      "memory.transact",
+      async (span): Promise<ResponseMessage<Engine.AppliedCommit>> => {
+        span.setAttribute("space.did", message.space);
+        if (
+          session.principal !== undefined &&
+          session.principal !== ANYONE_USER
+        ) {
+          span.setAttribute("user.did", session.principal);
         }
-      }
-      if (aclTouched) {
-        this.#invalidateAclCapabilities(message.space);
-        // Pass the writing session so it isn't sent the terminal revocation
-        // before its own transact response (the client treats session/revoked
-        // as terminal). It's still dropped from the registry, so a
-        // self-deauthorized writer receives no further pushes.
-        this.#revokeDeauthorizedSessions(
-          engine,
-          message.space,
-          message.sessionId,
-        );
-      }
-      await this.runPostCommitSchedulerSideEffects(
-        message.space,
-        commit,
-        schedulerObservations,
-        previousReadSpaces,
-        session,
-      );
-      this.markSpaceDirty(
-        message.space,
-        message.commit.operations
-          .filter((operation) => operation.op !== "sqlite")
-          .map((operation) =>
-            toDirtyKey(operation.id, declaredScope(operation.scope))
-          ),
-        {
-          sessionId: message.sessionId,
-          seq: commit.seq,
-        },
-      );
-      return {
-        type: "response",
-        requestId: message.requestId,
-        ok: commit,
-      };
-    } catch (error) {
-      let retryAfterSeq: number | undefined;
-      if (error instanceof Engine.ConflictError) {
-        this.stageConflictRefreshDirtyIds(
-          message.space,
-          session,
-          message.commit,
-        );
-        const engine = await this.openEngine(message.space);
-        retryAfterSeq = Engine.serverSeq(engine);
-      }
-      const messageText = error instanceof Error
-        ? error.message
-        : String(error);
-      const preconditionError = toPreconditionFailedError(error, messageText);
-      const responseError = preconditionError ? preconditionError : toError(
-        error instanceof Engine.ConflictError
-          ? "ConflictError"
-          : error instanceof Engine.ProtocolError
-          ? "ProtocolError"
-          : "TransactionError",
-        messageText,
-      );
-      if (retryAfterSeq !== undefined) {
-        responseError.retryAfterSeq = retryAfterSeq;
-      }
-      return respondTypedError<Engine.AppliedCommit>(
-        message.requestId,
-        responseError,
-      );
-    }
+        if (message.requestId !== undefined) {
+          span.setAttribute("request.id", message.requestId);
+        }
+        if (message.commit.branch !== undefined) {
+          span.setAttribute("branch", message.commit.branch);
+        }
+        try {
+          const engine = await this.openEngine(message.space);
+          // ACL-document writes change who may access the space — OWNER only.
+          const aclTouched = commitTouchesAclDoc(
+            message.commit.operations,
+            message.space,
+          );
+          const deny = await this.#authorizeMessage(
+            message.space,
+            session.principal,
+            aclTouched ? "OWNER" : "WRITE",
+          );
+          if (deny) {
+            return respondTypedError<Engine.AppliedCommit>(
+              message.requestId,
+              deny,
+            );
+          }
+          const schedulerStateEnabled = getPersistentSchedulerStateConfig();
+          const commitPayload = schedulerStateEnabled ? message.commit : {
+            ...message.commit,
+            schedulerObservation: undefined,
+            schedulerObservationBatch: undefined,
+          };
+          const schedulerObservations = schedulerStateEnabled
+            ? schedulerObservationsFromCommit(commitPayload)
+            : [];
+          const previousReadSpaces = new Map<number, Set<string>>();
+          for (const { localSeq, observation } of schedulerObservations) {
+            previousReadSpaces.set(
+              localSeq,
+              this.schedulerObservationReadSpaces(
+                Engine.getLatestSchedulerActionSnapshot(engine, {
+                  branch: message.commit.branch ?? "",
+                  ownerSpace: message.space,
+                  pieceId: observation.pieceId,
+                  processGeneration: observation.processGeneration,
+                  actionId: observation.actionId,
+                })?.observation,
+              ),
+            );
+          }
+          // Fold-in SQLite writes: ATTACH their cell-db(s) BEFORE applyCommit (ATTACH
+          // cannot run inside a transaction); the engine executes them inside the
+          // commit txn (atomic with cell ops). Detach in finally.
+          const sqliteAttachments = this.#attachCommitSqliteDbs(
+            engine,
+            message.space,
+            commitPayload.operations,
+            { principal: session.principal, sessionId: message.sessionId },
+          );
+          let commit: Engine.AppliedCommit;
+          try {
+            commit = tracer.startActiveSpan(
+              "memory.commit.persist",
+              (persistSpan) => {
+                try {
+                  return Engine.applyCommit(engine, {
+                    sessionId: message.sessionId,
+                    space: message.space,
+                    principal: session.principal,
+                    commit: commitPayload,
+                    sqliteAttachments,
+                  });
+                } finally {
+                  persistSpan.end();
+                }
+              },
+            );
+          } finally {
+            // Detach BEFORE any await. `engine.database` is shared per space, so
+            // holding a cell-db attached across the post-commit await would let a
+            // concurrent connection's commit attach a SECOND cell-db — breaking the
+            // ≤1-attached invariant that unqualified-name resolution relies on
+            // (B1). `applyCommit` is synchronous and is the only step that needs the
+            // attachments.
+            for (const alias of sqliteAttachments.values()) {
+              detachDatabase(engine.database, alias);
+            }
+          }
+          if (aclTouched) {
+            this.#invalidateAclCapabilities(message.space);
+            // Pass the writing session so it isn't sent the terminal revocation
+            // before its own transact response (the client treats session/revoked
+            // as terminal). It's still dropped from the registry, so a
+            // self-deauthorized writer receives no further pushes.
+            this.#revokeDeauthorizedSessions(
+              engine,
+              message.space,
+              message.sessionId,
+            );
+          }
+          await this.runPostCommitSchedulerSideEffects(
+            message.space,
+            commit,
+            schedulerObservations,
+            previousReadSpaces,
+            session,
+          );
+          this.markSpaceDirty(
+            message.space,
+            message.commit.operations
+              .filter((operation) => operation.op !== "sqlite")
+              .map((operation) =>
+                toDirtyKey(operation.id, declaredScope(operation.scope))
+              ),
+            {
+              sessionId: message.sessionId,
+              seq: commit.seq,
+            },
+          );
+          span.setAttribute("commit.seq", commit.seq);
+          span.setAttribute(
+            "entity.count",
+            message.commit.operations.filter((operation) =>
+              operation.op !== "sqlite"
+            ).length,
+          );
+          return {
+            type: "response",
+            requestId: message.requestId,
+            ok: commit,
+          };
+        } catch (error) {
+          let retryAfterSeq: number | undefined;
+          if (error instanceof Engine.ConflictError) {
+            span.setAttribute("ct.conflict", true);
+            this.stageConflictRefreshDirtyIds(
+              message.space,
+              session,
+              message.commit,
+            );
+            const engine = await this.openEngine(message.space);
+            retryAfterSeq = Engine.serverSeq(engine);
+          }
+          const messageText = error instanceof Error
+            ? error.message
+            : String(error);
+          const preconditionError = toPreconditionFailedError(
+            error,
+            messageText,
+          );
+          const responseError = preconditionError ? preconditionError : toError(
+            error instanceof Engine.ConflictError
+              ? "ConflictError"
+              : error instanceof Engine.ProtocolError
+              ? "ProtocolError"
+              : "TransactionError",
+            messageText,
+          );
+          if (retryAfterSeq !== undefined) {
+            responseError.retryAfterSeq = retryAfterSeq;
+          }
+          span.recordException(
+            error instanceof Error ? error : new Error(messageText),
+          );
+          span.setStatus({ code: SpanStatusCode.ERROR, message: messageText });
+          return respondTypedError<Engine.AppliedCommit>(
+            message.requestId,
+            responseError,
+          );
+        } finally {
+          span.end();
+        }
+      },
+    );
   }
 
   async graphQuery(
@@ -2162,159 +2216,191 @@ export class Server {
     if (session === null) {
       return null;
     }
-    const pendingCaughtUpLocalSeq = session.pendingCaughtUpLocalSeq;
-    const hasPendingCatchUp =
-      pendingCaughtUpLocalSeq > session.caughtUpLocalSeq;
-    const finishCatchUp = (sync: SessionSync): SessionEffectMessage => {
-      if (hasPendingCatchUp) {
-        session.caughtUpLocalSeq = Math.max(
-          session.caughtUpLocalSeq,
-          pendingCaughtUpLocalSeq,
-        );
-        if (session.pendingCaughtUpLocalSeq <= session.caughtUpLocalSeq) {
-          session.pendingCaughtUpLocalSeq = 0;
+    return tracer.startActiveSpan(
+      "memory.subscriber.sync",
+      async (span): Promise<SessionEffectMessage | null> => {
+        span.setAttribute("space.did", space);
+        if (
+          session.principal !== undefined &&
+          session.principal !== ANYONE_USER
+        ) {
+          span.setAttribute("user.did", session.principal);
         }
-        sync.caughtUpLocalSeq = session.caughtUpLocalSeq;
-      }
-      return {
-        type: "session/effect",
-        space,
-        sessionId,
-        effect: sync,
-      };
-    };
-    const emptyCatchUp = async (
-      fromSeq = session.lastSyncedSeq,
-      toSeq?: number,
-    ): Promise<SessionEffectMessage | null> => {
-      if (!hasPendingCatchUp) {
-        return null;
-      }
-      const serverSeq = toSeq ?? Engine.serverSeq(await this.openEngine(space));
-      session.lastSyncedSeq = Math.max(session.lastSyncedSeq, serverSeq);
-      return finishCatchUp({
-        type: "sync",
-        fromSeq,
-        toSeq: serverSeq,
-        upserts: [],
-        removes: [],
-      });
-    };
-    if (session.watches.length === 0) {
-      return await emptyCatchUp();
-    }
-    if (dirtyIds !== undefined) {
-      const startedAt = performance.now();
-      let touched = false;
-      for (const dirtyId of dirtyIds) {
-        if (session.trackedIds.has(dirtyId)) {
-          touched = true;
-          break;
-        }
-      }
-      if (!touched) {
-        return await emptyCatchUp();
-      }
-
-      const engine = await this.openEngine(space);
-      const fromSeq = session.lastSyncedSeq;
-      const updates = new Map<string, SessionCacheEntry>();
-
-      for (const graph of session.graphs.values()) {
-        const refreshed = refreshTrackedGraph(
-          space,
-          engine,
-          graph,
-          dirtyIds,
-        );
-        if (refreshed === null) {
-          continue;
-        }
-        for (const entity of refreshed.updates.values()) {
-          const entry = toCacheEntry(entity);
-          updates.set(
-            cacheKeyForEntity(
-              entry.branch,
-              entry.id,
-              declaredScope(entry.scope),
-            ),
-            entry,
-          );
-        }
-      }
-
-      if (updates.size === 0) {
-        return await emptyCatchUp();
-      }
-
-      const upserts: SessionCacheEntry[] = [];
-      for (const [key, entry] of updates) {
-        const previous = session.entities.get(key);
-        session.entities.set(key, entry);
-        session.trackedIds.add(
-          toDirtyKey(entry.id, declaredScope(entry.scope)),
-        );
-        if (!sameSnapshot(previous, entry)) {
-          const dirtyKey = toDirtyKey(entry.id, declaredScope(entry.scope));
-          const origin = dirtyOrigins?.get(dirtyKey);
-          if (
-            origin === undefined ||
-            origin.sessionId !== sessionId ||
-            origin.seq !== entry.seq
-          ) {
-            upserts.push(entry);
+        span.setAttribute("watch.count", session.watches.length);
+        try {
+          const pendingCaughtUpLocalSeq = session.pendingCaughtUpLocalSeq;
+          const hasPendingCatchUp =
+            pendingCaughtUpLocalSeq > session.caughtUpLocalSeq;
+          const finishCatchUp = (sync: SessionSync): SessionEffectMessage => {
+            if (hasPendingCatchUp) {
+              session.caughtUpLocalSeq = Math.max(
+                session.caughtUpLocalSeq,
+                pendingCaughtUpLocalSeq,
+              );
+              if (session.pendingCaughtUpLocalSeq <= session.caughtUpLocalSeq) {
+                session.pendingCaughtUpLocalSeq = 0;
+              }
+              sync.caughtUpLocalSeq = session.caughtUpLocalSeq;
+            }
+            return {
+              type: "session/effect",
+              space,
+              sessionId,
+              effect: sync,
+            };
+          };
+          const emptyCatchUp = async (
+            fromSeq = session.lastSyncedSeq,
+            toSeq?: number,
+          ): Promise<SessionEffectMessage | null> => {
+            if (!hasPendingCatchUp) {
+              return null;
+            }
+            const serverSeq = toSeq ??
+              Engine.serverSeq(await this.openEngine(space));
+            session.lastSyncedSeq = Math.max(session.lastSyncedSeq, serverSeq);
+            return finishCatchUp({
+              type: "sync",
+              fromSeq,
+              toSeq: serverSeq,
+              upserts: [],
+              removes: [],
+            });
+          };
+          if (session.watches.length === 0) {
+            return await emptyCatchUp();
           }
-        }
-      }
-      const toSeq = Engine.serverSeq(engine);
-      if (upserts.length === 0) {
-        // The watched set was re-evaluated current as of toSeq even though it
-        // produced no net upserts; advance the watermark so a later default
-        // fromSeq is not stale. emptyCatchUp receives the original fromSeq
-        // explicitly, so this does not mutate the bounds of this sync (the
-        // Cubic fix keeps fromSeq pinned to the pre-refresh value).
-        session.lastSyncedSeq = Math.max(session.lastSyncedSeq, toSeq);
-        return await emptyCatchUp(fromSeq, toSeq);
-      }
-      session.lastSyncedSeq = toSeq;
-      recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
-        watches: session.watches.length,
-      });
-      return finishCatchUp({
-        type: "sync",
-        fromSeq,
-        toSeq,
-        upserts: upserts.toSorted((left, right) =>
-          left.branch.localeCompare(right.branch) ||
-          left.id.localeCompare(right.id)
-        ),
-        removes: [],
-      });
-    }
+          if (dirtyIds !== undefined) {
+            const startedAt = performance.now();
+            let touched = false;
+            for (const dirtyId of dirtyIds) {
+              if (session.trackedIds.has(dirtyId)) {
+                touched = true;
+                break;
+              }
+            }
+            span.setAttribute("ct.touched", touched);
+            if (!touched) {
+              return await emptyCatchUp();
+            }
 
-    const { serverSeq, graphs, entities } = await this.evaluateWatchSet(
-      space,
-      session.watches,
-      undefined,
-      {
-        principal: session.principal,
-        sessionId,
+            const engine = await this.openEngine(space);
+            const fromSeq = session.lastSyncedSeq;
+            const updates = new Map<string, SessionCacheEntry>();
+
+            for (const graph of session.graphs.values()) {
+              const refreshed = tracer.startActiveSpan(
+                "memory.watch.refresh",
+                (watchSpan) => {
+                  watchSpan.setAttribute("space.did", space);
+                  try {
+                    return refreshTrackedGraph(
+                      space,
+                      engine,
+                      graph,
+                      dirtyIds,
+                    );
+                  } finally {
+                    watchSpan.end();
+                  }
+                },
+              );
+              if (refreshed === null) {
+                continue;
+              }
+              for (const entity of refreshed.updates.values()) {
+                const entry = toCacheEntry(entity);
+                updates.set(
+                  cacheKeyForEntity(
+                    entry.branch,
+                    entry.id,
+                    declaredScope(entry.scope),
+                  ),
+                  entry,
+                );
+              }
+            }
+
+            if (updates.size === 0) {
+              return await emptyCatchUp();
+            }
+
+            const upserts: SessionCacheEntry[] = [];
+            for (const [key, entry] of updates) {
+              const previous = session.entities.get(key);
+              session.entities.set(key, entry);
+              session.trackedIds.add(
+                toDirtyKey(entry.id, declaredScope(entry.scope)),
+              );
+              if (!sameSnapshot(previous, entry)) {
+                const dirtyKey = toDirtyKey(
+                  entry.id,
+                  declaredScope(entry.scope),
+                );
+                const origin = dirtyOrigins?.get(dirtyKey);
+                if (
+                  origin === undefined ||
+                  origin.sessionId !== sessionId ||
+                  origin.seq !== entry.seq
+                ) {
+                  upserts.push(entry);
+                }
+              }
+            }
+            const toSeq = Engine.serverSeq(engine);
+            if (upserts.length === 0) {
+              // The watched set was re-evaluated current as of toSeq even though it
+              // produced no net upserts; advance the watermark so a later default
+              // fromSeq is not stale. emptyCatchUp receives the original fromSeq
+              // explicitly, so this does not mutate the bounds of this sync (the
+              // Cubic fix keeps fromSeq pinned to the pre-refresh value).
+              session.lastSyncedSeq = Math.max(session.lastSyncedSeq, toSeq);
+              return await emptyCatchUp(fromSeq, toSeq);
+            }
+            session.lastSyncedSeq = toSeq;
+            recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
+              watches: session.watches.length,
+            });
+            return finishCatchUp({
+              type: "sync",
+              fromSeq,
+              toSeq,
+              upserts: upserts.toSorted((left, right) =>
+                left.branch.localeCompare(right.branch) ||
+                left.id.localeCompare(right.id)
+              ),
+              removes: [],
+            });
+          }
+
+          const { serverSeq, graphs, entities } = await this.evaluateWatchSet(
+            space,
+            session.watches,
+            undefined,
+            {
+              principal: session.principal,
+              sessionId,
+            },
+          );
+          const sync = buildDiffSync(
+            session.entities,
+            entities,
+            session.lastSyncedSeq,
+            serverSeq,
+          );
+          session.graphs = graphs;
+          session.entities = entities;
+          session.trackedIds = trackedIdsFromEntries(entities.values());
+          session.lastSyncedSeq = serverSeq;
+          if (isEmptySync(sync)) {
+            return await emptyCatchUp(sync.fromSeq, sync.toSeq);
+          }
+          return finishCatchUp(sync);
+        } finally {
+          span.end();
+        }
       },
     );
-    const sync = buildDiffSync(
-      session.entities,
-      entities,
-      session.lastSyncedSeq,
-      serverSeq,
-    );
-    session.graphs = graphs;
-    session.entities = entities;
-    session.trackedIds = trackedIdsFromEntries(entities.values());
-    session.lastSyncedSeq = serverSeq;
-    if (isEmptySync(sync)) {
-      return await emptyCatchUp(sync.fromSeq, sync.toSeq);
-    }
-    return finishCatchUp(sync);
   }
 
   markSpaceDirty(
@@ -2493,9 +2579,20 @@ export class Server {
         if (dirtyOrigins !== undefined) {
           this.#dirtyOriginsBySpace.delete(space);
         }
-        for (const connection of this.#connections.values()) {
-          await connection.refreshDirty(space, dirtyIds, dirtyOrigins);
-        }
+        // Fan-out is a scheduled/batched timer decoupled from transact, so this
+        // is a separate root span (not parented under memory.transact).
+        await tracer.startActiveSpan("memory.fanout", async (span) => {
+          span.setAttribute("space.did", space);
+          span.setAttribute("subscriber.count", this.#connections.size);
+          span.setAttribute("dirty.count", dirtyIds?.size ?? 0);
+          try {
+            for (const connection of this.#connections.values()) {
+              await connection.refreshDirty(space, dirtyIds, dirtyOrigins);
+            }
+          } finally {
+            span.end();
+          }
+        });
       }
 
       if (initial !== undefined) {

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -9,6 +9,7 @@
     "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts"
   },
   "imports": {
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.7.0",
     "ses": "npm:ses@^1.15.0",
     "typescript": "npm:typescript"
   },

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -18,6 +18,7 @@
     "./shared": "./src/shared.ts",
     "./slugs": "./src/slugs.ts",
     "./schemas": "./src/schemas.ts",
+    "./telemetry-otel-bridge": "./src/telemetry-otel-bridge.ts",
     "./storage/inspector": "./src/storage/inspector.ts",
     "./storage/telemetry": "./src/storage/telemetry.ts",
     "./storage/write-stack-trace": "./src/storage/write-stack-trace.ts",

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -177,6 +177,12 @@ export {
   type SchedulerGraphNode,
   type SchedulerGraphSnapshot,
 } from "./telemetry.ts";
+export {
+  attachRuntimeTelemetryOtelBridge,
+  createRuntimeTelemetryOtelBridge,
+  type OtelBridgeOptions,
+  type RuntimeTelemetryOtelBridge,
+} from "./telemetry-otel-bridge.ts";
 
 // Utility functions (split from utils.ts)
 export { createJsonSchema } from "./builder/json-utils.ts";

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -177,11 +177,16 @@ export {
   type SchedulerGraphNode,
   type SchedulerGraphSnapshot,
 } from "./telemetry.ts";
-export {
-  attachRuntimeTelemetryOtelBridge,
-  createRuntimeTelemetryOtelBridge,
-  type OtelBridgeOptions,
-  type RuntimeTelemetryOtelBridge,
+// Export the bridge TYPES from the barrel, but NOT its values. A static value
+// re-export would pull telemetry-otel-bridge.ts -> @opentelemetry/api (whose node
+// platform build does `require("perf_hooks")`) into every bundle that imports the
+// runner barrel, including the browser web-worker — which breaks worker load.
+// Consumers import the values via the dedicated subpath
+// `@commonfabric/runner/telemetry-otel-bridge` (see deno.jsonc) so the OTel
+// dependency only reaches hosts that actually set up a provider.
+export type {
+  OtelBridgeOptions,
+  RuntimeTelemetryOtelBridge,
 } from "./telemetry-otel-bridge.ts";
 
 // Utility functions (split from utils.ts)

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -1,0 +1,318 @@
+// OpenTelemetry bridge for the runtime's existing telemetry stream.
+//
+// This does NOT add a parallel instrumentation layer. It subscribes to the
+// SAME `RuntimeTelemetry` event bus that the debug tooling consumes (see
+// telemetry.ts / runtime-client) and translates each `RuntimeTelemetryMarker`
+// into OpenTelemetry spans and metrics. The debug tooling keeps working
+// unchanged; OTel is just a second consumer of one event stream.
+//
+// It depends ONLY on `@opentelemetry/api` (interface-only, side-effect free), so
+// importing it never pulls the OTel SDK into a bundle and never forces
+// `--allow-sys`. Each host (background-piece-service, toolshed, browser shell)
+// owns its SDK provider setup and passes a Tracer + Meter in. When no provider
+// is registered the API returns no-op instruments, so the bridge is inert.
+//
+// Reuse across runtimes: the worker/server side exposes an EventTarget
+// (`runtime.telemetry`); the main thread / browser receives the same markers via
+// `runtime-client.on("telemetry", ...)`. Both feed `handleMarker()`, so one
+// translation table serves all three execution contexts.
+
+import {
+  type Attributes,
+  type Meter,
+  type Span,
+  SpanStatusCode,
+  type Tracer,
+} from "@opentelemetry/api";
+import type {
+  RuntimeTelemetryEvent,
+  RuntimeTelemetryMarkerResult,
+} from "./telemetry.ts";
+
+export interface OtelBridgeOptions {
+  tracer: Tracer;
+  meter: Meter;
+  /**
+   * Attributes stamped on every emitted span and metric — the dimensions the
+   * markers themselves don't carry. Set here once at attach time from the host's
+   * session/identity, e.g.:
+   *   { "user.did": principal, "space.did": space, "ct.runtime": "bg-piece" }
+   */
+  attributes?: Attributes;
+}
+
+export interface RuntimeTelemetryOtelBridge {
+  /** Translate a single marker into spans/metrics. Safe to call for any type. */
+  handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  /** Close any spans still open (e.g. storage ops without a completion). */
+  shutdown(): void;
+}
+
+/**
+ * Attach a bridge directly to a RuntimeTelemetry EventTarget (worker/server
+ * side). Returns a detach function that removes the listener and closes any
+ * in-flight spans.
+ */
+export function attachRuntimeTelemetryOtelBridge(
+  telemetry: EventTarget,
+  options: OtelBridgeOptions,
+): () => void {
+  const bridge = createRuntimeTelemetryOtelBridge(options);
+  const listener = (event: Event) => {
+    bridge.handleMarker((event as RuntimeTelemetryEvent).marker);
+  };
+  telemetry.addEventListener("telemetry", listener);
+  return () => {
+    telemetry.removeEventListener("telemetry", listener);
+    bridge.shutdown();
+  };
+}
+
+/**
+ * Create a bridge whose `handleMarker` can be wired to any marker source —
+ * an EventTarget listener (worker/server) or `runtime-client.on("telemetry")`
+ * (main thread / browser).
+ */
+export function createRuntimeTelemetryOtelBridge(
+  options: OtelBridgeOptions,
+): RuntimeTelemetryOtelBridge {
+  const { tracer, meter } = options;
+  const base = options.attributes ?? {};
+  const attrs = (extra?: Attributes): Attributes =>
+    extra ? { ...base, ...extra } : base;
+
+  // --- Instruments (created once; no-ops when no MeterProvider is set) --------
+  const runs = meter.createCounter("ct.scheduler.runs", {
+    description: "Scheduler action runs",
+  });
+  const invocations = meter.createCounter("ct.scheduler.invocations", {
+    description: "Scheduler handler invocations",
+  });
+  const cellUpdates = meter.createCounter("ct.cell.updates", {
+    description: "Cell/document updates observed by the runtime",
+  });
+  const commits = meter.createCounter("ct.scheduler.commits", {
+    description: "Scheduler event commits",
+  });
+  const commitRetries = meter.createCounter("ct.scheduler.commit.retries", {
+    description: "Commit retries due to transient write conflicts",
+  });
+  const commitChangedWrites = meter.createHistogram(
+    "ct.scheduler.commit.changed_writes",
+    { description: "Changed writes per commit" },
+  );
+  // Per-phase preflight timings — the scheduler's own breakdown of where an
+  // event's cost goes. These are the multi-user hot-path signals.
+  const preflightPhase = {
+    populate: meter.createHistogram("ct.scheduler.preflight.populate_ms", {
+      unit: "ms",
+    }),
+    txToLog: meter.createHistogram("ct.scheduler.preflight.tx_to_log_ms", {
+      unit: "ms",
+    }),
+    depCommit: meter.createHistogram("ct.scheduler.preflight.dep_commit_ms", {
+      unit: "ms",
+    }),
+    collect: meter.createHistogram("ct.scheduler.preflight.collect_ms", {
+      unit: "ms",
+    }),
+    schedule: meter.createHistogram("ct.scheduler.preflight.schedule_ms", {
+      unit: "ms",
+    }),
+    total: meter.createHistogram("ct.scheduler.preflight.total_ms", {
+      unit: "ms",
+    }),
+  };
+  const preflightDirtyDeps = meter.createHistogram(
+    "ct.scheduler.preflight.dirty_dependency_count",
+    { description: "Dirty dependencies collected per event" },
+  );
+  // busyRatio is the runner-thrash smoking gun: fraction of a window spent busy.
+  const busyRatio = meter.createHistogram("ct.scheduler.busy_ratio", {
+    description: "Non-settling window busy ratio (0..1)",
+  });
+  const nonSettling = meter.createCounter("ct.scheduler.non_settling.events", {
+    description: "Non-settling windows detected",
+  });
+  const storageOps = meter.createCounter("ct.storage.ops", {
+    description: "Storage push/pull operations",
+  });
+  const storageDuration = meter.createHistogram("ct.storage.op.duration_ms", {
+    unit: "ms",
+    description: "Storage push/pull duration",
+  });
+  const storageConnection = meter.createCounter("ct.storage.connection.updates", {
+    description: "Storage connection status transitions",
+  });
+  const subscriptions = meter.createUpDownCounter("ct.storage.subscriptions", {
+    description: "Active storage subscriptions",
+  });
+
+  // --- In-flight storage spans, keyed by the marker `id` ---------------------
+  type OpenOp = { span: Span; startMs: number };
+  const openOps = new Map<string, OpenOp>();
+
+  const patternAttrs = (
+    info?: { patternName?: string; moduleName?: string },
+  ): Attributes => {
+    if (!info) return {};
+    const out: Attributes = {};
+    if (info.patternName) out["ct.pattern"] = info.patternName;
+    if (info.moduleName) out["ct.module"] = info.moduleName;
+    return out;
+  };
+
+  // Cell paths are "space/id/path..." — expose the space dimension per-event so
+  // a runtime that spans multiple spaces is still attributable.
+  const spaceFromPath = (path?: string): Attributes => {
+    if (!path) return {};
+    const slash = path.indexOf("/");
+    return slash > 0 ? { "space.did": path.slice(0, slash) } : {};
+  };
+
+  const startStorageOp = (
+    id: string,
+    kind: "push" | "pull",
+    operation: string,
+  ) => {
+    const span = tracer.startSpan(`storage.${kind}`, {
+      attributes: attrs({ "ct.storage.kind": kind, "ct.storage.operation": operation }),
+    });
+    openOps.set(id, { span, startMs: nowMs() });
+  };
+
+  const endStorageOp = (id: string, kind: "push" | "pull", error?: string) => {
+    const open = openOps.get(id);
+    const durationMs = open ? nowMs() - open.startMs : undefined;
+    if (open) {
+      if (error) {
+        open.span.setStatus({ code: SpanStatusCode.ERROR, message: error });
+        open.span.setAttribute("error", true);
+      }
+      open.span.end();
+      openOps.delete(id);
+    }
+    storageOps.add(1, attrs({ "ct.storage.kind": kind, "ct.storage.error": !!error }));
+    if (durationMs !== undefined) {
+      storageDuration.record(durationMs, attrs({ "ct.storage.kind": kind }));
+    }
+  };
+
+  const handleMarker = (marker: RuntimeTelemetryMarkerResult): void => {
+    switch (marker.type) {
+      case "scheduler.run":
+        runs.add(1, attrs({ ...patternAttrs(marker.actionInfo), "ct.error": !!marker.error }));
+        break;
+      case "scheduler.invocation":
+        invocations.add(1, attrs(patternAttrs(marker.handlerInfo)));
+        break;
+      case "cell.update":
+        cellUpdates.add(1, attrs());
+        break;
+      case "scheduler.event.commit": {
+        commits.add(
+          1,
+          attrs({
+            ...patternAttrs(marker.handlerInfo),
+            "ct.commit.terminal": marker.terminal ?? "none",
+            "ct.error": !!marker.error,
+          }),
+        );
+        commitChangedWrites.record(marker.changedWriteCount, attrs());
+        if (marker.retryAttempt && marker.retryAttempt > 1) {
+          commitRetries.add(1, attrs(patternAttrs(marker.handlerInfo)));
+        }
+        break;
+      }
+      case "scheduler.event.preflight": {
+        const total = marker.populateMs + marker.txToLogMs + marker.depCommitMs +
+          marker.collectMs + marker.scheduleMs;
+        const a = attrs(patternAttrs(marker.handlerInfo));
+        preflightPhase.populate.record(marker.populateMs, a);
+        preflightPhase.txToLog.record(marker.txToLogMs, a);
+        preflightPhase.depCommit.record(marker.depCommitMs, a);
+        preflightPhase.collect.record(marker.collectMs, a);
+        preflightPhase.schedule.record(marker.scheduleMs, a);
+        preflightPhase.total.record(total, a);
+        preflightDirtyDeps.record(marker.dirtyDependencyCount, a);
+        // Retroactive span: the work already happened, so reconstruct its
+        // window from the marker's total so it shows on a trace timeline.
+        const end = Date.now();
+        const span = tracer.startSpan("scheduler.preflight", {
+          startTime: end - Math.round(total),
+          attributes: attrs({
+            ...patternAttrs(marker.handlerInfo),
+            "ct.handler_id": marker.handlerId,
+            "ct.read_count": marker.readCount,
+            "ct.shallow_read_count": marker.shallowReadCount,
+            "ct.dirty_dependency_count": marker.dirtyDependencyCount,
+            "ct.preflight.max_depth": marker.stats.maxDepth,
+            "ct.preflight.work_set_add_count": marker.stats.workSetAddCount,
+            "ct.preflight.reverse_dependency_edge_count":
+              marker.stats.reverseDependencyEdgeCount,
+          }),
+        });
+        if (marker.error) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: marker.error });
+        }
+        span.end(end);
+        break;
+      }
+      case "scheduler.non-settling":
+        busyRatio.record(marker.busyRatio, attrs());
+        nonSettling.add(1, attrs());
+        break;
+      case "storage.push.start":
+        startStorageOp(marker.id, "push", marker.operation);
+        break;
+      case "storage.push.complete":
+        endStorageOp(marker.id, "push");
+        break;
+      case "storage.push.error":
+        endStorageOp(marker.id, "push", marker.error);
+        break;
+      case "storage.pull.start":
+        startStorageOp(marker.id, "pull", marker.operation);
+        break;
+      case "storage.pull.complete":
+        endStorageOp(marker.id, "pull");
+        break;
+      case "storage.pull.error":
+        endStorageOp(marker.id, "pull", marker.error);
+        break;
+      case "storage.connection.update":
+        storageConnection.add(
+          1,
+          attrs({ "ct.connection.status": marker.status, "ct.connection.attempt": marker.attempt }),
+        );
+        break;
+      case "storage.subscription.add":
+        subscriptions.add(1, attrs());
+        break;
+      case "storage.subscription.remove":
+        subscriptions.add(-1, attrs());
+        break;
+      case "scheduler.dependencies.update":
+        // Dependency-graph churn is high-volume and mainly of interest to the
+        // debug graph view; skip from OTel to keep cardinality/volume sane.
+        break;
+      case "scheduler.graph.snapshot":
+      case "scheduler.subscribe":
+        // Debug-view only; not exported.
+        break;
+    }
+  };
+
+  const shutdown = () => {
+    for (const { span } of openOps.values()) span.end();
+    openOps.clear();
+  };
+
+  return { handleMarker, shutdown };
+}
+
+function nowMs(): number {
+  return typeof performance !== "undefined" && performance.now
+    ? performance.now()
+    : Date.now();
+}

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -180,14 +180,6 @@ export function createRuntimeTelemetryOtelBridge(
     return out;
   };
 
-  // Cell paths are "space/id/path..." — expose the space dimension per-event so
-  // a runtime that spans multiple spaces is still attributable.
-  const spaceFromPath = (path?: string): Attributes => {
-    if (!path) return {};
-    const slash = path.indexOf("/");
-    return slash > 0 ? { "space.did": path.slice(0, slash) } : {};
-  };
-
   const startStorageOp = (
     id: string,
     kind: "push" | "pull",

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -39,6 +39,15 @@ export interface OtelBridgeOptions {
    *   { "user.did": principal, "space.did": space, "ct.runtime": "bg-piece" }
    */
   attributes?: Attributes;
+  /**
+   * Attributes stamped on METRICS ONLY, merged over `attributes`. Backends
+   * don't map OTel resource attributes onto metric datapoint labels, so pass
+   * service.name / deployment.environment here to make metrics scopable by
+   * service and environment. Kept off spans deliberately: spans already carry
+   * these on their resource, and duplicating them as span attributes makes the
+   * bare key ambiguous (resource vs attribute context) in SigNoz queries.
+   */
+  metricAttributes?: Attributes;
 }
 
 export interface RuntimeTelemetryOtelBridge {
@@ -80,6 +89,12 @@ export function createRuntimeTelemetryOtelBridge(
   const base = options.attributes ?? {};
   const attrs = (extra?: Attributes): Attributes =>
     extra ? { ...base, ...extra } : base;
+  // Metric datapoints get the extra scoping labels; spans keep `base` only.
+  const mbase = options.metricAttributes
+    ? { ...base, ...options.metricAttributes }
+    : base;
+  const mattrs = (extra?: Attributes): Attributes =>
+    extra ? { ...mbase, ...extra } : mbase;
 
   // --- Instruments (created once; no-ops when no MeterProvider is set) --------
   const runs = meter.createCounter("ct.scheduler.runs", {
@@ -141,9 +156,12 @@ export function createRuntimeTelemetryOtelBridge(
     unit: "ms",
     description: "Storage push/pull duration",
   });
-  const storageConnection = meter.createCounter("ct.storage.connection.updates", {
-    description: "Storage connection status transitions",
-  });
+  const storageConnection = meter.createCounter(
+    "ct.storage.connection.updates",
+    {
+      description: "Storage connection status transitions",
+    },
+  );
   const subscriptions = meter.createUpDownCounter("ct.storage.subscriptions", {
     description: "Active storage subscriptions",
   });
@@ -176,7 +194,10 @@ export function createRuntimeTelemetryOtelBridge(
     operation: string,
   ) => {
     const span = tracer.startSpan(`storage.${kind}`, {
-      attributes: attrs({ "ct.storage.kind": kind, "ct.storage.operation": operation }),
+      attributes: attrs({
+        "ct.storage.kind": kind,
+        "ct.storage.operation": operation,
+      }),
     });
     openOps.set(id, { span, startMs: nowMs() });
   };
@@ -192,42 +213,52 @@ export function createRuntimeTelemetryOtelBridge(
       open.span.end();
       openOps.delete(id);
     }
-    storageOps.add(1, attrs({ "ct.storage.kind": kind, "ct.storage.error": !!error }));
+    storageOps.add(
+      1,
+      mattrs({ "ct.storage.kind": kind, "ct.storage.error": !!error }),
+    );
     if (durationMs !== undefined) {
-      storageDuration.record(durationMs, attrs({ "ct.storage.kind": kind }));
+      storageDuration.record(durationMs, mattrs({ "ct.storage.kind": kind }));
     }
   };
 
   const handleMarker = (marker: RuntimeTelemetryMarkerResult): void => {
     switch (marker.type) {
       case "scheduler.run":
-        runs.add(1, attrs({ ...patternAttrs(marker.actionInfo), "ct.error": !!marker.error }));
+        runs.add(
+          1,
+          mattrs({
+            ...patternAttrs(marker.actionInfo),
+            "ct.error": !!marker.error,
+          }),
+        );
         break;
       case "scheduler.invocation":
-        invocations.add(1, attrs(patternAttrs(marker.handlerInfo)));
+        invocations.add(1, mattrs(patternAttrs(marker.handlerInfo)));
         break;
       case "cell.update":
-        cellUpdates.add(1, attrs());
+        cellUpdates.add(1, mattrs());
         break;
       case "scheduler.event.commit": {
         commits.add(
           1,
-          attrs({
+          mattrs({
             ...patternAttrs(marker.handlerInfo),
             "ct.commit.terminal": marker.terminal ?? "none",
             "ct.error": !!marker.error,
           }),
         );
-        commitChangedWrites.record(marker.changedWriteCount, attrs());
+        commitChangedWrites.record(marker.changedWriteCount, mattrs());
         if (marker.retryAttempt && marker.retryAttempt > 1) {
-          commitRetries.add(1, attrs(patternAttrs(marker.handlerInfo)));
+          commitRetries.add(1, mattrs(patternAttrs(marker.handlerInfo)));
         }
         break;
       }
       case "scheduler.event.preflight": {
-        const total = marker.populateMs + marker.txToLogMs + marker.depCommitMs +
+        const total = marker.populateMs + marker.txToLogMs +
+          marker.depCommitMs +
           marker.collectMs + marker.scheduleMs;
-        const a = attrs(patternAttrs(marker.handlerInfo));
+        const a = mattrs(patternAttrs(marker.handlerInfo));
         preflightPhase.populate.record(marker.populateMs, a);
         preflightPhase.txToLog.record(marker.txToLogMs, a);
         preflightPhase.depCommit.record(marker.depCommitMs, a);
@@ -259,8 +290,8 @@ export function createRuntimeTelemetryOtelBridge(
         break;
       }
       case "scheduler.non-settling":
-        busyRatio.record(marker.busyRatio, attrs());
-        nonSettling.add(1, attrs());
+        busyRatio.record(marker.busyRatio, mattrs());
+        nonSettling.add(1, mattrs());
         break;
       case "storage.push.start":
         startStorageOp(marker.id, "push", marker.operation);
@@ -283,14 +314,17 @@ export function createRuntimeTelemetryOtelBridge(
       case "storage.connection.update":
         storageConnection.add(
           1,
-          attrs({ "ct.connection.status": marker.status, "ct.connection.attempt": marker.attempt }),
+          mattrs({
+            "ct.connection.status": marker.status,
+            "ct.connection.attempt": marker.attempt,
+          }),
         );
         break;
       case "storage.subscription.add":
-        subscriptions.add(1, attrs());
+        subscriptions.add(1, mattrs());
         break;
       case "storage.subscription.remove":
-        subscriptions.add(-1, attrs());
+        subscriptions.add(-1, mattrs());
         break;
       case "scheduler.dependencies.update":
         // Dependency-graph churn is high-volume and mainly of interest to the

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -1,0 +1,368 @@
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type {
+  Attributes,
+  Meter,
+  Span,
+  SpanOptions,
+  Tracer,
+} from "@opentelemetry/api";
+import {
+  attachRuntimeTelemetryOtelBridge,
+  createRuntimeTelemetryOtelBridge,
+} from "../src/telemetry-otel-bridge.ts";
+import {
+  RuntimeTelemetryEvent,
+  type RuntimeTelemetryMarkerResult,
+} from "../src/telemetry.ts";
+
+// ---------------------------------------------------------------------------
+// Hand-rolled recording fakes for the OTel API interfaces. The bridge only
+// depends on `@opentelemetry/api` (interfaces), so tests don't need the SDK:
+// we record every instrument call and assert on the translation directly.
+// ---------------------------------------------------------------------------
+
+interface InstrumentCall {
+  instrument: string;
+  value: number;
+  attributes?: Attributes;
+}
+
+interface SpanRecord {
+  name: string;
+  attributes: Attributes;
+  setAttributes: Attributes;
+  status?: { code: number; message?: string };
+  ended: boolean;
+  startTime?: number;
+  endTime?: number;
+}
+
+function makeRecordingMeter(): { meter: Meter; calls: InstrumentCall[] } {
+  const calls: InstrumentCall[] = [];
+  const record =
+    (instrument: string) => (value: number, attributes?: Attributes) => {
+      calls.push({ instrument, value, attributes });
+    };
+  const meter = {
+    createCounter: (name: string) => ({ add: record(name) }),
+    createUpDownCounter: (name: string) => ({ add: record(name) }),
+    createHistogram: (name: string) => ({ record: record(name) }),
+  } as unknown as Meter;
+  return { meter, calls };
+}
+
+function makeRecordingTracer(): { tracer: Tracer; spans: SpanRecord[] } {
+  const spans: SpanRecord[] = [];
+  const tracer = {
+    startSpan(name: string, options?: SpanOptions): Span {
+      const rec: SpanRecord = {
+        name,
+        attributes: (options?.attributes ?? {}) as Attributes,
+        setAttributes: {},
+        ended: false,
+        startTime: options?.startTime as number | undefined,
+      };
+      spans.push(rec);
+      return {
+        setAttribute(key: string, value: unknown) {
+          rec.setAttributes[key] = value as Attributes[string];
+          return this;
+        },
+        setStatus(status: { code: number; message?: string }) {
+          rec.status = status;
+          return this;
+        },
+        end(endTime?: number) {
+          rec.ended = true;
+          rec.endTime = endTime as number | undefined;
+        },
+      } as unknown as Span;
+    },
+  } as unknown as Tracer;
+  return { tracer, spans };
+}
+
+function marker(
+  partial: Record<string, unknown>,
+): RuntimeTelemetryMarkerResult {
+  return {
+    id: "m-1",
+    timestamp: 0,
+    ...partial,
+  } as unknown as RuntimeTelemetryMarkerResult;
+}
+
+describe("createRuntimeTelemetryOtelBridge", () => {
+  let meterCalls: InstrumentCall[];
+  let spans: SpanRecord[];
+  let bridge: ReturnType<typeof createRuntimeTelemetryOtelBridge>;
+
+  const setup = (options: {
+    attributes?: Attributes;
+    metricAttributes?: Attributes;
+  } = {}) => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    meterCalls = m.calls;
+    spans = t.spans;
+    bridge = createRuntimeTelemetryOtelBridge({
+      tracer: t.tracer,
+      meter: m.meter,
+      ...options,
+    });
+  };
+
+  beforeEach(() => setup());
+
+  it("counts scheduler runs with pattern and error attributes", () => {
+    bridge.handleMarker(marker({
+      type: "scheduler.run",
+      actionInfo: { patternName: "lunch-poll", moduleName: "vote" },
+      error: "boom",
+    }));
+    expect(meterCalls).toEqual([{
+      instrument: "ct.scheduler.runs",
+      value: 1,
+      attributes: {
+        "ct.pattern": "lunch-poll",
+        "ct.module": "vote",
+        "ct.error": true,
+      },
+    }]);
+  });
+
+  it("counts commits, changed writes, and retries only when retrying", () => {
+    bridge.handleMarker(marker({
+      type: "scheduler.event.commit",
+      changedWriteCount: 4,
+      retryAttempt: 1,
+    }));
+    expect(meterCalls.map((c) => c.instrument)).toEqual([
+      "ct.scheduler.commits",
+      "ct.scheduler.commit.changed_writes",
+    ]);
+
+    meterCalls.length = 0;
+    bridge.handleMarker(marker({
+      type: "scheduler.event.commit",
+      changedWriteCount: 2,
+      retryAttempt: 3,
+      terminal: "completed",
+    }));
+    expect(meterCalls.map((c) => c.instrument)).toEqual([
+      "ct.scheduler.commits",
+      "ct.scheduler.commit.changed_writes",
+      "ct.scheduler.commit.retries",
+    ]);
+    expect(meterCalls[0].attributes?.["ct.commit.terminal"]).toBe("completed");
+  });
+
+  it("records every preflight phase and a retroactive span", () => {
+    bridge.handleMarker(marker({
+      type: "scheduler.event.preflight",
+      handlerId: "h-1",
+      populateMs: 1,
+      txToLogMs: 2,
+      depCommitMs: 3,
+      collectMs: 4,
+      scheduleMs: 5,
+      readCount: 10,
+      shallowReadCount: 6,
+      dirtyDependencyCount: 7,
+      stats: {
+        maxDepth: 2,
+        workSetAddCount: 8,
+        reverseDependencyEdgeCount: 9,
+      },
+    }));
+    const names = meterCalls.map((c) => c.instrument);
+    expect(names).toEqual([
+      "ct.scheduler.preflight.populate_ms",
+      "ct.scheduler.preflight.tx_to_log_ms",
+      "ct.scheduler.preflight.dep_commit_ms",
+      "ct.scheduler.preflight.collect_ms",
+      "ct.scheduler.preflight.schedule_ms",
+      "ct.scheduler.preflight.total_ms",
+      "ct.scheduler.preflight.dirty_dependency_count",
+    ]);
+    // total = sum of phases
+    expect(meterCalls[5].value).toBe(15);
+    // retroactive span reconstructs its window from the total
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("scheduler.preflight");
+    expect(spans[0].ended).toBe(true);
+    expect(spans[0].endTime! - spans[0].startTime!).toBe(15);
+    expect(spans[0].attributes["ct.handler_id"]).toBe("h-1");
+  });
+
+  it("opens a span on storage push start and closes it on complete", () => {
+    bridge.handleMarker(marker({
+      id: "op-1",
+      type: "storage.push.start",
+      operation: "send",
+    }));
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("storage.push");
+    expect(spans[0].ended).toBe(false);
+
+    bridge.handleMarker(marker({ id: "op-1", type: "storage.push.complete" }));
+    expect(spans[0].ended).toBe(true);
+    expect(spans[0].status).toBeUndefined();
+    const ops = meterCalls.filter((c) => c.instrument === "ct.storage.ops");
+    expect(ops).toHaveLength(1);
+    expect(ops[0].attributes?.["ct.storage.error"]).toBe(false);
+    expect(
+      meterCalls.some((c) => c.instrument === "ct.storage.op.duration_ms"),
+    ).toBe(true);
+  });
+
+  it("marks a storage pull error span as errored", () => {
+    bridge.handleMarker(marker({
+      id: "op-2",
+      type: "storage.pull.start",
+      operation: "sync",
+    }));
+    bridge.handleMarker(marker({
+      id: "op-2",
+      type: "storage.pull.error",
+      error: "connection reset",
+    }));
+    expect(spans[0].ended).toBe(true);
+    expect(spans[0].status?.message).toBe("connection reset");
+    expect(spans[0].setAttributes["error"]).toBe(true);
+    const ops = meterCalls.filter((c) => c.instrument === "ct.storage.ops");
+    expect(ops[0].attributes?.["ct.storage.error"]).toBe(true);
+  });
+
+  it("tracks subscriptions up and down and connection updates", () => {
+    bridge.handleMarker(marker({ type: "storage.subscription.add" }));
+    bridge.handleMarker(marker({ type: "storage.subscription.remove" }));
+    bridge.handleMarker(marker({
+      type: "storage.connection.update",
+      status: "connected",
+      attempt: 2,
+    }));
+    expect(meterCalls).toEqual([
+      { instrument: "ct.storage.subscriptions", value: 1, attributes: {} },
+      { instrument: "ct.storage.subscriptions", value: -1, attributes: {} },
+      {
+        instrument: "ct.storage.connection.updates",
+        value: 1,
+        attributes: {
+          "ct.connection.status": "connected",
+          "ct.connection.attempt": 2,
+        },
+      },
+    ]);
+  });
+
+  it("records non-settling windows as busy ratio + counter", () => {
+    bridge.handleMarker(marker({
+      type: "scheduler.non-settling",
+      busyRatio: 0.75,
+    }));
+    expect(meterCalls).toEqual([
+      { instrument: "ct.scheduler.busy_ratio", value: 0.75, attributes: {} },
+      {
+        instrument: "ct.scheduler.non_settling.events",
+        value: 1,
+        attributes: {},
+      },
+    ]);
+  });
+
+  it("ignores debug-view-only markers", () => {
+    bridge.handleMarker(marker({ type: "scheduler.dependencies.update" }));
+    bridge.handleMarker(marker({ type: "scheduler.graph.snapshot" }));
+    bridge.handleMarker(marker({ type: "scheduler.subscribe" }));
+    expect(meterCalls).toHaveLength(0);
+    expect(spans).toHaveLength(0);
+  });
+
+  it("stamps base attributes on spans and metrics alike", () => {
+    setup({ attributes: { "user.did": "did:key:alice" } });
+    bridge.handleMarker(marker({ type: "cell.update" }));
+    bridge.handleMarker(marker({
+      id: "op-3",
+      type: "storage.push.start",
+      operation: "send",
+    }));
+    expect(meterCalls[0].attributes?.["user.did"]).toBe("did:key:alice");
+    expect(spans[0].attributes["user.did"]).toBe("did:key:alice");
+  });
+
+  it("stamps metricAttributes on metrics but never on spans", () => {
+    setup({
+      attributes: { "user.did": "did:key:alice" },
+      metricAttributes: { "service.name": "bg-piece-service" },
+    });
+    bridge.handleMarker(marker({ type: "cell.update" }));
+    bridge.handleMarker(marker({
+      id: "op-4",
+      type: "storage.push.start",
+      operation: "send",
+    }));
+    expect(meterCalls[0].attributes).toEqual({
+      "user.did": "did:key:alice",
+      "service.name": "bg-piece-service",
+    });
+    // span keeps resource-style keys off its attributes (SigNoz treats a key
+    // present in both resource and attribute context as ambiguous)
+    expect(spans[0].attributes["service.name"]).toBeUndefined();
+    expect(spans[0].attributes["user.did"]).toBe("did:key:alice");
+  });
+
+  it("closes in-flight storage spans on shutdown", () => {
+    bridge.handleMarker(marker({
+      id: "op-5",
+      type: "storage.pull.start",
+      operation: "sync",
+    }));
+    expect(spans[0].ended).toBe(false);
+    bridge.shutdown();
+    expect(spans[0].ended).toBe(true);
+  });
+});
+
+describe("attachRuntimeTelemetryOtelBridge", () => {
+  it("feeds telemetry events through the bridge until detached", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const telemetry = new EventTarget();
+    const detach = attachRuntimeTelemetryOtelBridge(telemetry, {
+      tracer: t.tracer,
+      meter: m.meter,
+    });
+
+    telemetry.dispatchEvent(
+      new RuntimeTelemetryEvent(marker({ type: "cell.update" })),
+    );
+    expect(m.calls).toHaveLength(1);
+
+    detach();
+    telemetry.dispatchEvent(
+      new RuntimeTelemetryEvent(marker({ type: "cell.update" })),
+    );
+    expect(m.calls).toHaveLength(1);
+  });
+
+  it("closes in-flight spans when detached", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const telemetry = new EventTarget();
+    const detach = attachRuntimeTelemetryOtelBridge(telemetry, {
+      tracer: t.tracer,
+      meter: m.meter,
+    });
+    telemetry.dispatchEvent(
+      new RuntimeTelemetryEvent(
+        marker({ id: "op-6", type: "storage.push.start", operation: "send" }),
+      ),
+    );
+    expect(t.spans[0].ended).toBe(false);
+    detach();
+    expect(t.spans[0].ended).toBe(true);
+  });
+});

--- a/packages/shell/deno.jsonc
+++ b/packages/shell/deno.jsonc
@@ -16,6 +16,10 @@
   },
   "imports": {
     "@lit/context": "npm:@lit/context@^1.1.5",
-    "@lit/task": "npm:@lit/task@^1.0.2"
+    "@lit/task": "npm:@lit/task@^1.0.2",
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.7.0",
+    "@opentelemetry/exporter-trace-otlp-http": "npm:@opentelemetry/exporter-trace-otlp-http@^0.46.0",
+    "@opentelemetry/resources": "npm:@opentelemetry/resources@^1.19.0",
+    "@opentelemetry/sdk-trace-web": "npm:@opentelemetry/sdk-trace-web@^1.19.0"
   }
 }

--- a/packages/shell/src/lib/otel.ts
+++ b/packages/shell/src/lib/otel.ts
@@ -1,0 +1,131 @@
+// Browser-side OpenTelemetry setup for the shell (Phase 3).
+//
+// This is GATED and LAZY: nothing OpenTelemetry-related is imported at module
+// load. `initBrowserOtel` only pulls in the web SDK via dynamic `import(...)`
+// when `localStorage["telemetryEnabled"] === "true"`, mirroring the server's
+// lazy-import pattern in packages/background-piece-service/src/otel.ts. With
+// telemetry disabled the default bundle is untouched and there is zero added
+// network/CPU.
+//
+// Only type-only imports appear at the top; they are erased at build time and
+// never pull the OTel packages into the default bundle.
+import type { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
+
+// localStorage key that gates telemetry — the same flag the debugger controller
+// toggles (packages/shell/src/lib/debugger-controller.ts).
+const TELEMETRY_ENABLED_KEY = "telemetryEnabled";
+const SERVICE_NAME = "toolshed-ui";
+const SERVICE_VERSION = "1.0.0";
+
+export interface InitBrowserOtelOptions {
+  /** Same-origin (by default) toolshed API base; the OTLP proxy lives under it. */
+  apiUrl: URL | string;
+  userDid: string;
+  spaceDid: string;
+  environment: string;
+}
+
+/**
+ * A minimal telemetry sink handed to the runtime. It wraps the reused
+ * `createRuntimeTelemetryOtelBridge` from `@commonfabric/runner`, so the runtime
+ * package never imports any OTel code itself.
+ */
+export interface BrowserTelemetry {
+  /** Feed one RuntimeTelemetry marker into the OTel bridge. */
+  handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  /** Close open spans and flush + shut down the tracer provider. */
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Initialize browser OpenTelemetry (traces only) and return a telemetry sink, or
+ * `null` when telemetry is disabled or setup fails (fail-open — telemetry must
+ * never break the app).
+ */
+export async function initBrowserOtel(
+  options: InitBrowserOtelOptions,
+): Promise<BrowserTelemetry | null> {
+  // Gate: only initialize when the operator has opted in.
+  try {
+    if (localStorage.getItem(TELEMETRY_ENABLED_KEY) !== "true") {
+      return null;
+    }
+  } catch {
+    // localStorage can throw in locked-down contexts — treat as disabled.
+    return null;
+  }
+
+  try {
+    // Lazy web-SDK imports: pulled into the bundle only on this path.
+    const { WebTracerProvider, BatchSpanProcessor } = await import(
+      "@opentelemetry/sdk-trace-web"
+    );
+    const { OTLPTraceExporter } = await import(
+      "@opentelemetry/exporter-trace-otlp-http"
+    );
+    const { Resource } = await import("@opentelemetry/resources");
+    const { metrics } = await import("@opentelemetry/api");
+    // Reuse the shared marker->OTel translator (interface-only; @opentelemetry/api).
+    const { createRuntimeTelemetryOtelBridge } = await import(
+      "@commonfabric/runner/telemetry-otel-bridge"
+    );
+
+    const base = String(options.apiUrl).replace(/\/$/, "");
+    const exporter = new OTLPTraceExporter({
+      // Browsers can't reach the internal collector; POST to toolshed's proxy
+      // (routes/telemetry), which forwards to its local collector.
+      url: `${base}/api/telemetry/v1/traces`,
+    });
+
+    const provider = new WebTracerProvider({
+      resource: new Resource({
+        "service.name": SERVICE_NAME,
+        "service.version": SERVICE_VERSION,
+        "deployment.environment": options.environment,
+        "user.did": options.userDid,
+        "space.did": options.spaceDid,
+      }),
+    });
+    provider.addSpanProcessor(new BatchSpanProcessor(exporter));
+    // Register globally so W3C traceparent is available for propagation. The
+    // bridge still receives the tracer explicitly below, so exporting does not
+    // depend on this registration.
+    provider.register();
+
+    const tracer = provider.getTracer(SERVICE_NAME, SERVICE_VERSION);
+    // No MeterProvider is registered — browser is traces-only for now, so this
+    // is the API no-op meter. The bridge's metric instruments become no-ops.
+    const meter = metrics.getMeter(SERVICE_NAME);
+
+    const bridge = createRuntimeTelemetryOtelBridge({
+      tracer,
+      meter,
+      attributes: {
+        "ct.runtime": "browser",
+        "user.did": options.userDid,
+        "space.did": options.spaceDid,
+      },
+    });
+
+    return {
+      handleMarker: (marker) => bridge.handleMarker(marker),
+      shutdown: async () => {
+        // Close any spans the bridge left open, then flush + tear down the SDK.
+        try {
+          bridge.shutdown();
+        } catch (error) {
+          console.error("[otel] bridge shutdown failed:", error);
+        }
+        try {
+          await provider.shutdown();
+        } catch (error) {
+          console.error("[otel] provider shutdown failed:", error);
+        }
+      },
+    };
+  } catch (error) {
+    // Fail open: a setup error must not block the app.
+    console.error("[otel] browser OpenTelemetry init failed:", error);
+    return null;
+  }
+}

--- a/packages/shell/src/lib/otel.ts
+++ b/packages/shell/src/lib/otel.ts
@@ -33,6 +33,11 @@ export interface InitBrowserOtelOptions {
 export interface BrowserTelemetry {
   /** Feed one RuntimeTelemetry marker into the OTel bridge. */
   handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  /**
+   * Update the space.did stamped on subsequent spans. The runtime (and this
+   * sink) lives across space navigations, so the host must keep this current.
+   */
+  setSpace(spaceDid: string | undefined): void;
   /** Close open spans and flush + shut down the tracer provider. */
   shutdown(): Promise<void>;
 }
@@ -77,13 +82,15 @@ export async function initBrowserOtel(
       url: `${base}/api/telemetry/v1/traces`,
     });
 
+    // Resource attributes are fixed for the provider's lifetime, so only
+    // session-stable values belong here; space.did changes on navigation and
+    // is stamped per-span by the bridge below instead.
     const provider = new WebTracerProvider({
       resource: new Resource({
         "service.name": SERVICE_NAME,
         "service.version": SERVICE_VERSION,
         "deployment.environment": options.environment,
         "user.did": options.userDid,
-        "space.did": options.spaceDid,
       }),
     });
     provider.addSpanProcessor(new BatchSpanProcessor(exporter));
@@ -97,18 +104,28 @@ export async function initBrowserOtel(
     // is the API no-op meter. The bridge's metric instruments become no-ops.
     const meter = metrics.getMeter(SERVICE_NAME);
 
+    // The bridge holds this object by reference and reads it per marker, so
+    // mutating it (see setSpace below) updates attribution for later spans.
+    const attributes: Record<string, string> = {
+      "ct.runtime": "browser",
+      "user.did": options.userDid,
+      "space.did": options.spaceDid,
+    };
     const bridge = createRuntimeTelemetryOtelBridge({
       tracer,
       meter,
-      attributes: {
-        "ct.runtime": "browser",
-        "user.did": options.userDid,
-        "space.did": options.spaceDid,
-      },
+      attributes,
     });
 
     return {
       handleMarker: (marker) => bridge.handleMarker(marker),
+      setSpace: (spaceDid) => {
+        if (spaceDid === undefined) {
+          delete attributes["space.did"];
+        } else {
+          attributes["space.did"] = spaceDid;
+        }
+      },
       shutdown: async () => {
         // Close any spans the bridge left open, then flush + tear down the SDK.
         try {

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -28,8 +28,9 @@ import {
   getThemePreference,
   type ThemePreference,
 } from "../lib/theme-preference.ts";
-import { EXPERIMENTAL } from "../lib/env.ts";
+import { ENVIRONMENT, EXPERIMENTAL } from "../lib/env.ts";
 import { isWorkerConsoleForwardingEnabled } from "../lib/worker-console.ts";
+import { initBrowserOtel } from "../lib/otel.ts";
 
 function getCommonfabricGlobal(): typeof globalThis & {
   commonfabric?: CommonfabricDebugState;
@@ -104,6 +105,19 @@ export class XRootView extends BaseView {
           return undefined;
         }
 
+        // Browser OpenTelemetry (Phase 3): self-gated + lazy — returns null
+        // (and imports no OTel SDK) unless telemetryEnabled is set. Attributes
+        // use the identity's DID and the currently resolved space (home space
+        // as the coarse default; the bridge also derives per-marker space.did
+        // from cell paths).
+        const userDid = app.identity.did();
+        const telemetry = await initBrowserOtel({
+          apiUrl: app.apiUrl,
+          userDid,
+          spaceDid: this.space ?? userDid,
+          environment: ENVIRONMENT,
+        });
+
         const rt = await RuntimeInternals.create({
           identity: app.identity,
           apiUrl: app.apiUrl,
@@ -113,6 +127,8 @@ export class XRootView extends BaseView {
           // mapNavigationView (shared/navigate.ts) maps a DID back to the
           // human-readable spaceName URL at the Navigation layer.
           navigate,
+          // Purely additive; null when telemetry is disabled.
+          telemetry: telemetry ?? undefined,
         });
 
         if (signal.aborted) {

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -30,7 +30,7 @@ import {
 } from "../lib/theme-preference.ts";
 import { ENVIRONMENT, EXPERIMENTAL } from "../lib/env.ts";
 import { isWorkerConsoleForwardingEnabled } from "../lib/worker-console.ts";
-import { initBrowserOtel } from "../lib/otel.ts";
+import { type BrowserTelemetry, initBrowserOtel } from "../lib/otel.ts";
 
 function getCommonfabricGlobal(): typeof globalThis & {
   commonfabric?: CommonfabricDebugState;
@@ -101,15 +101,16 @@ export class XRootView extends BaseView {
           // Clear the runtime and space when no app state
           this.runtime = undefined;
           this.space = undefined;
+          this.#telemetry = undefined;
           clearRuntimeDebugGlobals(getCommonfabricGlobal());
           return undefined;
         }
 
         // Browser OpenTelemetry (Phase 3): self-gated + lazy — returns null
         // (and imports no OTel SDK) unless telemetryEnabled is set. Attributes
-        // use the identity's DID and the currently resolved space (home space
-        // as the coarse default; the bridge also derives per-marker space.did
-        // from cell paths).
+        // use the identity's DID and the currently resolved space; the runtime
+        // (and this sink) outlives navigations, so #resolveViewSpace keeps the
+        // sink's space.did current via setSpace.
         const userDid = app.identity.did();
         const telemetry = await initBrowserOtel({
           apiUrl: app.apiUrl,
@@ -117,6 +118,7 @@ export class XRootView extends BaseView {
           spaceDid: this.space ?? userDid,
           environment: ENVIRONMENT,
         });
+        this.#telemetry = telemetry ?? undefined;
 
         const rt = await RuntimeInternals.create({
           identity: app.identity,
@@ -200,6 +202,10 @@ export class XRootView extends BaseView {
     }
   }
 
+  // The active browser telemetry sink (undefined when telemetry is disabled
+  // or no runtime); kept only so space.did attribution can track navigation.
+  #telemetry: BrowserTelemetry | undefined;
+
   // Resolve the current view to a space DID — view state, independent of
   // the runtime's lifecycle.
   #resolveSpaceToken = 0;
@@ -224,6 +230,9 @@ export class XRootView extends BaseView {
     }
     if (token !== this.#resolveSpaceToken) return;
     this.space = space;
+    // Keep browser OTel span attribution in sync with the resolved space —
+    // the telemetry sink lives across navigations.
+    this.#telemetry?.setSpace(space);
   }
 
   private _onThemeChanged = (e: Event) => {

--- a/packages/toolshed/app.ts
+++ b/packages/toolshed/app.ts
@@ -1,5 +1,6 @@
 import createApp from "@/lib/create-app.ts";
 import health from "@/routes/health/health.index.ts";
+import telemetry from "@/routes/telemetry/telemetry.index.ts";
 import aiLLM from "@/routes/ai/llm/llm.index.ts";
 import configureOpenAPI from "@/lib/configure-open-api.ts";
 import aiImg from "@/routes/ai/img/img.index.ts";
@@ -28,6 +29,7 @@ configureOpenAPI(app);
 // Static routes (non-OAuth2, plus non-standard OAuth like Discord and Plaid)
 const routes = [
   health,
+  telemetry,
   aiLLM,
   aiImg,
   aiVoice,

--- a/packages/toolshed/middlewares/first-party-http-auth.ts
+++ b/packages/toolshed/middlewares/first-party-http-auth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "@hono/hono";
 import { verifyFirstPartyHttpRequest } from "@commonfabric/runner/toolshed-http-auth";
+import { trace } from "@opentelemetry/api";
 import type { AppBindings } from "@/lib/types.ts";
 
 export function requireFirstPartyHttpAuth(): MiddlewareHandler<
@@ -11,6 +12,10 @@ export function requireFirstPartyHttpAuth(): MiddlewareHandler<
         request: c.req.raw,
       });
       c.set("verifiedUserDid", userDid);
+      // Enrich the active request span (started by the otel middleware, which
+      // runs earlier in the chain) with the verified user. Defensive: no-op if
+      // no span/provider is active.
+      trace.getActiveSpan()?.setAttribute("user.did", userDid);
       // TODO(auth): Check that the verified DID is authorized for this privileged route before continuing.
     } catch (error) {
       const logger = c.get("logger");

--- a/packages/toolshed/middlewares/opentelemetry.ts
+++ b/packages/toolshed/middlewares/opentelemetry.ts
@@ -121,6 +121,14 @@ export function otelTracing(config: OtelConfig = {}): MiddlewareHandler {
         const route = c.req.routePath || path;
         span.setAttribute("http.route", route);
         span.updateName(`${method} ${route}`);
+        // Attribute the request to its space when the route carries a
+        // `:spaceDid` param (resolved only after `next()`). Defensive: no-op if
+        // absent. `user.did` is set by the auth middleware while this span is
+        // active.
+        const spaceDid = c.req.param("spaceDid");
+        if (spaceDid) {
+          span.setAttribute("space.did", spaceDid);
+        }
         span.end();
       }
     });

--- a/packages/toolshed/middlewares/opentelemetry.ts
+++ b/packages/toolshed/middlewares/opentelemetry.ts
@@ -1,5 +1,12 @@
 import { MiddlewareHandler } from "@hono/hono";
-import { context, Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+  context,
+  Span,
+  SpanStatusCode,
+  type TextMapGetter,
+  trace,
+} from "@opentelemetry/api";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { getTracerProvider } from "@/lib/otel.ts";
 
 // Dynamically resolve the tracer so we don't capture the no-op global tracer
@@ -8,6 +15,17 @@ const obtainTracer = () => {
   return provider
     ? provider.getTracer("toolshed-middleware", "1.0.0")
     : trace.getTracer("toolshed-middleware", "1.0.0");
+};
+
+// Extract any inbound W3C `traceparent`/`tracestate` so a request span links to
+// the caller's trace (e.g. the browser shell, which stamps traceparent on its
+// telemetry/API calls). No global propagator is registered under Deno, so build
+// one explicitly. When no traceparent is present, `extract` returns the input
+// context unchanged and the span starts as a fresh root — identical to before.
+const propagator = new W3CTraceContextPropagator();
+const headersGetter: TextMapGetter<Headers> = {
+  keys: (carrier) => [...carrier.keys()],
+  get: (carrier, key) => carrier.get(key) ?? undefined,
 };
 
 export interface OtelConfig {
@@ -37,101 +55,114 @@ export function otelTracing(config: OtelConfig = {}): MiddlewareHandler {
     const path = c.req.path;
     const method = c.req.method;
 
-    await obtainTracer().startActiveSpan(`${method} ${path}`, async (span) => {
-      span.setAttribute("http.method", method);
-      span.setAttribute("http.host", c.req.header("host") || "unknown");
-      span.setAttribute(
-        "http.user_agent",
-        c.req.header("user-agent") || "unknown",
-      );
+    // Start the request span as a child of any inbound traceparent context.
+    const parentCtx = propagator.extract(
+      context.active(),
+      c.req.raw.headers,
+      headersGetter,
+    );
 
-      // Add request ID if it exists in headers
-      const requestId = c.req.header("x-request-id");
-      if (requestId) {
-        span.setAttribute("http.request_id", requestId);
-      }
+    await context.with(
+      parentCtx,
+      () =>
+        obtainTracer().startActiveSpan(`${method} ${path}`, async (span) => {
+          span.setAttribute("http.method", method);
+          span.setAttribute("http.host", c.req.header("host") || "unknown");
+          span.setAttribute(
+            "http.user_agent",
+            c.req.header("user-agent") || "unknown",
+          );
 
-      // Add custom attributes if configured
-      if (config.additionalAttributes) {
-        Object.entries(config.additionalAttributes).forEach(([key, value]) => {
-          span.setAttribute(key, value);
-        });
-      }
-
-      // Include request body if configured
-      if (config.includeRequestBody) {
-        try {
-          const bodyClone = c.req.raw.clone();
-          const body = await bodyClone.text();
-          if (body) {
-            span.setAttribute("http.request.body", body);
+          // Add request ID if it exists in headers
+          const requestId = c.req.header("x-request-id");
+          if (requestId) {
+            span.setAttribute("http.request_id", requestId);
           }
-        } catch (_) {
-          /* swallow */
-        }
-      }
 
-      try {
-        // Execute the downstream handlers while this span is active
-        await next();
+          // Add custom attributes if configured
+          if (config.additionalAttributes) {
+            Object.entries(config.additionalAttributes).forEach(
+              ([key, value]) => {
+                span.setAttribute(key, value);
+              },
+            );
+          }
 
-        // Capture status code from response if available
-        if (c.res?.status) {
-          span.setAttribute("http.status_code", c.res.status);
-        }
-
-        // Include response body if configured
-        if (config.includeResponseBody && c.res?.body) {
-          try {
-            const clonedResponse = c.res.clone();
-            const text = await clonedResponse.text();
-            if (text) {
-              span.setAttribute("http.response.body", text);
+          // Include request body if configured
+          if (config.includeRequestBody) {
+            try {
+              const bodyClone = c.req.raw.clone();
+              const body = await bodyClone.text();
+              if (body) {
+                span.setAttribute("http.request.body", body);
+              }
+            } catch (_) {
+              /* swallow */
             }
-          } catch (_) {
-            /* swallow */
           }
-        }
-      } catch (error) {
-        span.setAttribute("error", true);
-        span.setAttribute(
-          "error.message",
-          error instanceof Error ? error.message : String(error),
-        );
-        span.setAttribute(
-          "error.type",
-          error instanceof Error ? error.name : "UnknownError",
-        );
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
-        });
 
-        if (error instanceof Error && error.stack) {
-          span.setAttribute("error.stack", error.stack);
-        }
+          try {
+            // Execute the downstream handlers while this span is active
+            await next();
 
-        throw error;
-      } finally {
-        // `c.req.routePath` only resolves to the matched route *template* (e.g.
-        // "/api/foo/:id") after `next()` has run; read before, it is this
-        // middleware's own "*", and `path` is the high-cardinality concrete URL.
-        // Set the template now so http.route and the span name aggregate
-        // per-route in the backend instead of exploding cardinality.
-        const route = c.req.routePath || path;
-        span.setAttribute("http.route", route);
-        span.updateName(`${method} ${route}`);
-        // Attribute the request to its space when the route carries a
-        // `:spaceDid` param (resolved only after `next()`). Defensive: no-op if
-        // absent. `user.did` is set by the auth middleware while this span is
-        // active.
-        const spaceDid = c.req.param("spaceDid");
-        if (spaceDid) {
-          span.setAttribute("space.did", spaceDid);
-        }
-        span.end();
-      }
-    });
+            // Capture status code from response if available
+            if (c.res?.status) {
+              span.setAttribute("http.status_code", c.res.status);
+            }
+
+            // Include response body if configured
+            if (config.includeResponseBody && c.res?.body) {
+              try {
+                const clonedResponse = c.res.clone();
+                const text = await clonedResponse.text();
+                if (text) {
+                  span.setAttribute("http.response.body", text);
+                }
+              } catch (_) {
+                /* swallow */
+              }
+            }
+          } catch (error) {
+            span.setAttribute("error", true);
+            span.setAttribute(
+              "error.message",
+              error instanceof Error ? error.message : String(error),
+            );
+            span.setAttribute(
+              "error.type",
+              error instanceof Error ? error.name : "UnknownError",
+            );
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: error instanceof Error ? error.message : String(error),
+            });
+
+            if (error instanceof Error && error.stack) {
+              span.setAttribute("error.stack", error.stack);
+            }
+
+            throw error;
+          } finally {
+            // `c.req.routePath` only resolves to the matched route *template* (e.g.
+            // "/api/foo/:id") after `next()` has run; read before, it is this
+            // middleware's own "*", and `path` is the high-cardinality concrete URL.
+            // Set the template now so http.route and the span name aggregate
+            // per-route in the backend instead of exploding cardinality.
+            const route = c.req.routePath || path;
+            span.setAttribute("http.route", route);
+            span.updateName(`${method} ${route}`);
+            // Attribute the request to its space when the route carries a
+            // `:spaceDid` param (resolved only after `next()`). Defensive: no-op if
+            // absent. `user.did` is set by the auth middleware while this span is
+            // active.
+            const spaceDid = c.req.param("spaceDid");
+            if (spaceDid) {
+              span.setAttribute("space.did", spaceDid);
+            }
+            span.end();
+          }
+        }),
+    );
   };
 }
 

--- a/packages/toolshed/routes/telemetry/telemetry.handlers.ts
+++ b/packages/toolshed/routes/telemetry/telemetry.handlers.ts
@@ -34,19 +34,40 @@ export async function forwardOtlp(
     return c.body(null, 413);
   }
 
-  let body: ArrayBuffer;
+  // Stream the body and enforce the cap as bytes arrive, so a chunked upload
+  // (no Content-Length) can never buffer more than the limit before being
+  // rejected — `arrayBuffer()` would buffer the whole body first.
+  let body: Uint8Array<ArrayBuffer>;
   try {
-    body = await c.req.arrayBuffer();
+    const stream = c.req.raw.body;
+    if (!stream) {
+      body = new Uint8Array(new ArrayBuffer(0));
+    } else {
+      const reader = stream.getReader();
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > MAX_TELEMETRY_BYTES) {
+          await reader.cancel();
+          return c.body(null, 413);
+        }
+        chunks.push(value);
+      }
+      body = new Uint8Array(new ArrayBuffer(total));
+      let offset = 0;
+      for (const chunk of chunks) {
+        body.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+    }
   } catch (error) {
     // Reading the body failed — log and still answer 202 so the exporter's
     // retry/backoff doesn't hammer us and nothing bubbles to the app.
     console.error("[telemetry-proxy] failed to read request body:", error);
     return c.body(null, 202);
-  }
-
-  // Enforce the cap for chunked uploads that omit Content-Length.
-  if (body.byteLength > MAX_TELEMETRY_BYTES) {
-    return c.body(null, 413);
   }
 
   const contentType = c.req.header("content-type") ?? "application/json";

--- a/packages/toolshed/routes/telemetry/telemetry.handlers.ts
+++ b/packages/toolshed/routes/telemetry/telemetry.handlers.ts
@@ -1,0 +1,71 @@
+import type { Context } from "@hono/hono";
+import env from "@/env.ts";
+
+// OTLP payloads from the browser are small (a batch of spans). Cap the body so a
+// misbehaving/hostile client can't stream an unbounded upload through the proxy.
+const MAX_TELEMETRY_BYTES = 1024 * 1024; // 1MB
+
+export type TelemetrySignal = "traces" | "metrics";
+
+/**
+ * Forward a browser OTLP payload to toolshed's local collector.
+ *
+ * Browsers can't reach the internal collector directly, so the same-origin app
+ * POSTs here and toolshed relays to `${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/<signal>`,
+ * preserving the incoming Content-Type (the browser exporter sends
+ * application/json).
+ *
+ * This is fail-open by design: telemetry must NEVER break the app, so every
+ * error path is caught and still answered with 202 (or 204/413 for the explicit
+ * no-op / too-large cases). We never surface a 5xx to the browser exporter.
+ */
+export async function forwardOtlp(
+  c: Context,
+  signal: TelemetrySignal,
+): Promise<Response> {
+  // When telemetry is disabled, accept-and-drop: 204 No Content, no forwarding.
+  if (!env.OTEL_ENABLED) {
+    return c.body(null, 204);
+  }
+
+  // Cheap pre-check on the declared length before buffering anything.
+  const declaredLength = Number(c.req.header("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_TELEMETRY_BYTES) {
+    return c.body(null, 413);
+  }
+
+  let body: ArrayBuffer;
+  try {
+    body = await c.req.arrayBuffer();
+  } catch (error) {
+    // Reading the body failed — log and still answer 202 so the exporter's
+    // retry/backoff doesn't hammer us and nothing bubbles to the app.
+    console.error("[telemetry-proxy] failed to read request body:", error);
+    return c.body(null, 202);
+  }
+
+  // Enforce the cap for chunked uploads that omit Content-Length.
+  if (body.byteLength > MAX_TELEMETRY_BYTES) {
+    return c.body(null, 413);
+  }
+
+  const contentType = c.req.header("content-type") ?? "application/json";
+  const endpoint = `${
+    env.OTEL_EXPORTER_OTLP_ENDPOINT.replace(/\/$/, "")
+  }/v1/${signal}`;
+
+  // Fire-and-forget: return 202 immediately so collector latency never affects
+  // the app. Any forwarding failure is logged, never thrown.
+  fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": contentType },
+    body,
+  }).catch((error) => {
+    console.error(
+      `[telemetry-proxy] failed to forward ${signal} to ${endpoint}:`,
+      error,
+    );
+  });
+
+  return c.body(null, 202);
+}

--- a/packages/toolshed/routes/telemetry/telemetry.index.ts
+++ b/packages/toolshed/routes/telemetry/telemetry.index.ts
@@ -1,0 +1,26 @@
+import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
+import { forwardOtlp } from "./telemetry.handlers.ts";
+
+const router = createRouter();
+
+// The shell app MAY be served from a different origin than the API in dev
+// (see packages/shell/src/lib/env.ts — API_URL can be overridden), so allow
+// cross-origin telemetry POSTs. Reflect the request origin and allow the
+// headers the browser OTLP exporter + W3C trace propagation send.
+router.use(
+  "/api/telemetry/*",
+  cors({
+    origin: (origin) => origin ?? "*",
+    allowMethods: ["POST", "OPTIONS"],
+    allowHeaders: ["Content-Type", "traceparent", "tracestate"],
+  }),
+);
+
+// OTLP/HTTP signal endpoints. Traces is what the browser sends today; metrics is
+// wired for future use and behaves identically.
+router.post("/api/telemetry/v1/traces", (c) => forwardOtlp(c, "traces"));
+router.post("/api/telemetry/v1/metrics", (c) => forwardOtlp(c, "metrics"));
+
+export default router;


### PR DESCRIPTION
## Why

We're troubleshooting multiplayer runner performance (lunch-poll-style patterns, everyone voting at once). This wires the paths involved into OpenTelemetry → SigNoz (`https://signoz.stage.commontools.dev`) so contention is measurable per user / space / request — without adding a parallel instrumentation layer: everything hooks into the telemetry seams that already exist.

## What (by commit)

1. **runner + bg-piece: bridge RuntimeTelemetry to OTel** — a passive second consumer of the existing `RuntimeTelemetry` event bus (debug tooling unchanged). Translates markers into spans (`storage.push/pull`, `scheduler.preflight`) and `ct.*` metrics (scheduler runs/invocations/commits/retries, preflight phase timings, busy ratio, storage ops, subscriptions). Depends only on `@opentelemetry/api` — inert without a provider.
2. **memory + toolshed: trace the write/fan-out path** — `memory.transact` (w/ `user.did`, `space.did`, `request.id`, `ct.conflict`), `memory.commit.persist`, `memory.fanout` (`subscriber.count`, `dirty.count`), `memory.subscriber.sync` (`ct.touched` = wasted-wakeup signal), `memory.watch.refresh`; toolshed middleware attributes spans by authenticated user + space param.
3. **shell + toolshed: browser OTel via same-origin OTLP proxy** — opt-in (`localStorage["telemetryEnabled"]`), lazy-loaded, browser → `POST /api/telemetry/v1/{traces,metrics}` → local collector; fail-open by design; W3C traceparent extraction in toolshed.
4. **runner: keep the OTel bridge out of the browser worker bundle** — bridge values only via the `@commonfabric/runner/telemetry-otel-bridge` subpath; the barrel exports types only (a value re-export pulled `@opentelemetry/api`'s Node build into the web-worker bundle and broke worker load).
5. **bg-piece: init OTel per worker, delta temporality, metric scoping labels** — workers are separate isolates so they must init their own provider (the bridge was attaching to no-op instruments otherwise); delta temporality so SigNoz `rate()`/`increase()` work; `metricAttributes` bridge option stamps `service.name`/`deployment.environment` on metric datapoints only (SigNoz doesn't map resource attrs onto metric labels; keeping them off spans avoids ambiguous-key warnings).

## Verified

- End-to-end against SigNoz on stage with a headless 5-user lunch-poll scenario: 2333 `memory.transact` span pairs across 5 distinct `user.did`s; conflict rate ~28% under 5-way concurrency; fan-out cost scaling with subscriber count (2 subs ≈ 4ms avg → 10 subs ≈ 57ms avg); commit retries appearing only under concurrency; wasted wakeups measurable via `ct.touched`.
- Dashboard consuming all of this: `CT Runner / Memory — Multiplayer` on stage (dashboards-as-code in the infra repo, PR commontoolsinc/infra#57).
- `packages/runner` 735 tests pass; `packages/background-piece-service` 12 tests pass; shell/felt build clean; worker bundle contains 0 `@opentelemetry` references.

## Not in this PR

- Staging env fix: staging toolshed reports `deployment.environment=development` (`ENV` not set) — infra-side env change at deploy time.
- Deploy/rollout is separate (infra ansible already has `OTEL_ENABLED=true` staged for toolshed + bg-piece-service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridged existing runtime telemetry to OpenTelemetry and traced the memory write/fan‑out path so multiplayer contention is visible in SigNoz. Added opt‑in browser tracing via a same‑origin OTLP proxy and tightened build/runtime safeguards.

- **New Features**
  - Reusable OTel bridge maps `RuntimeTelemetry` markers to spans/metrics; exported via `@commonfabric/runner/telemetry-otel-bridge` with unit tests.
  - Memory server spans: `memory.transact`, `memory.commit.persist`, `memory.fanout` (root), `memory.subscriber.sync`, `memory.watch.refresh`; spans carry `user.did`, `space.did`, `request.id`, and relevant counters.
  - Toolshed: extracts W3C `traceparent`; stamps request spans with `user.did`/`space.did`; adds `POST /api/telemetry/v1/{traces,metrics}` proxy to `OTEL_EXPORTER_OTLP_ENDPOINT`.
  - Background piece service: per‑worker tracer+meter (delta temporality); bridge stamps `ct.runtime`/`user.did`/`space.did`; flushes and shuts down on cleanup.
  - Browser shell: lazy, opt‑in tracing that forwards runtime markers and exports OTLP/HTTP to toolshed; keeps `space.did` current across navigation.
  - Build: esbuild plugin remaps `@opentelemetry/*` `./platform` to browser builds; runner barrel exports bridge types only to keep node APIs out of browser bundles.

- **Bug Fixes**
  - Telemetry proxy streams with a 1MB cap; fail‑open with 202 and permissive CORS.
  - bg‑piece cleanup: detach the bridge after final storage sync and runtime dispose; trace and meter providers flush/shutdown independently; first error rethrown after both attempts.
  - `memory.fanout` spans start as explicit roots to avoid accidental parenting from `transact`.
  - Browser telemetry: moved `space.did` from provider Resource to per‑span attributes and update via a sink setter.
  - Build tooling: browser‑platform remap only falls back on NotFound; real I/O errors now fail the build.

<sup>Written for commit a97c7b154da8844e73f93319de4377cf40db6b3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Coverage ratchet

The bridge (the logic-heavy addition) now has unit tests. The remaining additions are fail-open telemetry plumbing (SDK init, OTLP proxy relay, browser bootstrap, felt resolver plugin) — accepting that debt narrowly per metric:

NEW_PERF_BASELINE: coverage-debt: packages/background-piece-service uncovered lines = 23 lines
NEW_PERF_BASELINE: coverage-debt: packages/lib-shell uncovered lines = 161 lines
NEW_PERF_BASELINE: coverage-debt: packages/felt uncovered lines = 576 lines
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 8011 lines
NEW_PERF_BASELINE: coverage-debt: packages/shell uncovered lines = 7225 lines
NEW_PERF_BASELINE: coverage-debt: packages/toolshed uncovered lines = 4934 lines
NEW_PERF_BASELINE: coverage-debt: packages/memory uncovered lines = 1379 lines