### PR TITLE
perf(js-compiler): compose bundle source maps at the VLQ text level (cold-load bucket #8)

### DIFF
--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -8,6 +8,235 @@ import { LRUCache } from "@commonfabric/utils/cache";
 
 export type { MappedPosition };
 
+// ---------------------------------------------------------------------------
+// VLQ-level composition (the fast path of `composeBundleSourceMap`)
+// ---------------------------------------------------------------------------
+
+/** Input shape the textual transcoder cannot prove position-equivalent for. */
+class FastPathUnsupported extends Error {}
+
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const BASE64_VALUES = (() => {
+  const table = new Int8Array(128).fill(-1);
+  for (let i = 0; i < BASE64_CHARS.length; i++) {
+    table[BASE64_CHARS.charCodeAt(i)] = i;
+  }
+  return table;
+})();
+
+/** Decode one signed base64-VLQ value starting at `cursor.i`; advances it. */
+function decodeVLQ(mappings: string, cursor: { i: number }): number {
+  let result = 0;
+  let shift = 0;
+  for (;;) {
+    const code = mappings.charCodeAt(cursor.i++);
+    const digit = code < 128 ? BASE64_VALUES[code] : -1;
+    if (digit === -1) throw new FastPathUnsupported("malformed VLQ");
+    result += (digit & 0x1f) << shift;
+    if ((digit & 0x20) === 0) break;
+    shift += 5;
+  }
+  const negative = (result & 1) === 1;
+  result >>>= 1;
+  return negative ? -result : result;
+}
+
+/** Encode one signed value as base64 VLQ. */
+function encodeVLQ(value: number): string {
+  let vlq = value < 0 ? ((-value) << 1) + 1 : value << 1;
+  let out = "";
+  do {
+    let digit = vlq & 0x1f;
+    vlq >>>= 5;
+    if (vlq > 0) digit |= 0x20;
+    out += BASE64_CHARS[digit];
+  } while (vlq > 0);
+  return out;
+}
+
+const atSegmentEnd = (mappings: string, i: number): boolean =>
+  i >= mappings.length || mappings[i] === "," || mappings[i] === ";";
+
+/**
+ * Textual `composeBundleSourceMap`: transcode each module's `mappings` stream
+ * directly — one decode+re-encode pass per segment, no mapping objects, no
+ * sort, no generator, no JSON round-trip. Segment fields 2–5 are deltas that
+ * run across the whole stream, so each module's stream is rebased onto the
+ * running output state (plus its source/name index base) as it is appended;
+ * per-line field 1 restarts at every `;` exactly as in the inputs.
+ *
+ * Position-equivalent to the legacy path, with one benign divergence: modules
+ * contribute their declared `sources`/`names` arrays wholesale (indices stay
+ * valid), where the generator collects only first-use entries — lookups
+ * resolve identically, the arrays may just carry unused entries. Mappings
+ * without an original position (1-field segments) are dropped, matching the
+ * legacy `m.source == null` filter. Throws {@link FastPathUnsupported} on
+ * shapes whose equivalence would need the full decode: a `source` override
+ * over a multi-source map (the legacy path collapses every mapping onto the
+ * override), a non-empty `sourceRoot` (legacy resolves sources against it),
+ * and unsorted or malformed streams (the generator re-sorts).
+ */
+function composeBundleSourceMapTextual(
+  modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
+  bundleFilename: string,
+  startLineOffset = 0,
+): SourceMap | undefined {
+  const sources: string[] = [];
+  const names: string[] = [];
+  const contents: (string | null)[] = [];
+  let anyContent = false;
+  const out: string[] = [];
+  // Running absolutes of the emitted stream (fields 2–5 are stream-global).
+  let prevSrc = 0;
+  let prevOrigLine = 0;
+  let prevOrigCol = 0;
+  let prevName = 0;
+  // Line index (0-based) the next emitted `;` would move past.
+  let emittedLines = 0;
+  let any = false;
+  let lineOffset = startLineOffset;
+
+  for (const { body, map, source } of modules) {
+    if (map) {
+      if (typeof map.sourceRoot === "string" && map.sourceRoot !== "") {
+        throw new FastPathUnsupported("sourceRoot");
+      }
+      // Materialize every map field into plain locals ONCE. On the cached
+      // boot path these maps are storage-backed proxies whose property reads
+      // run a transaction read each — per-segment `.length` checks against
+      // the live objects turn the hot loop into tens of ms of storage reads
+      // (measured: ~9ms → ~87ms per boot). One shallow copy per module keeps
+      // the loop on plain data for proxies and plain maps alike.
+      const mapSources = [...(map.sources ?? [])];
+      if (source !== undefined && mapSources.length > 1) {
+        throw new FastPathUnsupported("source override over multi-source map");
+      }
+      const effectiveSources = source !== undefined ? [source] : mapSources;
+      const mapNames = [...(map.names ?? [])];
+      const rawContents =
+        (map as { sourcesContent?: (string | null)[] }).sourcesContent;
+      const mapContents = rawContents ? [...rawContents] : undefined;
+      const sourceCount = mapSources.length;
+      const nameCount = mapNames.length;
+      const sourceBase = sources.length;
+      const nameBase = names.length;
+
+      // In-module absolutes (every stream starts its deltas from 0).
+      let mSrc = 0;
+      let mOrigLine = 0;
+      let mOrigCol = 0;
+      let mName = 0;
+      let moduleLine = 0;
+      let genColAbs = 0;
+      let linePrevGen = 0;
+      let lineOpen = false; // an output segment exists for the current line
+      let emitted = false;
+      const s = map.mappings ?? "";
+      const cursor = { i: 0 };
+      while (cursor.i < s.length) {
+        const ch = s[cursor.i];
+        if (ch === ";") {
+          moduleLine++;
+          genColAbs = 0;
+          linePrevGen = 0;
+          lineOpen = false;
+          cursor.i++;
+          continue;
+        }
+        if (ch === ",") {
+          cursor.i++;
+          continue;
+        }
+        genColAbs += decodeVLQ(s, cursor);
+        if (genColAbs < 0) throw new FastPathUnsupported("negative column");
+        if (atSegmentEnd(s, cursor.i)) continue; // 1-field segment: dropped
+        mSrc += decodeVLQ(s, cursor);
+        mOrigLine += decodeVLQ(s, cursor);
+        mOrigCol += decodeVLQ(s, cursor);
+        let hasName = false;
+        if (!atSegmentEnd(s, cursor.i)) {
+          mName += decodeVLQ(s, cursor);
+          hasName = true;
+          if (!atSegmentEnd(s, cursor.i)) {
+            throw new FastPathUnsupported("oversized segment");
+          }
+        }
+        if (
+          mSrc < 0 || mSrc >= sourceCount || mOrigLine < 0 ||
+          mOrigCol < 0 || (hasName && (mName < 0 || mName >= nameCount))
+        ) {
+          throw new FastPathUnsupported("index out of range");
+        }
+        if (lineOpen) {
+          if (genColAbs < linePrevGen) {
+            throw new FastPathUnsupported("unsorted mappings");
+          }
+          out.push(",");
+        } else {
+          const bundleLine = lineOffset + moduleLine;
+          if (bundleLine < emittedLines) {
+            throw new FastPathUnsupported("module maps beyond its body");
+          }
+          out.push(";".repeat(bundleLine - emittedLines));
+          emittedLines = bundleLine;
+          lineOpen = true;
+        }
+        const srcGlobal = sourceBase + (source !== undefined ? 0 : mSrc);
+        let segment = encodeVLQ(genColAbs - linePrevGen) +
+          encodeVLQ(srcGlobal - prevSrc) +
+          encodeVLQ(mOrigLine - prevOrigLine) +
+          encodeVLQ(mOrigCol - prevOrigCol);
+        linePrevGen = genColAbs;
+        prevSrc = srcGlobal;
+        prevOrigLine = mOrigLine;
+        prevOrigCol = mOrigCol;
+        if (hasName) {
+          const nameGlobal = nameBase + mName;
+          segment += encodeVLQ(nameGlobal - prevName);
+          prevName = nameGlobal;
+        }
+        out.push(segment);
+        emitted = true;
+        any = true;
+      }
+
+      if (emitted) {
+        sources.push(...effectiveSources);
+        names.push(...mapNames);
+        if (source !== undefined) {
+          // Overridden single source: its content is the first non-null entry
+          // (per-module compiler maps carry exactly one source).
+          const content = mapContents?.find((c) => c != null) ?? null;
+          contents.push(content);
+          if (content != null) anyContent = true;
+        } else {
+          for (let i = 0; i < effectiveSources.length; i++) {
+            const content = mapContents?.[i] ?? null;
+            contents.push(content);
+            if (content != null) anyContent = true;
+          }
+        }
+      }
+    }
+    // Lines this body occupies in the "\n"-joined bundle = (newlines in body)+1.
+    // Robust to trailing newlines, unlike split().length.
+    lineOffset += (body.match(/\n/g)?.length ?? 0) + 1;
+  }
+  if (!any) return undefined;
+  const composed = {
+    version: 3,
+    file: bundleFilename,
+    sources,
+    names,
+    mappings: out.join(""),
+    ...(anyContent ? { sourcesContent: contents } : {}),
+  };
+  // Same `version` shape as the legacy path's `JSON.parse(generator.toString())`
+  // (a numeric 3 behind the RawSourceMap string type).
+  return composed as unknown as SourceMap;
+}
+
 /**
  * Compose a single bundle source map for the concatenated module bodies
  * (`[...bodies].join("\n")`) from each module's own source map, offsetting each
@@ -35,6 +264,42 @@ export function composeBundleSourceMap(
   // loader's `(function (exports, require, module) {\n` factory wrapper adds 1
   // line before the compiled body), so coordinates from `new Error().stack`
   // (1-based, relative to the eval'd string) map correctly.
+  startLineOffset = 0,
+): SourceMap | undefined {
+  // Compose at the VLQ text level when possible. The composition runs inside
+  // the runtime worker at every piece boot (once for the eval bundle plus once
+  // per module, for every record-graph evaluation), and the
+  // consumer→generator round-trip below decodes every mapping into an object,
+  // re-sorts, re-encodes, and JSON-parses — tens of ms per cold boot for the
+  // system-app closure. The textual transcoder produces position-equivalent
+  // output in one allocation-free pass; anything it cannot prove equivalent
+  // falls back to the legacy path.
+  try {
+    return composeBundleSourceMapTextual(
+      modules,
+      bundleFilename,
+      startLineOffset,
+    );
+  } catch (error) {
+    if (!(error instanceof FastPathUnsupported)) throw error;
+    return composeBundleSourceMapLegacy(
+      modules,
+      bundleFilename,
+      startLineOffset,
+    );
+  }
+}
+
+/**
+ * Reference composition via `SourceMapConsumer`/`SourceMapGenerator`. Kept as
+ * the fallback for input shapes the textual fast path rejects (multi-source
+ * maps under a `source` override, non-empty `sourceRoot`, unsorted or
+ * malformed mappings) — rare in practice: per-module compiler maps are
+ * single-source, rootless, and sorted.
+ */
+function composeBundleSourceMapLegacy(
+  modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
+  bundleFilename: string,
   startLineOffset = 0,
 ): SourceMap | undefined {
   const generator = new SourceMapGenerator({ file: bundleFilename });
@@ -106,16 +371,20 @@ export function composeBundleSourceMap(
  * map only re-labels the bundle coordinate with the per-module source name.
  */
 export function identitySourceMap(body: string, source: string): SourceMap {
-  const generator = new SourceMapGenerator({ file: source });
   const lineCount = (body.match(/\n/g)?.length ?? 0) + 1;
-  for (let line = 1; line <= lineCount; line++) {
-    generator.addMapping({
-      generated: { line, column: 0 },
-      original: { line, column: 0 },
-      source,
-    });
-  }
-  return JSON.parse(generator.toString()) as SourceMap;
+  // Synthesized directly — the stream is a fixed token per line: line 1 maps
+  // column 0 to source 0, line 1, column 0 (`AAAA`); every following line
+  // advances only the original line by one (`AACA`). Byte-identical to what a
+  // SourceMapGenerator loop over the same mappings emits, without paying the
+  // per-line addMapping/serialize round-trip on the boot path.
+  const mappings = "AAAA" + ";AACA".repeat(lineCount - 1);
+  return {
+    version: 3,
+    file: source,
+    sources: [source],
+    names: [],
+    mappings,
+  } as unknown as SourceMap;
 }
 
 /**

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -1,9 +1,5 @@
 import { SourceMap } from "./interface.ts";
-import {
-  MappedPosition,
-  SourceMapConsumer,
-  SourceMapGenerator,
-} from "source-map-js";
+import { MappedPosition, SourceMapConsumer } from "source-map-js";
 import { LRUCache } from "@commonfabric/utils/cache";
 
 export type { MappedPosition };
@@ -12,8 +8,19 @@ export type { MappedPosition };
 // VLQ-level composition (the fast path of `composeBundleSourceMap`)
 // ---------------------------------------------------------------------------
 
-/** Input shape the textual transcoder cannot prove position-equivalent for. */
-class FastPathUnsupported extends Error {}
+/**
+ * A mappings stream the transcoder cannot compose: malformed VLQs, unsorted
+ * segments, out-of-range indices, or shapes our compiler never emits (a
+ * non-empty `sourceRoot`). These indicate corrupt or foreign input, so they
+ * fail loud rather than degrade — the pre-#4455 consumer/generator
+ * implementation survives only as the differential oracle in the tests.
+ */
+export class SourceMapComposeError extends Error {
+  constructor(reason: string) {
+    super(`composeBundleSourceMap: ${reason}`);
+    this.name = "SourceMapComposeError";
+  }
+}
 
 const BASE64_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -32,7 +39,7 @@ function decodeVLQ(mappings: string, cursor: { i: number }): number {
   for (;;) {
     const code = mappings.charCodeAt(cursor.i++);
     const digit = code < 128 ? BASE64_VALUES[code] : -1;
-    if (digit === -1) throw new FastPathUnsupported("malformed VLQ");
+    if (digit === -1) throw new SourceMapComposeError("malformed VLQ");
     result += (digit & 0x1f) << shift;
     if ((digit & 0x20) === 0) break;
     shift += 5;
@@ -71,11 +78,9 @@ const atSegmentEnd = (mappings: string, i: number): boolean =>
  * valid), where the generator collects only first-use entries — lookups
  * resolve identically, the arrays may just carry unused entries. Mappings
  * without an original position (1-field segments) are dropped, matching the
- * legacy `m.source == null` filter. Throws {@link FastPathUnsupported} on
- * shapes whose equivalence would need the full decode: a `source` override
- * over a multi-source map (the legacy path collapses every mapping onto the
- * override), a non-empty `sourceRoot` (legacy resolves sources against it),
- * and unsorted or malformed streams (the generator re-sorts).
+ * legacy `m.source == null` filter. Corrupt or foreign shapes (malformed
+ * VLQs, unsorted streams, out-of-range indices, non-empty `sourceRoot`) throw
+ * {@link SourceMapComposeError} — fail loud, no silent degradation.
  */
 function composeBundleSourceMapTextual(
   modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
@@ -100,7 +105,9 @@ function composeBundleSourceMapTextual(
   for (const { body, map, source } of modules) {
     if (map) {
       if (typeof map.sourceRoot === "string" && map.sourceRoot !== "") {
-        throw new FastPathUnsupported("sourceRoot");
+        throw new SourceMapComposeError(
+          "non-empty sourceRoot (never emitted by our compiler)",
+        );
       }
       // Materialize every map field into plain locals ONCE. On the cached
       // boot path these maps are storage-backed proxies whose property reads
@@ -109,9 +116,9 @@ function composeBundleSourceMapTextual(
       // (measured: ~9ms → ~87ms per boot). One shallow copy per module keeps
       // the loop on plain data for proxies and plain maps alike.
       const mapSources = [...(map.sources ?? [])];
-      if (source !== undefined && mapSources.length > 1) {
-        throw new FastPathUnsupported("source override over multi-source map");
-      }
+      // A `source` override collapses every mapping onto the override entry
+      // (srcGlobal below always emits the override index), so multi-source
+      // inputs are fine; range checks still validate against the declared set.
       const effectiveSources = source !== undefined ? [source] : mapSources;
       const mapNames = [...(map.names ?? [])];
       const rawContents =
@@ -149,7 +156,9 @@ function composeBundleSourceMapTextual(
           continue;
         }
         genColAbs += decodeVLQ(s, cursor);
-        if (genColAbs < 0) throw new FastPathUnsupported("negative column");
+        if (genColAbs < 0) {
+          throw new SourceMapComposeError("negative generated column");
+        }
         if (atSegmentEnd(s, cursor.i)) continue; // 1-field segment: dropped
         mSrc += decodeVLQ(s, cursor);
         mOrigLine += decodeVLQ(s, cursor);
@@ -159,24 +168,28 @@ function composeBundleSourceMapTextual(
           mName += decodeVLQ(s, cursor);
           hasName = true;
           if (!atSegmentEnd(s, cursor.i)) {
-            throw new FastPathUnsupported("oversized segment");
+            throw new SourceMapComposeError("segment with more than 5 fields");
           }
         }
         if (
           mSrc < 0 || mSrc >= sourceCount || mOrigLine < 0 ||
           mOrigCol < 0 || (hasName && (mName < 0 || mName >= nameCount))
         ) {
-          throw new FastPathUnsupported("index out of range");
+          throw new SourceMapComposeError("source/name index out of range");
         }
         if (lineOpen) {
           if (genColAbs < linePrevGen) {
-            throw new FastPathUnsupported("unsorted mappings");
+            throw new SourceMapComposeError(
+              "mappings not sorted by generated position",
+            );
           }
           out.push(",");
         } else {
           const bundleLine = lineOffset + moduleLine;
           if (bundleLine < emittedLines) {
-            throw new FastPathUnsupported("module maps beyond its body");
+            throw new SourceMapComposeError(
+              "module mapping extends past its body",
+            );
           }
           out.push(";".repeat(bundleLine - emittedLines));
           emittedLines = bundleLine;
@@ -266,91 +279,11 @@ export function composeBundleSourceMap(
   // (1-based, relative to the eval'd string) map correctly.
   startLineOffset = 0,
 ): SourceMap | undefined {
-  // Compose at the VLQ text level when possible. The composition runs inside
-  // the runtime worker at every piece boot (once for the eval bundle plus once
-  // per module, for every record-graph evaluation), and the
-  // consumer→generator round-trip below decodes every mapping into an object,
-  // re-sorts, re-encodes, and JSON-parses — tens of ms per cold boot for the
-  // system-app closure. The textual transcoder produces position-equivalent
-  // output in one allocation-free pass; anything it cannot prove equivalent
-  // falls back to the legacy path.
-  try {
-    return composeBundleSourceMapTextual(
-      modules,
-      bundleFilename,
-      startLineOffset,
-    );
-  } catch (error) {
-    if (!(error instanceof FastPathUnsupported)) throw error;
-    return composeBundleSourceMapLegacy(
-      modules,
-      bundleFilename,
-      startLineOffset,
-    );
-  }
-}
-
-/**
- * Reference composition via `SourceMapConsumer`/`SourceMapGenerator`. Kept as
- * the fallback for input shapes the textual fast path rejects (multi-source
- * maps under a `source` override, non-empty `sourceRoot`, unsorted or
- * malformed mappings) — rare in practice: per-module compiler maps are
- * single-source, rootless, and sorted.
- */
-function composeBundleSourceMapLegacy(
-  modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
-  bundleFilename: string,
-  startLineOffset = 0,
-): SourceMap | undefined {
-  const generator = new SourceMapGenerator({ file: bundleFilename });
-  let lineOffset = startLineOffset;
-  let any = false;
-  for (const { body, map, source } of modules) {
-    if (map) {
-      const consumer = new SourceMapConsumer(map);
-      consumer.eachMapping((m) => {
-        if (
-          m.source == null || m.originalLine == null ||
-          m.originalColumn == null
-        ) return;
-        generator.addMapping({
-          generated: {
-            line: m.generatedLine + lineOffset,
-            column: m.generatedColumn,
-          },
-          original: { line: m.originalLine, column: m.originalColumn },
-          source: source ?? m.source,
-          name: m.name ?? undefined,
-        });
-        any = true;
-      });
-      const contents =
-        (map as { sourcesContent?: (string | null)[] }).sourcesContent;
-      if (source) {
-        // Source overridden to a single full module path: register that
-        // module's content under the override name so DevTools can still show
-        // the authored text (parity with the AMD bundle map). Per-module
-        // compiler maps carry exactly one source, so the first content is it.
-        const content = contents?.find((c) => c != null);
-        if (content != null) generator.setSourceContent(source, content);
-      } else {
-        const sources = map.sources ?? [];
-        if (contents) {
-          sources.forEach((src, i) => {
-            const content = contents[i];
-            if (src != null && content != null) {
-              generator.setSourceContent(src, content);
-            }
-          });
-        }
-      }
-    }
-    // Lines this body occupies in the "\n"-joined bundle = (newlines in body)+1.
-    // Robust to trailing newlines, unlike split().length.
-    lineOffset += (body.match(/\n/g)?.length ?? 0) + 1;
-  }
-  if (!any) return undefined;
-  return JSON.parse(generator.toString()) as SourceMap;
+  return composeBundleSourceMapTextual(
+    modules,
+    bundleFilename,
+    startLineOffset,
+  );
 }
 
 /**

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -730,6 +730,67 @@ export const tag = "util";
     expect(gets).toBeLessThan(24);
   });
 
+  it("matches legacy on hostile streams via the guard fallbacks", () => {
+    // Each shape trips a distinct transcoder guard (malformed VLQ, negative
+    // column, oversized segment, out-of-range index, module mapping past its
+    // body); the public function must still behave exactly like the legacy
+    // composer — same result or same throw.
+    const raw = (mappings: string, sources: string[] = ["a.ts"]): SourceMap =>
+      ({
+        version: "3",
+        file: "a.js",
+        sourceRoot: "",
+        sources,
+        names: [],
+        mappings,
+      }) as SourceMap;
+    const expectSameOutcome = (
+      modules: ReadonlyArray<
+        { body: string; map?: SourceMap; source?: string }
+      >,
+    ) => {
+      let fast: SourceMap | undefined;
+      let fastErr: unknown;
+      let legacy: SourceMap | undefined;
+      let legacyErr: unknown;
+      try {
+        fast = composeBundleSourceMap(modules, "hostile.js");
+      } catch (e) {
+        fastErr = e;
+      }
+      try {
+        legacy = legacyCompose(modules, "hostile.js");
+      } catch (e) {
+        legacyErr = e;
+      }
+      expect(fastErr === undefined).toBe(legacyErr === undefined);
+      if (fast !== undefined && legacy !== undefined) {
+        expect(mappingTuples(fast)).toEqual(mappingTuples(legacy));
+      } else {
+        expect(fast === undefined).toBe(legacy === undefined);
+      }
+    };
+    // Malformed VLQ characters.
+    expectSameOutcome([{ body: "x", map: raw("!!invalid!!") }]);
+    // Negative generated column (VLQ -1 = "D").
+    expectSameOutcome([{ body: "x", map: raw("DAAA") }]);
+    // Oversized segment (6 VLQ fields).
+    expectSameOutcome([{ body: "x", map: raw("AAAAAA") }]);
+    // Source index out of range (delta +1 with a single source).
+    expectSameOutcome([{ body: "x", map: raw("ACAA") }]);
+    // First module's map claims more lines than its 1-line body occupies, so
+    // the second module's offset falls behind the emitted line cursor.
+    expectSameOutcome([
+      { body: "x", map: raw("AAAA;AACA;AACA") },
+      { body: "y", map: raw("AAAA", ["b.ts"]) },
+    ]);
+    // Empty mappings alongside a real module (contributes nothing).
+    expectSameOutcome([
+      { body: "x", map: raw("") },
+      { body: "y", map: raw("AAAA", ["b.ts"]) },
+    ]);
+  });
+
   it("identitySourceMap synthesizes the generator-equivalent map", () => {
     for (const body of ["one line", "a\nb\nc", "trailing\n", ""]) {
       const direct = identitySourceMap(body, "/id/main.tsx");

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -399,9 +399,10 @@ describe("composeBundleSourceMap", () => {
 
 describe("composeBundleSourceMap textual fast path (vs consumer/generator)", () => {
   /**
-   * The pre-fast-path implementation, verbatim: consumer → generator →
-   * JSON.parse. The public function must stay position-equivalent to this for
-   * every input shape (taking the fast path or falling back).
+   * The pre-#4455 implementation, verbatim, kept as the TEST-ONLY differential
+   * oracle (the production fallback was removed — no live users; guards fail
+   * loud instead). The public composer must stay position-equivalent to this
+   * for every well-formed input shape.
    */
   function legacyCompose(
     modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
@@ -623,7 +624,7 @@ export const tag = "util";
     expectEquivalent([{ body: "x", map }], "drop.js", 0, { minMappings: 2 });
   });
 
-  it("falls back on a source override over a multi-source map", () => {
+  it("collapses a multi-source map onto a source override like the oracle", () => {
     const g = new SourceMapGenerator({ file: "a.js" });
     g.addMapping({
       generated: { line: 1, column: 0 },
@@ -647,7 +648,7 @@ export const tag = "util";
     );
   });
 
-  it("falls back on non-empty sourceRoot and on unsorted mappings", () => {
+  it("fails loud on non-empty sourceRoot and on unsorted mappings", () => {
     const rooted: SourceMap = {
       version: "3",
       file: "a.js",
@@ -656,8 +657,9 @@ export const tag = "util";
       names: [],
       mappings: "AAAA",
     } as SourceMap;
-    expectEquivalent([{ body: "x", map: rooted }], "rooted.js");
-    // genCol 4 then genCol 2 on the same line — the generator re-sorts.
+    expect(() => composeBundleSourceMap([{ body: "x", map: rooted }], "r.js"))
+      .toThrow(/sourceRoot/);
+    // genCol 4 then genCol 2 on the same line.
     const unsorted: SourceMap = {
       version: "3",
       file: "a.js",
@@ -666,9 +668,8 @@ export const tag = "util";
       names: [],
       mappings: "IAAA,FAAC",
     } as SourceMap;
-    expectEquivalent([{ body: "x", map: unsorted }], "unsorted.js", 0, {
-      minMappings: 2,
-    });
+    expect(() => composeBundleSourceMap([{ body: "x", map: unsorted }], "u.js"))
+      .toThrow(/not sorted/);
   });
 
   it("takes the fast path on compiler-shaped inputs (observable via kept declared names)", () => {
@@ -730,11 +731,9 @@ export const tag = "util";
     expect(gets).toBeLessThan(24);
   });
 
-  it("matches legacy on hostile streams via the guard fallbacks", () => {
-    // Each shape trips a distinct transcoder guard (malformed VLQ, negative
-    // column, oversized segment, out-of-range index, module mapping past its
-    // body); the public function must still behave exactly like the legacy
-    // composer — same result or same throw.
+  it("fails loud on corrupt streams, per guard", () => {
+    // Each shape trips a distinct transcoder guard; with the legacy fallback
+    // removed these are hard, descriptive errors.
     const raw = (mappings: string, sources: string[] = ["a.ts"]): SourceMap =>
       ({
         version: "3",
@@ -770,21 +769,29 @@ export const tag = "util";
         expect(fast === undefined).toBe(legacy === undefined);
       }
     };
+    const boom = (
+      modules: ReadonlyArray<
+        { body: string; map?: SourceMap; source?: string }
+      >,
+      msg: RegExp,
+    ) =>
+      expect(() => composeBundleSourceMap(modules, "hostile.js")).toThrow(msg);
     // Malformed VLQ characters.
-    expectSameOutcome([{ body: "x", map: raw("!!invalid!!") }]);
+    boom([{ body: "x", map: raw("!!invalid!!") }], /malformed VLQ/);
     // Negative generated column (VLQ -1 = "D").
-    expectSameOutcome([{ body: "x", map: raw("DAAA") }]);
+    boom([{ body: "x", map: raw("DAAA") }], /negative generated column/);
     // Oversized segment (6 VLQ fields).
-    expectSameOutcome([{ body: "x", map: raw("AAAAAA") }]);
+    boom([{ body: "x", map: raw("AAAAAA") }], /more than 5 fields/);
     // Source index out of range (delta +1 with a single source).
-    expectSameOutcome([{ body: "x", map: raw("ACAA") }]);
+    boom([{ body: "x", map: raw("ACAA") }], /index out of range/);
     // First module's map claims more lines than its 1-line body occupies, so
     // the second module's offset falls behind the emitted line cursor.
-    expectSameOutcome([
+    boom([
       { body: "x", map: raw("AAAA;AACA;AACA") },
       { body: "y", map: raw("AAAA", ["b.ts"]) },
-    ]);
-    // Empty mappings alongside a real module (contributes nothing).
+    ], /extends past its body/);
+    // Empty mappings alongside a real module (contributes nothing) stays
+    // equivalent to the oracle.
     expectSameOutcome([
       { body: "x", map: raw("") },
       { body: "y", map: raw("AAAA", ["b.ts"]) },

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import {
   composeBundleSourceMap,
   getTypeScriptEnvironmentTypes,
+  identitySourceMap,
   InMemoryProgram,
   type SourceMap,
   SourceMapParser,
@@ -393,5 +394,359 @@ describe("composeBundleSourceMap", () => {
       composed.sourcesContent?.[composed.sources.indexOf("/id/dir/main.tsx")],
     )
       .toBe("const authored = 1;");
+  });
+});
+
+describe("composeBundleSourceMap textual fast path (vs consumer/generator)", () => {
+  /**
+   * The pre-fast-path implementation, verbatim: consumer → generator →
+   * JSON.parse. The public function must stay position-equivalent to this for
+   * every input shape (taking the fast path or falling back).
+   */
+  function legacyCompose(
+    modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
+    bundleFilename: string,
+    startLineOffset = 0,
+  ): SourceMap | undefined {
+    const generator = new SourceMapGenerator({ file: bundleFilename });
+    let lineOffset = startLineOffset;
+    let any = false;
+    for (const { body, map, source } of modules) {
+      if (map) {
+        const consumer = new SourceMapConsumer(map);
+        consumer.eachMapping((m) => {
+          if (
+            m.source == null || m.originalLine == null ||
+            m.originalColumn == null
+          ) return;
+          generator.addMapping({
+            generated: {
+              line: m.generatedLine + lineOffset,
+              column: m.generatedColumn,
+            },
+            original: { line: m.originalLine, column: m.originalColumn },
+            source: source ?? m.source,
+            name: m.name ?? undefined,
+          });
+          any = true;
+        });
+        const contents =
+          (map as { sourcesContent?: (string | null)[] }).sourcesContent;
+        if (source) {
+          const content = contents?.find((c) => c != null);
+          if (content != null) generator.setSourceContent(source, content);
+        } else {
+          const sources = map.sources ?? [];
+          if (contents) {
+            sources.forEach((src, i) => {
+              const content = contents[i];
+              if (src != null && content != null) {
+                generator.setSourceContent(src, content);
+              }
+            });
+          }
+        }
+      }
+      lineOffset += (body.match(/\n/g)?.length ?? 0) + 1;
+    }
+    if (!any) return undefined;
+    return JSON.parse(generator.toString()) as SourceMap;
+  }
+
+  /** Every mapping as an ordered position tuple — the equivalence currency. */
+  function mappingTuples(map: SourceMap): string[] {
+    const out: string[] = [];
+    new SourceMapConsumer(map).eachMapping((m) => {
+      out.push(
+        [
+          m.generatedLine,
+          m.generatedColumn,
+          m.source,
+          m.originalLine,
+          m.originalColumn,
+          m.name ?? "",
+        ].join("|"),
+      );
+    });
+    return out;
+  }
+
+  function expectEquivalent(
+    modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
+    bundleFilename: string,
+    startLineOffset = 0,
+    { minMappings = 1 }: { minMappings?: number } = {},
+  ) {
+    const fast = composeBundleSourceMap(
+      modules,
+      bundleFilename,
+      startLineOffset,
+    );
+    const legacy = legacyCompose(modules, bundleFilename, startLineOffset);
+    expect(fast === undefined).toBe(legacy === undefined);
+    if (fast === undefined || legacy === undefined) return;
+    const fastTuples = mappingTuples(fast);
+    expect(fastTuples.length).toBeGreaterThanOrEqual(minMappings);
+    expect(fastTuples).toEqual(mappingTuples(legacy));
+    expect(fast.file).toBe(legacy.file);
+    // Content must resolve identically under every mapped source name.
+    const legacyConsumer = new SourceMapConsumer(legacy);
+    const fastConsumer = new SourceMapConsumer(fast);
+    for (const source of legacy.sources) {
+      expect(fastConsumer.sourceContentFor(source, true)).toBe(
+        legacyConsumer.sourceContentFor(source, true),
+      );
+    }
+  }
+
+  /** Compile a real multi-module program and return each module's js + map. */
+  async function compileTwoModules(): Promise<
+    Array<{ js: string; sourceMap?: SourceMap }>
+  > {
+    const compiler = new TypeScriptCompiler(types);
+    const program = new InMemoryProgram("/main.tsx", {
+      "/main.tsx": `
+import { helper, tag } from "./util.ts";
+
+export function test(n: number) {
+  return helper(n) + tag.length;
+}
+
+export default test;
+`,
+      "/util.ts": `
+export function helper(n: number): number {
+  const doubled = n * 2;
+  return doubled + 1;
+}
+
+export const tag = "util";
+`,
+    });
+    const resolved = await compiler.resolveProgram(program);
+    const emitted = compiler.compileToModules(resolved);
+    return [emitted.get("/main.tsx")!, emitted.get("/util.ts")!];
+  }
+
+  it("matches on real compiler maps with overrides (the eval-bundle shape)", async () => {
+    const [main, util] = await compileTwoModules();
+    expectEquivalent(
+      [
+        { body: main.js, map: main.sourceMap, source: "/id/main.tsx" },
+        { body: util.js, map: util.sourceMap, source: "/id/util.ts" },
+      ],
+      "load1.js",
+      0,
+      { minMappings: 10 },
+    );
+  });
+
+  it("matches on a single module with the wrapper offset (the per-module shape)", async () => {
+    const [main] = await compileTwoModules();
+    expectEquivalent(
+      [{ body: "", map: main.sourceMap, source: "/id/main.tsx" }],
+      "/main.tsx",
+      1,
+      { minMappings: 5 },
+    );
+  });
+
+  it("matches on identity maps mixed with real maps and mapless modules", async () => {
+    const [main, util] = await compileTwoModules();
+    expectEquivalent(
+      [
+        { body: main.js, map: identitySourceMap(main.js, "/id/main.tsx") },
+        { body: "no map\nfor me" },
+        { body: util.js, map: util.sourceMap, source: "/id/util.ts" },
+      ],
+      "mixed.js",
+      0,
+      { minMappings: 10 },
+    );
+  });
+
+  it("matches when mappings carry names across module boundaries", () => {
+    // This compiler config emits empty `names`, so exercise the cross-stream
+    // name-index rebasing with generator-built maps that do carry names.
+    const named = (
+      file: string,
+      entries: Array<{ line: number; col: number; name: string }>,
+    ) => {
+      const g = new SourceMapGenerator({ file });
+      for (const e of entries) {
+        g.addMapping({
+          generated: { line: e.line, column: e.col },
+          original: { line: e.line, column: 0 },
+          source: `${file}.ts`,
+          name: e.name,
+        });
+      }
+      return JSON.parse(g.toString()) as SourceMap;
+    };
+    const mapA = named("a", [
+      { line: 1, col: 0, name: "alpha" },
+      { line: 1, col: 8, name: "beta" },
+      { line: 2, col: 0, name: "alpha" },
+    ]);
+    const mapB = named("b", [
+      { line: 1, col: 4, name: "gamma" },
+      { line: 2, col: 2, name: "delta" },
+    ]);
+    expect(mapA.names.length).toBeGreaterThan(0);
+    expectEquivalent(
+      [
+        { body: "x\ny", map: mapA },
+        { body: "p\nq", map: mapB },
+      ],
+      "names.js",
+      0,
+      { minMappings: 5 },
+    );
+  });
+
+  it("drops generated-only (1-field) segments like the legacy filter", () => {
+    const g = new SourceMapGenerator({ file: "a.js" });
+    g.addMapping({
+      generated: { line: 1, column: 0 },
+      original: { line: 3, column: 0 },
+      source: "a.ts",
+    });
+    // A mapping with no original position — serialized as a 1-field segment.
+    g.addMapping({ generated: { line: 1, column: 8 } });
+    g.addMapping({
+      generated: { line: 1, column: 12 },
+      original: { line: 4, column: 2 },
+      source: "a.ts",
+    });
+    const map = JSON.parse(g.toString());
+    expect(map.mappings).toContain(","); // the 1-field segment is really there
+    expectEquivalent([{ body: "x", map }], "drop.js", 0, { minMappings: 2 });
+  });
+
+  it("falls back on a source override over a multi-source map", () => {
+    const g = new SourceMapGenerator({ file: "a.js" });
+    g.addMapping({
+      generated: { line: 1, column: 0 },
+      original: { line: 1, column: 0 },
+      source: "one.ts",
+    });
+    g.addMapping({
+      generated: { line: 2, column: 0 },
+      original: { line: 1, column: 0 },
+      source: "two.ts",
+    });
+    const map = JSON.parse(g.toString());
+    expect(map.sources.length).toBe(2);
+    // The override collapses both mappings onto one source — only the legacy
+    // path can do that, so the public function must match it via fallback.
+    expectEquivalent(
+      [{ body: "x\ny", map, source: "/override.ts" }],
+      "multi.js",
+      0,
+      { minMappings: 2 },
+    );
+  });
+
+  it("falls back on non-empty sourceRoot and on unsorted mappings", () => {
+    const rooted: SourceMap = {
+      version: "3",
+      file: "a.js",
+      sourceRoot: "/root",
+      sources: ["a.ts"],
+      names: [],
+      mappings: "AAAA",
+    } as SourceMap;
+    expectEquivalent([{ body: "x", map: rooted }], "rooted.js");
+    // genCol 4 then genCol 2 on the same line — the generator re-sorts.
+    const unsorted: SourceMap = {
+      version: "3",
+      file: "a.js",
+      sourceRoot: "",
+      sources: ["a.ts"],
+      names: [],
+      mappings: "IAAA,FAAC",
+    } as SourceMap;
+    expectEquivalent([{ body: "x", map: unsorted }], "unsorted.js", 0, {
+      minMappings: 2,
+    });
+  });
+
+  it("takes the fast path on compiler-shaped inputs (observable via kept declared names)", () => {
+    // The generator collects only first-USE names; the textual path carries the
+    // declared array wholesale. An unused declared name surviving into the
+    // composed map proves the fast path ran (tuple equivalence above proves the
+    // divergence is benign).
+    const map: SourceMap = {
+      version: "3",
+      file: "a.js",
+      sourceRoot: "",
+      sources: ["a.ts"],
+      names: ["used", "unused"],
+      // line 1, col 0 -> a.ts:1:0 with name index 0.
+      mappings: "AAAAA",
+    } as SourceMap;
+    const composed = composeBundleSourceMap([{ body: "x", map }], "fast.js")!;
+    expect(composed.names).toContain("unused");
+    expect(mappingTuples(composed)).toEqual(
+      mappingTuples(legacyCompose([{ body: "x", map }], "fast.js")!),
+    );
+  });
+
+  it("keeps the hot loop off live map objects (proxy-backed maps)", async () => {
+    const [main, util] = await compileTwoModules();
+    let gets = 0;
+    const proxied = (map: SourceMap): SourceMap =>
+      new Proxy(map, {
+        get(t, p, r) {
+          gets++;
+          return Reflect.get(t, p, r);
+        },
+      }) as SourceMap;
+    const composed = composeBundleSourceMap(
+      [
+        {
+          body: main.js,
+          map: proxied(main.sourceMap!),
+          source: "/id/main.tsx",
+        },
+        { body: util.js, map: proxied(util.sourceMap!), source: "/id/util.ts" },
+      ],
+      "prox.js",
+    )!;
+    // Correctness: identical to composing the plain maps.
+    expect(mappingTuples(composed)).toEqual(mappingTuples(
+      composeBundleSourceMap(
+        [
+          { body: main.js, map: main.sourceMap, source: "/id/main.tsx" },
+          { body: util.js, map: util.sourceMap, source: "/id/util.ts" },
+        ],
+        "prox.js",
+      )!,
+    ));
+    // On the cached boot path these maps are storage-backed proxies whose every
+    // property read is a transaction read. The transcoder must materialize the
+    // handful of fields once per module — not consult the live object
+    // per-segment (measured as a ~9ms → ~87ms per-boot regression).
+    expect(gets).toBeLessThan(24);
+  });
+
+  it("identitySourceMap synthesizes the generator-equivalent map", () => {
+    for (const body of ["one line", "a\nb\nc", "trailing\n", ""]) {
+      const direct = identitySourceMap(body, "/id/main.tsx");
+      const g = new SourceMapGenerator({ file: "/id/main.tsx" });
+      const lineCount = (body.match(/\n/g)?.length ?? 0) + 1;
+      for (let line = 1; line <= lineCount; line++) {
+        g.addMapping({
+          generated: { line, column: 0 },
+          original: { line, column: 0 },
+          source: "/id/main.tsx",
+        });
+      }
+      const viaGenerator = JSON.parse(g.toString()) as SourceMap;
+      expect(direct.mappings).toBe(viaGenerator.mappings);
+      expect([...direct.sources]).toEqual([...viaGenerator.sources]);
+      expect(direct.file).toBe(viaGenerator.file);
+      expect(mappingTuples(direct)).toEqual(mappingTuples(viaGenerator));
+    }
   });
 });


### PR DESCRIPTION
Part of the cold-load boot-floor investigation (buckets thread; follows #4441/#4442's bucket #2). This takes the bucket formerly known as "#7 mystery quicksort": profile re-derivation on current main showed the `doQuickSort ← randomIntInRange` frames are mozilla source-map's `parseMappings` sort, and the real owner is `composeBundleSourceMap ← evaluateGraph ← evaluateCachedModules` — a **~53ms/cold-boot bucket** (bigger than the module-glue bucket).

## Mechanism

At every piece boot the worker composes source maps for the record graph: once for the eval bundle (`engine.ts:878`) plus once per module (`engine.ts:920`, the CT-1754 per-module registration) — and the shared 9-module system-app closure is evaluated 4× per cold boot, so the same 75KB of mappings is composed 5× (direct in-worker probes; `identity=0` — these are real persisted maps, not identity fallbacks). Each compose ran `SourceMapConsumer.eachMapping` (full VLQ decode + quicksort) into a `SourceMapGenerator` (re-validate, re-encode, `JSON.parse`): **~41ms probed per cold boot**, and every registered map got parsed *twice* (compose's consumer + the registry's lazy consumer).

## Fix

`composeBundleSourceMapTextual`: a streaming VLQ transcoder — one decode+re-encode pass per segment, rebasing the stream-global delta fields (source/line/col/name) onto the running output state; 1-field segments are dropped exactly like the legacy `source == null` filter. Corrupt or foreign stream shapes (non-empty `sourceRoot`, unsorted/malformed streams) **fail loud with `SourceMapComposeError`** — per team decision (CT-1816 pulled forward: no live users yet), the legacy implementation was removed from production and survives as the test-only differential oracle; a source override over a multi-source map is supported natively. `identitySourceMap` now synthesizes its constant-token stream directly. No engine/runner changes.

**The lesson that almost shipped as a regression:** on cached boots these maps arrive as storage-backed proxies — every property read is a transaction read. My first version did per-segment `.length` range checks against the live object: ~9ms on plain maps, **~87ms on proxied ones (worse than legacy, which copies once into the consumer)**. Caught by re-measuring the steady-state boot, not just the post-restart boot. All fields are now materialized into plain locals before the hot loop, and a proxy-counting test (`gets < 24`) pins the regression class.

## Measurements (offset-12 rig, trivial pattern, cold boots ×2 each)

| | before | after |
|---|---|---|
| compose, direct in-worker probes | ~41ms | **~10ms** (plain) / ~17ms (proxied, under profiler) |
| profile bucket (nearest-marker) | 52.5 / 54.4ms | **16.9 / 16.2ms** |
| worker busy total | ~497ms | **~462ms** |

~6ms migrated into the debug-annotation bucket: the consumer parse that eager compose pre-paid (twice) now runs once, lazily, under the first `originalPositionFor` — and disappears entirely when the identity thread's lazy-`.src` (C) lands. Settle wall-time is too noisy (±50ms) to resolve this win; the probes + stable profile buckets are the evidence, per the thread's measurement discipline.

## Equivalence & gates

- Differential tests compare the public function against a verbatim replica of the legacy composer via `eachMapping` tuple equality + `sourceContentFor` parity: real compiled multi-module maps (override/offset shapes matching both engine call sites), identity maps, mixed/mapless, cross-module name rebasing, dropped 1-field segments, all three fallback shapes, and a fast-path-liveness probe.
- Benign divergence, documented: declared-but-unused `sources`/`names` entries are carried wholesale (indices stay valid; the generator collected only first-use entries).
- js-compiler suite green; **full runner suite 735/0**; `pattern-tests` (68) + `generated-patterns` (147) green; fmt/lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes bundle source maps at the VLQ text level to remove the `SourceMapConsumer`/`SourceMapGenerator` round-trip and cut cold-boot time. Removes the legacy fallback; strict guards now throw `SourceMapComposeError` on corrupt/foreign shapes, and `identitySourceMap` synthesizes its stream directly.

- **Performance**
  - Streaming VLQ transcoder replaces the consumer→generator path (one decode+encode per segment; drops 1-field segments).
  - Guards fail loud on non-empty `sourceRoot`, unsorted/malformed streams, out-of-range indices, negative columns, oversized segments, and mappings past a module body; source overrides on multi-source maps are supported natively.
  - Materializes proxied map fields into locals to avoid per-segment reads.
  - Measured: compose ~41ms → ~10ms (plain) / ~17ms (proxied); profile bucket 52.5/54.4ms → 16.9/16.2ms; worker busy ~497ms → ~462ms. Equivalence pinned via differential tests vs the legacy oracle; full suite green.

<sup>Written for commit 684d7dc9e7720f7d209de390c510a9883f859418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

