### PR TITLE
test(ts-transformers): assert transformer output structurally; cover the zero-arg IIFE branch

### DIFF
--- a/packages/ts-transformers/test/ast/type-building-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/type-building-coverage.test.ts
@@ -1,9 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertStringIncludes,
-  assertThrows,
-} from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import ts from "typescript";
 
 import {
@@ -16,6 +11,35 @@ import {
   type CaptureTreeNode,
   createCaptureTreeNode,
 } from "../../src/utils/capture-tree.ts";
+import { collect, parseModule } from "../transformed-ast.ts";
+
+/**
+ * Reparse a printed capture-type literal and return its members keyed by name,
+ * each carrying its optional flag and the printed text of its declared type.
+ * Asserting on these AST-derived members is stronger than substring-matching
+ * the printed text: an optional token and a member type are pinned exactly.
+ */
+function typeLiteralProps(printed: string): Map<
+  string,
+  { optional: boolean; type: string }
+> {
+  const decl = collect(
+    parseModule(`type __T = ${printed};`),
+    ts.isTypeAliasDeclaration,
+  )[0];
+  if (!decl) throw new Error(`Could not parse type literal: ${printed}`);
+  const out = new Map<string, { optional: boolean; type: string }>();
+  for (const signature of collect(decl.type, ts.isPropertySignature)) {
+    const name = ts.isIdentifier(signature.name)
+      ? signature.name.text
+      : signature.name.getText(decl.getSourceFile());
+    out.set(name, {
+      optional: !!signature.questionToken,
+      type: signature.type ? signature.type.getText(decl.getSourceFile()) : "",
+    });
+  }
+  return out;
+}
 
 function createProgram(fileName: string, sourceText: string) {
   const sourceFile = ts.createSourceFile(
@@ -229,8 +253,9 @@ Deno.test("buildCaptureTypeElements: an optional intermediate property is emitte
       ts.factory.createTypeLiteralNode(elements),
       sourceFile,
     );
-    assertStringIncludes(printed, "nested?:");
-    assertStringIncludes(printed, "value: string");
+    const members = typeLiteralProps(printed);
+    assertEquals(members.get("nested")?.optional, true);
+    assertEquals(members.get("value")?.type, "string");
   });
 });
 
@@ -263,8 +288,11 @@ Deno.test("buildCaptureTypeElements: a required intermediate property has no que
       ts.factory.createTypeLiteralNode(elements),
       sourceFile,
     );
-    assertStringIncludes(printed, "nested: {");
-    assert(!printed.includes("nested?:"));
+    const members = typeLiteralProps(printed);
+    // The required `nested` intermediate is emitted without a question token,
+    // and resolves to an object literal carrying its `value` leaf.
+    assertEquals(members.get("nested")?.optional, false);
+    assertEquals(members.get("value")?.type, "string");
   });
 });
 

--- a/packages/ts-transformers/test/ast/type-building.test.ts
+++ b/packages/ts-transformers/test/ast/type-building.test.ts
@@ -1,9 +1,7 @@
-import {
-  assertEquals,
-  assertStrictEquals,
-  assertStringIncludes,
-} from "@std/assert";
+import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import ts from "typescript";
+
+import { parseModule } from "../transformed-ast.ts";
 
 import {
   buildCaptureTypeElements,
@@ -130,14 +128,51 @@ Deno.test("buildCaptureTypeElements handles destructured keys and renames identi
       sourceFile,
     );
 
-    assertStringIncludes(printed, "zero?: string");
-    assertStringIncludes(printed, "namedKey?: number");
-    assertStringIncludes(printed, "kept: boolean");
-    assertStringIncludes(printed, '"not-safe": boolean');
+    // Reparse the printed type literal and inspect its members: the optional
+    // destructured keys widen to `T | undefined`, the plain key keeps its
+    // type, and the identifier-unsafe key `not-safe` is emitted as a quoted
+    // string-literal property name.
+    const members = typeLiteralMembers(printed);
+    assertEquals(members.get("zero"), {
+      optional: true,
+      type: "string | undefined",
+    });
+    assertEquals(members.get("namedKey"), {
+      optional: true,
+      type: "number | undefined",
+    });
+    assertEquals(members.get("kept"), { optional: false, type: "boolean" });
+    assertEquals(members.get("not-safe"), { optional: false, type: "boolean" });
   } finally {
     transformed.dispose();
   }
 });
+
+// Reparse a printed type-literal into a map from member name to its optionality
+// and printed type keyword. Wrapping it in `type __T = …;` lets the parser
+// recover the members from text, so assertions read real nodes rather than
+// matching substrings of the print.
+function typeLiteralMembers(
+  printed: string,
+): Map<string, { optional: boolean; type: string }> {
+  const root = parseModule(`type __T = ${printed};`);
+  const alias = root.statements[0];
+  assert(ts.isTypeAliasDeclaration(alias) && ts.isTypeLiteralNode(alias.type));
+  const out = new Map<string, { optional: boolean; type: string }>();
+  for (const member of alias.type.members) {
+    assert(ts.isPropertySignature(member) && member.type);
+    const name = member.name;
+    const key = ts.isStringLiteralLike(name) || ts.isIdentifier(name)
+      ? name.text
+      : undefined;
+    assert(key !== undefined, "unexpected member name");
+    out.set(key, {
+      optional: member.questionToken !== undefined,
+      type: member.type.getText(root),
+    });
+  }
+  return out;
+}
 
 function createProgram(fileName: string, sourceText: string) {
   const sourceFile = ts.createSourceFile(

--- a/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
@@ -1,6 +1,14 @@
-import { assert, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import {
+  callsMatching,
+  extractedCallbackBody,
+  hasKeyPathRead,
+  iifeCalls,
+  parseModule,
+} from "./transformed-ast.ts";
 
 // `emitCallExpression` has a dedicated branch for an authored zero-argument
 // inline IIFE — `(() => ...)()` — that appears inside a reactive array-method
@@ -11,13 +19,11 @@ import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 // an IIFE inside a `.map()`/`.filter()` callback and assert on how the branch
 // treats it.
 //
-// Two outcomes are exercised. When the IIFE's body still performs a direct cell
-// read on a receiver declared outside the IIFE, the branch wraps the IIFE so the
-// read runs under a reactive cause context — the read is lowered and its cell
-// dependency is tracked into the callback's pattern input (`item.key("x")`).
-// When the IIFE instead decomposes through a local alias or an object-literal
-// projection, the branch preserves the authored IIFE verbatim so the inner
-// expression-site machinery handles it.
+// The assertions parse the transformer output back into an AST and inspect real
+// nodes (a `__cfLift*` wrapper call, an immediately-invoked function, a
+// `<receiver>.key("segment")` reactive path read) rather than matching printed
+// text, so they cannot be satisfied by a preserved comment or by a substring
+// that already appears in the input source.
 
 const HEAD = `/// <cts-enable />
 import { Cell, pattern, UI, VNode } from "commonfabric";
@@ -26,20 +32,19 @@ interface Input { items: Cell<Row[]>; base: Cell<number>; }
 interface Output { [UI]: VNode; }
 `;
 
-async function transformRender(body: string): Promise<string> {
+async function transformRender(body: string): Promise<ts.SourceFile> {
   const source = `${HEAD}
 export default pattern<Input, Output>(({ items, base }) => ({
   [UI]: <div>{${body}}</div>,
 }));`;
-  return await transformSource(source, { types: COMMONFABRIC_TYPES });
+  return parseModule(
+    await transformSource(source, { types: COMMONFABRIC_TYPES }),
+  );
 }
 
-/** The lowered `mapWithPattern` callback body extracted for focused assertions. */
-function patternCallbackBody(output: string): string {
-  const start = output.indexOf("__cfPattern_1 =");
-  assert(start >= 0, "expected an extracted map pattern callback");
-  const end = output.indexOf("}, {", start);
-  return output.slice(start, end);
+/** The lowered `mapWithPattern` callback body, isolated for assertions. */
+function mapCallbackBody(output: ts.SourceFile): ts.Node {
+  return extractedCallbackBody(output, "__cfPattern_1");
 }
 
 Deno.test(
@@ -48,17 +53,16 @@ Deno.test(
     const output = await transformRender(
       `items.map((item) => (() => item.x.get())() + 1)`,
     );
-    // The map lowered to mapWithPattern, and the IIFE's `item.x.get()` was
-    // wrapped into a lift-applied call whose input tracks the element cell path.
-    assertStringIncludes(output, "mapWithPattern");
-    const body = patternCallbackBody(output);
-    assertStringIncludes(body, "__cfLift");
-    assertStringIncludes(body, 'item.key("x")');
-    // The raw IIFE call form was replaced by the wrapper, not left authored.
-    assert(
-      !/\(\(\) =>/.test(body),
-      "expected the IIFE to be lowered, not preserved verbatim",
-    );
+    // The map lowered to a `mapWithPattern` pattern callback.
+    assert(callsMatching(output, /^mapWithPattern$/).length === 1);
+
+    const body = mapCallbackBody(output);
+    // The IIFE was replaced by a `__cfLift*` wrapper call — the authored
+    // immediately-invoked function no longer appears in the lowered body.
+    assertEquals(callsMatching(body, /^__cfLift/).length, 1);
+    assertEquals(iifeCalls(body).length, 0);
+    // The element cell read survived as a `item.key("x")` reactive dependency.
+    assert(hasKeyPathRead(body, "x", "item"));
   },
 );
 
@@ -68,12 +72,22 @@ Deno.test(
     const output = await transformRender(
       `items.map((item) => (() => base.get() || 0)() + item.x.get())`,
     );
-    const body = patternCallbackBody(output);
-    // Both the outer `base` cell and the element `item.x` cell reach the lift
-    // input, so neither reactive dependency is lost across the IIFE boundary.
-    assertStringIncludes(body, "__cfLift");
-    assertStringIncludes(body, "base: base");
-    assertStringIncludes(body, 'item.key("x")');
+    const body = mapCallbackBody(output);
+    // Both dependencies reach the lift input, so neither is lost across the IIFE
+    // boundary: the outer `base` cell (passed by identifier) and the element's
+    // `item.key("x")` reactive path read.
+    const lift = callsMatching(body, /^__cfLift/);
+    assertEquals(lift.length, 1);
+    const inputArg = lift[0]!.arguments[0];
+    assert(inputArg && ts.isObjectLiteralExpression(inputArg));
+    const propNames = inputArg.properties.map((p) =>
+      p.name && ts.isIdentifier(p.name) ? p.name.text : undefined
+    );
+    assert(
+      propNames.includes("base"),
+      "expected the outer base cell as a lift input",
+    );
+    assert(hasKeyPathRead(body, "x", "item"));
   },
 );
 
@@ -83,12 +97,12 @@ Deno.test(
     const output = await transformRender(
       `items.filter((item) => (() => item.x.get() > 0)()).map((item) => item.label)`,
     );
-    // The filter+map chain lowers to filterWithPattern/mapWithPattern and the
-    // predicate IIFE's cell read is wrapped into a lift tracking the element.
-    assertStringIncludes(output, "filterWithPattern");
-    assertStringIncludes(output, "mapWithPattern");
-    assertStringIncludes(output, "__cfLift");
-    assertStringIncludes(output, 'item.key("x")');
+    // The filter+map chain lowers to filterWithPattern/mapWithPattern.
+    assertEquals(callsMatching(output, /^filterWithPattern$/).length, 1);
+    assertEquals(callsMatching(output, /^mapWithPattern$/).length, 1);
+    // The predicate IIFE's cell read is wrapped into a lift over `item.key("x")`.
+    assert(callsMatching(output, /^__cfLift/).length >= 1);
+    assert(hasKeyPathRead(output, "x", "item"));
   },
 );
 
@@ -98,15 +112,13 @@ Deno.test(
     const output = await transformRender(
       `items.map((item) => (() => { const p = item.x.get() || 0; return p; })() + 1)`,
     );
-    const body = patternCallbackBody(output);
+    const body = mapCallbackBody(output);
     // The IIFE holds a local alias (`const p = item.x.get() || 0`), so the branch
-    // leaves the authored IIFE in place for the inner machinery to decompose
-    // rather than forcing a blanket wrapper around the whole call.
-    assert(
-      /\(\(\) =>/.test(body),
-      "expected the authored IIFE to be preserved",
-    );
-    assertStringIncludes(body, "item.x.get()");
+    // leaves the authored IIFE in place — it is still an immediately-invoked
+    // function and was not replaced by a lift wrapper — for the inner machinery
+    // to decompose.
+    assertEquals(iifeCalls(body).length, 1);
+    assertEquals(callsMatching(body, /^__cfLift/).length, 0);
   },
 );
 
@@ -116,14 +128,11 @@ Deno.test(
     const output = await transformRender(
       `items.map((item) => (() => ({ v: item.x.get() }))().v)`,
     );
-    const body = patternCallbackBody(output);
+    const body = mapCallbackBody(output);
     // The IIFE returns an object literal that is immediately projected (`.v`);
     // no direct external cell read survives the child rewrite, so the IIFE is
-    // returned unchanged.
-    assert(
-      /\(\(\) =>/.test(body),
-      "expected the authored IIFE to be preserved",
-    );
-    assertStringIncludes(body, "item.x.get()");
+    // returned unchanged and not wrapped in a lift.
+    assertEquals(iifeCalls(body).length, 1);
+    assertEquals(callsMatching(body, /^__cfLift/).length, 0);
   },
 );

--- a/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
@@ -1,0 +1,129 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// `emitCallExpression` has a dedicated branch for an authored zero-argument
+// inline IIFE — `(() => ...)()` — that appears inside a reactive array-method
+// callback. That branch (and its receiver-scanning helpers) runs today only as
+// a side effect of patterns compiling through the transformer in CI's
+// pattern-integration jobs, because reaching it needs the in-place expression
+// rewrite that array-method callback lowering performs. These tests place such
+// an IIFE inside a `.map()`/`.filter()` callback and assert on how the branch
+// treats it.
+//
+// Two outcomes are exercised. When the IIFE's body still performs a direct cell
+// read on a receiver declared outside the IIFE, the branch wraps the IIFE so the
+// read runs under a reactive cause context — the read is lowered and its cell
+// dependency is tracked into the callback's pattern input (`item.key("x")`).
+// When the IIFE instead decomposes through a local alias or an object-literal
+// projection, the branch preserves the authored IIFE verbatim so the inner
+// expression-site machinery handles it.
+
+const HEAD = `/// <cts-enable />
+import { Cell, pattern, UI, VNode } from "commonfabric";
+interface Row { x: Cell<number>; label: Cell<string>; }
+interface Input { items: Cell<Row[]>; base: Cell<number>; }
+interface Output { [UI]: VNode; }
+`;
+
+async function transformRender(body: string): Promise<string> {
+  const source = `${HEAD}
+export default pattern<Input, Output>(({ items, base }) => ({
+  [UI]: <div>{${body}}</div>,
+}));`;
+  return await transformSource(source, { types: COMMONFABRIC_TYPES });
+}
+
+/** The lowered `mapWithPattern` callback body extracted for focused assertions. */
+function patternCallbackBody(output: string): string {
+  const start = output.indexOf("__cfPattern_1 =");
+  assert(start >= 0, "expected an extracted map pattern callback");
+  const end = output.indexOf("}, {", start);
+  return output.slice(start, end);
+}
+
+Deno.test(
+  "zero-arg IIFE reading an element cell inside a map callback wraps the read into a reactive lift",
+  async () => {
+    const output = await transformRender(
+      `items.map((item) => (() => item.x.get())() + 1)`,
+    );
+    // The map lowered to mapWithPattern, and the IIFE's `item.x.get()` was
+    // wrapped into a lift-applied call whose input tracks the element cell path.
+    assertStringIncludes(output, "mapWithPattern");
+    const body = patternCallbackBody(output);
+    assertStringIncludes(body, "__cfLift");
+    assertStringIncludes(body, 'item.key("x")');
+    // The raw IIFE call form was replaced by the wrapper, not left authored.
+    assert(
+      !/\(\(\) =>/.test(body),
+      "expected the IIFE to be lowered, not preserved verbatim",
+    );
+  },
+);
+
+Deno.test(
+  "zero-arg IIFE mixing an outer cell and an element cell tracks both dependencies",
+  async () => {
+    const output = await transformRender(
+      `items.map((item) => (() => base.get() || 0)() + item.x.get())`,
+    );
+    const body = patternCallbackBody(output);
+    // Both the outer `base` cell and the element `item.x` cell reach the lift
+    // input, so neither reactive dependency is lost across the IIFE boundary.
+    assertStringIncludes(body, "__cfLift");
+    assertStringIncludes(body, "base: base");
+    assertStringIncludes(body, 'item.key("x")');
+  },
+);
+
+Deno.test(
+  "zero-arg IIFE read inside a filter predicate is wrapped while the chain lowers",
+  async () => {
+    const output = await transformRender(
+      `items.filter((item) => (() => item.x.get() > 0)()).map((item) => item.label)`,
+    );
+    // The filter+map chain lowers to filterWithPattern/mapWithPattern and the
+    // predicate IIFE's cell read is wrapped into a lift tracking the element.
+    assertStringIncludes(output, "filterWithPattern");
+    assertStringIncludes(output, "mapWithPattern");
+    assertStringIncludes(output, "__cfLift");
+    assertStringIncludes(output, 'item.key("x")');
+  },
+);
+
+Deno.test(
+  "zero-arg IIFE decomposing through a local alias is preserved verbatim",
+  async () => {
+    const output = await transformRender(
+      `items.map((item) => (() => { const p = item.x.get() || 0; return p; })() + 1)`,
+    );
+    const body = patternCallbackBody(output);
+    // The IIFE holds a local alias (`const p = item.x.get() || 0`), so the branch
+    // leaves the authored IIFE in place for the inner machinery to decompose
+    // rather than forcing a blanket wrapper around the whole call.
+    assert(
+      /\(\(\) =>/.test(body),
+      "expected the authored IIFE to be preserved",
+    );
+    assertStringIncludes(body, "item.x.get()");
+  },
+);
+
+Deno.test(
+  "zero-arg IIFE projecting an object-literal property is preserved verbatim",
+  async () => {
+    const output = await transformRender(
+      `items.map((item) => (() => ({ v: item.x.get() }))().v)`,
+    );
+    const body = patternCallbackBody(output);
+    // The IIFE returns an object literal that is immediately projected (`.v`);
+    // no direct external cell read survives the child rewrite, so the IIFE is
+    // returned unchanged.
+    assert(
+      /\(\(\) =>/.test(body),
+      "expected the authored IIFE to be preserved",
+    );
+    assertStringIncludes(body, "item.x.get()");
+  },
+);

--- a/packages/ts-transformers/test/cfc-transformer-coverage.test.ts
+++ b/packages/ts-transformers/test/cfc-transformer-coverage.test.ts
@@ -1,9 +1,15 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals } from "@std/assert";
+import ts from "typescript";
 import { transformSource, validateSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { collect, emittedSchemas, parseModule } from "./transformed-ast.ts";
 
-function normalizeOutput(output: string): string {
-  return output.replace(/\s+/g, " ");
+/** The single emitted schema literal, evaluated to its JS value. */
+async function schemaValue(source: string): Promise<Record<string, unknown>> {
+  const out = await transformSource(source, { types: COMMONFABRIC_TYPES });
+  const schemas = emittedSchemas(parseModule(out));
+  assertEquals(schemas.length, 1, `expected one emitted schema in:\n${out}`);
+  return schemas[0]!;
 }
 
 Deno.test("transformer coverage: nested aliases expand to canonical metadata", async () => {
@@ -22,13 +28,11 @@ Deno.test("transformer coverage: nested aliases expand to canonical metadata", a
     export default schema;
   `;
 
-  const output = normalizeOutput(
-    await transformSource(source, { types: COMMONFABRIC_TYPES }),
-  );
-
-  assertStringIncludes(output, "confidentiality: [");
-  assertStringIncludes(output, '"secret"');
-  assertStringIncludes(output, 'value: { type: "string" }');
+  const schema = await schemaValue(source);
+  const secret = (schema.properties as Record<string, any>).secret;
+  assertEquals(secret.type, "object");
+  assertEquals(secret.properties.value, { type: "string" });
+  assertEquals(secret.ifc, { confidentiality: ["secret"] });
 });
 
 Deno.test("transformer coverage: projection paths lower as canonical pointers", async () => {
@@ -47,15 +51,12 @@ Deno.test("transformer coverage: projection paths lower as canonical pointers", 
     export default schema;
   `;
 
-  const output = normalizeOutput(
-    await transformSource(source, { types: COMMONFABRIC_TYPES }),
-  );
-
-  assertStringIncludes(
-    output,
-    'projection: { from: "/", path: "/nested/path" }',
-  );
-  assertStringIncludes(output, 'title: { type: "string" }');
+  const schema = await schemaValue(source);
+  const projection = (schema.properties as Record<string, any>).projection;
+  assertEquals(projection.properties.title, { type: "string" });
+  assertEquals(projection.ifc, {
+    projection: { from: "/", path: "/nested/path" },
+  });
 });
 
 Deno.test("transformer coverage: opaque inputs lower to ifc.opaque", async () => {
@@ -73,12 +74,10 @@ Deno.test("transformer coverage: opaque inputs lower to ifc.opaque", async () =>
     export default schema;
   `;
 
-  const output = normalizeOutput(
-    await transformSource(source, { types: COMMONFABRIC_TYPES }),
-  );
-
-  assertStringIncludes(output, "ifc: { opaque: true }");
-  assertStringIncludes(output, 'token: { type: "string"');
+  const schema = await schemaValue(source);
+  const token = (schema.properties as Record<string, any>).token;
+  assertEquals(token.type, "string");
+  assertEquals(token.ifc, { opaque: true });
 });
 
 Deno.test("transformer coverage: imported Cfc metadata survives Writable.of type arguments", async () => {
@@ -102,16 +101,14 @@ Deno.test("transformer coverage: imported Cfc metadata survives Writable.of type
     export default body;
   `;
 
-  const output = normalizeOutput(
-    await transformSource(source, { types: COMMONFABRIC_TYPES }),
-  );
-
-  assertStringIncludes(output, 'type: "string"');
-  assertStringIncludes(
-    output,
-    'ifc: { integrity: [{ kind: "authored-by", subject: "alice" }] }',
-  );
-  assertEquals(output.includes("Unsupported intersection pattern"), false);
+  // The exact evaluated schema pins both the "string" base type and the
+  // integrity metadata, and its success proves the intersection was resolved
+  // rather than falling back to an "Unsupported intersection pattern" marker.
+  const schema = await schemaValue(source);
+  assertEquals(schema.type, "string");
+  assertEquals(schema.ifc, {
+    integrity: [{ kind: "authored-by", subject: "alice" }],
+  });
 });
 
 Deno.test("transformer coverage: UI helpers rewrite to intrinsic tags and data-ui markers", async () => {
@@ -126,12 +123,17 @@ Deno.test("transformer coverage: UI helpers rewrite to intrinsic tags and data-u
   const output = await transformSource(source, {
     types: COMMONFABRIC_TYPES,
   });
+  const root = parseModule(output);
 
-  assertStringIncludes(
-    output,
-    '<ct-button data-ui-action="SubmitDirectCommand">Go</ct-button>',
+  const buttons = collect(root, ts.isJsxElement).filter((element) =>
+    ts.isIdentifier(element.openingElement.tagName) &&
+    element.openingElement.tagName.text === "ct-button"
   );
-  assertEquals(output.includes("<UiAction"), false);
+  assertEquals(buttons.length, 1);
+  assertEquals(jsxStringAttr(buttons[0]!.openingElement, "data-ui-action"), {
+    value: "SubmitDirectCommand",
+  });
+  assertEquals(jsxTagNames(root).includes("UiAction"), false);
 });
 
 Deno.test("transformer coverage: WriteAuthorizedBy emits diagnostics for invalid forms", async () => {
@@ -162,3 +164,38 @@ Deno.test("transformer coverage: WriteAuthorizedBy emits diagnostics for invalid
     true,
   );
 });
+
+/** Every JSX tag name (opening/self-closing) appearing under `root`. */
+function jsxTagNames(root: ts.Node): string[] {
+  const names: string[] = [];
+  const add = (tagName: ts.JsxTagNameExpression): void => {
+    if (ts.isIdentifier(tagName)) names.push(tagName.text);
+  };
+  for (const element of collect(root, ts.isJsxElement)) {
+    add(element.openingElement.tagName);
+  }
+  for (const element of collect(root, ts.isJsxSelfClosingElement)) {
+    add(element.tagName);
+  }
+  return names;
+}
+
+/**
+ * The string-literal value of attribute `name` on a JSX opening/self-closing
+ * element, wrapped as `{ value }` when present so a missing attribute (`{}`) is
+ * distinguishable from an attribute whose value is empty or dynamic.
+ */
+function jsxStringAttr(
+  element: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
+  name: string,
+): { value: string } | Record<string, never> {
+  for (const attr of element.attributes.properties) {
+    if (!ts.isJsxAttribute(attr) || attr.name.getText() !== name) continue;
+    const initializer = attr.initializer;
+    if (initializer && ts.isStringLiteral(initializer)) {
+      return { value: initializer.text };
+    }
+    return {};
+  }
+  return {};
+}

--- a/packages/ts-transformers/test/cfc-ui-helper.test.ts
+++ b/packages/ts-transformers/test/cfc-ui-helper.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 import {
   CommonFabricTransformerPipeline,
@@ -7,6 +7,64 @@ import {
 } from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { transformSource } from "./utils.ts";
+import { collect, parseModule, patternSchemas } from "./transformed-ast.ts";
+
+/** Every JSX tag name (opening/self-closing) appearing under `root`. */
+function jsxTagNames(root: ts.Node): string[] {
+  const names: string[] = [];
+  const add = (tagName: ts.JsxTagNameExpression): void => {
+    if (ts.isIdentifier(tagName)) names.push(tagName.text);
+  };
+  for (const element of collect(root, ts.isJsxElement)) {
+    add(element.openingElement.tagName);
+  }
+  for (const element of collect(root, ts.isJsxSelfClosingElement)) {
+    add(element.tagName);
+  }
+  return names;
+}
+
+/**
+ * A JSX opening or self-closing element under `root` whose tag is `tag`.
+ * Fails when the count is not exactly one.
+ */
+function soleJsxElement(
+  root: ts.Node,
+  tag: string,
+): ts.JsxOpeningElement | ts.JsxSelfClosingElement {
+  const openings = collect(root, ts.isJsxElement)
+    .map((element) => element.openingElement)
+    .filter((opening) =>
+      ts.isIdentifier(opening.tagName) && opening.tagName.text === tag
+    );
+  const selfClosing = collect(root, ts.isJsxSelfClosingElement).filter((
+    element,
+  ) => ts.isIdentifier(element.tagName) && element.tagName.text === tag);
+  const all = [...openings, ...selfClosing];
+  assertEquals(all.length, 1, `expected exactly one <${tag}>`);
+  return all[0]!;
+}
+
+/**
+ * The value of attribute `name` on a JSX element. Returns `{ literal }` for a
+ * string-literal value, `{ dynamic: true }` for a `{...}` expression value, and
+ * `{}` when the attribute is absent — so a missing, literal, and dynamic
+ * attribute are all distinguishable.
+ */
+function jsxAttr(
+  element: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
+  name: string,
+): { literal: string } | { dynamic: true } | Record<string, never> {
+  for (const attr of element.attributes.properties) {
+    if (!ts.isJsxAttribute(attr) || attr.name.getText() !== name) continue;
+    const initializer = attr.initializer;
+    if (initializer && ts.isStringLiteral(initializer)) {
+      return { literal: initializer.text };
+    }
+    return { dynamic: true };
+  }
+  return {};
+}
 
 function createProgram(source: string): {
   program: ts.Program;
@@ -100,20 +158,29 @@ Deno.test(
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const root = parseModule(output);
 
-    assertStringIncludes(
-      output,
-      '<ct-button data-ui-action="SubmitDirectCommand"',
+    assertEquals(
+      jsxAttr(soleJsxElement(root, "ct-button"), "data-ui-action"),
+      { literal: "SubmitDirectCommand" },
     );
-    assertStringIncludes(
-      output,
-      '<ct-textarea data-ui-surface="PromptPane" data-ui-role="assistant"',
+    const textarea = soleJsxElement(root, "ct-textarea");
+    assertEquals(jsxAttr(textarea, "data-ui-surface"), {
+      literal: "PromptPane",
+    });
+    assertEquals(jsxAttr(textarea, "data-ui-role"), { literal: "assistant" });
+    const card = soleJsxElement(root, "ct-card");
+    assertEquals(jsxAttr(card, "data-ui-disclosure-kind"), {
+      literal: "warning",
+    });
+    const cardChild = (card as ts.JsxOpeningElement).parent as ts.JsxElement;
+    assertEquals(
+      cardChild.children.map((child) => child.getText()).join(""),
+      "Heads up",
     );
-    assertStringIncludes(
-      output,
-      '<ct-card data-ui-disclosure-kind="warning">Heads up</ct-card>',
-    );
-    assertEquals(output.includes("<UiAction"), false);
+    for (const helper of ["UiAction", "UiPromptSlot", "UiDisclosure"]) {
+      assertEquals(jsxTagNames(root).includes(helper), false);
+    }
   },
 );
 
@@ -195,9 +262,12 @@ Deno.test(
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const { output: outputSchema } = patternSchemas(parseModule(output));
 
-    assertStringIncludes(output, "uiContract");
-    assertStringIncludes(output, "SubmitDirectCommand");
+    assertEquals((outputSchema.ifc as Record<string, unknown>).uiContract, {
+      helper: "UiAction",
+      action: "SubmitDirectCommand",
+    });
   },
 );
 
@@ -218,10 +288,18 @@ Deno.test(
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const root = parseModule(output);
 
-    assertStringIncludes(output, 'data-ui-surface="PromptPane"');
-    assertStringIncludes(output, "data-ui-role={dynamicRole}");
-    assertEquals(output.includes("uiContract"), false);
+    const textarea = soleJsxElement(root, "ct-textarea");
+    assertEquals(jsxAttr(textarea, "data-ui-surface"), {
+      literal: "PromptPane",
+    });
+    assertEquals(jsxAttr(textarea, "data-ui-role"), { dynamic: true });
+    const { output: outputSchema } = patternSchemas(root);
+    assertEquals(
+      (outputSchema.ifc as Record<string, unknown> | undefined)?.uiContract,
+      undefined,
+    );
   },
 );
 
@@ -242,8 +320,11 @@ Deno.test(
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const { output: outputSchema } = patternSchemas(parseModule(output));
 
-    assertStringIncludes(output, "uiContract");
-    assertStringIncludes(output, "SubmitDirectCommand");
+    assertEquals((outputSchema.ifc as Record<string, unknown>).uiContract, {
+      helper: "UiAction",
+      action: "SubmitDirectCommand",
+    });
   },
 );

--- a/packages/ts-transformers/test/closures/array-method-utils-coverage.test.ts
+++ b/packages/ts-transformers/test/closures/array-method-utils-coverage.test.ts
@@ -1,6 +1,7 @@
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 
+import { collect } from "../transformed-ast.ts";
 import type { TransformationContext } from "../../src/core/mod.ts";
 import type { CaptureTreeNode } from "../../src/utils/capture-tree.ts";
 import {
@@ -87,14 +88,52 @@ function firstArrowParam(
   return found;
 }
 
-const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
-
-function print(node: ts.Node, file: ts.SourceFile): string {
-  return printer.printNode(ts.EmitHint.Unspecified, node, file);
-}
-
 const passthroughBindingId = (candidate: string): ts.Identifier =>
   ts.factory.createIdentifier(candidate);
+
+/**
+ * The bound leaf identifier names of a binding pattern (or any node containing
+ * binding elements), recursing through nested object and array patterns. This
+ * captures the identifiers a destructuring introduces regardless of how the
+ * printer lays the pattern out.
+ */
+function boundNames(node: ts.Node): string[] {
+  return collect(node, ts.isBindingElement).flatMap((element) =>
+    ts.isIdentifier(element.name) ? [element.name.text] : []
+  );
+}
+
+/** True when `node` contains a rest binding element (`...name`). */
+function hasRestElement(node: ts.Node): boolean {
+  return collect(node, ts.isBindingElement).some((element) =>
+    element.dotDotDotToken !== undefined
+  );
+}
+
+/** The identifiers a printed block reads or returns, by their source text. */
+function identifierTexts(node: ts.Node): Set<string> {
+  return new Set(collect(node, ts.isIdentifier).map((id) => id.text));
+}
+
+/**
+ * True when `node` declares `name` — as a plain `const name = ...` variable or
+ * as a leaf of a destructuring binding.
+ */
+function declaresName(node: ts.Node, name: string): boolean {
+  const asVariable = collect(node, ts.isVariableDeclaration).some((decl) =>
+    ts.isIdentifier(decl.name) && decl.name.text === name
+  );
+  return asVariable || boundNames(node).includes(name);
+}
+
+/** True when `node` contains `return <identifier>;` for the given name. */
+function returnsIdentifier(node: ts.Node, name: string): boolean {
+  return collect(node, ts.isReturnStatement).some((statement) =>
+    statement.expression !== undefined &&
+    ts.isIdentifier(statement.expression) &&
+    statement.expression.text === name
+  );
+}
 
 Deno.test("analyzeElementBinding synthesizes `element` when the callback takes no parameter", () => {
   const { checker } = createProgram("const x = 1;");
@@ -162,9 +201,7 @@ Deno.test("analyzeElementBinding normalizes a plain object destructuring paramet
   assertEquals(analysis.computedAliases.length, 0);
   assert(ts.isObjectBindingPattern(analysis.bindingName));
   assertEquals(analysis.elementIdentifier.text, "element");
-  const text = print(analysis.bindingName, sourceFile);
-  assertStringIncludes(text, "name");
-  assertStringIncludes(text, "value");
+  assertEquals(boundNames(analysis.bindingName), ["name", "value"]);
 });
 
 Deno.test("analyzeElementBinding walks nested object and array binding patterns", () => {
@@ -181,10 +218,10 @@ Deno.test("analyzeElementBinding walks nested object and array binding patterns"
   );
   assertEquals(analysis.computedAliases.length, 0);
   assert(ts.isObjectBindingPattern(analysis.bindingName));
-  const text = print(analysis.bindingName, sourceFile);
   // Nested object and array patterns are rebuilt with their leaf names intact.
-  assertStringIncludes(text, "inner");
-  assertStringIncludes(text, "first");
+  const names = new Set(boundNames(analysis.bindingName));
+  assert(names.has("inner"));
+  assert(names.has("first"));
 });
 
 Deno.test("analyzeElementBinding handles renamed and string-keyed object properties", () => {
@@ -200,9 +237,11 @@ Deno.test("analyzeElementBinding handles renamed and string-keyed object propert
     passthroughBindingId,
   );
   assertEquals(analysis.computedAliases.length, 0);
-  const text = print(analysis.bindingName, sourceFile);
-  assertStringIncludes(text, "renamed");
-  assertStringIncludes(text, "ok");
+  // The renamed property (`label: renamed`) and the string-keyed property
+  // (`"weird-key": ok`) bind their target identifiers, not their source keys.
+  const names = new Set(boundNames(analysis.bindingName));
+  assert(names.has("renamed"));
+  assert(names.has("ok"));
 });
 
 Deno.test("analyzeElementBinding preserves array holes and rest elements", () => {
@@ -219,10 +258,11 @@ Deno.test("analyzeElementBinding preserves array holes and rest elements", () =>
   );
   assertEquals(analysis.computedAliases.length, 0);
   assert(ts.isArrayBindingPattern(analysis.bindingName));
-  const text = print(analysis.bindingName, sourceFile);
   // The leading hole and the rest element are carried through the rebuild.
-  assertStringIncludes(text, "...rest");
-  assertStringIncludes(text, "second");
+  const names = new Set(boundNames(analysis.bindingName));
+  assert(names.has("second"));
+  assert(names.has("rest"));
+  assert(hasRestElement(analysis.bindingName));
 });
 
 Deno.test("analyzeElementBinding recurses into array elements that are themselves binding patterns", () => {
@@ -239,11 +279,11 @@ Deno.test("analyzeElementBinding recurses into array elements that are themselve
   );
   assertEquals(analysis.computedAliases.length, 0);
   assert(ts.isArrayBindingPattern(analysis.bindingName));
-  const text = print(analysis.bindingName, sourceFile);
   // Both the nested array pattern and the nested object pattern are rebuilt.
-  assertStringIncludes(text, "a");
-  assertStringIncludes(text, "b");
-  assertStringIncludes(text, "c");
+  const names = new Set(boundNames(analysis.bindingName));
+  assert(names.has("a"));
+  assert(names.has("b"));
+  assert(names.has("c"));
 });
 
 Deno.test("analyzeElementBinding drops nested object patterns that hold only a computed key inside an array", () => {
@@ -265,8 +305,7 @@ Deno.test("analyzeElementBinding drops nested object patterns that hold only a c
   assertEquals(analysis.computedAliases.length, 1);
   assertEquals(analysis.computedAliases[0].aliasName, "chosen");
   assert(analysis.destructureStatement);
-  const text = print(analysis.destructureStatement, sourceFile);
-  assertStringIncludes(text, "kept");
+  assert(boundNames(analysis.destructureStatement).includes("kept"));
 });
 
 Deno.test("analyzeElementBinding drops nested object patterns that hold only a computed key inside an object", () => {
@@ -286,10 +325,12 @@ Deno.test("analyzeElementBinding drops nested object patterns that hold only a c
   );
   assertEquals(analysis.computedAliases.length, 1);
   assert(analysis.destructureStatement);
-  const text = print(analysis.destructureStatement, sourceFile);
   // The nested-only-computed property is dropped; the sibling plain key stays.
-  assertStringIncludes(text, "kept");
-  assertEquals(text.includes("nested"), false);
+  assert(boundNames(analysis.destructureStatement).includes("kept"));
+  assertEquals(
+    identifierTexts(analysis.destructureStatement).has("nested"),
+    false,
+  );
 });
 
 Deno.test("analyzeElementBinding lifts a computed key into an alias with a residual destructure", () => {
@@ -311,9 +352,10 @@ Deno.test("analyzeElementBinding lifts a computed key into an alias with a resid
   assertEquals(analysis.computedAliases[0].aliasName, "chosen");
   assertEquals(analysis.elementIdentifier.text, "element");
   assert(analysis.destructureStatement);
-  const text = print(analysis.destructureStatement, sourceFile);
-  assertStringIncludes(text, "other");
-  assertStringIncludes(text, "element");
+  // The residual destructure binds the plain `other` property from the
+  // synthesized `element` receiver.
+  assert(boundNames(analysis.destructureStatement).includes("other"));
+  assert(identifierTexts(analysis.destructureStatement).has("element"));
 });
 
 Deno.test("rewriteCallbackBody returns the body unchanged when there are no computed aliases", () => {
@@ -348,9 +390,10 @@ Deno.test("rewriteCallbackBody injects alias and key prologues around an express
   // A concise expression body becomes a block; the key binding and the alias
   // binding are prepended, and the original expression returns from the block.
   assert(ts.isBlock(result));
-  const text = print(result, sourceFile);
-  assertStringIncludes(text, "chosen");
-  assertStringIncludes(text, "return chosen");
+  // The lifted alias `chosen` is bound in the prologue and the original
+  // expression body becomes a `return chosen;`.
+  assert(declaresName(result, "chosen"));
+  assert(returnsIdentifier(result, "chosen"));
 });
 
 Deno.test("rewriteCallbackBody reuses an existing block body when injecting alias prologues", () => {
@@ -370,9 +413,9 @@ Deno.test("rewriteCallbackBody reuses an existing block body when injecting alia
   );
   const result = rewriteCallbackBody(body, analysis, testContext(checker));
   assert(ts.isBlock(result));
-  const text = print(result, sourceFile);
   // The original block's statements are retained after the injected prologue.
-  assertStringIncludes(text, "return chosen");
+  assert(declaresName(result, "chosen"));
+  assert(returnsIdentifier(result, "chosen"));
 });
 
 /** Finds the body of the first arrow function in the source. */

--- a/packages/ts-transformers/test/closures/pattern-builder.test.ts
+++ b/packages/ts-transformers/test/closures/pattern-builder.test.ts
@@ -1,9 +1,10 @@
-import { assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 
 import { CrossStageState, TransformationContext } from "../../src/core/mod.ts";
 import type { CaptureTreeNode } from "../../src/utils/capture-tree.ts";
 import { PatternBuilder } from "../../src/closures/utils/pattern-builder.ts";
+import { collect, parseModule } from "../transformed-ast.ts";
 
 function createProgramAndContext(source: string): {
   sourceFile: ts.SourceFile;
@@ -99,5 +100,16 @@ Deno.test("PatternBuilder avoids capture collisions with nested explicit binding
     sourceFile,
   );
 
-  assertStringIncludes(printed, "isExpanded_1");
+  // The nested explicit `isExpanded` binding forces the captured `isExpanded`
+  // to be rebound under the fresh name `isExpanded_1`.
+  const root = parseModule(printed);
+  const renamed = collect(root, ts.isBindingElement).find((element) =>
+    element.propertyName !== undefined &&
+    ts.isIdentifier(element.propertyName) &&
+    element.propertyName.text === "isExpanded" &&
+    ts.isIdentifier(element.name)
+  );
+  assert(renamed, "expected an `isExpanded` binding element to be renamed");
+  assert(ts.isIdentifier(renamed.name));
+  assertEquals(renamed.name.text, "isExpanded_1");
 });

--- a/packages/ts-transformers/test/destructuring-lowering-coverage.test.ts
+++ b/packages/ts-transformers/test/destructuring-lowering-coverage.test.ts
@@ -105,6 +105,36 @@ function printType(node: ts.TypeNode, sourceFile: ts.SourceFile): string {
   ).replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Assert that `node` is a type-literal with a single property signature whose
+ * name (as `.text`) and numeric-literal value match. Pins the lowered default
+ * type on the returned AST node rather than on its printed text.
+ */
+function assertSingleNumericProp(
+  node: ts.TypeNode,
+  name: string,
+  value: string,
+): void {
+  assert(ts.isTypeLiteralNode(node), "expected a type literal");
+  assertEquals(node.members.length, 1);
+  const member = node.members[0]!;
+  assert(ts.isPropertySignature(member), "expected a property signature");
+  assert(
+    ts.isNumericLiteral(member.name) || ts.isStringLiteral(member.name),
+    "expected a numeric or string property name",
+  );
+  assertEquals(member.name.text, name);
+  assert(
+    member.type && ts.isLiteralTypeNode(member.type),
+    "expected a literal type",
+  );
+  assert(
+    ts.isNumericLiteral(member.type.literal),
+    "expected a numeric literal type value",
+  );
+  assertEquals(member.type.literal.text, value);
+}
+
 Deno.test("getStaticDefaultTypeNode lowers a bare bigint literal to its literal type", () => {
   const { sourceFile, checker } = createProgram("const big = 7n;");
   const context = testContext(checker);
@@ -163,7 +193,7 @@ Deno.test("getStaticDefaultTypeNode lowers a numeric object key and rejects a co
     context,
   );
   assert(numeric);
-  assertStringIncludes(printType(numeric, sourceFile), "3: 1;");
+  assertSingleNumericProp(numeric, "3", "1");
 
   // Computed property name is not a supported key kind, so the object is
   // rejected wholesale.
@@ -193,8 +223,7 @@ Deno.test("getStaticDefaultTypeNode lowers a no-substitution-template object key
 
   const typeNode = getStaticDefaultTypeNode(objectLiteral, context);
   assert(typeNode);
-  const blank = ts.createSourceFile("/x.ts", "", ts.ScriptTarget.ES2020, true);
-  assertStringIncludes(printType(typeNode, blank), '"tpl": 2;');
+  assertSingleNumericProp(typeNode, "tpl", "2");
 });
 
 Deno.test("getStaticDefaultTypeNode rejects an object whose property value is non-static", () => {

--- a/packages/ts-transformers/test/expression-rewrite-binary-coverage.test.ts
+++ b/packages/ts-transformers/test/expression-rewrite-binary-coverage.test.ts
@@ -1,5 +1,7 @@
-import { assert, assertStringIncludes, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import ts from "typescript";
+
+import { callsNamed, parseModule } from "./transformed-ast.ts";
 
 import { createDataFlowAnalyzer } from "../src/ast/mod.ts";
 import { CrossStageState, TransformationContext } from "../src/core/mod.ts";
@@ -160,7 +162,8 @@ Deno.test(
       },
     );
     assert(printed, "expected the && to be lowered");
-    assertStringIncludes(printed, "__cfHelpers.when(");
+    const root = parseModule(printed);
+    assertEquals(callsNamed(root, "when").length, 1);
   },
 );
 
@@ -180,7 +183,8 @@ Deno.test(
       },
     );
     assert(printed, "expected the || to be lowered");
-    assertStringIncludes(printed, "__cfHelpers.unless(");
+    const root = parseModule(printed);
+    assertEquals(callsNamed(root, "unless").length, 1);
   },
 );
 
@@ -200,10 +204,11 @@ Deno.test(
       },
     );
     assert(printed, "expected the && to be lowered");
-    assertStringIncludes(printed, "__cfHelpers.when(");
+    const root = parseModule(printed);
+    assertEquals(callsNamed(root, "when").length, 1);
     // The complex left operand is wrapped as a reactive condition rather than
     // passed through verbatim.
-    assertStringIncludes(printed, "__cfHelpers.lift(");
+    assertEquals(callsNamed(root, "lift").length, 1);
   },
 );
 
@@ -223,8 +228,9 @@ Deno.test(
       },
     );
     assert(printed, "expected the || to be lowered");
-    assertStringIncludes(printed, "__cfHelpers.unless(");
-    assertStringIncludes(printed, "__cfHelpers.lift(");
+    const root = parseModule(printed);
+    assertEquals(callsNamed(root, "unless").length, 1);
+    assertEquals(callsNamed(root, "lift").length, 1);
   },
 );
 
@@ -312,7 +318,7 @@ Deno.test(
       },
     );
     assert(printed, "expected arithmetic to be wrapped");
-    assertStringIncludes(printed, "__cfHelpers.lift(");
+    assertEquals(callsNamed(parseModule(printed), "lift").length, 1);
   },
 );
 
@@ -406,7 +412,7 @@ Deno.test(
     // (which would otherwise throw for a compute-owned node) and still emits a
     // lift wrapper.
     assert(printed, "expected the synthetic array receiver to be wrapped");
-    assertStringIncludes(printed, "__cfHelpers.lift(");
+    assertEquals(callsNamed(parseModule(printed), "lift").length, 1);
   },
 );
 

--- a/packages/ts-transformers/test/fetch-json-injection.test.ts
+++ b/packages/ts-transformers/test/fetch-json-injection.test.ts
@@ -1,6 +1,24 @@
-import { assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { callsNamed, emittedSchemas, parseModule } from "./transformed-ast.ts";
+
+// The Repo schema the transformer derives from `fetchJson<Repo>(...)`.
+const REPO_SCHEMA = {
+  type: "object",
+  properties: { name: { type: "string" }, stars: { type: "number" } },
+  required: ["name", "stars"],
+};
+
+/** The object-literal argument passed to the single emitted `fetchJson` call. */
+function fetchJsonArg(output: string): ts.ObjectLiteralExpression {
+  const call = callsNamed(parseModule(output), "fetchJson").at(-1);
+  assert(call, "expected an emitted fetchJson call");
+  const arg = call.arguments[0];
+  assert(arg && ts.isObjectLiteralExpression(arg));
+  return arg;
+}
 
 const REPO = `
 interface Repo {
@@ -26,9 +44,21 @@ Deno.test("fetchJson injects a schema by spreading a non-literal argument", asyn
 
   const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
 
-  // The derived schema is emitted, and the original argument is spread in.
-  assertStringIncludes(output, "schema");
-  assertStringIncludes(output, "...opts");
+  // The derived schema is emitted as the `schema` property, and the original
+  // argument is spread in alongside it.
+  const root = parseModule(output);
+  assertEquals(emittedSchemas(root), [REPO_SCHEMA]);
+  const arg = fetchJsonArg(output);
+  const hasSchemaProp = arg.properties.some((property) =>
+    ts.isPropertyAssignment(property) &&
+    ts.isIdentifier(property.name) && property.name.text === "schema"
+  );
+  assert(hasSchemaProp, "expected an injected `schema` property");
+  const spreadsOpts = arg.properties.some((property) =>
+    ts.isSpreadAssignment(property) &&
+    ts.isIdentifier(property.expression) && property.expression.text === "opts"
+  );
+  assert(spreadsOpts, "expected the original argument spread as `...opts`");
 });
 
 Deno.test("fetchJson injects a schema when called with no argument", async () => {
@@ -44,5 +74,14 @@ Deno.test("fetchJson injects a schema when called with no argument", async () =>
 
   // With no argument, the injected schema becomes the sole property of a fresh
   // params object.
-  assertStringIncludes(output, "schema");
+  const root = parseModule(output);
+  assertEquals(emittedSchemas(root), [REPO_SCHEMA]);
+  const arg = fetchJsonArg(output);
+  assertEquals(arg.properties.length, 1);
+  const [only] = arg.properties;
+  assert(
+    ts.isPropertyAssignment(only) && ts.isIdentifier(only.name) &&
+      only.name.text === "schema",
+    "expected `schema` to be the sole property",
+  );
 });

--- a/packages/ts-transformers/test/lift-applied/create-lift-applied-call.test.ts
+++ b/packages/ts-transformers/test/lift-applied/create-lift-applied-call.test.ts
@@ -1,9 +1,10 @@
-import { assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 
 import { createLiftAppliedCall } from "../../src/transformers/builtins/lift-applied.ts";
 import { CFHelpers } from "../../src/core/cf-helpers.ts";
 import { CrossStageState } from "../../src/core/mod.ts";
+import { callsNamed, parseModule } from "../transformed-ast.ts";
 
 Deno.test("createLiftAppliedCall keeps fallback refs synced when names collide", () => {
   const source = ts.createSourceFile(
@@ -99,5 +100,28 @@ Deno.test("createLiftAppliedCall keeps fallback refs synced when names collide",
     throw new Error("derive call not printed");
   }
 
-  assertStringIncludes(printed, "=> _v1_1");
+  // The colliding fallback binding is renamed: the lift callback destructures
+  // `v1__` under the fresh name `_v1_1` and returns that same identifier.
+  const root = parseModule(printed);
+  const liftCall = callsNamed(root, "lift").at(0);
+  assert(liftCall, "expected a lift call");
+  const callback = liftCall.arguments[0];
+  assert(callback && ts.isArrowFunction(callback), "expected a lift callback");
+  const binding = callback.parameters[0]?.name;
+  assert(
+    binding && ts.isObjectBindingPattern(binding),
+    "expected a destructuring parameter",
+  );
+  const renamed = binding.elements.find((element) =>
+    element.propertyName !== undefined &&
+    ts.isIdentifier(element.propertyName) &&
+    element.propertyName.text === "v1__"
+  );
+  assert(renamed, "expected a `v1__` binding element");
+  assert(ts.isIdentifier(renamed.name));
+  assertEquals(renamed.name.text, "_v1_1");
+  assert(
+    ts.isIdentifier(callback.body) && callback.body.text === "_v1_1",
+    "expected the callback body to return the renamed binding",
+  );
 });

--- a/packages/ts-transformers/test/module-scope-cf-data-coverage.test.ts
+++ b/packages/ts-transformers/test/module-scope-cf-data-coverage.test.ts
@@ -1,9 +1,64 @@
-import { assert, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { ModuleScopeCfDataTransformer } from "../src/transformers/module-scope-cf-data.ts";
 import { TransformationContext } from "../src/core/mod.ts";
+import {
+  calleeName,
+  callsNamed,
+  collect,
+  parseModule,
+} from "./transformed-ast.ts";
+
+/**
+ * True when the module imports `{ <imported> as <local> }` from `<module>`.
+ */
+function hasNamedImport(
+  root: ts.SourceFile,
+  imported: string,
+  local: string,
+  moduleSpecifier: string,
+): boolean {
+  return collect(root, ts.isImportDeclaration).some((decl) => {
+    if (
+      !ts.isStringLiteral(decl.moduleSpecifier) ||
+      decl.moduleSpecifier.text !== moduleSpecifier
+    ) {
+      return false;
+    }
+    const bindings = decl.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) return false;
+    return bindings.elements.some((element) =>
+      element.name.text === local &&
+      (element.propertyName?.text ?? element.name.text) === imported
+    );
+  });
+}
+
+/**
+ * The bare-identifier argument of the sole `__cfDataHelper(...)` wrap call, or
+ * undefined if there is no such call. Asserts there is at most one.
+ */
+function cfDataHelperArgText(root: ts.SourceFile): string | undefined {
+  const calls = callsNamed(root, "__cfDataHelper");
+  assert(
+    calls.length <= 1,
+    `expected at most one wrap call, got ${calls.length}`,
+  );
+  const call = calls[0];
+  return call?.arguments[0]?.getText(root);
+}
+
+/** The expression of `export default <expr>`, or undefined if there is none. */
+function defaultExportExpression(
+  root: ts.SourceFile,
+): ts.Expression | undefined {
+  const assignment = collect(root, ts.isExportAssignment).find((node) =>
+    !node.isExportEquals
+  );
+  return assignment?.expression;
+}
 
 // The module-scope cf-data transformer wraps top-level data expressions with a
 // `__cf_data` helper call. The existing `module-scope-cf-data.test.ts` drives
@@ -74,11 +129,12 @@ Deno.test(
     );
     // With no `__cfHelpers` import present the transformer prepends its own
     // named import and wraps the snapshot call with the bare identifier form.
-    assertStringIncludes(
-      output,
-      'import { __cf_data as __cfDataHelper } from "commonfabric"',
+    const root = parseModule(output);
+    assert(
+      hasNamedImport(root, "__cf_data", "__cfDataHelper", "commonfabric"),
+      "expected the injected __cf_data import",
     );
-    assertStringIncludes(output, "const z = __cfDataHelper(n())");
+    assertEquals(cfDataHelperArgText(root), "n()");
   },
 );
 
@@ -90,7 +146,7 @@ Deno.test(
     );
     // A union return type is classified as primitive-like when every member is
     // primitive-like, so the snapshot call is wrapped.
-    assertStringIncludes(output, "const z = __cfDataHelper(u())");
+    assertEquals(cfDataHelperArgText(parseModule(output)), "u()");
   },
 );
 
@@ -101,7 +157,7 @@ Deno.test(
       `type A = string;\ntype B = string;\ndeclare function u(): A & B;\nconst z = u();\n`,
     );
     // An intersection is primitive-like when every member is primitive-like.
-    assertStringIncludes(output, "const z = __cfDataHelper(u())");
+    assertEquals(cfDataHelperArgText(parseModule(output)), "u()");
   },
 );
 
@@ -113,8 +169,9 @@ Deno.test(
     );
     // The object member is not primitive-like, so the intersection fails the
     // `every` check and the call is not treated as a snapshot.
-    assert(
-      !output.includes("__cfDataHelper"),
+    assertEquals(
+      callsNamed(parseModule(output), "__cfDataHelper").length,
+      0,
       "expected the non-primitive intersection to be left unwrapped",
     );
   },
@@ -129,10 +186,15 @@ Deno.test(
     // `callableMayReturnCallResult` returns false for a declaration without a
     // body, so the ambient callable is not classified as a default-exported
     // data callable.
-    assert(
-      !output.includes("__cfDataHelper"),
+    const root = parseModule(output);
+    assertEquals(
+      callsNamed(root, "__cfDataHelper").length,
+      0,
       "expected the body-less declared callable to be left unwrapped",
     );
+    // The default export stays the bare identifier, not a wrap call.
+    const exported = defaultExportExpression(root);
+    assert(exported && ts.isIdentifier(exported) && exported.text === "helper");
   },
 );
 
@@ -147,7 +209,11 @@ Deno.test(
     // The nested-expression walk skips the leading class boundary, finds the
     // `factory()()` call-on-call, then short-circuits over the trailing member,
     // classifying `nested` as a default-exported data callable.
-    assertStringIncludes(output, "export default __cfDataHelper(nested)");
+    const root = parseModule(output);
+    const exported = defaultExportExpression(root);
+    assert(exported && ts.isCallExpression(exported), "expected a wrap call");
+    assertEquals(calleeName(exported), "__cfDataHelper");
+    assertEquals(exported.arguments[0]?.getText(root), "nested");
   },
 );
 
@@ -167,9 +233,17 @@ Deno.test(
     );
     // The block traversal finds the call-on-call return inside the branch, then
     // short-circuits the visit over the remaining statements.
-    assertStringIncludes(
-      output,
-      "export default __cfHelpers.__cf_data(helper)",
+    const root = parseModule(output);
+    const exported = defaultExportExpression(root);
+    assert(exported && ts.isCallExpression(exported), "expected a wrap call");
+    const callee = exported.expression;
+    assert(
+      ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        callee.expression.text === "__cfHelpers" &&
+        callee.name.text === "__cf_data",
+      "expected __cfHelpers.__cf_data callee",
     );
+    assertEquals(exported.arguments[0]?.getText(root), "helper");
   },
 );

--- a/packages/ts-transformers/test/module-scope-cf-data.test.ts
+++ b/packages/ts-transformers/test/module-scope-cf-data.test.ts
@@ -1,6 +1,19 @@
-import { assert, assertStringIncludes } from "@std/assert";
+import { assert } from "@std/assert";
+import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { callsNamed, parseModule } from "./transformed-ast.ts";
+
+// The default export is `__cfHelpers.__cf_data(helper)`: one call to the member
+// `__cf_data` whose sole argument is the identifier `helper`.
+function wrapsHelper(out: string): boolean {
+  const calls = callsNamed(parseModule(out), "__cf_data");
+  return calls.some((call) => {
+    const arg = call.arguments[0];
+    return call.arguments.length === 1 && arg !== undefined &&
+      ts.isIdentifier(arg) && arg.text === "helper";
+  });
+}
 
 // The module-scope cf-data transformer wraps a default-exported callable with
 // `__cfHelpers.__cf_data` when that callable's body may return a call applied to
@@ -23,7 +36,7 @@ Deno.test("module-scope cf-data wraps an arrow callable returning a call-on-call
     "const helper = () => factory()();",
     "export default helper;",
   ]);
-  assertStringIncludes(out, "export default __cfHelpers.__cf_data(helper)");
+  assert(wrapsHelper(out));
 });
 
 Deno.test("module-scope cf-data wraps a block-body callable whose return is a call-on-call result", async () => {
@@ -35,7 +48,7 @@ Deno.test("module-scope cf-data wraps a block-body callable whose return is a ca
     "};",
     "export default helper;",
   ]);
-  assertStringIncludes(out, "export default __cfHelpers.__cf_data(helper)");
+  assert(wrapsHelper(out));
 });
 
 Deno.test("module-scope cf-data wraps when the call-on-call result is nested in the returned expression", async () => {
@@ -43,7 +56,7 @@ Deno.test("module-scope cf-data wraps when the call-on-call result is nested in 
     "const helper = () => ({ value: factory()() });",
     "export default helper;",
   ]);
-  assertStringIncludes(out, "export default __cfHelpers.__cf_data(helper)");
+  assert(wrapsHelper(out));
 });
 
 Deno.test("module-scope cf-data ignores a call-on-call result inside a nested function boundary", async () => {
@@ -56,10 +69,7 @@ Deno.test("module-scope cf-data ignores a call-on-call result inside a nested fu
   ]);
   // The call-on-call result lives inside the inner arrow, which is a traversal
   // boundary, so the outer callable is not treated as returning a call result.
-  assert(
-    !out.includes("__cf_data(helper)"),
-    "expected helper to be left unwrapped",
-  );
+  assert(!wrapsHelper(out), "expected helper to be left unwrapped");
 });
 
 Deno.test("module-scope cf-data ignores a callable whose body expression is itself a function", async () => {
@@ -69,8 +79,5 @@ Deno.test("module-scope cf-data ignores a callable whose body expression is itse
   ]);
   // The arrow body is a function expression — a traversal boundary — so the
   // nested call-on-call result is not attributed to `helper`.
-  assert(
-    !out.includes("__cf_data(helper)"),
-    "expected helper to be left unwrapped",
-  );
+  assert(!wrapsHelper(out), "expected helper to be left unwrapped");
 });

--- a/packages/ts-transformers/test/module-scope-function-hardening-coverage.test.ts
+++ b/packages/ts-transformers/test/module-scope-function-hardening-coverage.test.ts
@@ -1,6 +1,39 @@
-import { assert, assertStringIncludes } from "@std/assert";
+import { assert } from "@std/assert";
+import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { callsNamed, collect, parseModule } from "./transformed-ast.ts";
+
+/** The single default-export assignment's expression, if any. */
+function defaultExportExpression(
+  root: ts.SourceFile,
+): ts.Expression | undefined {
+  const assignment = collect(root, ts.isExportAssignment).find((node) =>
+    !node.isExportEquals
+  );
+  return assignment?.expression;
+}
+
+/** The variable declaration whose name starts with `prefix`, if any. */
+function variableNamed(
+  root: ts.SourceFile,
+  prefix: string,
+): ts.VariableDeclaration | undefined {
+  return collect(root, ts.isVariableDeclaration).find((decl) =>
+    ts.isIdentifier(decl.name) && decl.name.text.startsWith(prefix)
+  );
+}
+
+/** The `__cfHardenFn(...)` call whose first argument is a function expression. */
+function hardenedFunctionExpression(
+  root: ts.SourceFile,
+): ts.FunctionExpression | undefined {
+  for (const call of callsNamed(root, "__cfHardenFn")) {
+    const arg = call.arguments[0];
+    if (arg && ts.isFunctionExpression(arg)) return arg;
+  }
+  return undefined;
+}
 
 // Module-scope function hardening freezes every top-level callable and, for
 // callables a `WriteAuthorizedBy` / `TrustedActionWrite` type references,
@@ -28,9 +61,18 @@ Deno.test(
     // The nameless default export cannot be referenced by name, so it is
     // lowered into a hoisted `const` bound to a hardened function expression and
     // re-exported by that generated name.
-    assertStringIncludes(output, "const __cfDefaultFn");
-    assertStringIncludes(output, "export default __cfDefaultFn");
-    assertStringIncludes(output, "__cfHardenFn(function () { return 1; })");
+    const root = parseModule(output);
+    const decl = variableNamed(root, "__cfDefaultFn");
+    assert(decl, "expected a `const __cfDefaultFn` declaration");
+    const exported = defaultExportExpression(root);
+    assert(exported && ts.isIdentifier(exported));
+    assert(exported.text.startsWith("__cfDefaultFn"));
+    const wrapped = hardenedFunctionExpression(root);
+    assert(wrapped, "expected __cfHardenFn to wrap a function expression");
+    assert(
+      !wrapped.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword),
+      "expected the wrapped function to be non-async",
+    );
   },
 );
 
@@ -46,9 +88,18 @@ Deno.test(
     // Only the `async` modifier survives on the generated function expression;
     // the export/default modifiers are dropped because the const carries the
     // export.
-    assertStringIncludes(output, "const __cfDefaultFn");
-    assertStringIncludes(output, "__cfHardenFn(async function () {");
-    assertStringIncludes(output, "export default __cfDefaultFn");
+    const root = parseModule(output);
+    const decl = variableNamed(root, "__cfDefaultFn");
+    assert(decl, "expected a `const __cfDefaultFn` declaration");
+    const exported = defaultExportExpression(root);
+    assert(exported && ts.isIdentifier(exported));
+    assert(exported.text.startsWith("__cfDefaultFn"));
+    const wrapped = hardenedFunctionExpression(root);
+    assert(wrapped, "expected __cfHardenFn to wrap a function expression");
+    assert(
+      wrapped.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword),
+      "expected the wrapped function expression to keep its async modifier",
+    );
   },
 );
 
@@ -69,11 +120,27 @@ Deno.test(
     // exported. The identity annotation and the hardening wrap are therefore
     // emitted as separate statements after the declaration rather than inlined
     // into the initializer.
+    const root = parseModule(output);
+    const saveTitle = variableNamed(root, "saveTitle");
+    assert(saveTitle?.initializer, "expected a `saveTitle` declaration");
     assert(
-      !output.includes("const saveTitle = __cfBindVerifiedBinding("),
-      "expected the annotation to be statement-form, not inlined",
+      ts.isArrowFunction(saveTitle.initializer),
+      "expected the annotation to be statement-form, not inlined into the initializer",
     );
-    assertStringIncludes(output, "__cfBindVerifiedBinding(saveTitle, {");
-    assertStringIncludes(output, "__cfHardenFn(saveTitle)");
+
+    const argIsSaveTitle = (call: ts.CallExpression): boolean => {
+      const arg = call.arguments[0];
+      return !!arg && ts.isIdentifier(arg) && arg.text === "saveTitle";
+    };
+    assert(
+      callsNamed(root, "__cfBindVerifiedBinding").some((call) =>
+        argIsSaveTitle(call) && ts.isObjectLiteralExpression(call.arguments[1]!)
+      ),
+      "expected a statement-form __cfBindVerifiedBinding(saveTitle, { ... }) call",
+    );
+    assert(
+      callsNamed(root, "__cfHardenFn").some(argIsSaveTitle),
+      "expected a separate __cfHardenFn(saveTitle) hardening call",
+    );
   },
 );

--- a/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
+++ b/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
@@ -1,8 +1,9 @@
 import ts from "typescript";
-import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertMatch } from "@std/assert";
 import {
   PatternCoverageTransformer,
 } from "../src/transformers/pattern-coverage.ts";
+import { collect, literalToValue, parseModule } from "./transformed-ast.ts";
 import { CommonFabricTransformerPipeline } from "../src/cf-pipeline.ts";
 import {
   type PatternCoverageOptions,
@@ -102,6 +103,21 @@ function transformWithDirectCall(source: string): string {
   ]);
 
   return printResult(result);
+}
+
+// Every emitted `(globalThis.__cfPatternCoverage?.hit)(file, id)` call, with its
+// arguments evaluated to their JS values. The callee is a parenthesized
+// optional-chain member access, so it is matched by unwrapping the parens and
+// checking the `.hit` member name rather than by a simple call-name lookup.
+function hitCallArgs(root: ts.Node): unknown[][] {
+  return collect(root, ts.isCallExpression)
+    .filter((call) => {
+      let callee: ts.Expression = call.expression;
+      while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+      return ts.isPropertyAccessExpression(callee) &&
+        callee.name.text === "hit";
+    })
+    .map((call) => call.arguments.map((arg) => literalToValue(arg)));
 }
 
 function sourceTextForSpan(source: string, span: PatternCoverageSpan): string {
@@ -281,11 +297,24 @@ export {};
   expectSpanContaining(spans, source, "return this.value;");
   expectSpanContaining(spans, source, "this.value = value;");
   expectSpanContaining(spans, source, "return arrowExpression(this.value);");
-  assertStringIncludes(
-    output,
-    '(globalThis.__cfPatternCoverage?.hit)("mapped:/pattern.tsx", 1001);',
+  const root = parseModule(output);
+  // The first mapped span (id 1 + 1000) becomes a hit call keyed by the mapped
+  // file name and mapped id.
+  assert(
+    hitCallArgs(root).some((args) =>
+      args.length === 2 && args[0] === "mapped:/pattern.tsx" && args[1] === 1001
+    ),
+    "expected a hit call for the mapped file and id 1001",
   );
-  assertStringIncludes(output, "function declaredFunction(flag: boolean) {");
+  // The authored `declaredFunction(flag: boolean)` signature survives the
+  // instrumenting transform.
+  const declared = collect(root, ts.isFunctionDeclaration).find((fn) =>
+    fn.name?.text === "declaredFunction"
+  );
+  assert(declared, "expected declaredFunction to be emitted");
+  const flag = declared.parameters[0];
+  assert(flag && ts.isIdentifier(flag.name) && flag.name.text === "flag");
+  assertEquals(flag.type?.kind, ts.SyntaxKind.BooleanKeyword);
   assertMatch(
     output,
     /function declaredFunction\(flag: boolean\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -1,56 +1,152 @@
-import {
-  assert,
-  assertEquals,
-  assertMatch,
-  assertStringIncludes,
-} from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
 import { CFC_TRANSFORMER_STAGE_NAMES } from "../src/cf-pipeline.ts";
 import { transformSource, validateSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import {
+  callsNamed,
+  collect,
+  emittedSchemas,
+  hasKeyPathRead,
+  literalToValue,
+  parseModule,
+} from "./transformed-ast.ts";
 
-function extractSchemas(output: string): string[] {
-  const schemas: string[] = [];
-  const marker = "as const satisfies __cfHelpers.JSONSchema";
-  let searchFrom = 0;
-  while (true) {
-    const markerIdx = output.indexOf(marker, searchFrom);
-    if (markerIdx === -1) break;
-
-    let start = markerIdx - 1;
-    while (start >= 0 && /\s/.test(output[start]!)) start--;
-
-    let schemaText: string | undefined;
-    if (output[start] === "}") {
-      let depth = 1;
-      start--;
-      while (start >= 0 && depth > 0) {
-        if (output[start] === "}") depth++;
-        else if (output[start] === "{") depth--;
-        start--;
-      }
-      start++;
-      schemaText = output.slice(start, markerIdx).trim();
-    } else {
-      let tokenStart = start;
-      while (tokenStart >= 0 && /[A-Za-z]/.test(output[tokenStart]!)) {
-        tokenStart--;
-      }
-      tokenStart++;
-      const token = output.slice(tokenStart, start + 1).trim();
-      if (token === "true" || token === "false") {
-        schemaText = token;
-      }
-    }
-
-    if (!schemaText) {
-      searchFrom = markerIdx + marker.length;
-      continue;
-    }
-
-    schemas.push(schemaText);
-    searchFrom = markerIdx + marker.length;
+/**
+ * The hoisted `const __cfLift_N = __cfHelpers.lift(...)` call that ultimately
+ * produces `const <resultName> = …`. Walks the `.for(...)` chain on the result
+ * initializer down to the `__cfLift_N(...)` application, then finds the matching
+ * declaration.
+ */
+function liftCallFor(
+  root: ts.SourceFile,
+  resultName: string,
+): ts.CallExpression {
+  const decl = collect(root, ts.isVariableDeclaration).find((d) =>
+    ts.isIdentifier(d.name) && d.name.text === resultName
+  );
+  if (!decl?.initializer) {
+    throw new Error(`No \`const ${resultName} = …\` declaration`);
   }
-  return schemas;
+  let expr: ts.Expression = decl.initializer;
+  while (
+    ts.isCallExpression(expr) && ts.isPropertyAccessExpression(expr.expression)
+  ) {
+    expr = expr.expression.expression;
+  }
+  if (!ts.isCallExpression(expr) || !ts.isIdentifier(expr.expression)) {
+    throw new Error(`Expected ${resultName} to apply a hoisted lift`);
+  }
+  const liftId = expr.expression.text;
+  const liftDecl = collect(root, ts.isVariableDeclaration).find((d) =>
+    ts.isIdentifier(d.name) && d.name.text === liftId
+  );
+  if (!liftDecl?.initializer || !ts.isCallExpression(liftDecl.initializer)) {
+    throw new Error(`No hoisted lift declaration for ${liftId}`);
+  }
+  return liftDecl.initializer;
+}
+
+/**
+ * The `... satisfies …JSONSchema` argument literals of a hoisted lift call,
+ * evaluated in argument order. The lift signature is `lift(cb, argSchema,
+ * resSchema)`, so index 0 is the input schema and index 1 the result schema.
+ */
+function liftSchemaArgs(call: ts.CallExpression): Record<string, unknown>[] {
+  return call.arguments
+    .filter((arg): arg is ts.SatisfiesExpression =>
+      ts.isSatisfiesExpression(arg)
+    )
+    .map((arg) => literalToValue(arg) as Record<string, unknown>);
+}
+
+/** The argument and result schemas of the hoisted lift driving `resultName`. */
+function liftSchemasFor(
+  root: ts.SourceFile,
+  resultName: string,
+): { argSchema: Record<string, unknown>; resSchema: Record<string, unknown> } {
+  const schemas = liftSchemaArgs(liftCallFor(root, resultName));
+  if (schemas.length < 2) {
+    throw new Error(`Expected two schema arguments for ${resultName}`);
+  }
+  return { argSchema: schemas[0]!, resSchema: schemas[1]! };
+}
+
+/**
+ * The input (argument) schema of the first hoisted lift emitted in `root` — the
+ * lift a lone `computed()` capture lowers to.
+ */
+function firstLiftArgSchema(root: ts.SourceFile): Record<string, unknown> {
+  const liftCall = callsNamed(root, "lift").find((call) =>
+    ts.isPropertyAccessExpression(call.expression) &&
+    ts.isIdentifier(call.expression.expression) &&
+    call.expression.expression.text === "__cfHelpers"
+  );
+  if (!liftCall) {
+    throw new Error("expected an emitted __cfHelpers.lift(...) call");
+  }
+  const schemas = liftSchemaArgs(liftCall);
+  if (schemas.length < 1) throw new Error("lift call had no schema arguments");
+  return schemas[0]!;
+}
+
+/** Every `type` string that appears anywhere within an evaluated schema. */
+function collectSchemaTypes(value: unknown, acc: string[] = []): string[] {
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      if (key === "type" && typeof child === "string") acc.push(child);
+      collectSchemaTypes(child, acc);
+    }
+  }
+  return acc;
+}
+
+/**
+ * True when `node` sits inside a callback arrow that a reactive compute owns —
+ * an arrow passed directly to `lift`/`derive`, or the callback of a hoisted
+ * `const __cfLift_N = __cfHelpers.lift(cb, …)` declaration. This distinguishes a
+ * call the pipeline extracted into a synthetic compute from one left structural.
+ */
+function isInsideExtractedComputeCallback(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) {
+      const arrowParent = current.parent;
+      if (arrowParent && ts.isCallExpression(arrowParent)) {
+        const callee = arrowParent.expression;
+        const calleeName = ts.isIdentifier(callee)
+          ? callee.text
+          : ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : undefined;
+        if (calleeName === "lift" || calleeName === "derive") return true;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+/**
+ * True when `node` has an ancestor call whose target name (bare or member) is
+ * `name` — e.g. it is nested inside a `derive(...)` / `__cfHelpers.derive(...)`
+ * call.
+ */
+function isInsideCallNamed(node: ts.Node, name: string): boolean {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isCallExpression(current)) {
+      const callee = current.expression;
+      const calleeName = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee)
+        ? callee.name.text
+        : undefined;
+      if (calleeName === name) return true;
+    }
+    current = current.parent;
+  }
+  return false;
 }
 
 Deno.test(
@@ -83,11 +179,34 @@ const p = pattern<{ items: string[] }>((state) => ({
     );
 
     assertEquals(computationDiagnostics.length, 0);
-    assertStringIncludes(
-      output,
-      "const fontSize = __cf_pattern_input.params.style[key];",
+
+    const root = parseModule(output);
+    // `fontSize` binds to a dynamic element access `…style[key]`, keyed by the
+    // `key` identifier, never resolved to the static `.small` member.
+    const fontSizeDecl = collect(root, ts.isVariableDeclaration).find((decl) =>
+      ts.isIdentifier(decl.name) && decl.name.text === "fontSize"
     );
-    assert(!output.includes("__cf_pattern_input.params.style.small"));
+    assert(fontSizeDecl?.initializer, "expected a fontSize declaration");
+    const access = fontSizeDecl.initializer;
+    assert(
+      ts.isElementAccessExpression(access) &&
+        ts.isIdentifier(access.argumentExpression) &&
+        access.argumentExpression.text === "key",
+      "expected fontSize to bind a `[key]` element access",
+    );
+    const style = access.expression;
+    assert(
+      ts.isPropertyAccessExpression(style) && style.name.text === "style",
+      "expected the element access base to be `…style`",
+    );
+    assert(
+      !collect(root, ts.isPropertyAccessExpression).some((pa) =>
+        pa.name.text === "small" &&
+        ts.isPropertyAccessExpression(pa.expression) &&
+        pa.expression.name.text === "style"
+      ),
+      "expected no static `style.small` resolution",
+    );
   },
 );
 
@@ -136,11 +255,33 @@ const p = pattern<{ item: { title: string } }>((state) => {
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(
-      output,
-      'const __cf_destructure_1 = state.key("item"), title = __cf_destructure_1.key(getKey());',
+    const root = parseModule(output);
+    // `state.key("item")` reactive read survives, and `title` binds to a
+    // `.key(getKey())` dynamic read — the key argument stays the `getKey()`
+    // call, never resolved to the literal `"title"`.
+    assert(hasKeyPathRead(root, "item", "state"));
+    const titleDecl = collect(root, ts.isVariableDeclaration).find((decl) =>
+      ts.isIdentifier(decl.name) && decl.name.text === "title"
     );
-    assert(!output.includes('title = __cf_destructure_1.key("title")'));
+    assert(titleDecl?.initializer, "expected a title declaration");
+    const keyCall = titleDecl.initializer;
+    assert(
+      ts.isCallExpression(keyCall) &&
+        ts.isPropertyAccessExpression(keyCall.expression) &&
+        keyCall.expression.name.text === "key",
+      "expected title to bind a `.key(...)` call",
+    );
+    const keyArg = keyCall.arguments[0];
+    assert(
+      keyArg && ts.isCallExpression(keyArg) &&
+        ts.isIdentifier(keyArg.expression) &&
+        keyArg.expression.text === "getKey",
+      "expected the key argument to stay the getKey() call, not the literal",
+    );
+    assert(
+      !(keyArg && ts.isStringLiteralLike(keyArg)),
+      "expected the dynamic key not to resolve to a string literal",
+    );
   },
 );
 
@@ -171,10 +312,38 @@ const p = pattern<{ mentionable: MentionablePiece[] }, { [UI]: any }>((
     // c[__cfHelpers.NAME])`. The surface form must include the helper
     // expression on the `c` root specifically — generic substring
     // checks could pass even if `c` got renamed by an unrelated bug.
-    assertStringIncludes(output, "c.key(__cfHelpers.NAME)");
+    const root = parseModule(output);
+    const isHelperName = (node: ts.Expression): boolean =>
+      ts.isPropertyAccessExpression(node) && node.name.text === "NAME" &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "__cfHelpers";
+    const keyOnC = callsNamed(root, "key").filter((call) =>
+      ts.isPropertyAccessExpression(call.expression) &&
+      ts.isIdentifier(call.expression.expression) &&
+      call.expression.expression.text === "c"
+    );
     assert(
-      !output.includes("c.key(NAME)") && !output.includes("c[NAME]"),
-      "Bare NAME identifier must not appear in lowered output",
+      keyOnC.some((call) =>
+        call.arguments[0] !== undefined && isHelperName(call.arguments[0])
+      ),
+      "expected c.key(__cfHelpers.NAME) helper-backed read",
+    );
+    // No `.key(NAME)` with a bare NAME identifier argument.
+    assert(
+      !callsNamed(root, "key").some((call) =>
+        call.arguments[0] !== undefined &&
+        ts.isIdentifier(call.arguments[0]) &&
+        call.arguments[0].text === "NAME"
+      ),
+      "Bare NAME identifier must not appear as a .key() argument",
+    );
+    // No `c[NAME]` element access with a bare NAME identifier.
+    assert(
+      !collect(root, ts.isElementAccessExpression).some((el) =>
+        ts.isIdentifier(el.argumentExpression) &&
+        el.argumentExpression.text === "NAME"
+      ),
+      "Bare NAME identifier must not appear as an element access key",
     );
   },
 );
@@ -191,36 +360,44 @@ Deno.test(
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    const schemas = extractSchemas(output);
+    const root = parseModule(output);
 
-    const outerMapSchema =
-      schemas.find((schema) =>
-        schema.includes('required: ["element", "params"]') &&
-        schema.includes("globalAccent") &&
-        schema.includes("selectedTaskId") &&
-        schema.includes("hoveredSectionId")
-      ) ?? "";
-    assert(outerMapSchema.length > 0, "expected outer sections map schema");
-    assertStringIncludes(outerMapSchema, "id");
-    assertStringIncludes(outerMapSchema, "title");
-    assertStringIncludes(outerMapSchema, "expanded");
-    assertStringIncludes(outerMapSchema, "accent");
-    assertStringIncludes(outerMapSchema, "tasks");
+    // Every property name that appears anywhere in an evaluated schema.
+    const keysDeep = (value: unknown, acc = new Set<string>()): Set<string> => {
+      if (value && typeof value === "object") {
+        for (const [key, child] of Object.entries(value)) {
+          acc.add(key);
+          keysDeep(child, acc);
+        }
+      }
+      return acc;
+    };
 
-    const innerMapSchema =
-      schemas.find((schema) =>
-        schema.includes('required: ["element", "params"]') &&
-        schema.includes("sectionIndex") &&
-        schema.includes("selectedTaskId") &&
-        schema.includes("hoveredSectionId") &&
-        !schema.includes("globalAccent")
-      ) ?? "";
-    assert(innerMapSchema.length > 0, "expected inner tasks map schema");
-    assertStringIncludes(innerMapSchema, "id");
-    assertStringIncludes(innerMapSchema, "label");
-    assertStringIncludes(innerMapSchema, "done");
-    assertStringIncludes(innerMapSchema, "tags");
-    assertStringIncludes(innerMapSchema, "note");
+    const mapSchemas = emittedSchemas(root)
+      .filter((schema) => {
+        const required = schema.required;
+        return Array.isArray(required) && required.includes("element") &&
+          required.includes("params");
+      })
+      .map((schema) => ({ schema, keys: keysDeep(schema) }));
+
+    const outerMap = mapSchemas.find(({ keys }) =>
+      keys.has("globalAccent") && keys.has("selectedTaskId") &&
+      keys.has("hoveredSectionId")
+    );
+    assert(outerMap, "expected outer sections map schema");
+    for (const field of ["id", "title", "expanded", "accent", "tasks"]) {
+      assert(outerMap.keys.has(field), `outer map schema missing ${field}`);
+    }
+
+    const innerMap = mapSchemas.find(({ keys }) =>
+      keys.has("sectionIndex") && keys.has("selectedTaskId") &&
+      keys.has("hoveredSectionId") && !keys.has("globalAccent")
+    );
+    assert(innerMap, "expected inner tasks map schema");
+    for (const field of ["id", "label", "done", "tags", "note"]) {
+      assert(innerMap.keys.has(field), `inner map schema missing ${field}`);
+    }
   },
 );
 
@@ -339,43 +516,72 @@ export default pattern<{
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(
-      output,
-      "=> f.validationIssue !== undefined",
-    );
     // After CT-1644 Phase 2, the synthesized predicate wrapper is hoisted to a
     // module-scope const and applied at the call site:
     //   const __cfLift_N = __cfHelpers.lift(
     //     argSchema, resSchema, ({ f }) => f.validationIssue !== undefined);
     //   ...__cfLift_N({ f: { validationIssue: f.key("validationIssue") } })
-    // The callback lives on the hoisted lift decl; the input on the applied
-    // site. Anchor on the unique predicate callback text, walk back to the
-    // nearest `const __cfLift_N =` that owns it (decls don't nest, so the last
-    // such declaration before the callback is its owner), then assert that same
-    // id is applied with the `f` validationIssue capture.
-    const predicateIdx = output.indexOf(
-      "({ f }) => f.validationIssue !== undefined",
+    // Find the lift decl whose callback is the validationIssue predicate, then
+    // assert the same hoisted id is applied with the `f` validationIssue
+    // capture as its input.
+    const root = parseModule(output);
+
+    // A `something !== undefined` test on a `.validationIssue` access.
+    const isValidationPredicate = (node: ts.Node): boolean => {
+      if (!ts.isBinaryExpression(node)) return false;
+      if (
+        node.operatorToken.kind !==
+          ts.SyntaxKind.ExclamationEqualsEqualsToken
+      ) return false;
+      const left = node.left;
+      const right = node.right;
+      const isValidationAccess = ts.isPropertyAccessExpression(left) &&
+        left.name.text === "validationIssue";
+      const isUndefined = ts.isIdentifier(right) && right.text === "undefined";
+      return isValidationAccess && isUndefined;
+    };
+
+    const predicateLift = collect(root, ts.isVariableDeclaration).find(
+      (decl) => {
+        if (!ts.isIdentifier(decl.name)) return false;
+        if (!decl.initializer || !ts.isCallExpression(decl.initializer)) {
+          return false;
+        }
+        const callee = decl.initializer.expression;
+        const isLift = ts.isPropertyAccessExpression(callee) &&
+          callee.name.text === "lift";
+        if (!isLift) return false;
+        return decl.initializer.arguments.some((arg) =>
+          ts.isArrowFunction(arg) && !ts.isBlock(arg.body) &&
+          isValidationPredicate(arg.body)
+        );
+      },
     );
     assert(
-      predicateIdx >= 0,
-      "expected the synthesized validationIssue predicate callback",
-    );
-    const declMatches = [
-      ...output.slice(0, predicateIdx).matchAll(
-        /const (__cfLift_\d+) = __cfHelpers\.lift/g,
-      ),
-    ];
-    assert(
-      declMatches.length > 0,
+      predicateLift && ts.isIdentifier(predicateLift.name),
       "expected a hoisted lift decl owning the validationIssue predicate",
     );
-    const validationLiftId = declMatches[declMatches.length - 1][1];
-    assertMatch(
-      output,
-      new RegExp(
-        validationLiftId +
-          '\\(\\{ f: \\{[\\s\\S]*?validationIssue: f(?:\\.validationIssue|\\.key\\("validationIssue"\\))[\\s\\S]*?\\} \\}\\)',
-      ),
+    const validationLiftId = (predicateLift.name as ts.Identifier).text;
+
+    // The hoisted lift is applied with `{ f: { validationIssue: <read> } }`.
+    const applied = callsNamed(root, validationLiftId).find((call) => {
+      const arg = call.arguments[0];
+      if (!arg || !ts.isObjectLiteralExpression(arg)) return false;
+      const fProp = arg.properties.find((p) =>
+        ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) &&
+        p.name.text === "f"
+      );
+      if (!fProp || !ts.isPropertyAssignment(fProp)) return false;
+      const fValue = fProp.initializer;
+      if (!ts.isObjectLiteralExpression(fValue)) return false;
+      return fValue.properties.some((p) =>
+        ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) &&
+        p.name.text === "validationIssue"
+      );
+    });
+    assert(
+      applied,
+      "expected the hoisted lift applied with the f validationIssue capture",
     );
   },
 );
@@ -429,12 +635,43 @@ export default pattern<{
     );
 
     assertEquals(computationDiagnostics.length, 0);
-    assertStringIncludes(output, ".mapWithPattern(");
-    assertStringIncludes(output, "=> fieldCheckStates[fieldKey] === true");
+    const root = parseModule(output);
+
     assert(
-      !output.includes(
-        "const isChecked = fieldCheckStates[fieldKey] === true;",
+      callsNamed(root, "mapWithPattern").length >= 1,
+      "expected a mapWithPattern call",
+    );
+
+    // `fieldCheckStates[fieldKey] === true` — a strict-equality test whose left
+    // side reads element `[fieldKey]` off `fieldCheckStates`.
+    const isFieldCheckEquality = (node: ts.Node): boolean => {
+      if (!ts.isBinaryExpression(node)) return false;
+      if (
+        node.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken
+      ) return false;
+      const left = node.left;
+      return ts.isElementAccessExpression(left) &&
+        ts.isIdentifier(left.expression) &&
+        left.expression.text === "fieldCheckStates" &&
+        ts.isIdentifier(left.argumentExpression) &&
+        left.argumentExpression.text === "fieldKey" &&
+        node.right.kind === ts.SyntaxKind.TrueKeyword;
+    };
+
+    // The equality survives as an extracted arrow body, not an eager local.
+    assert(
+      collect(root, ts.isArrowFunction).some((arrow) =>
+        !ts.isBlock(arrow.body) && isFieldCheckEquality(arrow.body)
       ),
+      "expected the fieldCheckStates equality to lower into an arrow body",
+    );
+    assert(
+      !collect(root, ts.isVariableDeclaration).some((decl) =>
+        ts.isIdentifier(decl.name) && decl.name.text === "isChecked" &&
+        decl.initializer !== undefined &&
+        isFieldCheckEquality(decl.initializer)
+      ),
+      "expected no eager `const isChecked = fieldCheckStates[fieldKey] === true`",
     );
   },
 );
@@ -449,8 +686,13 @@ Deno.test(
       types: COMMONFABRIC_TYPES,
     });
 
+    const root = parseModule(output);
     assert(
-      output.includes("{examples.mapWithPattern("),
+      callsNamed(root, "mapWithPattern").some((call) =>
+        ts.isPropertyAccessExpression(call.expression) &&
+        ts.isIdentifier(call.expression.expression) &&
+        call.expression.expression.text === "examples"
+      ),
       "expected transformed examples.mapWithPattern call site",
     );
 
@@ -460,19 +702,39 @@ Deno.test(
     // lives at module scope, ABOVE the `examples.mapWithPattern(__cfPattern_N,
     // …)` call site rather than inline at it. The property this test guards is
     // unchanged: the examples capture's params-keyed prologue survives the
-    // pipeline. Assert against the whole output (the prologue lines are unique
-    // to this map's callback).
-    assertStringIncludes(
-      output,
-      'const selectedExampleId = __cf_pattern_input.key("params", "selectedExampleId");',
+    // pipeline.
+    // `const <name> = __cf_pattern_input.key("params", "<seg>")`.
+    const hasParamsPrologue = (name: string, seg: string): boolean =>
+      collect(root, ts.isVariableDeclaration).some((decl) => {
+        if (!ts.isIdentifier(decl.name) || decl.name.text !== name) {
+          return false;
+        }
+        const init = decl.initializer;
+        if (!init || !ts.isCallExpression(init)) return false;
+        const callee = init.expression;
+        if (
+          !ts.isPropertyAccessExpression(callee) ||
+          callee.name.text !== "key" ||
+          !ts.isIdentifier(callee.expression) ||
+          callee.expression.text !== "__cf_pattern_input"
+        ) return false;
+        const args = init.arguments.map((a) =>
+          ts.isStringLiteralLike(a) ? a.text : undefined
+        );
+        return args[0] === "params" && args[1] === seg;
+      });
+
+    assert(
+      hasParamsPrologue("selectedExampleId", "selectedExampleId"),
+      "expected selectedExampleId params-keyed prologue",
     );
-    assertStringIncludes(
-      output,
-      'const currentItem = __cf_pattern_input.key("params", "currentItem");',
+    assert(
+      hasParamsPrologue("currentItem", "currentItem"),
+      "expected currentItem params-keyed prologue",
     );
-    assertStringIncludes(
-      output,
-      'const examples = __cf_pattern_input.key("params", "examples");',
+    assert(
+      hasParamsPrologue("examples", "examples"),
+      "expected examples params-keyed prologue",
     );
   },
 );
@@ -487,10 +749,29 @@ Deno.test(
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, "itemsWithAisles.mapWithPattern(");
+    const root = parseModule(output);
     assert(
-      !output.includes(
-        'required: ["itemsWithAisles", "items", "correctionIndex", "correctionTitle", "hasConnectedStore"]',
+      callsNamed(root, "mapWithPattern").some((call) =>
+        ts.isPropertyAccessExpression(call.expression) &&
+        ts.isIdentifier(call.expression.expression) &&
+        call.expression.expression.text === "itemsWithAisles"
+      ),
+      "expected itemsWithAisles.mapWithPattern call site",
+    );
+    // No emitted schema requires the whole branch's captures, which would mean
+    // the branch got wrapped in a single derive rather than staying
+    // pattern-lowered.
+    const wholeBranchRequired = [
+      "itemsWithAisles",
+      "items",
+      "correctionIndex",
+      "correctionTitle",
+      "hasConnectedStore",
+    ];
+    assert(
+      !emittedSchemas(root).some((schema) =>
+        Array.isArray(schema.required) &&
+        JSON.stringify(schema.required) === JSON.stringify(wholeBranchRequired)
       ),
       "expected shopping-list sorted branch to stay pattern-lowered instead of wrapping the whole branch in derive",
     );
@@ -519,10 +800,23 @@ export default pattern(() => {
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, "const child = Child({ value });");
-    assertStringIncludes(output, 'childValue: child.key("value")');
+    const root = parseModule(output);
+    // `const child = Child({ value })` stays a plain structural call.
+    const childCall = callsNamed(root, "Child").find((call) =>
+      call.parent && ts.isVariableDeclaration(call.parent) &&
+      ts.isIdentifier(call.parent.name) && call.parent.name.text === "child"
+    );
+    assert(childCall, "expected `const child = Child(...)`");
+    // `childValue: child.key("value")` — a `.key("value")` read on `child`.
     assert(
-      !/__cfHelpers\.derive\([\s\S]{0,240}Child\(\{ value \}\)\)/.test(output),
+      hasKeyPathRead(root, "value", "child"),
+      'expected childValue to read child.key("value")',
+    );
+    // The Child call is not nested inside any derive call.
+    assert(
+      !callsNamed(root, "Child").some((call) =>
+        isInsideCallNamed(call, "derive")
+      ),
       "expected pattern factory invocation to stay structural instead of being wrapped in derive",
     );
   },
@@ -563,21 +857,44 @@ export default pattern<{ entries: Entry[] }, { [UI]: VNode }>(({ entries }) => (
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, "const row = EntryRow({");
-    assertStringIncludes(output, 'piece: entry.key("piece")');
-    assertStringIncludes(output, 'name: entry.key("name")');
-    assertStringIncludes(output, 'backlinks: entry.key("backlinks")');
+    const root = parseModule(output);
+    // `const row = EntryRow({...})` stays structural.
+    assert(
+      callsNamed(root, "EntryRow").some((call) =>
+        call.parent && ts.isVariableDeclaration(call.parent) &&
+        ts.isIdentifier(call.parent.name) && call.parent.name.text === "row"
+      ),
+      "expected `const row = EntryRow(...)`",
+    );
+    // Element fields lower to `entry.key("<field>")` reactive reads.
+    assert(hasKeyPathRead(root, "piece", "entry"));
+    assert(hasKeyPathRead(root, "name", "entry"));
+    assert(hasKeyPathRead(root, "backlinks", "entry"));
     // CT-1586: row[UI] must lower to row.key(__cfHelpers.UI) in-place,
     // never to a derive wrapper around the [UI] element access. This is
     // the exact ticket repro — without the assertion below, the bug
     // (derive(..., ({row}) => row[__cfHelpers.UI])) would have passed the
     // outer "stays structural" check above unnoticed.
-    assertStringIncludes(output, "row.key(__cfHelpers.UI)");
     assert(
-      !/__cfHelpers\.derive\([\s\S]{0,500}EntryRow: EntryRow[\s\S]{0,500}EntryRow\(\{/
-        .test(
-          output,
-        ),
+      callsNamed(root, "key").some((call) => {
+        const callee = call.expression;
+        if (
+          !ts.isPropertyAccessExpression(callee) ||
+          !ts.isIdentifier(callee.expression) ||
+          callee.expression.text !== "row"
+        ) return false;
+        const arg = call.arguments[0];
+        return arg !== undefined && ts.isPropertyAccessExpression(arg) &&
+          arg.name.text === "UI" && ts.isIdentifier(arg.expression) &&
+          arg.expression.text === "__cfHelpers";
+      }),
+      "expected row.key(__cfHelpers.UI) in-place lowering",
+    );
+    // The EntryRow call is not nested inside any derive call.
+    assert(
+      !callsNamed(root, "EntryRow").some((call) =>
+        isInsideCallNamed(call, "derive")
+      ),
       "expected mapped pattern factory invocation to stay structural instead of being wrapped in derive",
     );
   },
@@ -622,18 +939,26 @@ export default pattern<{ entries: Entry[] }, { [UI]: VNode }>(({ entries }) => (
       types: COMMONFABRIC_TYPES,
     });
 
+    const root = parseModule(output);
     // The plain helper call is preserved.
-    assertStringIncludes(output, "plainHelper(");
-    // Because plainHelper is NOT classified as opaque-origin, the call
-    // result must be derive-wrapped — the call should appear inside a
-    // synthetic compute callback's body. The arrow `({ entry }) =>
-    // plainHelper(...)` is the tell. If isPatternFactoryCalleeExpression
-    // matched it, the call would land structurally as `const row =
-    // plainHelper(...)` with no surrounding derive.
-    assertStringIncludes(output, "}) => plainHelper(");
+    const plainHelperCalls = callsNamed(root, "plainHelper");
+    assert(plainHelperCalls.length >= 1, "expected a plainHelper call");
+    // Because plainHelper is NOT classified as opaque-origin, its result is
+    // wrapped in a synthetic reactive compute — the call moves into an
+    // extracted callback arrow whose enclosing context is a `lift`/`derive`
+    // application, rather than staying at `const row = plainHelper(...)`. If
+    // isPatternFactoryCalleeExpression matched it, the call would land
+    // structurally as a direct `row` initializer with no surrounding compute.
     assert(
-      !/const row = plainHelper\(/.test(output),
-      "expected plainHelper call to be wrapped in derive(...) — non-opaque-origin calls must NOT be treated as pattern factories",
+      plainHelperCalls.some((call) => isInsideExtractedComputeCallback(call)),
+      "expected plainHelper call to be wrapped in a reactive compute — non-opaque-origin calls must NOT be treated as pattern factories",
+    );
+    assert(
+      !plainHelperCalls.some((call) =>
+        call.parent && ts.isVariableDeclaration(call.parent) &&
+        ts.isIdentifier(call.parent.name) && call.parent.name.text === "row"
+      ),
+      "expected no structural `const row = plainHelper(...)`",
     );
   },
 );
@@ -677,14 +1002,31 @@ export default pattern<{ entries: Entry[] }, { [UI]: VNode }>(({ entries }) => (
       types: COMMONFABRIC_TYPES,
     });
 
+    const root = parseModule(output);
     // The pattern-factory call itself still stays structural.
-    assertStringIncludes(output, "const row = EntryRow({");
+    assert(
+      callsNamed(root, "EntryRow").some((call) =>
+        call.parent && ts.isVariableDeclaration(call.parent) &&
+        ts.isIdentifier(call.parent.name) && call.parent.name.text === "row"
+      ),
+      "expected `const row = EntryRow(...)`",
+    );
     // The dynamic access should NOT have lowered to `.key()` — `.key()` is
     // only valid for known-static path segments. The dynamic-wrap path
-    // is responsible for this case.
+    // is responsible for this case. No `row.key(entry.…)`.
     assert(
-      !/row\.key\(entry\./.test(output),
-      "expected dynamic key access not to lower to row.key(...)",
+      !callsNamed(root, "key").some((call) => {
+        const callee = call.expression;
+        if (
+          !ts.isPropertyAccessExpression(callee) ||
+          !ts.isIdentifier(callee.expression) ||
+          callee.expression.text !== "row"
+        ) return false;
+        const arg = call.arguments[0];
+        return arg !== undefined && ts.isPropertyAccessExpression(arg) &&
+          ts.isIdentifier(arg.expression) && arg.expression.text === "entry";
+      }),
+      "expected dynamic key access not to lower to row.key(entry.…)",
     );
   },
 );
@@ -716,9 +1058,22 @@ export default pattern<{ entries: Entry[] }, { [UI]: VNode }>(({ entries }) => (
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, "const row = EntryRow({");
+    const root = parseModule(output);
     assert(
-      !output.includes("EntryRow: EntryRow"),
+      callsNamed(root, "EntryRow").some((call) =>
+        call.parent && ts.isVariableDeclaration(call.parent) &&
+        ts.isIdentifier(call.parent.name) && call.parent.name.text === "row"
+      ),
+      "expected `const row = EntryRow(...)`",
+    );
+    // No `EntryRow: EntryRow` capture property — the module-scope factory must
+    // stay in lexical scope, not be threaded through derive data.
+    assert(
+      !collect(root, ts.isPropertyAssignment).some((prop) =>
+        ts.isIdentifier(prop.name) && prop.name.text === "EntryRow" &&
+        ts.isIdentifier(prop.initializer) &&
+        prop.initializer.text === "EntryRow"
+      ),
       "expected module-scope pattern factory to stay in lexical scope instead of being captured as derive data",
     );
   },
@@ -756,13 +1111,33 @@ export default pattern(() => {
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, "const authManager = createAuthManager({");
-    assertStringIncludes(output, "accountType: selectedAccountType,");
+    const root = parseModule(output);
+    // `const authManager = createAuthManager({ accountType: selectedAccountType })`.
+    const factoryCall = callsNamed(root, "createAuthManager").find((call) =>
+      call.parent && ts.isVariableDeclaration(call.parent) &&
+      ts.isIdentifier(call.parent.name) &&
+      call.parent.name.text === "authManager"
+    );
     assert(
-      !/__ctHelpers\.derive\([\s\S]{0,280}createAuthManager\(\{[\s\S]{0,120}accountType: selectedAccountType[\s\S]{0,120}\}\)\)/
-        .test(
-          output,
+      factoryCall,
+      "expected `const authManager = createAuthManager(...)`",
+    );
+    const arg = factoryCall.arguments[0];
+    assert(
+      arg && ts.isObjectLiteralExpression(arg) &&
+        arg.properties.some((prop) =>
+          ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) &&
+          prop.name.text === "accountType" &&
+          ts.isIdentifier(prop.initializer) &&
+          prop.initializer.text === "selectedAccountType"
         ),
+      "expected accountType: selectedAccountType argument",
+    );
+    // The factory call is not nested inside any derive call.
+    assert(
+      !callsNamed(root, "createAuthManager").some((call) =>
+        isInsideCallNamed(call, "derive")
+      ),
       "expected opaque-returning factory helper to stay structural instead of being wrapped in derive",
     );
   },
@@ -784,14 +1159,45 @@ export default pattern<{ values: string[] }>(({ values }) => {
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    const normalized = output.replace(/\s+/g, " ");
+    const root = parseModule(output);
 
     // computed(() => summarize(values.get())) closure-extracts `values` and
     // lowers to a hoisted lift; after CT-1644 Phase 2 the call site applies
     // the hoisted const: const result = __cfLift_N({ values: values }).for(...)
-    assertMatch(
-      normalized,
-      /const result = __cfLift_\d+\(\{ values: values \}\)\.for\("result", true\);/,
+    const resultDecl = collect(root, ts.isVariableDeclaration).find((decl) =>
+      ts.isIdentifier(decl.name) && decl.name.text === "result"
+    );
+    assert(resultDecl?.initializer, "expected a result declaration");
+    const forCall = resultDecl.initializer;
+    assert(
+      ts.isCallExpression(forCall) &&
+        ts.isPropertyAccessExpression(forCall.expression) &&
+        forCall.expression.name.text === "for",
+      "expected result to bind a `.for(...)` call",
+    );
+    assertEquals(
+      forCall.arguments.map((a) => literalToValue(a)),
+      ["result", true],
+    );
+    // The `.for` receiver applies a hoisted lift with `{ values: values }`.
+    const liftApply = forCall.expression.expression;
+    assert(
+      ts.isCallExpression(liftApply) && ts.isIdentifier(liftApply.expression) &&
+        /^__cfLift_\d+$/.test(liftApply.expression.text),
+      "expected the .for receiver to be a hoisted __cfLift_N application",
+    );
+    const liftArg = liftApply.arguments[0];
+    assert(
+      liftArg && ts.isObjectLiteralExpression(liftArg) &&
+        liftArg.properties.some((prop) =>
+          (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) &&
+            prop.name.text === "values" &&
+            ts.isIdentifier(prop.initializer) &&
+            prop.initializer.text === "values") ||
+          (ts.isShorthandPropertyAssignment(prop) &&
+            prop.name.text === "values")
+        ),
+      "expected the hoisted lift applied with the `values` capture",
     );
   },
 );
@@ -851,23 +1257,92 @@ export default pattern<{ items: Writable<Item[]>; votes: Writable<Vote[]> }>(
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, 'const onVoteYes = () => myVote === "yes"');
-    assertStringIncludes(output, "boundClearVote.send({ itemId: iid })");
-    assertStringIncludes(
-      output,
-      'boundCastVote.send({ itemId: iid, vote: "yes" })',
+    const root = parseModule(output);
+    const onVoteYesDecl = collect(root, ts.isVariableDeclaration).find((decl) =>
+      ts.isIdentifier(decl.name) && decl.name.text === "onVoteYes"
     );
+    assert(onVoteYesDecl?.initializer, "expected an onVoteYes declaration");
+
+    // The handler stays function-valued: a plain arrow whose body is the
+    // imperative ternary `myVote === "yes" ? … : …`.
+    const arrow = onVoteYesDecl.initializer;
+    assert(
+      ts.isArrowFunction(arrow),
+      "local event handler variable must stay a plain arrow function",
+    );
+    const ternary = ts.isParenthesizedExpression(arrow.body)
+      ? arrow.body.expression
+      : arrow.body;
+    assert(
+      ts.isConditionalExpression(ternary) &&
+        ts.isBinaryExpression(ternary.condition) &&
+        ts.isIdentifier(ternary.condition.left) &&
+        ternary.condition.left.text === "myVote" &&
+        ternary.condition.operatorToken.kind ===
+          ts.SyntaxKind.EqualsEqualsEqualsToken &&
+        ts.isStringLiteralLike(ternary.condition.right) &&
+        ternary.condition.right.text === "yes",
+      'expected the handler body to be the `myVote === "yes"` ternary',
+    );
+
+    // Both branches keep their `.send({...})` calls. The `iid` argument is a
+    // reactive identifier, so assert on the property shape rather than
+    // evaluating the object literal.
+    const sendCallOn = (receiver: string): ts.CallExpression | undefined =>
+      callsNamed(root, "send").find((call) =>
+        ts.isPropertyAccessExpression(call.expression) &&
+        ts.isIdentifier(call.expression.expression) &&
+        call.expression.expression.text === receiver
+      );
+    const propNames = (call: ts.CallExpression): string[] => {
+      const arg = call.arguments[0];
+      if (!arg || !ts.isObjectLiteralExpression(arg)) return [];
+      return arg.properties.flatMap((prop) =>
+        prop.name && ts.isIdentifier(prop.name) ? [prop.name.text] : []
+      );
+    };
+    const itemIdReadsIid = (call: ts.CallExpression): boolean => {
+      const arg = call.arguments[0] as ts.ObjectLiteralExpression;
+      return arg.properties.some((prop) =>
+        ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) &&
+        prop.name.text === "itemId" && ts.isIdentifier(prop.initializer) &&
+        prop.initializer.text === "iid"
+      );
+    };
+    const clearSend = sendCallOn("boundClearVote");
+    assert(clearSend, "expected boundClearVote.send(...)");
+    assertEquals(propNames(clearSend), ["itemId"]);
+    assert(
+      itemIdReadsIid(clearSend),
+      "expected boundClearVote.send itemId: iid",
+    );
+    const castSend = sendCallOn("boundCastVote");
+    assert(castSend, "expected boundCastVote.send(...)");
+    assertEquals(propNames(castSend), ["itemId", "vote"]);
+    assert(itemIdReadsIid(castSend), "expected boundCastVote.send itemId: iid");
+    const castVoteProp = (castSend.arguments[0] as ts.ObjectLiteralExpression)
+      .properties.find((prop) =>
+        ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) &&
+        prop.name.text === "vote"
+      );
+    assert(
+      castVoteProp && ts.isPropertyAssignment(castVoteProp) &&
+        ts.isStringLiteralLike(castVoteProp.initializer) &&
+        castVoteProp.initializer.text === "yes",
+      'expected boundCastVote.send vote: "yes"',
+    );
+
     // After CT-1644 Phase 2 a genuinely reactive computed lowers to a hoisted
     // lift whose call site is `const onVoteYes = __cfLift_N(...)`. The local
-    // event handler must stay a plain arrow, so no such hoisted application is
-    // assigned to onVoteYes.
+    // event handler must stay a plain arrow, so its initializer is not a
+    // lift application.
     assert(
-      !output.includes("const onVoteYes = __cfHelpers.lift(") &&
-        !/const onVoteYes = __cfLift_\d+\(/.test(output),
+      !ts.isCallExpression(arrow),
       "local event handler variable must not become a reactive cell containing a function",
     );
+    // The handler body contains no ifElse lowering.
     assert(
-      !output.includes("=> () => __cfHelpers.ifElse("),
+      callsNamed(root, "ifElse").length === 0,
       "local event handler body must keep imperative ternary semantics",
     );
   },
@@ -890,11 +1365,41 @@ export default pattern<{ enabled: Writable<boolean> }>(({ enabled }) => ({
       types: COMMONFABRIC_TYPES,
     });
 
+    const root = parseModule(output);
+    // The eager `const raw = enabled.get()` read must not survive.
     assert(
-      !output.includes("const raw = enabled.get();"),
+      !collect(root, ts.isVariableDeclaration).some((decl) => {
+        if (!ts.isIdentifier(decl.name) || decl.name.text !== "raw") {
+          return false;
+        }
+        const init = decl.initializer;
+        return init !== undefined && ts.isCallExpression(init) &&
+          ts.isPropertyAccessExpression(init.expression) &&
+          init.expression.name.text === "get" &&
+          ts.isIdentifier(init.expression.expression) &&
+          init.expression.expression.text === "enabled";
+      }),
       "expected the eager cell read to be lowered into a derive before the IIFE body uses it",
     );
-    assertStringIncludes(output, "({ enabled }) => enabled.get()");
+    // A derive arrow `({ enabled }) => enabled.get()` takes over the read.
+    assert(
+      collect(root, ts.isArrowFunction).some((arrow) => {
+        const param = arrow.parameters[0];
+        const hasEnabledBinding = param !== undefined &&
+          ts.isObjectBindingPattern(param.name) &&
+          param.name.elements.some((el) =>
+            ts.isIdentifier(el.name) && el.name.text === "enabled"
+          );
+        if (!hasEnabledBinding || ts.isBlock(arrow.body)) return false;
+        const body = arrow.body;
+        return ts.isCallExpression(body) &&
+          ts.isPropertyAccessExpression(body.expression) &&
+          body.expression.name.text === "get" &&
+          ts.isIdentifier(body.expression.expression) &&
+          body.expression.expression.text === "enabled";
+      }),
+      "expected a derive arrow `({ enabled }) => enabled.get()`",
+    );
   },
 );
 
@@ -931,39 +1436,40 @@ export default pattern<{ options: Option[] }, { [UI]: any }>(({ options }) => {
     });
     // computed(() => options.length > 0 ? options[0].title : null) closure-
     // extracts `options` and lowers to a hoisted lift. After CT-1644 Phase 2
-    // the schema-bearing decl lives at `const __cfLift_N = __cfHelpers.lift(`
-    // and the call site is `const minimalNullable = __cfLift_N({ options })`.
-    const minimalNullableSite = output.match(
-      /const minimalNullable = (__cfLift_\d+)\(/,
+    // the schema-bearing decl is `const __cfLift_N = __cfHelpers.lift(cb,
+    // argSchema, resSchema)` and the call site applies it to `{ options }`.
+    const root = parseModule(output);
+    const { argSchema, resSchema } = liftSchemasFor(root, "minimalNullable");
+
+    // Input schema keeps `options` array-shaped with object items carrying
+    // `title` — never shrunk to an object with numeric string keys.
+    const options = (argSchema.properties as Record<string, unknown>)
+      .options as Record<string, unknown>;
+    assertEquals(options.type, "array");
+    const items = options.items as Record<string, unknown>;
+    assertEquals(items.type, "object");
+    assertEquals(
+      ((items.properties as Record<string, unknown>).title as Record<
+        string,
+        unknown
+      >).type,
+      "string",
     );
     assert(
-      minimalNullableSite !== null,
-      "expected transformed minimalNullable lift-applied call",
-    );
-    const minimalNullableLiftId = minimalNullableSite[1];
-    const minimalNullableStart = output.indexOf(
-      `const ${minimalNullableLiftId} = __cfHelpers.lift`,
+      !("0" in (items.properties as Record<string, unknown>)),
+      "expected array items schema not to shrink to numeric-key object",
     );
     assert(
-      minimalNullableStart >= 0,
-      "expected hoisted minimalNullable lift declaration",
-    );
-    const minimalNullableWindow = output.slice(
-      minimalNullableStart,
-      minimalNullableStart + 1200,
+      !Array.isArray(options.required) ||
+        !(options.required as string[]).includes("0"),
+      "expected the input schema not to require object-style array members",
     );
 
-    assertStringIncludes(minimalNullableWindow, 'type: "array"');
-    assertStringIncludes(minimalNullableWindow, "items:");
-    assertStringIncludes(minimalNullableWindow, "title:");
-    assertStringIncludes(minimalNullableWindow, 'type: "null"');
+    // Result schema is the nullable `string | null` produced by the ternary.
+    const resultTypes = collectSchemaTypes(resSchema);
     assert(
-      !minimalNullableWindow.includes('properties: {\n        "0"'),
-      "expected the derive input schema to stay array-shaped, not shrink to an object with numeric keys",
-    );
-    assert(
-      !minimalNullableWindow.includes('required: ["length", "0"]'),
-      "expected the derive input schema not to require object-style array members",
+      resultTypes.includes("null"),
+      "expected the nullable result schema to admit null",
     );
   },
 );
@@ -1001,24 +1507,21 @@ export default pattern<Input, { [NAME]: string; [UI]: VNode }>(({ question, ["my
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    // After CT-1644 Phase 2, computed() lowers to a hoisted lift:
-    //   const __cfLift_N = __cfHelpers.lift({argSchema}, {resSchema}, cb);
-    // The hoisted decl carries the capture's input schema; it is the first
-    // __cfHelpers.lift( occurrence in the module.
-    // Hoisted lift may carry generic type args (`lift<In, Out>(`) or not
-    // (`lift(`); match the helper-call head either way.
-    const liftMatch = output.match(/__cfHelpers\.lift(?:<[\s\S]*?>)?\(/);
-    assert(
-      liftMatch && liftMatch.index !== undefined,
-      "expected computed() to lower to a hoisted lift; output had no __cfHelpers.lift(",
-    );
-    const liftWindow = output.slice(liftMatch.index, liftMatch.index + 1200);
+    // After CT-1644 Phase 2, computed() lowers to a hoisted lift carrying the
+    // capture's input schema; it is the first __cfHelpers.lift( in the module.
+    const root = parseModule(output);
+    const argSchema = firstLiftArgSchema(root);
 
-    // Capture-input properties appear in the hoisted lift's argument schema.
-    assertStringIncludes(liftWindow, "displayName: {");
-    assertStringIncludes(liftWindow, 'type: "string"');
-    assertStringIncludes(liftWindow, '"default": ""');
-    assertStringIncludes(liftWindow, 'scope: "user"');
+    // The destructured `displayName` capture keeps its PerUser string default.
+    const displayName = (argSchema.properties as Record<string, unknown>)
+      .displayName as Record<
+        string,
+        unknown
+      >;
+    assert(displayName, "expected displayName in the lift argument schema");
+    assertEquals(displayName.type, "string");
+    assertEquals(displayName["default"], "");
+    assertEquals(displayName.scope, "user");
   },
 );
 
@@ -1042,20 +1545,22 @@ export default pattern<Input, { [NAME]: string; [UI]: VNode }>(({ draftTitle }) 
       types: COMMONFABRIC_TYPES,
     });
     // After CT-1644 Phase 2, computed() lowers to a hoisted lift whose decl is
-    // the first __cfHelpers.lift( occurrence in the module.
-    // Hoisted lift may carry generic type args (`lift<In, Out>(`) or not
-    // (`lift(`); match the helper-call head either way.
-    const liftMatch = output.match(/__cfHelpers\.lift(?:<[\s\S]*?>)?\(/);
-    assert(
-      liftMatch && liftMatch.index !== undefined,
-      "expected computed() to lower to a hoisted lift; output had no __cfHelpers.lift(",
-    );
-    const liftWindow = output.slice(liftMatch.index, liftMatch.index + 1200);
+    // the first __cfHelpers.lift( in the module.
+    const root = parseModule(output);
+    const argSchema = firstLiftArgSchema(root);
 
-    assertStringIncludes(liftWindow, "draftTitle: {");
-    assertStringIncludes(liftWindow, 'type: "string"');
-    assertStringIncludes(liftWindow, '"default": ""');
-    assertStringIncludes(liftWindow, "asCell:");
+    const draftTitle = (argSchema.properties as Record<string, unknown>)
+      .draftTitle as Record<
+        string,
+        unknown
+      >;
+    assert(draftTitle, "expected draftTitle in the lift argument schema");
+    assertEquals(draftTitle.type, "string");
+    assertEquals(draftTitle["default"], "");
+    assert(
+      Array.isArray(draftTitle.asCell),
+      "expected the Writable capture to carry an asCell descriptor",
+    );
   },
 );
 
@@ -1079,19 +1584,25 @@ export default pattern<Input, { [NAME]: string; [UI]: VNode }>(({ selections }) 
       types: COMMONFABRIC_TYPES,
     });
     // After CT-1644 Phase 2, computed() lowers to a hoisted lift whose decl is
-    // the first __cfHelpers.lift( occurrence in the module.
-    // Hoisted lift may carry generic type args (`lift<In, Out>(`) or not
-    // (`lift(`); match the helper-call head either way.
-    const liftMatch = output.match(/__cfHelpers\.lift(?:<[\s\S]*?>)?\(/);
-    assert(
-      liftMatch && liftMatch.index !== undefined,
-      "expected computed() to lower to a hoisted lift; output had no __cfHelpers.lift(",
-    );
-    const liftWindow = output.slice(liftMatch.index, liftMatch.index + 1400);
+    // the first __cfHelpers.lift( in the module.
+    const root = parseModule(output);
+    const argSchema = firstLiftArgSchema(root);
 
-    assertStringIncludes(liftWindow, "selections:");
     assert(
-      !liftWindow.includes("AnonymousType_"),
+      "selections" in (argSchema.properties as Record<string, unknown>),
+      "expected selections in the lift argument schema",
+    );
+    // No orphan anonymous-type ref anywhere in the evaluated schema.
+    const hasAnonymousRef = (value: unknown): boolean => {
+      if (typeof value === "string") return value.includes("AnonymousType_");
+      if (Array.isArray(value)) return value.some(hasAnonymousRef);
+      if (value && typeof value === "object") {
+        return Object.values(value).some(hasAnonymousRef);
+      }
+      return false;
+    };
+    assert(
+      !hasAnonymousRef(argSchema),
       "expected Writable<Record<...Default...>> capture not to emit orphan anonymous refs",
     );
   },
@@ -1119,22 +1630,19 @@ export default pattern<Input>(({ departments }) => {
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    // After CT-1644 Phase 2 the materializer options live in the hoisted
-    // decl `const __cfLift_N = __cfHelpers.lift(...)`; the call site is
-    // `const init = __cfLift_N(...)`.
-    const initSite = output.match(/const init = (__cfLift_\d+)\(/);
+    // After CT-1644 Phase 2 the materializer options live in the hoisted decl
+    // `const __cfLift_N = __cfHelpers.lift(cb, argSchema, resSchema, options)`;
+    // the call site is `const init = __cfLift_N(...)`. The options are the last
+    // argument, a plain object literal (not a JSONSchema).
+    const root = parseModule(output);
+    const liftCall = liftCallFor(root, "init");
+    const optionsArg = liftCall.arguments.at(-1)!;
     assert(
-      initSite !== null,
-      "expected computed() to lower to a hoisted lift call site for init",
+      ts.isObjectLiteralExpression(optionsArg),
+      "expected a trailing materializer options object",
     );
-    const initStart = output.indexOf(
-      `const ${initSite[1]} = __cfHelpers.lift`,
-    );
-    assert(initStart >= 0, "expected hoisted lift declaration for init");
-    const liftWindow = output.slice(initStart, initStart + 1400);
-
-    assertStringIncludes(liftWindow, "materializerWriteInputPaths");
-    assertStringIncludes(liftWindow, '["departments"]');
+    const options = literalToValue(optionsArg) as Record<string, unknown>;
+    assertEquals(options.materializerWriteInputPaths, [["departments"]]);
   },
 );
 
@@ -1159,20 +1667,30 @@ export default pattern<Input>(({ departments }) => {
     });
     // After CT-1644 Phase 2 the schema/options live in the hoisted decl
     // `const __cfLift_N = __cfHelpers.lift(...)`; the call site is
-    // `const count = __cfLift_N(...)`.
-    const countSite = output.match(/const count = (__cfLift_\d+)\(/);
+    // `const count = __cfLift_N(...)`. A readonly computation carries no
+    // materializer options, so no lift argument mentions
+    // materializerWriteInputPaths.
+    const root = parseModule(output);
+    const liftCall = liftCallFor(root, "count");
+    const hasMaterializerKey = (value: unknown): boolean => {
+      if (Array.isArray(value)) return value.some(hasMaterializerKey);
+      if (value && typeof value === "object") {
+        return Object.keys(value).includes("materializerWriteInputPaths") ||
+          Object.values(value).some(hasMaterializerKey);
+      }
+      return false;
+    };
     assert(
-      countSite !== null,
-      "expected computed() to lower to a hoisted lift call site for count",
-    );
-    const countStart = output.indexOf(
-      `const ${countSite[1]} = __cfHelpers.lift`,
-    );
-    assert(countStart >= 0, "expected hoisted lift declaration for count");
-    const liftWindow = output.slice(countStart, countStart + 1200);
-
-    assert(
-      !liftWindow.includes("materializerWriteInputPaths"),
+      !liftCall.arguments.some((arg) => {
+        if (
+          !ts.isObjectLiteralExpression(arg) && !ts.isSatisfiesExpression(arg)
+        ) return false;
+        try {
+          return hasMaterializerKey(literalToValue(arg));
+        } catch {
+          return false;
+        }
+      }),
       "readonly computed() should remain a normal pull computation",
     );
   },

--- a/packages/ts-transformers/test/schema-generator-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-generator-coverage.test.ts
@@ -1,6 +1,13 @@
-import { assert, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import {
+  collect,
+  emittedSchemas,
+  parseModule,
+  patternSchemas,
+} from "./transformed-ast.ts";
 
 /**
  * Drives the SchemaGeneratorTransformer end to end through the pipeline. Each
@@ -11,60 +18,117 @@ import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
  * the option-object value evaluator.
  */
 
-async function schemaLiteral(source: string): Promise<string> {
+/**
+ * Parse the transformed output and return the single emitted schema object
+ * evaluated to its JS value. Fails if the source produced no schema literal.
+ */
+async function schemaValue(source: string): Promise<Record<string, unknown>> {
   const out = await transformSource(source, { types: COMMONFABRIC_TYPES });
-  const match = out.match(
-    /const s = [\s\S]*?satisfies __cfHelpers\.JSONSchema/,
+  const schemas = emittedSchemas(parseModule(out));
+  assertEquals(schemas.length, 1, `expected one emitted schema in:\n${out}`);
+  return schemas[0]!;
+}
+
+/** Unwrap `{...} as const satisfies ...JSONSchema` to the object literal. */
+function schemaObjectLiteral(root: ts.SourceFile): ts.ObjectLiteralExpression {
+  const sat = collect(root, ts.isSatisfiesExpression).find((node) =>
+    /JSONSchema/.test(node.type.getText(root))
   );
-  assert(match, `no schema literal found in output:\n${out}`);
-  return match[0];
+  assert(sat, "no `... satisfies ...JSONSchema` expression found");
+  let expr: ts.Expression = sat.expression;
+  while (ts.isAsExpression(expr) || ts.isParenthesizedExpression(expr)) {
+    expr = expr.expression;
+  }
+  assert(ts.isObjectLiteralExpression(expr), "schema is not an object literal");
+  return expr;
+}
+
+/** The initializer expression of property `key` on an object literal. */
+function propInitializer(
+  object: ts.ObjectLiteralExpression,
+  key: string,
+): ts.Expression | undefined {
+  for (const property of object.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = property.name;
+    const text = ts.isIdentifier(name) || ts.isStringLiteralLike(name)
+      ? name.text
+      : undefined;
+    if (text === key) return property.initializer;
+  }
+  return undefined;
 }
 
 Deno.test("numeric-literal types lower to NaN, Infinity, -Infinity and negatives", async () => {
   // NaN has no numeric-literal form (emitted as the global NaN), positive and
   // negative infinity emit the Infinity identifier with an optional unary minus,
   // and a negative literal emits a unary-minus wrapper around a positive value.
-  const literal = await schemaLiteral(`/// <cts-enable />
+  // These non-finite values cannot be evaluated to JS numbers by the literal
+  // evaluator, so assert on the emitted expression text of the schema AST.
+  const out = await transformSource(
+    `/// <cts-enable />
 import { toSchema } from "commonfabric";
 const enum E { NaNValue = 0 / 0 }
 interface C { big: 1e999; small: -1e999; neg: -7; tag: E.NaNValue; }
 const s = toSchema<C>({ maximum: E.NaNValue });
 export { s };
-`);
-  assertStringIncludes(literal, '"enum": [Infinity]');
-  assertStringIncludes(literal, '"enum": [-Infinity]');
-  assertStringIncludes(literal, '"enum": [-7]');
-  assertStringIncludes(literal, '"enum": [NaN]');
-  assertStringIncludes(literal, "maximum: NaN");
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  const root = parseModule(out);
+  const schema = schemaObjectLiteral(root);
+
+  const enumText = (
+    owner: ts.ObjectLiteralExpression,
+    key: string,
+  ): string[] => {
+    const sub = propInitializer(owner, key) as ts.ObjectLiteralExpression;
+    assert(sub && ts.isObjectLiteralExpression(sub), `missing ${key} schema`);
+    const arr = propInitializer(sub, "enum") as ts.ArrayLiteralExpression;
+    assert(arr && ts.isArrayLiteralExpression(arr), `missing ${key} enum`);
+    return arr.elements.map((element) => element.getText(root));
+  };
+
+  const props = propInitializer(
+    schema,
+    "properties",
+  ) as ts.ObjectLiteralExpression;
+  assertEquals(enumText(props, "big"), ["Infinity"]);
+  assertEquals(enumText(props, "small"), ["-Infinity"]);
+  assertEquals(enumText(props, "neg"), ["-7"]);
+
+  const defs = propInitializer(schema, "$defs") as ts.ObjectLiteralExpression;
+  assertEquals(enumText(defs, "NaNValue"), ["NaN"]);
+
+  assertEquals(propInitializer(schema, "maximum")!.getText(root), "NaN");
 });
 
 Deno.test("WriteAuthorizedBy attaches a writer-identity marker with file and path", async () => {
   // The second type argument `typeof saver` is a simple identifier type-query,
   // so the schema gains an `ifc.writeAuthorizedBy.__ctWriterIdentityOf` marker
   // carrying the source file and the binding path.
-  const literal = await schemaLiteral(`/// <cts-enable />
+  const schema = await schemaValue(`/// <cts-enable />
 import { toSchema, WriteAuthorizedBy, handler } from "commonfabric";
 const saver = handler({}, {}, () => {});
 const s = toSchema<WriteAuthorizedBy<{ title: string }, typeof saver>>();
 export { s };
 `);
-  assertStringIncludes(literal, "writeAuthorizedBy");
-  assertStringIncludes(literal, "__ctWriterIdentityOf");
-  assertStringIncludes(literal, 'path: ["saver"]');
-  assertStringIncludes(literal, 'file: "/test.tsx"');
+  const marker = (schema.ifc as any).writeAuthorizedBy.__ctWriterIdentityOf;
+  assertEquals(marker.file, "/test.tsx");
+  assertEquals(marker.path, ["saver"]);
 });
 
 Deno.test("WriteAuthorizedBy with a qualified typeof binding attaches no marker", async () => {
   // A qualified `typeof container.save` is not a plain identifier type-query, so
   // the identity extraction bails and no writer-identity marker is emitted.
-  const literal = await schemaLiteral(`/// <cts-enable />
+  const schema = await schemaValue(`/// <cts-enable />
 import { toSchema, WriteAuthorizedBy } from "commonfabric";
 const container = { save() {} };
 const s = toSchema<WriteAuthorizedBy<{ title: string }, typeof container.save>>();
 export { s };
 `);
-  assertStringIncludes(literal, 'type: "object"');
-  assert(!literal.includes("writeAuthorizedBy"));
+  assertEquals(schema.type, "object");
+  assertEquals(schema.ifc, undefined);
 });
 
 Deno.test("UI-contract hint attaches to an object $UI property schema", async () => {
@@ -80,9 +144,11 @@ export default pattern<{ title: string }>((state) => ({
 `,
     { types: COMMONFABRIC_TYPES },
   );
-  assertStringIncludes(out, "uiContract");
-  assertStringIncludes(out, '"UiAction"');
-  assertStringIncludes(out, '"SubmitDirectCommand"');
+  const { output } = patternSchemas(parseModule(out));
+  const contract = ((output.properties as any).$UI.ifc as any)
+    .uiContract as any;
+  assertEquals(contract.helper, "UiAction");
+  assertEquals(contract.action, "SubmitDirectCommand");
 });
 
 Deno.test("UI-contract hint wraps a boolean-true $UI property as an ifc-only schema", async () => {
@@ -99,9 +165,11 @@ export default pattern<{ title: string }, Out>((state) => ({
 `,
     { types: COMMONFABRIC_TYPES },
   );
-  assertStringIncludes(out, "$UI: {");
-  assertStringIncludes(out, "uiContract");
-  assertStringIncludes(out, '"SubmitDirectCommand"');
+  const { output } = patternSchemas(parseModule(out));
+  const uiSchema = (output.properties as any).$UI;
+  // The property schema is the ifc-only object: no `type`, just `ifc`.
+  assertEquals(Object.keys(uiSchema), ["ifc"]);
+  assertEquals((uiSchema.ifc as any).uiContract.action, "SubmitDirectCommand");
 });
 
 Deno.test("UI-contract hint on a whole boolean-true schema becomes an ifc-only schema", async () => {
@@ -117,9 +185,9 @@ export default pattern<{ title: string }, any>((state) => ({
 `,
     { types: COMMONFABRIC_TYPES },
   );
-  assertStringIncludes(out, "uiContract");
-  assertStringIncludes(out, '"SubmitDirectCommand"');
-  assert(!out.includes("not: true"), `unexpected not:true in ${out}`);
+  const { output } = patternSchemas(parseModule(out));
+  assertEquals((output.ifc as any).uiContract.action, "SubmitDirectCommand");
+  assertEquals(output.not, undefined);
 });
 
 Deno.test("UI-contract hint on a whole boolean-false schema negates via not:true", async () => {
@@ -135,15 +203,16 @@ export default pattern<{ title: string }, never>((state) => ({
 `,
     { types: COMMONFABRIC_TYPES },
   );
-  assertStringIncludes(out, "not: true");
-  assertStringIncludes(out, "uiContract");
+  const { output } = patternSchemas(parseModule(out));
+  assertEquals(output.not, true);
+  assertEquals((output.ifc as any).uiContract.action, "SubmitDirectCommand");
 });
 
 Deno.test("toSchema option object evaluates literals, arrays, nested objects and constants", async () => {
   // The options bag is spread onto the emitted schema; booleans, null, arrays,
   // nested object literals and enum-constant references are all evaluated, while
   // an undefined-valued option is dropped.
-  const literal = await schemaLiteral(`/// <cts-enable />
+  const schema = await schemaValue(`/// <cts-enable />
 import { toSchema } from "commonfabric";
 const enum E { V = 5 }
 interface C { value: number; }
@@ -158,12 +227,11 @@ const s = toSchema<C>({
 });
 export { s };
 `);
-  assertStringIncludes(literal, "flagTrue: true");
-  assertStringIncludes(literal, "flagFalse: false");
-  assertStringIncludes(literal, "nothing: null");
-  assertStringIncludes(literal, 'list: [1, "a", true, null]');
-  assertStringIncludes(literal, "inner: 3");
-  assertStringIncludes(literal, 'x: "y"');
-  assertStringIncludes(literal, "constant: 5");
-  assert(!literal.includes("undef:"), "undefined option should be dropped");
+  assertEquals(schema.flagTrue, true);
+  assertEquals(schema.flagFalse, false);
+  assertEquals(schema.nothing, null);
+  assertEquals(schema.list, [1, "a", true, null]);
+  assertEquals(schema.nested, { inner: 3, deep: { x: "y" } });
+  assertEquals(schema.constant, 5);
+  assert(!("undef" in schema), "undefined option should be dropped");
 });

--- a/packages/ts-transformers/test/schema-injection-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-coverage.test.ts
@@ -1,6 +1,16 @@
+import ts from "typescript";
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { transformSource, validateSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import {
+  callSchemas,
+  callsNamed,
+  collect,
+  emittedSchemas,
+  literalToValue,
+  parseModule,
+  patternSchemas,
+} from "./transformed-ast.ts";
 
 // Unit coverage for schema-injection.ts. These tests drive the whole
 // transformer pipeline with `/// <cts-enable />` pattern sources that exercise
@@ -16,6 +26,19 @@ function t(source: string): Promise<string> {
   return transformSource(source, { types: COMMONFABRIC_TYPES });
 }
 
+// Every `... satisfies ...JSONSchema` expression under `root`, including
+// non-object ones such as `false as const satisfies __cfHelpers.JSONSchema`,
+// evaluated in source order. `emittedSchemas` drops the non-object values, so
+// tests that need to see a `false` schema use this instead.
+function allEmittedSchemaValues(root: ts.SourceFile): unknown[] {
+  return collect(root, ts.isSatisfiesExpression)
+    .filter((node) => /JSONSchema/.test(node.type.getText(root)))
+    .map((node) => literalToValue(node.expression));
+}
+
+// deno-lint-ignore no-explicit-any
+type Obj = Record<string, any>;
+
 // ---------------------------------------------------------------------------
 // pattern<Input, Output> — property type schemas
 // ---------------------------------------------------------------------------
@@ -29,10 +52,12 @@ Deno.test("pattern schema encodes primitive property types and a required array"
     "export default pattern<Input, Output>((s) => ({ [UI]: s.name as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'name: {\n            type: "string"');
-  assertStringIncludes(output, 'count: {\n            type: "number"');
-  assertStringIncludes(output, 'ok: {\n            type: "boolean"');
-  assertStringIncludes(output, 'required: ["name", "count", "ok"]');
+  const { input } = patternSchemas(parseModule(output));
+  const props = input.properties as Obj;
+  assertEquals(props.name.type, "string");
+  assertEquals(props.count.type, "number");
+  assertEquals(props.ok.type, "boolean");
+  assertEquals(input.required, ["name", "count", "ok"]);
 });
 
 Deno.test("pattern schema omits optional properties from the required array", async () => {
@@ -44,10 +69,10 @@ Deno.test("pattern schema omits optional properties from the required array", as
     "export default pattern<Input, Output>((s) => ({ [UI]: s.a as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
+  const { input } = patternSchemas(parseModule(output));
   // `b` is present as a property but excluded from required.
-  assertStringIncludes(output, "b: {");
-  assertStringIncludes(output, 'required: ["a"]');
-  assertEquals(output.includes('required: ["a", "b"]'), false);
+  assert(Object.keys(input.properties as Obj).includes("b"));
+  assertEquals(input.required, ["a"]);
 });
 
 Deno.test("pattern schema encodes a Default<> wrapper as a JSON schema default", async () => {
@@ -59,7 +84,8 @@ Deno.test("pattern schema encodes a Default<> wrapper as a JSON schema default",
     "export default pattern<Input, Output>((s) => ({ [UI]: s.name as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, '"default": "seed"');
+  const { input } = patternSchemas(parseModule(output));
+  assertEquals((input.properties as Obj).name.default, "seed");
 });
 
 Deno.test("pattern schema encodes array item types", async () => {
@@ -71,8 +97,10 @@ Deno.test("pattern schema encodes array item types", async () => {
     "export default pattern<Input, Output>((s) => ({ [UI]: s.tags as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'type: "array"');
-  assertStringIncludes(output, 'items: {\n                type: "string"');
+  const { input } = patternSchemas(parseModule(output));
+  const tags = (input.properties as Obj).tags;
+  assertEquals(tags.type, "array");
+  assertEquals(tags.items.type, "string");
 });
 
 Deno.test("pattern schema encodes nested object shapes with their own required arrays", async () => {
@@ -84,8 +112,11 @@ Deno.test("pattern schema encodes nested object shapes with their own required a
     "export default pattern<Input, Output>((s) => ({ [UI]: s.nested as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'required: ["a", "b"]');
-  assertStringIncludes(output, 'required: ["c"]');
+  const { input } = patternSchemas(parseModule(output));
+  const nested = (input.properties as Obj).nested;
+  assertEquals(nested.required, ["a", "b"]);
+  assertEquals(nested.properties.b.required, ["c"]);
+  assertEquals(nested.properties.b.properties.c.type, "string");
 });
 
 Deno.test("pattern schema encodes a Record<string, T> as additionalProperties", async () => {
@@ -97,10 +128,9 @@ Deno.test("pattern schema encodes a Record<string, T> as additionalProperties", 
     "export default pattern<Input, Output>((s) => ({ [UI]: s.rec as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(
-    output,
-    'additionalProperties: {\n                type: "number"',
-  );
+  const { input } = patternSchemas(parseModule(output));
+  const rec = (input.properties as Obj).rec;
+  assertEquals(rec.additionalProperties.type, "number");
 });
 
 Deno.test("pattern schema encodes a union as anyOf", async () => {
@@ -112,8 +142,11 @@ Deno.test("pattern schema encodes a union as anyOf", async () => {
     "export default pattern<Input, Output>((s) => ({ [UI]: s.u as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, "anyOf: [");
-  assertStringIncludes(output, '"enum": ["a", "b"]');
+  const { input } = patternSchemas(parseModule(output));
+  const u = (input.properties as Obj).u;
+  assert(Array.isArray(u.anyOf));
+  const enums = (u.anyOf as Obj[]).find((m) => m.enum !== undefined);
+  assertEquals(enums!.enum, ["a", "b"]);
 });
 
 Deno.test("pattern output schema encodes a VNode UI slot as a $ref", async () => {
@@ -125,9 +158,10 @@ Deno.test("pattern output schema encodes a VNode UI slot as a $ref", async () =>
     "export default pattern<Input, Output>((s) => ({ [UI]: s.x as unknown as VNode, total: s.x }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(
-    output,
-    '$UI: {\n            $ref: "https://commonfabric.org/schemas/vnode.json"',
+  const { output: out } = patternSchemas(parseModule(output));
+  assertEquals(
+    (out.properties as Obj).$UI.$ref,
+    "https://commonfabric.org/schemas/vnode.json",
   );
 });
 
@@ -144,10 +178,11 @@ Deno.test("handler<E, S> injects two schemas and marks a written Cell state fiel
     ");",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'amount: {\n            type: "number"');
+  const [event, state] = callSchemas(parseModule(output), "handler");
+  assertEquals((event.properties as Obj).amount.type, "number");
   // The state Cell is only written (.set), so the capability summary narrows
   // the marker to writeonly rather than the read/write "cell".
-  assertStringIncludes(output, 'asCell: ["writeonly"]');
+  assertEquals((state.properties as Obj).total.asCell, ["writeonly"]);
 });
 
 Deno.test("handler inline form injects the event schema from the annotated parameter", async () => {
@@ -159,7 +194,8 @@ Deno.test("handler inline form injects the event schema from the annotated param
     ");",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'label: {\n            type: "string"');
+  const [event] = callSchemas(parseModule(output), "handler");
+  assertEquals((event.properties as Obj).label.type, "string");
 });
 
 // ---------------------------------------------------------------------------
@@ -173,8 +209,9 @@ Deno.test("lift<T, R> injects input and result schemas from type arguments", asy
     "const fn = lift<{ count: number }, string>((s) => `n:${s.count}`);",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'count: {\n            type: "number"');
-  assertStringIncludes(output, 'type: "string"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).count.type, "number");
+  assertEquals(result.type, "string");
 });
 
 Deno.test("lift<T> single type argument infers the result schema from the callback body", async () => {
@@ -184,9 +221,10 @@ Deno.test("lift<T> single type argument infers the result schema from the callba
     "const fn = lift<{ count: number }>((s) => s.count > 0);",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'count: {\n            type: "number"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).count.type, "number");
   // result is boolean
-  assertStringIncludes(output, 'type: "boolean"');
+  assertEquals(result.type, "boolean");
 });
 
 Deno.test("lift inline form infers input and result schemas from annotations", async () => {
@@ -196,7 +234,9 @@ Deno.test("lift inline form infers input and result schemas from annotations", a
     "const fn = lift((s: { a: number }): number => s.a * 2);",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'a: {\n            type: "number"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).a.type, "number");
+  assertEquals(result.type, "number");
 });
 
 Deno.test("lift(toSchema<T>(), fn) transfers the authored input schema into the injected slot", async () => {
@@ -206,7 +246,8 @@ Deno.test("lift(toSchema<T>(), fn) transfers the authored input schema into the 
     "const fn = lift(toSchema<{ label: string }>(), undefined, (s) => s.label);",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'label: {\n            type: "string"');
+  const [input] = emittedSchemas(parseModule(output));
+  assertEquals((input.properties as Obj).label.type, "string");
 });
 
 // ---------------------------------------------------------------------------
@@ -220,9 +261,10 @@ Deno.test("cell(value) infers a widened schema from the seed value and injects i
     "const c = cell(42);",
   ].join("\n");
   const output = await t(source);
-  // literal 42 is widened to number
-  assertStringIncludes(output, 'type: "number"');
-  assertEquals(output.includes('"enum": [42]'), false);
+  const [schema] = emittedSchemas(parseModule(output));
+  // literal 42 is widened to number, not an enum of the literal.
+  assertEquals(schema.type, "number");
+  assertEquals(schema.enum, undefined);
 });
 
 Deno.test("cell<T>() with an explicit type argument injects the T schema", async () => {
@@ -232,7 +274,8 @@ Deno.test("cell<T>() with an explicit type argument injects the T schema", async
     "const c = cell<{ name: string }>();",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'name: {\n            type: "string"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals((schema.properties as Obj).name.type, "string");
 });
 
 // ---------------------------------------------------------------------------
@@ -246,7 +289,8 @@ Deno.test("wish<T>() injects a schema argument for the wished type", async () =>
     "const w = wish<{ answer: number }>();",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'answer: {\n            type: "number"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals((schema.properties as Obj).answer.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -260,8 +304,11 @@ Deno.test("generateObject<T>({...}) injects a schema property into the existing 
     'const r = generateObject<{ title: string }>({ prompt: "hi" });',
   ].join("\n");
   const output = await t(source);
+  const root = parseModule(output);
+  const [schema] = emittedSchemas(root);
+  assertEquals((schema.properties as Obj).title.type, "string");
+  // The injected schema rides in a `schema:` property on the options literal.
   assertStringIncludes(output, "schema:");
-  assertStringIncludes(output, "title: {\n");
 });
 
 // ---------------------------------------------------------------------------
@@ -276,9 +323,11 @@ Deno.test("sqliteQuery<Row>({...}) injects a rowSchema property from the Row typ
     'const q = sqliteQuery<{ id: number; name: string }>({ db, sql: "select 1" });',
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals((schema.properties as Obj).id.type, "number");
+  assertEquals((schema.properties as Obj).name.type, "string");
+  // The injected schema rides in a `rowSchema:` property on the options literal.
   assertStringIncludes(output, "rowSchema:");
-  assertStringIncludes(output, "id: {\n");
-  assertStringIncludes(output, "name: {\n");
 });
 
 // ---------------------------------------------------------------------------
@@ -294,9 +343,10 @@ Deno.test("when(condition, value) prepends condition, value and result schemas",
     "export default pattern<Input, Output>((s) => ({ [UI]: when(s.flag, s.flag) as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
+  const schemas = allEmittedSchemaValues(parseModule(output)) as Obj[];
   // when is 2-arity; the rewrite prepends condition + value + result schemas,
-  // so three boolean schema literals appear ahead of the original arguments.
-  const boolSchemas = output.split('type: "boolean"').length - 1;
+  // so three boolean schema literals appear ahead of the pattern schemas.
+  const boolSchemas = schemas.filter((s) => s.type === "boolean").length;
   assert(boolSchemas >= 3, `expected >=3 boolean schemas, got ${boolSchemas}`);
 });
 
@@ -309,10 +359,12 @@ Deno.test("unless(condition, value) prepends generated schemas ahead of the argu
     "export default pattern<Input, Output>((s) => ({ [UI]: unless(s.flag, s.label) as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, "unless({");
-  // condition schema is boolean, value schema is string
-  assertStringIncludes(output, 'type: "boolean"');
-  assertStringIncludes(output, 'type: "string"');
+  const root = parseModule(output);
+  assertEquals(callsNamed(root, "unless").length, 1);
+  const schemas = allEmittedSchemaValues(root) as Obj[];
+  // condition schema is boolean, value schema is string.
+  assert(schemas.some((s) => s.type === "boolean"));
+  assert(schemas.some((s) => s.type === "string"));
 });
 
 Deno.test("ifElse(condition, ifTrue, ifFalse) prepends four schemas for its 3-arity form", async () => {
@@ -324,9 +376,11 @@ Deno.test("ifElse(condition, ifTrue, ifFalse) prepends four schemas for its 3-ar
     "export default pattern<Input, Output>((s) => ({ [UI]: ifElse(s.flag, s.a, s.b) as unknown as VNode }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, "ifElse({");
+  const root = parseModule(output);
+  assertEquals(callsNamed(root, "ifElse").length, 1);
+  const schemas = allEmittedSchemaValues(root) as Obj[];
   // condition boolean + two number branches + number result = >=3 number schemas
-  const numSchemas = output.split('type: "number"').length - 1;
+  const numSchemas = schemas.filter((s) => s.type === "number").length;
   assert(numSchemas >= 3, `expected >=3 number schemas, got ${numSchemas}`);
 });
 
@@ -343,12 +397,16 @@ Deno.test("lift-applied object-literal input builds a schema from composed react
     "const combined = lift((snap) => `${snap.a}-${snap.b}`)({ a: a, b: b });",
   ].join("\n");
   const output = await t(source);
+  const schemas = emittedSchemas(parseModule(output));
   // The composed input schema recovers a: number and b: string from the
   // upstream lift results rather than collapsing to unknown.
-  assertStringIncludes(output, "a: {\n");
-  assertStringIncludes(output, "b: {\n");
-  assertStringIncludes(output, 'type: "number"');
-  assertStringIncludes(output, 'type: "string"');
+  const composed = schemas.find((s) =>
+    (s.properties as Obj | undefined)?.a !== undefined &&
+    (s.properties as Obj | undefined)?.b !== undefined
+  );
+  assert(composed, "expected composed input schema with a and b");
+  assertEquals((composed!.properties as Obj).a.type, "number");
+  assertEquals((composed!.properties as Obj).b.type, "string");
 });
 
 Deno.test("lift-applied direct property projection recovers the result schema from the input property", async () => {
@@ -359,8 +417,9 @@ Deno.test("lift-applied direct property projection recovers the result schema fr
     "const proj = lift((y: { a: number; b: string }) => y.a)(src);",
   ].join("\n");
   const output = await t(source);
+  const schemas = emittedSchemas(parseModule(output)) as Obj[];
   // The projection `y => y.a` recovers a number result schema.
-  assertStringIncludes(output, 'type: "number"');
+  assert(schemas.some((s) => s.type === "number"));
 });
 
 Deno.test("lift-applied empty-object input lowers the no-capture placeholder to a false input schema", async () => {
@@ -370,9 +429,14 @@ Deno.test("lift-applied empty-object input lowers the no-capture placeholder to 
     'const c = lift(() => "static")({});',
   ].join("\n");
   const output = await t(source);
+  const root = parseModule(output);
   // The single empty object literal is the no-capture placeholder, so the
-  // injected input schema is `false` (no input) rather than an object schema.
-  assertStringIncludes(output, "false");
+  // injected input schema is the `false` literal (no input) rather than an
+  // object schema. It rides as the second argument of the extracted lift call.
+  const liftCall = callsNamed(root, "lift").at(-1);
+  assert(liftCall, "expected an emitted lift call");
+  const inputArg = liftCall!.arguments[1];
+  assert(inputArg && inputArg.kind === ts.SyntaxKind.FalseKeyword);
 });
 
 // ---------------------------------------------------------------------------
@@ -387,9 +451,10 @@ Deno.test("pattern<Input> with a single type argument infers the result schema f
     "export default pattern<Input>((s) => ({ doubled: s.count * 2 }));",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'count: {\n            type: "number"');
+  const { input, output: out } = patternSchemas(parseModule(output));
+  assertEquals((input.properties as Obj).count.type, "number");
   // result schema carries the inferred `doubled: number`.
-  assertStringIncludes(output, "doubled: {");
+  assertEquals((out.properties as Obj).doubled.type, "number");
 });
 
 Deno.test("pattern(fn, inputSchema) keeps the author input schema and appends an inferred result schema", async () => {
@@ -402,13 +467,18 @@ Deno.test("pattern(fn, inputSchema) keeps the author input schema and appends an
     ");",
   ].join("\n");
   const output = await t(source);
+  const root = parseModule(output);
   // Author supplied one schema (input) verbatim; the transformer infers and
   // appends the result schema (case 3a). The author input keeps its bare
-  // `{ type: "object" } as const` form while the appended result carries the
-  // `satisfies` marker and the inferred `label` property.
+  // `{ type: "object" } as const` form (no satisfies marker) while the appended
+  // result carries the satisfies marker and the inferred `label` property.
+  const emitted = emittedSchemas(root);
+  assertEquals(emitted.length, 1);
+  assertEquals(
+    ((emitted[0].properties as Obj).label.properties as Obj).count.type,
+    "number",
+  );
   assertStringIncludes(output, '{ type: "object" } as const,');
-  assertStringIncludes(output, "label: {");
-  assertStringIncludes(output, "as const satisfies __cfHelpers.JSONSchema");
 });
 
 // ---------------------------------------------------------------------------
@@ -426,8 +496,9 @@ Deno.test("handler(fn) with no type args infers both event and state schemas fro
     ");",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'delta: {\n            type: "number"');
-  assertStringIncludes(output, "count: {");
+  const [event, state] = callSchemas(parseModule(output), "handler");
+  assertEquals((event.properties as Obj).delta.type, "number");
+  assert(Object.keys(state.properties as Obj).includes("count"));
 });
 
 Deno.test("handler(fn) with an underscore-prefixed unused event param yields a false event schema", async () => {
@@ -439,11 +510,10 @@ Deno.test("handler(fn) with an underscore-prefixed unused event param yields a f
     ");",
   ].join("\n");
   const output = await t(source);
-  // Intentionally-unused `_event` collapses to a `never`/`false` event schema.
-  assertStringIncludes(
-    output,
-    "false as const satisfies __cfHelpers.JSONSchema",
-  );
+  // Intentionally-unused `_event` collapses to a `never`/`false` event schema,
+  // emitted as the first satisfies-marked argument.
+  const values = allEmittedSchemaValues(parseModule(output));
+  assertEquals(values[0], false);
 });
 
 // ---------------------------------------------------------------------------
@@ -459,8 +529,9 @@ Deno.test("new Writable.perUser(seed) reads the user scope and injects it into t
     "}",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'scope: "user"');
-  assertStringIncludes(output, 'type: "number"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals(schema.scope, "user");
+  assertEquals(schema.type, "number");
 });
 
 Deno.test("new Writable.perSpace(seed) reads the space scope and injects it into the schema", async () => {
@@ -472,8 +543,9 @@ Deno.test("new Writable.perSpace(seed) reads the space scope and injects it into
     "}",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'scope: "space"');
-  assertStringIncludes(output, 'type: "boolean"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals(schema.scope, "space");
+  assertEquals(schema.type, "boolean");
 });
 
 // ---------------------------------------------------------------------------
@@ -487,13 +559,12 @@ Deno.test("lift property projection recovers the result schema from the projecte
     "const f = lift((s: { a: number; b: string }) => s.a);",
   ].join("\n");
   const output = await t(source);
+  const [input, result] = callSchemas(parseModule(output), "lift");
   // The result schema is recovered as number from `s.a`. Capability shrinking
   // narrows the input to the single accessed field `a`, dropping the unused `b`.
-  assertStringIncludes(output, 'a: {\n            type: "number"');
-  assertStringIncludes(
-    output,
-    'type: "number"\n} as const satisfies __cfHelpers.JSONSchema',
-  );
+  assertEquals((input.properties as Obj).a.type, "number");
+  assertEquals(Object.keys(input.properties as Obj), ["a"]);
+  assertEquals(result.type, "number");
 });
 
 Deno.test("lift element-access projection recovers the result schema from the indexed field", async () => {
@@ -503,8 +574,10 @@ Deno.test("lift element-access projection recovers the result schema from the in
     'const f = lift((s: { title: string; other: number }) => s["title"]);',
   ].join("\n");
   const output = await t(source);
+  const [input, result] = callSchemas(parseModule(output), "lift");
   // `s["title"]` is a direct projection; the result schema recovers string.
-  assertStringIncludes(output, 'title: {\n            type: "string"');
+  assertEquals((input.properties as Obj).title.type, "string");
+  assertEquals(result.type, "string");
 });
 
 // ---------------------------------------------------------------------------
@@ -542,9 +615,10 @@ Deno.test("handler event schema encodes an optional field as not required", asyn
     ");",
   ].join("\n");
   const output = await t(source);
+  const [event] = callSchemas(parseModule(output), "handler");
   // Optional event field is present but excluded from required.
-  assertStringIncludes(output, "amount: {");
-  assertEquals(output.includes('required: ["amount"]'), false);
+  assert(Object.keys(event.properties as Obj).includes("amount"));
+  assert(!((event.required as string[] | undefined) ?? []).includes("amount"));
 });
 
 // ---------------------------------------------------------------------------
@@ -558,8 +632,9 @@ Deno.test("generateObject<T>() with no options builds a fresh options object car
     "const r = generateObject<{ score: number }>();",
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals((schema.properties as Obj).score.type, "number");
   assertStringIncludes(output, "schema:");
-  assertStringIncludes(output, "score: {");
 });
 
 Deno.test("generateObject<T>(spreadOptions) spreads a non-literal options expression and adds the schema", async () => {
@@ -570,9 +645,11 @@ Deno.test("generateObject<T>(spreadOptions) spreads a non-literal options expres
     "const r = generateObject<{ ok: boolean }>(opts);",
   ].join("\n");
   const output = await t(source);
-  // Non-literal options become { ...opts, schema: ... }.
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals((schema.properties as Obj).ok.type, "boolean");
+  // Non-literal options become { ...opts, schema: ... }; the spread is a
+  // printer-level construct, so it is checked as text.
   assertStringIncludes(output, "...opts");
-  assertStringIncludes(output, "schema:");
 });
 
 // ---------------------------------------------------------------------------
@@ -586,8 +663,10 @@ Deno.test("sqliteQuery<Row>() with no options builds a fresh options object carr
     "const q = sqliteQuery<{ id: number; label: string }>();",
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals((schema.properties as Obj).id.type, "number");
+  assertEquals((schema.properties as Obj).label.type, "string");
   assertStringIncludes(output, "rowSchema:");
-  assertStringIncludes(output, "label: {");
 });
 
 Deno.test("untyped sqliteQuery(options) injects no rowSchema", async () => {
@@ -599,7 +678,7 @@ Deno.test("untyped sqliteQuery(options) injects no rowSchema", async () => {
   ].join("\n");
   const output = await t(source);
   // Untyped form must lower to no schema; runtime falls back to detection.
-  assertEquals(output.includes("rowSchema:"), false);
+  assertEquals(emittedSchemas(parseModule(output)).length, 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -613,9 +692,10 @@ Deno.test("cell(value) assigned to a PerSession<T> variable reads the session sc
     "const c: PerSession<number> = cell(0);",
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
   // The scope brand is recovered from the `PerSession` alias on the contextual
   // type rather than from any accessor on the call.
-  assertStringIncludes(output, 'scope: "session"');
+  assertEquals(schema.scope, "session");
 });
 
 Deno.test("cell(value) assigned to a PerUser<T> variable reads the user scope from the annotation", async () => {
@@ -625,7 +705,8 @@ Deno.test("cell(value) assigned to a PerUser<T> variable reads the user scope fr
     'const c: PerUser<string> = cell("hi");',
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'scope: "user"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals(schema.scope, "user");
 });
 
 Deno.test("cell(value) assigned to a PerSpace<T> variable reads the space scope from the annotation", async () => {
@@ -635,7 +716,8 @@ Deno.test("cell(value) assigned to a PerSpace<T> variable reads the space scope 
     "const c: PerSpace<boolean> = cell(true);",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'scope: "space"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals(schema.scope, "space");
 });
 
 // ---------------------------------------------------------------------------
@@ -677,9 +759,10 @@ Deno.test("lift<T, R> encodes a tuple result as an array schema with a positiona
     'const f = lift<{ a: number }, [string, number]>((s) => ["x", s.a]);',
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'type: "array"');
+  const [, result] = callSchemas(parseModule(output), "lift");
+  assertEquals(result.type, "array");
   // tuple element union of the two positional types
-  assertStringIncludes(output, 'type: ["number", "string"]');
+  assertEquals((result.items as Obj).type, ["number", "string"]);
 });
 
 Deno.test("lift<T, R> encodes a string-literal-union result as an enum", async () => {
@@ -689,7 +772,8 @@ Deno.test("lift<T, R> encodes a string-literal-union result as an enum", async (
     'const f = lift<{ n: number }, "lo" | "hi">((s) => (s.n > 0 ? "hi" : "lo"));',
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, '"enum": ["lo", "hi"]');
+  const [, result] = callSchemas(parseModule(output), "lift");
+  assertEquals(result.enum, ["lo", "hi"]);
 });
 
 Deno.test("lift<T, R> encodes a nested array-of-objects result schema", async () => {
@@ -699,8 +783,9 @@ Deno.test("lift<T, R> encodes a nested array-of-objects result schema", async ()
     "const f = lift<{ n: number }, { id: number }[]>((s) => [{ id: s.n }]);",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'type: "array"');
-  assertStringIncludes(output, "id: {");
+  const [, result] = callSchemas(parseModule(output), "lift");
+  assertEquals(result.type, "array");
+  assertEquals(((result.items as Obj).properties as Obj).id.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -715,8 +800,9 @@ Deno.test("scoped cell-for value schema carries the scope marker", async () => {
     "const scoped: PerSession<number> = base;",
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
   // The base cell schema is injected; assigning to PerSession keeps the schema.
-  assertStringIncludes(output, 'type: "number"');
+  assertEquals(schema.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -732,9 +818,10 @@ Deno.test("new Writable(value) infers a widened schema from the seed and injects
     "}",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'type: "number"');
+  const [schema] = emittedSchemas(parseModule(output));
+  assertEquals(schema.type, "number");
   // No scope accessor was used, so no scope marker is injected.
-  assertEquals(output.includes("scope:"), false);
+  assertEquals(schema.scope, undefined);
 });
 
 Deno.test("new Writable<T>() with an explicit type argument and no value injects an undefined first argument", async () => {
@@ -746,10 +833,19 @@ Deno.test("new Writable<T>() with an explicit type argument and no value injects
     "}",
   ].join("\n");
   const output = await t(source);
+  const root = parseModule(output);
   // Schema is always the second argument, so `undefined` is inserted first.
-  assertStringIncludes(output, "new Writable<{");
-  assertStringIncludes(output, "undefined, {");
-  assertStringIncludes(output, "n: {");
+  const ctor = collect(root, ts.isNewExpression).find((n) =>
+    ts.isIdentifier(n.expression) && n.expression.text === "Writable"
+  );
+  assert(ctor, "expected a `new Writable<...>()` construction");
+  assertEquals(
+    ctor!.arguments![0].kind,
+    ts.SyntaxKind.Identifier,
+  );
+  assertEquals((ctor!.arguments![0] as ts.Identifier).text, "undefined");
+  const schema = literalToValue(ctor!.arguments![1]) as Obj;
+  assertEquals((schema.properties as Obj).n.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -763,9 +859,10 @@ Deno.test("cell(value) typed as raw Scoped<T, scope> reads the scope from the SC
     'const c: Scoped<number, "session"> = cell(0);',
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
   // `Scoped` is not one of the PerX aliases, so the scope is recovered from the
   // scope-brand property rather than the alias name.
-  assertStringIncludes(output, 'scope: "session"');
+  assertEquals(schema.scope, "session");
 });
 
 // ---------------------------------------------------------------------------
@@ -779,8 +876,9 @@ Deno.test("lift<T, R>(fn)(input) reads the schemas from the inner lift type argu
     "const f = lift<{ a: number }, string>((s) => `${s.a}`)({ a: 1 });",
   ].join("\n");
   const output = await t(source);
-  assertStringIncludes(output, 'a: {\n            type: "number"');
-  assertStringIncludes(output, 'type: "string"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).a.type, "number");
+  assertEquals(result.type, "string");
 });
 
 // ---------------------------------------------------------------------------
@@ -798,9 +896,10 @@ Deno.test("chained lift-applied recovers the input schema from the upstream lift
   // step2's callback param has no annotation; its type is recovered from
   // step1's inferred `{ a, b }` result, and capability shrinking keeps only the
   // accessed `b` field. The result schema is number.
-  const step2Def = output.slice(output.indexOf("__cfLift_2 = lift"));
-  assertStringIncludes(step2Def, "b: {");
-  assertStringIncludes(step2Def, 'type: "number"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).b.type, "number");
+  assertEquals(Object.keys(input.properties as Obj), ["b"]);
+  assertEquals(result.type, "number");
 });
 
 Deno.test("chained lift-applied whose upstream is a single-field object recovers a concrete input schema, not unknown", async () => {
@@ -811,11 +910,11 @@ Deno.test("chained lift-applied whose upstream is a single-field object recovers
     "const second = lift((v) => v.name.length)(first);",
   ].join("\n");
   const output = await t(source);
-  const secondDef = output.slice(output.indexOf("__cfLift_2 = lift"));
   // The recovered input carries the concrete `name: string` field rather than a
   // permissive `true`/unknown schema.
-  assertStringIncludes(secondDef, "name: {");
-  assertEquals(secondDef.slice(0, 200).includes("true as const"), false);
+  const [input] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).name.type, "string");
+  assertEquals(input.type, "object");
 });
 
 // ---------------------------------------------------------------------------
@@ -829,9 +928,10 @@ Deno.test("cell typed as Scoped<T, union-of-scopes> recovers the first concrete 
     'const c: Scoped<number, "user" | "session"> = cell(0);',
   ].join("\n");
   const output = await t(source);
+  const [schema] = emittedSchemas(parseModule(output));
   // The scope-brand type is a union; the recovery walks the members and returns
   // the first concrete scope value.
-  assertStringIncludes(output, 'scope: "user"');
+  assertEquals(schema.scope, "user");
 });
 
 // ---------------------------------------------------------------------------
@@ -850,9 +950,9 @@ Deno.test("applying a captured lift factory recovers the downstream input schema
   const output = await t(source);
   // `used`'s callback param is untyped; its type is recovered from `applied`,
   // whose type comes from the `makeIt` factory callback returning `{ a, b }`.
-  const usedDef = output.slice(output.lastIndexOf("= lift((y)"));
-  assertStringIncludes(usedDef, "b: {");
-  assertStringIncludes(usedDef, 'type: "number"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).b.type, "number");
+  assertEquals(result.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -907,9 +1007,10 @@ Deno.test("new Writable(value, schema) with two arguments is left untouched", as
     "}",
   ].join("\n");
   const output = await t(source);
-  // The schema slot is already filled, so no second schema is injected.
+  // The schema slot is already filled (bare `as const`, no satisfies marker),
+  // so the transformer injects no schema of its own.
+  assertEquals(emittedSchemas(parseModule(output)).length, 0);
   assertStringIncludes(output, 'new Writable(5, { type: "number" }');
-  assertEquals((output.match(/type: "number"/g) ?? []).length, 1);
 });
 
 Deno.test("wish(hint, schema) with an author-supplied schema is left untouched", async () => {
@@ -921,11 +1022,8 @@ Deno.test("wish(hint, schema) with an author-supplied schema is left untouched",
   const output = await t(source);
   // The two-argument wish already has its schema; the transformer does not add
   // a satisfies-marked schema of its own.
+  assertEquals(emittedSchemas(parseModule(output)).length, 0);
   assertStringIncludes(output, '{ type: "object" } as const');
-  assertEquals(
-    output.includes("as const satisfies __cfHelpers.JSONSchema"),
-    false,
-  );
 });
 
 Deno.test("generateObject({ schema }) already carrying a schema property is left untouched", async () => {
@@ -935,7 +1033,9 @@ Deno.test("generateObject({ schema }) already carrying a schema property is left
     'const r = generateObject({ prompt: "hi", schema: { type: "object" } as const });',
   ].join("\n");
   const output = await t(source);
-  // Exactly the author's single schema property remains; none is injected.
+  // No satisfies-marked schema is injected; only the author's bare schema
+  // property remains.
+  assertEquals(emittedSchemas(parseModule(output)).length, 0);
   assertEquals((output.match(/schema:/g) ?? []).length, 1);
 });
 
@@ -948,6 +1048,7 @@ Deno.test("untyped sqliteQuery already carrying a rowSchema is left untouched", 
   ].join("\n");
   const output = await t(source);
   // A rowSchema is already present, so the typed form does not inject a second.
+  assertEquals(emittedSchemas(parseModule(output)).length, 0);
   assertEquals((output.match(/rowSchema:/g) ?? []).length, 1);
 });
 
@@ -964,11 +1065,17 @@ Deno.test("new Writable.perSession() with no value derives the value type from t
     "}",
   ].join("\n");
   const output = await t(source);
+  const root = parseModule(output);
   // No seed value, so the value type is recovered from the contextual
   // PerSession<number> annotation and the accessor supplies the session scope.
-  assertStringIncludes(output, 'scope: "session"');
-  assertStringIncludes(output, 'type: "number"');
-  assertStringIncludes(output, "undefined, {");
+  const [schema] = emittedSchemas(root);
+  assertEquals(schema.scope, "session");
+  assertEquals(schema.type, "number");
+  // Schema is always the second argument, so `undefined` is inserted first.
+  const ctor = collect(root, ts.isNewExpression).at(-1);
+  assert(ctor, "expected a `new Writable.perSession()` construction");
+  assertEquals(ctor!.arguments![0].kind, ts.SyntaxKind.Identifier);
+  assertEquals((ctor!.arguments![0] as ts.Identifier).text, "undefined");
 });
 
 // ---------------------------------------------------------------------------
@@ -987,9 +1094,9 @@ Deno.test("lift-applied element-access projection recovers the result schema fro
   // The downstream callback `y => y["title"]` has no annotation; its input is
   // recovered from the upstream result and the string result schema is derived
   // from the indexed `title` field.
-  const s2Def = output.slice(output.lastIndexOf("= lift((y)"));
-  assertStringIncludes(s2Def, "title: {");
-  assertStringIncludes(s2Def, 'type: "string"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assert(Object.keys(input.properties as Obj).includes("title"));
+  assertEquals(result.type, "string");
 });
 
 Deno.test("lift-applied property-access projection recovers the result schema from the accessed field", async () => {
@@ -1000,9 +1107,9 @@ Deno.test("lift-applied property-access projection recovers the result schema fr
     "const s2 = lift((y) => y.count)(s1);",
   ].join("\n");
   const output = await t(source);
-  const s2Def = output.slice(output.lastIndexOf("= lift((y)"));
-  assertStringIncludes(s2Def, "count: {");
-  assertStringIncludes(s2Def, 'type: "number"');
+  const [input, result] = callSchemas(parseModule(output), "lift");
+  assert(Object.keys(input.properties as Obj).includes("count"));
+  assertEquals(result.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -1018,9 +1125,10 @@ Deno.test("handler<E, S> marks a read-only Cell state field with asCell readonly
     ");",
   ].join("\n");
   const output = await t(source);
+  const [, state] = callSchemas(parseModule(output), "handler");
   // The state Cell is only read (.get), so the capability summary narrows the
   // marker to readonly.
-  assertStringIncludes(output, 'asCell: ["readonly"]');
+  assertEquals((state.properties as Obj).total.asCell, ["readonly"]);
 });
 
 // ---------------------------------------------------------------------------
@@ -1040,7 +1148,7 @@ Deno.test("lift-applied untyped callback using Cell.get on a Cell input recovers
   // The callback param has no annotation but calls `.get()`; because the input
   // is a Cell, the input schema is recovered from the cell-like fallback type
   // and carries the readonly asCell marker with the inner `{ n: number }` shape.
-  const liftDef = output.slice(output.indexOf("lift((x)"));
-  assertStringIncludes(liftDef, "n: {");
-  assertStringIncludes(liftDef, 'asCell: ["readonly"]');
+  const [input] = callSchemas(parseModule(output), "lift");
+  assertEquals((input.properties as Obj).n.type, "number");
+  assertEquals(input.asCell, ["readonly"]);
 });

--- a/packages/ts-transformers/test/schema-injection-scope-and-args.test.ts
+++ b/packages/ts-transformers/test/schema-injection-scope-and-args.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { emittedSchemas, parseModule } from "./transformed-ast.ts";
 
 // Targeted coverage for schema-injection branches that ran in CI only through
 // patterns: the per-session scope on a `new` cell constructor, and the schema-
@@ -16,7 +17,14 @@ Deno.test("schema injection reads the session scope from a `new X.perSession(...
   ].join("\n");
 
   const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
-  assertStringIncludes(output, 'scope: "session"');
+  const root = parseModule(output);
+  // The injected cell schema carries the per-session scope read off the
+  // `.perSession` constructor.
+  const scoped = emittedSchemas(root).find((schema) =>
+    schema.scope === "session"
+  );
+  assert(scoped, "expected an emitted schema with a session scope");
+  assertEquals(scoped.type, "string");
 });
 
 Deno.test("schema injection skips a pattern that already supplies input and result schemas", async () => {
@@ -30,9 +38,8 @@ Deno.test("schema injection skips a pattern that already supplies input and resu
   ].join("\n");
 
   const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
+  const root = parseModule(output);
   // Injection is skipped, so the pattern keeps exactly the two author-supplied
   // schema literals — no inferred input/result schema is added.
-  const schemaCount =
-    output.split("as const satisfies __cfHelpers.JSONSchema").length - 1;
-  assertEquals(schemaCount, 2);
+  assertEquals(emittedSchemas(root).length, 2);
 });

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -1,60 +1,66 @@
-import { assertEquals, assertGreater, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertStringIncludes,
+} from "@std/assert";
 import { validateSource } from "./utils.ts";
 import type { TransformationDiagnostic } from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { emittedSchemas, parseModule } from "./transformed-ast.ts";
+
+/** Evaluated emitted schema object literals from transformed output, in order. */
+function schemasOf(output: string): Record<string, unknown>[] {
+  return emittedSchemas(parseModule(output));
+}
 
 /**
- * Extracts JSON schema literals from transformed output.
- * Schemas appear as either:
- * - `{ type: "object", ... } as const satisfies __cfHelpers.JSONSchema`
- * - `true as const satisfies __cfHelpers.JSONSchema`
- * - `false as const satisfies __cfHelpers.JSONSchema`
- * Returns them in order of appearance.
+ * Every property key that appears anywhere in a JSON schema, walking into
+ * `properties`, `items`, `additionalProperties`, `anyOf`/`allOf`/`oneOf`, and
+ * `$defs`. Lets a test assert that a field survived (or was dropped from)
+ * schema shrinking without matching printed text.
  */
-function extractSchemas(output: string): string[] {
-  const schemas: string[] = [];
-  const marker = "as const satisfies __cfHelpers.JSONSchema";
-  let searchFrom = 0;
-  while (true) {
-    const markerIdx = output.indexOf(marker, searchFrom);
-    if (markerIdx === -1) break;
-    // Walk backwards from marker to find the schema literal.
-    let start = markerIdx - 1;
-    // Skip whitespace before marker
-    while (start >= 0 && /\s/.test(output[start]!)) start--;
-
-    let schemaText: string | undefined;
-    if (output[start] === "}") {
-      let depth = 1;
-      start--;
-      while (start >= 0 && depth > 0) {
-        if (output[start] === "}") depth++;
-        else if (output[start] === "{") depth--;
-        start--;
-      }
-      start++; // back to the opening brace
-      schemaText = output.slice(start, markerIdx).trim();
-    } else {
-      let tokenStart = start;
-      while (tokenStart >= 0 && /[A-Za-z]/.test(output[tokenStart]!)) {
-        tokenStart--;
-      }
-      tokenStart++;
-      const token = output.slice(tokenStart, start + 1).trim();
-      if (token === "true" || token === "false") {
-        schemaText = token;
-      }
+function schemaPropertyNames(schema: unknown): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const element of node) visit(element);
+      return;
     }
-
-    if (!schemaText) {
-      searchFrom = markerIdx + marker.length;
-      continue;
+    if (typeof node !== "object" || node === null) return;
+    const record = node as Record<string, unknown>;
+    const properties = record.properties;
+    if (typeof properties === "object" && properties !== null) {
+      for (const key of Object.keys(properties)) names.add(key);
     }
+    for (const value of Object.values(record)) visit(value);
+  };
+  visit(schema);
+  return names;
+}
 
-    schemas.push(schemaText);
-    searchFrom = markerIdx + marker.length;
-  }
-  return schemas;
+/**
+ * True when a schema preserves `undefined` as a union member — either as an
+ * `anyOf` entry `{ type: "undefined" }` or as `"undefined"` inside a
+ * `type: [...]` array.
+ */
+function hasUndefinedMember(schema: unknown): boolean {
+  let found = false;
+  const visit = (node: unknown): void => {
+    if (found) return;
+    if (Array.isArray(node)) {
+      for (const element of node) visit(element);
+      return;
+    }
+    if (typeof node !== "object" || node === null) return;
+    const record = node as Record<string, unknown>;
+    const type = record.type;
+    if (type === "undefined") found = true;
+    if (Array.isArray(type) && type.includes("undefined")) found = true;
+    for (const value of Object.values(record)) visit(value);
+  };
+  visit(schema);
+  return found;
 }
 
 function getErrors(diagnostics: readonly TransformationDiagnostic[]) {
@@ -737,8 +743,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
           fmtErrors(rInline.diagnostics)
         }`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
       assertEquals(
         schemasTA,
         schemasInline,
@@ -789,17 +795,15 @@ Deno.test("Schema Shrink Validation", async (t) => {
           fmtErrors(rInline.diagnostics)
         }`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
-      // Both event schemas should contain "undefined" (not stripped)
-      assertEquals(
-        schemasTA[0]!.includes('"undefined"'),
-        true,
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
+      // Both event schemas should preserve `undefined` as a union member.
+      assert(
+        hasUndefinedMember(schemasTA[0]!),
         "type-arg event schema should preserve undefined",
       );
-      assertEquals(
-        schemasInline[0]!.includes('"undefined"'),
-        true,
+      assert(
+        hasUndefinedMember(schemasInline[0]!),
         "inline event schema should preserve undefined",
       );
       // State schemas (second schema) should match exactly
@@ -854,17 +858,15 @@ Deno.test("Schema Shrink Validation", async (t) => {
           fmtErrors(rInline.diagnostics)
         }`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
-      // Both event schemas should contain "undefined" (not stripped)
-      assertEquals(
-        schemasTA[0]!.includes('"undefined"'),
-        true,
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
+      // Both event schemas should preserve `undefined` as a union member.
+      assert(
+        hasUndefinedMember(schemasTA[0]!),
         "type-arg event schema should preserve undefined",
       );
-      assertEquals(
-        schemasInline[0]!.includes('"undefined"'),
-        true,
+      assert(
+        hasUndefinedMember(schemasInline[0]!),
         "inline event schema should preserve undefined",
       );
       // State schemas (second schema) should match exactly
@@ -909,8 +911,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
         0,
         `lift inline had shrink errors: ${fmtErrors(rInline.diagnostics)}`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
       assertEquals(
         schemasTA,
         schemasInline,
@@ -955,17 +957,15 @@ Deno.test("Schema Shrink Validation", async (t) => {
           fmtErrors(rInline.diagnostics)
         }`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
-      // Both input schemas should contain "undefined" (not stripped)
-      assertEquals(
-        schemasTA[0]!.includes('"undefined"'),
-        true,
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
+      // Both input schemas should preserve `undefined` as a union member.
+      assert(
+        hasUndefinedMember(schemasTA[0]!),
         "type-arg input schema should preserve undefined",
       );
-      assertEquals(
-        schemasInline[0]!.includes('"undefined"'),
-        true,
+      assert(
+        hasUndefinedMember(schemasInline[0]!),
         "inline input schema should preserve undefined",
       );
       // Result schemas (second schema) should match exactly
@@ -1016,8 +1016,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
           fmtErrors(rInline.diagnostics)
         }`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
       assertEquals(
         schemasTA,
         schemasInline,
@@ -1059,8 +1059,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
         0,
         `pattern inline had shrink errors: ${fmtErrors(rInline.diagnostics)}`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
       assertGreater(
         schemasTA.length,
         0,
@@ -1118,8 +1118,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
           fmtErrors(rInline.diagnostics)
         }`,
       );
-      const schemasTA = extractSchemas(rTA.output);
-      const schemasInline = extractSchemas(rInline.output);
+      const schemasTA = schemasOf(rTA.output);
+      const schemasInline = schemasOf(rInline.output);
       assertGreater(
         schemasTA.length,
         0,
@@ -1179,14 +1179,19 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      assertStringIncludes(result.output, "stage: {");
-      assertStringIncludes(result.output, "attempts: {");
-      assertStringIncludes(result.output, "accepted: {");
-      assertStringIncludes(result.output, "rejected: {");
-      assertEquals(result.output.includes("stage: true"), false);
-      assertEquals(result.output.includes("attempts: true"), false);
-      assertEquals(result.output.includes("accepted: true"), false);
-      assertEquals(result.output.includes("rejected: true"), false);
+      const snapshotSchema = schemasOf(result.output).find((schema) =>
+        (schema.properties as Record<string, unknown> | undefined)?.stage !==
+          undefined
+      );
+      const props = snapshotSchema?.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+      // Each object-literal input property carries its own value schema, not
+      // the widened `true` schema.
+      assertEquals(props?.stage, { type: "string" });
+      assertEquals(props?.attempts, { type: "number" });
+      assertEquals(props?.accepted, { type: "number" });
+      assertEquals(props?.rejected, { type: "number" });
     },
   );
 
@@ -1228,12 +1233,12 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "stage");
-      assertStringIncludes(inputSchema, "owner");
-      assertEquals(inputSchema.includes("unused"), false);
-      assertEquals(inputSchema.includes("nested"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("id"));
+      assert(names.has("stage"));
+      assert(names.has("owner"));
+      assert(!names.has("unused"));
+      assert(!names.has("nested"));
     },
   );
 
@@ -1269,9 +1274,10 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "score");
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("id"));
+      assert(names.has("score"));
+      assert(!names.has("unused"));
     },
   );
 
@@ -1310,11 +1316,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "score");
-      assertEquals(inputSchema.includes("name"), false);
-      assertEquals(inputSchema.includes("unused"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("id"));
+      assert(names.has("score"));
+      assert(!names.has("name"));
+      assert(!names.has("unused"));
     },
   );
 
@@ -1346,11 +1352,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "label");
-      assertStringIncludes(inputSchema, "capacity");
-      assertEquals(inputSchema.includes("unused"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("id"));
+      assert(names.has("label"));
+      assert(names.has("capacity"));
+      assert(!names.has("unused"));
     },
   );
 
@@ -1380,11 +1386,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "components");
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "name");
-      assertEquals(inputSchema.includes("unused"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("components"));
+      assert(names.has("id"));
+      assert(names.has("name"));
+      assert(!names.has("unused"));
     },
   );
 
@@ -1418,10 +1424,10 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "age");
-      assertEquals(inputSchema.includes("unused"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("id"));
+      assert(names.has("age"));
+      assert(!names.has("unused"));
     },
   );
 
@@ -1454,11 +1460,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "eligible");
-      assertStringIncludes(inputSchema, "candidate");
-      assertStringIncludes(inputSchema, "id");
-      assertEquals(inputSchema.includes("unused"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("eligible"));
+      assert(names.has("candidate"));
+      assert(names.has("id"));
+      assert(!names.has("unused"));
     },
   );
 
@@ -1494,12 +1500,12 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "list");
-      assertStringIncludes(inputSchema, "id");
-      assertStringIncludes(inputSchema, "title");
-      assertStringIncludes(inputSchema, "active");
-      assertEquals(inputSchema.includes("owner"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("list"));
+      assert(names.has("id"));
+      assert(names.has("title"));
+      assert(names.has("active"));
+      assert(!names.has("owner"));
     },
   );
 
@@ -1531,11 +1537,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "people");
-      assertStringIncludes(inputSchema, "name");
-      assertStringIncludes(inputSchema, "priorityRank");
-      assertEquals(inputSchema.includes("defaultSpot"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("people"));
+      assert(names.has("name"));
+      assert(names.has("priorityRank"));
+      assert(!names.has("defaultSpot"));
     },
   );
 
@@ -1568,13 +1574,13 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "people");
-      assertStringIncludes(inputSchema, "active");
-      assertStringIncludes(inputSchema, "name");
-      assertStringIncludes(inputSchema, "priorityRank");
-      assertStringIncludes(inputSchema, "defaultSpot");
-      assertEquals(inputSchema.includes("other"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("people"));
+      assert(names.has("active"));
+      assert(names.has("name"));
+      assert(names.has("priorityRank"));
+      assert(names.has("defaultSpot"));
+      assert(!names.has("other"));
     },
   );
 
@@ -1610,12 +1616,12 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "people");
-      assertStringIncludes(inputSchema, "active");
-      assertStringIncludes(inputSchema, "name");
-      assertStringIncludes(inputSchema, "priorityRank");
-      assertStringIncludes(inputSchema, "defaultSpot");
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("people"));
+      assert(names.has("active"));
+      assert(names.has("name"));
+      assert(names.has("priorityRank"));
+      assert(names.has("defaultSpot"));
     },
   );
 
@@ -1648,10 +1654,10 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "notes");
-      assertStringIncludes(inputSchema, "title");
-      assertEquals(inputSchema.includes("body"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("notes"));
+      assert(names.has("title"));
+      assert(!names.has("body"));
     },
   );
 
@@ -1690,11 +1696,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "overloaded");
-      assertStringIncludes(inputSchema, "key");
-      assertEquals(inputSchema.includes("title"), false);
-      assertEquals(inputSchema.includes("limit"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("overloaded"));
+      assert(names.has("key"));
+      assert(!names.has("title"));
+      assert(!names.has("limit"));
     },
   );
 
@@ -1722,9 +1728,9 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "name");
-      assertStringIncludes(inputSchema, "firstItem");
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("name"));
+      assert(names.has("firstItem"));
     },
   );
 
@@ -1750,9 +1756,9 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, 'asCell: ["readonly"]');
-      assertEquals(inputSchema.includes("asOpaque: true"), false);
+      const inputSchema = schemasOf(result.output)[0]!;
+      assertEquals(inputSchema.asCell, ["readonly"]);
+      assertEquals(inputSchema.asOpaque, undefined);
     },
   );
 
@@ -1778,9 +1784,9 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, 'asCell: ["readonly"]');
-      assertEquals(inputSchema.includes("asOpaque: true"), false);
+      const inputSchema = schemasOf(result.output)[0]!;
+      assertEquals(inputSchema.asCell, ["readonly"]);
+      assertEquals(inputSchema.asOpaque, undefined);
     },
   );
 
@@ -1812,14 +1818,21 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertEquals(
-        inputSchema === "true",
-        false,
-        "event schema should not widen to true",
+      const inputSchema = schemasOf(result.output)[0]!;
+      // The event schema keeps its union structure rather than widening to the
+      // `true` schema.
+      assert(
+        Array.isArray(inputSchema.anyOf),
+        "event schema should retain its anyOf union",
       );
-      assertStringIncludes(inputSchema, '"undefined"');
-      assertStringIncludes(inputSchema, "value");
+      assert(
+        hasUndefinedMember(inputSchema),
+        "event schema should preserve undefined",
+      );
+      assert(
+        schemaPropertyNames(inputSchema).has("value"),
+        "event schema should keep the object member's `value` field",
+      );
     },
   );
 
@@ -1849,10 +1862,10 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "$NAME");
-      assertEquals(inputSchema.includes("metadata"), false);
-      assertEquals(inputSchema.includes("author"), false);
+      const names = schemaPropertyNames(schemasOf(result.output)[0]);
+      assert(names.has("$NAME"));
+      assert(!names.has("metadata"));
+      assert(!names.has("author"));
     },
   );
 
@@ -1883,9 +1896,12 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, "$NAME");
-      assertStringIncludes(inputSchema, '"default": "Untitled"');
+      const inputSchema = schemasOf(result.output)[0]!;
+      const props = inputSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+      assert(props?.$NAME !== undefined, "input schema should keep $NAME");
+      assertEquals(props?.$NAME.default, "Untitled");
     },
   );
 
@@ -1911,9 +1927,12 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, 'type: "undefined"');
-      assertStringIncludes(inputSchema, 'asCell: ["comparable"]');
+      const inputSchema = schemasOf(result.output)[0]!;
+      assert(
+        hasUndefinedMember(inputSchema),
+        "input schema should preserve undefined",
+      );
+      assertEquals(inputSchema.asCell, ["comparable"]);
     },
   );
 
@@ -1942,9 +1961,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      assertStringIncludes(result.output, 'asCell: ["readonly"]');
-      assertStringIncludes(result.output, '"foo"');
-      assertStringIncludes(result.output, '"bar"');
+      const inputSchema = schemasOf(result.output)[0]!;
+      assertEquals(inputSchema.asCell, ["readonly"]);
+      const names = schemaPropertyNames(inputSchema);
+      assert(names.has("foo"));
+      assert(names.has("bar"));
     },
   );
 
@@ -1972,9 +1993,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      assertStringIncludes(result.output, 'asCell: ["readonly"]');
-      assertStringIncludes(result.output, '"foo"');
-      assertStringIncludes(result.output, '"bar"');
+      const stateSchema = schemasOf(result.output)[1]!;
+      assertEquals(stateSchema.asCell, ["readonly"]);
+      const names = schemaPropertyNames(stateSchema);
+      assert(names.has("foo"));
+      assert(names.has("bar"));
     },
   );
 

--- a/packages/ts-transformers/test/transform-guards.test.ts
+++ b/packages/ts-transformers/test/transform-guards.test.ts
@@ -1,7 +1,37 @@
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
 
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { transformSource } from "./utils.ts";
+import { callsNamed, collect, parseModule } from "./transformed-ast.ts";
+
+/** True when a `<receiver>.key(...)` call reads the exact segment path. */
+function hasKeyPath(root: ts.Node, receiver: string, ...segments: string[]) {
+  return callsNamed(root, "key").some((call) => {
+    const callee = call.expression;
+    if (!ts.isPropertyAccessExpression(callee)) return false;
+    const base = callee.expression;
+    if (!ts.isIdentifier(base) || base.text !== receiver) return false;
+    if (call.arguments.length !== segments.length) return false;
+    return call.arguments.every((arg, index) =>
+      ts.isStringLiteralLike(arg) && arg.text === segments[index]
+    );
+  });
+}
+
+/** Every call whose callee is `<object>.<name>(...)` with `object` as base. */
+function memberCalls(
+  root: ts.Node,
+  object: string,
+  name: string,
+): ts.CallExpression[] {
+  return callsNamed(root, name).filter((call) => {
+    const callee = call.expression;
+    return ts.isPropertyAccessExpression(callee) &&
+      ts.isIdentifier(callee.expression) &&
+      callee.expression.text === object;
+  });
+}
 
 Deno.test(
   "Transform guards: nested block shadowing does not leak opaque alias roots",
@@ -18,10 +48,19 @@ const p = pattern((input: { user: { name: string }; value: { foo: number } }) =>
 `;
 
     const output = await transformSource(source);
+    const root = parseModule(output);
 
-    assertStringIncludes(output, 'const value = input.key("user");');
-    assertStringIncludes(output, "return <div>{value.foo}</div>;");
-    assert(!output.includes('value.key("foo")'));
+    // The inner block's `value` aliases input.user, so it lowers to key reads;
+    // the outer `value` is a plain object and its `.foo` read stays structural.
+    assert(hasKeyPath(root, "input", "user"));
+    assert(hasKeyPath(root, "value", "name"));
+    assert(!hasKeyPath(root, "value", "foo"));
+    const plainFooReads = collect(root, ts.isPropertyAccessExpression).filter(
+      (access) =>
+        access.name.text === "foo" && ts.isIdentifier(access.expression) &&
+        access.expression.text === "value",
+    );
+    assertEquals(plainFooReads.length, 1);
   },
 );
 
@@ -36,9 +75,10 @@ const p = pattern((input: { ok: boolean }) => {
 `;
 
     const output = await transformSource(source);
+    const root = parseModule(output);
 
-    assertStringIncludes(output, "arr.map((x) => x + 1)");
-    assert(!output.includes(".mapWithPattern("));
+    assertEquals(memberCalls(root, "arr", "map").length, 1);
+    assertEquals(callsNamed(root, "mapWithPattern").length, 0);
   },
 );
 
@@ -50,12 +90,10 @@ const p = pattern((input: { list: Array<{ name: string; age: number }> }) => <di
 `;
 
     const output = await transformSource(source);
+    const root = parseModule(output);
 
-    assertStringIncludes(output, ".mapWithPattern(");
-    assertStringIncludes(
-      output,
-      'const name = __cf_pattern_input.key("element", "name");',
-    );
+    assertEquals(callsNamed(root, "mapWithPattern").length, 1);
+    assert(hasKeyPath(root, "__cf_pattern_input", "element", "name"));
   },
 );
 
@@ -66,11 +104,11 @@ Deno.test(
       const { property, extraAssert } of [
         {
           property: "filter",
-          extraAssert: (output: string) =>
-            assert(!output.includes("filterWithPattern")),
+          extraAssert: (root: ts.Node) =>
+            assertEquals(callsNamed(root, "filterWithPattern").length, 0),
         },
-        { property: "map", extraAssert: (_output: string) => {} },
-        { property: "set", extraAssert: (_output: string) => {} },
+        { property: "map", extraAssert: (_root: ts.Node) => {} },
+        { property: "set", extraAssert: (_root: ts.Node) => {} },
       ]
     ) {
       const source = `import { pattern, UI } from "commonfabric";
@@ -82,8 +120,9 @@ const p = pattern<State>((state) => ({
       const output = await transformSource(source, {
         types: COMMONFABRIC_TYPES,
       });
-      assertStringIncludes(output, `state.key("${property}")`);
-      extraAssert(output);
+      const root = parseModule(output);
+      assert(hasKeyPath(root, "state", property));
+      extraAssert(root);
     }
   },
 );
@@ -100,12 +139,15 @@ const p = pattern((input: { groups: Group[] }) =>
 `;
 
     const output = await transformSource(source);
+    const root = parseModule(output);
 
-    assertStringIncludes(
-      output,
-      'input.key("groups", "100", "items").mapWithPattern(',
+    // The 1e2 element index canonicalizes to the string key "100".
+    assert(hasKeyPath(root, "input", "groups", "100", "items"));
+    assertEquals(callsNamed(root, "mapWithPattern").length, 1);
+    const keyArgs = callsNamed(root, "key").flatMap((call) =>
+      call.arguments.filter(ts.isStringLiteralLike).map((arg) => arg.text)
     );
-    assert(!output.includes('"1e2"'));
+    assertEquals(keyArgs.includes("1e2"), false);
   },
 );
 
@@ -121,8 +163,10 @@ const p = pattern<State>((state) => ({
 `;
 
     const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
+    const root = parseModule(output);
 
-    assert(!output.includes("findWithPattern"));
+    assertEquals(callsNamed(root, "find").length, 1);
+    assertEquals(callsNamed(root, "findWithPattern").length, 0);
   },
 );
 
@@ -168,16 +212,16 @@ export default pattern<Input>(({ habits, logs, todayDate }) => {
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const root = parseModule(output);
 
-    assertStringIncludes(output, "const logList = logs.get();");
-    assertStringIncludes(
-      output,
-      "return logList.some((log) => log.habitName === habit.name &&",
-    );
-    assert(
-      !output.includes("return logList.some((log) => __cfHelpers.when("),
-      "aliased plain array some() callback should stay plain inside computed()/derive()",
-    );
+    // The get-result alias keeps its `.get()` and its `.some()` predicate stays
+    // a plain arrow: the transformer wraps no `when(...)` around it.
+    assertEquals(memberCalls(root, "logs", "get").length, 1);
+    const someCalls = memberCalls(root, "logList", "some");
+    assertEquals(someCalls.length, 1);
+    const predicate = someCalls[0]!.arguments[0]!;
+    assert(ts.isArrowFunction(predicate));
+    assertEquals(callsNamed(root, "when").length, 0);
   },
 );
 
@@ -218,14 +262,20 @@ export default pattern<State>((state) => ({
 
     // After CT-1615 Phase 1, synthesized derives lower to lift-applied:
     //   __cfHelpers.lift<...>(cb)(input)
-    // Match `__cfHelpers.lift<` since the synthesized form always has
-    // type arguments.
-    assertEquals(output.match(/__cfHelpers\.lift</g)?.length ?? 0, 2);
-    assertStringIncludes(output, "item.price * (1 - state.discount)");
-    assert(
-      !output.includes("item.price * (__cfHelpers.lift<"),
-      "expected ternary branch lift-applied to absorb inner arithmetic instead of nesting a second lift",
+    // The predicate lift and the discount-arithmetic lift make exactly two.
+    const root = parseModule(output);
+    assertEquals(callsNamed(root, "lift").length, 2);
+    const multiplies = collect(root, ts.isBinaryExpression).filter((node) =>
+      node.operatorToken.kind === ts.SyntaxKind.AsteriskToken
     );
+    // The arithmetic sits inside a lift body verbatim, and its left operand
+    // stays `item.price` rather than nesting another lift call.
+    const priceMultiply = multiplies.find((node) =>
+      ts.isPropertyAccessExpression(node.left) &&
+      node.left.name.text === "price"
+    );
+    assert(priceMultiply, "expected an `item.price * (...)` multiplication");
+    assertEquals(callsNamed(priceMultiply, "lift").length, 0);
   },
 );
 
@@ -259,9 +309,19 @@ export default pattern<{ fields: Field[] }>((state) => ({
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const root = parseModule(output);
 
-    assertStringIncludes(output, "ifElse(");
-    assertStringIncludes(output, "=> field.validationIssue !== undefined");
+    assert(callsNamed(root, "ifElse").length >= 1);
+    // The predicate `field.validationIssue !== undefined` lowers into a lift
+    // arrow whose body is that inequality, not a pattern-owned branch.
+    const predicateArrows = collect(root, ts.isArrowFunction).filter((arrow) =>
+      ts.isBinaryExpression(arrow.body) &&
+      arrow.body.operatorToken.kind ===
+        ts.SyntaxKind.ExclamationEqualsEqualsToken &&
+      ts.isPropertyAccessExpression(arrow.body.left) &&
+      arrow.body.left.name.text === "validationIssue"
+    );
+    assertEquals(predicateArrows.length, 1);
   },
 );
 
@@ -292,14 +352,13 @@ export default pattern<State>((state) => {
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const root = parseModule(output);
 
-    assertStringIncludes(output, "lookup.get(");
-    assert(
-      !/__cfHelpers\.(?:computed|derive)\([\s\S]{0,160}lookup\.get\(/.test(
-        output,
-      ),
-      "expected non-cell helper-owned get() calls to remain plain method calls",
-    );
+    // The non-cell `lookup.get(...)` stays a plain method call: the transformer
+    // wraps no computed/derive around it.
+    assertEquals(memberCalls(root, "lookup", "get").length, 1);
+    assertEquals(callsNamed(root, "computed").length, 0);
+    assertEquals(callsNamed(root, "derive").length, 0);
   },
 );
 
@@ -349,21 +408,14 @@ export default pattern<{ left: Default<number, 0>; right: Default<number, 0> }>(
       types: COMMONFABRIC_TYPES,
     });
 
-    assertStringIncludes(output, 'left: leftChild.key("value")');
-    assertStringIncludes(output, 'right: rightChild.key("value")');
-    assertStringIncludes(output, 'increment: rightChild.key("increment")');
-    assert(
-      !output.includes(
-        '__cfHelpers.computed((): any => leftChild.key("value"))',
-      ),
-      "expected child value cell reference to stay structural inside helper-owned arguments",
-    );
-    assert(
-      !output.includes(
-        '__cfHelpers.computed((): any => rightChild.key("increment"))',
-      ),
-      "expected child stream reference to stay structural inside helper-owned arguments",
-    );
+    const root = parseModule(output);
+
+    // The child cell and stream references stay structural key reads; none is
+    // wrapped in a computed inside the helper-owned argument objects.
+    assert(hasKeyPath(root, "leftChild", "value"));
+    assert(hasKeyPath(root, "rightChild", "value"));
+    assert(hasKeyPath(root, "rightChild", "increment"));
+    assertEquals(callsNamed(root, "computed").length, 0);
   },
 );
 
@@ -405,17 +457,16 @@ export default pattern<{ child: Default<number, 0> }>(({ child }) => {
     const output = await transformSource(source, {
       types: COMMONFABRIC_TYPES,
     });
+    const root = parseModule(output);
 
-    assertStringIncludes(
-      output,
-      'childIncrement: asIncrementStream(childState.key("increment"))',
-    );
-    assert(
-      !/__cfHelpers\.(?:computed|derive)\([\s\S]{0,240}asIncrementStream\(childState\.key\("increment"\)\)/
-        .test(
-          output,
-        ),
-      "expected child stream key reference to stay structural inside ordinary helper call arguments",
-    );
+    // The ordinary helper call `asIncrementStream(...)` receives the structural
+    // key read directly, not a computed/derive-wrapped value.
+    const wrapperCalls = callsNamed(root, "asIncrementStream");
+    assertEquals(wrapperCalls.length, 1);
+    const arg = wrapperCalls[0]!.arguments[0]!;
+    assert(ts.isCallExpression(arg));
+    assert(hasKeyPath(arg, "childState", "increment"));
+    assertEquals(callsNamed(root, "computed").length, 0);
+    assertEquals(callsNamed(root, "derive").length, 0);
   },
 );

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -1,13 +1,42 @@
+import ts from "typescript";
 import { describe, it } from "@std/testing/bdd";
-import {
-  assert,
-  assertMatch,
-  assertNotMatch,
-  assertRejects,
-  assertStringIncludes,
-} from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { transformFiles } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import {
+  callsMatching,
+  callsNamed,
+  collect,
+  forCauses,
+  hasKeyPathRead,
+  literalToValue,
+  parseModule,
+} from "./transformed-ast.ts";
+
+/**
+ * True when some emitted `.for(...)` call is attached directly to a
+ * `<receiver>.key("<key>")` reactive read — the shape the transformer must
+ * avoid, since a stable cause belongs on the lowered result, not on the raw
+ * property read.
+ */
+function hasForOnKeyRead(root: ts.Node, key: string): boolean {
+  return callsNamed(root, "for").some((call) => {
+    const callee = call.expression;
+    if (!ts.isPropertyAccessExpression(callee)) return false;
+    const receiver = callee.expression;
+    if (!ts.isCallExpression(receiver)) return false;
+    const receiverCallee = receiver.expression;
+    if (
+      !ts.isPropertyAccessExpression(receiverCallee) ||
+      receiverCallee.name.text !== "key"
+    ) {
+      return false;
+    }
+    const firstArg = receiver.arguments[0];
+    return !!firstArg && ts.isStringLiteralLike(firstArg) &&
+      firstArg.text === key;
+  });
+}
 
 const fixture = `
 import { toSchema } from "commonfabric";
@@ -44,13 +73,24 @@ export function make() {
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(
-      main,
-      'const foo = Writable.of(1, {\n        type: "number"\n    } as const satisfies __cfHelpers.JSONSchema).for("foo", true);',
+    const root = parseModule(main);
+    const causes = forCauses(root);
+    assert(causes.includes("foo"));
+    assert(causes.includes("bar"));
+    assert(causes.includes("baz"));
+    assert(!causes.includes("already"));
+
+    // The fresh `Writable.of(1, …)` initializer gains an inferred schema; the
+    // `.for("foo", true)` cause hangs off that `Writable.of` call.
+    const fooFor = callsNamed(root, "for").find((c) =>
+      literalToValue(c.arguments[0]!) === "foo"
     );
-    assertStringIncludes(main, '.for("bar", true);');
-    assertStringIncludes(main, '.for("baz", true);');
-    assert(!main.includes('.for("already", true)'));
+    assert(fooFor);
+    const receiver = (fooFor.expression as ts.PropertyAccessExpression)
+      .expression;
+    assert(ts.isCallExpression(receiver));
+    assertEquals(receiver.arguments.length, 2);
+    assertEquals(literalToValue(receiver.arguments[1]!), { type: "number" });
   });
 
   it("registers cast-wrapped non-exported builder consts in __cfReg (CT-1743)", async () => {
@@ -88,10 +128,18 @@ const openNoCast = handler<
     });
     const main = output["/main.ts"]!;
 
-    const reg = main.match(/__cfReg\(\{([\s\S]*?)\}\)/);
-    assert(reg, "expected a __cfReg registration call in the output");
-    assertStringIncludes(reg[1], "openNoCast"); // positive control
-    assertStringIncludes(reg[1], "openWithCast"); // CT-1743 regression guard
+    const root = parseModule(main);
+    const regCalls = callsNamed(root, "__cfReg");
+    assertEquals(regCalls.length, 1);
+    const arg = regCalls[0]!.arguments[0]!;
+    assert(ts.isObjectLiteralExpression(arg));
+    const keys = arg.properties.map((p) =>
+      p.name && (ts.isIdentifier(p.name) || ts.isStringLiteralLike(p.name))
+        ? p.name.text
+        : undefined
+    );
+    assert(keys.includes("openNoCast")); // positive control
+    assert(keys.includes("openWithCast")); // CT-1743 regression guard
   });
 
   it("adds stable property causes to pattern-owned lowered derives", async () => {
@@ -113,10 +161,11 @@ export default pattern<{ count: number }, { doubled: number }>((state) => ({
     // After CT-1615 Phase 1 the pattern-owned synthesized derive lowers to
     // lift-applied; after CT-1644 Phase 2 the lift call is hoisted to a
     // module-scope const and the result reads as `doubled: __cfLift_N(input)`.
-    assertStringIncludes(main, "const __cfLift_1 = __cfHelpers.lift<");
-    assertMatch(main, /doubled: __cfLift_\d+\(/);
-    assertStringIncludes(main, '.for(["__patternResult", "doubled"], true)');
-    assertNotMatch(main, /state\.key\("count"\)\.for/);
+    const root = parseModule(main);
+    assertEquals(callsNamed(root, "lift").length, 1);
+    assert(callsMatching(root, /^__cfLift/).length >= 1);
+    assertEquals(forCauses(root), [["__patternResult", "doubled"]]);
+    assert(!hasForOnKeyRead(root, "count"));
   });
 
   it("adds stable nested causes to pattern result cells", async () => {
@@ -139,16 +188,23 @@ export default pattern<{ count: number }>((state) => ({
     });
     const main = output["/main.tsx"]!;
 
-    assertStringIncludes(main, '.for(["__patternResult", "foo"], true)');
-    assertStringIncludes(
-      main,
-      '.for(["__patternResult", "nested", "bar"], true)',
+    const root = parseModule(main);
+    const causes = forCauses(root);
+    assertEquals(
+      causes.find((c) =>
+        Array.isArray(c) && c[0] === "__patternResult" && c[1] === "foo"
+      ),
+      ["__patternResult", "foo"],
     );
-    assertStringIncludes(
-      main,
-      '.for(["__patternResult", "tuple", 0], true)',
+    assertEquals(
+      causes.find((c) => Array.isArray(c) && c[1] === "nested"),
+      ["__patternResult", "nested", "bar"],
     );
-    assertNotMatch(main, /state\.key\("count"\)\.for/);
+    assertEquals(
+      causes.find((c) => Array.isArray(c) && c[1] === "tuple"),
+      ["__patternResult", "tuple", 0],
+    );
+    assert(!hasForOnKeyRead(root, "count"));
   });
 
   it("uses stream-scoped causes for handler result streams", async () => {
@@ -175,15 +231,28 @@ export default pattern(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assertMatch(main, /\.for\(\{\s*stream: "save"\s*\}, true\)/s);
-    assertMatch(
-      main,
-      /\.for\(\{\s*stream: \[\s*"__patternResult",\s*"nested",\s*"cancel"\s*\]\s*\}, true\)/s,
+    const causes = forCauses(parseModule(main));
+    assertEquals(
+      causes.find((c) =>
+        typeof c === "object" && c !== null && !Array.isArray(c) &&
+        (c as Record<string, unknown>).stream === "save"
+      ),
+      { stream: "save" },
     );
-    assertNotMatch(main, /\.for\("save", true\)/);
-    assertNotMatch(
-      main,
-      /\.for\(\["__patternResult", "nested", "cancel"\], true\)/,
+    assertEquals(
+      causes.find((c) =>
+        typeof c === "object" && c !== null && !Array.isArray(c) &&
+        Array.isArray((c as Record<string, unknown>).stream)
+      ),
+      { stream: ["__patternResult", "nested", "cancel"] },
+    );
+    // Streams keep a stream-scoped cause, never a bare string or array path.
+    assert(!causes.includes("save"));
+    assert(
+      !causes.some((c) =>
+        Array.isArray(c) && c[0] === "__patternResult" && c[1] === "nested" &&
+        c[2] === "cancel"
+      ),
     );
   });
 
@@ -207,14 +276,25 @@ export default pattern(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assertStringIncludes(main, '.for("foo", true);');
-    assertStringIncludes(
-      main,
-      'foo: foo.for(["__patternResult", "foo"], true)',
+    const root = parseModule(main);
+    const causes = forCauses(root);
+    assert(causes.includes("foo")); // variable-declaration cause
+    // Both result members re-root onto the `foo` identifier with a nested cause.
+    const rerooted = callsNamed(root, "for").filter((call) => {
+      const callee = call.expression;
+      return ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) && callee.expression.text === "foo";
+    });
+    const rerootedCauses = rerooted.map((c) => literalToValue(c.arguments[0]!));
+    assert(
+      rerootedCauses.some((c) =>
+        Array.isArray(c) && c[0] === "__patternResult" && c[1] === "foo"
+      ),
     );
-    assertStringIncludes(
-      main,
-      'explicit: foo.for(["__patternResult", "explicit"], true)',
+    assert(
+      rerootedCauses.some((c) =>
+        Array.isArray(c) && c[0] === "__patternResult" && c[1] === "explicit"
+      ),
     );
   });
 
@@ -244,10 +324,14 @@ export function make() {
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(main, '.for(["foo", "param"], true)');
-    assertStringIncludes(main, '.for(["foo", "nested", "result"], true)');
-    assertStringIncludes(main, '.for(["foo", "tuple", 0], true)');
-    assert(!main.includes('.for(["foo", "already"], true)'));
+    const causes = forCauses(parseModule(main));
+    const arrayEq = (a: unknown, b: unknown[]) =>
+      Array.isArray(a) && a.length === b.length &&
+      a.every((x, i) => x === b[i]);
+    assert(causes.some((c) => arrayEq(c, ["foo", "param"])));
+    assert(causes.some((c) => arrayEq(c, ["foo", "nested", "result"])));
+    assert(causes.some((c) => arrayEq(c, ["foo", "tuple", 0])));
+    assert(!causes.some((c) => arrayEq(c, ["foo", "already"])));
   });
 
   it("does not add positional cause segments for wrapped single object arguments", async () => {
@@ -270,8 +354,12 @@ export function make() {
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(main, '.for(["foo", "param"], true)');
-    assert(!main.includes('.for(["foo", 0, "param"], true)'));
+    const causes = forCauses(parseModule(main));
+    const arrayEq = (a: unknown, b: unknown[]) =>
+      Array.isArray(a) && a.length === b.length &&
+      a.every((x, i) => x === b[i]);
+    assert(causes.some((c) => arrayEq(c, ["foo", "param"])));
+    assert(!causes.some((c) => arrayEq(c, ["foo", 0, "param"])));
   });
 
   it("does not retarget plain handler params inside local object initializers", async () => {
@@ -303,8 +391,27 @@ export { runBoth };
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(main, "text: prompt");
-    assertNotMatch(main, /prompt\.for\(/);
+    const root = parseModule(main);
+    // The `text` message field stays bound to the bare `prompt` identifier,
+    // not to a reactive read.
+    const textAssign = collect(root, ts.isPropertyAssignment).find((p) =>
+      (ts.isIdentifier(p.name) || ts.isStringLiteralLike(p.name)) &&
+      p.name.text === "text" && ts.isIdentifier(p.initializer) &&
+      p.initializer.text === "prompt"
+    );
+    assert(
+      textAssign,
+      "expected `text: prompt` to survive as a bare identifier",
+    );
+    // No stable cause is attached to `prompt`.
+    assert(
+      !callsNamed(root, "for").some((call) => {
+        const callee = call.expression;
+        return ts.isPropertyAccessExpression(callee) &&
+          ts.isIdentifier(callee.expression) &&
+          callee.expression.text === "prompt";
+      }),
+    );
   });
 
   it("does not duplicate stable causes on asserted reactive initializers", async () => {
@@ -328,11 +435,9 @@ export default pattern<{ entries: Default<Entry[], []> }>(({ entries }) => {
     });
     const main = output["/main.tsx"]!;
 
-    const treeCauseCount = main.match(/\.for\("tree", true\)/g)?.length ?? 0;
-    assert(
-      treeCauseCount === 1,
-      `expected one tree cause, found ${treeCauseCount}`,
-    );
+    const treeCauseCount =
+      forCauses(parseModule(main)).filter((c) => c === "tree").length;
+    assertEquals(treeCauseCount, 1);
   });
 
   it("does not add causes to plain array methods in lift callbacks", async () => {
@@ -362,9 +467,14 @@ export const summarize = lift((summaries: Summary[]) => {
     });
     const main = output["/main.ts"]!;
 
-    assert(!main.includes('.for("labels", true)'));
-    assert(!main.includes('.for("active", true)'));
-    assert(!main.includes('.for(["labels"], true)'));
+    const causes = forCauses(parseModule(main));
+    assert(!causes.includes("labels"));
+    assert(!causes.includes("active"));
+    assert(
+      !causes.some((c) =>
+        Array.isArray(c) && c.length === 1 && c[0] === "labels"
+      ),
+    );
   });
 
   it("does not add causes to plain array methods in lowered handler callbacks", async () => {
@@ -392,7 +502,19 @@ export default pattern(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assert(!main.includes('.filter(() => true).for("handlers", true)'));
+    const root = parseModule(main);
+    // No stable cause is attached to a plain `.filter(...)` array read.
+    assert(
+      !callsNamed(root, "for").some((call) => {
+        if (literalToValue(call.arguments[0]!) !== "handlers") return false;
+        const callee = call.expression;
+        if (!ts.isPropertyAccessExpression(callee)) return false;
+        const receiver = callee.expression;
+        return ts.isCallExpression(receiver) &&
+          ts.isPropertyAccessExpression(receiver.expression) &&
+          receiver.expression.name.text === "filter";
+      }),
+    );
   });
 
   it("does not add causes to receiver calls in property access chains", async () => {
@@ -417,8 +539,22 @@ export default pattern(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assert(!main.includes('.for("mentionable", true).result'));
-    assertStringIncludes(main, '.for(["picked", "param"], true)');
+    const root = parseModule(main);
+    // No `.for("mentionable", …)` is inserted mid-chain before `.result`.
+    assert(
+      !callsNamed(root, "for").some((call) => {
+        if (literalToValue(call.arguments[0]!) !== "mentionable") return false;
+        const parent = call.parent;
+        return ts.isPropertyAccessExpression(parent) &&
+          parent.expression === call && parent.name.text === "result";
+      }),
+    );
+    const causes = forCauses(root);
+    assert(
+      causes.some((c) =>
+        Array.isArray(c) && c[0] === "picked" && c[1] === "param"
+      ),
+    );
   });
 
   it("lowers local reactive roots in zero-input pattern bodies", async () => {
@@ -443,11 +579,9 @@ export default pattern<Record<string, never>>(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assertStringIncludes(main, '.for("mentionableWish", true)');
-    assertStringIncludes(
-      main,
-      'const mentionable = mentionableWish.key("result")',
-    );
+    const root = parseModule(main);
+    assert(forCauses(root).includes("mentionableWish"));
+    assert(hasKeyPathRead(root, "result", "mentionableWish"));
   });
 
   it("does not add root causes to pattern factory outputs", async () => {
@@ -471,8 +605,13 @@ export default pattern(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assert(!main.includes('.for("child", true)'));
-    assertStringIncludes(main, '.for(["child", "value"], true)');
+    const causes = forCauses(parseModule(main));
+    assert(!causes.includes("child"));
+    assert(
+      causes.some((c) =>
+        Array.isArray(c) && c[0] === "child" && c[1] === "value"
+      ),
+    );
   });
 
   it("does not re-root pattern factory identifiers in tool descriptors", async () => {
@@ -501,9 +640,36 @@ export default pattern(() => {
     });
     const main = output["/main.tsx"]!;
 
-    assertStringIncludes(main, "pattern: searchWeb");
-    assertStringIncludes(main, "wrappedSearch: patternTool(searchWeb)");
-    assert(!main.includes("searchWeb.for("));
+    const root = parseModule(main);
+    const props = collect(root, ts.isPropertyAssignment);
+    const patternProp = props.find((p) =>
+      (ts.isIdentifier(p.name) || ts.isStringLiteralLike(p.name)) &&
+      p.name.text === "pattern"
+    );
+    assert(patternProp && ts.isIdentifier(patternProp.initializer));
+    assertEquals(patternProp.initializer.text, "searchWeb");
+    const wrappedProp = props.find((p) =>
+      (ts.isIdentifier(p.name) || ts.isStringLiteralLike(p.name)) &&
+      p.name.text === "wrappedSearch"
+    );
+    assert(wrappedProp && ts.isCallExpression(wrappedProp.initializer));
+    const wrapCall = wrappedProp.initializer;
+    assert(ts.isIdentifier(wrapCall.expression));
+    assertEquals(wrapCall.expression.text, "patternTool");
+    assert(
+      wrapCall.arguments.length === 1 &&
+        ts.isIdentifier(wrapCall.arguments[0]!) &&
+        wrapCall.arguments[0].text === "searchWeb",
+    );
+    // The pattern factory identifier is never given a stable cause.
+    assert(
+      !callsNamed(root, "for").some((call) => {
+        const callee = call.expression;
+        return ts.isPropertyAccessExpression(callee) &&
+          ts.isIdentifier(callee.expression) &&
+          callee.expression.text === "searchWeb";
+      }),
+    );
   });
 
   it("does not add shared property causes inside dynamic array callbacks", async () => {
@@ -524,7 +690,7 @@ export const build = lift((values: number[]) =>
     });
     const main = output["/main.ts"]!;
 
-    assert(!main.includes('.for("token", true)'));
+    assert(!forCauses(parseModule(main)).includes("token"));
   });
 
   it("transforms by default and supports cf-disable-transform opt-out", async () => {
@@ -538,17 +704,17 @@ export { value };
     const enabledByDefault = await transformFiles({
       "/main.ts": source,
     });
-    assertStringIncludes(
-      enabledByDefault["/main.ts"]!,
-      "__cfHelpers.lift(",
-    );
+    const enabledRoot = parseModule(enabledByDefault["/main.ts"]!);
+    assert(callsNamed(enabledRoot, "lift").length >= 1);
+    assertEquals(callsNamed(enabledRoot, "computed").length, 0);
 
     const disabled = await transformFiles({
       "/main.ts": `/// <cf-disable-transform />\n${source}`,
     });
 
-    assertStringIncludes(disabled["/main.ts"]!, "computed(() => 1)");
-    assertNotMatch(disabled["/main.ts"]!, /__cfHelpers\.lift/);
+    const disabledRoot = parseModule(disabled["/main.ts"]!);
+    assertEquals(callsNamed(disabledRoot, "computed").length, 1);
+    assertEquals(callsNamed(disabledRoot, "lift").length, 0);
   });
 
   it("wraps top-level data candidates with __cfHelpers.__cf_data", async () => {
@@ -580,41 +746,34 @@ export { model, lookup, days, matcher, scopes, years, tags, proxied, passthrough
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(
-      main,
-      'const model = __cfHelpers.__cf_data(schema({ type: "string" } as const));',
+    const root = parseModule(main);
+    // The variable names whose top-level initializer is a `__cf_data(...)` wrap.
+    const wrapped = new Set(
+      collect(root, ts.isVariableDeclaration).filter((d) =>
+        d.initializer && ts.isCallExpression(d.initializer) &&
+        ts.isPropertyAccessExpression(d.initializer.expression) &&
+        d.initializer.expression.name.text === "__cf_data"
+      ).map((d) => ts.isIdentifier(d.name) ? d.name.text : undefined),
     );
-    assertStringIncludes(
-      main,
-      'const lookup = __cfHelpers.__cf_data((() => ({ open: "Open" }))());',
-    );
-    assertStringIncludes(
-      main,
-      "const days = __cfHelpers.__cf_data(Array.from({ length: 3 }, (_, index) => String(index + 1)));",
-    );
-    assertStringIncludes(
-      main,
-      "const matcher = __cfHelpers.__cf_data(/^[a-z]+$/);",
-    );
-    assertStringIncludes(
-      main,
-      "const scopes = __cfHelpers.__cf_data(Object.fromEntries(",
-    );
-    assertStringIncludes(
-      main,
-      "const years = __cfHelpers.__cf_data(buildYears());",
-    );
-    assertStringIncludes(
-      main,
-      'const tags = __cfHelpers.__cf_data(new Set(["a", "b"]));',
-    );
+    for (
+      const name of ["model", "lookup", "days", "matcher", "scopes", "years"]
+    ) {
+      assert(wrapped.has(name), `expected ${name} to be __cf_data-wrapped`);
+    }
+    // `tags` (a `new Set(...)`) is wrapped; the wrapped inner is the NewExpression.
+    assert(wrapped.has("tags"));
+    // Proxy snapshots stay unsupported until Proxy is re-enabled in SES
+    // compartments, and top-level builder calls are never wrapped.
+    assert(!wrapped.has("proxied"));
+    assert(!wrapped.has("passthrough"));
+    // No `__cf_data` wrap takes a `lift(...)` call as its argument.
     assert(
-      !main.includes('__cfHelpers.__cf_data(new Proxy({ open: "Open" }, {}));'),
-      "Proxy snapshots stay unsupported until Proxy is re-enabled in SES compartments",
-    );
-    assert(
-      !main.includes("__cfHelpers.__cf_data(lift("),
-      "top-level builder calls should not be wrapped",
+      !callsNamed(root, "__cf_data").some((c) => {
+        const inner = c.arguments[0];
+        return !!inner && ts.isCallExpression(inner) &&
+          ts.isIdentifier(inner.expression) &&
+          inner.expression.text === "lift";
+      }),
     );
   });
 
@@ -631,12 +790,30 @@ export default function next(value: number) {
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(main, "function __cfHardenFn");
-    assertStringIncludes(
-      main,
-      "const step = __cfHardenFn((value: number) => value + 1);",
+    const root = parseModule(main);
+    // The canonical hardening helper is declared as a function.
+    assert(
+      collect(root, ts.isFunctionDeclaration).some((f) =>
+        f.name?.text === "__cfHardenFn"
+      ),
     );
-    assertStringIncludes(main, "__cfHardenFn(next);");
+    // `step`'s initializer wraps its arrow in `__cfHardenFn(...)`.
+    const stepDecl = collect(root, ts.isVariableDeclaration).find((d) =>
+      ts.isIdentifier(d.name) && d.name.text === "step"
+    );
+    assert(stepDecl?.initializer && ts.isCallExpression(stepDecl.initializer));
+    assert(
+      ts.isIdentifier(stepDecl.initializer.expression) &&
+        stepDecl.initializer.expression.text === "__cfHardenFn",
+    );
+    assert(ts.isArrowFunction(stepDecl.initializer.arguments[0]!));
+    // The exported default function `next` is hardened by identifier.
+    assert(
+      callsNamed(root, "__cfHardenFn").some((c) =>
+        c.arguments.length === 1 && ts.isIdentifier(c.arguments[0]!) &&
+        c.arguments[0].text === "next"
+      ),
+    );
   });
 
   it("wraps explicit snapshot helpers with __cfHelpers.__cf_data", async () => {
@@ -656,21 +833,31 @@ export default function probe() {
     });
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(
-      main,
-      "const startedAt = __cfHelpers.__cf_data(safeDateNow());",
-    );
-    assertStringIncludes(
-      main,
-      "const seed = __cfHelpers.__cf_data(nonPrivateRandom());",
-    );
+    const root = parseModule(main);
+    const wrapsCall = (variableName: string, callee: string) => {
+      const decl = collect(root, ts.isVariableDeclaration).find((d) =>
+        ts.isIdentifier(d.name) && d.name.text === variableName
+      );
+      assert(decl?.initializer && ts.isCallExpression(decl.initializer));
+      const outer = decl.initializer;
+      assert(
+        ts.isPropertyAccessExpression(outer.expression) &&
+          outer.expression.name.text === "__cf_data",
+      );
+      const inner = outer.arguments[0];
+      assert(inner && ts.isCallExpression(inner));
+      assert(
+        ts.isIdentifier(inner.expression) && inner.expression.text === callee,
+      );
+    };
+    wrapsCall("startedAt", "safeDateNow");
+    wrapsCall("seed", "nonPrivateRandom");
+    // Explicit helper calls stay bare, not rewritten onto `__cfHelpers`.
     assert(
-      !main.includes("__cfHelpers.safeDateNow"),
-      "explicit helper calls should not be rewritten",
-    );
-    assert(
-      !main.includes("__cfHelpers.nonPrivateRandom"),
-      "explicit helper calls should not be rewritten",
+      !collect(root, ts.isPropertyAccessExpression).some((p) =>
+        ts.isIdentifier(p.expression) && p.expression.text === "__cfHelpers" &&
+        (p.name.text === "safeDateNow" || p.name.text === "nonPrivateRandom")
+      ),
     );
   });
 
@@ -687,12 +874,15 @@ export default pow(5);
 
     const main = output["/main.ts"]!;
 
-    assertStringIncludes(
-      main,
-      "export default pow(5);",
-    );
-    assertNotMatch(main, /__cfHelpers\.__ct_data/);
-    assertNotMatch(main, /__cfDataHelper/);
+    const root = parseModule(main);
+    // The default export stays the bare `pow(5)` call, untouched by wrapping.
+    const defaultExport = collect(root, ts.isExportAssignment)[0];
+    assert(defaultExport && ts.isCallExpression(defaultExport.expression));
+    const call = defaultExport.expression;
+    assert(ts.isIdentifier(call.expression) && call.expression.text === "pow");
+    assertEquals(literalToValue(call.arguments[0]!), 5);
+    // No snapshot wrapping was inserted.
+    assertEquals(callsNamed(root, "__cf_data").length, 0);
   });
 });
 

--- a/packages/ts-transformers/test/transformed-ast.ts
+++ b/packages/ts-transformers/test/transformed-ast.ts
@@ -97,6 +97,20 @@ export function hasKeyPathRead(
   });
 }
 
+/**
+ * The evaluated first argument of every emitted `<receiver>.for(<cause>, true)`
+ * stable-cause call, in source order. A cause is a string (`"foo"`), an array
+ * path (`["__patternResult", "foo"]`), or a stream descriptor
+ * (`{ stream: "save" }`), so each entry is the JS value that argument denotes.
+ * Lets a test assert on the exact cause the transformer attached instead of
+ * matching printed `.for(...)` text.
+ */
+export function forCauses(root: ts.Node): unknown[] {
+  return callsNamed(root, "for")
+    .filter((call) => call.arguments.length >= 1)
+    .map((call) => literalToValue(call.arguments[0]!));
+}
+
 /** Unwrap parenthesized / `as` / `satisfies` / non-null wrappers. */
 function unwrap(node: ts.Expression): ts.Expression {
   let current = node;

--- a/packages/ts-transformers/test/transformed-ast.ts
+++ b/packages/ts-transformers/test/transformed-ast.ts
@@ -1,0 +1,244 @@
+import ts from "typescript";
+
+// Structural queries over transformer output. Tests parse the printed output
+// back into an AST and assert on real nodes instead of matching substrings.
+// Parsing drops comments as trivia, so these queries cannot be satisfied by a
+// preserved comment, and — unlike a substring that also occurs in the input —
+// a structural match only holds when the transformer actually produced the
+// node.
+
+/** Parse printed transformer output into a source file. */
+export function parseModule(source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    "/transformed.tsx",
+    source,
+    ts.ScriptTarget.ESNext,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TSX,
+  );
+}
+
+/** Collect every descendant node (inclusive) matching a type guard. */
+export function collect<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T,
+): T[] {
+  const out: T[] = [];
+  const visit = (node: ts.Node): void => {
+    if (guard(node)) out.push(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return out;
+}
+
+/**
+ * The simple name a call targets: the identifier for `foo(...)` or the member
+ * name for `obj.foo(...)`. Returns undefined for other callee shapes.
+ */
+export function calleeName(call: ts.CallExpression): string | undefined {
+  const callee = call.expression;
+  if (ts.isIdentifier(callee)) return callee.text;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  return undefined;
+}
+
+/** Every call whose target name equals `name` (bare or member call). */
+export function callsNamed(root: ts.Node, name: string): ts.CallExpression[] {
+  return collect(root, ts.isCallExpression).filter((call) =>
+    calleeName(call) === name
+  );
+}
+
+/** Every call whose target name matches `pattern` (e.g. /^__cfLift/). */
+export function callsMatching(
+  root: ts.Node,
+  pattern: RegExp,
+): ts.CallExpression[] {
+  return collect(root, ts.isCallExpression).filter((call) => {
+    const name = calleeName(call);
+    return name !== undefined && pattern.test(name);
+  });
+}
+
+/** True when `call` is an immediately-invoked arrow/function expression. */
+export function isImmediatelyInvokedFunction(call: ts.CallExpression): boolean {
+  let callee: ts.Expression = call.expression;
+  while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+  return ts.isArrowFunction(callee) || ts.isFunctionExpression(callee);
+}
+
+/** Every immediately-invoked arrow/function call under `root`. */
+export function iifeCalls(root: ts.Node): ts.CallExpression[] {
+  return collect(root, ts.isCallExpression).filter(
+    isImmediatelyInvokedFunction,
+  );
+}
+
+/**
+ * True when `root` contains a `<receiver>.key("<segment>")` reactive path read
+ * — the lowered form of an element/property access on a reactive value. Pass
+ * `receiver` to also require the immediate receiver identifier (e.g. "item").
+ */
+export function hasKeyPathRead(
+  root: ts.Node,
+  segment: string,
+  receiver?: string,
+): boolean {
+  return callsNamed(root, "key").some((call) => {
+    const arg = call.arguments[0];
+    if (!arg || !ts.isStringLiteralLike(arg) || arg.text !== segment) {
+      return false;
+    }
+    if (receiver === undefined) return true;
+    const callee = call.expression as ts.PropertyAccessExpression;
+    const base = callee.expression;
+    return ts.isIdentifier(base) && base.text === receiver;
+  });
+}
+
+/** Unwrap parenthesized / `as` / `satisfies` / non-null wrappers. */
+function unwrap(node: ts.Expression): ts.Expression {
+  let current = node;
+  while (true) {
+    if (
+      ts.isParenthesizedExpression(current) || ts.isAsExpression(current) ||
+      ts.isSatisfiesExpression(current) || ts.isNonNullExpression(current) ||
+      ts.isTypeAssertionExpression(current)
+    ) {
+      current = current.expression;
+      continue;
+    }
+    return current;
+  }
+}
+
+/**
+ * Evaluate a pure literal expression (object/array/string/number/boolean/null,
+ * through `as const`/`satisfies` wrappers) into the JS value it denotes. Throws
+ * on any non-literal node, so callers only use it on emitted literal data such
+ * as generated JSON schemas. This lets a test assert on real values
+ * (`schema.properties.name.type === "string"`) instead of matching printed text.
+ */
+export function literalToValue(node: ts.Expression): unknown {
+  const expr = unwrap(node);
+  if (ts.isStringLiteralLike(expr)) return expr.text;
+  if (ts.isNumericLiteral(expr)) return Number(expr.text);
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (
+    ts.isPrefixUnaryExpression(expr) &&
+    expr.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(expr.operand)
+  ) {
+    return -Number(expr.operand.text);
+  }
+  if (ts.isArrayLiteralExpression(expr)) {
+    return expr.elements.map((element) => literalToValue(element));
+  }
+  if (ts.isObjectLiteralExpression(expr)) {
+    const out: Record<string, unknown> = {};
+    for (const property of expr.properties) {
+      if (!ts.isPropertyAssignment(property)) {
+        throw new Error(
+          `Unsupported property kind in literal: ${
+            ts.SyntaxKind[property.kind]
+          }`,
+        );
+      }
+      const name = property.name;
+      const key = ts.isIdentifier(name) || ts.isStringLiteralLike(name)
+        ? name.text
+        : undefined;
+      if (key === undefined) {
+        throw new Error("Unsupported property name in literal");
+      }
+      out[key] = literalToValue(property.initializer);
+    }
+    return out;
+  }
+  throw new Error(`Not a literal expression: ${ts.SyntaxKind[expr.kind]}`);
+}
+
+/**
+ * Every emitted schema object literal — an object written `... as const
+ * satisfies ...JSONSchema` — evaluated to its JS value, in source order. Lets a
+ * test assert on the generated schema structure directly.
+ */
+export function emittedSchemas(root: ts.Node): Record<string, unknown>[] {
+  return collect(root, ts.isSatisfiesExpression)
+    .filter((node) =>
+      /JSONSchema/.test(node.type.getText(root.getSourceFile()))
+    )
+    .map((node) => literalToValue(node.expression))
+    .filter((value): value is Record<string, unknown> =>
+      typeof value === "object" && value !== null && !Array.isArray(value)
+    );
+}
+
+/**
+ * The `{ input, output }` schemas of the emitted default `pattern(cb, input,
+ * output)` call, evaluated to JS values.
+ */
+export function patternSchemas(
+  root: ts.SourceFile,
+): { input: Record<string, unknown>; output: Record<string, unknown> } {
+  const call = callsNamed(root, "pattern").find((c) => c.arguments.length >= 3);
+  if (!call) throw new Error("No emitted `pattern(cb, input, output)` call");
+  return {
+    input: literalToValue(call.arguments[1]!) as Record<string, unknown>,
+    output: literalToValue(call.arguments[2]!) as Record<string, unknown>,
+  };
+}
+
+/**
+ * The schema object-literal arguments of the last emitted call to `name`
+ * (e.g. `handler(cb, eventSchema, stateSchema)` or `lift(cb, input, result)`),
+ * evaluated to JS values. Only arguments that are `... satisfies ...JSONSchema`
+ * literals are returned, in argument order.
+ */
+export function callSchemas(
+  root: ts.SourceFile,
+  name: string,
+): Record<string, unknown>[] {
+  const call = callsNamed(root, name).at(-1);
+  if (!call) return [];
+  const out: Record<string, unknown>[] = [];
+  for (const arg of call.arguments) {
+    if (
+      ts.isSatisfiesExpression(arg) &&
+      /JSONSchema/.test(arg.type.getText(root))
+    ) {
+      out.push(literalToValue(arg.expression) as Record<string, unknown>);
+    }
+  }
+  return out;
+}
+
+/**
+ * The initializer arrow/function body of `const <name> = <fn>(cb, ...)` — used
+ * to isolate an extracted callback (e.g. the `__cfPattern_1` map callback) for
+ * focused structural assertions.
+ */
+export function extractedCallbackBody(
+  root: ts.SourceFile,
+  variableName: string,
+): ts.Node {
+  const decl = collect(root, ts.isVariableDeclaration).find((d) =>
+    ts.isIdentifier(d.name) && d.name.text === variableName
+  );
+  if (!decl?.initializer || !ts.isCallExpression(decl.initializer)) {
+    throw new Error(`Expected \`const ${variableName} = call(...)\``);
+  }
+  const firstArg = decl.initializer.arguments[0];
+  if (
+    !firstArg ||
+    (!ts.isArrowFunction(firstArg) && !ts.isFunctionExpression(firstArg))
+  ) {
+    throw new Error(
+      `Expected a callback as the first argument of ${variableName}`,
+    );
+  }
+  return firstArg.body;
+}

--- a/packages/ts-transformers/test/type-inference.test.ts
+++ b/packages/ts-transformers/test/type-inference.test.ts
@@ -1,5 +1,7 @@
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
+
+import { parseModule } from "./transformed-ast.ts";
 
 import {
   ensureTypeNodeRegistered,
@@ -132,6 +134,34 @@ function typeText(
   return type ? checker.typeToString(type) : "undefined";
 }
 
+// Reparse a printed type (the checker's `typeToString` output) into a real
+// type node by wrapping it in `type __T = …;`. Assertions then read the
+// parsed structure instead of matching a substring of the printed string,
+// which a wider type (`{ title: string } & X`) could otherwise satisfy.
+function reparseType(printed: string): ts.TypeNode {
+  const root = parseModule(`type __T = ${printed};`);
+  const alias = root.statements[0];
+  assert(
+    ts.isTypeAliasDeclaration(alias),
+    `expected a type alias for ${printed}`,
+  );
+  return alias.type;
+}
+
+// The property names of a printed object type, as a set.
+function objectMemberNames(printed: string): Set<string> {
+  const node = reparseType(printed);
+  assert(ts.isTypeLiteralNode(node), `expected an object type for ${printed}`);
+  const names = new Set<string>();
+  for (const member of node.members) {
+    assert(ts.isPropertySignature(member));
+    const name = member.name;
+    assert(ts.isIdentifier(name) || ts.isStringLiteralLike(name));
+    names.add(name.text);
+  }
+  return names;
+}
+
 Deno.test("type inference helpers classify special types and widen literals", () => {
   const { sourceFile, checker } = createProgram(`
     type Generic<T> = T;
@@ -214,14 +244,16 @@ Deno.test("type inference helpers infer parameters, returns, and contextual type
     getTypeFromTypeNodeWithFallback(explicit.typeNode, checker, registry),
     explicit.type,
   );
-  assertStringIncludes(typeText(explicit.type, checker), "title");
+  assert(objectMemberNames(typeText(explicit.type, checker)).has("title"));
 
   const inferredFromSignature = inferParameterType(
     undefined,
     declaredSignature,
     checker,
   );
-  assertStringIncludes(typeText(inferredFromSignature, checker), "count");
+  assert(
+    objectMemberNames(typeText(inferredFromSignature, checker)).has("count"),
+  );
   assertEquals(
     inferParameterType(typed.parameters[0], typedSignature, checker),
     explicit.type,
@@ -230,9 +262,20 @@ Deno.test("type inference helpers infer parameters, returns, and contextual type
     typeText(inferReturnType(typed, typedSignature, checker), checker),
     "string",
   );
-  assertStringIncludes(
+  // The contextual type is the whole function signature; its first parameter
+  // is the object carrying `count`.
+  const contextualType = reparseType(
     typeText(inferContextualType(contextual, checker), checker),
-    "count",
+  );
+  assert(ts.isFunctionTypeNode(contextualType));
+  const contextualParam = contextualType.parameters[0]?.type;
+  assert(contextualParam && ts.isTypeLiteralNode(contextualParam));
+  assert(
+    contextualParam.members.some((member) =>
+      ts.isPropertySignature(member) &&
+      ts.isIdentifier(member.name) &&
+      member.name.text === "count"
+    ),
   );
   assertEquals(
     typeText(
@@ -283,17 +326,26 @@ Deno.test("type inference helpers register synthetic type nodes", () => {
     getTypeFromTypeNodeWithFallback(existingNode, checker, registry),
     ensureTypeNodeRegistered(existingNode, checker, registry),
   );
-  assertStringIncludes(
-    typeText(ensureTypeNodeRegistered(typeLiteral, checker, registry), checker),
-    "name",
+  assert(
+    objectMemberNames(
+      typeText(
+        ensureTypeNodeRegistered(typeLiteral, checker, registry),
+        checker,
+      ),
+    ).has("name"),
   );
-  assertStringIncludes(
+  const arrayType = reparseType(
     typeText(ensureTypeNodeRegistered(arrayNode, checker, registry), checker),
-    "string[]",
   );
-  assertStringIncludes(
+  assert(ts.isArrayTypeNode(arrayType));
+  assertEquals(arrayType.elementType.kind, ts.SyntaxKind.StringKeyword);
+  const unionType = reparseType(
     typeText(ensureTypeNodeRegistered(unionNode, checker, registry), checker),
-    "string | number",
+  );
+  assert(ts.isUnionTypeNode(unionType));
+  assertEquals(
+    unionType.types.map((member) => member.kind).sort(),
+    [ts.SyntaxKind.StringKeyword, ts.SyntaxKind.NumberKeyword].sort(),
   );
   assertEquals(
     ensureTypeNodeRegistered(parenthesizedNode, checker, registry),
@@ -437,23 +489,24 @@ Deno.test("type inference helpers convert and unwrap types conservatively", () =
   );
   const value = findIdentifier(sourceFile, "value");
 
-  assertStringIncludes(
+  const unwrappedUnion = reparseType(
     typeText(unwrapOpaqueLikeType(unionType, checker), checker),
-    "string | number",
+  );
+  assert(ts.isUnionTypeNode(unwrappedUnion));
+  assertEquals(
+    unwrappedUnion.types.map((member) => member.kind).sort(),
+    [ts.SyntaxKind.StringKeyword, ts.SyntaxKind.NumberKeyword].sort(),
   );
   assertEquals(unwrapCellLikeType(undefined, checker), undefined);
   assertEquals(unwrapCellLikeType(boxType, checker), boxType);
 
   const asTypeNode = typeToTypeNode(boxType, checker, sourceFile);
   assert(asTypeNode);
-  assertStringIncludes(
-    ts.createPrinter().printNode(
-      ts.EmitHint.Unspecified,
-      asTypeNode,
-      sourceFile,
-    ),
-    "NameBox",
-  );
+  // The converted node refers back to the named alias rather than inlining the
+  // object shape.
+  assert(ts.isTypeReferenceNode(asTypeNode));
+  assert(ts.isIdentifier(asTypeNode.typeName));
+  assertEquals(asTypeNode.typeName.text, "NameBox");
   const schemaTypeNode = typeToSchemaTypeNode(
     checker.getTypeAtLocation(value),
     checker,

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -10,6 +10,73 @@ import {
   applyShrinkAndWrap,
   printTypeNode,
 } from "../src/transformers/type-shrinking.ts";
+import { collect, parseModule } from "./transformed-ast.ts";
+
+// ---------------------------------------------------------------------------
+// Structural inspection of printed type nodes.
+//
+// `printTypeNode` renders a `ts.TypeNode` to text. Asserting on that text with
+// `assertStringIncludes` is weak: it matches on formatting and cannot tell a
+// property named `title` apart from the word `title` appearing anywhere. These
+// helpers reparse the printed type node and expose its members as real AST
+// nodes so tests can assert on property names, optional flags, exact member
+// types, and the shape of the root node.
+// ---------------------------------------------------------------------------
+
+/** Reparse a printed type node into a `ts.TypeNode`. */
+function parseType(printed: string): ts.TypeNode {
+  const decl = collect(
+    parseModule(`type __T = ${printed};`),
+    ts.isTypeAliasDeclaration,
+  )[0];
+  if (!decl) throw new Error(`Could not parse type node: ${printed}`);
+  return decl.type;
+}
+
+interface PropInfo {
+  optional: boolean;
+  type: string;
+}
+
+/**
+ * Every property signature reachable under `node`, keyed by name, carrying its
+ * optional flag and the printed text of its declared type. Nested literals
+ * contribute their own members, so `unused` being absent from the map means it
+ * appears nowhere in the shape.
+ */
+function props(node: ts.Node): Map<string, PropInfo> {
+  const sf = node.getSourceFile();
+  const out = new Map<string, PropInfo>();
+  for (const signature of collect(node, ts.isPropertySignature)) {
+    const name = ts.isIdentifier(signature.name)
+      ? signature.name.text
+      : signature.name.getText(sf);
+    out.set(name, {
+      optional: !!signature.questionToken,
+      type: signature.type ? signature.type.getText(sf) : "",
+    });
+  }
+  return out;
+}
+
+/** Reparse the printed shrink result and return its member map. */
+function shrunkProps(result: ts.TypeNode, sourceFile: ts.SourceFile): {
+  node: ts.TypeNode;
+  props: Map<string, PropInfo>;
+} {
+  const node = parseType(printTypeNode(result, sourceFile));
+  return { node, props: props(node) };
+}
+
+/** True when `node` contains a reference to the qualified name `left.right`. */
+function hasQualifiedRef(node: ts.Node, left: string, right: string): boolean {
+  return collect(node, ts.isTypeReferenceNode).some((ref) => {
+    const name = ref.typeName;
+    return ts.isQualifiedName(name) &&
+      ts.isIdentifier(name.left) && name.left.text === left &&
+      name.right.text === right;
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Harness (mirrors test/type-shrinking.test.ts so cases stay comparable).
@@ -139,13 +206,16 @@ Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed field
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "title: string;");
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("title")?.type, "string");
   // The `Array<Item>` reference is rebuilt with the shrunk element, staying an
-  // Array<...> reference rather than collapsing to a numeric-key object.
-  assertStringIncludes(printed, "Array<{");
-  assertEquals(printed.includes("unused"), false);
-  assertEquals(printed.includes("id"), false);
+  // Array<...> reference around a type literal rather than collapsing to a
+  // numeric-key object.
+  assert(ts.isTypeReferenceNode(node));
+  assertEquals((node.typeName as ts.Identifier).text, "Array");
+  assert(ts.isTypeLiteralNode(node.typeArguments![0]!));
+  assertEquals(members.has("unused"), false);
+  assertEquals(members.has("id"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -203,10 +273,10 @@ Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", (
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "shared: string;");
-  assertEquals(printed.includes("onlyA"), false);
-  assertEquals(printed.includes("onlyB"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("shared")?.type, "string");
+  assertEquals(members.has("onlyA"), false);
+  assertEquals(members.has("onlyB"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -239,11 +309,12 @@ Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: string;");
-  assertEquals(printed.includes("drop"), false);
-  // Single non-nullish member survived; undefined was dropped after collapse.
-  assertEquals(printed.includes("undefined"), false);
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "string");
+  assertEquals(members.has("drop"), false);
+  // Single non-nullish member survived; undefined was dropped after collapse,
+  // so the root is the bare object literal rather than a union.
+  assert(ts.isTypeLiteralNode(node));
 });
 
 // ---------------------------------------------------------------------------
@@ -275,10 +346,14 @@ Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a 
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: string;");
-  assertStringIncludes(printed, "undefined");
-  assertEquals(printed.includes("drop"), false);
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "string");
+  assertEquals(members.has("drop"), false);
+  // The nullable object is rebuilt as a union that re-appends `undefined`.
+  assert(ts.isUnionTypeNode(node));
+  assert(
+    node.types.some((member) => member.kind === ts.SyntaxKind.UndefinedKeyword),
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -309,10 +384,11 @@ Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-dr
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "text: string;");
-  assertEquals(printed.includes("length: number"), false);
-  assertEquals(printed.includes("other"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  // `text` keeps its string leaf rather than shrinking to `{ length }`.
+  assertEquals(members.get("text")?.type, "string");
+  assertEquals(members.has("length"), false);
+  assertEquals(members.has("other"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -343,10 +419,10 @@ Deno.test("applyShrinkAndWrap represents index-signature access as an optional m
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "anyKey?:");
-  assertStringIncludes(printed, "name: string;");
-  assertEquals(printed.includes("unused"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("anyKey")?.optional, true);
+  assertEquals(members.get("name")?.type, "string");
+  assertEquals(members.has("unused"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -377,10 +453,10 @@ Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccess
 
   // The reference resolves to its declared members and the unaccessed `z` is
   // dropped, so the shrink differs from the original (isUnchangedShrink false).
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "x: number;");
-  assertStringIncludes(printed, "y: number;");
-  assertEquals(printed.includes("z:"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("x")?.type, "number");
+  assertEquals(members.get("y")?.type, "number");
+  assertEquals(members.has("z"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -411,10 +487,10 @@ Deno.test("applyShrinkAndWrap merges inherited interface members and honors over
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "baseOnly: number;");
-  assertStringIncludes(printed, "derivedOnly: boolean;");
-  assertEquals(printed.includes("shared"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("baseOnly")?.type, "number");
+  assertEquals(members.get("derivedOnly")?.type, "boolean");
+  assertEquals(members.has("shared"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -661,12 +737,12 @@ Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base typ
     "defaults_only",
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(
-    printed,
-    'title: __cfHelpers.Default<string, "Untitled">',
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(
+    members.get("title")?.type,
+    '__cfHelpers.Default<string, "Untitled">',
   );
-  assertStringIncludes(printed, "count: number;");
+  assertEquals(members.get("count")?.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -694,8 +770,12 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple i
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, 'name?: __cfHelpers.Default<string, "Anon">');
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("name")?.optional, true);
+  assertEquals(
+    members.get("name")?.type,
+    '__cfHelpers.Default<string, "Anon">',
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -723,8 +803,8 @@ Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertEquals(printed.includes("__cfHelpers.Default"), false);
+  const node = parseType(printTypeNode(result, sourceFile));
+  assertEquals(hasQualifiedRef(node, "__cfHelpers", "Default"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -753,12 +833,18 @@ Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", ()
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
+  const node = parseType(printTypeNode(result, sourceFile));
   // Each non-nullish member collapses to `unknown`; undefined is preserved.
-  assertStringIncludes(printed, "unknown");
-  assertStringIncludes(printed, "undefined");
-  assertEquals(printed.includes("a:"), false);
-  assertEquals(printed.includes("b:"), false);
+  assert(ts.isUnionTypeNode(node));
+  assert(
+    node.types.some((member) => member.kind === ts.SyntaxKind.UnknownKeyword),
+  );
+  assert(
+    node.types.some((member) => member.kind === ts.SyntaxKind.UndefinedKeyword),
+  );
+  const members = props(node);
+  assertEquals(members.has("a"), false);
+  assertEquals(members.has("b"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -819,9 +905,9 @@ Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> refe
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
 });
 
 // ---------------------------------------------------------------------------
@@ -857,10 +943,10 @@ Deno.test("applyShrinkAndWrap applies identity paths across union members", () =
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
-  assertStringIncludes(printed, "other: boolean");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
+  assertEquals(members.get("other")?.type, "boolean");
 });
 
 // ---------------------------------------------------------------------------
@@ -928,8 +1014,8 @@ Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized li
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "value: __cfHelpers.ReadonlyCell<number>");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("value")?.type, "__cfHelpers.ReadonlyCell<number>");
 });
 
 // ---------------------------------------------------------------------------
@@ -987,7 +1073,13 @@ Deno.test("applyShrinkAndWrap keeps a readonly array unchanged for an unresolved
     ts.factory,
   );
 
-  assertStringIncludes(printTypeNode(result, sourceFile), "readonly Item[]");
+  const node = parseType(printTypeNode(result, sourceFile));
+  // The readonly-array node is returned unchanged: a `readonly` type operator
+  // over an `Item[]` array.
+  assert(ts.isTypeOperatorNode(node));
+  assertEquals(node.operator, ts.SyntaxKind.ReadonlyKeyword);
+  assert(ts.isArrayTypeNode(node.type));
+  assertEquals(node.type.elementType.getText(node.getSourceFile()), "Item");
 });
 
 // Identity path through a parenthesized literal that DOES change a leaf: the
@@ -1017,9 +1109,9 @@ Deno.test("applyShrinkAndWrap rebuilds a parenthesized identity root when a leaf
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
 });
 
 // Identity path through a Cell-like wrapper reference descends into the inner
@@ -1048,11 +1140,12 @@ Deno.test("applyShrinkAndWrap descends identity paths through a Cell-like wrappe
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
+  const { node, props: members } = shrunkProps(result, sourceFile);
   // The Cell wrapper is retained; its inner `keep` leaf is wrapped in place.
-  assertStringIncludes(printed, "Cell<");
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
+  assert(ts.isTypeReferenceNode(node));
+  assertEquals((node.typeName as ts.Identifier).text, "Cell");
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
 });
 
 // Node-driven array shrink where the base node is a type alias resolving to an
@@ -1110,10 +1203,11 @@ Deno.test("applyShrinkAndWrap shrinks array-like type literals with numeric inde
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "title: string;");
-  assert(printed.endsWith("[]"), `expected array shape, got: ${printed}`);
-  assertEquals(printed.includes("unused"), false);
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  // The array-like literal shrinks into an array of the shrunk element.
+  assert(ts.isArrayTypeNode(node));
+  assertEquals(members.get("title")?.type, "string");
+  assertEquals(members.has("unused"), false);
 });
 
 // findPropertySymbol resolves a property that lives only on one union
@@ -1141,8 +1235,8 @@ Deno.test("applyShrinkAndWrap resolves a union-only property during type-driven 
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "common: string;");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("common")?.type, "string");
 });
 
 // Type-driven shrink where a deeper path fails to materialise on a nested
@@ -1171,9 +1265,9 @@ Deno.test("applyShrinkAndWrap drops an unresolved deep child during type-driven 
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "present: string;");
-  assertStringIncludes(printed, "other: number;");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("present")?.type, "string");
+  assertEquals(members.get("other")?.type, "number");
 });
 
 // applyCapabilityDefaultsToTypeNode applies a default through a union member
@@ -1198,8 +1292,9 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a union m
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, 'a?: __cfHelpers.Default<string, "x">');
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("a")?.optional, true);
+  assertEquals(members.get("a")?.type, '__cfHelpers.Default<string, "x">');
 });
 
 // defaults-only fallback where a default is nested under a property: the
@@ -1228,14 +1323,14 @@ Deno.test("applyShrinkAndWrap expands nested defaults-only fallback leaves", () 
     "defaults_only",
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(
-    printed,
-    'title: __cfHelpers.Default<string, "Untitled">',
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(
+    members.get("title")?.type,
+    '__cfHelpers.Default<string, "Untitled">',
   );
   // Sibling leaf under the same parent is retained in the expanded fallback.
-  assertStringIncludes(printed, "note: string;");
-  assertStringIncludes(printed, "count: number;");
+  assertEquals(members.get("note")?.type, "string");
+  assertEquals(members.get("count")?.type, "number");
 });
 
 // Identity-only root whose resolved semantic type is undefined falls back to the
@@ -1291,9 +1386,9 @@ Deno.test("applyShrinkAndWrap selects writable capability for read-and-write cel
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "field: __cfHelpers.Writable<number>");
-  assertEquals(printed.includes("untouched"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("field")?.type, "__cfHelpers.Writable<number>");
+  assertEquals(members.has("untouched"), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -1357,11 +1452,12 @@ Deno.test("applyShrinkAndWrap collapses a one-member union node to the shrunk me
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: string;");
-  assertEquals(printed.includes("drop"), false);
-  // Collapsed to the single shrunk member, so no union `|` remains.
-  assertEquals(printed.includes("|"), false);
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "string");
+  assertEquals(members.has("drop"), false);
+  // Collapsed to the single shrunk member, so the root is a bare object literal
+  // rather than a union.
+  assert(ts.isTypeLiteralNode(node));
 });
 
 // A union node with only nullish members is returned unchanged
@@ -1385,9 +1481,19 @@ Deno.test("applyShrinkAndWrap leaves an all-nullish union node unchanged", () =>
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "undefined");
-  assertStringIncludes(printed, "null");
+  const node = parseType(printTypeNode(result, sourceFile));
+  // The all-nullish union is returned unchanged: both the `undefined` keyword
+  // and the `null` literal member survive.
+  assert(ts.isUnionTypeNode(node));
+  assert(
+    node.types.some((member) => member.kind === ts.SyntaxKind.UndefinedKeyword),
+  );
+  assert(
+    node.types.some((member) =>
+      ts.isLiteralTypeNode(member) &&
+      member.literal.kind === ts.SyntaxKind.NullKeyword
+    ),
+  );
 });
 
 // A valid tuple index whose nested default path does not resolve leaves the
@@ -1414,8 +1520,6 @@ Deno.test("applyCapabilityDefaultsToTypeNode ignores a tuple default whose neste
   );
 
   // The nested path names no member, so no default wrapper is applied.
-  assertEquals(
-    printTypeNode(result, sourceFile).includes("__cfHelpers.Default"),
-    false,
-  );
+  const node = parseType(printTypeNode(result, sourceFile));
+  assertEquals(hasQualifiedRef(node, "__cfHelpers", "Default"), false);
 });

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 
 import type { CapabilityParamSummary } from "../src/core/mod.ts";
@@ -13,6 +13,73 @@ import {
   printTypeNode,
   wrapTypeNodeWithCapability,
 } from "../src/transformers/type-shrinking.ts";
+import { collect, parseModule } from "./transformed-ast.ts";
+
+// ---------------------------------------------------------------------------
+// Structural inspection of printed type nodes.
+//
+// `printTypeNode` renders a `ts.TypeNode` to text. Asserting on that text with
+// `assertStringIncludes` is weak: it matches on formatting and cannot tell a
+// property named `title` apart from the word `title` appearing anywhere. These
+// helpers reparse the printed type node and expose its members as real AST
+// nodes so tests can assert on property names, optional flags, exact member
+// types, and the shape of the root node.
+// ---------------------------------------------------------------------------
+
+/** Reparse a printed type node into a `ts.TypeNode`. */
+function parseType(printed: string): ts.TypeNode {
+  const decl = collect(
+    parseModule(`type __T = ${printed};`),
+    ts.isTypeAliasDeclaration,
+  )[0];
+  if (!decl) throw new Error(`Could not parse type node: ${printed}`);
+  return decl.type;
+}
+
+interface PropInfo {
+  optional: boolean;
+  type: string;
+}
+
+/**
+ * Every property signature reachable under `node`, keyed by name, carrying its
+ * optional flag and the printed text of its declared type. Nested literals
+ * contribute their own members, so `unused` being absent from the map means it
+ * appears nowhere in the shape.
+ */
+function props(node: ts.Node): Map<string, PropInfo> {
+  const sf = node.getSourceFile();
+  const out = new Map<string, PropInfo>();
+  for (const signature of collect(node, ts.isPropertySignature)) {
+    const name = ts.isIdentifier(signature.name)
+      ? signature.name.text
+      : signature.name.getText(sf);
+    out.set(name, {
+      optional: !!signature.questionToken,
+      type: signature.type ? signature.type.getText(sf) : "",
+    });
+  }
+  return out;
+}
+
+/** Reparse the printed shrink result and return its member map. */
+function shrunkProps(result: ts.TypeNode, sourceFile: ts.SourceFile): {
+  node: ts.TypeNode;
+  props: Map<string, PropInfo>;
+} {
+  const node = parseType(printTypeNode(result, sourceFile));
+  return { node, props: props(node) };
+}
+
+/** True when `node` contains a reference to the qualified name `left.right`. */
+function hasQualifiedRef(node: ts.Node, left: string, right: string): boolean {
+  return collect(node, ts.isTypeReferenceNode).some((ref) => {
+    const name = ref.typeName;
+    return ts.isQualifiedName(name) &&
+      ts.isIdentifier(name.left) && name.left.text === left &&
+      name.right.text === right;
+  });
+}
 
 function createProgram(source: string): {
   sourceFile: ts.SourceFile;
@@ -268,12 +335,12 @@ Deno.test("applyShrinkAndWrap preserves full array item shapes for direct array 
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "people");
-  assertStringIncludes(printed, "active");
-  assertStringIncludes(printed, "name");
-  assertStringIncludes(printed, "priorityRank");
-  assertEquals(printed.includes("other"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assert(members.has("people"));
+  assertEquals(members.get("active")?.type, "boolean");
+  assertEquals(members.get("name")?.type, "string");
+  assertEquals(members.get("priorityRank")?.type, "number");
+  assertEquals(members.has("other"), false);
 });
 
 Deno.test("applyShrinkAndWrap keeps numeric array access array-shaped", () => {
@@ -429,10 +496,15 @@ Deno.test("applyShrinkAndWrap defaults-only fallback expands repeated child leav
     "defaults_only",
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "right: {\n            a: string;");
-  assertStringIncludes(printed, "\n            b: string;");
-  assertEquals(printed.includes("right: Shared"), false);
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  // Both `left` and `right` are expanded into inline literals with `a` and `b`
+  // leaves rather than left as `Shared` references.
+  assertEquals(members.get("a")?.type, "string");
+  assertEquals(members.get("b")?.type, "string");
+  const right = collect(node, ts.isPropertySignature).find((signature) =>
+    ts.isIdentifier(signature.name) && signature.name.text === "right"
+  );
+  assert(right && right.type && ts.isTypeLiteralNode(right.type));
 });
 
 Deno.test("applyShrinkAndWrap preserves nested primitive leaves for property-only access", () => {
@@ -455,9 +527,9 @@ Deno.test("applyShrinkAndWrap preserves nested primitive leaves for property-onl
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "text: string;");
-  assertEquals(printed.includes("length: number"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("text")?.type, "string");
+  assertEquals(members.has("length"), false);
 });
 
 Deno.test("applyShrinkAndWrap turns identity-only wrapped inputs into OpaqueCell<unknown>", () => {
@@ -563,11 +635,11 @@ Deno.test("applyShrinkAndWrap turns identity-only cell leaves into OpaqueCell<un
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "left: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "right: __cfHelpers.OpaqueCell<unknown>");
-  assertEquals(printed.includes("name"), false);
-  assertEquals(printed.includes("nested"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("left")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("right")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.has("name"), false);
+  assertEquals(members.has("nested"), false);
 });
 
 Deno.test("applyShrinkAndWrap turns read-only cell leaves into ReadonlyCell", () => {
@@ -597,9 +669,9 @@ Deno.test("applyShrinkAndWrap turns read-only cell leaves into ReadonlyCell", ()
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "value: __cfHelpers.ReadonlyCell<number>");
-  assertEquals(printed.includes("untouched"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("value")?.type, "__cfHelpers.ReadonlyCell<number>");
+  assertEquals(members.has("untouched"), false);
 });
 
 Deno.test("applyShrinkAndWrap turns opaque derivation cell leaves into OpaqueCell", () => {
@@ -628,10 +700,12 @@ Deno.test("applyShrinkAndWrap turns opaque derivation cell leaves into OpaqueCel
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "items: __cfHelpers.OpaqueCell");
-  assertStringIncludes(printed, "name: string");
-  assertEquals(printed.includes("untouched"), false);
+  const { node, props: members } = shrunkProps(result, sourceFile);
+  const items = members.get("items");
+  assert(items && hasQualifiedRef(node, "__cfHelpers", "OpaqueCell"));
+  assert(items.type.startsWith("__cfHelpers.OpaqueCell<"));
+  assertEquals(members.get("name")?.type, "string");
+  assertEquals(members.has("untouched"), false);
 });
 
 Deno.test("applyShrinkAndWrap turns comparable cell leaves into ComparableCell<unknown>", () => {
@@ -662,11 +736,17 @@ Deno.test("applyShrinkAndWrap turns comparable cell leaves into ComparableCell<u
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "left: __cfHelpers.ComparableCell<unknown>");
-  assertStringIncludes(printed, "right: __cfHelpers.ComparableCell<unknown>");
-  assertEquals(printed.includes("name"), false);
-  assertEquals(printed.includes("nested"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(
+    members.get("left")?.type,
+    "__cfHelpers.ComparableCell<unknown>",
+  );
+  assertEquals(
+    members.get("right")?.type,
+    "__cfHelpers.ComparableCell<unknown>",
+  );
+  assertEquals(members.has("name"), false);
+  assertEquals(members.has("nested"), false);
 });
 
 Deno.test("applyShrinkAndWrap lets identity containers cover retained child paths", () => {
@@ -692,10 +772,10 @@ Deno.test("applyShrinkAndWrap lets identity containers cover retained child path
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "item: unknown");
-  assertEquals(printed.includes("active"), false);
-  assertEquals(printed.includes("name"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("item")?.type, "unknown");
+  assertEquals(members.has("active"), false);
+  assertEquals(members.has("name"), false);
 });
 
 Deno.test("applyShrinkAndWrap shrinks direct array parameters to used item fields", () => {
@@ -723,12 +803,12 @@ Deno.test("applyShrinkAndWrap shrinks direct array parameters to used item field
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "id: string;");
-  assertStringIncludes(printed, "stage: string;");
-  assertStringIncludes(printed, "owner: string;");
-  assertEquals(printed.includes("unused"), false);
-  assertEquals(printed.includes("nested"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("id")?.type, "string");
+  assertEquals(members.get("stage")?.type, "string");
+  assertEquals(members.get("owner")?.type, "string");
+  assertEquals(members.has("unused"), false);
+  assertEquals(members.has("nested"), false);
 });
 
 Deno.test("applyShrinkAndWrap preserves inherited interface fields in array unions", () => {
@@ -760,11 +840,11 @@ Deno.test("applyShrinkAndWrap preserves inherited interface fields in array unio
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "id: string;");
-  assertStringIncludes(printed, "score: number;");
-  assertEquals(printed.includes("name"), false);
-  assertEquals(printed.includes("unused"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("id")?.type, "string");
+  assertEquals(members.get("score")?.type, "number");
+  assertEquals(members.has("name"), false);
+  assertEquals(members.has("unused"), false);
 });
 
 Deno.test("applyShrinkAndWrap preserves aliased fixed-symbol keys in node-driven shrinking", () => {
@@ -795,11 +875,11 @@ Deno.test("applyShrinkAndWrap preserves aliased fixed-symbol keys in node-driven
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "[CF_SELF]?: {");
-  assertStringIncludes(printed, "id: string;");
-  assertEquals(printed.includes("title"), false);
-  assertEquals(printed.includes("value"), false);
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("[CF_SELF]")?.optional, true);
+  assertEquals(members.get("id")?.type, "string");
+  assertEquals(members.has("title"), false);
+  assertEquals(members.has("value"), false);
 });
 
 Deno.test("applyCapabilityDefaultsToTypeNode applies defaults through tuples and unions", () => {
@@ -829,14 +909,16 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies defaults through tuples and
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(
-    printed,
-    'name?: __cfHelpers.Default<string, "Anonymous">;',
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("name")?.optional, true);
+  assertEquals(
+    members.get("name")?.type,
+    '__cfHelpers.Default<string, "Anonymous">',
   );
-  assertStringIncludes(
-    printed,
-    'fallback?: __cfHelpers.Default<string, "Fallback">;',
+  assertEquals(members.get("fallback")?.optional, true);
+  assertEquals(
+    members.get("fallback")?.type,
+    '__cfHelpers.Default<string, "Fallback">',
   );
 });
 
@@ -892,13 +974,13 @@ Deno.test("applyShrinkAndWrap descends identity paths through named interface re
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
+  const { props: members } = shrunkProps(result, sourceFile);
   // The reference resolves to declared members, recurses into `inner`, and
   // wraps the `keep` leaf. Identity-path application transforms the targeted
   // leaf in place and leaves the surrounding structure intact.
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
-  assertStringIncludes(printed, "other: string");
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
+  assertEquals(members.get("other")?.type, "string");
 });
 
 Deno.test("applyShrinkAndWrap rebuilds inline literals when a nested identity leaf changes", () => {
@@ -927,10 +1009,10 @@ Deno.test("applyShrinkAndWrap rebuilds inline literals when a nested identity le
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
-  assertStringIncludes(printed, "other: string");
+  const { props: members } = shrunkProps(result, sourceFile);
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
+  assertEquals(members.get("other")?.type, "string");
 });
 
 Deno.test("applyShrinkAndWrap returns an inline literal unchanged when a nested identity path does not resolve", () => {
@@ -955,11 +1037,11 @@ Deno.test("applyShrinkAndWrap returns an inline literal unchanged when a nested 
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
+  const { node, props: members } = shrunkProps(result, sourceFile);
   // No member changes, so the literal (and its `a` member) is returned as-is.
-  assertStringIncludes(printed, "x: string");
-  assertStringIncludes(printed, "b: string");
-  assertEquals(printed.includes("OpaqueCell"), false);
+  assertEquals(members.get("x")?.type, "string");
+  assertEquals(members.get("b")?.type, "string");
+  assertEquals(hasQualifiedRef(node, "__cfHelpers", "OpaqueCell"), false);
 });
 
 Deno.test("applyShrinkAndWrap leaves array elements untouched when an identity item path does not resolve", () => {
@@ -1013,12 +1095,13 @@ Deno.test("applyShrinkAndWrap descends identity item paths through readonly arra
     ts.factory,
   );
 
-  const printed = printTypeNode(result, sourceFile);
+  const { node, props: members } = shrunkProps(result, sourceFile);
   // The readonly-array node recurses into its element type, resolves the item
   // interface's members, and wraps the requested leaf in place.
-  assertStringIncludes(printed, "readonly");
-  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
-  assertStringIncludes(printed, "drop: number");
+  assert(ts.isTypeOperatorNode(node));
+  assertEquals(node.operator, ts.SyntaxKind.ReadonlyKeyword);
+  assertEquals(members.get("keep")?.type, "__cfHelpers.OpaqueCell<unknown>");
+  assertEquals(members.get("drop")?.type, "number");
 });
 
 Deno.test("wrapTypeNodeWithCapability emits the expected cell wrappers", () => {
@@ -1034,10 +1117,16 @@ Deno.test("wrapTypeNodeWithCapability emits the expected cell wrappers", () => {
   ] as const;
 
   for (const [capability, wrapperName] of wrappers) {
-    const printed = printTypeNode(
+    const node = parseType(printTypeNode(
       wrapTypeNodeWithCapability(valueNode, capability, ts.factory),
       sourceFile,
+    ));
+    assert(ts.isTypeReferenceNode(node));
+    assert(hasQualifiedRef(node, "__cfHelpers", wrapperName));
+    assert(node.typeArguments && node.typeArguments.length === 1);
+    assertEquals(
+      node.typeArguments[0]!.getText(node.getSourceFile()),
+      "string",
     );
-    assertStringIncludes(printed, `__cfHelpers.${wrapperName}<string>`);
   }
 });

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -1,7 +1,14 @@
-import { assertEquals, assertGreater, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertStringIncludes,
+} from "@std/assert";
+import ts from "typescript";
 import { validateSource } from "./utils.ts";
 import type { TransformationDiagnostic } from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { collect, hasKeyPathRead, parseModule } from "./transformed-ast.ts";
 
 function getErrors(diagnostics: readonly TransformationDiagnostic[]) {
   return diagnostics.filter((d) => d.severity === "error");
@@ -4396,11 +4403,13 @@ Deno.test("Inline reactive-root chain rewrite", async (t) => {
           errors.map((e) => e.message).join("; ")
         })`,
       );
-      assertStringIncludes(
-        output,
-        "result: ResultShape",
-        "The `as { result: ResultShape }` cast should survive the chain rewrite",
-      );
+      // The `as { result: ResultShape }` cast should survive the chain rewrite,
+      // so a `ResultShape` type reference remains in the emitted output.
+      const hasResultShapeRef = collect(
+        parseModule(output),
+        ts.isTypeReferenceNode,
+      ).some((ref) => ref.typeName.getText() === "ResultShape");
+      assert(hasResultShapeRef, "expected the ResultShape cast to survive");
     },
   );
 });
@@ -4437,16 +4446,11 @@ Deno.test("Module-extracted reactive callback bodies (CT-1587)", async (t) => {
           errors.map((e) => e.message).join("; ")
         })`,
       );
-      assertStringIncludes(
-        output,
-        'fooWish.key("result")',
-        'fooWish.result! inside computed() should lower to fooWish.key("result")',
-      );
-      assertStringIncludes(
-        output,
-        'foo.key("0")',
-        'foo[0] inside computed() should lower to foo.key("0")',
-      );
+      // `fooWish.result!` inside computed() lowers to `fooWish.key("result")`
+      // and `foo[0]` lowers to `foo.key("0")`.
+      const root = parseModule(output);
+      assert(hasKeyPathRead(root, "result", "fooWish"));
+      assert(hasKeyPathRead(root, "0", "foo"));
     },
   );
 });


### PR DESCRIPTION
## What

Two related changes to the `ts-transformers` test suite. No production code is
touched — this PR is test-only (0 files changed under `src/`).

### 1. Assert on structure, not printed text

Many transformer tests checked the compiler's output with
`assertStringIncludes(output, "...")` — a substring match against the printed
code or the printed schema. That form is unsound in two ways:

- The printer preserves authored comments, so a test can pass on the strength of
  a comment that happens to contain the expected substring rather than on the
  code the transformer actually emitted.
- When the expected substring already appears in the input source, a transform
  that did nothing at all would still satisfy the check.

This PR adds a shared test helper, `test/transformed-ast.ts`, that parses the
transformer's output back into a TypeScript AST (parsing discards comments as
trivia) and exposes focused queries: locating emitted calls by name or pattern,
finding immediately-invoked functions, detecting a `receiver.key("segment")`
reactive path read, reading the stable `.for(cause, true)` arguments, and
evaluating an emitted `... satisfies JSONSchema` object literal to a real
JavaScript value so a test can compare the generated schema by value.

Every genuinely weak printed-output check across the suite is rewritten to use
these queries and assert on real nodes and evaluated schema values. Assertions
that read a diagnostic, error, or analyzer reason message are deliberately left
as string checks: there the message text is the contract, and reading it off the
diagnostic object is not vulnerable to either failure mode above. Twenty-five
existing test files are converted.

### 2. Cover the zero-argument IIFE branch of the call-expression emitter

`emitCallExpression` has a dedicated branch for an authored zero-argument inline
function that is immediately invoked — `(() => ...)()` — appearing inside a
reactive array-method callback. That branch, and the helpers that scan it for
cell reads on receivers declared outside the function, previously ran only as a
side effect of patterns compiling through the transformer in the CI
pattern-integration jobs, never from a focused unit test.

Reaching it needs the in-place expression rewrite that array-method callback
lowering performs: a bare IIFE at a plain JSX site is skipped, and any
surrounding reactive expression is otherwise lifted whole before the emitter
recurses into the function. Placing the IIFE inside a `.map()` or `.filter()`
callback is what drives the emitter over it in place. A new test file,
`call-expression-iife-coverage.test.ts`, exercises both outcomes of the branch:
when the function body performs a direct cell read on an outer receiver, the
branch wraps it so the read runs under a reactive context and the cell
dependency is tracked into the callback's pattern input; when the function
decomposes through a local alias or an object-literal projection, the branch
leaves the authored function in place. This brings 78 of the branch's 95
previously integration-only lines under unit coverage; the remainder are
secondary sub-branches unreachable from source without contortion (local cell
aliases are inlined by the transformer, and the lift-applied fallback fires only
when the reactive-wrapper builder declines), documented in the test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `ts-transformers` tests from substring checks to AST-based structural assertions, and add unit coverage for the zero‑arg IIFE branch in `emitCallExpression`. No production code is changed.

- **Refactors**
  - Added `packages/ts-transformers/test/transformed-ast.ts` with helpers to parse output, collect nodes, find named/matching calls, detect IIFEs and `.key(...)` reads, read stable `.for(cause, true)` args, evaluate `... satisfies JSONSchema` literals, and pull pattern/lift input/output schemas.
  - Converted tests across schema generation/injection/shrink‑validation, type shrinking/building/inference, pipeline regressions/core transform, guards, CF data/UI helpers, module-scope hardening/cf‑data, destructuring, array‑method utilities, binary rewrite, fetch‑json injection, lift‑applied call creation, pattern coverage transformer, and targeted validation cases to assert on real nodes and evaluated schema values. Diagnostic message checks remain string assertions.

- **New Features**
  - Added `packages/ts-transformers/test/call-expression-iife-coverage.test.ts` to unit‑cover the zero‑arg IIFE branch inside `.map`/`.filter()` callbacks, asserting:
    - Wrap when the IIFE body reads an outer cell directly (dependency tracked via `item.key("...")` and lowered under lift).
    - Preserve the authored IIFE when reads are via aliases or object projections.
  - Brings 78/95 lines of this branch under unit coverage.

<sup>Written for commit 96964eaccef1c8e701004b65901482b729438653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

