### PR TITLE
fix(runner,cli): register evaluated modules in the pattern-test harness (CT-1811)

### DIFF
--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -222,13 +222,13 @@ const handlers: Record<
         args.root as string | undefined,
       ),
     );
-    const evalResult = await engine.compileAndEvaluateModules(program, {
-      patternCoverage,
-    });
-    // Index evaluated artifacts so map/filter/flatMap ops resolve via their
-    // content-addressed canonical artifact instead of the defer-corrupted embedded
-    // graph (CT-1811); see test-runner.ts. Idempotent per identity.
-    runtime.patternManager.registerEvaluatedModules(evalResult);
+    // `compileAndRegisterModules` seals compile + evaluate + register (see
+    // test-runner.ts): map/filter/flatMap ops resolve via their content-addressed
+    // canonical artifact instead of the defer-corrupted embedded graph (CT-1811).
+    const evalResult = await runtime.patternManager.compileAndRegisterModules(
+      program,
+      { patternCoverage },
+    );
     const { main } = evalResult;
     // Channel 2: snapshot logger counts AFTER compile, before the run phase.
     loggerCountsBeforeRun = snapshotLoggerErrorWarnCounts();

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -222,9 +222,14 @@ const handlers: Record<
         args.root as string | undefined,
       ),
     );
-    const { main } = await engine.compileAndEvaluateModules(program, {
+    const evalResult = await engine.compileAndEvaluateModules(program, {
       patternCoverage,
     });
+    // Index evaluated artifacts so map/filter/flatMap ops resolve via their
+    // content-addressed canonical artifact instead of the defer-corrupted embedded
+    // graph (CT-1811); see test-runner.ts. Idempotent per identity.
+    runtime.patternManager.registerEvaluatedModules(evalResult);
+    const { main } = evalResult;
     // Channel 2: snapshot logger counts AFTER compile, before the run phase.
     loggerCountsBeforeRun = snapshotLoggerErrorWarnCounts();
     consoleCaptureActive = true;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -999,10 +999,20 @@ export async function runTestPattern(
           new FileSystemProgramResolver(testPath, options.root),
         ),
     );
-    const { main } = await withPhase(
+    const evalResult = await withPhase(
       ["runTestPattern", "compile"],
       () => engine.compileAndEvaluateModules(program, { patternCoverage }),
     );
+    // Index the evaluated artifacts, exactly as the deployed runtime does via
+    // `PatternManager.patternFromEvaluation` (and the generated-patterns harness
+    // via `compilePattern`). Using the evaluated namespace directly without this
+    // step leaves anonymous map/filter/flatMap ops un-indexed, so they fall back
+    // to their embedded pattern graph — whose nested output-alias `defer` levels
+    // are corrupted one step by the `getImmutableCell` round-trip (CT-1811), so a
+    // grandchild derived-internal output resolves one level too early and throws
+    // "Unknown derived internal cell with partial cause". Idempotent per identity.
+    runtime.patternManager.registerEvaluatedModules(evalResult);
+    const { main } = evalResult;
 
     if (!main?.default) {
       throw new Error(

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1001,17 +1001,16 @@ export async function runTestPattern(
     );
     const evalResult = await withPhase(
       ["runTestPattern", "compile"],
-      () => engine.compileAndEvaluateModules(program, { patternCoverage }),
+      // `compileAndRegisterModules` seals compile + evaluate + register, so the
+      // evaluated artifacts are indexed exactly as the deployed runtime's load
+      // path does (`patternFromEvaluation`). Without registration, anonymous
+      // map/filter/flatMap ops fall back to a defer-corrupted embedded graph and a
+      // grandchild derived-internal output throws at bind time (CT-1811).
+      () =>
+        runtime.patternManager.compileAndRegisterModules(program, {
+          patternCoverage,
+        }),
     );
-    // Index the evaluated artifacts, exactly as the deployed runtime does via
-    // `PatternManager.patternFromEvaluation` (and the generated-patterns harness
-    // via `compilePattern`). Using the evaluated namespace directly without this
-    // step leaves anonymous map/filter/flatMap ops un-indexed, so they fall back
-    // to their embedded pattern graph — whose nested output-alias `defer` levels
-    // are corrupted one step by the `getImmutableCell` round-trip (CT-1811), so a
-    // grandchild derived-internal output resolves one level too early and throws
-    // "Unknown derived internal cell with partial cause". Idempotent per identity.
-    runtime.patternManager.registerEvaluatedModules(evalResult);
     const { main } = evalResult;
 
     if (!main?.default) {

--- a/packages/patterns/gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx
+++ b/packages/patterns/gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Regression test for CT-1811.
+ *
+ * A sub-pattern that exposes a derived-internal computed OUTPUT, nested as a
+ * GRANDCHILD pattern node under a reactive `.map()` (parent.map -> Wrapper ->
+ * Child), used to throw at bind time under the `cf test` harness:
+ *   "Unknown derived internal cell with partial cause: <name>"
+ *
+ * Root cause: the harness evaluated the test bundle via
+ * `Engine.compileAndEvaluateModules` WITHOUT registering the evaluated artifacts,
+ * so anonymous map ops never got a content-addressed entry ref and fell back to
+ * their embedded pattern graph -- whose nested output-alias `defer` levels are
+ * decremented one step too far by the `getImmutableCell` round-trip, so a
+ * grandchild derived-internal output resolved one instantiation level too early.
+ * The deployed runtime (`patternFromEvaluation`) and the generated-patterns
+ * harness (`compilePattern`) register on load, so it only reproduced under
+ * `cf test`. Fix: the harness now calls `registerEvaluatedModules` after eval.
+ *
+ * No fetch is involved: the ticket's `fetchData` was incidental -- fetch just
+ * happened to be how the original art sub-pattern acquired a derived-internal
+ * output. ANY derived-internal computed output of a mapped grandchild trips it.
+ *
+ * The assertion must TRAVERSE the rendered UI: the bind (and thus the throw)
+ * only happens once the `.map()` materializes its elements; a lazy assertion
+ * that never reads the mapped output would not trigger it.
+ */
+import {
+  computed,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+const isRecord = (v: unknown): v is Record<PropertyKey, unknown> =>
+  typeof v === "object" && v !== null;
+
+const read = (v: unknown): unknown =>
+  isRecord(v) && typeof v.get === "function" ? (v.get as () => unknown)() : v;
+
+const asArray = (v: unknown): unknown[] => {
+  const value = read(v);
+  if (Array.isArray(value)) return value;
+  return value === undefined || value === null || typeof value === "boolean"
+    ? []
+    : [value];
+};
+
+const childNodes = (node: unknown): unknown[] => {
+  const value = read(node);
+  if (Array.isArray(value)) return value;
+  if (!isRecord(value)) return [];
+  const ui = value[UI];
+  return [
+    ...(ui === undefined || ui === value ? [] : [ui]),
+    ...asArray(value.children),
+  ];
+};
+
+// Collect leaf string/number values in the rendered tree. Walking the tree is
+// what forces the map to materialize each element (instantiate Wrapper + Child).
+const leafValues = (root: unknown, depth = 0): string[] => {
+  if (depth > 40) return [];
+  const value = read(root);
+  const kids = childNodes(value);
+  if (kids.length === 0) {
+    return typeof value === "string" || typeof value === "number"
+      ? [String(value)]
+      : [];
+  }
+  const out: string[] = [];
+  for (const k of kids) out.push(...leafValues(k, depth + 1));
+  return out;
+};
+
+interface ChildIn {
+  n: number;
+}
+interface ChildOut {
+  [NAME]: string;
+  [UI]: VNode;
+  doubled: number;
+}
+
+// The grandchild: exposes a derived-internal computed OUTPUT (`doubled`).
+const Child = pattern<ChildIn, ChildOut>(({ n }) => {
+  const doubled = computed(() => n * 2);
+  return {
+    [NAME]: "child",
+    [UI]: <div>{doubled}</div>,
+    doubled,
+  };
+});
+
+interface WrapperIn {
+  n: number;
+}
+interface WrapperOut {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+// The child pattern node nests Child, so Child is a GRANDCHILD of the map op.
+const Wrapper = pattern<WrapperIn, WrapperOut>(({ n }) => ({
+  [NAME]: "wrapper",
+  [UI]: (
+    <div>
+      <Child n={n} />
+    </div>
+  ),
+}));
+
+export default pattern(() => {
+  const items = new Writable<number[]>([1, 2, 3]);
+  const ui = <div>{items.map((n) => <Wrapper n={n} />)}</div>;
+  // Reading the rendered tree forces the map to materialize; each Child then
+  // renders its derived-internal `doubled` output (2, 4, 6). Without the fix,
+  // binding throws before any of this and the harness fails the run.
+  const rendered = computed(() => {
+    const values = leafValues(ui);
+    return values.includes("2") && values.includes("4") &&
+      values.includes("6");
+  });
+  return {
+    [NAME]: "ct-1811-mapped-subpattern-derived-output",
+    [UI]: ui,
+    tests: [
+      { assertion: rendered },
+    ],
+  };
+});

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -750,6 +750,14 @@ export class Engine extends EventTarget implements Harness {
   /**
    * Compile + evaluate a program through the ESM module-record path,
    * returning `{ main, exportMap }` plus the per-identity namespaces.
+   *
+   * Low-level: this does NOT register the evaluated artifacts in the pattern
+   * index, so anonymous map/filter/flatMap ops from the returned namespace have
+   * no content-addressed entry ref and would resolve via their embedded graph.
+   * To RUN a pattern from the returned namespace, use
+   * `PatternManager.compileAndRegisterModules`, which fuses registration in (see
+   * CT-1811). Reach for this bare form only to inspect serialized/verified output
+   * without running.
    */
   async compileAndEvaluateModules(
     program: RuntimeProgram,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -22,6 +22,7 @@ import type {
   CompiledModuleArtifact,
   EvaluateResult,
   Exports,
+  TypeScriptHarnessProcessOptions,
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
@@ -467,6 +468,37 @@ export class PatternManager {
       program.files,
     );
     return this.patternFromEvaluation(result, program);
+  }
+
+  /**
+   * Compile + evaluate a program's modules AND register the evaluated artifacts,
+   * returning the full module namespace (`EvaluateResult`).
+   *
+   * This is the load seam for callers that need the raw evaluated namespace —
+   * `main.default`, a named `fetchMocks` export, multi-user descriptors — rather
+   * than the single `Pattern` that `compilePattern` returns. It is the reason the
+   * CLI pattern-test harness and the multi-user worker previously reached for the
+   * lower-level `Engine.compileAndEvaluateModules` directly and skipped
+   * registration (CT-1811): map/filter/flatMap ops then had no content-addressed
+   * entry ref and fell back to a defer-corrupted embedded graph instead of their
+   * canonical `$patternRef` artifact.
+   *
+   * Registration is fused with evaluation here on purpose, so it cannot be
+   * forgotten — mirroring what the runtime's own `compilePattern` /
+   * `patternFromEvaluation` load path does. Reach for the bare
+   * `Engine.compileAndEvaluateModules` only to inspect serialized/verified output
+   * *without running* (engine unit tests), where stamping entry refs is unwanted.
+   */
+  async compileAndRegisterModules(
+    program: RuntimeProgram,
+    options?: TypeScriptHarnessProcessOptions,
+  ): Promise<EvaluateResult> {
+    const result = await this.runtime.harness.compileAndEvaluateModules(
+      program,
+      options,
+    );
+    this.registerEvaluatedModules(result);
+    return result;
   }
 
   /**
@@ -996,17 +1028,17 @@ export class PatternManager {
    *
    * Public because it is the shared indexing step every path that RUNS a
    * just-evaluated pattern must perform: the runtime's own load path calls it via
-   * `patternFromEvaluation`, and the CLI test harness (`test-runner`) and the
-   * multi-user worker call it after `Engine.compileAndEvaluateModules` (which they
-   * use to keep the evaluated module namespace). Skipping it leaves anonymous
-   * map/filter/flatMap ops un-indexed, so `getArtifactEntryRef` misses and the op
-   * falls back to its embedded graph instead of the content-addressed canonical
-   * artifact — the CT-1811 defer corruption. It is deliberately NOT folded into
-   * `compileAndEvaluateModules`, since that primitive is also used to inspect
-   * serialized/verified output without running (engine unit tests), where the
-   * side effect of stamping entry refs is unwanted. Idempotent per identity
-   * (re-registering refreshes the LRU), so paths that already registered are
-   * unaffected.
+   * `patternFromEvaluation`, and the namespace load seam `compileAndRegisterModules`
+   * (used by the CLI test harness and the multi-user worker) calls it too.
+   * Skipping it leaves anonymous map/filter/flatMap ops un-indexed, so
+   * `getArtifactEntryRef` misses and the op falls back to its embedded graph
+   * instead of the content-addressed canonical artifact — the CT-1811 defer
+   * corruption. It is deliberately NOT folded into `Engine.compileAndEvaluateModules`,
+   * since that primitive is also used to inspect serialized/verified output
+   * without running (engine unit tests), where the side effect of stamping entry
+   * refs is unwanted — `compileAndRegisterModules` is the fused seam callers use to
+   * run. Idempotent per identity (re-registering refreshes the LRU), so paths that
+   * already registered are unaffected.
    */
   registerEvaluatedModules(result: EvaluateResult): void {
     const byId = result.exportsByIdentity;

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -993,8 +993,22 @@ export class PatternManager {
    * Index every module of a just-evaluated ESM bundle by its content identity
    * (CT-1623). Lets `loadPatternByIdentity` reuse a sub-pattern module already
    * evaluated as part of its parent's bundle — no storage read, no SES re-eval.
+   *
+   * Public because it is the shared indexing step every path that RUNS a
+   * just-evaluated pattern must perform: the runtime's own load path calls it via
+   * `patternFromEvaluation`, and the CLI test harness (`test-runner`) and the
+   * multi-user worker call it after `Engine.compileAndEvaluateModules` (which they
+   * use to keep the evaluated module namespace). Skipping it leaves anonymous
+   * map/filter/flatMap ops un-indexed, so `getArtifactEntryRef` misses and the op
+   * falls back to its embedded graph instead of the content-addressed canonical
+   * artifact — the CT-1811 defer corruption. It is deliberately NOT folded into
+   * `compileAndEvaluateModules`, since that primitive is also used to inspect
+   * serialized/verified output without running (engine unit tests), where the
+   * side effect of stamping entry refs is unwanted. Idempotent per identity
+   * (re-registering refreshes the LRU), so paths that already registered are
+   * unaffected.
    */
-  private registerEvaluatedModules(result: EvaluateResult): void {
+  registerEvaluatedModules(result: EvaluateResult): void {
     const byId = result.exportsByIdentity;
     if (byId) {
       for (const [identity, exports] of byId) {

--- a/packages/runner/test/compile-and-register-modules.test.ts
+++ b/packages/runner/test/compile-and-register-modules.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  Engine,
+  Runtime,
+  signer,
+  StorageManager,
+} from "./engine-test-support.ts";
+import type { RuntimeProgram } from "./engine-test-support.ts";
+
+/**
+ * Conformance guard for CT-1811.
+ *
+ * The pattern-load seam `PatternManager.compileAndRegisterModules` must INDEX
+ * the evaluated artifacts (so a pattern/op gets a content-addressed entry ref and
+ * resolves via its canonical `$patternRef` artifact), while the bare
+ * `Engine.compileAndEvaluateModules` primitive must NOT. This pins the contract
+ * that lets harness callers get the full evaluated namespace without silently
+ * skipping registration — the divergence that caused CT-1811.
+ */
+describe("PatternManager.compileAndRegisterModules", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const program: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: `import { NAME, pattern } from "commonfabric";\n` +
+          `export default pattern(() => ({ [NAME]: "conformance" }));\n`,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("indexes evaluated artifacts (default export gets an entry ref)", async () => {
+    const result = await runtime.patternManager.compileAndRegisterModules(
+      program,
+    );
+    const entry = result.main!["default"] as object;
+    expect(runtime.patternManager.getArtifactEntryRef(entry)).toBeDefined();
+  });
+
+  it("the bare Engine.compileAndEvaluateModules does NOT index artifacts", async () => {
+    const engine = runtime.harness as Engine;
+    const result = await engine.compileAndEvaluateModules(program);
+    const entry = result.main!["default"] as object;
+    // No registration → no content-addressed entry ref → map/filter/flatMap ops
+    // would fall back to the embedded graph (this is the CT-1811 hazard the seam
+    // exists to remove).
+    expect(runtime.patternManager.getArtifactEntryRef(entry)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **CT-1811**. A sub-pattern that exposes a derived-internal computed output, nested as a **grandchild** pattern node under a `.map()` / `filter` / `flatMap`, threw at bind time under the `cf test` harness — `Error: Unknown derived internal cell with partial cause: "<name>"` — while working fine in the deployed runtime.

## Root cause

The pattern-test harness (`test-runner.ts`) and the multi-user worker evaluate the test bundle via `Engine.compileAndEvaluateModules` and use the returned namespace directly, **without registering the evaluated artifacts**. The deployed runtime loads patterns via `PatternManager.patternFromEvaluation`, and the generated-patterns harness via `compilePattern` — **both call `registerEvaluatedModules`**.

Without registration, anonymous map ops never get a content-addressed entry ref, so `substituteOpPatternRefs` is a no-op and the op falls back to its **embedded pattern graph**. The embedded graph's nested output-alias `defer` levels get decremented one step too far by the `getImmutableCell` round-trip, so a grandchild derived-internal output resolves one instantiation level too early and throws.

This was a genuine **harness-vs-runtime code-path divergence**, not the strict-vs-lenient binding the ticket suspected (that is pattern-dependent, identical in both). An adversarial audit of 47 candidate divergences found this to be the *only* one that changes pattern semantics.

## Fix — a sealed load seam

Rather than have the harness "remember to also register" (the very drift that caused this), registration is **fused into a single load seam**:

```ts
// PatternManager
compileAndRegisterModules(program, opts?): Promise<EvaluateResult>
//   = compileAndEvaluateModules + registerEvaluatedModules
//   returns the full namespace (main.default, fetchMocks, multi-user descriptors)
```

Both harness callers use it, so an evaluated namespace **cannot** be obtained without registration — mirroring the runtime's own `patternFromEvaluation` path. `Engine.compileAndEvaluateModules` is documented as the low-level "does **not** register" primitive (for inspecting serialized/verified output without running; folding registration into it was rejected because engine serialization unit tests rely on the non-registering form). This **dissolves the divergence structurally**, not by discipline.

## Tests

- **Regression** (`gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx`): fetch-free grandchild-under-map derived-output case; fails without the fix, passes with it. (Fetch was incidental to the ticket — any derived-internal output of a mapped grandchild trips it.)
- **Conformance** (`runner/test/compile-and-register-modules.test.ts`): asserts the seam indexes artifacts (default export gets an entry ref) while the bare primitive does not — pins the contract so the class can't silently return.

## Verification

| Gate | Result |
|---|---|
| Conformance test | 2/2 |
| Regression test (fails-without / passes-with, via the seam) | ✅ |
| Full pattern-tests suite (incl. multi-user) | 84/84 |
| generated-patterns suite | green |
| Runner units (engine, pattern-manager, map-op-by-identity, artifact-index, content-addressed-identity, load-by-identity, derived-copy) | green |
| fmt · lint · check | clean |

## Follow-up

- [CT-1812] — the embedded-graph path's `defer` corruption is a separate latent bug (now only reachable by genuinely ref-less dynamic ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
