### PR TITLE
feat(home): make favorites and spaces mergeable via keyed writes

### DIFF
--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -321,6 +321,52 @@ mergeable methods to stop false-conflicting and clobbering under contention; the
 favorites, spaces, MRU, and pin lists on the owner-protected home space are the
 highest-value remaining candidates.
 
+### Home-space migration outcome
+
+The favorites and spaces lists on the home space are migrated, both to the
+keyed `elementById` form. A favorite is addressed by its piece's identity, and a
+space by its name; adding sets the keyed entity and `addUnique`s it, and removing
+is `removeByValue` of the same entity. The whole-value `addUnique(value)` and
+`removeByValue(value)` do not apply to either list, because a list element that
+is an object is stored as a link to a separate entity: two objects that are equal
+by content are still distinct entities, so a value comparison never matches, an
+`addUnique` of an equal object never dedups, and a `removeByValue` of an equal
+object never removes. Addressing the element by a deterministic key and matching
+by that link is the form that works — the same form the lunch poll uses for its
+votes and options.
+
+Pattern code cannot read a cell's link, so a favorite's key is derived by the
+client that adds or removes it (the client holds the piece's address as strings)
+and passed in as event data. The handler stores that key on the entry, so the
+in-app remove button can address the same entity without introspecting the piece
+cell. A space's key is the space name, which the handler already has from the
+event.
+
+The MRU lists — the profile most-recently-used list and the recent-pieces list —
+stay a read-modify-write `set`. Their write is not a set-membership change: it
+moves an entry to the front of the list and caps the length, so its correctness
+depends on reading the current order and count. That is a condition other than
+uniqueness, which the mergeable ops do not preserve: `addUnique` appends at the
+tail and never reorders, and there is no mergeable "keep only the first N". A
+concurrent pair of most-recently-used stamps conflicts and one retries, which
+only reorders a recency heuristic, so the read-modify-write is acceptable here.
+
+The profile pinned-elements list is owner-protected by a `writeAuthorizedBy`
+claim on its container. A mergeable op is authorized by that claim the same way a
+whole-value `set` is: the authorization runs over the transaction's write log and
+the schema write-policy inputs, and the mergeable ops record those inputs exactly
+as `set` does, so migrating the list would not weaken the owner-write protection.
+A test in `packages/runner/test/profile-owner-cfc.test.ts` confirms this — an
+authorized writer's `addUnique` and `removeByValue` on an owner-protected list
+commit, and an unauthorized writer's are rejected. The list is left unmigrated
+for two other reasons. A pin is addressed by its element cell's identity rather
+than a scalar key, so a keyed migration needs an addressing scheme the entries do
+not yet carry — unlike a space, which is keyed by its name, or a favorite, which
+is keyed by its piece's identity. And a keyed removal takes on the
+add-wins-after-delete ordering, so a pin removed while a stale add is in flight
+would reappear, which is a semantic change worth weighing for an owner-protected
+list.
+
 ## Residual: profile-append-during-rehydration (closed by mergeable-op retry windowing)
 
 This work was motivated by profile creates being lost when issued while the home

--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -16,6 +16,10 @@ export const favoriteEntrySchema = {
     tags: { type: "array", items: { type: "string" }, default: [] },
     userTags: { type: "array", items: { type: "string" }, default: [] },
     spaceName: { type: "string" },
+    // Stable key derived from the favorited piece's address (see favoriteKey).
+    // The favorite entity is addressed by this key, so a re-favorite dedups and
+    // an unfavorite removes by identity without reading the whole list.
+    id: { type: "string" },
   },
   required: ["cell"],
 } as const satisfies JSONSchema;
@@ -28,3 +32,18 @@ export const favoriteListSchema = {
 } as const satisfies JSONSchema;
 
 export type FavoriteList = Schema<typeof favoriteListSchema>;
+
+/**
+ * The key a favorite is addressed by: the favorited piece's address — its
+ * space, entity id, and value path. Computed by the caller that adds or removes
+ * the favorite (which holds the piece's address as strings) and stored on the
+ * entry as `id`, so the home handlers reach the same favorite entity with
+ * `favorites.elementById(id)`. Pattern code cannot introspect a cell's link, so
+ * the key is derived here and passed in as event data rather than recomputed in
+ * the handler.
+ */
+export function favoriteKey(
+  ref: { space: string; id: string; path?: readonly unknown[] },
+): string {
+  return JSON.stringify([ref.space, ref.id, ref.path ?? []]);
+}

--- a/packages/home-schemas/mod.ts
+++ b/packages/home-schemas/mod.ts
@@ -18,6 +18,7 @@ import { Schema } from "@commonfabric/api/schema";
 export {
   type FavoriteEntry,
   favoriteEntrySchema,
+  favoriteKey,
   type FavoriteList,
   favoriteListSchema,
 } from "./favorites.ts";

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -16,17 +16,32 @@ type Favorite = {
   tag: string;
   userTags: Writable<string[]>;
   spaceName?: string;
+  // Stable key the favorite entity is addressed by (the piece's identity),
+  // stored on the entry by home's addFavorite so the remove reaches it.
+  id?: string;
 };
 
 const onRemoveFavorite = handler<
   Record<string, never>,
   {
     favorites: Writable<Array<Favorite> | Default<[]>>;
-    item: Writable<unknown>;
+    id?: string;
+    item?: Writable<unknown>;
   }
->((_, { favorites, item }) => {
-  const favorite = favorites.get().find((f: Favorite) => f.cell.equals(item));
-  if (favorite) favorites.remove(favorite);
+>((_, { favorites, id, item }) => {
+  // A favorite added through the keyed path carries an id. Drop its membership
+  // by that id — the same key home's addFavorite used, so both reach the same
+  // entity — and clear the entity, since it outlives its link.
+  if (id) {
+    favorites.removeByValue(favorites.elementById(id));
+    const entry: Writable<Favorite | undefined> = favorites.elementById(id);
+    entry.set(undefined);
+    return;
+  }
+  // A favorite added before keyed addressing has no id; remove it by matching
+  // its piece cell.
+  if (!item) return;
+  favorites.set(favorites.get().filter((f) => !f.cell.equals(item)));
 });
 
 const onUpdateUserTags = handler<
@@ -56,6 +71,7 @@ export default pattern<Record<string, never>>((_) => {
                   size="sm"
                   onClick={onRemoveFavorite({
                     favorites: favorites!,
+                    id: item.id,
                     item: item.cell,
                   })}
                 >

--- a/packages/patterns/system/home.test.tsx
+++ b/packages/patterns/system/home.test.tsx
@@ -1,8 +1,11 @@
-import { computed, pattern } from "commonfabric";
+import { action, computed, NAME, pattern, Writable } from "commonfabric";
 import Home from "./home.tsx";
 
 export default pattern(() => {
   const home = Home({});
+
+  // A stable piece cell to favorite and unfavorite by identity.
+  const piece = new Writable<{ [NAME]?: string }>({ [NAME]: "Fav Piece" });
 
   const assert_initial_profile_missing = computed(() =>
     ((home.profiles as unknown[])?.length ?? 0) === 0
@@ -18,8 +21,57 @@ export default pattern(() => {
   // `inSpace` write incidentally threw a write-isolation error — which the
   // multi-profile change legitimately allows via a multi-space commit.
 
+  // Favorites are keyed by the piece's identity (the client-supplied id): the
+  // handler sets the keyed entity and add-uniques it.
+  const action_add_favorite = action(() => {
+    home.addFavorite.send({
+      piece,
+      tags: ["demo"],
+      spaceName: "space-a",
+      id: "fav-1",
+    });
+  });
+
+  // The first removal takes the keyed path (the entity exists) and clears it.
+  const action_remove_favorite = action(() => {
+    home.removeFavorite.send({ piece, id: "fav-1" });
+  });
+
+  // A second removal with the same id finds no entity (it was cleared), so it
+  // takes the piece-cell fallback that keeps a pre-keyed favorite deletable.
+  const action_remove_favorite_again = action(() => {
+    home.removeFavorite.send({ piece, id: "fav-1" });
+  });
+
+  // The journal append is an exported mergeable push.
+  const action_add_journal = action(() => {
+    home.addJournalEntry.send({
+      entry: {
+        timestamp: 1,
+        eventType: "piece:created",
+        space: "space-a",
+      },
+    });
+  });
+
+  // Spaces are keyed by name: the add sets the keyed entity and add-uniques it,
+  // and the remove matches that identity via removeByValue.
+  const action_add_space = action(() => {
+    home.addSpace.send({ detail: { message: "Space One" } });
+  });
+  const action_remove_space = action(() => {
+    home.removeSpace.send({ name: "Space One" });
+  });
+
   return {
     tests: [
+      { assertion: assert_initial_profile_missing },
+      { action: action_add_favorite },
+      { action: action_remove_favorite },
+      { action: action_remove_favorite_again },
+      { action: action_add_journal },
+      { action: action_add_space },
+      { action: action_remove_space },
       { assertion: assert_initial_profile_missing },
     ],
   };

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -27,6 +27,8 @@ type Favorite = {
   tags: string[];
   userTags: string[];
   spaceName?: string;
+  // Stable key the favorite entity is addressed by (the piece's identity).
+  id?: string;
 };
 
 type JournalEntry = {
@@ -56,35 +58,71 @@ export type HomeOutput = {
   defaultProfile: TrustedDefaultProfile;
   mru: TrustedProfileMru;
   createProfile: Stream<CreateProfileEvent>;
+  addFavorite: Stream<{
+    piece: Writable<{ [NAME]?: string }>;
+    tags?: string[];
+    spaceName?: string;
+    id?: string;
+  }>;
+  removeFavorite: Stream<{ piece?: Writable<unknown>; id?: string }>;
+  addJournalEntry: Stream<{ entry: JournalEntry }>;
+  addSpace: Stream<{ detail: { message: string } }>;
+  removeSpace: Stream<{ name?: string }>;
 };
 
 // Handler to add a favorite
 const addFavorite = handler<
-  { piece: Writable<{ [NAME]?: string }>; tags?: string[]; spaceName?: string },
+  {
+    piece: Writable<{ [NAME]?: string }>;
+    tags?: string[];
+    spaceName?: string;
+    id?: string;
+  },
   { favorites: Writable<Favorite[]> }
->(({ piece, tags, spaceName }, { favorites }) => {
-  const current = favorites.get();
-  if (!current.some((f) => f && equals(f.cell, piece))) {
-    // Discovery tags are derived by the client (which can see the piece's
-    // schema) and passed in; the handler just stores them.
-    favorites.push({
+>(({ piece, tags, spaceName, id }, { favorites }) => {
+  // The favorite is addressed by the piece's identity (the client-supplied id),
+  // so favoriting the same piece from two sessions resolves to one membership
+  // entry and favorites of distinct pieces merge, without reading the whole
+  // list.
+  if (!id) return;
+  const entry = favorites.elementById(id);
+  // Only seed the entity on a fresh favorite; a re-favorite keeps the existing
+  // userTags. Discovery tags are derived by the client (which can see the
+  // piece's schema) and passed in; the handler just stores them.
+  if (!entry.get()) {
+    entry.set({
       cell: piece,
       tags: tags ?? [],
       userTags: [],
       spaceName,
+      id,
     });
   }
+  favorites.addUnique(entry);
 });
 
 // Handler to remove a favorite
 const removeFavorite = handler<
-  { piece: Writable<unknown> },
+  { piece?: Writable<unknown>; id?: string },
   { favorites: Writable<Favorite[]> }
->(({ piece }, { favorites }) => {
-  const favorite = favorites.get().find((f) => f && equals(f.cell, piece));
-  if (favorite) {
-    favorites.remove(favorite);
+>(({ piece, id }, { favorites }) => {
+  // A favorite added through the keyed path has an entity at elementById(id).
+  // Drop its membership by identity (concurrent unfavorites of distinct pieces
+  // merge) and clear the entity, since it outlives its link — a later
+  // re-favorite reads it back to decide whether to seed fresh.
+  if (id) {
+    const entry: Writable<Favorite | undefined> = favorites.elementById(id);
+    if (entry.get()) {
+      favorites.removeByValue(favorites.elementById(id));
+      entry.set(undefined);
+      return;
+    }
   }
+  // A favorite added before keyed addressing has no such entity; remove it by
+  // matching its piece cell. This rewrites the whole list, but keyed entries
+  // keep their addressing.
+  if (!piece) return;
+  favorites.set(favorites.get().filter((f) => f && !equals(f.cell, piece)));
 });
 
 // Handler to add a journal entry (kept for schema compatibility)
@@ -102,20 +140,26 @@ const addSpaceHandler = handler<
 >(({ detail }, { spaces }) => {
   const name = detail?.message?.trim();
   if (!name) return;
-  const current = spaces.get();
-  if (!current.some((s) => s.name === name)) {
-    spaces.push({ name });
-  }
+  // Address the space entity by its name. Setting the entity and add-uniquing
+  // it means two sessions adding the same name resolve to one membership entry,
+  // and adds of distinct names merge, without reading the whole list.
+  const entry = spaces.elementById(name);
+  entry.set({ name });
+  spaces.addUnique(entry);
 });
 
-// Handler to remove a space from the managed list
+// Handler to remove a space from the managed list. The per-row button binds the
+// name as state; the exported `removeSpace` stream passes it in the event.
 const removeSpaceHandler = handler<
-  Record<string, never>,
-  { name: string; spaces: Writable<SpaceEntry[]> }
->((_, { name, spaces }) => {
-  const current = spaces.get();
-  const filtered = current.filter((s) => s.name !== name);
-  spaces.set(filtered);
+  { name?: string },
+  { name?: string; spaces: Writable<SpaceEntry[]> }
+>(({ name: eventName }, { name: stateName, spaces }) => {
+  const name = eventName ?? stateName;
+  if (!name) return;
+  // Remove the membership entry addressed by name. removeByValue matches by the
+  // deterministic link, so concurrent removes of distinct spaces merge instead
+  // of clobbering through a whole-list set.
+  spaces.removeByValue(spaces.elementById(name));
 });
 
 export default pattern<Record<string, never>, HomeOutput>((_) => {
@@ -281,6 +325,8 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
     addFavorite: addFavorite({ favorites }),
     removeFavorite: removeFavorite({ favorites }),
     addJournalEntry: addJournalEntry({ journal }),
+    addSpace: addSpaceHandler({ spaces }),
+    removeSpace: removeSpaceHandler({ spaces }),
     createProfile: createProfileStream,
   };
 });

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -1234,3 +1234,376 @@ describe("mergeable op guards and single-session branches", () => {
     expect(await readDurable(server)).toEqual(["c"]);
   });
 });
+
+// The home-space `spaces` list shape: an array of `{ name }` records addressed
+// by name via `elementById`. Adding sets the keyed entity and add-uniques it
+// (dedup by the deterministic link); removing matches that link. This mirrors
+// home.tsx's addSpaceHandler / removeSpaceHandler after the keyed migration —
+// object elements are stored as links, so membership merges by identity, not by
+// whole-record value equality.
+interface NamedEntry {
+  name: string;
+}
+
+const NAMED_CAUSE = "keyed-named-list";
+
+const namedListSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: { name: { type: "string" } },
+  },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+async function readDurableNamed(
+  server: MemoryV2Server.Server,
+): Promise<NamedEntry[]> {
+  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: storage,
+  });
+  try {
+    const cell = rt.getCell<NamedEntry[]>(space, NAMED_CAUSE, namedListSchema);
+    await cell.sync();
+    await cell.pull();
+    return (cell.get() ?? []) as NamedEntry[];
+  } finally {
+    await rt.dispose();
+    await storage.close();
+  }
+}
+
+describe("keyed object list (home spaces shape)", () => {
+  let server: MemoryV2Server.Server;
+  let storage1: SharedServerStorageManager;
+  let storage2: SharedServerStorageManager;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
+    storage2 = SharedServerStorageManager.connectTo(server, { as: signer });
+  });
+  afterEach(async () => {
+    await storage1?.close();
+    await storage2?.close();
+    await server?.close();
+  });
+
+  // Two sessions add spaces with distinct names against the same base; both
+  // memberships merge rather than the second clobbering the first.
+  it("two sessions add distinct names concurrently — both survive", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<NamedEntry[]>(space, NAMED_CAUSE, namedListSchema, tx0).set(
+        [],
+      );
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+      );
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      const spacesA = rt1.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        txA,
+      );
+      const a = spacesA.elementById("alpha");
+      a.set({ name: "alpha" });
+      spacesA.addUnique(a);
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // rt2 still holds [] (has not observed "alpha").
+      const txB = rt2.edit();
+      const spacesB = rt2.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        txB,
+      );
+      const b = spacesB.elementById("beta");
+      b.set({ name: "beta" });
+      spacesB.addUnique(b);
+      await txB.commit();
+      await rt2.storageManager.synced();
+
+      const durable = await readDurableNamed(server);
+      expect(durable.map((e) => e.name).sort()).toEqual(["alpha", "beta"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // Two sessions add the SAME name against the same base; the key derives to the
+  // same entity, so add-unique dedups by link to one membership entry.
+  it("two sessions add the same name concurrently — dedups to one", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<NamedEntry[]>(space, NAMED_CAUSE, namedListSchema, tx0).set(
+        [],
+      );
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+      );
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      const spacesA = rt1.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        txA,
+      );
+      const a = spacesA.elementById("dup");
+      a.set({ name: "dup" });
+      spacesA.addUnique(a);
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      const txB = rt2.edit();
+      const spacesB = rt2.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        txB,
+      );
+      const b = spacesB.elementById("dup");
+      b.set({ name: "dup" });
+      spacesB.addUnique(b);
+      await txB.commit();
+      await rt2.storageManager.synced();
+
+      const durable = await readDurableNamed(server);
+      expect(durable.map((e) => e.name)).toEqual(["dup"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // Two sessions remove different spaces by key concurrently; both removals land
+  // instead of clobbering through a whole-list rewrite.
+  it("two sessions remove distinct names concurrently — both land", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      const seed = rt1.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        tx0,
+      );
+      seed.set([]);
+      for (const name of ["a", "b", "c"]) {
+        const e = seed.elementById(name);
+        e.set({ name });
+        seed.addUnique(e);
+      }
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+      );
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      const spacesA = rt1.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        txA,
+      );
+      spacesA.removeByValue(spacesA.elementById("b"));
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // rt2, still holding all three, removes a different space.
+      const txB = rt2.edit();
+      const spacesB = rt2.getCell<NamedEntry[]>(
+        space,
+        NAMED_CAUSE,
+        namedListSchema,
+        txB,
+      );
+      spacesB.removeByValue(spacesB.elementById("c"));
+      await txB.commit();
+      await rt2.storageManager.synced();
+
+      const durable = await readDurableNamed(server);
+      expect(durable.map((e) => e.name)).toEqual(["a"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});
+
+// The home-space `favorites` list shape: each element is a keyed entity whose
+// value CONTAINS a cell reference to the favorited piece, addressed by a key
+// derived from that piece's intrinsic link. This mirrors home.tsx's addFavorite
+// / removeFavorite after the keyed migration — the favorite's identity is the
+// piece, so keying by the piece link dedups a re-favorite and lets an unfavorite
+// remove by identity without reading the whole list.
+interface FavoriteLike {
+  cell: unknown;
+  tags: string[];
+  userTags: string[];
+  spaceName?: string;
+}
+
+const FAV_CAUSE = "keyed-favorites-list";
+
+const favoriteLikeSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      cell: { type: "unknown", asCell: ["cell"] },
+      tags: { type: "array", items: { type: "string" } },
+      userTags: { type: "array", items: { type: "string" } },
+      spaceName: { type: "string" },
+    },
+    required: ["cell"],
+  },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+// The key a favorite is addressed by: the favorited piece's intrinsic link,
+// identical in any session that references the same piece.
+function favoriteKeyFor(piece: { getAsNormalizedFullLink(): unknown }): string {
+  const link = piece.getAsNormalizedFullLink() as {
+    space: string;
+    id: string;
+    path: readonly unknown[];
+  };
+  return JSON.stringify([link.space, link.id, link.path]);
+}
+
+describe("keyed entity holding a cell reference (home favorites shape)", () => {
+  let server: MemoryV2Server.Server;
+  let storage1: SharedServerStorageManager;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+  });
+  afterEach(async () => {
+    await rt?.dispose();
+    await storage1?.close();
+    await server?.close();
+  });
+
+  it("favoriting a piece by its link dedups and removes by identity", () => {
+    const tx = rt.edit();
+    // The piece being favorited: any cell with a stable link.
+    const piece = rt.getCell(space, "favorited-piece", anySchema, tx);
+    piece.set({ title: "a piece" });
+
+    const favorites = rt.getCell<FavoriteLike[]>(
+      space,
+      FAV_CAUSE,
+      favoriteLikeSchema,
+      tx,
+    );
+    favorites.set([]);
+
+    const key = favoriteKeyFor(piece);
+    const entry = favorites.elementById(key);
+    entry.set({ cell: piece, tags: ["x"], userTags: [], spaceName: "s" });
+    favorites.addUnique(entry);
+    expect(favorites.get()?.length).toBe(1);
+    // The stored element carries the piece as a cell reference and the tags.
+    expect(favorites.get()?.[0].cell).toBeTruthy();
+    expect(favorites.get()?.[0].tags).toEqual(["x"]);
+
+    // Re-favoriting the same piece resolves to the same key — dedups to one.
+    const again = favorites.elementById(favoriteKeyFor(piece));
+    again.set({ cell: piece, tags: ["x"], userTags: [], spaceName: "s" });
+    favorites.addUnique(again);
+    expect(favorites.get()?.length).toBe(1);
+
+    // Unfavoriting removes the membership entry by identity.
+    favorites.removeByValue(favorites.elementById(favoriteKeyFor(piece)));
+    expect(favorites.get()?.length ?? 0).toBe(0);
+  });
+
+  it("favorites of two distinct pieces coexist and remove independently", () => {
+    const tx = rt.edit();
+    const pieceA = rt.getCell(space, "piece-a", anySchema, tx);
+    pieceA.set({ title: "A" });
+    const pieceB = rt.getCell(space, "piece-b", anySchema, tx);
+    pieceB.set({ title: "B" });
+
+    const favorites = rt.getCell<FavoriteLike[]>(
+      space,
+      FAV_CAUSE,
+      favoriteLikeSchema,
+      tx,
+    );
+    favorites.set([]);
+
+    for (const [piece, tag] of [[pieceA, "a"], [pieceB, "b"]] as const) {
+      const entry = favorites.elementById(favoriteKeyFor(piece));
+      entry.set({ cell: piece, tags: [tag], userTags: [] });
+      favorites.addUnique(entry);
+    }
+    expect(favorites.get()?.length).toBe(2);
+
+    // Removing one leaves the other intact.
+    favorites.removeByValue(favorites.elementById(favoriteKeyFor(pieceA)));
+    const remaining = favorites.get() ?? [];
+    expect(remaining.length).toBe(1);
+    // The surviving favorite is pieceB's, identified by its tag.
+    expect(remaining[0].tags).toEqual(["b"]);
+    expect(remaining[0].cell).toBeTruthy();
+  });
+});

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -4,38 +4,40 @@ import { join } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { favoriteKey } from "@commonfabric/home-schemas";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { Cell } from "../src/cell.ts";
 
 const signer = await Identity.fromPassphrase("home add-favorite tests");
 const space = signer.did();
 
-type FavoriteEntry = { tags?: string[]; tag?: string; userTags?: string[] };
+type FavoriteEntry = {
+  tags?: string[];
+  tag?: string;
+  userTags?: string[];
+  id?: string;
+};
 
-// Compiles and runs the real home pattern, then drives its addFavorite handler
-// the way the runtime client does after deriving tags: it sends the tags as
-// data, and the handler just stores them.
-describe("home addFavorite handler", () => {
+// Compiles and runs the real home pattern, then drives its addFavorite /
+// removeFavorite handlers the way the runtime client does: it derives the
+// piece's stable key and the discovery tags as data, and the handlers key the
+// favorite entity by that id.
+describe("home favorites handlers", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
+  // deno-lint-ignore no-explicit-any
+  let home: any;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     storageManager = StorageManager.emulate({ as: signer });
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
     });
     tx = runtime.edit();
-  });
 
-  afterEach(async () => {
-    await tx.commit();
-    await runtime?.dispose();
-    await storageManager?.close();
-  });
-
-  it("stores the discovery tags it is given", async () => {
     const patternsRoot = join(import.meta.dirname!, "..", "..", "patterns");
     const program = await runtime.harness.resolve(
       new FileSystemProgramResolver(
@@ -46,24 +48,29 @@ describe("home addFavorite handler", () => {
     const homePattern = await runtime.patternManager.compilePattern(program, {
       space,
     });
-
     const resultCell = runtime.getCell(space, "home-instance");
-    const home = await runtime.runSynced(resultCell, homePattern, {});
+    home = await runtime.runSynced(resultCell, homePattern, {});
     await home.pull();
     await runtime.idle();
+  });
 
-    const target = runtime.getCell(space, "favorited-piece", undefined, tx);
-    target.set({ content: "x" });
+  afterEach(async () => {
     await tx.commit();
-    tx = runtime.edit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
 
-    // deno-lint-ignore no-explicit-any
-    (home.key("addFavorite") as any).send({
-      piece: target.getAsLink(),
-      tags: ["alpha", "beta"],
-      spaceName: "test-space",
-    });
+  // Create a piece cell and return the (link, id) a client would send for it.
+  function makePiece(cause: string): { piece: unknown; id: string } {
+    const target = runtime.getCell(space, cause, undefined, tx) as Cell<
+      unknown
+    >;
+    target.set({ content: cause });
+    const id = favoriteKey(target.getAsNormalizedFullLink());
+    return { piece: target.getAsLink(), id };
+  }
 
+  async function readFavorites(): Promise<FavoriteEntry[]> {
     let favorites: FavoriteEntry[] = [];
     for (let i = 0; i < 50; i++) {
       await runtime.idle();
@@ -72,9 +79,90 @@ describe("home addFavorite handler", () => {
       if (favorites.length > 0) break;
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
+    return favorites;
+  }
 
+  it("stores the discovery tags it is given", async () => {
+    const { piece, id } = makePiece("favorited-piece");
+    await tx.commit();
+    tx = runtime.edit();
+
+    home.key("addFavorite").send({
+      piece,
+      tags: ["alpha", "beta"],
+      spaceName: "test-space",
+      id,
+    });
+
+    const favorites = await readFavorites();
     expect(favorites.length).toBe(1);
     expect(favorites[0].tags).toEqual(["alpha", "beta"]);
     expect(favorites[0].userTags).toEqual([]);
+    expect(favorites[0].id).toBe(id);
+  });
+
+  it("dedups a re-favorite and removes by piece identity", async () => {
+    const { piece, id } = makePiece("favorited-piece");
+    await tx.commit();
+    tx = runtime.edit();
+
+    home.key("addFavorite").send({ piece, tags: ["one"], id });
+    expect((await readFavorites()).length).toBe(1);
+
+    // Re-favoriting the same piece resolves to the same key — no duplicate.
+    home.key("addFavorite").send({ piece, tags: ["one"], id });
+    for (let i = 0; i < 10; i++) await runtime.idle();
+    expect(
+      (home.key("favorites").get() as FavoriteEntry[] | undefined)?.length,
+    ).toBe(1);
+
+    // Unfavoriting removes the membership entry by identity.
+    home.key("removeFavorite").send({ piece, id });
+    for (let i = 0; i < 20; i++) {
+      await runtime.idle();
+      const favorites =
+        (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
+      if (favorites.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(
+      (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [],
+    ).toEqual([]);
+  });
+
+  it("removes a legacy favorite (no keyed entity) via the piece-cell fallback", async () => {
+    const { piece, id } = makePiece("legacy-piece");
+    await tx.commit();
+    tx = runtime.edit();
+
+    // Simulate a favorite added before keyed addressing: push a wrapper with no
+    // id straight onto the list, so it lives at a per-event entity id the key
+    // cannot reach.
+    home.key("favorites").withTx(tx).push({
+      cell: piece,
+      tags: [],
+      userTags: [],
+    });
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+    const seeded =
+      (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
+    expect(seeded.length).toBe(1);
+    expect(seeded[0].id).toBeUndefined();
+
+    // The keyed removal cannot reach it, so removeFavorite falls back to
+    // matching the piece cell and still deletes it.
+    home.key("removeFavorite").send({ piece, id });
+    for (let i = 0; i < 20; i++) {
+      await runtime.idle();
+      const favs =
+        (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
+      if (favs.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(
+      (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [],
+    ).toEqual([]);
   });
 });

--- a/packages/runner/test/profile-owner-cfc.test.ts
+++ b/packages/runner/test/profile-owner-cfc.test.ts
@@ -291,6 +291,108 @@ describe("profile owner CFC policy", () => {
     }
   });
 
+  // A mergeable array op (add-unique / remove-by-value) records the same schema
+  // write-policy input and produces the same array-path write as a whole-value
+  // `set`, so the owner-write authorization applies to it unchanged. An
+  // owner-protected string list keeps the assertion on the op itself, not on the
+  // keyed-entity machinery.
+  const ownerProtectedTagList = (ownerDid: string): JSONSchema => ({
+    type: "object",
+    properties: {
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        ifc: {
+          ownerPrincipal: ownerDid,
+          addIntegrity: [ownerAtom(ownerDid)],
+          writeAuthorizedBy: [PROFILE_WRITER],
+          uiContract: {
+            helper: "UiAction",
+            action: "EditProfile",
+            trustedPattern: "ProfileHome",
+            requiredEventIntegrity: ["ProfileHome"],
+          },
+        },
+      },
+    },
+    required: ["tags"],
+  });
+
+  it("authorizes mergeable add-unique and remove-by-value on an owner-protected list", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const schema = ownerProtectedTagList(alice.did());
+      const seed = runtime.edit();
+      setTrustedProfileWriter(seed, alice.did());
+      const seedCell = runtime.getCell(
+        alice.did(),
+        "cfc-mergeable-list",
+        schema,
+        seed,
+      );
+      seedCell.set({ tags: [] });
+      const target = seedCell.getAsNormalizedFullLink();
+      recordTrustedEdit(seed, target, ["tags"]);
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // The authorized writer adds through the mergeable op.
+      const add = runtime.edit();
+      setTrustedProfileWriter(add, alice.did());
+      runtime.getCell(alice.did(), "cfc-mergeable-list", schema, add)
+        .key("tags").addUnique("x");
+      recordTrustedEdit(add, target, ["tags"]);
+      add.prepareCfc();
+      expect((await add.commit()).error).toBeUndefined();
+
+      // ...and removes through the mergeable op.
+      const rm = runtime.edit();
+      setTrustedProfileWriter(rm, alice.did());
+      runtime.getCell(alice.did(), "cfc-mergeable-list", schema, rm)
+        .key("tags").removeByValue("x");
+      recordTrustedEdit(rm, target, ["tags"]);
+      rm.prepareCfc();
+      expect((await rm.commit()).error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects an unauthorized mergeable write to an owner-protected list", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const schema = ownerProtectedTagList(alice.did());
+      const seed = runtime.edit();
+      setTrustedProfileWriter(seed, alice.did());
+      const seedCell = runtime.getCell(
+        alice.did(),
+        "cfc-mergeable-list-rejected",
+        schema,
+        seed,
+      );
+      seedCell.set({ tags: [] });
+      const target = seedCell.getAsNormalizedFullLink();
+      recordTrustedEdit(seed, target, ["tags"]);
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // Bob add-uniques to Alice's owner-protected list: the mergeable op is
+      // gated by the same ownerPrincipal check as a whole-value set.
+      const tx = runtime.edit();
+      setTrustedProfileWriter(tx, bob.did());
+      runtime.getCell(alice.did(), "cfc-mergeable-list-rejected", schema, tx)
+        .key("tags").addUnique("x");
+      recordTrustedEdit(tx, target, ["tags"]);
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("ownerPrincipal");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("rejects unauthenticated owner-protected profile writes", async () => {
     const { runtime, storageManager } = createRuntime();
     try {

--- a/packages/runtime-client/favorites-manager.test.ts
+++ b/packages/runtime-client/favorites-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import type { DID } from "@commonfabric/identity";
+import { favoriteKey } from "@commonfabric/home-schemas";
 import { FavoritesManager } from "./favorites-manager.ts";
 import type { RuntimeClient } from "./runtime-client.ts";
 
@@ -84,6 +85,11 @@ describe("FavoritesManager.addFavorite tag derivation", () => {
     await new FavoritesManager(stub.rt).addFavorite(space, "piece-1");
     expect(stub.sent[0].tags).toEqual(["search", "go"]);
     expect(stub.sent[0].piece).toMatchObject({ id: "of:piece-1", space });
+    // The favorite is addressed by the piece's identity so the handler can dedup
+    // a re-favorite and remove by identity.
+    expect(stub.sent[0].id).toBe(
+      favoriteKey({ space, id: "of:piece-1", path: [] }),
+    );
   });
 
   it("prefers an explicit tag and skips the schema read", async () => {
@@ -107,12 +113,16 @@ describe("FavoritesManager.addFavorite tag derivation", () => {
 });
 
 describe("FavoritesManager other operations", () => {
-  it("removeFavorite sends the piece reference", async () => {
+  it("removeFavorite sends the piece reference and its key", async () => {
     const stub = makeStub();
     await new FavoritesManager(stub.rt).removeFavorite(space, "piece-x");
     expect(stub.sent[0]).toMatchObject({
       piece: { id: "of:piece-x", space },
     });
+    // The same key add uses, so the removal reaches the same favorite entity.
+    expect(stub.sent[0].id).toBe(
+      favoriteKey({ space, id: "of:piece-x", path: [] }),
+    );
   });
 
   it("getFavorites returns the favorites list", async () => {

--- a/packages/runtime-client/favorites-manager.ts
+++ b/packages/runtime-client/favorites-manager.ts
@@ -11,6 +11,7 @@ import { RuntimeClient } from "./runtime-client.ts";
 import type { CellRef } from "./protocol/types.ts";
 import {
   FavoriteEntry,
+  favoriteKey,
   favoriteListSchema,
   Home,
   homeSchema,
@@ -50,7 +51,11 @@ export class FavoritesManager {
     const handler = await this.#getHandler("addFavorite");
     const pieceCellRef = this.#createPieceRef(space, pieceId);
     const tags = await this.#deriveTags(space, pieceId, tag);
-    await handler.send({ piece: pieceCellRef, tags, spaceName });
+    // The favorite is addressed by the piece's identity, so a re-favorite dedups
+    // and an unfavorite removes by identity. Pattern code cannot introspect the
+    // piece cell's link, so the key is computed here from the piece address.
+    const id = favoriteKey(pieceCellRef);
+    await handler.send({ piece: pieceCellRef, tags, spaceName, id });
   }
 
   /**
@@ -88,7 +93,10 @@ export class FavoritesManager {
   async removeFavorite(space: DID, pieceId: string): Promise<void> {
     const handler = await this.#getHandler("removeFavorite");
     const pieceCellRef = this.#createPieceRef(space, pieceId);
-    await handler.send({ piece: pieceCellRef });
+    // Address the favorite entity by the same key add used, so the removal
+    // reaches it regardless of the whole list's contents.
+    const id = favoriteKey(pieceCellRef);
+    await handler.send({ piece: pieceCellRef, id });
   }
 
   /**


### PR DESCRIPTION
The favorites and spaces lists on the owner-protected home space used a read-modify-write `set` (and, for unfavorite, a clobbering `.remove()`). That shape false-conflicts and clobbers under concurrent multi-replica edits and during the space rehydration race, because it reads the whole list, changes it, and writes the whole list back. Migrate both lists to the mergeable keyed collection writes: address one element by a deterministic key with `elementById`, then manage membership with `addUnique` / `removeByValue`.

The whole-value mergeable ops do not apply to these lists. A list element that is an object is stored as a link to a separate entity, so two objects that are equal by content are still distinct entities: a value comparison never matches, an `addUnique(value)` never dedups, and a `removeByValue(value)` never removes. Addressing the element by a deterministic key and matching by that link is the form that works, the same form the lunch poll uses for its votes and options.

Spaces are keyed by name, which the add and remove handlers already have from the event. Favorites are keyed by the favorited piece's identity. Pattern code cannot read a cell's link, so the key is derived by the client (which holds the piece's address as strings) and passed in as event data; the handler stores it on the entry so the in-app remove button can reach the same entity without introspecting the piece cell. Every removal clears the entity, since it outlives its membership link and a later re-favorite reads it back to decide whether to seed a fresh entry or keep the existing user tags.

The most-recently-used and pinned-elements lists stay a read-modify-write set; the reasons are recorded in docs/development/mergeable-collection-writes.md. A test confirms that the mergeable ops are authorized by an owner-protected list's writeAuthorizedBy claim exactly as a whole-value set is, so the deferral of the pinned-elements list is about its addressing scheme and delete semantics, not about write authorization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make home favorites and spaces use keyed mergeable writes to avoid false conflicts and clobbers during concurrent edits. Favorites are keyed by piece identity; spaces are keyed by name.

- **New Features**
  - Migrated favorites and spaces to `elementById` with `addUnique`/`removeByValue`; unfavorite also clears the keyed entity.
  - Favorites: added `id` on entries and exported `favoriteKey` in `@commonfabric/home-schemas`; `FavoritesManager` now computes and sends `id` for add/remove; UI removal uses `id` when present and falls back to piece-cell match for legacy items.
  - `HomeOutput` now exposes `addFavorite`, `removeFavorite`, `addSpace`, `removeSpace`, and `addJournalEntry`; `removeSpace` reads the name from the event or bound state.
  - Docs add “Home-space migration outcome”; tests cover keyed merges for spaces and favorites, legacy-delete fallback, and confirm owner-protected lists authorize mergeable ops.

- **Migration**
  - No action if you use `FavoritesManager`.
  - If you send home events directly, include `id = favoriteKey({ space, id, path })` when calling `addFavorite`/`removeFavorite`.

<sup>Written for commit 26621bb061f4a5425d5d0a9c6b978625a7b10138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

