### PR TITLE
docs(ts-transformers): document the unit-test harnesses and assertion…

### DIFF
--- a/packages/ts-transformers/README.md
+++ b/packages/ts-transformers/README.md
@@ -104,6 +104,17 @@ Run it from the repository root, targeting a pattern that lives in the workspace
 transform. Add `--no-run` to emit the transformed output without running the
 pattern.
 
+### Unit Tests
+
+Most other `*.test.ts` files under `test/` are unit tests that drive a single
+transformer function or the full pipeline directly and assert on the result,
+rather than comparing against a golden file. See
+[test/README.md](test/README.md) for the two harnesses (driving an exported
+function directly vs. `transformSource`/`validateSource`) and the convention for
+asserting on emitted code: parse the output back into an AST via
+`test/transformed-ast.ts` and assert on real nodes or evaluated schema values,
+not printed-text substrings.
+
 ### Adding New Transformations
 
 1. Create `test/fixtures/closures/my-new-case.input.tsx` with the natural

--- a/packages/ts-transformers/test/README.md
+++ b/packages/ts-transformers/test/README.md
@@ -1,0 +1,72 @@
+# Unit Tests
+
+Most `*.test.ts` files in this directory (and its subdirectories, e.g. `ast/`,
+`policy/`, `closures/`) are ordinary unit tests: each drives a piece of the
+transformer directly and asserts on what it returns or emits.
+
+This is distinct from the golden/snapshot tests in `test/fixtures/` — see
+[fixtures/README.md](fixtures/README.md) for that convention — and from the
+one-shot investigation scripts in `test/diagnostics/` — see
+[diagnostics/README.md](diagnostics/README.md).
+
+## Two harnesses
+
+**A. Drive an exported function directly.** Most `src/ast/*.ts` and
+`src/policy/*.ts` modules export pure functions that take a `ts.Node` and a
+`ts.TypeChecker`. Build a `ts.Program` from an in-memory source string, locate
+the node, call the function, assert on the result. See `ast/call-kind.test.ts`,
+`ast/dataflow.test.ts`, and `policy/capability-analysis.test.ts` for the
+program/host setup and node-finding helpers — copy the setup from the closest
+existing test for your source file rather than inventing a new one.
+
+**B. Drive the full pipeline.** `utils.ts` exports two entry points: a
+`transformSource` function returning the transformed output string, and a
+`validateSource` function returning the diagnostics and output together. Both
+take a source string and a `types` option. Use these for diagnostic/validation
+transformers and for whole-file transform behavior. `commonfabric-test-types.ts`
+exports `COMMONFABRIC_TYPES`, the `commonfabric.d.ts`/`cfc.ts` type definitions
+used by harness B and by any harness-A program that needs to resolve
+`Cell`/`Reactive` branded types.
+
+## Assert on structure, not printed text
+
+A test that checks the compiler's output with a printed-text substring match
+(e.g. `assertStringIncludes`) is weaker than it looks:
+
+- The printer preserves authored comments, so a substring can be satisfied by a
+  comment in the input rather than by anything the transformer emitted.
+- If the expected substring already appears verbatim in the input, a transform
+  that did nothing at all still passes.
+
+`transformed-ast.ts` exists to close both gaps. It parses the transformer's
+output back into a `ts.SourceFile` — parsing discards comments as trivia — and
+exposes typed queries over the result:
+
+- `collect`, `callsNamed`/`callsMatching`, `calleeName` — find emitted calls by
+  name or pattern.
+- `iifeCalls`, `isImmediatelyInvokedFunction` — find immediately-invoked
+  function expressions (e.g. to check whether an authored IIFE survived a
+  rewrite or was replaced).
+- `hasKeyPathRead(root, segment, receiver?)` — check for the lowered
+  `<receiver>.key("segment")` reactive path read.
+- `forCauses(root)` — the evaluated first argument of every emitted
+  `.for(cause, true)` stable-cause call.
+- `literalToValue`, `emittedSchemas`, `patternSchemas`, `callSchemas` — evaluate
+  an emitted `... as const satisfies ...JSONSchema` object literal (or a whole
+  `pattern(cb, input, output)` / `handler(cb, event, state)` /
+  `lift(cb, input, result)` call's schema arguments) into a real JS value, so a
+  test can assert `schema.properties.name.type === "string"` instead of matching
+  printed text.
+- `extractedCallbackBody(root, variableName)` — isolate the body of an extracted
+  callback (e.g. the hoisted `__cfPattern_1` map callback) for focused
+  assertions.
+
+Use these — or add a new query to `transformed-ast.ts` when a test needs one
+that doesn't exist yet — for any assertion that inspects emitted code or an
+emitted schema.
+
+**The one legitimate exception is a diagnostic, error, or analyzer-reason
+message.** There the message text _is_ the contract the test is pinning, not
+incidental printed code, so a substring match against a diagnostic's message, a
+caught error's `.message`, or an analyzer's returned reason string is the right
+check and should stay a string match.


### PR DESCRIPTION
… convention

PR #4463 converted printed-text substring checks across the test suite to structural AST/schema-value assertions and added test/transformed-ast.ts as the shared helper for doing so, but the convention itself lived only in commit messages. Write it down where the next test author will actually see it, following this package's existing test/fixtures/README.md and test/diagnostics/README.md convention of a README per test style.

Add test/README.md covering:

- The two unit-test harnesses: driving an exported AST/policy function directly against a hand-built ts.Program, versus driving the full pipeline through transformSource/validateSource.
- Why a printed-text substring match is weaker than it looks (the printer preserves comments, so a stray comment can satisfy it; a substring already present in the input source passes even a no-op transform).
- The transformed-ast.ts queries to use instead, with what each one answers.
- The one legitimate exception: a diagnostic/error/analyzer-reason message, where the message text is the contract being pinned, not incidental printed code.

Add a short pointer to it from the package README's Development section, next to the existing Fixture-Based Testing section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the unit-test harnesses and assertion conventions for `ts-transformers`, steering tests to assert on AST structure or evaluated schema values instead of printed text. Adds `test/README.md` covering the two harnesses and `test/transformed-ast.ts` queries, plus a pointer in `README.md`; diagnostic messages remain the only valid string-match case.

<sup>Written for commit fd9c26e86a46ee207ed34eeee8f53a4175b8e8c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

