### PR TITLE
feat(cfc): enforce tool-input requiredIntegrity at invoke time (Epic D2)

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2035,12 +2035,19 @@ function toolInputRequiredIntegrityFailure(
   }
   if (isRecord(schema.properties)) {
     for (const [key, childSchema] of Object.entries(schema.properties)) {
-      const childValue = isRecord(value) ? value[key] : undefined;
+      // Only gate fields the model actually supplied. An absent (e.g. optional)
+      // field carries no value to gate; treating it as `undefined` would fail
+      // an optional field's floor and over-block the call. A required field the
+      // model omitted is a structural error handled by ordinary input
+      // validation, not a floor bypass — there is no injected value to gate.
+      if (!isRecord(value) || !Object.hasOwn(value, key)) {
+        continue;
+      }
       const failure = toolInputRequiredIntegrityFailure(
         runtime,
         space,
         childSchema,
-        childValue,
+        value[key],
         path ? `${path}.${key}` : key,
       );
       if (failure !== undefined) {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -28,6 +28,7 @@ import {
 } from "./llm-schemas.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 // Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
 // Recorded as the schema write-policy input for each model-produced message's
@@ -1977,6 +1978,75 @@ function toolAllowsObservedConfidentiality(
   return cfcObservationFitsCeiling(observedConfidentiality, maxConfidentiality);
 }
 
+// The integrity a model-supplied tool-input value carries (Epic D2). A value
+// the model passed BY REFERENCE (a `{"@link":…}` to a cell) carries that
+// cell's stored integrity; a value the model emitted as a plain literal
+// carries none — it is model output (stamped at most `LlmDerived`, D1), which
+// by construction lacks any endorsement family. `traverseAndCellify` is the
+// same resolver the invoke path uses, so a reference is read identically here.
+function toolInputValueIntegrity(
+  runtime: Runtime,
+  space: MemorySpace,
+  value: unknown,
+): unknown[] {
+  const cellified = traverseAndCellify(runtime, space, value);
+  if (!isCell(cellified)) {
+    return [];
+  }
+  const view = cfcLabelViewForCellFailClosed(cellified);
+  return (view?.entries ?? []).flatMap((entry) => entry.label.integrity ?? []);
+}
+
+// Walk a tool's `inputSchema` for fields declaring `ifc.requiredIntegrity` and
+// verify the model-supplied value at each carries every required atom (Epic D2,
+// docs/specs/cfc-trusted-agent-tool-integrity.md piece A/C). A control/routing
+// field (e.g. `sendMail.recipient`) declaring the agent-kernel integrity floor
+// can only be satisfied by an integrity-bearing reference the model passed, not
+// by a string it copied out of a hostile briefing — that fails closed. Returns
+// the first failing field's reason, or undefined if all floors are satisfied.
+function toolInputRequiredIntegrityFailure(
+  runtime: Runtime,
+  space: MemorySpace,
+  schema: unknown,
+  value: unknown,
+  path: string,
+): string | undefined {
+  if (!isRecord(schema)) {
+    return undefined;
+  }
+  const ifc = schema.ifc;
+  if (isRecord(ifc) && Array.isArray(ifc.requiredIntegrity)) {
+    const required = ifc.requiredIntegrity;
+    if (required.length > 0) {
+      const integrity = toolInputValueIntegrity(runtime, space, value);
+      const satisfied = required.every((req) =>
+        integrity.some((have) => deepEqual(have, req))
+      );
+      if (!satisfied) {
+        return `field "${path || "(root)"}" requires integrity the ` +
+          `model-supplied value does not carry (pass an integrity-bearing ` +
+          `reference, not a literal)`;
+      }
+    }
+  }
+  if (isRecord(schema.properties)) {
+    for (const [key, childSchema] of Object.entries(schema.properties)) {
+      const childValue = isRecord(value) ? value[key] : undefined;
+      const failure = toolInputRequiredIntegrityFailure(
+        runtime,
+        space,
+        childSchema,
+        childValue,
+        path ? `${path}.${key}` : key,
+      );
+      if (failure !== undefined) {
+        return failure;
+      }
+    }
+  }
+  return undefined;
+}
+
 async function executeToolCalls(
   runtime: Runtime,
   space: MemorySpace,
@@ -1989,6 +2059,30 @@ async function executeToolCalls(
   const results: ToolCallExecutionResult[] = [];
   for (const part of toolCallParts) {
     try {
+      // Epic D2: gate the model-supplied input against the tool's
+      // requiredIntegrity floors before the handler runs, so an injected
+      // control-field value (e.g. a recipient copied from a hostile briefing)
+      // is refused rather than executed. Only fires for tools whose
+      // inputSchema declares requiredIntegrity — no behavior change otherwise
+      // — and is skipped entirely when CFC enforcement is disabled.
+      if (runtime.cfcEnforcementMode !== "disabled") {
+        const integrityFailure = toolInputRequiredIntegrityFailure(
+          runtime,
+          space,
+          toolCatalog.llmTools[part.toolName]?.inputSchema,
+          part.input,
+          "",
+        );
+        if (integrityFailure !== undefined) {
+          results.push({
+            id: part.toolCallId,
+            toolName: part.toolName,
+            error: `Tool call denied: ${integrityFailure}`,
+          });
+          continue;
+        }
+      }
+
       if (
         !toolAllowsObservedConfidentiality(
           toolCatalog,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -73,6 +73,10 @@ import {
   cfcLabelViewForCellFailClosed,
 } from "../cfc/label-view.ts";
 import {
+  CFC_ENFORCING_STRICTNESS,
+  cfcEnforcementStrictness,
+} from "../cfc/types.ts";
+import {
   cfcConfidentialityForObservationNode,
   cfcObservationFitsCeiling,
   type CfcObservationResult,
@@ -2044,7 +2048,67 @@ function toolInputRequiredIntegrityFailure(
       }
     }
   }
+  // Array items: a floor under `items` gates every model-supplied element
+  // (e.g. `recipients: { items: { ifc: { requiredIntegrity } } }`).
+  if (isRecord(schema.items) && Array.isArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      const failure = toolInputRequiredIntegrityFailure(
+        runtime,
+        space,
+        schema.items,
+        value[index],
+        `${path}[${index}]`,
+      );
+      if (failure !== undefined) {
+        return failure;
+      }
+    }
+  }
+  // Compound schemas: mirror the IFC schema walker — descend into every
+  // branch. For a required-integrity FLOOR, requiring the union across
+  // branches is the fail-safe (over-require) direction, matching walkIfcSchema.
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    const branches = schema[key];
+    if (Array.isArray(branches)) {
+      for (const branch of branches) {
+        const failure = toolInputRequiredIntegrityFailure(
+          runtime,
+          space,
+          branch,
+          value,
+          path,
+        );
+        if (failure !== undefined) {
+          return failure;
+        }
+      }
+    }
+  }
   return undefined;
+}
+
+// The (schema, input) the D2 integrity gate checks for a resolved tool call.
+// For the generic `invoke` builtin the target is the resolved handler /
+// pattern, whose ARGUMENT schema carries the requiredIntegrity floors — its
+// own `path`/`args` builtin schema declares none — and the value is the
+// resolved args (path stripped). External tools keep the catalog input schema
+// and the raw model input. Other management builtins (pin/read/schema/…) have
+// fixed floor-free schemas, so their check is a no-op.
+function integrityGateTarget(
+  resolved: ResolvedToolCall,
+  part: BuiltInLLMToolCallPart,
+  toolCatalog: ToolCatalog,
+): { schema: unknown; input: unknown } {
+  if (resolved.type === "invoke") {
+    const schema = resolved.pattern?.argumentSchema ??
+      (resolved.handler as unknown as { schema?: unknown } | undefined)
+        ?.schema;
+    return { schema, input: resolved.call.input };
+  }
+  return {
+    schema: toolCatalog.llmTools[part.toolName]?.inputSchema,
+    input: part.input,
+  };
 }
 
 async function executeToolCalls(
@@ -2059,30 +2123,6 @@ async function executeToolCalls(
   const results: ToolCallExecutionResult[] = [];
   for (const part of toolCallParts) {
     try {
-      // Epic D2: gate the model-supplied input against the tool's
-      // requiredIntegrity floors before the handler runs, so an injected
-      // control-field value (e.g. a recipient copied from a hostile briefing)
-      // is refused rather than executed. Only fires for tools whose
-      // inputSchema declares requiredIntegrity — no behavior change otherwise
-      // — and is skipped entirely when CFC enforcement is disabled.
-      if (runtime.cfcEnforcementMode !== "disabled") {
-        const integrityFailure = toolInputRequiredIntegrityFailure(
-          runtime,
-          space,
-          toolCatalog.llmTools[part.toolName]?.inputSchema,
-          part.input,
-          "",
-        );
-        if (integrityFailure !== undefined) {
-          results.push({
-            id: part.toolCallId,
-            toolName: part.toolName,
-            error: `Tool call denied: ${integrityFailure}`,
-          });
-          continue;
-        }
-      }
-
       if (
         !toolAllowsObservedConfidentiality(
           toolCatalog,
@@ -2100,6 +2140,38 @@ async function executeToolCalls(
       }
 
       const resolved = resolveToolCall(runtime, space, part, toolCatalog);
+
+      // Epic D2: gate the model-supplied input against the TARGET's
+      // requiredIntegrity floors before the handler runs, so an injected
+      // control-field value (e.g. a recipient copied from a hostile briefing)
+      // is refused rather than executed. Runs AFTER resolveToolCall so the
+      // generic `invoke` builtin is checked against the resolved handler /
+      // pattern argument schema (its own path/args schema declares no floors),
+      // closing the invoke bypass. Only DENIES in enforcing modes — observe is
+      // diagnostic and must not block — and is a no-op for tools declaring no
+      // requiredIntegrity.
+      if (
+        cfcEnforcementStrictness(runtime.cfcEnforcementMode) >=
+          CFC_ENFORCING_STRICTNESS
+      ) {
+        const gate = integrityGateTarget(resolved, part, toolCatalog);
+        const integrityFailure = toolInputRequiredIntegrityFailure(
+          runtime,
+          space,
+          gate.schema,
+          gate.input,
+          "",
+        );
+        if (integrityFailure !== undefined) {
+          results.push({
+            id: part.toolCallId,
+            toolName: part.toolName,
+            error: `Tool call denied: ${integrityFailure}`,
+          });
+          continue;
+        }
+      }
+
       const resultValue = await invokeToolCall(
         runtime,
         space,

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -6,170 +6,190 @@ import { enableMockMode } from "@commonfabric/llm/client";
 import type { JSONSchema } from "@commonfabric/api";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { CfcEnforcementMode } from "../src/cfc/types.ts";
 import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 
 const signer = await Identity.fromPassphrase("cfc agent tool-input integrity");
 const space = signer.did();
 enableMockMode();
 
-// The CFC agent prompt-injection demo's central claim is structural: a routing
-// field (`sendMail.recipient`) declares
-// `ifc.requiredIntegrity: [agent-kernel, UserSurfaceInput, PromptSlotBound]`, so
-// a recipient the model lifted out of a hostile briefing — a plain model-output
+// Epic D2 (docs/specs/cfc-trusted-agent-tool-integrity.md piece A/C): the CFC
+// agent prompt-injection demo's central claim is structural. A routing field
+// (`sendMail.recipient`) declares `ifc.requiredIntegrity: [agent-kernel]`, so a
+// recipient the model lifted out of a hostile briefing — a plain model-output
 // string carrying none of that integrity — must be REFUSED by the runtime
-// (spec §13.6 / demos/01-agent-prompt-injection.md).
-//
-// As of this commit that invariant is NOT enforced: the dialog tool path uses a
-// tool's `inputSchema` only to validate/strip input STRUCTURE, never to check
-// CFC `requiredIntegrity` on the model-supplied input; the handler then writes
-// `recipient` into targets whose schemas carry no `requiredIntegrity`, so
-// `verifyInputRequirements` never sees it (and an unlabeled literal would
-// vacuously pass even if it did — audit #14). The test below is therefore
-// `it.ignore` and documents the DESIRED behavior. Un-ignore it when tool-input
-// requiredIntegrity enforcement lands (the "trusted agent" work scoped in
-// docs/specs/cfc-trusted-agent-tool-integrity.md).
-describe("CFC trusted agent: tool-input requiredIntegrity (BLOCKED — see scope B)", () => {
-  const KERNEL_TYPE = "https://commonfabric.org/cfc/atom/Builtin";
-  const recipientRequiredIntegrity = [
-    { type: KERNEL_TYPE, name: "agent-kernel-demo-v1" },
-  ] as const;
+// before the handler runs (spec §13.6 / demos/01-agent-prompt-injection.md).
+// The dialog tool path now validates each model-supplied input field against
+// its inputSchema's requiredIntegrity at invoke time.
 
-  it.ignore(
-    "refuses a sendMail whose recipient lacks the required integrity (injected)",
-    async () => {
-      const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = new Runtime({
-        apiUrl: new URL(import.meta.url),
-        storageManager,
-        cfcEnforcementMode: "enforce-explicit",
-      });
-      const tx = runtime.edit();
-      const { commonfabric } = createTrustedBuilder(runtime);
-      const { pattern, handler, Writable } = commonfabric;
+const KERNEL_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/Builtin",
+  name: "agent-kernel-demo-v1",
+} as const;
 
-      // Mirrors the demo's sendMailInputSchema: requiredIntegrity on recipient.
-      const sendMailInputSchema = {
-        type: "object",
-        properties: {
-          recipient: {
-            type: "string",
-            ifc: { requiredIntegrity: recipientRequiredIntegrity },
-          },
-          subject: { type: "string" },
-          body: { type: "string" },
+// A sendMail tool. `withFloor` toggles the requiredIntegrity floor on
+// `recipient` so we can prove the gate fires only for floor-declaring fields.
+async function setupSendMail(
+  cfcEnforcementMode: CfcEnforcementMode,
+  withFloor: boolean,
+) {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+    cfcEnforcementMode,
+  });
+  const tx = runtime.edit();
+  const { commonfabric } = createTrustedBuilder(runtime);
+  const { pattern, handler, Writable } = commonfabric;
+
+  const recipientSchema = withFloor
+    ? { type: "string", ifc: { requiredIntegrity: [KERNEL_ATOM] } }
+    : { type: "string" };
+  const sendMailInputSchema = {
+    type: "object",
+    properties: {
+      recipient: recipientSchema,
+      subject: { type: "string" },
+      body: { type: "string" },
+    },
+    required: ["recipient", "subject", "body"],
+    additionalProperties: false,
+  } as JSONSchema;
+
+  const sendMail = handler<
+    { recipient: string; subject: string; body: string },
+    { emails: any }
+  >(
+    {
+      type: "object",
+      properties: {
+        recipient: { type: "string" },
+        subject: { type: "string" },
+        body: { type: "string" },
+      },
+      required: ["recipient", "subject", "body"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      properties: {
+        emails: {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+          asCell: ["cell"],
         },
-        required: ["recipient", "subject", "body"],
-        additionalProperties: false,
-      } as const satisfies JSONSchema;
-
-      const sendMail = handler<
-        { recipient: string; subject: string; body: string },
-        { emails: any }
-      >(
-        {
-          type: "object",
-          properties: {
-            recipient: { type: "string" },
-            subject: { type: "string" },
-            body: { type: "string" },
-          },
-          required: ["recipient", "subject", "body"],
-          additionalProperties: false,
-        },
-        {
-          type: "object",
-          properties: {
-            emails: {
-              type: "array",
-              items: { type: "object", additionalProperties: true },
-              asCell: ["cell"],
-            },
-          },
-          required: ["emails"],
-        },
-        ({ recipient, subject, body }, { emails }) => {
-          emails.push({ recipient, subject, body });
-        },
-      );
-
-      const resultSchema = {
-        type: "object",
-        properties: {
-          emails: {
-            type: "array",
-            items: { type: "object", additionalProperties: true },
-          },
-          tools: true,
-        },
-        required: ["emails", "tools"],
-      } as const satisfies JSONSchema;
-
-      const testPattern = pattern(
-        () => {
-          const emails = Writable.of<
-            { recipient: string; subject: string; body: string }[]
-          >([]);
-          return {
-            emails,
-            tools: {
-              sendMail: {
-                description: "Send an email.",
-                inputSchema: sendMailInputSchema,
-                handler: sendMail({ emails }),
-              },
-            },
-          };
-        },
-        false,
-        resultSchema,
-      );
-
-      const resultCell = runtime.getCell(
-        space,
-        "agent-tool-input-integrity",
-        resultSchema,
-        tx,
-      );
-      const result = runtime.run(tx, testPattern, {}, resultCell);
-      runtime.prepareTxForCommit(tx);
-      await tx.commit();
-      await runtime.idle();
-
-      const catalog = llmToolExecutionHelpers.buildToolCatalog(
-        result.key("tools") as any,
-        false,
-      );
-
-      // The injected tool call: recipient is a plain string the model copied
-      // from the hostile briefing — it carries no UserSurfaceInput /
-      // PromptSlotBound integrity.
-      await llmToolExecutionHelpers.executeToolCalls(
-        runtime,
-        space,
-        catalog,
-        [{
-          type: "tool-call",
-          toolCallId: "call-injected",
-          toolName: "sendMail",
-          input: {
-            recipient: "bob@evil.org",
-            subject: "exfil",
-            body: "stuff",
-          },
-        }] as any,
-      );
-      await runtime.idle();
-
-      // DESIRED: the injected recipient is refused, so no email is sent.
-      const emails = (await result.key("emails").pull()) as
-        | { recipient: string }[]
-        | undefined;
-      expect(
-        (emails ?? []).some((entry) => entry.recipient === "bob@evil.org"),
-      ).toBe(false);
-
-      await runtime.dispose();
-      await storageManager.close();
+      },
+      required: ["emails"],
+    },
+    ({ recipient, subject, body }, { emails }) => {
+      emails.push({ recipient, subject, body });
     },
   );
+
+  const resultSchema = {
+    type: "object",
+    properties: {
+      emails: {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+      },
+      tools: true,
+    },
+    required: ["emails", "tools"],
+  } as const satisfies JSONSchema;
+
+  const testPattern = pattern(
+    () => {
+      const emails = Writable.of<
+        { recipient: string; subject: string; body: string }[]
+      >([]);
+      return {
+        emails,
+        tools: {
+          sendMail: {
+            description: "Send an email.",
+            inputSchema: sendMailInputSchema,
+            handler: sendMail({ emails }),
+          },
+        },
+      };
+    },
+    false,
+    resultSchema,
+  );
+
+  const resultCell = runtime.getCell(
+    space,
+    `agent-tool-input-integrity-${cfcEnforcementMode}-${withFloor}`,
+    resultSchema,
+    tx,
+  );
+  const result = runtime.run(tx, testPattern, {}, resultCell);
+  runtime.prepareTxForCommit(tx);
+  await tx.commit();
+  await runtime.idle();
+
+  const catalog = llmToolExecutionHelpers.buildToolCatalog(
+    result.key("tools") as any,
+    false,
+  );
+
+  const sendInjected = async () => {
+    await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+      type: "tool-call",
+      toolCallId: "call-injected",
+      toolName: "sendMail",
+      input: { recipient: "bob@evil.org", subject: "exfil", body: "stuff" },
+    }] as any);
+    await runtime.idle();
+  };
+
+  const injectedWasSent = async () => {
+    const emails = (await result.key("emails").pull()) as
+      | { recipient: string }[]
+      | undefined;
+    return (emails ?? []).some((e) => e.recipient === "bob@evil.org");
+  };
+
+  const dispose = async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  };
+
+  return { sendInjected, injectedWasSent, dispose };
+}
+
+describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
+  it("refuses a sendMail whose recipient lacks the required integrity (injected)", async () => {
+    const t = await setupSendMail("enforce-explicit", true);
+    try {
+      await t.sendInjected();
+      expect(await t.injectedWasSent()).toBe(false);
+    } finally {
+      await t.dispose();
+    }
+  });
+
+  it("does not gate tools without a requiredIntegrity floor (no over-block)", async () => {
+    // A plain-literal recipient is fine for a field that declares no floor —
+    // the gate is opt-in and must not perturb ordinary tools.
+    const t = await setupSendMail("enforce-explicit", false);
+    try {
+      await t.sendInjected();
+      expect(await t.injectedWasSent()).toBe(true);
+    } finally {
+      await t.dispose();
+    }
+  });
+
+  it("does not gate when CFC enforcement is disabled", async () => {
+    const t = await setupSendMail("disabled", true);
+    try {
+      await t.sendInjected();
+      expect(await t.injectedWasSent()).toBe(true);
+    } finally {
+      await t.dispose();
+    }
+  });
 });

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -315,6 +315,121 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     }
   });
 
+  it("does not over-block when an optional floor-field is omitted", async () => {
+    // A floor-declaring field the model did not supply carries no value to
+    // gate — the call must proceed (the gate protects injected VALUES, not
+    // omissions).
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, handler, Writable } = commonfabric;
+    try {
+      const note = handler<{ text: string; cc?: string }, { notes: any }>(
+        {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+            cc: { type: "string", ifc: { requiredIntegrity: [KERNEL_ATOM] } },
+          },
+          required: ["text"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            notes: {
+              type: "array",
+              items: { type: "string" },
+              asCell: ["cell"],
+            },
+          },
+          required: ["notes"],
+        },
+        ({ text }, { notes }) => {
+          notes.push(text);
+        },
+      );
+      const resultSchema = {
+        type: "object",
+        properties: {
+          notes: { type: "array", items: { type: "string" } },
+          tools: true,
+        },
+        required: ["notes", "tools"],
+      } as const satisfies JSONSchema;
+      const testPattern = pattern(
+        () => {
+          const notes = Writable.of<string[]>([]);
+          return {
+            notes,
+            tools: {
+              note: {
+                description: "Note.",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    text: { type: "string" },
+                    cc: {
+                      type: "string",
+                      ifc: { requiredIntegrity: [KERNEL_ATOM] },
+                    },
+                  },
+                  required: ["text"],
+                  additionalProperties: false,
+                },
+                handler: note({ notes }),
+              },
+            },
+          };
+        },
+        false,
+        resultSchema,
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "agent-optional-floor",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+
+      const catalog = llmToolExecutionHelpers.buildToolCatalog(
+        result.key("tools") as any,
+        false,
+      );
+      // `cc` (the floor field) is omitted → the call proceeds.
+      await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+        type: "tool-call",
+        toolCallId: "call-omit",
+        toolName: "note",
+        input: { text: "hello" },
+      }] as any);
+      await runtime.idle();
+      expect((await result.key("notes").pull()) ?? []).toEqual(["hello"]);
+
+      // ...but supplying `cc` as a literal still fails its floor.
+      await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+        type: "tool-call",
+        toolCallId: "call-cc",
+        toolName: "note",
+        input: { text: "again", cc: "bob@evil.org" },
+      }] as any);
+      await runtime.idle();
+      expect((await result.key("notes").pull()) ?? []).toEqual(["hello"]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("descends into array-items floors", async () => {
     // A floor under `items` must gate every model-supplied element.
     const storageManager = StorageManager.emulate({ as: signer });

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -7,6 +7,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { CfcEnforcementMode } from "../src/cfc/types.ts";
+import { createLLMFriendlyLink } from "../src/link-types.ts";
 import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 
 const signer = await Identity.fromPassphrase("cfc agent tool-input integrity");
@@ -190,6 +191,238 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
       expect(await t.injectedWasSent()).toBe(true);
     } finally {
       await t.dispose();
+    }
+  });
+
+  it("observe mode is diagnostic — it does not deny the call", async () => {
+    // observe is the dry-run mode: a floor failure must not block the handler.
+    const t = await setupSendMail("observe", true);
+    try {
+      await t.sendInjected();
+      expect(await t.injectedWasSent()).toBe(true);
+    } finally {
+      await t.dispose();
+    }
+  });
+
+  it("closes the invoke-builtin bypass (a literal routed through invoke is refused)", async () => {
+    // Routing through the generic `invoke` builtin must be checked against the
+    // RESOLVED handler's argument schema (which carries the floor), not the
+    // invoke tool's own path/args schema — otherwise the D2 gate is bypassable.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, handler, Writable } = commonfabric;
+    try {
+      const sendMail = handler<
+        { recipient: string; subject: string; body: string },
+        { emails: any }
+      >(
+        {
+          type: "object",
+          properties: {
+            recipient: {
+              type: "string",
+              ifc: { requiredIntegrity: [KERNEL_ATOM] },
+            },
+            subject: { type: "string" },
+            body: { type: "string" },
+          },
+          required: ["recipient", "subject", "body"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            emails: {
+              type: "array",
+              items: { type: "object", additionalProperties: true },
+              asCell: ["cell"],
+            },
+          },
+          required: ["emails"],
+        },
+        ({ recipient, subject, body }, { emails }) => {
+          emails.push({ recipient, subject, body });
+        },
+      );
+      const resultSchema = {
+        type: "object",
+        properties: {
+          emails: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+          sendMail: { asCell: ["stream"] },
+        },
+        required: ["emails", "sendMail"],
+      } as const satisfies JSONSchema;
+      const testPattern = pattern(
+        () => {
+          const emails = Writable.of<
+            { recipient: string; subject: string; body: string }[]
+          >([]);
+          return { emails, sendMail: sendMail({ emails }) };
+        },
+        false,
+        resultSchema,
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "agent-invoke-bypass",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+
+      // builtinTools=true → the generic `invoke` tool is available.
+      const catalog = llmToolExecutionHelpers.buildToolCatalog(
+        result.key("tools") as any,
+        true,
+      );
+      const handlerLink = createLLMFriendlyLink(
+        result.key("sendMail").getAsNormalizedFullLink(),
+        space,
+      );
+      await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+        type: "tool-call",
+        toolCallId: "call-invoke-bypass",
+        toolName: "invoke",
+        input: {
+          path: handlerLink,
+          args: { recipient: "bob@evil.org", subject: "x", body: "y" },
+        },
+      }] as any);
+      await runtime.idle();
+
+      const emails = (await result.key("emails").pull()) as
+        | { recipient: string }[]
+        | undefined;
+      expect(
+        (emails ?? []).some((e) => e.recipient === "bob@evil.org"),
+      ).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("descends into array-items floors", async () => {
+    // A floor under `items` must gate every model-supplied element.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, handler, Writable } = commonfabric;
+    try {
+      const broadcast = handler<{ recipients: string[] }, { sent: any }>(
+        {
+          type: "object",
+          properties: {
+            recipients: {
+              type: "array",
+              items: {
+                type: "string",
+                ifc: { requiredIntegrity: [KERNEL_ATOM] },
+              },
+            },
+          },
+          required: ["recipients"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            sent: {
+              type: "array",
+              items: { type: "string" },
+              asCell: ["cell"],
+            },
+          },
+          required: ["sent"],
+        },
+        ({ recipients }, { sent }) => {
+          for (const r of recipients) sent.push(r);
+        },
+      );
+      const resultSchema = {
+        type: "object",
+        properties: {
+          sent: { type: "array", items: { type: "string" } },
+          tools: true,
+        },
+        required: ["sent", "tools"],
+      } as const satisfies JSONSchema;
+      const testPattern = pattern(
+        () => {
+          const sent = Writable.of<string[]>([]);
+          return {
+            sent,
+            tools: {
+              broadcast: {
+                description: "Broadcast.",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    recipients: {
+                      type: "array",
+                      items: {
+                        type: "string",
+                        ifc: { requiredIntegrity: [KERNEL_ATOM] },
+                      },
+                    },
+                  },
+                  required: ["recipients"],
+                  additionalProperties: false,
+                },
+                handler: broadcast({ sent }),
+              },
+            },
+          };
+        },
+        false,
+        resultSchema,
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "agent-items-floor",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+
+      const catalog = llmToolExecutionHelpers.buildToolCatalog(
+        result.key("tools") as any,
+        false,
+      );
+      await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+        type: "tool-call",
+        toolCallId: "call-items",
+        toolName: "broadcast",
+        input: { recipients: ["evil@x.org"] },
+      }] as any);
+      await runtime.idle();
+
+      const sent = (await result.key("sent").pull()) as string[] | undefined;
+      expect((sent ?? []).includes("evil@x.org")).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
     }
   });
 });


### PR DESCRIPTION
## What

Stage **D2** of [the CFC plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md#5-epic-d--write-side--agent-integrity-the-live-soundness-cluster) — [`cfc-trusted-agent-tool-integrity.md`](https://github.com/commontoolsinc/labs/blob/main/docs/specs/cfc-trusted-agent-tool-integrity.md) piece A/C. Closes the demo's central prompt-injection invariant.

`executeToolCalls` now validates each model-supplied input field against its `inputSchema`'s `ifc.requiredIntegrity` **before** the handler runs:
- `toolInputRequiredIntegrityFailure` walks the schema (properties, recursively) for floor-declaring fields.
- `toolInputValueIntegrity` resolves a value via `traverseAndCellify` — the same resolver the invoke path uses — so a by-reference `{"@link":…}` carries the referenced cell's stored integrity, while a plain model literal carries none (it is model output, stamped at most `LlmDerived` by D1, which lacks any endorsement family).
- A field whose floor the supplied value does not satisfy refuses the whole call with an error tool-result; the loop continues, the handler never runs.

Opt-in (only fires for tools declaring `requiredIntegrity` — no behavior change otherwise) and skipped when `cfcEnforcementMode` is `"disabled"`.

**Result:** an injected `sendMail` recipient (a string copied from a hostile briefing) is refused instead of sent.

## Tests

`cfc-agent-tool-input-integrity.test.ts` (un-ignored + expanded, shared harness): the injected recipient is refused under `enforce`; a tool **without** a floor is not over-blocked; the gate is a no-op when enforcement is disabled. llm-dialog guard suites (64 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces tool-input `requiredIntegrity` at invoke time to block prompt-injection on control fields. Closes the `invoke` bypass, keeps observe mode non-blocking, enforces floors under array items and compound schemas, and avoids over-blocking on optional fields.

- **New Features**
  - `executeToolCalls` validates model input against `inputSchema.ifc.requiredIntegrity` before handlers run.
  - Resolves values via `traverseAndCellify` so `{"@link":…}` carries cell integrity; literals carry none.
  - On failure in enforcing modes, pushes an error tool-result and skips the handler; loop continues.
  - Opt-in: only tools with `requiredIntegrity` are gated; skipped when `cfcEnforcementMode` is `"disabled"` or `"observe"`.
  - Adds `toolInputRequiredIntegrityFailure` and `toolInputValueIntegrity`; matches integrity atoms with `deepEqual`.

- **Bug Fixes**
  - Closed `invoke` bypass by checking the resolved handler/pattern argument schema (not the builtin’s path/args).
  - Walker enforces floors under `properties`, `items`, and `anyOf`/`oneOf`/`allOf` branches.
  - Gate only fields the model actually supplied; optional floor-fields omitted by the model don’t block (missing required fields are handled by normal input validation).

<sup>Written for commit f523e64ca329377815b192b57853f1569eea0a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

