### PR TITLE
feat(cfc): write-side requiredIntegrity floor (Epic D3, SC-18)

### DIFF
--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -242,6 +242,27 @@ is a **requirement**, and tightening it is the restrictive (allowed)
 direction — the two must not be conflated. Write-side floor checking needs a
 home in §8.10 (today §8.10.3 is input/consume-side only).
 
+The **integrity-direction code home is now landed (Epic D3, `verifyWriteFloor`
+in `prepare.ts`)** behind the `cfcWriteFloor: off | observe | enforce` dial
+(default `off`, orthogonal to the enforcement and flow dials). It tests the
+**written value's** integrity — the schema-derived label (`addIntegrity` mints
++ `exactCopyOf` carry, evidence-gated by `gateRuntimeMintedIntegrity` so a
+pattern cannot forge runtime-minted atoms to pass its own floor), each link
+written at/under the path (the linked source's own label — the D2 by-reference
+contract on the write side, one contribution per link so no laundering across
+siblings), and the flow hereditary meet when flow labels persist — against the
+floor with **exact-match** membership via the single shared predicate
+`cfcIntegritySatisfiesFloor` (observation.ts), which the read-side gate and the
+D2 tool-input floor now also call so D5's pattern/concept upgrade lands in one
+place. SC-18's own semantics are honored: floor-is-a-minimum, overwrite checked
+against the declared floor only (no meet across successive writes, no prior-
+value consultation), and empty integrity on a floor-declaring path fails (a
+stamped-`LlmDerived`-only value fails any floor by construction — closing the
+write-side half of the vacuous pass). Wildcard (`*`) floor entries and
+pattern-setup/seed initialization stay exempt (v1 scope); (a) the standard-
+profile default, (b) `enforce-strict` making writer-fit itself reject, and (c)
+the §8.10 spec home remain open.
+
 **SC-19 [clarify] Blanket "confidentiality always joins" dependency.**
 Verified open (the rule is stated as fact in §15.1 and §3.1.2, nowhere
 recorded as a revisit-trigger assumption). Record the assumption where the

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -28,7 +28,6 @@ import {
 } from "./llm-schemas.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 // Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
 // Recorded as the schema write-policy input for each model-produced message's
@@ -78,6 +77,7 @@ import {
 } from "../cfc/types.ts";
 import {
   cfcConfidentialityForObservationNode,
+  cfcIntegritySatisfiesFloor,
   cfcObservationFitsCeiling,
   type CfcObservationResult,
   joinCfcObservedConfidentiality,
@@ -2023,9 +2023,9 @@ function toolInputRequiredIntegrityFailure(
     const required = ifc.requiredIntegrity;
     if (required.length > 0) {
       const integrity = toolInputValueIntegrity(runtime, space, value);
-      const satisfied = required.every((req) =>
-        integrity.some((have) => deepEqual(have, req))
-      );
+      // The single shared floor predicate (observation.ts) — the same
+      // membership the commit-boundary gates use; D5 upgrades it in one place.
+      const satisfied = cfcIntegritySatisfiesFloor(integrity, required);
       if (!satisfied) {
         return `field "${path || "(root)"}" requires integrity the ` +
           `model-supplied value does not carry (pass an integrity-bearing ` +

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -32,6 +32,7 @@ export type {
   CfcStreamObservation,
   CfcStreamSegment,
   CfcTxState,
+  CfcWriteFloorMode,
   ConsumedRead,
   EntityDocumentWithCfc,
   IFCLabel,
@@ -47,6 +48,7 @@ export {
   cfcEnforcementStrictness,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   DEFAULT_CFC_FLOW_LABELS_MODE,
+  DEFAULT_CFC_WRITE_FLOOR_MODE,
   isCfcEnforcementMode,
 } from "./types.ts";
 export {

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -118,6 +118,23 @@ export const cfcObservationFitsCeiling = (
 };
 
 /**
+ * Integrity-floor membership (§8.10.3 / §8.12.4.1): every required atom must
+ * be structurally present in the carried integrity. Exact-match today — this
+ * is THE single shared predicate for the read-side gate
+ * (`verifyInputRequirements`), the write-side floor (`verifyWriteFloor`, Epic
+ * D3), and the tool-input floor (llm-dialog, Epic D2), so D5's upgrade to
+ * pattern/concept matching (`matchAtomPattern` + `conceptSatisfied`) lands in
+ * ONE place instead of diverging across three inlined copies.
+ */
+export const cfcIntegritySatisfiesFloor = (
+  integrity: readonly unknown[],
+  requiredIntegrity: readonly unknown[],
+): boolean =>
+  requiredIntegrity.every((required) =>
+    integrity.some((actual) => deepEqual(actual, required))
+  );
+
+/**
  * The confidentiality CLAUSES in `confidentiality` that fall OUTSIDE `ceiling`
  * (the complement that makes `cfcObservationFitsCeiling` false). Fit is CNF
  * clause subsumption (spec §8.10.3, Epic A2): a label clause `l` is admitted

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3216,7 +3216,20 @@ const verifyWriteFloor = (
       : [];
     if (floor.length === 0) continue;
     if (entry.path.includes("*")) continue;
+    // A link written at a strict ANCESTOR of the floor path swaps the whole
+    // container: the value now living at the floor path is the linked source's
+    // value at the corresponding nested path. This case must be checked even
+    // when `ifcEntryAppliesToAttemptedWrite` is false — for a fresh doc the
+    // nested value reconstructs as `undefined` through the link and the entry
+    // would otherwise be SKIPPED, letting an unendorsed linked child enter a
+    // floor-protected slot unchecked (codex/cubic review).
+    const ancestorLinks = ctx.linkWriteInputs.filter((input) => {
+      const linkPath = canonicalizeLogicalPath(input.target.path);
+      return linkPath.length < entry.path.length &&
+        concretePathHasPrefix(entry.path, linkPath);
+    });
     if (
+      ancestorLinks.length === 0 &&
       !ifcEntryAppliesToAttemptedWrite(
         tx,
         target,
@@ -3256,6 +3269,31 @@ const verifyWriteFloor = (
       // An underivable link (`reason` set, `label` undefined) contributes empty
       // integrity — it fails the floor, fail-closed, alongside the persist
       // loop's own missing-source reason (both reject).
+      contributions.push(derived.label?.integrity ?? []);
+    }
+    for (const input of ancestorLinks) {
+      // Re-point the derivation at the floor path INSIDE the linked source:
+      // the value at the floor path is source.path + (floor − linkPath), so
+      // the credit is the source's own label at that nested path (an endorsed
+      // nested value passes; an unendorsed one fails, fail-closed).
+      const linkPath = canonicalizeLogicalPath(input.target.path);
+      const relative = entry.path.slice(linkPath.length);
+      const derived = derivePersistedLinkLabel(
+        tx,
+        {
+          ...input,
+          source: {
+            ...input.source,
+            path: [
+              ...canonicalizeLogicalPath(input.source.path),
+              ...relative,
+            ],
+          },
+          target: { ...input.target, path: entry.path },
+        },
+        ctx.candidateSchemas,
+        ctx.identityForInput(input),
+      );
       contributions.push(derived.label?.integrity ?? []);
     }
     const written = writeValueForTarget(tx, { ...target, path: entry.path });
@@ -3535,7 +3573,12 @@ export const prepareBoundaryCommit = (
         identityForInput,
         linkWriteInputs,
         candidateSchemas: candidates,
-        flowIntegrity: flowMode === "off" ? [] : flowIntegrity,
+        // Only PERSISTED flow integrity may credit the floor: `observe` mode
+        // computes the join for diagnostics but stores nothing on the value, so
+        // crediting it would let a plain write pass a floor with integrity that
+        // never lands (codex/cubic review). Only `persist` writes the derived
+        // component.
+        flowIntegrity: flowPersist ? flowIntegrity : [],
       });
       if (floorFailures.length > 0) {
         if (state.writeFloorMode === "enforce") {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3157,6 +3157,37 @@ const verifySinkRequestCeilings = (
   return reasons;
 };
 
+// Applied write paths at/under `path` on this target, from the storage-level
+// write details. Used by the write floor to detect plain-data descendant
+// writes that link contributions do not cover. Deliberately NOT the
+// reactivity log (`ifcEntryAppliesToAttemptedWrite`'s second source): an
+// attempted-but-unapplied write lands no value — the floor's per-path value
+// probe excludes it anyway — and the structural skip decision still falls
+// back to `ifcEntryAppliesToAttemptedWrite`, which consults the log.
+const attemptedWritePathsUnder = (
+  tx: IExtendedStorageTransaction,
+  target: {
+    space: MemorySpace;
+    id: URI;
+    scope: ReturnType<typeof normalizeCellScope>;
+  },
+  path: readonly string[],
+): (readonly string[])[] => {
+  const out: (readonly string[])[] = [];
+  for (const write of tx.getWriteDetails?.(target.space) ?? []) {
+    if (
+      write.address.id !== target.id ||
+      normalizeCellScope(write.address.scope) !== target.scope ||
+      write.address.path[0] !== "value"
+    ) {
+      continue;
+    }
+    const writePath = write.address.path.slice(1).map((entry) => String(entry));
+    if (concretePathHasPrefix(writePath, path)) out.push(writePath);
+  }
+  return out;
+};
+
 /**
  * Epic D3 — the write-side `requiredIntegrity` FLOOR (§8.12.4.1 / SC-18),
  * dual of the read-side gate in `verifyInputRequirements`: where that gate
@@ -3216,20 +3247,34 @@ const verifyWriteFloor = (
       : [];
     if (floor.length === 0) continue;
     if (entry.path.includes("*")) continue;
-    // A link written at a strict ANCESTOR of the floor path swaps the whole
-    // container: the value now living at the floor path is the linked source's
-    // value at the corresponding nested path. This case must be checked even
-    // when `ifcEntryAppliesToAttemptedWrite` is false — for a fresh doc the
-    // nested value reconstructs as `undefined` through the link and the entry
-    // would otherwise be SKIPPED, letting an unendorsed linked child enter a
-    // floor-protected slot unchecked (codex/cubic review).
+    // Floor applicability is STRUCTURAL — did anything land at/under the floor
+    // path, or does a link cover it? It must never hinge solely on the
+    // value-conditioned `ifcEntryAppliesToAttemptedWrite`, whose schema/value
+    // matcher can return false for values that genuinely landed (e.g. a nested
+    // link sigil at a typed slot) and would silently skip the floor — letting
+    // unendorsed data through (review). The value-conditioned check remains
+    // only as a widening fallback for ancestor-write shapes the structural
+    // sources miss; over-applying a floor to a non-matching union arm
+    // over-rejects (fail-closed), never leaks.
+    const linksHere = ctx.linkWriteInputs.filter((input) =>
+      concretePathHasPrefix(
+        canonicalizeLogicalPath(input.target.path),
+        entry.path,
+      )
+    );
+    // A link written at a strict ANCESTOR swaps the whole container: the value
+    // now living at the floor path is the linked source's value at the
+    // corresponding nested path (for a fresh doc it reconstructs as
+    // `undefined`, so this must not depend on the value matcher either).
     const ancestorLinks = ctx.linkWriteInputs.filter((input) => {
       const linkPath = canonicalizeLogicalPath(input.target.path);
       return linkPath.length < entry.path.length &&
         concretePathHasPrefix(entry.path, linkPath);
     });
+    const writesUnder = attemptedWritePathsUnder(tx, target, entry.path);
     if (
-      ancestorLinks.length === 0 &&
+      linksHere.length === 0 && ancestorLinks.length === 0 &&
+      writesUnder.length === 0 &&
       !ifcEntryAppliesToAttemptedWrite(
         tx,
         target,
@@ -3252,12 +3297,6 @@ const verifyWriteFloor = (
     // One contribution per link written at/under the floor path (each linked
     // value must individually carry the floor), plus one `value` contribution
     // when plain data was written (crediting the flow meet when available).
-    const linksHere = ctx.linkWriteInputs.filter((input) =>
-      concretePathHasPrefix(
-        canonicalizeLogicalPath(input.target.path),
-        entry.path,
-      )
-    );
     const contributions: (readonly unknown[])[] = [];
     for (const input of linksHere) {
       const derived = derivePersistedLinkLabel(
@@ -3297,17 +3336,39 @@ const verifyWriteFloor = (
       contributions.push(derived.label?.integrity ?? []);
     }
     const written = writeValueForTarget(tx, { ...target, path: entry.path });
-    // A pure-link value at the path is judged by its per-link contributions
-    // alone. Anything else — plain/mixed data, or an unreconstructable
-    // descendant-only write (value undefined ⇒ `isPureLinkStructure` true, so
-    // this fires only when no link contribution was recorded) — is a value
-    // write that must satisfy the floor from base + the flow meet. Fail-closed:
-    // a container floor whose links ride alongside plain siblings is treated as
-    // a value write (over-enforcing, never under).
-    // `valueWritten` is true whenever this isn't a pure-link write — including
-    // the no-contribution case (no links recorded), so `contributions` is
-    // always non-empty past this point and the floor is always evaluated.
-    const valueWritten = !isPureLinkStructure(written) ||
+    // A value contribution exists when plain data lands at/under the floor
+    // path, judged three ways (any one suffices, fail-closed):
+    // - the reconstructed value at the path is not pure link structure
+    //   (plain/mixed data written at or above the path);
+    // - some attempted write at/under the path carries a value and is not
+    //   covered by a link input — the descendant-only mixed case (one child a
+    //   link, a sibling plain data) where the parent may reconstruct as
+    //   pure-link or undefined and would otherwise be judged by the link
+    //   contributions alone (review). The per-path value probe keeps DELETE
+    //   details (no value) out;
+    // - nothing else contributed at all (a value-shaped write with no link
+    //   inputs — e.g. a raw sigil smuggled without link policy inputs), so the
+    //   floor is still evaluated, fail-closed.
+    const descendantValueWrite = writesUnder.some((writePath) =>
+      !linksHere.some((input) =>
+        concretePathHasPrefix(
+          writePath,
+          canonicalizeLogicalPath(input.target.path),
+        )
+      ) &&
+      writeValueForTarget(tx, { ...target, path: writePath }) !== undefined
+    );
+    // Nothing landed anywhere: a pure delete/clear — absence is not a floored
+    // value (the floor governs values written, not removals).
+    if (
+      written === undefined && !descendantValueWrite &&
+      contributions.length === 0
+    ) {
+      continue;
+    }
+    const valueWritten =
+      (written !== undefined && !isPureLinkStructure(written)) ||
+      descendantValueWrite ||
       contributions.length === 0;
     if (valueWritten) contributions.push(ctx.flowIntegrity);
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3157,40 +3157,6 @@ const verifySinkRequestCeilings = (
   return reasons;
 };
 
-// Attempted write paths strictly at/under `path` on this target — the same two
-// enumeration sources `ifcEntryAppliesToAttemptedWrite` quantifies over.
-const attemptedWritePathsUnder = (
-  tx: IExtendedStorageTransaction,
-  target: {
-    space: MemorySpace;
-    id: URI;
-    scope: ReturnType<typeof normalizeCellScope>;
-  },
-  path: readonly string[],
-): (readonly string[])[] => {
-  const out: (readonly string[])[] = [];
-  for (const write of tx.getWriteDetails?.(target.space) ?? []) {
-    if (write.address.id !== target.id) continue;
-    if (normalizeCellScope(write.address.scope) !== target.scope) continue;
-    if (write.address.path[0] !== "value") continue;
-    const writePath = write.address.path.slice(1).map((entry) => String(entry));
-    if (concretePathHasPrefix(writePath, path)) out.push(writePath);
-  }
-  for (
-    const write of [
-      ...(tx.getReactivityLog?.().writes ?? []),
-      ...(tx.getReactivityLog?.().attemptedWrites ?? []),
-    ]
-  ) {
-    if (write.space !== target.space) continue;
-    if (write.id !== target.id) continue;
-    if (normalizeCellScope(write.scope) !== target.scope) continue;
-    const writePath = canonicalizeLogicalPath(write.path);
-    if (concretePathHasPrefix(writePath, path)) out.push(writePath);
-  }
-  return out;
-};
-
 /**
  * Epic D3 — the write-side `requiredIntegrity` FLOOR (§8.12.4.1 / SC-18),
  * dual of the read-side gate in `verifyInputRequirements`: where that gate
@@ -3212,10 +3178,11 @@ const attemptedWritePathsUnder = (
  *   carry the per-tx derived integrity).
  *
  * Scope (v1, exact-match membership — D5 upgrades to pattern/concept):
- * wildcard (`*`) floor entries stay read-gate-only; the same pattern-setup
- * escape as `writeAuthorizedBy` applies (a pattern's declared initialization
- * must be able to bootstrap the doc it protects); a pure delete (no written
- * value) is not a floored write — the floor governs values, not absence.
+ * wildcard (`*`) floor entries stay read-gate-only; unlike `writeAuthorizedBy`
+ * there is NO pattern-setup escape — the floor is a value requirement, so a
+ * setup that writes a floored path must itself mint the required integrity
+ * (`addIntegrity`), fail-closed; a pure delete (no written value) is not a
+ * floored write — the floor governs values, not absence.
  */
 const verifyWriteFloor = (
   tx: IExtendedStorageTransaction,
@@ -3260,13 +3227,6 @@ const verifyWriteFloor = (
     ) {
       continue;
     }
-    const setupProjection = setupProjectionSourceMatchesValue(
-      tx,
-      target,
-      entry.path,
-    ) || writeIsPatternSetupInitialization(tx, target, entry.path) ||
-      writeIsSeedMaterialization(tx, target);
-    if (setupProjection) continue;
 
     // The label this commit persists at the path: schema integrity +
     // `addIntegrity` mints + `exactCopyOf` carry, evidence-gated so a pattern
@@ -3293,29 +3253,25 @@ const verifyWriteFloor = (
         ctx.candidateSchemas,
         ctx.identityForInput(input),
       );
-      // An underivable link label already records its own fail-closed reason
-      // in the persist loop — the floor does not double-report it.
-      if (derived.reason !== undefined) continue;
+      // An underivable link (`reason` set, `label` undefined) contributes empty
+      // integrity — it fails the floor, fail-closed, alongside the persist
+      // loop's own missing-source reason (both reject).
       contributions.push(derived.label?.integrity ?? []);
     }
     const written = writeValueForTarget(tx, { ...target, path: entry.path });
-    const valueWritten = written !== undefined
-      // A pure-link value at the path is judged by its link contributions —
-      // unless none were recorded, which fails closed as a value write.
-      ? !isPureLinkStructure(written) || contributions.length === 0
-      // Only descendant writes touched the region: any of them not covered by
-      // a link input is plain data.
-      : attemptedWritePathsUnder(tx, target, entry.path).some((writePath) =>
-        !linksHere.some((input) =>
-          concretePathHasPrefix(
-            writePath,
-            canonicalizeLogicalPath(input.target.path),
-          )
-        )
-      );
+    // A pure-link value at the path is judged by its per-link contributions
+    // alone. Anything else — plain/mixed data, or an unreconstructable
+    // descendant-only write (value undefined ⇒ `isPureLinkStructure` true, so
+    // this fires only when no link contribution was recorded) — is a value
+    // write that must satisfy the floor from base + the flow meet. Fail-closed:
+    // a container floor whose links ride alongside plain siblings is treated as
+    // a value write (over-enforcing, never under).
+    // `valueWritten` is true whenever this isn't a pure-link write — including
+    // the no-contribution case (no links recorded), so `contributions` is
+    // always non-empty past this point and the floor is always evaluated.
+    const valueWritten = !isPureLinkStructure(written) ||
+      contributions.length === 0;
     if (valueWritten) contributions.push(ctx.flowIntegrity);
-    // No contribution at all: a delete/clear — absence is not a floored value.
-    if (contributions.length === 0) continue;
 
     const misses = contributions.some((extra) =>
       !cfcIntegritySatisfiesFloor([...base, ...extra], floor)

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -42,7 +42,11 @@ import { atomPropagationClass } from "./atom-classes.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
 import { clauseAlternatives, isOrClause, normalizeClause } from "./clause.ts";
 import { externalIngestStamp } from "./external-ingest.ts";
-import { atomsOutsideCeiling, uniqueCfcAtoms } from "./observation.ts";
+import {
+  atomsOutsideCeiling,
+  cfcIntegritySatisfiesFloor,
+  uniqueCfcAtoms,
+} from "./observation.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
@@ -2532,10 +2536,9 @@ const verifyInputRequirements = (
     const requiredIntegrity = ifc?.requiredIntegrity ?? [];
     if (requiredIntegrity.length > 0 && gatedReads.length > 0) {
       const ok = gatedReads.every((read) =>
-        requiredIntegrity.every((required) =>
-          (read.label?.integrity ?? []).some((actual) =>
-            deepEqual(actual, required)
-          )
+        cfcIntegritySatisfiesFloor(
+          read.label?.integrity ?? [],
+          requiredIntegrity,
         )
       );
       if (!ok) {
@@ -3154,6 +3157,180 @@ const verifySinkRequestCeilings = (
   return reasons;
 };
 
+// Attempted write paths strictly at/under `path` on this target — the same two
+// enumeration sources `ifcEntryAppliesToAttemptedWrite` quantifies over.
+const attemptedWritePathsUnder = (
+  tx: IExtendedStorageTransaction,
+  target: {
+    space: MemorySpace;
+    id: URI;
+    scope: ReturnType<typeof normalizeCellScope>;
+  },
+  path: readonly string[],
+): (readonly string[])[] => {
+  const out: (readonly string[])[] = [];
+  for (const write of tx.getWriteDetails?.(target.space) ?? []) {
+    if (write.address.id !== target.id) continue;
+    if (normalizeCellScope(write.address.scope) !== target.scope) continue;
+    if (write.address.path[0] !== "value") continue;
+    const writePath = write.address.path.slice(1).map((entry) => String(entry));
+    if (concretePathHasPrefix(writePath, path)) out.push(writePath);
+  }
+  for (
+    const write of [
+      ...(tx.getReactivityLog?.().writes ?? []),
+      ...(tx.getReactivityLog?.().attemptedWrites ?? []),
+    ]
+  ) {
+    if (write.space !== target.space) continue;
+    if (write.id !== target.id) continue;
+    if (normalizeCellScope(write.scope) !== target.scope) continue;
+    const writePath = canonicalizeLogicalPath(write.path);
+    if (concretePathHasPrefix(writePath, path)) out.push(writePath);
+  }
+  return out;
+};
+
+/**
+ * Epic D3 — the write-side `requiredIntegrity` FLOOR (§8.12.4.1 / SC-18),
+ * dual of the read-side gate in `verifyInputRequirements`: where that gate
+ * quantifies over the transaction's consumed reads, the floor tests the
+ * WRITTEN VALUE's integrity at each floor-declaring path. Per SC-18 the floor
+ * is a minimum (above-floor writes pass); an overwrite is checked against the
+ * declared floor only — never the prior value's integrity, no meet across
+ * successive writes; a value with no (or only forged-then-stripped) integrity
+ * on a floor-declaring path fails.
+ *
+ * What credits the value (mirrors what this commit persists at the path):
+ * - the schema-derived label — `addIntegrity` mints and `exactCopyOf` carry,
+ *   evidence-gated by the write's authoring identity (a pattern cannot forge
+ *   runtime-minted evidence to pass its own floor);
+ * - each link written at/under the path — the linked source's own label, the
+ *   D2 by-reference contract on the write side. Every link must individually
+ *   satisfy the floor (one endorsed sibling never launders another);
+ * - the flow hereditary meet, when flow labels are on (`value` contributions
+ *   carry the per-tx derived integrity).
+ *
+ * Scope (v1, exact-match membership — D5 upgrades to pattern/concept):
+ * wildcard (`*`) floor entries stay read-gate-only; the same pattern-setup
+ * escape as `writeAuthorizedBy` applies (a pattern's declared initialization
+ * must be able to bootstrap the doc it protects); a pure delete (no written
+ * value) is not a floored write — the floor governs values, not absence.
+ */
+const verifyWriteFloor = (
+  tx: IExtendedStorageTransaction,
+  schema: JSONSchema,
+  target: {
+    space: MemorySpace;
+    id: URI;
+    scope: ReturnType<typeof normalizeCellScope>;
+  },
+  ctx: {
+    identityForPath: (
+      path: readonly string[],
+    ) => ImplementationIdentity | undefined;
+    identityForInput: (
+      input: WritePolicyInput,
+    ) => ImplementationIdentity | undefined;
+    linkWriteInputs: readonly LinkWritePolicyInput[];
+    candidateSchemas: ReadonlyMap<string, JSONSchema>;
+    flowIntegrity: readonly unknown[];
+  },
+): string[] => {
+  const failures: string[] = [];
+  const entries = walkIfcSchema(schema);
+  const entryLabels = new Map<string, IFCLabel>(
+    entries.map((entry) => [pathKey(entry.path), entry.label]),
+  );
+  for (const entry of entries) {
+    const ifc = isRecord(entry.schema) ? entry.schema.ifc : undefined;
+    const floor = Array.isArray(ifc?.requiredIntegrity)
+      ? ifc.requiredIntegrity
+      : [];
+    if (floor.length === 0) continue;
+    if (entry.path.includes("*")) continue;
+    if (
+      !ifcEntryAppliesToAttemptedWrite(
+        tx,
+        target,
+        entry.path,
+        entry.schema,
+        entry.root,
+      )
+    ) {
+      continue;
+    }
+    const setupProjection = setupProjectionSourceMatchesValue(
+      tx,
+      target,
+      entry.path,
+    ) || writeIsPatternSetupInitialization(tx, target, entry.path) ||
+      writeIsSeedMaterialization(tx, target);
+    if (setupProjection) continue;
+
+    // The label this commit persists at the path: schema integrity +
+    // `addIntegrity` mints + `exactCopyOf` carry, evidence-gated so a pattern
+    // author cannot forge runtime-minted atoms to satisfy their own floor.
+    const base = gateRuntimeMintedIntegrity(
+      derivePersistedLabel(tx, entry.schema, entry.label, entryLabels),
+      ctx.identityForPath(entry.path),
+    ).integrity ?? [];
+
+    // One contribution per link written at/under the floor path (each linked
+    // value must individually carry the floor), plus one `value` contribution
+    // when plain data was written (crediting the flow meet when available).
+    const linksHere = ctx.linkWriteInputs.filter((input) =>
+      concretePathHasPrefix(
+        canonicalizeLogicalPath(input.target.path),
+        entry.path,
+      )
+    );
+    const contributions: (readonly unknown[])[] = [];
+    for (const input of linksHere) {
+      const derived = derivePersistedLinkLabel(
+        tx,
+        input,
+        ctx.candidateSchemas,
+        ctx.identityForInput(input),
+      );
+      // An underivable link label already records its own fail-closed reason
+      // in the persist loop — the floor does not double-report it.
+      if (derived.reason !== undefined) continue;
+      contributions.push(derived.label?.integrity ?? []);
+    }
+    const written = writeValueForTarget(tx, { ...target, path: entry.path });
+    const valueWritten = written !== undefined
+      // A pure-link value at the path is judged by its link contributions —
+      // unless none were recorded, which fails closed as a value write.
+      ? !isPureLinkStructure(written) || contributions.length === 0
+      // Only descendant writes touched the region: any of them not covered by
+      // a link input is plain data.
+      : attemptedWritePathsUnder(tx, target, entry.path).some((writePath) =>
+        !linksHere.some((input) =>
+          concretePathHasPrefix(
+            writePath,
+            canonicalizeLogicalPath(input.target.path),
+          )
+        )
+      );
+    if (valueWritten) contributions.push(ctx.flowIntegrity);
+    // No contribution at all: a delete/clear — absence is not a floored value.
+    if (contributions.length === 0) continue;
+
+    const misses = contributions.some((extra) =>
+      !cfcIntegritySatisfiesFloor([...base, ...extra], floor)
+    );
+    if (misses) {
+      failures.push(
+        `write floor failed at /${
+          entry.path.join("/")
+        } (requiredIntegrity, §8.12.4.1)`,
+      );
+    }
+  }
+  return failures;
+};
+
 export const prepareBoundaryCommit = (
   tx: IExtendedStorageTransaction,
 ): string[] => {
@@ -3389,6 +3566,32 @@ export const prepareBoundaryCommit = (
       reasons.push(exactCopyFailure);
       if (!isIngestTarget) continue;
       ingestVerificationFailed = true;
+    }
+
+    // Epic D3 (§8.12.4.1 / SC-18): the write-side requiredIntegrity floor —
+    // the WRITTEN VALUE's integrity must satisfy each floor-declaring entry.
+    // `observe` diagnoses; `enforce` records a reason (rejecting the commit
+    // under the enforcing enforcement modes, mirroring requirementFailure).
+    if (state.writeFloorMode !== "off") {
+      const floorFailures = verifyWriteFloor(tx, verificationSchema, target, {
+        identityForPath: (path) =>
+          identityForSchemaPath(writeAuthorIdentities.get(key), path),
+        identityForInput,
+        linkWriteInputs,
+        candidateSchemas: candidates,
+        flowIntegrity: flowMode === "off" ? [] : flowIntegrity,
+      });
+      if (floorFailures.length > 0) {
+        if (state.writeFloorMode === "enforce") {
+          reasons.push(...floorFailures);
+          if (!isIngestTarget) continue;
+          ingestVerificationFailed = true;
+        } else {
+          for (const failure of floorFailures) {
+            state.diagnostics.push(`write-floor(observe): ${failure}`);
+          }
+        }
+      }
     }
 
     const schemaAndHash = internSchema(mergedSchema, true);

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -330,10 +330,25 @@ export type CfcFlowLabelsMode = "off" | "observe" | "persist";
 
 export const DEFAULT_CFC_FLOW_LABELS_MODE: CfcFlowLabelsMode = "off";
 
+/**
+ * Write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18, Epic D3),
+ * orthogonal to the enforcement ladder and the flow dial: `off` = no check;
+ * `observe` = evaluate the floor and emit diagnostics, never reject;
+ * `enforce` = a floor miss records a prepare reason (which rejects the commit
+ * under the enforcing enforcement modes, and is logged otherwise). The floor
+ * tests the WRITTEN VALUE's integrity — schema mints, carried link-view
+ * integrity, the flow hereditary meet — never the consumed-read set (that is
+ * the read-side gate in `verifyInputRequirements`).
+ */
+export type CfcWriteFloorMode = "off" | "observe" | "enforce";
+
+export const DEFAULT_CFC_WRITE_FLOOR_MODE: CfcWriteFloorMode = "off";
+
 export type CfcTxState = {
   relevant: boolean;
   enforcementMode: CfcEnforcementMode;
   flowLabelsMode: CfcFlowLabelsMode;
+  writeFloorMode: CfcWriteFloorMode;
   prepare: CfcPrepareState;
   dereferenceTraces: CfcDereferenceTrace[];
   // Addresses whose invalidating writes scheduled this run (§8.9.2 trigger

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -66,6 +66,7 @@ import {
   type CfcEnforcementMode,
   type CfcFlowLabelsMode,
   type CfcLabelView,
+  type CfcWriteFloorMode,
   DEFAULT_SINK_MAX_CONFIDENTIALITY,
   externalIngestStamp,
   flowLabelWorkExists,
@@ -239,6 +240,14 @@ export interface RuntimeOptions {
    * boundary; it derives and persists labels but never rejects by itself.
    */
   cfcFlowLabels?: CfcFlowLabelsMode;
+  /**
+   * Write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18, Epic D3).
+   * Defaults to `off`. `observe` evaluates the floor and emits diagnostics;
+   * `enforce` records a prepare reason on a floor miss (rejecting the commit
+   * under the enforcing enforcement modes). The floor tests the written
+   * value's integrity, never the consumed-read set.
+   */
+  cfcWriteFloor?: CfcWriteFloorMode;
   /** Per-sink confidentiality ceilings for the sink-request egress gate. A sink
    *  absent from the map is ungated; a declared ceiling rejects (or, in observe
    *  mode, flags) a request carrying confidentiality outside it. Defaults to
@@ -374,6 +383,7 @@ export class Runtime {
   readonly cfc: ContextualFlowControl;
   readonly cfcEnforcementMode: CfcEnforcementMode;
   readonly cfcFlowLabels: CfcFlowLabelsMode;
+  readonly cfcWriteFloor: CfcWriteFloorMode;
   readonly cfcSinkMaxConfidentiality: SinkMaxConfidentiality;
   readonly staticCache: StaticCache;
   readonly storageManager: IStorageManager;
@@ -495,6 +505,7 @@ export class Runtime {
     this.cfcEnforcementMode = options.cfcEnforcementMode ??
       "enforce-explicit";
     this.cfcFlowLabels = options.cfcFlowLabels ?? "off";
+    this.cfcWriteFloor = options.cfcWriteFloor ?? "off";
     // Deep-freeze: the ceiling is CFC enforcement config, so a caller must not
     // be able to mutate it (per-sink array or the map) after construction to
     // change what egresses are allowed (review on #3993).
@@ -744,6 +755,7 @@ export class Runtime {
     });
     wrapped.setCfcEnforcementMode(this.cfcEnforcementMode);
     wrapped.setCfcFlowLabelsMode(this.cfcFlowLabels);
+    wrapped.setCfcWriteFloorMode(this.cfcWriteFloor);
     wrapped.setCfcSinkMaxConfidentiality(this.cfcSinkMaxConfidentiality);
     wrapped.setCfcTrustSnapshot(this.trustSnapshotProvider());
     return wrapped;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -63,9 +63,11 @@ import {
   cfcEnforcementStrictness,
   type CfcFlowLabelsMode,
   type CfcTxState,
+  type CfcWriteFloorMode,
   type ConsumedRead,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   DEFAULT_CFC_FLOW_LABELS_MODE,
+  DEFAULT_CFC_WRITE_FLOOR_MODE,
   flowLabelWorkExists,
   flowReadExcluded,
   gatedSinkRequestExists,
@@ -119,6 +121,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     relevant: false,
     enforcementMode: DEFAULT_CFC_ENFORCEMENT_MODE,
     flowLabelsMode: DEFAULT_CFC_FLOW_LABELS_MODE,
+    writeFloorMode: DEFAULT_CFC_WRITE_FLOOR_MODE,
     prepare: { status: "unprepared" },
     dereferenceTraces: [],
     triggerReads: [],
@@ -204,6 +207,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (mode === "persist") {
       this.cfcFlowLabelsPinned = true;
     }
+  }
+
+  setCfcWriteFloorMode(mode: CfcWriteFloorMode): void {
+    this.cfcState.writeFloorMode = mode;
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {
@@ -1166,6 +1173,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   setCfcFlowLabelsMode(mode: CfcFlowLabelsMode): void {
     this.wrapped.setCfcFlowLabelsMode(mode);
+  }
+
+  setCfcWriteFloorMode(mode: CfcWriteFloorMode): void {
+    this.wrapped.setCfcWriteFloorMode(mode);
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -140,6 +140,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // off — same shape as the enforcement floor (audit S3): code holding a
   // Cell must not disable propagation mid-transaction to launder a value.
   private cfcFlowLabelsPinned = false;
+  private cfcWriteFloorPinned = false;
   // Depth of the runtime's privileged system-write scope. The runtime's own
   // label/schema persistence (prepareBoundaryCommit) runs inside it; any write
   // to a protected system path outside it is recorded as unprivileged (S18).
@@ -210,7 +211,20 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   setCfcWriteFloorMode(mode: CfcWriteFloorMode): void {
+    // Anti-downgrade pin (mirrors flow labels): once `enforce` is set — by the
+    // runtime at tx creation — pattern/handler code that reaches the tx cannot
+    // weaken it to `observe`/`off` to slip an SC-18 floor violation through
+    // (cubic review). Strengthening to `enforce` is always allowed.
+    if (this.cfcWriteFloorPinned && mode !== "enforce") {
+      throw new Error(
+        `CFC write-floor mode cannot be weakened to "${mode}": transaction ` +
+          `is pinned at "enforce"`,
+      );
+    }
     this.cfcState.writeFloorMode = mode;
+    if (mode === "enforce") {
+      this.cfcWriteFloorPinned = true;
+    }
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -43,6 +43,7 @@ import type {
   CfcEnforcementMode,
   CfcFlowLabelsMode,
   CfcTxState,
+  CfcWriteFloorMode,
   ImplementationIdentity,
   PostCommitSideEffect,
   TrustSnapshot,
@@ -844,6 +845,8 @@ export interface IExtendedStorageTransaction
   getCfcState(): Readonly<CfcTxState>;
   setCfcEnforcementMode(mode: CfcEnforcementMode): void;
   setCfcFlowLabelsMode(mode: CfcFlowLabelsMode): void;
+  /** Set the write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18). */
+  setCfcWriteFloorMode(mode: CfcWriteFloorMode): void;
   /**
    * Record the addresses whose invalidating writes scheduled this run
    * (§8.9.2 trigger reads). Their labels join the flow-label derivation

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -24,7 +24,11 @@ type StoredEntry = {
 // the headline case proves the mark is still minted there.
 describe("CFC external-ingest provenance mint (split-mint)", () => {
   const makeRuntime = (
-    overrides: { cfcEnforcementMode?: string; cfcFlowLabels?: string } = {},
+    overrides: {
+      cfcEnforcementMode?: string;
+      cfcFlowLabels?: string;
+      cfcWriteFloor?: string;
+    } = {},
   ) => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime(
@@ -252,6 +256,59 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
 
       // ...but the payload's own (unverified) declared policy label did NOT
       // persist — a failed write must not store unverified policy metadata.
+      const declared = entriesOf(storageManager, id)
+        .filter((e) => e.origin === "declared");
+      expect(declared.length).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("persists the mark even when the payload fails the write floor", async () => {
+    // Same invariant as the schema-verification case, for the D3 write floor:
+    // an ingest payload violating a requiredIntegrity floor records the reason
+    // (enforcing modes abort the whole tx), but on a committing (disabled)
+    // runtime the runtime-authored mark still persists and only the payload's
+    // declared policy label is dropped. Exercises the floor's ingest-target
+    // branch (ingestVerificationFailed instead of skipping the mint).
+    const { storageManager, runtime } = makeRuntime({
+      cfcWriteFloor: "enforce",
+    });
+    try {
+      const floored = internSchema(
+        {
+          type: "object",
+          properties: {
+            field: {
+              type: "string",
+              ifc: { requiredIntegrity: ["ingest-endorsement"] },
+            },
+          },
+          required: ["field"],
+        } as JSONSchema,
+        true,
+      );
+
+      const id = runtime.getCell(space, "ingest-floored")
+        .getAsNormalizedFullLink().id;
+      const { error } = await runtime.editWithRetry((tx) => {
+        stampExternalIngest(tx, meta(id, "sha256:floor-miss"));
+        const cell = runtime.getCell(
+          space,
+          "ingest-floored",
+          floored.schema,
+          tx,
+        );
+        cell.set({ field: "unendorsed" });
+      });
+      // Disabled enforcement commits despite the recorded floor reason.
+      expect(error).toBeUndefined();
+
+      const marks = entriesOf(storageManager, id)
+        .flatMap((e) => e.label.integrity ?? []);
+      expect(marks).toContainEqual(externalIngestAtom("sha256:floor-miss"));
+
       const declared = entriesOf(storageManager, id)
         .filter((e) => e.origin === "declared");
       expect(declared.length).toBe(0);

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -352,7 +352,160 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
-  it("a write elsewhere on the doc does not trip an untouched floor path", async () => {
+  it("a floor-less ifc entry on the same schema is skipped", async () => {
+    // A confidentiality-only sibling declares an ifc entry with NO
+    // requiredIntegrity — the floor loop skips it (floor.length === 0) and
+    // still enforces the real floor field.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          pub: { type: "string", ifc: { confidentiality: ["c"] } },
+          out: { type: "string", ifc: { requiredIntegrity: [ADMIN_ATOM] } },
+        },
+        required: ["pub", "out"],
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-floorless-sink",
+        schema,
+        tx,
+      );
+      sink.set({ pub: "visible", out: "unendorsed" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      // The floor field still rejects; the confidentiality-only field is inert.
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed at /out",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a wildcard (*) floor entry is not enforced by the write floor (read-gate only, v1)", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      // Array items produce a `*` floor entry path (walkIfcSchema), which the
+      // write floor skips in v1 — the per-element read gate still covers it.
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "string",
+              ifc: { requiredIntegrity: [ADMIN_ATOM] },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-wildcard-sink",
+        schema,
+        tx,
+      );
+      sink.set({ items: ["unendorsed"] });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      // The wildcard floor is skipped by verifyWriteFloor (v1 scope), so no
+      // write-floor rejection.
+      expect(
+        String((result.error as Error | undefined)?.message ?? ""),
+      ).not.toContain("write floor failed");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a link with no derivable source label is skipped by the floor (reason recorded elsewhere)", async () => {
+    // A link whose source has no stored metadata and no candidate schema is
+    // underivable: derivePersistedLinkLabel returns a reason (the persist loop
+    // reports it), and the floor does not double-count it as a contribution.
+    // The whole commit still rejects — via that missing-source reason.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const tx = runtime.edit();
+      const src = runtime.getCell(
+        signer.did(),
+        "wf-link-nometa-src",
+        undefined,
+        tx,
+      );
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-link-nometa-sink",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: src as unknown as string });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      // Underivable link source => the commit rejects (missing link source
+      // metadata), and the floor contributes nothing spurious.
+      expect(result.error).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("clearing a floor-declaring path (delete) is not a floored write", async () => {
+    // Establish the floor field with an endorsed value, then delete it. A
+    // delete writes no value at the path, so the floor (which governs values,
+    // not absence) does not reject.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          out: {
+            type: "string",
+            ifc: {
+              requiredIntegrity: [ADMIN_ATOM],
+              addIntegrity: [ADMIN_ATOM],
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+      const seedTx = runtime.edit();
+      const seeded = runtime.getCell(
+        signer.did(),
+        "wf-delete-sink",
+        schema,
+        seedTx,
+      );
+      seeded.set({ out: "endorsed" });
+      seedTx.prepareCfc();
+      expect((await seedTx.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const sink = runtime.getCell(signer.did(), "wf-delete-sink", schema, tx);
+      sink.set({});
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("an unwritten floor path on the same schema is not enforced (only touched paths)", async () => {
+    // The schema declares a floor at /out but only the unprotected /note is
+    // written. `out` is absent from the attempted writes, so the floor entry
+    // does not apply (ifcEntryAppliesToAttemptedWrite=false) and no rejection
+    // follows — the floor governs paths this commit actually wrote.
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
     try {
@@ -362,40 +515,11 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
           out: { type: "string", ifc: { requiredIntegrity: [ADMIN_ATOM] } },
           note: { type: "string" },
         },
+        required: ["note"],
       } as const satisfies JSONSchema;
-      // Establish the doc with the floor path present (via the minting shape),
-      // then touch only the unprotected sibling.
-      const seedTx = runtime.edit();
-      const seeded = runtime.getCell(
-        signer.did(),
-        "wf-sibling-sink",
-        {
-          type: "object",
-          properties: {
-            out: {
-              type: "string",
-              ifc: {
-                requiredIntegrity: [ADMIN_ATOM],
-                addIntegrity: [ADMIN_ATOM],
-              },
-            },
-            note: { type: "string" },
-          },
-        } as const satisfies JSONSchema,
-        seedTx,
-      );
-      seeded.set({ out: "endorsed", note: "a" });
-      seedTx.prepareCfc();
-      expect((await seedTx.commit()).ok).toBeDefined();
-
       const tx = runtime.edit();
-      const sink = runtime.getCell(
-        signer.did(),
-        "wf-sibling-sink",
-        schema,
-        tx,
-      );
-      sink.key("note").set("b");
+      const sink = runtime.getCell(signer.did(), "wf-sibling-sink", schema, tx);
+      sink.set({ note: "b" });
       tx.prepareCfc();
       const result = await tx.commit();
       expect(result.error).toBeUndefined();

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -46,6 +46,7 @@ const MINT_SCHEMA = {
 const makeRuntime = (opts: {
   storageManager: ReturnType<typeof StorageManager.emulate>;
   cfcWriteFloor?: CfcWriteFloorMode;
+  cfcFlowLabels?: "off" | "observe" | "persist";
 }) =>
   new Runtime({
     apiUrl: new URL("https://example.com"),
@@ -53,6 +54,9 @@ const makeRuntime = (opts: {
     cfcEnforcementMode: "enforce-explicit",
     ...(opts.cfcWriteFloor !== undefined
       ? { cfcWriteFloor: opts.cfcWriteFloor }
+      : {}),
+    ...(opts.cfcFlowLabels !== undefined
+      ? { cfcFlowLabels: opts.cfcFlowLabels }
       : {}),
   });
 
@@ -93,6 +97,37 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
       const sink = runtime.getCell(
         signer.did(),
         "wf-bare-sink",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "unendorsed" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("flow-persist with an empty hereditary meet does not weaken the floor", async () => {
+    // Under cfcFlowLabels:"persist" the floor credits the flow meet — but an
+    // empty meet (the common case: some unlabeled read empties it) credits
+    // nothing, so an unendorsed write still rejects. Pins the flowPersist
+    // credit branch AND that flow mode cannot become an accidental bypass.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcWriteFloor: "enforce",
+      cfcFlowLabels: "persist",
+    });
+    try {
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-flow-sink",
         FLOOR_SCHEMA,
         tx,
       );

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -595,6 +595,57 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
+  it("a plain sibling write next to an endorsed link child still fails the container floor", async () => {
+    // Descendant-only mixed write under a floored CONTAINER: one child gets an
+    // endorsed link, a sibling gets plain data in the same tx. The endorsed
+    // link contribution must not launder the plain sibling — the value
+    // contribution (empty integrity) fails the floor (cubic review: the
+    // pure-link classification must not skip the value credit here).
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      await seedLabeledDoc(runtime, "wf-mixed-src", "endorsed-child", {
+        integrity: [ADMIN_ATOM],
+      });
+      const containerFloor = {
+        type: "object",
+        properties: {
+          out: {
+            type: "object",
+            ifc: { requiredIntegrity: [ADMIN_ATOM] },
+            properties: {
+              a: { type: "string" },
+              b: { type: "string" },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const src = runtime.getCell(signer.did(), "wf-mixed-src", undefined, tx);
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-mixed-sink",
+        containerFloor,
+        tx,
+      );
+      sink.set({
+        out: { a: src as unknown as string, b: "plain-unendorsed" },
+      });
+      // An unrelated doc written in the same tx: the floor's write enumeration
+      // must scope to the floored target, not sweep the whole transaction.
+      runtime.getCell(signer.did(), "wf-mixed-unrelated", undefined, tx)
+        .set("elsewhere");
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed at /out",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("clearing a floor-declaring path (delete) is not a floored write", async () => {
     // Establish the floor field with an endorsed value, then delete it. A
     // delete writes no value at the path, so the floor (which governs values,

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -459,6 +459,107 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
+  it("an ancestor link cannot smuggle an unendorsed value under a nested floor", async () => {
+    // Floor at /out/secret; the write links /out (an ANCESTOR) to a source
+    // whose .secret carries no integrity. The nested value reconstructs as
+    // undefined through the link, so without the ancestor-link check the floor
+    // entry would be skipped entirely — the bypass this test pins closed.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      await seedLabeledDoc(
+        runtime,
+        "wf-anc-src-bad",
+        { secret: "unendorsed" },
+        {},
+      );
+      const nestedFloor = {
+        type: "object",
+        properties: {
+          out: {
+            type: "object",
+            properties: {
+              secret: {
+                type: "string",
+                ifc: { requiredIntegrity: [ADMIN_ATOM] },
+              },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const src = runtime.getCell(
+        signer.did(),
+        "wf-anc-src-bad",
+        undefined,
+        tx,
+      );
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-anc-sink-bad",
+        nestedFloor,
+        tx,
+      );
+      sink.set({ out: src as unknown as { secret: string } });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed at /out/secret",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("an ancestor link whose source carries the nested floor atom passes", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      await seedLabeledDoc(
+        runtime,
+        "wf-anc-src-good",
+        { secret: "endorsed" },
+        { integrity: [ADMIN_ATOM] },
+        ["secret"],
+      );
+      const nestedFloor = {
+        type: "object",
+        properties: {
+          out: {
+            type: "object",
+            properties: {
+              secret: {
+                type: "string",
+                ifc: { requiredIntegrity: [ADMIN_ATOM] },
+              },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const src = runtime.getCell(
+        signer.did(),
+        "wf-anc-src-good",
+        undefined,
+        tx,
+      );
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-anc-sink-good",
+        nestedFloor,
+        tx,
+      );
+      sink.set({ out: src as unknown as { secret: string } });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("clearing a floor-declaring path (delete) is not a floored write", async () => {
     // Establish the floor field with an endorsed value, then delete it. A
     // delete writes no value at the path, so the floor (which governs values,
@@ -495,6 +596,30 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
       tx.prepareCfc();
       const result = await tx.commit();
       expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("the enforce pin cannot be weakened mid-transaction", async () => {
+    // Once the runtime sets `enforce` at tx creation, code that can reach the
+    // transaction must not be able to dial the floor back down and slip a
+    // violation through (mirrors the flow-labels persist pin).
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const tx = runtime.edit();
+      expect(() => tx.setCfcWriteFloorMode("off")).toThrow(
+        "cannot be weakened",
+      );
+      expect(() => tx.setCfcWriteFloorMode("observe")).toThrow(
+        "cannot be weakened",
+      );
+      // Re-asserting enforce is fine.
+      tx.setCfcWriteFloorMode("enforce");
+      expect(tx.getCfcState().writeFloorMode).toBe("enforce");
+      await tx.commit();
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -1,0 +1,407 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcWriteFloorMode } from "../src/cfc/mod.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-write-floor");
+
+// Epic D3 (§8.12.4.1 / SC-18): the write-side `requiredIntegrity` FLOOR. The
+// read-side gate (verifyInputRequirements) quantifies over consumed reads; the
+// floor tests the WRITTEN VALUE's integrity — schema `addIntegrity` mints,
+// carried link-view integrity, the flow hereditary meet — against the declared
+// floor. Dial `cfcWriteFloor: off | observe | enforce`, default off.
+const ADMIN_ATOM = "admin-approved";
+const LLM_DERIVED_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/LlmDerived",
+};
+
+const FLOOR_SCHEMA = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { requiredIntegrity: [ADMIN_ATOM] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+// The declaring schema also MINTS the floor atom: writes through it carry the
+// integrity they require (the authoring pattern for floor-protected paths).
+const MINT_SCHEMA = {
+  type: "object",
+  properties: {
+    out: {
+      type: "string",
+      ifc: {
+        requiredIntegrity: [ADMIN_ATOM],
+        addIntegrity: [ADMIN_ATOM],
+      },
+    },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const makeRuntime = (opts: {
+  storageManager: ReturnType<typeof StorageManager.emulate>;
+  cfcWriteFloor?: CfcWriteFloorMode;
+}) =>
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager: opts.storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    ...(opts.cfcWriteFloor !== undefined
+      ? { cfcWriteFloor: opts.cfcWriteFloor }
+      : {}),
+  });
+
+// Seed a doc's stored CFC metadata directly via an ungated path-[] full-document
+// write (how the runtime persists it), so a later link to it carries the label.
+const seedLabeledDoc = async (
+  runtime: Runtime,
+  id: string,
+  value: unknown,
+  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+  path: string[] = [],
+): Promise<void> => {
+  const seed = runtime.edit();
+  const cell = runtime.getCell(signer.did(), id, undefined, seed);
+  const docId = cell.getAsNormalizedFullLink().id as URI;
+  seed.writeOrThrow({
+    space: signer.did(),
+    id: docId,
+    type: "application/json",
+    path: [],
+  }, {
+    value,
+    cfc: {
+      version: 1,
+      schemaHash: `seed-${id}`,
+      labelMap: { version: 1, entries: [{ path, label }] },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
+  it("rejects an integrity-less write to a floor-declaring path under enforce", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-bare-sink",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "unendorsed" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("dial off (the default): the same write commits — byte-compat", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager });
+    try {
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-off-sink",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "unendorsed" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("observe: the write commits and a diagnostic records the miss", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "observe" });
+    try {
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-observe-sink",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "unendorsed" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+      expect(
+        tx.getCfcState().diagnostics.some((d) =>
+          d.includes("write-floor(observe)") && d.includes("write floor")
+        ),
+      ).toBe(true);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a schema minting its own floor atom passes (addIntegrity credits the value)", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-mint-sink",
+        MINT_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "endorsed" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("the floor is a minimum: extra minted integrity is fine", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          out: {
+            type: "string",
+            ifc: {
+              requiredIntegrity: [ADMIN_ATOM],
+              addIntegrity: [ADMIN_ATOM, "second-endorsement"],
+            },
+          },
+        },
+        required: ["out"],
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const sink = runtime.getCell(signer.did(), "wf-min-sink", schema, tx);
+      sink.set({ out: "endorsed-plus" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("an overwrite is checked against the DECLARED floor only, never the prior value's integrity", async () => {
+    // Write 1 links /out to a source whose stored integrity is
+    // [ADMIN_ATOM, "extra-endorsement"] — the prior VALUE's integrity exceeds
+    // the floor. Write 2 replaces it with a plain value minting only the floor
+    // atom. SC-18: sibling replacement B≱A with both ≥ floor conforms — the
+    // prior value's richer integrity is never consulted (no meet across
+    // successive writes), and integrity legitimately does not regrow.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      await seedLabeledDoc(runtime, "wf-overwrite-src", "endorsed-rich", {
+        integrity: [ADMIN_ATOM, "extra-endorsement"],
+      });
+      const seedTx = runtime.edit();
+      const src = runtime.getCell(
+        signer.did(),
+        "wf-overwrite-src",
+        undefined,
+        seedTx,
+      );
+      const first = runtime.getCell(
+        signer.did(),
+        "wf-overwrite-sink",
+        MINT_SCHEMA,
+        seedTx,
+      );
+      first.set({ out: src as unknown as string });
+      seedTx.prepareCfc();
+      expect((await seedTx.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-overwrite-sink",
+        MINT_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "new" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a forged runtime-minted atom cannot satisfy a floor keyed to it (mint gate strips first)", async () => {
+    // A pattern-authored schema self-attaching LlmDerived: the S4 mint gate
+    // strips it from the persisted label, so the written value's integrity is
+    // empty and the floor (keyed to LlmDerived) fails — forging evidence
+    // satisfies nothing.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          out: {
+            type: "string",
+            ifc: {
+              requiredIntegrity: [LLM_DERIVED_ATOM],
+              addIntegrity: [LLM_DERIVED_ATOM],
+            },
+          },
+        },
+        required: ["out"],
+      } as const satisfies JSONSchema;
+      const tx = runtime.edit();
+      const sink = runtime.getCell(signer.did(), "wf-forged-sink", schema, tx);
+      sink.set({ out: "forged" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a link whose source carries the floor atom passes (carried link-view integrity)", async () => {
+    // The D2 by-reference contract on the write side: a floor-protected slot
+    // accepts a REFERENCE to a value that genuinely carries the endorsement.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      await seedLabeledDoc(runtime, "wf-link-src-good", "endorsed-value", {
+        integrity: [ADMIN_ATOM],
+      });
+      const tx = runtime.edit();
+      const src = runtime.getCell(
+        signer.did(),
+        "wf-link-src-good",
+        undefined,
+        tx,
+      );
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-link-sink-good",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: src as unknown as string });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a link whose source lacks the floor atom is rejected", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      // An empty stored label: the source read is excluded from the READ-side
+      // gate (same trust level as unlabeled), so the write-side FLOOR is the
+      // check that rejects — which is the point of this test.
+      await seedLabeledDoc(runtime, "wf-link-src-bad", "unendorsed-value", {});
+      const tx = runtime.edit();
+      const src = runtime.getCell(
+        signer.did(),
+        "wf-link-src-bad",
+        undefined,
+        tx,
+      );
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-link-sink-bad",
+        FLOOR_SCHEMA,
+        tx,
+      );
+      sink.set({ out: src as unknown as string });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "write floor failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a write elsewhere on the doc does not trip an untouched floor path", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          out: { type: "string", ifc: { requiredIntegrity: [ADMIN_ATOM] } },
+          note: { type: "string" },
+        },
+      } as const satisfies JSONSchema;
+      // Establish the doc with the floor path present (via the minting shape),
+      // then touch only the unprotected sibling.
+      const seedTx = runtime.edit();
+      const seeded = runtime.getCell(
+        signer.did(),
+        "wf-sibling-sink",
+        {
+          type: "object",
+          properties: {
+            out: {
+              type: "string",
+              ifc: {
+                requiredIntegrity: [ADMIN_ATOM],
+                addIntegrity: [ADMIN_ATOM],
+              },
+            },
+            note: { type: "string" },
+          },
+        } as const satisfies JSONSchema,
+        seedTx,
+      );
+      seeded.set({ out: "endorsed", note: "a" });
+      seedTx.prepareCfc();
+      expect((await seedTx.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const sink = runtime.getCell(
+        signer.did(),
+        "wf-sibling-sink",
+        schema,
+        tx,
+      );
+      sink.key("note").set("b");
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Performance baseline — accepted coverage-debt (measurement drift)

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7839 lines

The flagged debt is ratchet drift, not new untested code (three consecutive runs of covered-only pushes measured 7823, 7838, 7839 against a moving main baseline): the head commit
(8c66a30) adds **tests only** (no runner source), and the **same commit
measured 7823 (±0 vs main) on this run's first attempt** — the +15 appeared
only after the flaked `Package Integration Tests (runtime-client)` job was
re-run and its coverage profile regenerated, changing which files/lines the
aggregated report counts. The D3 additions themselves are fully covered
(verifyWriteFloor, the ingest-target branch, the flowPersist credit branch,
the enforce pin — all with dedicated tests in this PR).

---

## What

Epic D3 of the [CFC future-work plan](docs/plans/cfc-future-work-implementation.md): the **write-side `requiredIntegrity` floor** (§8.12.4.1 / SC-18). The dual of the read-side gate — where `verifyInputRequirements` quantifies over consumed reads, the floor tests the **written value's** integrity at each floor-declaring path.

New dial `cfcWriteFloor: "off" | "observe" | "enforce"` (default `off`, orthogonal to the enforcement and flow dials). `observe` diagnoses; `enforce` records a prepare reason (rejecting the commit under the enforcing enforcement modes).

## What credits the value

`verifyWriteFloor` ([prepare.ts](packages/runner/src/cfc/prepare.ts)) checks the integrity this commit persists at the path:
- the schema-derived label — `addIntegrity` mints + `exactCopyOf` carry, **evidence-gated** by `gateRuntimeMintedIntegrity` so a pattern author cannot forge a runtime-minted atom to satisfy its own floor;
- each link written at/under the path — the linked source's own label (the D2 by-reference contract on the *write* side), one contribution per link so one endorsed sibling never launders another;
- the flow hereditary meet, when flow labels persist.

## SC-18 semantics (tested one by one)

Floor-is-a-minimum; overwrite checked against the **declared floor only** (no meet across successive writes, prior value never consulted); empty integrity on a floor-declaring path fails — a `LlmDerived`-only value fails any floor by construction, closing the write-side half of the vacuous pass. Exact-match membership (D5 upgrades to pattern/concept).

## Shared predicate (addresses a review-debt note)

Extracted `cfcIntegritySatisfiesFloor` ([observation.ts](packages/runner/src/cfc/observation.ts)) and routed the read-side gate, this D3 floor, **and D2's inlined tool-input floor** through it — so D5's pattern/concept upgrade lands in one place instead of three diverging copies.

## Tests

10 red-first tests ([cfc-write-floor.test.ts](packages/runner/test/cfc-write-floor.test.ts)): integrity-less write rejects under enforce; dial-off byte-compat; observe diagnoses; self-minting schema passes; floor-is-minimum; overwrite-vs-declared-floor; forged-atom stripped; link source carries/lacks the atom; untouched sibling path. Full runner `cfc-*` suite green (71 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the write-side `requiredIntegrity` floor (SC-18) with a `cfcWriteFloor` dial to observe or enforce that each floored path’s written value carries the required integrity. Now uses structural applicability to catch mixed descendant writes, alongside ancestor-link coverage; off by default.

- **New Features**
  - Implemented `verifyWriteFloor` with structural checks: evaluates the written value using schema `addIntegrity`/`exactCopyOf`, per-link source labels (including ancestor links), and the flow meet when persisted; `observe` logs, `enforce` records prepare reasons.
  - Added `cfcWriteFloor: "off" | "observe" | "enforce"` (default `off`) and the shared predicate `cfcIntegritySatisfiesFloor` used by the read gate and tool-input floor. SC‑18 semantics: floor is a minimum; overwrites check only the declared floor; forged runtime-minted atoms don’t satisfy; deletes are not floored.

- **Bug Fixes**
  - Closed the mixed-write skip by making floor applicability structural (links at/under or ancestor, and applied writes at/under the path); raw-sigil-without-link-input is evaluated, deletes are not floored, and checks stay scoped to the target doc.
  - Kept earlier fixes: ancestor-link bypass closed, flow credited only when persisted, `setCfcWriteFloorMode` pinned at `enforce`, and external‑ingest commits still mint the runtime mark when the payload fails the floor (dropping the payload’s declared label).

<sup>Written for commit fbcfd06892541acf0fa653fb0d0fbb86d163cf24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


