### PR TITLE
docs(cfc): correct decision-6 clause meet to pairwise union; C0 patches

### DIFF
--- a/docs/plans/cfc-future-work-implementation.md
+++ b/docs/plans/cfc-future-work-implementation.md
@@ -128,11 +128,29 @@ Integrity stays flat forever (no OR-integrity — spec §3.1.6; mixed integrity 
    (spec §3.1.8 rationale: OR-Expires inverts most-restrictive-wins; OR-Caveat
    makes risk dischargeable by identity).
 6. **Ceiling meet.** `meetCfcObservationCeilings`
-   ([observation.ts:157](../../packages/runner/src/cfc/observation.ts)) — for
-   clause entries, meet = pairwise alternative-set intersection of clause
-   pairs, dropping empties (sound: the intersection clause subsumes via both
-   parents). Flat/flat stays the current set intersection. Property-test
-   soundness: `fits(L, meet(C1,C2)) ⟹ fits(L,C1) ∧ fits(L,C2)`.
+   ([observation.ts:188](../../packages/runner/src/cfc/observation.ts)).
+   _Corrected 2026-07-02 — the original decision here ("pairwise
+   alternative-set intersection, sound: the intersection clause subsumes via
+   both parents") was **unsound**._ Ceiling clauses sit on the demanding side
+   of subsumption (`alts(c) ⊆ alts(l)`): fewer alternatives = a weaker demand
+   = admits **more** labels, so intersecting alternative sets *loosens*.
+   Counterexample: `meet([{A,B}], [{B,C}]) = [{B}]` admits label `[[B]]`,
+   which ceiling `[{A,B}]` alone rejects. The sound **and complete** clause
+   meet is the **pairwise alternative-set UNION**: `alts(c1) ∪ alts(c2) ⊆
+   alts(l)` holds iff both parents subsume `l`, and any label fitting both
+   ceilings has a witness pair whose union it fits. The union meet is also
+   the true meet on flat/flat inputs — `meet([A],[B]) = [{anyOf:[A,B]}]`,
+   decision-equivalent to today's atom intersection for flat *labels* but
+   additionally admitting OR-labels the intersection wrongly rejects.
+   Implementations may keep the flat-pair intersection fast path (equal-atom
+   pairs collapse to the atom) and may drop cross pairs to bound
+   `O(|C1|·|C2|)` ceiling growth — both are sound over-restrictions; the
+   intersection of alternative sets is never sound. Status: A2 (#4470)
+   landed the conservative deepEqual-identical meet with the general meet
+   explicitly deferred (rationale documented at the site); the union meet +
+   the **both-direction** property test `fits(L, meet(C1,C2)) ⟺ fits(L,C1) ∧
+   fits(L,C2)` must land before clause ceilings first reach this seam (B5
+   `BoundaryContext`/sink ceilings, H3b render ceiling).
 
 ### Stages
 
@@ -148,7 +166,9 @@ ordering of alternatives in `canonical.ts` (`canonicalizeCfcMetadata` must sort
 Rewrite `atomsOutsideCeiling` → clause-subsumption membership (return offending
 label *clauses*); `cfcObservationFitsCeiling` signature unchanged; the
 ungrantable `CFC_LABEL_READ_FAILED_ATOM` handling unchanged (it can never be
-subsumed-in). `meetCfcObservationCeilings` per decision 6.
+subsumed-in). `meetCfcObservationCeilings` per decision 6 (as landed in
+#4470: the conservative deepEqual meet; the union clause-meet is a
+follow-up owed before B5/H3b — see decision 6).
 **Red first:** the multi-party counterexample — label `[[User(A)],[User(B)]]`
 (nobody alone may read) vs ceiling `[{anyOf:[User(A),User(B)]}]` (readers A or
 B) must **fail** fit. Also: OR-clause label `[{anyOf:[A,B]}]` vs flat ceiling
@@ -419,8 +439,11 @@ shape-only via `nonRecursive` / followRef via `linkResolutionProbe`) in
 `forEachFlowObservation` ([prepare.ts:1215](../../packages/runner/src/cfc/prepare.ts));
 `effectiveReadLabel` selects entries by class-compatibility instead of the
 boolean; `excludeLinkOrigin` becomes class selection (link-origin entries
-consumed by `followRef` reads). Flow-taint parity test: with only legacy
-covering entries, derived joins are byte-identical to today.
+consumed by `followRef` reads). Flow-taint parity test, scoped per C0 §6:
+with only legacy covering entries, derived joins are byte-identical to today
+for `value`/`shape`/`enumerate` reads; the `followRef` path intentionally
+widens (that widening *is* the SC-8 fix) and is asserted as the new wider
+join, not claimed as parity.
 
 **C2 — persist split.** The persist region writes `observes:"value"` derived
 entries plus a `shape` entry per written path; the existing `structure` stamps
@@ -445,9 +468,16 @@ the epic).
 [sqlite-builtins.ts:205](../../packages/runner/src/builtins/sqlite-builtins.ts))
 narrows to the classes actually consumed.
 
-**Rollout.** No dial needed: entries are additive and legacy readers treat
-them as covering. Perf: labelMap grows ~2× entries per written path — bench
-before/after (canonicalize + label-sync).
+**Rollout.** _Corrected by C0 (#4476) — two regimes, not one._
+`value`/`shape`/`enumerate` entries are additive and legacy readers treat
+them as covering (over-taint, fail-safe — no dial needed). The **followRef
+slice is NOT fail-safe writer-first**: a legacy reader *drops*
+`origin:"link"` entries via `excludeLinkOrigin`, so a new writer + old
+reader **under-taints**. Deploy the class-aware reader before the writer, or
+gate followRef persistence behind a dial flipped only after readers
+understand it — a hard prerequisite for the SC-8 slice
+(`docs/specs/cfc-observation-classes.md` §9). Perf: labelMap grows ~2×
+entries per written path — bench before/after (canonicalize + label-sync).
 
 ---
 

--- a/docs/plans/cfc-future-work-implementation.md
+++ b/docs/plans/cfc-future-work-implementation.md
@@ -143,14 +143,21 @@ Integrity stays flat forever (no OR-integrity — spec §3.1.6; mixed integrity 
    decision-equivalent to today's atom intersection for flat *labels* but
    additionally admitting OR-labels the intersection wrongly rejects.
    Implementations may keep the flat-pair intersection fast path (equal-atom
-   pairs collapse to the atom) and may drop cross pairs to bound
-   `O(|C1|·|C2|)` ceiling growth — both are sound over-restrictions; the
+   pairs collapse to the atom — that *is* their union) and, if
+   `O(|C1|·|C2|)` ceiling growth ever bites, may drop cross pairs — a sound
+   over-restriction, but one that forfeits completeness (a pruned meet is
+   strictly tighter than the true meet: `[{anyOf:[A,B]}]` fits `[A]` and
+   `[B]` individually but not a meet whose cross pair was dropped). The
    intersection of alternative sets is never sound. Status: A2 (#4470)
    landed the conservative deepEqual-identical meet with the general meet
-   explicitly deferred (rationale documented at the site); the union meet +
-   the **both-direction** property test `fits(L, meet(C1,C2)) ⟺ fits(L,C1) ∧
-   fits(L,C2)` must land before clause ceilings first reach this seam (B5
-   `BoundaryContext`/sink ceilings, H3b render ceiling).
+   explicitly deferred (rationale documented at the site); the union meet
+   must land before clause ceilings first reach this seam (B5
+   `BoundaryContext`/sink ceilings, H3b render ceiling), with the property
+   test matched to the implementation: the full pairwise-union meet gets the
+   **both-direction** test `fits(L, meet(C1,C2)) ⟺ fits(L,C1) ∧ fits(L,C2)`;
+   a cross-pair-pruning variant only ever gets the soundness direction
+   (`⟹`), stated as such. Prefer the full meet — the biconditional is the
+   guard worth having.
 
 ### Stages
 

--- a/docs/specs/cfc-observation-classes.md
+++ b/docs/specs/cfc-observation-classes.md
@@ -49,8 +49,9 @@ Better than the audit implied — most of the plumbing is present:
   })` inside `deriveFlowJoin` (`prepare.ts`) already selects labels by a
   boolean shape flag and by origin.
 - **The `structure` origin already labels container shape** at exact paths
-  (`prepare.ts` persist region), applying only to reads *at* the container path,
-  not strictly below it.
+  (`prepare.ts` persist region), applying to reads *at* the container path and
+  to recursive ancestor reads, never to reads strictly below it (per the
+  `types.ts` component contract and the SC-7 note in `cfc-spec-changes.md`).
 
 So C is a *refinement* of existing axes, not new machinery.
 
@@ -77,6 +78,17 @@ type LabelMapEntry = {
   legacy (pre-C) entry is therefore covering, so a class-unaware reader
   over-taints (fail-safe) and old persisted data needs no migration. This is the
   same wire-compat move as the clause `anyOf` wrapper in Epic A.
+- **One carve-out, forced by the §6 parity contract: legacy `origin:"link"`
+  entries.** Read literally, "absent = covering" would make a plain value read
+  start consuming link-origin entries — but today `deriveFlowJoin` *drops*
+  them via `excludeLinkOrigin`, so the literal reading would break §6's
+  byte-identity contract for `value`/`shape`/`enumerate` reads on day one.
+  Normative rule: **an entry with `origin:"link"` and absent `observes` is
+  implicitly `observes:"followRef"`** — consumed by `followRef` reads only,
+  never as a covering entry. This reproduces today's behavior exactly
+  (dropped for value reads), and the followRef consumption it enables is the
+  new SC-8 behavior, arriving under §9's reader-first rollout. Every other
+  origin keeps the plain covering rule.
 
 **Alternative considered and rejected:** a single `PathLabelTemplate`-shaped
 entry carrying per-class label fields (`{ value?, shape?, enumerate? }`). It
@@ -100,6 +112,14 @@ A read consumes the join of every entry whose class is in its consumed set:
 The load-bearing change is the third row: the `followRef` observation, today
 dropped from the flow join, becomes a consumed class carrying the link entry's
 label — closing SC-8.
+
+**Where `count` went.** The spec's fifth class (§4.6.3) deliberately does not
+get its own axis value: a count observation (cardinality without membership)
+is strictly weaker than `enumerate`, so count-shaped reads (length, `COUNT`)
+consume the `enumerate` class — a sound over-approximation. A distinct
+`count` value is additive later if a consumer ever needs the precision (e.g.
+releasing a count more widely than membership); nothing in C1–C5 depends on
+the distinction.
 
 ## 5. SC-4: existence grows, value replaces
 
@@ -142,10 +162,26 @@ entries via `excludeLinkOrigin: true` (`prepare.ts`). Two distinct effects:
 
 ## 7. Observation ceiling (LLM path) and render
 
-The LLM observation ceiling (`llm.ts`) and render label views consume per-class
-in C4: a public `value` read of a child under a secret container `shape` no
-longer inherits the container's shape label (today the flat model takes the
-max). That precision win is what pays for the epic on the LLM/agent surface.
+C4 makes the two big consumers class-aware, both via the §4 table — same
+classification, same longest-prefix resolution, applied to the ceiling fit
+instead of the flow join:
+
+- **LLM observation ceiling (`llm.ts` / llm-dialog).** Serializing a value
+  into a prompt or tool context is a **recursive value read**: the ceiling
+  fit consumes `value + shape + enumerate` entries at each serialized path.
+  The genuinely new case is **opaque link handles**
+  (`cfcOpaqueLinkForPath`): rendering WHICH reference sits at a slot without
+  dereferencing it is a `followRef` observation, so an opaque handle
+  consumes the link entry's `followRef` label only — not the target's
+  `value` label. An opaque handle to a secret document taints the prompt
+  with the pointer's label, not the secret's. Mechanically, the ceiling-fit
+  path applies the same read-classification helper C1 adds for
+  `forEachFlowObservation`; C4 settles which call site carries it.
+- **Render label views** consume per-class the same way: a public `value`
+  read of a child under a secret container `shape` no longer inherits the
+  container's shape label (today the flat model takes the max).
+
+That precision win is what pays for the epic on the LLM/agent surface.
 
 ## 8. Staging (C1–C5)
 

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -105,6 +105,12 @@ Minimal needed now: reading an array whose items resolve to references _without
 dereferencing_ consumes container enumeration + per-item shape only — not
 element `value`. (This is what makes SC-7's coordinator taint well-defined.) A
 fuller table can come with the observation-class implementation.
+(Design settled 2026-07-02, C0 #4476 + follow-up patches:
+`docs/specs/cfc-observation-classes.md` — the §4 read-API → class table, the
+§5 SC-4 grow-vs-replace split, the §3 `origin:"link"` ⇒ implicit
+`observes:"followRef"` covering-rule carve-out, and `count` folding into
+`enumerate`. The spec PR to `commontoolsinc/specs` for §4.6.3 is now owed;
+file it once C1 validates the mapping in code.)
 
 **SC-9 [normative] Staged conformance for the default transition — §8.9.3 or
 §18.** §8.9.3 derives both confidentiality and integrity (TransformedBy +


### PR DESCRIPTION
## What

Post-merge review of the 12 future-work PRs (#4466–#4478) against the plan (#4461) surfaced two plan-level design errors and three C0 doc gaps. This fixes the documents so the follow-up implementations (union clause-meet before B5/H3b; Epic C stages C1–C4) build on sound text.

### Plan — `docs/plans/cfc-future-work-implementation.md`

- **Decision 6 (ceiling meet) rewritten.** The prescribed pairwise alternative-set **intersection** is unsound: ceiling clauses sit on the *demanding* side of subsumption (`alts(c) ⊆ alts(l)`), so fewer alternatives = weaker demand = admits more — intersection **loosens**. Counterexample: `meet([{A,B}], [{B,C}]) = [{B}]` admits label `[[B]]`, which ceiling `[{A,B}]` alone rejects, violating the decision's own soundness property. The sound **and complete** meet is the pairwise alternative-set **union** (`alts(c1) ∪ alts(c2) ⊆ alts(l)` iff both parents subsume `l`). Flat-pair fast path and cross-pair dropping remain sound over-restrictions. The rewrite records #4470's conservative deepEqual-identical meet as the landed state (rationale already documented at the site in `observation.ts`) and the union meet + both-direction property test as owed before clause ceilings reach the seam (B5 sink/`BoundaryContext` ceilings, H3b render ceiling).
- **Epic C rollout corrected per C0 (#4476):** two regimes — `value`/`shape`/`enumerate` additively fail-safe; **followRef requires reader-first or dialed rollout** (legacy readers *drop* `origin:"link"` entries via `excludeLinkOrigin`, so writer-first deployment under-taints). C1's parity test scoped to match.

### C0 doc — `docs/specs/cfc-observation-classes.md`

- **§3 carve-out (was an internal contradiction):** `origin:"link"` with absent `observes` is implicitly `observes:"followRef"`, never covering — the literal "absent = covering" rule would have made value reads consume link-origin entries and broken §6's own byte-identity contract on day one.
- **§4 `count` disposition (was silently dropped):** folds into `enumerate` (sound over-approximation); a distinct `count` value stays additive later.
- **§7 settled (was one thin paragraph):** how the LLM observation ceiling consumes classes — prompt/tool-context serialization is a recursive value read (`value+shape+enumerate` per the §4 table); **opaque link handles** (`cfcOpaqueLinkForPath`) are `followRef` observations, consuming the pointer's label rather than the target's.
- §2: structure-origin scope fixed (at-path + recursive ancestor reads, never strictly below — per the `types.ts` contract and SC-7).

### Tracking — `docs/specs/cfc-spec-changes.md`

SC-8 entry updated: C0 settled the fuller read-API → class table; the specs-repo PR for §4.6.3 is owed once C1 validates the mapping in code (the plan §9 bookkeeping step #4476 skipped).

## Scope

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the clause-ceiling meet to use pairwise union and updates C0 docs for `followRef`, `count`, structure-origin scope, and LLM/render consumption. Docs only; records the current conservative behavior and scopes rollout and parity for Epic C.

- **Bug Fixes**
  - Decision 6: clause meet is pairwise union, not intersection; records the current deepEqual-only meet and aligns the property test to the implementation — full pairwise-union ⇒ biconditional, any cross-pair pruning ⇒ soundness direction only; flat-pair fast path is allowed.
  - C0 docs: link-origin with absent `observes` is implicitly `followRef`; `count` folds into `enumerate`; structure-origin applies at-path and to recursive ancestor reads only; LLM/render consume classes via the read table (opaque link handles use `followRef`); parity notes call out that `followRef` intentionally widens and is asserted as the new join.
  - SC-8 tracking updated; specs-repo PR is owed after C1 validates the table.

- **Migration**
  - Two regimes: `value`/`shape`/`enumerate` are additive and safe; `followRef` needs a reader-first rollout or a dial (legacy readers drop link-origin entries). Parity test limits to `value`/`shape`/`enumerate`; `followRef` is intentionally wider.

<sup>Written for commit 04c176ceba971df6028d1a9b9eada62a95f95454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

