### PR TITLE
chore(runner): rename Cell value debug alias

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -404,7 +404,7 @@ declare module "@commonfabric/api" {
     runtime: Runtime;
     tx: IExtendedStorageTransaction | undefined;
     schema?: JSONSchema;
-    value: T;
+    __debugValue: T;
     cellLink: SigilLink;
     space: MemorySpace;
     entityId: EntityRef;
@@ -2538,7 +2538,7 @@ export class CellImpl<T extends FabricValue>
     return createSigilLinkFromParsedLink(this.link);
   }
 
-  get value(): T {
+  get __debugValue(): T {
     return this.get();
   }
 

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -409,6 +409,21 @@ describe("Cell", () => {
     expect(c.key("a").key("b").key("c").get()).toBe(42);
   });
 
+  it("should expose only the debug value alias", () => {
+    const cell = runtime.getCell<number>(
+      space,
+      "should expose only the debug value alias",
+      undefined,
+      tx,
+    );
+    cell.set(42);
+
+    expect(
+      (cell as unknown as { __debugValue: number }).__debugValue,
+    ).toBe(42);
+    expect("value" in cell).toBe(false);
+  });
+
   it("should get raw value using getRaw", () => {
     const cell = runtime.getCell<{ x: number; y: number }>(
       space,


### PR DESCRIPTION
CT-1635 tracks cleanup for CellImpl's debug-only value getter. The getter was added as a devtools convenience, but the public read API is get() and sample(), and authored pattern .value reads are transformed into .key("value").

Keeping the getter under value makes the runtime surface look like part of the author API even though authored cells cannot normally reach it. Rename the getter and runner cell type augmentation to __debugValue so devtools can still inspect a raw cell value without claiming the common value property.

Add a runner test that the new alias returns the cell value and that a raw Cell no longer has a value property.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Cell debug-only getter from value to __debugValue to avoid implying `.value` is part of the public API (use get()/sample()). Added a runner test verifying `.__debugValue` returns the value and that `.value` is absent; aligns with CT-1635.

<sup>Written for commit 2d331cbf9a43d75d02fefdcc54b3448700023eee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

