### PR TITLE
feat(cfc): CNF clause kernel + digest-stable anyOf canonicalization (Epic A1)

### DIFF
--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -158,8 +158,24 @@ export const canonicalizeWritePolicyInput = (
       };
     case "trusted-event":
       return { ...input, target: canonicalizeAttemptedWrite(input.target) };
+    // Clause-canonicalization coverage note: the digest hashes label-bearing
+    // material in two places beyond the labelMap. Carried `link-write` label
+    // views are RUNTIME-DERIVED (view merges can order alternatives
+    // differently across derivations), so their clause interiors are
+    // canonicalized here. `schema` inputs are deliberately NOT touched: a
+    // schema is a content-addressed authored artifact whose bytes are its
+    // identity (`schemaHash`) — rewriting `ifc` clause interiors inside the
+    // digest view would diverge it from the schema's own hash, and a single
+    // artifact's internal ordering is stable by construction anyway.
     case "link-write": {
-      const cfcLabelView = cloneCfcLabelView(input.cfcLabelView);
+      const cloned = cloneCfcLabelView(input.cfcLabelView);
+      const cfcLabelView = cloned === undefined ? undefined : {
+        version: cloned.version,
+        entries: cloned.entries.map((entry) => ({
+          path: entry.path,
+          label: canonicalizeCfcLabel(entry.label),
+        })),
+      };
       return {
         ...input,
         target: canonicalizeAttemptedWrite(input.target),

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -9,7 +9,8 @@ import type {
   PreparedDigestInput,
   WritePolicyInput,
 } from "./types.ts";
-import { cloneCfcLabelView } from "./label-view-core.ts";
+import { cloneCfcLabelView, type IFCLabel } from "./label-view-core.ts";
+import { isOrClause, normalizeClause } from "./clause.ts";
 
 /**
  * Returns a canonical-form logical path: any leading `"value"` element
@@ -175,6 +176,29 @@ export const canonicalizeWritePolicyInput = (
   }
 };
 
+/**
+ * Canonical form of a label for digest purposes. Clause-INTERIOR
+ * canonicalization only: each confidentiality entry that is an OR-clause gets
+ * its alternatives deduped/sorted (and singletons unwrapped) via
+ * `normalizeClause`, so two labels differing only in alternative insertion
+ * order digest identically. The top-level entry lists (clause list, integrity
+ * set) keep their given order — flat labels pass through byte-identical, and
+ * persisted forms are never reordered by canonicalization (SC-11 idempotence
+ * comparisons stay stable).
+ */
+export const canonicalizeCfcLabel = (label: IFCLabel): IFCLabel => {
+  const confidentiality = label.confidentiality;
+  if (
+    !Array.isArray(confidentiality) || !confidentiality.some(isOrClause)
+  ) {
+    return label;
+  }
+  return {
+    ...label,
+    confidentiality: confidentiality.map(normalizeClause),
+  };
+};
+
 export const canonicalizeCfcMetadata = (
   metadata: CfcMetadata,
 ): CfcMetadata => ({
@@ -184,7 +208,7 @@ export const canonicalizeCfcMetadata = (
     version: 1,
     entries: [...metadata.labelMap.entries].map((entry) => ({
       path: canonicalizeLogicalPath(entry.path),
-      label: entry.label,
+      label: canonicalizeCfcLabel(entry.label),
       ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
     })).sort((left, right) => {
       const leftKey = logicalPathToPointer(left.path);

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -1,0 +1,103 @@
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isRecord } from "@commonfabric/utils/types";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { uniqueCfcAtoms } from "./observation.ts";
+
+/**
+ * CNF confidentiality clauses (spec §3.1.8 / §4.2.1; Epic A of
+ * docs/plans/cfc-future-work-implementation.md).
+ *
+ * A confidentiality label is a conjunction of clauses. Each clause is either
+ * a bare atom (a singleton clause — every entry in today's flat labels) or an
+ * authored/exchange-produced disjunction written as `{ anyOf: [atom, …] }`.
+ * The `anyOf` wrapper is the wire discriminator, chosen so a clause-unaware
+ * reader deep-equals the whole object against ceiling atoms, finds no match,
+ * and treats the data as MORE restricted — never less (mixed-version
+ * fail-closed by construction).
+ *
+ * The `anyOf` key is therefore reserved: an atom must never use it. To keep
+ * accidental collisions fail-closed, only a record whose SOLE own key is
+ * `anyOf` (with an array value) is recognized as a clause; any other shape
+ * stays an opaque atom (unsatisfiable against ceilings — restrictive).
+ */
+export type CfcOrClause = { readonly anyOf: readonly unknown[] };
+
+/** A confidentiality clause: a bare atom, or an OR of atoms. */
+export type CfcConfClause = unknown;
+
+export const isOrClause = (value: unknown): value is CfcOrClause =>
+  isRecord(value) &&
+  Array.isArray((value as { anyOf?: unknown }).anyOf) &&
+  Object.keys(value).length === 1;
+
+/** The alternatives of a clause; a bare atom is its own single alternative. */
+export const clauseAlternatives = (
+  clause: CfcConfClause,
+): readonly unknown[] => isOrClause(clause) ? clause.anyOf : [clause];
+
+const compareByCanonicalHash = (left: unknown, right: unknown): number => {
+  const leftHash = hashStringOf(left);
+  const rightHash = hashStringOf(right);
+  return leftHash < rightHash ? -1 : leftHash > rightHash ? 1 : 0;
+};
+
+/**
+ * Canonical form of a clause:
+ * - a non-clause value (bare atom) is returned unchanged (identity — flat
+ *   labels are byte-identical through canonicalization);
+ * - an OR-clause gets its alternatives structurally deduped and sorted by
+ *   canonical value hash, so two clauses that differ only in alternative
+ *   insertion order canonicalize (and hash) identically;
+ * - a singleton `{anyOf: [a]}` unwraps to the bare atom `a` (semantically
+ *   identical, so the two spellings must not hash differently);
+ * - an empty `{anyOf: []}` is kept as-is: it is an unsatisfiable clause
+ *   (see `clauseSubsumes` for how both positions treat it fail-closed).
+ *
+ * Canonicalization never merges clauses, never unions alternative sets
+ * across clauses, and never dedups an atom across a singleton clause and an
+ * OR-clause containing it — `[A]` and `[A ∨ B]` are different constraints
+ * (spec §3.1.8 normalization prohibitions).
+ */
+export const normalizeClause = (clause: CfcConfClause): CfcConfClause => {
+  if (!isOrClause(clause)) return clause;
+  const unique = uniqueCfcAtoms(clause.anyOf);
+  if (unique.length === 1) return unique[0];
+  return { anyOf: unique.sort(compareByCanonicalHash) };
+};
+
+/** Structural clause equality, insensitive to alternative order. */
+export const clausesEqual = (
+  left: CfcConfClause,
+  right: CfcConfClause,
+): boolean => deepEqual(normalizeClause(left), normalizeClause(right));
+
+/**
+ * Clause subsumption — the ceiling-fit kernel (spec §8.10.3):
+ * a ceiling clause `c` subsumes a label clause `l` when every alternative of
+ * `c` appears among `l`'s alternatives (`alts(c) ⊆ alts(l)`) — then any
+ * principal satisfying `c` satisfies `l`, so an observer admitted by the
+ * ceiling clause is entitled to data guarded by the label clause.
+ *
+ * Deliberate fail-closed divergence from the pure set algebra: an EMPTY
+ * ceiling clause never subsumes. Mathematically `∅ ⊆ alts(l)` holds and an
+ * unsatisfiable destination-audience clause would admit any flow, but an
+ * empty `anyOf` in an authored ceiling is far more likely malformed input
+ * than a deliberate "nobody observes this" claim — so it contributes
+ * nothing. (On the label side the algebra already fails closed: no
+ * non-empty ceiling clause is a subset of an empty alternative set, so a
+ * label containing `{anyOf: []}` never fits any ceiling.)
+ *
+ * Atom comparison is structural equality for now; the per-family entailment
+ * hook (`Expires` ordering etc.) arrives with the Epic B matcher.
+ */
+export const clauseSubsumes = (
+  ceilingClause: CfcConfClause,
+  labelClause: CfcConfClause,
+): boolean => {
+  const ceilingAlternatives = clauseAlternatives(ceilingClause);
+  if (ceilingAlternatives.length === 0) return false;
+  const labelAlternatives = clauseAlternatives(labelClause);
+  return ceilingAlternatives.every((ceilingAtom) =>
+    labelAlternatives.some((labelAtom) => deepEqual(ceilingAtom, labelAtom))
+  );
+};

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -49,7 +49,12 @@ const compareByCanonicalHash = (left: unknown, right: unknown): number => {
  *   canonical value hash, so two clauses that differ only in alternative
  *   insertion order canonicalize (and hash) identically;
  * - a singleton `{anyOf: [a]}` unwraps to the bare atom `a` (semantically
- *   identical, so the two spellings must not hash differently);
+ *   identical, so the two spellings must not hash differently) — UNLESS `a`
+ *   is itself clause-shaped: `{anyOf: [{anyOf: […]}]}` is malformed (the
+ *   reserved key must not appear in atom position), and its sole alternative
+ *   is an opaque, unsatisfiable atom. Unwrapping would PROMOTE that inner
+ *   value into an active OR-clause, loosening what the raw label admits —
+ *   the wrong direction. Malformed nesting stays wrapped and opaque;
  * - an empty `{anyOf: []}` is kept as-is: it is an unsatisfiable clause
  *   (see `clauseSubsumes` for how both positions treat it fail-closed).
  *
@@ -61,7 +66,7 @@ const compareByCanonicalHash = (left: unknown, right: unknown): number => {
 export const normalizeClause = (clause: CfcConfClause): CfcConfClause => {
   if (!isOrClause(clause)) return clause;
   const unique = uniqueCfcAtoms(clause.anyOf);
-  if (unique.length === 1) return unique[0];
+  if (unique.length === 1 && !isOrClause(unique[0])) return unique[0];
   return { anyOf: unique.sort(compareByCanonicalHash) };
 };
 

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -50,6 +50,7 @@ export {
   isCfcEnforcementMode,
 } from "./types.ts";
 export {
+  canonicalizeCfcLabel,
   canonicalizeCfcMetadata,
   canonicalizeDereferenceTrace,
   canonicalizeLogicalPath,
@@ -58,6 +59,14 @@ export {
   logicalPathToPointer,
   preparedDigestFor,
 } from "./canonical.ts";
+export type { CfcConfClause, CfcOrClause } from "./clause.ts";
+export {
+  clauseAlternatives,
+  clausesEqual,
+  clauseSubsumes,
+  isOrClause,
+  normalizeClause,
+} from "./clause.ts";
 export {
   flowLabelWorkExists,
   flowReadExcluded,

--- a/packages/runner/test/cfc-clause.test.ts
+++ b/packages/runner/test/cfc-clause.test.ts
@@ -1,0 +1,177 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import {
+  clauseAlternatives,
+  clausesEqual,
+  clauseSubsumes,
+  isOrClause,
+  normalizeClause,
+} from "../src/cfc/clause.ts";
+import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
+import type { CfcMetadata } from "../src/cfc/types.ts";
+
+// Epic A1 (docs/plans/cfc-future-work-implementation.md): the CNF clause
+// kernel. Pure helpers — no runtime behavior change; A2 wires subsumption
+// into the ceiling checks.
+
+const userA = { type: "https://commonfabric.org/cfc/atom/User", subject: "A" };
+const userB = { type: "https://commonfabric.org/cfc/atom/User", subject: "B" };
+const userC = { type: "https://commonfabric.org/cfc/atom/User", subject: "C" };
+
+describe("CFC clause kernel", () => {
+  describe("isOrClause", () => {
+    it("recognizes the exact {anyOf: [...]} wire form only", () => {
+      expect(isOrClause({ anyOf: [userA, userB] })).toBe(true);
+      expect(isOrClause({ anyOf: [] })).toBe(true);
+      // The anyOf key is reserved, but any OTHER shape stays an opaque atom
+      // (fail-closed: unsatisfiable against ceilings), never a clause.
+      expect(isOrClause({ anyOf: [userA], extra: 1 })).toBe(false);
+      expect(isOrClause({ anyOf: "not-an-array" })).toBe(false);
+      expect(isOrClause(userA)).toBe(false);
+      expect(isOrClause("string-atom")).toBe(false);
+      expect(isOrClause([userA, userB])).toBe(false);
+      expect(isOrClause(null)).toBe(false);
+    });
+  });
+
+  describe("clauseAlternatives", () => {
+    it("treats a bare atom as its own single alternative", () => {
+      expect(clauseAlternatives(userA)).toEqual([userA]);
+      expect(clauseAlternatives("string-atom")).toEqual(["string-atom"]);
+    });
+
+    it("returns the alternatives of an OR-clause", () => {
+      expect(clauseAlternatives({ anyOf: [userA, userB] }))
+        .toEqual([userA, userB]);
+    });
+  });
+
+  describe("normalizeClause", () => {
+    it("returns bare atoms unchanged (identity for flat labels)", () => {
+      expect(normalizeClause(userA)).toBe(userA);
+      expect(normalizeClause("string-atom")).toBe("string-atom");
+      // A malformed hybrid is an opaque atom, not a clause — untouched.
+      const hybrid = { anyOf: [userA], extra: 1 };
+      expect(normalizeClause(hybrid)).toBe(hybrid);
+    });
+
+    it("canonicalizes alternative order deterministically", () => {
+      const forward = normalizeClause({ anyOf: [userA, userB, userC] });
+      const backward = normalizeClause({ anyOf: [userC, userB, userA] });
+      expect(forward).toEqual(backward);
+      expect(hashStringOf(forward)).toBe(hashStringOf(backward));
+    });
+
+    it("dedups alternatives structurally", () => {
+      const clone = { ...userA };
+      expect(normalizeClause({ anyOf: [userA, clone, userB] }))
+        .toEqual(normalizeClause({ anyOf: [userA, userB] }));
+    });
+
+    it("unwraps a singleton {anyOf: [a]} to the bare atom", () => {
+      expect(normalizeClause({ anyOf: [userA] })).toEqual(userA);
+      // ... including after dedup collapses to one.
+      expect(normalizeClause({ anyOf: [userA, { ...userA }] })).toEqual(userA);
+    });
+
+    it("keeps the empty (unsatisfiable) clause as-is", () => {
+      expect(normalizeClause({ anyOf: [] })).toEqual({ anyOf: [] });
+    });
+
+    it("never dedups across a singleton and an OR-clause containing it", () => {
+      // [A] and [A ∨ B] are different constraints — normalization is
+      // clause-interior only, so both survive side by side in a label.
+      const label = [userA, { anyOf: [userA, userB] }].map(normalizeClause);
+      expect(label).toHaveLength(2);
+      expect(label[0]).toEqual(userA);
+      expect(clauseAlternatives(label[1])).toHaveLength(2);
+    });
+  });
+
+  describe("clausesEqual", () => {
+    it("is insensitive to alternative order and spelling", () => {
+      expect(clausesEqual({ anyOf: [userA, userB] }, { anyOf: [userB, userA] }))
+        .toBe(true);
+      expect(clausesEqual({ anyOf: [userA] }, userA)).toBe(true);
+      expect(clausesEqual({ anyOf: [userA, userB] }, userA)).toBe(false);
+      expect(clausesEqual(userA, userB)).toBe(false);
+    });
+  });
+
+  describe("clauseSubsumes", () => {
+    it("singleton ceiling clause subsumes a label clause containing it", () => {
+      // Ceiling audience {A} ⊆ label alternatives {A, B}: anyone the ceiling
+      // admits (A) satisfies the label clause.
+      expect(clauseSubsumes(userA, { anyOf: [userA, userB] })).toBe(true);
+      expect(clauseSubsumes(userA, userA)).toBe(true);
+      expect(clauseSubsumes(userA, userB)).toBe(false);
+      expect(clauseSubsumes(userC, { anyOf: [userA, userB] })).toBe(false);
+    });
+
+    it("reader-enumeration ceiling clause requires EVERY reader in the label clause", () => {
+      // The §8.10.3 quantifier fix: ceiling {A ∨ B} = "either A or B may
+      // observe the destination", so BOTH must satisfy the label clause.
+      expect(
+        clauseSubsumes({ anyOf: [userA, userB] }, { anyOf: [userA, userB] }),
+      )
+        .toBe(true);
+      expect(
+        clauseSubsumes({ anyOf: [userA, userB] }, {
+          anyOf: [userA, userB, userC],
+        }),
+      ).toBe(true);
+      // The multi-party counterexample kernel: a singleton label clause
+      // [User(A)] is NOT subsumed by the enumeration {A ∨ B} — showing the
+      // destination to B would violate A's clause.
+      expect(clauseSubsumes({ anyOf: [userA, userB] }, userA)).toBe(false);
+    });
+
+    it("fails closed on empty clauses in either position", () => {
+      // Empty CEILING clause: mathematically ∅ ⊆ anything, but an authored
+      // empty audience is treated as malformed — it never subsumes.
+      expect(clauseSubsumes({ anyOf: [] }, userA)).toBe(false);
+      expect(clauseSubsumes({ anyOf: [] }, { anyOf: [] })).toBe(false);
+      // Empty LABEL clause: unsatisfiable — no non-empty ceiling clause fits.
+      expect(clauseSubsumes(userA, { anyOf: [] })).toBe(false);
+    });
+  });
+
+  describe("canonicalizeCfcMetadata clause interiors", () => {
+    const metadataWith = (confidentiality: unknown[]): CfcMetadata => ({
+      version: 1,
+      schemaHash: "hash",
+      labelMap: {
+        version: 1,
+        entries: [{ path: ["field"], label: { confidentiality } }],
+      },
+    });
+
+    it("digests identically across alternative insertion order", () => {
+      const forward = canonicalizeCfcMetadata(
+        metadataWith([{ anyOf: [userA, userB] }, userC]),
+      );
+      const backward = canonicalizeCfcMetadata(
+        metadataWith([{ anyOf: [userB, userA] }, userC]),
+      );
+      expect(hashStringOf(forward)).toBe(hashStringOf(backward));
+    });
+
+    it("does not reorder the top-level clause list", () => {
+      const canonical = canonicalizeCfcMetadata(
+        metadataWith([userC, { anyOf: [userB, userA] }]),
+      );
+      const entry = canonical.labelMap.entries[0];
+      expect(entry.label.confidentiality?.[0]).toEqual(userC);
+      expect(isOrClause(entry.label.confidentiality?.[1])).toBe(true);
+    });
+
+    it("passes flat labels through by reference (no gratuitous copies)", () => {
+      const flat = metadataWith([userA, userB]);
+      const canonical = canonicalizeCfcMetadata(flat);
+      expect(canonical.labelMap.entries[0].label).toBe(
+        flat.labelMap.entries[0].label,
+      );
+    });
+  });
+});

--- a/packages/runner/test/cfc-clause.test.ts
+++ b/packages/runner/test/cfc-clause.test.ts
@@ -8,8 +8,15 @@ import {
   isOrClause,
   normalizeClause,
 } from "../src/cfc/clause.ts";
-import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
-import type { CfcMetadata } from "../src/cfc/types.ts";
+import {
+  canonicalizeCfcMetadata,
+  canonicalizeWritePolicyInput,
+} from "../src/cfc/canonical.ts";
+import type {
+  CfcAddress,
+  CfcMetadata,
+  WritePolicyInput,
+} from "../src/cfc/types.ts";
 
 // Epic A1 (docs/plans/cfc-future-work-implementation.md): the CNF clause
 // kernel. Pure helpers — no runtime behavior change; A2 wires subsumption
@@ -77,6 +84,20 @@ describe("CFC clause kernel", () => {
 
     it("keeps the empty (unsatisfiable) clause as-is", () => {
       expect(normalizeClause({ anyOf: [] })).toEqual({ anyOf: [] });
+    });
+
+    it("never promotes a malformed nested clause via singleton unwrap", () => {
+      // {anyOf:[{anyOf:[A,B]}]} is malformed: the reserved key in atom
+      // position makes the sole alternative an opaque, unsatisfiable atom.
+      // Unwrapping would turn it into an ACTIVE OR-clause — admitting at a
+      // ceiling naming A what the raw label never would. It must stay
+      // wrapped and opaque.
+      const malformed = { anyOf: [{ anyOf: [userA, userB] }] };
+      const normalized = normalizeClause(malformed);
+      expect(normalized).toEqual(malformed);
+      // The soundness assertion: no loosening through normalization.
+      expect(clauseSubsumes(userA, normalized)).toBe(false);
+      expect(clauseSubsumes(userA, malformed)).toBe(false);
     });
 
     it("never dedups across a singleton and an OR-clause containing it", () => {
@@ -172,6 +193,36 @@ describe("CFC clause kernel", () => {
       expect(canonical.labelMap.entries[0].label).toBe(
         flat.labelMap.entries[0].label,
       );
+    });
+  });
+
+  describe("canonicalizeWritePolicyInput carried label views", () => {
+    const address = (id: string): CfcAddress =>
+      ({
+        space: "did:key:space" as CfcAddress["space"],
+        id,
+        scope: "space",
+        path: [],
+      }) as CfcAddress;
+
+    const linkWriteWith = (confidentiality: unknown[]): WritePolicyInput => ({
+      kind: "link-write",
+      target: address("of:target"),
+      source: address("of:source"),
+      cfcLabelView: {
+        version: 1,
+        entries: [{ path: ["field"], label: { confidentiality } }],
+      },
+    });
+
+    it("digests link-write label views identically across alternative order", () => {
+      const forward = canonicalizeWritePolicyInput(
+        linkWriteWith([{ anyOf: [userA, userB] }, userC]),
+      );
+      const backward = canonicalizeWritePolicyInput(
+        linkWriteWith([{ anyOf: [userB, userA] }, userC]),
+      );
+      expect(hashStringOf(forward)).toBe(hashStringOf(backward));
     });
   });
 });


### PR DESCRIPTION
## What

Stage **A1** of [the CFC future-work implementation plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md#2-epic-a--cnf-clause-label-representation) (Epic A — CNF clause label representation; spec §3.1.8/§4.2.1/§8.10.3, `proposals/author-disjunctive-confidentiality.md` §9).

- **`packages/runner/src/cfc/clause.ts`** — the pure clause kernel:
  - `isOrClause`: strict `{anyOf:[…]}`-only wire form (sole own key). Any other shape stays an opaque atom — fail-closed against ceiling checks by construction.
  - `clauseAlternatives`, `normalizeClause` (structural dedup + canonical-hash ordering + singleton unwrap; empty clause kept as-is/unsatisfiable), `clausesEqual`.
  - `clauseSubsumes` — the §8.10.3 ceiling-fit kernel (`alts(ceiling) ⊆ alts(label)`), including the deliberate fail-closed divergence from pure set algebra: an **empty ceiling clause never subsumes** (mathematically `∅ ⊆ x`, but an authored empty audience is treated as malformed rather than as "unobservable destination admits everything").
- **`canonical.ts`** — `canonicalizeCfcLabel`: clause-**interior** canonicalization only, wired into `canonicalizeCfcMetadata`. Labels differing only in alternative insertion order digest identically; flat labels pass through **by reference** and the top-level entry order is never touched (SC-11 idempotence comparisons stay stable).

## Behavior change

None. Nothing produces clauses yet — A2 (next stage) generalizes `atomsOutsideCeiling`/`cfcObservationFitsCeiling` to subsumption with the reader-enumeration red test. The digest/canonical-adjacent suites (`cfc-boundary`, `cfc-prepare-bypass`, `cfc-labelmap-monotone`, `cfc-request-snapshot`) pass unmodified.

## Tests

`packages/runner/test/cfc-clause.test.ts` — 22 steps: wire-form strictness, normalization invariants (incl. the spec's no-cross-clause-dedup prohibition), subsumption (incl. the reader-enumeration quantifier kernel that A2's soundness fix rests on, and the empty-clause fail-closed rules in both positions), and digest-stability goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CNF clause kernel and digest-stable canonicalization for confidentiality labels. `anyOf` OR-clauses now normalize deterministically; carried `link-write` label views are canonicalized for stable digests; no runtime behavior change.

- **New Features**
  - Clause kernel in `packages/runner/src/cfc/clause.ts`: `isOrClause`, `clauseAlternatives`, `normalizeClause`, `clausesEqual`, `clauseSubsumes`.
  - Semantics: strict `{ anyOf: [...] }` only; other shapes stay atoms (fail-closed). `normalizeClause` dedups/sorts by canonical hash, unwraps singletons, keeps empty `anyOf`, and does not unwrap when the sole alternative is clause-shaped (prevents malformed nested promotion). `clauseSubsumes` uses `alts(ceiling) ⊆ alts(label)` and treats an empty ceiling as non-subsuming.
  - Canonicalization in `packages/runner/src/cfc/canonical.ts`: `canonicalizeCfcLabel` normalizes clause interiors only and is applied in both `canonicalizeCfcMetadata` and `canonicalizeWritePolicyInput` for `link-write` views (schema inputs are not rewritten). Flat labels pass by reference; top-level order unchanged; labels differing only by alternative order digest identically.

<sup>Written for commit 74ae6b9817efc6f3d559ca0dbc9d50c674cd9b98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

