### PR TITLE
feat(cfc): plumb the flow-label dial to hosts; shell defaults to observe (Epic H1)

### DIFF
--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -35,6 +35,10 @@ export type RuntimeCfcEnforcementMode = NonNullable<
   RuntimeClientOptions["cfcEnforcementMode"]
 >;
 
+export type RuntimeCfcFlowLabelsMode = NonNullable<
+  RuntimeClientOptions["cfcFlowLabels"]
+>;
+
 export type RuntimeTrustSnapshot = NonNullable<
   RuntimeClientOptions["trustSnapshot"]
 >;
@@ -57,6 +61,12 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   spaceHostMap?: Record<string, string>;
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
+  /**
+   * Flow-label propagation dial (S16). Shell hosts default to "observe"
+   * (Epic H1): derive the per-tx conservative join and emit diagnostics,
+   * persisting nothing — the measurement stage before "persist".
+   */
+  cfcFlowLabels?: RuntimeCfcFlowLabelsMode;
   trustSnapshot?: RuntimeTrustSnapshot | null;
   /**
    * When true, forward the worker runtime's console output to the main
@@ -116,6 +126,11 @@ export function createRuntimeClientOptions({
   spaceHostMap,
   experimental,
   cfcEnforcementMode = "enforce-explicit",
+  // Epic H1 (docs/plans/cfc-future-work-implementation.md): shell hosts run
+  // the flow-label dial at "observe" — derive the per-tx conservative join
+  // and emit diagnostics without persisting — as the measurement stage
+  // before flipping to "persist" (H2).
+  cfcFlowLabels = "observe",
   trustSnapshot,
   forwardWorkerConsole,
 }: {
@@ -124,6 +139,7 @@ export function createRuntimeClientOptions({
   spaceHostMap?: Record<string, string>;
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
+  cfcFlowLabels?: RuntimeCfcFlowLabelsMode;
   trustSnapshot?: RuntimeTrustSnapshot | null;
   forwardWorkerConsole?: boolean;
 }) {
@@ -143,6 +159,7 @@ export function createRuntimeClientOptions({
     spaceName: session.spaceName,
     experimental,
     cfcEnforcementMode,
+    cfcFlowLabels,
     trustSnapshot: resolvedTrustSnapshot,
     forwardWorkerConsole,
   };
@@ -470,6 +487,7 @@ export class RuntimeInternals extends EventTarget {
     spaceHostMap,
     experimental,
     cfcEnforcementMode,
+    cfcFlowLabels,
     trustSnapshot,
     forwardWorkerConsole,
     getBuildHash = fetchBuildHash,
@@ -511,6 +529,7 @@ export class RuntimeInternals extends EventTarget {
         spaceHostMap,
         experimental,
         cfcEnforcementMode,
+        cfcFlowLabels,
         trustSnapshot,
         forwardWorkerConsole,
       }),

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -297,6 +297,9 @@ describe("RuntimeInternals", () => {
     });
 
     expect(options.cfcEnforcementMode).toBe("enforce-explicit");
+    // Epic H1: shell hosts run the flow-label dial at "observe" by default —
+    // the measurement stage before "persist" (H2).
+    expect(options.cfcFlowLabels).toBe("observe");
     expect(options.trustSnapshot).toEqual({
       id: `principal:${session.as.did()}`,
       actingPrincipal: session.as.did(),
@@ -329,10 +332,12 @@ describe("RuntimeInternals", () => {
       session,
       apiUrl: new URL("http://shell.test/"),
       cfcEnforcementMode: "observe",
+      cfcFlowLabels: "off",
       trustSnapshot,
     });
 
     expect(options.cfcEnforcementMode).toBe("observe");
+    expect(options.cfcFlowLabels).toBe("off");
     expect(options.trustSnapshot).toBe(trustSnapshot);
 
     const withoutTrust = createRuntimeClientOptions({

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1598,6 +1598,7 @@ describe("runtimeOptionsFromInitializationData", () => {
         identity: {} as never,
         spaceDid: "did:key:space",
         cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "observe",
         trustSnapshot: {
           id: "principal:did:key:worker",
           actingPrincipal: "did:key:worker",
@@ -1608,6 +1609,7 @@ describe("runtimeOptionsFromInitializationData", () => {
     );
 
     expect(options.cfcEnforcementMode).toBe("enforce-explicit");
+    expect(options.cfcFlowLabels).toBe("observe");
     expect(options.trustSnapshotProvider?.()).toEqual({
       id: "principal:did:key:worker",
       actingPrincipal: "did:key:worker",

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -169,6 +169,7 @@ export function runtimeOptionsFromInitializationData(
     telemetry,
     experimental: data.experimental,
     cfcEnforcementMode: data.cfcEnforcementMode,
+    cfcFlowLabels: data.cfcFlowLabels,
     trustSnapshotProvider: data.trustSnapshot
       ? () => data.trustSnapshot
       : undefined,

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -159,6 +159,13 @@ export interface InitializationData {
     | "observe"
     | "enforce-explicit"
     | "enforce-strict";
+  // Flow-label propagation dial for the worker runtime (S16 default
+  // transition; docs/plans/cfc-future-work-implementation.md Epic H1):
+  // "off" = no derivation; "observe" = compute the per-tx conservative
+  // join and emit diagnostics, persist nothing; "persist" = write derived
+  // label components. Propagation never rejects by itself. Absent =
+  // the runner's default ("off").
+  cfcFlowLabels?: "off" | "observe" | "persist";
   // Whether author-supplied render-boundary declassification is honored.
   // Defaults to "allow" (current behavior). "deny" ignores author-supplied
   // `declassifyConfidentiality` so a pattern can't release a secret upward

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -119,6 +119,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       spaceName: options.spaceName,
       experimental: options.experimental,
       cfcEnforcementMode: options.cfcEnforcementMode,
+      cfcFlowLabels: options.cfcFlowLabels,
       renderDeclassificationPolicy: options.renderDeclassificationPolicy,
       renderConfidentialityCeiling: options.renderConfidentialityCeiling,
       trustSnapshot: options.trustSnapshot,


### PR DESCRIPTION
## What

Stage **H1** of [the CFC future-work implementation plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md#7-epic-h--enforcement--flow-activation): activate the S16 flow-label propagation dial in shipped hosts, at `observe`.

The dial (`off | observe | persist`) existed only as a `RuntimeOptions` field — **not** in the worker IPC protocol — so no host could turn it on, leaving inv-9's flow-taint derivation (the router-attack defense that is §10's own worked example) dormant in every deployment.

- **runtime-client**: `cfcFlowLabels` joins `InitializationData` (and therefore `RuntimeClientOptions`, via the `Omit`-extends), threaded through `RuntimeClient.initialize` → `runtimeOptionsFromInitializationData` → the worker `Runtime` construction — mirroring `cfcEnforcementMode`'s existing path exactly.
- **lib-shell**: `createRuntimeClientOptions` gains the param and defaults shell hosts to **`"observe"`** — derive the per-tx conservative join (`deriveFlowJoin`) and emit diagnostics when `flowLabelWorkExists`, persisting nothing. This is the measurement stage before flipping to `persist` (H2), per the plan's rollout ordering (SC-13). Hosts can override, including back to `"off"`.

## Behavior change

Shell-hosted worker runtimes move from flow-labels `off` → `observe`. Observe mode never rejects and never persists — it computes the join and emits diagnostics only on transactions that actually touch pre-existing labeled data (`flowLabelWorkExists` gate). Toolshed/CLI runtimes construct `Runtime` directly without these options and keep the runner default (`off`).

## Tests

- `lib-shell/test/runtime.test.ts`: default is `observe`; explicit override (`off`) honored.
- `runtime-client/backends/runtime-processor.test.ts`: `InitializationData.cfcFlowLabels` maps into `RuntimeOptions`.

(The dial's runner-side semantics — off/observe/persist gating in `prepareTxForCommit`/`prepareBoundaryCommit` — are covered by existing runner tests; this PR is the plumbing + host default.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the S16 flow-label propagation dial (`cfcFlowLabels`: off | observe | persist) over the worker IPC and default shell hosts to observe. This makes flow-taint derivation visible without persisting labels; non-shell hosts remain unchanged.

- **New Features**
  - `runtime-client`/protocol: add `cfcFlowLabels` to `InitializationData` and thread it through `RuntimeClient.initialize` → `runtimeOptionsFromInitializationData` → worker runtime.
  - `lib-shell`: `createRuntimeClientOptions` accepts `cfcFlowLabels` and defaults to "observe"; hosts can override (including "off"). Shell-hosted runtimes compute joins and emit diagnostics only; Toolshed/CLI keep the runner default ("off").

<sup>Written for commit 80a3e530b5189282e968e3ecb9a622c471d20239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

