### PR TITLE
fix(runner): conflict catch-up, named-entity pull, and a write-set-sized write-back retry budget (CT-1824)

### DIFF
--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertExists, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertMatch,
+  assertThrows,
+} from "@std/assert";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   type EntityRef,
@@ -9,6 +14,7 @@ import { Database } from "@db/sqlite";
 import {
   applyCommit,
   close,
+  ConflictError,
   createBranch,
   deleteBranch,
   type Engine,
@@ -546,6 +552,88 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
         }),
       Error,
       "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+// CT-1824 contract: a stale-read ConflictError must name the conflicted
+// entity BOTH structurally (of/seq/conflictSeq — read in-process by
+// editWithRetry's pull) AND in the message with this exact shape — server
+// Error fields do not survive serialization to the browser, so the runner
+// client re-derives `of` by parsing the message (runner storage/v2.ts
+// toRejectedError). Changing either surface breaks conflict recovery for
+// blind writes.
+Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted entity structurally and in the message", async () => {
+  const { engine, path } = await createEngine();
+  const sessionId = "session:alice";
+  const principal = "did:key:alice";
+
+  try {
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:stale-named",
+          value: toEntityDocument({ v: 1 }),
+        }],
+      },
+    });
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:stale-named",
+          value: toEntityDocument({ v: 2 }),
+        }],
+      },
+    });
+
+    const error = assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 3,
+            reads: {
+              confirmed: [{
+                id: "entity:stale-named",
+                path: toDocumentPath(["value"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:stale-result",
+              value: toEntityDocument("late"),
+            }],
+          },
+        }),
+      ConflictError,
+    );
+    assertEquals(error.of, "entity:stale-named");
+    assertEquals(error.seq, 1);
+    assertEquals(error.conflictSeq, 2);
+    assertMatch(
+      error.message,
+      /^stale confirmed read: \S+ at seq \d+ conflicted with seq \d+$/,
+    );
+    // The exact parse the runner client performs on the wire-crossed message.
+    assertEquals(
+      error.message.match(/stale confirmed read: (\S+) at seq/)?.[1],
+      "entity:stale-named",
     );
   } finally {
     close(engine);

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -674,9 +674,21 @@ export interface Engine {
 }
 
 export class ConflictError extends Error {
-  constructor(message: string) {
+  /** Entity whose confirmed read went stale (stale-read conflicts only). */
+  readonly of?: string;
+  readonly seq?: number;
+  readonly conflictSeq?: number;
+  constructor(
+    message: string,
+    details?: { of: string; seq: number; conflictSeq: number },
+  ) {
     super(message);
     this.name = "ConflictError";
+    if (details !== undefined) {
+      this.of = details.of;
+      this.seq = details.seq;
+      this.conflictSeq = details.conflictSeq;
+    }
   }
 }
 
@@ -3515,6 +3527,7 @@ const validateConfirmedReads = (
     if (conflictSeq !== null) {
       throw new ConflictError(
         `stale confirmed read: ${read.id} at seq ${read.seq} conflicted with seq ${conflictSeq}`,
+        { of: read.id, seq: read.seq, conflictSeq },
       );
     }
   }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1357,10 +1357,26 @@ export class PatternManager {
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncCompileCacheWriteTargets(space, modules, opts);
+    // The write-back re-writes source docs whose values carry quote-cell
+    // indirections (one derived doc per import edge). On a cold replica those
+    // derived docs are unknown, and each commit attempt discovers exactly ONE
+    // of them: the engine rejects on the first stale read, editWithRetry
+    // pulls that doc, and only then does the next attempt's diff reach the
+    // following one (CT-1824, live-traced on the browser rig — the system-app
+    // closure re-write conflicts on ~24 pre-existing edge docs, one per
+    // round). Convergence therefore needs one retry per pre-existing derived
+    // doc; the general DEFAULT_MAX_RETRIES (5) exhausts long before that and
+    // the cache never heals, so every later cold boot recompiles. Budget by
+    // the write set's edge count (source + compiled edge docs) with slack.
+    // Rounds are bounded by actual conflicts — a conflict-free write-back
+    // still commits on the first attempt — so the ceiling is only paid during
+    // recovery after a compiler-version bump.
+    const importEdges = modules.reduce((n, m) => n + m.imports.length, 0);
+    const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
     const { error } = await this.runtime.editWithRetry((tx) => {
       writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
       writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
-    });
+    }, writebackMaxRetries);
     logger.time(writebackStart, "compile-cache", "writeback");
     if (error) {
       logger.error("compile-cache-writeback-failed", () => [

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -37,6 +37,7 @@ import type {
   IStorageManager,
   IStorageProvider,
   MemorySpace,
+  URI,
 } from "./storage/interface.ts";
 import {
   type Cell,
@@ -892,9 +893,52 @@ export class Runtime {
       });
     }
     this.prepareTxForCommit(tx);
-    return tx.commit().then(({ error }) => {
+    return tx.commit().then(async ({ error }) => {
       if (error) {
         if (maxRetries > 0) {
+          // A CONFLICT means this replica is behind the authoritative
+          // version: re-running immediately re-reads the same stale local
+          // state and fails identically, so without waiting the retries all
+          // burn on one deterministic conflict (CT-1824 — the compile-cache
+          // write-back looped this way and stale-version pieces recompiled
+          // on every cold boot). The conflict carries the catch-up gate;
+          // await it so the retry runs against fresh state — same protocol
+          // as the scheduler's conflict handling (scheduler/action-run.ts).
+          // A readiness gate that rejects (session closed/replaced while
+          // waiting) is control flow, not an error: retry anyway and let
+          // commit produce the definitive outcome.
+          const readyToRetry =
+            (error as { readyToRetry?: () => unknown }).readyToRetry;
+          if (typeof readyToRetry === "function") {
+            try {
+              await readyToRetry();
+            } catch {
+              // Readiness aborted — the retry's commit decides.
+            }
+          }
+          // The catch-up gate advances the session past the conflicting
+          // commit, but a doc this replica never READ does not arrive with
+          // it — and a conflicted blind WRITE means exactly that (the
+          // compile-cache write-back rewrites derived docs a cold replica
+          // has never seen). Pull the named doc so the retry's write
+          // carries its true version instead of re-asserting seq 0.
+          const conflict = (error as {
+            conflict?: { space?: MemorySpace; of?: string };
+          }).conflict;
+          if (
+            conflict?.space !== undefined &&
+            typeof conflict.of === "string" &&
+            conflict.of !== "of:unknown"
+          ) {
+            try {
+              await this.storageManager.open(conflict.space).sync(
+                conflict.of as unknown as URI,
+                { path: [], schema: false },
+              );
+            } catch {
+              // Pull failed — the retry's commit decides.
+            }
+          }
           return this.editWithRetry<T>(fn, maxRetries - 1);
         } else {
           return { error };

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4,6 +4,7 @@ import {
   cloneWithValueAtPath,
 } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
+import type { Entity } from "@commonfabric/memory/interface";
 import {
   type ConflictError as IConflictError,
   type ConnectionError as IConnectionError,
@@ -2845,20 +2846,27 @@ const toRejectedError = (
   ) {
     const retryAfterSeq = (error as { retryAfterSeq?: unknown })?.retryAfterSeq;
     const readyToRetry = (error as { readyToRetry?: unknown })?.readyToRetry;
+    // The conflicted entity: structured field when the error is in-process;
+    // parsed from the message when it crossed the wire (Error fields do not
+    // survive serialization, the message does — its format is owned by
+    // memory/v2/engine.ts's ConflictError construction).
+    const staleReadOf = (error as { of?: unknown })?.of ??
+      message.match(/stale confirmed read: (\S+) at seq/)?.[1];
     const firstOperation = (commit as Partial<NativeStorageCommit>)
       .operations?.[0];
     const rejected: IConflictError = {
       name: "ConflictError",
       message,
       transaction: commit as Transaction,
-      // Diagnostic-only conflict descriptor: the storage layer surfaces a
-      // ConflictError by name/readyToRetry, not by inspecting these fields.
-      // `the`/`expected`/`actual` are placeholders; space and of are filled in
-      // so the debug log is accurate.
+      // Conflict descriptor: for stale-read conflicts `of` is authoritative
+      // (the memory engine names the conflicted entity structurally), so a
+      // retrier can pull exactly that doc before re-running (CT-1824).
+      // `the`/`expected`/`actual` remain placeholders.
       conflict: {
         space,
         the: DOCUMENT_MIME,
-        of: firstOperation?.id ?? "of:unknown",
+        of: ((typeof staleReadOf === "string" ? staleReadOf : undefined) ??
+          firstOperation?.id ?? "of:unknown") as Entity,
         expected: null,
         actual: null,
         existsInHistory: false,

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -1,0 +1,206 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import { setCompileCacheRuntimeVersionForTesting } from "../src/compilation-cache/cell-cache.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+// Shared-server helper (same shape as cell-cache.test.ts): several managers —
+// each a SEPARATE client replica — over ONE in-process memory server, so a
+// fresh runtime is genuinely cold the way a fresh browser worker is.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager._sharedServer = server;
+    return manager;
+  }
+  private _sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this._sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const signer = await Identity.fromPassphrase("writeback conflict test");
+const space = signer.did();
+
+// CT-1824 regression: a runtime-version bump sends loads through the
+// cold-load recovery path (recompile + write-back). The write-back re-writes
+// version-independent source docs whose cell-layer-derived documents (link/
+// import-edge cells) already exist from the original compile — documents a
+// cold replica has never read. The commit then carries stale seq-0 reads and
+// fails with a ConflictError; before the fix, editWithRetry re-ran
+// immediately against the same stale replica, so every retry failed
+// identically, the compiled cache never healed, and EVERY subsequent cold
+// boot recompiled. The conflict's `readyToRetry` catch-up gate is the
+// designed remedy; editWithRetry must await it like the scheduler does
+// (scheduler/action-run.ts).
+describe("compile-cache write-back after a runtime-version bump", () => {
+  it("recovery write-back persists despite pre-existing docs on a cold replica", async () => {
+    const server = newSharedServer();
+    const program = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "const inc = lift((x:number)=>x+1);",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: inc(value) };",
+          "});",
+        ].join("\n"),
+      }],
+    };
+
+    // Version A: compile + persist (source docs, their derived link cells,
+    // and compiled docs keyed under vA).
+    const restoreVersion = setCompileCacheRuntimeVersionForTesting(
+      "test-version-A",
+    );
+    const smA = SharedServerStorageManager.connectTo(server, { as: signer });
+    const runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: smA,
+    });
+    let smB: SharedServerStorageManager | undefined;
+    let runtimeB: Runtime | undefined;
+    let smC: SharedServerStorageManager | undefined;
+    let runtimeC: Runtime | undefined;
+    try {
+      const txA = runtimeA.edit();
+      const compiled = await runtimeA.patternManager.compilePattern(program, {
+        space,
+        tx: txA,
+      });
+      const ref = runtimeA.patternManager.getArtifactEntryRef(compiled)!;
+      const entryIdentity = ref.identity;
+      const symbol = ref.symbol;
+      await runtimeA.patternManager.flushCompileCacheWrites();
+      await txA.commit();
+      await smA.synced();
+
+      // Version B ("the compiler shipped"): a COLD replica finds no compiled
+      // docs under vB and takes the recovery path — recompile, then write
+      // back source docs (which already exist server-side, with their derived
+      // cells this replica has never read) plus compiled docs under vB.
+      setCompileCacheRuntimeVersionForTesting("test-version-B");
+      smB = SharedServerStorageManager.connectTo(server, { as: signer });
+      runtimeB = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smB,
+      });
+      const recovered = await runtimeB.patternManager.loadPatternByIdentity(
+        entryIdentity,
+        symbol,
+        space,
+      );
+      expect(recovered).toBeDefined();
+      // Proof B took the recovery path (a warm by-identity closure hit would
+      // have incremented byIdentityHits; recovery does not).
+      expect(runtimeB.patternManager.getCompileCacheStats().byIdentityHits)
+        .toBe(0);
+      // The write-back is fire-and-forget from the load's perspective; force
+      // it to settle so its outcome is observable.
+      await runtimeB.patternManager.flushCompileCacheWrites();
+      await smB.synced();
+
+      // Healing proof: a THIRD cold replica at vB warm-hits the compiled
+      // closure B wrote back — no recovery, no recompile. Before the fix,
+      // B's write-back died on a deterministic ConflictError (stale seq-0
+      // read of a pre-existing derived doc), so C recompiled again — and so
+      // did every cold boot after it, forever.
+      smC = SharedServerStorageManager.connectTo(server, { as: signer });
+      runtimeC = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smC,
+      });
+      const warm = await runtimeC.patternManager.loadPatternByIdentity(
+        entryIdentity,
+        symbol,
+        space,
+      );
+      expect(warm).toBeDefined();
+      expect(runtimeC.patternManager.getCompileCacheStats().byIdentityHits)
+        .toBeGreaterThan(0);
+    } finally {
+      restoreVersion();
+      await runtimeC?.dispose();
+      await runtimeB?.dispose();
+      await runtimeA.dispose();
+      await smC?.close();
+      await smB?.close();
+      await smA.close();
+      await server.close();
+    }
+  });
+});
+
+// Direct contract test for the fix: a conflict's `readyToRetry` catch-up gate
+// must be awaited BEFORE the retry re-runs, and the retry then succeeds.
+describe("editWithRetry conflict catch-up", () => {
+  it("awaits readyToRetry between attempts and then succeeds", async () => {
+    const server = newSharedServer();
+    const sm = SharedServerStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const events: string[] = [];
+    let commits = 0;
+    const fakeTx = () => ({
+      tx: {},
+      abort: () => {},
+      commit: () => {
+        commits++;
+        if (commits === 1) {
+          return Promise.resolve({
+            error: {
+              name: "ConflictError",
+              message:
+                "stale confirmed read: of:test at seq 0 conflicted with seq 9",
+              readyToRetry: () => {
+                events.push("caught-up");
+                return Promise.resolve();
+              },
+            },
+          });
+        }
+        return Promise.resolve({});
+      },
+    });
+    // deno-lint-ignore no-explicit-any
+    (runtime as any).edit = () => fakeTx();
+    // deno-lint-ignore no-explicit-any
+    (runtime as any).prepareTxForCommit = () => {};
+    try {
+      const result = await runtime.editWithRetry(() => {
+        events.push(`attempt-${commits + 1}`);
+      });
+      expect(result.error).toBeUndefined();
+      // The catch-up gate resolves BEFORE the second attempt runs.
+      expect(events).toEqual(["attempt-1", "caught-up", "attempt-2"]);
+    } finally {
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -204,3 +204,143 @@ describe("editWithRetry conflict catch-up", () => {
     }
   });
 });
+
+// The browser cold-boot shape of CT-1824 (live-traced on the rig): the
+// write-back's derived docs are discovered ONE per attempt — the engine
+// rejects on the first stale read, the retry pulls exactly that doc, and only
+// then does the next attempt's diff reach the following one. editWithRetry
+// must (a) pull the doc each conflict names so each round makes progress, and
+// (b) survive a pull or catch-up failure without giving up the round (the
+// retry's commit is the definitive outcome). Convergence takes one round per
+// pre-existing derived doc, which is why writeBackCompileCache passes a
+// budget sized to its write set instead of DEFAULT_MAX_RETRIES.
+describe("editWithRetry sequential conflict discovery", () => {
+  it("pulls each named doc and converges one doc per round", async () => {
+    const server = newSharedServer();
+    const sm = SharedServerStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const CONFLICTS = 8;
+    const pulls: string[] = [];
+    const provider = sm.open(space);
+    // deno-lint-ignore no-explicit-any
+    (provider as any).sync = (uri: string) => {
+      pulls.push(uri);
+      // Round 3's pull fails; the round must still proceed to its retry.
+      if (uri === "of:doc-3") {
+        return Promise.reject(new Error("pull failed"));
+      }
+      return Promise.resolve({ ok: {} });
+    };
+    let commits = 0;
+    const fakeTx = () => ({
+      tx: {},
+      abort: () => {},
+      commit: () => {
+        commits++;
+        if (commits <= CONFLICTS) {
+          const k = commits;
+          return Promise.resolve({
+            error: {
+              name: "ConflictError",
+              message:
+                `stale confirmed read: of:doc-${k} at seq 0 conflicted with seq ${
+                  10 + k
+                }`,
+              // Round 5's catch-up gate rejects (session churn); the retry
+              // must run anyway.
+              readyToRetry: () =>
+                k === 5
+                  ? Promise.reject(new Error("session replaced"))
+                  : Promise.resolve(),
+              conflict: {
+                space,
+                the: "application/json",
+                of: `of:doc-${k}`,
+                expected: null,
+                actual: null,
+                existsInHistory: false,
+                history: [],
+              },
+            },
+          });
+        }
+        return Promise.resolve({});
+      },
+    });
+    // deno-lint-ignore no-explicit-any
+    (runtime as any).edit = () => fakeTx();
+    // deno-lint-ignore no-explicit-any
+    (runtime as any).prepareTxForCommit = () => {};
+    try {
+      const result = await runtime.editWithRetry(() => {}, 64);
+      expect(result.error).toBeUndefined();
+      // One commit per conflict round plus the converging attempt.
+      expect(commits).toBe(CONFLICTS + 1);
+      // Every round pulled exactly the doc its conflict named, in order.
+      expect(pulls).toEqual(
+        Array.from({ length: CONFLICTS }, (_, i) => `of:doc-${i + 1}`),
+      );
+    } finally {
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+
+  it("exhausts the default budget when discovery outlasts it", async () => {
+    const server = newSharedServer();
+    const sm = SharedServerStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const provider = sm.open(space);
+    // deno-lint-ignore no-explicit-any
+    (provider as any).sync = () => Promise.resolve({ ok: {} });
+    let commits = 0;
+    const fakeTx = () => ({
+      tx: {},
+      abort: () => {},
+      commit: () => {
+        commits++;
+        return Promise.resolve({
+          error: {
+            name: "ConflictError",
+            message: `stale confirmed read: of:doc-${commits} at seq 0 ` +
+              `conflicted with seq ${10 + commits}`,
+            readyToRetry: () => Promise.resolve(),
+            conflict: {
+              space,
+              the: "application/json",
+              of: `of:doc-${commits}`,
+              expected: null,
+              actual: null,
+              existsInHistory: false,
+              history: [],
+            },
+          },
+        });
+      },
+    });
+    // deno-lint-ignore no-explicit-any
+    (runtime as any).edit = () => fakeTx();
+    // deno-lint-ignore no-explicit-any
+    (runtime as any).prepareTxForCommit = () => {};
+    try {
+      // With the general default (5 retries = 6 attempts), a write set with
+      // more never-read derived docs than that cannot converge — the CT-1824
+      // cold-boot loop. This is the behavior writeBackCompileCache's larger
+      // budget exists to clear.
+      const result = await runtime.editWithRetry(() => {});
+      expect(result.error).toBeDefined();
+      expect(commits).toBe(6);
+    } finally {
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
Stale-version pieces (deployed before a compiler-fingerprint bump) recompiled in-worker on EVERY cold boot (~1.4s vs ~190ms) because the recovery write-back died on deterministic ConflictErrors. Three layers, live-verified end to end on an isolated browser rig (CT-1824):

1. **`editWithRetry` awaits the conflict's `readyToRetry` catch-up gate** before re-running (the scheduler's established protocol). Previously every retry re-ran instantly against the same stale replica and the whole budget burned on one conflict.
2. **Stale-read ConflictErrors carry the conflicted entity** (`memory/v2` `ConflictError.of/seq/conflictSeq`), the client normalization prefers the structured field and falls back to parsing the message (server `Error` fields do not survive the wire; the message does), and `editWithRetry` pulls that doc before retrying so a blind write can learn the doc's true version.
3. **`writeBackCompileCache` sizes its retry budget to its own write set** (import-edge count) instead of `DEFAULT_MAX_RETRIES` (5). The engine reveals ONE stale confirmed read per attempt, and the write-back's pre-existing derived quote docs (one per import edge) are discoverable only one per round — the next one only enters the diff's reach after the previous is client-known (live-traced; pulling the *entire* asserted set per round changes nothing). The system-app closure carries ~24 such docs, so the general budget could never converge. Rounds are conflict-bounded: a healthy write-back still commits on attempt 1.

**Live proof (rig, stale piece):** with layers 1+2 only — six rounds, six *different* conflicted docs, budget exhausted, cache never heals. With 3 — 23 healing rounds, write-back committed, and the next cold boot is clean: no recovery, no recompile, no conflicts.

**Why the two-runtime fixture in `compile-cache-writeback-conflict.test.ts` does not reproduce the cold gap:** its closure sync warms the derived docs. It stays as the healing-property guard; the `editWithRetry` contract tests pin the per-round mechanics directly (catch-up ordering, per-round named-doc pull, pull/catch-up failure tolerance, default-budget exhaustion), and the engine test pins the structured + message error contract the client depends on.

Remaining structural questions (server-side traversal emitting quote docs as entities; catch-up delivering conflict-staged unwatched ids; multi-stale-read reporting) are posed to the storage owners on CT-1824 — none block this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
