### PR TITLE
fix(cli): point cli task's --config flag at deno.jsonc

### DIFF
--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -1,7 +1,7 @@
 {
   "name": "@commonfabric/cli",
   "tasks": {
-    "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.json --cli-entrypoint ./mod.ts --",
+    "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.jsonc --cli-entrypoint ./mod.ts --",
     "cli-no-pwd-override": "CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env --allow-net=127.0.0.1 test/*.test.ts support",
     "integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/integration.sh",


### PR DESCRIPTION
The cli task in packages/cli/deno.jsonc passed --config ../../deno.json, but the repo root config file is deno.jsonc. The launcher's own default already resolves to deno.jsonc, so this only mattered when the task's explicit flag overrode that default, sending the CLI harness looking for a config file that doesn't exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `cli` task to pass `--config ../../deno.jsonc` (the repo root file) instead of `../../deno.json`, preventing missing-config errors when running `@commonfabric/cli`.

<sup>Written for commit 496a07bdcec4af321758831ae60490f06dc333c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

