### PR TITLE
feat(runner): reject $generated in user-supplied causes (build-time throw)

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -890,6 +890,9 @@ export interface ICreatable<C extends AnyBrandedCell<any>> {
   /**
    * Set a cause for this cell. Used to create a link when the cell doesn't have
    * one yet.
+   *
+   * Record causes may not use the top-level key `$generated` — it is
+   * reserved for system-generated causes and setting one throws.
    * @param cause - The cause to associate with this cell
    * @returns This cell for method chaining
    */

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
   type CellScope,
   type FactoryInput,
@@ -198,6 +199,36 @@ export function patternFromFrame<T, R>(
   );
 }
 
+/**
+ * Reject user-supplied causes carrying a top-level `$generated` record key.
+ *
+ * That key marks the causes the pattern builder mints itself
+ * (`{ $generated: N }`, plus `$kind` on streams and `name` on duplicate-name
+ * wraps): a user cause like `Cell.for({ $generated: 0 })` would deliberately
+ * mimic that namespace, and keeping the namespaces disjoint is what lets the
+ * partial-cause assignment in `factoryFromPattern` skip collision checks for
+ * generated causes entirely. `$generated` alone suffices — every builder-minted
+ * cause carries it, so a cause without it can never hash-equal one (`$kind`
+ * and other sigil-looking keys stay usable). Only the top level matters —
+ * causes collide as whole records under the canonical value hash, and every
+ * builder-minted cause is a flat record, so a `$generated` nested deeper can
+ * never equal one.
+ *
+ * Enforced at the single intake point (`Cell.for`, the only writer of
+ * `_causeContainer.cause`) and re-asserted at the assignment site that relies
+ * on it.
+ */
+export function assertNoReservedCauseKeys(cause: unknown): void {
+  if (isRecord(cause) && "$generated" in cause) {
+    throw new Error(
+      `Cannot use cause ${
+        toCompactDebugString(cause)
+      }: top-level key "$generated" is reserved\n` +
+        `help: "$generated" marks system-generated cell causes; rename the key`,
+    );
+  }
+}
+
 function factoryFromPattern<T, R>(
   argumentSchemaArg: JSONSchema | undefined,
   resultSchemaArg: JSONSchema | undefined,
@@ -308,19 +339,19 @@ function factoryFromPattern<T, R>(
   };
 
   const assignedInternalPartialCauses = new Map<OpaqueCell<any>, JSONValue>();
-  // Canonical keys of the causes already assigned. Testing a candidate cause for
-  // collision is then an O(1) `Set` lookup instead of a `deepEqual` scan over
-  // every previously-assigned cause — the scan made this loop O(N²) in the number
-  // of internal cells (negligible for small patterns, but a scaling cliff for
-  // large ones, and it runs on every pattern instantiation, not just at boot).
-  const assignedCauseKeys = new Set<string>();
-  // The canonical value hash is exactly the collision test the previous
-  // `deepEqual` scan performed: records hash key-order-insensitively (keys are
-  // fed in sorted UTF-8 byte order), numbers hash by their float64 bits with a
-  // dedicated `-0` cache entry, and `NaN` hashes canonically — i.e. `Object.is`
-  // primitive semantics and order-insensitive records, matching `deepEqual` on
-  // the JSON values causes are made of.
-  const causeKey = (cause: JSONValue): string => hashStringOf(cause);
+  // Canonical keys of the NAMED causes already assigned. Only named causes need
+  // collision handling: `.for()` rejects reserved keys at intake
+  // (`assertNoReservedCauseKeys`), so no user-supplied cause carries
+  // `$generated` — which makes every cause minted by
+  // `nextAnonymousPartialCause` (per-build-unique counter) and every
+  // `{name, $generated}` disambiguation wrap collision-free by construction:
+  // no check, no set entry. A candidate name's collision test is an O(1) `Set`
+  // lookup on `hashStringOf` — the canonical value hash, which is exactly
+  // `deepEqual`'s comparison on the JSON values causes are made of: records
+  // hash key-order-insensitively (keys fed in sorted UTF-8 byte order), numbers
+  // by their float64 bits with a dedicated `-0` cache entry, and `NaN`
+  // canonically — i.e. `Object.is` primitive semantics.
+  const assignedNamedCauseKeys = new Set<string>();
   let anonymousPartialCauseCount = 0;
   const nextAnonymousPartialCause = (isStream: boolean): JSONObject => {
     const generated = { $generated: anonymousPartialCauseCount++ };
@@ -336,19 +367,29 @@ function factoryFromPattern<T, R>(
     }
 
     const isStream = isRecord(value) && value.$stream === true;
-    let partialCause = name === undefined
-      ? nextAnonymousPartialCause(isStream)
-      : name as JSONValue;
-    let key = causeKey(partialCause);
-    while (assignedCauseKeys.has(key)) {
-      const generated = nextAnonymousPartialCause(isStream);
-      partialCause = name === undefined
-        ? generated
-        : { name: name as JSONValue, ...generated };
-      key = causeKey(partialCause);
+    let partialCause: JSONValue;
+    if (name === undefined) {
+      partialCause = nextAnonymousPartialCause(isStream);
+    } else {
+      // `.for()` already rejected reserved keys; re-assert at the assignment
+      // site because the no-collision-check reasoning above relies on it (a
+      // future second writer of causes must not silently void it).
+      assertNoReservedCauseKeys(name);
+      const key = hashStringOf(name as JSONValue);
+      if (assignedNamedCauseKeys.has(key)) {
+        // Duplicate name: disambiguate with a fresh generated counter. The
+        // wrap is unique by construction and unforgeable (user causes can't
+        // carry `$generated`), so it needs no re-check and no set entry.
+        partialCause = {
+          name: name as JSONValue,
+          ...nextAnonymousPartialCause(isStream),
+        };
+      } else {
+        assignedNamedCauseKeys.add(key);
+        partialCause = name as JSONValue;
+      }
     }
     assignedInternalPartialCauses.set(top, partialCause);
-    assignedCauseKeys.add(key);
   });
 
   const cellReferenceForCell = (

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -36,7 +36,7 @@ import { checkSqliteRowLabelWrite } from "./builtins/sqlite/row-label-write.ts";
 import { recordSinkRequestPolicyInput } from "./cfc/sink-request.ts";
 import { cfcLabelViewForCell } from "./cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "./cfc/observation.ts";
-import { getTopFrame } from "./builder/pattern.ts";
+import { assertNoReservedCauseKeys, getTopFrame } from "./builder/pattern.ts";
 import { createNodeFactory, lift } from "./builder/module.ts";
 import {
   type AnyCell,
@@ -753,6 +753,9 @@ export class CellImpl<T extends FabricValue>
    * Set a cause for this cell. This is used to create a link when the cell doesn't have one yet.
    * This affects all sibling cells (created via .key(), .asSchema(), .withTx()) since they
    * share the same container.
+   *
+   * Record causes may not use the top-level key `$generated` — it is
+   * reserved for system-generated causes.
    * @param cause - The cause to associate with this cell
    * @param allowIfSet - If true, treat as suggestion and silently ignore if cause already set. If false (default), throw error if cause already set.
    * @returns This cell for method chaining
@@ -770,6 +773,11 @@ export class CellImpl<T extends FabricValue>
         );
       }
     }
+
+    // Reject reserved keys before the cause can take effect: a user cause
+    // carrying a top-level `$generated` key would mimic the pattern builder's
+    // generated-cause namespace.
+    assertNoReservedCauseKeys(cause);
 
     // Store the cause in the shared container - all siblings will see this
     this._causeContainer.cause = cause;

--- a/packages/runner/test/cell-optional-link.test.ts
+++ b/packages/runner/test/cell-optional-link.test.ts
@@ -93,6 +93,66 @@ describe("Cell with Optional Link", () => {
       // Should return a cell (even without link)
       expect(result).toBeDefined();
     });
+
+    describe("reserved cause keys", () => {
+      it("rejects a top-level $generated key in record causes", () => {
+        const cell = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(() => cell.for({ $generated: 0 })).toThrow(
+          'top-level key "$generated" is reserved',
+        );
+        const cell2 = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(() => cell2.for({ $kind: "stream", $generated: 1 })).toThrow(
+          "is reserved",
+        );
+      });
+
+      it("reserves only $generated, not other $-prefixed keys", () => {
+        // Every builder-minted cause carries `$generated`, so a cause without
+        // it can never collide with one — other sigil-looking keys stay legal.
+        const cell = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(cell.for({ $kind: "stream" })).toBe(cell);
+        const cell2 = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(cell2.for({ $anythingElse: true })).toBe(cell2);
+      });
+
+      it("allows $generated nested below the top level", () => {
+        const cell = new CellImpl(runtime, tx, { path: [], space }, false);
+        // Nested keys can never collide with the flat generated causes
+        expect(cell.for({ outer: { $generated: 0 } })).toBe(cell);
+      });
+
+      it("leaves non-record causes untouched", () => {
+        const a = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(a.for("$generated")).toBe(a); // a string, not a record key
+        const b = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(b.for(["$generated", 0])).toBe(b); // array elements aren't keys
+        const c = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(c.for(42)).toBe(c);
+      });
+
+      it("stays a silent no-op when the cause is already set (allowIfSet)", () => {
+        const existingCell = runtime.getCell<number>(
+          space,
+          "test-cell-reserved-ignored",
+          undefined,
+          tx,
+        );
+        existingCell.set(42);
+
+        // The reserved cause never takes effect on this cell, so the
+        // suggestion path stays a no-op rather than throwing.
+        const result = existingCell.for({ $generated: 0 }, true);
+        expect(result).toBe(existingCell);
+        expect(existingCell.get()).toBe(42);
+      });
+
+      it("rejects reserved keys on a fresh cell even with allowIfSet", () => {
+        const cell = new CellImpl(runtime, tx, { path: [], space }, false);
+        expect(() => cell.for({ $generated: 0 }, true)).toThrow(
+          "is reserved",
+        );
+      });
+    });
   });
 
   describe(".key() without link", () => {

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -151,6 +151,49 @@ describe("pattern", () => {
     ]);
   });
 
+  it("rejects a reserved $generated key in user-supplied causes at build time", () => {
+    const isPositive = lift((value: number) => value > 0);
+
+    // A user cause carrying `$generated` would mimic the anonymous-cause
+    // namespace — the build throws at the `.for()` call.
+    expect(() =>
+      pattern(() => {
+        const sneaky = (isPositive(1) as any).for({ $generated: 0 });
+        return { sneaky };
+      })
+    ).toThrow('top-level key "$generated" is reserved');
+
+    expect(() =>
+      pattern(() => {
+        const sneaky = (isPositive(1) as any).for({
+          $kind: "stream",
+          $generated: 0,
+        });
+        return { sneaky };
+      })
+    ).toThrow("is reserved");
+  });
+
+  it("accepts record causes without a top-level $generated key", () => {
+    const isPositive = lift((value: number) => value > 0);
+
+    const testPattern = pattern(() => {
+      // Nested `$generated` can't collide with the flat generated causes, and
+      // only `$generated` is reserved — other `$`-keys stay legal.
+      const nested = (isPositive(1) as any).for({ outer: { $generated: 0 } });
+      const sigilish = (isPositive(2) as any).for({ $kind: "stream" });
+      return { nested, sigilish };
+    });
+
+    // Both records flow through as partial causes unchanged.
+    expect((testPattern.result as any).nested.$alias.partialCause).toEqual({
+      outer: { $generated: 0 },
+    });
+    expect((testPattern.result as any).sigilish.$alias.partialCause).toEqual({
+      $kind: "stream",
+    });
+  });
+
   it("complex pattern has correct schema and nodes", () => {
     const doublePattern = pattern<{ x: number }>(({ x }) => {
       const double = lift<number>((x) => x * 2);


### PR DESCRIPTION
## What

Reject user-supplied cell causes carrying a top-level `$generated` record key —
throw at `.for()` time with a clear "reserved key" message. Follow-up to #4447,
proposed by @ubik2 in review (CT-1822).

A user cause like `Cell.for({ $generated: 0 })` deliberately mimics the
anonymous-cause namespace the pattern builder mints for itself
(`{ $generated: N }`, `{ $generated: N, $kind: "stream" }`, and the
`{ name, $generated: N }` duplicate-name wrap). The O(1) dedup shipped in #4447
handles the mimicry silently, but the "deceptively named cause" confusion class
stays alive. Rejecting `$generated` at intake deletes the class at the root.

### The contract (scope per review discussion)

- **Reserved: exactly `$generated`.** Every builder-minted cause carries it, so
  a cause without it can never hash-equal one — that alone restores
  collision-freedom. Other sigil-looking keys (`$kind`, `/Map@1`-style magic
  values, etc.) stay legal.
- **Top-level only:** causes collide as whole records under the canonical value
  hash, and every builder-minted cause is a flat record — a `$generated` nested
  deeper can never equal one, so deep-checking would tax every `.for()` for no
  safety.
- **Enforced at the single funnel:** `Cell.for()` (cell.ts) is the only writer
  of `_causeContainer.cause`, which is exactly what `factoryFromPattern` reads
  back as `export().name`. Throwing there gives the error at the user's own
  `.for()` call site and also covers runtime causes feeding `createRef`. The
  assignment site re-asserts the invariant it relies on (defense against a
  future second writer).
- **`allowIfSet` suggestion path stays a no-op:** a reserved-key cause that is
  ignored (cause already set) never takes effect, so it doesn't throw — pinned
  by test.

### Error surfacing (sanity-checked per review ask)

`cf check` on a pattern using `new Writable(0).for({ $generated: 0 })` prints
the message + help line verbatim, with the stack pointing at the user's own
`.for()` call (`<pattern>.tsx:5:45`), and exits 1:

```
Error: Cannot use cause {"$generated":0}: top-level key "$generated" is reserved
help: "$generated" marks system-generated cell causes; rename the key
  at assertNoReservedCauseKeys (packages/runner/src/builder/pattern.ts:223:11)
  at CellImpl.for (packages/runner/src/cell.ts:780:5)
    at exports.default.type (/fid1:…/pattern.tsx:5:45)
```

### The payoff (why the ticket exists)

With user causes unable to carry `$generated`, every builder-minted cause is
collision-free **by construction** (per-build-unique counter, unforgeable
namespace). The partial-cause assignment loop loses its collision handling for
generated causes entirely:

- anonymous causes: assigned directly, no check, no set entry;
- named causes: one `Set` lookup; on duplicate, wrap once with a fresh counter —
  no re-check loop;
- only named causes enter the dedup set.

Cause sequences are bit-identical to the old loop for all now-legal inputs
(the counter burns in the same order), so no cell identity moves — confirmed by
the existing partial-cause pins and the pattern-tests/generated-patterns
integration suites.

## Semantic change (why not folded into #4447)

Previously-valid builds now throw: any pattern calling `.for()` with a record
cause carrying a top-level `$generated`. A repo-wide sweep (all
`$generated`/`$kind` occurrences + classification of all 274 `.for()` call
sites, including every transformer-emitted cause shape) found **zero** such
uses — the only `$generated` occurrences are the implementation and test
assertions on generated output.

## Tests

- Rejection matrix on `Cell.for`: `{$generated}` and `{$kind, $generated}`
  throw; `{$kind}` alone, arbitrary `$`-keys, nested `$generated`, strings,
  arrays, numbers pass; `allowIfSet` no-op path pinned; fresh-cell `allowIfSet`
  still throws.
- Builder path: reserved cause inside a `pattern(...)` body throws at build
  time; `{outer: {$generated}}` and `{$kind: "stream"}` flow through as partial
  causes unchanged.
- Duplicate-name wrap (`{ name, $generated: N }`) already pinned by
  "uniquifies repeated stable internal paths with schemas" — unchanged.

## Gates

- `deno fmt --check`, `deno lint`, `deno task check`: clean.
- Full runner suite: green (754+ tests, 0 failed).
- `deno task integration pattern-tests`: ✅ all 85 pattern tests passed.
- `deno task integration generated-patterns`: ✅ 145 passed / 0 failed.

Closes CT-1822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject user-supplied causes with a top-level "$generated" key by throwing at Cell.for(); this prevents deceptive collisions and lets the builder skip collision checks for generated causes. Implements CT-1822.

- **New Features**
  - Enforce reserved key: throw when a record cause has top-level "$generated" (checked in Cell.for(), re-asserted in the builder).
  - Scope: only "$generated", top-level only; nested "$generated" allowed; other "$"-keys allowed; non-record causes unaffected; allowIfSet remains a no-op if a cause already exists.
  - Builder simplification: generated causes are collision-free by construction; only named causes are deduped via a Set of value hashes.
  - Docs and tests: added API comment in `packages/api`, and tests in `packages/runner/test`.

- **Migration**
  - If any `.for({ $generated: ... })` exists, rename the key (e.g., to "generated").

<sup>Written for commit 5d73f453def87087864441f91194a2647be6f8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

