### PR TITLE
Enable disk-backed compile byte cache for cf test

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -237,9 +237,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.compile-cache/generated-patterns-${{ matrix.shard }}.json
-          key: cc-generated-patterns-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/generated-patterns/**/*.ts') }}
+          key: cc-generated-patterns-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/generated-patterns/**/*.ts') }}
           restore-keys: |
-            cc-generated-patterns-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
+            cc-generated-patterns-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db
@@ -535,13 +535,14 @@ jobs:
       # Cross-run compile cache: persist the per-shard compiled-module-byte cache
       # so unchanged patterns reuse last run's emitted bytes (skip the
       # type-check + transform + emit). The key folds in a hash of everything
-      # that shapes the emitted bytes — the js-compiler, the CF transformer, the
-      # schema-generator it bakes schemas from, runner code that prepares and
-      # verifies compiled module records, static type assets loaded by the
-      # in-memory compiler, the api types lowered into schemas, the root
-      # deno.jsonc compiler options (jsx/jsxImportSource), and the lockfile — so
-      # any change to what emits or trusts the bytes invalidates the whole file
-      # even when it leaves module identity and the runtime-version tag untouched.
+      # that shapes emitted bytes or cached coverage spans — the js-compiler,
+      # the CF transformer, the schema-generator it bakes schemas from, runner
+      # code that prepares and verifies compiled module records, static type
+      # assets loaded by the in-memory compiler, the api types lowered into
+      # schemas, the root deno.jsonc compiler options (jsx/jsxImportSource), and
+      # the lockfile — so any change to what emits or trusts the bytes
+      # invalidates the whole file even when it leaves module identity and the
+      # runtime-version tag untouched.
       # This input list mirrors COMPILE_FINGERPRINT_INPUTS in
       # packages/runner/src/compilation-cache/compiler-fingerprint.deno.ts, which
       # fingerprints the same set for the durable runtime cache; the
@@ -552,9 +553,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json
-          key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.tsx') }}
+          key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.tsx') }}
           restore-keys: |
-            cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
+            cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
 
       - name: 📥 Download built binaries
         uses: actions/download-artifact@v8
@@ -697,6 +698,14 @@ jobs:
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db
 
+      - name: ♻️ Restore/save pattern unit compile byte cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.compile-cache/pattern-unit-coverage-${{ matrix.chunk }}.json
+          key: cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.chunk }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx') }}
+          restore-keys: |
+            cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.chunk }}-
+
       - name: 📥 Download built binaries
         uses: actions/download-artifact@v8
         with:
@@ -706,9 +715,10 @@ jobs:
       - name: 🧪 Run pattern unit tests
         run: |
           chmod +x ./common-binaries/cf
-          mkdir -p test-results coverage/lcov/pattern-runtime/pattern-unit-${{ matrix.chunk }}
+          mkdir -p test-results .compile-cache coverage/lcov/pattern-runtime/pattern-unit-${{ matrix.chunk }}
           DENO_COVERAGE_DIR=coverage/raw/pattern-unit-${{ matrix.chunk }} \
           CF_PATTERN_COVERAGE_DIR=coverage/lcov/pattern-runtime/pattern-unit-${{ matrix.chunk }} \
+          CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-unit-coverage-${{ matrix.chunk }}.json" \
           CF_BINARY=./common-binaries/cf \
           deno task integration --junit-dir=test-results pattern-tests ${{ matrix.chunk }}/${{ matrix.total }}
 

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -119,14 +119,13 @@ The pattern unit job runs each `packages/patterns/**/*.test.tsx` file through
 files against a running Toolshed server.
 
 The compile byte cache is available to `cf test` through
-`CF_COMPILE_CACHE_FILE` when authored-pattern coverage is not active. The
-`pattern-unit-test` job still leaves that cache unwired because it sets
-`CF_PATTERN_COVERAGE_DIR`. Coverage compiles must transform the TypeScript
-source so the current collector can register spans and emit hit calls. Reusing
-restored module bytes would skip that registration, so the `cf test` cache path
-does not read or write byte-cache entries for those direct coverage compiles.
-If CI later separates a non-coverage pattern unit lane, that lane can set
-`CF_COMPILE_CACHE_FILE`.
+`CF_COMPILE_CACHE_FILE`. Coverage and non-coverage compiles use different cache
+keys. Coverage cache entries also carry the spans registered during the
+transform, so a restored coverage compile can rebuild the current collector
+before the cached module bytes run. The `pattern-unit-test` job wires both
+`CF_PATTERN_COVERAGE_DIR` and `CF_COMPILE_CACHE_FILE`, which lets CI reuse
+coverage-transformed module bytes between runs without mixing them with ordinary
+compiled bytes.
 
 ## Why the two integration jobs do not set `CF_PATTERN_COVERAGE_DIR`
 

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -118,6 +118,16 @@ The pattern unit job runs each `packages/patterns/**/*.test.tsx` file through
 `cf test` in-process. The two integration jobs run browser-driven `deno test`
 files against a running Toolshed server.
 
+The compile byte cache is available to `cf test` through
+`CF_COMPILE_CACHE_FILE` when authored-pattern coverage is not active. The
+`pattern-unit-test` job still leaves that cache unwired because it sets
+`CF_PATTERN_COVERAGE_DIR`. Coverage compiles must transform the TypeScript
+source so the current collector can register spans and emit hit calls. Reusing
+restored module bytes would skip that registration, so the `cf test` cache path
+does not read or write byte-cache entries for those direct coverage compiles.
+If CI later separates a non-coverage pattern unit lane, that lane can set
+`CF_COMPILE_CACHE_FILE`.
+
 ## Why the two integration jobs do not set `CF_PATTERN_COVERAGE_DIR`
 
 Adding `CF_PATTERN_COVERAGE_DIR` to `pattern-integration-test` or

--- a/packages/cli/lib/compile-byte-cache.ts
+++ b/packages/cli/lib/compile-byte-cache.ts
@@ -1,0 +1,22 @@
+import { type ModuleByteCache } from "@commonfabric/runner";
+import {
+  createCompileByteCache,
+  flushCompileByteCache,
+} from "@commonfabric/test-support/compile-byte-cache";
+
+let defaultModuleByteCache: ModuleByteCache | undefined;
+
+export function getDefaultModuleByteCache(): ModuleByteCache {
+  defaultModuleByteCache ??= createCompileByteCache();
+  return defaultModuleByteCache;
+}
+
+export function flushDefaultModuleByteCache(): void {
+  if (defaultModuleByteCache !== undefined) {
+    try {
+      flushCompileByteCache(defaultModuleByteCache);
+    } catch (error) {
+      console.error("[compile-byte-cache] failed to write cache file:", error);
+    }
+  }
+}

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -251,6 +251,7 @@ export async function runMultiUserTestPattern(
           );
         }
       } catch (error) {
+        await worker.call("dispose").catch(() => {});
         worker.terminate();
         throw error;
       }

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -34,6 +34,10 @@ import {
   snapshotLoggerErrorWarnCounts,
 } from "./console-capture.ts";
 import {
+  flushDefaultModuleByteCache,
+  getDefaultModuleByteCache,
+} from "./compile-byte-cache.ts";
+import {
   createSession,
   Identity,
   type KeyPairRaw,
@@ -163,6 +167,7 @@ const handlers: Record<
       spaceName: args.spaceName as string,
     });
     const space = session.space;
+    const moduleByteCache = getDefaultModuleByteCache();
     const { StorageManager } = await import(
       "@commonfabric/runner/storage/cache.deno"
     );
@@ -179,6 +184,7 @@ const handlers: Record<
       // declared `ifc` policies (the production runtime default).
       cfcEnforcementMode: "enforce-explicit",
       apiUrl: new URL(import.meta.url),
+      moduleByteCache,
       errorHandlers: [(error: Error) => runtimeErrors.push(String(error))],
     });
     runtime.enableIdempotencyCheck();
@@ -410,6 +416,7 @@ const handlers: Record<
     // `engine` is the runtime's own harness; runtime.dispose() disposes it.
     await runtime?.dispose();
     await storageManager?.close();
+    flushDefaultModuleByteCache();
     runtime = undefined;
     storageManager = undefined;
     engine = undefined;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -28,6 +28,7 @@
 import { Identity } from "@commonfabric/identity";
 import {
   ConsoleMethod,
+  type ModuleByteCache,
   PatternCoverageCollector,
   patternCoverageOutputPath,
   Runtime,
@@ -61,6 +62,7 @@ import {
   multiUserDescriptorMeta,
   runMultiUserTestPattern,
 } from "./multi-user-test-runner.ts";
+import { getDefaultModuleByteCache } from "./compile-byte-cache.ts";
 import {
   type FetchMockEntry,
   makeMockFetch,
@@ -271,6 +273,8 @@ export interface TestRunnerOptions {
   storageStatsLimit?: number;
   /** Directory for pattern runtime coverage LCOV artifacts. */
   patternCoverageDir?: string;
+  /** Shared compiled-module-byte cache for direct harness compiles. */
+  moduleByteCache?: ModuleByteCache;
 }
 
 // ---------------------------------------------------------------------------
@@ -883,6 +887,8 @@ export async function runTestPattern(
     ? new PatternCoverageCollector()
     : undefined;
   let writeLocalPatternCoverage = patternCoverage !== undefined;
+  const moduleByteCache = options.moduleByteCache ??
+    getDefaultModuleByteCache();
 
   // Collect pattern-code console.error / console.warn calls (channel 1: harness
   // console event) and logger-level error/warn activity (channel 2: logger count
@@ -943,6 +949,7 @@ export async function runTestPattern(
         cfcEnforcementMode: options.cfcEnforcementMode ?? "enforce-explicit",
         experimental: experimentalOptionsFromEnv(),
         apiUrl: new URL(import.meta.url),
+        moduleByteCache,
         errorHandlers: [(error: ErrorWithContext) => runtimeErrors.push(error)],
         navigateCallback: (target) => {
           const name = (target.key("$NAME") as Cell<string | undefined>).get();

--- a/packages/cli/test/test-runner-compile-byte-cache.test.ts
+++ b/packages/cli/test/test-runner-compile-byte-cache.test.ts
@@ -28,6 +28,22 @@ class CountingProcessModuleByteCache extends ProcessModuleByteCache {
   }
 }
 
+async function readCoverageText(coverageDir: string): Promise<string> {
+  const chunks: string[] = [];
+  async function readDirectory(dir: string): Promise<void> {
+    for await (const entry of Deno.readDir(dir)) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory) {
+        await readDirectory(path);
+      } else if (entry.isFile && entry.name.endsWith(".lcov")) {
+        chunks.push(await Deno.readTextFile(path));
+      }
+    }
+  }
+  await readDirectory(coverageDir);
+  return chunks.join("\n");
+}
+
 describe(
   "cf test compile byte cache",
   { sanitizeOps: false, sanitizeResources: false },
@@ -96,6 +112,61 @@ describe(
             expect(
               second.stdout.some((line) => line.includes("compile-cache-hit")),
             ).toBe(true);
+          });
+        });
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("uses a coverage-specific cache key across cf test processes", async () => {
+      const dir = await Deno.makeTempDir({
+        prefix: "cf-test-compile-byte-cache-coverage-env-",
+      });
+      const cacheFile = join(dir, "cache.json");
+      const coverageDir = join(dir, "coverage");
+      const command = `test "${TEST_FILE}" --root "${FIXTURES}"`;
+
+      try {
+        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
+          await withEnv("CF_PATTERN_COVERAGE_DIR", coverageDir, async () => {
+            await withEnv("CF_LOG_LEVEL", "info", async () => {
+              const first = await cf(command);
+              expect(first.code).toBe(0);
+              checkStderr(first.stderr);
+
+              const entries = JSON.parse(await Deno.readTextFile(cacheFile));
+              expect(Array.isArray(entries)).toBe(true);
+              expect(
+                entries.some((entry: { key?: unknown }) =>
+                  typeof entry.key === "string" &&
+                  entry.key.includes("/pattern-coverage\0")
+                ),
+              ).toBe(true);
+              expect(
+                entries.some((
+                  entry: { patternCoverageSpans?: unknown },
+                ) => Array.isArray(entry.patternCoverageSpans)),
+              ).toBe(true);
+
+              const second = await cf(command);
+              expect(second.code).toBe(0);
+              checkStderr(second.stderr);
+              expect(
+                second.stdout.some((line) =>
+                  line.includes("[compile-byte-cache] restored")
+                ),
+              ).toBe(true);
+              expect(
+                second.stdout.some((line) =>
+                  line.includes("compile-cache-hit")
+                ),
+              ).toBe(true);
+
+              const coverage = await readCoverageText(coverageDir);
+              expect(coverage).toContain("SF:");
+              expect(coverage).toMatch(/LH:[1-9]/);
+            });
           });
         });
       } finally {

--- a/packages/cli/test/test-runner-compile-byte-cache.test.ts
+++ b/packages/cli/test/test-runner-compile-byte-cache.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join, resolve } from "@std/path";
+import type { CompiledModuleArtifact } from "@commonfabric/runner";
+import {
+  ProcessModuleByteCache,
+  restoreCompileByteCacheForTesting,
+  writeCompileByteCacheForTesting,
+} from "@commonfabric/test-support/compile-byte-cache";
+import { runTests } from "../lib/test-runner.ts";
+import { cf, checkStderr, withEnv } from "./utils.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/pattern-coverage");
+const TEST_FILE = join(FIXTURES, "single.test.tsx").replaceAll("\\", "/");
+
+class CountingProcessModuleByteCache extends ProcessModuleByteCache {
+  fullHits = 0;
+
+  override getCompleteSet(
+    runtimeVersion: string,
+    identities: readonly string[],
+  ): Map<string, CompiledModuleArtifact> | undefined {
+    const result = super.getCompleteSet(runtimeVersion, identities);
+    if (result !== undefined) {
+      this.fullHits++;
+    }
+    return result;
+  }
+}
+
+describe(
+  "cf test compile byte cache",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("restores compiled modules from disk for a later compile", async () => {
+      const dir = await Deno.makeTempDir({
+        prefix: "cf-test-compile-byte-cache-",
+      });
+      const cacheFile = join(dir, "cache.json");
+
+      try {
+        const firstCache = new ProcessModuleByteCache();
+        const first = await runTests(TEST_FILE, {
+          root: FIXTURES,
+          moduleByteCache: firstCache,
+        });
+
+        expect(first.failed).toBe(0);
+        expect(first.passed).toBeGreaterThan(0);
+        expect(firstCache.stats().entries).toBeGreaterThan(0);
+        expect(writeCompileByteCacheForTesting(firstCache, cacheFile))
+          .toBeGreaterThan(0);
+
+        const restoredCache = new CountingProcessModuleByteCache();
+        expect(restoreCompileByteCacheForTesting(restoredCache, cacheFile))
+          .toBeGreaterThan(0);
+
+        const second = await runTests(TEST_FILE, {
+          root: FIXTURES,
+          moduleByteCache: restoredCache,
+        });
+
+        expect(second.failed).toBe(0);
+        expect(second.passed).toBe(first.passed);
+        expect(restoredCache.fullHits).toBeGreaterThan(0);
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("uses CF_COMPILE_CACHE_FILE across cf test processes", async () => {
+      const dir = await Deno.makeTempDir({
+        prefix: "cf-test-compile-byte-cache-env-",
+      });
+      const cacheFile = join(dir, "cache.json");
+      const command = `test "${TEST_FILE}" --root "${FIXTURES}"`;
+
+      try {
+        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
+          await withEnv("CF_LOG_LEVEL", "info", async () => {
+            const first = await cf(command);
+            expect(first.code).toBe(0);
+            checkStderr(first.stderr);
+            const entries = JSON.parse(await Deno.readTextFile(cacheFile));
+            expect(Array.isArray(entries)).toBe(true);
+            expect(entries.length).toBeGreaterThan(0);
+
+            const second = await cf(command);
+            expect(second.code).toBe(0);
+            checkStderr(second.stderr);
+            expect(
+              second.stdout.some((line) =>
+                line.includes("[compile-byte-cache] restored")
+              ),
+            ).toBe(true);
+            expect(
+              second.stdout.some((line) => line.includes("compile-cache-hit")),
+            ).toBe(true);
+          });
+        });
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+  },
+);

--- a/packages/cli/test/test-runner-compile-byte-cache.test.ts
+++ b/packages/cli/test/test-runner-compile-byte-cache.test.ts
@@ -7,11 +7,16 @@ import {
   restoreCompileByteCacheForTesting,
   writeCompileByteCacheForTesting,
 } from "@commonfabric/test-support/compile-byte-cache";
+import { runMultiUserTestPattern } from "../lib/multi-user-test-runner.ts";
 import { runTests } from "../lib/test-runner.ts";
 import { cf, checkStderr, withEnv } from "./utils.ts";
 
 const FIXTURES = resolve(import.meta.dirname!, "fixtures/pattern-coverage");
 const TEST_FILE = join(FIXTURES, "single.test.tsx").replaceAll("\\", "/");
+const COMPILE_BYTE_CACHE_MODULE = new URL(
+  "../lib/compile-byte-cache.ts",
+  import.meta.url,
+);
 
 class CountingProcessModuleByteCache extends ProcessModuleByteCache {
   fullHits = 0;
@@ -44,10 +49,97 @@ async function readCoverageText(coverageDir: string): Promise<string> {
   return chunks.join("\n");
 }
 
+async function importFreshCompileByteCacheModule(): Promise<
+  typeof import("../lib/compile-byte-cache.ts")
+> {
+  const url = new URL(COMPILE_BYTE_CACHE_MODULE);
+  url.searchParams.set("testRun", crypto.randomUUID());
+  return await import(url.href);
+}
+
 describe(
   "cf test compile byte cache",
   { sanitizeOps: false, sanitizeResources: false },
   () => {
+    it("flushes safely before the default cache is initialized", async () => {
+      const module = await importFreshCompileByteCacheModule();
+
+      module.flushDefaultModuleByteCache();
+    });
+
+    it("flushes the default cache to CF_COMPILE_CACHE_FILE", async () => {
+      const dir = await Deno.makeTempDir({
+        prefix: "cf-test-default-compile-byte-cache-",
+      });
+      const cacheFile = join(dir, "cache.json");
+
+      try {
+        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
+          const module = await importFreshCompileByteCacheModule();
+          const cache = module.getDefaultModuleByteCache();
+          cache.putAll("rt", [{ identity: "id", js: "JS" }]);
+
+          module.flushDefaultModuleByteCache();
+
+          const entries = JSON.parse(await Deno.readTextFile(cacheFile));
+          expect(entries).toEqual([{ key: "rt\0id", js: "JS" }]);
+        });
+      } finally {
+        globalThis.addEventListener("unload", () => {
+          try {
+            Deno.removeSync(dir, { recursive: true });
+          } catch {
+            // The test may have already removed the directory.
+          }
+        });
+        await Deno.remove(dir, { recursive: true }).catch(() => {});
+      }
+    });
+
+    it("reports default cache flush failures", async () => {
+      const dir = await Deno.makeTempDir({
+        prefix: "cf-test-default-compile-byte-cache-error-",
+      });
+      const cacheFile = join(dir, "cache.json");
+      const originalOpenSync = Deno.openSync;
+      const originalError = console.error;
+      const errors: string[] = [];
+
+      console.error = (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      };
+
+      try {
+        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
+          const module = await importFreshCompileByteCacheModule();
+          const cache = module.getDefaultModuleByteCache();
+          cache.putAll("rt", [{ identity: "id", js: "JS" }]);
+
+          Deno.openSync = (() => {
+            throw new Error("lock unavailable");
+          }) as typeof Deno.openSync;
+          module.flushDefaultModuleByteCache();
+        });
+
+        expect(
+          errors.some((line) =>
+            line.includes("[compile-byte-cache] failed to write cache file:")
+          ),
+        ).toBe(true);
+      } finally {
+        Deno.openSync = originalOpenSync;
+        console.error = originalError;
+        globalThis.addEventListener("unload", () => {
+          try {
+            Deno.removeSync(dir, { recursive: true });
+          } catch {
+            // The test may have already removed the directory.
+          }
+        });
+        await Deno.remove(dir, { recursive: true }).catch(() => {});
+      }
+    });
+
     it("restores compiled modules from disk for a later compile", async () => {
       const dir = await Deno.makeTempDir({
         prefix: "cf-test-compile-byte-cache-",
@@ -169,6 +261,33 @@ describe(
             });
           });
         });
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("flushes a multi-user worker cache when participant init fails", async () => {
+      const dir = await Deno.makeTempDir({
+        prefix: "cf-test-multi-user-init-failure-",
+      });
+      const missingTest = join(dir, "missing.test.tsx");
+      const cacheFile = join(dir, "cache.json");
+
+      try {
+        let result:
+          | Awaited<ReturnType<typeof runMultiUserTestPattern>>
+          | undefined;
+        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
+          result = await runMultiUserTestPattern(
+            missingTest,
+            { participants: [{ name: "alice", user: "alice" }] },
+            { root: dir },
+          );
+        });
+
+        if (result === undefined) throw new Error("missing test result");
+        expect(result.error).toBeDefined();
+        expect(JSON.parse(await Deno.readTextFile(cacheFile))).toEqual([]);
       } finally {
         await Deno.remove(dir, { recursive: true });
       }

--- a/packages/runner/src/compilation-cache/compiler-fingerprint.deno.ts
+++ b/packages/runner/src/compilation-cache/compiler-fingerprint.deno.ts
@@ -23,11 +23,12 @@ import { SOURCE_COMPILE_CACHE_RUNTIME_VERSION } from "./compile-cache-version.ts
 
 /**
  * Repo-relative inputs hashed into the fingerprint: the source that determines
- * the compiler's emitted bytes, plus the lockfile and root compiler options.
- * Directory inputs are hashed whole, so the version also moves when a test,
- * fixture, or doc under them changes, and the whole-file `deno.lock` moves it on
- * any dependency bump. The result over-invalidates rather than under-
- * invalidates: a redundant recompile, never a stale read.
+ * the compiler's emitted bytes and cached coverage span metadata, plus the
+ * lockfile and root compiler options. Directory inputs are hashed whole, so the
+ * version also moves when a test, fixture, or doc under them changes, and the
+ * whole-file `deno.lock` moves it on any dependency bump. The result
+ * over-invalidates rather than under-invalidates: a redundant recompile, never
+ * a stale read.
  *
  * This is the single definition of the input set. The CI compile-cache key
  * fingerprints the same inputs; {@link ciHashFilesArgs} renders this list into
@@ -39,6 +40,8 @@ import { SOURCE_COMPILE_CACHE_RUNTIME_VERSION } from "./compile-cache-version.ts
  *  - `packages/js-compiler` — the TypeScript-to-JS compiler driver;
  *  - `packages/runner/src/harness` — runner code that prepares resolved
  *    programs before they reach the compiler;
+ *  - `packages/runner/src/pattern-coverage.ts` — coverage span mapping stored
+ *    beside coverage-transformed bytes;
  *  - `packages/runner/src/sandbox` — module-record assembly and verification
  *    used before cached compiled bodies execute;
  *  - `packages/schema-generator` — schema emission consumed by the pipeline;
@@ -54,6 +57,7 @@ export const COMPILE_FINGERPRINT_INPUTS: readonly string[] = [
   "packages/ts-transformers",
   "packages/js-compiler",
   "packages/runner/src/harness",
+  "packages/runner/src/pattern-coverage.ts",
   "packages/runner/src/sandbox",
   "packages/schema-generator",
   "packages/api",

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1,6 +1,7 @@
 import { Console } from "./console.ts";
 import {
   type CacheableModule,
+  type CompiledModuleArtifact,
   type EvaluateResult,
   type Exports,
   type Harness,
@@ -330,17 +331,18 @@ export class Engine extends EventTarget implements Harness {
       // transitively sensitive, so a partial set cannot be trusted — fall back
       // to a full recompile. The cache is queried by identity (directly, or
       // lazily once identities are known) without leaking the engine's prefix.
-      // Coverage compiles need fresh emitted JavaScript because cached bodies do
-      // not include counters.
-      const cached = patternCoverage !== undefined
+      const cachedCandidate = options.precompiledModules ??
+        (options.precompiledModulesFor
+          ? await options.precompiledModulesFor({
+            entryIdentity,
+            identities: [...new Set(identityByPath.values())],
+          })
+          : undefined);
+      const cached = patternCoverage !== undefined &&
+          cachedCandidate !== undefined &&
+          !cachedArtifactsIncludePatternCoverage(cachedCandidate)
         ? undefined
-        : options.precompiledModules ??
-          (options.precompiledModulesFor
-            ? await options.precompiledModulesFor({
-              entryIdentity,
-              identities: [...new Set(identityByPath.values())],
-            })
-            : undefined);
+        : cachedCandidate;
       const fullHit = cached !== undefined &&
         moduleFiles.every((f) => cached.has(identityByPath.get(f.name)!));
 
@@ -358,6 +360,11 @@ export class Engine extends EventTarget implements Harness {
             precompiledSourceMaps.set(
               file.name,
               artifact.sourceMap as SourceMap,
+            );
+          }
+          if (options.patternCoverage !== undefined) {
+            options.patternCoverage.registerSpans(
+              artifact.patternCoverageSpans ?? [],
             );
           }
         }
@@ -505,6 +512,11 @@ export class Engine extends EventTarget implements Harness {
       const modules: CacheableModule[] = pristineModuleFiles.map((file) => {
         const identity = identityByPath.get(file.name)!;
         const sourceMap = precompiledSourceMaps.get(file.name);
+        const patternCoverageSpans = patternCoverage === undefined
+          ? undefined
+          : options.patternCoverage?.spansForFile(
+            coverageFilenameFor(file.name, id, mounts),
+          );
         const imports = cacheableImportsFor(
           file.name,
           importEdges,
@@ -517,6 +529,9 @@ export class Engine extends EventTarget implements Harness {
           source: file.contents,
           js: precompiledBodies.get(file.name)!,
           ...(sourceMap === undefined ? {} : { sourceMap }),
+          ...(patternCoverageSpans === undefined
+            ? {}
+            : { patternCoverageSpans }),
           imports,
         };
       });
@@ -1507,6 +1522,15 @@ function patternCoverageOptionsForCompile(
     },
     registerSpan: (span) => collector.registerSpan(span),
   };
+}
+
+function cachedArtifactsIncludePatternCoverage(
+  artifacts: ReadonlyMap<string, CompiledModuleArtifact>,
+): boolean {
+  for (const artifact of artifacts.values()) {
+    if (!Array.isArray(artifact.patternCoverageSpans)) return false;
+  }
+  return true;
 }
 
 function coverageFilenameFor(

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -10,6 +10,7 @@ import type {
   HoistRegistrationSink,
 } from "../sandbox/module-record-compiler.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
+import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 
 export type HarnessedFunction = (input: any) => void;
 
@@ -90,6 +91,7 @@ export interface ResolvedFabricPin {
 export interface CompiledModuleArtifact {
   js: string;
   sourceMap?: unknown;
+  patternCoverageSpans?: PatternCoverageSpan[];
 }
 
 /**
@@ -108,6 +110,8 @@ export interface CacheableModule {
   js: string;
   /** Per-module source map, when available. */
   sourceMap?: unknown;
+  /** Pattern coverage spans registered while compiling this module. */
+  patternCoverageSpans?: PatternCoverageSpan[];
   /** Internal import edges: specifier → the dependency module's identity. */
   imports: { specifier: string; targetIdentity: string }[];
 }

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -3,6 +3,7 @@ import type {
   ProgramResolver,
   Source,
 } from "@commonfabric/js-compiler";
+import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 import type { MemorySpace } from "../runtime.ts";
 import type {
   CachedCompiledModule,
@@ -10,7 +11,6 @@ import type {
   HoistRegistrationSink,
 } from "../sandbox/module-record-compiler.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
-import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 
 export type HarnessedFunction = (input: any) => void;
 
@@ -87,7 +87,7 @@ export interface ResolvedFabricPin {
   chain: string[];
 }
 
-/** A cached/compiled per-module artifact: emitted JS plus optional source map. */
+/** A cached/compiled per-module artifact: emitted JS plus optional metadata. */
 export interface CompiledModuleArtifact {
   js: string;
   sourceMap?: unknown;
@@ -99,19 +99,13 @@ export interface CompiledModuleArtifact {
  * later reload) one module, surfaced by `compileToRecordGraph` in identity
  * space — callers never see the engine's internal `/<id>` path prefix.
  */
-export interface CacheableModule {
+export interface CacheableModule extends CompiledModuleArtifact {
   /** Prefix-free content identity (the `cf:module/<hash>` hash, no scheme). */
   identity: string;
   /** Normalized authored module path (no `/<id>` prefix; e.g. `/main.tsx`). */
   filename: string;
   /** Resolved TypeScript source whose bytes are folded into `identity`. */
   source: string;
-  /** Compiled CommonJS body. */
-  js: string;
-  /** Per-module source map, when available. */
-  sourceMap?: unknown;
-  /** Pattern coverage spans registered while compiling this module. */
-  patternCoverageSpans?: PatternCoverageSpan[];
   /** Internal import edges: specifier → the dependency module's identity. */
   imports: { specifier: string; targetIdentity: string }[];
 }

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -195,6 +195,9 @@ export {
 export type { ModuleByteCache } from "./runtime.ts";
 export type { CompiledModuleArtifact } from "./harness/types.ts";
 export {
+  getCompileCacheRuntimeVersion,
+} from "./compilation-cache/cell-cache.ts";
+export {
   isSlugAddress,
   slugCause,
   slugIdForSpace,

--- a/packages/runner/src/pattern-coverage.ts
+++ b/packages/runner/src/pattern-coverage.ts
@@ -46,6 +46,16 @@ export class PatternCoverageCollector {
     this.#spans.set(spanKey(span.fileName, span.id), span);
   }
 
+  registerSpans(spans: readonly PatternCoverageSpan[]): void {
+    for (const span of spans) this.registerSpan(span);
+  }
+
+  spansForFile(fileName: string): PatternCoverageSpan[] {
+    return [...this.#spans.values()]
+      .filter((span) => span.fileName === fileName)
+      .map((span) => ({ ...span }));
+  }
+
   hit(fileName: string, id: number): void {
     const key = spanKey(fileName, id);
     this.#hits.set(key, (this.#hits.get(key) ?? 0) + 1);

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -62,6 +62,16 @@ function throwableStorageError(error: CommitError): Error {
   });
 }
 
+function moduleByteCacheRuntimeVersion(
+  runtimeVersion: string | undefined,
+  options: { patternCoverage: boolean },
+): string | undefined {
+  if (runtimeVersion === undefined) return undefined;
+  return options.patternCoverage
+    ? `${runtimeVersion}/pattern-coverage`
+    : runtimeVersion;
+}
+
 /**
  * Re-derive a stored module's fabric edges from its SOURCE text (source docs
  * deliberately do not store them as links). Unpinned specifiers are skipped:
@@ -505,12 +515,13 @@ export class PatternManager {
     program: RuntimeProgram,
     options?: TypeScriptHarnessProcessOptions,
   ): Promise<EvaluateResult> {
-    const byteCache = options?.patternCoverage === undefined
-      ? this.runtime.moduleByteCache
-      : undefined;
+    const byteCache = this.runtime.moduleByteCache;
     const runtimeVersion = byteCache === undefined
       ? undefined
-      : await getCompileCacheRuntimeVersion();
+      : moduleByteCacheRuntimeVersion(
+        await getCompileCacheRuntimeVersion(),
+        { patternCoverage: options?.patternCoverage !== undefined },
+      );
     if (byteCache === undefined || runtimeVersion === undefined) {
       const result = await this.runtime.harness.compileAndEvaluateModules(
         program,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -505,9 +505,33 @@ export class PatternManager {
     program: RuntimeProgram,
     options?: TypeScriptHarnessProcessOptions,
   ): Promise<EvaluateResult> {
-    const result = await this.runtime.harness.compileAndEvaluateModules(
-      program,
-      options,
+    const byteCache = options?.patternCoverage === undefined
+      ? this.runtime.moduleByteCache
+      : undefined;
+    const runtimeVersion = byteCache === undefined
+      ? undefined
+      : await getCompileCacheRuntimeVersion();
+    if (byteCache === undefined || runtimeVersion === undefined) {
+      const result = await this.runtime.harness.compileAndEvaluateModules(
+        program,
+        options,
+      );
+      this.registerEvaluatedModules(result);
+      return result;
+    }
+
+    const { id, graph, mainSpecifier, modules } = await this.runtime.harness
+      .compileToRecordGraph(program, {
+        ...options,
+        precompiledModulesFor: ({ identities }) =>
+          Promise.resolve(byteCache.getCompleteSet(runtimeVersion, identities)),
+      });
+    byteCache.putAll(runtimeVersion, modules);
+    const result = this.runtime.harness.evaluateRecordGraph(
+      id,
+      graph,
+      mainSpecifier,
+      program.files,
     );
     this.registerEvaluatedModules(result);
     return result;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -209,7 +209,7 @@ export interface ModuleByteCache {
    */
   putAll(
     runtimeVersion: string,
-    modules: readonly { identity: string; js: string; sourceMap?: unknown }[],
+    modules: readonly ({ identity: string } & CompiledModuleArtifact)[],
   ): void;
 }
 

--- a/packages/runner/test/compiler-fingerprint.test.ts
+++ b/packages/runner/test/compiler-fingerprint.test.ts
@@ -231,7 +231,7 @@ describe("compile-cache version axis", () => {
     );
   });
 
-  it("fingerprints the compiler-input packages that shape emitted bytes", () => {
+  it("fingerprints the inputs that shape emitted bytes and coverage spans", () => {
     // `api` carries the pattern-facing types the schema-generator lowers into
     // baked schemas, so it is fingerprinted alongside the pipeline.
     for (
@@ -239,6 +239,7 @@ describe("compile-cache version axis", () => {
         "packages/ts-transformers",
         "packages/js-compiler",
         "packages/runner/src/harness",
+        "packages/runner/src/pattern-coverage.ts",
         "packages/runner/src/sandbox",
         "packages/schema-generator",
         "packages/api",
@@ -258,7 +259,7 @@ describe("compile-cache version axis", () => {
     const workflow = await Deno.readTextFile(denoWorkflowPath);
     const expected = `hashFiles(${ciHashFilesArgs()})`;
     const occurrences = workflow.split(expected).length - 1;
-    expect(occurrences).toBe(4);
+    expect(occurrences).toBe(6);
     expect(workflow).toContain(
       "hashFiles('packages/generated-patterns/**/*.ts')",
     );

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -7,6 +7,7 @@ import { Runtime } from "../src/runtime.ts";
 import { Engine } from "../src/harness/engine.ts";
 import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 
 const signer = await Identity.fromPassphrase("test operator");
 
@@ -192,6 +193,27 @@ describe("Engine.compileToRecordGraph", () => {
         ) => [m.identity, { js: `${m.js}\n//cached:${m.identity}` }]),
       );
 
+    const taggedCoverageFrom = (
+      modules: {
+        identity: string;
+        js: string;
+        sourceMap?: unknown;
+        patternCoverageSpans?: PatternCoverageSpan[];
+      }[],
+    ) =>
+      new Map(
+        modules.map((m) => [
+          m.identity,
+          {
+            js: `${m.js}\n//cached:${m.identity}`,
+            ...(m.sourceMap === undefined ? {} : { sourceMap: m.sourceMap }),
+            ...(m.patternCoverageSpans === undefined
+              ? {}
+              : { patternCoverageSpans: m.patternCoverageSpans }),
+          },
+        ]),
+      );
+
     it("returns a descriptor per emitted module in identity space", async () => {
       const { modules, entryIdentity, graph } = await engine
         .compileToRecordGraph(MULTI);
@@ -237,7 +259,7 @@ describe("Engine.compileToRecordGraph", () => {
       expect((main as { total(): number }).total()).toBe(42);
     });
 
-    it("ignores precompiled bodies when pattern coverage is enabled", async () => {
+    it("ignores precompiled bodies without coverage spans when pattern coverage is enabled", async () => {
       const first = await engine.compileToRecordGraph(MULTI);
       const tagged = taggedFrom(first.modules);
       const coverage = new PatternCoverageCollector();
@@ -258,6 +280,34 @@ describe("Engine.compileToRecordGraph", () => {
       );
       expect((main as { total(): number }).total()).toBe(42);
       expect(coverage.report().totals.coveredRuntimeLines).toBeGreaterThan(0);
+    });
+
+    it("reuses coverage precompiled bodies and restores their spans", async () => {
+      const firstCoverage = new PatternCoverageCollector();
+      const first = await engine.compileToRecordGraph(MULTI, {
+        patternCoverage: firstCoverage,
+      });
+      const tagged = taggedCoverageFrom(first.modules);
+      const coverage = new PatternCoverageCollector();
+
+      const compiled = await engine.compileToRecordGraph(MULTI, {
+        patternCoverage: coverage,
+        precompiledModules: tagged,
+      });
+      for (const m of compiled.modules) {
+        expect(m.js).toContain(`//cached:${m.identity}`);
+      }
+
+      const { main } = engine.evaluateRecordGraph(
+        compiled.id,
+        compiled.graph,
+        compiled.mainSpecifier,
+        MULTI.files,
+      );
+      expect((main as { total(): number }).total()).toBe(42);
+      const report = coverage.report();
+      expect(report.totals.runtimeLines).toBeGreaterThan(0);
+      expect(report.totals.coveredRuntimeLines).toBeGreaterThan(0);
     });
 
     it("security-verifies UNtrusted direct precompiled injection (no blind trust)", async () => {

--- a/packages/runner/test/module-byte-cache.test.ts
+++ b/packages/runner/test/module-byte-cache.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   getCompileCacheRuntimeVersion,
   loadCompiledClosure,
+  setCompileCacheRuntimeVersionForTesting,
 } from "../src/compilation-cache/cell-cache.ts";
 
 const signer = await Identity.fromPassphrase("module byte cache test");
@@ -26,11 +27,14 @@ const runtimeVersion = resolvedRuntimeVersion;
 // (eviction, disk persistence) lives in test code outside the runtime and is
 // tested there.
 class FakeByteCache implements ModuleByteCache {
+  gets = 0;
+  puts = 0;
   private readonly m = new Map<string, CompiledModuleArtifact>();
   getCompleteSet(
     rt: string,
     ids: readonly string[],
   ): Map<string, CompiledModuleArtifact> | undefined {
+    this.gets++;
     const out = new Map<string, CompiledModuleArtifact>();
     for (const id of ids) {
       const a = this.m.get(`${rt}\0${id}`);
@@ -43,6 +47,7 @@ class FakeByteCache implements ModuleByteCache {
     rt: string,
     mods: readonly { identity: string; js: string; sourceMap?: unknown }[],
   ): void {
+    this.puts++;
     for (const x of mods) {
       this.m.set(
         `${rt}\0${x.identity}`,
@@ -90,6 +95,31 @@ describe("ModuleByteCache cross-runtime reuse", () => {
       storageManager,
       moduleByteCache: byteCache,
     });
+
+  it("skips the injected byte cache when the runtime version is unavailable", async () => {
+    const restoreRuntimeVersion = setCompileCacheRuntimeVersionForTesting(
+      undefined,
+    );
+    const byteCache = new FakeByteCache();
+    const rt = runtimeIn(byteCache);
+
+    try {
+      const result = await rt.patternManager.compileAndRegisterModules({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: "export const answer = 42;\nexport default answer;",
+        }],
+      });
+
+      expect((result.main as { answer: number }).answer).toBe(42);
+      expect(byteCache.gets).toBe(0);
+      expect(byteCache.puts).toBe(0);
+    } finally {
+      restoreRuntimeVersion();
+      await rt.dispose();
+    }
+  });
 
   it("a fresh runtime + fresh space process-hits and persists the closure", async () => {
     const byteCache = new FakeByteCache();

--- a/packages/test-support/src/compile-byte-cache.test.ts
+++ b/packages/test-support/src/compile-byte-cache.test.ts
@@ -3,6 +3,8 @@ import { expect } from "@std/expect";
 
 import {
   createCompileByteCache,
+  flushCompileByteCache,
+  type ModuleByteCache,
   ProcessModuleByteCache,
   restoreCompileByteCacheForTesting,
   writeCompileByteCacheForTesting,
@@ -127,6 +129,7 @@ describe("ProcessModuleByteCache", () => {
       { key: 42, js: "no" }, // bad key
       { key: `${RT}\0nojs` }, // missing js
       { key: `${RT}\0badspans`, js: "NO", patternCoverageSpans: ["bad"] },
+      { key: `${RT}\0badspanstype`, js: "NO", patternCoverageSpans: "bad" },
       null,
       "garbage",
     ] as unknown[]);
@@ -136,6 +139,16 @@ describe("ProcessModuleByteCache", () => {
 });
 
 describe("createCompileByteCache", () => {
+  it("does not flush caches without disk persistence", () => {
+    const fakeCache: ModuleByteCache = {
+      getCompleteSet: () => undefined,
+      putAll: () => {},
+    };
+
+    expect(flushCompileByteCache(fakeCache)).toBeUndefined();
+    expect(flushCompileByteCache(new ProcessModuleByteCache())).toBeUndefined();
+  });
+
   it("creates an in-memory cache when CF_COMPILE_CACHE_FILE is unset", () => {
     const previous = Deno.env.get("CF_COMPILE_CACHE_FILE");
     try {

--- a/packages/test-support/src/compile-byte-cache.test.ts
+++ b/packages/test-support/src/compile-byte-cache.test.ts
@@ -44,9 +44,19 @@ describe("ProcessModuleByteCache", () => {
     const cache = new ProcessModuleByteCache();
     cache.putAll(RT, [
       { identity: "a", js: "JS_A" },
-      { identity: "b", js: "JS_B", sourceMap: "MAP_B" },
+      {
+        identity: "b",
+        js: "JS_B",
+        sourceMap: "MAP_B",
+        patternCoverageSpans: [SPAN],
+      },
     ]);
     expect(cache.getCompleteSet(RT, ["a", "b"])?.size).toBe(2);
+    expect(cache.get(RT, "b")).toEqual({
+      js: "JS_B",
+      sourceMap: "MAP_B",
+      patternCoverageSpans: [SPAN],
+    });
     cache.clear();
     expect(cache.getCompleteSet(RT, ["a", "b"])).toBeUndefined();
     expect(cache.stats().entries).toBe(0);

--- a/packages/test-support/src/compile-byte-cache.test.ts
+++ b/packages/test-support/src/compile-byte-cache.test.ts
@@ -9,6 +9,15 @@ import {
 } from "./compile-byte-cache.ts";
 
 const RT = "rtv";
+const SPAN = {
+  fileName: "/subject.tsx",
+  id: 1,
+  kind: "runtime" as const,
+  startLine: 3,
+  endLine: 4,
+  startColumn: 5,
+  endColumn: 6,
+};
 
 describe("ProcessModuleByteCache", () => {
   it("returns stored bytes by identity and reports a full set", () => {
@@ -56,7 +65,11 @@ describe("ProcessModuleByteCache", () => {
   it("round-trips through snapshot/restore into a fresh cache", () => {
     const a = new ProcessModuleByteCache();
     a.put(RT, "x", { js: "JS_X" });
-    a.put(RT, "y", { js: "JS_Y", sourceMap: "MAP_Y" });
+    a.put(RT, "y", {
+      js: "JS_Y",
+      sourceMap: "MAP_Y",
+      patternCoverageSpans: [SPAN],
+    });
     a.put("v2", "z", { js: "JS_Z" });
 
     const serialized = JSON.parse(JSON.stringify(a.snapshot())); // survives JSON
@@ -64,9 +77,37 @@ describe("ProcessModuleByteCache", () => {
     b.restore(serialized);
 
     expect(b.get(RT, "x")).toEqual({ js: "JS_X" });
-    expect(b.get(RT, "y")).toEqual({ js: "JS_Y", sourceMap: "MAP_Y" });
+    expect(b.get(RT, "y")).toEqual({
+      js: "JS_Y",
+      sourceMap: "MAP_Y",
+      patternCoverageSpans: [SPAN],
+    });
     expect(b.get("v2", "z")).toEqual({ js: "JS_Z" });
     expect(b.getCompleteSet(RT, ["x", "y"])?.size).toBe(2);
+  });
+
+  it("put replaces an existing artifact for the same key", () => {
+    const cache = new ProcessModuleByteCache();
+    cache.restore([{ key: `${RT}\0id`, js: "OLD" }]);
+
+    cache.put(RT, "id", { js: "NEW", patternCoverageSpans: [SPAN] });
+
+    expect(cache.get(RT, "id")).toEqual({
+      js: "NEW",
+      patternCoverageSpans: [SPAN],
+    });
+  });
+
+  it("restore preserves an existing in-memory artifact for the same key", () => {
+    const cache = new ProcessModuleByteCache();
+    cache.put(RT, "id", { js: "NEW", patternCoverageSpans: [SPAN] });
+
+    cache.restore([{ key: `${RT}\0id`, js: "OLD" }]);
+
+    expect(cache.get(RT, "id")).toEqual({
+      js: "NEW",
+      patternCoverageSpans: [SPAN],
+    });
   });
 
   it("restore skips malformed entries and tolerates junk", () => {
@@ -75,6 +116,7 @@ describe("ProcessModuleByteCache", () => {
       { key: `${RT}\0ok`, js: "GOOD" },
       { key: 42, js: "no" }, // bad key
       { key: `${RT}\0nojs` }, // missing js
+      { key: `${RT}\0badspans`, js: "NO", patternCoverageSpans: ["bad"] },
       null,
       "garbage",
     ] as unknown[]);

--- a/packages/test-support/src/compile-byte-cache.ts
+++ b/packages/test-support/src/compile-byte-cache.ts
@@ -19,11 +19,23 @@ export interface SerializedModuleBytes {
   key: string;
   js: string;
   sourceMap?: unknown;
+  patternCoverageSpans?: CachedPatternCoverageSpan[];
+}
+
+export interface CachedPatternCoverageSpan {
+  fileName: string;
+  id: number;
+  kind: "runtime";
+  startLine: number;
+  endLine: number;
+  startColumn: number;
+  endColumn: number;
 }
 
 export interface CompiledModuleArtifact {
   js: string;
   sourceMap?: unknown;
+  patternCoverageSpans?: CachedPatternCoverageSpan[];
 }
 
 export interface ModuleByteCache {
@@ -34,7 +46,7 @@ export interface ModuleByteCache {
 
   putAll(
     runtimeVersion: string,
-    modules: readonly { identity: string; js: string; sourceMap?: unknown }[],
+    modules: readonly ({ identity: string } & CompiledModuleArtifact)[],
   ): void;
 }
 
@@ -71,6 +83,9 @@ export class ProcessModuleByteCache implements ModuleByteCache {
     if (typeof artifact.sourceMap === "string") {
       size += artifact.sourceMap.length;
     }
+    if (artifact.patternCoverageSpans !== undefined) {
+      size += JSON.stringify(artifact.patternCoverageSpans).length;
+    }
     return size;
   }
 
@@ -104,15 +119,27 @@ export class ProcessModuleByteCache implements ModuleByteCache {
     identity: string,
     artifact: CompiledModuleArtifact,
   ): void {
-    this.insert(ProcessModuleByteCache.key(runtimeVersion, identity), artifact);
+    this.insert(
+      ProcessModuleByteCache.key(runtimeVersion, identity),
+      artifact,
+      { replaceExisting: true },
+    );
   }
 
-  private insert(key: string, artifact: CompiledModuleArtifact): void {
+  private insert(
+    key: string,
+    artifact: CompiledModuleArtifact,
+    options: { replaceExisting: boolean },
+  ): void {
     const existing = this.entries.get(key);
     if (existing !== undefined) {
       this.entries.delete(key);
-      this.entries.set(key, existing);
-      return;
+      this.totalBytes -= existing.size;
+      if (!options.replaceExisting) {
+        this.entries.set(key, existing);
+        this.totalBytes += existing.size;
+        return;
+      }
     }
     const size = ProcessModuleByteCache.sizeOf(artifact);
     this.entries.set(key, { artifact, size });
@@ -122,16 +149,10 @@ export class ProcessModuleByteCache implements ModuleByteCache {
 
   putAll(
     runtimeVersion: string,
-    modules: readonly { identity: string; js: string; sourceMap?: unknown }[],
+    modules: readonly ({ identity: string } & CompiledModuleArtifact)[],
   ): void {
     for (const module of modules) {
-      this.put(
-        runtimeVersion,
-        module.identity,
-        module.sourceMap === undefined
-          ? { js: module.js }
-          : { js: module.js, sourceMap: module.sourceMap },
-      );
+      this.put(runtimeVersion, module.identity, artifactFromModule(module));
     }
   }
 
@@ -149,11 +170,16 @@ export class ProcessModuleByteCache implements ModuleByteCache {
   snapshot(): SerializedModuleBytes[] {
     const out: SerializedModuleBytes[] = [];
     for (const [key, { artifact }] of this.entries) {
-      out.push(
-        artifact.sourceMap === undefined
-          ? { key, js: artifact.js }
-          : { key, js: artifact.js, sourceMap: artifact.sourceMap },
-      );
+      const serialized: SerializedModuleBytes = { key, js: artifact.js };
+      if (artifact.sourceMap !== undefined) {
+        serialized.sourceMap = artifact.sourceMap;
+      }
+      if (artifact.patternCoverageSpans !== undefined) {
+        serialized.patternCoverageSpans = artifact.patternCoverageSpans.map(
+          copyPatternCoverageSpan,
+        );
+      }
+      out.push(serialized);
     }
     return out;
   }
@@ -167,11 +193,22 @@ export class ProcessModuleByteCache implements ModuleByteCache {
       if (entry === null || typeof entry !== "object") continue;
       const e = entry as Partial<SerializedModuleBytes>;
       if (typeof e.key !== "string" || typeof e.js !== "string") continue;
+      const patternCoverageSpans = normalizePatternCoverageSpans(
+        e.patternCoverageSpans,
+      );
+      if (
+        e.patternCoverageSpans !== undefined &&
+        patternCoverageSpans === undefined
+      ) continue;
+      const artifact: CompiledModuleArtifact = { js: e.js };
+      if (e.sourceMap !== undefined) artifact.sourceMap = e.sourceMap;
+      if (patternCoverageSpans !== undefined) {
+        artifact.patternCoverageSpans = patternCoverageSpans;
+      }
       this.insert(
         e.key,
-        e.sourceMap === undefined
-          ? { js: e.js }
-          : { js: e.js, sourceMap: e.sourceMap },
+        artifact,
+        { replaceExisting: false },
       );
     }
   }
@@ -184,6 +221,60 @@ export class ProcessModuleByteCache implements ModuleByteCache {
   stats(): { entries: number; bytes: number } {
     return { entries: this.entries.size, bytes: this.totalBytes };
   }
+}
+
+function artifactFromModule(
+  module: { identity: string } & CompiledModuleArtifact,
+): CompiledModuleArtifact {
+  const artifact: CompiledModuleArtifact = { js: module.js };
+  if (module.sourceMap !== undefined) artifact.sourceMap = module.sourceMap;
+  if (module.patternCoverageSpans !== undefined) {
+    artifact.patternCoverageSpans = module.patternCoverageSpans.map(
+      copyPatternCoverageSpan,
+    );
+  }
+  return artifact;
+}
+
+function normalizePatternCoverageSpans(
+  spans: unknown,
+): CachedPatternCoverageSpan[] | undefined {
+  if (spans === undefined) return undefined;
+  if (!Array.isArray(spans)) return undefined;
+  const normalized: CachedPatternCoverageSpan[] = [];
+  for (const span of spans) {
+    if (!isPatternCoverageSpan(span)) return undefined;
+    normalized.push(copyPatternCoverageSpan(span));
+  }
+  return normalized;
+}
+
+function isPatternCoverageSpan(
+  span: unknown,
+): span is CachedPatternCoverageSpan {
+  if (span === null || typeof span !== "object") return false;
+  const s = span as Partial<CachedPatternCoverageSpan>;
+  return typeof s.fileName === "string" &&
+    typeof s.id === "number" &&
+    s.kind === "runtime" &&
+    typeof s.startLine === "number" &&
+    typeof s.endLine === "number" &&
+    typeof s.startColumn === "number" &&
+    typeof s.endColumn === "number";
+}
+
+function copyPatternCoverageSpan(
+  span: CachedPatternCoverageSpan,
+): CachedPatternCoverageSpan {
+  return {
+    fileName: span.fileName,
+    id: span.id,
+    kind: span.kind,
+    startLine: span.startLine,
+    endLine: span.endLine,
+    startColumn: span.startColumn,
+    endColumn: span.endColumn,
+  };
 }
 
 /**

--- a/packages/test-support/src/compile-byte-cache.ts
+++ b/packages/test-support/src/compile-byte-cache.ts
@@ -6,15 +6,13 @@ import { dirname } from "@std/path";
 // place an instance is created. So the cache is, by construction, a single
 // feature that exists only when tests install it — never in production.
 //
-// `createCompileByteCache` returns the instance to inject into the runtimes a
-// test builds. The in-memory cache is always created (cross-runtime reuse within
-// the process). Disk persistence is added only when `CF_COMPILE_CACHE_FILE` is
-// set — which only the CI workflow sets — so a run reuses bytes it compiled on a
-// previous run. Cross-run correctness rests on the CI cache key (see the
-// workflow): the persisted bytes are a function of the compiler / transformer
-// build, which a module's content identity does not cover, so the key folds in a
-// hash of the compiler sources + lockfile and invalidates the whole file when
-// the code that emits the bytes changes.
+// `createCompileByteCache` returns the instance to inject into test runtimes.
+// The in-memory cache is always created for cross-runtime reuse within the
+// process. Disk persistence is added only when `CF_COMPILE_CACHE_FILE` is set,
+// so a run can reuse bytes it compiled on a previous run. Cross-run correctness
+// rests on the cache key used by the caller: the persisted bytes are a function
+// of the compiler and transformer build, which a module's content identity does
+// not cover.
 
 /** A serialized {@link ProcessModuleByteCache} entry (for disk persistence). */
 export interface SerializedModuleBytes {
@@ -39,6 +37,8 @@ export interface ModuleByteCache {
     modules: readonly { identity: string; js: string; sourceMap?: unknown }[],
   ): void;
 }
+
+const cacheFiles = new WeakMap<ProcessModuleByteCache, string>();
 
 /**
  * Process-level, content-addressed cache of compiled module bytes. An entry is
@@ -187,11 +187,9 @@ export class ProcessModuleByteCache implements ModuleByteCache {
 }
 
 /**
- * Create the compiled-module-byte cache and return it for injection into the
- * runtimes a test builds (via `PiecesController.initialize`'s `moduleByteCache`).
- * When `CF_COMPILE_CACHE_FILE` is set, the cache is also seeded from that file
- * now and written back at process exit. Unset everywhere but CI, so locally the
- * cache is in-memory only.
+ * Create the compiled-module-byte cache and return it for injection into test
+ * runtimes. When `CF_COMPILE_CACHE_FILE` is set, the cache is seeded from that
+ * file now and written back at process exit.
  */
 export function createCompileByteCache(): ModuleByteCache {
   const cache = new ProcessModuleByteCache();
@@ -205,9 +203,10 @@ export function createCompileByteCache(): ModuleByteCache {
     );
   }
 
+  cacheFiles.set(cache, cacheFile);
   globalThis.addEventListener("unload", () => {
     try {
-      const written = writeCompileByteCache(cache, cacheFile);
+      const written = flushCompileByteCache(cache);
       console.log(
         `[compile-byte-cache] wrote ${written} modules to ${cacheFile}`,
       );
@@ -220,6 +219,15 @@ export function createCompileByteCache(): ModuleByteCache {
   });
 
   return cache;
+}
+
+export function flushCompileByteCache(
+  cache: ModuleByteCache,
+): number | undefined {
+  if (!(cache instanceof ProcessModuleByteCache)) return undefined;
+  const cacheFile = cacheFiles.get(cache);
+  if (cacheFile === undefined) return undefined;
+  return writeCompileByteCache(cache, cacheFile);
 }
 
 function restoreCompileByteCache(

--- a/packages/test-support/src/mod.test.ts
+++ b/packages/test-support/src/mod.test.ts
@@ -5,6 +5,7 @@ import {
   createCompileByteCache,
   createUnifiedDiff,
   defineFixtureSuite,
+  flushCompileByteCache,
   ProcessModuleByteCache,
   runDenoCheckWithTemporaryConfig,
   runDenoCommandWithTemporaryLock,
@@ -16,6 +17,7 @@ describe("test-support module exports", () => {
     expect(createCompileByteCache()).toBeInstanceOf(ProcessModuleByteCache);
     expect(typeof createUnifiedDiff).toBe("function");
     expect(typeof defineFixtureSuite).toBe("function");
+    expect(typeof flushCompileByteCache).toBe("function");
     expect(typeof runDenoCheckWithTemporaryConfig).toBe("function");
     expect(typeof runDenoCommandWithTemporaryLock).toBe("function");
     expect(typeof shouldUpdateGoldens).toBe("function");

--- a/packages/test-support/src/mod.ts
+++ b/packages/test-support/src/mod.ts
@@ -1,5 +1,6 @@
 export {
   createCompileByteCache,
+  flushCompileByteCache,
   ProcessModuleByteCache,
 } from "./compile-byte-cache.ts";
 export {

--- a/packages/test-support/src/mod.ts
+++ b/packages/test-support/src/mod.ts
@@ -19,6 +19,7 @@ export type {
   FixtureSuiteConfig,
 } from "./fixture-runner.ts";
 export type {
+  CachedPatternCoverageSpan,
   CompiledModuleArtifact,
   ModuleByteCache,
   SerializedModuleBytes,

--- a/tasks/build-binaries.test.ts
+++ b/tasks/build-binaries.test.ts
@@ -111,6 +111,10 @@ async function makeFakeRepo(): Promise<string> {
     "export const pretransform = 1;",
   );
   await writeFile(
+    `${root}/packages/runner/src/pattern-coverage.ts`,
+    "export const patternCoverage = 1;",
+  );
+  await writeFile(
     `${root}/packages/runner/src/sandbox/module-record-verifier.ts`,
     "export const verifier = 1;",
   );


### PR DESCRIPTION
## Summary

This enables the disk-backed compile byte cache for Pattern Unit Tests that run through `cf test`.

`cf test` now installs the shared `ModuleByteCache` on its runtime. `PatternManager.compileAndRegisterModules` reads complete compiled module sets from that cache before compiling. Fresh compiles write emitted module artifacts back to the cache before evaluation.

Coverage compiles use a separate cache key when `CF_PATTERN_COVERAGE_DIR` is present. Cached coverage artifacts also carry pattern coverage spans, so a later cache hit can restore the collector state before evaluation.

## Details

Pattern Integration Tests already used `CF_COMPILE_CACHE_FILE`, but Pattern Unit Tests compile through `cf test`. That path now goes through `PatternManager.compileAndRegisterModules`, so the cache support lives there instead of in a separate direct engine compile helper.

This keeps the current module registration behavior intact. It also lets single-runtime and multi-user `cf test` runs share the same cache behavior.

The workflow now persists a per-chunk Pattern Unit Test coverage compile cache. Its cache key includes the same compiler fingerprint inputs, plus the coverage span mapper input.

## Tests

- `deno fmt --check ...`
- `deno check ...`
- `deno lint ...`
- Focused cache, coverage, fingerprint, and test-support tests
- `deno task --cwd packages/cli test`
- `deno task --cwd packages/runner test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables a disk-backed compile byte cache for `cf test` to speed up Pattern Unit Tests by reusing compiled module bytes. Coverage runs use a separate cache and restore coverage spans to keep reports accurate.

- **New Features**
  - `cf test` installs a shared `ModuleByteCache`; reads a complete set before compile and writes emitted artifacts after.
  - Coverage compiles use a distinct runtime-version key when `CF_PATTERN_COVERAGE_DIR` is set. Cached artifacts include `patternCoverageSpans` and are replayed on restore; non-span artifacts are ignored for coverage.
  - `PatternManager.compileAndRegisterModules` consults the cache and writes back fresh artifacts; existing module registration behavior is unchanged.
  - `Engine` restores spans for valid coverage hits.
  - CLI adds a default cache helper that seeds from `CF_COMPILE_CACHE_FILE` and flushes on worker dispose; multi-user workers flush on shutdown and after failed init.
  - CI persists a per-chunk Pattern Unit coverage cache and fingerprints `packages/runner/src/pattern-coverage.ts` in keys; docs describe the coverage-specific cache axis; build-binaries fixture includes the coverage mapper.
  - The runtime falls back to a fresh compile when the compile-cache runtime version is unavailable.

- **Migration**
  - Optional: set `CF_COMPILE_CACHE_FILE=/path/to/cache.json` to enable the cache for `cf test`.
  - When collecting pattern coverage, also set `CF_PATTERN_COVERAGE_DIR=...` to use the coverage-specific cache; older non-coverage artifacts are ignored automatically.

<sup>Written for commit f8817bf4ee3da0858b512763a710b46bf2c472f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

