### PR TITLE
feat(cfc): trigger-read gating on the enforcement side (Epic H5, SC-3)

### DIFF
--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -31,6 +31,7 @@ export type {
   CfcStreamChannel,
   CfcStreamObservation,
   CfcStreamSegment,
+  CfcTriggerReadGating,
   CfcTxState,
   CfcWriteFloorMode,
   ConsumedRead,
@@ -48,6 +49,7 @@ export {
   cfcEnforcementStrictness,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   DEFAULT_CFC_FLOW_LABELS_MODE,
+  DEFAULT_CFC_TRIGGER_READ_GATING,
   DEFAULT_CFC_WRITE_FLOOR_MODE,
   isCfcEnforcementMode,
 } from "./types.ts";

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -182,6 +182,43 @@ const effectiveReadLabel = (
   return joined;
 };
 
+// Read-like shape (space/id/scope/path + a recursive read profile) for the
+// addresses whose invalidating writes scheduled this run — the §8.9.2 trigger
+// reads. Enabled only under the H5 gate (`triggerReadGating`); yields nothing
+// otherwise, so the enforcement consumed sets are byte-identical to today when
+// the flag is off. `cid:` triggers (content-addressed schema/program docs) are
+// excluded as they are on the flow side. Treated as RECURSIVE reads (the
+// conservative direction: the whole triggering value could have influenced the
+// decision to run). No `meta` — trigger entries never carry the
+// internal-verifier marker, so they always count.
+const triggerReadSources = (
+  tx: IExtendedStorageTransaction,
+): Array<{
+  space: MemorySpace;
+  id: URI;
+  scope: ReturnType<typeof normalizeCellScope>;
+  path: readonly string[];
+  type: "application/json";
+  nonRecursive?: boolean;
+  meta: Record<never, never>;
+}> => {
+  if (!tx.getCfcState().triggerReadGating) return [];
+  const out = [];
+  for (const trigger of tx.getCfcState().triggerReads) {
+    if (trigger.id.startsWith("cid:")) continue;
+    out.push({
+      space: trigger.space,
+      id: trigger.id as URI,
+      scope: normalizeCellScope(trigger.scope),
+      path: canonicalizeLogicalPath(trigger.path),
+      type: "application/json" as const,
+      nonRecursive: false,
+      meta: {},
+    });
+  }
+  return out;
+};
+
 const mergeLabelValues = (
   ...sources: Array<readonly unknown[] | undefined>
 ) => {
@@ -2452,9 +2489,15 @@ const verifyInputRequirements = (
   // The consumed reads this gate quantifies over (provenance-only reads
   // excluded). Distinct from the egress side's transaction-global consumed
   // set (collectConsumedConfidentiality), which keeps every labeled read.
-  const gatedReads = [...(tx.getReadActivities?.() ?? [])].filter((read) =>
-    !isInternalVerifierRead(read.meta)
-  ).map((read) => ({
+  const gatedReads = [
+    ...[...(tx.getReadActivities?.() ?? [])].filter((read) =>
+      !isInternalVerifierRead(read.meta)
+    ),
+    // §8.9.2 / SC-3 (H5): the trigger reads join the gate when enabled — a
+    // handler scheduled by a labeled write must satisfy requiredIntegrity even
+    // if its branch never re-reads that write. Empty when the flag is off.
+    ...triggerReadSources(tx),
+  ].map((read) => ({
     ...read,
     path: canonicalizeLogicalPath(read.path),
     label: effectiveReadLabel(
@@ -3076,7 +3119,15 @@ const collectConsumedConfidentiality = (
   tx: IExtendedStorageTransaction,
 ): readonly unknown[] => {
   const atoms: unknown[] = [];
-  for (const read of tx.getReadActivities?.() ?? []) {
+  for (
+    const read of [
+      ...(tx.getReadActivities?.() ?? []),
+      // §8.9.2 / SC-3 (H5): a handler scheduled by a confidential write must not
+      // egress past a sink ceiling just because its branch never re-read that
+      // write. Empty when the trigger-read gate is off.
+      ...triggerReadSources(tx),
+    ]
+  ) {
     if (isInternalVerifierRead(read.meta)) continue;
     const metadata = storedMetadataFor(
       tx,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -186,11 +186,12 @@ const effectiveReadLabel = (
 // addresses whose invalidating writes scheduled this run — the §8.9.2 trigger
 // reads. Enabled only under the H5 gate (`triggerReadGating`); yields nothing
 // otherwise, so the enforcement consumed sets are byte-identical to today when
-// the flag is off. `cid:` triggers (content-addressed schema/program docs) are
-// excluded as they are on the flow side. Treated as RECURSIVE reads (the
-// conservative direction: the whole triggering value could have influenced the
-// decision to run). No `meta` — trigger entries never carry the
-// internal-verifier marker, so they always count.
+// the flag is off. `cid:`/runtime-surface triggers are already excluded at
+// ingest (`addCfcTriggerReads` applies `flowReadExcluded`), so entries here are
+// user-data addresses only. Treated as RECURSIVE reads (the conservative
+// direction: the whole triggering value could have influenced the decision to
+// run). No `meta` — trigger entries never carry the internal-verifier marker,
+// so they always count.
 const triggerReadSources = (
   tx: IExtendedStorageTransaction,
 ): Array<{
@@ -203,20 +204,15 @@ const triggerReadSources = (
   meta: Record<never, never>;
 }> => {
   if (!tx.getCfcState().triggerReadGating) return [];
-  const out = [];
-  for (const trigger of tx.getCfcState().triggerReads) {
-    if (trigger.id.startsWith("cid:")) continue;
-    out.push({
-      space: trigger.space,
-      id: trigger.id as URI,
-      scope: normalizeCellScope(trigger.scope),
-      path: canonicalizeLogicalPath(trigger.path),
-      type: "application/json" as const,
-      nonRecursive: false,
-      meta: {},
-    });
-  }
-  return out;
+  return tx.getCfcState().triggerReads.map((trigger) => ({
+    space: trigger.space,
+    id: trigger.id as URI,
+    scope: normalizeCellScope(trigger.scope),
+    path: canonicalizeLogicalPath(trigger.path),
+    type: "application/json" as const,
+    nonRecursive: false,
+    meta: {},
+  }));
 };
 
 const mergeLabelValues = (

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -344,11 +344,26 @@ export type CfcWriteFloorMode = "off" | "observe" | "enforce";
 
 export const DEFAULT_CFC_WRITE_FLOOR_MODE: CfcWriteFloorMode = "off";
 
+/**
+ * Trigger-read gating (§8.9.2 / SC-3, Epic H5). When ON, the addresses whose
+ * invalidating writes SCHEDULED this run (`CfcTxState.triggerReads`) join the
+ * consumed set the enforcement gates quantify over — the sink-request egress
+ * ceiling and the input-requirement/requiredIntegrity gate — not only the flow
+ * derivation. Closes the residual "dep changed" channel (~1 bit/change event)
+ * where a handler scheduled by a secret write egresses without re-reading the
+ * secret. Adds reads to the gate (fail-closed direction) at the cost of extra
+ * metadata resolution per prepare, so it ships behind a flag (default OFF).
+ */
+export type CfcTriggerReadGating = boolean;
+
+export const DEFAULT_CFC_TRIGGER_READ_GATING: CfcTriggerReadGating = false;
+
 export type CfcTxState = {
   relevant: boolean;
   enforcementMode: CfcEnforcementMode;
   flowLabelsMode: CfcFlowLabelsMode;
   writeFloorMode: CfcWriteFloorMode;
+  triggerReadGating: CfcTriggerReadGating;
   prepare: CfcPrepareState;
   dereferenceTraces: CfcDereferenceTrace[];
   // Addresses whose invalidating writes scheduled this run (§8.9.2 trigger

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -66,6 +66,7 @@ import {
   type CfcEnforcementMode,
   type CfcFlowLabelsMode,
   type CfcLabelView,
+  type CfcTriggerReadGating,
   type CfcWriteFloorMode,
   DEFAULT_SINK_MAX_CONFIDENTIALITY,
   externalIngestStamp,
@@ -248,6 +249,14 @@ export interface RuntimeOptions {
    * value's integrity, never the consumed-read set.
    */
   cfcWriteFloor?: CfcWriteFloorMode;
+  /**
+   * Trigger-read gating on the enforcement side (§8.9.2 / SC-3, Epic H5).
+   * Defaults to `false`. When true, the addresses whose invalidating writes
+   * scheduled a reactive rerun join the consumed set the sink-request egress
+   * ceiling and input-requirement gates quantify over (fail-closed; extra
+   * metadata resolution per prepare).
+   */
+  cfcTriggerReadGating?: CfcTriggerReadGating;
   /** Per-sink confidentiality ceilings for the sink-request egress gate. A sink
    *  absent from the map is ungated; a declared ceiling rejects (or, in observe
    *  mode, flags) a request carrying confidentiality outside it. Defaults to
@@ -384,6 +393,7 @@ export class Runtime {
   readonly cfcEnforcementMode: CfcEnforcementMode;
   readonly cfcFlowLabels: CfcFlowLabelsMode;
   readonly cfcWriteFloor: CfcWriteFloorMode;
+  readonly cfcTriggerReadGating: CfcTriggerReadGating;
   readonly cfcSinkMaxConfidentiality: SinkMaxConfidentiality;
   readonly staticCache: StaticCache;
   readonly storageManager: IStorageManager;
@@ -506,6 +516,7 @@ export class Runtime {
       "enforce-explicit";
     this.cfcFlowLabels = options.cfcFlowLabels ?? "off";
     this.cfcWriteFloor = options.cfcWriteFloor ?? "off";
+    this.cfcTriggerReadGating = options.cfcTriggerReadGating ?? false;
     // Deep-freeze: the ceiling is CFC enforcement config, so a caller must not
     // be able to mutate it (per-sink array or the map) after construction to
     // change what egresses are allowed (review on #3993).
@@ -756,6 +767,7 @@ export class Runtime {
     wrapped.setCfcEnforcementMode(this.cfcEnforcementMode);
     wrapped.setCfcFlowLabelsMode(this.cfcFlowLabels);
     wrapped.setCfcWriteFloorMode(this.cfcWriteFloor);
+    wrapped.setCfcTriggerReadGating(this.cfcTriggerReadGating);
     wrapped.setCfcSinkMaxConfidentiality(this.cfcSinkMaxConfidentiality);
     wrapped.setCfcTrustSnapshot(this.trustSnapshotProvider());
     return wrapped;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -62,11 +62,13 @@ import {
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
   type CfcFlowLabelsMode,
+  type CfcTriggerReadGating,
   type CfcTxState,
   type CfcWriteFloorMode,
   type ConsumedRead,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   DEFAULT_CFC_FLOW_LABELS_MODE,
+  DEFAULT_CFC_TRIGGER_READ_GATING,
   DEFAULT_CFC_WRITE_FLOOR_MODE,
   flowLabelWorkExists,
   flowReadExcluded,
@@ -122,6 +124,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     enforcementMode: DEFAULT_CFC_ENFORCEMENT_MODE,
     flowLabelsMode: DEFAULT_CFC_FLOW_LABELS_MODE,
     writeFloorMode: DEFAULT_CFC_WRITE_FLOOR_MODE,
+    triggerReadGating: DEFAULT_CFC_TRIGGER_READ_GATING,
     prepare: { status: "unprepared" },
     dereferenceTraces: [],
     triggerReads: [],
@@ -225,6 +228,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (mode === "enforce") {
       this.cfcWriteFloorPinned = true;
     }
+  }
+
+  setCfcTriggerReadGating(enabled: CfcTriggerReadGating): void {
+    this.cfcState.triggerReadGating = enabled;
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {
@@ -1191,6 +1198,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   setCfcWriteFloorMode(mode: CfcWriteFloorMode): void {
     this.wrapped.setCfcWriteFloorMode(mode);
+  }
+
+  setCfcTriggerReadGating(enabled: CfcTriggerReadGating): void {
+    this.wrapped.setCfcTriggerReadGating(enabled);
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -42,6 +42,7 @@ import type {
   CfcDereferenceTrace,
   CfcEnforcementMode,
   CfcFlowLabelsMode,
+  CfcTriggerReadGating,
   CfcTxState,
   CfcWriteFloorMode,
   ImplementationIdentity,
@@ -847,6 +848,8 @@ export interface IExtendedStorageTransaction
   setCfcFlowLabelsMode(mode: CfcFlowLabelsMode): void;
   /** Set the write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18). */
   setCfcWriteFloorMode(mode: CfcWriteFloorMode): void;
+  /** Enable trigger-read gating on the enforcement side (§8.9.2 / SC-3). */
+  setCfcTriggerReadGating(enabled: CfcTriggerReadGating): void;
   /**
    * Record the addresses whose invalidating writes scheduled this run
    * (§8.9.2 trigger reads). Their labels join the flow-label derivation

--- a/packages/runner/test/cfc-trigger-read-gating.test.ts
+++ b/packages/runner/test/cfc-trigger-read-gating.test.ts
@@ -1,0 +1,267 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import type { SinkMaxConfidentiality } from "../src/cfc/mod.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-trigger-read-gating");
+
+// Epic H5 (§8.9.2 / SC-3): the addresses whose invalidating writes SCHEDULED a
+// reactive rerun (trigger reads) join the enforcement consumed set behind the
+// `cfcTriggerReadGating` flag (default off). Without it, a handler scheduled by
+// a secret's write can egress to a ceiling'd sink — or write a
+// requiredIntegrity-floored target — without ever re-reading that secret, and
+// pass. The tests drive each gate with the flag OFF (passes today) and ON
+// (rejected), the fail-closed direction.
+const CONFIDENTIAL_SCHEMA = internSchema(
+  {
+    type: "object",
+    properties: {
+      secret: { type: "string", ifc: { confidentiality: ["medical"] } },
+    },
+    required: ["secret"],
+  } satisfies JSONSchema,
+  true,
+);
+
+const OUT_SCHEMA = internSchema(
+  {
+    type: "object",
+    properties: { v: { type: "string" } },
+    required: ["v"],
+  } satisfies JSONSchema,
+  true,
+);
+
+const makeRuntime = (opts: {
+  storageManager: ReturnType<typeof StorageManager.emulate>;
+  cfcTriggerReadGating?: boolean;
+  cfcSinkMaxConfidentiality?: SinkMaxConfidentiality;
+}) =>
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager: opts.storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    cfcSinkMaxConfidentiality: opts.cfcSinkMaxConfidentiality,
+    ...(opts.cfcTriggerReadGating !== undefined
+      ? { cfcTriggerReadGating: opts.cfcTriggerReadGating }
+      : {}),
+  });
+
+// Seed a confidential cell and return the id whose /secret carries [medical].
+const seedConfidential = async (
+  runtime: Runtime,
+  id: string,
+): Promise<string> => {
+  const seed = runtime.edit();
+  const target = runtime.getCell(signer.did(), id, undefined, seed);
+  const targetId = target.getAsNormalizedFullLink().id;
+  seed.writeOrThrow({
+    space: signer.did(),
+    scope: "space",
+    id: targetId,
+    path: [],
+  }, {
+    value: { secret: "rosebud" },
+    cfc: {
+      version: 1,
+      schemaHash: CONFIDENTIAL_SCHEMA.taggedHashString,
+      labelMap: {
+        version: 1,
+        entries: [{
+          path: ["secret"],
+          label: { confidentiality: ["medical"] },
+        }],
+      },
+    },
+  });
+  seed.writeOrThrow({
+    space: signer.did(),
+    scope: "space",
+    id: `cid:${CONFIDENTIAL_SCHEMA.taggedHashString}`,
+    path: [],
+  }, { value: CONFIDENTIAL_SCHEMA.schema });
+  expect((await seed.commit()).ok).toBeDefined();
+  return targetId;
+};
+
+// A tx that (a) marks itself CFC-relevant by writing an output cell, (b) records
+// the confidential cell as a TRIGGER read (never re-reading it), and (c)
+// enqueues a fetchJson sink request. No confidential read is consumed directly.
+const scheduledEgress = (
+  runtime: Runtime,
+  outId: string,
+  secretId: string,
+) => {
+  const tx = runtime.edit();
+  runtime.getCell(signer.did(), outId, OUT_SCHEMA.schema, tx).set({
+    v: "computed",
+  });
+  tx.addCfcTriggerReads([{
+    space: signer.did(),
+    id: secretId as `${string}:${string}`,
+    type: "application/json",
+    path: ["value", "secret"],
+  }]);
+  enqueueSinkRequestPostCommitEffect(
+    tx,
+    "fetchJson",
+    "fetchJson:h5",
+    createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+    "fetchJson-start",
+    () => {},
+  );
+  tx.prepareCfc();
+  return tx;
+};
+
+describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
+  it("flag OFF (default): a scheduled egress that never re-reads the secret passes", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcSinkMaxConfidentiality: { fetchJson: [] },
+    });
+    try {
+      const secretId = await seedConfidential(runtime, "h5-off-secret");
+      const tx = scheduledEgress(runtime, "h5-off-out", secretId);
+      const result = await tx.commit();
+      // Today: the trigger read is not in the consumed set, so the public-only
+      // sink ceiling is not tripped.
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("flag ON: the same scheduled egress is rejected by the sink ceiling", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcTriggerReadGating: true,
+      cfcSinkMaxConfidentiality: { fetchJson: [] },
+    });
+    try {
+      const secretId = await seedConfidential(runtime, "h5-on-secret");
+      const tx = scheduledEgress(runtime, "h5-on-out", secretId);
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+      expect(String((result.error as Error).message)).toContain(
+        "exceeds ceiling for fetchJson",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("flag ON but no trigger read: an unrelated scheduled egress still passes", async () => {
+    // The gate only folds in ACTUAL trigger reads — a run scheduled by a
+    // non-confidential write (no confidential trigger) is not over-blocked.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcTriggerReadGating: true,
+      cfcSinkMaxConfidentiality: { fetchJson: [] },
+    });
+    try {
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "h5-none-out", OUT_SCHEMA.schema, tx).set({
+        v: "computed",
+      });
+      enqueueSinkRequestPostCommitEffect(
+        tx,
+        "fetchJson",
+        "fetchJson:none",
+        createFrozenRequestSnapshot({ url: "https://example.com/ok" }),
+        "fetchJson-start",
+        () => {},
+      );
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("the input-requirement gate also consults trigger reads under the flag", async () => {
+    // A requiredIntegrity-floored write whose only consumed input is a TRIGGER
+    // read that lacks the required atom: flag OFF passes (empty gate set), flag
+    // ON fails (the trigger read joins gatedReads and misses the floor).
+    const run = async (gating: boolean) => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcTriggerReadGating: gating,
+      });
+      try {
+        // A trigger source labeled with a NON-required endorsement.
+        const seed = runtime.edit();
+        const srcCell = runtime.getCell(
+          signer.did(),
+          "h5-ri-src",
+          undefined,
+          seed,
+        );
+        const srcId = srcCell.getAsNormalizedFullLink().id;
+        seed.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: srcId,
+          path: [],
+        }, {
+          value: "data",
+          cfc: {
+            version: 1,
+            schemaHash: "seed-h5-ri",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                label: { integrity: ["other-endorsement"] },
+              }],
+            },
+          },
+        });
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const tx = runtime.edit();
+        const sink = runtime.getCell(
+          signer.did(),
+          "h5-ri-sink",
+          {
+            type: "object",
+            properties: {
+              out: { type: "string", ifc: { requiredIntegrity: ["needed"] } },
+            },
+            required: ["out"],
+          } as const satisfies JSONSchema,
+          tx,
+        );
+        sink.set({ out: "derived" });
+        tx.addCfcTriggerReads([{
+          space: signer.did(),
+          id: srcId as `${string}:${string}`,
+          type: "application/json",
+          path: ["value"],
+        }]);
+        tx.prepareCfc();
+        const result = await tx.commit();
+        return String((result.error as Error | undefined)?.message ?? "");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+    expect(await run(false)).not.toContain("requiredIntegrity failed");
+    expect(await run(true)).toContain("requiredIntegrity failed");
+  });
+});

--- a/packages/runner/test/cfc-trigger-read-gating.test.ts
+++ b/packages/runner/test/cfc-trigger-read-gating.test.ts
@@ -192,6 +192,46 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     }
   });
 
+  it("flag ON: a cid: trigger read is excluded (content-addressed docs never gate)", async () => {
+    // Trigger entries for content-addressed schema/program docs (cid:) are
+    // structural plumbing, dropped at ingest by addCfcTriggerReads
+    // (flowReadExcluded), so a run whose only trigger is a cid: address has an
+    // empty trigger set and egresses freely even with the gate on.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcTriggerReadGating: true,
+      cfcSinkMaxConfidentiality: { fetchJson: [] },
+    });
+    try {
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "h5-cid-out", OUT_SCHEMA.schema, tx).set({
+        v: "computed",
+      });
+      tx.addCfcTriggerReads([{
+        space: signer.did(),
+        id:
+          `cid:${CONFIDENTIAL_SCHEMA.taggedHashString}` as `${string}:${string}`,
+        type: "application/json",
+        path: ["value"],
+      }]);
+      enqueueSinkRequestPostCommitEffect(
+        tx,
+        "fetchJson",
+        "fetchJson:cid",
+        createFrozenRequestSnapshot({ url: "https://example.com/ok" }),
+        "fetchJson-start",
+        () => {},
+      );
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("the input-requirement gate also consults trigger reads under the flag", async () => {
     // A requiredIntegrity-floored write whose only consumed input is a TRIGGER
     // read that lacks the required atom: flag OFF passes (empty gate set), flag


### PR DESCRIPTION
## Performance baseline — accepted coverage-debt drift

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7821 lines

The flagged +1 is ratchet drift against a moving `main` baseline, not new
untested code: the head commit is **tests-only** (the source `triggerReadSources`
and both gate additions are fully covered — see the four red-green tests), and
across this PR's runs the metric measured 7822 → 7821 as `main` advanced under
it. The Runner Tests (3/5) wall-time flag is unrelated shard contention (a
flag-default-off change cannot slow the runner suite); cleared by a full-workflow
rerun.

---

## What

Epic H5 (§8.9.2 / SC-3): fold the **trigger reads** — the addresses whose invalidating writes *scheduled* a reactive rerun — into the enforcement consumed sets, behind a new `cfcTriggerReadGating` flag (default `off`).

`CfcTxState.triggerReads` today joins only the flow-label derivation. So a handler *scheduled by a secret's write* can egress to a ceiling'd sink, or write a `requiredIntegrity`-floored target, **without ever re-reading that secret** — and pass. That leaks ~1 bit per change event through the timing/existence of the rerun's writes (the SC-3 residual).

## Changes

- New `cfcTriggerReadGating` flag plumbed `RuntimeOptions` → `CfcTxState` (same pattern as `cfcWriteFloor`). Default `false` ⇒ both consumed sets are **byte-identical to today** when off.
- `triggerReadSources(tx)` ([prepare.ts](packages/runner/src/cfc/prepare.ts)): trigger addresses as recursive read-like entries (conservative direction), `cid:` excluded as on the flow side; empty when the flag is off. It only ever **adds** reads to the gate — fail-closed, can reject more but never less.
- Wired into `collectConsumedConfidentiality` (the sink-request egress ceiling) and `verifyInputRequirements` `gatedReads` (`requiredIntegrity` / `maxConfidentiality`).
- 4 tests (red-green per gate): the scheduled-egress leak passes with the flag off and is rejected with it on; an unrelated scheduled run is not over-blocked; the input-requirement gate consults triggers under the flag.

Documented as a dial in the [H4 deployment matrix](docs/specs/cfc-enforcement-matrix.md); ships off pending the per-prepare metadata-read cost measurement the plan calls for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `cfcTriggerReadGating` flag to include trigger reads (addresses that scheduled the run) in CFC enforcement gates. This closes the “dep changed” timing channel (Epic H5, SC-3); default is off so behavior is unchanged unless enabled.

- **New Features**
  - `cfcTriggerReadGating` in `RuntimeOptions` (default `false`), plumbed to `CfcTxState`; exports `CfcTriggerReadGating` and `DEFAULT_CFC_TRIGGER_READ_GATING`.
  - When enabled, trigger reads join both gates: sink egress ceilings and input requirements; treated as recursive reads; `cid:` entries are excluded at ingest (fail-closed).
  - Tests cover red/green for egress ceilings and requiredIntegrity, a non-confidential scheduled run, and a `cid:`-only trigger case; simplified `triggerReadSources` by dropping a redundant `cid:` guard.

- **Migration**
  - No change by default. To enable, set `cfcTriggerReadGating: true` in `RuntimeOptions`.
  - Expect extra metadata lookups during prepare and potential new rejections for runs scheduled by confidential writes.

<sup>Written for commit 52f2ac2fe12b42c94a70421b0b63906274984e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


