### PR TITLE
feat(runner): make fn.src lazy/debug-only — re-root identity off .src (Part B core)

### DIFF
--- a/packages/background-piece-service/src/env.ts
+++ b/packages/background-piece-service/src/env.ts
@@ -56,6 +56,7 @@ const envSchema = z.object({
   // other boolean env vars in this file have the same latent bug.
   EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
+  EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: flagValue(),
   // Background Piece Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
   //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -51,6 +51,7 @@ export function createRuntime(env: EnvVars, identity: Identity): Runtime {
     experimental: {
       modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
       persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
+      eagerSourceAnnotation: env.EXPERIMENTAL_EAGER_SOURCE_ANNOTATION,
     },
   });
 }

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -29,6 +29,7 @@ export function experimentalOptionsFromEnv(): ExperimentalOptions {
     persistentSchedulerState: read(
       "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
     ),
+    eagerSourceAnnotation: read("EXPERIMENTAL_EAGER_SOURCE_ANNOTATION"),
   };
 
   // Log any overridden experimental flags.

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -29,6 +29,7 @@ const identityLogger = getLogger("lib-shell.identity", {
 export type ExperimentalRuntimeFlags = {
   modernCellRep?: boolean;
   persistentSchedulerState?: boolean;
+  eagerSourceAnnotation?: boolean;
 };
 
 export type RuntimeCfcEnforcementMode = NonNullable<

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -580,9 +580,17 @@ export function __setSrcAnnotationTransformForTest(
  * CFC verified-identity were re-rooted off `.src` (content-addressed
  * `{ identity, symbol }` provenance — see cfc/implementation-identity.ts and the
  * `src-garble-identity-invariant` harness), so nothing load-bearing reads them.
- * With this OFF the resolution is skipped and that cost is not paid; a debug
- * session turns it on via {@link setEagerSourceAnnotation}. `.preview` (a cheap
- * `fn.toString` slice) is always kept.
+ * With this OFF the resolution is skipped and that cost is not paid; `.preview`
+ * (a cheap `fn.toString` slice) is always kept.
+ *
+ * Enablement: shell DEVELOPMENT builds turn this on by default (so `.src`
+ * debugging keeps working locally — `ENVIRONMENT === "development"` in
+ * shell/src/lib/env.ts), production builds leave it off; either is overridable
+ * via the `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` define/env everywhere the
+ * experimental flags flow (shell, toolshed, background-piece-service, cf CLI —
+ * `ExperimentalOptions.eagerSourceAnnotation`). Tests toggle the ambient flag
+ * directly via {@link setEagerSourceAnnotation}; the Runtime constructor only
+ * propagates an EXPLICIT option so it never stomps that seam.
  */
 let eagerSourceAnnotationEnabled = false;
 

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -569,6 +569,31 @@ export function __setSrcAnnotationTransformForTest(
   srcAnnotationTransformForTest = transform;
 }
 
+/**
+ * Gate for the eager per-primitive source-location resolution. Default OFF.
+ *
+ * Resolving `.src` for every lift/handler/computed at module-eval —
+ * `getExternalSourceLocation` (a `new Error().stack` capture per primitive) plus
+ * the source-map walk in `resolveLocationFromFunctionSource` — is the boot
+ * floor's #1 cost (~83ms across the full system-app module graph). `.src` /
+ * `.name` / `.sourceLocationSample` are now DEBUG-ONLY: scheduler identity and
+ * CFC verified-identity were re-rooted off `.src` (content-addressed
+ * `{ identity, symbol }` provenance — see cfc/implementation-identity.ts and the
+ * `src-garble-identity-invariant` harness), so nothing load-bearing reads them.
+ * With this OFF the resolution is skipped and that cost is not paid; a debug
+ * session turns it on via {@link setEagerSourceAnnotation}. `.preview` (a cheap
+ * `fn.toString` slice) is always kept.
+ */
+let eagerSourceAnnotationEnabled = false;
+
+export function setEagerSourceAnnotation(enabled: boolean): void {
+  eagerSourceAnnotationEnabled = enabled;
+}
+
+export function isEagerSourceAnnotationEnabled(): boolean {
+  return eagerSourceAnnotationEnabled;
+}
+
 function annotateFunctionDebugMetadata(
   fn: (...args: any[]) => unknown,
 ): void {
@@ -576,29 +601,33 @@ function annotateFunctionDebugMetadata(
     return;
   }
 
-  const { location, sample } = getExternalSourceLocation();
-  const fallbackLocation = location ?? resolveLocationFromFunctionSource(fn);
-  // The test-only seam garbles the annotated location (both `.src` and the
-  // `name` mirror below); identity must not move as a result.
-  const finalLocation = fallbackLocation && srcAnnotationTransformForTest
-    ? srcAnnotationTransformForTest(fallbackLocation)
-    : fallbackLocation;
-  if (finalLocation) {
-    if (location) {
-      Object.defineProperty(fn, "name", {
-        value: finalLocation,
-        configurable: true,
-      });
-    }
-    // Also set .src as backup (name can be finicky)
-    (fn as {
-      src?: string;
-      sourceLocationSample?: Record<string, unknown>;
-    }).src = finalLocation;
-    if (sample) {
+  // Skip the expensive source-location resolution unless debugging is on (the
+  // ~83ms boot lever). `.src` is debug-only; identity does not read it.
+  if (eagerSourceAnnotationEnabled) {
+    const { location, sample } = getExternalSourceLocation();
+    const fallbackLocation = location ?? resolveLocationFromFunctionSource(fn);
+    // The test-only seam garbles the annotated location (both `.src` and the
+    // `name` mirror below); identity must not move as a result.
+    const finalLocation = fallbackLocation && srcAnnotationTransformForTest
+      ? srcAnnotationTransformForTest(fallbackLocation)
+      : fallbackLocation;
+    if (finalLocation) {
+      if (location) {
+        Object.defineProperty(fn, "name", {
+          value: finalLocation,
+          configurable: true,
+        });
+      }
+      // Also set .src as backup (name can be finicky)
       (fn as {
+        src?: string;
         sourceLocationSample?: Record<string, unknown>;
-      }).sourceLocationSample = sample;
+      }).src = finalLocation;
+      if (sample) {
+        (fn as {
+          sourceLocationSample?: Record<string, unknown>;
+        }).sourceLocationSample = sample;
+      }
     }
   }
 

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -2,10 +2,7 @@ import type { Module } from "../builder/types.ts";
 import type { HarnessedFunction } from "../harness/types.ts";
 import type { ImplementationIdentity } from "./types.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import {
-  getVerifiedProvenance,
-  identityFromCanonicalSource,
-} from "../harness/verified-provenance.ts";
+import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
 
 /**
  * Resolve the policy-facing implementation identity for a module invocation.
@@ -61,23 +58,16 @@ const resolveProvenanceImplementationIdentity = (
   const provenance = getVerifiedProvenance(implementation);
   if (!provenance) return undefined;
 
-  const src = (implementation as { src?: string }).src;
-  const sourceLocation = parseVerifiedSourceLocation(src);
-  // Fail closed: the canonical source location must point INTO the provenance
-  // module. A mismatch means the src annotation and the registration disagree
-  // — treat as unsupported rather than guessing.
-  if (
-    !sourceLocation ||
-    identityFromCanonicalSource(src) !== provenance.identity
-  ) {
-    return {
-      kind: "unsupported",
-      className: "verified",
-      reason:
-        "provenance identity must match the implementation's canonical source",
-    };
-  }
-
+  // `.src` (the debug source location) is NO LONGER consulted for identity: the
+  // WeakMap provenance lookup above IS the anti-spoof proof (an attacker-supplied
+  // function has no entry), and every field the `writeAuthorizedBy` gate checks
+  // (`moduleIdentity`, `sourceFile`, `bindingPath` — prepare.ts) is provenance-
+  // derived, never `.src`-derived. The former `identityFromCanonicalSource(.src)
+  // === provenance.identity` consistency check was defense-in-depth, not the
+  // security boundary; it is dropped so that making `.src` lazy/debug-only
+  // (skipped at boot) cannot flip a genuinely-verified implementation to
+  // `unsupported` and deny its authorized writes. `.src` garble/absence is now
+  // identity-inert (the `src-garble-identity-invariant` harness asserts this).
   return {
     kind: "verified",
     moduleIdentity: provenance.identity,
@@ -90,34 +80,10 @@ const resolveProvenanceImplementationIdentity = (
         bindingPath: [...provenance.bindingIdentity.bindingPath],
       }
       : {}),
-    sourceLocation: {
-      line: sourceLocation.line,
-      column: sourceLocation.column,
-    },
     ...(provenance.bindingIdentity ? {} : {
       codeHash: hashOf(Function.prototype.toString.call(implementation))
         .toString(),
     }),
-  };
-};
-
-const parseVerifiedSourceLocation = (
-  location: string | undefined,
-): { source: string; line: number; column: number } | undefined => {
-  if (typeof location !== "string" || location.length === 0) {
-    return undefined;
-  }
-
-  const match = /^(.*):(\d+):(\d+)$/.exec(location);
-  if (!match) {
-    return undefined;
-  }
-
-  const [, source, line, column] = match;
-  return {
-    source: normalizeIdentitySource(source),
-    line: Number.parseInt(line, 10),
-    column: Number.parseInt(column, 10),
   };
 };
 

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -272,7 +272,6 @@ export type ImplementationIdentity =
     symbol?: string;
     sourceFile?: string;
     bindingPath?: string[];
-    sourceLocation?: { line: number; column: number };
     codeHash?: string;
   }
   | { kind: "unsupported"; className: string; reason: string };

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -81,7 +81,7 @@ import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 import { ExecutableRegistry } from "./executable-registry.ts";
 import { isTrustedBuilderArtifact } from "../builder/pattern-metadata.ts";
 import {
-  identityFromCanonicalSource,
+  getDefiningModule,
   readBindingIdentity,
   recordVerifiedProvenance,
 } from "./verified-provenance.ts";
@@ -1073,20 +1073,21 @@ export class Engine extends EventTarget implements Harness {
       if (typeof implementation !== "function") return;
       // Reject a CONFIRMED cross-module mismatch: a re-exporting module
       // (`export { setName } from "./defn"`) surfaces the same function under
-      // its own identity, but the function's canonical `fn.src` names its
-      // defining module. Provenance is first-write-wins and CFC fails closed on
-      // an identity/`fn.src` mismatch, so letting a re-exporter (possibly
-      // visited first) stamp its identity would make a valid verified artifact
-      // resolve as `unsupported`; dropping the re-exporter's record leaves the
-      // defining module's (matching) record to stick. A non-canonical `src`
-      // (e.g. a standalone-engine load whose src isn't rewritten to
-      // `cf:module/<hash>`) is left ALONE — recording it is harmless (CFC then
-      // fail-closes on its own src check), and blocking it would needlessly
-      // strip the `$implRef` such a module can still resolve by.
-      const srcIdentity = identityFromCanonicalSource(
-        (implementation as { src?: string }).src,
-      );
-      if (srcIdentity !== undefined && srcIdentity !== identity) return;
+      // its own identity. Provenance is first-write-wins, so letting a
+      // re-exporter (possibly visited first here) stamp its identity would give a
+      // genuinely-verified artifact the WRONG (re-exporter's) module identity —
+      // and its `writeAuthorizedBy` claims (which name the defining module) would
+      // then be denied. The defining module stamps `getDefiningModule` at its
+      // own (dependency-ordered) evaluation, so drop any record whose recording
+      // identity disagrees; the defining module's (matching) record sticks. An
+      // UNSTAMPED function (undefined — e.g. a runtime/host module, or a
+      // standalone-engine load) is left ALONE: recording it is harmless.
+      // (This replaces the former canonical-`fn.src` guard; `.src` is now
+      // lazy/debug-only and no longer names the defining module.)
+      const definingIdentity = getDefiningModule(implementation);
+      if (definingIdentity !== undefined && definingIdentity !== identity) {
+        return;
+      }
       const bindingIdentity = readBindingIdentity(value);
       recordVerifiedProvenance(implementation, {
         identity,

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -68,6 +68,34 @@ export function getVerifiedProvenance(
 }
 
 /**
+ * The content identity of the module that DEFINED an implementation function,
+ * stamped at that module's evaluation (module-record-compiler `execute`). This
+ * is the `.src`-free replacement for the re-exporter provenance guard: a
+ * re-exporting module surfaces the SAME function object under its own identity,
+ * and `recordModuleProvenance` is first-write-wins, so without a discriminator a
+ * re-exporter visited first would stamp its identity onto a function it did not
+ * define. Modules evaluate in dependency order (a re-exporter imports — so runs
+ * after — its definer), and this WeakMap is first-write-wins, so the defining
+ * module's stamp always wins. A WeakMap (not a property) because implementations
+ * are hardened/frozen after creation.
+ *
+ * `.src` USED to serve this role (its canonical `cf:module/<hash>` named the
+ * defining module), but `.src` is now lazy/debug-only, so identity — including
+ * this guard — must not depend on it.
+ */
+const definingModuleByFn = new WeakMap<object, string>();
+
+/** First-write-wins: only the defining (dependency-first) module's stamp sticks. */
+export function recordDefiningModule(fn: unknown, identity: string): void {
+  if (typeof fn !== "function") return;
+  if (!definingModuleByFn.has(fn)) definingModuleByFn.set(fn, identity);
+}
+
+export function getDefiningModule(fn: unknown): string | undefined {
+  return typeof fn === "function" ? definingModuleByFn.get(fn) : undefined;
+}
+
+/**
  * Read the CT-1665 verified-binding annotation off a builder factory (the
  * transformer's `__cfBindVerifiedBinding` attaches it to the factory object,
  * which shares its implementation function with the node module).

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -120,16 +120,3 @@ export function readBindingIdentity(
   }
   return { sourceFile, bindingPath: [...bindingPath] };
 }
-
-/**
- * Derive the module content identity from a function's canonical source
- * location (`cf:module/<identity>/<path>:line:col`), or undefined for
- * non-canonical sources (host functions, builtins).
- */
-export function identityFromCanonicalSource(
-  src: unknown,
-): string | undefined {
-  if (typeof src !== "string") return undefined;
-  const match = /^cf:module\/([^/]+)\//.exec(src);
-  return match ? match[1] : undefined;
-}

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3582,24 +3582,33 @@ export class Runner {
       }
     };
 
+    // Identity stamping is UNCONDITIONAL — the single identity channel (the
+    // scheduler reads only these stamps; there is no fallback derivation).
+    // The debug NAME below depends on `name` (fn.src / fn.name — absent for
+    // anonymous arrows when the eager source annotation is off), but identity
+    // must not: gating the stamps on `name` silently re-opened the per-symbol
+    // multi-instance collision (N instances of one lift sharing one id, so one
+    // actionStats entry and one durable observation) whenever annotation was
+    // off — the production default.
+    //
+    // Use the RESOLVED implementation `fn` (`resolveByImplRef(module) ?? …`),
+    // not `module.implementation`: an `$implRef`-resolved module (reloaded from
+    // a serialized graph) carries the ref, not the live function, so reading
+    // provenance off `module.implementation` would drop the content-addressed
+    // scheduler identity on reload.
+    this.applyImplementationHash(action, fn);
+    (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
+      schedulerActionInstanceKey({
+        process: processCell.getAsNormalizedFullLink(),
+        reads,
+        writes,
+      });
     if (name) {
       setRunnableName(
         action,
         schedulerJavaScriptActionName(name, processCell, reads, writes),
         { setSrc: true },
       );
-      // Use the RESOLVED implementation `fn` (`resolveByImplRef(module) ?? …`),
-      // not `module.implementation`: an `$implRef`-resolved module (reloaded from
-      // a serialized graph) carries the ref, not the live function, so reading
-      // provenance off `module.implementation` would drop the content-addressed
-      // scheduler identity on reload.
-      this.applyImplementationHash(action, fn);
-      (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
-        schedulerActionInstanceKey({
-          process: processCell.getAsNormalizedFullLink(),
-          reads,
-          writes,
-        });
     }
 
     // Writable arguments alone do not make an output-producing action a

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -129,36 +129,23 @@ type InternalCellDescriptor = {
   link: SigilLink;
 };
 
+// The debug-name builders reuse the action's already-computed
+// `schedulerActionInstanceKey` as their uniquifying suffix instead of hashing
+// the same links a second time (one hashOf per action creation, not two). The
+// name stays per-instance-unique — same-named actions differ in links, so the
+// suffix differs; differently-named actions differ in the prefix.
 function schedulerRawActionName(
   rawTargetName: string,
-  inputCells: readonly NormalizedFullLink[],
-  outputCells: readonly NormalizedFullLink[],
+  instanceKey: string,
 ): string {
-  const identity = hashOf({
-    type: "raw-node",
-    name: rawTargetName,
-    inputs: inputCells.map(schedulerActionLinkIdentity),
-    outputs: outputCells.map(schedulerActionLinkIdentity),
-  }).hashString.slice(0, 12);
-  return `raw:${rawTargetName}:${identity}`;
+  return `raw:${rawTargetName}:${instanceKey}`;
 }
 
 function schedulerJavaScriptActionName(
   actionName: string,
-  processCell: Cell<unknown>,
-  reads: readonly NormalizedFullLink[],
-  writes: readonly NormalizedFullLink[],
+  instanceKey: string,
 ): string {
-  const identity = hashOf({
-    type: "javascript-node",
-    name: actionName,
-    process: schedulerActionLinkIdentity(
-      processCell.getAsNormalizedFullLink(),
-    ),
-    reads: reads.map(schedulerActionLinkIdentity),
-    writes: writes.map(schedulerActionLinkIdentity),
-  }).hashString.slice(0, 12);
-  return `action:${actionName}:${identity}`;
+  return `action:${actionName}:${instanceKey}`;
 }
 
 function schedulerActionLinkIdentity(link: NormalizedFullLink) {
@@ -3597,16 +3584,17 @@ export class Runner {
     // provenance off `module.implementation` would drop the content-addressed
     // scheduler identity on reload.
     this.applyImplementationHash(action, fn);
+    const instanceKey = schedulerActionInstanceKey({
+      process: processCell.getAsNormalizedFullLink(),
+      reads,
+      writes,
+    });
     (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
-      schedulerActionInstanceKey({
-        process: processCell.getAsNormalizedFullLink(),
-        reads,
-        writes,
-      });
+      instanceKey;
     if (name) {
       setRunnableName(
         action,
-        schedulerJavaScriptActionName(name, processCell, reads, writes),
+        schedulerJavaScriptActionName(name, instanceKey),
         { setSrc: true },
       );
     }
@@ -4040,11 +4028,11 @@ export class Runner {
       sanitizeDebugLabel(impl.src) ??
       sanitizeDebugLabel(impl.name) ??
       "anonymous";
-    const rawName = schedulerRawActionName(
-      rawTargetName,
-      inputCells,
-      outputCells,
-    );
+    const rawInstanceKey = schedulerActionInstanceKey({
+      reads: inputCells,
+      writes: outputCells,
+    });
+    const rawName = schedulerRawActionName(rawTargetName, rawInstanceKey);
 
     const action: Action = (tx: IExtendedStorageTransaction) => {
       logger.timeStart("raw", "run", rawTargetName);
@@ -4065,7 +4053,7 @@ export class Runner {
     setRunnableName(action, rawName, { setSrc: true });
     this.applyImplementationHash(action, impl);
     (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
-      schedulerActionInstanceKey({ reads: inputCells, writes: outputCells });
+      rawInstanceKey;
 
     // Seed raw actions with their pattern/module/write metadata so pull-mode
     // scheduling can discover pending computations before their first run.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -28,6 +28,10 @@ import {
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
+import {
+  isEagerSourceAnnotationEnabled,
+  setEagerSourceAnnotation,
+} from "./builder/module.ts";
 import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
 import type {
   ChangeGroup,
@@ -172,6 +176,15 @@ export interface ExperimentalOptions {
   persistentSchedulerState?: boolean | undefined;
   /** Attach origin-committed preconditions to scheduler-v2 lineage commits. */
   commitPreconditions?: boolean | undefined;
+  /**
+   * Eagerly resolve the per-primitive debug source annotation (`fn.src`) at
+   * module evaluation. Debug-only — identity never reads `.src` — and OFF by
+   * default: the resolution (a stack capture + source-map walk per primitive)
+   * is the boot floor's largest single cost (~80ms+ per cold piece boot).
+   * Shell development builds turn it on so `.src` debugging keeps working;
+   * see `setEagerSourceAnnotation` (builder/module.ts).
+   */
+  eagerSourceAnnotation?: boolean | undefined;
 }
 
 /**
@@ -428,6 +441,7 @@ export class Runtime {
       modernCellRep: undefined,
       persistentSchedulerState: undefined,
       commitPreconditions: undefined,
+      eagerSourceAnnotation: undefined,
       ...options.experimental,
     };
 
@@ -455,6 +469,14 @@ export class Runtime {
       getPersistentSchedulerStateConfig();
     setCommitPreconditionsConfig(this.experimental.commitPreconditions);
     this.experimental.commitPreconditions = getCommitPreconditionsConfig();
+    // Unlike the flags above, only propagate when EXPLICITLY set: the ambient
+    // flag is also a test seam (tests toggle `setEagerSourceAnnotation`
+    // directly around runtime construction), and an unconditional
+    // `undefined -> default` write would stomp it.
+    if (this.experimental.eagerSourceAnnotation !== undefined) {
+      setEagerSourceAnnotation(this.experimental.eagerSourceAnnotation);
+    }
+    this.experimental.eagerSourceAnnotation = isEagerSourceAnnotationEnabled();
 
     this.commitBackpressure = resolveCommitBackpressure(
       options.commitBackpressure,

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -199,9 +199,8 @@ function stampDefiningModule(
     // succeeded, and a getter's return value must never receive this module's
     // defining stamp. Real builder factories carry `.implementation` as an own
     // data property, so legitimate artifacts are unaffected.
-    const implementation = typeof value === "function"
-      ? value
-      : Object.getOwnPropertyDescriptor(value, "implementation")?.value;
+    const implementation =
+      Object.getOwnPropertyDescriptor(value, "implementation")?.value ?? value;
     if (typeof implementation === "function") {
       recordDefiningModule(implementation, identity);
     }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -7,6 +7,7 @@ import {
   computeModuleHashes,
   findInternalTarget,
 } from "../harness/module-identity.ts";
+import { recordDefiningModule } from "../harness/verified-provenance.ts";
 import type { VirtualModuleRecord } from "./esm-module-loader.ts";
 
 /**
@@ -165,6 +166,39 @@ export function populateModuleExports(
     moduleExports[name] = hardenExportedValue(writeOnceExports[name]);
   }
   moduleExports.__esModule = true;
+}
+
+/**
+ * Stamp each exported builder-artifact implementation with the DEFINING module's
+ * content identity (`recordDefiningModule`, first-write-wins). Called from a
+ * module's `execute` — which runs in dependency order — so a re-exporting module
+ * (which imports, therefore runs after, its definer) never overwrites the
+ * defining module's stamp. `recordModuleProvenance`'s guard reads this to keep a
+ * re-exporter from stamping its own identity onto a function it did not define
+ * (the `.src`-free replacement for the former canonical-`fn.src` guard).
+ */
+function stampDefiningModule(
+  moduleExports: Record<string, unknown>,
+  identity: string,
+): void {
+  for (const name of Object.keys(moduleExports)) {
+    if (name === "__esModule") continue;
+    const value = moduleExports[name];
+    if (
+      value === null ||
+      (typeof value !== "object" && typeof value !== "function")
+    ) {
+      continue;
+    }
+    // Match what `recordModuleProvenance` keys provenance on: the artifact's
+    // `.implementation` function, or the value itself when it is a function.
+    const implementation =
+      (value as { implementation?: unknown }).implementation ??
+        value;
+    if (typeof implementation === "function") {
+      recordDefiningModule(implementation, identity);
+    }
+  }
 }
 
 /**
@@ -752,6 +786,10 @@ export function compileSourcesToRecords(
         // Reached only if the factory returned normally — commit staged hoist
         // registrations (transactional: a throw above skips this).
         commit();
+        // Stamp the defining module identity on this module's exported artifacts
+        // (dependency-ordered, first-write-wins) so the re-exporter provenance
+        // guard works without reading `.src`.
+        stampDefiningModule(moduleExports, moduleHash);
       },
     });
   }
@@ -974,6 +1012,9 @@ export function buildRecordsFromCompiled(
           register,
         );
         commit();
+        // Stamp the defining module identity (see the cold path above) so the
+        // re-exporter provenance guard works on warm/cached reloads too.
+        stampDefiningModule(moduleExports, m.identity);
       },
     });
   }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -192,9 +192,16 @@ function stampDefiningModule(
     }
     // Match what `recordModuleProvenance` keys provenance on: the artifact's
     // `.implementation` function, or the value itself when it is a function.
-    const implementation =
-      (value as { implementation?: unknown }).implementation ??
-        value;
+    // Read via the OWN data-property descriptor, never a normal get: this walk
+    // runs over every export BEFORE any trust gate, so a plain `.implementation`
+    // read would execute a module-authored accessor during this host-initiated
+    // pass — a throwing getter would fail the module load after its factory
+    // succeeded, and a getter's return value must never receive this module's
+    // defining stamp. Real builder factories carry `.implementation` as an own
+    // data property, so legitimate artifacts are unaffected.
+    const implementation = typeof value === "function"
+      ? value
+      : Object.getOwnPropertyDescriptor(value, "implementation")?.value;
     if (typeof implementation === "function") {
       recordDefiningModule(implementation, identity);
     }

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -23,10 +23,7 @@ import {
   runIdempotencyRecheck,
 } from "./diagnosis.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
-import {
-  contentAddressedActionIdentity,
-  toActionRunTraceAddress,
-} from "./diagnostics.ts";
+import { toActionRunTraceAddress } from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
 import { filterIgnoredAddresses, txToReactivityLog } from "./reactivity.ts";
 import { type ActionTimingState, recordActionTime } from "./timing.ts";
@@ -732,20 +729,14 @@ export function schedulerImplementationFingerprint(
   // `cf:module/<hash>:<symbol>` — stable across reloads, entry points, and TCB
   // upgrades (see docs/specs/content-addressed-action-identity.md). It is
   // deliberately per-SYMBOL (it identifies the implementation code), with NO
-  // per-instance key — unlike the action id (`getSchedulerActionId`). `.src` is
-  // no longer consulted (the prior `src:` fallback depended on the source-map
-  // path).
+  // per-instance key — unlike the action id (`getSchedulerActionId`). It is
+  // read from the stamp set at action creation (`applyImplementationHash`) —
+  // the single identity channel; no re-derivation here, and `.src` is never
+  // consulted (the prior `src:` fallback depended on the source-map path).
   const implementationHash = (action as { implementationHash?: unknown })
     .implementationHash;
   if (typeof implementationHash === "string" && implementationHash.length > 0) {
     return `impl:${implementationHash}`;
-  }
-  // `.src` is no longer consulted for the durable fingerprint; resolve the
-  // content-addressed `{ identity, symbol }` directly (the prior `src:` fallback
-  // depended on the source-map path).
-  const contentId = contentAddressedActionIdentity(action);
-  if (contentId) {
-    return `impl:${contentId}`;
   }
   const telemetryId = schedulerObservationPieceId(actionId, telemetry);
   return `action:${telemetryId}:${actionId}`;

--- a/packages/runner/src/scheduler/diagnostics.ts
+++ b/packages/runner/src/scheduler/diagnostics.ts
@@ -24,68 +24,39 @@ import {
 } from "../sandbox/ses-runtime.ts";
 import type { SchedulerActionInfo } from "../telemetry.ts";
 import { MAX_TRIGGER_TRACE_HISTORY } from "./constants.ts";
-import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
 
 export interface SchedulerActionIdentityState {
   readonly anonymousActionIds: WeakMap<Action | EventHandler, string>;
   anonymousActionCounter: number;
 }
 
-/**
- * Content-addressed action identity — `cf:module/<identity>:<symbol>` resolved
- * from the action's module implementation via the verified-provenance index
- * (populated by `Engine.recordModuleProvenance`). This is `.src`-INDEPENDENT:
- * it does not read the source-location annotation or its source-map resolution,
- * so identity is stable regardless of whether `.src` resolves correctly. The
- * `symbol` (the hoisted `__cfLift_N`/export name) is the within-module
- * discriminator — see docs/specs/content-addressed-action-identity.md (§3 uses
- * the same `{ moduleIdentity, symbol }`). Returns undefined for actions with no
- * verified provenance (host / dynamic / test builders), which fall back to
- * `.name` / a generated id.
- */
-export function contentAddressedActionIdentity(
-  action: Action | EventHandler,
-): string | undefined {
-  const impl = (action as { module?: { implementation?: unknown } }).module
-    ?.implementation;
-  const provenance = getVerifiedProvenance(impl);
-  if (!provenance?.identity) return undefined;
-  return provenance.symbol
-    ? `cf:module/${provenance.identity}:${provenance.symbol}`
-    : `cf:module/${provenance.identity}`;
-}
-
 export function getSchedulerActionId(
   state: SchedulerActionIdentityState,
   action: Action | EventHandler,
 ): string {
-  // Content-addressed identity, consistent with the durable fingerprint
-  // (`schedulerImplementationFingerprint`): a pre-set `implementationHash` (the
-  // spec's stated content key) wins, else `{ identity, symbol }` from provenance.
-  // `.src` is no longer consulted for identity (debug-only; its source-map path
-  // is broken/colliding).
+  // Content-addressed identity is read from the STAMPS set at action creation
+  // (`applyImplementationHash` + `schedulerInstanceKey`, runner.ts) — the
+  // single identity channel; there is deliberately no re-derivation here (a
+  // fallback that reached through `action.module` would silently diverge from
+  // the stamps — it once did, dropping the per-instance key). `.src` is never
+  // consulted (debug-only; its source-map path is broken/colliding).
   //
   // The content address is per-SYMBOL — it identifies the implementation, not
   // the action instance. The action id must stay per-INSTANCE (it keys
-  // `actionStats` and the durable observation), so we append the
-  // source-independent `schedulerInstanceKey` (a hash of the action's
-  // process/reads/writes, set at action creation). Without it, N instances of
-  // one hoisted op (e.g. one `lift` called twice / a `map`) would collide on a
-  // single id. The fingerprint deliberately keeps NO instance key (it is the
-  // per-symbol code identity).
+  // `actionStats` and the durable observation), so the source-independent
+  // `schedulerInstanceKey` (a hash of the action's process/reads/writes) is
+  // appended. Without it, N instances of one hoisted op (e.g. one `lift`
+  // called twice / a `map`) would collide on a single id. The fingerprint
+  // deliberately keeps NO instance key (it is the per-symbol code identity).
   const instanceKey = (action as { schedulerInstanceKey?: unknown })
     .schedulerInstanceKey;
-  const withInstance = (id: string): string =>
-    typeof instanceKey === "string" && instanceKey.length > 0
-      ? `${id}:${instanceKey}`
-      : id;
   const implementationHash =
     (action as { implementationHash?: unknown }).implementationHash;
   if (typeof implementationHash === "string" && implementationHash.length > 0) {
-    return withInstance(implementationHash);
+    return typeof instanceKey === "string" && instanceKey.length > 0
+      ? `${implementationHash}:${instanceKey}`
+      : implementationHash;
   }
-  const contentId = contentAddressedActionIdentity(action);
-  if (contentId) return withInstance(contentId);
   if (action.name && action.name !== "anonymous") return action.name;
 
   const existingId = state.anonymousActionIds.get(action);

--- a/packages/runner/test/action-fingerprint.test.ts
+++ b/packages/runner/test/action-fingerprint.test.ts
@@ -22,15 +22,20 @@ describe("schedulerImplementationFingerprint", () => {
     );
   });
 
-  it("derives a content-addressed impl: id from provenance, NOT from src", () => {
+  it("reads ONLY the creation-time stamp — no re-derivation through action.module", () => {
+    // The stamp (`applyImplementationHash` at action creation) is the single
+    // identity channel. A provenance-carrying `action.module` WITHOUT a stamp
+    // must NOT resolve an impl: fingerprint — the former fallback derivation
+    // silently diverged from the stamps (no instance key on the id side) and
+    // was deleted. Unstamped actions take the telemetry fingerprint.
     const impl = (() => {}) as () => void;
     recordVerifiedProvenance(impl, { identity: "HASH", symbol: "__cfLift_1" });
     const action = makeAction({
       src: "/abc123/pattern.tsx:1:1", // present but must be ignored
-      module: { implementation: impl },
+      module: { implementation: impl }, // provenance present but UNSTAMPED
     });
     expect(schedulerImplementationFingerprint(action, "id", undefined)).toBe(
-      "impl:cf:module/HASH:__cfLift_1",
+      "action:action:id:id",
     );
   });
 

--- a/packages/runner/test/cfc-implementation-identity.test.ts
+++ b/packages/runner/test/cfc-implementation-identity.test.ts
@@ -147,6 +147,8 @@ describe("CFC builtin implementation identity", () => {
     // the only source of `kind: "verified"`. This drives the resolver through
     // the same registration channel the engine uses.
     const implementation = Object.assign(() => undefined, {
+      // `.src` is present but NO LONGER consulted — identity is provenance-only,
+      // so no `sourceLocation` is derived from it.
       src: "cf:module/module-hash-1/main.tsx:4:12",
     });
     recordVerifiedProvenance(implementation, {
@@ -166,7 +168,6 @@ describe("CFC builtin implementation identity", () => {
       symbol: "localFunction",
       sourceFile: "/main.tsx",
       bindingPath: ["localFunction"],
-      sourceLocation: { line: 4, column: 12 },
     });
   });
 
@@ -240,10 +241,14 @@ describe("CFC builtin implementation identity", () => {
     ).toBeUndefined();
   });
 
-  it("fails closed when the canonical source disagrees with the provenance identity", () => {
-    // The provenance analogue of the former out-of-bundle check: a recorded
-    // identity must match the module the function's canonical src points
-    // into; a mismatch is rejected as unsupported rather than guessed at.
+  it("ignores a canonical source that disagrees with the provenance identity", () => {
+    // Re-rooted off `.src`: the former consistency check (src identity ===
+    // provenance identity, else `unsupported`) is GONE. The WeakMap provenance is
+    // the anti-spoof proof and the sole identity source, so a `.src` that points
+    // at a DIFFERENT module — or is garbled/absent, as it will be under lazy
+    // debug-only `.src` — is inert and does NOT downgrade the identity. (An
+    // attacker cannot exploit this: a forged function has no provenance entry at
+    // all and resolves to nothing — see the provenance-less test above.)
     const implementation = Object.assign(() => undefined, {
       src: "cf:module/other-module-hash/other.tsx:4:12",
     });
@@ -253,13 +258,12 @@ describe("CFC builtin implementation identity", () => {
     });
     const module = { type: "javascript" as const };
 
-    expect(
-      resolvePolicyFacingImplementationIdentity(module, { implementation }),
-    ).toEqual({
-      kind: "unsupported",
-      className: "verified",
-      reason:
-        "provenance identity must match the implementation's canonical source",
+    const identity = resolvePolicyFacingImplementationIdentity(module, {
+      implementation,
     });
+    expect(identity?.kind).toBe("verified");
+    expect((identity as { moduleIdentity?: string }).moduleIdentity).toBe(
+      "module-hash-1",
+    );
   });
 });

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -130,19 +130,20 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       expect(identity?.kind).not.toBe("verified");
     });
 
-    it("a forged twin that ALSO steals the real fn's canonical src still gets no provenance", async () => {
+    it("a forged twin carrying a plausible canonical src still gets no provenance", async () => {
       const pattern = await setup();
       const real = handlerModules(pattern)[0]
         .implementation as HarnessedFunction;
-      const stolenSrc = (real as { src?: string }).src!;
-      expect(stolenSrc).toContain("cf:module/");
+      expect(getVerifiedProvenance(real)).toBeDefined();
 
-      // The forged fn carries the genuine canonical src — but src is just an
-      // own-property; verification keys on the provenance WeakMap, which has no
-      // entry for this object.
+      // The forged fn carries a plausible canonical src — but `.src` is just an
+      // own-property (and now identity-inert / debug-only anyway); verification
+      // keys on the provenance WeakMap, which has no entry for this object. (We
+      // fabricate the src rather than read the real one, which is lazy/unset by
+      // default — precisely because src can no longer confer identity.)
       const forged = Object.assign(
         new Function(`return ${Function.prototype.toString.call(real)}`)(),
-        { src: stolenSrc },
+        { src: "cf:module/FORGED_HASH/main.tsx:1:0" },
       ) as HarnessedFunction;
       expect(getVerifiedProvenance(forged)).toBeUndefined();
 
@@ -670,9 +671,19 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     // These probe resolveProvenanceImplementationIdentity directly: we fabricate
     // a provenance entry (the trusted channel's effect) on a function WE control,
     // then mismatch its src. recordVerifiedProvenance is the exact write the real
-    // indexer performs; here we use it to isolate the src↔provenance check.
+    // indexer performs; here we use it to isolate the identity↔src relationship.
+    //
+    // RE-ROOT (workstream C prerequisite): `.src` is no longer consulted for CFC
+    // identity. The WeakMap provenance IS the anti-spoof proof — a function the
+    // attacker controls has NO entry and gets NO identity (see "provenance-less
+    // function stays untrusted"). Since `.src` is attacker-controllable, the
+    // *security* property is that spoofing it is INERT: identity resolves to the
+    // function's REAL provenance module, never the spoofed target, and never
+    // escalates. (The former src-consistency check only ever DOWNGRADED a genuine
+    // identity to `unsupported`; it granted nothing, so dropping it opens no hole
+    // and removes an over-restriction that denied legitimate writes.)
 
-    it("a verified fn whose src names a DIFFERENT module than its provenance fails closed", () => {
+    it("a verified fn whose src names a DIFFERENT module is resolved by PROVENANCE, not the spoofed src", () => {
       const fn = Object.assign(() => undefined, {
         src: "cf:module/REAL_MODULE_A/main.tsx:4:12",
       });
@@ -680,17 +691,22 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
         identity: "REAL_MODULE_A",
         symbol: "ownerHandler",
       });
-      // Now spoof src to claim it belongs to a different (victim) module.
+      // Spoof src to claim it belongs to a different (victim) module.
       (fn as { src: string }).src = "cf:module/VICTIM_MODULE_B/main.tsx:4:12";
 
       const identity = resolvePolicyFacingImplementationIdentity(
         { type: "javascript" } as Module,
         { implementation: fn },
       );
-      expect(identity?.kind).toBe("unsupported");
+      // The spoof is inert: identity is the REAL provenance module (A), never the
+      // spoofed victim (B) — so it can never gain B's write authority.
+      expect(identity?.kind).toBe("verified");
+      const v = identity as { kind: "verified"; moduleIdentity?: string };
+      expect(v.moduleIdentity).toBe("REAL_MODULE_A");
+      expect(v.moduleIdentity).not.toBe("VICTIM_MODULE_B");
     });
 
-    it("a verified fn whose src OMITS the cf:module prefix fails closed (no identity to extract)", () => {
+    it("a verified fn whose src OMITS the cf:module prefix is still resolved by provenance", () => {
       const fn = Object.assign(() => undefined, {
         src: "/main.tsx:4:12", // no cf:module/<hash>/ prefix
       });
@@ -702,11 +718,13 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
         { type: "javascript" } as Module,
         { implementation: fn },
       );
-      // identityFromCanonicalSource("/main.tsx...") is undefined ≠ provenance id.
-      expect(identity?.kind).toBe("unsupported");
+      // `.src` is inert; identity comes from provenance regardless of its shape.
+      expect(identity?.kind).toBe("verified");
+      const v = identity as { kind: "verified"; moduleIdentity?: string };
+      expect(v.moduleIdentity).toBe("SOME_MODULE");
     });
 
-    it("a verified fn whose src matches its provenance resolves verified (check is not vacuous)", () => {
+    it("a verified fn whose src matches its provenance resolves verified", () => {
       const fn = Object.assign(() => undefined, {
         src: "cf:module/CONSISTENT_MODULE/main.tsx:7:3",
       });
@@ -749,7 +767,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       expect(getVerifiedProvenance(fn)!.symbol).toBeUndefined();
     });
 
-    it("a dynamic-provenance fn whose src disagrees with its identity still fails closed", () => {
+    it("a dynamic-provenance fn whose src disagrees with its identity is resolved by provenance (src inert)", () => {
       const fn = Object.assign(() => undefined, {
         src: "cf:module/OTHER_MODULE/main.tsx:2:1",
       });
@@ -758,7 +776,12 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
         { type: "javascript" } as Module,
         { implementation: fn },
       );
-      expect(identity?.kind).toBe("unsupported");
+      // Same as attack 6 for the dynamic path: the spoofed src is inert; identity
+      // is the real (dynamic) provenance module. A dynamic artifact still carries
+      // no symbol, so it has no cross-session $implRef authority (next test).
+      expect(identity?.kind).toBe("verified");
+      const v = identity as { kind: "verified"; moduleIdentity?: string };
+      expect(v.moduleIdentity).toBe("DYN_MODULE");
     });
 
     it("a dynamic artifact (no symbol) serializes without $implRef", async () => {

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -92,10 +92,9 @@ describe("content-addressed action identity", () => {
     // The non-exported `bump` handler registers via the transformer's
     // `__cfReg` hoist; its symbol is the hoist/binding name.
     expect(typeof provenance!.symbol).toBe("string");
-    // The canonical fn.src points into the same module identity.
-    expect((fn as { src?: string }).src ?? "").toContain(
-      `cf:module/${provenance!.identity}`,
-    );
+    // (`fn.src` is no longer asserted here: it is lazy/debug-only and off by
+    // default, and identity no longer depends on it — provenance is the source
+    // of truth above.)
   });
 
   it("serializes javascript modules with $implRef only (no legacy fields)", async () => {
@@ -261,7 +260,10 @@ export default pattern<{ out: string }>(({ out }) => ({
       sourceLocation?: { line: number; column: number };
     };
     expect(verified.moduleIdentity).toBe(getVerifiedProvenance(fn)!.identity);
-    expect(verified.sourceLocation).toBeDefined();
+    // `.src`-derived `sourceLocation` is no longer populated: CFC identity is
+    // re-rooted onto provenance, so no `.src` is read (it can be lazy/absent at
+    // boot). The field stays optional in the type but is not set here.
+    expect(verified.sourceLocation).toBeUndefined();
   });
 
   it("a forged function with identical source fails closed", async () => {

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
+import { setEagerSourceAnnotation } from "../src/builder/module.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
@@ -11,11 +12,14 @@ import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementa
 // Regression: under the ESM module-record loader, a verified handler's
 // `implementation.src` must resolve back to its ORIGINAL authored source
 // (`/main.tsx:line:col`), not the raw concatenated-bundle coordinate
-// (`<evalId>.js:line:col`). Otherwise the CFC provenance src check fails
-// closed (canonical-source mismatch → kind "unsupported"), which breaks every
-// CFC trusted action. The fix composes a per-evaluation bundle source map
+// (`<evalId>.js:line:col`). The fix composes a per-evaluation bundle source map
 // (see composeBundleSourceMap) and registers it so `mapPosition` can translate
 // the coordinate.
+//
+// `.src` is now DEBUG-ONLY (identity was re-rooted off it — see
+// cfc/implementation-identity.ts), and its eager resolution is off by default
+// (the boot lever). So this suite enables it explicitly (beforeEach) to exercise
+// and guard the resolution's correctness for debug-time / on-demand use.
 
 const signer = await Identity.fromPassphrase("test operator");
 
@@ -82,7 +86,12 @@ describe("ESM loader: verified-source location resolution", () => {
     });
   };
 
+  // Source-location resolution is now off by default (debug-only; the boot
+  // lever). This suite exercises that resolution, so enable it here.
+  beforeEach(() => setEagerSourceAnnotation(true));
+
   afterEach(async () => {
+    setEagerSourceAnnotation(false);
     await runtime?.dispose();
     await storageManager?.close();
   });

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -42,6 +42,9 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        // Read back from the ambient flag (a test seam that deliberately does
+        // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
+        eagerSourceAnnotation: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -60,6 +63,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        eagerSourceAnnotation: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -76,6 +80,9 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        // Read back from the ambient flag (a test seam that deliberately does
+        // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
+        eagerSourceAnnotation: false,
       });
       await runtime.dispose();
       await sm.close();

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -58,6 +58,27 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
     expect(ns.default()).toBe(42);
   });
 
+  it("never executes exported accessors during the defining-module stamp", () => {
+    // The stamp walks every export after the factory returns and keys on the
+    // artifact's `.implementation`. It must read the OWN DATA descriptor —
+    // a plain get would run this module-authored accessor during a
+    // host-initiated pass: the throw below would fail the module load AFTER
+    // its factory completed (and a getter's return value could receive the
+    // module's defining stamp).
+    const sources = files({
+      "/hostile.ts": `export const probe = {
+  get implementation(): number {
+    throw new Error("boom: accessor executed during a host pass");
+  },
+};
+export const ok = (): number => 7;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const entry = specifierByPath.get("/hostile.ts")!;
+    const ns = importModuleGraphNow(entry, { records }) as { ok(): number };
+    expect(ns.ok()).toBe(7);
+  });
+
   it("does not let a newline in a source name inject code via sourceURL", () => {
     // A file name with a newline must not break out of the `//# sourceURL=`
     // line comment and execute as code.

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -16,8 +16,8 @@ import {
 import {
   action,
   handler,
-  lift,
   isEagerSourceAnnotationEnabled,
+  lift,
   parseStackFrame,
   resolveSourceLocationFromStack,
   setEagerSourceAnnotation,

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -19,6 +19,7 @@ import {
   isEagerSourceAnnotationEnabled,
   lift,
   parseStackFrame,
+  resolveLocationFromFunctionSource,
   resolveSourceLocationFromStack,
   setEagerSourceAnnotation,
 } from "../src/builder/module.ts";
@@ -426,6 +427,20 @@ describe("module", () => {
   describe("eagerSourceAnnotation runtime option", () => {
     afterEach(() => setEagerSourceAnnotation(false));
 
+    it("annotates the RAW (unmapped) stack location when eager annotation is on", () => {
+      // Builder calls from plain test code have no source map behind them, so
+      // the stack walk takes the raw-resolution arm (`file:line:col` of the
+      // first external frame). On main this arm ran for every unit-test
+      // builder call; with the annotation default-off it is only reachable
+      // through eager-on tests — keep it exercised.
+      setEagerSourceAnnotation(true);
+      const dbl = lift((n: number) => n * 2);
+      const impl = (dbl as unknown as Module).implementation as {
+        src?: string;
+      };
+      expect(impl.src).toMatch(/module\.test\.ts:\d+:\d+$/);
+    });
+
     it("propagates an explicit option to the ambient flag; undefined leaves it alone", async () => {
       const mk = (experimental?: { eagerSourceAnnotation?: boolean }) =>
         new Runtime({
@@ -649,6 +664,78 @@ describe("module", () => {
           testCase.label,
         ).not.toContain("main.tsx:1:23");
       }
+    });
+  });
+
+  describe("resolveLocationFromFunctionSource", () => {
+    // The `indexOf`-into-script path — the eager annotation's fallback when
+    // the stack capture yields nothing (in-worker, SES-censored stacks make
+    // this the MAIN path). Annotation is off by default now, so exercise the
+    // helper directly with an explicit frame.
+    const makeFrame = (script: string, nextSearchOffset = 0) =>
+      ({
+        sourceLocationContext: {
+          filename: "/probe.tsx",
+          script,
+          nextSearchOffset,
+        },
+        runtime: { harness: { mapPosition: () => null } },
+      }) as unknown as Frame;
+
+    it("resolves file:line:col by locating the fn source in the script", () => {
+      const fn = (n: number) => n * 2;
+      const script = `// header line\nconst dbl = ${fn.toString()};\n`;
+      const result = resolveLocationFromFunctionSource(fn, makeFrame(script));
+      expect(result).toBe("/probe.tsx:2:12");
+    });
+
+    it("restarts the scan from the top when the offset overshoots", () => {
+      const fn = (n: number) => n + 1;
+      const script = `const inc = ${fn.toString()};\n// tail`;
+      // nextSearchOffset past the match forces the second indexOf pass.
+      const result = resolveLocationFromFunctionSource(
+        fn,
+        makeFrame(script, script.length - 3),
+      );
+      expect(result).toBe("/probe.tsx:1:12");
+    });
+
+    it("returns null when the source is not in the script or no frame context", () => {
+      const fn = (n: number) => n - 1;
+      expect(resolveLocationFromFunctionSource(fn, makeFrame("// nothing")))
+        .toBe(null);
+      expect(resolveLocationFromFunctionSource(fn, undefined)).toBe(null);
+    });
+
+    it("returns null for an empty fn source", () => {
+      const fn = (n: number) => n;
+      Object.defineProperty(fn, "toString", { value: () => "" });
+      expect(resolveLocationFromFunctionSource(fn, makeFrame("anything")))
+        .toBe(null);
+    });
+
+    it("prefers the source-mapped location when the range maps", () => {
+      const fn = (n: number) => n * 3;
+      const script = `const tri = ${fn.toString()};`;
+      const frame = {
+        sourceLocationContext: {
+          filename: "/probe.tsx",
+          script,
+          nextSearchOffset: 0,
+        },
+        runtime: {
+          harness: {
+            mapPosition: () => ({
+              source: "/authored.tsx",
+              line: 7,
+              column: 3,
+              name: null,
+            }),
+          },
+        },
+      } as unknown as Frame;
+      const result = resolveLocationFromFunctionSource(fn, frame);
+      expect(result).toBe("/authored.tsx:7:3");
     });
   });
 

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -19,6 +19,7 @@ import {
   lift,
   parseStackFrame,
   resolveSourceLocationFromStack,
+  setEagerSourceAnnotation,
 } from "../src/builder/module.ts";
 import { reactive } from "../src/builder/reactive.ts";
 import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
@@ -422,6 +423,11 @@ describe("module", () => {
   });
 
   describe("source location tracking", () => {
+    // Eager source-location resolution is off by default (debug-only; the boot
+    // lever). This block tests that resolution, so enable it here.
+    beforeEach(() => setEagerSourceAnnotation(true));
+    afterEach(() => setEagerSourceAnnotation(false));
+
     const compileMain = async (source: string) => {
       const program = {
         main: "/main.tsx",

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -427,6 +427,16 @@ describe("module", () => {
   describe("eagerSourceAnnotation runtime option", () => {
     afterEach(() => setEagerSourceAnnotation(false));
 
+    it("skips annotation entirely for a non-extensible implementation", () => {
+      // Hardened/frozen fns cannot carry the debug annotation; the annotator
+      // must early-return rather than throw (with eager on OR off).
+      setEagerSourceAnnotation(true);
+      const frozen = Object.freeze((n: number) => n * 5);
+      const fact = lift(frozen);
+      expect(isModule(fact)).toBe(true);
+      expect((frozen as { src?: string }).src).toBe(undefined);
+    });
+
     it("annotates the RAW (unmapped) stack location when eager annotation is on", () => {
       // Builder calls from plain test code have no source map behind them, so
       // the stack walk takes the raw-resolution arm (`file:line:col` of the
@@ -667,11 +677,12 @@ describe("module", () => {
     });
   });
 
-  describe("resolveLocationFromFunctionSource", () => {
-    // The `indexOf`-into-script path — the eager annotation's fallback when
-    // the stack capture yields nothing (in-worker, SES-censored stacks make
-    // this the MAIN path). Annotation is off by default now, so exercise the
-    // helper directly with an explicit frame.
+  describe("source-location resolution helpers (direct)", () => {
+    // Annotation is off by default now, so these arms are only reachable
+    // through eager-on paths — exercise the helpers directly.
+    // resolveLocationFromFunctionSource is the `indexOf`-into-script path,
+    // the eager annotation's fallback when the stack capture yields nothing
+    // (in-worker, SES-censored stacks make it the MAIN path).
     const makeFrame = (script: string, nextSearchOffset = 0) =>
       ({
         sourceLocationContext: {
@@ -705,6 +716,20 @@ describe("module", () => {
       expect(resolveLocationFromFunctionSource(fn, makeFrame("// nothing")))
         .toBe(null);
       expect(resolveLocationFromFunctionSource(fn, undefined)).toBe(null);
+    });
+
+    it("skips unmapped frames from the capturing file itself (thisFile)", () => {
+      // The first parsed frame names the file doing the capture; an unmapped
+      // frame from that same file later in the walk is self-referential and
+      // must be skipped in favor of the first genuinely external frame.
+      const stack = [
+        "Error",
+        "    at capture (/probe/self.ts:10:5)",
+        "    at alsoSelf (/probe/self.ts:11:9)",
+        "    at userCode (/probe/user-code.ts:42:7)",
+      ].join("\n");
+      const result = resolveSourceLocationFromStack(stack, () => null);
+      expect(result.location).toBe("/probe/user-code.ts:42:7");
     });
 
     it("returns null for an empty fn source", () => {

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -17,6 +17,7 @@ import {
   action,
   handler,
   lift,
+  isEagerSourceAnnotationEnabled,
   parseStackFrame,
   resolveSourceLocationFromStack,
   setEagerSourceAnnotation,
@@ -419,6 +420,38 @@ describe("module", () => {
 
       // If we reach here, the types compiled correctly
       expect(true).toBe(true);
+    });
+  });
+
+  describe("eagerSourceAnnotation runtime option", () => {
+    afterEach(() => setEagerSourceAnnotation(false));
+
+    it("propagates an explicit option to the ambient flag; undefined leaves it alone", async () => {
+      const mk = (experimental?: { eagerSourceAnnotation?: boolean }) =>
+        new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+          ...(experimental ? { experimental } : {}),
+        });
+
+      // Explicit true / false propagate (and read back on `experimental`).
+      const on = mk({ eagerSourceAnnotation: true });
+      expect(isEagerSourceAnnotationEnabled()).toBe(true);
+      expect(on.experimental.eagerSourceAnnotation).toBe(true);
+      await on.dispose();
+
+      const off = mk({ eagerSourceAnnotation: false });
+      expect(isEagerSourceAnnotationEnabled()).toBe(false);
+      expect(off.experimental.eagerSourceAnnotation).toBe(false);
+      await off.dispose();
+
+      // Undefined must NOT stomp the ambient flag — it doubles as the test
+      // seam (`setEagerSourceAnnotation` toggled directly around runtimes).
+      setEagerSourceAnnotation(true);
+      const inherit = mk();
+      expect(isEagerSourceAnnotationEnabled()).toBe(true);
+      expect(inherit.experimental.eagerSourceAnnotation).toBe(true);
+      await inherit.dispose();
     });
   });
 

--- a/packages/runner/test/patterns-handlers.test.ts
+++ b/packages/runner/test/patterns-handlers.test.ts
@@ -9,6 +9,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type Cell } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
+import { setEagerSourceAnnotation } from "../src/builder/module.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type ErrorWithContext } from "../src/scheduler.ts";
@@ -46,6 +47,7 @@ describe("Pattern Runner - Handlers", () => {
   });
 
   afterEach(async () => {
+    setEagerSourceAnnotation(false);
     await tx.commit();
     await runtime?.dispose();
     await storageManager?.close();
@@ -127,6 +129,9 @@ describe("Pattern Runner - Handlers", () => {
   });
 
   it("should propagate handler source location to scheduler via .name", async () => {
+    // `.name` source-location propagation is a debug feature; its eager
+    // resolution is off by default (the boot lever), so enable it for this test.
+    setEagerSourceAnnotation(true);
     // Spy on addEventHandler to capture the handler passed to it
     const addEventHandlerSpy = spy(runtime.scheduler, "addEventHandler");
 

--- a/packages/runner/test/reexport-provenance.test.ts
+++ b/packages/runner/test/reexport-provenance.test.ts
@@ -7,6 +7,7 @@ import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementa
 import {
   getDefiningModule,
   getVerifiedProvenance,
+  recordDefiningModule,
 } from "../src/harness/verified-provenance.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
@@ -106,4 +107,18 @@ describe("re-export provenance", () => {
     });
     expect(identity?.kind).toBe("verified");
   });
+});
+
+Deno.test("defining-module stamps: non-function values are ignored; first write wins", () => {
+  // Non-functions never enter the WeakMap (mirrors recordVerifiedProvenance).
+  recordDefiningModule({ not: "a function" }, "MODULE_X");
+  expect(getDefiningModule({ not: "a function" })).toBe(undefined);
+  expect(getDefiningModule("also not")).toBe(undefined);
+
+  // First-write-wins: the defining (dependency-first) module's stamp sticks;
+  // a later re-exporter's stamp is a no-op.
+  const fn = () => {};
+  recordDefiningModule(fn, "DEFINER");
+  recordDefiningModule(fn, "REEXPORTER");
+  expect(getDefiningModule(fn)).toBe("DEFINER");
 });

--- a/packages/runner/test/reexport-provenance.test.ts
+++ b/packages/runner/test/reexport-provenance.test.ts
@@ -4,7 +4,10 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
-import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import {
+  getDefiningModule,
+  getVerifiedProvenance,
+} from "../src/harness/verified-provenance.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
 
@@ -84,16 +87,20 @@ describe("re-export provenance", () => {
     const module = node!.module as Module;
     const fn = module.implementation as HarnessedFunction;
 
-    // Provenance identity matches the function's own canonical source — the
-    // DEFINING module (handlers.tsx), never the re-exporting entry.
+    // Provenance identity is the DEFINING module (handlers.tsx), never the
+    // re-exporting entry. `.src` is now lazy/debug-only, so the guard is
+    // re-rooted onto the defining-module stamp (recorded at each module's
+    // dependency-ordered evaluation): the defining module's stamp equals the
+    // provenance identity that stuck. Under the bug (re-exporter visited first,
+    // no guard) the re-exporter's identity would have stamped provenance instead,
+    // so these would DIFFER.
     const provenance = getVerifiedProvenance(fn);
     expect(provenance).toBeDefined();
-    expect((fn as { src?: string }).src ?? "").toContain(
-      `cf:module/${provenance!.identity}`,
-    );
+    expect(getDefiningModule(fn)).toBe(provenance!.identity);
 
-    // CFC resolves it as verified — NOT unsupported (the bug would have made a
-    // re-exporter's identity stamp it, failing the fn.src consistency check).
+    // CFC resolves it as verified — NOT unsupported. With the wrong (re-exporter)
+    // identity, a `writeAuthorizedBy` claim naming the defining module would be
+    // denied.
     const identity = resolvePolicyFacingImplementationIdentity(module, {
       implementation: fn,
     });

--- a/packages/runner/test/src-garble-identity-invariant.test.ts
+++ b/packages/runner/test/src-garble-identity-invariant.test.ts
@@ -308,3 +308,31 @@ Deno.test(
     expect(garbled).toEqual(baseline);
   },
 );
+
+Deno.test(
+  "multi-instance ids stay per-instance with the eager annotation OFF (production default)",
+  async () => {
+    // THE REGRESSION THIS PINS: with eager annotation off, anonymous arrow
+    // implementations have an empty fn.name, and identity stamping was once
+    // gated behind the name — the stamps were skipped and identity fell to a
+    // per-symbol re-derivation with NO instance key, silently collapsing two
+    // instances of one lift onto one durable observation (and one actionStats
+    // entry, mis-tuning auto-debounce for maps/repeated ops). Stamping is now
+    // unconditional and the fallback derivation is deleted, so the DEFAULT
+    // (annotation-off) state must produce the same per-instance shape the
+    // eager-on test above pins.
+    const observations = await runMultiAndCollect(
+      StorageManager.emulate({ as: signer }),
+    );
+
+    expect(observations.length).toBe(2);
+    expect(new Set(observations.map((o) => o.actionId)).size).toBe(2);
+    for (const { actionId, fingerprint } of observations) {
+      // Per-instance id: content address + `:dbl` symbol + instance suffix.
+      expect(actionId).toMatch(/^cf:module\/[^:]+:dbl:[^:]+$/);
+      // Per-symbol fingerprint: NO instance suffix, shared by both instances.
+      expect(fingerprint).toMatch(/^impl:cf:module\/[^:]+:dbl$/);
+    }
+    expect(new Set(observations.map((o) => o.fingerprint)).size).toBe(1);
+  },
+);

--- a/packages/runner/test/src-garble-identity-invariant.test.ts
+++ b/packages/runner/test/src-garble-identity-invariant.test.ts
@@ -5,7 +5,10 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 import type { Module } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
-import { __setSrcAnnotationTransformForTest } from "../src/builder/module.ts";
+import {
+  __setSrcAnnotationTransformForTest,
+  setEagerSourceAnnotation,
+} from "../src/builder/module.ts";
 import { recordVerifiedProvenance } from "../src/harness/verified-provenance.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
 
@@ -27,14 +30,14 @@ import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementa
 // garble is in effect during module eval + action creation — any `.src` -> id
 // path *anywhere* in the pipeline makes the two runs diverge loudly.
 //
-// THE BOUNDARY (second test): B re-rooted the SCHEDULER action layer only. CFC
-// verified-implementation identity (resolveProvenanceImplementationIdentity,
-// which feeds `writeAuthorizedBy`) STILL consults `.src` as a fail-closed
-// consistency check, so garbling `.src` flips it `verified` -> `unsupported`.
-// That is the remaining `.src` dependency the red-team pass must bless and that
-// the lazy/debug-only `.src` follow-up (workstream C) must re-root before `.src`
-// can be deferred. This test characterizes that boundary so a future "make
-// `.src` lazy" change trips a loud, self-documenting failure here.
+// THE BOUNDARY (second test): CFC verified-implementation identity
+// (resolveProvenanceImplementationIdentity, which feeds `writeAuthorizedBy`) is
+// now ALSO `.src`-independent — re-rooted off `.src` onto the WeakMap provenance
+// (the anti-spoof proof) so lazy/debug-only `.src` (skipped at boot) cannot deny
+// authorized writes. Garbling OR removing `.src` must keep identity `verified`
+// with the same moduleIdentity. This test characterizes that boundary so a future
+// change that re-introduces a `.src` dependency in CFC identity trips a loud,
+// self-documenting failure here.
 //
 // See docs/specs/content-addressed-action-identity.md and
 // packages/patterns/lunch-poll/perf-seed/B-IDENTITY-REROOT-HANDOFF.md.
@@ -137,6 +140,9 @@ async function runAndCollect(
 Deno.test(
   "scheduler action ids + fingerprints are byte-identical with .src garbled",
   async () => {
+    // This harness exercises the annotation path — enable the (default-off)
+    // eager source-location resolution so `.src` is actually written + garbled.
+    setEagerSourceAnnotation(true);
     // Baseline: real `.src`.
     const baseline = await runAndCollect(
       StorageManager.emulate({ as: signer }),
@@ -168,6 +174,7 @@ Deno.test(
       garbled = await runAndCollect(StorageManager.emulate({ as: signer }));
     } finally {
       __setSrcAnnotationTransformForTest(undefined);
+      setEagerSourceAnnotation(false);
     }
 
     // The whole point: identity did not move.
@@ -178,35 +185,44 @@ Deno.test(
 );
 
 Deno.test(
-  "BOUNDARY: CFC verified-implementation identity still fail-closes on .src",
+  "BOUNDARY: CFC verified-implementation identity is .src-independent",
   () => {
-    // This documents the remaining `.src` dependency B did NOT remove: CFC
-    // verified-source identity (the `writeAuthorizedBy` arm) reads `.src` as a
-    // fail-closed consistency check. It is NOT part of the scheduler-identity
-    // invariant above — and it is the gate workstream C (lazy `.src`) must
-    // re-root first. If a future change makes `.src` lazy without re-rooting
-    // this check, this test trips.
+    // Part B (workstream C prerequisite) re-rooted CFC verified-source identity
+    // OFF `.src`: the WeakMap provenance lookup IS the anti-spoof proof, and every
+    // field the `writeAuthorizedBy` arm checks (moduleIdentity / sourceFile /
+    // bindingPath) is provenance-derived. So garbling or REMOVING `.src` must NOT
+    // change the resolved identity — that is exactly what makes lazy/debug-only
+    // `.src` (skipped at boot) safe for authorized writes. If a future change
+    // re-introduces a `.src` dependency in CFC identity, this test trips.
     const impl = (() => {}) as unknown as HarnessedFunction;
     recordVerifiedProvenance(impl, { identity: "HASH", symbol: "__cfLift_1" });
 
+    const resolve = () =>
+      resolvePolicyFacingImplementationIdentity({} as Module, {
+        implementation: impl,
+      });
+
     // Canonical `.src` pointing into the provenance module => verified.
     (impl as { src?: string }).src = "cf:module/HASH/main.tsx:3:20";
-    const verified = resolvePolicyFacingImplementationIdentity(
-      {} as Module,
-      { implementation: impl },
-    );
-    expect(verified?.kind).toBe("verified");
-    expect((verified as { moduleIdentity?: string }).moduleIdentity).toBe(
+    const canonical = resolve();
+    expect(canonical?.kind).toBe("verified");
+    expect((canonical as { moduleIdentity?: string }).moduleIdentity).toBe(
       "HASH",
     );
 
-    // Garbled `.src` => CFC fails closed (NOT byte-identical, by design).
+    // Garbled `.src` => STILL verified, same identity (`.src` is identity-inert).
     (impl as { src?: string }).src = "GARBLED-SRC";
-    const garbled = resolvePolicyFacingImplementationIdentity(
-      {} as Module,
-      { implementation: impl },
+    const garbled = resolve();
+    expect(garbled?.kind).toBe("verified");
+    expect((garbled as { moduleIdentity?: string }).moduleIdentity).toBe(
+      "HASH",
     );
-    expect(garbled?.kind).toBe("unsupported");
+
+    // Absent `.src` (the lazy/debug-only boot state) => STILL verified.
+    delete (impl as { src?: string }).src;
+    const absent = resolve();
+    expect(absent?.kind).toBe("verified");
+    expect((absent as { moduleIdentity?: string }).moduleIdentity).toBe("HASH");
   },
 );
 
@@ -259,6 +275,7 @@ async function runMultiAndCollect(
 Deno.test(
   "two instances of one lift get DISTINCT per-instance ids (no collision), .src-independent",
   async () => {
+    setEagerSourceAnnotation(true);
     const baseline = await runMultiAndCollect(
       StorageManager.emulate({ as: signer }),
     );
@@ -286,6 +303,7 @@ Deno.test(
       );
     } finally {
       __setSrcAnnotationTransformForTest(undefined);
+      setEagerSourceAnnotation(false);
     }
     expect(garbled).toEqual(baseline);
   },

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -152,6 +152,7 @@ export interface InitializationData {
   experimental?: {
     modernCellRep?: boolean;
     persistentSchedulerState?: boolean;
+    eagerSourceAnnotation?: boolean;
   };
   // Commit-boundary CFC mode for the worker runtime.
   cfcEnforcementMode?:

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -49,6 +49,9 @@ const config: Config = {
       "$EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE": Deno.env.get(
         "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
       ),
+      "$EXPERIMENTAL_EAGER_SOURCE_ANNOTATION": Deno.env.get(
+        "EXPERIMENTAL_EAGER_SOURCE_ANNOTATION",
+      ),
       "globalThis.__cfCompileCacheRuntimeVersion":
         COMPILE_CACHE_RUNTIME_VERSION,
     },

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -53,6 +53,7 @@ export const EXPERIMENTAL = {
   // Debug `.src` source annotation: ON in development builds (so per-primitive
   // source locations keep working for debugging), OFF in production (it is the
   // boot floor's largest single cost). The define overrides either way.
-  eagerSourceAnnotation: flagValue(EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE) ??
-    (ENVIRONMENT === "development"),
+  eagerSourceAnnotation:
+    flagValue(EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE) ??
+      (ENVIRONMENT === "development"),
 };

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -4,6 +4,7 @@ declare global {
   var $COMMIT_SHA: string | undefined;
   var $EXPERIMENTAL_MODERN_CELL_REP: string | undefined;
   var $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: string | undefined;
+  var $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: string | undefined;
 }
 
 const ENVIRONMENT_DEFINE = typeof $ENVIRONMENT === "string"
@@ -20,6 +21,10 @@ const EXPERIMENTAL_MODERN_CELL_REP_DEFINE =
 const EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE =
   typeof $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE === "string"
     ? $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE
+    : undefined;
+const EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE =
+  typeof $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION === "string"
+    ? $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION
     : undefined;
 
 export const ENVIRONMENT: "development" | "production" =
@@ -45,4 +50,9 @@ export const EXPERIMENTAL = {
   persistentSchedulerState: flagValue(
     EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE,
   ),
+  // Debug `.src` source annotation: ON in development builds (so per-primitive
+  // source locations keep working for debugging), OFF in production (it is the
+  // boot floor's largest single cost). The define overrides either way.
+  eagerSourceAnnotation: flagValue(EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE) ??
+    (ENVIRONMENT === "development"),
 };

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -35,11 +35,39 @@ Deno.test({
       $API_URL: "http://shell.test/",
       $EXPERIMENTAL_MODERN_CELL_REP: "true",
       $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "true",
+      // Explicit define overrides the environment-derived default (this
+      // unpatched module resolves ENVIRONMENT=development, whose default
+      // would otherwise be true).
+      $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: "false",
     }, importFreshEnvModule);
 
     expect(mod.EXPERIMENTAL).toEqual({
       modernCellRep: true,
       persistentSchedulerState: true,
+      eagerSourceAnnotation: false,
     });
+  },
+});
+
+Deno.test({
+  name: "eagerSourceAnnotation defaults from the build environment",
+  permissions: { read: true },
+  async fn() {
+    // Development (the default when $ENVIRONMENT is unset): debug `.src`
+    // annotation ON so local debugging keeps per-primitive source locations.
+    const dev = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: undefined,
+    }, importFreshEnvModule);
+    expect(dev.EXPERIMENTAL.eagerSourceAnnotation).toBe(true);
+
+    // Production: OFF — the eager resolution is the boot floor's largest
+    // single cost.
+    const prod = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $ENVIRONMENT: "production",
+      $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: undefined,
+    }, importFreshEnvModule);
+    expect(prod.EXPERIMENTAL.eagerSourceAnnotation).toBe(false);
   },
 });

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { EnvSchema } from "@/env.ts";
+import { EnvSchema, runtimeExperimentalOptions } from "@/env.ts";
 
 // Regression guard for the z.coerce.boolean() footgun: Boolean("false") === true,
 // which would silently enable telemetry (and, with the all-span exporter, ship
@@ -36,4 +36,27 @@ Deno.test("DISABLE_LOG_REQ_RES / PLAID_SYNC_ALL_TRANSACTIONS parse strictly", ()
     assertEquals(flag(key, "0"), false);
     assertEquals(flag(key, undefined), false);
   }
+});
+
+Deno.test("runtimeExperimentalOptions maps env flags with tri-state fidelity", () => {
+  const base = EnvSchema.parse({});
+  // Unset flags stay undefined — the runner distinguishes "unset" from an
+  // explicit false (an unset eagerSourceAnnotation must not stomp the
+  // runner's ambient default).
+  assertEquals(runtimeExperimentalOptions(base), {
+    modernCellRep: undefined,
+    persistentSchedulerState: undefined,
+    eagerSourceAnnotation: undefined,
+  });
+
+  const explicit = EnvSchema.parse({
+    EXPERIMENTAL_MODERN_CELL_REP: "true",
+    EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "false",
+    EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: "true",
+  });
+  assertEquals(runtimeExperimentalOptions(explicit), {
+    modernCellRep: true,
+    persistentSchedulerState: false,
+    eagerSourceAnnotation: true,
+  });
 });

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -280,6 +280,26 @@ export const EnvSchema = z.object({
 
 export type env = z.infer<typeof EnvSchema>;
 
+/**
+ * The runner `ExperimentalOptions` derived from the environment flags —
+ * assembled here rather than inline in the server entrypoint so the
+ * env → option mapping is unit-testable. Tri-state semantics matter: an
+ * unset flag must stay `undefined` (the runner distinguishes "unset" from an
+ * explicit false — e.g. an explicit `eagerSourceAnnotation` overrides the
+ * runner's ambient default, an unset one leaves it alone).
+ */
+export function runtimeExperimentalOptions(e: env): {
+  modernCellRep?: boolean;
+  persistentSchedulerState?: boolean;
+  eagerSourceAnnotation?: boolean;
+} {
+  return {
+    modernCellRep: e.EXPERIMENTAL_MODERN_CELL_REP,
+    persistentSchedulerState: e.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
+    eagerSourceAnnotation: e.EXPERIMENTAL_EAGER_SOURCE_ANNOTATION,
+  };
+}
+
 // CLI args override env vars (needed for --watch compatibility)
 const cliOverrides = parseCliArgs();
 const { data: env, error } = EnvSchema.safeParse({

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -259,6 +259,7 @@ export const EnvSchema = z.object({
   // ===========================================================================
   EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
+  EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: flagValue(),
 
   // Git SHA of the deployed commit. Set at deploy time; takes priority over
   // the build-baked SHA (see lib/build-info.ts).

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,5 +1,5 @@
 import app from "@/app.ts";
-import env from "@/env.ts";
+import env, { runtimeExperimentalOptions } from "@/env.ts";
 import { identity } from "@/lib/identity.ts";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -25,11 +25,7 @@ const initializeRuntime = () => {
         memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
-      experimental: {
-        modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
-        persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
-        eagerSourceAnnotation: env.EXPERIMENTAL_EAGER_SOURCE_ANNOTATION,
-      },
+      experimental: runtimeExperimentalOptions(env),
     });
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -28,6 +28,7 @@ const initializeRuntime = () => {
       experimental: {
         modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
         persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
+        eagerSourceAnnotation: env.EXPERIMENTAL_EAGER_SOURCE_ANNOTATION,
       },
     });
     console.log("Runtime initialized successfully");


### PR DESCRIPTION
## What & why

Pulls per-primitive **source-location resolution off the cold-load critical path** — the #1 boot-floor lever (~83ms across the full system-app module graph: `getExternalSourceLocation`'s `new Error().stack` capture per primitive + the source-map walk in `resolveLocationFromFunctionSource`). The short-circuit experiment (perf-seed) measured trivial-pattern settle **~662 → ~579ms** with this annotation off.

That cost is only safe to skip once nothing load-bearing reads `fn.src`. `.src`/`.location` is already **debug-only / inert** per `docs/specs/content-addressed-action-identity.md`, and #4436 made scheduler identity content-addressed. This PR completes that principle: it re-roots the **two remaining `.src` readers on the identity/security path** onto content-addressed provenance, then gates the eager resolution behind a default-off flag.

~~Stacked on #4436~~ — #4436 merged; this PR now targets `main` directly.

## The three coupled changes

1. **CFC verified-identity re-root** — `cfc/implementation-identity.ts`, `resolveProvenanceImplementationIdentity`.
   Drops the `.src` read and the former fail-closed check `identityFromCanonicalSource(src) === provenance.identity`. `kind: "verified"` is now proven **solely by the `getVerifiedProvenance` WeakMap**; `moduleIdentity` / `symbol` / `sourceFile` / `bindingPath` are all provenance-derived. The `.src`-derived `sourceLocation` field (read by no production consumer — only a test assertion) is removed.

2. **Re-exporter provenance guard re-root** — `harness/engine.ts` `recordModuleProvenance`, `harness/verified-provenance.ts` (new `definingModuleByFn` WeakMap + `recordDefiningModule`/`getDefiningModule`), `sandbox/module-record-compiler.ts` (new `stampDefiningModule`, called in **both** `execute` paths after `populateModuleExports`).
   The guard that keeps a re-exported handler bound to its **defining** module (so its `writeAuthorizedBy` claims match) used to rely on canonical `fn.src`. It now uses a defining-module stamp recorded at each module's **dependency-ordered** evaluation (first-write-wins), so the definer — which a re-exporter imports, hence runs after — always wins. This was surfaced by the runner suite when `.src` went lazy; without it, a re-exported `writeAuthorizedBy` handler would take the *re-exporter's* identity and its writes would be denied.

3. **Gate the eager annotation** — `builder/module.ts` `annotateFunctionDebugMetadata`.
   The source-location resolution is now behind a default-**off** `setEagerSourceAnnotation(true)` flag; `.preview` (a cheap `fn.toString` slice) is still set. This is what banks the ~83ms.

## Post-review fixups (2026-07-02, on the rebased head)

1. **Unconditional identity stamping + fallback deletion (the substantive one).** Review found that with the annotation off — the default this PR introduces — anonymous arrow implementations have an empty `fn.name`, so the `if (name)` gate at the JS-action site skipped the identity stamps, and identity silently fell to a per-symbol re-derivation through `action.module` with NO instance key — re-opening the multi-instance collision #4436 closed (demonstrated: two instances of one `lift` → ONE durable observation, and one shared `actionStats` entry mis-tuning auto-debounce for maps). Stamps now apply unconditionally, and the re-derivation (`contentAddressedActionIdentity` + both consumer arms) is **deleted** rather than repaired — it was unreachable in #4436-as-merged, only this gating bug ever made it live, and two derivations of one identity selected by an unrelated debug flag is exactly the failure shape to remove. One channel: stamp at creation, read the stamp. Pinned by an annotation-OFF multi-instance regression test.
2. **Dev-mode `.src` enablement (resolves open question 3).** `ExperimentalOptions.eagerSourceAnnotation`, threaded shell → runtime-client protocol → worker runtime, plus toolshed / background-piece-service / cf CLI env passthrough. Shell **development builds default ON** (local debugging keeps `.src` with zero action), production stays off; `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` overrides either way. The Runtime constructor only propagates an explicit option, so the ambient flag keeps doubling as the test seam.
3. **One hash per action creation** — the debug-name builders reuse the already-computed instance key instead of hashing the same links twice.
4. **Dropped `ImplementationIdentity.sourceLocation`** — written nowhere after the re-root; repo-wide sweep found no readers.

## Security considerations (please scrutinize)

- **Dropping the CFC `.src` check is safe because it was defense-in-depth, not the boundary.** The WeakMap lookup *is* the anti-spoof proof — an attacker-supplied function (even byte-identical source) was never registered during a verified evaluation, so it has no entry. The `.src` check only ever *downgraded* a genuine identity to `unsupported`; it granted nothing. `writeAuthorizedByReason` (`cfc/prepare.ts`) compares provenance-derived `moduleIdentity` / `sourceFile` / `bindingPath` — never `.src`. A spoofed `.src` is now **inert**: identity resolves to the fn's *real* provenance module, never the spoofed target (adversarial test "attack 6").

- **The re-export guard trades `.src`-dependence for eval-order-dependence.** This is the deliberate design change most worth your eye. It's robust in the normal (acyclic) case — a re-exporter imports its definer, so the definer's `execute` (and its stamp) completes first; the stamp runs *after* `populateModuleExports` (i.e. after the factory's nested `require`s), so the definer always stamps before any re-exporter. Even in import cycles you can't re-export a builder that isn't defined yet. Unstamped functions (host/runtime/dynamic) leave the guard a no-op, and `isTrustedBuilderArtifact` + fail-closed-on-no-provenance keep forged values out. Worst case is availability (a mislabeled handler's writes denied), never escalation.

- **Adversarial red-team pass**: 5 independent lenses / 14 attack scenarios (CFC spoof, guard gaming, availability false-negative, dynamic/host artifacts, residual `.src` readers). Two candidate breaks (a circular-import stamp race; scheduler-observation loss) were both **refuted** by independent verifiers — the stamp-after-factory ordering defeats the race, and scheduler identity is already `.src`-independent. **0 confirmed breaks.** This is a pre-check, not a substitute for your review.

## Verification

- runner suite **755 / 0** (at the rebased + fixed-up head)
- `deno task integration pattern-tests` + `generated-patterns` — green at the same head (the runtime gate)
- whole-workspace `deno task check`, `deno fmt --check`, `deno lint` — all clean
- the `src-garble-identity-invariant` harness asserts identity (scheduler **and** CFC) is byte-identical under garbled/absent `.src`; its BOUNDARY test now asserts CFC stays `verified` under `.src` garble/absence (previously asserted it flipped to `unsupported` — that dependency is what this PR removes).

## Open questions for review

1. Bless dropping the CFC `.src` consistency check (WeakMap-only verified identity)?
2. Bless the re-export guard's move from canonical-`fn.src` to the dependency-ordered defining-module stamp — in particular the eval-order reasoning for cycles?
3. ~~Module-level flag vs per-runtime option~~ — resolved by fixup 2: `ExperimentalOptions.eagerSourceAnnotation` with dev-build default-on.

Follow-on (separate stacked PR): **A′** — inject the authored source location at transform time so debug `.src` is correct + free when enabled, letting the eager runtime resolution (and its broken cheap path) be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `.src` lazy and debug-only to shave ~83ms off cold boot, and fully re-roots action and CFC identity on content‑addressed provenance. Dev builds keep `.src` on for local debugging; identity stamps are set unconditionally and names reuse the instance key.

- **New Features**
  - Gate source annotation with `setEagerSourceAnnotation(true)`; exposed as `Runtime.experimental.eagerSourceAnnotation` and `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`. Defaults: `shell` development ON, production OFF; wired through `shell`, `runtime-client` protocol, `toolshed`, `background-piece-service`, and `CLI`. The Runtime only propagates an explicit option.
  - Provenance-only identity: CFC drops the `.src` consistency check and the `.src`-derived `sourceLocation` field. Verified identity is proven solely by the WeakMap provenance.
  - Re-export guard without `.src`: stamp a defining-module id at module eval (first‑write‑wins) in the module-record compiler; the harness guard reads this stamp to ensure the defining module’s identity sticks.

- **Bug Fixes**
  - One identity channel: stamp `implementationHash` and per‑instance `schedulerInstanceKey` at action creation unconditionally; delete the fallback re-derivation and any `.src` use. Scheduler ids/fingerprints now read only these stamps, preventing multi‑instance collisions when annotation is off.
  - Guard hardening: read `.implementation` via its own data-property descriptor to avoid executing accessors during host passes, and stamp the implementation (not the factory). Debug names now reuse the instance key (one hash per action).

<sup>Written for commit b9922347d616c7f8ca31ebc74e33409ab0db7944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

