### PR TITLE
feat(runner): Runtime construction presets + canonical experimental-env mapping (CT-1814)

### DIFF
--- a/packages/background-piece-service/cast-admin.ts
+++ b/packages/background-piece-service/cast-admin.ts
@@ -1,6 +1,11 @@
 import { parseArgs } from "@std/cli/parse-args";
 import { PieceManager } from "@commonfabric/piece";
-import { compileAndSavePattern, Runtime } from "@commonfabric/runner";
+import {
+  compileAndSavePattern,
+  experimentalOptionsFromEnv,
+  Runtime,
+  runtimePresets,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type DID } from "@commonfabric/identity";
 import { createSession } from "@commonfabric/identity";
@@ -43,13 +48,17 @@ export function createRuntime(
   toolshedUrl: string,
   identity: Identity,
 ): Runtime {
-  return new Runtime({
+  // Shared first-party posture for client runtimes against a deployed API
+  // (CT-1814); this admin CLI now honors EXPERIMENTAL_* like the rest of the
+  // service instead of silently ignoring it.
+  return new Runtime(runtimePresets.remoteClient({
     apiUrl: new URL(toolshedUrl),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(toolshedUrl),
     }),
-  });
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
+  }));
 }
 
 export function requireCellCause(cause: string | undefined): string {

--- a/packages/background-piece-service/cast-admin.ts
+++ b/packages/background-piece-service/cast-admin.ts
@@ -21,7 +21,11 @@ export interface CastAdminDependencies {
   args: string[];
   envGet: typeof Deno.env.get;
   getIdentity: typeof getIdentity;
-  createRuntime: (toolshedUrl: string, identity: Identity) => Runtime;
+  createRuntime: (
+    toolshedUrl: string,
+    identity: Identity,
+    envGet: typeof Deno.env.get,
+  ) => Runtime;
   readTextFile: typeof Deno.readTextFile;
   createSession: typeof createSession;
   createPieceManager: (
@@ -47,17 +51,19 @@ export interface CastAdminDependencies {
 export function createRuntime(
   toolshedUrl: string,
   identity: Identity,
+  envGet: typeof Deno.env.get = Deno.env.get,
 ): Runtime {
   // Shared first-party posture for client runtimes against a deployed API
   // (CT-1814); this admin CLI now honors EXPERIMENTAL_* like the rest of the
-  // service instead of silently ignoring it.
+  // service instead of silently ignoring it, read through the same injected
+  // env boundary as every other env consultation here (CastAdminDependencies).
   return new Runtime(runtimePresets.remoteClient({
     apiUrl: new URL(toolshedUrl),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(toolshedUrl),
     }),
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    experimental: experimentalOptionsFromEnv(envGet),
   }));
 }
 
@@ -87,7 +93,11 @@ export async function castPattern(
     quit,
   });
 
-  const runtime = dependencies.createRuntime(toolshedUrl, identity);
+  const runtime = dependencies.createRuntime(
+    toolshedUrl,
+    identity,
+    dependencies.envGet,
+  );
 
   try {
     // Load and compile the pattern first

--- a/packages/background-piece-service/src/env.ts
+++ b/packages/background-piece-service/src/env.ts
@@ -1,21 +1,5 @@
 import { z } from "zod";
 
-/**
- * Results in `true` (on), `false` (off), or `undefined` (default).
- */
-function flagValue() {
-  return z.string().default("default").transform((v) => {
-    switch (v) {
-      case "default":
-        return undefined;
-      case "false":
-        return false;
-      default:
-        return true;
-    }
-  });
-}
-
 const envSchema = z.object({
   // Job queue settings
   //MAX_CONCURRENT_JOBS: z.coerce.number().positive().default(5),
@@ -48,15 +32,12 @@ const envSchema = z.object({
   ),
   OTEL_SERVICE_NAME: z.string().default("bg-piece-service"),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
+  // EXPERIMENTAL_* feature flags are no longer declared here: the runtime
+  // construction site reads them through the canonical mapping
+  // (`experimentalOptionsFromEnv` / EXPERIMENTAL_ENV_VARS in
+  // @commonfabric/runner runtime-presets), shared with toolshed and the CLI
+  // so the wirings cannot drift (CT-1814).
 
-  // Experimental feature flags. See `ExperimentalOptions` in `runner`.
-  // Note: We intentionally avoid `z.coerce.boolean()` here. Zod's coerce uses
-  // `Boolean()`, which treats any non-empty string as truthy -- so setting an
-  // env var to the string `"false"` would incorrectly enable the flag. The
-  // other boolean env vars in this file have the same latent bug.
-  EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
-  EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
-  EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: flagValue(),
   // Background Piece Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
   //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -1,5 +1,10 @@
 import { parseArgs } from "@std/cli/parse-args";
-import { Runtime } from "@commonfabric/runner";
+import {
+  type EnvReader,
+  experimentalOptionsFromEnv,
+  Runtime,
+  runtimePresets,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { BackgroundPieceService } from "./service.ts";
 import { getIdentity } from "./utils.ts";
@@ -41,19 +46,24 @@ export function parseWorkerTimeout(args: string[]): number {
   return DEFAULT_WORKER_TIMEOUT_MS;
 }
 
-export function createRuntime(env: EnvVars, identity: Identity): Runtime {
-  return new Runtime({
+export function createRuntime(
+  env: EnvVars,
+  identity: Identity,
+  // Injectable for tests, mirroring loadEnv's `source`. The EXPERIMENTAL_*
+  // flags are read through the canonical runner mapping rather than declared
+  // in EnvVars (CT-1814), so they are read here, not in loadEnv.
+  readEnv: EnvReader = (key) => Deno.env.get(key),
+): Runtime {
+  // Shared first-party posture (CT-1814). This runtime's experimental flags
+  // are the single source the service forwards to its workers (service.ts).
+  return new Runtime(runtimePresets.productionServer({
     apiUrl: new URL(env.API_URL),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(env.API_URL),
     }),
-    experimental: {
-      modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
-      persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
-      eagerSourceAnnotation: env.EXPERIMENTAL_EAGER_SOURCE_ANNOTATION,
-    },
-  });
+    experimental: experimentalOptionsFromEnv(readEnv),
+  }));
 }
 
 export function shutdown(

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -8,6 +8,7 @@ import {
   type ErrorWithContext,
   isStream,
   Runtime,
+  runtimePresets,
   Stream,
 } from "@commonfabric/runner";
 import { attachRuntimeTelemetryOtelBridge } from "@commonfabric/runner/telemetry-otel-bridge";
@@ -163,18 +164,24 @@ export async function initialize(
     spaceDid: spaceId,
   });
 
-  // Initialize runtime and piece manager
-  runtime = new Runtime({
-    apiUrl: new URL(toolshedUrl),
+  // Initialize runtime and piece manager. Shared first-party posture
+  // (CT-1814); `experimental` arrives as data from the main process so the
+  // service has one flag decision point (see main.ts createRuntime). The
+  // preset pins patternEnvironment to `apiUrl`, matching the explicit pin
+  // this site previously carried.
+  runtime = new Runtime(runtimePresets.productionServer({
+    apiUrl,
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(toolshedUrl),
     }),
-    patternEnvironment: { apiUrl },
+    // The IPC type allows absence, but the service always forwards the main
+    // runtime's resolved flags; `{}` (constructor defaults) covers a bare
+    // caller.
+    experimental: experimental ?? {},
     consoleHandler: consoleHandler,
     errorHandlers: [errorHandler],
-    experimental,
-  });
+  }));
   // Each worker is its own isolate: the provider main.ts registers doesn't
   // exist here, so initialize OTel in-worker (idempotent, fail-open) or the
   // bridge below would attach to no-op instruments.

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -7,7 +7,7 @@ import {
   assertThrows,
 } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
+import { EXPERIMENTAL_ENV_VARS, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   isWorkerIPCResponse,
@@ -1450,6 +1450,29 @@ describe("cast admin entry point", () => {
     await cell.sync();
     await runtime.storageManager.synced();
     await runtime.dispose();
+  });
+
+  it("threads the injected env reader into the cast runtime's experimental flags", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const consulted = new Set<string>();
+    const runtime = createCastRuntime(
+      "memory://cast-env-reader",
+      identity,
+      (key) => {
+        consulted.add(key);
+        return undefined;
+      },
+    );
+    try {
+      // The canonical mapping consults the reader passed through the
+      // CastAdminDependencies boundary — not process env — for every
+      // env-wired EXPERIMENTAL_* flag.
+      for (const envVar of Object.values(EXPERIMENTAL_ENV_VARS)) {
+        if (envVar !== null) assert(consulted.has(envVar));
+      }
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it("syncs and exits with failure when casting fails with quit", async () => {

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -372,21 +372,13 @@ describe("background piece utility functions", () => {
     assert(!isValidPieceId("short"));
   });
 
-  it("loads environment defaults and explicit feature flag values", () => {
+  it("loads environment defaults", () => {
+    // EXPERIMENTAL_* flags are no longer part of EnvVars: createRuntime reads
+    // them through the canonical runner mapping (CT-1814); see the
+    // "creates a configured runtime" test below.
     const defaults = loadEnv(() => undefined);
     assertEquals(defaults.API_URL, "http://localhost:8000");
     assertEquals(defaults.OPERATOR_PASS, "implicit trust");
-    assertEquals(defaults.EXPERIMENTAL_MODERN_CELL_REP, undefined);
-
-    const disabled = loadEnv((key) =>
-      key === "EXPERIMENTAL_MODERN_CELL_REP" ? "false" : undefined
-    );
-    assertEquals(disabled.EXPERIMENTAL_MODERN_CELL_REP, false);
-
-    const enabled = loadEnv((key) =>
-      key === "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE" ? "1" : undefined
-    );
-    assertEquals(enabled.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE, true);
   });
 
   it("loads identities from a key file, a passphrase, or neither", async () => {
@@ -1143,14 +1135,15 @@ describe("background piece service entry point", () => {
         API_URL: "memory://main-runtime-test",
         OPERATOR_PASS: "operator",
         IDENTITY: undefined,
-        EXPERIMENTAL_MODERN_CELL_REP: true,
-        EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: false,
         ENV: "test",
         OTEL_ENABLED: false,
         OTEL_SERVICE_NAME: "bg-piece-service",
         OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
       },
       identity,
+      // Experimental flags flow through the injectable reader and the
+      // canonical runner mapping, not EnvVars (CT-1814).
+      (key) => key === "EXPERIMENTAL_MODERN_CELL_REP" ? "true" : undefined,
     );
     assertEquals(runtime.experimental.modernCellRep, true);
     await runtime.dispose();
@@ -1176,8 +1169,6 @@ describe("background piece service entry point", () => {
         API_URL: "http://localhost:8000",
         OPERATOR_PASS: "operator",
         IDENTITY: undefined,
-        EXPERIMENTAL_MODERN_CELL_REP: true,
-        EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: false,
         ENV: "test",
         OTEL_ENABLED: false,
         OTEL_SERVICE_NAME: "bg-piece-service",
@@ -1225,8 +1216,6 @@ describe("background piece service entry point", () => {
       API_URL: "http://localhost:8000",
       OPERATOR_PASS: "operator",
       IDENTITY: undefined,
-      EXPERIMENTAL_MODERN_CELL_REP: true,
-      EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: false,
       ENV: "test",
       OTEL_ENABLED: false,
       OTEL_SERVICE_NAME: "bg-piece-service",

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -1,6 +1,11 @@
 import { createSession, isDID, Session } from "@commonfabric/identity";
 import { loadIdentity } from "./identity.ts";
-import { ACLManager, Runtime } from "@commonfabric/runner";
+import {
+  ACLManager,
+  experimentalOptionsFromEnv,
+  Runtime,
+  runtimePresets,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import {
   ACL,
@@ -8,7 +13,7 @@ import {
   type Capability,
   isACLUser,
 } from "@commonfabric/memory/acl";
-import { awaitSyncWithTimeout, experimentalOptionsFromEnv } from "./utils.ts";
+import { awaitSyncWithTimeout } from "./utils.ts";
 
 export interface SpaceConfig {
   apiUrl: URL;
@@ -35,15 +40,17 @@ export async function createRuntime(
   config: SpaceConfig,
   session: Session,
 ): Promise<Runtime> {
-  const runtime = new Runtime({
+  // Shared first-party posture for client runtimes against a deployed API
+  // (CT-1814).
+  const runtime = new Runtime(runtimePresets.remoteClient({
     apiUrl: config.apiUrl,
-    experimental: experimentalOptionsFromEnv(),
     storageManager: StorageManager.open({
       as: session.as,
       memoryHost: new URL(config.apiUrl),
       spaceIdentity: session.spaceIdentity,
     }),
-  });
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
+  }));
 
   if (!(await runtime.healthCheck())) {
     throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -9,12 +9,13 @@ import {
 import { TARGET } from "@commonfabric/js-compiler/typescript";
 import { Identity } from "@commonfabric/identity";
 import {
+  experimentalOptionsFromEnv,
   type MemorySpace,
   parseFabricRef,
   Runtime,
+  runtimePresets,
   type RuntimeProgram,
 } from "@commonfabric/runner";
-import { experimentalOptionsFromEnv } from "./utils.ts";
 
 const FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE =
   "fabric imports require a space context (options.fabricImports)";
@@ -26,11 +27,13 @@ export async function createRuntime() {
   const storageManager = StorageManager.emulate({
     as: await Identity.fromPassphrase("builder"),
   });
-  return new Runtime({
-    storageManager,
-    experimental: experimentalOptionsFromEnv(),
+  // Shared first-party posture (CT-1814); emulated storage is the local-dev
+  // delta and stays visible here.
+  return new Runtime(runtimePresets.localDev({
     apiUrl: new URL(import.meta.url),
-  });
+    storageManager,
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
+  }));
 }
 
 export interface ProcessOptions {

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -20,23 +20,25 @@ import {
   type ConsoleHandler,
   ConsoleMethod,
   type Engine,
+  experimentalOptionsFromEnv,
   type Pattern,
   PatternCoverageCollector,
   patternCoverageOutputPath,
   Runtime,
+  runtimePresets,
   writePatternCoverageLcov,
 } from "@commonfabric/runner";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  flushDefaultModuleByteCache,
+  getDefaultModuleByteCache,
+} from "./compile-byte-cache.ts";
 import { buildActionEvent } from "./trusted-test-event.ts";
 import {
   appendLoggerDeltaMessages,
   type LoggerErrorWarnSnapshot,
   snapshotLoggerErrorWarnCounts,
 } from "./console-capture.ts";
-import {
-  flushDefaultModuleByteCache,
-  getDefaultModuleByteCache,
-} from "./compile-byte-cache.ts";
 import {
   createSession,
   Identity,
@@ -167,7 +169,6 @@ const handlers: Record<
       spaceName: args.spaceName as string,
     });
     const space = session.space;
-    const moduleByteCache = getDefaultModuleByteCache();
     const { StorageManager } = await import(
       "@commonfabric/runner/storage/cache.deno"
     );
@@ -178,15 +179,18 @@ const handlers: Record<
       // internally (see createStorageAddressResolver).
       memoryHost: new URL(args.apiUrl as string),
     });
-    runtime = new Runtime({
-      storageManager: storageManager as never,
-      // Same default as single-runtime pattern tests: enforce explicitly
-      // declared `ifc` policies (the production runtime default).
-      cfcEnforcementMode: "enforce-explicit",
+    // `runtimePresets.patternTest` carries the shared first-party posture
+    // (CT-1814), including the enforce-explicit CFC pin this site previously
+    // restated — and the same env-honored experimental flags as the
+    // single-user runner (this worker previously ignored EXPERIMENTAL_*, so
+    // the two harness modes could run under different flags).
+    runtime = new Runtime(runtimePresets.patternTest({
       apiUrl: new URL(import.meta.url),
-      moduleByteCache,
+      storageManager: storageManager as never,
+      experimental: experimentalOptionsFromEnv(Deno.env.get),
       errorHandlers: [(error: Error) => runtimeErrors.push(String(error))],
-    });
+      moduleByteCache: getDefaultModuleByteCache(),
+    }));
     runtime.enableIdempotencyCheck();
     // Channel 1: capture pattern-code console.error / console.warn calls.
     runtime.scheduler.onConsole(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4,10 +4,12 @@ import { loadIdentity } from "./identity.ts";
 import {
   Cell,
   entityIdFrom,
+  experimentalOptionsFromEnv,
   getPatternIdentityRef,
   isSlugAddress,
   NAME,
   Runtime,
+  runtimePresets,
   RuntimeProgram,
   UI,
   VNode,
@@ -30,7 +32,7 @@ import { setLLMUrl } from "@commonfabric/llm";
 import { isRecord } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { isHandlerCell } from "../../fuse/callables.ts";
-import { awaitSyncWithTimeout, experimentalOptionsFromEnv } from "./utils.ts";
+import { awaitSyncWithTimeout } from "./utils.ts";
 import {
   callableCommandSpec,
   type CallableExecutionDeps,
@@ -193,14 +195,17 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
   const runtime = await timeCliPhase(
     "loadManager.runtime",
     () =>
-      new Runtime({
+      // Shared first-party posture for client runtimes against a deployed
+      // API (CT-1814); collectors and the navigate hook are this CLI's
+      // declared deltas.
+      new Runtime(runtimePresets.remoteClient({
         apiUrl: new URL(config.apiUrl),
-        experimental: experimentalOptionsFromEnv(),
         storageManager: StorageManager.open({
           as: session.as,
           memoryHost: new URL(config.apiUrl),
           spaceIdentity: session.spaceIdentity,
         }),
+        experimental: experimentalOptionsFromEnv(Deno.env.get),
         errorHandlers: [
           (error) => {
             runtimeErrors.push({
@@ -245,7 +250,7 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
             console.error("navigateTo callback error:", e);
           }
         },
-      }),
+      })),
   );
   (runtime as Runtime & { [CF_RUNTIME_ERROR_LOG]?: CliRuntimeErrorRecord[] })[
     CF_RUNTIME_ERROR_LOG

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -28,28 +28,30 @@
 import { Identity } from "@commonfabric/identity";
 import {
   ConsoleMethod,
-  type ModuleByteCache,
+  experimentalOptionsFromEnv,
   PatternCoverageCollector,
   patternCoverageOutputPath,
   Runtime,
+  runtimePresets,
   writePatternCoverageLcov,
 } from "@commonfabric/runner";
 import type {
   Cell,
   ConsoleHandler,
   ErrorWithContext,
+  ModuleByteCache,
   Pattern,
   SettleStats,
   Stream,
 } from "@commonfabric/runner";
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import { getDefaultModuleByteCache } from "./compile-byte-cache.ts";
 import type { Reactive } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { basename } from "@std/path";
 import { timeout } from "@commonfabric/utils/sleep";
-import { experimentalOptionsFromEnv } from "./utils.ts";
 import {
   appendLoggerDeltaMessages,
   snapshotLoggerErrorWarnCounts,
@@ -62,7 +64,6 @@ import {
   multiUserDescriptorMeta,
   runMultiUserTestPattern,
 } from "./multi-user-test-runner.ts";
-import { getDefaultModuleByteCache } from "./compile-byte-cache.ts";
 import {
   type FetchMockEntry,
   makeMockFetch,
@@ -267,14 +268,14 @@ export interface TestRunnerOptions {
   statsActionLimit?: number;
   /** Override CFC enforcement mode for the test runtime. */
   cfcEnforcementMode?: CfcEnforcementMode;
+  /** Shared compiled-module-byte cache for direct harness compiles. */
+  moduleByteCache?: ModuleByteCache;
   /** Print storage-related logger timings and counts after each test file. */
   storageStats?: boolean;
   /** Limit for storage timing/count tables when storageStats is enabled. */
   storageStatsLimit?: number;
   /** Directory for pattern runtime coverage LCOV artifacts. */
   patternCoverageDir?: string;
-  /** Shared compiled-module-byte cache for direct harness compiles. */
-  moduleByteCache?: ModuleByteCache;
 }
 
 // ---------------------------------------------------------------------------
@@ -887,8 +888,6 @@ export async function runTestPattern(
     ? new PatternCoverageCollector()
     : undefined;
   let writeLocalPatternCoverage = patternCoverage !== undefined;
-  const moduleByteCache = options.moduleByteCache ??
-    getDefaultModuleByteCache();
 
   // Collect pattern-code console.error / console.warn calls (channel 1: harness
   // console event) and logger-level error/warn activity (channel 2: logger count
@@ -937,19 +936,24 @@ export async function runTestPattern(
   const runtime = await withPhase(
     ["runTestPattern", "runtime"],
     () =>
-      new Runtime({
+      // `runtimePresets.patternTest` carries the shared first-party posture
+      // (CT-1814): the enforce-explicit CFC pin lives in the preset core, so
+      // pattern tests act as a regression net for CFC without this site
+      // restating the production default. Params below are this harness's
+      // declared deltas.
+      new Runtime(runtimePresets.patternTest({
+        apiUrl: new URL(import.meta.url),
         storageManager,
+        experimental: experimentalOptionsFromEnv(Deno.env.get),
+        moduleByteCache: options.moduleByteCache ??
+          getDefaultModuleByteCache(),
         // Inject a fetch that honors test-declared `fetchMocks` (scoped to this
         // runtime; no process-global mutation).
         fetch: mockFetch,
-        // Match the production runtime default: enforce explicitly declared
-        // `ifc` policies so pattern tests act as a regression net for CFC.
-        // Patterns without CFC annotations are unaffected; tests that need a
-        // laxer mode can pass `cfcEnforcementMode` explicitly.
-        cfcEnforcementMode: options.cfcEnforcementMode ?? "enforce-explicit",
-        experimental: experimentalOptionsFromEnv(),
-        apiUrl: new URL(import.meta.url),
-        moduleByteCache,
+        // Tests that need a laxer mode than the shared pin opt out per test.
+        ...(options.cfcEnforcementMode !== undefined
+          ? { cfcEnforcementMode: options.cfcEnforcementMode }
+          : {}),
         errorHandlers: [(error: ErrorWithContext) => runtimeErrors.push(error)],
         navigateCallback: (target) => {
           const name = (target.key("$NAME") as Cell<string | undefined>).get();
@@ -962,7 +966,7 @@ export async function runTestPattern(
             console.log(`    → navigateTo: ${label}`);
           }
         },
-      }),
+      })),
   );
   runtime.enableIdempotencyCheck();
   // Channel 1: capture pattern-code console.error / console.warn calls that

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -1,6 +1,4 @@
 import { isAbsolute, join } from "@std/path";
-import type { ExperimentalOptions } from "@commonfabric/runner";
-import { cliName } from "./cli-name.ts";
 
 export function absPath(relpath: string, cwd = Deno.cwd()): string {
   // TODO(js): homedir check is not cross platform
@@ -9,40 +7,6 @@ export function absPath(relpath: string, cwd = Deno.cwd()): string {
     return relpath;
   }
   return join(cwd, relpath);
-}
-
-/**
- * Read EXPERIMENTAL_* env vars and return an ExperimentalOptions object.
- * Mirrors the same env var names used by toolshed (env.ts) and shell
- * (felt.config.ts) so all three share one source of truth.
- */
-export function experimentalOptionsFromEnv(): ExperimentalOptions {
-  /**
-   * Results in `true` (on), `false` (off), or `undefined` (default).
-   */
-  const read = (name: string): boolean | undefined => {
-    const v = Deno.env.get(name);
-    return v === undefined ? undefined : v === "true";
-  };
-  const opts: ExperimentalOptions = {
-    modernCellRep: read("EXPERIMENTAL_MODERN_CELL_REP"),
-    persistentSchedulerState: read(
-      "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
-    ),
-    eagerSourceAnnotation: read("EXPERIMENTAL_EAGER_SOURCE_ANNOTATION"),
-  };
-
-  // Log any overridden experimental flags.
-  const overrideFlags = Object.entries(opts)
-    .filter(([_, v]) => v !== undefined)
-    .map(([k, v]) => `${k}=${v}`);
-  if (overrideFlags.length > 0) {
-    console.error(
-      `[${cliName()}] Experimental flag overrides: ${overrideFlags.join(", ")}`,
-    );
-  }
-
-  return opts;
 }
 
 const SYNC_TIMEOUT_MS = 30_000;

--- a/packages/generated-patterns/integration/pattern-harness.ts
+++ b/packages/generated-patterns/integration/pattern-harness.ts
@@ -5,7 +5,11 @@ import { fromFileUrl } from "@std/path";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../../runner/src/storage/cache.deno.ts";
-import { Runtime } from "@commonfabric/runner";
+import {
+  experimentalOptionsFromEnv,
+  Runtime,
+  runtimePresets,
+} from "@commonfabric/runner";
 import { sleep } from "@commonfabric/utils/sleep";
 import { createCompileByteCache } from "@commonfabric/test-support/compile-byte-cache";
 
@@ -65,14 +69,17 @@ function resolveModulePath(moduleRef: string | URL): string {
 export async function runPatternScenario(scenario: PatternIntegrationScenario) {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtimeErrors: Error[] = [];
-  const runtime = new Runtime({
+  // Same preset as the CLI pattern-test harness (CT-1814): shared CFC pin
+  // and env-honored experimental flags, so the two harnesses cannot drift.
+  const runtime = new Runtime(runtimePresets.patternTest({
     apiUrl: new URL(import.meta.url),
     storageManager,
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     moduleByteCache,
     errorHandlers: [(error) => {
       runtimeErrors.push(error);
     }],
-  });
+  }));
 
   const modulePath = resolveModulePath(scenario.module);
   const programResolver = new FileSystemProgramResolver(modulePath);

--- a/packages/html/bench/worker-reconciler-mount.bench.ts
+++ b/packages/html/bench/worker-reconciler-mount.bench.ts
@@ -20,7 +20,7 @@
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "@commonfabric/runner";
+import { Runtime, runtimePresets } from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import type { Cell } from "@commonfabric/runner";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
@@ -35,10 +35,10 @@ type BenchEnv = {
 
 function createEnv(): BenchEnv {
   const storageManager = StorageManager.emulate({ as: signer });
-  const runtime = new Runtime({
+  const runtime = new Runtime(runtimePresets.unitTest({
     apiUrl: new URL(import.meta.url),
     storageManager,
-  });
+  }));
   return { runtime, storageManager };
 }
 

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1,9 +1,12 @@
 import {
   type Cell,
   entityIdFrom,
+  type EnvReader,
+  experimentalOptionsFromEnv,
   type JSONSchema,
   type ModuleByteCache,
   Runtime,
+  runtimePresets,
   RuntimeProgram,
   type Schema,
 } from "@commonfabric/runner";
@@ -26,6 +29,11 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 // the logger is disabled, so controller phases show up in the load summaries
 // (browser worker included) as `piece/phase/<label>`.
 const pieceTimingLogger = getLogger("piece", { enabled: false });
+
+// This module can load outside Deno (browser-safe storage import above), so
+// env reads are guarded like PIECE_TRACE_TIMINGS: absent env ⇒ defaults.
+const readEnv: EnvReader = (key) =>
+  typeof Deno !== "undefined" ? Deno.env.get(key) : undefined;
 
 async function timePiecesPhase<T>(
   label: string,
@@ -162,20 +170,23 @@ export class PiecesController<T = unknown> {
     moduleByteCache?: ModuleByteCache;
   }): Promise<PiecesController> {
     const session = await createSession({ identity, spaceName });
-    const runtime = new Runtime({
+    // Shared first-party posture for client runtimes against a deployed API
+    // (CT-1814); the CFC pin this site previously restated lives in the
+    // preset core. Trust provenance stays a visible delta of this controller.
+    const runtime = new Runtime(runtimePresets.remoteClient({
       apiUrl: new URL(apiUrl),
       storageManager: StorageManager.open({
         as: session.as,
         memoryHost: new URL(apiUrl),
         spaceIdentity: session.spaceIdentity,
       }),
-      cfcEnforcementMode: "enforce-explicit",
+      experimental: experimentalOptionsFromEnv(readEnv),
       moduleByteCache,
       trustSnapshotProvider: () => ({
         id: `principal:${session.as.did()}`,
         actingPrincipal: session.as.did(),
       }),
-    });
+    }));
 
     const manager = new PieceManager(session, runtime);
     await manager.synced();

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -7,6 +7,19 @@ export type {
   RuntimeOptions,
   SpaceCellContents,
 } from "./runtime.ts";
+export {
+  type BrowserWorkerPresetParams,
+  type EnvReader,
+  EXPERIMENTAL_ENV_VARS,
+  experimentalOptionsFromEnv,
+  type PatternTestPresetParams,
+  type ProductionServerPresetParams,
+  type RemoteClientPresetParams,
+  RUNTIME_OPTION_KEYS,
+  type RuntimeOptionKey,
+  runtimePresets,
+  type UnitTestPresetParams,
+} from "./runtime-presets.ts";
 export type {
   UnsafeHostTrust,
   UnsafeHostTrustOptions,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -1,0 +1,444 @@
+/**
+ * First-party `RuntimeOptions` presets — the one place Runtime construction
+ * config is assembled for our own environments (CT-1814).
+ *
+ * CT-1811 was a harness-vs-runtime divergence on the LOAD path, sealed by
+ * `PatternManager.compileAndRegisterModules`. This module seals the second
+ * axis: CONSTRUCTION-CONFIG drift. Before it, 13+ sites hand-rolled a subset
+ * of `RuntimeOptions`, so a new option (or a changed constructor default)
+ * could land unevenly and make the harness silently behave differently from
+ * production. Observed instances: three parallel copies of the
+ * env→`ExperimentalOptions` mapping whose parsers disagreed on non-canonical
+ * values; the multi-user test worker not honoring `EXPERIMENTAL_*` while the
+ * single-user runner did; client CLIs running patterns against the builder's
+ * hardcoded-localhost `patternEnvironment` fallback.
+ *
+ * How the seal works — three gates, all in this file:
+ *
+ * 1. {@link RUNTIME_OPTION_KEYS} is a type-gated exhaustive registry of
+ *    `keyof RuntimeOptions`. Adding an option to `RuntimeOptions` without
+ *    registering it here is a COMPILE ERROR, which forces the author to
+ *    decide, fleet-wide, how every environment treats the new option.
+ * 2. {@link EXPERIMENTAL_ENV_VARS} is the canonical (and only) env mapping
+ *    for `ExperimentalOptions`, type-gated the same way. A flag that is
+ *    deliberately not env-reachable is declared `null` here instead of being
+ *    silently absent from one wiring.
+ * 3. Every preset composes the same {@link coreOptions}, so the invariant
+ *    posture (today: the CFC dials) is written once. The conformance test
+ *    (`runner/test/runtime-presets.test.ts`) pins each preset's full output
+ *    as a golden, so any change to fleet posture is a visible diff there.
+ *
+ * Presets return a complete `RuntimeOptions`; call sites keep the
+ * `new Runtime(...)` expression so construction stays greppable. Deliberate
+ * per-environment deltas (mock fetch, error collectors, byte caches) are
+ * explicit, documented parameters — a preset that hid them would be worse
+ * than hand-rolled config. This is a convention, not a gate: a site CAN still
+ * hand-roll `RuntimeOptions`, but first-party code should not.
+ *
+ * Classification of every option (the conformance test asserts this table):
+ *
+ * | Option                     | Treatment                                        |
+ * | -------------------------- | ------------------------------------------------ |
+ * | apiUrl                     | per-site (required param)                        |
+ * | storageManager             | per-site (required param; open vs emulate, and   |
+ * |                            | its identity/session, are the caller's domain)   |
+ * | experimental               | per-site (required param — pass                  |
+ * |                            | `experimentalOptionsFromEnv(...)`, host data, or |
+ * |                            | an explicit `{}`; requiredness is the seal)      |
+ * | cfcEnforcementMode         | core-pinned `"enforce-explicit"`; overridable in |
+ * |                            | patternTest/unitTest (per-test laxer mode) and   |
+ * |                            | browserWorker (host-controlled rollout)          |
+ * | cfcFlowLabels              | core-default (off); browserWorker delta          |
+ * | cfcWriteFloor              | core-default (off) — flip in coreOptions when a  |
+ * |                            | first-party rollout begins                       |
+ * | cfcTriggerReadGating       | core-default (off) — same                        |
+ * | cfcPolicyEvaluation        | core-default (off) — same                        |
+ * | cfcPolicyRecords           | core-default (none declared) — same              |
+ * | cfcTrustConfig             | core-default (none declared) — same              |
+ * | cfcSinkMaxConfidentiality  | core-default (none declared) — same              |
+ * | patternEnvironment         | pinned from apiUrl in productionServer /         |
+ * |                            | remoteClient / browserWorker (patterns fetch     |
+ * |                            | against the real deployment, not the builder's   |
+ * |                            | localhost fallback); constructor default in the  |
+ * |                            | local presets (patternTest/localDev/unitTest)    |
+ * | fetch                      | real everywhere; patternTest delta (mock)        |
+ * | errorHandlers              | delta (collectors/telemetry), per preset         |
+ * | consoleHandler             | delta (productionServer, browserWorker)          |
+ * | navigateCallback           | delta (patternTest, remoteClient, browserWorker) |
+ * | pieceCreatedCallback       | delta (browserWorker only)                       |
+ * | telemetry                  | delta (productionServer, browserWorker)          |
+ * | moduleByteCache            | delta (patternTest, remoteClient, unitTest)      |
+ * | trustSnapshotProvider      | delta (remoteClient, browserWorker)              |
+ * | spaceHostMap               | delta (browserWorker only — federation routing   |
+ * |                            | is decided by the shell host)                    |
+ * | commitBackpressure         | core-default; unitTest delta (scheduler tests    |
+ * |                            | shrink the backoff window)                       |
+ * | debug                      | core-default everywhere                          |
+ * | hideInternalStackFrames    | core-default everywhere                          |
+ */
+
+import type {
+  CfcEnforcementMode,
+  CfcFlowLabelsMode,
+  TrustSnapshot,
+} from "./cfc/mod.ts";
+import type { CommitBackpressurePolicy } from "./scheduler/backpressure.ts";
+import type { IStorageManager } from "./storage/interface.ts";
+import type { RuntimeTelemetry } from "./telemetry.ts";
+import type {
+  ConsoleHandler,
+  ErrorHandler,
+  ExperimentalOptions,
+  ModuleByteCache,
+  NavigateCallback,
+  PieceCreatedCallback,
+  RuntimeOptions,
+} from "./runtime.ts";
+
+// ---------------------------------------------------------------------------
+// Gate 1: the exhaustive option registry.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every key of `RuntimeOptions`, by hand. The `satisfies` clause rejects
+ * entries that are not real options; {@link _allOptionsClassified} below
+ * rejects real options that are missing here. Together they force every
+ * future `RuntimeOptions` addition through this file (and its review) before
+ * it can ship — the point is not the list, it is the forced decision about
+ * how each first-party environment treats the new option.
+ */
+export const RUNTIME_OPTION_KEYS = [
+  "apiUrl",
+  "spaceHostMap",
+  "storageManager",
+  "consoleHandler",
+  "errorHandlers",
+  "patternEnvironment",
+  "navigateCallback",
+  "pieceCreatedCallback",
+  "debug",
+  "telemetry",
+  "experimental",
+  "cfcEnforcementMode",
+  "cfcFlowLabels",
+  "cfcWriteFloor",
+  "cfcTriggerReadGating",
+  "cfcPolicyEvaluation",
+  "cfcPolicyRecords",
+  "cfcTrustConfig",
+  "cfcSinkMaxConfidentiality",
+  "trustSnapshotProvider",
+  "hideInternalStackFrames",
+  "commitBackpressure",
+  "moduleByteCache",
+  "fetch",
+] as const satisfies readonly (keyof RuntimeOptions)[];
+
+export type RuntimeOptionKey = (typeof RUNTIME_OPTION_KEYS)[number];
+
+type MissingOptionKeys = Exclude<keyof RuntimeOptions, RuntimeOptionKey>;
+// If the next line errors, a new `RuntimeOptions` key exists that the presets
+// have not classified: add it to RUNTIME_OPTION_KEYS, decide its row in the
+// table above, and extend the conformance-test goldens. The type error names
+// the missing key(s).
+const _unclassifiedOptions: never[] = [] as MissingOptionKeys[];
+
+// ---------------------------------------------------------------------------
+// Gate 2: the canonical experimental-flag env mapping.
+// ---------------------------------------------------------------------------
+
+/** Reads one environment variable; pass `Deno.env.get` in Deno contexts. */
+export type EnvReader = (name: string) => string | undefined;
+
+/**
+ * The one env mapping for {@link ExperimentalOptions}. `null` declares a flag
+ * as deliberately programmatic-only, so "not env-wired" is a decision on
+ * record rather than an omission in one of several parallel wirings.
+ * (Previously toolshed, background-piece-service, and the CLI each kept their
+ * own copy, and the two parser families disagreed on non-canonical values:
+ * `flagValue()` read anything but "false" as true, the CLI read anything but
+ * "true" as false — so `EXPERIMENTAL_MODERN_CELL_REP=1` enabled the flag on
+ * toolshed and disabled it under `cf test`.)
+ */
+export const EXPERIMENTAL_ENV_VARS = {
+  modernCellRep: "EXPERIMENTAL_MODERN_CELL_REP",
+  persistentSchedulerState: "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
+  eagerSourceAnnotation: "EXPERIMENTAL_EAGER_SOURCE_ANNOTATION",
+  // Scheduler-v2 lineage (#4090): no env exposure yet; set programmatically
+  // by its tests. Wire an env var here (one line) when rollout wants it.
+  commitPreconditions: null,
+} as const satisfies Record<keyof ExperimentalOptions, string | null>;
+
+/**
+ * Read `ExperimentalOptions` from the environment via the canonical mapping.
+ * Accepted values are exactly `"true"` and `"false"`; unset means "use the
+ * default". Anything else is ignored WITH A WARNING rather than coerced —
+ * the old wirings silently coerced garbage, in opposite directions.
+ */
+export function experimentalOptionsFromEnv(
+  env: EnvReader,
+): ExperimentalOptions {
+  const opts: ExperimentalOptions = {};
+  for (
+    const [key, envVar] of Object.entries(EXPERIMENTAL_ENV_VARS) as [
+      keyof ExperimentalOptions,
+      string | null,
+    ][]
+  ) {
+    if (envVar === null) continue;
+    const raw = env(envVar);
+    if (raw === undefined) continue;
+    if (raw === "true" || raw === "false") {
+      opts[key] = raw === "true";
+    } else {
+      console.warn(
+        `[runtime-presets] Ignoring ${envVar}="${raw}" — ` +
+          `expected "true" or "false" (unset = default).`,
+      );
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3: the shared core all presets compose.
+// ---------------------------------------------------------------------------
+
+interface CoreParams {
+  /** Base URL of the memory/API service this runtime talks to. */
+  apiUrl: URL;
+  /** Storage backend — `StorageManager.open(...)` against a deployment, or `.emulate(...)` in-memory. */
+  storageManager: IStorageManager;
+  /**
+   * Experimental flags. Required on purpose: pass
+   * `experimentalOptionsFromEnv(Deno.env.get)` where the environment should
+   * be honored, host-provided data where the host decides (browser worker),
+   * or an explicit `{}` — each of which is a visible, reviewable choice,
+   * where an omitted field was silent drift.
+   */
+  experimental: ExperimentalOptions;
+}
+
+/**
+ * The invariant first-party posture, written once. Rollout dials (the CFC
+ * modes) get flipped HERE, in one reviewed place, for every preset user at
+ * once — the constructor defaults then only govern non-preset constructions.
+ */
+function coreOptions(params: CoreParams): RuntimeOptions {
+  return {
+    apiUrl: params.apiUrl,
+    storageManager: params.storageManager,
+    experimental: params.experimental,
+    // Pinned, not defaulted: several sites pinned this individually so that a
+    // changed constructor default could not silently relax them; the pin now
+    // lives once. Same value as the constructor default today.
+    cfcEnforcementMode: "enforce-explicit",
+    // cfcFlowLabels / cfcWriteFloor / cfcTriggerReadGating /
+    // cfcPolicyEvaluation / cfcPolicyRecords / cfcTrustConfig /
+    // cfcSinkMaxConfidentiality ride the constructor defaults (off / none) —
+    // deliberately absent here until a first-party rollout begins.
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The presets.
+// ---------------------------------------------------------------------------
+
+export interface ProductionServerPresetParams extends CoreParams {
+  /**
+   * Base URL patterns see (`patternEnvironment.apiUrl`) for relative fetches.
+   * Defaults to `apiUrl`; toolshed passes its public API_URL here while
+   * `apiUrl` carries MEMORY_URL.
+   */
+  patternApiUrl?: URL;
+  consoleHandler?: ConsoleHandler;
+  errorHandlers?: ErrorHandler[];
+  telemetry?: RuntimeTelemetry;
+}
+
+export interface RemoteClientPresetParams extends CoreParams {
+  errorHandlers?: ErrorHandler[];
+  navigateCallback?: NavigateCallback;
+  /** Shared compiled-module-byte cache (integration suites). */
+  moduleByteCache?: ModuleByteCache;
+  /** Trust provenance for CFC-relevant writes (pieces controller). */
+  trustSnapshotProvider?: () => TrustSnapshot | undefined;
+}
+
+export interface PatternTestPresetParams extends CoreParams {
+  /** Mock fetch honoring test-declared `fetchMocks` (CT-1768). */
+  fetch?: typeof globalThis.fetch;
+  errorHandlers?: ErrorHandler[];
+  navigateCallback?: NavigateCallback;
+  moduleByteCache?: ModuleByteCache;
+  /** Per-test laxer mode; defaults to the shared core pin. */
+  cfcEnforcementMode?: CfcEnforcementMode;
+}
+
+export interface BrowserWorkerPresetParams extends CoreParams {
+  /** Space DID → host base URL map (federation); decided by the shell host. */
+  spaceHostMap?: Record<string, string>;
+  /** Host-controlled rollout dials, from `InitializationData`. */
+  cfcEnforcementMode?: CfcEnforcementMode;
+  cfcFlowLabels?: CfcFlowLabelsMode;
+  trustSnapshotProvider?: () => TrustSnapshot | undefined;
+  telemetry?: RuntimeTelemetry;
+  consoleHandler?: ConsoleHandler;
+  errorHandlers?: ErrorHandler[];
+  navigateCallback?: NavigateCallback;
+  pieceCreatedCallback?: PieceCreatedCallback;
+}
+
+export interface UnitTestPresetParams extends Omit<CoreParams, "experimental"> {
+  /** Optional here (unlike the first-party presets): unit tests default to no flags. */
+  experimental?: ExperimentalOptions;
+  fetch?: typeof globalThis.fetch;
+  errorHandlers?: ErrorHandler[];
+  moduleByteCache?: ModuleByteCache;
+  cfcEnforcementMode?: CfcEnforcementMode;
+  /** Scheduler tests shrink the backoff/retry window. */
+  commitBackpressure?: Partial<CommitBackpressurePolicy>;
+}
+
+export const runtimePresets = {
+  /**
+   * Long-running server process (toolshed, background-piece-service main and
+   * worker). Remote storage, real fetch, patterns fetch against the
+   * deployment's own API base.
+   */
+  productionServer(params: ProductionServerPresetParams): RuntimeOptions {
+    return {
+      ...coreOptions(params),
+      patternEnvironment: { apiUrl: params.patternApiUrl ?? params.apiUrl },
+      ...(params.consoleHandler !== undefined
+        ? { consoleHandler: params.consoleHandler }
+        : {}),
+      ...(params.errorHandlers !== undefined
+        ? { errorHandlers: params.errorHandlers }
+        : {}),
+      ...(params.telemetry !== undefined
+        ? { telemetry: params.telemetry }
+        : {}),
+    };
+  },
+
+  /**
+   * Short-lived client runtime operating against a deployed API (cast-admin,
+   * pieces controller, `cf acl` / `cf piece`). Same posture as
+   * productionServer; the deltas are collectors and caches.
+   */
+  remoteClient(params: RemoteClientPresetParams): RuntimeOptions {
+    return {
+      ...coreOptions(params),
+      patternEnvironment: { apiUrl: params.apiUrl },
+      ...(params.errorHandlers !== undefined
+        ? { errorHandlers: params.errorHandlers }
+        : {}),
+      ...(params.navigateCallback !== undefined
+        ? { navigateCallback: params.navigateCallback }
+        : {}),
+      ...(params.moduleByteCache !== undefined
+        ? { moduleByteCache: params.moduleByteCache }
+        : {}),
+      ...(params.trustSnapshotProvider !== undefined
+        ? { trustSnapshotProvider: params.trustSnapshotProvider }
+        : {}),
+    };
+  },
+
+  /**
+   * Pattern-test harness runtime (single-user `cf test`, the multi-user test
+   * worker, the generated-patterns integration harness). Local by design:
+   * `patternEnvironment` stays on the constructor default so unmocked
+   * relative fetches keep today's local-dev fall-through.
+   */
+  patternTest(params: PatternTestPresetParams): RuntimeOptions {
+    const core = coreOptions(params);
+    return {
+      ...core,
+      ...(params.cfcEnforcementMode !== undefined
+        ? { cfcEnforcementMode: params.cfcEnforcementMode }
+        : {}),
+      ...(params.fetch !== undefined ? { fetch: params.fetch } : {}),
+      ...(params.errorHandlers !== undefined
+        ? { errorHandlers: params.errorHandlers }
+        : {}),
+      ...(params.navigateCallback !== undefined
+        ? { navigateCallback: params.navigateCallback }
+        : {}),
+      ...(params.moduleByteCache !== undefined
+        ? { moduleByteCache: params.moduleByteCache }
+        : {}),
+    };
+  },
+
+  /** Local CLI development runtime (`cf check` / `cf dev`): emulated storage, real fetch. */
+  localDev(params: CoreParams): RuntimeOptions {
+    return coreOptions(params);
+  },
+
+  /**
+   * In-browser worker runtime behind the shell (runtime-client's
+   * RuntimeProcessor). Everything host-decided arrives as data from
+   * `InitializationData` — experimental flags are the shell's build-time
+   * defines, the CFC dials are host-controlled rollout.
+   */
+  browserWorker(params: BrowserWorkerPresetParams): RuntimeOptions {
+    return {
+      ...coreOptions(params),
+      patternEnvironment: { apiUrl: params.apiUrl },
+      ...(params.spaceHostMap !== undefined
+        ? { spaceHostMap: params.spaceHostMap }
+        : {}),
+      ...(params.cfcEnforcementMode !== undefined
+        ? { cfcEnforcementMode: params.cfcEnforcementMode }
+        : {}),
+      ...(params.cfcFlowLabels !== undefined
+        ? { cfcFlowLabels: params.cfcFlowLabels }
+        : {}),
+      ...(params.trustSnapshotProvider !== undefined
+        ? { trustSnapshotProvider: params.trustSnapshotProvider }
+        : {}),
+      ...(params.telemetry !== undefined
+        ? { telemetry: params.telemetry }
+        : {}),
+      ...(params.consoleHandler !== undefined
+        ? { consoleHandler: params.consoleHandler }
+        : {}),
+      ...(params.errorHandlers !== undefined
+        ? { errorHandlers: params.errorHandlers }
+        : {}),
+      ...(params.navigateCallback !== undefined
+        ? { navigateCallback: params.navigateCallback }
+        : {}),
+      ...(params.pieceCreatedCallback !== undefined
+        ? { pieceCreatedCallback: params.pieceCreatedCallback }
+        : {}),
+    };
+  },
+
+  /**
+   * Bare unit-test runtime: the `{ apiUrl, storageManager: emulate }` shape
+   * the runner test suite constructs by hand today. Adoption is incremental
+   * and optional (CT-1814 scopes the migration to harness + production
+   * sites); it exists so new tests have a preset to reach for.
+   */
+  unitTest(params: UnitTestPresetParams): RuntimeOptions {
+    return {
+      ...coreOptions({ ...params, experimental: params.experimental ?? {} }),
+      ...(params.cfcEnforcementMode !== undefined
+        ? { cfcEnforcementMode: params.cfcEnforcementMode }
+        : {}),
+      ...(params.fetch !== undefined ? { fetch: params.fetch } : {}),
+      ...(params.errorHandlers !== undefined
+        ? { errorHandlers: params.errorHandlers }
+        : {}),
+      ...(params.moduleByteCache !== undefined
+        ? { moduleByteCache: params.moduleByteCache }
+        : {}),
+      ...(params.commitBackpressure !== undefined
+        ? { commitBackpressure: params.commitBackpressure }
+        : {}),
+    };
+  },
+} as const;

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -1,0 +1,347 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  EXPERIMENTAL_ENV_VARS,
+  experimentalOptionsFromEnv,
+  RUNTIME_OPTION_KEYS,
+  type RuntimeOptionKey,
+  runtimePresets,
+} from "../src/runtime-presets.ts";
+import type { ExperimentalOptions, RuntimeOptions } from "../src/runtime.ts";
+import type { IStorageManager } from "../src/storage/interface.ts";
+import { Runtime, signer, StorageManager } from "./engine-test-support.ts";
+
+/**
+ * Conformance guard for CT-1814 (the construction-config axis of CT-1811).
+ *
+ * The presets exist so a new `RuntimeOptions` key — or a changed default —
+ * cannot land unevenly across first-party environments. Two mechanisms are
+ * pinned here:
+ *
+ * 1. TREATMENT: for every registered option key, each preset's minimal-args
+ *    output must match the declared classification (per-site sentinel /
+ *    core-pinned value / pinned-in-family / absent). `MINIMAL_TREATMENT` is
+ *    a `Record<RuntimeOptionKey, ...>`, so registering a new option in
+ *    `RUNTIME_OPTION_KEYS` forces a row here too — the compiler walks a new
+ *    option all the way into this spec.
+ * 2. DELTA ROUTING: every declared preset parameter must land on exactly its
+ *    `RuntimeOptions` key (full-args goldens), so a param cannot be silently
+ *    dropped or mis-mapped.
+ */
+
+type PresetName = keyof typeof runtimePresets;
+const PRESET_NAMES = Object.keys(runtimePresets) as PresetName[];
+
+const apiUrl = new URL("https://conformance.example/api");
+const storageManager = {
+  id: "conformance-storage",
+} as unknown as IStorageManager;
+const experimental: ExperimentalOptions = { modernCellRep: true };
+const minimalCore = { apiUrl, storageManager, experimental };
+
+const minimalOutputs: Record<PresetName, RuntimeOptions> = {
+  productionServer: runtimePresets.productionServer(minimalCore),
+  remoteClient: runtimePresets.remoteClient(minimalCore),
+  patternTest: runtimePresets.patternTest(minimalCore),
+  localDev: runtimePresets.localDev(minimalCore),
+  browserWorker: runtimePresets.browserWorker(minimalCore),
+  // unitTest is the one preset where `experimental` is optional (so the 282
+  // hand-rolled test constructions can adopt it without ceremony).
+  unitTest: runtimePresets.unitTest({ apiUrl, storageManager }),
+};
+
+/** Presets whose runtimes serve patterns against a real deployment. */
+const DEPLOYMENT_FACING: PresetName[] = [
+  "productionServer",
+  "remoteClient",
+  "browserWorker",
+];
+
+type MinimalTreatment =
+  /** Equals the sentinel passed in, in every preset. */
+  | { treat: "per-site" }
+  /** Present in every preset with this exact shared value. */
+  | { treat: "core-pinned"; value: unknown }
+  /** Present (derived, not caller-supplied) in exactly these presets. */
+  | { treat: "pinned-in"; presets: PresetName[]; value: unknown }
+  /** No minimal output owns the key: the constructor default governs. */
+  | { treat: "absent" };
+
+const MINIMAL_TREATMENT: Record<RuntimeOptionKey, MinimalTreatment> = {
+  apiUrl: { treat: "per-site" },
+  storageManager: { treat: "per-site" },
+  experimental: { treat: "per-site" },
+  // Same value as the Runtime constructor default today; pinned so a changed
+  // constructor default cannot silently relax first-party environments.
+  cfcEnforcementMode: { treat: "core-pinned", value: "enforce-explicit" },
+  // Deployment-facing runtimes point patterns at the deployment itself;
+  // local presets keep the builder-env default (localhost fall-through).
+  patternEnvironment: {
+    treat: "pinned-in",
+    presets: DEPLOYMENT_FACING,
+    value: { apiUrl },
+  },
+  // Everything below rides the constructor default unless a preset's
+  // declared delta param supplies it (covered by the routing tests).
+  spaceHostMap: { treat: "absent" },
+  consoleHandler: { treat: "absent" },
+  errorHandlers: { treat: "absent" },
+  navigateCallback: { treat: "absent" },
+  pieceCreatedCallback: { treat: "absent" },
+  debug: { treat: "absent" },
+  telemetry: { treat: "absent" },
+  cfcFlowLabels: { treat: "absent" },
+  cfcWriteFloor: { treat: "absent" },
+  cfcTriggerReadGating: { treat: "absent" },
+  cfcPolicyEvaluation: { treat: "absent" },
+  cfcPolicyRecords: { treat: "absent" },
+  cfcTrustConfig: { treat: "absent" },
+  cfcSinkMaxConfidentiality: { treat: "absent" },
+  trustSnapshotProvider: { treat: "absent" },
+  hideInternalStackFrames: { treat: "absent" },
+  commitBackpressure: { treat: "absent" },
+  moduleByteCache: { treat: "absent" },
+  fetch: { treat: "absent" },
+};
+
+describe("runtimePresets conformance (CT-1814)", () => {
+  it("every registered option key gets its declared treatment in every preset", () => {
+    for (const key of RUNTIME_OPTION_KEYS) {
+      const treatment = MINIMAL_TREATMENT[key];
+      for (const preset of PRESET_NAMES) {
+        const output = minimalOutputs[preset];
+        const owns = Object.hasOwn(output, key);
+        const context = `${preset}.${key}`;
+        switch (treatment.treat) {
+          case "per-site": {
+            expect(owns, `${context} must be set from its param`).toBe(true);
+            if (key === "experimental" && preset === "unitTest") {
+              // unitTest defaulted it; every other preset got the sentinel.
+              expect(output.experimental).toEqual({});
+            } else {
+              expect(output[key], context).toBe(
+                minimalCore[
+                  key as keyof typeof minimalCore
+                ],
+              );
+            }
+            break;
+          }
+          case "core-pinned": {
+            expect(owns, `${context} must carry the shared pin`).toBe(true);
+            expect(output[key], context).toEqual(treatment.value);
+            break;
+          }
+          case "pinned-in": {
+            const expected = treatment.presets.includes(preset);
+            expect(
+              owns,
+              `${context} pinned-in mismatch (expected ${expected})`,
+            ).toBe(expected);
+            if (expected) expect(output[key], context).toEqual(treatment.value);
+            break;
+          }
+          case "absent": {
+            expect(
+              owns,
+              `${context} must ride the constructor default in minimal form`,
+            ).toBe(false);
+            break;
+          }
+        }
+      }
+    }
+  });
+
+  it("presets set no keys outside the registry", () => {
+    for (const preset of PRESET_NAMES) {
+      for (const key of Object.keys(minimalOutputs[preset])) {
+        expect(RUNTIME_OPTION_KEYS, `${preset} sets unregistered "${key}"`)
+          .toContain(key);
+      }
+    }
+  });
+
+  describe("delta routing (full-args goldens)", () => {
+    const fetchSentinel = (() =>
+      Promise.reject(
+        new Error("sentinel"),
+      )) as unknown as typeof globalThis.fetch;
+    const errorHandlers = [() => {}];
+    const navigateCallback = () => {};
+    const consoleHandler = (
+      { args }: { args: unknown[] },
+    ) => args;
+    const pieceCreatedCallback = () => {};
+    const moduleByteCache = {
+      get: () => undefined,
+      set: () => {},
+    } as unknown as NonNullable<RuntimeOptions["moduleByteCache"]>;
+    const trustSnapshotProvider = () => undefined;
+    const telemetry = {
+      dispatchEvent: () => true,
+    } as unknown as NonNullable<RuntimeOptions["telemetry"]>;
+    const commitBackpressure = { retryWindowMs: 100 };
+    const spaceHostMap = { "did:key:zSpace": "https://host.example" };
+
+    it("productionServer", () => {
+      const patternApiUrl = new URL("https://public.example/api");
+      expect(runtimePresets.productionServer({
+        ...minimalCore,
+        patternApiUrl,
+        consoleHandler,
+        errorHandlers,
+        telemetry,
+      })).toEqual({
+        ...minimalOutputs.productionServer,
+        patternEnvironment: { apiUrl: patternApiUrl },
+        consoleHandler,
+        errorHandlers,
+        telemetry,
+      });
+    });
+
+    it("remoteClient", () => {
+      expect(runtimePresets.remoteClient({
+        ...minimalCore,
+        errorHandlers,
+        navigateCallback,
+        moduleByteCache,
+        trustSnapshotProvider,
+      })).toEqual({
+        ...minimalOutputs.remoteClient,
+        errorHandlers,
+        navigateCallback,
+        moduleByteCache,
+        trustSnapshotProvider,
+      });
+    });
+
+    it("patternTest", () => {
+      expect(runtimePresets.patternTest({
+        ...minimalCore,
+        fetch: fetchSentinel,
+        errorHandlers,
+        navigateCallback,
+        moduleByteCache,
+        cfcEnforcementMode: "observe",
+      })).toEqual({
+        ...minimalOutputs.patternTest,
+        fetch: fetchSentinel,
+        errorHandlers,
+        navigateCallback,
+        moduleByteCache,
+        cfcEnforcementMode: "observe",
+      });
+    });
+
+    it("browserWorker", () => {
+      expect(runtimePresets.browserWorker({
+        ...minimalCore,
+        spaceHostMap,
+        cfcEnforcementMode: "observe",
+        cfcFlowLabels: "observe",
+        trustSnapshotProvider,
+        telemetry,
+        consoleHandler,
+        errorHandlers,
+        navigateCallback,
+        pieceCreatedCallback,
+      })).toEqual({
+        ...minimalOutputs.browserWorker,
+        spaceHostMap,
+        cfcEnforcementMode: "observe",
+        cfcFlowLabels: "observe",
+        trustSnapshotProvider,
+        telemetry,
+        consoleHandler,
+        errorHandlers,
+        navigateCallback,
+        pieceCreatedCallback,
+      });
+    });
+
+    it("unitTest", () => {
+      expect(runtimePresets.unitTest({
+        apiUrl,
+        storageManager,
+        experimental,
+        fetch: fetchSentinel,
+        errorHandlers,
+        moduleByteCache,
+        cfcEnforcementMode: "disabled",
+        commitBackpressure,
+      })).toEqual({
+        ...minimalOutputs.unitTest,
+        experimental,
+        fetch: fetchSentinel,
+        errorHandlers,
+        moduleByteCache,
+        cfcEnforcementMode: "disabled",
+        commitBackpressure,
+      });
+    });
+  });
+
+  describe("experimentalOptionsFromEnv", () => {
+    it("consults exactly the env-wired canonical mapping", () => {
+      const read: string[] = [];
+      experimentalOptionsFromEnv((name) => {
+        read.push(name);
+        return undefined;
+      });
+      const wired = Object.values(EXPERIMENTAL_ENV_VARS)
+        .flatMap((v) => v === null ? [] : [v]);
+      expect(read.toSorted()).toEqual(wired.toSorted());
+    });
+
+    it("parses canonical values and leaves unset flags to their defaults", () => {
+      const env: Record<string, string> = {
+        EXPERIMENTAL_MODERN_CELL_REP: "true",
+        EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "false",
+      };
+      expect(experimentalOptionsFromEnv((name) => env[name])).toEqual({
+        modernCellRep: true,
+        persistentSchedulerState: false,
+      });
+      expect(experimentalOptionsFromEnv(() => undefined)).toEqual({});
+    });
+
+    it("ignores (with a warning) non-canonical values instead of coercing", () => {
+      // The wirings this replaced coerced garbage in OPPOSITE directions
+      // (toolshed's flagValue(): anything but "false" ⇒ true; the CLI reader:
+      // anything but "true" ⇒ false). Ignoring keeps the flag on its default
+      // and surfaces the typo.
+      const warnings: unknown[][] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args);
+      };
+      try {
+        expect(
+          experimentalOptionsFromEnv((name) =>
+            name === "EXPERIMENTAL_MODERN_CELL_REP" ? "1" : undefined
+          ),
+        ).toEqual({});
+      } finally {
+        console.warn = originalWarn;
+      }
+      expect(warnings.length).toBe(1);
+      expect(String(warnings[0][0])).toContain("EXPERIMENTAL_MODERN_CELL_REP");
+    });
+  });
+
+  it("preset output constructs a working Runtime", async () => {
+    const emulated = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime(runtimePresets.unitTest({
+      apiUrl: new URL(import.meta.url),
+      storageManager: emulated,
+    }));
+    try {
+      expect(runtime.cfcEnforcementMode).toBe("enforce-explicit");
+    } finally {
+      await runtime.dispose();
+      await emulated.close();
+    }
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1820,6 +1820,28 @@ describe("browserWorkerParamsFromInitializationData", () => {
     expect(options.cfcEnforcementMode).toBe("enforce-explicit");
     expect(options.cfcFlowLabels).toBeUndefined();
   });
+
+  it("threads the host-decided space-host map through to the runtime options", () => {
+    const options = runtimePresets.browserWorker(
+      browserWorkerParamsFromInitializationData(
+        {
+          apiUrl: "http://worker.test/",
+          identity: {} as never,
+          spaceDid: "did:key:space",
+          spaceHostMap: { "did:key:federated": "http://other-host.test/" },
+        },
+        { as: { did: () => "did:key:worker" } } as unknown as Parameters<
+          typeof browserWorkerParamsFromInitializationData
+        >[1],
+        { marker() {} } as unknown as Parameters<
+          typeof browserWorkerParamsFromInitializationData
+        >[2],
+      ),
+    );
+    expect(options.spaceHostMap).toEqual({
+      "did:key:federated": "http://other-host.test/",
+    });
+  });
 });
 
 // Federation PR2: one worker serves page operations for many spaces.

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -6,14 +6,15 @@ import type { MemorySpace } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
+  browserWorkerParamsFromInitializationData,
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
-  runtimeOptionsFromInitializationData,
   RuntimeProcessor,
   sanitizeForPostMessage,
 } from "./runtime-processor.ts";
 import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
+import { runtimePresets } from "@commonfabric/runner";
 import {
   type CellRef,
   type CfcLabelView,
@@ -1761,29 +1762,33 @@ describe("runtime-client CellRef conversion", () => {
   });
 });
 
-describe("runtimeOptionsFromInitializationData", () => {
-  it("threads CFC initialization settings into runtime options", () => {
+describe("browserWorkerParamsFromInitializationData", () => {
+  it("threads CFC initialization settings through the preset into runtime options", () => {
     const telemetry = { marker() {} } as unknown as Parameters<
-      typeof runtimeOptionsFromInitializationData
+      typeof browserWorkerParamsFromInitializationData
     >[2];
     const storageManager = {
       as: { did: () => "did:key:worker" },
-    } as unknown as Parameters<typeof runtimeOptionsFromInitializationData>[1];
+    } as unknown as Parameters<
+      typeof browserWorkerParamsFromInitializationData
+    >[1];
 
-    const options = runtimeOptionsFromInitializationData(
-      {
-        apiUrl: "http://worker.test/",
-        identity: {} as never,
-        spaceDid: "did:key:space",
-        cfcEnforcementMode: "enforce-explicit",
-        cfcFlowLabels: "observe",
-        trustSnapshot: {
-          id: "principal:did:key:worker",
-          actingPrincipal: "did:key:worker",
+    const options = runtimePresets.browserWorker(
+      browserWorkerParamsFromInitializationData(
+        {
+          apiUrl: "http://worker.test/",
+          identity: {} as never,
+          spaceDid: "did:key:space",
+          cfcEnforcementMode: "enforce-explicit",
+          cfcFlowLabels: "observe",
+          trustSnapshot: {
+            id: "principal:did:key:worker",
+            actingPrincipal: "did:key:worker",
+          },
         },
-      },
-      storageManager,
-      telemetry,
+        storageManager,
+        telemetry,
+      ),
     );
 
     expect(options.cfcEnforcementMode).toBe("enforce-explicit");
@@ -1792,6 +1797,28 @@ describe("runtimeOptionsFromInitializationData", () => {
       id: "principal:did:key:worker",
       actingPrincipal: "did:key:worker",
     });
+    // The preset pins patterns to the host's own API base.
+    expect(options.patternEnvironment?.apiUrl.href).toBe("http://worker.test/");
+  });
+
+  it("falls back to the shared CFC pin when the host sends no dial", () => {
+    const options = runtimePresets.browserWorker(
+      browserWorkerParamsFromInitializationData(
+        {
+          apiUrl: "http://worker.test/",
+          identity: {} as never,
+          spaceDid: "did:key:space",
+        },
+        { as: { did: () => "did:key:worker" } } as unknown as Parameters<
+          typeof browserWorkerParamsFromInitializationData
+        >[1],
+        { marker() {} } as unknown as Parameters<
+          typeof browserWorkerParamsFromInitializationData
+        >[2],
+      ),
+    );
+    expect(options.cfcEnforcementMode).toBe("enforce-explicit");
+    expect(options.cfcFlowLabels).toBeUndefined();
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -14,6 +14,7 @@ import {
   resetAllTimingBaselines,
 } from "@commonfabric/utils/logger";
 import {
+  type BrowserWorkerPresetParams,
   type Cancel,
   type Cell,
   convertCellsToLinks,
@@ -24,6 +25,7 @@ import {
   isCellResult,
   markUiInputBlindWriteTx,
   Runtime,
+  runtimePresets,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
   setBlindStructuralTarget,
@@ -160,24 +162,36 @@ function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
   return new URL(url, spaceBaseUrl).href;
 }
 
-export function runtimeOptionsFromInitializationData(
+/**
+ * Map host-decided `InitializationData` onto `runtimePresets.browserWorker`
+ * params (CT-1814): the shared first-party posture (CFC pins,
+ * patternEnvironment from apiUrl) lives in the preset; this function only
+ * carries what the host actually decided. Exported for testing.
+ */
+export function browserWorkerParamsFromInitializationData(
   data: InitializationData,
   storageManager: RuntimeOptions["storageManager"],
   telemetry: RuntimeTelemetry,
-): RuntimeOptions {
-  const apiUrlObj = new URL(data.apiUrl);
+): BrowserWorkerPresetParams {
   return {
-    apiUrl: apiUrlObj,
-    spaceHostMap: data.spaceHostMap,
+    apiUrl: new URL(data.apiUrl),
     storageManager,
-    patternEnvironment: { apiUrl: apiUrlObj },
+    // The host decides the flags (shell build-time defines); absent ⇒ runtime
+    // defaults.
+    experimental: data.experimental ?? {},
     telemetry,
-    experimental: data.experimental,
-    cfcEnforcementMode: data.cfcEnforcementMode,
-    cfcFlowLabels: data.cfcFlowLabels,
-    trustSnapshotProvider: data.trustSnapshot
-      ? () => data.trustSnapshot
-      : undefined,
+    ...(data.spaceHostMap !== undefined
+      ? { spaceHostMap: data.spaceHostMap }
+      : {}),
+    ...(data.cfcEnforcementMode !== undefined
+      ? { cfcEnforcementMode: data.cfcEnforcementMode }
+      : {}),
+    ...(data.cfcFlowLabels !== undefined
+      ? { cfcFlowLabels: data.cfcFlowLabels }
+      : {}),
+    ...(data.trustSnapshot
+      ? { trustSnapshotProvider: () => data.trustSnapshot }
+      : {}),
   };
 }
 
@@ -475,8 +489,11 @@ export class RuntimeProcessor {
 
     let pieceManager: PieceManager | undefined = undefined;
     let processor: RuntimeProcessor | undefined = undefined;
-    const runtime = new Runtime({
-      ...runtimeOptionsFromInitializationData(
+    // Everything below goes through the browserWorker preset (CT-1814):
+    // host-decided data via the params mapper, plus this worker's declared
+    // deltas (the postMessage bridges for console/navigate/piece/errors).
+    const runtime = new Runtime(runtimePresets.browserWorker({
+      ...browserWorkerParamsFromInitializationData(
         data,
         storageManager,
         telemetry,
@@ -539,7 +556,7 @@ export class RuntimeProcessor {
           });
         },
       ],
-    });
+    }));
 
     if (!await runtime.healthCheck()) {
       throw new Error(`Could not connect to "${data.apiUrl}"`);

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { EnvSchema, runtimeExperimentalOptions } from "@/env.ts";
+import { EnvSchema } from "@/env.ts";
 
 // Regression guard for the z.coerce.boolean() footgun: Boolean("false") === true,
 // which would silently enable telemetry (and, with the all-span exporter, ship
@@ -38,25 +38,8 @@ Deno.test("DISABLE_LOG_REQ_RES / PLAID_SYNC_ALL_TRANSACTIONS parse strictly", ()
   }
 });
 
-Deno.test("runtimeExperimentalOptions maps env flags with tri-state fidelity", () => {
-  const base = EnvSchema.parse({});
-  // Unset flags stay undefined — the runner distinguishes "unset" from an
-  // explicit false (an unset eagerSourceAnnotation must not stomp the
-  // runner's ambient default).
-  assertEquals(runtimeExperimentalOptions(base), {
-    modernCellRep: undefined,
-    persistentSchedulerState: undefined,
-    eagerSourceAnnotation: undefined,
-  });
-
-  const explicit = EnvSchema.parse({
-    EXPERIMENTAL_MODERN_CELL_REP: "true",
-    EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "false",
-    EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: "true",
-  });
-  assertEquals(runtimeExperimentalOptions(explicit), {
-    modernCellRep: true,
-    persistentSchedulerState: false,
-    eagerSourceAnnotation: true,
-  });
-});
+// The EXPERIMENTAL_* → ExperimentalOptions mapping (including its tri-state
+// unset/true/false fidelity) now lives in the runner's canonical
+// `experimentalOptionsFromEnv` / `EXPERIMENTAL_ENV_VARS` (CT-1814), shared by
+// toolshed, the CLI, and the background-piece-service; its coverage lives in
+// `packages/runner/test/runtime-presets.test.ts`.

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -251,15 +251,11 @@ export const EnvSchema = z.object({
   // In development, you can optionally proxy the upstream SHELL
   SHELL_URL: z.string().optional(),
 
-  // ===========================================================================
-  // Experimental feature flags (see ExperimentalOptions in runner)
-  // These use flagValue() (tri-state: true/false/undefined) because the runner
-  // distinguishes "unset" from an explicit false. The plain on/off booleans
-  // above use boolFlag(); both avoid z.coerce.boolean()'s Boolean("false") trap.
-  // ===========================================================================
-  EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
-  EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
-  EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: flagValue(),
+  // EXPERIMENTAL_* feature flags are no longer declared here: the runtime
+  // construction site reads them through the canonical mapping
+  // (`experimentalOptionsFromEnv` / EXPERIMENTAL_ENV_VARS in
+  // @commonfabric/runner runtime-presets), shared with the CLI and the
+  // background-piece-service so the wirings cannot drift (CT-1814).
 
   // Git SHA of the deployed commit. Set at deploy time; takes priority over
   // the build-baked SHA (see lib/build-info.ts).
@@ -279,26 +275,6 @@ export const EnvSchema = z.object({
 });
 
 export type env = z.infer<typeof EnvSchema>;
-
-/**
- * The runner `ExperimentalOptions` derived from the environment flags —
- * assembled here rather than inline in the server entrypoint so the
- * env → option mapping is unit-testable. Tri-state semantics matter: an
- * unset flag must stay `undefined` (the runner distinguishes "unset" from an
- * explicit false — e.g. an explicit `eagerSourceAnnotation` overrides the
- * runner's ambient default, an unset one leaves it alone).
- */
-export function runtimeExperimentalOptions(e: env): {
-  modernCellRep?: boolean;
-  persistentSchedulerState?: boolean;
-  eagerSourceAnnotation?: boolean;
-} {
-  return {
-    modernCellRep: e.EXPERIMENTAL_MODERN_CELL_REP,
-    persistentSchedulerState: e.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
-    eagerSourceAnnotation: e.EXPERIMENTAL_EAGER_SOURCE_ANNOTATION,
-  };
-}
 
 // CLI args override env vars (needed for --watch compatibility)
 const cliOverrides = parseCliArgs();

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,12 +1,9 @@
 import app from "@/app.ts";
 import env from "@/env.ts";
 import { identity } from "@/lib/identity.ts";
-import {
-  experimentalOptionsFromEnv,
-  Runtime,
-  runtimePresets,
-} from "@commonfabric/runner";
+import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toolshedRuntimeOptions } from "@/runtime-options.ts";
 import { memory } from "@/routes/storage/memory.ts";
 import { shutdownOpenTelemetry } from "@/lib/otel.ts";
 
@@ -19,20 +16,15 @@ const initializeRuntime = () => {
   try {
     console.log(`Initializing runtime with signer ${identity.did()}...`);
 
-    // Shared first-party posture (CT-1814). `apiUrl` is the storage/memory
-    // base; patterns fetch against the public API base instead (the preset
-    // would otherwise pin them to `apiUrl`, and the builder/env.ts fallback
-    // is a hardcoded `localhost:<ports.toolshed>` — wrong for any non-default
-    // port).
-    runtime = new Runtime(runtimePresets.productionServer({
-      apiUrl: new URL(env.MEMORY_URL),
-      patternApiUrl: new URL(env.API_URL),
-      storageManager: StorageManager.open({
+    // Options assembly (the MEMORY_URL/API_URL split, EXPERIMENTAL_* wiring)
+    // lives in runtime-options.ts, where it is unit-tested (CT-1814).
+    runtime = new Runtime(toolshedRuntimeOptions(
+      env,
+      StorageManager.open({
         memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
-      experimental: experimentalOptionsFromEnv(Deno.env.get),
-    }));
+    ));
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);
   } catch (error) {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,7 +1,11 @@
 import app from "@/app.ts";
-import env, { runtimeExperimentalOptions } from "@/env.ts";
+import env from "@/env.ts";
 import { identity } from "@/lib/identity.ts";
-import { Runtime } from "@commonfabric/runner";
+import {
+  experimentalOptionsFromEnv,
+  Runtime,
+  runtimePresets,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { memory } from "@/routes/storage/memory.ts";
 import { shutdownOpenTelemetry } from "@/lib/otel.ts";
@@ -15,18 +19,20 @@ const initializeRuntime = () => {
   try {
     console.log(`Initializing runtime with signer ${identity.did()}...`);
 
-    runtime = new Runtime({
+    // Shared first-party posture (CT-1814). `apiUrl` is the storage/memory
+    // base; patterns fetch against the public API base instead (the preset
+    // would otherwise pin them to `apiUrl`, and the builder/env.ts fallback
+    // is a hardcoded `localhost:<ports.toolshed>` — wrong for any non-default
+    // port).
+    runtime = new Runtime(runtimePresets.productionServer({
       apiUrl: new URL(env.MEMORY_URL),
-      // Patterns running in this runtime (e.g. handlers doing `fetch`) target
-      // this toolshed's API base, not the hardcoded `localhost:<ports.toolshed>`
-      // default in builder/env.ts (wrong for any non-default port).
-      patternEnvironment: { apiUrl: new URL(env.API_URL) },
+      patternApiUrl: new URL(env.API_URL),
       storageManager: StorageManager.open({
         memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
-      experimental: runtimeExperimentalOptions(env),
-    });
+      experimental: experimentalOptionsFromEnv(Deno.env.get),
+    }));
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);
   } catch (error) {

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -1,0 +1,34 @@
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import type { RuntimeOptions } from "@commonfabric/runner";
+import { toolshedRuntimeOptions } from "@/runtime-options.ts";
+
+// Pins toolshed's runtime wiring decisions (CT-1814): the runtime's storage
+// base is MEMORY_URL while patterns fetch against the public API_URL; the
+// storage manager passes through untouched; EXPERIMENTAL_* flags come from
+// the injected env reader via the canonical mapping; and the shared
+// first-party posture (the CFC pin) rides along from the preset.
+Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env reader", () => {
+  const storageManager = {
+    sentinel: true,
+  } as unknown as RuntimeOptions["storageManager"];
+
+  const options = toolshedRuntimeOptions(
+    {
+      MEMORY_URL: "http://memory.test:8000/",
+      API_URL: "http://api.test:9000/",
+    },
+    storageManager,
+    (name) => name === "EXPERIMENTAL_MODERN_CELL_REP" ? "true" : undefined,
+  );
+
+  assertEquals(options.apiUrl.href, "http://memory.test:8000/");
+  assertEquals(
+    options.patternEnvironment?.apiUrl.href,
+    "http://api.test:9000/",
+  );
+  assertStrictEquals(options.storageManager, storageManager);
+  assertEquals(options.experimental?.modernCellRep, true);
+  // Unset flags stay unset (tri-state fidelity), not coerced.
+  assertEquals(options.experimental?.persistentSchedulerState, undefined);
+  assertEquals(options.cfcEnforcementMode, "enforce-explicit");
+});

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -1,0 +1,29 @@
+import {
+  type EnvReader,
+  experimentalOptionsFromEnv,
+  type RuntimeOptions,
+  runtimePresets,
+} from "@commonfabric/runner";
+import type { env as ToolshedEnv } from "@/env.ts";
+
+/**
+ * Assemble this toolshed's `RuntimeOptions` (CT-1814), extracted pure from
+ * the server startup path so the wiring decisions are unit-testable:
+ * `apiUrl` is the storage/memory base (MEMORY_URL), while patterns fetch
+ * against the public API base (API_URL) — the builder/env.ts fallback is a
+ * hardcoded `localhost:<ports.toolshed>`, wrong for any non-default port.
+ * EXPERIMENTAL_* flags come from the injected env reader via the canonical
+ * mapping.
+ */
+export function toolshedRuntimeOptions(
+  config: Pick<ToolshedEnv, "MEMORY_URL" | "API_URL">,
+  storageManager: RuntimeOptions["storageManager"],
+  envGet: EnvReader = Deno.env.get,
+): RuntimeOptions {
+  return runtimePresets.productionServer({
+    apiUrl: new URL(config.MEMORY_URL),
+    patternApiUrl: new URL(config.API_URL),
+    storageManager,
+    experimental: experimentalOptionsFromEnv(envGet),
+  });
+}


### PR DESCRIPTION
## Summary

Implements **CT-1814** — the second axis of the CT-1811 divergence class. PR #4454 sealed the pattern **load path** (the harness could evaluate without registering artifacts); this PR seals **runtime construction config**: 13 first-party sites hand-rolled subsets of `RuntimeOptions`, so a new option — or a changed constructor default — could land unevenly and make the harness silently behave differently from production. That axis is growing under us: `RuntimeOptions` is 21 options and gained two CFC dials this week alone (#4479, #4488), which no construction site sets.

## What this adds

**`packages/runner/src/runtime-presets.ts`** — first-party construction presets. Three gates, all in one reviewed file:

1. **`RUNTIME_OPTION_KEYS`** — a type-gated exhaustive registry of `keyof RuntimeOptions`. A new option that is not classified here is a **compile error** that names the missing key. Adding an option now forces a fleet-wide decision (core-pinned / core-default / declared delta / per-site), instead of an incidental per-site choice.
2. **`EXPERIMENTAL_ENV_VARS` + `experimentalOptionsFromEnv(env)`** — the canonical (and now only Deno-side) env mapping for `ExperimentalOptions`, type-gated against `keyof ExperimentalOptions`. It replaces three parallel copies (toolshed `env.ts`, background-piece-service `env.ts`, cli `utils.ts`) whose parsers disagreed in opposite directions on non-canonical values. A deliberately-unwired flag is declared `null` in the mapping (today: `commitPreconditions`, from #4090) instead of being silently absent from one wiring.
3. **Six presets** — `productionServer`, `remoteClient`, `patternTest`, `localDev`, `browserWorker`, `unitTest` — all composed from one internal `coreOptions`. First-party rollout dials (the CFC modes) get flipped there, once, for every environment at once; constructor defaults then govern only non-preset constructions. Deliberate deltas (mock fetch, collectors, byte caches, host-decided dials) are explicit, documented preset parameters — visible at each call site, per the ticket's "don't over-centralize" constraint. Sites keep the `new Runtime(...)` expression so construction stays greppable.

**Conformance test** (`packages/runner/test/runtime-presets.test.ts`):
- a `Record<RuntimeOptionKey, Treatment>` spec — type-forced to cover every registered key — asserting each key's minimal-args treatment in every preset (per-site sentinel / core-pinned value / pinned-in-family / absent);
- full-args goldens proving every declared delta param routes to exactly its `RuntimeOptions` key (a param cannot be dropped or mis-mapped);
- canonical-parse tests for `experimentalOptionsFromEnv` (including the garbage-value warning) and a check that it consults exactly the env-wired mapping entries;
- a constructor smoke test (preset output builds a working `Runtime` with the pinned CFC mode).

## Migrated sites (13)

| Site | Preset |
| -- | -- |
| `toolshed/index.ts` | `productionServer` (apiUrl=MEMORY_URL, patternApiUrl=API_URL) |
| `background-piece-service/src/main.ts` | `productionServer` |
| `background-piece-service/src/worker.ts` | `productionServer` (experimental arrives as IPC data) |
| `background-piece-service/cast-admin.ts` | `remoteClient` |
| `piece/src/ops/pieces-controller.ts` | `remoteClient` (trust provenance stays a visible delta) |
| `runtime-client/backends/runtime-processor.ts` | `browserWorker` (host `InitializationData` → params mapper) |
| `cli/lib/test-runner.ts` | `patternTest` |
| `cli/lib/multi-user-test-worker.ts` | `patternTest` |
| `generated-patterns/integration/pattern-harness.ts` | `patternTest` |
| `cli/lib/dev.ts` | `localDev` |
| `cli/lib/acl.ts` | `remoteClient` |
| `cli/lib/piece.ts` | `remoteClient` |
| `html/bench/worker-reconciler-mount.bench.ts` | `unitTest` |

`runtimeOptionsFromInitializationData` is reshaped into `browserWorkerParamsFromInitializationData` (data → preset params), so the processor's whole options object goes through the seal, callbacks included.

## Behavior changes (each deliberate, each toward uniformity)

1. **Non-canonical `EXPERIMENTAL_*` values are now ignored with a warning, uniformly.** Previously toolshed/bg-service coerced anything ≠ `"false"` to **true** while the CLI coerced anything ≠ `"true"` to **false** — so `EXPERIMENTAL_MODERN_CELL_REP=1` enabled the flag on toolshed and disabled it under `cf test`. Canonical `"true"`/`"false"`/unset behave exactly as before everywhere.
2. **The multi-user test worker and the generated-patterns harness now honor `EXPERIMENTAL_*`** like the single-user test-runner. Previously they silently ignored it, so the harness modes could run under different flags than the code under test (the CT-1811 flavor of drift, inside the harness family itself).
3. **cast-admin and `PiecesController` now honor `EXPERIMENTAL_*`** (parity with their environment class; `PiecesController` reads env only under Deno, mirroring its existing `PIECE_TRACE_TIMINGS` guard).
4. **Deployment-facing runtimes now pin `patternEnvironment` to their API base.** Previously `cf acl` / `cf piece` / cast-admin / `PiecesController` / bg-service main left it unset, so a pattern-relative fetch resolved against the builder's hardcoded `localhost:<toolshed-port>` fallback even when operating against a remote deployment (`setPatternEnvironment` is process-global; the builder default only fit local dev). bg-worker and toolshed already pinned it; test/dev presets deliberately keep the localhost fall-through.
5. **`EXPERIMENTAL_*` entries removed from toolshed and bg-service env schemas** — the construction sites read the canonical mapping directly (with a pointer comment left in each env.ts). bg-service's `createRuntime` takes an injectable `EnvReader` (mirroring its `loadEnv(source)` DI idiom), and its env tests moved accordingly.

**Non-changes:** the core `cfcEnforcementMode` pin (`"enforce-explicit"`) equals today's constructor default — the pin exists so a future default change cannot silently relax one environment. All other CFC dials remain constructor defaults (off), now flippable in one place. Test presets keep `patternEnvironment` on the builder default (local fall-through for unmocked fetches), matching today.

## Observations recorded, deliberately out of scope

- `commitPreconditions` (and `patternEnvironment`, and `modernCellRep`/`persistentSchedulerState`) propagate through **module-level globals** (`memory/v2`, `builder/env.ts`), so the *last constructed runtime in a process* wins. Pre-existing; the presets reduce practical exposure but the globals deserve their own look.
- `DEFAULT_CFC_ENFORCEMENT_MODE = "disabled"` (cfc/types.ts) names the *transaction-layer* default, which the runtime always overrides — a naming trap next to the actual runtime default (`"enforce-explicit"`).
- The shell keeps a **fourth** copy of the experimental mapping as build-time `$`-defines (`shell/src/lib/env.ts`, garbage → false). It feeds `browserWorker` as host data by design; unifying its parse/names onto `EXPERIMENTAL_ENV_VARS` is a small follow-up.
- `runtime-client/protocol/types.ts` declares its own inline copy of the experimental-flags shape (wire type; defensible, noted).
- **282 test files** still construct `Runtime` by hand; the `unitTest` preset exists so they can adopt incrementally (the three runner fixtures included). A phased lint rule (`new Runtime(` outside presets) remains an option; deliberately not in this PR.

## Verification

| Gate | Result |
| -- | -- |
| Conformance test (13 steps) | ✅ |
| Repo-wide `deno task check` | ✅ |
| fmt · lint | ✅ |
| runner full suite | 754 passed / 0 failed |
| cli full suite | 912 passed / 0 failed |
| background-piece-service suite | 12 passed / 0 failed |
| runtime-client suite | 29 passed / 0 failed |
| piece suite | 10 passed / 0 failed |
| toolshed suite | 57 passed / 0 failed |
| generated-patterns integration (via migrated harness) | 145 passed / 0 failed |
| pattern-tests sweep (`cf test packages/patterns`, incl. multi-user + CT-1811 regression) | 616 passed; 34 failures **byte-identical on clean main** (pre-existing `cf test <dir>` sibling-import resolution artifact — verified via a clean `origin/main` worktree running the same command; failure sets diff-identical) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first‑party runtime construction presets and a canonical `EXPERIMENTAL_*` env mapping in `@commonfabric/runner` to remove config drift across sites (CT‑1814). Migrates all first‑party construction sites and adds conformance tests that pin shared posture and flag wiring.

- **New Features**
  - `@commonfabric/runner/runtime-presets.ts`: exhaustive `RUNTIME_OPTION_KEYS`; canonical `EXPERIMENTAL_ENV_VARS` + `experimentalOptionsFromEnv(env)`; six presets — `productionServer`, `remoteClient`, `patternTest`, `localDev`, `browserWorker`, `unitTest` — exported via `@commonfabric/runner` index; conformance tests cover per‑key treatment and delta routing.
  - Runtime‑client: `browserWorkerParamsFromInitializationData` feeds `runtimePresets.browserWorker`, threading `spaceHostMap` and pinning `patternEnvironment` to the host API.
  - Toolshed: options assembly extracted to `toolshedRuntimeOptions` (splits `MEMORY_URL`/`API_URL`, uses canonical flag mapping) with a unit test.
  - CLI/harness: `cf test` and the multi‑user worker use `runtimePresets.patternTest` (shared CFC pin, shared `moduleByteCache`, env‑honored flags); `cf dev` uses `localDev`; `cf acl`/`cf piece` use `remoteClient`. Bench uses `unitTest`.

- **Bug Fixes**
  - One strict, shared flag parser: only `"true"`/`"false"`/unset; garbage is ignored with a warning. Redundant parsers removed from toolshed, CLI, and background‑piece‑service.
  - Cast‑admin reads `EXPERIMENTAL_*` via its injected env reader; test pins the injected reader is consulted. Background‑piece‑service main reads flags via an injectable `EnvReader` and forwards them to workers; both use `productionServer`.
  - Harness parity: the multi‑user worker and generated‑patterns harness honor `EXPERIMENTAL_*` and use `runtimePresets.patternTest`; deployment‑facing clients pin `patternEnvironment` to their API base.

<sup>Written for commit 9b24c62f8ff73e4f9ea429af968c5dd3850d77d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

