### PR TITLE
feat(ts-transformers): warn on read-then-mergeable-push in handlers

### DIFF
--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -278,10 +278,28 @@ Two further responses make the keyed case cheaper and catch misuse (see
   elements") are not generally mergeable and keep a read-modify-write `set`/`push`,
   which the narrowing above keeps safe.
 
-- **Catch misuse at build time (future).** The transformer's capability analysis
-  already tracks per-handler reads and writes; a diagnostic can flag a handler
-  that reads a collection and then mergeable-`push`es to it, pointing at the
-  identity-addressed `addUnique` or at `set`. Not yet built.
+- **Catch misuse at build time (implemented).** The transformer's capability
+  analysis already tracks per-handler reads and the mergeable write methods. The
+  `MergeablePushValidationTransformer`
+  ([packages/ts-transformers/src/transformers/mergeable-push-validation.ts](../../packages/ts-transformers/src/transformers/mergeable-push-validation.ts))
+  runs that analysis over each handler and flags a handler that both reads a
+  collection (an explicit `.get()` or an iteration) and mergeable-`push`es to the
+  same collection path. The diagnostic (`mergeable-push:read-then-push`) points at
+  the identity-addressed `elementById` + `addUnique` for a uniqueness condition,
+  or at a read-modify-write `set` for other content-dependent conditions. It is a
+  warning, not an error: the kept read keeps the shape safe today (it forces the
+  conflict-and-retry), so the check nudges toward the better expression without
+  failing the build. A bare push with no read of that path, or a read of a
+  different path, is left alone. The analysis exposes the findings through an
+  optional `mergeablePushMisuseSink`; the read-vs-push correlation lives next to
+  the read/write classification in `capability-analysis.ts`. The lunch poll's
+  `addUser` read-then-push is the worked example the warning fires on. The check
+  is path-correlated but order- and purpose-blind: a handler that mergeable-
+  `push`es and *also* runs an independent read-modify-write on the same list —
+  for example appending an entry and then trimming the list to a maximum length —
+  trips the warning too, because the trimming read keeps the append in the
+  conflict set. The remedy there is to keep the independent read-modify-write in
+  its own handler so the append stays mergeable.
 
 ## Scope
 

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -4,6 +4,7 @@ import {
   EmptyArrayOfValidationTransformer,
   HelperOwnedExpressionSiteLoweringTransformer,
   JsxExpressionSiteRouterTransformer,
+  MergeablePushValidationTransformer,
   ModuleScopeCfDataTransformer,
   ModuleScopeFunctionHardeningTransformer,
   ModuleScopeShadowingTransformer,
@@ -48,6 +49,10 @@ const CFC_TRANSFORMER_STAGE_SPECS: readonly TransformerStageSpec[] = [
   {
     name: "PatternContextValidationTransformer",
     create: (options) => new PatternContextValidationTransformer(options),
+  },
+  {
+    name: "MergeablePushValidationTransformer",
+    create: (options) => new MergeablePushValidationTransformer(options),
   },
   {
     name: "JsxExpressionSiteRouterTransformer",

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -34,6 +34,30 @@ export interface CapabilityAnalysisOptions {
    * capability summary mis-shapes or drops inputs. Consulted before the checker.
    */
   readonly typeRegistry?: WeakMap<ts.Node, ts.Type>;
+  /**
+   * Optional sink for the read-then-mergeable-`push` misuse check. When set,
+   * the analysis reports every `Cell.push` whose receiver collection path the
+   * same function also reads explicitly (a `.get()` or an iteration). A handler
+   * that reads a collection and then mergeable-`push`es to it keeps
+   * conflicting-and-retrying under write contention; the intent is usually
+   * better expressed as an identity-addressed `addUnique` or a read-modify-write
+   * `set`. Left unset (the default), the analysis records no push sites.
+   */
+  readonly mergeablePushMisuseSink?: (finding: MergeablePushMisuse) => void;
+}
+
+/**
+ * A `Cell.push(...)` whose receiver collection is also read explicitly within
+ * the same analyzed function. Reported through
+ * {@link CapabilityAnalysisOptions.mergeablePushMisuseSink}.
+ */
+export interface MergeablePushMisuse {
+  /** The `push(...)` call to point the diagnostic at. */
+  readonly node: ts.Node;
+  /** The collection path that is both read and pushed, relative to its root. */
+  readonly path: readonly string[];
+  /** The analyzed parameter/root the collection belongs to. */
+  readonly rootName: string;
 }
 
 interface MutableCapabilityState {
@@ -125,6 +149,12 @@ const ARRAY_IDENTITY_WRITER_METHODS = new Set([
   "removeByValue",
 ]);
 const ARRAY_IDENTITY_PRESERVING_CHAIN_METHODS = new Set(["slice"]);
+// The mergeable tail-append op. Only `push` commits as a mergeable `append`
+// that drops the op's own array read from conflict detection; a handler that
+// also reads the same collection then has a fragile read-then-push shape. The
+// other identity writers either dedup/remove by value (the recommended
+// replacements) or are ordinary read-modify-writes, so they are not flagged.
+const MERGEABLE_APPEND_METHODS = new Set(["push"]);
 const READER_METHODS = new Set(["get"]);
 const OPAQUE_DERIVATION_METHODS = new Set([
   "map",
@@ -1101,6 +1131,16 @@ export function analyzeFunctionCapabilities(
     const interprocedural = !!options?.interprocedural && !!checker;
     const includeNestedCallbacks = !!options?.includeNestedCallbacks;
     const summarySourceFile = fn.getSourceFile();
+
+    // Mergeable `push` call sites, collected only when a misuse sink is given.
+    // After the walk, a site whose receiver path the function also reads is a
+    // read-then-push and is reported through the sink.
+    const mergeablePushMisuseSink = options?.mergeablePushMisuseSink;
+    const mergeablePushSites: Array<{
+      readonly root: string;
+      readonly encodedPath: string;
+      readonly node: ts.Node;
+    }> = [];
 
     if (!fn.body) {
       const empty = { params: [] };
@@ -2530,6 +2570,17 @@ export function analyzeFunctionCapabilities(
               trackWriteRef(receiver);
             } else if (ARRAY_IDENTITY_WRITER_METHODS.has(methodName)) {
               trackWriteRef(receiver);
+              if (
+                mergeablePushMisuseSink &&
+                MERGEABLE_APPEND_METHODS.has(methodName) &&
+                !receiver.dynamic
+              ) {
+                mergeablePushSites.push({
+                  root: receiver.root,
+                  encodedPath: encodePath(receiver.path),
+                  node,
+                });
+              }
               let hasIdentityArgument = false;
               for (const argument of node.arguments) {
                 const argumentRef = resolveSourceRef(argument);
@@ -2777,6 +2828,18 @@ export function analyzeFunctionCapabilities(
       }
     } else {
       visit(fn.body);
+    }
+
+    if (mergeablePushMisuseSink) {
+      for (const site of mergeablePushSites) {
+        if (states.get(site.root)?.reads.has(site.encodedPath)) {
+          mergeablePushMisuseSink({
+            node: site.node,
+            path: decodePath(site.encodedPath),
+            rootName: site.root,
+          });
+        }
+      }
     }
 
     const params: CapabilityParamSummary[] = [];

--- a/packages/ts-transformers/src/policy/mod.ts
+++ b/packages/ts-transformers/src/policy/mod.ts
@@ -1,4 +1,7 @@
-export { analyzeFunctionCapabilities } from "./capability-analysis.ts";
+export {
+  analyzeFunctionCapabilities,
+  type MergeablePushMisuse,
+} from "./capability-analysis.ts";
 export {
   classifyReactiveReceiverKind,
   type ReactiveReceiverKind,

--- a/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
+++ b/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
@@ -1,0 +1,78 @@
+/**
+ * Mergeable Push Validation Transformer
+ *
+ * Flags the read-then-mergeable-`push` shape inside a handler: a handler that
+ * reads a collection (an explicit `.get()` or an iteration) and then
+ * mergeable-`push`es to that same collection.
+ *
+ * A mergeable `push` commits as a tail-relative `append` and drops the op's own
+ * array read from conflict detection so disjoint appends merge. When the
+ * handler reads the collection on its own — the dedup-then-push shape — that
+ * explicit read stays in the conflict set, so two concurrent appends conflict
+ * and the loser retries. The intent is usually better expressed as an
+ * identity-addressed `addUnique` (no retry) for a uniqueness condition, or a
+ * read-modify-write `set` for other content-dependent conditions.
+ *
+ * The check reuses the capability analysis, which already tracks per-parameter
+ * reads and the mergeable write methods. It is a warning, not an error: the
+ * shape stays safe today (the kept read forces the retry), so this nudges
+ * toward the better expression without failing the build.
+ */
+import ts from "typescript";
+import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+import { getCapabilitySummaryCallbackArgument } from "../ast/mod.ts";
+import { analyzeFunctionCapabilities } from "../policy/mod.ts";
+
+export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
+  transform(context: TransformationContext): ts.SourceFile {
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const callback = getCapabilitySummaryCallbackArgument(
+          node,
+          context.checker,
+        );
+        if (callback) {
+          this.checkCallback(callback, context);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(context.sourceFile);
+    return context.sourceFile;
+  }
+
+  private checkCallback(
+    callback: ts.ArrowFunction | ts.FunctionExpression,
+    context: TransformationContext,
+  ): void {
+    // One warning per collection per handler: several pushes to the same read
+    // collection share a root cause, so the first push site stands for them.
+    const reported = new Set<string>();
+    analyzeFunctionCapabilities(callback, {
+      checker: context.checker,
+      typeRegistry: context.options.state?.typeRegistry,
+      mergeablePushMisuseSink: (finding) => {
+        const key = JSON.stringify([finding.rootName, ...finding.path]);
+        if (reported.has(key)) return;
+        reported.add(key);
+        const label = finding.path.length > 0
+          ? `'${finding.path.join(".")}'`
+          : "the collection";
+        context.reportDiagnostic({
+          severity: "warning",
+          type: "mergeable-push:read-then-push",
+          message:
+            `This handler both reads ${label} and mergeable-'push'es to it. ` +
+            "The explicit read keeps the append in the conflict set, so it " +
+            "conflicts and retries under write contention instead of merging. " +
+            "For a uniqueness condition, address the element by identity with " +
+            "'elementById(...)' and 'addUnique(...)' instead. For other " +
+            "content-dependent conditions, use a read-modify-write 'set', and " +
+            "keep any independent append in its own handler.",
+          node: finding.node,
+        });
+      },
+    });
+  }
+}

--- a/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
+++ b/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
@@ -25,13 +25,20 @@ import { analyzeFunctionCapabilities } from "../policy/mod.ts";
 
 export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
+    // A single callback can be reachable from more than one call site: the
+    // lift-applied shape `lift(cb)(input)` exposes both the applied outer call
+    // and the unapplied inner `lift(cb)` call, and both resolve to the same
+    // callback. Check each callback once so the "one warning per handler"
+    // guarantee holds regardless of how many call sites reference it.
+    const checked = new Set<ts.Node>();
     const visit = (node: ts.Node): void => {
       if (ts.isCallExpression(node)) {
         const callback = getCapabilitySummaryCallbackArgument(
           node,
           context.checker,
         );
-        if (callback) {
+        if (callback && !checked.has(callback)) {
+          checked.add(callback);
           this.checkCallback(callback, context);
         }
       }

--- a/packages/ts-transformers/src/transformers/mod.ts
+++ b/packages/ts-transformers/src/transformers/mod.ts
@@ -4,6 +4,7 @@ export { PatternCallbackLoweringTransformer } from "./pattern-callback-lowering.
 export { EmptyArrayOfValidationTransformer } from "./empty-array-of-validation.ts";
 export { HelperOwnedExpressionSiteLoweringTransformer } from "./helper-owned-expression-site-lowering.ts";
 export { JsxExpressionSiteRouterTransformer } from "./jsx-expression-site-router.ts";
+export { MergeablePushValidationTransformer } from "./mergeable-push-validation.ts";
 export { ModuleScopeCfDataTransformer } from "./module-scope-cf-data.ts";
 export { ModuleScopeFunctionHardeningTransformer } from "./module-scope-function-hardening.ts";
 export { ModuleScopeShadowingTransformer } from "./module-scope-shadowing.ts";

--- a/packages/ts-transformers/test/mergeable-push-validation.test.ts
+++ b/packages/ts-transformers/test/mergeable-push-validation.test.ts
@@ -1,0 +1,146 @@
+import { assert, assertEquals } from "@std/assert";
+import { validateSource } from "./utils.ts";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+const DIAGNOSTIC_TYPE = "mergeable-push:read-then-push";
+
+function getReadThenPushWarnings(
+  diagnostics: readonly TransformationDiagnostic[],
+): readonly TransformationDiagnostic[] {
+  return diagnostics.filter((d) =>
+    d.type === DIAGNOSTIC_TYPE && d.severity === "warning"
+  );
+}
+
+Deno.test("Mergeable push validation", async (t) => {
+  await t.step(
+    "warns on a dedup-then-push to the same collection",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  const existing = users.get();",
+        "  if (existing.some((u) => u.name === event.name)) return;",
+        "  users.push({ name: event.name });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = getReadThenPushWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      // The message points at the two recommended alternatives.
+      assert(warnings[0]!.message.includes("addUnique"));
+      assert(warnings[0]!.message.includes("set"));
+      // It is non-fatal: no error of this type.
+      assertEquals(
+        diagnostics.filter((d) =>
+          d.type === DIAGNOSTIC_TYPE && d.severity === "error"
+        ).length,
+        0,
+      );
+    },
+  );
+
+  await t.step(
+    "does not warn on an unconditional push with no read",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  users.push({ name: event.name });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(getReadThenPushWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
+    "does not warn when the read is of a different collection",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "  log: Cell<string[]>;",
+        "}>((event, { users, log }) => {",
+        "  log.get();",
+        "  users.push({ name: event.name });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(getReadThenPushWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
+    "reports one warning even with several pushes to the same read collection",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ a: string; b: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  const existing = users.get();",
+        "  if (existing.some((u) => u.name === event.a)) return;",
+        "  users.push({ name: event.a });",
+        "  users.push({ name: event.b });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(getReadThenPushWarnings(diagnostics).length, 1);
+    },
+  );
+
+  await t.step(
+    "does not warn on the identity-addressed addUnique fix",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  const existing = users.get();",
+        "  if (existing.some((u) => u.name === event.name)) return;",
+        "  users.addUnique({ name: event.name });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(getReadThenPushWarnings(diagnostics).length, 0);
+    },
+  );
+});

--- a/packages/ts-transformers/test/mergeable-push-validation.test.ts
+++ b/packages/ts-transformers/test/mergeable-push-validation.test.ts
@@ -121,6 +121,31 @@ Deno.test("Mergeable push validation", async (t) => {
   );
 
   await t.step(
+    "reports one warning for a lift-applied callback, not one per call site",
+    async () => {
+      // `lift(cb)(input)` exposes both the applied outer call and the unapplied
+      // inner `lift(cb)` call, and both resolve to the same callback node.
+      // Without per-callback deduplication the read-then-push warns twice.
+      const source = [
+        'import { lift } from "commonfabric";',
+        "",
+        "declare const someInput: { items: number[] };",
+        "",
+        "export const doubled = lift((s: { items: number[] }) => {",
+        "  const current = s.items;",
+        "  s.items.push(current.length);",
+        "  return current;",
+        "})(someInput);",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(getReadThenPushWarnings(diagnostics).length, 1);
+    },
+  );
+
+  await t.step(
     "does not warn on the identity-addressed addUnique fix",
     async () => {
       const source = [

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -99,6 +99,7 @@ Deno.test(
       "EmptyArrayOfValidationTransformer",
       "OpaqueGetValidationTransformer",
       "PatternContextValidationTransformer",
+      "MergeablePushValidationTransformer",
       "JsxExpressionSiteRouterTransformer",
       "LiftLoweringTransformer",
       "ClosureTransformer",

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -1,7 +1,20 @@
 import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
-import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
+import {
+  analyzeFunctionCapabilities,
+  type MergeablePushMisuse,
+} from "../../src/policy/mod.ts";
 import { COMMONFABRIC_TYPES } from "../commonfabric-test-types.ts";
+
+function collectMergeablePushMisuses(
+  source: string,
+): MergeablePushMisuse[] {
+  const findings: MergeablePushMisuse[] = [];
+  analyzeFunctionCapabilities(parseFirstCallback(source), {
+    mergeablePushMisuseSink: (finding) => findings.push(finding),
+  });
+  return findings;
+}
 
 function parseFirstCallback(
   source: string,
@@ -2133,3 +2146,127 @@ Deno.test("Capability analysis tracks reads through a nullish-fallback alias", (
   assert(getPaths(summary, "a").readPaths.includes("user"));
   assert(getPaths(summary, "b").readPaths.includes("user"));
 });
+Deno.test(
+  "Mergeable-push misuse: flags a read-then-push to the same collection",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        if (existing.some((u) => u.name === "a")) return;
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.rootName, "input");
+    assertEquals(findings[0]!.path.join("."), "users");
+    assert(ts.isCallExpression(findings[0]!.node));
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: flags an iterate-then-push to the same collection",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        for (const u of input.key("users")) { u; }
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.path.join("."), "users");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: flags a read-then-push in a destructured handler",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = ({ name }, { users, myName }) => {
+        if (myName.get()) return;
+        const existing = users.get();
+        if (existing.some((u) => u.name === name)) return;
+        users.push({ name });
+        myName.set(name);
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.path.join("."), "users");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: ignores an unconditional push with no read",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 0);
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: ignores a push when the read is of a different path",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        input.key("log").get();
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 0);
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: ignores a read-then-addUnique (the keyed fix)",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        input.key("users").get();
+        input.key("users").addUnique({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 0);
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: ignores a read-modify-write set",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const current = input.key("users").get();
+        input.key("users").set([...current, { name: "a" }]);
+      };`,
+    );
+
+    assertEquals(findings.length, 0);
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: records no sites when no sink is provided",
+  () => {
+    // Without a sink the analysis stays a pure capability summary; the
+    // read-then-push above is still classified as read+write (writable).
+    const summary = analyzeFunctionCapabilities(
+      parseFirstCallback(
+        `const fn = (input) => {
+          input.key("users").get();
+          input.key("users").push({ name: "a" });
+        };`,
+      ),
+    );
+    const input = summary.params.find((entry) => entry.name === "input");
+    assert(input);
+    assertEquals(input!.capability, "writable");
+  },
+);


### PR DESCRIPTION
A mergeable `Cell.push` commits as a tail-relative `append` op and drops the op's own incidental array read from conflict detection, so disjoint appends from concurrent writers merge instead of conflicting. That makes one handler shape fragile: a handler that explicitly reads a collection (a `.get()` or an iteration) and then mergeable-`push`es to the same collection keeps its own read in the conflict set. Two such appends then conflict, and the loser retries — the dedup-then-push shape. The intent is usually better expressed as an identity-addressed `addUnique` (via `elementById`), which resolves concurrent same-key adds to one entity with no retry, or as a read-modify-write `set` for other content- dependent conditions.

Add a build-time diagnostic that flags this shape. The capability analysis already tracks, per parameter, which paths are read and which are written by the mergeable methods. Extend it with an optional `mergeablePushMisuseSink`: during the walk it records each `push` call site (root, path, node), and after the walk it reports a site only when the same root's read set contains that exact path. A bare push records only a write, so it never triggers itself; an unconditional push, or a read of a different path, is left alone. Only `push` is treated as a mergeable append — `addUnique`, `removeByValue`, and read-modify-write `set` are the recommended replacements and are not flagged. The check adds no work when no sink is supplied, keeping the summary hot path unchanged.

A new `MergeablePushValidationTransformer` runs the analysis over each handler/action/lift/computed callback on authored source and reports a `mergeable-push:read-then-push` diagnostic pointing at the two better expressions. It is a warning, not an error: the kept read keeps the shape safe today by forcing the conflict-and-retry, and there are legitimate read-then-push handlers in the tree, so the check nudges toward the better expression without failing the build. Warnings from several pushes to the same read collection collapse to one per handler.

The check is path-correlated but order- and purpose-blind, so a handler that appends and also runs an independent read-modify-write on the same list (for example appending and then trimming to a maximum length) also warns; the remedy there is to keep the independent read-modify-write in its own handler. This is noted in the docs alongside the diagnostic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a build-time warning for handlers that read a collection and then mergeable-`push` to it, pointing authors to `elementById` + `addUnique` or `set`. Dedupes to one warning per collection per handler and across multiple call sites; no runtime changes.

- **New Features**
  - Added `MergeablePushValidationTransformer` to flag `mergeable-push:read-then-push` misuse with clear suggestions; warns, not errors.
  - Extended capability analysis with `mergeablePushMisuseSink` to correlate `push` sites with explicit reads; no overhead when unset.
  - Wired into the `cf` pipeline; only flags `push` (not `addUnique`, `removeByValue`, or `set`); updated docs and tests; exported `MergeablePushMisuse`.

- **Bug Fixes**
  - Ensured one warning per collection per handler and deduped across multiple call sites (e.g., `lift(cb)(input)`).

<sup>Written for commit 916c646c4f6028d8a102876b31e4b4e234bcab8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

