### PR TITLE
feat(cfc): un-reserve sqlite any() → authored OR-clauses (Epic E1)

### DIFF
--- a/packages/memory/test/v2-sqlite-row-label-test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-test.ts
@@ -154,6 +154,44 @@ Deno.test("any() builds and validates an OR-clause (Epic E1)", () => {
   );
 });
 
+Deno.test("any() rejects a conjunctive alternative — no (A∧B)∨C → A∨B∨C widening (Epic E1)", () => {
+  // A direct all() as an any() alternative is rejected: union-flattening it
+  // would make the row readable by A alone even though the author required
+  // A AND B.
+  assertThrows(
+    () =>
+      table(EMAIL_COLUMNS, (f) => ({
+        confidentiality: any(
+          all(
+            principal("mailto", match(f.from, ADDR)),
+            principal("mailto", match(f.to, ADDR)),
+          ),
+          dbOwner(),
+        ),
+      })),
+    Error,
+    "all()/any()",
+  );
+  // ...and a when() gating an all() is rejected too (recursive check).
+  assertThrows(
+    () =>
+      table(EMAIL_COLUMNS, (f) => ({
+        confidentiality: any(
+          whenMatches(
+            f.auth,
+            /dmarc=pass/,
+            all(
+              principal("mailto", match(f.from, ADDR)),
+              principal("mailto", match(f.to, ADDR)),
+            ),
+          ),
+          dbOwner(),
+        ),
+      })),
+    Error,
+  );
+});
+
 Deno.test("a rule referencing an unknown column throws", () => {
   assertThrows(
     () =>

--- a/packages/memory/test/v2-sqlite-row-label-test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-test.ts
@@ -552,6 +552,41 @@ Deno.test("an anyOf node evaluates to a structural OR-clause (Epic E1)", () => {
   ]);
 });
 
+Deno.test("evalConf fails closed on a conjunctive any() alternative that bypassed validation (Epic E1)", () => {
+  // A raw wire spec (not built through table(), so validation was skipped)
+  // with a conjunction as an any() alternative must fail closed at eval —
+  // never union-flatten (A∧B)∨C into A∨B∨C. Both the direct all() and the
+  // when()-wrapped all() shapes are rejected.
+  const direct: RowLabelSpec = {
+    version: 1,
+    confidentiality: {
+      anyOf: [
+        { allOf: [{ dbOwner: true }, { constant: "x" }] },
+        { dbOwner: true },
+      ],
+    } as never,
+  };
+  const dRes = evaluateRowLabel(direct, {}, { dbOwner: OWNER });
+  assert("error" in dRes && dRes.error.includes("conjunction"));
+
+  const gated: RowLabelSpec = {
+    version: 1,
+    confidentiality: {
+      anyOf: [
+        {
+          when: { match: { field: "from", source: ADDR.source, flags: "" } },
+          then: { allOf: [{ dbOwner: true }, { constant: "x" }] },
+        },
+        { dbOwner: true },
+      ],
+    } as never,
+  };
+  const gRes = evaluateRowLabel(gated, { from: "a@b.example" }, {
+    dbOwner: OWNER,
+  });
+  assert("error" in gRes && gRes.error.includes("conjunction"));
+});
+
 Deno.test("an all() of any()-clauses is proper CNF (Epic E1)", () => {
   // all(any(owner ∨ from), to-participants) → (owner∨from) ∧ to.
   const spec = table(EMAIL_COLUMNS, (f) => ({

--- a/packages/memory/test/v2-sqlite-row-label-test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-test.ts
@@ -131,17 +131,26 @@ Deno.test("match() forces the global flag so split-on-match works", () => {
 // Fail-closed at authoring (table() throws)
 // ---------------------------------------------------------------------------
 
-Deno.test("any() errors at table() time until the clause-aware profile lands", () => {
-  assertThrows(
-    () =>
-      table(EMAIL_COLUMNS, (f) => ({
-        confidentiality: any(
-          principal("mailto", match(f.from, ADDR)),
-          dbOwner(),
-        ),
-      })),
-    TypeError,
-    "any(",
+Deno.test("any() builds and validates an OR-clause (Epic E1)", () => {
+  // any() no longer throws at table() time — it produces an authored OR-clause
+  // the runner's clause-aware profile enforces by subsumption.
+  const schema = table(EMAIL_COLUMNS, (f) => ({
+    confidentiality: any(
+      principal("mailto", match(f.from, ADDR)),
+      dbOwner(),
+    ),
+  }));
+  const spec = schema.rowLabel as RowLabelSpec;
+  assertEquals(
+    validateRowLabelSpec(spec, Object.keys(EMAIL_COLUMNS)),
+    undefined,
+  );
+  // An any() with no alternatives is rejected.
+  assert(
+    typeof validateRowLabelSpec(
+      { version: 1, confidentiality: { anyOf: [] } } as RowLabelSpec,
+      Object.keys(EMAIL_COLUMNS),
+    ) === "string",
   );
 });
 
@@ -235,13 +244,34 @@ Deno.test("validateRowLabelSpec re-validates a wire-supplied spec (fail closed)"
     validateRowLabelSpec(good, Object.keys(EMAIL_COLUMNS)),
     undefined,
   );
-  // anyOf smuggled over the wire is rejected, not silently flattened.
-  const smuggled = JSON.parse(JSON.stringify(good)) as RowLabelSpec;
-  (smuggled as { confidentiality: unknown }).confidentiality = {
-    anyOf: [{ dbOwner: true }],
-  };
+  // A well-formed anyOf over the wire now validates (Epic E1)...
+  const withClause = table(EMAIL_COLUMNS, (f) => ({
+    confidentiality: any(
+      dbOwner(),
+      principal("mailto", match(f.from, ADDR)),
+    ),
+  })).rowLabel as RowLabelSpec;
+  assertEquals(
+    validateRowLabelSpec(
+      JSON.parse(JSON.stringify(withClause)) as RowLabelSpec,
+      Object.keys(EMAIL_COLUMNS),
+    ),
+    undefined,
+  );
+  // ...but a malformed alternative (unknown column) is still rejected.
+  const badClause = {
+    version: 1,
+    confidentiality: {
+      anyOf: [{
+        principal: {
+          protocol: "mailto",
+          of: { match: { field: "nonesuch", source: ADDR.source, flags: "g" } },
+        },
+      }],
+    },
+  } as unknown as RowLabelSpec;
   assert(
-    typeof validateRowLabelSpec(smuggled, Object.keys(EMAIL_COLUMNS)) ===
+    typeof validateRowLabelSpec(badClause, Object.keys(EMAIL_COLUMNS)) ===
       "string",
   );
   // Unknown column in a wire spec is rejected.
@@ -469,12 +499,39 @@ Deno.test("dbOwner() with no owner in ctx fails closed", () => {
   );
 });
 
-Deno.test("an anyOf node reaching the evaluator fails closed (never silently flattened)", () => {
-  const spec: RowLabelSpec = {
-    version: 1,
-    confidentiality: { anyOf: [{ dbOwner: true }] } as never,
-  };
-  expectError(spec, {}, { dbOwner: OWNER }, "anyOf");
+Deno.test("an anyOf node evaluates to a structural OR-clause (Epic E1)", () => {
+  // any(dbOwner ∨ from-participants): the row is readable by the owner OR any
+  // sender — ONE OR-clause, not flattened into bare atoms.
+  const spec = table(EMAIL_COLUMNS, (f) => ({
+    confidentiality: any(dbOwner(), principal("mailto", match(f.from, ADDR))),
+  })).rowLabel as RowLabelSpec;
+  const res = evaluateRowLabel(spec, { from: "alice@a.example" }, {
+    dbOwner: OWNER,
+  });
+  if ("error" in res) throw new Error(`unexpected error: ${res.error}`);
+  assertEquals(res.confidentiality, [
+    { anyOf: [OWNER, "did:mailto:alice@a.example"] },
+  ]);
+});
+
+Deno.test("an all() of any()-clauses is proper CNF (Epic E1)", () => {
+  // all(any(owner ∨ from), to-participants) → (owner∨from) ∧ to.
+  const spec = table(EMAIL_COLUMNS, (f) => ({
+    confidentiality: all(
+      any(dbOwner(), principal("mailto", match(f.from, ADDR))),
+      principal("mailto", match(f.to, ADDR)),
+    ),
+  })).rowLabel as RowLabelSpec;
+  const res = evaluateRowLabel(
+    spec,
+    { from: "alice@a.example", to: "bob@example.com" },
+    { dbOwner: OWNER },
+  );
+  if ("error" in res) throw new Error(`unexpected error: ${res.error}`);
+  assertEquals(res.confidentiality, [
+    { anyOf: [OWNER, "did:mailto:alice@a.example"] },
+    "did:mailto:bob@example.com",
+  ]);
 });
 
 Deno.test("an unknown op reaching the evaluator fails closed", () => {

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -247,8 +247,8 @@ function regexLintReason(source: string): string | undefined {
 
 // Validate an `any(...)` node: every alternative must be a valid confidentiality
 // term (Epic E1). Atom-shape restrictions on alternatives (principal-like only;
-// no Caveat/Expires) are enforced runner-side at the boundary (§3.1.8), so this
-// only checks structural well-formedness of each alternative.
+// no Caveat/Expires) are enforced runner-side at the boundary (§3.1.8); here we
+// check structural well-formedness AND that no alternative is a conjunction.
 function validateConfAnyOf(
   node: Record<string, unknown>,
   columns: ReadonlySet<string>,
@@ -258,10 +258,38 @@ function validateConfAnyOf(
     return "any() needs at least one alternative";
   }
   for (const t of terms) {
-    const r = validateConfTerm(t, columns);
+    const r = validateAnyOfAlternative(t, columns);
     if (r) return r;
   }
   return undefined;
+}
+
+// An `any()` alternative is one INDEPENDENT reader (a disjunct), so it must be
+// a leaf that evaluates to reader atoms — `principal()`, `dbOwner()`,
+// `constant()`, or a `whenMatches(...)` gating one of those. A CONJUNCTION
+// (`all()`) or a nested `any()` is rejected: the evaluator's union-flatten
+// would turn `any(all(A,B), C)` into `A ∨ B ∨ C`, silently widening
+// `(A ∧ B) ∨ C` so a row becomes readable by A alone (CFC spec §3.1.8:
+// alternatives are principal-like atoms, not clauses). The `when` gate is
+// checked recursively so `whenMatches(…, all(A,B))` is rejected too.
+function validateAnyOfAlternative(
+  node: unknown,
+  columns: ReadonlySet<string>,
+): string | undefined {
+  if (isRecord(node) && ("allOf" in node || "anyOf" in node)) {
+    return "an any() alternative must be a single principal-like term, not " +
+      "all()/any() — a conjunction or nested disjunction cannot be an " +
+      "OR-clause alternative (CFC spec §3.1.8)";
+  }
+  if (isRecord(node) && "when" in node) {
+    const test = (node as { when?: unknown }).when;
+    const gate = isRecord(test) && "match" in test
+      ? validateMatchNode(test.match, columns, "when")
+      : "malformed when gate (use whenMatches())";
+    if (gate) return gate;
+    return validateAnyOfAlternative((node as { then?: unknown }).then, columns);
+  }
+  return validateConfTerm(node, columns);
 }
 
 function validateMatchNode(
@@ -599,12 +627,25 @@ function evalConf(
     const terms = node.anyOf;
     if (!Array.isArray(terms)) return fail("malformed any()");
     // One OR-clause: the alternatives are the union of what each term
-    // evaluates to (a `principal(match)` may yield several). The clause is
-    // ONE element of the row's conjunctive confidentiality list, so an
-    // enclosing `all(...)` concatenates it with sibling clauses
-    // (`all(any(A,B), C)` → `[{anyOf:[A,B]}, C]` = (A∨B)∧C). Kept structural,
-    // never flattened into bare atoms (Epic E1, CFC spec §3.1.8).
-    const alternatives = terms.flatMap((t) => evalConf(t, row, ctx));
+    // evaluates to (a `principal(match)` may yield several INDEPENDENT
+    // readers — a disjunction, which flattens correctly). The clause is ONE
+    // element of the row's conjunctive confidentiality list, so an enclosing
+    // `all(...)` concatenates it with sibling clauses (`all(any(A,B), C)` →
+    // `[{anyOf:[A,B]}, C]` = (A∨B)∧C). Kept structural, never flattened into
+    // bare atoms (Epic E1, CFC spec §3.1.8). Defense in depth against a wire
+    // spec that bypassed validation: reject a CONJUNCTION (`all()`) or nested
+    // `any()` as an alternative — union-flattening it would silently widen
+    // `(A∧B)∨C` into `A∨B∨C` (readable by A alone).
+    const alternatives: unknown[] = [];
+    for (const t of terms) {
+      if (isRecord(t) && ("allOf" in t || "anyOf" in t)) {
+        return fail(
+          "an any() alternative must not be all()/any() — a conjunction " +
+            "cannot be an OR-clause alternative (CFC spec §3.1.8)",
+        );
+      }
+      alternatives.push(...evalConf(t, row, ctx));
+    }
     return [{ anyOf: alternatives }];
   }
   if ("allOf" in node) {

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -9,10 +9,12 @@
 // commit, and read re-derivation. There is deliberately NO acting-principal
 // term (a read-time `currentUser()` would resolve to the *reader* — in an
 // OR-clause that self-grants access; the acting user belongs in the result
-// ceiling). `any(...)` (one authored OR-clause) serializes but is REJECTED by
-// validation until the runtime ships the clause-aware label profile (CFC spec
-// §18.5.3 rule 3) — authored OR semantics is never silently lowered to the
-// conjunctive form, and a smuggled `anyOf` fails closed at evaluation too.
+// ceiling). `any(...)` evaluates to one authored OR-clause `{anyOf:[…]}` — any
+// single alternative can read (CFC spec §18.5.3 / §3.1.8, Epic E1). The
+// runner's clause-aware label profile enforces subsumption at the boundary and
+// rejects non-principal-like alternatives (Caveat/Expires); this evaluator
+// keeps the disjunction structural, never silently lowered to conjunctive
+// atoms.
 //
 // Pure module: no FFI, no engine imports — safe for client-side import.
 
@@ -243,10 +245,24 @@ function regexLintReason(source: string): string | undefined {
   return undefined;
 }
 
-const ANY_REJECTION =
-  "any() requires the clause-aware label profile (CFC spec §18.5.3 rule 3) " +
-  "— an authored OR-clause is not enforceable on this runtime and is never " +
-  "silently lowered to the conjunctive form; use all() for now";
+// Validate an `any(...)` node: every alternative must be a valid confidentiality
+// term (Epic E1). Atom-shape restrictions on alternatives (principal-like only;
+// no Caveat/Expires) are enforced runner-side at the boundary (§3.1.8), so this
+// only checks structural well-formedness of each alternative.
+function validateConfAnyOf(
+  node: Record<string, unknown>,
+  columns: ReadonlySet<string>,
+): string | undefined {
+  const terms = node.anyOf;
+  if (!Array.isArray(terms) || terms.length === 0) {
+    return "any() needs at least one alternative";
+  }
+  for (const t of terms) {
+    const r = validateConfTerm(t, columns);
+    if (r) return r;
+  }
+  return undefined;
+}
 
 function validateMatchNode(
   node: unknown,
@@ -308,7 +324,7 @@ function validateConfTerm(
   columns: ReadonlySet<string>,
 ): string | undefined {
   if (!isRecord(node)) return "malformed confidentiality term";
-  if ("anyOf" in node) return ANY_REJECTION;
+  if ("anyOf" in node) return validateConfAnyOf(node, columns);
   if ("intersect" in node) {
     return "intersect() is integrity-only (the trust-floor meet); " +
       "confidentiality combines by all() — and any() once OR-clauses land";
@@ -340,7 +356,7 @@ function validateConfExpr(
   columns: ReadonlySet<string>,
 ): string | undefined {
   if (!isRecord(node)) return "malformed confidentiality expression";
-  if ("anyOf" in node) return ANY_REJECTION;
+  if ("anyOf" in node) return validateConfAnyOf(node, columns);
   if ("allOf" in node) {
     const terms = node.allOf;
     if (!Array.isArray(terms) || terms.length === 0) {
@@ -580,10 +596,16 @@ function evalConf(
 ): unknown[] {
   if (!isRecord(node)) return fail("malformed confidentiality term");
   if ("anyOf" in node) {
-    return fail(
-      "anyOf (authored OR-clause) is not evaluable on this runtime — " +
-        "fail closed, never flattened (CFC spec §18.5.3 rule 4)",
-    );
+    const terms = node.anyOf;
+    if (!Array.isArray(terms)) return fail("malformed any()");
+    // One OR-clause: the alternatives are the union of what each term
+    // evaluates to (a `principal(match)` may yield several). The clause is
+    // ONE element of the row's conjunctive confidentiality list, so an
+    // enclosing `all(...)` concatenates it with sibling clauses
+    // (`all(any(A,B), C)` → `[{anyOf:[A,B]}, C]` = (A∨B)∧C). Kept structural,
+    // never flattened into bare atoms (Epic E1, CFC spec §3.1.8).
+    const alternatives = terms.flatMap((t) => evalConf(t, row, ctx));
+    return [{ anyOf: alternatives }];
   }
   if ("allOf" in node) {
     const terms = node.allOf;

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -617,6 +617,20 @@ function evalPrincipal(
   );
 }
 
+// True if an `any()` alternative is (directly, or via a `when()` gate) a
+// conjunction/nested disjunction — the shape the evaluator must reject rather
+// than union-flatten. Mirrors `validateAnyOfAlternative`'s recursion so eval
+// fails closed on the same shape the validator rejects, even for a wire spec
+// that bypassed validation.
+function anyOfAlternativeHasConjunction(node: unknown): boolean {
+  if (!isRecord(node)) return false;
+  if ("allOf" in node || "anyOf" in node) return true;
+  if ("when" in node) {
+    return anyOfAlternativeHasConjunction((node as { then?: unknown }).then);
+  }
+  return false;
+}
+
 function evalConf(
   node: unknown,
   row: Record<string, unknown>,
@@ -638,10 +652,11 @@ function evalConf(
     // `(A∧B)∨C` into `A∨B∨C` (readable by A alone).
     const alternatives: unknown[] = [];
     for (const t of terms) {
-      if (isRecord(t) && ("allOf" in t || "anyOf" in t)) {
+      if (anyOfAlternativeHasConjunction(t)) {
         return fail(
-          "an any() alternative must not be all()/any() — a conjunction " +
-            "cannot be an OR-clause alternative (CFC spec §3.1.8)",
+          "an any() alternative must not be all()/any() (directly or under " +
+            "a when() gate) — a conjunction cannot be an OR-clause " +
+            "alternative (CFC spec §3.1.8)",
         );
       }
       alternatives.push(...evalConf(t, row, ctx));

--- a/packages/runner/test/sqlite-row-label-read.test.ts
+++ b/packages/runner/test/sqlite-row-label-read.test.ts
@@ -190,19 +190,33 @@ describe("computeRowLabelRead — per-row labels from origins", () => {
     expectError(res, "aggregate");
   });
 
-  it("an invalid wire-supplied spec refuses (smuggled anyOf — never flattened)", () => {
-    const tables = JSON.parse(JSON.stringify(emailTables)) as Record<
+  it("a well-formed anyOf wire spec is accepted; a malformed one refuses (Epic E1)", () => {
+    // A well-formed OR-clause validates and produces per-row labels...
+    const okTables = JSON.parse(JSON.stringify(emailTables)) as Record<
       string,
       { rowLabel?: { confidentiality?: unknown } }
     >;
-    tables.emails.rowLabel!.confidentiality = { anyOf: [{ dbOwner: true }] };
-    const res = computeRowLabelRead({
-      tables,
+    okTables.emails.rowLabel!.confidentiality = { anyOf: [{ dbOwner: true }] };
+    const ok = computeRowLabelRead({
+      tables: okTables,
       columns: FULL_COLUMNS,
       rows: ROWS,
       owner: OWNER,
     });
-    expectError(res, "any");
+    assert(!("error" in ok), "a well-formed anyOf should be accepted");
+    // ...but an empty anyOf (no alternatives) still refuses.
+    const badTables = JSON.parse(JSON.stringify(emailTables)) as Record<
+      string,
+      { rowLabel?: { confidentiality?: unknown } }
+    >;
+    badTables.emails.rowLabel!.confidentiality = { anyOf: [] };
+    const bad = computeRowLabelRead({
+      tables: badTables,
+      columns: FULL_COLUMNS,
+      rows: ROWS,
+      owner: OWNER,
+    });
+    expectError(bad, "any");
   });
 
   it("a query joining TWO rule-bearing tables refuses (cross-rule joins deferred)", () => {


### PR DESCRIPTION
## What

Stage **E1** of [the CFC plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md#6-epic-e--row-set-reads-per-row-labels--sqlite-3b3c): now that the runner ships the clause-aware label profile (Epic A), the sqlite row-label evaluator **emits OR-clauses** instead of rejecting `any()`.

- `validateConfTerm`/`validateConfExpr` validate an `any()` node's alternatives (structural well-formedness — atom-shape restrictions like principal-like-only / no `Caveat`/`Expires` are enforced runner-side at the boundary per §3.1.8).
- `evalConf` emits one `{anyOf:[…]}` clause whose alternatives are the union of what each term evaluates to, kept structural and never flattened into bare atoms. `all(any(A,B), C)` → `[{anyOf:[A,B]}, C]` = (A∨B)∧C.

This delivers the **"any participant may read"** per-row semantics the flat conjunctive form could not express (the email OR-set use case).

## Tests

- memory `v2-sqlite-row-label-test`: `any()` builds+validates an OR-clause; a well-formed wire `anyOf` validates while empty/malformed refuse; `evalConf` produces `{anyOf:[…]}`; `all`-of-`any` is proper CNF.
- runner `sqlite-row-label-read`: a well-formed `anyOf` wire spec is accepted, an empty one refuses.

Memory (35) + runner sqlite (49 steps) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds authored OR-clauses for sqlite row labels: `any()` now validates and evaluates to a single `{anyOf:[…]}` clause, enabling “any participant may read” and proper CNF like `all(any(A,B), C)`. Conjunctive or nested-OR `any()` alternatives (including under `when()`) are rejected and also fail closed at eval to prevent widening `(A∧B)∨C`.

- **New Features**
  - `any()` is accepted and validated; wire `anyOf` is allowed when well-formed and rejected when empty/malformed. Conjunctive or nested `any()` alternatives are refused, including under `when()`.
  - `evalConf` returns one structural OR-clause; never flattened to atoms. Defense in depth: rejects conjunctive or nested-OR alternatives at evaluation too, even if validation was skipped.

<sup>Written for commit d60565820c6cf5caaedad7523c0da1499ef2cc30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

