### PR TITLE
test(cfc): cross-reader regression test for read-time-clearance isolation

### DIFF
--- a/packages/patterns/integration/fixtures/sqlite-read-clearance/main.tsx
+++ b/packages/patterns/integration/fixtures/sqlite-read-clearance/main.tsx
@@ -1,0 +1,92 @@
+/// <cts-enable />
+// FIXTURE (multi-runtime integration, CFC Phase 3.b): cross-reader isolation
+// of read-time-clearance query results.
+//
+// Each notes row names its intended reader (a full did:key string) in its own
+// `reader` column, and the row rule mints exactly that principal as the row's
+// confidentiality. A `readClearance: true` query therefore returns each acting
+// reader ONLY the rows naming them — and because the cleared result is
+// reader-specific, each reader must get an ISOLATED result cell (per-`user`
+// scope) keyed by a reader-aware request hash. Regression fixture for the
+// #4478 review P0 (52e3e7e7): a space-scoped result cell plus a reader-blind
+// request hash let one reader observe another reader's filtered rows.
+import {
+  cfSqlite,
+  handler,
+  NAME,
+  pattern,
+  sqliteDatabase,
+  type SqliteDb,
+} from "commonfabric";
+
+interface NoteRow {
+  id: number;
+  reader: string;
+  body: string;
+}
+
+/** Seed rows addressed to specific readers (full did:key strings). */
+const seed = handler<
+  { rows: { reader: string; body: string }[] },
+  { db: SqliteDb }
+>(({ rows }, { db }) => {
+  for (const row of rows) {
+    db.exec("INSERT INTO notes (reader, body) VALUES (?, ?)", [
+      row.reader,
+      row.body,
+    ]);
+  }
+});
+
+export default pattern(() => {
+  // In-body destructuring: top-level destructuring is rejected by the SES
+  // verifier, and the rule callback is the recognized `table(columns, rule)`
+  // boundary (evaluated eagerly into a serialized AST).
+  const { table, principal, match } = cfSqlite;
+  // The base58btc multikey suffix of a did:key (z6Mk…). principal("key", …)
+  // re-mints `did:key:<match>`, so each row's confidentiality is exactly the
+  // did:key stored in its own reader column — one conjunctive clause naming
+  // one principal.
+  const KEY = /z[1-9A-HJ-NP-Za-km-z]+/g;
+
+  const notes = table(
+    {
+      id: "integer primary key",
+      reader: "text",
+      body: "text",
+    },
+    // A BARE term (no all() list): a rule term LIST is an array of objects,
+    // which splits into per-element linked docs on the handle value — and a
+    // second runtime's schema-less deep read of the handle can see that link
+    // unresolved (null), destabilizing the request hash across runtimes. The
+    // bare term stays inline, so every runtime reads the identical rule.
+    (f) => ({
+      confidentiality: principal("key", match(f.reader, KEY, { min: 1 })),
+    }),
+    // Phase 3.b: opt the table into read-time clearance.
+    { allowReadClearance: true },
+  );
+
+  const db = sqliteDatabase({ tables: { notes } });
+
+  // Baseline (no clearance): a shared, reader-blind result — every reader
+  // sees every row, so any isolation observed on qClear is clearance-made.
+  const qAll = db.query<NoteRow>(
+    "SELECT id, reader, body FROM notes ORDER BY id",
+    { reactOn: db },
+  );
+
+  // Read-time clearance: rows filtered to the ACTING reader per runtime.
+  const qClear = db.query<NoteRow>(
+    "SELECT id, reader, body FROM notes ORDER BY id",
+    { reactOn: db, readClearance: true },
+  );
+
+  return {
+    [NAME]: "SQLite read-time clearance (multi-runtime fixture)",
+    db,
+    qAll,
+    qClear,
+    seed: seed({ db }),
+  };
+});

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -200,6 +200,13 @@ export class MultiRuntimeSession {
     return await this.#client.call("read", { path });
   }
 
+  /** Read the RAW stored value at `path` (links resolved to the target cell,
+   *  no result-schema shaping) — for state the declared schema does not
+   *  carry, e.g. a query result's `requestHash`. */
+  async readRaw(path: (string | number)[] = []): Promise<unknown> {
+    return await this.#client.call("readRaw", { path });
+  }
+
   /** Inspect the normalized link (id, space, scope) at `path` in the result. */
   async link(
     path: (string | number)[] = [],

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -251,6 +251,22 @@ const handlers: Record<
   },
 
   /**
+   * Read the RAW stored value of the cell reached from the piece result by
+   * `path` (links resolved to the target cell, NO result-schema shaping) —
+   * for state the declared schema does not carry, e.g. a query result's
+   * `requestHash`. Nested links in the raw value stay sigils.
+   */
+  async readRaw({ path }) {
+    const target = result();
+    await target.pull();
+    let cell = target;
+    for (const segment of (path ?? []) as (string | number)[]) {
+      cell = cell.key(segment as never);
+    }
+    return sanitizeForTransfer(cell.resolveAsCell().getRaw());
+  },
+
+  /**
    * Inspect the normalized link (id, space, scope) of a cell reached from
    * the piece result by `path`, resolving links along the way. Lets tests
    * assert the storage addressing (e.g. scope) of pattern state.

--- a/packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts
+++ b/packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Multi-runtime regression test: CFC Phase 3.b read-time-clearance results
+ * are READER-ISOLATED (#4478 review P0, fixed in 52e3e7e7).
+ *
+ * Two users (alice, bob) share one space and one rule-bearing SQLite db whose
+ * rows each name their intended reader. Both runtimes run the same
+ * `readClearance: true` query. Before the fix the cleared result landed in a
+ * SPACE-scoped result cell keyed by a reader-blind request hash, so the
+ * runtime that settled second either reused the other reader's filtered rows
+ * (request-hash dedup) or clobbered them with its own — cross-reader
+ * disclosure either way. The fix forces the cleared result to per-`user`
+ * scope and keys the request hash by the acting reader.
+ *
+ * Asserts:
+ * - each reader's cleared query returns EXACTLY the rows naming them;
+ * - `withheld` is per-reader (each reader's own audit count);
+ * - the cleared result cell resolves at scope "user" (isolated instance per
+ *   reader on one shared link);
+ * - the two readers' cleared request hashes DIFFER, while the non-clearance
+ *   query keeps ONE shared hash (non-clearance queries unchanged).
+ *
+ * No toolshed or browser required (Deno workers + in-process storage server).
+ */
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const PROGRAM_PATH = join(
+  import.meta.dirname!,
+  "fixtures",
+  "sqlite-read-clearance",
+  "main.tsx",
+);
+const ROOT_PATH = join(import.meta.dirname!, "..");
+
+interface NoteRow {
+  id: number;
+  reader: string;
+  body: string;
+}
+
+interface QueryState {
+  pending?: boolean;
+  result?: NoteRow[];
+  error?: unknown;
+  withheld?: number;
+}
+
+async function queryState(
+  session: MultiRuntimeSession,
+  key: string,
+): Promise<QueryState> {
+  return ((await session.read([key])) ?? {}) as QueryState;
+}
+
+describe("sqlite read-time clearance across runtimes", () => {
+  let harness: MultiRuntimeHarness;
+  let alice: MultiRuntimeSession;
+  let bob: MultiRuntimeSession;
+
+  beforeAll(async () => {
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      sessions: ["alice", "bob"],
+    });
+    alice = harness.session("alice");
+    bob = harness.session("bob");
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("returns each reader only their own admissible rows", async () => {
+    const aliceDid = alice.identity.did();
+    const bobDid = bob.identity.did();
+
+    // One writer seeds rows for BOTH readers (the write gate labels each row
+    // from its own data; it does not require the writer to be a reader).
+    await alice.send("seed", {
+      rows: [
+        { reader: aliceDid, body: "alice-1" },
+        { reader: aliceDid, body: "alice-2" },
+        { reader: bobDid, body: "bob-only" },
+      ],
+    });
+
+    const settled = async (
+      session: MultiRuntimeSession,
+      key: string,
+      rows: number,
+    ): Promise<QueryState | undefined> => {
+      const state = await queryState(session, key);
+      return state.pending === false && state.error === undefined &&
+          (state.result?.length ?? -1) === rows
+        ? state
+        : undefined;
+    };
+
+    // Baseline sanity: without clearance BOTH readers see all three rows —
+    // the table is genuinely shared, so any qClear narrowing is clearance-made.
+    await harness.waitFor(
+      "baseline query settles on all rows in both runtimes",
+      async () =>
+        (await settled(alice, "qAll", 3)) !== undefined &&
+        (await settled(bob, "qAll", 3)) !== undefined,
+    );
+
+    // THE POINT — the cleared query is per-reader: each runtime's acting
+    // principal admits exactly the rows naming it, with a per-reader
+    // withheld audit count.
+    await harness.waitFor(
+      "alice's cleared query settles on her two rows",
+      async () => (await settled(alice, "qClear", 2)) !== undefined,
+    );
+    await harness.waitFor(
+      "bob's cleared query settles on his one row",
+      async () => (await settled(bob, "qClear", 1)) !== undefined,
+    );
+
+    const aliceClear = await queryState(alice, "qClear");
+    assertEquals(
+      aliceClear.result?.map((r) => r.body),
+      ["alice-1", "alice-2"],
+      "alice must see exactly her rows",
+    );
+    assert(
+      aliceClear.result!.every((r) => r.reader === aliceDid),
+      "every row alice sees must name alice as its reader",
+    );
+    assertEquals(aliceClear.withheld, 1, "alice's withheld count (bob's row)");
+
+    const bobClear = await queryState(bob, "qClear");
+    assertEquals(
+      bobClear.result?.map((r) => r.body),
+      ["bob-only"],
+      "bob must see exactly his row",
+    );
+    assert(
+      bobClear.result!.every((r) => r.reader === bobDid),
+      "every row bob sees must name bob as its reader",
+    );
+    assertEquals(bobClear.withheld, 2, "bob's withheld count (alice's rows)");
+  });
+
+  it("isolates the cleared result cell per user and keys the request hash by reader", async () => {
+    // One shared link, per-user instances: the cleared result cell must
+    // resolve at scope "user" in both runtimes (a space-scoped cell is the
+    // pre-fix shared-result leak).
+    const aliceLink = await alice.link(["qClear"]);
+    const bobLink = await bob.link(["qClear"]);
+    assertEquals(aliceLink.scope, "user", "alice's cleared result scope");
+    assertEquals(bobLink.scope, "user", "bob's cleared result scope");
+    assertEquals(
+      aliceLink.id,
+      bobLink.id,
+      "same base entity — isolation comes from the per-user scope partition",
+    );
+
+    // Belt-and-suspenders: a cleared result's request hash includes the
+    // acting reader, so the two runtimes must record DIFFERENT hashes (a
+    // shared reader-blind hash is what let one reader dedup against the
+    // other's rows). requestHash is not in the declared result schema, so
+    // read it raw.
+    const aliceClearRaw = await alice.readRaw(["qClear"]) as QueryState & {
+      requestHash?: string;
+    };
+    const bobClearRaw = await bob.readRaw(["qClear"]) as QueryState & {
+      requestHash?: string;
+    };
+    assert(aliceClearRaw.requestHash, "alice's cleared query recorded a hash");
+    assert(bobClearRaw.requestHash, "bob's cleared query recorded a hash");
+    assertNotEquals(
+      aliceClearRaw.requestHash,
+      bobClearRaw.requestHash,
+      "cleared request hashes must be keyed by the acting reader",
+    );
+
+    // Contrast: the non-clearance query stays reader-blind — one shared
+    // space-scoped result cell, one shared hash (the fix must not re-scope or
+    // re-hash plain queries).
+    const aliceAllLink = await alice.link(["qAll"]);
+    assertEquals(aliceAllLink.scope, "space", "baseline result stays shared");
+    const aliceAllRaw = await alice.readRaw(["qAll"]) as {
+      requestHash?: string;
+    };
+    const bobAllRaw = await bob.readRaw(["qAll"]) as { requestHash?: string };
+    assert(aliceAllRaw.requestHash, "baseline query recorded a hash");
+    assertEquals(
+      aliceAllRaw.requestHash,
+      bobAllRaw.requestHash,
+      "baseline request hash stays reader-blind",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds the missing regression test for the #4478 review P0 (fixed in 52e3e7e7 within that PR): a read-time-clearance query result was initially written to a **space-scoped** result cell keyed by a **reader-blind** request hash, so in a shared db one reader could observe another reader's filtered rows. The fix (per-`user` result scope + `clearanceReader` in the request hash) landed with zero test coverage — this PR adds the cross-reader test.

## How

A multi-runtime test (two worker-isolated runtimes for two users, one shared in-process storage server — the #3958 harness): both users run the same `readClearance: true` query against one shared rule-bearing table whose rows each name their intended reader (the row rule mints the did:key stored in the row's own `reader` column).

Asserts:
- each reader's cleared query returns **exactly** the rows naming them (alice 2, bob 1);
- `withheld` is per-reader (1 vs 2 — the audit count is reader-specific);
- the cleared result cell resolves at scope `"user"` in both runtimes (one shared link, per-user instances);
- the two readers record **different** request hashes, while the non-clearance baseline query keeps one shared space-scoped cell and one reader-blind hash (non-clearance queries unchanged by the fix).

Red-checked against a working tree with 52e3e7e7 reverted: bob then never settles on his own row — his runtime request-hash-dedups against alice's shared cleared result and keeps seeing *her* rows (the disclosure itself) — and the scope assertion fails (`"space"` ≠ `"user"`).

Also adds a `readRaw` command to the multi-runtime worker/harness (raw resolved read, no result-schema shaping) since `requestHash` is not part of the declared query-state schema.

## Pre-existing issues surfaced (not fixed here, tracked as follow-ups)

1. **Shared-query ping-pong from split rule-term docs**: a rowLabel term LIST (`all(a, b, …)`) splits into per-element linked docs on the db handle; a second runtime can deep-resolve that link to `null`, destabilizing the request hash across runtimes so a shared query result cell re-issues forever. The fixture deliberately uses a BARE confidentiality term to stay inline (see fixture comment).
2. **Owner re-mint**: every runtime opening the piece re-runs `sqliteDatabase` and rewrites the handle's `owner` as its own acting principal (last opener wins), so `dbOwner()` rules / `__ctDbOwner` ceilings can resolve to the wrong principal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-runtime regression test to ensure read-time clearance results are reader-isolated and keyed by the acting reader, preventing cross-reader disclosure in shared SQLite DBs. Also adds `readRaw` to the multi-runtime harness to inspect raw query state like `requestHash`.

- **New Features**
  - Multi-runtime test for `readClearance: true`: verifies per-reader rows, per-reader `withheld`, cleared result cell scope "user", and different request hashes; baseline query remains space-scoped with a shared hash.
  - Adds `readRaw` to the worker/harness to read unshaped values (e.g., `requestHash`) for assertions.

<sup>Written for commit 680cc8b0194944dc6c3a3343d475a9ffd984146c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

