### PR TITLE
feat(cfc): clause-concatenation join with normalize-on-ingest (Epic A3)

### DIFF
--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,6 +1,7 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { uniqueCfcAtoms } from "./observation.ts";
+import { normalizeClause } from "./clause.ts";
 
 export type IFCLabel = {
   confidentiality?: unknown[];
@@ -130,6 +131,20 @@ export const mergeLabel = (
       ...(Array.isArray(left?.[key]) ? left[key] : []),
       ...(Array.isArray(right[key]) ? right[key] : []),
     ];
+    // Confidentiality is CNF clauses (Epic A3): the join is clause
+    // CONCATENATION — `[[A∨B]] ⊔ [C] = [[A∨B], C]` — the OR stays clause-local
+    // and `C` remains an independent gate. Normalizing each clause on ingest
+    // (dedup + canonical alternative order + singleton unwrap) makes two
+    // equivalent OR-clauses that differ only in alternative order coalesce
+    // through the structural dedup below. It MUST NOT merge distinct clauses
+    // or union their alternative sets — `normalizeClause` only rewrites a
+    // clause's own interior, so concatenation + clause-granular dedup upholds
+    // the §3.1.8 normalization prohibitions. Integrity carries no OR-clauses,
+    // and `normalizeClause` is identity on non-clause atoms, so it is applied
+    // only to confidentiality to keep intent explicit.
+    const normalized = key === "confidentiality"
+      ? values.map(normalizeClause)
+      : values;
     // Dedup structurally via `uniqueCfcAtoms()` rather than by reference
     // (`new Set()`). Atoms can be fabric-converted clones (each call to
     // `cloneIfNecessary()` produces a fresh frozen object), so two
@@ -138,7 +153,7 @@ export const mergeLabel = (
     // observe as both `confidentiality` bloat and -- since downstream
     // entry-merging compares labels structurally -- as label entries
     // failing to coalesce at the right path.
-    const unique = uniqueCfcAtoms(values);
+    const unique = uniqueCfcAtoms(normalized);
     if (unique.length > 0) {
       merged[key] = unique;
     }

--- a/packages/runner/test/cfc-clause-join.test.ts
+++ b/packages/runner/test/cfc-clause-join.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { mergeCfcLabelViews, mergeLabel } from "../src/cfc/label-view-core.ts";
+import { clauseAlternatives, isOrClause } from "../src/cfc/clause.ts";
+
+// Epic A3 (docs/plans/cfc-future-work-implementation.md): the confidentiality
+// join is clause CONCATENATION with normalize-on-ingest. It upholds the
+// §3.1.8 prohibitions: never merge distinct clauses, never union alternative
+// sets, never dedup an atom across a singleton and an OR-clause containing it.
+
+const A = { type: "https://commonfabric.org/cfc/atom/User", subject: "A" };
+const B = { type: "https://commonfabric.org/cfc/atom/User", subject: "B" };
+const C = { type: "https://commonfabric.org/cfc/atom/User", subject: "C" };
+
+describe("CFC clause join (mergeLabel)", () => {
+  it("concatenates clauses: [[A∨B]] ⊔ [C] = [[A∨B], C]", () => {
+    const merged = mergeLabel(
+      { confidentiality: [{ anyOf: [A, B] }] },
+      { confidentiality: [C] },
+    );
+    const conf = merged.confidentiality!;
+    expect(conf).toHaveLength(2);
+    const orClause = conf.find(isOrClause);
+    expect(orClause && clauseAlternatives(orClause)).toEqual([A, B]);
+    expect(conf).toContainEqual(C);
+  });
+
+  it("coalesces OR-clauses that differ only in alternative order", () => {
+    const merged = mergeLabel(
+      { confidentiality: [{ anyOf: [A, B] }] },
+      { confidentiality: [{ anyOf: [B, A] }] },
+    );
+    // Two equivalent clauses normalize to one entry (bloat-free), NOT to a
+    // merged/unioned clause.
+    expect(merged.confidentiality).toHaveLength(1);
+    expect(isOrClause(merged.confidentiality![0])).toBe(true);
+    expect(clauseAlternatives(merged.confidentiality![0])).toHaveLength(2);
+  });
+
+  it("never merges distinct clauses or unions their alternative sets", () => {
+    const merged = mergeLabel(
+      { confidentiality: [{ anyOf: [A, B] }] },
+      { confidentiality: [{ anyOf: [B, C] }] },
+    );
+    // {A∨B} and {B∨C} are DIFFERENT constraints — both survive, no {A∨B∨C}.
+    expect(merged.confidentiality).toHaveLength(2);
+    for (const clause of merged.confidentiality!) {
+      expect(clauseAlternatives(clause)).toHaveLength(2);
+    }
+  });
+
+  it("never dedups an atom across a singleton and an OR-clause containing it", () => {
+    // [A] and [A∨B] are different constraints; both survive side by side.
+    const merged = mergeLabel(
+      { confidentiality: [A] },
+      { confidentiality: [{ anyOf: [A, B] }] },
+    );
+    expect(merged.confidentiality).toHaveLength(2);
+    expect(merged.confidentiality).toContainEqual(A);
+    expect(merged.confidentiality!.some(isOrClause)).toBe(true);
+  });
+
+  it("unwraps a singleton {anyOf:[a]} to the bare atom on ingest", () => {
+    const merged = mergeLabel(
+      { confidentiality: [{ anyOf: [A] }] },
+      { confidentiality: [A] },
+    );
+    // Both sides mean "readable by A" — coalesce to one bare atom.
+    expect(merged.confidentiality).toEqual([A]);
+  });
+
+  it("leaves flat labels and integrity untouched", () => {
+    const merged = mergeLabel(
+      { confidentiality: [A], integrity: [B] },
+      { confidentiality: [C], integrity: [B] },
+    );
+    expect(merged.confidentiality).toEqual([A, C]);
+    expect(merged.integrity).toEqual([B]);
+  });
+});
+
+describe("CFC clause join (mergeCfcLabelViews)", () => {
+  it("coalesces order-differing OR-clauses at the same path", () => {
+    const view = mergeCfcLabelViews([
+      {
+        version: 1,
+        entries: [{
+          path: ["x"],
+          label: { confidentiality: [{ anyOf: [A, B] }] },
+        }],
+      },
+      {
+        version: 1,
+        entries: [{
+          path: ["x"],
+          label: { confidentiality: [{ anyOf: [B, A] }] },
+        }],
+      },
+    ]);
+    const entry = view!.entries.find((e) => e.path.join("/") === "x")!;
+    expect(entry.label.confidentiality).toHaveLength(1);
+    expect(isOrClause(entry.label.confidentiality![0])).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Stage **A3** of [the CFC plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md#2-epic-a--cnf-clause-label-representation): `mergeLabel` treats confidentiality as CNF clauses.

The join is clause **concatenation** (`[[A∨B]] ⊔ [C] = [[A∨B], C]` — the OR stays clause-local and `C` remains an independent gate), with each clause **normalized on ingest** so two OR-clauses differing only in alternative order coalesce through the existing structural dedup. It upholds the §3.1.8 prohibitions: `normalizeClause` only rewrites a clause's own interior, so distinct clauses are never merged, alternative sets never unioned, and an atom is never deduped across a singleton and an OR-clause containing it. Integrity (no OR-clauses) is left untouched.

## Tests

`cfc-clause-join.test.ts`: concatenation, order-coalescing, the no-merge / no-union / no-cross-clause-dedup prohibitions, singleton unwrap, flat + integrity untouched, and the same at a labelMap path via `mergeCfcLabelViews`. Label-view/merge regression suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make confidentiality label joins clause-concatenation in CNF with normalize-on-ingest. OR clauses are order-insensitive and clause boundaries are preserved; integrity is unchanged.

- **New Features**
  - `mergeLabel` concatenates confidentiality clauses and runs `normalizeClause` per clause (dedup, canonical order, singleton unwrap); applied only to confidentiality.
  - Coalesces equivalent clauses without merging distinct ones or unioning alternatives; no cross-clause atom dedup. Tests added for `mergeLabel` and `mergeCfcLabelViews`.

<sup>Written for commit e6ffe208a5d5d9a474d489417195eb25452e36fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

