### PR TITLE
fix(patterns): empty-string guards in profile setName/setAvatar (CT-1828)

### DIFF
--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -17,6 +17,11 @@ export default pattern(() => {
     profile.setAvatar.send({ avatar: "AL" });
   });
 
+  // CT-1828: same empty-after-trim guard applies to setAvatar.
+  const action_clear_avatar = action(() => {
+    profile.setAvatar.send({ avatar: "" });
+  });
+
   // CT-1748 note: the presentation-vs-edit *content* lives behind `ifElse`, and
   // [UI] vnode traversal doesn't resolve through this test harness's `.get()`,
   // so the toggle is asserted via the exported `isEditing` and the bound data
@@ -31,6 +36,10 @@ export default pattern(() => {
   // The avatar the badge binds resolves (single context — owner-protected reads
   // are clean here; cross-stamp masking is the browser-only CT-1740 issue).
   const assert_avatar_set = computed(() => profile.avatar === "AL");
+  // CT-1828: an empty send must not clear a previously-set avatar.
+  const assert_avatar_unchanged_after_empty = computed(() =>
+    profile.avatar === "AL"
+  );
 
   const action_add_catalog_element = action(() => {
     profile.addElement.send({
@@ -56,8 +65,16 @@ export default pattern(() => {
     profile.removeElement.send({});
   });
 
+  // CT-1828: an empty (or whitespace-only) send must be a no-op — it must
+  // NOT clear the canonical name. Clearing here would fall back to the
+  // literal "Profile" display product-wide (unlike setBio, which is
+  // deliberately left clearable).
   const action_clear_name = action(() => {
     profile.setName.send({ name: "" });
+  });
+
+  const action_whitespace_name = action(() => {
+    profile.setName.send({ name: "   " });
   });
 
   const action_set_name = action(() => {
@@ -73,7 +90,11 @@ export default pattern(() => {
     profile.initialNameApplied === "Grace Hopper"
   );
 
-  const assert_name_cleared = computed(() => profile.initialNameApplied === "");
+  // The prior (non-empty) name must survive both an empty and a
+  // whitespace-only send.
+  const assert_name_unchanged_after_empty = computed(() =>
+    profile.initialNameApplied === "Grace Hopper"
+  );
 
   const assert_added_element = computed(() => {
     const element = profile.elements[0];
@@ -93,11 +114,17 @@ export default pattern(() => {
       { assertion: assert_not_editing },
       { action: action_set_name },
       { assertion: assert_name_set },
+      // CT-1828: empty and whitespace-only sends must not erase the name.
       { action: action_clear_name },
-      { assertion: assert_name_cleared },
+      { assertion: assert_name_unchanged_after_empty },
+      { action: action_whitespace_name },
+      { assertion: assert_name_unchanged_after_empty },
       // CT-1748: the avatar the badge binds resolves.
       { action: action_set_avatar },
       { assertion: assert_avatar_set },
+      // CT-1828: an empty send must not erase the avatar either.
+      { action: action_clear_avatar },
+      { assertion: assert_avatar_unchanged_after_empty },
       // Add/remove exercise the full owner-protected element write stack:
       // the same-transaction card instantiation linked into the
       // writeAuthorizedBy-protected list (prepare's setup-schema / child-doc

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -329,6 +329,13 @@ const setName = handler<SetProfileNameEvent, { name: Writable<string> }>(
     }
     const name = (event.name ?? event.detail?.message ??
       event.target?.value ?? "").trim();
+    // CT-1828: an empty (or whitespace-only) send is a no-op, not a clear.
+    // The canonical name display falls back to the literal "Profile" once
+    // empty, so blanking it here would erase it product-wide. Unlike bio,
+    // clearing a name is never intentional through this handler.
+    if (!name) {
+      return;
+    }
     state.name.set(name);
   },
 );
@@ -340,6 +347,10 @@ const setAvatar = handler<SetProfileAvatarEvent, { avatar: Writable<string> }>(
     }
     const avatar = (event.avatar ?? event.detail?.message ??
       event.target?.value ?? "").trim();
+    // CT-1828: same empty-after-trim guard as setName — see comment above.
+    if (!avatar) {
+      return;
+    }
     state.avatar.set(avatar);
   },
 );


### PR DESCRIPTION
## Why

Hitting send on an empty name or avatar box erases the canonical value product-wide — the display falls back to the literal "Profile" once the name is blanked. `setName` and `setAvatar` in `profile-home.tsx` trim the incoming value and call `.set()` unconditionally, so an accidental empty submit destroys the profile's identity with no undo. The create handler (`profile-create.tsx:90`) already guards against this (`if (name)`); the edit-time handlers did not. This becomes embedder-facing once Loom mounts the profile editor: https://github.com/commontoolsinc/loom/pull/3627.

## What

- Add an empty-after-trim guard to `setName` and `setAvatar` in `packages/patterns/system/profile-home.tsx`: if the trimmed value is empty, the handler returns (no-op) instead of writing `""`.
- `setBio` is deliberately left untouched and clearable — clearing a bio is a legitimate action; erasing a name or avatar is not.
- Extend `packages/patterns/system/profile-home.test.tsx` (the existing pattern-unit-test harness for this pattern) to cover the guard: an empty send and a whitespace-only send both leave the prior name/avatar intact, and a genuine non-empty send still writes.

Linear: CT-1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents empty name or avatar submissions from wiping a profile. Adds no-op guards so blank or whitespace input is ignored, aligning with Linear CT-1828.

- **Bug Fixes**
  - Add empty-after-trim guards in `packages/patterns/system/profile-home.tsx` for `setName` and `setAvatar` to avoid writing `""`.
  - Leave `setBio` clearable by design.
  - Extend `packages/patterns/system/profile-home.test.tsx` to cover empty/whitespace sends as no-ops and verify non-empty writes still apply.

<sup>Written for commit a58975358a822e89fd461193b52c6bdae75d13eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

