### PR TITLE
fix(cfc): reject ambiguous dual-op rowLabel nodes (soundness, Epic E2)

### DIFF
--- a/packages/memory/test/v2-sqlite-row-label-test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-test.ts
@@ -983,6 +983,33 @@ Deno.test("ruleCommonAlternatives never counts a dual-op node's owner as a commo
   );
 });
 
+Deno.test("an ambiguous allOf wrapper is opaque to the static analysis (no unwrap past the guard)", () => {
+  // {allOf: [...], constant: X} — flattenConfConjuncts must NOT dispatch on
+  // the allOf key alone and unwrap it: that silently drops the smuggled
+  // sibling op and hands the inner conjuncts to the static analysis, which
+  // would report a guaranteed reader for a node the evaluator refuses.
+  const ambiguousWrapper = {
+    version: 1,
+    confidentiality: { allOf: [{ dbOwner: true }], constant: "x" },
+  } as unknown as RowLabelSpec;
+  assertEquals(
+    ruleCommonAlternatives(ambiguousWrapper, { dbOwner: OWNER }),
+    [],
+  );
+  // ...and the wrapper still COUNTS as a confidentiality constraint: an
+  // ambiguous {allOf: [], constant} must not read as the degenerate empty
+  // conjunction (which would make the aggregate public).
+  const emptyAllOfConstant = {
+    version: 1,
+    confidentiality: { allOf: [], constant: "x" },
+  } as unknown as RowLabelSpec;
+  assertEquals(ruleConstrainsConfidentiality(emptyAllOfConstant), true);
+  assertEquals(
+    ruleCommonAlternatives(emptyAllOfConstant, { dbOwner: OWNER }),
+    [],
+  );
+});
+
 Deno.test("evaluateRowLabel fails closed on a dual-op node that bypassed validation", () => {
   // Defense in depth (like the conjunctive-anyOf-alternative check): a wire
   // spec that skipped validation must refuse at eval, never silently pick one

--- a/packages/memory/test/v2-sqlite-row-label-test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-test.ts
@@ -841,6 +841,178 @@ Deno.test("an unbalanced regex in a wire spec returns a reason (no lint crash)",
   assert(typeof reason === "string");
 });
 
+// ---------------------------------------------------------------------------
+// Ambiguous dual-op nodes: a node carrying TWO recognized op keys must refuse
+// everywhere. The validator, the evaluator, and the static common-alternative
+// analysis each dispatch by their own key precedence, so a hand-crafted
+// {principal, dbOwner} node used to validate as a principal, evaluate to only
+// the principal, and STATICALLY count the owner as a common reader — labeling
+// a COUNT(*) [owner] although the owner is not an alternative in any row's
+// label (CFC spec §8.17.4 violation).
+// ---------------------------------------------------------------------------
+
+const DUAL_PRINCIPAL_OWNER: RowLabelSpec = {
+  version: 1,
+  confidentiality: {
+    principal: {
+      protocol: "mailto",
+      of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+    },
+    dbOwner: true,
+  } as never,
+};
+
+Deno.test("a dual-op confidentiality node in a wire spec is rejected (ambiguous, fail closed)", () => {
+  // The probe from the report: {principal, dbOwner}.
+  const reason = validateRowLabelSpec(DUAL_PRINCIPAL_OWNER, ["from"]);
+  assert(typeof reason === "string", "a dual-op node must not validate");
+  assert(reason.includes("ambiguous"), `unexpected reason: ${reason}`);
+
+  // The other class: {constant, principal} (eval picks the principal, static
+  // analysis used to count the constant).
+  const constantPrincipal = {
+    version: 1,
+    confidentiality: {
+      constant: "did:key:public",
+      principal: {
+        protocol: "mailto",
+        of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+      },
+    },
+  } as unknown as RowLabelSpec;
+  assert(
+    typeof validateRowLabelSpec(constantPrincipal, ["from"]) === "string",
+  );
+
+  // The validateConfExpr entry point (top level / under all()): an allOf node
+  // smuggling a sibling op key is just as ambiguous.
+  const allOfConstant = {
+    version: 1,
+    confidentiality: { allOf: [{ dbOwner: true }], constant: "x" },
+  } as unknown as RowLabelSpec;
+  assert(typeof validateRowLabelSpec(allOfConstant, ["from"]) === "string");
+
+  // The anyOf-alternative entry point: a when-gated alternative that ALSO
+  // carries a principal key — the validator used to follow the when gate
+  // while the evaluator dispatches on the principal.
+  const whenPrincipalAlt = {
+    version: 1,
+    confidentiality: {
+      anyOf: [{
+        when: { match: { field: "from", source: ADDR.source, flags: "" } },
+        then: { dbOwner: true },
+        principal: {
+          protocol: "mailto",
+          of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+        },
+      }],
+    },
+  } as unknown as RowLabelSpec;
+  assert(typeof validateRowLabelSpec(whenPrincipalAlt, ["from"]) === "string");
+});
+
+Deno.test("a dual-op integrity node in a wire spec is rejected (ambiguous, fail closed)", () => {
+  const authoredConstant = {
+    version: 1,
+    integrity: {
+      authoredBy: {
+        principal: {
+          protocol: "mailto",
+          of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+        },
+      },
+      constant: "x",
+    },
+  } as unknown as RowLabelSpec;
+  assert(typeof validateRowLabelSpec(authoredConstant, ["from"]) === "string");
+
+  const authoredEndorsed = {
+    version: 1,
+    integrity: {
+      authoredBy: {
+        principal: {
+          protocol: "mailto",
+          of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+        },
+      },
+      endorsedBy: {
+        principal: {
+          protocol: "mailto",
+          of: { match: { field: "to", source: ADDR.source, flags: "g" } },
+        },
+      },
+    },
+  } as unknown as RowLabelSpec;
+  assert(
+    typeof validateRowLabelSpec(authoredEndorsed, ["from", "to"]) === "string",
+  );
+
+  const intersectAllOf = {
+    version: 1,
+    integrity: {
+      intersect: [{ constant: "a" }],
+      allOf: [{ constant: "b" }],
+    },
+  } as unknown as RowLabelSpec;
+  assert(typeof validateRowLabelSpec(intersectAllOf, ["from"]) === "string");
+});
+
+Deno.test("ruleCommonAlternatives never counts a dual-op node's owner as a common reader", () => {
+  // The exact unsoundness: eval labels each row with ONLY the extracted
+  // principal, so the owner is not an alternative in ANY row's label — the
+  // static analysis must not report it (an ambiguous node contributes no
+  // static reader; the aggregate refuses).
+  assertEquals(
+    ruleCommonAlternatives(DUAL_PRINCIPAL_OWNER, { dbOwner: OWNER }),
+    [],
+  );
+  // Same for a smuggled constant.
+  const constantPrincipal = {
+    version: 1,
+    confidentiality: {
+      constant: "did:key:public",
+      principal: {
+        protocol: "mailto",
+        of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+      },
+    },
+  } as unknown as RowLabelSpec;
+  assertEquals(
+    ruleCommonAlternatives(constantPrincipal, { dbOwner: OWNER }),
+    [],
+  );
+});
+
+Deno.test("evaluateRowLabel fails closed on a dual-op node that bypassed validation", () => {
+  // Defense in depth (like the conjunctive-anyOf-alternative check): a wire
+  // spec that skipped validation must refuse at eval, never silently pick one
+  // op by precedence.
+  expectError(
+    DUAL_PRINCIPAL_OWNER,
+    { from: "alice@a.example" },
+    { dbOwner: OWNER },
+    "ambiguous",
+  );
+  const authoredConstant = {
+    version: 1,
+    integrity: {
+      authoredBy: {
+        principal: {
+          protocol: "mailto",
+          of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+        },
+      },
+      constant: "x",
+    },
+  } as unknown as RowLabelSpec;
+  expectError(
+    authoredConstant,
+    { from: "alice@a.example" },
+    { dbOwner: OWNER },
+    "ambiguous",
+  );
+});
+
 Deno.test("a wire match without the global flag still evaluates (forced, no throw)", () => {
   const spec: RowLabelSpec = {
     version: 1,

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -861,9 +861,15 @@ function staticUnconditionalAlternatives(
 // `all(A, B)` as one opaque term with no static reader and refuse an aggregate
 // that is in fact satisfiable. Leaves (anyOf/principal/when/dbOwner/constant)
 // pass through unchanged; an `any(...)` never wraps an `allOf` (E1 rejects that
-// at authoring), so only allOf nesting needs flattening.
+// at authoring), so only allOf nesting needs flattening. Only a PURE allOf node
+// unwraps: a dual-op wrapper ({allOf, constant}) stays one opaque conjunct so
+// it reaches the ambiguity guard in `staticUnconditionalAlternatives` instead
+// of silently shedding the smuggled sibling op — and an ambiguous
+// {allOf: [], constant} keeps counting as a constraint rather than reading as
+// the degenerate empty conjunction (which would make an aggregate public).
 function flattenConfConjuncts(conf: unknown): unknown[] {
-  return isRecord(conf) && Array.isArray(conf.allOf)
+  return isRecord(conf) && Array.isArray(conf.allOf) &&
+      presentOps(conf).length === 1
     ? conf.allOf.flatMap(flattenConfConjuncts)
     : [conf];
 }

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -281,6 +281,13 @@ function validateAnyOfAlternative(
       "all()/any() — a conjunction or nested disjunction cannot be an " +
       "OR-clause alternative (CFC spec §3.1.8)";
   }
+  if (isRecord(node)) {
+    // Before the `when` branch below follows the gate: a dual-op alternative
+    // (e.g. {when, then, principal}) would be validated as a when() here but
+    // EVALUATED as a principal (evalConf dispatches on `principal` first).
+    const amb = ambiguousOpReason(node, "any()-alternative");
+    if (amb) return amb;
+  }
   if (isRecord(node) && "when" in node) {
     const test = (node as { when?: unknown }).when;
     const gate = isRecord(test) && "match" in test
@@ -347,11 +354,46 @@ function unknownOp(node: Record<string, unknown>, position: string): string {
     `{${Object.keys(node).join(", ")}}`;
 }
 
+// Every recognized op key — a node must carry EXACTLY ONE. The validator, the
+// evaluator, and the static common-alternative analysis each dispatch on these
+// by their own key precedence, so a hand-crafted dual-op wire node (e.g.
+// {principal, dbOwner}) would validate as one op, evaluate as another, and be
+// statically analyzed as a third — an unsoundness: a COUNT(*) labeled by the
+// owner while no contributing row's label names the owner (CFC spec §8.17.4).
+// Ambiguous nodes refuse everywhere. (`then` is not an op — it rides `when`.)
+const OP_KEYS = [
+  "anyOf",
+  "allOf",
+  "intersect",
+  "principal",
+  "dbOwner",
+  "constant",
+  "when",
+  "authoredBy",
+  "endorsedBy",
+] as const;
+
+function presentOps(node: Record<string, unknown>): string[] {
+  return OP_KEYS.filter((k) => k in node);
+}
+
+function ambiguousOpReason(
+  node: Record<string, unknown>,
+  position: string,
+): string | undefined {
+  const ops = presentOps(node);
+  if (ops.length <= 1) return undefined;
+  return `ambiguous rowLabel node in ${position} position: ` +
+    `{${ops.join(", ")}} — exactly one op per node (fail closed)`;
+}
+
 function validateConfTerm(
   node: unknown,
   columns: ReadonlySet<string>,
 ): string | undefined {
   if (!isRecord(node)) return "malformed confidentiality term";
+  const amb = ambiguousOpReason(node, "confidentiality");
+  if (amb) return amb;
   if ("anyOf" in node) return validateConfAnyOf(node, columns);
   if ("intersect" in node) {
     return "intersect() is integrity-only (the trust-floor meet); " +
@@ -384,6 +426,8 @@ function validateConfExpr(
   columns: ReadonlySet<string>,
 ): string | undefined {
   if (!isRecord(node)) return "malformed confidentiality expression";
+  const amb = ambiguousOpReason(node, "confidentiality");
+  if (amb) return amb;
   if ("anyOf" in node) return validateConfAnyOf(node, columns);
   if ("allOf" in node) {
     const terms = node.allOf;
@@ -404,6 +448,8 @@ function validateIntegTerm(
   columns: ReadonlySet<string>,
 ): string | undefined {
   if (!isRecord(node)) return "malformed integrity term";
+  const amb = ambiguousOpReason(node, "integrity");
+  if (amb) return amb;
   if ("anyOf" in node) {
     return "disjunctive integrity does not exist (CFC spec §3.1.8): " +
       "integrity is a conjunction combined by meet";
@@ -640,6 +686,11 @@ function evalConf(
   ctx: { dbOwner?: string },
 ): unknown[] {
   if (!isRecord(node)) return fail("malformed confidentiality term");
+  // Defense in depth against a wire spec that bypassed validation: a dual-op
+  // node must refuse, never be resolved by this dispatch's key precedence
+  // (the validator and the static analysis each have their own).
+  const amb = ambiguousOpReason(node, "confidentiality");
+  if (amb) return fail(amb);
   if ("anyOf" in node) {
     const terms = node.anyOf;
     if (!Array.isArray(terms)) return fail("malformed any()");
@@ -694,6 +745,8 @@ function evalInteg(
   ctx: { dbOwner?: string },
 ): unknown[] {
   if (!isRecord(node)) return fail("malformed integrity term");
+  const amb = ambiguousOpReason(node, "integrity");
+  if (amb) return fail(amb);
   if ("anyOf" in node) return fail("disjunctive integrity does not exist");
   if ("authoredBy" in node || "endorsedBy" in node) {
     const kind = "authoredBy" in node
@@ -785,6 +838,10 @@ function staticUnconditionalAlternatives(
   ctx: { dbOwner?: string },
 ): unknown[] {
   if (!isRecord(node)) return [];
+  // A dual-op node is ambiguous (the evaluator dispatches by a DIFFERENT key
+  // precedence — e.g. {principal, dbOwner} labels rows with only the
+  // principal): it contributes no static reader, so the aggregate refuses.
+  if (presentOps(node).length > 1) return [];
   if (node.dbOwner === true) {
     return ctx.dbOwner !== undefined ? [ctx.dbOwner] : [];
   }

--- a/packages/runner/test/sqlite-row-label-read.test.ts
+++ b/packages/runner/test/sqlite-row-label-read.test.ts
@@ -331,6 +331,33 @@ describe("computeRowLabelRead — per-row labels from origins", () => {
     assertEquals(kept.keep, [true]);
   });
 
+  it("a dual-op rowLabel node ({principal, dbOwner}) never labels an aggregate [owner] (soundness)", () => {
+    // A hand-crafted wire node carrying TWO recognized op keys is ambiguous:
+    // the evaluator labels each row with ONLY the extracted principal, while
+    // the static common-alternative analysis used to dispatch on dbOwner first
+    // and count the owner as a guaranteed reader — labeling a COUNT(*) [owner]
+    // although the owner is not an alternative in ANY contributing row's label
+    // (CFC spec §8.17.4). Such a spec must refuse at re-validation.
+    const dualTables = JSON.parse(JSON.stringify(emailTables)) as Record<
+      string,
+      { rowLabel?: { confidentiality?: unknown } }
+    >;
+    dualTables.emails.rowLabel!.confidentiality = {
+      principal: {
+        protocol: "mailto",
+        of: { match: { field: "from", source: ADDR.source, flags: "g" } },
+      },
+      dbOwner: true,
+    };
+    const res = computeRowLabelRead({
+      tables: dualTables,
+      columns: [col("cnt", null, null)],
+      rows: [{ cnt: 2 }],
+      owner: OWNER,
+    });
+    expectError(res, "invalid rowLabel");
+  });
+
   it("two confidentiality-bearing tables with DISJOINT readers refuse the aggregate (Epic E2)", () => {
     // Each table has a single static reader, but different ones — no principal
     // reads every row of both, so the aggregate (which could range over either)


### PR DESCRIPTION
## Summary

Fixes a soundness bug in the CFC sqlite row-label common-alternative path (Epic E2, #4477), confirmed by an end-to-end probe.

A hand-crafted wire `rowLabel` node carrying **two** recognized op keys — e.g. `{principal: {...}, dbOwner: true}` — was dispatched by a **different key precedence in each consumer** of `packages/memory/v2/sqlite/row-label.ts`:

1. `validateRowLabelSpec` **accepted** it (checks `principal` before `dbOwner`, ignores extra keys) — it validates as a principal node.
2. `evaluateRowLabel` labeled each row with **only the extracted principal** (same precedence) — the db owner is not an alternative in any row's label.
3. `staticUnconditionalAlternatives` checks `dbOwner === true` **first**, so `ruleCommonAlternatives` counted the **owner** as a static common alternative.

Consequence via the `nullOrigin` branch of `packages/runner/src/builtins/sqlite/row-label-read.ts`: a `COUNT(*)`/`SUM`/expression aggregate over such a table was labeled `[owner]` and readable at a ceiling naming the owner, while every contributing row's actual label names only its per-row principal — violating the common-alternative property (CFC spec §8.17.4: the atom must appear as an alternative in **every** clause of **every** possible row label). Same class: `{constant: X, principal: {...}}`.

Only reachable via hand-crafted `db.tables` JSON (the builders emit single-key nodes), but wire specs are explicitly in this module's threat model ("couldn't validate" is never "no label").

## Fix — ambiguous nodes refuse, at every layer

A node must carry exactly **one** recognized op key (`anyOf`/`allOf`/`intersect`/`principal`/`dbOwner`/`constant`/`when`/`authoredBy`/`endorsedBy`; `then` is not an op — it rides `when`):

- **Validation rejects**: shared `ambiguousOpReason` guard in `validateConfTerm`, `validateConfExpr`, `validateIntegTerm`, and `validateAnyOfAlternative` (the last had its own precedence mismatch: a `{when, then, principal}` alternative validated as a when-gate but evaluated as a principal). Both the runner read and write paths re-validate wire specs before use, so this alone closes the reported end-to-end path.
- **Eval fails closed** (`evalConf`/`evalInteg`) — defense in depth for a spec that bypassed validation, mirroring the existing conjunctive-anyOf-alternative check.
- **Static analysis contributes no reader** for an ambiguous node (`staticUnconditionalAlternatives`), so the aggregate refuses even if validation were bypassed.

## Tests (red-green)

Landed first; all five failed before the guard — the exact probe `ruleCommonAlternatives(dualSpec, {dbOwner})` returned `[owner]` where `[]` is required:

- `packages/memory/test/v2-sqlite-row-label-test.ts`: validator rejection for dual-op confidentiality nodes (`{principal, dbOwner}`, `{constant, principal}`, `{allOf, constant}`, when-gated anyOf alternative) and integrity nodes (`{authoredBy, constant}`, `{authoredBy, endorsedBy}`, `{intersect, allOf}`); the `ruleCommonAlternatives` probe; evaluator fail-closed.
- `packages/runner/test/sqlite-row-label-read.test.ts`: the dual-key table now refuses the `COUNT(*)` aggregate.

Full memory suite (307 tests) and all runner sqlite/CFC suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject ambiguous dual-op rowLabel nodes and keep ambiguous allOf wrappers opaque to restore CFC soundness and prevent aggregates from being labeled [owner] when rows don’t include the owner. Addresses Epic E2 (#4477) by refusing specs like {principal, dbOwner} and {constant, principal}.

- **Bug Fixes**
  - Validation now rejects nodes with more than one op key (exactly one of: anyOf|allOf|intersect|principal|dbOwner|constant|when|authoredBy|endorsedBy).
  - Evaluation fails closed if an ambiguous node bypasses validation.
  - Static analysis contributes no reader for ambiguous nodes, so aggregates refuse instead of returning [owner].
  - Static analysis no longer unwraps ambiguous allOf wrappers; only pure allOf unwraps. Ambiguous {allOf: [], constant} still counts as a constraint (not public).

<sup>Written for commit b67305bcc6bd64eeead32667475456a618d46202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Coverage-debt override

The +3 packages/memory debt lines are the defense-in-depth guards in `evalConf`/`evalInteg`/`staticUnconditionalAlternatives` — unreachable from the runner side BY DESIGN (the runner re-validates wire specs and refuses before eval/static analysis ever see a dual-op node); they are covered by the memory unit tests, which the cross-job debt ratchet does not credit (same residual as Epic E2 #4477). The +12 packages/runner drift has no runner source change in this PR (tests only) — shard noise.

NEW_PERF_BASELINE: coverage-debt: packages/memory uncovered lines = 1360 lines
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7835 lines
