### PR TITLE
feat(cfc): flow-label dial to persist in shell + SC-11 idempotent envelope (Epic H2)

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -94,10 +94,9 @@ dial is not yet producing. The states a deployment is expected to pass through:
 | State | enforcement | flow | write-floor | Meaning |
 |---|---|---|---|---|
 | **Operator / toolshed** | `disabled` | `off` | `off` | CFC descriptive only; provenance mints run, nothing rejects. |
-| **Shell today** | `enforce-explicit` | `observe` | `off` | Explicit checks enforce; flow derivation measured (H1), not persisted; floor not yet dialed. |
-| **Shell + floor observe** | `enforce-explicit` | `observe` | `observe` | Add the write floor as diagnostics (D3 dial-up step). |
-| **Shell + floor enforce** | `enforce-explicit` | `observe` | `enforce` | Floor rejects; sound at flow-observe (floor credits no flow meet). |
-| **Flow persist** | `enforce-explicit` | `persist` | `enforce` | Derived labels now stored (H2); inv-9 active; floor now also *complete* on flow-endorsed writes. |
+| **Shell today** | `enforce-explicit` | `persist` | `off` | Explicit checks enforce; flow labels persisted (H2, inv-9 active); floor not yet dialed. |
+| **Shell + floor observe** | `enforce-explicit` | `persist` | `observe` | Add the write floor as diagnostics (D3 dial-up step). |
+| **Shell + floor enforce** | `enforce-explicit` | `persist` | `enforce` | Floor rejects; complete on flow-endorsed writes (flow persists). |
 | **Strict** | `enforce-strict` | `persist` | `enforce` | Missing-policy and writer-fit fail-closed (H4); render ceiling consumes derived labels (H3b). The end state. |
 
 **Non-conforming** examples (a linter/deploy-check should reject): any
@@ -142,4 +141,4 @@ Grounded in the three implemented dials — `cfcEnforcementMode`
 `cfcWriteFloor` (D3, #4479) — plus the SC-13 rollout constraint in
 `cfc-spec-changes.md` and the current shell posture
 ([lib-shell/src/runtime.ts](../../packages/lib-shell/src/runtime.ts):
-`enforce-explicit` + flow `observe`).
+`enforce-explicit` + flow `persist`, H2).

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -126,11 +126,17 @@ export function createRuntimeClientOptions({
   spaceHostMap,
   experimental,
   cfcEnforcementMode = "enforce-explicit",
-  // Epic H1 (docs/plans/cfc-future-work-implementation.md): shell hosts run
-  // the flow-label dial at "observe" — derive the per-tx conservative join
-  // and emit diagnostics without persisting — as the measurement stage
-  // before flipping to "persist" (H2).
-  cfcFlowLabels = "observe",
+  // Epic H2 (docs/plans/cfc-future-work-implementation.md): shell hosts run the
+  // flow-label dial at "persist" — the per-tx conservative join is derived AND
+  // written as a `derived` label component on every value write. This
+  // activates inv-9 (flow-path confidentiality) in real shell deployments:
+  // reading labeled data and writing a derived value no longer launders the
+  // label away. Safe to persist because re-derivation is idempotent (SC-11:
+  // an unchanged label writes no envelope — see prepare.ts) so a rerun that
+  // reads the same inputs does not churn the ["cfc"] doc; replace-on-overwrite
+  // (§8.12.8) keeps the derived component tracking the current value rather
+  // than ratcheting forever. H1 shipped "observe" as the measurement stage.
+  cfcFlowLabels = "persist",
   trustSnapshot,
   forwardWorkerConsole,
 }: {

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -297,9 +297,11 @@ describe("RuntimeInternals", () => {
     });
 
     expect(options.cfcEnforcementMode).toBe("enforce-explicit");
-    // Epic H1: shell hosts run the flow-label dial at "observe" by default —
-    // the measurement stage before "persist" (H2).
-    expect(options.cfcFlowLabels).toBe("observe");
+    // Epic H2: shell hosts run the flow-label dial at "persist" by default —
+    // derived label components are written on every value write, activating
+    // inv-9. H1 shipped "observe" (measurement); H2 flips to "persist" now that
+    // re-derivation is idempotent (SC-11).
+    expect(options.cfcFlowLabels).toBe("persist");
     expect(options.trustSnapshot).toEqual({
       id: `principal:${session.as.did()}`,
       actingPrincipal: session.as.did(),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -39,7 +39,10 @@ import { getValueAtPath, setValueAtPath } from "../path-utils.ts";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { atomPropagationClass } from "./atom-classes.ts";
-import { canonicalizeLogicalPath } from "./canonical.ts";
+import {
+  canonicalizeCfcMetadata,
+  canonicalizeLogicalPath,
+} from "./canonical.ts";
 import { clauseAlternatives, isOrClause, normalizeClause } from "./clause.ts";
 import { externalIngestStamp } from "./external-ingest.ts";
 import {
@@ -4000,6 +4003,26 @@ export const prepareBoundaryCommit = (
         entries: coalescedLabelEntries,
       },
     };
+
+    // SC-11 idempotence: skip the envelope write when the derived metadata is
+    // canonically identical to what is already stored. Re-deriving an unchanged
+    // label must not rewrite the `["cfc"]` doc — that would bump the document
+    // revision and churn the sync/conflict machinery on every recompute. This
+    // is load-bearing once `cfcFlowLabels:"persist"` attaches a derived
+    // component to EVERY value write (H2): the common case is a rerun that
+    // reads the same inputs and derives the same labels, which must be a no-op.
+    // `canonicalizeCfcMetadata` sorts entries + canonicalizes clauses, so the
+    // comparison is order-insensitive and matches `cfcLabelViewsEqual`
+    // semantics.
+    if (
+      existing !== undefined &&
+      deepEqual(
+        canonicalizeCfcMetadata(existing),
+        canonicalizeCfcMetadata(metadata),
+      )
+    ) {
+      continue;
+    }
 
     tx.writeOrThrow({
       space,

--- a/packages/runner/test/cfc-flow-labels.test.ts
+++ b/packages/runner/test/cfc-flow-labels.test.ts
@@ -355,6 +355,96 @@ describe("CFC flow labels (default transition)", () => {
     }
   });
 
+  it("SC-11: re-deriving an unchanged label writes no envelope (idempotent)", async () => {
+    // The load-bearing prereq for cfcFlowLabels:"persist" — a rerun that reads
+    // the same inputs derives the same labels and must NOT rewrite the ["cfc"]
+    // doc (which would bump the revision and churn sync/conflict every
+    // recompute). Observed directly: the second, identical derivation records
+    // no write to the target's ["cfc"] path.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+    try {
+      const seed = runtime.edit();
+      const sourceId = parseLink(
+        runtime.getCell(
+          signer.did(),
+          "cfc-flow-idem-source",
+          { type: "object", properties: { secret: { type: "string" } } },
+        ).getAsLink(),
+      ).id!;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: sourceId,
+        path: [],
+      }, {
+        value: { secret: "s3cr3t" },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [{ path: ["secret"], label: { confidentiality: ["x"] } }],
+          },
+        },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const deriveOnce = () => {
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "cfc-flow-idem-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const target = runtime.getCell(
+          signer.did(),
+          "cfc-flow-idem-target",
+          undefined,
+          tx,
+        );
+        target.set({ note: raw.secret });
+        tx.prepareCfc();
+        const targetId = target.getAsNormalizedFullLink().id;
+        const wroteCfc = [...(tx.getWriteDetails?.(signer.did()) ?? [])].some(
+          (w) => w.address.id === targetId && w.address.path[0] === "cfc",
+        );
+        return { tx, targetId, wroteCfc };
+      };
+
+      // First derivation: the envelope IS written (a real derived component).
+      const first = deriveOnce();
+      expect(first.wroteCfc).toBe(true);
+      expect((await first.tx.commit()).ok).toBeDefined();
+      expect(
+        replicaEntries(storageManager, first.targetId).find((e) =>
+          e.origin === "derived"
+        )?.label.confidentiality,
+      ).toContainEqual("x");
+
+      // Identical re-derivation: the envelope write is SKIPPED (idempotent).
+      const second = deriveOnce();
+      expect(second.wroteCfc).toBe(false);
+      expect((await second.tx.commit()).ok).toBeDefined();
+      // ...and the stored label is unchanged.
+      expect(
+        replicaEntries(storageManager, second.targetId).find((e) =>
+          e.origin === "derived"
+        )?.label.confidentiality,
+      ).toContainEqual("x");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   // A2: trigger reads (§8.9.2). The decision to run was influenced by the
   // triggering change even when the run never reads the changed value, so
   // its labels join the derivation.


### PR DESCRIPTION
## What

Epic H2: flip shell hosts `cfcFlowLabels` **`observe` → `persist`**. The per-tx conservative flow join is now written as a `derived` label component on every value write — activating **inv-9** (flow-path confidentiality) in real deployments: reading labeled data and writing a derived value no longer launders the label away. H1 shipped `observe` as the measurement stage.

## The load-bearing prereq — SC-11 idempotence

The concern with persisting (the "breaking impact" question): under `persist` a derived component is attached on **every** value write, so the common case is a rerun that reads the same inputs and derives the same labels. Without a guard, that would rewrite the `["cfc"]` envelope every recompute — bumping the doc revision and churning the sync/conflict machinery.

Fix: the envelope write in `prepareBoundaryCommit` ([prepare.ts](packages/runner/src/cfc/prepare.ts)) now **skips when the derived metadata is canonically identical** to what's stored (`canonicalizeCfcMetadata` + `deepEqual`). So re-deriving an unchanged label is a genuine no-op. This is what makes `persist` non-breaking — and it's a general win (fewer redundant envelope writes in every mode). Replace-on-overwrite (§8.12.8) already keeps the derived component tracking the current value (existing test).

## Changes

- **prepare.ts**: unchanged-envelope skip. Test asserts the *second* identical re-derivation records **no** `["cfc"]` write (observed via `getWriteDetails`) while the first does, and the stored label is unchanged.
- **lib-shell**: default `persist` + updated assertion.
- **enforcement-matrix.md**: shell baseline row moved to flow `persist`.
- Toolshed stays `off` — its operator posture runs enforcement `disabled`, so persisting labels nothing consumes is pointless (per the [matrix](docs/specs/cfc-enforcement-matrix.md)).

Full runner `cfc-*` suite (72) + lib-shell runtime tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches shell default `cfcFlowLabels` from "observe" to "persist" and makes envelope writes idempotent (SC-11). This enables flow-path confidentiality (inv-9) without revision churn.

- **New Features**
  - `lib-shell`: default `cfcFlowLabels: "persist"` so derived labels are written on every value write; toolshed remains `off`. Docs matrix updated to reflect the new shell baseline.
  - `prepareBoundaryCommit`: skip `["cfc"]` writes when canonicalized derived metadata matches what’s stored (`canonicalizeCfcMetadata` + `deepEqual`). Adds a test verifying the second identical derivation writes no envelope and the stored label is unchanged.

<sup>Written for commit c49eced8ff3a77022b7e9fff69115b2d9b1d4c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

