### PR TITLE
feat(ui): cancellable cf-open-external event for modifier-click new-tab navigation (CT-1830)

### DIFF
--- a/packages/shell/shared/navigate.ts
+++ b/packages/shell/shared/navigate.ts
@@ -29,6 +29,39 @@ export function navigate(command: NavigationCommand) {
   globalThis.dispatchEvent(new NavigationEvent(command));
 }
 
+const OpenExternalEventName = "cf-open-external";
+
+// Cancellable event dispatched before a modifier-click ("open in new tab")
+// builds a shell URL. An embedder (e.g. Loom) can host `cf-open-external` and
+// call `preventDefault()` to apply its own URL scheme; if the event is not
+// cancelled, the shell default runs (`appViewToUrlPath` + `globalThis.open`).
+// Mirrors the `cf-navigate` idiom so plain and modifier clicks are both
+// interceptable from a single, well-known event surface.
+class OpenExternalEvent extends CustomEvent<NavigationCommand> {
+  command: NavigationCommand;
+  constructor(command: NavigationCommand) {
+    super(OpenExternalEventName, { detail: command, cancelable: true });
+    this.command = command;
+  }
+}
+
+// Open a navigation target in a new tab. Dispatches a cancellable
+// `cf-open-external` event first; if a host cancels it via `preventDefault()`,
+// the host owns the new-tab navigation. Otherwise the shell default builds a
+// URL from the current location and calls `globalThis.open`.
+export function openInNewTab(command: NavigationCommand) {
+  const event = new OpenExternalEvent(command);
+  const proceed = globalThis.dispatchEvent(event);
+  if (!proceed) return;
+  const url = appViewToUrlPath(
+    preserveAppViewMode(
+      urlToAppView(new URL(globalThis.location.href)),
+      command,
+    ),
+  );
+  globalThis.open(url, "_blank", "noopener");
+}
+
 class ReplaceNavigationEvent extends CustomEvent<NavigationCommand> {
   command: NavigationCommand;
   constructor(command: NavigationCommand) {

--- a/packages/shell/test/navigate.test.ts
+++ b/packages/shell/test/navigate.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type NavigationCommand, openInNewTab } from "../shared/navigate.ts";
+
+// Exercises the `openInNewTab` helper that backs modifier-click ("open in new
+// tab") navigation for cf-cell-link, cf-profile-badge and cf-render (CT-1830).
+// The helper dispatches a cancellable `cf-open-external` event before building
+// a shell URL; a host cancels it via `preventDefault()` to apply its own URL
+// scheme, otherwise the shell default (`globalThis.open`) runs.
+
+// `openInNewTab` reads `globalThis.location.href` and calls `globalThis.open`.
+// Deno has neither unless configured, so stub both around the call and restore.
+function withStubbedEnv<T>(
+  href: string,
+  run: (calls: { openArgs: unknown[][] }) => T,
+): T {
+  const calls = { openArgs: [] as unknown[][] };
+  const hadLocation = "location" in globalThis &&
+    globalThis.location !== undefined;
+  // deno-lint-ignore no-explicit-any
+  const origLocation = (globalThis as any).location;
+  // deno-lint-ignore no-explicit-any
+  const origOpen = (globalThis as any).open;
+  Object.defineProperty(globalThis, "location", {
+    value: { href },
+    configurable: true,
+    writable: true,
+  });
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).open = (...args: unknown[]) => {
+    calls.openArgs.push(args);
+    return null;
+  };
+  try {
+    return run(calls);
+  } finally {
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).open = origOpen;
+    if (hadLocation) {
+      Object.defineProperty(globalThis, "location", {
+        value: origLocation,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      // deno-lint-ignore no-explicit-any
+      delete (globalThis as any).location;
+    }
+  }
+}
+
+describe("openInNewTab", () => {
+  const view: NavigationCommand = {
+    spaceDid: "did:key:zSpaceX",
+    pieceId: "fid1:pieceX",
+  };
+
+  it("dispatches a cancellable cf-open-external with the navigation target", () => {
+    let captured: NavigationCommand | undefined;
+    let cancelable = false;
+    const onOpen = (e: Event) => {
+      captured = (e as CustomEvent<NavigationCommand>).detail;
+      cancelable = e.cancelable;
+    };
+    globalThis.addEventListener("cf-open-external", onOpen);
+    try {
+      withStubbedEnv("http://localhost:8000/home", () => openInNewTab(view));
+    } finally {
+      globalThis.removeEventListener("cf-open-external", onOpen);
+    }
+    expect(captured).toEqual(view);
+    expect(cancelable).toBe(true);
+  });
+
+  it("falls through to globalThis.open when the event is not cancelled", () => {
+    const { openArgs } = withStubbedEnv(
+      "http://localhost:8000/home",
+      (calls) => {
+        openInNewTab(view);
+        return calls;
+      },
+    );
+    expect(openArgs.length).toBe(1);
+    const [url, target, features] = openArgs[0];
+    expect(String(url)).toContain("fid1:pieceX");
+    expect(target).toBe("_blank");
+    expect(features).toBe("noopener");
+  });
+
+  it("preventDefault() on the event suppresses globalThis.open", () => {
+    const onOpen = (e: Event) => e.preventDefault();
+    globalThis.addEventListener("cf-open-external", onOpen);
+    let openArgs: unknown[][];
+    try {
+      ({ openArgs } = withStubbedEnv(
+        "http://localhost:8000/home",
+        (calls) => {
+          openInNewTab(view);
+          return calls;
+        },
+      ));
+    } finally {
+      globalThis.removeEventListener("cf-open-external", onOpen);
+    }
+    expect(openArgs.length).toBe(0);
+  });
+});

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
@@ -13,12 +13,7 @@ import {
 } from "@commonfabric/runtime-client";
 import type { DID } from "@commonfabric/identity";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
-import {
-  appViewToUrlPath,
-  navigate,
-  preserveAppViewMode,
-  urlToAppView,
-} from "@commonfabric/shell/shared";
+import { navigate, openInNewTab } from "@commonfabric/shell/shared";
 import {
   createDragPreview,
   endDrag,
@@ -396,13 +391,7 @@ export class CFCellLink extends BaseElement {
 
       // Cmd (Mac) or Ctrl (Windows/Linux) opens in new tab
       if (e.metaKey || e.ctrlKey) {
-        const url = appViewToUrlPath(
-          preserveAppViewMode(
-            urlToAppView(new URL(globalThis.location.href)),
-            view,
-          ),
-        );
-        globalThis.open(url, "_blank");
+        openInNewTab(view);
       } else {
         navigate(view);
       }

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -392,6 +392,123 @@ describe("CFProfileBadge", () => {
       expect(navigated).toBe(false);
     });
 
+    it("cmd/ctrl-click dispatches cancellable cf-open-external (CT-1830)", async () => {
+      const resolved = navResolvedCell({
+        path: [],
+        space: "did:key:zSpaceX",
+        id: "fid1:profileX",
+      });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      const hadLocation = "location" in globalThis &&
+        globalThis.location !== undefined;
+      // deno-lint-ignore no-explicit-any
+      const origLocation = (globalThis as any).location;
+      // deno-lint-ignore no-explicit-any
+      const origOpen = (globalThis as any).open;
+      let captured: unknown;
+      let cancelable = false;
+      const onOpen = (e: Event) => {
+        captured = (e as CustomEvent).detail;
+        cancelable = e.cancelable;
+      };
+      Object.defineProperty(globalThis, "location", {
+        value: { href: "http://localhost:8000/home" },
+        configurable: true,
+        writable: true,
+      });
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).open = () => null;
+      globalThis.addEventListener("cf-open-external", onOpen);
+      try {
+        el._handleClick({
+          stopPropagation() {},
+          metaKey: true,
+          ctrlKey: false,
+          // deno-lint-ignore no-explicit-any
+        } as any);
+      } finally {
+        globalThis.removeEventListener("cf-open-external", onOpen);
+        // deno-lint-ignore no-explicit-any
+        (globalThis as any).open = origOpen;
+        if (hadLocation) {
+          Object.defineProperty(globalThis, "location", {
+            value: origLocation,
+            configurable: true,
+            writable: true,
+          });
+        } else {
+          // deno-lint-ignore no-explicit-any
+          delete (globalThis as any).location;
+        }
+      }
+
+      expect(captured).toEqual({
+        spaceDid: "did:key:zSpaceX",
+        pieceId: "fid1:profileX",
+      });
+      expect(cancelable).toBe(true);
+    });
+
+    it("preventDefault() on cf-open-external suppresses globalThis.open (CT-1830)", async () => {
+      const resolved = navResolvedCell({
+        path: [],
+        space: "did:key:zSpaceX",
+        id: "fid1:profileX",
+      });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      const hadLocation = "location" in globalThis &&
+        globalThis.location !== undefined;
+      // deno-lint-ignore no-explicit-any
+      const origLocation = (globalThis as any).location;
+      // deno-lint-ignore no-explicit-any
+      const origOpen = (globalThis as any).open;
+      let opened = false;
+      const onOpen = (e: Event) => e.preventDefault();
+      Object.defineProperty(globalThis, "location", {
+        value: { href: "http://localhost:8000/home" },
+        configurable: true,
+        writable: true,
+      });
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).open = () => {
+        opened = true;
+        return null;
+      };
+      globalThis.addEventListener("cf-open-external", onOpen);
+      try {
+        el._handleClick({
+          stopPropagation() {},
+          metaKey: true,
+          ctrlKey: false,
+          // deno-lint-ignore no-explicit-any
+        } as any);
+      } finally {
+        globalThis.removeEventListener("cf-open-external", onOpen);
+        // deno-lint-ignore no-explicit-any
+        (globalThis as any).open = origOpen;
+        if (hadLocation) {
+          Object.defineProperty(globalThis, "location", {
+            value: origLocation,
+            configurable: true,
+            writable: true,
+          });
+        } else {
+          // deno-lint-ignore no-explicit-any
+          delete (globalThis as any).location;
+        }
+      }
+
+      expect(opened).toBe(false);
+    });
+
     it("stays non-navigable when noNavigate is set, even on a root cell", async () => {
       // The profile-home self-badge is bound to a `computed()` projection that
       // happens to resolve as a root cell (path []) but is NOT a real piece, so

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -11,12 +11,7 @@ import {
   type RuntimeClient,
 } from "@commonfabric/runtime-client";
 import type { DID } from "@commonfabric/identity";
-import {
-  appViewToUrlPath,
-  navigate,
-  preserveAppViewMode,
-  urlToAppView,
-} from "@commonfabric/shell/shared";
+import { navigate, openInNewTab } from "@commonfabric/shell/shared";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
 import { ownerPrincipalFromLabel } from "../../core/cfc-label.ts";
 import { type IdentitySeal, identitySeal } from "./identity-seal.ts";
@@ -710,19 +705,13 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
    * cell is a navigable root piece. Mirrors cf-cell-link's navigation; Cmd/Ctrl
    * opens in a new tab.
    */
-  private _navigateToProfile(openInNewTab: boolean): void {
+  private _navigateToProfile(newTab: boolean): void {
     if (this.noNavigate) return;
     const cell = this._resolvedCell;
     if (!cell || cell.ref().path.length > 0) return;
     const view = { spaceDid: cell.space(), pieceId: cell.id() };
-    if (openInNewTab) {
-      const url = appViewToUrlPath(
-        preserveAppViewMode(
-          urlToAppView(new URL(globalThis.location.href)),
-          view,
-        ),
-      );
-      globalThis.open(url, "_blank", "noopener");
+    if (newTab) {
+      openInNewTab(view);
     } else {
       navigate(view);
     }

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -5,12 +5,7 @@ import { BaseElement } from "../../core/base-element.ts";
 import { render } from "@commonfabric/html/client";
 import type { CellHandle } from "@commonfabric/runtime-client";
 import { CHIP_UI, TILE_UI, type VNode } from "@commonfabric/runtime-client";
-import {
-  appViewToUrlPath,
-  navigate,
-  preserveAppViewMode,
-  urlToAppView,
-} from "@commonfabric/shell/shared";
+import { navigate, openInNewTab } from "@commonfabric/shell/shared";
 import "../cf-loader/index.ts";
 import "../cf-cell-link/index.ts";
 
@@ -359,13 +354,7 @@ export class CFRender extends BaseElement {
       };
       // Cmd (Mac) / Ctrl (Win/Linux) opens in a new tab.
       if (e.metaKey || e.ctrlKey) {
-        const url = appViewToUrlPath(
-          preserveAppViewMode(
-            urlToAppView(new URL(globalThis.location.href)),
-            view,
-          ),
-        );
-        globalThis.open(url, "_blank");
+        openInNewTab(view);
       } else {
         navigate(view);
       }


### PR DESCRIPTION
## Why

Plain clicks in `cf-cell-link`, `cf-profile-badge`, and `cf-render` tiles dispatch the interceptable `cf-navigate` event on `globalThis` — an embedder like Loom can host it and apply its own URL scheme. But **modifier-click** (cmd/ctrl → "open in new tab") did not: each component built a shell URL via `appViewToUrlPath` and called `globalThis.open()` directly, dispatching nothing.

That makes the new-tab path **un-interceptable** and a **guaranteed 404 on any non-shell origin**. Loom is shipping a server-side redirect as a stopgap (commontoolsinc/loom#3627); the right fix is upstream — make new-tab navigation interceptable the same way in-place navigation already is.

## What

- **New `openInNewTab(command)` helper** next to `navigate()` in `packages/shell/shared/navigate.ts` (re-exported through `@commonfabric/shell/shared`, where all three components already import `navigate`). It dispatches a **cancellable `cf-open-external`** event on `globalThis` (matching where `cf-navigate` is dispatched) carrying the same `AppView` detail (`{spaceDid|spaceName, pieceId}`) **before** URL construction.
  - A host cancels via `preventDefault()` and owns the navigation.
  - If not cancelled, the shell default runs: today's `appViewToUrlPath` + `globalThis.open` — **shell behavior unchanged, zero callback plumbing**.
- **All three components** (`cf-cell-link`, `cf-profile-badge`, `cf-render`) now call the one helper — no three copies of the URL-building logic. Their modifier-click branches collapse to `openInNewTab(view)`.
- **Event typing** mirrors the existing `cf-navigate` idiom: a `CustomEvent<NavigationCommand>` subclass (`OpenExternalEvent`), consistent with `NavigationEvent`/`ReplaceNavigationEvent`. (The repo does not use a `WindowEventMap`/`HTMLElementEventMap` augmentation for these — the pattern is a typed `CustomEvent` subclass + cast on the listener.)

### Event contract

- **Name:** `cf-open-external`
- **Detail:** `NavigationCommand` (= `AppView`, e.g. `{spaceDid, pieceId}`) — same shape as `cf-navigate`
- **Dispatch target:** `globalThis` (same as `cf-navigate`)
- **Cancelable:** yes — `preventDefault()` suppresses the default `globalThis.open`

### Deliberate unification

`cf-profile-badge` already passed `"noopener"` to `globalThis.open`; `cf-cell-link` and `cf-render` did not. The unified helper uses `globalThis.open(url, "_blank", "noopener")` for all three — `"noopener"` is strictly safer for externally-opened tabs.

## Tests

- `packages/shell/test/navigate.test.ts` (new) — covers the helper directly: dispatches a cancellable `cf-open-external` with the right detail; falls through to `globalThis.open` with `_blank` + `noopener` and the expected URL when not cancelled; `preventDefault()` suppresses `globalThis.open`.
- `packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts` — added two tests following the existing `cf-navigate`-contract idiom: modifier-click dispatches cancellable `cf-open-external` with the right detail; `preventDefault()` suppresses `globalThis.open`. The pre-existing new-tab test (default URL unchanged) still passes.

`deno fmt`, `deno lint`, `deno check`, and the touched-package tests all pass.

Linear: CT-1830
Loom stopgap: https://github.com/commontoolsinc/loom/pull/3627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make modifier-click “open in new tab” interceptable by dispatching a cancellable `cf-open-external` event, preventing 404s on non-shell origins. Default shell behavior stays the same; addresses Linear CT-1830.

- **New Features**
  - Added `openInNewTab(command)` in `packages/shell/shared/navigate.ts` (re-exported via `@commonfabric/shell/shared`). It dispatches cancellable `cf-open-external` on `globalThis` with `NavigationCommand` detail; hosts can `preventDefault()`. If not cancelled, falls back to `appViewToUrlPath` + `globalThis.open(url, "_blank", "noopener")`.
  - Updated `cf-cell-link`, `cf-profile-badge`, and `cf-render` to use the helper on cmd/ctrl-click. Unified new-tab opens to include `"noopener"` for all.

<sup>Written for commit 44508f545bd871a1ee4aab21430eb9936036b036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

