### PR TITLE
feat(cfc): stamp model output LlmDerived at the store boundary (Epic D1)

### DIFF
--- a/packages/api/cfc.ts
+++ b/packages/api/cfc.ts
@@ -35,6 +35,14 @@ export const CFC_ATOM_TYPE = {
   ExternalIngest: "https://commonfabric.org/cfc/atom/ExternalIngest",
   InjectionSafe: "https://commonfabric.org/cfc/atom/InjectionSafe",
   LinkReference: "https://commonfabric.org/cfc/atom/LinkReference",
+  // Runtime-minted LLM-derivation provenance: these bytes were produced by a
+  // model (assistant content, or a tool result entering the dialog
+  // transcript). Makes "untrusted model output" EXPLICIT provenance rather
+  // than mere absence of integrity, so requiredIntegrity floors fail
+  // positively on model-derived values (Epic D1,
+  // docs/specs/cfc-trusted-agent-tool-integrity.md piece B). Evidence — not
+  // authorable in schemas.
+  LlmDerived: "https://commonfabric.org/cfc/atom/LlmDerived",
   Origin: "https://commonfabric.org/cfc/atom/Origin",
   // Hereditary certification (spec §15.1.1 / §3.1.6.1): survives combination
   // via the class-aware meet — present on an output only when present on
@@ -112,6 +120,14 @@ export type CfcUserSurfaceInputAtom = CfcAtomObject & {
   readonly user: string;
   readonly surface: string;
   readonly valueDigest: string;
+};
+
+export type CfcLlmDerivedAtom = CfcAtomObject & {
+  readonly type: typeof CFC_ATOM_TYPE.LlmDerived;
+  // The model that produced the bytes, when known. Audit/display metadata —
+  // policies match on the atom type, so the default mint omits it to keep
+  // the persisted atom canonical across models.
+  readonly model?: string;
 };
 
 export type CfcExternalIngestAtom = CfcAtomObject & {
@@ -206,6 +222,12 @@ export const cfcAtom = {
     return {
       type: CFC_ATOM_TYPE.InjectionSafe,
     };
+  },
+
+  llmDerived(model?: string): CfcLlmDerivedAtom {
+    return model === undefined
+      ? { type: CFC_ATOM_TYPE.LlmDerived }
+      : { type: CFC_ATOM_TYPE.LlmDerived, model };
   },
 
   userSurfaceInput(

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -19,6 +19,7 @@ import {
   toDeepFrozenSchema,
 } from "@commonfabric/data-model/schema-utils";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import {
   LLMDialogResultSchema,
   LLMMessageSchema,
@@ -27,8 +28,22 @@ import {
 } from "./llm-schemas.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
+
+// Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
+// Recorded as the schema write-policy input for each model-produced message's
+// own entity doc, so the CFC persist pass stamps a labelMap integrity entry on
+// exactly that message — see `pushModelMessages`.
+const LLM_DERIVED_MESSAGE_SCHEMA = internSchema({
+  ...LLMMessageSchema,
+  ifc: { addIntegrity: [cfcAtom.llmDerived()] },
+} as JSONSchema);
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
-import { isCell, isStream } from "../cell.ts";
+import {
+  isCell,
+  isStream,
+  recordRelevantSchemaWritePolicyInput,
+} from "../cell.ts";
+import { resolveLinkScope } from "../scope.ts";
 import { type CellScope, ID, NAME, type Pattern } from "../builder/types.ts";
 import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
 import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
@@ -2935,6 +2950,69 @@ async function startRequest(
   const builtinTools = inputs.key("builtinTools").get() !== false;
 
   const messagesCell = inputs.key("messages");
+
+  // Epic D1 (docs/specs/cfc-trusted-agent-tool-integrity.md piece B): model-
+  // produced bytes — assistant content and tool results entering the dialog
+  // transcript — are stamped `LlmDerived` at the point they enter the store,
+  // so "untrusted model output" is explicit provenance rather than absence of
+  // integrity. The stamp rides the item schema's `ifc.addIntegrity`, which
+  // persists a labelMap entry on exactly the pushed message; the plain-schema
+  // pushes (user messages via `addMessage`, builtin-authored error literals)
+  // stay unstamped. The write is attributed to the builtin because
+  // `LlmDerived` is a runtime-minted evidence family: the persist-time gate
+  // (`gateRuntimeMintedIntegrity`, audit S4) strips it from any other author,
+  // which is also what stops pattern code from forging the stamp.
+  const pushModelMessages = (
+    tx: IExtendedStorageTransaction,
+    messages: Schema<typeof LLMMessageSchema>[],
+  ) => {
+    const startIndex = (messagesCell.withTx(tx).get() as
+      | readonly unknown[]
+      | undefined)?.length ?? 0;
+    messagesCell.withTx(tx).push(...messages);
+    if (runtime.cfcEnforcementMode === "disabled") {
+      return;
+    }
+    // Attribute the writes to the builtin: `LlmDerived` is a runtime-minted
+    // evidence family, so the persist-time gate (`gateRuntimeMintedIntegrity`,
+    // audit S4) admits it only from builtin authors — the same gating that
+    // stops pattern code from forging the stamp.
+    tx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: "llmDialog",
+    });
+    // Record the stamping schema for each pushed message's own entity doc
+    // (every model push carries an [ID] sigil, so each message splits into
+    // its own doc). The messages link carries its own schema, which wins over
+    // an `asSchema` handle inside `push()` (`resolvedLink.schema ?? ...`), so
+    // the stamp cannot ride the array handle — instead this mirrors the
+    // split-entity idiom in data-updating.ts (`recordRelevantSchemaWrite-
+    // PolicyInput` on the child doc), which also marks the transaction
+    // CFC-relevant so `prepareTxForCommit` runs the persist pass that mints
+    // the labelMap entry.
+    const base = messagesCell.getAsNormalizedFullLink();
+    for (let index = 0; index < messages.length; index++) {
+      const raw = messagesCell.withTx(tx).key(startIndex + index).getRaw();
+      const link = parseLink(raw);
+      const id = link?.id;
+      if (link === undefined || id === undefined) {
+        logger.warn(
+          "llm",
+          "model message did not split into its own doc; LlmDerived stamp skipped",
+        );
+        continue;
+      }
+      recordRelevantSchemaWritePolicyInput(tx, {
+        ...link,
+        id,
+        space: link.space ?? base.space ?? space,
+        scope: resolveLinkScope(link.scope, base.scope),
+        path: [],
+        schema: LLM_DERIVED_MESSAGE_SCHEMA,
+      }, LLM_DERIVED_MESSAGE_SCHEMA);
+    }
+  };
+
   const toolsCell = inputs.key("tools") as Cell<
     Record<string, Schema<typeof LLMToolSchema>>
   >;
@@ -3174,9 +3252,9 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
                   observedConfidentiality: requestObservedConfidentiality,
                 },
               ]);
-              messagesCell.withTx(tx).push(
+              pushModelMessages(tx, [
                 assistantMessage as Schema<typeof LLMMessageSchema>,
-              );
+              ]);
             },
           );
 
@@ -3274,8 +3352,9 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
                     toolResults[index]?.observedConfidentiality ?? [],
                 })),
               );
-              messagesCell.withTx(tx).push(
-                ...(toolResultMessages as Schema<typeof LLMMessageSchema>[]),
+              pushModelMessages(
+                tx,
+                toolResultMessages as Schema<typeof LLMMessageSchema>[],
               );
             },
           );
@@ -3356,9 +3435,9 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
                 observedConfidentiality: requestObservedConfidentiality,
               },
             ]);
-            messagesCell.withTx(tx).push(
+            pushModelMessages(tx, [
               assistantMessage as Schema<typeof LLMMessageSchema>,
-            );
+            ]);
             pending.withTx(tx).set(false);
           },
         );

--- a/packages/runner/src/cfc/atom-classes.ts
+++ b/packages/runner/src/cfc/atom-classes.ts
@@ -28,6 +28,7 @@ const CLASS_BY_TYPE = new Map<string, PropagationClass>([
   [CFC_ATOM_TYPE.Resource, "value-bound"],
   [CFC_ATOM_TYPE.Builtin, "provenance"],
   [CFC_ATOM_TYPE.ExternalIngest, "provenance"],
+  [CFC_ATOM_TYPE.LlmDerived, "provenance"],
   [CFC_ATOM_TYPE.Origin, "provenance"],
   [CFC_ATOM_TYPE.PromptSlotInfluence, "provenance"],
   [CFC_ATOM_TYPE.TransformedBy, "provenance"],

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2660,6 +2660,11 @@ const RUNTIME_MINTED_INTEGRITY_ATOM_TYPES = new Set<string>([
   // identity, so any ExternalIngest atom an attacker smuggles into the payload
   // is stripped — the trusted mark can only come from the builtin mint step.
   CFC_ATOM_TYPE.ExternalIngest,
+  // LLM-derivation provenance is minted by the llm builtins at the point
+  // model bytes enter the store (Epic D1). Gating it keeps the stamp honest
+  // in BOTH directions: pattern code can neither forge it onto values the
+  // model never produced nor author schemas that mint it.
+  CFC_ATOM_TYPE.LlmDerived,
 ]);
 
 const isRuntimeMintedIntegrityAtom = (atom: unknown): boolean =>

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -1,0 +1,323 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import {
+  clearMockResponses,
+  enableMockMode,
+  loadConversationFixture,
+} from "@commonfabric/llm/client";
+import type { BuiltInLLMMessage } from "@commonfabric/api";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
+import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { ID, type JSONSchema } from "../src/builder/types.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-llm-derived-stamp");
+
+// Epic D1 (docs/plans/cfc-future-work-implementation.md): model output must
+// carry an explicit LlmDerived provenance stamp instead of representing
+// untrust as mere absence of integrity. This file starts with the stamping
+// MECHANISM kernel: a builtin-identity write through an item schema carrying
+// ifc.addIntegrity persists the atom on exactly the written element — and
+// only there (a sibling written through the plain schema stays unstamped).
+
+const LLM_DERIVED_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/LlmDerived",
+} as const;
+
+const messageSchema = {
+  type: "object",
+  properties: {
+    role: { type: "string" },
+    content: { type: "string" },
+  },
+} as const satisfies JSONSchema;
+
+const messagesSchema = {
+  type: "array",
+  items: messageSchema,
+} as const satisfies JSONSchema;
+
+const stampingMessagesSchema = {
+  type: "array",
+  items: {
+    ...messageSchema,
+    ifc: { addIntegrity: [LLM_DERIVED_ATOM] },
+  },
+} as const satisfies JSONSchema;
+
+describe("CFC LlmDerived stamping mechanism", () => {
+  it("stamps exactly the element pushed through the addIntegrity schema", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      // Model-output push: builtin identity, item schema carries the stamp.
+      const modelTx = runtime.edit();
+      modelTx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "llm-dialog",
+      });
+      const stamping = runtime.getCell(
+        signer.did(),
+        "llm-derived-messages",
+        stampingMessagesSchema,
+        modelTx,
+      );
+      stamping.push({ role: "assistant", content: "model bytes" });
+      modelTx.prepareCfc();
+      expect((await modelTx.commit()).ok).toBeDefined();
+
+      // User push into the SAME array through the plain schema: no stamp.
+      const userTx = runtime.edit();
+      const plain = runtime.getCell(
+        signer.did(),
+        "llm-derived-messages",
+        messagesSchema,
+        userTx,
+      );
+      plain.push({ role: "user", content: "typed by the user" });
+      userTx.prepareCfc();
+      expect((await userTx.commit()).ok).toBeDefined();
+
+      const readTx = runtime.edit();
+      const messages = runtime.getCell(
+        signer.did(),
+        "llm-derived-messages",
+        messagesSchema,
+        readTx,
+      );
+
+      const assistantView = cfcLabelViewForCell(messages.key(0));
+      const assistantIntegrity = (assistantView?.entries ?? []).flatMap(
+        (entry) => entry.label.integrity ?? [],
+      );
+      expect(assistantIntegrity).toContainEqual(LLM_DERIVED_ATOM);
+
+      const userView = cfcLabelViewForCell(messages.key(1));
+      const userIntegrity = (userView?.entries ?? []).flatMap(
+        (entry) => entry.label.integrity ?? [],
+      );
+      expect(userIntegrity).not.toContainEqual(LLM_DERIVED_ATOM);
+      readTx.commit();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("stamps an [ID]-split element on its own doc", async () => {
+    // Real dialog messages carry an [ID] sigil and split into their own
+    // entity docs; the stamp must land on the split doc and surface through
+    // the element's label view.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const modelTx = runtime.edit();
+      modelTx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "llm-dialog",
+      });
+      const stamping = runtime.getCell(
+        signer.did(),
+        "llm-derived-id-split",
+        stampingMessagesSchema,
+        modelTx,
+      );
+      stamping.push({
+        [ID]: { llmDialog: { message: "m", id: "id-split-1" } },
+        role: "assistant",
+        content: "model bytes",
+      } as unknown as { role: string; content: string });
+      modelTx.prepareCfc();
+      expect((await modelTx.commit()).ok).toBeDefined();
+
+      const readTx = runtime.edit();
+      const messages = runtime.getCell(
+        signer.did(),
+        "llm-derived-id-split",
+        messagesSchema,
+        readTx,
+      );
+      const view = cfcLabelViewForCell(messages.key(0));
+      const integrity = (view?.entries ?? []).flatMap(
+        (entry) => entry.label.integrity ?? [],
+      );
+      expect(integrity).toContainEqual(LLM_DERIVED_ATOM);
+      readTx.commit();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("strips an author-minted LlmDerived (runtime-minted evidence gate)", async () => {
+    // LlmDerived is registered runtime-minted evidence (audit S4 posture):
+    // a NON-builtin author pushing through the same stamping schema must not
+    // persist the atom — pattern code can neither forge the stamp nor author
+    // schemas that mint it.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const authorTx = runtime.edit();
+      const stamping = runtime.getCell(
+        signer.did(),
+        "llm-derived-forge",
+        stampingMessagesSchema,
+        authorTx,
+      );
+      stamping.push({ role: "assistant", content: "forged provenance" });
+      authorTx.prepareCfc();
+      expect((await authorTx.commit()).ok).toBeDefined();
+
+      const readTx = runtime.edit();
+      const messages = runtime.getCell(
+        signer.did(),
+        "llm-derived-forge",
+        messagesSchema,
+        readTx,
+      );
+      const view = cfcLabelViewForCell(messages.key(0));
+      const integrity = (view?.entries ?? []).flatMap(
+        (entry) => entry.label.integrity ?? [],
+      );
+      expect(integrity).not.toContainEqual(LLM_DERIVED_ATOM);
+      readTx.commit();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});
+
+describe("llmDialog LlmDerived stamping (end to end)", () => {
+  it("stamps the assistant message; the user message stays unstamped", async () => {
+    enableMockMode();
+    clearMockResponses();
+    loadConversationFixture({
+      description: "LlmDerived stamping: single reply",
+      responses: [
+        {
+          type: "sendRequest",
+          expectRequest: { messagesContain: ["Hello"], messageCount: 1 },
+          response: { role: "assistant", content: "Hi there!", id: "d1-r1" },
+        },
+      ],
+    });
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, llmDialog, Cell } = commonfabric;
+
+    try {
+      const resultSchema = {
+        type: "object",
+        properties: {
+          addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+          pending: { type: "boolean" },
+          messages: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+        },
+        required: ["addMessage"],
+      } as const satisfies JSONSchema;
+
+      const testPattern = pattern(
+        () => {
+          const messages = Cell.of<BuiltInLLMMessage[]>([]);
+          const dialog = llmDialog({ messages });
+          return {
+            addMessage: dialog.addMessage,
+            pending: dialog.pending,
+            messages,
+          };
+        },
+        false,
+        resultSchema,
+      );
+
+      const resultCell = runtime.getCell(
+        signer.did(),
+        "llm-derived-e2e",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      tx.commit();
+
+      const addMessage = await result.key("addMessage").pull();
+      addMessage.send({ role: "user", content: "Hello" });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timeout waiting for assistant reply")),
+          5000,
+        );
+        const cancel = result.sink(
+          ({ pending, messages }: {
+            pending?: boolean;
+            messages?: readonly unknown[];
+          } = {}) => {
+            if (pending === false && messages?.length === 2) {
+              clearTimeout(timeout);
+              cancel();
+              resolve();
+            }
+          },
+        );
+      });
+      await runtime.idle();
+
+      // The contract is the PERSISTED metadata on each message's own entity
+      // doc (messages carry [ID] and split); read it there directly — the
+      // multi-hop handle chain (result → messages link → element link) is a
+      // separate label-view surfacing concern.
+      const messagesCell = result.key("messages");
+      const rtx = runtime.edit();
+      const integrityAtDoc = (index: number): unknown[] => {
+        const raw = messagesCell.withTx(rtx).key(index).getRaw();
+        const link = parseLink(raw);
+        if (link?.id === undefined) return [];
+        const metadata = readStoredCfcMetadata(rtx, {
+          space: link.space ?? signer.did(),
+          id: link.id,
+          scope: link.scope === "inherit" ? undefined : link.scope,
+        });
+        return (metadata?.labelMap.entries ?? []).flatMap(
+          (entry) => entry.label.integrity ?? [],
+        );
+      };
+      expect(integrityAtDoc(1)).toContainEqual(cfcAtom.llmDerived());
+      expect(integrityAtDoc(0)).not.toContainEqual(cfcAtom.llmDerived());
+      rtx.commit();
+    } finally {
+      clearMockResponses();
+      await runtime.idle();
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -330,4 +330,110 @@ describe("llmDialog LlmDerived stamping (end to end)", () => {
       await storageManager.close();
     }
   });
+
+  it("does not stamp when CFC enforcement is disabled", async () => {
+    // The disabled dial must be a strict no-op: messages flow through the
+    // plain push path and no CFC metadata is minted on the message docs.
+    enableMockMode();
+    clearMockResponses();
+    loadConversationFixture({
+      description: "LlmDerived stamping: disabled dial",
+      responses: [
+        {
+          type: "sendRequest",
+          expectRequest: { messagesContain: ["Hello"], messageCount: 1 },
+          response: { role: "assistant", content: "Hi there!", id: "d1-r2" },
+        },
+      ],
+    });
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, llmDialog, Cell } = commonfabric;
+
+    try {
+      const resultSchema = {
+        type: "object",
+        properties: {
+          addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+          pending: { type: "boolean" },
+          messages: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+        },
+        required: ["addMessage"],
+      } as const satisfies JSONSchema;
+
+      const testPattern = pattern(
+        () => {
+          const messages = Cell.of<BuiltInLLMMessage[]>([]);
+          const dialog = llmDialog({ messages });
+          return {
+            addMessage: dialog.addMessage,
+            pending: dialog.pending,
+            messages,
+          };
+        },
+        false,
+        resultSchema,
+      );
+
+      const resultCell = runtime.getCell(
+        signer.did(),
+        "llm-derived-e2e-disabled",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      tx.commit();
+
+      const addMessage = await result.key("addMessage").pull();
+      addMessage.send({ role: "user", content: "Hello" });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timeout waiting for assistant reply")),
+          5000,
+        );
+        const cancel = result.sink(
+          ({ pending, messages }: {
+            pending?: boolean;
+            messages?: readonly unknown[];
+          } = {}) => {
+            if (pending === false && messages?.length === 2) {
+              clearTimeout(timeout);
+              cancel();
+              resolve();
+            }
+          },
+        );
+      });
+      await runtime.idle();
+
+      const messagesCell = result.key("messages");
+      const rtx = runtime.edit();
+      const raw = messagesCell.withTx(rtx).key(1).getRaw();
+      const link = parseLink(raw);
+      expect(link?.id).toBeDefined();
+      const metadata = readStoredCfcMetadata(rtx, {
+        space: link!.space ?? signer.did(),
+        id: link!.id!,
+        scope: link!.scope === "inherit" ? undefined : link!.scope,
+      });
+      expect(metadata).toBeUndefined();
+      rtx.commit();
+    } finally {
+      clearMockResponses();
+      await runtime.idle();
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -52,6 +52,16 @@ const stampingMessagesSchema = {
 } as const satisfies JSONSchema;
 
 describe("CFC LlmDerived stamping mechanism", () => {
+  it("mints the atom with and without a model binding", () => {
+    // The default mint omits `model` so the persisted atom stays canonical
+    // across models; the model arm exists for audit/display consumers.
+    expect(cfcAtom.llmDerived()).toEqual(LLM_DERIVED_ATOM);
+    expect(cfcAtom.llmDerived("mock-model")).toEqual({
+      ...LLM_DERIVED_ATOM,
+      model: "mock-model",
+    });
+  });
+
   it("stamps exactly the element pushed through the addIntegrity schema", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/static/assets/types/cfc.ts
+++ b/packages/static/assets/types/cfc.ts
@@ -32,6 +32,7 @@ export declare const CFC_ATOM_TYPE: {
   readonly ExternalIngest: "https://commonfabric.org/cfc/atom/ExternalIngest";
   readonly InjectionSafe: "https://commonfabric.org/cfc/atom/InjectionSafe";
   readonly LinkReference: "https://commonfabric.org/cfc/atom/LinkReference";
+  readonly LlmDerived: "https://commonfabric.org/cfc/atom/LlmDerived";
   readonly Origin: "https://commonfabric.org/cfc/atom/Origin";
   readonly PolicyCertified: "https://commonfabric.org/cfc/atom/PolicyCertified";
   readonly PromptSlotBound: "https://commonfabric.org/cfc/atom/PromptSlotBound";
@@ -79,6 +80,10 @@ export type CfcUserSurfaceInputAtom = CfcAtomObject & {
   readonly user: string;
   readonly surface: string;
   readonly valueDigest: string;
+};
+type CfcLlmDerivedAtom = CfcAtomObject & {
+  readonly type: typeof CFC_ATOM_TYPE.LlmDerived;
+  readonly model?: string;
 };
 export type CfcExternalIngestAtom = CfcAtomObject & {
   readonly type: typeof CFC_ATOM_TYPE.ExternalIngest;
@@ -138,6 +143,7 @@ export declare const cfcAtom: {
   ) => CfcCaveatAtom;
   readonly builtin: (name: string) => CfcBuiltinAtom;
   readonly injectionSafe: () => CfcInjectionSafeAtom;
+  readonly llmDerived: (model?: string) => CfcLlmDerivedAtom;
   readonly userSurfaceInput: (
     user: string,
     surface: string,


### PR DESCRIPTION
## What

Stage **D1** of [the CFC future-work implementation plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md#5-epic-d--write-side--agent-integrity-the-live-soundness-cluster) — piece B of [`docs/specs/cfc-trusted-agent-tool-integrity.md`](https://github.com/commontoolsinc/labs/blob/main/docs/specs/cfc-trusted-agent-tool-integrity.md): model-produced bytes are stamped with an `LlmDerived` provenance atom at the point they enter the store, so "untrusted model output" is **explicit provenance** rather than mere absence of integrity. This is the enabler for the invoke-time tool-input `requiredIntegrity` gate (piece A, next stage D2).

- **`packages/api/cfc.ts`**: `CFC_ATOM_TYPE.LlmDerived` + atom type + `cfcAtom.llmDerived(model?)` mint helper.
- **`atom-classes.ts`**: propagation class `provenance` — never propagates through the default transition.
- **`prepare.ts`**: joins `RUNTIME_MINTED_INTEGRITY_ATOM_TYPES`, so the persist-time evidence gate strips it from any non-builtin author — pattern code can neither forge the stamp nor author schemas that mint it (tested).
- **`llm-dialog.ts`**: `pushModelMessages` stamps assistant + tool-result messages at their push sites; builtin-authored error literals and user messages (`addMessage`) stay unstamped. No-op when `cfcEnforcementMode` is `"disabled"`.

## Implementation note (the interesting seam)

The dialog's messages link carries its own schema, which wins over an `asSchema` handle inside `push()` (`resolvedLink.schema ?? this.schema`) — so the stamp cannot ride the array handle's item schema. Instead each model message (they all carry `[ID]` and split into their own entity docs) gets the stamping schema recorded explicitly via `recordRelevantSchemaWritePolicyInput` on its doc — the same split-entity idiom `data-updating.ts` uses — which also marks the continuation tx CFC-relevant so `prepareTxForCommit` runs the persist pass (the same seam the external-ingest stamp handles explicitly).

## Tests

`packages/runner/test/cfc-llm-derived-stamp.test.ts`:
- stamping mechanism kernel — the pushed element is stamped, a sibling pushed through the plain schema is not;
- `[ID]`-split element stamped on its own doc;
- **forge attempt stripped**: a non-builtin author pushing through the same stamping schema does not persist the atom (evidence-gate guard);
- **end-to-end mock dialog**: the assistant message's doc carries `LlmDerived`; the user message's doc does not.

Guard suites unperturbed (llm-dialog, llm-dialog-outbox, conversation fixtures, cfc mint-gate/flow/boundary — 65+122 steps green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamp all model-produced dialog bytes with a `LlmDerived` CFC atom at the store boundary so model output is explicit provenance. This enables the upcoming invoke-time tool-input `requiredIntegrity` gate (D2) and adds coverage for the disabled-dial no-op path.

- **New Features**
  - Added `CFC_ATOM_TYPE.LlmDerived`, `cfcAtom.llmDerived(model?)`, and registered it as a provenance class.
  - Gated as runtime-minted evidence; the persist-time gate strips `LlmDerived` from non-builtin authors.
  - `llm-dialog` stamps assistant and tool-result messages at push; user messages and builtin-authored error literals stay unstamped; no-op when `cfcEnforcementMode` is "disabled".
  - Records the stamping schema per split message entity using `recordRelevantSchemaWritePolicyInput`; tests cover both `cfcAtom.llmDerived` mint arms and the disabled-dial no-op branch.

- **Dependencies**
  - Regenerated `packages/static/assets/types/cfc.ts` to include `CFC_ATOM_TYPE.LlmDerived`, `CfcLlmDerivedAtom`, and `cfcAtom.llmDerived`.

<sup>Written for commit 0fc8f2a8798945879e3e018e48c633dd7e37a9a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

