### PR TITLE
perf(runner): single-flight the by-identity pattern load (cold-load 4× closure eval)

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -119,6 +119,19 @@ export class PatternManager {
   // instance. The hash is computed with `createRef` purely as a stable digest
   // function — no `pattern:` cell is ever minted. Bounded FIFO to cap memory.
   private inProgressCompilations = new Map<string, Promise<Pattern>>();
+  // Single-flight dedup for the expensive tail of `loadPatternByIdentity`
+  // (storage closure read + SES evaluation), keyed by `${space}\0${identity}`.
+  // Boot references the same entry several times at once (one load per
+  // referencing piece/system pattern); without this every concurrent miss ran
+  // its own full closure evaluation — measured as 4 identical 9-module SES
+  // evals per cold worker boot, the multiplier behind most of the per-module
+  // boot-floor buckets. Followers await the leader and then resolve their own
+  // symbol from the indexes the leader's evaluation populated — the same path
+  // a load arriving after completion takes.
+  private inProgressByIdentityLoads = new Map<
+    string,
+    Promise<Pattern | undefined>
+  >();
   // Content-hash → { compiled pattern, the space its closure was first written
   // into }. The space is tracked so a cross-space cache hit can replicate the
   // source/compiled closure into the requested space (see compileOrGetPattern):
@@ -782,7 +795,6 @@ export class PatternManager {
     symbol: string,
     space: MemorySpace,
   ): Promise<Pattern | undefined> {
-    const harness = this.runtime.harness;
     // In-memory artifact index: the pattern may already be live this session —
     // an evaluated ESM artifact, or a hand-built pattern given a synthetic
     // pointer via `associatePatternIdentity`. This path is independent of the
@@ -804,6 +816,43 @@ export class PatternManager {
       this.esmCacheStats.byIdentityHits++;
       return live;
     }
+    // Single-flight the expensive tail (see `inProgressByIdentityLoads`).
+    const key = `${space}\0${entryIdentity}`;
+    const pending = this.inProgressByIdentityLoads.get(key);
+    if (pending === undefined) {
+      const load = this.loadPatternByIdentityFromStorage(
+        entryIdentity,
+        symbol,
+        space,
+      ).finally(() => this.inProgressByIdentityLoads.delete(key));
+      this.inProgressByIdentityLoads.set(key, load);
+      return await load;
+    }
+    // Follower: the leader's evaluation indexes every symbol of the closure,
+    // so after it settles the in-memory lookups above serve this call. Its
+    // failure is the leader caller's to surface; this call retries on its own
+    // behalf below.
+    await pending.catch(() => {});
+    // Back through the front door: hits the now-populated indexes in the
+    // common case. If the leader failed or did not surface this symbol, the
+    // in-flight entry is gone, so this call becomes the leader of its own
+    // attempt — the same load it would have run without dedup. Each pass
+    // consumes a settled leader, so the recursion is bounded by the number of
+    // concurrent callers.
+    return await this.loadPatternByIdentity(entryIdentity, symbol, space);
+  }
+
+  /**
+   * The storage-backed tail of {@link loadPatternByIdentity}: closure read,
+   * SES evaluation, artifact indexing, and the cold-load recovery fallbacks.
+   * Callers must hold the single-flight slot for `(space, entryIdentity)`.
+   */
+  private async loadPatternByIdentityFromStorage(
+    entryIdentity: string,
+    symbol: string,
+    space: MemorySpace,
+  ): Promise<Pattern | undefined> {
+    const harness = this.runtime.harness;
     const runtimeVersion = await getCompileCacheRuntimeVersion();
     if (runtimeVersion === undefined) {
       return await this.tryColdLoadByIdentity(entryIdentity, symbol, space);

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -101,6 +101,79 @@ describe("PatternManager program persistence", () => {
   });
 });
 
+describe("PatternManager.loadPatternByIdentity single-flight", () => {
+  it("concurrent loads of one identity share a single evaluation's artifact", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    // Runtime A persists the closure; a FRESH runtime B then loads it with
+    // cold in-memory indexes, so concurrent calls all miss the sync fast
+    // paths and race into the storage/eval tail. Without the single-flight
+    // dedup, each call ran its own full SES evaluation of the closure
+    // (measured as 4 identical evaluations per cold worker boot); with it,
+    // one leader evaluates and every caller resolves to the same shared
+    // content-addressed artifact — the behavior sequential callers get.
+    const runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    let runtimeB: Runtime | undefined;
+    try {
+      const txA = runtimeA.edit();
+      const compiled = await runtimeA.patternManager.compilePattern({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { pattern, lift } from 'commonfabric';",
+            "const inc = lift((x:number)=>x+1);",
+            "export default pattern<{ value: number }>(({ value }) => {",
+            "  return { result: inc(value) };",
+            "});",
+          ].join("\n"),
+        }],
+      }, { space, tx: txA });
+      const { identity: entryIdentity, symbol } = runtimeA.patternManager
+        .getArtifactEntryRef(compiled)!;
+      // Make the closure durable before runtime B reads it.
+      await runtimeA.patternManager.flushCompileCacheWrites();
+      await txA.commit();
+      await storageManager.synced();
+
+      // Runtime B shares the storage but has cold in-memory indexes, so the
+      // three concurrent loads all miss the sync fast paths and race into
+      // the single-flight tail.
+      runtimeB = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      const [first, second, third] = await Promise.all([
+        runtimeB.patternManager.loadPatternByIdentity(
+          entryIdentity,
+          symbol,
+          space,
+        ),
+        runtimeB.patternManager.loadPatternByIdentity(
+          entryIdentity,
+          symbol,
+          space,
+        ),
+        runtimeB.patternManager.loadPatternByIdentity(
+          entryIdentity,
+          symbol,
+          space,
+        ),
+      ]);
+      expect(first).toBeDefined();
+      // One artifact, not three: followers resolve from the leader's indexes.
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    } finally {
+      await runtimeB?.dispose();
+      await runtimeA.dispose();
+      await storageManager.close();
+    }
+  });
+});
+
 describe("PatternManager.loadPatternByIdentity error handling", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;


### PR DESCRIPTION
Part of the cold-load boot-floor investigation (#4441/#4442, #4455, #4459). This one fell out of scoping bucket #3 (schema-intern): per-construction-site attribution showed the "88% redundant schema hashes" weren't a memoization gap at all — they were **the same module closure being fully re-evaluated four times per cold boot**.

## Mechanism

Timestamped probes on a trivial-pattern cold boot: four `loadPatternByIdentity` calls for the **identical (entryIdentity, symbol)** arrive in the same millisecond (one per referencing piece), all miss the artifact index (which only dedupes *completed* loads), and all four run the full storage closure read + 9-module SES evaluation concurrently — four `evaluateCachedModules` STARTs at t=3247, four interleaved 438ms evals. Every per-module boot bucket (debug-annotation, schema-intern, harden, factory-build, source-map compose) was paying ~4×.

## Fix

Mirror the file's existing `inProgressCompilations` single-flight idiom: the expensive tail of `loadPatternByIdentity` becomes single-flight per `(space, entryIdentity)`. Followers await the leader, then re-enter through the front door and resolve their own symbol from the indexes the leader's evaluation populated — **the exact path a load arriving after completion already takes** (`byIdentityHits`), so concurrent callers now converge to the established sequential behavior (one shared, content-addressed artifact) instead of minting duplicate evaluations. If the leader failed or didn't surface the follower's symbol, the settled entry is gone and the follower leads its own attempt (same load it would have run without dedup); each pass consumes a settled leader, so recursion is bounded by concurrent-caller count.

## Measurements (offset rig, trivial pattern, cold boots ×2, on the #4459 baseline)

| bucket | before | after |
|---|---|---|
| #1 debug-metadata | 97.8ms | **24.5** |
| #3 schema-intern | 78.0 | **34.6** |
| #4 SES harden | 47.3 | **13.5** |
| #5 factory-build | 38.0 | **12.3** |
| #8 sourcemap-compose | 55.3 | **22.3** |
| **worker busy total** | **~442ms** | **~206ms** |

Both runs within ±2ms per bucket; the ~4× collapse across exactly the per-eval buckets is the fix's signature. Composes independently with #4455/#4459 — with all three, the trivial-pattern cold-boot worker floor goes **~640ms (investigation start) → ~206ms**.

## Gates

Runner suite 735/0; `pattern-tests` + `generated-patterns` integrations green; fmt/lint/check clean; live browser boot renders. The dedup path is additionally exercised by every boot (the four concurrent system-pattern loads now take leader/follower roles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `loadPatternByIdentity` single-flight per `(space, entryIdentity)` so cold boots evaluate the closure once instead of four times. Dedup the storage-read + SES-eval tail; followers await the leader and resolve from its indexes, and a new test races three calls and verifies they all return the same shared artifact (worker busy ~442ms → ~206ms).

<sup>Written for commit dd358bf04cd66be3bb24616d72554ea1bff90265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




## Perf-check note (coverage-debt)

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7824 lines

The +2 is the leader-REJECTION path of the single-flight (chiefly the `.catch(() => {})` swallow arrow followers use before retrying on their own behalf): it executes only when the storage/eval tail rejects mid-race, which requires fault-injection into the storage layer to reach. The happy-path follower branches (await, front-door re-entry, shared-artifact resolution) are covered by the concurrency regression test; the missing-identity case resolves (does not reject) and is covered by the error-handling test.
