### PR TITLE
Treat imported cell wrapper types as a capability contract

### DIFF
--- a/packages/patterns/google/core/util/gmail-send-client.ts
+++ b/packages/patterns/google/core/util/gmail-send-client.ts
@@ -265,13 +265,27 @@ export interface GmailSendClient {
   listLabels(retryCount?: number): Promise<GmailLabel[]>;
 }
 
+// The Writable<Auth> and AuthCell forms are kept as separate overloads rather
+// than a single union parameter. Overload resolution then selects the
+// Writable<Auth> signature for a live handler auth cell, which lets capability
+// analysis see the write the client performs when it persists a refreshed token
+// through that cell. The AuthCell overload covers read-only contexts where
+// refreshes are not persisted.
 type GmailSendClientFactory = {
   new (
-    auth: AuthCell | Writable<Auth>,
+    auth: Writable<Auth>,
+    config?: GmailSendClientConfig,
+  ): GmailSendClient;
+  new (
+    auth: AuthCell,
     config?: GmailSendClientConfig,
   ): GmailSendClient;
   (
-    auth: AuthCell | Writable<Auth>,
+    auth: Writable<Auth>,
+    config?: GmailSendClientConfig,
+  ): GmailSendClient;
+  (
+    auth: AuthCell,
     config?: GmailSendClientConfig,
   ): GmailSendClient;
 };

--- a/packages/patterns/google/core/util/google-docs-client.ts
+++ b/packages/patterns/google/core/util/google-docs-client.ts
@@ -17,7 +17,7 @@
  * const comments = await client.listComments(fileId);
  * ```
  */
-import { Cell, getPatternEnvironment } from "commonfabric";
+import { getPatternEnvironment, type Writable } from "commonfabric";
 
 const env = getPatternEnvironment();
 
@@ -109,7 +109,7 @@ export function extractFileId(url: string): string | null {
  * See: community-docs/superstitions/2025-12-03-derive-creates-readonly-cells-use-property-access.md
  */
 export class GoogleDocsClient {
-  private auth: Cell<Auth>;
+  private auth: Writable<Auth>;
   private retries: number;
   private delay: number;
   private delayIncrement: number;
@@ -117,7 +117,7 @@ export class GoogleDocsClient {
   private onRefresh?: () => Promise<void>;
 
   constructor(
-    auth: Cell<Auth>,
+    auth: Writable<Auth>,
     {
       retries = 3,
       delay = 1000,

--- a/packages/ts-transformers/SCHEMA_INJECTION_NOTES.md
+++ b/packages/ts-transformers/SCHEMA_INJECTION_NOTES.md
@@ -206,6 +206,88 @@ on TypeScript's understanding, even when that might not match user expectations.
 - BigInt literals: `10n` → `bigint` (integer in JSON Schema)
 - Nested literals: Recursively widened through union merging
 
+### Imported Cell Parameters Are a Capability Contract
+
+Capability analysis decides how a handler input cell is shrunk. Body analysis
+can see reads and direct writes (`auth.update(...)`), but it cannot see what a
+callee does inside a body that lives in another file. When a handler passes a
+cell to such a callee, the callee's declared Common Fabric wrapper parameter
+type is the capability contract at that import boundary, and it accounts for
+that argument at that call.
+
+A recognized wrapper parameter type maps to a capability: `Writable<T>` → read
+and write, `ReadonlyCell<T>` → read, `WriteonlyCell<T>` → write, and the
+opaque/stream/comparable/sqlite wrappers to their respective handling.
+`Writable<T>` is a _structural_ alias of `Cell<T>` — an identical type — so
+those two are distinguished only by the spelling on the declared type node; the
+transformer's matching is what is nominal (by name). Bare `Cell<T>` and
+same-named types from other libraries are not recognized and leave the
+conservative default in place; unknown callees stay conservative.
+
+The other wrappers carry distinct compile-time brands, so they are genuinely
+different types, not just different spellings. In particular a `Writable<T>`
+value is not assignable to a `ReadonlyCell<T>` parameter — that is a `TS2345`
+error (the `[CELL_BRAND]` tags `"cell"` and `"readonly"` are incompatible). So
+the `ReadonlyCell<T>` → readonly shrink is reached when a handler's own input is
+declared `ReadonlyCell<T>`, or through an explicit cast; a writable cell cannot
+be passed to a read-only parameter directly. This is why granting write is the
+only direction the contract needs to relax the least-authority default — the
+type system already prevents the read-only direction from silently discarding a
+writable cell.
+
+Why the declared type is the right contract, and why it is trusted in both
+directions: the schema this analysis produces is what the runtime enforces. Per
+spec 8.15, a field's `writeAuthorizedBy` set is composed from the handlers that
+declare they write it, and `authorizeWrite` allows a runtime write only when the
+handler identity is in that set. The threat model (spec 9.1.1, 9.2.2) treats
+handler code as untrusted and able to attempt privilege escalation. So the
+analysis derives least authority: it grants write only where a write is
+demonstrated, and passing a cell to a declared reader demonstrates no write.
+Preserving write authority a handler does not use would broaden
+`writeAuthorizedBy` and weaken least authority; a cast that tries to write past
+a declared read-only type is denied at runtime because the schema, not the cast,
+is enforced. Trusting the declared type to reduce authority is therefore safe,
+and trusting it to grant write is bounded by the caller's own declaration and is
+what real refresh clients need.
+
+A recognized wrapper accounts for its argument: it replaces the conservative
+whole-cell root fallback for that specific argument and call, and it does not
+erase other evidence found elsewhere in the handler (a direct `auth.update(...)`
+still contributes a write). A provider client whose factory accepts both a live
+cell and a read-only wrapper should expose them as separate overloads
+(`Writable<T>` and the wrapper type) rather than a single union parameter, so
+overload resolution selects the writable form only for a live cell. See
+`GmailSendClient` for the pattern.
+
+Authoring rule: an imported function or constructor that writes a cell argument
+must declare that parameter `Writable<T>` (or `WriteonlyCell<T>`). Declaring it
+`ReadonlyCell<T>` shrinks callers' schemas to read-only and their writes are
+denied at runtime — the honest fix is the declared type, not broader authority
+in the caller.
+
+### Diagnostic for ambiguous cell-union parameters
+
+Most unclassifiable parameter shapes degrade conservatively and are safe or are
+legitimate framework types, so they are left alone. One shape is a genuine
+authoring bug: a union parameter that mixes a recognized cell wrapper with a
+member the contract cannot resolve to the same capability — for example
+`AuthCell | Writable<Auth>`, or `Writable<Auth> | ReadonlyCell<Auth>`. Overload
+resolution cannot pick the capability, so a cell argument silently degrades.
+When a branded cell argument flows to such a parameter, capability analysis
+records it and the schema-injection transformer raises a
+`capability:unreadable-cell-argument` error telling the author to split the
+callee into overloads (the fix `GmailSendClient` already applies). This makes
+the split-overload rule fail loudly rather than by convention.
+
+The diagnostic is deliberately narrow, and only fires for the mixed-wrapper
+union. It does **not** fire for value-or-cell framework types
+(`FactoryInput<T>`, `CellLike<T>`, `U | AnyBrandedCell<U>`), which accept a
+value or a cell by design and are either not unions or unions with no
+recognized-wrapper member; nor for bare `Cell<T>`, generic parameters,
+structural cell-like interfaces on their own, array identity-writer methods, or
+`any`/`unknown` sinks. A sweep of the pattern corpus confirmed zero matches for
+anything but the true overload-split shape.
+
 ---
 
 ## Test Coverage

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -216,6 +216,7 @@ export type {
   TransformationOptions,
   TransformMode,
   TypeRegistry,
+  UnreadableCellArgument,
 } from "./transformers.ts";
 export {
   HelpersOnlyTransformer,

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -52,10 +52,23 @@ export interface CapabilityParamSummary {
   readonly defaults?: readonly CapabilityParamDefault[];
 }
 
+/**
+ * A cell argument that flows to an out-of-file parameter whose declared type the
+ * capability contract cannot read (bare `Cell<T>`, a mixed union, an unbounded
+ * generic, or a non-branded cell-like interface). The capability silently
+ * degrades, so the caller surfaces this as a diagnostic.
+ */
+export interface UnreadableCellArgument {
+  readonly node: ts.Node;
+  readonly message: string;
+}
+
 export interface FunctionCapabilitySummary {
   readonly params: readonly CapabilityParamSummary[];
   /** True when analysis was short-circuited due to recursion. */
   readonly recursive?: boolean;
+  /** Cell arguments passed to parameters the contract could not classify. */
+  readonly unreadableCellArguments?: readonly UnreadableCellArgument[];
 }
 
 export type PatternCoverageKind = "runtime";

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import {
   classifyArrayCallbackContainerCall,
+  getNodeText,
   isCellLikeType,
   isWildcardTraversalCall,
 } from "../ast/mod.ts";
@@ -9,7 +10,9 @@ import {
   type FunctionCapabilitySummary,
   type ReactiveCapability,
   resolvesToCommonFabricSymbol,
+  type UnreadableCellArgument,
 } from "../core/mod.ts";
+import { isBrandedCellType } from "../transformers/cell-type.ts";
 import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
 import { decodePath, encodePath } from "../utils/path-serialization.ts";
 import { unwrapExpression } from "../utils/expression.ts";
@@ -219,6 +222,245 @@ function isInterproceduralSummaryTarget(
 ): declaration is CapabilityAnalyzableFunction {
   return isCapabilityAnalyzableFunction(declaration) &&
     declaration.getSourceFile() === sourceFile;
+}
+
+// Body analysis cannot see writes performed inside a callee whose body lives in
+// another file. The callee's declared parameter type is the only available
+// description of what it does with the cell, so it is treated as a contract for
+// the one capability the body cannot reveal: a hidden write.
+function isSignatureDeclaredOutsideSourceFile(
+  signature: ts.Signature,
+  sourceFile: ts.SourceFile,
+): boolean {
+  const declaration = signature.declaration;
+  return !!declaration && declaration.getSourceFile() !== sourceFile;
+}
+
+function getParameterAtArgument(
+  signature: ts.Signature,
+  argumentIndex: number,
+): ts.Symbol | undefined {
+  const parameters = signature.getParameters();
+  if (argumentIndex < parameters.length) {
+    return parameters[argumentIndex];
+  }
+  const lastParameter = parameters[parameters.length - 1];
+  const declaration = lastParameter?.valueDeclaration;
+  return declaration && ts.isParameter(declaration) &&
+      declaration.dotDotDotToken
+    ? lastParameter
+    : undefined;
+}
+
+type SignatureCellKind =
+  | "opaque"
+  | "cell"
+  | "stream"
+  | "comparable"
+  | "readonly"
+  | "writeonly"
+  | "sqlite";
+
+// Read the capability an imported callee declares for a parameter from its
+// Common Fabric cell wrapper type. `Writable<T>` is a structural alias of
+// `Cell<T>` (an identical type), so the two are distinguished only by the
+// spelling on the declared type node; the wrapper is matched nominally, by name,
+// rather than by the resolved type. The other wrappers (`ReadonlyCell`,
+// `WriteonlyCell`, etc.) carry distinct brands and are genuinely different
+// types. A type that is not a recognized Common Fabric wrapper returns undefined
+// and leaves the conservative default in place.
+// In a union type node, `undefined` parses as a keyword type node but `null`
+// parses as a LiteralTypeNode wrapping a null literal, so a bare NullKeyword
+// check never matches. Skip both so a nullable wrapper such as
+// `Writable<T> | null` is still recognized by its non-null member.
+function isNullOrUndefinedTypeNode(typeNode: ts.TypeNode): boolean {
+  if (typeNode.kind === ts.SyntaxKind.UndefinedKeyword) return true;
+  return ts.isLiteralTypeNode(typeNode) &&
+    typeNode.literal.kind === ts.SyntaxKind.NullKeyword;
+}
+
+// A bounded generic parameter (`<C extends Writable<T>>`) carries the capability
+// of its constraint, so read the constraint node. Unbounded generics have no
+// constraint and stay unreadable.
+function getTypeParameterConstraintTypeNode(
+  symbol: ts.Symbol | undefined,
+): ts.TypeNode | undefined {
+  for (const declaration of symbol?.getDeclarations() ?? []) {
+    if (ts.isTypeParameterDeclaration(declaration) && declaration.constraint) {
+      return declaration.constraint;
+    }
+  }
+  return undefined;
+}
+
+function getExplicitCellKindFromTypeNode(
+  typeNode: ts.TypeNode | undefined,
+  checker: ts.TypeChecker,
+  depth = 0,
+): SignatureCellKind | undefined {
+  // The depth guard bounds the type-parameter-constraint recursion below
+  // against a circular constraint on ill-typed input.
+  if (!typeNode || depth > 16) return undefined;
+
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return getExplicitCellKindFromTypeNode(typeNode.type, checker, depth + 1);
+  }
+
+  if (ts.isUnionTypeNode(typeNode)) {
+    const kinds = new Set<SignatureCellKind>();
+    for (const member of typeNode.types) {
+      if (isNullOrUndefinedTypeNode(member)) {
+        continue;
+      }
+      const kind = getExplicitCellKindFromTypeNode(member, checker, depth + 1);
+      if (!kind) {
+        return undefined;
+      }
+      kinds.add(kind);
+    }
+    return kinds.size === 1 ? kinds.values().next().value : undefined;
+  }
+
+  if (!ts.isTypeReferenceNode(typeNode)) {
+    return undefined;
+  }
+
+  const symbol = checker.getSymbolAtLocation(typeNode.typeName);
+  // `Writable<T>` is the spelling that declares write intent. Bare `Cell<T>` is
+  // the neutral base alias and is intentionally not matched here: a callee that
+  // writes a cell argument must declare `Writable<T>` (or `WriteonlyCell<T>`),
+  // so an ambiguous `Cell<T>` parameter stays conservative and does not grant
+  // the caller write authority it has not demonstrated.
+  if (resolvesToCommonFabricSymbol(symbol, checker, "Writable")) {
+    return "cell";
+  }
+  if (resolvesToCommonFabricSymbol(symbol, checker, "ReadonlyCell")) {
+    return "readonly";
+  }
+  if (resolvesToCommonFabricSymbol(symbol, checker, "WriteonlyCell")) {
+    return "writeonly";
+  }
+  if (resolvesToCommonFabricSymbol(symbol, checker, "Stream")) {
+    return "stream";
+  }
+  if (resolvesToCommonFabricSymbol(symbol, checker, "ComparableCell")) {
+    return "comparable";
+  }
+  if (
+    resolvesToCommonFabricSymbol(symbol, checker, "OpaqueCell") ||
+    resolvesToCommonFabricSymbol(symbol, checker, "OpaqueRef")
+  ) {
+    return "opaque";
+  }
+  if (resolvesToCommonFabricSymbol(symbol, checker, "SqliteDb")) {
+    return "sqlite";
+  }
+  const constraint = getTypeParameterConstraintTypeNode(symbol);
+  if (constraint) {
+    return getExplicitCellKindFromTypeNode(constraint, checker, depth + 1);
+  }
+  return undefined;
+}
+
+// The declared type node that governs a single argument at this parameter: the
+// element type for a rest parameter, otherwise the parameter's own type.
+function getEffectiveParameterTypeNode(
+  parameter: ts.Symbol | undefined,
+): ts.TypeNode | undefined {
+  const declaration = parameter?.valueDeclaration;
+  if (!declaration || !ts.isParameter(declaration)) {
+    return undefined;
+  }
+  if (declaration.dotDotDotToken) {
+    return getRestParameterElementTypeNode(declaration.type);
+  }
+  return declaration.type;
+}
+
+function getParameterDeclaredCellKind(
+  parameter: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+): SignatureCellKind | undefined {
+  return getExplicitCellKindFromTypeNode(
+    getEffectiveParameterTypeNode(parameter),
+    checker,
+  );
+}
+
+// A missing annotation (implicit any) or an explicit `any`/`unknown` parameter
+// A union parameter that mixes a recognized cell wrapper with a member the
+// contract cannot collapse to the same capability — for example
+// `AuthCell | Writable<Auth>`, or `Writable<Auth> | ReadonlyCell<Auth>`. Such a
+// union defeats classification: overload resolution can't pick the intended
+// capability, so a cell argument silently degrades. This is deliberately narrow
+// — it does not fire for value-or-cell framework types (`FactoryInput<T>`,
+// `U | AnyBrandedCell<U>`), which are unions with no recognized-wrapper member
+// (or not unions at all), nor for bare `Cell<T>`, generics, or `any`/`unknown`.
+function isAmbiguousCellWrapperUnion(
+  typeNode: ts.TypeNode | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  let node = typeNode;
+  while (node && ts.isParenthesizedTypeNode(node)) {
+    node = node.type;
+  }
+  if (!node || !ts.isUnionTypeNode(node)) return false;
+  // If the union collapses to a single capability it is readable; only flag when
+  // it does not, yet at least one member is a recognized cell wrapper.
+  if (getExplicitCellKindFromTypeNode(node, checker)) return false;
+  return node.types.some((member) =>
+    !isNullOrUndefinedTypeNode(member) &&
+    getExplicitCellKindFromTypeNode(member, checker) !== undefined
+  );
+}
+
+function buildUnreadableCellArgumentMessage(
+  typeNode: ts.TypeNode | undefined,
+): string {
+  const typeText = typeNode ? getNodeText(typeNode) : "unknown";
+  return `Cell argument flows to an imported parameter typed \`${typeText}\`, ` +
+    `a union that mixes cell capabilities the analysis cannot resolve to one ` +
+    `kind. Split the callee into overloads (one per cell wrapper, such as ` +
+    `\`Writable<T>\` and the other type) so overload resolution selects the ` +
+    `intended capability; otherwise the argument silently degrades to a ` +
+    `read-only cell and a needed write is denied at runtime.`;
+}
+
+// A rest parameter declares an array, but each variadic argument has the
+// element type. Unwrap `T[]`, `readonly T[]`, `Array<T>`, and `ReadonlyArray<T>`
+// to the element.
+function getRestParameterElementTypeNode(
+  typeNode: ts.TypeNode | undefined,
+): ts.TypeNode | undefined {
+  if (!typeNode) return undefined;
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return getRestParameterElementTypeNode(typeNode.type);
+  }
+  if (
+    ts.isTypeOperatorNode(typeNode) &&
+    typeNode.operator === ts.SyntaxKind.ReadonlyKeyword
+  ) {
+    return getRestParameterElementTypeNode(typeNode.type);
+  }
+  if (ts.isArrayTypeNode(typeNode)) {
+    return typeNode.elementType;
+  }
+  if (
+    ts.isTypeReferenceNode(typeNode) &&
+    ts.isIdentifier(typeNode.typeName) &&
+    (typeNode.typeName.text === "Array" ||
+      typeNode.typeName.text === "ReadonlyArray") &&
+    typeNode.typeArguments?.length === 1
+  ) {
+    return typeNode.typeArguments[0];
+  }
+  return undefined;
+}
+
+function isRestParameter(parameter: ts.Symbol | undefined): boolean {
+  const declaration = parameter?.valueDeclaration;
+  return !!declaration && ts.isParameter(declaration) &&
+    !!declaration.dotDotDotToken;
 }
 
 function isLiteralElement(
@@ -1369,6 +1611,8 @@ export function analyzeFunctionCapabilities(
     // the blanket read if the alias already has a more specific path.
     const aliasesWithSpecificPaths = new Set<string>();
     const identityArrayLocals = collectArrayLocalsPassedToSet(fn.body, checker);
+    const signatureCapabilityArgumentUses = new WeakSet<ts.Expression>();
+    const unreadableCellArguments: UnreadableCellArgument[] = [];
 
     const getIdentifierName = (
       expression: ts.Expression,
@@ -1998,6 +2242,110 @@ export function analyzeFunctionCapabilities(
       });
     };
 
+    // Apply the capability an out-of-file callee declares for a cell argument
+    // through its Common Fabric wrapper parameter type. Body analysis cannot see
+    // what the callee does with the cell, so the declared wrapper type is the
+    // contract: it accounts for that argument at that call and replaces the
+    // conservative default. Returns the handled argument indices so the
+    // whole-cell root fallback skips them; the argument's usage site is recorded
+    // so ordinary identifier handling does not add a second, broader read.
+    const applySignatureCellCapabilities = (
+      call: ts.CallExpression | ts.NewExpression,
+    ): Set<number> => {
+      const handled = new Set<number>();
+      if (!checker) return handled;
+
+      const signature = checker.getResolvedSignature(call);
+      if (!signature) return handled;
+      if (!isSignatureDeclaredOutsideSourceFile(signature, summarySourceFile)) {
+        return handled;
+      }
+
+      const args = call.arguments;
+      if (!args) return handled;
+
+      for (let index = 0; index < args.length; index++) {
+        const argument = args[index];
+        if (!argument) continue;
+
+        const parameter = getParameterAtArgument(signature, index);
+        const isSpreadArgument = ts.isSpreadElement(argument);
+        // An array spread has unknown runtime length, so it cannot be matched to
+        // later fixed parameters; stop signature mapping there. A spread into a
+        // rest parameter is a collection of rest elements, recorded below at the
+        // representative array-item path.
+        if (isSpreadArgument && !isRestParameter(parameter)) break;
+
+        const capabilityArgument = isSpreadArgument
+          ? argument.expression
+          : argument;
+        const source = resolveSourceRef(capabilityArgument);
+        if (!source) continue;
+
+        const cellKind = getParameterDeclaredCellKind(parameter, checker);
+        if (!cellKind) {
+          // The parameter type is not a recognized wrapper. Flag only the
+          // genuinely ambiguous shape: a union that mixes a cell wrapper with an
+          // unresolvable member (the overload-split case), and only when an
+          // actual cell argument flows there. Value-or-cell framework types and
+          // bare `Cell<T>`/generics/`any` are intentionally not flagged.
+          const effectiveTypeNode = getEffectiveParameterTypeNode(parameter);
+          if (
+            isAmbiguousCellWrapperUnion(effectiveTypeNode, checker) &&
+            isBrandedCellType(
+              checker.getTypeAtLocation(capabilityArgument),
+              checker,
+            )
+          ) {
+            unreadableCellArguments.push({
+              node: capabilityArgument,
+              message: buildUnreadableCellArgumentMessage(effectiveTypeNode),
+            });
+          }
+          continue;
+        }
+
+        handled.add(index);
+        signatureCapabilityArgumentUses.add(
+          unwrapExpressionUsageSite(capabilityArgument),
+        );
+
+        if (source.dynamic) {
+          markWildcard(source.root);
+          continue;
+        }
+
+        const sourcePath = isSpreadArgument
+          ? [...source.path, "0"]
+          : source.path;
+
+        switch (cellKind) {
+          case "cell":
+            trackRead(source.root, sourcePath);
+            trackWrite(source.root, sourcePath);
+            break;
+          case "readonly":
+            trackRead(source.root, sourcePath);
+            break;
+          case "writeonly":
+            trackWrite(source.root, sourcePath);
+            break;
+          case "comparable":
+            recordComparablePath(source.root, sourcePath, {
+              cellLike: true,
+            });
+            break;
+          case "opaque":
+          case "stream":
+          case "sqlite":
+            recordOpaquePath(source.root, sourcePath);
+            break;
+        }
+      }
+
+      return handled;
+    };
+
     const visitScopedFunctionBody = (
       callback: CapabilityAnalyzableFunction,
       paramBindings?: ReadonlyMap<number, AliasBinding>,
@@ -2236,6 +2584,11 @@ export function analyzeFunctionCapabilities(
               // aware so it sees through synthetic `any` params — routes
               // primitives to the full read above instead of into this skip.
             } else if (
+              signatureCapabilityArgumentUses.has(usage)
+            ) {
+              // Explicit Common Fabric cell parameter types account for this
+              // argument.
+            } else if (
               !(
                 parent &&
                 ts.isPropertyAccessExpression(parent) &&
@@ -2353,7 +2706,13 @@ export function analyzeFunctionCapabilities(
           if (
             !(parent && ts.isCallExpression(parent) &&
               parent.expression === node) &&
-            !isOptionalAliasInitializerMemberUsage(node)
+            !isOptionalAliasInitializerMemberUsage(node) &&
+            // A member-access argument (e.g. `state.auth`) whose callee parameter
+            // type already supplied the capability is accounted for, same as a
+            // destructured identifier; don't add a second read here.
+            !signatureCapabilityArgumentUses.has(
+              unwrapExpressionUsageSite(node),
+            )
           ) {
             const ref = resolveSourceRef(node);
             if (ref) {
@@ -2420,7 +2779,7 @@ export function analyzeFunctionCapabilities(
 
         const identityEqualsCall = isKnownIdentityEqualsCall(node, checker);
         const identityArgumentCall = isKnownIdentityArgumentCall(node, checker);
-        const interproceduralHandledArgs = new Set<number>();
+        const capabilityHandledArgs = new Set<number>();
         const calleeSummary = resolveInterproceduralSummary(node);
         if (calleeSummary) {
           const count = Math.min(
@@ -2434,7 +2793,7 @@ export function analyzeFunctionCapabilities(
 
             const source = resolveSourceRef(argument);
             if (!source) continue;
-            interproceduralHandledArgs.add(index);
+            capabilityHandledArgs.add(index);
 
             if (source.dynamic || paramSummary.wildcard) {
               markWildcard(source.root);
@@ -2506,6 +2865,10 @@ export function analyzeFunctionCapabilities(
                 paramSummary.identityOnly ? { identityOnly: true } : undefined,
               );
             }
+          }
+        } else if (!identityArgumentCall) {
+          for (const index of applySignatureCellCapabilities(node)) {
+            capabilityHandledArgs.add(index);
           }
         }
 
@@ -2638,7 +3001,7 @@ export function analyzeFunctionCapabilities(
         // indirect traversal/mutation; conservatively disable shrinking.
         if (!identityArgumentCall) {
           for (let index = 0; index < node.arguments.length; index++) {
-            if (interproceduralHandledArgs.has(index)) {
+            if (capabilityHandledArgs.has(index)) {
               continue;
             }
             const argument = node.arguments[index];
@@ -2671,6 +3034,10 @@ export function analyzeFunctionCapabilities(
         }
 
         visitInlineEagerCallbackArguments(node);
+      }
+
+      if (ts.isNewExpression(node)) {
+        applySignatureCellCapabilities(node);
       }
 
       if (ts.isVariableDeclaration(node)) {
@@ -2854,7 +3221,9 @@ export function analyzeFunctionCapabilities(
       params.push(buildCapabilityParamSummary(summaryName, state));
     }
 
-    const result = { params };
+    const result: FunctionCapabilitySummary = unreadableCellArguments.length
+      ? { params, unreadableCellArguments }
+      : { params };
     summaryCache.set(fn, result);
     return result;
   } finally {

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -13,6 +13,7 @@ import {
   type UnreadableCellArgument,
 } from "../core/mod.ts";
 import { isBrandedCellType } from "../transformers/cell-type.ts";
+import { type CellBrand } from "@commonfabric/schema-generator/cell-brand";
 import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
 import { decodePath, encodePath } from "../utils/path-serialization.ts";
 import { unwrapExpression } from "../utils/expression.ts";
@@ -252,15 +253,6 @@ function getParameterAtArgument(
     : undefined;
 }
 
-type SignatureCellKind =
-  | "opaque"
-  | "cell"
-  | "stream"
-  | "comparable"
-  | "readonly"
-  | "writeonly"
-  | "sqlite";
-
 // Read the capability an imported callee declares for a parameter from its
 // Common Fabric cell wrapper type. `Writable<T>` is a structural alias of
 // `Cell<T>` (an identical type), so the two are distinguished only by the
@@ -297,7 +289,7 @@ function getExplicitCellKindFromTypeNode(
   typeNode: ts.TypeNode | undefined,
   checker: ts.TypeChecker,
   depth = 0,
-): SignatureCellKind | undefined {
+): CellBrand | undefined {
   // The depth guard bounds the type-parameter-constraint recursion below
   // against a circular constraint on ill-typed input.
   if (!typeNode || depth > 16) return undefined;
@@ -307,7 +299,7 @@ function getExplicitCellKindFromTypeNode(
   }
 
   if (ts.isUnionTypeNode(typeNode)) {
-    const kinds = new Set<SignatureCellKind>();
+    const kinds = new Set<CellBrand>();
     for (const member of typeNode.types) {
       if (isNullOrUndefinedTypeNode(member)) {
         continue;
@@ -380,7 +372,7 @@ function getEffectiveParameterTypeNode(
 function getParameterDeclaredCellKind(
   parameter: ts.Symbol | undefined,
   checker: ts.TypeChecker,
-): SignatureCellKind | undefined {
+): CellBrand | undefined {
   return getExplicitCellKindFromTypeNode(
     getEffectiveParameterTypeNode(parameter),
     checker,

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -259,6 +259,19 @@ function findCapabilitySummaryForParameter(
       checker: options?.checker,
     });
   if (!summary) return undefined;
+  if (context && summary.unreadableCellArguments) {
+    // A cell argument reached an imported parameter the capability contract
+    // could not classify, so its capability was silently lost. Deduped by
+    // source range across the per-parameter calls that share this summary.
+    for (const unreadable of summary.unreadableCellArguments) {
+      context.reportDiagnosticOnce({
+        severity: "error",
+        type: "capability:unreadable-cell-argument",
+        message: unreadable.message,
+        node: unreadable.node,
+      });
+    }
+  }
   const parameter = fn.parameters[index];
   if (!parameter) return undefined;
   const paramName = ts.isIdentifier(parameter.name)

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -812,6 +812,707 @@ const fn = (input) => helper(input);`;
   },
 );
 
+Deno.test(
+  "Capability analysis records write intent from imported Writable parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(auth: Writable<Auth>): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.readPaths.includes("auth"));
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent for a nullable imported Writable parameter",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(auth: Writable<Auth> | null): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent for a null-and-undefined imported Writable parameter",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(
+          auth: Writable<Auth> | null | undefined,
+        ): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent from imported WriteonlyCell parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { WriteonlyCell } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(auth: WriteonlyCell<Auth>): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assert(state.writePaths.includes("auth"));
+    // A write-only parameter records only a write; the passing-read is
+    // suppressed, so the destructured argument stays write-only.
+    assertEquals(state.readPaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis keeps a member-access WriteonlyCell argument write-only",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { WriteonlyCell } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function persist(auth: WriteonlyCell<Auth>): void;
+      `,
+      "/test.ts": `
+        import { persist, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          state: { auth: Writable<Auth> },
+        ) => {
+          persist(state.auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "state");
+
+    // A member-access argument (state.auth) must be treated the same as a
+    // destructured one: the write-only parameter records only a write.
+    assert(state.writePaths.includes("auth"));
+    assertEquals(state.readPaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis does not record write intent from imported Cell parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Cell } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(auth: Cell<Auth>): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "readonly");
+    assert(state.readPaths.includes("auth"));
+    assertEquals(state.writePaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis ignores imported Writable type names from other libraries",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        export type Auth = { token: string };
+        export type Writable<T> = any;
+        export function createClient(auth: Writable<Auth>): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "readonly");
+    assert(state.readPaths.includes("auth"));
+    assertEquals(state.writePaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis selects the Writable overload for imported clients",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export interface AuthCell {
+          get(): Auth | undefined;
+          update(values: { token?: string }): void;
+        }
+        export interface ClientFactory {
+          (auth: Writable<Auth>): void;
+          (auth: AuthCell): void;
+        }
+        export const createClient: ClientFactory;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent from imported Writable constructors",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export class Client {
+          constructor(auth: Writable<Auth>);
+        }
+      `,
+      "/test.ts": `
+        import { Client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          new Client(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis does not record write intent from imported Cell constructors",
+  () => {
+    // A constructor whose auth parameter is declared bare `Cell<Auth>` does not
+    // grant write authority. Write intent must be spelled `Writable<Auth>`; a
+    // client that writes the cell (such as a token refresh) must declare it that
+    // way rather than rely on the neutral `Cell<Auth>` alias.
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Cell } from "commonfabric";
+
+        export type Auth = { token: string };
+        export class Client {
+          constructor(auth: Cell<Auth>);
+        }
+      `,
+      "/test.ts": `
+        import { Client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          new Client(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "readonly");
+    assertEquals(state.writePaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis does not record write intent for unmatched extra arguments",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(auth: Writable<Auth>): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          createClient("ignored", auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.writePaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis reads a generic constraint to classify an imported parameter",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function persist<C extends Writable<Auth>>(auth: C): void;
+      `,
+      "/test.ts": `
+        import { persist, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          persist(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // A bounded generic parameter carries the capability of its constraint.
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis reads a ReadonlyCell generic constraint as readonly",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { ReadonlyCell } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function readAll<C extends ReadonlyCell<Auth>>(auth: C): void;
+      `,
+      "/test.ts": `
+        import { readAll, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          readAll(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "readonly");
+    assertEquals(state.writePaths.includes("auth"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent for imported Writable rest parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function writeAll(...auths: Writable<Auth>[]): void;
+      `,
+      "/test.ts": `
+        import { writeAll, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          writeAll(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent for imported Array rest parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function writeAll(...auths: Array<Writable<Auth>>): void;
+      `,
+      "/test.ts": `
+        import { writeAll, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          writeAll(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records write intent for imported readonly-array rest parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function writeAll(...auths: readonly Writable<Auth>[]): void;
+      `,
+      "/test.ts": `
+        import { writeAll, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          writeAll(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.capability, "writable");
+    assert(state.writePaths.includes("auth"));
+  },
+);
+
+Deno.test(
+  "Capability analysis does not map array spreads to imported fixed parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function createClient(
+          first: Writable<Auth>,
+          second: Writable<Auth>,
+          third: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { createClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          {
+            first,
+            rest,
+            later,
+          }: {
+            first: Writable<Auth>;
+            rest: Writable<Auth>[];
+            later: Writable<Auth>;
+          },
+        ) => {
+          createClient(first, ...rest, later);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assert(state.writePaths.includes("first"));
+    assertEquals(state.writePaths.includes("rest.0"), false);
+    assertEquals(state.writePaths.includes("later"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis maps spread calls to imported Writable rest parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function writeAll(
+          first: Writable<Auth>,
+          ...rest: Writable<Auth>[]
+        ): void;
+      `,
+      "/test.ts": `
+        import { writeAll, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          {
+            first,
+            rest,
+            later,
+          }: {
+            first: Writable<Auth>;
+            rest: Writable<Auth>[];
+            later: Writable<Auth>;
+          },
+        ) => {
+          writeAll(first, ...rest, later);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assert(state.writePaths.includes("first"));
+    assert(state.writePaths.includes("rest.0"));
+    assert(state.writePaths.includes("later"));
+  },
+);
+
+Deno.test(
+  "Capability analysis shrinks a root cell to readonly for a ReadonlyCell parameter",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { ReadonlyCell } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function readClient(auth: ReadonlyCell<Auth>): void;
+      `,
+      "/test.ts": `
+        import { readClient, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (auth: Writable<Auth>) => {
+          readClient(auth);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "auth");
+
+    // The declared read-only contract accounts for this argument, so the
+    // whole-cell root fallback does not also grant write. Passing a cell to a
+    // declared reader demonstrates only read need, and the handler is not given
+    // write authority it never uses. In well-typed code a `Writable<Auth>` value
+    // cannot be passed to a `ReadonlyCell<Auth>` parameter (distinct brands,
+    // TS2345), so this shape is reached through a `ReadonlyCell`-typed input or
+    // an explicit cast; the snippet exercises the parameter-type mapping the
+    // analysis applies at that call.
+    assertEquals(state.capability, "readonly");
+    assertEquals(state.writePaths.includes(""), false);
+    assertEquals(state.wildcard, false);
+  },
+);
+
 Deno.test("Capability analysis marks for...in over tracked source as wildcard", () => {
   const fn = parseFirstCallback(
     `const fn = (input) => {

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -67,6 +67,13 @@ function getErrors(diagnostics: readonly TransformationDiagnostic[]) {
   return diagnostics.filter((d) => d.severity === "error");
 }
 
+function outputWindow(output: string, startNeedle: string, endNeedle: string) {
+  const start = output.indexOf(startNeedle);
+  const end = start === -1 ? -1 : output.indexOf(endNeedle, start);
+  if (start === -1 || end === -1) return "";
+  return output.slice(start, end + endNeedle.length);
+}
+
 Deno.test("Schema Shrink Validation", async (t) => {
   await t.step(
     "errors when parameter is 'unknown' but code accesses properties",
@@ -2064,6 +2071,277 @@ Deno.test("Schema Shrink Validation", async (t) => {
         (e) => e.type === "schema:path-not-in-type",
       );
       assertGreater(shrinkErrors.length, 0);
+    },
+  );
+
+  await t.step(
+    "keeps auth writable when handlers pass it to provider clients that refresh tokens",
+    async () => {
+      const source = [
+        "/// <cts-enable />",
+        'import { handler, type Writable } from "commonfabric";',
+        'import { CalendarWriteClient, GmailSendClient, type Auth } from "provider-clients";',
+        "const send = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    GmailSendClient(auth);",
+        "  },",
+        ");",
+        "const writeCalendar = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    CalendarWriteClient(auth);",
+        "  },",
+        ");",
+      ].join("\n");
+
+      const result = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "provider-clients.d.ts": [
+            'declare module "provider-clients" {',
+            '  import type { Writable } from "commonfabric";',
+            "  export type Auth = { token: string };",
+            "  export interface AuthCell {",
+            "    get(): Auth | undefined;",
+            "    update(values: { token?: string }): void;",
+            "  }",
+            "  export interface GmailSendClientFactory {",
+            "    (auth: Writable<Auth>): void;",
+            "    (auth: AuthCell): void;",
+            "  }",
+            "  export const GmailSendClient: GmailSendClientFactory;",
+            "  export function CalendarWriteClient(auth: Writable<Auth>): void;",
+            "}",
+          ].join("\n"),
+        },
+      });
+      const errors = getErrors(result.diagnostics);
+
+      assertEquals(
+        errors.length,
+        0,
+        `expected no validation errors but got: ${
+          errors.map((e) => `${e.type}: ${e.message}`).join("; ")
+        }`,
+      );
+
+      const send = outputWindow(
+        result.output,
+        "const send = handler",
+        "GmailSendClient(auth)",
+      );
+      const calendar = outputWindow(
+        result.output,
+        "const writeCalendar = handler",
+        "CalendarWriteClient(auth)",
+      );
+
+      assertStringIncludes(send, 'asCell: ["cell"]');
+      assertEquals(send.includes('asCell: ["readonly"]'), false);
+      assertStringIncludes(calendar, 'asCell: ["cell"]');
+      assertEquals(calendar.includes('asCell: ["readonly"]'), false);
+    },
+  );
+
+  await t.step(
+    "handler keeps imported write-only cell arguments write-only",
+    async () => {
+      const source = [
+        "/// <cts-enable />",
+        'import { handler, type Writable } from "commonfabric";',
+        'import { persistAuth, type Auth } from "auth-writer";',
+        "const persist = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    persistAuth(auth);",
+        "  },",
+        ");",
+      ].join("\n");
+
+      const result = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "auth-writer.d.ts": [
+            'declare module "auth-writer" {',
+            '  import type { WriteonlyCell } from "commonfabric";',
+            "  export type Auth = { token: string };",
+            "  export function persistAuth(auth: WriteonlyCell<Auth>): void;",
+            "}",
+          ].join("\n"),
+        },
+      });
+      const errors = getErrors(result.diagnostics);
+
+      assertEquals(
+        errors.length,
+        0,
+        `expected no validation errors but got: ${
+          errors.map((e) => `${e.type}: ${e.message}`).join("; ")
+        }`,
+      );
+
+      const persist = outputWindow(
+        result.output,
+        "const persist = handler",
+        "persistAuth(auth)",
+      );
+
+      assertStringIncludes(persist, 'asCell: ["writeonly"]');
+      assertEquals(persist.includes('asCell: ["cell"]'), false);
+      assertEquals(persist.includes('asCell: ["readonly"]'), false);
+    },
+  );
+
+  await t.step(
+    "shrinks auth to readonly when an imported callee declares a ReadonlyCell parameter",
+    async () => {
+      // A handler hands its whole auth cell to an out-of-file client whose
+      // parameter is declared ReadonlyCell<Auth>. That declaration is the
+      // capability contract at the import boundary: the callee needs only read
+      // authority, so the handler demonstrates no write need and is not placed
+      // in the field's write-authority set. A client that persists a refresh
+      // must instead declare Writable or WriteonlyCell, which makes the write
+      // explicit to the transformer (see the provider-clients step above).
+      // In well-typed code a Writable<Auth> value is not assignable to a
+      // ReadonlyCell<Auth> parameter (distinct brands, TS2345), so this shape is
+      // reached through a ReadonlyCell-typed input or an explicit cast; the
+      // snippet drives the parameter-type mapping the analysis applies.
+      const source = [
+        "/// <cts-enable />",
+        'import { handler, type Writable } from "commonfabric";',
+        'import { readAuth, type Auth } from "readonly-auth-client";',
+        "const inspect = handler(",
+        "  (_event: unknown, auth: Writable<Auth>) => {",
+        "    readAuth(auth);",
+        "  },",
+        ");",
+      ].join("\n");
+
+      const result = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "readonly-auth-client.d.ts": [
+            'declare module "readonly-auth-client" {',
+            '  import type { ReadonlyCell } from "commonfabric";',
+            "  export type Auth = { token: string };",
+            "  export function readAuth(auth: ReadonlyCell<Auth>): void;",
+            "}",
+          ].join("\n"),
+        },
+      });
+      const errors = getErrors(result.diagnostics);
+
+      assertEquals(
+        errors.length,
+        0,
+        `expected no validation errors but got: ${
+          errors.map((e) => `${e.type}: ${e.message}`).join("; ")
+        }`,
+      );
+
+      const inspect = outputWindow(
+        result.output,
+        "const inspect = handler",
+        "readAuth(auth)",
+      );
+
+      assertStringIncludes(inspect, 'asCell: ["readonly"]');
+      assertEquals(inspect.includes('asCell: ["cell"]'), false);
+    },
+  );
+
+  await t.step(
+    "errors when a cell argument flows to an ambiguous cell-union parameter",
+    async () => {
+      // `sendMixed` declares `AuthCell | Writable<Auth>` — a union that mixes a
+      // cell wrapper with an unresolvable member, so overload resolution cannot
+      // pick the capability and the auth cell silently degrades. That is the
+      // overload-split case and must be flagged. `persistBare` declares bare
+      // `Cell<Auth>`: intentionally NOT flagged (not a union; passing a cell to
+      // a neutral Cell parameter is not, on its own, an ambiguity worth a hard
+      // error).
+      const source = [
+        "/// <cts-enable />",
+        'import { handler, type Writable } from "commonfabric";',
+        'import { sendMixed, persistBare, type Auth } from "ambiguous-clients";',
+        "const a = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    sendMixed(auth);",
+        "  },",
+        ");",
+        "const b = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    persistBare(auth);",
+        "  },",
+        ");",
+      ].join("\n");
+
+      const result = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "ambiguous-clients.d.ts": [
+            'declare module "ambiguous-clients" {',
+            '  import type { Cell, Writable } from "commonfabric";',
+            "  export type Auth = { token: string };",
+            "  export interface AuthCell {",
+            "    get(): Auth | undefined;",
+            "    update(values: { token?: string }): void;",
+            "  }",
+            "  export function sendMixed(auth: AuthCell | Writable<Auth>): void;",
+            "  export function persistBare(auth: Cell<Auth>): void;",
+            "}",
+          ].join("\n"),
+        },
+      });
+      const unreadable = result.diagnostics.filter(
+        (d) => d.type === "capability:unreadable-cell-argument",
+      );
+
+      assertEquals(
+        unreadable.length,
+        1,
+        `expected one diagnostic, got: ${
+          result.diagnostics.map((d) => d.type).join(", ")
+        }`,
+      );
+    },
+  );
+
+  await t.step(
+    "does not flag a cell argument to a classifiable or escape-hatch parameter",
+    async () => {
+      const source = [
+        "/// <cts-enable />",
+        'import { handler, type Writable } from "commonfabric";',
+        'import { writeIt, logIt, type Auth } from "ok-clients";',
+        "const a = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    writeIt(auth);",
+        "  },",
+        ");",
+        "const b = handler(",
+        "  (_event: unknown, { auth }: { auth: Writable<Auth> }) => {",
+        "    logIt(auth);",
+        "  },",
+        ");",
+      ].join("\n");
+
+      const result = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "ok-clients.d.ts": [
+            'declare module "ok-clients" {',
+            '  import type { Writable } from "commonfabric";',
+            "  export type Auth = { token: string };",
+            "  export function writeIt(auth: Writable<Auth>): void;",
+            "  export function logIt(value: unknown): void;",
+            "}",
+          ].join("\n"),
+        },
+      });
+      const unreadable = result.diagnostics.filter(
+        (d) => d.type === "capability:unreadable-cell-argument",
+      );
+
+      assertEquals(unreadable.length, 0);
     },
   );
 });


### PR DESCRIPTION
Capability analysis shrinks a handler's declared input schema to the minimum capability its body uses, emitting an asCell marker that drives the field's write-authority set: per spec 8.15 a field's writeAuthorizedBy is composed from the handlers that declare they write it, and a runtime write is allowed only when the handler identity is in that set. Body analysis can see reads and direct writes, but not what a callee does inside a body that lives in another file. So a handler that receives a Writable auth cell and passes it to an imported provider client that persists a refreshed OAuth token — writing the cell inside the client — had its auth input shrunk to read-only, dropping the handler from writeAuthorizedBy, and the refresh write was denied at runtime.

Use the callee's declared Common Fabric wrapper parameter type as the capability contract at the import boundary. A recognized wrapper maps to a capability: Writable to read and write, ReadonlyCell to read, WriteonlyCell to write, and the opaque/stream/comparable/sqlite wrappers to their handling. Writable is a structural alias of Cell, so the wrapper is matched nominally by name on the declared type node, not the resolved type. A recognized wrapper accounts for its argument and replaces the conservative whole-cell fallback for that argument and call, while other evidence in the handler (such as a direct update) still contributes; bare Cell and same-named foreign types are not recognized and stay conservative, as do unknown callees.

This is the least-authority behavior the runtime enforces. Handler code is untrusted (threat model 9.1.1, 9.2.2), so preserving write authority a handler does not demonstrate would broaden writeAuthorizedBy and enable escalation; a cast that writes past a declared read-only type is denied at runtime because the schema, not the cast, is enforced. Trusting the declared type to reduce authority is therefore safe, and trusting it to grant write is bounded by the caller's own declaration and is what real refresh clients need.

Details:

- Split GmailSendClient's factory into separate Writable<Auth> and AuthCell overloads so overload resolution surfaces the writable form for a live cell; a union parameter is a mixed type node the name-based detector cannot read. Declare GoogleDocsClient's constructor auth parameter Writable<Auth> so its token-refresh write is explicit.
- Classify a bounded generic parameter by its constraint. Recognize nullable wrappers (Writable<T> | null), the readonly-array rest spelling (...args: readonly Writable<T>[]) alongside T[]/Array<T>/ReadonlyArray<T>, and map spreads into rest parameters while leaving array spreads into fixed parameters conservative.
- Suppress the passing-read for both destructured and member-access arguments so a WriteonlyCell argument stays write-only.
- Raise a capability:unreadable-cell-argument error when a branded cell argument flows to a union parameter that mixes a recognized wrapper with an unresolvable member (AuthCell | Writable<Auth>) — the overload-split case, enforced until now only by convention. The check is deliberately narrow: it does not fire for value-or-cell framework types (FactoryInput, CellLike, U | AnyBrandedCell<U>), bare Cell, generics, lone structural interfaces, array identity-writer methods, or any/unknown sinks. A transform of the full pattern corpus produced zero matches outside the overload-split shape.

The read/write-violation direction is already enforced elsewhere: reading a WriteonlyCell or writing a ReadonlyCell is a compile error via the branded interfaces, and runtime write authority is enforced in the runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat imported Common Fabric cell wrapper types on functions and constructors as the capability contract so handlers keep correct read/write authority across file boundaries. Adds a diagnostic for ambiguous cell-union parameters and updates Google client types to declare writable auth explicitly.

- **New Features**
  - Capability analysis reads callee parameter wrappers: `Writable<T>` → read+write, `ReadonlyCell<T>` → read, `WriteonlyCell<T>` → write; also handles opaque/stream/comparable/sqlite.
  - Works through generic constraints, nullable unions, and rest params (including `readonly` arrays); spreads into rest are mapped, array spreads into fixed params stay conservative.
  - Suppresses the passing-read for destructured and member-access args so `WriteonlyCell` stays write-only.
  - Emits `capability:unreadable-cell-argument` for mixed wrapper unions (e.g., `AuthCell | Writable<Auth>`).
  - `GmailSendClient` factory split into `Writable<Auth>` and `AuthCell` overloads; `GoogleDocsClient` constructor now takes `Writable<Auth>`; uses canonical `CellBrand` for capability mapping.

- **Migration**
  - If a callee writes a cell, type the parameter as `Writable<T>` or `WriteonlyCell<T>`; readers should use `ReadonlyCell<T>`.
  - Replace unions that mix wrappers with overloads (fixes the new error).
  - Do not rely on bare `Cell<T>` or non-`commonfabric` `Writable` to grant write; they remain conservative.

<sup>Written for commit 1db55054b6e902aaeed6991f97748cbdd58cc07b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

