### PR TITLE
fix(runner): retry a stale-basis storm on mergeable-op event commits

### DIFF
--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -297,24 +297,47 @@ mergeable methods to stop false-conflicting and clobbering under contention; the
 favorites, spaces, MRU, and pin lists on the owner-protected home space are the
 highest-value remaining candidates.
 
-## Residual: profile-append-during-rehydration is not fully closed by this change
+## Residual: profile-append-during-rehydration (closed by mergeable-op retry windowing)
 
 This work was motivated by profile creates being lost when issued while the home
 space is rehydrating. The mergeable-append mechanism here is necessary for that
-case and fixes the part where a stale or empty base produced a clobbering or
-position-wrong op. It is not sufficient on its own.
+case: it fixes the part where a stale or empty base produced a clobbering or
+position-wrong op. It was not sufficient on its own. A second failure remained on
+the cross-space, multi-space commit path. That failure is described and closed
+below.
 
-An end-to-end probe — create one profile, reload, then create two more using only
-an idle-wait (no full-sync barrier) between steps, reading a durable count of the
-home `profiles` list — still ends at one. Server-side op tracing during that run
-shows the home `profiles` entity receiving its initial `set` and exactly one
-`append` op (the first, pre-reload create); the two post-reload creates
-produce no append revision on that entity at all. A commit that is rejected on a
-conflict never reaches the revision-apply path, so the two appends are being
-attempted and conflict-rejected (or reverted and not replayed) during the
-post-reload churn — not clobbered at the tail. That is a separate failure: an
-optimistic event-handler write reverted by an unrelated conflict during
-rehydration and never successfully retried (and/or the home rehydration storm
-itself), on the cross-space, multi-space commit path. Closing it needs work on
-the revert/replay of event-handler writes or on eliminating the rehydration
-storm, beyond making the append mergeable.
+A profile create is a multi-space commit. The handler pushes a freshly-created
+`ProfileHome.inSpace()` onto the home `profiles` list, so a single transaction
+both appends to the home space and writes the new profile's own space. A
+multi-space commit runs one per-space commit in order — the child space first,
+then the home space — with no rollback. During the reload storm the home-space
+commit fails repeatedly with transient errors: a stale read, or a same-replica
+race as rehydration applies revisions to the local replica concurrently with the
+commit. The child space, committed first, is already durable, so the new
+profile exists in its own space; but the home-space append keeps failing.
+
+The event-handler commit path retried these failures, but a transient error that
+is not a `ConflictError` consumed the handler's fixed retry budget (five
+attempts). Once the budget was exhausted the commit hit the give-up disposition,
+which drops the write. The mergeable append — add-wins, commutative, and unable
+to truly conflict — was dropped along with it. The durable result is a profile
+whose `ProfileHome` exists but which is absent from the home list, so the durable
+count of `profiles` ends at one.
+
+The fix routes the storm's stale-basis inconsistency through the windowed-retry
+path a `ConflictError` already used — rather than the fixed budget — when the
+commit carries a mergeable op. A `StorageTransactionInconsistent` is a same-basis
+race: a value the transaction read changed on this replica between the read and
+the commit, which re-running against fresh state resolves. A mergeable op's
+durable intent commutes, so retrying it is always safe and it lands once the
+storm clears. The extra windowing is scoped to that stale-basis error: an
+authorization failure, a malformed store op, or a transport error still keeps the
+fixed budget even with a mergeable op present, because re-running cannot resolve
+it. A commit that genuinely cannot converge within the retry window surfaces a
+loud `CommitConvergenceError` instead of silently dropping the append. See
+`classifyCommitDisposition` in `packages/runner/src/scheduler/events.ts`, and the
+regression test
+`packages/runner/test/mergeable-append-multispace-conflict.test.ts`, which
+injects a stale-basis inconsistency storm longer than the fixed budget on the
+home-space commit of a multi-space mergeable append and asserts the append
+survives durably.

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -16,7 +16,9 @@ import type {
 import {
   isConflictRejection,
   isPermanentRejection,
+  isStorageTransactionInconsistent,
 } from "../storage/rejection.ts";
+import { getDirectTransactionMergeableOpAddresses } from "../storage/transaction-inspection.ts";
 import {
   type CommitBackpressurePolicy,
   CommitConvergenceError,
@@ -645,6 +647,13 @@ export async function dispatchQueuedEvent(state: {
     state.runtime.prepareTxForCommit(tx);
     const log = txToReactivityLog(tx);
     const changedWrites = collectChangedWritesForTransaction(tx, log);
+    // A commit that carries a mergeable op (append/add-unique/increment/
+    // remove-by-value) represents durable, commutative user intent that cannot
+    // truly conflict. A stale-basis inconsistency — the same-replica race the
+    // space-rehydration storm produces — must not exhaust the fixed retry budget
+    // and drop that intent; it is retried within the retry window like a
+    // conflict instead (see classifyCommitDisposition).
+    const hasMergeableOps = transactionHasMergeableOps(tx);
     const telemetryWrites = log.writes
       .slice(0, EVENT_COMMIT_TELEMETRY_WRITE_LIMIT)
       .map(formatEventCommitAddress);
@@ -673,6 +682,7 @@ export async function dispatchQueuedEvent(state: {
         result.error,
         queuedEvent,
         state.backpressure,
+        hasMergeableOps,
       );
 
       state.runtime.telemetry.submit({
@@ -840,6 +850,13 @@ function formatEventCommitAddress(address: {
   return `${address.space}/${address.id}/${address.path.join("/")}`;
 }
 
+function transactionHasMergeableOps(tx: IExtendedStorageTransaction): boolean {
+  for (const _ of getDirectTransactionMergeableOpAddresses(tx) ?? []) {
+    return true;
+  }
+  return false;
+}
+
 type CommitDisposition =
   | { kind: "success" }
   | { kind: "permanent" }
@@ -860,17 +877,28 @@ type CommitDisposition =
  *  - success: nothing more to do.
  *  - permanent: a precondition failure; never retried.
  *  - backoff / convergence-failed: a stale-basis ConflictError under
- *    contention. It backs off and retries until it lands or the retry window
- *    elapses, after which it fails terminally rather than being silently
- *    dropped. This is the backpressure path.
+ *    contention, or a stale-basis StorageTransactionInconsistent on a commit
+ *    that carries a mergeable op. It backs off and retries until it lands or the
+ *    retry window elapses, after which it fails terminally rather than being
+ *    silently dropped. This is the backpressure path.
  *  - bounded-retry / give-up: any other transient error (a handler-initiated
- *    abort, a system error). These are not contention, so backpressure would
- *    not help; they keep the fixed retriesLeft budget and stop after it.
+ *    abort, a system error). These are not a stale basis, so re-running against
+ *    fresh state would not help; they keep the fixed retriesLeft budget and stop
+ *    after it.
+ *
+ * The extra windowing for a mergeable-op commit is scoped to the stale-basis
+ * StorageTransactionInconsistent — the same-replica race the rehydration storm
+ * produces, which re-running resolves. A mergeable op is add-wins and
+ * commutative, so retrying it against fresh state is always safe and its durable
+ * intent must not be dropped when the fixed budget runs out. A non-stale-basis
+ * rejection (authorization, malformed store op, transport) still keeps the fixed
+ * budget even with a mergeable op present, since retrying cannot resolve it.
  */
 function classifyCommitDisposition(
   error: { name?: string } | undefined,
   queuedEvent: QueuedEvent,
   policy: CommitBackpressurePolicy,
+  hasMergeableOps: boolean,
 ): CommitDisposition {
   if (!error) {
     return { kind: "success" };
@@ -878,7 +906,9 @@ function classifyCommitDisposition(
   if (isPermanentRejection(error)) {
     return { kind: "permanent" };
   }
-  if (!isConflictRejection(error)) {
+  const windowed = isConflictRejection(error) ||
+    (hasMergeableOps && isStorageTransactionInconsistent(error));
+  if (!windowed) {
     return queuedEvent.retriesLeft > 0
       ? { kind: "bounded-retry" }
       : { kind: "give-up" };

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -32,3 +32,17 @@ export function isConflictRejection(
 ): boolean {
   return error?.name === "ConflictError";
 }
+
+/**
+ * A stale-basis inconsistency: a value the transaction read changed on this
+ * replica between the read and the commit (see storage/v2-transaction.ts
+ * `validate()`). Like a conflict it is resolved by re-running the transaction
+ * against fresh state; unlike a conflict the invalidating change is local
+ * rather than a rejection from upstream. A transport, authorization, or
+ * malformed-store error is not a stale basis and re-running does not resolve it.
+ */
+export function isStorageTransactionInconsistent(
+  error: { name?: string } | undefined | null,
+): boolean {
+  return error?.name === "StorageTransactionInconsistent";
+}

--- a/packages/runner/test/mergeable-append-multispace-conflict.test.ts
+++ b/packages/runner/test/mergeable-append-multispace-conflict.test.ts
@@ -1,0 +1,299 @@
+// Probe + regression for the residual profile-append-during-rehydration loss
+// (docs/development/mergeable-collection-writes.md "Residual" section), distilled
+// to the essential runtime mechanism and made deterministic:
+//
+//   A single event handler that, in ONE multi-space transaction, mergeable-appends
+//   to a home-space list AND creates a cross-space `inSpace` child — the shape of
+//   `submitProfileCreation` pushing a `ProfileHome.inSpace()` onto the home
+//   `profiles` list.
+//
+// During a reload storm the home-space commit hits transient rejections. This
+// test injects that storm deterministically: the home replica's commit is failed
+// a handful of times with a NON-conflict transient error (a same-replica race,
+// the kind the rehydration churn produces), then allowed through. The
+// cross-space child lands on its first attempt (multi-space commits have no
+// rollback), so the profile's ProfileHome exists — but the mergeable append is
+// dropped when the event handler exhausts its bounded-retry budget and gives up,
+// leaving the profile absent from the list. That is the residual loss.
+//
+// The append is add-wins and commutes; it must not be dropped just because the
+// surrounding multi-space commit exhausted its retry budget on unrelated churn.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("mergeable-append-multispace");
+const space = signer.did();
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+  private sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+// A child pattern instantiated in its own anonymous inSpace space, plus a host
+// that holds the home `items` list and an `addItem` handler that pushes a
+// cross-space child onto `items` (a multi-space commit).
+const CHILD_SRC = [
+  "import { pattern, computed } from 'commonfabric';",
+  "export default pattern<{ seed: string }, { label: unknown }>(({ seed }) => {",
+  "  const label = computed(() => `child-${seed}`);",
+  "  return { label };",
+  "});",
+].join("\n");
+
+const HOST_SRC = [
+  "import { pattern, handler, Writable } from 'commonfabric';",
+  "import Child from './child.tsx';",
+  "",
+  "const addItem = handler<{ seed: string }, {",
+  "  items: Writable<unknown[]>;",
+  "}>((event, { items }) => {",
+  "  items.push(Child.inSpace()({ seed: event.seed }));",
+  "});",
+  "",
+  "export default pattern(() => {",
+  "  const items = new Writable<unknown[]>([]).for('items');",
+  "  return { items, addItem: addItem({ items }) };",
+  "});",
+].join("\n");
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    { name: "/main.tsx", contents: HOST_SRC },
+    { name: "/child.tsx", contents: CHILD_SRC },
+  ],
+};
+
+const RESULT_CAUSE = "mergeable-append-multispace host";
+
+const itemLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+async function readDurableItemCount(
+  server: MemoryV2Server.Server,
+): Promise<number> {
+  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: storage,
+  });
+  try {
+    const tx = rt.edit();
+    const parent = await rt.patternManager.compilePattern(PROGRAM, {
+      space,
+      tx,
+    });
+    const resultCell = rt.getCell<Record<string, unknown>>(
+      space,
+      RESULT_CAUSE,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const handle = rt.run(tx, parent as any, {}, resultCell);
+    rt.prepareTxForCommit(tx);
+    await tx.commit();
+    for (let i = 0; i < 8; i++) {
+      await handle.pull();
+      await rt.idle();
+      await storage.synced();
+    }
+    const items = handle.key("items").asSchema(itemLinkListSchema)
+      // deno-lint-ignore no-explicit-any
+      .get() as any[];
+    return Array.isArray(items) ? items.length : 0;
+  } finally {
+    await rt.dispose();
+    await storage.close();
+  }
+}
+
+describe("mergeable append in a multi-space commit survives a transient storm", () => {
+  let server: MemoryV2Server.Server;
+  let manager: SharedServerStorageManager;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    manager = SharedServerStorageManager.connectTo(server, { as: signer });
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    });
+  });
+  afterEach(async () => {
+    await rt.dispose();
+    await manager.close();
+    await server.close();
+  });
+
+  it("the append survives when the home commit hits transient non-conflict rejections", async () => {
+    const tx = rt.edit();
+    const parent = await rt.patternManager.compilePattern(PROGRAM, {
+      space,
+      tx,
+    });
+    const resultCell = rt.getCell<Record<string, unknown>>(
+      space,
+      RESULT_CAUSE,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const handle = rt.run(tx, parent as any, {}, resultCell);
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await handle.pull();
+    await rt.idle();
+    await manager.synced();
+
+    // Wrap the HOME replica's commitNative to inject a transient, non-conflict
+    // rejection (a same-replica inconsistency, the kind the rehydration storm
+    // produces) for the first several commit attempts, then let it through. The
+    // count (8) is above the event handler's fixed retry budget
+    // (DEFAULT_RETRIES_FOR_EVENTS = 5), so the pre-fix handler exhausts its
+    // budget and gives up before the storm clears. The cross-space child lives
+    // in its own replica and is unaffected: it commits durably on the first
+    // attempt (the multi-space split has no rollback), so pre-fix the child
+    // exists but the home append is dropped.
+    const replica = manager.open(space).replica as unknown as {
+      commitNative: (...args: unknown[]) => Promise<unknown>;
+    };
+    const realCommitNative = replica.commitNative.bind(replica);
+    let injectedRemaining = 8;
+    replica.commitNative = (...args: unknown[]) => {
+      if (injectedRemaining > 0) {
+        injectedRemaining--;
+        return Promise.resolve({
+          error: {
+            name: "StorageTransactionInconsistent",
+            message: "injected transient storm rejection",
+          },
+        });
+      }
+      return realCommitNative(...args);
+    };
+
+    // Fire the multi-space create. Its home append hits the injected storm.
+    const addTx = rt.edit();
+    handle.withTx(addTx).key("addItem").send({ seed: "X" });
+    await addTx.commit();
+    for (let i = 0; i < 30; i++) {
+      await rt.idle();
+      await manager.synced();
+    }
+
+    // The append must survive: after the transient storm clears, the item is in
+    // the durable list. Pre-fix the event handler exhausts its bounded-retry
+    // budget on the injected non-conflict errors and gives up, dropping the
+    // mergeable append even though it commutes and could never truly conflict.
+    const count = await readDurableItemCount(server);
+    expect(count).toBe(1);
+
+    // The handler rode out the whole storm (8 rejections, above the fixed
+    // budget) rather than giving up partway through.
+    expect(injectedRemaining).toBe(0);
+  });
+
+  it("a non-stale-basis rejection on a mergeable commit still fails fast (not windowed)", async () => {
+    const tx = rt.edit();
+    const parent = await rt.patternManager.compilePattern(PROGRAM, {
+      space,
+      tx,
+    });
+    const resultCell = rt.getCell<Record<string, unknown>>(
+      space,
+      RESULT_CAUSE,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const handle = rt.run(tx, parent as any, {}, resultCell);
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await handle.pull();
+    await rt.idle();
+    await manager.synced();
+
+    // Inject an AuthorizationError — a non-stale-basis rejection that re-running
+    // cannot resolve. The mergeable op present in the commit must NOT widen this
+    // into the retry window; it keeps the fixed budget and gives up. The count
+    // (8) is above the budget, so if it were wrongly windowed the handler would
+    // ride past the injections and land the append.
+    const replica = manager.open(space).replica as unknown as {
+      commitNative: (...args: unknown[]) => Promise<unknown>;
+    };
+    const realCommitNative = replica.commitNative.bind(replica);
+    let injectedRemaining = 8;
+    replica.commitNative = (...args: unknown[]) => {
+      if (injectedRemaining > 0) {
+        injectedRemaining--;
+        return Promise.resolve({
+          error: {
+            name: "AuthorizationError",
+            message: "injected non-stale-basis rejection",
+          },
+        });
+      }
+      return realCommitNative(...args);
+    };
+
+    let sawWindowedBackoff = false;
+    // deno-lint-ignore no-explicit-any
+    rt.telemetry.addEventListener("telemetry", (ev: any) => {
+      const m = ev.marker;
+      if (m?.type === "scheduler.event.commit" && m.backoffMs !== undefined) {
+        sawWindowedBackoff = true;
+      }
+    });
+
+    const addTx = rt.edit();
+    handle.withTx(addTx).key("addItem").send({ seed: "Y" });
+    await addTx.commit();
+    for (let i = 0; i < 30; i++) {
+      await rt.idle();
+      await manager.synced();
+    }
+
+    // The handler gave up on the fixed budget before the injections cleared, so
+    // the append did not land and the window was never entered.
+    expect(await readDurableItemCount(server)).toBe(0);
+    expect(sawWindowedBackoff).toBe(false);
+    expect(injectedRemaining).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
A profile create is a multi-space commit: the handler pushes a ProfileHome.inSpace() child onto the home profiles list, so one transaction both appends to the home space (a mergeable append) and writes the new profile's own space. The multi-space split commits the child first, durably and without rollback, then the home append.

During a space-rehydration storm the home-space commit fails repeatedly with StorageTransactionInconsistent: a same-replica race where the local replica advances between the transaction's read and its commit. That error is not a ConflictError, so the event handler consumed its fixed retry budget and then reached the give-up disposition, which reverts and drops the write. The mergeable append was dropped along with it even though it is add-wins and commutative and can never truly conflict. The child survived in its own space, so the profile existed but was absent from the home list.

Route the stale-basis StorageTransactionInconsistent through the same windowed-retry path a ConflictError already uses, rather than the fixed budget, when the commit carries a mergeable op. Re-running such an op is always safe because it commutes, so it lands once the storm clears; a commit that cannot converge within the retry window surfaces a loud CommitConvergenceError instead of a silent drop.

Scope the widening to the stale-basis error only. An authorization failure, a malformed store operation, or a transport error keeps the fixed budget even with a mergeable op present, because re-running cannot resolve it. Permanent precondition failures and the retries:0 opt-out are unchanged.

Add isStorageTransactionInconsistent to storage/rejection.ts and rewrite the residual section of the mergeable-collection-writes note to describe the mechanism and the fix.

Add a deterministic runner regression test: it injects a stale-basis storm above the fixed budget on the home-space commit of a multi-space mergeable append and asserts the append survives durably, and a second case injects a non-stale-basis rejection and asserts it still fails fast, guarding the scope of the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry stale-basis inconsistencies (`StorageTransactionInconsistent`) on event commits that carry mergeable ops so add-wins appends survive rehydration storms. Non-stale errors still use bounded retries; if the window can’t land the commit we raise `CommitConvergenceError`.

- **Bug Fixes**
  - Treat `StorageTransactionInconsistent` like `ConflictError` for mergeable-op commits by routing to the retry window; keep bounded retries for other transient errors; permanent failures and `retries:0` unchanged.
  - Add `isStorageTransactionInconsistent`; pass `hasMergeableOps` into `classifyCommitDisposition`; detect mergeable ops via `getDirectTransactionMergeableOpAddresses` in a new `transactionHasMergeableOps` helper.
  - Add deterministic regression tests for a multi-space mergeable append surviving a stale-basis storm and for non-stale rejections failing fast; update docs to mark the residual closed and explain the mechanism.

<sup>Written for commit 7137bc68ae042bbdec550fc809bce7263b2770a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_COVERAGE_BASELINE