### PR TITLE
perf(runner): defer the TypeScript compiler stack off the worker boot path (cold-load bucket #6)

### DIFF
--- a/packages/js-compiler/deno.jsonc
+++ b/packages/js-compiler/deno.jsonc
@@ -11,7 +11,12 @@
     ".": "./mod.ts",
     "./interface": "./interface.ts",
     "./typescript": "./typescript/mod.ts",
-    "./source-map": "./source-map.ts"
+    "./source-map": "./source-map.ts",
+    // Typescript-free entries for runtime consumers: the worker bundle must
+    // not initialize the compiler at boot (see the runner's compiler-stack).
+    "./program": "./program.ts",
+    "./specifier": "./specifier.ts",
+    "./errors": "./typescript/diagnostics/errors.ts"
   },
   "fmt": {
     "exclude": ["test/fixtures/"]

--- a/packages/js-compiler/specifier.ts
+++ b/packages/js-compiler/specifier.ts
@@ -1,0 +1,23 @@
+import { dirname, join } from "@std/path/posix";
+import type { Source } from "./interface.ts";
+
+/**
+ * Resolve an import specifier relative to the importing source's path.
+ * Relative specifiers (`./`, `../`) are joined against the importer's
+ * directory; bare specifiers (e.g. `commonfabric`) are returned unchanged.
+ *
+ * Lives outside `typescript/resolver.ts` so runtime consumers (the worker's
+ * module-record path) can import it without a static edge into the TypeScript
+ * compiler — this module must stay free of `typescript` value imports.
+ */
+export function resolveImportSpecifier(
+  specifier: string,
+  from: Source,
+): string {
+  if (
+    specifier.substring(0, 2) === "./" || specifier.substring(0, 3) === "../"
+  ) {
+    return join(dirname(from.name), specifier);
+  }
+  return specifier;
+}

--- a/packages/js-compiler/test/typescript.errors.test.ts
+++ b/packages/js-compiler/test/typescript.errors.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import ts, { type DiagnosticMessageChain } from "typescript";
+import {
+  CompilationError,
+  type DiagnosticMessageTransformer,
+} from "../typescript/diagnostics/errors.ts";
+
+// errors.ts keeps a local mirror of `ts.flattenDiagnosticMessageText` so the
+// module stays free of typescript value imports (it is boot-eager in the
+// runtime worker). These tests pin the mirror to the real thing.
+
+function chainDiagnostic(
+  messageText: string | DiagnosticMessageChain,
+): ts.Diagnostic {
+  return {
+    category: ts.DiagnosticCategory.Error,
+    code: 1,
+    file: undefined,
+    start: undefined,
+    length: undefined,
+    messageText,
+  };
+}
+
+describe("CompilationError message flattening", () => {
+  it("flattens nested message chains byte-identically to typescript", () => {
+    const chain: DiagnosticMessageChain = {
+      messageText: "Type 'A' is not assignable to type 'B'.",
+      category: ts.DiagnosticCategory.Error,
+      code: 2322,
+      next: [
+        {
+          messageText: "Types of property 'x' are incompatible.",
+          category: ts.DiagnosticCategory.Error,
+          code: 2326,
+          next: [
+            {
+              messageText: "Type 'string' is not assignable to type 'number'.",
+              category: ts.DiagnosticCategory.Error,
+              code: 2322,
+            },
+            {
+              messageText: "A sibling elaboration at the same depth.",
+              category: ts.DiagnosticCategory.Message,
+              code: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const error = new CompilationError({ diagnostic: chainDiagnostic(chain) });
+    expect(error.message).toBe(ts.flattenDiagnosticMessageText(chain, "\n"));
+    expect(error.type).toBe("ERROR");
+  });
+
+  it("passes plain string messages through and classifies module-not-found", () => {
+    const plain = new CompilationError({
+      diagnostic: chainDiagnostic("Cannot find module './missing.ts'."),
+    });
+    expect(plain.type).toBe("MODULE_NOT_FOUND");
+    expect(plain.message).toBe("Cannot find module './missing.ts'.");
+  });
+
+  it("applies a message transformer over the flattened text", () => {
+    const transformer: DiagnosticMessageTransformer = {
+      transform: (message) =>
+        message.includes("assignable") ? `friendly: ${message}` : null,
+    };
+    const chain: DiagnosticMessageChain = {
+      messageText: "Type 'A' is not assignable to type 'B'.",
+      category: ts.DiagnosticCategory.Error,
+      code: 2322,
+    };
+    const error = new CompilationError(
+      { diagnostic: chainDiagnostic(chain) },
+      transformer,
+    );
+    expect(error.message).toBe(
+      `friendly: ${ts.flattenDiagnosticMessageText(chain, "\n")}`,
+    );
+  });
+});

--- a/packages/js-compiler/typescript/diagnostics/errors.ts
+++ b/packages/js-compiler/typescript/diagnostics/errors.ts
@@ -1,5 +1,35 @@
-import ts, { type Diagnostic, DiagnosticMessageChain } from "typescript";
+// Type-only: this module is boot-eager in the runtime worker (CompilerError is
+// the `instanceof` contract for compile failures, imported by runner builtins),
+// so it must not carry a value edge into the TypeScript compiler.
+import type { Diagnostic, DiagnosticMessageChain } from "typescript";
 import { renderInline } from "./render.ts";
+
+/**
+ * Mirror of `ts.flattenDiagnosticMessageText` (same output, byte for byte):
+ * a chain node renders its text at two spaces per indent level, children one
+ * level deeper. Local so this module stays typescript-value-free (above).
+ */
+function flattenDiagnosticMessageText(
+  diag: string | DiagnosticMessageChain | undefined,
+  newLine: string,
+  indent = 0,
+): string {
+  if (typeof diag === "string") return diag;
+  if (diag === undefined) return "";
+  let result = "";
+  if (indent) {
+    result += newLine;
+    for (let i = 0; i < indent; i++) result += "  ";
+  }
+  result += diag.messageText;
+  indent++;
+  if (diag.next) {
+    for (const kid of diag.next) {
+      result += flattenDiagnosticMessageText(kid, newLine, indent);
+    }
+  }
+  return result;
+}
 
 /**
  * Interface for transforming diagnostic error messages.
@@ -73,7 +103,7 @@ export class CompilationError {
     input: string | DiagnosticMessageChain,
     messageTransformer?: DiagnosticMessageTransformer,
   ): { type: CompilationErrorType; message: string } {
-    const message = ts.flattenDiagnosticMessageText(input, "\n");
+    const message = flattenDiagnosticMessageText(input, "\n");
 
     // Apply custom message transformer if configured
     if (messageTransformer) {

--- a/packages/js-compiler/typescript/resolver.ts
+++ b/packages/js-compiler/typescript/resolver.ts
@@ -1,6 +1,5 @@
 import ts from "typescript";
 import { Program, ProgramResolver, Source } from "../interface.ts";
-import { dirname, join } from "@std/path/posix";
 
 export type UnresolvedModuleHandling =
   | { type: "allow"; identifiers: string[] }
@@ -82,26 +81,11 @@ function isUnresolvedModuleOk(
   }
 }
 
-/**
- * Resolve an import specifier relative to the importing source's path.
- * Relative specifiers (`./`, `../`) are joined against the importer's
- * directory; bare specifiers (e.g. `commonfabric`) are returned unchanged.
- */
-export function resolveImportSpecifier(
-  specifier: string,
-  from: Source,
-): string {
-  return resolveSpecifier(specifier, from);
-}
-
-function resolveSpecifier(specifier: string, from: Source): string {
-  if (
-    specifier.substring(0, 2) === "./" || specifier.substring(0, 3) === "../"
-  ) {
-    return join(dirname(from.name), specifier);
-  }
-  return specifier;
-}
+// Moved to `../specifier.ts` (typescript-free) so runtime consumers can use it
+// without pulling the compiler into their bundle; re-exported here for the
+// existing compile-path importers.
+export { resolveImportSpecifier } from "../specifier.ts";
+import { resolveImportSpecifier as resolveSpecifier } from "../specifier.ts";
 
 /**
  * Collect every import/`export … from` specifier referenced by a source file,

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -14,7 +14,7 @@ import { PieceManager } from "../index.ts";
 import { PieceController } from "./piece-controller.ts";
 import { compileProgram } from "./utils.ts";
 import { createSession, Identity } from "@commonfabric/identity";
-import { HttpProgramResolver } from "@commonfabric/js-compiler";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { ACLManager } from "./acl-manager.ts";
 import { homeSchema } from "@commonfabric/home-schemas";
 

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -5,7 +5,7 @@ import { type Action } from "../scheduler.ts";
 import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Program } from "@commonfabric/js-compiler";
-import { CompilerError } from "@commonfabric/js-compiler/typescript";
+import { CompilerError } from "@commonfabric/js-compiler/errors";
 import type { CellScope } from "../builder/types.ts";
 import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
 import { narrowestScope } from "../scope.ts";

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -4,8 +4,8 @@ import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { CellScope } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { HttpProgramResolver } from "@commonfabric/js-compiler";
-import { resolveProgram, TARGET } from "@commonfabric/js-compiler/typescript";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
+import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { computeInputHashFromValue } from "./fetch-utils.ts";
@@ -340,11 +340,14 @@ async function startFetch(
     // Create HTTP program resolver
     const resolver = new HttpProgramResolver(url);
 
+    // Program resolution parses; load the deferred compiler stack first.
+    const { resolveProgram, ts } = await ensureCompilerStack();
+
     // Resolve the program with all dependencies
     const program = await resolveProgram(resolver, {
       unresolvedModules: { type: "allow-all" },
       resolveUnresolvedModuleTypes: true,
-      target: TARGET,
+      target: ts.ScriptTarget.ES2023,
     });
 
     // Check if aborted during resolution

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -7,7 +7,7 @@ import {
 } from "@commonfabric/api";
 import { h } from "@commonfabric/html";
 import { favoriteListSchema } from "@commonfabric/home-schemas";
-import { HttpProgramResolver } from "@commonfabric/js-compiler";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { type Cell } from "../cell.ts";
 import { type Action, type ReactivityLog } from "../scheduler.ts";
 import { type Runtime, spaceCellSchema } from "../runtime.ts";

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -2,6 +2,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import { CFC_COMPILED_BY_ATOM } from "@commonfabric/api/cfc";
 import { computeModuleHashes } from "../harness/module-identity.ts";
+import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
 import { deriveModuleRecordFields } from "../sandbox/module-record-compiler.ts";
 import type { CacheableModule } from "../harness/types.ts";
 import type { MemorySpace, Runtime } from "../runtime.ts";
@@ -571,6 +572,11 @@ export async function loadVerifiedSourceClosure(
 ): Promise<Map<string, SourceDoc> | undefined> {
   const closure = await loadSourceClosure(runtime, space, entryIdentity, tx);
   if (closure === undefined) return undefined;
+  // Identity verification parses source (module hashing scans imports), and
+  // every source-closure consumer parses further downstream (fabric-import
+  // scans, recompiles) — this is the shared entry those flows funnel through,
+  // so load the deferred compiler stack here, once.
+  await ensureCompilerStack();
   const verification = verifySourceDocs(
     entryIdentity,
     closure,

--- a/packages/runner/src/fabric-pin-rewrite.ts
+++ b/packages/runner/src/fabric-pin-rewrite.ts
@@ -1,4 +1,8 @@
-import ts from "typescript";
+import type ts from "typescript";
+import {
+  compilerStack,
+  ensureCompilerStack,
+} from "./harness/deferred-compiler-stack.ts";
 import {
   type FabricRef,
   formatFabricRef,
@@ -6,8 +10,6 @@ import {
   pinnedIdentity,
   withPin,
 } from "./sandbox/fabric-import-specifier.ts";
-
-const REWRITE_TARGET = ts.ScriptTarget.ES2023;
 
 export interface PinRewrite {
   specifier: string;
@@ -35,10 +37,11 @@ export async function rewriteFabricPins(
     specifier: string,
   ) => Promise<string | null>,
 ): Promise<{ contents: string; rewrites: PinRewrite[] }> {
-  const sourceFile = ts.createSourceFile(
+  const { ts: tsc } = await ensureCompilerStack();
+  const sourceFile = tsc.createSourceFile(
     "fabric-pin-rewrite.tsx",
     contents,
-    REWRITE_TARGET,
+    tsc.ScriptTarget.ES2023,
     true,
   );
   const literals = collectImportSpecifierLiterals(sourceFile);
@@ -85,33 +88,34 @@ export async function rewriteFabricPins(
 function collectImportSpecifierLiterals(
   sourceFile: ts.SourceFile,
 ): ts.StringLiteral[] {
+  const { ts: tsc } = compilerStack();
   const literals: ts.StringLiteral[] = [];
 
   function visit(node: ts.Node) {
-    if (ts.isImportDeclaration(node)) {
+    if (tsc.isImportDeclaration(node)) {
       const moduleSpecifier = node.moduleSpecifier;
-      if (ts.isStringLiteral(moduleSpecifier)) {
+      if (tsc.isStringLiteral(moduleSpecifier)) {
         literals.push(moduleSpecifier);
       }
     }
 
-    if (ts.isExportDeclaration(node)) {
+    if (tsc.isExportDeclaration(node)) {
       const moduleSpecifier = node.moduleSpecifier;
-      if (moduleSpecifier && ts.isStringLiteral(moduleSpecifier)) {
+      if (moduleSpecifier && tsc.isStringLiteral(moduleSpecifier)) {
         literals.push(moduleSpecifier);
       }
     }
 
-    if (ts.isImportTypeNode(node)) {
+    if (tsc.isImportTypeNode(node)) {
       const argument = node.argument;
       if (
-        ts.isLiteralTypeNode(argument) && ts.isStringLiteral(argument.literal)
+        tsc.isLiteralTypeNode(argument) && tsc.isStringLiteral(argument.literal)
       ) {
         literals.push(argument.literal);
       }
     }
 
-    ts.forEachChild(node, visit);
+    tsc.forEachChild(node, visit);
   }
 
   visit(sourceFile);

--- a/packages/runner/src/harness/compiler-stack.ts
+++ b/packages/runner/src/harness/compiler-stack.ts
@@ -1,0 +1,32 @@
+/**
+ * The ONLY static importer of the TypeScript compiler stack inside the runner.
+ *
+ * `typescript` is ~10MB and its CJS→ESM interop alone costs tens of ms of
+ * every runtime-worker spawn, yet the steady-state boot path (evaluate
+ * already-compiled patterns by identity) never compiles or parses. Keeping
+ * every compiler-stack value import behind this module — loaded via the
+ * dynamic import in `deferred-compiler-stack.ts` — defers that cost to the
+ * first flow that actually compiles, resolves, or verifies source.
+ *
+ * Rules:
+ * - Runtime modules must not import `typescript`, `@commonfabric/js-compiler`
+ *   (the root or `./typescript` entries), or `@commonfabric/ts-transformers`
+ *   (the root entry) as VALUES. `import type` is fine (erased); the
+ *   typescript-free subpaths (`js-compiler/{program,specifier,source-map,
+ *   errors,interface}`, `ts-transformers/runtime-contract`) are fine.
+ * - Add new compiler-stack values HERE and reach them through
+ *   `compilerStack()` after an `ensureCompilerStack()` on the owning flow.
+ */
+import ts from "typescript";
+export { ts };
+export {
+  CommonFabricTransformerPipeline,
+  ReactiveErrorTransformer,
+  transformCfDirective,
+} from "@commonfabric/ts-transformers";
+export {
+  collectImportSpecifiers,
+  getTypeScriptEnvironmentTypes,
+  TypeScriptCompiler,
+} from "@commonfabric/js-compiler";
+export { resolveProgram } from "@commonfabric/js-compiler/typescript";

--- a/packages/runner/src/harness/deferred-compiler-stack.ts
+++ b/packages/runner/src/harness/deferred-compiler-stack.ts
@@ -1,0 +1,34 @@
+/**
+ * Deferred access to the TypeScript compiler stack (see compiler-stack.ts for
+ * why it must not load at worker boot).
+ *
+ * Flows that compile, resolve, or parse source `await ensureCompilerStack()`
+ * once at their (async) entry point; the sync code under them reaches values
+ * through `compilerStack()`, which throws — loudly, with the fix — when a
+ * flow forgot its ensure. Boot-path code must do neither.
+ */
+import type * as CompilerStackModule from "./compiler-stack.ts";
+
+export type CompilerStack = typeof CompilerStackModule;
+
+let loaded: CompilerStack | undefined;
+let loading: Promise<CompilerStack> | undefined;
+
+/** Load (once) the compiler stack; idempotent and cheap when already loaded. */
+export function ensureCompilerStack(): Promise<CompilerStack> {
+  return loading ??= import("./compiler-stack.ts").then((m) => (loaded = m));
+}
+
+/**
+ * The loaded compiler stack. Throws when no flow has awaited
+ * {@link ensureCompilerStack} yet — a missed ensure on a new flow fails loud
+ * here rather than silently re-eagering the compiler into the boot path.
+ */
+export function compilerStack(): CompilerStack {
+  if (loaded === undefined) {
+    throw new Error(
+      "compiler stack not loaded — this flow must `await ensureCompilerStack()` before parsing/compiling",
+    );
+  }
+  return loaded;
+}

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -9,24 +9,23 @@ import {
   type RuntimeProgram,
   type TypeScriptHarnessProcessOptions,
 } from "./types.ts";
-import {
-  collectImportSpecifiers,
-  getTypeScriptEnvironmentTypes,
-  InMemoryProgram,
-  type MappedPosition,
-  type Program,
-  type ProgramResolver,
-  type Source,
+import type {
+  MappedPosition,
+  Program,
+  ProgramResolver,
+  Source,
   TypeScriptCompiler,
 } from "@commonfabric/js-compiler";
-import ts from "typescript";
+import { InMemoryProgram } from "@commonfabric/js-compiler/program";
+import type { PatternCoverageOptions } from "@commonfabric/ts-transformers";
 import {
-  CommonFabricTransformerPipeline,
   PATTERN_COVERAGE_GLOBAL,
-  type PatternCoverageOptions,
-  ReactiveErrorTransformer,
   sourceDisablesCfTransform,
-} from "@commonfabric/ts-transformers";
+} from "@commonfabric/ts-transformers/runtime-contract";
+import {
+  compilerStack,
+  ensureCompilerStack,
+} from "./deferred-compiler-stack.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { type MemorySpace, Runtime } from "../runtime.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
@@ -52,8 +51,8 @@ import {
 import {
   composeBundleSourceMap,
   identitySourceMap,
-  type SourceMap,
-} from "@commonfabric/js-compiler";
+} from "@commonfabric/js-compiler/source-map";
+import type { SourceMap } from "@commonfabric/js-compiler";
 import {
   loadModuleGraph,
   runtimeModuleRecords,
@@ -89,7 +88,6 @@ import { FabricAwareResolver } from "./fabric-resolver.ts";
 import { isFabricImportSpecifier } from "../sandbox/fabric-import-specifier.ts";
 
 const logger = getLogger("engine");
-const IMPORT_SCAN_TARGET = ts.ScriptTarget.ES2023;
 
 // Extends a TypeScript program with 3P module types, if referenced.
 export class EngineProgramResolver extends InMemoryProgram {
@@ -197,6 +195,9 @@ export class Engine extends EventTarget implements Harness {
   }
 
   async initializeCompiler(): Promise<CompilerInternals> {
+    // First compiler use on this engine: load the deferred compiler stack
+    // (typescript + transformers), kept off the worker-boot path.
+    const { TypeScriptCompiler } = await ensureCompilerStack();
     const environmentTypes = await Engine.getEnvironmentTypes(
       this.ctRuntime.staticCache,
     );
@@ -247,6 +248,9 @@ export class Engine extends EventTarget implements Harness {
   > {
     logger.timeStart("compileToRecordGraph");
     try {
+      // Pretransform/import-scan below parse before the compiler internals
+      // are awaited — load the deferred compiler stack up front.
+      await ensureCompilerStack();
       const id = options.identifier ?? computeId(program);
       assertNoReservedFabricPaths(program.files);
       const mappedProgram = pretransformProgramForModules(program, id);
@@ -366,11 +370,13 @@ export class Engine extends EventTarget implements Harness {
           getTransformedProgram: options.getTransformedProgram
             ? (nextProgram) => options.getTransformedProgram?.(nextProgram)
             : undefined,
-          diagnosticMessageTransformer: new ReactiveErrorTransformer({
+          diagnosticMessageTransformer: new (compilerStack()
+            .ReactiveErrorTransformer)({
             verbose: options.verboseErrors,
           }),
           beforeTransformers: (program) => {
-            const pipeline = new CommonFabricTransformerPipeline({
+            const pipeline = new (compilerStack()
+              .CommonFabricTransformerPipeline)({
               patternCoverage,
             });
             return {
@@ -557,6 +563,8 @@ export class Engine extends EventTarget implements Harness {
       return { patternCount: 0, fileCount: 0, diagnostics: [] };
     }
 
+    // Pretransform parses before the compiler internals are awaited.
+    await ensureCompilerStack();
     const runTransform = options.transform ?? true;
     const unioned = new Map<string, Source>();
     const mains: string[] = [];
@@ -585,7 +593,8 @@ export class Engine extends EventTarget implements Harness {
         runtimeModules: Engine.runtimeModuleNames(),
         beforeTransformers: runTransform
           ? (program) => {
-            const pipeline = new CommonFabricTransformerPipeline();
+            const pipeline = new (compilerStack()
+              .CommonFabricTransformerPipeline)();
             return {
               factories: pipeline.toFactories(program),
               getDiagnostics: () => pipeline.getDiagnostics(),
@@ -707,7 +716,8 @@ export class Engine extends EventTarget implements Harness {
       runtimeModules: Engine.runtimeModuleNames(),
       specifierAliases,
       beforeTransformers: (program) => {
-        const pipeline = new CommonFabricTransformerPipeline();
+        const pipeline = new (compilerStack()
+          .CommonFabricTransformerPipeline)();
         return {
           factories: pipeline.toFactories(program),
           getDiagnostics: () => pipeline.getDiagnostics(),
@@ -1109,6 +1119,19 @@ export class Engine extends EventTarget implements Harness {
       ]),
     );
 
+    // A module without the persisted record surface (legacy doc, or a test
+    // building modules by hand) makes buildRecordsFromCompiled parse its body
+    // — load the deferred compiler stack first. The warm-cache boot path
+    // always carries the surface (runtimeVersion fingerprints the extractor),
+    // so the steady boot stays compiler-free.
+    if (
+      modules.some((m) =>
+        m.exportNames === undefined || m.starTargetSpecs === undefined ||
+        m.importSpecs === undefined
+      )
+    ) {
+      await ensureCompilerStack();
+    }
     const graph = buildRecordsFromCompiled(modules, {
       runtimeModules: runtimeModulesOption,
     });
@@ -1291,7 +1314,8 @@ export class Engine extends EventTarget implements Harness {
     return getRuntimeModuleTypes(cache);
   }
 
-  static getEnvironmentTypes(cache: StaticCache) {
+  static async getEnvironmentTypes(cache: StaticCache) {
+    const { getTypeScriptEnvironmentTypes } = await ensureCompilerStack();
     return getTypeScriptEnvironmentTypes(cache);
   }
 
@@ -1366,9 +1390,15 @@ function assertFabricImportsHaveSpace(
   options: { fabricImports?: { space: MemorySpace } },
 ): void {
   if (options.fabricImports !== undefined) return;
+  // Deferred compiler stack (parses): only called from compileToRecordGraph,
+  // which awaits ensureCompilerStack() first.
+  const { collectImportSpecifiers, ts } = compilerStack();
   for (const file of files) {
     for (
-      const specifier of collectImportSpecifiers(file, IMPORT_SCAN_TARGET)
+      const specifier of collectImportSpecifiers(
+        file,
+        ts.ScriptTarget.ES2023,
+      )
     ) {
       if (isFabricImportSpecifier(specifier)) {
         throw new Error(

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -1,9 +1,5 @@
-import ts from "typescript";
-import {
-  collectImportSpecifiers,
-  type ProgramResolver,
-  type Source,
-} from "@commonfabric/js-compiler";
+import type { ProgramResolver, Source } from "@commonfabric/js-compiler";
+import { compilerStack } from "./deferred-compiler-stack.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   loadVerifiedSourceClosure,
@@ -21,7 +17,6 @@ import {
 import { resolveFabricRefToIdentity } from "../fabric-ref-resolution.ts";
 import type { FabricImportOptions, ResolvedFabricPin } from "./types.ts";
 
-const TARGET = ts.ScriptTarget.ES2023;
 const MAX_FABRIC_MOUNTS = 32;
 const DID_RE = /^did:[a-z0-9]+:.+$/;
 const logger = getLogger("fabric-resolver");
@@ -177,9 +172,18 @@ export class FabricAwareResolver implements ProgramResolver {
     identity: string,
     docs: ReadonlyMap<string, SourceDoc>,
   ): void {
+    // Deferred compiler stack (parses): this runs under resolveSource, whose
+    // flows load source closures and compile — ensureCompilerStack() is
+    // awaited by loadVerifiedSourceClosure before any doc reaches here.
+    const { collectImportSpecifiers, ts } = compilerStack();
     for (const doc of docs.values()) {
       const source = { name: doc.filename, contents: doc.code };
-      for (const specifier of collectImportSpecifiers(source, TARGET)) {
+      for (
+        const specifier of collectImportSpecifiers(
+          source,
+          ts.ScriptTarget.ES2023,
+        )
+      ) {
         if (specifier.startsWith("/")) {
           throw new Error(
             `imported pattern ${identity} uses root-absolute imports; not supported`,

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -1,9 +1,6 @@
-import ts from "typescript";
 import type { Program } from "@commonfabric/js-compiler";
-import {
-  collectImportSpecifiers,
-  resolveImportSpecifier,
-} from "@commonfabric/js-compiler";
+import { resolveImportSpecifier } from "@commonfabric/js-compiler/specifier";
+import { compilerStack } from "./deferred-compiler-stack.ts";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 /**
@@ -29,7 +26,6 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
  * See docs/specs/module-loading.md for the full rationale.
  */
 
-const TARGET = ts.ScriptTarget.ES2023;
 const VERSION_TAG = "cf/module-id/v1";
 
 // Candidate suffixes used to match a resolved bare path (which usually omits an
@@ -90,12 +86,20 @@ export interface ModuleImportEdges {
 export function resolveModuleImports(
   program: Program,
 ): Map<string, ModuleImportEdges> {
+  // Deferred compiler stack: import scanning parses with the TS parser, so
+  // every flow reaching this must have awaited ensureCompilerStack().
+  const { collectImportSpecifiers, ts } = compilerStack();
   const fileNames = new Set(program.files.map((f) => f.name));
   const edges = new Map<string, ModuleImportEdges>();
   for (const file of program.files) {
     const internalDeps: { specifier: string; target: string }[] = [];
     const externalDeps: string[] = [];
-    for (const specifier of collectImportSpecifiers(file, TARGET)) {
+    for (
+      const specifier of collectImportSpecifiers(
+        file,
+        ts.ScriptTarget.ES2023,
+      )
+    ) {
       const resolved = resolveImportSpecifier(specifier, file);
       const target = findInternalTarget(fileNames, resolved);
       if (target !== undefined && target !== file.name) {

--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -1,5 +1,5 @@
-import { transformCfDirective } from "@commonfabric/ts-transformers";
-import ts from "typescript";
+import type ts from "typescript";
+import { compilerStack } from "./deferred-compiler-stack.ts";
 import { RuntimeProgram } from "./types.ts";
 
 export function pretransformProgram(
@@ -17,6 +17,9 @@ export function pretransformProgram(
 export function transformInjectHelperModule(
   program: RuntimeProgram,
 ): RuntimeProgram {
+  // Deferred compiler stack (parses + prints): pretransform only runs on
+  // compile flows, which await ensureCompilerStack() at their entry.
+  const { transformCfDirective } = compilerStack();
   return {
     main: program.main,
     files: program.files.map((source) => ({
@@ -86,22 +89,23 @@ function prefix(filename: string, id: string): string {
 }
 
 function normalizeMixedModuleImports(source: string): string {
-  const sourceFile = ts.createSourceFile(
+  const { ts: tsc } = compilerStack();
+  const sourceFile = tsc.createSourceFile(
     "source.tsx",
     source,
-    ts.ScriptTarget.ES2023,
+    tsc.ScriptTarget.ES2023,
     true,
-    ts.ScriptKind.TSX,
+    tsc.ScriptKind.TSX,
   );
-  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const printer = tsc.createPrinter({ newLine: tsc.NewLineKind.LineFeed });
   const replacements: { start: number; end: number; text: string }[] = [];
 
   for (const statement of sourceFile.statements) {
     if (
-      !ts.isImportDeclaration(statement) ||
+      !tsc.isImportDeclaration(statement) ||
       !statement.importClause ||
       !statement.importClause.namedBindings ||
-      !ts.isNamedImports(statement.importClause.namedBindings)
+      !tsc.isNamedImports(statement.importClause.namedBindings)
     ) {
       continue;
     }
@@ -112,19 +116,19 @@ function normalizeMixedModuleImports(source: string): string {
     let rewrittenStatements: ts.ImportDeclaration[] | undefined;
     if (importClause.name) {
       rewrittenStatements = [
-        ts.factory.createImportDeclaration(
+        tsc.factory.createImportDeclaration(
           statement.modifiers,
-          ts.factory.createImportClause(
+          tsc.factory.createImportClause(
             importClause.isTypeOnly,
-            ts.factory.createIdentifier(importClause.name.text),
+            tsc.factory.createIdentifier(importClause.name.text),
             undefined,
           ),
           cloneModuleSpecifier(statement.moduleSpecifier),
           cloneImportAttributes(statement.attributes, sourceFile),
         ),
-        ts.factory.createImportDeclaration(
+        tsc.factory.createImportDeclaration(
           statement.modifiers,
-          ts.factory.createImportClause(
+          tsc.factory.createImportClause(
             importClause.isTypeOnly,
             undefined,
             cloneNamedImports(namedBindings, sourceFile),
@@ -145,11 +149,11 @@ function normalizeMixedModuleImports(source: string): string {
         element,
       ) => element !== defaultSpecifier);
       rewrittenStatements = [
-        ts.factory.createImportDeclaration(
+        tsc.factory.createImportDeclaration(
           statement.modifiers,
-          ts.factory.createImportClause(
+          tsc.factory.createImportClause(
             importClause.isTypeOnly || defaultSpecifier.isTypeOnly,
-            ts.factory.createIdentifier(defaultSpecifier.name.text),
+            tsc.factory.createIdentifier(defaultSpecifier.name.text),
             undefined,
           ),
           cloneModuleSpecifier(statement.moduleSpecifier),
@@ -159,9 +163,9 @@ function normalizeMixedModuleImports(source: string): string {
 
       if (remainingElements.length > 0) {
         rewrittenStatements.push(
-          ts.factory.createImportDeclaration(
+          tsc.factory.createImportDeclaration(
             statement.modifiers,
-            ts.factory.createImportClause(
+            tsc.factory.createImportClause(
               importClause.isTypeOnly,
               undefined,
               cloneNamedImportsFromElements(remainingElements, sourceFile),
@@ -181,7 +185,7 @@ function normalizeMixedModuleImports(source: string): string {
       text: preserveLineCount(
         source.slice(start, end),
         rewrittenStatements.map((entry) =>
-          printer.printNode(ts.EmitHint.Unspecified, entry, sourceFile)
+          printer.printNode(tsc.EmitHint.Unspecified, entry, sourceFile)
         ).join(" "),
       ),
     });
@@ -198,8 +202,9 @@ function normalizeMixedModuleImports(source: string): string {
 }
 
 function cloneModuleSpecifier(moduleSpecifier: ts.Expression): ts.Expression {
-  return ts.isStringLiteral(moduleSpecifier)
-    ? ts.factory.createStringLiteral(moduleSpecifier.text)
+  const { ts: tsc } = compilerStack();
+  return tsc.isStringLiteral(moduleSpecifier)
+    ? tsc.factory.createStringLiteral(moduleSpecifier.text)
     : moduleSpecifier;
 }
 
@@ -207,11 +212,12 @@ function cloneImportAttributes(
   attributes: ts.ImportAttributes | undefined,
   sourceFile: ts.SourceFile,
 ): ts.ImportAttributes | undefined {
+  const { ts: tsc } = compilerStack();
   if (!attributes) return undefined;
-  const cloned = ts.factory.createImportAttributes(
-    ts.factory.createNodeArray(
+  const cloned = tsc.factory.createImportAttributes(
+    tsc.factory.createNodeArray(
       attributes.elements.map((element) =>
-        ts.factory.createImportAttribute(
+        tsc.factory.createImportAttribute(
           cloneModuleExportName(element.name, sourceFile),
           cloneImportAttributeValue(element.value),
         )
@@ -233,14 +239,15 @@ function cloneNamedImportsFromElements(
   elements: readonly ts.ImportSpecifier[],
   sourceFile: ts.SourceFile,
 ): ts.NamedImports {
-  return ts.factory.createNamedImports(
+  const { ts: tsc } = compilerStack();
+  return tsc.factory.createNamedImports(
     elements.map((element) =>
-      ts.factory.createImportSpecifier(
+      tsc.factory.createImportSpecifier(
         element.isTypeOnly,
         element.propertyName
           ? cloneModuleExportName(element.propertyName, sourceFile)
           : undefined,
-        ts.factory.createIdentifier(element.name.text),
+        tsc.factory.createIdentifier(element.name.text),
       )
     ),
   );
@@ -250,14 +257,16 @@ function cloneModuleExportName(
   name: ts.ModuleExportName,
   sourceFile: ts.SourceFile,
 ): ts.ModuleExportName {
-  return ts.isIdentifier(name)
-    ? ts.factory.createIdentifier(name.text)
-    : ts.factory.createStringLiteral(name.text ?? name.getText(sourceFile));
+  const { ts: tsc } = compilerStack();
+  return tsc.isIdentifier(name)
+    ? tsc.factory.createIdentifier(name.text)
+    : tsc.factory.createStringLiteral(name.text ?? name.getText(sourceFile));
 }
 
 function cloneImportAttributeValue(value: ts.Expression): ts.Expression {
-  if (ts.isStringLiteral(value)) {
-    return ts.factory.createStringLiteral(value.text);
+  const { ts: tsc } = compilerStack();
+  if (tsc.isStringLiteral(value)) {
+    return tsc.factory.createStringLiteral(value.text);
   }
   return value;
 }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1,9 +1,6 @@
-import ts from "typescript";
 import { getLogger } from "@commonfabric/utils/logger";
-import {
-  collectImportSpecifiers,
-  type Source,
-} from "@commonfabric/js-compiler";
+import type { Source } from "@commonfabric/js-compiler";
+import { compilerStack } from "./harness/deferred-compiler-stack.ts";
 import { Module, Pattern } from "./builder/types.ts";
 import {
   brandTrustedPattern,
@@ -55,7 +52,6 @@ const logger = getLogger("pattern-manager");
 // bundle is ~10 modules), and entries are cheap (a reference to an already-live
 // namespace).
 const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
-const FABRIC_IMPORT_SCAN_TARGET = ts.ScriptTarget.ES2023;
 
 function throwableStorageError(error: CommitError): Error {
   if (error instanceof Error) return error;
@@ -76,13 +72,16 @@ function throwableStorageError(error: CommitError): Error {
 function fabricImportRefsFromSource(
   doc: SourceDoc,
 ): CacheableModule["imports"] {
+  // Deferred compiler stack (parses): source docs only reach this via
+  // loadVerifiedSourceClosure, which awaits ensureCompilerStack().
+  const { collectImportSpecifiers, ts } = compilerStack();
   const source: Source = { name: doc.filename, contents: doc.code };
   const refs: CacheableModule["imports"] = [];
   const seen = new Set<string>();
   for (
     const specifier of collectImportSpecifiers(
       source,
-      FABRIC_IMPORT_SCAN_TARGET,
+      ts.ScriptTarget.ES2023,
     )
   ) {
     if (!isFabricImportSpecifier(specifier)) continue;

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,7 +1,8 @@
-import ts from "typescript";
+import type ts from "typescript";
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Source, SourceMap } from "@commonfabric/js-compiler";
-import { resolveImportSpecifier } from "@commonfabric/js-compiler";
+import { resolveImportSpecifier } from "@commonfabric/js-compiler/specifier";
+import { compilerStack } from "../harness/deferred-compiler-stack.ts";
 import {
   computeModuleHashes,
   findInternalTarget,
@@ -23,8 +24,6 @@ import type { VirtualModuleRecord } from "./esm-module-loader.ts";
  * Engine drives it with CF-transformer-pipeline output via `precompiledBodies`;
  * the bare `ts.transpileModule` fallback is for the standalone/test path.
  */
-
-const TARGET = ts.ScriptTarget.ES2023;
 
 const logger = getLogger("module-record-compiler");
 
@@ -633,12 +632,13 @@ export function compileSourcesToRecords(
       exportNames = cached.exports;
       compiled = cached.compiled;
     } else {
+      const { ts: tsc } = compilerStack();
       exportNames = resolveFullExports(source.name);
-      compiled = ts.transpileModule(source.contents, {
+      compiled = tsc.transpileModule(source.contents, {
         fileName: source.name,
         compilerOptions: {
-          module: ts.ModuleKind.CommonJS,
-          target: TARGET,
+          module: tsc.ModuleKind.CommonJS,
+          target: tsc.ScriptTarget.ES2023,
           esModuleInterop: true,
         },
       }).outputText;
@@ -1000,24 +1000,29 @@ export function buildRecordsFromCompiled(
 export function extractCompiledExports(
   compiled: string,
 ): { names: readonly string[]; starTargetSpecs: readonly string[] } {
-  const sourceFile = ts.createSourceFile(
+  // Deferred compiler stack (parses): reached only on compile flows and the
+  // legacy-doc fallback, both of which await ensureCompilerStack() first
+  // (compile entries in the engine; evaluateCachedModules for fields-less
+  // docs). The persisted-surface boot path never gets here.
+  const { ts: tsc } = compilerStack();
+  const sourceFile = tsc.createSourceFile(
     "compiled.js",
     compiled,
-    TARGET,
+    tsc.ScriptTarget.ES2023,
     true,
-    ts.ScriptKind.JS,
+    tsc.ScriptKind.JS,
   );
   const names = new Set<string>();
   const starTargetSpecs = new Set<string>();
 
   const isExportsRef = (node: ts.Expression): boolean =>
-    ts.isIdentifier(node) && node.text === "exports";
+    tsc.isIdentifier(node) && node.text === "exports";
 
   const requireArg = (node: ts.Expression): string | undefined => {
     if (
-      ts.isCallExpression(node) && ts.isIdentifier(node.expression) &&
+      tsc.isCallExpression(node) && tsc.isIdentifier(node.expression) &&
       node.expression.text === "require" && node.arguments.length === 1 &&
-      ts.isStringLiteralLike(node.arguments[0])
+      tsc.isStringLiteralLike(node.arguments[0])
     ) {
       return (node.arguments[0] as ts.StringLiteralLike).text;
     }
@@ -1027,26 +1032,26 @@ export function extractCompiledExports(
   function visit(node: ts.Node): void {
     // exports.<name> = …
     if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isPropertyAccessExpression(node.left) &&
+      tsc.isBinaryExpression(node) &&
+      node.operatorToken.kind === tsc.SyntaxKind.EqualsToken &&
+      tsc.isPropertyAccessExpression(node.left) &&
       isExportsRef(node.left.expression)
     ) {
       const name = node.left.name.text;
       if (name !== "__esModule") names.add(name);
     }
-    if (ts.isCallExpression(node)) {
+    if (tsc.isCallExpression(node)) {
       const callee = node.expression;
-      const calleeName = ts.isIdentifier(callee)
+      const calleeName = tsc.isIdentifier(callee)
         ? callee.text
-        : ts.isPropertyAccessExpression(callee)
+        : tsc.isPropertyAccessExpression(callee)
         ? callee.name.text
         : undefined;
       // Object.defineProperty(exports, "<name>", …) — named re-export / getter.
       if (
         calleeName === "defineProperty" && node.arguments.length >= 2 &&
         isExportsRef(node.arguments[0]) &&
-        ts.isStringLiteralLike(node.arguments[1])
+        tsc.isStringLiteralLike(node.arguments[1])
       ) {
         const name = (node.arguments[1] as ts.StringLiteralLike).text;
         if (name !== "__esModule") names.add(name);
@@ -1057,7 +1062,7 @@ export function extractCompiledExports(
         if (spec !== undefined) starTargetSpecs.add(spec);
       }
     }
-    ts.forEachChild(node, visit);
+    tsc.forEachChild(node, visit);
   }
   visit(sourceFile);
   return { names: [...names], starTargetSpecs: [...starTargetSpecs] };
@@ -1074,25 +1079,26 @@ export function extractCompiledExports(
  * for a real dependency edge.
  */
 function extractRuntimeImports(compiled: string): readonly string[] {
-  const sourceFile = ts.createSourceFile(
+  const { ts: tsc } = compilerStack();
+  const sourceFile = tsc.createSourceFile(
     "compiled.js",
     compiled,
-    TARGET,
+    tsc.ScriptTarget.ES2023,
     true,
-    ts.ScriptKind.JS,
+    tsc.ScriptKind.JS,
   );
   const out = new Set<string>();
   function visit(node: ts.Node): void {
     if (
-      ts.isCallExpression(node) &&
-      ts.isIdentifier(node.expression) &&
+      tsc.isCallExpression(node) &&
+      tsc.isIdentifier(node.expression) &&
       node.expression.text === "require" &&
       node.arguments.length === 1 &&
-      ts.isStringLiteralLike(node.arguments[0])
+      tsc.isStringLiteralLike(node.arguments[0])
     ) {
       out.add((node.arguments[0] as ts.StringLiteralLike).text);
     }
-    ts.forEachChild(node, visit);
+    tsc.forEachChild(node, visit);
   }
   visit(sourceFile);
   return [...out];
@@ -1100,13 +1106,14 @@ function extractRuntimeImports(compiled: string): readonly string[] {
 
 /** Collect bound identifier names from a (possibly destructuring) binding. */
 function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
-  if (ts.isIdentifier(name)) {
+  const { ts: tsc } = compilerStack();
+  if (tsc.isIdentifier(name)) {
     out.add(name.text);
     return;
   }
   // Object/array binding patterns: `export const { a, b } = …` / `[x] = …`.
   for (const element of name.elements) {
-    if (ts.isBindingElement(element)) {
+    if (tsc.isBindingElement(element)) {
       collectBindingNames(element.name, out);
     }
   }
@@ -1124,28 +1131,29 @@ interface ModuleExports {
 }
 
 function collectModuleExports(source: Source): ModuleExports {
-  const sourceFile = ts.createSourceFile(
+  const { ts: tsc } = compilerStack();
+  const sourceFile = tsc.createSourceFile(
     source.name,
     source.contents,
-    TARGET,
+    tsc.ScriptTarget.ES2023,
     true,
   );
   const names = new Set<string>();
   const starTargets: string[] = [];
 
   for (const statement of sourceFile.statements) {
-    const isExported = ts.canHaveModifiers(statement) &&
-      ts.getModifiers(statement)?.some((m) =>
-        m.kind === ts.SyntaxKind.ExportKeyword
+    const isExported = tsc.canHaveModifiers(statement) &&
+      tsc.getModifiers(statement)?.some((m) =>
+        m.kind === tsc.SyntaxKind.ExportKeyword
       );
-    const isDefault = ts.canHaveModifiers(statement) &&
-      ts.getModifiers(statement)?.some((m) =>
-        m.kind === ts.SyntaxKind.DefaultKeyword
+    const isDefault = tsc.canHaveModifiers(statement) &&
+      tsc.getModifiers(statement)?.some((m) =>
+        m.kind === tsc.SyntaxKind.DefaultKeyword
       );
 
     if (
-      (ts.isFunctionDeclaration(statement) ||
-        ts.isClassDeclaration(statement)) && isExported
+      (tsc.isFunctionDeclaration(statement) ||
+        tsc.isClassDeclaration(statement)) && isExported
     ) {
       if (isDefault) {
         names.add("default");
@@ -1153,42 +1161,42 @@ function collectModuleExports(source: Source): ModuleExports {
         names.add(statement.name.text);
       }
     } else if (
-      (ts.isEnumDeclaration(statement) ||
-        ts.isModuleDeclaration(statement)) && isExported
+      (tsc.isEnumDeclaration(statement) ||
+        tsc.isModuleDeclaration(statement)) && isExported
     ) {
-      if (statement.name && ts.isIdentifier(statement.name)) {
+      if (statement.name && tsc.isIdentifier(statement.name)) {
         names.add(statement.name.text);
       }
-    } else if (ts.isVariableStatement(statement) && isExported) {
+    } else if (tsc.isVariableStatement(statement) && isExported) {
       for (const decl of statement.declarationList.declarations) {
         collectBindingNames(decl.name, names);
       }
-    } else if (ts.isExportAssignment(statement)) {
+    } else if (tsc.isExportAssignment(statement)) {
       if (statement.isExportEquals) {
         throw new Error(
           `${source.name}: 'export =' is not supported by the ESM module-record adapter (authored sources must be ES modules)`,
         );
       }
       names.add("default"); // `export default <expr>`
-    } else if (ts.isExportDeclaration(statement)) {
+    } else if (tsc.isExportDeclaration(statement)) {
       // `export type ...` re-exports are compile-time only; ignore them.
       if (statement.isTypeOnly) {
         continue;
       }
       const clause = statement.exportClause;
-      if (clause && ts.isNamedExports(clause)) {
+      if (clause && tsc.isNamedExports(clause)) {
         // `export { a, b }` or `export { a } from "./m"`; skip `export { type T }`.
         for (const element of clause.elements) {
           if (!element.isTypeOnly) {
             names.add(element.name.text);
           }
         }
-      } else if (clause && ts.isNamespaceExport(clause)) {
+      } else if (clause && tsc.isNamespaceExport(clause)) {
         // `export * as ns from "./m"`.
         names.add(clause.name.text);
       } else if (
         statement.moduleSpecifier &&
-        ts.isStringLiteral(statement.moduleSpecifier)
+        tsc.isStringLiteral(statement.moduleSpecifier)
       ) {
         // Bare `export * from "./m"`: record the target so its export names can
         // be unioned in (resolved transitively by the caller).

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -1,9 +1,8 @@
+import type { JsScript, SourceMap } from "@commonfabric/js-compiler";
 import {
-  JsScript,
-  MappedPosition,
-  SourceMap,
+  type MappedPosition,
   SourceMapParser,
-} from "@commonfabric/js-compiler";
+} from "@commonfabric/js-compiler/source-map";
 import { getLogger } from "@commonfabric/utils/logger";
 import "ses";
 import { createCallbackCompartmentGlobals } from "./compartment-globals.ts";

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -12,6 +12,12 @@ import {
   extractCompiledExports,
 } from "../src/sandbox/module-record-compiler.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 const signer = await Identity.fromPassphrase("build-from-compiled");
 
 // The warm load path builds records directly from cached compiled bodies — no

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -29,6 +29,12 @@ import {
 } from "../src/compilation-cache/cell-cache.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 // ---------------------------------------------------------------------------
 // Shared-server helper: two managers with DIFFERENT signers over ONE in-process
 // memory server. Modelled after cross-space-value-read.test.ts. The shared

--- a/packages/runner/test/deferred-compiler-stack.test.ts
+++ b/packages/runner/test/deferred-compiler-stack.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+// The deferred compiler stack's contract has two halves: flows that parse or
+// compile await `ensureCompilerStack()` once at their entry, and the sync
+// internals under them reach values through `compilerStack()` — which must
+// FAIL LOUD if some future flow forgets its ensure, rather than silently
+// re-eagering the compiler onto the worker boot path. Pin both halves.
+//
+// The module memoizes process-globally (by design), and other test files
+// preload it — so import a FRESH instance via a cache-busting query to
+// observe the pre-load state.
+
+describe("deferred compiler stack", () => {
+  it("compilerStack() throws with instructions before any flow ensured", async () => {
+    const fresh = await import(
+      "../src/harness/deferred-compiler-stack.ts?virgin"
+    );
+    expect(() => fresh.compilerStack()).toThrow(
+      /await ensureCompilerStack\(\)/,
+    );
+
+    const stack = await fresh.ensureCompilerStack();
+    // Loaded: the accessor now returns the same module the ensure resolved,
+    // and ensure is memoized (idempotent across flows).
+    expect(fresh.compilerStack()).toBe(stack);
+    expect(await fresh.ensureCompilerStack()).toBe(stack);
+    // The stack carries the compiler surface the runner's flows reach for.
+    expect(typeof stack.ts.createSourceFile).toBe("function");
+    expect(typeof stack.TypeScriptCompiler).toBe("function");
+    expect(typeof stack.collectImportSpecifiers).toBe("function");
+  });
+});

--- a/packages/runner/test/esm-module-body-verifier.test.ts
+++ b/packages/runner/test/esm-module-body-verifier.test.ts
@@ -3,6 +3,11 @@ import { expect } from "@std/expect";
 
 import { compileSourcesToRecords } from "../src/sandbox/module-record-compiler.ts";
 import { verifyCompiledModuleBody } from "../src/sandbox/module-record-verifier.ts";
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync transpile/record internals directly (below the
+// async flow boundaries that normally load the deferred compiler stack).
+await ensureCompilerStack();
 
 // D2: the ESM verifier front-end classifies each module's compiled-CommonJS
 // body. Unlike the AMD factory (deps are params), the CJS body has a

--- a/packages/runner/test/fabric-import-specifier.test.ts
+++ b/packages/runner/test/fabric-import-specifier.test.ts
@@ -17,6 +17,12 @@ import {
 } from "../src/sandbox/runtime-module-policy.ts";
 import { toURI } from "../src/uri-utils.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 const HASH = "Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
 const HASH_B = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
 const HEX_LOOKING_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";

--- a/packages/runner/test/fabric-module-identity.test.ts
+++ b/packages/runner/test/fabric-module-identity.test.ts
@@ -8,6 +8,11 @@ import {
   FABRIC_MOUNT_ROOT,
   type FabricMount,
 } from "../src/sandbox/module-record-compiler.ts";
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync identity-hash internals directly (below the async
+// flow boundaries that normally load the deferred compiler stack).
+await ensureCompilerStack();
 
 const OTHER_HASH = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
 

--- a/packages/runner/test/fabric-resolver.test.ts
+++ b/packages/runner/test/fabric-resolver.test.ts
@@ -23,6 +23,12 @@ import { slugIdForSpace } from "../src/slugs.ts";
 import { entityIdFrom } from "../src/create-ref.ts";
 import type { Cell } from "../src/cell.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 const signer = await Identity.fromPassphrase("fabric resolver test");
 const space = signer.did();
 const otherSpace = "did:key:z6MkFabricResolverOtherSpace";

--- a/packages/runner/test/module-identity.test.ts
+++ b/packages/runner/test/module-identity.test.ts
@@ -4,6 +4,12 @@ import { expect } from "@std/expect";
 import type { Program } from "@commonfabric/js-compiler";
 import { computeModuleHashes } from "../src/harness/module-identity.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 function program(main: string, files: Record<string, string>): Program {
   return {
     main,

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -12,6 +12,12 @@ import {
   runtimeModuleRecords,
 } from "../src/sandbox/esm-module-loader.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 class MapRecordCache implements ModuleRecordCache {
   store = new Map<string, CompiledModuleArtifact>();
   hits = 0;

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -10,6 +10,12 @@ import {
 } from "../src/harness/pretransform.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
 Deno.test("transformInjectHelperModule transforms by default and respects cf-disable-transform", () => {
   const program: RuntimeProgram = {
     main: "/main.tsx",

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -115,7 +115,8 @@ import {
   type VDomUnmountRequest,
   type WriteStackTraceResponse,
 } from "../protocol/mod.ts";
-import { HttpProgramResolver, Program } from "@commonfabric/js-compiler";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
+import type { Program } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
 import {
   type SiteTable,

--- a/packages/ts-transformers/deno.jsonc
+++ b/packages/ts-transformers/deno.jsonc
@@ -5,7 +5,9 @@
     ".": "./src/mod.ts",
     "./core/context": "./src/core/context.ts",
     "./core/imports": "./src/core/imports.ts",
-    "./runtime-registry": "./src/core/commonfabric-runtime-registry.ts"
+    "./runtime-registry": "./src/core/commonfabric-runtime-registry.ts",
+    // Typescript-free transformer↔runtime contract values (boot-safe).
+    "./runtime-contract": "./src/core/runtime-contract.ts"
   },
   "imports": {
     "typescript": "npm:typescript"

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -154,8 +154,16 @@ export class CFHelpers {
   }
 }
 
-const CF_DISABLE_TRANSFORM_DIRECTIVE_RE =
-  /^\/\/\/\s*<cf-disable-transform\s*\/>/m;
+// The disable-directive check lives in runtime-contract.ts (typescript-free,
+// runtime-importable); re-exported here for the existing compile-side callers.
+export {
+  findFirstContentLineIndex,
+  sourceDisablesCfTransform,
+} from "./runtime-contract.ts";
+import {
+  findFirstContentLineIndex,
+  sourceDisablesCfTransform,
+} from "./runtime-contract.ts";
 
 // Rewrite a leading transform directive line, or inject helpers by default,
 // so the AST transformer pipeline has access to helpers like `lift`.
@@ -220,26 +228,6 @@ export function injectCfDataHelper(source: string): string {
     source,
     CF_DATA_HELPER_USED_STMT,
   ].join("\n");
-}
-
-export function sourceDisablesCfTransform(source: string): boolean {
-  const lines = source.split("\n");
-  const firstContentLineIndex = findFirstContentLineIndex(lines);
-  return firstContentLineIndex !== null &&
-    isCFTransformDisabled(lines[firstContentLineIndex]!);
-}
-
-function isCFTransformDisabled(line: string) {
-  return CF_DISABLE_TRANSFORM_DIRECTIVE_RE.test(line);
-}
-
-function findFirstContentLineIndex(lines: readonly string[]): number | null {
-  for (const [index, line] of lines.entries()) {
-    if (line.trim().length > 0) {
-      return index;
-    }
-  }
-  return null;
 }
 
 // Throws if `__cfHelpers` was found as an Identifier

--- a/packages/ts-transformers/src/core/runtime-contract.ts
+++ b/packages/ts-transformers/src/core/runtime-contract.ts
@@ -1,0 +1,42 @@
+/**
+ * The transformer↔runtime contract surface that the RUNTIME needs at boot:
+ * values the runner reads while evaluating already-compiled patterns, with no
+ * compilation in sight. This module must stay free of `typescript` (and other
+ * compiler-stack) value imports — the runtime worker imports it eagerly, and a
+ * value edge here would pull the whole compiler into every worker spawn (see
+ * the runner's compiler-stack module).
+ */
+
+/**
+ * Name of the sandbox global the pattern-coverage transformer emits probe
+ * calls against; the engine installs a collector under this name when
+ * coverage is enabled.
+ */
+export const PATTERN_COVERAGE_GLOBAL = "__cfPatternCoverage";
+
+const CF_DISABLE_TRANSFORM_DIRECTIVE_RE =
+  /^\/\/\/\s*<cf-disable-transform\s*\/>/m;
+
+/** True when the source's first content line is the disable directive. */
+export function sourceDisablesCfTransform(source: string): boolean {
+  const lines = source.split("\n");
+  const firstContentLineIndex = findFirstContentLineIndex(lines);
+  return firstContentLineIndex !== null &&
+    isCFTransformDisabled(lines[firstContentLineIndex]!);
+}
+
+function isCFTransformDisabled(line: string) {
+  return CF_DISABLE_TRANSFORM_DIRECTIVE_RE.test(line);
+}
+
+/** Index of the first non-blank line, or null for an all-blank source. */
+export function findFirstContentLineIndex(
+  lines: readonly string[],
+): number | null {
+  for (const [index, line] of lines.entries()) {
+    if (line.trim().length > 0) {
+      return index;
+    }
+  }
+  return null;
+}

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -60,7 +60,9 @@ export interface FunctionCapabilitySummary {
 
 export type PatternCoverageKind = "runtime";
 
-export const PATTERN_COVERAGE_GLOBAL = "__cfPatternCoverage";
+// Moved to runtime-contract.ts (typescript-free) so the runtime can import it
+// without the compiler stack; re-exported here for the compile-side callers.
+export { PATTERN_COVERAGE_GLOBAL } from "./runtime-contract.ts";
 
 export interface PatternCoverageSpan {
   readonly fileName: string;


### PR DESCRIPTION
Part of the cold-load boot-floor investigation (follows #4441/#4442 = bucket #2, #4455 = bucket #8). This takes **bucket #6 (esbuild CJS→ESM glue)** — and the prize turned out to be bigger than the bucket.

## Mechanism

`typescript.js` is **9.96MB of the 14.3MB worker bundle**, with **~100 static importers** (75 in ts-transformers, 14 in schema-generator, 7 in runner, 4 in js-compiler — esbuild metafile). At every worker spawn: the 10MB CJS factory evaluates, and each of the ~100 importing modules runs its own `__toESM(require_typescript())` — `__copyProps` re-copies typescript's ~2.5k exports as getters per site (~250k `defineProperty` calls). Post-#4441/#4442 the steady-state boot path never parses or compiles, so all of it was dead weight — paid on **every worker spawn, warm reloads included**.

## Fix

Sever every static value edge from the worker entry into the compiler stack; esbuild then defers the whole subtree's execution (`init_*`/`require_*`) to first use — no code splitting needed, identical semantics under Deno:

- **runner**: `harness/compiler-stack.ts` is the single static importer of typescript / ts-transformers / js-compiler-compiler, behind one memoized `import()` (`deferred-compiler-stack.ts`). Sync parse internals use a `compilerStack()` accessor that **throws loudly** if a flow forgot its `await ensureCompilerStack()` — a missed ensure on a future flow fails visibly rather than silently re-eagering the compiler. Ensures at the flow entries: engine compile/typecheck/resolve, `evaluateCachedModules` (only when a legacy doc lacks the persisted record surface), `loadVerifiedSourceClosure` (one ensure covers closure replication, cold-load recovery, and fabric resolution — everything downstream funnels through it), and the fetch-program / pin-rewrite builtins.
- **js-compiler**: typescript-free subpath entries for runtime consumers — `./program`, `./specifier` (`resolveImportSpecifier` was pure path logic mislocated in `typescript/resolver.ts`), `./errors` (`CompilerError` keeps single-module identity for `instanceof`; its one ts value use is a local mirror of `flattenDiagnosticMessageText`).
- **ts-transformers**: `./runtime-contract` — a typescript-free home for `PATTERN_COVERAGE_GLOBAL` (read at boot by `evaluateGraph`) and `sourceDisablesCfTransform`, re-exported from their old locations.
- Type-only imports stay wherever they were (erased; no bundle edge).

## Measurements (offset-12 rig, trivial pattern, cold boots ×2 each)

| | before | after |
|---|---|---|
| #6 esbuild-glue bucket | 34.5 / 34.0ms | **0.1 / 0.0ms** |
| diffuse remainder (hidden ts factory eval; `__require2` self 13.5→2.4ms) | ~140ms | ~122ms |
| **worker busy total** | ~497ms | **~441ms (−56ms)** |

All other buckets stable within noise (no behavior change on the boot path). The same init cost also disappears from **warm-reload** worker spawns (it was pure bundle-init). Metafile assert: **no static path from the worker entry to typescript**; the only statically-reachable transformer module is the deliberately ts-free `runtime-contract.ts`; exactly one dynamic-import edge exists (the deferred stack).

Combined with #4455, the trivial-pattern cold-boot worker floor goes ~497 → ~405ms (was ~640ms when the investigation started).

## Gates

Workspace `deno check`; **runner 735/0** (nine test files that drive the sync parse internals directly now preload the stack — the throwing accessor caught exactly those, which is it working as designed); js-compiler + ts-transformers suites; `pattern-tests` + `generated-patterns` integrations (the compile flows end-to-end over the new lazy boundary, including the runtime-version-bump recompile this change itself triggers); shell build; live browser boot renders patterns on the new bundle.

Follow-on (not this PR): the 10MB of typescript *bytes* still ship in the bundle (download/parse); code-splitting the worker build would shed them from the wire too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers the TypeScript compiler stack off the runtime worker’s boot path by routing all compiler value imports through one memoized dynamic import and exposing TypeScript‑free runtime subpaths. Removes ~56ms from cold boot and eliminates the compiler init cost on warm reloads.

- **Refactors**
  - Runner: add `harness/compiler-stack.ts` (single static importer) and `harness/deferred-compiler-stack.ts` (`ensureCompilerStack()` and a throwing `compilerStack()`); ensure at engine compile/typecheck/resolve, `loadVerifiedSourceClosure`, legacy record builds, and the fetch‑program/pin‑rewrite builtins.
  - Runtime‑safe APIs: new `@commonfabric/js-compiler/{program,specifier,errors,source-map}`; moved `resolveImportSpecifier`; `CompilerError` mirrors `flattenDiagnosticMessageText` locally.
  - Transformers: new `@commonfabric/ts-transformers/runtime-contract` exporting `PATTERN_COVERAGE_GLOBAL` and `sourceDisablesCfTransform` (re‑exported for compile‑side callers).
  - Import/flow updates: runner/piece/runtime‑client switch to subpaths; parse/transform/scan now reach TS via `compilerStack()` after `ensureCompilerStack()`; tests preload the stack; add a test pinning the fail‑loud deferred‑stack contract (throws before ensure, memoizes after).

- **Migration**
  - In runtime code, import from `@commonfabric/js-compiler/{program,specifier,errors}`; avoid `typescript` and root compiler entries.
  - For any parse/resolve/compile flow, call `await ensureCompilerStack()` once at async entry, then access values via `compilerStack()`.

<sup>Written for commit 044ba2f8241944478fbe52a4a952742a31ebbe01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




## Perf-check note (coverage-debt)

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7821 lines

Residual +1: the `ensureCompilerStack()` line inside `fetch-program.ts`'s `startFetch` — the entire ~60-line network path has never had unit coverage (no harness drives the builtin through the scheduler against a real endpoint). The other five new-line debts are covered by the deferred-stack fail-loud contract test. Proper `startFetch` coverage is ticketed (CT-1820) rather than squeezed in here.


NEW_PERF_BASELINE: coverage-debt: packages/ts-transformers uncovered lines = 1945 lines

The ts-transformers delta (+33) is a structural artifact of the deferral, not missing tests: coverage-contributing jobs that never compile no longer execute the package's module-init lines eagerly, so top-level lines lose incidental cross-package credit. The package's own suite is unchanged and the files this PR touches measure 96-100% locally (runtime-contract.ts and core/transformers.ts at 100%).
