### PR TITLE
Make client idle await user-intent event commits so a create survives…

### DIFF
--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -33,10 +33,21 @@ export function pipeConsole(e: ConsoleEvent) {
 // ```ts
 // page.addEventListener("dialog", dismissDialogs);
 // ```
+//
+// A beforeunload confirmation is accepted ("Leave") rather than dismissed:
+// dismissing it cancels the navigation the test just requested, which then
+// times out. The shell raises this dialog when a reload would drop writes the
+// server has not yet confirmed; a test that navigates at that point means to
+// navigate anyway, and durability assertions belong to the runtime-idle
+// checkpoint, not to this prompt.
 export async function dismissDialogs(e: DialogEvent) {
   const dialog = e.detail;
   console.log(`Browser Dialog: ${dialog.type} - ${dialog.message}`);
-  await dialog.dismiss();
+  if (dialog.type === "beforeunload") {
+    await dialog.accept();
+  } else {
+    await dialog.dismiss();
+  }
 }
 
 // Wrapper around `@astral/astral`'s `Page`.

--- a/packages/patterns/integration/home-profile-reload-durability.test.ts
+++ b/packages/patterns/integration/home-profile-reload-durability.test.ts
@@ -1,0 +1,147 @@
+import { env, Page } from "@commonfabric/integration";
+import { Identity } from "@commonfabric/identity";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import {
+  clickCfButton,
+  clickTrustedAction,
+  fillCfInput,
+  waitForRuntimeIdle,
+  waitForRuntimeSynced,
+  waitForText,
+} from "./cfc-browser-helpers.ts";
+
+// Durability of home profile creation across a reload, using ONLY
+// `waitForRuntimeIdle` between steps — never `waitForRuntimeSynced`. This
+// mirrors what a user does: create a profile, then quickly reload or create
+// another, before the create's cross-space commit has been confirmed.
+//
+// The mechanism these tests guard: a profile create is an event-handler commit
+// that is deliberately not awaited (scheduler/events.ts: "Do not await event
+// commits here"), and a full page reload tears down the runtime worker at the
+// browser level with no graceful dispose, dropping any commit the server has
+// not yet confirmed. The client-facing idle is therefore required to include
+// commit durability: the worker's idle handler waits on the storage manager's
+// pending-commit barrier (Scheduler.idleWithPendingCommits) in addition to
+// reactive quiescence, so once `waitForRuntimeIdle` returns the create is
+// durable and the reload cannot lose it. Without that guarantee, a reload
+// drops whichever create's commit is still in flight — the profile created
+// just before the reload, or the most recent of several rapid creates, whose
+// commit has had the least time to confirm.
+//
+// These tests read durable truth by fully settling AFTER the flow (so each
+// surviving profile's own cross-space space loads and its name renders) and
+// asserting every created name is present.
+
+const { FRONTEND_URL } = env;
+const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
+
+async function profileTabHidden(page: Page): Promise<boolean> {
+  return await page.evaluate(() => {
+    const deepFind = (sel: string): Element | null => {
+      const stack: (Document | ShadowRoot)[] = [document];
+      while (stack.length) {
+        const root = stack.pop()!;
+        const hit = root.querySelector(sel);
+        if (hit) return hit;
+        for (const e of root.querySelectorAll("*")) {
+          const sr =
+            (e as HTMLElement & { shadowRoot?: ShadowRoot }).shadowRoot;
+          if (sr) stack.push(sr);
+        }
+      }
+      return null;
+    };
+    const panel = deepFind('cf-tab-panel[value="profile"]') as
+      | HTMLElement
+      | null;
+    return !panel || getComputedStyle(panel).display === "none";
+  });
+}
+
+async function ensureProfileTabActive(page: Page) {
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    await waitForRuntimeIdle(page);
+    if (!(await profileTabHidden(page))) return;
+    await clickCfButton(page, 'cf-tab[value="profile"]');
+  }
+}
+
+async function createProfile(page: Page, name: string) {
+  await ensureProfileTabActive(page);
+  await fillCfInput(page, "#wish-profile-picker-name-input", name);
+  await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
+  // The runtime-idle checkpoint includes commit durability: once this returns,
+  // the create is server-confirmed — the property the reload tests assert.
+  await waitForRuntimeIdle(page);
+}
+
+// Fully settle so every surviving profile's own space is loaded and its name
+// renders. This is the durability read: a lost profile's name never appears
+// here, because no space was ever durably created for it.
+async function thoroughSettle(page: Page) {
+  for (let round = 0; round < 6; round++) {
+    await waitForRuntimeSynced(page);
+    await waitForRuntimeIdle(page);
+  }
+}
+
+async function gotoHome(
+  shell: ShellIntegration,
+  page: Page,
+  identity: Identity,
+) {
+  await shell.goto({
+    frontendUrl: FRONTEND_URL,
+    view: { builtin: "home" },
+    identity,
+  });
+  await clickCfButton(page, 'cf-tab[value="profile"]');
+}
+
+describe("home profile durability across reload", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let identityA: Identity;
+  let identityB: Identity;
+
+  beforeAll(async () => {
+    identityA = await Identity.generate({ implementation: "noble" });
+    identityB = await Identity.generate({ implementation: "noble" });
+  });
+
+  it("a profile created before a reload survives the reload", async () => {
+    const page = shell.page();
+
+    // Session 1: create a profile; settle only the scheduler, then reload.
+    await gotoHome(shell, page, identityA);
+    await createProfile(page, "Ada Lovelace");
+
+    // Reload (new session on the same home space).
+    await gotoHome(shell, page, identityA);
+    await thoroughSettle(page);
+
+    // The profile created before the reload must still be present.
+    await waitForText(page, "#home-profile-summary", "Ada Lovelace");
+  });
+
+  it("the most recent of several rapid creates survives a following reload", async () => {
+    const page = shell.page();
+
+    // Create two profiles in quick succession (only scheduler settles between),
+    // then reload immediately — the second create's commit is still in flight.
+    await gotoHome(shell, page, identityB);
+    await createProfile(page, "Grace Hopper");
+    await createProfile(page, "Alan Turing");
+
+    // Reload, then settle so surviving profiles render.
+    await gotoHome(shell, page, identityB);
+    await thoroughSettle(page);
+
+    // Both must be durably present; today the trailing one ("Alan Turing") is
+    // lost because its commit had the least time to confirm before the reload.
+    await waitForText(page, "#home-profile-summary", "Grace Hopper");
+    await waitForText(page, "#home-profile-summary", "Alan Turing");
+  });
+});

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -648,7 +648,10 @@ export class Runtime {
   }
 
   /**
-   * Wait for all pending operations to complete
+   * Wait for reactive quiescence: no scheduler pass running, no queued events,
+   * no background scheduler work. Does NOT wait for issued commits to be
+   * confirmed by the server (`scheduler.idleWithPendingCommits()`), for async
+   * builtin I/O (`settled()`), or for storage sync (`storageManager.synced()`).
    */
   idle(): Promise<void> {
     return this.scheduler.idle();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -961,16 +961,59 @@ export class Scheduler {
   }
 
   idle(): Promise<void> {
+    return this.#waitForQuiescence(false);
+  }
+
+  // Client-facing quiescence: reactive quiescence AND durability of in-flight
+  // commits. Commits are issued fire-and-forget (event handlers, direct cell
+  // writes over IPC, reactive recomputation write-backs), so plain idle()
+  // reports quiescence while a commit is still travelling to the server; a
+  // client that reads idle as a safe point to navigate or reload would then
+  // drop that write when the page and its worker are torn down. The pending
+  // set is sourced from the storage manager — the single chokepoint every
+  // commit flows through — so no write path can be forgotten. A landed commit
+  // also dirties readers of the committed write (onEventCommitWrites), which
+  // can re-trigger scheduler work that produces further commits, so durability
+  // and reactive quiescence are one joint fixpoint. This reuses the same
+  // recursive convergence idle() uses — a pending commit is just one more
+  // class of work to wait for — so there is no separate retry loop and no
+  // round cap. It resolves exactly when the scheduler is quiescent and no
+  // commit is in flight, and (like idle()) never resolves for a system that
+  // genuinely never settles.
+  idleWithPendingCommits(): Promise<void> {
+    return this.#waitForQuiescence(true);
+  }
+
+  #waitForQuiescence(awaitPendingCommits: boolean): Promise<void> {
     return new Promise<void>((resolve) => {
+      // Re-evaluate every condition from scratch once the thing we are waiting
+      // on settles.
+      const recheck = () =>
+        this.#waitForQuiescence(awaitPendingCommits).then(resolve);
+      // A parked waiter (idlePromises) resolves when the scheduler drains, but a
+      // commit can still be in flight then, so the commit-aware variant re-checks
+      // instead of resolving. That re-check is deferred to a microtask: it must
+      // not re-enter #waitForQuiescence synchronously while resolveIdlePromises
+      // is iterating idlePromises (draining runs before the scheduler marks
+      // itself not-scheduled, so a synchronous re-check would push back into the
+      // array mid-drain). The plain variant keeps the direct resolver.
+      const park = awaitPendingCommits
+        ? () => queueMicrotask(recheck)
+        : resolve;
       if (this.runningPromise) {
         // Something is currently running - wait for it then check again
-        this.runningPromise.then(() => this.idle().then(resolve));
+        this.runningPromise.then(recheck);
       } else if (this.backgroundTasks.size > 0) {
         // Async scheduler work, such as event-triggered auto-start, is still in
         // flight. Wait for it to settle and then re-check the scheduler state.
-        Promise.allSettled([...this.backgroundTasks]).then(() =>
-          this.idle().then(resolve)
-        );
+        Promise.allSettled([...this.backgroundTasks]).then(recheck);
+      } else if (
+        awaitPendingCommits && this.runtime.storageManager.hasPendingCommits()
+      ) {
+        // In-flight commits. Wait for them to settle (server confirmation or
+        // terminal failure) and then re-check: a landed commit can dirty
+        // readers and re-trigger scheduler work.
+        this.runtime.storageManager.pendingCommitsSettled().then(recheck);
       } else if (
         hasEventQueueWakeTimer(this.eventQueueWakeState) &&
         ((this.eventQueue.length > 0 &&
@@ -979,15 +1022,15 @@ export class Scheduler {
       ) {
         // A queued event is parked behind a throttled dependency. Wait for the
         // wake timer to re-schedule the queue and then re-check.
-        this.idlePromises.push(resolve);
+        this.idlePromises.push(park);
       } else if (this.hasPendingLineageHeadEvent()) {
         // A cross-space lineage head has no timer; its origin commit callback
         // is the wake source, so idle must stay open until that callback runs.
-        this.idlePromises.push(resolve);
+        this.idlePromises.push(park);
       } else if (!this.scheduled) {
         if (this.hasRunnablePullWork()) {
           this.queueExecution();
-          this.idlePromises.push(resolve);
+          this.idlePromises.push(park);
           return;
         }
         // Nothing is scheduled to run - we're idle.
@@ -996,7 +1039,7 @@ export class Scheduler {
         resolve();
       } else {
         // Execution is scheduled - wait for it to complete
-        this.idlePromises.push(resolve);
+        this.idlePromises.push(park);
       }
     });
   }

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -726,7 +726,10 @@ export async function dispatchQueuedEvent(state: {
     // flight. Downstream dirtying below is based on those locally applied
     // changed writes, not server-confirmed durability. If the server rejects
     // the commit, dependent speculative transactions are rejected as well and
-    // the normal retry path reruns the event.
+    // the normal retry path reruns the event. Durability is still observable:
+    // commit() registers itself with the storage manager's pending-commit
+    // barrier, which the client-facing idle (Scheduler.idleWithPendingCommits)
+    // waits on without blocking the scheduler loop here.
     tx.commit().then((result) => {
       const permanentRejection =
         result.error && isPermanentRejection(result.error)

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -161,6 +161,32 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   synced(): Promise<void>;
 
   /**
+   * Register an in-flight commit so the durability barrier
+   * (`hasPendingCommits` / `pendingCommitsSettled`) covers it. Called by the
+   * transaction layer at `commit()` entry, synchronously with the commit
+   * being issued, so there is no window where a commit is in flight but
+   * invisible to the barrier. The registration must tolerate rejection and
+   * drop the promise once it settles.
+   */
+  trackPendingCommit(promise: Promise<unknown>): void;
+
+  /**
+   * Whether any registered commit is still unconfirmed. Every write flows
+   * through `edit()` transactions, so this is the authoritative "are there
+   * unconfirmed local writes" signal — narrower than `synced()`, which also
+   * waits for pulls and cross-space read work.
+   */
+  hasPendingCommits(): boolean;
+
+  /**
+   * Wait for the currently pending commits to settle (server confirmation or
+   * terminal failure). One round only: commits issued after the call starts
+   * are not awaited — callers that need a fixpoint re-check `hasPendingCommits`
+   * after each round, as the scheduler's client-facing idle does.
+   */
+  pendingCommitsSettled(): Promise<void>;
+
+  /**
    * Add a promise to the list of cross-space promises.
    */
   addCrossSpacePromise(promise: Promise<void>): void;

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1805,7 +1805,17 @@ export class V2StorageTransaction implements IStorageTransaction {
     return { ok: {} };
   }
 
-  async commit(): Promise<Result<Unit, CommitError>> {
+  commit(): Promise<Result<Unit, CommitError>> {
+    const promise = this.#commitImpl();
+    // Synchronous registration with the manager's durability barrier: by the
+    // time commit() returns, the in-flight commit is visible to
+    // hasPendingCommits(), so a quiescence check started in the same turn
+    // cannot miss it.
+    this.storage.trackPendingCommit(promise);
+    return promise;
+  }
+
+  async #commitImpl(): Promise<Result<Unit, CommitError>> {
     this.assertWritable("commit()");
     const ready = this.editable();
     if (ready.error) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -705,6 +705,13 @@ export class StorageManager implements IStorageManager {
   #providers = new Map<MemorySpace, Provider>();
   #subscription = SubscriptionManager.create();
   #crossSpacePromises = new Set<Promise<void>>();
+  // In-flight commits, registered synchronously by the transaction layer at
+  // commit() entry (see IStorageManager.trackPendingCommit). This is the
+  // write-durability barrier: distinct from #crossSpacePromises, which also
+  // carries cross-space READ work (link-target loads) and so must not gate
+  // "are there unconfirmed writes" questions.
+  #pendingCommits = new Set<Promise<unknown>>();
+  #pendingCommitsSubscribers = new Set<(pending: boolean) => void>();
   #sessionFactory: SessionFactory;
   #spaceIdentity?: Signer;
   /** Seed map from Options — fixed for the manager's lifetime. */
@@ -829,6 +836,51 @@ export class StorageManager implements IStorageManager {
       [...this.#providers.values()].map((provider) => provider.synced()),
     ).finally(() => this.resolveCrossSpace(resolve));
     return promise;
+  }
+
+  trackPendingCommit(promise: Promise<unknown>): void {
+    // Normalize so a rejected commit settles the barrier instead of leaking an
+    // unhandled rejection; the caller keeps the original promise for results.
+    const tracked = promise.then(() => {}, () => {});
+    this.#pendingCommits.add(tracked);
+    if (this.#pendingCommits.size === 1) {
+      this.#notifyPendingCommits(true);
+    }
+    tracked.finally(() => {
+      this.#pendingCommits.delete(tracked);
+      if (this.#pendingCommits.size === 0) {
+        this.#notifyPendingCommits(false);
+      }
+    });
+  }
+
+  hasPendingCommits(): boolean {
+    return this.#pendingCommits.size > 0;
+  }
+
+  async pendingCommitsSettled(): Promise<void> {
+    await Promise.allSettled([...this.#pendingCommits]);
+  }
+
+  /**
+   * Observe transitions of the pending-commit state: `true` when the set of
+   * unconfirmed commits becomes non-empty, `false` when it drains. Drives the
+   * client-side "unconfirmed writes" flag (e.g. the shell's before-unload
+   * guard). Returns an unsubscribe function.
+   */
+  subscribePendingCommits(callback: (pending: boolean) => void): () => void {
+    this.#pendingCommitsSubscribers.add(callback);
+    return () => this.#pendingCommitsSubscribers.delete(callback);
+  }
+
+  #notifyPendingCommits(pending: boolean): void {
+    for (const callback of this.#pendingCommitsSubscribers) {
+      try {
+        callback(pending);
+      } catch (error) {
+        console.error("pending-commits subscriber threw:", error);
+      }
+    }
   }
 
   addCrossSpacePromise(promise: Promise<void>): void {

--- a/packages/runner/test/pending-commit-durability.test.ts
+++ b/packages/runner/test/pending-commit-durability.test.ts
@@ -1,0 +1,421 @@
+// The storage manager's pending-commit durability barrier and the scheduler's
+// client-facing quiescence built on it.
+//
+// Every write flows through a transaction from `storageManager.edit()`, and
+// `commit()` registers itself with the manager's barrier synchronously at the
+// entry point, so `hasPendingCommits()` is true from the moment a commit is
+// issued until the server confirms (or terminally rejects) it. The scheduler's
+// `idleWithPendingCommits()` — what the client-facing idle awaits — resolves
+// only when reactive quiescence and an empty barrier hold together, so a
+// client that treats "idle" as a safe point to navigate or reload cannot lose
+// an in-flight write. Plain `idle()` (internal reactive quiescence) ignores
+// the barrier by design.
+//
+// These tests drive REAL commits against the emulated server and gate its
+// responses, so they fail if the barrier ever stops observing the actual
+// commit pipeline (e.g. registration decoupled from the real commit promise)
+// and if the joint fixpoint ever stops re-checking after a commit settles.
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+} from "./scheduler-test-utils.ts";
+import type {
+  EventHandler,
+  IExtendedStorageTransaction,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+
+type TransactMessage = { requestId: string };
+type TransactResponse = {
+  type: "response";
+  requestId: string;
+  ok?: unknown;
+  error?: { name: string; message: string; precondition?: string };
+};
+type TestMemoryServer = {
+  transact(message: TransactMessage): Promise<TransactResponse>;
+};
+
+function emulatedServer(
+  storageManager: SchedulerTestStorageManager,
+): TestMemoryServer {
+  return (storageManager as unknown as { server(): TestMemoryServer }).server();
+}
+
+/**
+ * Gates every server commit response until released: the commit reaches the
+ * server but its confirmation is withheld, so the client-side commit promise
+ * stays pending. `releaseAll()` releases the currently held responses;
+ * responses arriving afterwards are held again until the next release.
+ */
+function holdServerTransacts(
+  storageManager: SchedulerTestStorageManager,
+): { held: () => number; releaseAll: () => void; restore: () => void } {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  let held = 0;
+  const gates: (() => void)[] = [];
+  server.transact = async (message) => {
+    held++;
+    await new Promise<void>((resolve) => gates.push(resolve));
+    return original(message);
+  };
+  return {
+    held: () => held,
+    releaseAll: () => {
+      for (const gate of gates.splice(0)) gate();
+    },
+    restore: () => {
+      server.transact = original;
+    },
+  };
+}
+
+/**
+ * Rejects server commits with `error` for the first `count` commits, then
+ * passes through. Mirrors the backpressure tests' injector.
+ */
+function rejectServerTransacts(
+  storageManager: SchedulerTestStorageManager,
+  count: number,
+  error: { name: string; message: string; precondition?: string },
+): { rejected: () => number; restore: () => void } {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  let rejected = 0;
+  server.transact = (message) => {
+    if (rejected < count) {
+      rejected++;
+      return Promise.resolve({
+        type: "response",
+        requestId: message.requestId,
+        error,
+      });
+    }
+    return original(message);
+  };
+  return {
+    rejected: () => rejected,
+    restore: () => {
+      server.transact = original;
+    },
+  };
+}
+
+const tick = (ms = 15) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("pending-commit durability barrier", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it("plain idle() returns while an event commit is unconfirmed; idleWithPendingCommits waits for it", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "durability-event-in",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    const resultCell = runtime.getCell<number>(
+      space,
+      "durability-event-out",
+      undefined,
+      tx,
+    );
+    resultCell.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    const handler: EventHandler = (handlerTx, event) => {
+      resultCell.withTx(handlerTx).send(event);
+    };
+    runtime.scheduler.addEventHandler(
+      handler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+
+    const hold = holdServerTransacts(storageManager);
+    try {
+      runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 5);
+
+      // Reactive quiescence only: the handler has run and its commit has been
+      // issued, but the server has not confirmed it. Plain idle() returns.
+      await runtime.idle();
+      expect(storageManager.hasPendingCommits()).toBe(true);
+
+      // The client-facing wait stays open until the commit confirms.
+      let settled = false;
+      const idleP = runtime.scheduler.idleWithPendingCommits().then(() => {
+        settled = true;
+      });
+      await tick();
+      expect(settled).toBe(false);
+
+      hold.releaseAll();
+      await idleP;
+      expect(settled).toBe(true);
+      expect(storageManager.hasPendingCommits()).toBe(false);
+    } finally {
+      hold.releaseAll();
+      hold.restore();
+    }
+  });
+
+  it("covers direct cell writes that never pass through the scheduler", async () => {
+    const cell = runtime.getCell<number>(
+      space,
+      "durability-direct-write",
+      undefined,
+      tx,
+    );
+    cell.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    const hold = holdServerTransacts(storageManager);
+    try {
+      // The same shape as a client cell-IPC write (applyCellWrite): an edit,
+      // a set, and a fire-and-forget commit — no scheduler event involved.
+      const writeTx = runtime.edit();
+      cell.withTx(writeTx).set(7);
+      runtime.prepareTxForCommit(writeTx);
+      const commitP = writeTx.commit();
+      // Registration is synchronous with commit(): the barrier reports the
+      // pending commit in the same turn, so a quiescence check started now
+      // cannot miss it.
+      expect(storageManager.hasPendingCommits()).toBe(true);
+
+      let settled = false;
+      const idleP = runtime.scheduler.idleWithPendingCommits().then(() => {
+        settled = true;
+      });
+      await tick();
+      expect(settled).toBe(false);
+
+      hold.releaseAll();
+      await commitP;
+      await idleP;
+      expect(settled).toBe(true);
+      expect(storageManager.hasPendingCommits()).toBe(false);
+    } finally {
+      hold.releaseAll();
+      hold.restore();
+    }
+  });
+
+  it("waits across a follow-on commit issued from a confirmed commit's continuation", async () => {
+    const cellA = runtime.getCell<number>(
+      space,
+      "durability-cascade-a",
+      undefined,
+      tx,
+    );
+    cellA.set(0);
+    const cellB = runtime.getCell<number>(
+      space,
+      "durability-cascade-b",
+      undefined,
+      tx,
+    );
+    cellB.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    const hold = holdServerTransacts(storageManager);
+    try {
+      // First commit; when it CONFIRMS, its continuation issues a second
+      // commit — the shape of confirmation-triggered reactive work.
+      const txA = runtime.edit();
+      cellA.withTx(txA).set(1);
+      runtime.prepareTxForCommit(txA);
+      const commitA = txA.commit().then(() => {
+        const txB = runtime.edit();
+        cellB.withTx(txB).set(2);
+        runtime.prepareTxForCommit(txB);
+        return txB.commit();
+      });
+
+      let settled = false;
+      const idleP = runtime.scheduler.idleWithPendingCommits().then(() => {
+        settled = true;
+      });
+      await tick();
+      expect(settled).toBe(false);
+
+      // Confirm commit A. Its continuation immediately issues commit B, which
+      // the gate holds again — the barrier must re-check and stay open rather
+      // than resolving because the commits it first saw have settled.
+      hold.releaseAll();
+      await tick();
+      expect(settled).toBe(false);
+      expect(storageManager.hasPendingCommits()).toBe(true);
+
+      hold.releaseAll();
+      await commitA;
+      await idleP;
+      expect(settled).toBe(true);
+    } finally {
+      hold.releaseAll();
+      hold.restore();
+    }
+  });
+
+  it("a terminally rejected commit settles the barrier instead of wedging it", async () => {
+    const cell = runtime.getCell<number>(
+      space,
+      "durability-rejected",
+      undefined,
+      tx,
+    );
+    cell.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    // Reject every commit: a direct transaction does not retry, so the commit
+    // resolves with an error and the barrier must drain.
+    const injector = rejectServerTransacts(storageManager, Infinity, {
+      name: "ConflictError",
+      message: "forced rejection",
+    });
+    try {
+      const writeTx = runtime.edit();
+      cell.withTx(writeTx).set(9);
+      runtime.prepareTxForCommit(writeTx);
+      const result = await writeTx.commit();
+      expect(result.error).toBeDefined();
+
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(storageManager.hasPendingCommits()).toBe(false);
+    } finally {
+      injector.restore();
+    }
+  });
+
+  it("stays open across an event commit's conflict-backoff retries until the write lands", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "durability-conflict-in",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    const resultCell = runtime.getCell<number>(
+      space,
+      "durability-conflict-out",
+      undefined,
+      tx,
+    );
+    resultCell.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    const handler: EventHandler = (handlerTx, event) => {
+      resultCell.withTx(handlerTx).send(event);
+    };
+    runtime.scheduler.addEventHandler(
+      handler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+
+    // Two transient conflicts, then pass through: the event backs off and
+    // retries (parking the queue behind a wake timer — the parked-waiter
+    // branch of the quiescence check), and the wait must span the whole
+    // conflict window, resolving only once the retry lands durably.
+    const injector = rejectServerTransacts(storageManager, 2, {
+      name: "ConflictError",
+      message: "forced transient conflict",
+    });
+    try {
+      runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 4);
+      await runtime.scheduler.idleWithPendingCommits();
+
+      expect(injector.rejected()).toBe(2);
+      expect(resultCell.get()).toBe(4);
+      expect(storageManager.hasPendingCommits()).toBe(false);
+    } finally {
+      injector.restore();
+    }
+  });
+
+  it("notifies pending-commit transitions once per drain, not per commit", async () => {
+    const cellOne = runtime.getCell<number>(
+      space,
+      "durability-notify-one",
+      undefined,
+      tx,
+    );
+    cellOne.set(0);
+    const cellTwo = runtime.getCell<number>(
+      space,
+      "durability-notify-two",
+      undefined,
+      tx,
+    );
+    cellTwo.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    const transitions: boolean[] = [];
+    const unsubscribe = storageManager.subscribePendingCommits((pending) =>
+      transitions.push(pending)
+    );
+    const hold = holdServerTransacts(storageManager);
+    try {
+      // Two overlapping held commits: one rising edge, one falling edge.
+      const tx1 = runtime.edit();
+      cellOne.withTx(tx1).set(1);
+      runtime.prepareTxForCommit(tx1);
+      const commit1 = tx1.commit();
+      const tx2 = runtime.edit();
+      cellTwo.withTx(tx2).set(2);
+      runtime.prepareTxForCommit(tx2);
+      const commit2 = tx2.commit();
+
+      expect(transitions).toEqual([true]);
+
+      // The emulated session serializes requests: the second commit's transact
+      // only reaches the server once the first's response is released, so keep
+      // releasing until both commits settle.
+      let bothSettled = false;
+      const settledP = Promise.allSettled([commit1, commit2]).then(() => {
+        bothSettled = true;
+      });
+      while (!bothSettled) {
+        hold.releaseAll();
+        await tick(1);
+      }
+      await settledP;
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(transitions[0]).toBe(true);
+      expect(transitions[transitions.length - 1]).toBe(false);
+    } finally {
+      hold.releaseAll();
+      hold.restore();
+      unsubscribe();
+    }
+  });
+});

--- a/packages/runner/test/pending-commit-durability.test.ts
+++ b/packages/runner/test/pending-commit-durability.test.ts
@@ -418,4 +418,40 @@ describe("pending-commit durability barrier", () => {
       unsubscribe();
     }
   });
+
+  it("a throwing subscriber does not stop the others from being notified", async () => {
+    // The notifier isolates subscribers: a callback that throws is caught and
+    // logged, and later subscribers still receive the transition.
+    const errors: unknown[][] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+    const calls: string[] = [];
+    const unsubThrowing = storageManager.subscribePendingCommits(() => {
+      calls.push("throwing");
+      throw new Error("subscriber boom");
+    });
+    const unsubHealthy = storageManager.subscribePendingCommits(() => {
+      calls.push("healthy");
+    });
+    try {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      // Rising edge (empty -> non-empty) notifies synchronously.
+      storageManager.trackPendingCommit(promise);
+      expect(calls).toEqual(["throwing", "healthy"]);
+      // Falling edge (non-empty -> empty) notifies after the promise settles.
+      resolve();
+      await promise;
+      await tick();
+      expect(calls).toEqual(["throwing", "healthy", "throwing", "healthy"]);
+      // Both throws were caught and logged, never propagated.
+      expect(errors.length).toBe(2);
+      expect(storageManager.hasPendingCommits()).toBe(false);
+    } finally {
+      console.error = originalError;
+      unsubThrowing();
+      unsubHealthy();
+    }
+  });
 });

--- a/packages/runner/test/transaction-notfound.test.ts
+++ b/packages/runner/test/transaction-notfound.test.ts
@@ -68,6 +68,16 @@ class MockStorageManager implements IStorageManager {
 
   trackUntilSettled() {}
 
+  trackPendingCommit() {}
+
+  hasPendingCommits() {
+    return false;
+  }
+
+  pendingCommitsSettled() {
+    return Promise.resolve();
+  }
+
   syncCell<T>(cell: Cell<T>): Promise<Cell<T>> {
     return Promise.resolve(cell);
   }

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1903,6 +1903,28 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     }
   });
 
+  it("handleIdle awaits commit-durability quiescence, not plain idle", async () => {
+    // The client reads "idle" as a safe point to navigate or reload, so the
+    // handler must await idleWithPendingCommits() — which includes in-flight
+    // commit durability — rather than runtime.idle() (reactive quiescence
+    // only). A fake exposing ONLY idleWithPendingCommits pins the wiring: a
+    // regression to runtime.idle() throws here.
+    const handleIdle = (RuntimeProcessor.prototype as any).handleIdle;
+    let calls = 0;
+    const fake = {
+      runtime: {
+        scheduler: {
+          idleWithPendingCommits: () => {
+            calls++;
+            return Promise.resolve();
+          },
+        },
+      },
+    };
+    await handleIdle.call(fake);
+    expect(calls).toBe(1);
+  });
+
   it("watchSiteTable registers table entries, isolating bad ones", async () => {
     const { runtime } = createRuntime();
     const { siteTableCause, siteTableSchema } = await import(

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -462,6 +462,17 @@ export class RuntimeProcessor {
       spaceHostMap: data.spaceHostMap,
     });
 
+    // Mirror the durability barrier to the page: `pending` is true while any
+    // issued commit is still unconfirmed. The shell keeps the latest value and
+    // consults it from its beforeunload handler, so a reload with unconfirmed
+    // writes prompts the user instead of silently dropping them.
+    storageManager.subscribePendingCommits((pending) => {
+      self.postMessage({
+        type: NotificationType.PendingWritesChanged,
+        pending,
+      });
+    });
+
     let pieceManager: PieceManager | undefined = undefined;
     let processor: RuntimeProcessor | undefined = undefined;
     const runtime = new Runtime({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1019,7 +1019,14 @@ export class RuntimeProcessor {
   }
 
   async handleIdle(): Promise<void> {
-    await this.runtime.idle();
+    // The client reads "idle" as a safe point to navigate or reload, so it
+    // must include durability of just-issued writes: idleWithPendingCommits()
+    // waits for reactive quiescence and for every in-flight commit together
+    // (see Scheduler.idleWithPendingCommits; the pending set is sourced from
+    // the storage manager, covering event handlers, direct cell IPC writes,
+    // and reactive write-backs alike). Internal callers that only need
+    // reactive quiescence use runtime.idle() and are unaffected.
+    await this.runtime.scheduler.idleWithPendingCommits();
   }
 
   // Persistence durability, distinct from handleIdle's reactive quiescence:

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -18,9 +18,11 @@ import {
   isIPCRemoteNotification,
   isIPCRemoteResponse,
   isNavigateRequestNotification,
+  isPendingWritesNotification,
   isTelemetryNotification,
   isVDomBatchNotification,
   NavigateRequestNotification,
+  PendingWritesNotification,
   RequestType,
   TelemetryNotification,
   VDomBatchNotification,
@@ -108,6 +110,7 @@ export type RuntimeConnectionEvents = {
   error: [ErrorNotification];
   telemetry: [TelemetryNotification];
   vdombatch: [VDomBatchNotification];
+  pendingwriteschange: [PendingWritesNotification];
 };
 
 export interface InitializedRuntimeConnection extends RuntimeConnection {}
@@ -500,6 +503,8 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
         this.emit("error", message);
       } else if (isVDomBatchNotification(message)) {
         this.emit("vdombatch", message);
+      } else if (isPendingWritesNotification(message)) {
+        this.emit("pendingwriteschange", message);
       } else {
         console.warn(`Unknown notification: ${JSON.stringify(message)}`);
       }

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -15,6 +15,7 @@ import {
   IPCRemoteResponse,
   NavigateRequestNotification,
   NotificationType,
+  PendingWritesNotification,
   RequestType,
   TelemetryNotification,
   VDomBatchNotification,
@@ -89,7 +90,7 @@ export function isIPCRemoteNotification(
   return isTelemetryNotification(value) || isCellUpdateNotification(value) ||
     isConsoleNotification(value) ||
     isNavigateRequestNotification(value) || isErrorNotification(value) ||
-    isVDomBatchNotification(value);
+    isVDomBatchNotification(value) || isPendingWritesNotification(value);
 }
 
 export function isCellUpdateNotification(
@@ -141,6 +142,16 @@ export function isTelemetryNotification(
     isRecord(value) &&
     value.type === NotificationType.Telemetry &&
     typeof value.marker === "object"
+  );
+}
+
+export function isPendingWritesNotification(
+  value: unknown,
+): value is PendingWritesNotification {
+  return (
+    isRecord(value) &&
+    value.type === NotificationType.PendingWritesChanged &&
+    typeof value.pending === "boolean"
   );
 }
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -107,6 +107,7 @@ export enum NotificationType {
   ErrorReport = "callback:error",
   Telemetry = "callback:telemetry",
   VDomBatch = "vdom:batch",
+  PendingWritesChanged = "callback:pending-writes",
 }
 
 export interface IPCClientMessage {
@@ -833,6 +834,17 @@ export interface TelemetryNotification {
 }
 
 /**
+ * Worker-to-page mirror of the storage manager's durability barrier: `pending`
+ * is true while any issued commit is still unconfirmed by the server, false
+ * once the pending set drains. The shell consults the latest value from its
+ * beforeunload handler so a reload with unconfirmed writes prompts the user.
+ */
+export interface PendingWritesNotification {
+  type: NotificationType.PendingWritesChanged;
+  pending: boolean;
+}
+
+/**
  * VDOM operation for IPC.
  */
 export type VDomOp =
@@ -901,7 +913,8 @@ export type IPCRemoteNotification =
   | ConsoleNotification
   | NavigateRequestNotification
   | ErrorNotification
-  | VDomBatchNotification;
+  | VDomBatchNotification
+  | PendingWritesNotification;
 
 export type Commands = {
   // Runtime requests

--- a/packages/runtime-client/runtime-client.test.ts
+++ b/packages/runtime-client/runtime-client.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { RuntimeClient } from "./runtime-client.ts";
-import { RequestType } from "./protocol/mod.ts";
+import { NotificationType, RequestType } from "./protocol/mod.ts";
 import type { RuntimeTransport } from "./client/transport.ts";
 
 describe("RuntimeClient.initialize option validation", () => {
@@ -82,6 +82,47 @@ describe("RuntimeClient.setForwardWorkerConsole", () => {
     expect(requests).toEqual([
       { type: RequestType.SetForwardWorkerConsole, enabled: false },
     ]);
+  });
+});
+
+describe("RuntimeClient.hasPendingWrites", () => {
+  // The constructor registers connection listeners; capture them so the
+  // pending-writes notification can be driven directly, no worker needed.
+  function clientWithConnHandlers(): {
+    client: RuntimeClient;
+    handlers: Map<string, (data: unknown) => void>;
+  } {
+    const handlers = new Map<string, (data: unknown) => void>();
+    const conn = {
+      on: (event: string, handler: (data: unknown) => void) => {
+        handlers.set(event, handler);
+      },
+    } as unknown as never;
+    const client = new (RuntimeClient as unknown as {
+      new (conn: never, options: unknown): RuntimeClient;
+    })(conn, {});
+    return { client, handlers };
+  }
+
+  it("mirrors a pending-writes notification into a synchronous flag and event", () => {
+    const { client, handlers } = clientWithConnHandlers();
+    const onChange = handlers.get("pendingwriteschange");
+    expect(onChange).toBeDefined();
+
+    const emitted: boolean[] = [];
+    client.on("pendingwriteschange", ({ pending }) => emitted.push(pending));
+
+    // Defaults to false, and reflects each transition synchronously — the
+    // property a beforeunload handler relies on (no async round-trip possible).
+    expect(client.hasPendingWrites()).toBe(false);
+
+    onChange!({ type: NotificationType.PendingWritesChanged, pending: true });
+    expect(client.hasPendingWrites()).toBe(true);
+
+    onChange!({ type: NotificationType.PendingWritesChanged, pending: false });
+    expect(client.hasPendingWrites()).toBe(false);
+
+    expect(emitted).toEqual([true, false]);
   });
 });
 

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -33,6 +33,7 @@ import {
   type LogLevel,
   NavigateRequestNotification,
   type PatternSourcesResponse,
+  PendingWritesNotification,
   RequestType,
   TelemetryNotification,
   type UploadBlobResponse,
@@ -62,6 +63,7 @@ export type RuntimeClientEvents = {
   navigaterequest: [{ cell: CellHandle }];
   error: [ErrorNotification];
   telemetry: [RuntimeTelemetryMarkerResult];
+  pendingwriteschange: [{ pending: boolean }];
 };
 
 export const $conn = Symbol("$request");
@@ -71,6 +73,7 @@ export const $conn = Symbol("$request");
  */
 export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   #conn: InitializedRuntimeConnection;
+  #pendingWrites = false;
 
   private constructor(
     conn: InitializedRuntimeConnection,
@@ -82,6 +85,18 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     this.#conn.on("navigaterequest", this._onNavigateRequest);
     this.#conn.on("error", this._onError);
     this.#conn.on("telemetry", this._onTelemetry);
+    this.#conn.on("pendingwriteschange", this._onPendingWritesChange);
+  }
+
+  /**
+   * Whether the worker runtime has issued commits that the server has not yet
+   * confirmed. Mirrored from the worker's storage manager on every transition,
+   * so it is synchronously readable — e.g. from a beforeunload handler, where
+   * no async round-trip is possible. Tearing the page down while this is true
+   * loses those writes.
+   */
+  hasPendingWrites(): boolean {
+    return this.#pendingWrites;
   }
 
   /**
@@ -631,5 +646,12 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
 
   private _onTelemetry = (data: TelemetryNotification): void => {
     this.emit("telemetry", data.marker);
+  };
+
+  private _onPendingWritesChange = (
+    data: PendingWritesNotification,
+  ): void => {
+    this.#pendingWrites = data.pending;
+    this.emit("pendingwriteschange", { pending: data.pending });
   };
 }

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -174,16 +174,23 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     return new CellHandle(this, response.cell);
   }
 
-  // TODO(unused)
+  /**
+   * Wait until the worker runtime is quiescent AND every issued commit has
+   * been confirmed by the server (or terminally failed). This is the client's
+   * "safe to navigate or reload" checkpoint: once it resolves, tearing the
+   * page down loses no writes. Waits for the joint fixpoint of reactive
+   * quiescence and commit durability (Scheduler.idleWithPendingCommits), not
+   * for pulls or subscription convergence — that is `allSynced()`.
+   */
   async idle(): Promise<void> {
     await this.#conn.request<RequestType.Idle>({ type: RequestType.Idle });
   }
 
   /**
-   * Await all in-flight compile-cache write-backs in the worker. Distinct from
-   * `idle()` (reactive/scheduler quiescence): this guarantees persistence
-   * durability, so a subsequent load of an already-compiled pattern reads the
-   * cached entry instead of recompiling in-client.
+   * Await all in-flight compile-cache write-backs in the worker. Narrower than
+   * `idle()`: it flushes only the compile cache, so a subsequent load of an
+   * already-compiled pattern reads the cached entry instead of recompiling
+   * in-client, without waiting for runtime quiescence.
    */
   async flushCompileCacheWrites(): Promise<void> {
     await this.#conn.request<RequestType.FlushCompileCacheWrites>({

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -168,6 +168,7 @@ export class XRootView extends BaseView {
       "theme-preference-changed",
       this._onThemeChanged,
     );
+    globalThis.addEventListener("beforeunload", this._onBeforeUnload);
   }
 
   override disconnectedCallback(): void {
@@ -176,8 +177,22 @@ export class XRootView extends BaseView {
       "theme-preference-changed",
       this._onThemeChanged,
     );
+    globalThis.removeEventListener("beforeunload", this._onBeforeUnload);
     super.disconnectedCallback();
   }
+
+  // A page teardown (reload, tab close, external navigation) terminates the
+  // runtime worker, dropping any commit the server has not yet confirmed. The
+  // worker mirrors its pending-commit state to `RuntimeClient.hasPendingWrites`
+  // on every transition, so this synchronous check is current; while writes are
+  // unconfirmed, ask the browser to confirm leaving instead of silently losing
+  // them. Commits confirm quickly (typically well under a second), so the
+  // prompt only appears in the narrow window a reload would actually lose data.
+  private _onBeforeUnload = (event: BeforeUnloadEvent): void => {
+    if (this.runtime?.hasPendingWrites()) {
+      event.preventDefault();
+    }
+  };
 
   protected override updated(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has("app")) {

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -16,7 +16,17 @@ function installBrowserGlobals(): () => void {
       value,
     });
   }
-  class TestHTMLElement extends EventTarget {}
+  class TestHTMLElement extends EventTarget {
+    // Minimal render root so Lit's connectedCallback (createRenderRoot ->
+    // attachShadow -> adoptStyles) runs without a real DOM.
+    attachShadow() {
+      return {
+        adoptedStyleSheets: [],
+        appendChild() {},
+        append() {},
+      };
+    }
+  }
   setGlobal("window", globalThis);
   setGlobal("HTMLElement", TestHTMLElement);
   setGlobal("customElements", {
@@ -80,6 +90,47 @@ describe("XRootView", () => {
       const markup = templateStrings(view.render());
       expect(markup).toContain("cf-theme");
       expect(markup).toContain("x-app-view");
+    } finally {
+      restore();
+    }
+  });
+
+  it("guards a browser reload only while the runtime reports pending writes", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const view = new XRootView();
+      // Stub Lit's render step: connectedCallback enables updating, which would
+      // otherwise schedule a real render (createComment etc.) this shim has no
+      // DOM for. We exercise the listener registration, not Lit rendering.
+      (view as unknown as { performUpdate: () => void }).performUpdate =
+        () => {};
+
+      // connect/disconnect register and remove the beforeunload listener.
+      view.connectedCallback();
+      view.disconnectedCallback();
+
+      const handler = (view as unknown as {
+        _onBeforeUnload: (event: { preventDefault: () => void }) => void;
+      })._onBeforeUnload;
+      let prevented = 0;
+      const event = () => ({ preventDefault: () => prevented++ });
+      const setRuntime = (runtime: unknown) =>
+        (view as unknown as { runtime: unknown }).runtime = runtime;
+
+      // No runtime yet: nothing to lose, so no prompt.
+      handler(event());
+      expect(prevented).toBe(0);
+
+      // A runtime with no unconfirmed writes: no prompt.
+      setRuntime({ hasPendingWrites: () => false });
+      handler(event());
+      expect(prevented).toBe(0);
+
+      // Unconfirmed writes in flight: prompt the user before unload.
+      setRuntime({ hasPendingWrites: () => true });
+      handler(event());
+      expect(prevented).toBe(1);
     } finally {
       restore();
     }


### PR DESCRIPTION
… an immediate reload

Creating a profile in the home space and then reloading the page dropped the new profile from durable storage. The same mechanism lost the most recent of several profiles created in quick succession before a reload, while the earlier ones survived.

A profile create is an event-handler write (`profiles.push(inSpace()(...))`), which is a cross-space commit. The scheduler issues event-handler commits fire-and-forget so it can keep processing later events against the locally applied state while server confirmation is still in flight. The client-facing notion of "idle" — what quiescence checks wait on — maps to the worker's `handleIdle` -> `runtime.idle()` -> `scheduler.idle()`, which reports quiescence as soon as the scheduler has no more reactive work to do. That happens while the create's commit is still travelling to the server. A full page reload tears down the page and its runtime worker at the browser level, and no graceful `Runtime.dispose()` runs on a reload (dispose runs only on an in-app runtime swap, such as logout or an identity change). So a create whose commit had not yet been confirmed was lost. The newest of several rapid creates was the most exposed, because its commit had the least time to confirm before the reload.

This makes the client-facing idle a trustworthy "safe to navigate or reload" checkpoint by waiting for in-flight user-intent event commits, not just for reactive quiescence. The scheduler tracks the commit of each event handler that changed a value; the client-facing idle waits for those to settle. In-app navigation was already durable through the navigation-convergence path (an idle followed by a connection-wide synced), and dispose already flushes pending commits before tearing storage down; this closes the remaining gap for a client that treats idle as a safe point to reload.

The wait is not a separate loop with a round cap. A landed event commit dirties the readers of the committed write (onEventCommitWrites -> markReadersDirtyForChangedWrites), which can re-trigger scheduler work, which can in turn produce further commits. So "safe to reload" is a joint fixpoint of two coupled subsystems: the reactive scheduler is quiescent AND no user-intent commit is in flight. The scheduler already converges its own fixpoint — a running pass, background tasks — by re-checking every condition each time the awaited thing settles, with no cap: a system that settles converges, one that never settles never reports idle. In-flight event commits are folded in as one more such condition. `idle()` and a new `idleWithEventCommits()` share a single `#waitForQuiescence(awaitEventCommits)` routine; the client-facing idle passes `true` so a pending commit is awaited and re-checked exactly like a background task, while the internal `idle()` passes `false` and is behaviorally unchanged (internal reactive-quiescence callers — builtins, cell sync, dispose, settled — must not block on commit I/O).

Parked waiters need one piece of care. A waiter that parks in `idlePromises` (behind a wake timer or a lineage head) is resolved when the scheduler drains, but a commit can still be in flight then, so the commit-aware variant re-checks instead of resolving. That re-check is deferred to a microtask: `resolveIdlePromises` drains the array before the scheduler marks itself not-scheduled, so a synchronous re-check would re-enter `#waitForQuiescence` and push back into the array mid-drain, spinning it. Deferring runs the re-check after the drain, once the scheduler state has settled.

Adds an integration test that creates profiles using only reactive-idle waits between steps — never a durability sync — then reloads, fully settles, and asserts each created profile's name renders; it fails without the fix and passes with it. Adds a scheduler unit test covering that plain `idle()` still returns while a commit is in flight but `idleWithEventCommits()` waits for it, that it converges when called while the scheduler is busy (a parked waiter, both with and without a pending commit — the no-commit case is the one that spins without the microtask deferral), that a rejecting commit settles the wait rather than wedging it, and that only value-changing events register a commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the client “idle” a durable checkpoint by waiting for storage-layer pending commits, so profile creates and other writes survive an immediate reload. Also prompt before a reload that would drop unconfirmed writes.

- **Bug Fixes**
  - Added a storage pending-commit barrier: `trackPendingCommit()`, `hasPendingCommits()`, `pendingCommitsSettled()`; transactions register commit promises synchronously.
  - Scheduler adds `idleWithPendingCommits()` and folds commit durability into quiescence; `idle()` remains reactive-only. Parked waiters re-check via microtask to avoid spins.
  - `RuntimeProcessor.handleIdle` now awaits `idleWithPendingCommits()`; event commits stay fire-and-forget but are covered by the barrier. Tests added for barrier behavior, fixpoint convergence, rejected-commit settling, and profile durability across reloads; added tests for notifier error isolation and the `beforeunload` guard.

- **New Features**
  - Worker mirrors pending-commit transitions to the page; `PendingWritesChanged` notification feeds `RuntimeClient.hasPendingWrites()` and a `pendingwriteschange` event.
  - The shell shows a `beforeunload` confirmation while unconfirmed writes exist; the integration harness accepts these dialogs (“Leave”).

<sup>Written for commit 0ae83edd6f6746731f3840ce5ce1d1bdde346f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_COVERAGE_BASELINE
