### PR TITLE
fix(runner): mint keyless op identities at instantiation (CT-1812)

### DIFF
--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -47,8 +47,17 @@ export function isPatternRefSentinel(
  *   same way when its module evaluated this session; a ref from a module that
  *   never evaluated here throws — loud, since a sync Action cannot await the
  *   storage-backed `loadPatternByIdentity`.
- * - Otherwise (no entry ref known at instantiation), `op` is the embedded
- *   pattern graph itself, used as-is.
+ * - Otherwise `op` is an embedded pattern graph, used as-is. Post-CT-1812
+ *   this is ONLY the stored-keyless remnant: a live op whose original is a
+ *   trusted builder pattern gets a `keyless:` identity minted at node
+ *   instantiation (`Runner.substituteOpPatternRefs`) and arrives here as a
+ *   sentinel; what still arrives embedded is a graph deserialized from a
+ *   stored no-entry-ref pattern VALUE (the live keyless writer path pinned
+ *   by stored-pattern-rehydration.test.ts), for which no pristine artifact
+ *   exists to resolve instead. CT-1812 residual: for THAT form, a nested
+ *   grandchild's derived-internal output aliases remain defer-corrupted by
+ *   the immutable-cell round-trip — re-rooting a bare stored graph without
+ *   binding is the open surgery recorded on the ticket.
  */
 export function resolveOpPattern(
   runtime: Runtime,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -88,7 +88,11 @@ import {
 } from "./cfc/types.ts";
 import { runInActionExecution } from "./builder/action-context.ts";
 import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
-import { getArtifactEntryRef } from "./builder/pattern-metadata.ts";
+import {
+  getArtifactEntryRef,
+  isTrustedBuilderArtifact,
+  resolveOriginal,
+} from "./builder/pattern-metadata.ts";
 import { diffAndUpdate } from "./data-updating.ts";
 import { setResultCell } from "./result-utils.ts";
 import { SigilLink } from "./sigil-types.ts";
@@ -3844,8 +3848,27 @@ export class Runner {
    * the freshly bound (mutable, unfrozen) copy produced by
    * `unwrapOneLevelAndBindtoDoc`; its pattern values carry their derivation
    * link (`noteDerivedCopy`), so `getArtifactEntryRef` can resolve the ref
-   * (assigned post-eval by `registerEvaluatedModules`). With no known ref the
-   * op is left as the embedded graph.
+   * (assigned post-eval by `registerEvaluatedModules`).
+   *
+   * An op with NO known ref but a LIVE trusted original is a KEYLESS pattern
+   * — hand-built through the in-process builder DSL, or evaluated through the
+   * bare non-registering `Engine.compileAndEvaluateModules` — whose serialized
+   * copy carries a derivation link to its pristine in-memory pattern. It is
+   * minted its content-hash session identity right here (the same pointer
+   * `entryRefForPattern` mints for a keyless ROOT pattern), so it rides a
+   * `$patternRef` to that pristine artifact. Leaving it embedded instead
+   * would send it through the immutable-cell JSON round-trip, which corrupts
+   * a nested sub-pattern's output-alias `defer` levels (CT-1812 — the
+   * CT-1811 corruption, reachable ref-lessly). The trust gate stays intact:
+   * minting BRANDS, so only a value whose original is already a trusted
+   * builder pattern is minted.
+   *
+   * An op with no ref AND no live original — a plain deserialized graph,
+   * i.e. a STORED no-entry-ref pattern value (the live keyless writer path
+   * pinned by stored-pattern-rehydration.test.ts) — is left embedded: there
+   * is no pristine artifact in existence to point at, and re-rooting the
+   * graph bind-free is exactly the defer surgery CT-1812 records as the
+   * residual there. Such an op takes the builtin's legacy graph path.
    */
   private substituteOpPatternRefs(
     moduleRefName: string | undefined,
@@ -3860,9 +3883,17 @@ export class Runner {
     if (!isRecord(inputBindings)) return;
     const op = (inputBindings as Record<string, unknown>).op;
     if (!isRecord(op)) return;
-    const ref = this.runtime.patternManager.getArtifactEntryRef(
+    let ref = this.runtime.patternManager.getArtifactEntryRef(
       op as unknown as object,
     );
+    if (!ref) {
+      const original = resolveOriginal(op as unknown as object);
+      if (isTrustedBuilderArtifact(original) && isPattern(original)) {
+        ref = this.runtime.patternManager.ensureKeylessPatternIdentity(
+          original as unknown as Pattern,
+        );
+      }
+    }
     if (ref) {
       (inputBindings as Record<string, unknown>).op = {
         $patternRef: { identity: ref.identity, symbol: ref.symbol },

--- a/packages/runner/test/keyless-op-identity.test.ts
+++ b/packages/runner/test/keyless-op-identity.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  Engine,
+  Runtime,
+  signer,
+  StorageManager,
+} from "./engine-test-support.ts";
+import type { RuntimeProgram } from "./engine-test-support.ts";
+
+/**
+ * Regression for CT-1812: a KEYLESS op (no content-addressed entry ref —
+ * here, evaluated through the bare, non-registering
+ * `Engine.compileAndEvaluateModules`) whose mapped sub-pattern nests a
+ * GRANDCHILD exposing a derived-internal computed output.
+ *
+ * Before the keyless-op mint, such an op fell back to its embedded pattern
+ * graph, whose nested output-alias `defer` levels the immutable-cell JSON
+ * round-trip decrements one step too far — the grandchild derived-internal
+ * output then resolved one instantiation level too early (throw under strict
+ * binding, mis-wire under lenient). This is the CT-1811 corruption on its
+ * ref-less remnant path: PR #4454 sealed the harness load path by
+ * registration; this test pins the remnant.
+ *
+ * Now `Runner.substituteOpPatternRefs` mints the op's `keyless:` content-hash
+ * session identity (the same pointer a keyless ROOT pattern gets via
+ * `entryRefForPattern`), so the op rides a `$patternRef` to its pristine
+ * artifact and the embedded round-trip never happens.
+ *
+ * The program is the CT-1811 regression pattern (gideon-tests/
+ * ct-1811-mapped-subpattern-derived-output.test.tsx), with the traversal
+ * result exposed as a readable `rendered` output and the Wrapper exported so
+ * the mint itself is observable.
+ */
+
+const CT_1812_PROGRAM_SOURCE = `
+import {
+  computed,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+const isRecord = (v: unknown): v is Record<PropertyKey, unknown> =>
+  typeof v === "object" && v !== null;
+
+const read = (v: unknown): unknown =>
+  isRecord(v) && typeof v.get === "function" ? (v.get as () => unknown)() : v;
+
+const asArray = (v: unknown): unknown[] => {
+  const value = read(v);
+  if (Array.isArray(value)) return value;
+  return value === undefined || value === null || typeof value === "boolean"
+    ? []
+    : [value];
+};
+
+const childNodes = (node: unknown): unknown[] => {
+  const value = read(node);
+  if (Array.isArray(value)) return value;
+  if (!isRecord(value)) return [];
+  const ui = value[UI];
+  return [
+    ...(ui === undefined || ui === value ? [] : [ui]),
+    ...asArray(value.children),
+  ];
+};
+
+// Collect leaf string/number values in the rendered tree. Walking the tree is
+// what forces the map to materialize each element (instantiate Wrapper + Child).
+const leafValues = (root: unknown, depth = 0): string[] => {
+  if (depth > 40) return [];
+  const value = read(root);
+  const kids = childNodes(value);
+  if (kids.length === 0) {
+    return typeof value === "string" || typeof value === "number"
+      ? [String(value)]
+      : [];
+  }
+  const out: string[] = [];
+  for (const k of kids) out.push(...leafValues(k, depth + 1));
+  return out;
+};
+
+interface ChildIn {
+  n: number;
+}
+interface ChildOut {
+  [NAME]: string;
+  [UI]: VNode;
+  doubled: number;
+}
+
+// The grandchild: exposes a derived-internal computed OUTPUT ('doubled').
+const Child = pattern<ChildIn, ChildOut>(({ n }) => {
+  const doubled = computed(() => n * 2);
+  return {
+    [NAME]: "child",
+    [UI]: <div>{doubled}</div>,
+    doubled,
+  };
+});
+
+interface WrapperIn {
+  n: number;
+}
+interface WrapperOut {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+// The child pattern node nests Child, so Child is a GRANDCHILD of the map op.
+const Wrapper = pattern<WrapperIn, WrapperOut>(({ n }) => ({
+  [NAME]: "wrapper",
+  [UI]: (
+    <div>
+      <Child n={n} />
+    </div>
+  ),
+}));
+
+export const wrapperOp = Wrapper;
+
+export default pattern(() => {
+  const items = new Writable<number[]>([1, 2, 3]);
+  const ui = <div>{items.map((n) => <Wrapper n={n} />)}</div>;
+  const rendered = computed(() => {
+    const values = leafValues(ui);
+    return values.includes("2") && values.includes("4") &&
+      values.includes("6");
+  });
+  return {
+    [NAME]: "ct-1812-keyless-op",
+    [UI]: ui,
+    rendered,
+  };
+});
+`;
+
+const program: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: CT_1812_PROGRAM_SOURCE }],
+};
+
+describe("keyless op identity (CT-1812)", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("runs a ref-less mapped op with a grandchild derived-internal output, minting its keyless identity", async () => {
+    // Evaluate WITHOUT registering — the op gets no module-scope entry ref.
+    const engine = runtime.harness as Engine;
+    const evalResult = await engine.compileAndEvaluateModules(program);
+    const main = evalResult.main!;
+    const factory = main.default as Parameters<Runtime["run"]>[1];
+    const wrapperOp = main.wrapperOp as object;
+
+    // Bare evaluation indexed nothing: the op is keyless going in.
+    expect(runtime.patternManager.getArtifactEntryRef(wrapperOp))
+      .toBeUndefined();
+
+    const space = signer.did();
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<{ rendered: boolean }>(
+      space,
+      { ct1812: "keyless-op-identity" },
+      (factory as { resultSchema?: never }).resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, factory, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    const commit = await tx.commit();
+    expect(commit.error).toBeUndefined();
+    const cancel = result.sink(() => {});
+    await runtime.idle();
+
+    // The CT-1811/CT-1812 shape works ref-lessly: every grandchild
+    // derived-internal output materialized (2, 4, 6 all present). Before the
+    // mint this threw "Unknown derived internal cell with partial cause"
+    // (strict) or mis-wired (lenient).
+    expect(result.key("rendered").get()).toBe(true);
+
+    // And it worked BY IDENTITY: instantiation minted the keyless pointer for
+    // the op, so it resolved to the pristine artifact instead of the
+    // defer-corrupted embedded graph.
+    const minted = runtime.patternManager.getArtifactEntryRef(wrapperOp);
+    expect(minted?.identity).toMatch(/^keyless:/);
+
+    cancel();
+    await runtime.idle();
+  });
+});

--- a/packages/runner/test/map-op-by-identity.test.ts
+++ b/packages/runner/test/map-op-by-identity.test.ts
@@ -67,7 +67,13 @@ describe("op-pattern-ref helpers", () => {
     );
   });
 
-  it("passes a non-sentinel value through unchanged (legacy graph)", () => {
+  it("passes a non-sentinel value through unchanged (stored-keyless remnant)", () => {
+    // Post-CT-1812 only a graph deserialized from a STORED no-entry-ref
+    // pattern value arrives embedded (a live op whose original is a trusted
+    // builder pattern is minted a keyless identity at instantiation and
+    // arrives as a sentinel — see keyless-op-identity.test.ts). The stored
+    // form must keep executing: stored-pattern-rehydration.test.ts pins that
+    // contract end-to-end.
     const graph = { nodes: [], result: {} } as never;
     const resolved = resolveOpPattern({} as never, graph, "map");
     expect(resolved).toBe(graph);

--- a/packages/runner/test/pattern-ref-boundary.test.ts
+++ b/packages/runner/test/pattern-ref-boundary.test.ts
@@ -157,6 +157,9 @@ describe("resolveOpPattern", () => {
   });
 
   it("passes a plain stored graph through (no-entry-ref writer)", () => {
+    // The stored-keyless remnant path (see stored-pattern-rehydration.test.ts
+    // for the end-to-end contract; live keyless ops are minted identities at
+    // instantiation instead — CT-1812).
     const graph = { nodes: [], result: {} } as never;
     expect(resolveOpPattern({} as never, graph, "map")).toBe(graph);
   });


### PR DESCRIPTION
## Summary

Fixes the reachable class of **CT-1812** by dissolving it: a keyless `map`/`filter`/`flatMap` op whose original is a live trusted builder pattern is now **minted its content-hash session identity at node instantiation**, so it rides a `$patternRef` to its pristine artifact instead of the embedded graph whose nested output-alias `defer` levels the immutable-cell round-trip corrupts (the CT-1811 mechanism, previously reachable ref-lessly). One narrowly-scoped residual remains and is documented in place (below).

## Why this shape

A design spike (evidence on the ticket) established that no product path used the embedded fallback — with it patched to throw: cli 912/0, full pattern sweep 956/0, generated-patterns 145/0, zero hits. The constituencies were (a) ~18 runner unit-test groups building patterns with the in-process builder DSL, and (b) one pinned contract test. The identity program (E4 #4083, E5 #4110) already converged on refs-only-and-loud, and the mint already existed: `PatternManager.ensureKeylessPatternIdentity` (CT-1623 structural dedup) is what `entryRefForPattern` mints for keyless ROOT patterns at run time. The gap was exactly that `Runner.substituteOpPatternRefs` consulted `getArtifactEntryRef` but never minted for nested ops.

## The change

**`Runner.substituteOpPatternRefs`**: on an entry-ref miss, resolve the op's derivation original and — only if it is already a **trusted builder pattern** (`isTrustedBuilderArtifact` + `isPattern`; minting brands, so it must never confer trust on a forged object) — mint via `ensureKeylessPatternIdentity` and stamp the sentinel. Structurally identical ops share one identity (content hash), so re-instantiation doesn't churn. This covers every live-object keyless case: in-process builder DSL patterns and bare-`Engine.compileAndEvaluateModules` namespaces.

## The residual, and why the builtin is NOT sealed

The spike recommended sealing `resolveOpPattern` against bare graphs outright. Implementation surfaced a **pinned live contract** the seal would break: `stored-pattern-rehydration.test.ts` — "a stored full graph (no-entry-ref writer) still executes via `runtime.run` — that is a live writer path, not a vintage." A graph deserialized from a stored keyless pattern VALUE has **no pristine artifact in existence** to mint a pointer to:

- Minting the bound instantiation copy self-cycles (its aliases are doc-bound to the map node — verified empirically: "link at [] targets its own subpath").
- Minting the raw embedded form hands per-element instantiation a one-level-too-deep graph.
- Constructing the canonical form would mean re-rooting defers bind-free — exactly the surgery CT-1812 records as the hard option this PR avoids.

So the embedded path remains, **reduced to precisely that stored-keyless remnant**, documented at both ends (`substituteOpPatternRefs`, `resolveOpPattern`): a stored keyless graph with a *simple* op keeps working (the pinned contract); one with a grandchild derived-internal output remains defer-corrupted — same as before this PR, now stated in place and on the ticket rather than latent. Every in-repo-reachable case rides identities.

(A container-trust tier and a builtin-side seal were both built and reverted during implementation: the first for the self-cycle above, the second for the pinned contract. `entryRefForPattern` brands every keyless root at run, so container-trust gating would also have guarded nothing.)

## Tests

- **New regression** (`runner/test/keyless-op-identity.test.ts`): the CT-1811 pattern shape (mapped Wrapper nesting a grandchild with a derived-internal computed output), evaluated through the bare non-registering `Engine.compileAndEvaluateModules`, run directly. Asserts the op was keyless going in, the grandchild outputs materialize correctly (2/4/6), and the op's `keyless:` identity was minted by instantiation. **Fails-without validated** (mint disabled → fails).
- The two pass-through pins (`map-op-by-identity.test.ts`, `pattern-ref-boundary.test.ts`) keep their pass-through expectation with enriched comments naming the remnant scope and cross-linking the contract test.
- **Acceptance**: the ~18 previously-fallback-dependent test groups (patterns-dynamic, pattern-scope, cfc-flow-pointwise, list-builtin-edge-paths, …) and the stored-graph contract test pass **unchanged**. The CFC pointwise suites passing answers the minted-provenance question empirically.

## Verification

| Gate | Result |
| -- | -- |
| New regression (fails-without / passes-with) | ✅ |
| runner full suite | 756 passed / 0 failed |
| cli full suite | 912 passed / 0 failed |
| pattern sweep (`--root packages/patterns`) | 956 passed / 0 failed |
| generated-patterns integration | 145 passed / 0 failed |
| Repo-wide `deno task check` | ✅ |
| fmt · lint | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mints a keyless content-hash identity for `map`/`filter`/`flatMap` ops at instantiation when their original is a trusted builder `pattern`, routing them via `$patternRef` to the pristine artifact. Fixes CT-1812 by avoiding the embedded-graph path that corrupts nested `defer` levels; only stored keyless graphs still run embedded.

- **Bug Fixes**
  - In `Runner.substituteOpPatternRefs`, on a missing entry ref resolve the op’s original and, if it’s a trusted builder `pattern`, mint via `ensureKeylessPatternIdentity` and substitute a `$patternRef` (uses `resolveOriginal` + `isTrustedBuilderArtifact` + `isPattern`).
  - Clarify in `resolveOpPattern` that the embedded path is now only the stored-keyless remnant; document the residual `defer` corruption in-code.
  - Add regression `keyless-op-identity.test.ts`; update comments in `map-op-by-identity.test.ts` and `pattern-ref-boundary.test.ts`.

<sup>Written for commit d316a2c058703a41b2ed186f4657a5f939bf4003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

