### PR TITLE
test(cfc): mixed-version fail-closed pin — flat pre-A2 reader rejects persisted OR-clause (Epic A4)

### DIFF
--- a/packages/runner/test/cfc-clause-authoring.test.ts
+++ b/packages/runner/test/cfc-clause-authoring.test.ts
@@ -57,7 +57,7 @@ describe("CFC authored disjunctive confidentiality", () => {
         id: runtime.getCell(signer.did(), "authored-or", schema, readTx)
           .getAsNormalizedFullLink().id,
       });
-      readTx.commit();
+      await readTx.commit();
 
       const conf = (metadata?.labelMap.entries ?? []).flatMap(
         (entry) => entry.label.confidentiality ?? [],
@@ -108,7 +108,7 @@ describe("CFC authored disjunctive confidentiality", () => {
         id: runtime.getCell(signer.did(), "mixed-version", schema, readTx)
           .getAsNormalizedFullLink().id,
       });
-      readTx.commit();
+      await readTx.commit();
 
       const label = (metadata?.labelMap.entries ?? []).flatMap(
         (entry) => entry.label.confidentiality ?? [],

--- a/packages/runner/test/cfc-clause-authoring.test.ts
+++ b/packages/runner/test/cfc-clause-authoring.test.ts
@@ -6,6 +6,11 @@ import { Runtime } from "../src/runtime.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import { isOrClause } from "../src/cfc/clause.ts";
 import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import {
+  CFC_LABEL_READ_FAILED_ATOM,
+  cfcObservationFitsCeiling,
+} from "../src/cfc/observation.ts";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-clause-authoring");
@@ -66,6 +71,87 @@ describe("CFC authored disjunctive confidentiality", () => {
       expect(orClause!.anyOf).toHaveLength(2);
       expect(orClause!.anyOf).toContainEqual(userA);
       expect(orClause!.anyOf).toContainEqual(userB);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("persisted clause read by a clause-UNAWARE flat reader is outside every ceiling (mixed-version fail-closed, design decision 1)", async () => {
+    // The mixed-version story of design decision 1
+    // (docs/plans/cfc-future-work-implementation.md, Epic A): a reader that
+    // predates clause subsumption (#4470) deepEquals the WHOLE `{anyOf:[…]}`
+    // object against each ceiling entry, so an authored clause can only ever
+    // over-restrict on old readers — never leak. Confirmed end-to-end: schema
+    // → committed labelMap → read-back label → flat fit.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const schema = {
+        type: "string",
+        ifc: { confidentiality: [{ anyOf: [userB, userA] }] },
+      } as const satisfies JSONSchema;
+
+      const tx = runtime.edit();
+      const cell = runtime.getCell(signer.did(), "mixed-version", schema, tx);
+      cell.set("participant-readable");
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const readTx = runtime.edit();
+      const metadata = readStoredCfcMetadata(readTx, {
+        space: signer.did(),
+        id: runtime.getCell(signer.did(), "mixed-version", schema, readTx)
+          .getAsNormalizedFullLink().id,
+      });
+      readTx.commit();
+
+      const label = (metadata?.labelMap.entries ?? []).flatMap(
+        (entry) => entry.label.confidentiality ?? [],
+      );
+      const clause = label.find(isOrClause)!;
+      expect(clause).toBeDefined();
+
+      // Faithful local reimplementation of the PRE-A2 fit — atomsOutsideCeiling
+      // as of #4055, before #4470 rewrote it to clause subsumption: plain
+      // deepEqual set-membership plus the ungrantable read-failed marker, no
+      // clause awareness.
+      const flatAtomsOutsideCeiling = (
+        confidentiality: readonly unknown[],
+        ceiling: readonly unknown[],
+      ): unknown[] =>
+        confidentiality.filter((value) =>
+          deepEqual(value, CFC_LABEL_READ_FAILED_ATOM) ||
+          !ceiling.some((allowed) => deepEqual(allowed, value))
+        );
+
+      // Ceilings naming each alternative — alone, together, and among
+      // unrelated atoms. The flat reader compares the whole clause object to
+      // each entry, so none admits it: fit fails everywhere.
+      const ceilings: (readonly unknown[])[] = [
+        [], // declared public-only
+        [userA],
+        [userB],
+        [userA, userB], // names every alternative — still not the clause object
+        [userA, userB, "did:key:carol"],
+      ];
+      for (const ceiling of ceilings) {
+        const outside = flatAtomsOutsideCeiling(label, ceiling);
+        expect(outside).toContainEqual(clause);
+        expect(flatAtomsOutsideCeiling([clause], ceiling)).toHaveLength(1);
+      }
+
+      // Contrast: the CURRENT clause-aware fit admits the same read-back
+      // clause at a flat ceiling naming one alternative (A2's weaker-clause
+      // direction), and still rejects it at public-only. The flat reader is
+      // strictly MORE restrictive than the clause-aware one — fail-closed by
+      // construction, not by coincidence.
+      expect(cfcObservationFitsCeiling([clause], [userA])).toBe(true);
+      expect(cfcObservationFitsCeiling([clause], [])).toBe(false);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/module-item-classifier.test.ts
+++ b/packages/runner/test/module-item-classifier.test.ts
@@ -93,4 +93,35 @@ describe("classifyModuleItems (format-agnostic security core)", () => {
       )
     ).toThrow(/mutable/i);
   });
+
+  it("classifies a bracket-notation member reference against a known root", () => {
+    // Pins the quoted-bracket branch of the member-reference parser
+    // (`greet["helper"]`), which compiled bundles only reach when a pattern
+    // happens to emit bracket access — CI coverage of it was flapping
+    // run-to-run. The root binding is known, so classification succeeds.
+    const body =
+      `function () { const greet = (n) => n + 1; exports.greet = greet; exports.alias = greet["helper"]; }`;
+    const { source, statements } = bodyStatements(body);
+    const env = new Map<string, BindingInfo>();
+    expect(() =>
+      classifyModuleItems(source, "<m>", statements, env, ESM_OPTIONS)
+    ).not.toThrow();
+  });
+
+  it("rejects bracket notation with a non-string or unterminated key", () => {
+    // The parser only admits quoted keys; a computed index falls out of the
+    // member grammar and the reference is rejected as a top-level value.
+    const body =
+      `function () { const greet = (n) => n + 1; exports.greet = greet; exports.alias = greet[0]; }`;
+    const { source, statements } = bodyStatements(body);
+    expect(() =>
+      classifyModuleItems(
+        source,
+        "<m>",
+        statements,
+        new Map<string, BindingInfo>(),
+        ESM_OPTIONS,
+      )
+    ).toThrow(/SES mode/);
+  });
 });


### PR DESCRIPTION
## Summary

Stage A4 and the Epic A acceptance criteria of [`docs/plans/cfc-future-work-implementation.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cfc-future-work-implementation.md) require a **mixed-version test**: a persisted `{anyOf:[…]}` clause label read by the FLAT fit logic (pre-A2 semantics — plain deepEqual set-membership, as `atomsOutsideCeiling` did before #4470) must be outside every ceiling. #4472 landed authoring + persistence but only asserted wire-shape preservation; no test simulated a clause-unaware reader.

This PR adds that test to `packages/runner/test/cfc-clause-authoring.test.ts` (reusing its persist-and-read-back scaffolding):

1. **End-to-end persistence** — authors `{anyOf:[userB, userA]}` via schema `ifc.confidentiality`, commits, reads the clause back out of the stored labelMap via `readStoredCfcMetadata`, so the flat check runs against what's actually persisted.
2. **Faithful pre-A2 reader** — a local reimplementation of `atomsOutsideCeiling` exactly as it stood at #4055 before #4470 rewrote it to clause subsumption (verbatim from `git show e837914e2`): deepEqual membership + the ungrantable read-failed marker.
3. **Outside every ceiling** — against ceilings naming each alternative alone, both together, and both among unrelated atoms (plus declared public-only), the whole clause object lands in the outside set every time. A clause-unaware reader can only over-restrict, never leak — the fail-closed-by-construction claim of Epic A design decision 1.
4. **Strictly-more-restrictive contrast** — the current clause-aware `cfcObservationFitsCeiling` admits the same read-back clause at a flat `[userA]` ceiling (A2's weaker-clause direction) and still rejects it at public-only.

The test also guards the regression that matters most: if persistence ever flattened the clause into individual atoms (which WOULD leak on old readers), the `isOrClause` find fails and the test goes red.

**Red-green-exempt**: pins existing behavior; passed immediately by design.

## Test plan

- [x] `deno test -A test/cfc-clause-authoring.test.ts` — 7 steps green
- [x] `deno fmt --check` / `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mixed-version test that persists an `{anyOf:[…]}` CFC confidentiality clause, reads it back, and verifies a pre-A2 flat reader treats the clause as outside all ceilings (fail-closed; Epic A4), while `cfcObservationFitsCeiling` admits it at `[userA]` and `isOrClause` ensures the clause survives `readStoredCfcMetadata`.
Also awaits read-only transaction `commit()` before dispose to avoid races, and pins bracket-notation member-reference classification with tests for `greet["helper"]` (accepted with a known root) and non-string/unterminated keys (rejected) to stabilize coverage.

<sup>Written for commit 96c71955f811b33e47bad110b736437399cf6b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

