### PR TITLE
feat(cfc): sqlite read-time clearance (Phase 3.b, Epic E3)

### DIFF
--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -316,8 +316,10 @@ with the pure half in
 
 **Declared output ceiling.** A query may declare the maximum confidentiality
 its result may carry — a consumer contract checked per row against the
-computed label (per-row joined with the projection's per-column atoms), **not**
-reader clearance (no read-time clearance model exists):
+computed label (per-row joined with the projection's per-column atoms). It is
+**not** reader clearance: the ceiling asks "may the result carry this?", not
+"may *this reader* see it?". Read-time clearance is a separate, opt-in mode
+(below).
 
 ```tsx
 // Shown for illustration only.
@@ -346,6 +348,42 @@ existence release (CFC spec §8.17.2, invariant 14): opt-in in the query
 contract, required to be policy-permitted and auditable — and it never applies
 to aggregates (a withheld row already contributed server-side; a count cannot
 be un-counted), where the mode is rejected outright.
+
+**Read-time clearance (Phase 3.b).** Filtering by *who is asking*, rather than
+by a declared contract: `db.query(sql, { readClearance: true })` keeps only the
+rows the **acting reader** may read and drops the rest. A reader may read a row
+iff, for **every** conjunctive clause of the row's re-derived confidentiality,
+the reader is one of that clause's alternatives (the label stores concrete
+principals — `dbOwner()` is resolved at eval time — so this is exact-match; a
+non-principal atom like a caveat is never reader-satisfiable, so the row is
+withheld — fail closed). Because dropping a row releases its presence bit, this
+is a **declared existence release** (CFC spec §8.17, invariant 14) and requires
+all three:
+
+- **(a) declared** in the query contract (the explicit `readClearance` option —
+  never a silent fallback);
+- **(b) policy-permitted**: the touched rule-bearing table must opt in with
+  `table(columns, rule, { allowReadClearance: true })` (serialized as
+  `rowLabelReadClearance` on the schema). A clearance query against a table that
+  has not opted in **refuses**; so does one that touches no rule-bearing table,
+  or that runs with no acting principal;
+- **(c) auditable**: the query result reports `withheld` — the count of rows the
+  reader could not read — so the release is observable in aggregate without
+  leaking which rows were dropped.
+
+It **never applies to aggregates** (a null-origin projection has no per-row
+reader to test), where the mode is rejected outright. Read-time clearance
+composes with a declared ceiling: a row survives only if **both** the contract
+admits it and the reader may read it.
+
+```tsx
+// Shown for illustration only.
+// Per-user mailbox view: each reader sees only their own messages.
+const mine = db.query<Row>("SELECT * FROM messages ORDER BY id", {
+  readClearance: true,
+});
+// mine.withheld === (rows the acting reader may not read)
+```
 
 ### Write — the runner gate (`db.exec`)
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2330,8 +2330,15 @@ export interface ISqliteQueryable {
       maxConfidentiality?: ReadonlyArray<unknown>;
       /** `"fail"` (default) | `"skip"` when a row exceeds the ceiling. */
       onExceed?: "fail" | "skip";
+      /** CFC Phase 3.b: filter rows to those the acting reader may read (a
+       *  declared existence release). Requires the table to opt in via
+       *  `table(…, { allowReadClearance: true })`; never for aggregates. The
+       *  count of withheld rows is reported as `withheld`. */
+      readClearance?: boolean;
     },
-  ): Reactive<{ pending: boolean; result?: Row[]; error?: any }>;
+  ): Reactive<
+    { pending: boolean; result?: Row[]; error?: any; withheld?: number }
+  >;
 }
 
 /**
@@ -2387,10 +2394,18 @@ export type SqliteQueryParams = {
    *  refuse the whole query) or `"skip"` (drop the offending rows; a declared
    *  existence release, row-returning queries only — never aggregates). */
   onExceed?: "fail" | "skip";
+  /** CFC Phase 3.b read-time clearance: when `true`, filter rows to those the
+   *  acting reader may read (a declared existence release under §8.17/inv-14).
+   *  Requires the touched rule-bearing table to opt in via
+   *  `table(…, { allowReadClearance: true })`; never for aggregates. The number
+   *  of withheld rows is reported back as `withheld`. */
+  readClearance?: boolean;
 };
 export type SqliteQueryFunction = <Row = Record<string, unknown>>(
   params: FactoryInput<SqliteQueryParams>,
-) => Reactive<{ pending: boolean; result?: Row[]; error?: any }>;
+) => Reactive<
+  { pending: boolean; result?: Row[]; error?: any; withheld?: number }
+>;
 
 // Writes are the imperative SqliteDb.exec method (see ISqliteExecutable), which
 // folds a `sqlite` op into the caller's commit (atomic with cell writes). There
@@ -2414,6 +2429,10 @@ export type SqliteRowLabelRule = (
 export type SqliteTableFunction = (
   columns: Record<string, SqliteColumnSpec>,
   rule?: SqliteRowLabelRule,
+  /** CFC Phase 3.b: `{ allowReadClearance: true }` opts the table into
+   *  read-time clearance (reader-filtered `db.query({ readClearance: true })`).
+   *  Needs a `rule` — throws at `table()` time without one. */
+  opts?: { allowReadClearance?: boolean },
 ) => JSONSchema;
 
 /**

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -119,10 +119,16 @@ function normalizeColumn(name: string, spec: ColumnSpec): ColumnSchema {
  * 3); it is built + validated eagerly — a malformed rule throws here, at
  * definition time — and serializes onto the schema as `rowLabel` (see
  * `row-label.ts` and docs/specs/sqlite-builtin/06-cfc.md).
+ *
+ * `opts.allowReadClearance` opts the table into CFC Phase 3.b read-time
+ * clearance: a `readClearance` query may then filter rows to those the acting
+ * reader can read (a declared existence release). It needs a `rowLabel` rule —
+ * clearance filters rows by their per-row label — so it throws without one.
  */
 export function table<C extends Record<string, ColumnSpec>>(
   columns: C,
   rule?: RowLabelRule<C>,
+  opts?: { allowReadClearance?: boolean },
 ): TableSchema {
   const properties: Record<string, ColumnSchema> = {};
   const required: string[] = [];
@@ -133,6 +139,15 @@ export function table<C extends Record<string, ColumnSpec>>(
   const schema: TableSchema = { type: "object", properties, required };
   if (rule !== undefined) {
     schema.rowLabel = buildRowLabelSpec(Object.keys(columns), rule);
+  }
+  if (opts?.allowReadClearance) {
+    if (rule === undefined) {
+      throw new Error(
+        "table(): allowReadClearance needs a rowLabel rule — read-time " +
+          "clearance filters rows by their per-row label",
+      );
+    }
+    schema.rowLabelReadClearance = true;
   }
   return schema;
 }

--- a/packages/runner/integration/sqlite-cfc-row-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-row-label.test.ts
@@ -67,9 +67,12 @@ async function runTest(base: URL) {
         const countPending = result.key("qCount").key("pending").get() as
           | boolean
           | unknown;
+        const clearPending = result.key("qClear").key("pending").get() as
+          | boolean
+          | unknown;
         if (
           qPending === false && skimPending === false &&
-          countPending === false
+          countPending === false && clearPending === false
         ) {
           const arr = result.key("q").key("result").getRaw() as
             | unknown[]
@@ -217,10 +220,37 @@ async function runTest(base: URL) {
         );
       }
 
+      // --- Read-time clearance (Phase 3.b): the owner satisfies no row's
+      // conjunctive rule (the did:mailto participants are required too), so a
+      // cleared query returns zero rows and reports withheld: 2. ---
+      const clearErr = result.key("qClear").key("error").getRaw();
+      const cleared = result.key("qClear").key("result").get() as
+        | unknown[]
+        | undefined;
+      const withheld = result.key("qClear").key("withheld").get() as unknown;
+      if (clearErr !== undefined) {
+        throw new Error(
+          `qClear should not error; got ${JSON.stringify(clearErr)}`,
+        );
+      }
+      if (!Array.isArray(cleared) || cleared.length !== 0) {
+        throw new Error(
+          `qClear should withhold every row for the owner; got ${
+            JSON.stringify(cleared)
+          }`,
+        );
+      }
+      if (withheld !== 2) {
+        throw new Error(
+          `qClear should report withheld: 2; got ${JSON.stringify(withheld)}`,
+        );
+      }
+
       console.log(
         "=== TEST PASSED: per-row data-derived labels (distinct per row, " +
           "origin-resolved, integrity-gated); aggregate failed closed; " +
-          "ceiling+skip returned exactly the fitting row ===",
+          "ceiling+skip returned exactly the fitting row; read-time clearance " +
+          "withheld all rows the owner cannot read ===",
       );
     } finally {
       cancelSink();

--- a/packages/runner/integration/sqlite-cfc-row-label.test.tsx
+++ b/packages/runner/integration/sqlite-cfc-row-label.test.tsx
@@ -62,6 +62,8 @@ export default pattern(() => {
         authoredBy(principal("mailto", match(f.from_addr, ADDR, { min: 1 }))),
       ),
     }),
+    // Phase 3.b: opt the table into read-time clearance.
+    { allowReadClearance: true },
   );
 
   const db = sqliteDatabase({ tables: { emails } });
@@ -94,5 +96,16 @@ export default pattern(() => {
     },
   );
 
-  return { q, qCount, qSkim, seed: seed({ db }) };
+  // Phase 3.b read-time clearance: the acting reader is the db owner (a
+  // did:key), but every emails row's CONJUNCTIVE rule also requires the row's
+  // did:mailto participants — which the owner is not — so the owner may read no
+  // row. A cleared query therefore returns zero rows and reports withheld: 2 (a
+  // declared, audited existence release). Proves the whole path end-to-end:
+  // option -> reader resolution -> per-row reader test -> withheld surfaced.
+  const qClear = db.query<{ id: number; body: string }>(
+    "SELECT id, from_addr, to_addrs, auth, body FROM emails ORDER BY id",
+    { reactOn: db, readClearance: true },
+  );
+
+  return { q, qCount, qSkim, qClear, seed: seed({ db }) };
 });

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -560,7 +560,19 @@ export function sqliteQuery(
         typeof (inputs.db as SqliteDbRef).id === "string")
       ? (inputs.db as SqliteDbRef).scope
       : undefined;
-    const scope = narrowestScope([outputBinding?.scope, dbScope]);
+    // CFC Phase 3.b: a read-time-clearance result is filtered to the ACTING
+    // READER, so it must never be shared across readers. Force it to (at least)
+    // per-`user` scope so each reader gets an isolated result cell — otherwise a
+    // space-scoped result cell would let one reader observe another's filtered
+    // rows (the shared cell + reader-independent request hash both leak).
+    const clearanceScope: CellScope | undefined = inputs?.readClearance
+      ? "user"
+      : undefined;
+    const scope = narrowestScope([
+      outputBinding?.scope,
+      dbScope,
+      clearanceScope,
+    ]);
 
     if (!initialized || resultScope !== scope) {
       result = makeResultCell<QueryState>(
@@ -597,6 +609,13 @@ export function sqliteQuery(
       maxConfidentiality: inputs.maxConfidentiality ?? null,
       onExceed: inputs.onExceed ?? null,
       readClearance: inputs.readClearance ?? null,
+      // Phase 3.b: a cleared result depends on WHO is asking, so the acting
+      // reader is part of the query identity (belt-and-suspenders with the
+      // per-user result scope above — a cleared result is never keyed only by
+      // the boolean). Absent for non-clearance queries so they do not re-hash.
+      clearanceReader: inputs.readClearance
+        ? (runtime.trustSnapshotProvider()?.actingPrincipal ?? null)
+        : null,
     });
     // Dedup against COMMITTED state: if the result cell already records this
     // request hash, the call was issued (and survives an abort+retry, unlike an

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -512,6 +512,10 @@ type QueryState = {
   result?: unknown[];
   error?: unknown;
   requestHash?: string;
+  /** CFC Phase 3.b read-time clearance audit: how many rows the acting reader
+   *  could not read were withheld (a declared existence release). Absent when
+   *  no clearance was requested. */
+  withheld?: number;
 };
 
 /** sqliteQuery: reactive server-side read. */
@@ -543,6 +547,10 @@ export function sqliteQuery(
       // MaxConfidentiality<> on the Row schema (rowSchema.ifc).
       maxConfidentiality?: unknown[];
       onExceed?: unknown;
+      // CFC Phase 3.b: opt into read-time clearance — filter rows to those the
+      // acting reader may read (a declared existence release). Requires the
+      // touched rule-bearing table to permit it (rowLabelReadClearance).
+      readClearance?: unknown;
     } | undefined;
 
     // The query result holds rows from a scope-partitioned db, so it must be at
@@ -588,6 +596,7 @@ export function sqliteQuery(
       // them re-issues the query (pre-existing queries re-hash once — benign).
       maxConfidentiality: inputs.maxConfidentiality ?? null,
       onExceed: inputs.onExceed ?? null,
+      readClearance: inputs.readClearance ?? null,
     });
     // Dedup against COMMITTED state: if the result cell already records this
     // request hash, the call was issued (and survives an abort+retry, unlike an
@@ -685,11 +694,17 @@ export function sqliteQuery(
             staticConfidentiality: staticConfidentialityOf(labelSchema),
             ceiling,
             onExceed: inputs.onExceed,
+            // Phase 3.b read-time clearance: the reader is the acting principal
+            // (same identity the ceiling placeholders resolve against).
+            readClearance: inputs.readClearance
+              ? { reader: runtime.trustSnapshotProvider()?.actingPrincipal }
+              : undefined,
           });
           if ("error" in rowLabels) {
             await failQuery(rowLabels.error);
             return;
           }
+          const withheld = rowLabels.withheld;
           // onExceed:"skip" — drop rows the declared ceiling does not admit
           // (a declared, observable existence release; 06-cfc.md ceiling).
           const keep = rowLabels.keep;
@@ -724,6 +739,7 @@ export function sqliteQuery(
               pending: false,
               result: resultRows,
               requestHash: hash,
+              ...(withheld !== undefined ? { withheld } : {}),
             });
             // Per-row label attachment (CFC Phase 3): each row split into its
             // own entity doc above; write each labeled row doc DIRECTLY (its

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -17,6 +17,7 @@ import {
 } from "@commonfabric/memory/sqlite/row-label";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
+import { clauseAlternatives } from "../../cfc/clause.ts";
 
 interface ResultColumn {
   output: string;
@@ -46,6 +47,11 @@ export interface RowLabelReadArgs {
   ceiling?: readonly unknown[];
   /** What to do when a row's label exceeds the ceiling (default "fail"). */
   onExceed?: unknown;
+  /** CFC Phase 3.b read-time clearance: when set, keep only rows the acting
+   *  reader may read (a declared existence release, §8.17/inv-14). Requires the
+   *  rule-bearing table to opt in (`rowLabelReadClearance`); never for
+   *  aggregates. `reader` is the acting principal (undefined → refuse). */
+  readClearance?: { reader: string | undefined };
 }
 
 export type RowLabelReadResult =
@@ -54,8 +60,13 @@ export type RowLabelReadResult =
     /** Per kept-order row: the per-row label for its row entity doc, or
      *  undefined when the row carries no per-row label. */
     labels: (PerRowIfc | undefined)[];
-    /** Row keep-mask under a declared ceiling (undefined: no ceiling). */
+    /** Row keep-mask under a declared ceiling and/or read-time clearance
+     *  (undefined: neither declared). */
     keep: boolean[] | undefined;
+    /** CFC Phase 3.b: rows withheld because the acting reader could not read
+     *  them (a declared, audited existence release). 0/undefined when no
+     *  clearance was requested. */
+    withheld?: number;
   };
 
 const isRecord = (x: unknown): x is Record<string, unknown> =>
@@ -105,6 +116,23 @@ function intersectCommonAlternatives(
   return { kind: "readers", atoms: acc === undefined ? [] : [...acc.values()] };
 }
 
+// CFC Phase 3.b — whether the acting reader may read a row carrying this
+// confidentiality label: EVERY conjunctive clause must list the reader among
+// its alternatives (an AND of ORs). A public row (no confidentiality) is
+// readable by all. Per-row labels store concrete principals (dbOwner() is
+// resolved to the owner at eval time), so an alternative admits the reader iff
+// it is exactly the reader principal; a non-principal alternative
+// (Caveat/Expires/material-risk marker) never admits a plain reader, so the row
+// is withheld — fail closed.
+function readerAdmitsLabel(
+  confidentiality: readonly unknown[],
+  reader: string,
+): boolean {
+  return confidentiality.every((clause) =>
+    clauseAlternatives(clause).some((alt) => alt === reader)
+  );
+}
+
 /**
  * Compute each result row's per-row label from the declared rules and the
  * projection's TRUE column origins, then apply the declared output ceiling.
@@ -132,8 +160,13 @@ export function computeRowLabelRead(
   const onExceed = (args.onExceed ?? "fail") as "fail" | "skip";
 
   // Discover + re-validate rule-bearing tables (db.tables is wire-supplied;
-  // "couldn't validate" is never "no label").
-  const rules: { name: string; spec: RowLabelSpec }[] = [];
+  // "couldn't validate" is never "no label"). `allowReadClearance` is the
+  // per-table policy opt-in for Phase 3.b read-time clearance.
+  const rules: {
+    name: string;
+    spec: RowLabelSpec;
+    allowReadClearance: boolean;
+  }[] = [];
   for (const [name, t] of Object.entries(tables ?? {})) {
     if (!tableDeclaresRowLabel(t)) continue;
     const spec = (t as { rowLabel: RowLabelSpec }).rowLabel;
@@ -147,7 +180,13 @@ export function computeRowLabelRead(
           reason,
       };
     }
-    rules.push({ name, spec });
+    rules.push({
+      name,
+      spec,
+      allowReadClearance:
+        (t as { rowLabelReadClearance?: unknown }).rowLabelReadClearance ===
+          true,
+    });
   }
 
   const nullOrigin =
@@ -292,7 +331,67 @@ export function computeRowLabelRead(
     }
   }
 
-  return { labels, keep };
+  // CFC Phase 3.b — read-time clearance (§8.17/inv-14). A declared existence
+  // release: keep only rows the acting reader may read. Requires (a) the query
+  // opted in (readClearance), (b) the touched rule-bearing table permits it
+  // (rowLabelReadClearance), (c) it is audited (withheld count). Never for
+  // aggregates — an aggregate has no per-row reader test.
+  let withheld: number | undefined;
+  if (args.readClearance !== undefined) {
+    if (nullOrigin) {
+      return {
+        error: "sqlite: read-time clearance never applies to an aggregate/" +
+          "expression projection — there is no per-row reader to test; remove " +
+          "readClearance or query the underlying rows directly",
+      };
+    }
+    const applicable = rules.filter((r) =>
+      columns?.some((c) => c.table === r.name)
+    );
+    if (applicable.length === 0) {
+      return {
+        error: "sqlite: read-time clearance needs a rule-bearing table with " +
+          "per-row labels to filter, but this query touches none — remove " +
+          "readClearance",
+      };
+    }
+    const forbidden = applicable.filter((r) => !r.allowReadClearance);
+    if (forbidden.length > 0) {
+      return {
+        error:
+          "sqlite: read-time clearance is not permitted by the governing " +
+          `policy of table ${
+            forbidden.map((r) => `"${r.name}"`).join(", ")
+          } — pass { allowReadClearance: true } to table() to opt in`,
+      };
+    }
+    const reader = args.readClearance.reader;
+    if (reader === undefined) {
+      return {
+        error: "sqlite: read-time clearance needs the acting reader, but no " +
+          "acting principal is available — refusing (fail closed)",
+      };
+    }
+    const staticConf = args.staticConfidentiality ?? [];
+    const clearanceKeep: boolean[] = [];
+    withheld = 0;
+    for (let i = 0; i < rows.length; i++) {
+      const effective = [
+        ...(labels[i]?.confidentiality ?? []),
+        ...staticConf,
+      ];
+      const admits = readerAdmitsLabel(effective, reader);
+      if (!admits) withheld++;
+      clearanceKeep.push(admits);
+    }
+    // Intersect with any ceiling keep-mask: a row survives iff BOTH the declared
+    // contract admits it and the reader may read it.
+    keep = keep === undefined
+      ? clearanceKeep
+      : keep.map((k, i) => k && clearanceKeep[i]);
+  }
+
+  return { labels, keep, withheld };
 }
 
 /**

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2329,8 +2329,11 @@ export class CellImpl<T extends FabricValue>
       reactOn?: unknown;
       maxConfidentiality?: ReadonlyArray<unknown>;
       onExceed?: "fail" | "skip";
+      readClearance?: boolean;
     },
-  ): Reactive<{ pending: boolean; result?: Row[]; error?: unknown }> {
+  ): Reactive<
+    { pending: boolean; result?: Row[]; error?: unknown; withheld?: number }
+  > {
     return sqliteQueryNodeFactory({
       db: this,
       sql,
@@ -2339,11 +2342,15 @@ export class CellImpl<T extends FabricValue>
       // CFC Phase 3 read surface: the declared output ceiling + exceed mode.
       maxConfidentiality: options?.maxConfidentiality,
       onExceed: options?.onExceed,
+      // CFC Phase 3.b: read-time clearance (reader-filtered rows).
+      readClearance: options?.readClearance,
       // Forward the transformer-injected `<Row>` schema (lowered into the
       // options object) to the node so the builtin can decode `_cf_link`
       // columns. Read loosely — it is not part of the public options type.
       rowSchema: (options as { rowSchema?: unknown } | undefined)?.rowSchema,
-    }) as Reactive<{ pending: boolean; result?: Row[]; error?: unknown }>;
+    }) as Reactive<
+      { pending: boolean; result?: Row[]; error?: unknown; withheld?: number }
+    >;
   }
 
   map<S>(

--- a/packages/runner/test/sqlite-row-label-read.test.ts
+++ b/packages/runner/test/sqlite-row-label-read.test.ts
@@ -6,7 +6,7 @@
 // attach, ceiling"; "Fail-closed rules").
 
 import { describe, it } from "@std/testing/bdd";
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   computeRowLabelRead,
   resolveCeilingPlaceholders,
@@ -550,5 +550,143 @@ describe("resolveCeilingPlaceholders", () => {
       { actingPrincipal: "did:key:zMe" },
     );
     assert("error" in noOwner);
+  });
+});
+
+describe("computeRowLabelRead — read-time clearance (Phase 3.b, Epic E3)", () => {
+  // A per-user mailbox: each row readable by the owner OR its sender OR its
+  // recipient (a disjunctive rule, un-reserved in E1), opted into clearance.
+  const mailboxTables = {
+    msgs: table(
+      { id: "integer", from: "text", to: "text", body: "text" },
+      (f) => ({
+        confidentiality: any(
+          dbOwner(),
+          principal("mailto", match(f.from, ADDR)),
+          principal("mailto", match(f.to, ADDR)),
+        ),
+      }),
+      { allowReadClearance: true },
+    ),
+  };
+  const MB_COLS = [
+    col("id", "msgs", "id"),
+    col("from", "msgs", "from"),
+    col("to", "msgs", "to"),
+    col("body", "msgs", "body"),
+  ];
+  const MB_ROWS = [
+    { id: 1, from: "alice@a.example", to: "bob@x.example", body: "hi bob" },
+    { id: 2, from: "carol@c.example", to: "dave@d.example", body: "hi dave" },
+    { id: 3, from: "bob@x.example", to: "erin@e.example", body: "to erin" },
+  ];
+  // Principal atoms are `did:mailto:<addr>` (see evalPrincipal).
+  const BOB = "did:mailto:bob@x.example";
+
+  it("keeps only rows the acting reader may read; withheld count is exact", () => {
+    const res = expectOk(computeRowLabelRead({
+      tables: mailboxTables,
+      columns: MB_COLS,
+      rows: MB_ROWS,
+      owner: OWNER,
+      readClearance: { reader: BOB },
+    }));
+    // bob is recipient of row 1 and sender of row 3; row 2 is carol↔dave.
+    assertEquals(res.keep, [true, false, true]);
+    assertEquals(res.withheld, 1);
+    // Kept rows still carry their per-row label for the row-doc write.
+    assert(res.labels[0]?.confidentiality);
+  });
+
+  it("the db owner is a common reader — sees every row, withholds none", () => {
+    const res = expectOk(computeRowLabelRead({
+      tables: mailboxTables,
+      columns: MB_COLS,
+      rows: MB_ROWS,
+      owner: OWNER,
+      readClearance: { reader: OWNER },
+    }));
+    assertEquals(res.keep, [true, true, true]);
+    assertEquals(res.withheld, 0);
+  });
+
+  it("intersects with a declared ceiling keep-mask — both must admit the row", () => {
+    // A permissive ceiling naming the owner fits every row (each clause lists
+    // the owner), so the combined mask is exactly the clearance mask.
+    const res = expectOk(computeRowLabelRead({
+      tables: mailboxTables,
+      columns: MB_COLS,
+      rows: MB_ROWS,
+      owner: OWNER,
+      ceiling: [OWNER],
+      onExceed: "skip",
+      readClearance: { reader: BOB },
+    }));
+    assertEquals(res.keep, [true, false, true]);
+    assertEquals(res.withheld, 1);
+  });
+
+  it("refuses when the table's policy does not opt into clearance", () => {
+    const noPolicy = {
+      msgs: table(
+        { id: "integer", from: "text", to: "text", body: "text" },
+        (f) => ({
+          confidentiality: any(
+            dbOwner(),
+            principal("mailto", match(f.from, ADDR)),
+            principal("mailto", match(f.to, ADDR)),
+          ),
+        }),
+      ),
+    };
+    const res = computeRowLabelRead({
+      tables: noPolicy,
+      columns: MB_COLS,
+      rows: MB_ROWS,
+      owner: OWNER,
+      readClearance: { reader: BOB },
+    });
+    expectError(res, "not permitted by the governing policy");
+  });
+
+  it("never applies to an aggregate (null-origin) projection", () => {
+    const res = computeRowLabelRead({
+      tables: mailboxTables,
+      columns: [col("cnt", null, null)],
+      rows: [{ cnt: 3 }],
+      owner: OWNER,
+      readClearance: { reader: BOB },
+    });
+    expectError(res, "aggregate");
+  });
+
+  it("refuses without an acting reader (fail closed)", () => {
+    const res = computeRowLabelRead({
+      tables: mailboxTables,
+      columns: MB_COLS,
+      rows: MB_ROWS,
+      owner: OWNER,
+      readClearance: { reader: undefined },
+    });
+    expectError(res, "acting reader");
+  });
+
+  it("refuses when the query touches no rule-bearing table", () => {
+    const res = computeRowLabelRead({
+      tables: { plain: table({ id: "integer", x: "text" }) },
+      columns: [col("id", "plain", "id"), col("x", "plain", "x")],
+      rows: [{ id: 1, x: "a" }],
+      owner: OWNER,
+      readClearance: { reader: BOB },
+    });
+    expectError(res, "touches none");
+  });
+
+  it("table() rejects allowReadClearance without a rowLabel rule", () => {
+    assertThrows(
+      () => table({ id: "integer" }, undefined, { allowReadClearance: true }),
+      Error,
+      "needs a rowLabel rule",
+    );
   });
 });


### PR DESCRIPTION
## What

Epic E3 of the [CFC future-work plan](docs/plans/cfc-future-work-implementation.md): **read-time clearance** for sqlite reads — filter query rows to those the *acting reader* may read. This is Phase 3.b: filtering by *who is asking*, distinct from the declared output ceiling (a contract on what the result may carry).

A reader may read a row iff, for **every** conjunctive clause of the row's re-derived confidentiality, the reader is one of that clause's alternatives. Per-row labels store concrete principals (`dbOwner()` resolved at eval time), so this is exact-match; a non-principal atom (caveat/expires) is never reader-satisfiable → the row is withheld (fail closed).

Per CFC spec §8.17/inv-14, dropping a row releases its presence bit, so it is a **declared existence release** requiring all three:
- **(a) declared** — the explicit `readClearance: true` query option (never a silent fallback);
- **(b) policy-permitted** — the touched rule-bearing table must opt in via `table(columns, rule, { allowReadClearance: true })`;
- **(c) auditable** — the result reports `withheld` (count of rows the reader could not read).

Never applies to aggregates (no per-row reader to test). Composes with a declared ceiling (a row survives iff **both** admit it).

## Changes

- **Core** ([row-label-read.ts](packages/runner/src/builtins/sqlite/row-label-read.ts)): `readClearance: { reader }` → `readerAdmitsLabel` keep-mask + `withheld`; refuses on aggregate / no reader / no rule-bearing table / table not opted in.
- **Policy opt-in** ([schema.ts](packages/memory/v2/sqlite/schema.ts)): `table(columns, rule, { allowReadClearance: true })` → `rowLabelReadClearance`; throws without a rule.
- **Plumbing**: `readClearance` on `db.query` ([cell.ts](packages/runner/src/cell.ts), [api types](packages/api/index.ts)) → inputs → reader = acting principal → `computeRowLabelRead`; `withheld` surfaced on the query result state ([sqlite-builtins.ts](packages/runner/src/builtins/sqlite-builtins.ts)).
- **Tests**: 8 unit tests (mailbox keep/withhold, owner-sees-all, ceiling intersect, policy refusal, aggregate refusal, no reader, no rule-table, builder throw) + an end-to-end integration case (owner withheld from every conjunctive-rule row, `withheld: 2`).
- **Doc**: [06-cfc.md](docs/specs/sqlite-builtin/06-cfc.md) "Read-time clearance (Phase 3.b)" section; corrected the stale "no read-time clearance model exists" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-time clearance for sqlite reads: `db.query({ readClearance: true })` filters rows to those the acting reader may read and reports `withheld` for audit. Also isolates cleared results per reader by scoping result cells to `user` and hashing the acting reader to prevent cross-user reuse.

- **New Features**
  - Reader filtering: a row is kept only if the reader appears in every clause of its re-derived confidentiality; intersects with any declared ceiling; never for aggregates.
  - API: adds `readClearance?: boolean` to `db.query` and `withheld?: number` on results; the runner resolves the reader from the acting principal.
  - Policy opt-in and safety: `table(columns, rule, { allowReadClearance: true })`; refuses when no rule, no acting principal, no rule-bearing table, or when the table hasn’t opted in; docs and tests included.

- **Bug Fixes**
  - Cleared results are now per-reader: forced per-`user` result scope and the acting principal is included in the request hash; non-clearance queries are unchanged.

<sup>Written for commit 52e3e7e75b03b9bdb3dc2271bba0aa7a94c1427a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

