### PR TITLE
feat(ts-transformers): classify read-then-push warnings by how the read relates to the push

### DIFF
--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -288,24 +288,36 @@ Two further responses make the keyed case cheaper and catch misuse (see
   analysis already tracks per-handler reads and the mergeable write methods. The
   `MergeablePushValidationTransformer`
   ([packages/ts-transformers/src/transformers/mergeable-push-validation.ts](../../packages/ts-transformers/src/transformers/mergeable-push-validation.ts))
-  runs that analysis over each handler and flags a handler that both reads a
-  collection (an explicit `.get()` or an iteration) and mergeable-`push`es to the
-  same collection path. The diagnostic (`mergeable-push:read-then-push`) points at
-  the identity-addressed `elementById` + `addUnique` for a uniqueness condition,
-  or at a read-modify-write `set` for other content-dependent conditions. It is a
-  warning, not an error: the kept read keeps the shape safe today (it forces the
+  runs that analysis over each handler, finds a handler that both reads a
+  collection (an explicit `.get()` or an iteration) and mergeable-`push`es to
+  the same collection path, and classifies how the read relates to the push
+  ([packages/ts-transformers/src/policy/mergeable-push-classification.ts](../../packages/ts-transformers/src/policy/mergeable-push-classification.ts)).
+  A push that *depends* on the read — through a guard (the dedup-then-push
+  shape: an enclosing condition or an earlier early-return derived from the
+  read) or through the pushed value — gets the diagnostic
+  (`mergeable-push:read-then-push`) pointing at the identity-addressed
+  `elementById` + `addUnique` for a uniqueness condition, or at a
+  read-modify-write `set` for other content-dependent appends. A read that
+  instead feeds an *independent* write to the same collection — for example
+  appending an entry and then trimming the list to a maximum length — still
+  costs the append its mergeability, so the same diagnostic fires with the
+  matching remedy: keep the independent read-modify-write in its own handler so
+  the append stays mergeable. A read related to neither the push nor another
+  write of the collection is not reported — the append forfeits merging, but
+  there is usually no better expression to point at, so warning would be noise.
+  Read influence is tracked by name through variable initializers, assignments,
+  and loop bindings, without scope analysis: over-approximation only promotes a
+  site to the dependent-push diagnosis (the diagnosis every flagged site got
+  before classification), while a missed influence demotes toward the softer
+  message or silence, never toward a wrong remedy. It is a warning, not an
+  error: the kept read keeps every flagged shape safe today (it forces the
   conflict-and-retry), so the check nudges toward the better expression without
   failing the build. A bare push with no read of that path, or a read of a
-  different path, is left alone. The analysis exposes the findings through an
-  optional `mergeablePushMisuseSink`; the read-vs-push correlation lives next to
-  the read/write classification in `capability-analysis.ts`. The lunch poll's
-  `addUser` read-then-push is the worked example the warning fires on. The check
-  is path-correlated but order- and purpose-blind: a handler that mergeable-
-  `push`es and *also* runs an independent read-modify-write on the same list —
-  for example appending an entry and then trimming the list to a maximum length —
-  trips the warning too, because the trimming read keeps the append in the
-  conflict set. The remedy there is to keep the independent read-modify-write in
-  its own handler so the append stays mergeable.
+  different path, is left alone. The analysis exposes the classified findings
+  through an optional `mergeablePushMisuseSink`; the read-vs-push correlation
+  lives next to the read/write classification in `capability-analysis.ts`. The
+  lunch poll's `addUser` read-then-push is the worked example the dependent-push
+  warning fires on: its push is both dedup-guarded and built from the read.
 
 ## Scope
 

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -21,6 +21,11 @@ import { type CellBrand } from "@commonfabric/schema-generator/cell-brand";
 import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
 import { decodePath, encodePath } from "../utils/path-serialization.ts";
 import { unwrapExpression } from "../utils/expression.ts";
+import {
+  createMergeablePushClassifier,
+  type MergeableCollectionSite,
+  type MergeablePushMisuse,
+} from "./mergeable-push-classification.ts";
 
 type CapabilityAnalyzableFunction =
   | ts.ArrowFunction
@@ -44,28 +49,17 @@ export interface CapabilityAnalysisOptions {
   readonly typeRegistry?: WeakMap<ts.Node, ts.Type>;
   /**
    * Optional sink for the read-then-mergeable-`push` misuse check. When set,
-   * the analysis reports every `Cell.push` whose receiver collection path the
-   * same function also reads explicitly (a `.get()` or an iteration). A handler
-   * that reads a collection and then mergeable-`push`es to it keeps
-   * conflicting-and-retrying under write contention; the intent is usually
-   * better expressed as an identity-addressed `addUnique` or a read-modify-write
-   * `set`. Left unset (the default), the analysis records no push sites.
+   * the analysis reports each `Cell.push` whose receiver collection path the
+   * same function also reads explicitly (a `.get()` or an iteration), classified
+   * by how that read relates to the push (see
+   * {@link MergeablePushMisuse.kind}): a push that depends on the read through
+   * a guard or its value is the dedup-then-push shape, better expressed as an
+   * identity-addressed `addUnique` or a read-modify-write `set`; a read that
+   * instead feeds an independent write to the same collection keeps the append
+   * conflict-prone and belongs in its own handler. A read unrelated to both is
+   * not reported. Left unset (the default), the analysis records no push sites.
    */
   readonly mergeablePushMisuseSink?: (finding: MergeablePushMisuse) => void;
-}
-
-/**
- * A `Cell.push(...)` whose receiver collection is also read explicitly within
- * the same analyzed function. Reported through
- * {@link CapabilityAnalysisOptions.mergeablePushMisuseSink}.
- */
-export interface MergeablePushMisuse {
-  /** The `push(...)` call to point the diagnostic at. */
-  readonly node: ts.Node;
-  /** The collection path that is both read and pushed, relative to its root. */
-  readonly path: readonly string[];
-  /** The analyzed parameter/root the collection belongs to. */
-  readonly rootName: string;
 }
 
 interface MutableCapabilityState {
@@ -1379,15 +1373,31 @@ export function analyzeFunctionCapabilities(
     const includeNestedCallbacks = !!options?.includeNestedCallbacks;
     const summarySourceFile = fn.getSourceFile();
 
-    // Mergeable `push` call sites, collected only when a misuse sink is given.
-    // After the walk, a site whose receiver path the function also reads is a
-    // read-then-push and is reported through the sink.
+    // Mergeable `push` call sites, explicit read sites (`.get()` and `for..of`
+    // iterables), and non-append same-collection write paths, collected only
+    // when a misuse sink is given. After the walk, a push site whose receiver
+    // path the function also reads is classified by how that read relates to
+    // the push and reported through the sink.
     const mergeablePushMisuseSink = options?.mergeablePushMisuseSink;
-    const mergeablePushSites: Array<{
-      readonly root: string;
-      readonly encodedPath: string;
-      readonly node: ts.Node;
-    }> = [];
+    const mergeablePushSites: MergeableCollectionSite[] = [];
+    const mergeableReadSites: MergeableCollectionSite[] = [];
+    const mergeableNonAppendWriteKeys = new Set<string>();
+    const mergeableWriteKey = (root: string, encodedPath: string): string =>
+      JSON.stringify([root, encodedPath]);
+    const recordMergeableReadSite = (ref: SourceRef, node: ts.Node): void => {
+      if (!mergeablePushMisuseSink || ref.dynamic) return;
+      mergeableReadSites.push({
+        root: ref.root,
+        encodedPath: encodePath(ref.path),
+        node,
+      });
+    };
+    const recordMergeableNonAppendWrite = (ref: SourceRef): void => {
+      if (!mergeablePushMisuseSink || ref.dynamic) return;
+      mergeableNonAppendWriteKeys.add(
+        mergeableWriteKey(ref.root, encodePath(ref.path)),
+      );
+    };
 
     if (!fn.body) {
       const empty = { params: [] };
@@ -2936,18 +2946,19 @@ export function analyzeFunctionCapabilities(
               });
             } else if (WRITER_METHODS.has(methodName)) {
               trackWriteRef(receiver);
+              recordMergeableNonAppendWrite(receiver);
             } else if (ARRAY_IDENTITY_WRITER_METHODS.has(methodName)) {
               trackWriteRef(receiver);
-              if (
-                mergeablePushMisuseSink &&
-                MERGEABLE_APPEND_METHODS.has(methodName) &&
-                !receiver.dynamic
-              ) {
-                mergeablePushSites.push({
-                  root: receiver.root,
-                  encodedPath: encodePath(receiver.path),
-                  node,
-                });
+              if (mergeablePushMisuseSink && !receiver.dynamic) {
+                if (MERGEABLE_APPEND_METHODS.has(methodName)) {
+                  mergeablePushSites.push({
+                    root: receiver.root,
+                    encodedPath: encodePath(receiver.path),
+                    node,
+                  });
+                } else {
+                  recordMergeableNonAppendWrite(receiver);
+                }
               }
               let hasIdentityArgument = false;
               for (const argument of node.arguments) {
@@ -2973,6 +2984,7 @@ export function analyzeFunctionCapabilities(
               // ["notes", "length"]), skip the blanket read.
               if (!resolvedGetCalls.has(node)) {
                 trackReadRef(receiver);
+                recordMergeableReadSite(receiver, node);
               }
             } else if (
               OPAQUE_DERIVATION_METHODS.has(methodName) &&
@@ -3123,6 +3135,7 @@ export function analyzeFunctionCapabilities(
             markPassthrough(iterableRef.root);
           } else {
             trackReadRef(iterableRef);
+            recordMergeableReadSite(iterableRef, node.expression);
           }
           if (ts.isCallExpression(iterableExpression)) {
             visit(node.expression);
@@ -3202,13 +3215,39 @@ export function analyzeFunctionCapabilities(
       visit(fn.body);
     }
 
-    if (mergeablePushMisuseSink) {
+    if (mergeablePushMisuseSink && mergeablePushSites.length > 0) {
+      // A push whose collection the function also reads explicitly is
+      // classified by how the read relates to the push: a push that depends on
+      // the read (guard or value) is the dedup-then-push shape; a read that
+      // instead feeds another write to the same collection is an independent
+      // read-modify-write sharing the handler; a read related to neither is
+      // not reported. Influence tracking is name-based and conservative in the
+      // noisy direction — ambiguity promotes to the dependent-push finding.
+      const classifier = createMergeablePushClassifier({
+        fn,
+        readSites: mergeableReadSites,
+        resolveAliasTarget: (name) => {
+          const binding = aliases.get(name);
+          if (!binding || binding.dynamic || binding.arrayElement) {
+            return undefined;
+          }
+          return { root: binding.root, encodedPath: encodePath(binding.path) };
+        },
+      });
       for (const site of mergeablePushSites) {
-        if (states.get(site.root)?.reads.has(site.encodedPath)) {
+        if (!states.get(site.root)?.reads.has(site.encodedPath)) continue;
+        const kind = classifier.classify(
+          site,
+          mergeableNonAppendWriteKeys.has(
+            mergeableWriteKey(site.root, site.encodedPath),
+          ),
+        );
+        if (kind) {
           mergeablePushMisuseSink({
             node: site.node,
             path: decodePath(site.encodedPath),
             rootName: site.root,
+            kind,
           });
         }
       }

--- a/packages/ts-transformers/src/policy/mergeable-push-classification.ts
+++ b/packages/ts-transformers/src/policy/mergeable-push-classification.ts
@@ -1,0 +1,377 @@
+/**
+ * Mergeable-push misuse classification
+ *
+ * The capability analysis reports a `Cell.push` whose receiver collection the
+ * same function also reads explicitly. This module classifies the relationship
+ * between that read and the push, so the diagnostic can say the right thing —
+ * or nothing:
+ *
+ * - `read-dependent-push`: the push depends on the read, either through a
+ *   guard (the dedup-then-push shape: an enclosing condition or an earlier
+ *   early-return derives from the read) or through its value (the pushed
+ *   content derives from the read). The intent is better expressed as an
+ *   identity-addressed `addUnique` or a read-modify-write `set`.
+ * - `independent-read-modify-write`: the read does not feed the push, but the
+ *   function also performs another write to the same collection (the
+ *   append-then-trim shape). The read still keeps the append in the conflict
+ *   set; the remedy is to move the independent read-modify-write into its own
+ *   handler.
+ * - `undefined` (no finding): the read neither feeds the push nor a sibling
+ *   write to the collection. The append does forfeit merging, but there is
+ *   usually no better expression, so the check stays silent.
+ *
+ * The classification is deliberately conservative in the noisy direction:
+ * read influence is tracked through variable initializers, assignments, and
+ * loop bindings by name, without scope analysis, so over-approximation can
+ * only promote a finding to `read-dependent-push` — the diagnosis the
+ * unstratified check gave every site. Under-approximation demotes to the
+ * independent-write message or to silence, never to a wrong recommendation.
+ */
+import ts from "typescript";
+
+export type MergeablePushMisuseKind =
+  | "read-dependent-push"
+  | "independent-read-modify-write";
+
+/**
+ * A `Cell.push(...)` whose receiver collection is also read explicitly within
+ * the same analyzed function. Reported through
+ * `CapabilityAnalysisOptions.mergeablePushMisuseSink`.
+ */
+export interface MergeablePushMisuse {
+  /** The `push(...)` call to point the diagnostic at. */
+  readonly node: ts.Node;
+  /** The collection path that is both read and pushed, relative to its root. */
+  readonly path: readonly string[];
+  /** The analyzed parameter/root the collection belongs to. */
+  readonly rootName: string;
+  /** How the explicit read relates to the push. */
+  readonly kind: MergeablePushMisuseKind;
+}
+
+/** A push or explicit-read call site collected during the capability walk. */
+export interface MergeableCollectionSite {
+  readonly root: string;
+  readonly encodedPath: string;
+  readonly node: ts.Node;
+}
+
+export interface MergeablePushClassifierInput {
+  /** The analyzed function; the ancestor climb and taint pass stop here. */
+  readonly fn: ts.Node;
+  /** Explicit read sites (`.get()` calls and `for..of` iterables). */
+  readonly readSites: readonly MergeableCollectionSite[];
+  /**
+   * Resolves a local identifier to the collection it aliases (from the
+   * capability walk's alias bindings), if any.
+   */
+  readonly resolveAliasTarget: (
+    name: string,
+  ) => { readonly root: string; readonly encodedPath: string } | undefined;
+}
+
+export interface MergeablePushClassifier {
+  /**
+   * Classifies one push site that the capability analysis already gated on
+   * "the function reads the same collection path". Returns `undefined` when
+   * the read is unrelated to both the push and any sibling write.
+   */
+  readonly classify: (
+    site: MergeableCollectionSite,
+    hasIndependentSameCollectionWrite: boolean,
+  ) => MergeablePushMisuseKind | undefined;
+}
+
+function isFunctionBoundary(node: ts.Node): boolean {
+  return ts.isArrowFunction(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isFunctionDeclaration(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isClassExpression(node);
+}
+
+/**
+ * Whether the statement can exit the enclosing function before the statements
+ * after it run. Returns inside nested callbacks don't count: they exit the
+ * callback, not this function.
+ */
+function containsEarlyExit(statement: ts.Node): boolean {
+  let found = false;
+  const scan = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isReturnStatement(node) || ts.isThrowStatement(node)) {
+      found = true;
+      return;
+    }
+    if (isFunctionBoundary(node)) return;
+    ts.forEachChild(node, scan);
+  };
+  scan(statement);
+  return found;
+}
+
+/**
+ * Identifier occurrences that name a member or binding rather than reference
+ * a value; these never carry read influence.
+ */
+function isNamePosition(identifier: ts.Identifier): boolean {
+  const parent = identifier.parent;
+  if (!parent) return false;
+  if (ts.isPropertyAccessExpression(parent)) return parent.name === identifier;
+  if (ts.isPropertyAssignment(parent)) return parent.name === identifier;
+  if (ts.isVariableDeclaration(parent)) return parent.name === identifier;
+  if (ts.isBindingElement(parent)) return true;
+  if (ts.isParameter(parent)) return parent.name === identifier;
+  if (ts.isFunctionDeclaration(parent)) return parent.name === identifier;
+  if (ts.isMethodDeclaration(parent)) return parent.name === identifier;
+  return false;
+}
+
+function collectBoundNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text);
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) continue;
+    collectBoundNames(element.name, out);
+  }
+}
+
+function isLogicalOrCoalescingOperator(kind: ts.SyntaxKind): boolean {
+  return kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+    kind === ts.SyntaxKind.BarBarToken ||
+    kind === ts.SyntaxKind.QuestionQuestionToken;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment &&
+    kind <= ts.SyntaxKind.LastAssignment;
+}
+
+function getStatementList(
+  node: ts.Node,
+): readonly ts.Statement[] | undefined {
+  if (ts.isBlock(node)) return node.statements;
+  if (ts.isCaseClause(node) || ts.isDefaultClause(node)) {
+    return node.statements;
+  }
+  return undefined;
+}
+
+export function createMergeablePushClassifier(
+  input: MergeablePushClassifierInput,
+): MergeablePushClassifier {
+  const { fn, readSites, resolveAliasTarget } = input;
+
+  interface TargetContext {
+    readonly siteNodes: ReadonlySet<ts.Node>;
+    readonly taintedNames: ReadonlySet<string>;
+  }
+  const contexts = new Map<string, TargetContext>();
+
+  const targetKey = (root: string, encodedPath: string): string =>
+    JSON.stringify([root, encodedPath]);
+
+  /**
+   * Whether the expression's value can derive from an explicit read of the
+   * target collection: it contains a read site, an identifier tainted by one,
+   * or an identifier aliasing the collection itself.
+   */
+  const touches = (
+    node: ts.Node,
+    root: string,
+    encodedPath: string,
+    siteNodes: ReadonlySet<ts.Node>,
+    taintedNames: ReadonlySet<string>,
+  ): boolean => {
+    let found = false;
+    const scan = (current: ts.Node): void => {
+      if (found) return;
+      if (siteNodes.has(current)) {
+        found = true;
+        return;
+      }
+      if (ts.isIdentifier(current) && !isNamePosition(current)) {
+        if (taintedNames.has(current.text)) {
+          found = true;
+          return;
+        }
+        const alias = resolveAliasTarget(current.text);
+        if (alias && alias.root === root && alias.encodedPath === encodedPath) {
+          found = true;
+          return;
+        }
+      }
+      ts.forEachChild(current, scan);
+    };
+    scan(node);
+    return found;
+  };
+
+  /**
+   * Names whose value derives from an explicit read of the target: variable
+   * initializers, assignments, and `for..of`/`for..in` bindings over touched
+   * expressions, iterated to a fixpoint. Names are matched without scope
+   * analysis; collisions over-approximate, which only promotes the finding.
+   */
+  const computeTaintedNames = (
+    root: string,
+    encodedPath: string,
+    siteNodes: ReadonlySet<ts.Node>,
+  ): Set<string> => {
+    const tainted = new Set<string>();
+    const touchesTarget = (node: ts.Node): boolean =>
+      touches(node, root, encodedPath, siteNodes, tainted);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      const taintBinding = (name: ts.BindingName): void => {
+        const before = tainted.size;
+        collectBoundNames(name, tainted);
+        if (tainted.size > before) changed = true;
+      };
+      const scan = (node: ts.Node): void => {
+        if (
+          ts.isVariableDeclaration(node) && node.initializer &&
+          touchesTarget(node.initializer)
+        ) {
+          taintBinding(node.name);
+        } else if (
+          ts.isBinaryExpression(node) &&
+          isAssignmentOperator(node.operatorToken.kind) &&
+          ts.isIdentifier(node.left) &&
+          !tainted.has(node.left.text) &&
+          touchesTarget(node.right)
+        ) {
+          tainted.add(node.left.text);
+          changed = true;
+        } else if (
+          (ts.isForOfStatement(node) || ts.isForInStatement(node)) &&
+          ts.isVariableDeclarationList(node.initializer) &&
+          touchesTarget(node.expression)
+        ) {
+          for (const declaration of node.initializer.declarations) {
+            taintBinding(declaration.name);
+          }
+        }
+        ts.forEachChild(node, scan);
+      };
+      scan(fn);
+    }
+    return tainted;
+  };
+
+  const contextFor = (root: string, encodedPath: string): TargetContext => {
+    const key = targetKey(root, encodedPath);
+    let context = contexts.get(key);
+    if (!context) {
+      const siteNodes = new Set<ts.Node>();
+      for (const site of readSites) {
+        if (site.root === root && site.encodedPath === encodedPath) {
+          siteNodes.add(site.node);
+        }
+      }
+      context = {
+        siteNodes,
+        taintedNames: computeTaintedNames(root, encodedPath, siteNodes),
+      };
+      contexts.set(key, context);
+    }
+    return context;
+  };
+
+  /**
+   * Everything the push is control-dependent on, walking up to the analyzed
+   * function: enclosing condition expressions, receivers of enclosing
+   * callback-taking calls, and — the canonical dedup shape — earlier sibling
+   * statements that can exit the function before the push runs.
+   */
+  const collectGuardContainers = (pushNode: ts.Node): ts.Node[] => {
+    const containers: ts.Node[] = [];
+    let child: ts.Node = pushNode;
+    let parent: ts.Node | undefined = child.parent;
+    while (parent && child !== fn) {
+      if (
+        ts.isIfStatement(parent) &&
+        (parent.thenStatement === child || parent.elseStatement === child)
+      ) {
+        containers.push(parent.expression);
+      } else if (
+        ts.isConditionalExpression(parent) &&
+        (parent.whenTrue === child || parent.whenFalse === child)
+      ) {
+        containers.push(parent.condition);
+      } else if (
+        ts.isBinaryExpression(parent) && parent.right === child &&
+        isLogicalOrCoalescingOperator(parent.operatorToken.kind)
+      ) {
+        containers.push(parent.left);
+      } else if (
+        (ts.isWhileStatement(parent) || ts.isDoStatement(parent)) &&
+        parent.statement === child
+      ) {
+        containers.push(parent.expression);
+      } else if (
+        ts.isForStatement(parent) && parent.statement === child &&
+        parent.condition
+      ) {
+        containers.push(parent.condition);
+      } else if (
+        (ts.isForOfStatement(parent) || ts.isForInStatement(parent)) &&
+        parent.statement === child
+      ) {
+        containers.push(parent.expression);
+      } else if (isFunctionBoundary(parent) && parent !== fn) {
+        const call = parent.parent;
+        if (
+          call && ts.isCallExpression(call) &&
+          call.arguments.some((argument) => argument === parent)
+        ) {
+          containers.push(call.expression);
+        }
+      } else {
+        const statements = getStatementList(parent);
+        if (statements) {
+          for (const statement of statements) {
+            if (statement === child) break;
+            if (containsEarlyExit(statement)) containers.push(statement);
+          }
+        }
+      }
+      child = parent;
+      parent = parent.parent;
+    }
+    return containers;
+  };
+
+  const classify = (
+    site: MergeableCollectionSite,
+    hasIndependentSameCollectionWrite: boolean,
+  ): MergeablePushMisuseKind | undefined => {
+    const { siteNodes, taintedNames } = contextFor(site.root, site.encodedPath);
+    const touchesTarget = (node: ts.Node): boolean =>
+      touches(node, site.root, site.encodedPath, siteNodes, taintedNames);
+
+    // Data dependence: the pushed value derives from the read.
+    if (
+      ts.isCallExpression(site.node) &&
+      site.node.arguments.some(touchesTarget)
+    ) {
+      return "read-dependent-push";
+    }
+    // Control dependence: a guard governing the push derives from the read.
+    if (collectGuardContainers(site.node).some(touchesTarget)) {
+      return "read-dependent-push";
+    }
+    if (hasIndependentSameCollectionWrite) {
+      return "independent-read-modify-write";
+    }
+    return undefined;
+  };
+
+  return { classify };
+}

--- a/packages/ts-transformers/src/policy/mod.ts
+++ b/packages/ts-transformers/src/policy/mod.ts
@@ -1,7 +1,8 @@
+export { analyzeFunctionCapabilities } from "./capability-analysis.ts";
 export {
-  analyzeFunctionCapabilities,
   type MergeablePushMisuse,
-} from "./capability-analysis.ts";
+  type MergeablePushMisuseKind,
+} from "./mergeable-push-classification.ts";
 export {
   classifyReactiveReceiverKind,
   type ReactiveReceiverKind,

--- a/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
+++ b/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
@@ -1,27 +1,64 @@
 /**
  * Mergeable Push Validation Transformer
  *
- * Flags the read-then-mergeable-`push` shape inside a handler: a handler that
- * reads a collection (an explicit `.get()` or an iteration) and then
- * mergeable-`push`es to that same collection.
+ * Flags a handler that reads a collection (an explicit `.get()` or an
+ * iteration) and mergeable-`push`es to that same collection, when the read
+ * actually matters to the push.
  *
  * A mergeable `push` commits as a tail-relative `append` and drops the op's own
- * array read from conflict detection so disjoint appends merge. When the
- * handler reads the collection on its own — the dedup-then-push shape — that
- * explicit read stays in the conflict set, so two concurrent appends conflict
- * and the loser retries. The intent is usually better expressed as an
- * identity-addressed `addUnique` (no retry) for a uniqueness condition, or a
- * read-modify-write `set` for other content-dependent conditions.
+ * array read from conflict detection so disjoint appends merge. An explicit
+ * read of the same collection stays in the conflict set, so two concurrent
+ * appends conflict and the loser retries. The capability analysis classifies
+ * how the read relates to the push, and the diagnostic says the matching
+ * thing:
  *
- * The check reuses the capability analysis, which already tracks per-parameter
- * reads and the mergeable write methods. It is a warning, not an error: the
- * shape stays safe today (the kept read forces the retry), so this nudges
- * toward the better expression without failing the build.
+ * - `read-dependent-push` — the push depends on the read through a guard (the
+ *   dedup-then-push shape) or through the pushed value. The intent is better
+ *   expressed as an identity-addressed `addUnique` (no retry) for a uniqueness
+ *   condition, or a read-modify-write `set` for other content-dependent
+ *   appends.
+ * - `independent-read-modify-write` — the read feeds a different write to the
+ *   same collection (the append-then-trim shape). The append still forfeits
+ *   merging; the remedy is to keep the independent read-modify-write in its
+ *   own handler.
+ *
+ * A read unrelated to both the push and any sibling write is not reported: the
+ * append does forfeit merging, but there is usually no better expression, so
+ * warning would be noise. It is a warning, not an error: the shape stays safe
+ * today (the kept read forces the retry), so this nudges toward the better
+ * expression without failing the build.
  */
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { getCapabilitySummaryCallbackArgument } from "../ast/mod.ts";
-import { analyzeFunctionCapabilities } from "../policy/mod.ts";
+import {
+  analyzeFunctionCapabilities,
+  type MergeablePushMisuse,
+} from "../policy/mod.ts";
+
+function diagnosticMessage(finding: MergeablePushMisuse): string {
+  const label = finding.path.length > 0
+    ? `'${finding.path.join(".")}'`
+    : "the collection";
+  if (finding.kind === "read-dependent-push") {
+    return (
+      `This handler both reads ${label} and mergeable-'push'es to it, and ` +
+      "the push depends on that read through a guard or the pushed value. " +
+      "The explicit read keeps the append in the conflict set, so it " +
+      "conflicts and retries under write contention instead of merging. " +
+      "For a uniqueness condition, address the element by identity with " +
+      "'elementById(...)' and 'addUnique(...)' instead. For other " +
+      "content-dependent appends, use a read-modify-write 'set'."
+    );
+  }
+  return (
+    `This handler mergeable-'push'es to ${label} and independently reads ` +
+    "it for another write to the same collection. That read keeps the " +
+    "append in the conflict set, so it conflicts and retries under write " +
+    "contention instead of merging. Keep the independent read-modify-write " +
+    "in its own handler so the append stays mergeable."
+  );
+}
 
 export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -54,32 +91,32 @@ export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
     context: TransformationContext,
   ): void {
     // One warning per collection per handler: several pushes to the same read
-    // collection share a root cause, so the first push site stands for them.
-    const reported = new Set<string>();
+    // collection share a root cause, so one site stands for them. When the
+    // sites classify differently, the read-dependent diagnosis is the
+    // stronger, more actionable one, so it wins.
+    const byCollection = new Map<string, MergeablePushMisuse>();
     analyzeFunctionCapabilities(callback, {
       checker: context.checker,
       typeRegistry: context.options.state?.typeRegistry,
       mergeablePushMisuseSink: (finding) => {
         const key = JSON.stringify([finding.rootName, ...finding.path]);
-        if (reported.has(key)) return;
-        reported.add(key);
-        const label = finding.path.length > 0
-          ? `'${finding.path.join(".")}'`
-          : "the collection";
-        context.reportDiagnostic({
-          severity: "warning",
-          type: "mergeable-push:read-then-push",
-          message:
-            `This handler both reads ${label} and mergeable-'push'es to it. ` +
-            "The explicit read keeps the append in the conflict set, so it " +
-            "conflicts and retries under write contention instead of merging. " +
-            "For a uniqueness condition, address the element by identity with " +
-            "'elementById(...)' and 'addUnique(...)' instead. For other " +
-            "content-dependent conditions, use a read-modify-write 'set', and " +
-            "keep any independent append in its own handler.",
-          node: finding.node,
-        });
+        const existing = byCollection.get(key);
+        if (
+          !existing ||
+          (existing.kind !== "read-dependent-push" &&
+            finding.kind === "read-dependent-push")
+        ) {
+          byCollection.set(key, finding);
+        }
       },
     });
+    for (const finding of byCollection.values()) {
+      context.reportDiagnostic({
+        severity: "warning",
+        type: "mergeable-push:read-then-push",
+        message: diagnosticMessage(finding),
+        node: finding.node,
+      });
+    }
   }
 }

--- a/packages/ts-transformers/test/mergeable-push-validation.test.ts
+++ b/packages/ts-transformers/test/mergeable-push-validation.test.ts
@@ -36,9 +36,11 @@ Deno.test("Mergeable push validation", async (t) => {
       });
       const warnings = getReadThenPushWarnings(diagnostics);
       assertEquals(warnings.length, 1);
-      // The message points at the two recommended alternatives.
+      // The message points at the two recommended alternatives, not at
+      // splitting handlers: the push depends on the read here.
       assert(warnings[0]!.message.includes("addUnique"));
       assert(warnings[0]!.message.includes("set"));
+      assert(!warnings[0]!.message.includes("its own handler"));
       // It is non-fatal: no error of this type.
       assertEquals(
         diagnostics.filter((d) =>
@@ -46,6 +48,144 @@ Deno.test("Mergeable push validation", async (t) => {
         ).length,
         0,
       );
+    },
+  );
+
+  await t.step(
+    "warns when the push is enclosed in a read-derived guard",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  const existing = users.get();",
+        "  if (!existing.some((u) => u.name === event.name)) {",
+        "    users.push({ name: event.name });",
+        "  }",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = getReadThenPushWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      assert(warnings[0]!.message.includes("addUnique"));
+    },
+  );
+
+  await t.step(
+    "warns on an iterate-dedup loop followed by a push",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  for (const u of users.get()) {",
+        "    if (u.name === event.name) return;",
+        "  }",
+        "  users.push({ name: event.name });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = getReadThenPushWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      assert(warnings[0]!.message.includes("addUnique"));
+    },
+  );
+
+  await t.step(
+    "warns with the split-handler message on an append plus independent trim",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "export const addMessage = handler<{ msg: string }, {",
+        "  messages: Cell<string[]>;",
+        "}>((event, { messages }) => {",
+        "  messages.push(event.msg);",
+        "  const current = messages.get();",
+        "  messages.set(current.slice(-50));",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = getReadThenPushWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      // The read serves the trim, not the push: the remedy is to split the
+      // handlers, and recommending addUnique would be a misdiagnosis.
+      assert(warnings[0]!.message.includes("its own handler"));
+      assert(!warnings[0]!.message.includes("addUnique"));
+    },
+  );
+
+  await t.step(
+    "does not warn when the read serves neither the push nor another write",
+    async () => {
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "  log: Cell<User[][]>;",
+        "}>((event, { users, log }) => {",
+        "  const snapshot = users.get();",
+        "  log.push(snapshot);",
+        "  users.push({ name: event.name });",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(getReadThenPushWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
+    "prefers the dependent-push diagnosis when both shapes touch the same collection",
+    async () => {
+      // The first push precedes the guard (independent, explained by the
+      // trailing set); the second is dedup-guarded (read-dependent). One
+      // warning, and the stronger dependent diagnosis wins.
+      const source = [
+        'import { handler, Cell } from "commonfabric";',
+        "",
+        "interface User { name: string; }",
+        "",
+        "export const addUser = handler<{ name: string }, {",
+        "  users: Cell<User[]>;",
+        "}>((event, { users }) => {",
+        "  const existing = users.get();",
+        '  users.push({ name: "audit" });',
+        "  if (existing.some((u) => u.name === event.name)) return;",
+        "  users.push({ name: event.name });",
+        "  users.set(existing.slice(-10));",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = getReadThenPushWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      assert(warnings[0]!.message.includes("addUnique"));
+      assert(!warnings[0]!.message.includes("its own handler"));
     },
   );
 
@@ -126,6 +266,7 @@ Deno.test("Mergeable push validation", async (t) => {
       // `lift(cb)(input)` exposes both the applied outer call and the unapplied
       // inner `lift(cb)` call, and both resolve to the same callback node.
       // Without per-callback deduplication the read-then-push warns twice.
+      // The pushed value derives from the read, so this is read-dependent.
       const source = [
         'import { lift } from "commonfabric";',
         "",

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -3122,6 +3122,29 @@ Deno.test(
 );
 
 Deno.test(
+  "Mergeable-push misuse: scans past a nested function declaration in a guard statement",
+  () => {
+    // The first early-exit sibling contains a function declaration; its name
+    // must read as a declaration name, not a value reference, and scanning
+    // continues to the real dedup guard.
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input, event) => {
+        const existing = input.key("users").get();
+        if (event.flag) {
+          function helper() { return 0; }
+          return;
+        }
+        if (existing.some((u) => u.name === event.name)) return;
+        input.key("users").push({ name: event.name });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
   "Mergeable-push misuse: classifies a destructuring iterate-dedup as read-dependent",
   () => {
     // The loop destructures the tainted element, dedups against it, and the

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -2907,7 +2907,10 @@ Deno.test(
     const findings = collectMergeablePushMisuses(
       `const fn = (input) => {
         const existing = input.key("users").get();
-        input.key("users").push({ position: existing.length });
+        input.key("users").push({
+          describe() { return "meta"; },
+          position: existing.length,
+        });
       };`,
     );
 
@@ -2945,6 +2948,198 @@ Deno.test(
     );
 
     assertEquals(findings.length, 0);
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a ternary-guarded push as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        existing.length < 5
+          ? input.key("users").push({ name: "a" })
+          : undefined;
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a coalescing-guarded push as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        existing.find((u) => u.name === "a") ??
+          input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a while-bounded push as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        while (existing.length < 2) {
+          input.key("users").push({ name: "a" });
+        }
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a for-condition-bounded push as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        for (let i = 0; i < existing.length; i++) {
+          input.key("users").push({ name: "a" });
+        }
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a push inside iteration of the read as read-dependent",
+  () => {
+    // The pushed value is a constant, so this classifies through the loop's
+    // control dependence on the read, not through the pushed value.
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        for (const u of existing) {
+          input.key("users").push({ name: "member" });
+        }
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a push keyed by a for-in over the read as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        for (const k in existing) {
+          input.key("users").push({ name: k });
+        }
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a push inside a callback over the read as read-dependent",
+  () => {
+    // Checker-less analysis only descends into nested callbacks when asked;
+    // the transformer path gets the same descent from the checker's eager
+    // array-callback classification.
+    const findings: MergeablePushMisuse[] = [];
+    analyzeFunctionCapabilities(
+      parseFirstCallback(
+        `const fn = (input) => {
+          const existing = input.key("users").get();
+          existing.forEach(() => {
+            input.key("users").push({ name: "a" });
+          });
+        };`,
+      ),
+      {
+        includeNestedCallbacks: true,
+        mergeablePushMisuseSink: (finding) => findings.push(finding),
+      },
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: tracks read influence through assignment and destructuring",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        let snapshot;
+        snapshot = input.key("users").get();
+        const [, first] = snapshot;
+        if (first) return;
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a dedup guard inside a switch case as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input, event) => {
+        const existing = input.key("users").get();
+        switch (event.kind) {
+          case "add":
+            if (existing.some((u) => u.name === event.name)) return;
+            input.key("users").push({ name: event.name });
+            break;
+          default:
+            break;
+        }
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a destructuring iterate-dedup as read-dependent",
+  () => {
+    // The loop destructures the tainted element, dedups against it, and the
+    // guard statement keeps scanning past an unrelated callback before the
+    // early return; the push after the loop is still read-dependent.
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input, event) => {
+        if (["reserved"].some((s) => s === event.name)) return;
+        for (const { name } of input.key("users")) {
+          if (name === event.name) return;
+          void name;
+        }
+        input.key("users").push({ name: event.name });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.kind, "read-dependent-push");
   },
 );
 

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -2861,13 +2861,35 @@ Deno.test(
     assertEquals(findings.length, 1);
     assertEquals(findings[0]!.rootName, "input");
     assertEquals(findings[0]!.path.join("."), "users");
+    assertEquals(findings[0]!.kind, "read-dependent-push");
     assert(ts.isCallExpression(findings[0]!.node));
   },
 );
 
 Deno.test(
-  "Mergeable-push misuse: flags an iterate-then-push to the same collection",
+  "Mergeable-push misuse: flags an iterate-dedup-then-push to the same collection",
   () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        for (const u of input.key("users")) {
+          if (u.name === "a") return;
+        }
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.path.join("."), "users");
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: ignores an iterate-then-push when the iteration serves neither the push nor a write",
+  () => {
+    // The iteration still keeps the append in the conflict set, but with no
+    // dedup guard, no value dependence, and no sibling write there is usually
+    // no better expression to point at, so the check stays silent.
     const findings = collectMergeablePushMisuses(
       `const fn = (input) => {
         for (const u of input.key("users")) { u; }
@@ -2875,8 +2897,54 @@ Deno.test(
       };`,
     );
 
+    assertEquals(findings.length, 0);
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies a value-dependent push as read-dependent",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const existing = input.key("users").get();
+        input.key("users").push({ position: existing.length });
+      };`,
+    );
+
     assertEquals(findings.length, 1);
-    assertEquals(findings[0]!.path.join("."), "users");
+    assertEquals(findings[0]!.kind, "read-dependent-push");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: classifies an append-then-trim as an independent read-modify-write",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        input.key("messages").push({ text: "a" });
+        const current = input.key("messages").get();
+        input.key("messages").set(current.slice(-50));
+      };`,
+    );
+
+    assertEquals(findings.length, 1);
+    assertEquals(findings[0]!.path.join("."), "messages");
+    assertEquals(findings[0]!.kind, "independent-read-modify-write");
+  },
+);
+
+Deno.test(
+  "Mergeable-push misuse: ignores a push when the read serves neither the push nor another write",
+  () => {
+    const findings = collectMergeablePushMisuses(
+      `const fn = (input) => {
+        const snapshot = input.key("users").get();
+        input.key("log").set(snapshot);
+        input.key("users").push({ name: "a" });
+      };`,
+    );
+
+    assertEquals(findings.length, 0);
   },
 );
 
@@ -2895,6 +2963,7 @@ Deno.test(
 
     assertEquals(findings.length, 1);
     assertEquals(findings[0]!.path.join("."), "users");
+    assertEquals(findings[0]!.kind, "read-dependent-push");
   },
 );
 

--- a/packages/ts-transformers/test/utils/expression.test.ts
+++ b/packages/ts-transformers/test/utils/expression.test.ts
@@ -1,0 +1,23 @@
+import ts from "typescript";
+import { assert, assertEquals } from "@std/assert";
+import { unwrapExpression } from "../../src/utils/expression.ts";
+
+Deno.test("unwrapExpression unwraps a partially emitted expression", () => {
+  const literal = ts.factory.createNumericLiteral("1");
+  const wrapped = ts.factory.createPartiallyEmittedExpression(literal);
+
+  assertEquals(unwrapExpression(wrapped), literal);
+});
+
+Deno.test(
+  "unwrapExpression keeps a partially emitted wrapper when excluded",
+  () => {
+    const literal = ts.factory.createNumericLiteral("1");
+    const wrapped = ts.factory.createPartiallyEmittedExpression(literal);
+
+    const result = unwrapExpression(wrapped, {
+      includePartiallyEmitted: false,
+    });
+    assert(ts.isPartiallyEmittedExpression(result));
+  },
+);

--- a/packages/ts-transformers/test/utils/path-serialization.test.ts
+++ b/packages/ts-transformers/test/utils/path-serialization.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { decodePath, encodePath } from "../../src/utils/path-serialization.ts";
+
+Deno.test("encodePath/decodePath round-trips a path", () => {
+  const path = ["users", "0", "name"];
+  assertEquals(decodePath(encodePath(path)), path);
+  assertEquals(decodePath(encodePath([])), []);
+});
+
+Deno.test("decodePath rejects an empty encoded path", () => {
+  assertThrows(
+    () => decodePath(""),
+    Error,
+    "non-empty encoded path",
+  );
+});
+
+Deno.test("decodePath returns an empty path for a non-string-array encoding", () => {
+  assertEquals(decodePath("[1,2]"), []);
+  assertEquals(decodePath('{"not":"a path"}'), []);
+});


### PR DESCRIPTION
Follow-up to #4450, answering the "how do we silence false positives without inventing load-bearing comment syntax" question: by not needing to silence them. The check was path-correlated but order- and purpose-blind — one bit of information ("same-path read exists"), one blended message. This PR classifies *how* the read relates to the push and lets the diagnostic say the matching thing, or nothing:

**`read-dependent-push`** — the push depends on the read, through a guard or through the pushed value. Guards cover the enclosing-condition shape, the canonical early-return sibling (`if (existing.some(...)) return; users.push(...)` — the push is a *sibling* of the guard, not a child, so syntactic enclosure alone would miss it), early-exit loops (iterate-dedup), and enclosing callback receivers. Value dependence covers `push({ color: colorForIndex(existing.length) })`. Keeps the strong message: `elementById` + `addUnique` for uniqueness, read-modify-write `set` otherwise.

**`independent-read-modify-write`** — the read doesn't feed the push but does feed another write to the same collection (append-then-trim). The append still forfeits merging, so it still warns — but now with the remedy that actually applies: keep the independent read-modify-write in its own handler. The old message recommended `addUnique` here, which was a misdiagnosis.

**Silent** — the read serves neither the push nor any sibling write of the collection (e.g. snapshotting the list into a log, then appending). The append forfeits merging, but there's usually no better expression to point at, so warning is noise. This is the false-positive family, deleted rather than suppressed.

## Mechanics

The classification lives in a new `policy/mergeable-push-classification.ts`; the capability analysis consults it at the existing post-walk flush. When the sink is set, the walk additionally records explicit read sites (`.get()` calls, `for..of` iterables) and non-append same-collection write paths — same pattern as the existing push-site recording, and still zero work when no sink is supplied. Read influence is tracked by name through variable initializers, assignments, and `for..of`/`for..in` bindings to a fixpoint, plus the walk's own alias bindings (that's what classifies the lift-applied `const current = s.items; s.items.push(current.length)` as value-dependent).

The imprecision direction is chosen deliberately: **over-approximation promotes to `read-dependent-push` — exactly the diagnosis every flagged site got before this PR — while a missed influence demotes toward the softer message or silence, never toward a wrong remedy.** Net: strictly fewer-or-equal warnings than today, and every message more specific.

Unchanged: the gating predicate (same-path explicit read), the diagnostic type string `mergeable-push:read-then-push`, one warning per collection per handler (when sites classify differently, the dependent diagnosis wins), warning-not-error severity. The lunch poll's `addUser` stays the worked example — its push is both dedup-guarded and built from the read.

## Deliberate behavior changes to review

- The analysis-level "iterate-then-push" unit test used an empty loop body (`for (const u of ...) { u; }`) — no early exit, no use of the iteration. That now classifies as unrelated-read and goes silent; the test was rewritten as an iterate-*dedup* (early return in the body), and a new test pins the silent case. If you think bare iterate-then-push deserves a warning on its own, that's a one-line classification argument to have on this PR.
- Handlers that read for one collection-write and push unconditionally alongside (the append+trim family) now get the split-handlers message without the `addUnique` recommendation.

## Not in this PR (deliberately)

An explicit suppression mechanism. The bet is that after classification the residual — intentional `read-dependent-push` sites where the author *wants* conflict-and-retry — is small enough not to force one. If it isn't, the right escape hatch is a typed one (an intent-named API verb, or a handler-level option the transformer reads), keyed per handler-per-collection to match the diagnostic's granularity — not comment pragmas. Easy to revisit with the concrete sites in hand.

## Testing

- `deno task check`, `deno lint`, `deno fmt --check`: clean
- Full package suite: **983 passed, 0 failed** (includes pipeline regressions and pattern compilation)
- New coverage: enclosed-guard, early-return-sibling, iterate-dedup, value-dependent, append-then-trim message, unrelated-read silence, dependent-wins preference, at both the analysis and transformer levels

---

Provenance: implemented by Gideon's Fable, following the design discussed in chat — "Do you want to have your Fable push on this some more?" — yes, it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies read-then-push warnings by how the read relates to the push and tailors the message to match, reducing noise and pointing to the right fix while keeping the same diagnostic and severity. Adds coverage for remaining guard and util edge cases.

- **New Features**
  - Adds `policy/mergeable-push-classification.ts` with two kinds: read-dependent-push and independent-read-modify-write; unrelated reads are silent.
  - Updates capability analysis to record explicit reads and same-collection non-append writes, and to classify pushes via guard/value dependence and conservative name-based influence tracking.
  - Updates the transformer to emit one warning per collection, preferring the read-dependent diagnosis; messages recommend `'elementById' + 'addUnique'` or `'set'`, or splitting handlers for independent writes.
  - Expands tests to cover ternary/coalescing/loop/switch guards, callback boundaries, and assignment/destructuring taint paths; adds edge-case coverage for function-declaration name positions, path encode/decode, and partially emitted expressions; docs updated.

<sup>Written for commit 904a7fb928ce0a7b9dd67c89dfbe5b6aed6a277a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

