### PR TITLE
feat(cfc): observation-class read plumbing (Epic C, stage C1)

### DIFF
--- a/docs/specs/cfc-observation-classes.md
+++ b/docs/specs/cfc-observation-classes.md
@@ -160,6 +160,39 @@ entries via `excludeLinkOrigin: true` (`prepare.ts`). Two distinct effects:
   path (or assert the new, wider result) — it is not, and must not be, claimed
   byte-identical.
 
+### 6.1 C1 code-validation refinements (2026-07-03)
+
+Landing C1 (`cfc/observation-classes.ts`, `forEachFlowObservation` /
+`effectiveReadLabel` in `prepare.ts`) validated the §4 mapping in code and
+forced three refinements the text above leaves ambiguous. Each was measured
+against the phase-B pointwise suite (`cfc-flow-pointwise.test.ts`), whose
+reader-visible guarantees break under the naive readings; all three are
+normative from C1 on:
+
+- **followRef reads consume only followRef-class entries — covering entries
+  are content.** §3's "absent `observes` = consumed by every read class"
+  holds for the content classes (`value`/`shape`/`enumerate`) only. A
+  followRef observation reads a pointer, not content: letting it consume
+  covering entries would taint the terminal resolution probe of every blind
+  pass-through with the target doc's content label, re-smearing the §2
+  pointer/content substrate. Still strictly wider than pre-C1, which
+  consumed nothing for probes.
+- **The §4 row 3 / row 4 boundary is the dereference trace.** A probe issued
+  while *following* a reference — its slot path covered at-or-above by a
+  same-tx recorded trace source — is resolution machinery (row 4,
+  unchanged); the follow's taint arrives via the ordinary reads of the
+  target. Only standalone probes (no covering trace: `lastNode:"top"` link
+  reads, raw link handles, unfollowed redirect checks) are row-3 followRef
+  observations. Without this boundary every value read's own traversal
+  probes consume each hop's pointer label, and a list coordinator's J joins
+  every slot's transport label — the same pointwise re-smear.
+- **followRef observations contribute confidentiality only.** The §8.9.3
+  hereditary integrity meet quantifies over the transformation's *content*
+  inputs; standalone probes rarely resolve any label, and admitting them
+  would empty the weakest-link meet on virtually every transaction,
+  silently ending TransformedBy / PolicyCertified propagation. Pointer
+  integrity evidence stays on the link entry (the LinkReference chain).
+
 ## 7. Observation ceiling (LLM path) and render
 
 C4 makes the two big consumers class-aware, both via the §4 table — same

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -168,8 +168,10 @@ export function map(
     // read of every element doc the coordinator never consumes — under
     // flow labels (S16) that joined every element's label into the
     // coordinator's J and smeared it across sibling scaffolding.
-    // resolveLink's probe reads are flow-excluded (linkResolutionProbe);
-    // no element value is loaded at all.
+    // resolveLink's probes belong to the dereferences it records, so flow
+    // derivation treats them as resolution machinery, not followRef
+    // observations (observation classes C1); no element value is loaded at
+    // all.
     const rawList = listCell.withTx(tx).getRaw() as unknown;
     const listBase = listCell.getAsNormalizedFullLink();
     const list: Cell<any>[] | undefined = rawList === undefined

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -226,6 +226,7 @@ export const canonicalizeCfcMetadata = (
       path: canonicalizeLogicalPath(entry.path),
       label: canonicalizeCfcLabel(entry.label),
       ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
+      ...(entry.observes !== undefined ? { observes: entry.observes } : {}),
     })).sort((left, right) => {
       const leftKey = logicalPathToPointer(left.path);
       const rightKey = logicalPathToPointer(right.path);
@@ -234,7 +235,19 @@ export const canonicalizeCfcMetadata = (
       }
       const leftOrigin = left.origin ?? "";
       const rightOrigin = right.origin ?? "";
-      return leftOrigin < rightOrigin ? -1 : leftOrigin > rightOrigin ? 1 : 0;
+      if (leftOrigin !== rightOrigin) {
+        return leftOrigin < rightOrigin ? -1 : 1;
+      }
+      // Same (path, origin) can legitimately hold per-class entries (the C2
+      // persist split writes `value` and `shape` siblings) — order by class
+      // so canonicalization stays deterministic.
+      const leftObserves = left.observes ?? "";
+      const rightObserves = right.observes ?? "";
+      return leftObserves < rightObserves
+        ? -1
+        : leftObserves > rightObserves
+        ? 1
+        : 0;
     }),
   },
 });

--- a/packages/runner/src/cfc/observation-classes.ts
+++ b/packages/runner/src/cfc/observation-classes.ts
@@ -1,0 +1,76 @@
+import type { LabelMapEntry, LabelObservationClass } from "./types.ts";
+
+// Read-side half of the observation-class design (Epic C stage C1,
+// docs/specs/cfc-observation-classes.md §4/§6; spec §4.6.3): every concrete
+// runtime read is classified by WHAT it observed, and consumes only the
+// labelMap entries whose class matches. The write side (persisting entries
+// with explicit `observes`) is stage C2 and must not ship before this reader
+// is deployed — a class-unaware reader DROPS link-origin entries instead of
+// treating them as covering, so writer-first would under-taint (C0 §9).
+
+/**
+ * How a read observed its path (the C0 §4 classification):
+ * - `value`: recursive value read — materializes content, which also reveals
+ *   presence/type and, for containers, membership.
+ * - `shape`: `nonRecursive` read (key-add, length) — observes presence and
+ *   cardinality, not element content. Count-shaped reads land here and
+ *   consume `enumerate` (the spec's `count` class folds into it, C0 §4).
+ * - `followRef`: a link-resolution probe / slot-pointer read without
+ *   dereference — observes WHICH reference sits at the slot.
+ */
+export type ReadObservationShape = "value" | "shape" | "followRef";
+
+/**
+ * Entry selection for a read: one of the classified shapes, or `"all"` for
+ * call sites that deliberately keep the legacy every-entry resolution (the
+ * write-gate quantification in `verifyInputRequirements` — over-inclusive is
+ * fail-safe for a screen; per-class narrowing there is C4 territory).
+ */
+export type ReadClassSelection = ReadObservationShape | "all";
+
+// Which entry classes each read shape consumes (C0 §4 table). A covering
+// entry (class undefined) is handled separately in `readConsumesEntry`.
+const CONSUMED_CLASSES: Record<
+  ReadObservationShape,
+  readonly LabelObservationClass[]
+> = {
+  value: ["value", "shape", "enumerate"],
+  shape: ["shape", "enumerate"],
+  followRef: ["followRef"],
+};
+
+/**
+ * The consumption class of a persisted entry; `undefined` means covering
+ * (consumed by every content read class). Implements the C0 §3 carve-out: a
+ * legacy `origin:"link"` entry with absent `observes` is implicitly
+ * `observes:"followRef"` — never covering. Without the carve-out, plain
+ * value reads would start consuming link-origin pointer labels, breaking
+ * the §6 byte-identity contract (and the blind-passing split) on day one.
+ */
+export const entryObservationClass = (
+  entry: Pick<LabelMapEntry, "origin" | "observes">,
+): LabelObservationClass | undefined =>
+  entry.observes ?? (entry.origin === "link" ? "followRef" : undefined);
+
+/** Whether a read of the given shape consumes the given entry's label. */
+export const readConsumesEntry = (
+  selection: ReadClassSelection,
+  entry: Pick<LabelMapEntry, "origin" | "observes">,
+): boolean => {
+  if (selection === "all") {
+    return true;
+  }
+  const entryClass = entryObservationClass(entry);
+  if (entryClass === undefined) {
+    // Covering entries conflate the CONTENT channels (value/shape/enumerate)
+    // of the legacy one-label model; a followRef observation reads the
+    // pointer, not the content. Consuming covering entries there would
+    // taint the terminal resolution probe of every blind pass-through with
+    // the target doc's content label — re-smearing exactly the
+    // pointer/content split the S16 substrate (C0 §2) preserves. followRef
+    // consumption is still strictly wider than pre-C1 behavior, which
+    // consumed nothing for probes.
+    return selection !== "followRef";
+  }
+  return CONSUMED_CLASSES[selection].includes(entryClass);
+};

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3098,18 +3098,25 @@ const cloneLabel = (label: IFCLabel): IFCLabel => ({
 const coalesceLabelEntries = (
   entries: ReadonlyArray<LabelMapEntry>,
 ): Array<LabelMapEntry> => {
-  // Coalesce per (path, origin): same-component entries at one path merge;
-  // entries of different components stay separate so each can follow its
-  // own update discipline (declared monotone, link/derived per-value).
+  // Coalesce per (path, origin, observes): same-component same-class entries
+  // at one path merge; entries of different components stay separate so each
+  // can follow its own update discipline (declared monotone, link/derived
+  // per-value), and entries of different observation classes stay separate
+  // so each keeps its own consumers — merging a `value` and a `shape` entry
+  // into one covering entry would both widen consumption and destroy the
+  // SC-4 grow-vs-replace split (C2).
   const byKey = new Map<string, LabelMapEntry>();
   for (const entry of entries) {
     const path = [...entry.path];
-    const key = `${entry.origin ?? ""}\u0000${pathKey(path)}`;
+    const key = `${entry.origin ?? ""}\u0000${entry.observes ?? ""}\u0000${
+      pathKey(path)
+    }`;
     const existing = byKey.get(key);
     byKey.set(key, {
       path,
       label: mergeLabels(existing?.label, cloneLabel(entry.label)),
       ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
+      ...(entry.observes !== undefined ? { observes: entry.observes } : {}),
     });
   }
   return [...byKey.values()].sort((left, right) => {
@@ -3120,7 +3127,16 @@ const coalesceLabelEntries = (
     }
     const leftOrigin = left.origin ?? "";
     const rightOrigin = right.origin ?? "";
-    return leftOrigin < rightOrigin ? -1 : leftOrigin > rightOrigin ? 1 : 0;
+    if (leftOrigin !== rightOrigin) {
+      return leftOrigin < rightOrigin ? -1 : 1;
+    }
+    const leftObserves = left.observes ?? "";
+    const rightObserves = right.observes ?? "";
+    return leftObserves < rightObserves
+      ? -1
+      : leftObserves > rightObserves
+      ? 1
+      : 0;
   });
 };
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -50,6 +50,11 @@ import {
   cfcIntegritySatisfiesFloor,
   uniqueCfcAtoms,
 } from "./observation.ts";
+import {
+  type ReadClassSelection,
+  readConsumesEntry,
+  type ReadObservationShape,
+} from "./observation-classes.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
@@ -143,37 +148,37 @@ const labelAtPath = (
 // e.g. `getRaw()` records one recursive root read and hands over labeled
 // children with no further journal entries). Non-recursive reads observe
 // only the node itself and keep ancestor-or-equal resolution.
+//
+// `consumes` selects entries by observation class (C1, C0 §4/§6): a read
+// consumes only the entries whose class matches what it actually observed.
+// This subsumes the old `excludeLinkOrigin` pointer/content split (SC-8):
+// link-origin entries label the *reference* as transport (so links carry
+// their target's sensitivity to wherever they land), but reading a value is
+// not reading the pointer — value/shape reads skip them (the implicit
+// `followRef` class of the C0 §3 carve-out), while followRef observations
+// now consume exactly them. Content taint still arrives when the target is
+// actually dereferenced, as an ordinary read of the target document.
+// Covering (class-less) entries may conflate pointer and content labels
+// and are consumed by every read class — over-taint, fail-safe.
 const effectiveReadLabel = (
   metadata: CfcMetadata | undefined,
   path: readonly string[],
-  nonRecursive: boolean | undefined,
-  options?: { excludeLinkOrigin?: boolean },
+  read: {
+    nonRecursive: boolean | undefined;
+    consumes: ReadClassSelection;
+  },
 ): IFCLabel | undefined => {
-  // `excludeLinkOrigin` implements the SC-8 pointer/content split for flow
-  // derivation: link-origin entries label the *reference* as transport (so
-  // links carry their target's sensitivity to wherever they land), but
-  // reading a pointer is not reading the target's content. Flow taint
-  // arrives when the target is actually dereferenced — which appears as an
-  // ordinary read of the target document and resolves the target's own
-  // entries. Without this split, every routing transaction (the list
-  // builtins' coordinators, anything shuffling references) joins the labels
-  // of everything it passes along, and blind passing stops being cheap.
-  // Legacy (untagged) entries may conflate pointer and content labels and
-  // stay included — over-taint, fail-safe.
-  const excludeLink = options?.excludeLinkOrigin === true;
-  const view = excludeLink && metadata !== undefined
-    ? {
-      ...metadata,
-      labelMap: {
-        ...metadata.labelMap,
-        entries: metadata.labelMap.entries.filter((entry) =>
-          entry.origin !== "link"
-        ),
-      },
-    }
-    : metadata;
+  const view = read.consumes === "all" || metadata === undefined ? metadata : {
+    ...metadata,
+    labelMap: {
+      ...metadata.labelMap,
+      entries: metadata.labelMap.entries.filter((entry) =>
+        readConsumesEntry(read.consumes, entry)
+      ),
+    },
+  };
   const base = labelAtPath(view, path);
-  if (nonRecursive === true || view === undefined) {
+  if (read.nonRecursive === true || view === undefined) {
     return base;
   }
   let joined = base;
@@ -1261,38 +1266,92 @@ const forEachFlowObservation = (
     scope: ReturnType<typeof normalizeCellScope>,
     type: MediaType,
     logicalPath: readonly string[],
-    nonRecursive: boolean | undefined,
+    observation: {
+      shape: ReadObservationShape;
+      nonRecursive: boolean | undefined;
+    },
   ) => boolean,
 ): boolean => {
+  // Probe reads issued while FOLLOWING a reference are resolution machinery,
+  // not observations of their own (C0 §4's dereference row): the follow is
+  // journaled as a dereference trace, and the taint of what was actually
+  // read arrives via the ordinary reads of the target document. Recognize
+  // them by the recorded trace sources: a probe at-or-below a followed
+  // slot's path in the same document belongs to that dereference.
+  let traceSourcesByDoc: Map<string, (readonly string[])[]> | undefined;
+  const probeBelongsToDereference = (
+    space: MemorySpace,
+    id: URI,
+    scope: ReturnType<typeof normalizeCellScope>,
+    logicalPath: readonly string[],
+  ): boolean => {
+    if (traceSourcesByDoc === undefined) {
+      traceSourcesByDoc = new Map();
+      for (const trace of tx.getCfcState().dereferenceTraces) {
+        const key = targetKey({
+          space: trace.source.space,
+          id: trace.source.id as URI,
+          scope: normalizeCellScope(trace.source.scope),
+        });
+        let sources = traceSourcesByDoc.get(key);
+        if (sources === undefined) {
+          sources = [];
+          traceSourcesByDoc.set(key, sources);
+        }
+        sources.push(canonicalizeLogicalPath(trace.source.path));
+      }
+    }
+    const sources = traceSourcesByDoc.get(targetKey({ space, id, scope }));
+    return sources !== undefined &&
+      sources.some((source) => isPrefix(source, logicalPath));
+  };
   for (const read of tx.getReadActivities?.() ?? []) {
     if (isInternalVerifierRead(read.meta)) {
-      continue;
-    }
-    // Link-resolution probes are shape observations of link topology, not
-    // content reads (SC-8): following a reference must not taint with the
-    // target's content label unless something actually reads its value
-    // (which appears as an ordinary, unmarked read).
-    if (isLinkResolutionProbe(read.meta)) {
       continue;
     }
     // Scheduler dependency seeding materializes declared deps so the
     // reactivity log covers them; it is scheduling machinery, not handler
     // consumption (§8.10.1) — the action body's own reads carry the taint.
+    // Checked before probe classification: seeding resolves links, and its
+    // probes carry both markers (ambient meta merges), so they stay
+    // machinery, not followRef observations.
     if (isSchedulerDependencyRead(read.meta)) {
       continue;
     }
     if (flowReadExcluded(read.id, read.path)) {
       continue;
     }
+    // Read classification (C1, C0 §4): a link-resolution probe that is NOT
+    // part of a dereference this transaction performed observed WHICH
+    // reference sits at the slot without following it — a followRef
+    // observation. These used to be skipped outright, which was the SC-8
+    // residual: the fact-of-which-element went unlabeled. They now consume
+    // followRef-class entries (the pointer's own link-origin label) — and
+    // only those; the target's content taint still arrives only via an
+    // ordinary read of the target document. `nonRecursive` reads (key-add,
+    // length, count) observe shape and membership; everything else is a
+    // recursive value read.
     const logicalPath = canonicalizeLogicalPath(read.path);
+    const space = read.space;
+    const id = read.id as URI;
+    const scope = normalizeCellScope(read.scope);
+    let shape: ReadObservationShape;
+    if (isLinkResolutionProbe(read.meta)) {
+      if (probeBelongsToDereference(space, id, scope, logicalPath)) {
+        continue;
+      }
+      shape = "followRef";
+    } else {
+      shape = read.nonRecursive === true ? "shape" : "value";
+    }
     if (
       consume(
-        read.space,
-        read.id as URI,
-        normalizeCellScope(read.scope),
+        space,
+        id,
+        scope,
         (read.type ?? "application/json") as MediaType,
         logicalPath,
-        read.nonRecursive,
+        { shape, nonRecursive: read.nonRecursive },
       )
     ) {
       return true;
@@ -1327,7 +1386,7 @@ const forEachFlowObservation = (
         normalizeCellScope(trigger.scope),
         "application/json",
         trigger.path,
-        false,
+        { shape: "value", nonRecursive: false },
       )
     ) {
       return true;
@@ -1350,7 +1409,7 @@ const forEachFlowObservation = (
         normalizeCellScope(trigger.scope),
         "application/json",
         trigger.path,
-        false,
+        { shape: "value", nonRecursive: false },
       )
     ) {
       return true;
@@ -1375,7 +1434,7 @@ const deriveFlowJoin = (
   const metadataByDoc = new Map<string, CfcMetadata | undefined>();
   forEachFlowObservation(
     tx,
-    (space, id, scope, type, logicalPath, nonRecursive) => {
+    (space, id, scope, type, logicalPath, observation) => {
       const key = targetKey({ space, id, scope });
       if (!metadataByDoc.has(key)) {
         metadataByDoc.set(key, storedMetadataFor(tx, space, id, scope, type));
@@ -1383,11 +1442,24 @@ const deriveFlowJoin = (
       const label = effectiveReadLabel(
         metadataByDoc.get(key),
         logicalPath,
-        nonRecursive,
-        { excludeLinkOrigin: true },
+        {
+          nonRecursive: observation.nonRecursive,
+          consumes: observation.shape,
+        },
       );
       if (label?.confidentiality?.length) {
         atoms.push(...label.confidentiality);
+      }
+      // followRef observations contribute confidentiality only. The
+      // hereditary meet quantifies over the transformation's CONTENT inputs
+      // (§8.9.3 derives certification for what the tx computed from);
+      // pointer-topology observations are transport, whose integrity
+      // evidence is the LinkReference chain on the link entry itself.
+      // Letting them into the meet would empty it on every terminal
+      // resolution probe (probes rarely resolve a label), silently ending
+      // TransformedBy/PolicyCertified propagation everywhere.
+      if (observation.shape === "followRef") {
+        return false;
       }
       const hereditary = (label?.integrity ?? []).filter((atom) =>
         atomPropagationClass(atom) === "hereditary"
@@ -1464,38 +1536,41 @@ export const flowLabelWorkExists = (
   }
   const entriesByDoc = new Map<
     string,
-    { any: boolean; nonLink: boolean }
+    { any: boolean; entries: readonly LabelMapEntry[] }
   >();
   const docEntries = (
     space: MemorySpace,
     id: URI,
     scope: ReturnType<typeof normalizeCellScope>,
     type: MediaType,
-  ): { any: boolean; nonLink: boolean } => {
+  ): { any: boolean; entries: readonly LabelMapEntry[] } => {
     const key = targetKey({ space, id, scope });
     let known = entriesByDoc.get(key);
     if (known === undefined) {
       if (selfMintedDocs.has(key)) {
-        known = { any: false, nonLink: false };
+        known = { any: false, entries: [] };
       } else {
         const entries =
           storedMetadataFor(tx, space, id, scope, type)?.labelMap.entries ??
             [];
-        known = {
-          any: entries.length > 0,
-          nonLink: entries.some((entry) => entry.origin !== "link"),
-        };
+        known = { any: entries.length > 0, entries };
       }
       entriesByDoc.set(key, known);
     }
     return known;
   };
-  // Read side mirrors the J derivation's pointer/content split: link-origin
-  // entries don't contribute to J, so they don't make a tx relevant either.
+  // Read side mirrors the J derivation's class selection: an entry makes a
+  // tx relevant only when a read class the tx performed consumes it. A doc
+  // holding only link-origin (implicit followRef) entries is relevant to a
+  // standalone probe read — the SC-8 consumption — but still not to
+  // value/shape reads.
   if (
     forEachFlowObservation(
       tx,
-      (space, id, scope, type) => docEntries(space, id, scope, type).nonLink,
+      (space, id, scope, type, _logicalPath, observation) =>
+        docEntries(space, id, scope, type).entries.some((entry) =>
+          readConsumesEntry(observation.shape, entry)
+        ),
     )
   ) {
     return true;
@@ -2488,6 +2563,9 @@ const verifyInputRequirements = (
   // The consumed reads this gate quantifies over (provenance-only reads
   // excluded). Distinct from the egress side's transaction-global consumed
   // set (collectConsumedConfidentiality), which keeps every labeled read.
+  // Deliberately class-blind (`consumes: "all"`): the gate is a screen over
+  // everything the tx consumed, and over-inclusive quantification is the
+  // fail-safe direction for it; per-class narrowing of consumers is C4.
   const gatedReads = [
     ...[...(tx.getReadActivities?.() ?? [])].filter((read) =>
       !isInternalVerifierRead(read.meta)
@@ -2508,7 +2586,7 @@ const verifyInputRequirements = (
         read.type ?? "application/json",
       ),
       canonicalizeLogicalPath(read.path),
-      read.nonRecursive,
+      { nonRecursive: read.nonRecursive, consumes: "all" },
     ),
   })).filter((read) =>
     read.label !== undefined &&
@@ -3826,11 +3904,13 @@ export const prepareBoundaryCommit = (
         (schemaEntry !== undefined && hasPersistedPolicyClaim(schemaEntry))
       ) {
         // Carry-forward of an untouched path preserves the entry's
-        // component (legacy entries stay legacy).
+        // component and consumption class (legacy entries stay legacy;
+        // covering entries stay covering).
         persistedLabelEntries.push({
           path: entryPath,
           label: cloneLabel(entry.label),
           ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
+          ...(entry.observes !== undefined ? { observes: entry.observes } : {}),
         });
       }
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -158,8 +158,9 @@ const labelAtPath = (
 // `followRef` class of the C0 §3 carve-out), while followRef observations
 // now consume exactly them. Content taint still arrives when the target is
 // actually dereferenced, as an ordinary read of the target document.
-// Covering (class-less) entries may conflate pointer and content labels
-// and are consumed by every read class — over-taint, fail-safe.
+// Covering (class-less) entries conflate the content channels and are
+// consumed by every content read class (value/shape/enumerate) — over-taint,
+// fail-safe — but never by followRef observations (C0 §6.1).
 const effectiveReadLabel = (
   metadata: CfcMetadata | undefined,
   path: readonly string[],

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -175,10 +175,36 @@ export type LabelEntryOrigin =
   | "structure"
   | "external-ingest";
 
+/**
+ * Consumption class of a persisted labelMap entry (Epic C,
+ * docs/specs/cfc-observation-classes.md §3-§4; spec §4.6.3): which kind of
+ * read observation consumes the entry's label. Orthogonal to `origin`, which
+ * stays the update-discipline axis.
+ *
+ * Absent `observes` = a covering entry, consumed by every read class — with
+ * one carve-out: an entry with `origin:"link"` and absent `observes` is
+ * implicitly `observes:"followRef"`, consumed by followRef reads only and
+ * never as a covering entry (see `entryObservationClass`). That reproduces
+ * the pointer/content split legacy link entries already had (value reads
+ * dropped them via `excludeLinkOrigin`), so old persisted data keeps its
+ * meaning without migration.
+ *
+ * The spec's fifth class, `count`, deliberately has no axis value: a count
+ * observation (cardinality without membership) is strictly weaker than
+ * `enumerate`, so count-shaped reads (length, COUNT) consume the `enumerate`
+ * class — a sound over-approximation (C0 §4).
+ */
+export type LabelObservationClass =
+  | "value"
+  | "shape"
+  | "enumerate"
+  | "followRef";
+
 export type LabelMapEntry = {
   path: readonly string[];
   label: IFCLabel;
   origin?: LabelEntryOrigin;
+  observes?: LabelObservationClass;
 };
 
 export type CfcMetadata = {

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -181,8 +181,11 @@ export type LabelEntryOrigin =
  * read observation consumes the entry's label. Orthogonal to `origin`, which
  * stays the update-discipline axis.
  *
- * Absent `observes` = a covering entry, consumed by every read class — with
- * one carve-out: an entry with `origin:"link"` and absent `observes` is
+ * Absent `observes` = a covering entry, consumed by every CONTENT read class
+ * (`value`/`shape`/`enumerate`) but never by `followRef` observations — a
+ * pointer read does not read content, and covering consumption there would
+ * taint blind pass-throughs with the target's content label (C0 §6.1). One
+ * carve-out: an entry with `origin:"link"` and absent `observes` is
  * implicitly `observes:"followRef"`, consumed by followRef reads only and
  * never as a covering entry (see `entryObservationClass`). That reproduces
  * the pointer/content split legacy link entries already had (value reads

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -71,11 +71,11 @@ export const internalVerifierRead: Metadata = {
 /**
  * Marks the "is there a link here?" probe reads issued by link resolution.
  * They stay in the journal (reactivity must re-resolve when a link appears
- * or changes), but flow-label derivation treats them as shape observations
- * of link topology, not content reads: following a reference must not taint
- * the follower with the target's content label when nothing reads the
- * target's value (SC-8 / blind-passing). The residual signal is the 1-bit
- * "this path holds no link", accepted until observation classes land.
+ * or changes), and flow-label derivation classifies them as `followRef`
+ * observations (observation classes, C0 §4): a probe consumes the pointer's
+ * own label (link-origin / `observes:"followRef"` entries) but never the
+ * target's content label — that still arrives only when something actually
+ * reads the target's value (SC-8 / blind-passing).
  */
 export const linkResolutionProbe: Metadata = {
   [linkResolutionProbeMarker]: true,

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
 import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
 import type { LabelMapEntry } from "../src/cfc/types.ts";
@@ -335,26 +337,83 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     ]);
 
     const rt = makeRuntime();
-    const id = await seedDoc(rt, "occ-carry-forward", {
-      slot: { "/": { "link@1": {} } },
-      other: 1,
-    }, [
-      {
-        path: ["slot"],
-        label: { confidentiality: ["ref-secret"] },
-        origin: "derived",
-        observes: "followRef",
+    // The persist region only rewrites a doc whose stored schemaHash loads
+    // (and skips docs entirely when the flow join is empty), so exercising
+    // carry-forward needs a real interned schema + its cid: document + a
+    // labeled read making the flow join non-empty.
+    const guarded = internSchema({ type: "object" } as JSONSchema, true);
+    const seed = rt.edit();
+    const cell0 = rt.getCell(space, "occ-carry-forward", undefined, seed);
+    const id = cell0.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value: { slot: { "/": { "link@1": {} } }, other: 1 },
+      cfc: {
+        version: 1,
+        schemaHash: guarded.taggedHashString,
+        labelMap: {
+          version: 1,
+          entries: [
+            {
+              path: ["slot"],
+              label: { confidentiality: ["ref-secret"] },
+              origin: "derived",
+              observes: "followRef",
+            },
+            // The C2 persist-split shape: same (path, origin), distinct
+            // classes. Coalescing keys per class — merging these into one
+            // covering entry would both widen (value reads would consume
+            // the existence label) and destroy the SC-4 grow-vs-replace
+            // split.
+            {
+              path: ["v"],
+              label: { confidentiality: ["v-content"] },
+              origin: "derived",
+              observes: "value",
+            },
+            {
+              path: ["v"],
+              label: { confidentiality: ["v-existence"] },
+              origin: "derived",
+              observes: "shape",
+            },
+          ],
+        },
       },
+    });
+    seed.writeOrThrow({
+      space,
+      scope: "space",
+      id: `cid:${guarded.taggedHashString}`,
+      path: [],
+    }, { value: guarded.schema });
+    expect((await seed.commit()).ok).toBeDefined();
+    const taintId = await seedDoc(rt, "occ-carry-forward-taint", { n: 1 }, [
+      { path: [], label: { confidentiality: ["taint"] } },
     ]);
 
     const tx = rt.edit();
+    tx.readOrThrow(readAddress(taintId, []));
     const cell = rt.getCell(space, "occ-carry-forward", undefined, tx);
     cell.key("other").set(2);
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
-    const entry = entriesOf(id).find((e) => e.path.join("/") === "slot");
-    expect(entry).toBeDefined();
-    expect(entry!.observes).toBe("followRef");
+    const stored = entriesOf(id);
+    // The write really did rewrite the labelMap (the flow stamp landed) —
+    // without this the assertions below pass trivially on untouched
+    // metadata.
+    expect(
+      stored.find((e) => e.origin === "derived" && e.path.join("/") === "other")
+        ?.label.confidentiality,
+    ).toEqual(["taint"]);
+    const slotEntry = stored.find((e) => e.path.join("/") === "slot");
+    expect(slotEntry).toBeDefined();
+    expect(slotEntry!.observes).toBe("followRef");
+    const vClasses = stored.filter((e) => e.path.join("/") === "v")
+      .map((e) => [e.observes, ...(e.label.confidentiality ?? [])]);
+    expect(vClasses.sort()).toEqual([
+      ["shape", "v-existence"],
+      ["value", "v-content"],
+    ]);
   });
 });

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
+import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
+import type { LabelMapEntry } from "../src/cfc/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-observation-classes");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// Epic C stage C1 (docs/specs/cfc-observation-classes.md §4/§6): flow
+// observations are classified by WHAT they observed — recursive value read,
+// nonRecursive shape read, or followRef slot-pointer probe — and consume
+// only class-compatible labelMap entries.
+//
+// The parity contract is SCOPED (C0 §6): value/shape/enumerate reads over
+// legacy covering entries stay byte-identical to the pre-C1 join; the
+// followRef path intentionally WIDENS — a standalone slot-pointer probe now
+// consumes the pointer's link-origin label, which is the SC-8 fix — and is
+// asserted below as the new, wider join, not claimed as parity.
+describe("CFC observation classes (C1 read-shape plumbing)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const seedDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    entries: LabelMapEntry[],
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: { version: 1, entries },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const derivedConfidentiality = (id: string): string[] | undefined =>
+    entriesOf(id).find((e) => e.origin === "derived")?.label.confidentiality;
+
+  const readAddress = (id: string, path: string[]) => ({
+    space,
+    scope: "space" as const,
+    id: id as `${string}:${string}`,
+    type: "application/json" as const,
+    path: ["value", ...path],
+  });
+
+  // The doc every test seeds: a legacy covering entry at the root, a
+  // covering derived entry on a field, and a link-origin pointer label on a
+  // slot (implicitly `observes:"followRef"` per the C0 §3 carve-out).
+  const seedMixedDoc = (rt: Runtime, cause: string) =>
+    seedDoc(rt, cause, { field: "f", slot: { "/": { "link@1": {} } } }, [
+      { path: [], label: { confidentiality: ["root-covering"] } },
+      {
+        path: ["field"],
+        label: { confidentiality: ["field-derived"] },
+        origin: "derived",
+      },
+      {
+        path: ["slot"],
+        label: { confidentiality: ["pointer-label"] },
+        origin: "link",
+      },
+    ]);
+
+  // Runs `observe` inside a fresh tx that also writes an output doc, then
+  // commits (prepareCfc explicitly unless `autoRelevance`), and returns the
+  // output doc's derived flow confidentiality.
+  const flowJoinOf = async (
+    rt: Runtime,
+    outCause: string,
+    observe: (tx: ReturnType<Runtime["edit"]>) => void,
+    options?: { autoRelevance?: boolean },
+  ): Promise<string[] | undefined> => {
+    const tx = rt.edit();
+    observe(tx);
+    const out = rt.getCell(space, outCause, undefined, tx);
+    out.set({ copied: true });
+    if (!options?.autoRelevance) {
+      tx.prepareCfc();
+    }
+    expect((await tx.commit()).ok).toBeDefined();
+    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+  };
+
+  // C0 §6 parity, scoped: a recursive VALUE read joins the covering root
+  // entry and the descendant derived entry — byte-identical to the pre-C1
+  // join — and still never consumes the link-origin pointer label (the
+  // §3 carve-out: origin:"link" with absent observes is followRef-only,
+  // never covering).
+  it("value reads: legacy covering join is byte-identical; link-origin entries stay excluded", async () => {
+    const rt = makeRuntime();
+    const id = await seedMixedDoc(rt, "occ-value-read");
+    const join = await flowJoinOf(rt, "occ-value-out", (tx) => {
+      tx.readOrThrow(readAddress(id, []));
+    });
+    expect(join).toEqual(["root-covering", "field-derived"]);
+  });
+
+  // Shape reads (nonRecursive: key-add, length — the spec's `count` class
+  // folds into `enumerate`, C0 §4) consume covering + shape + enumerate
+  // entries at the node: not descendants, not value-class entries, not
+  // pointer labels.
+  it("shape reads consume enumerate + covering at the node only; value-class entries are skipped", async () => {
+    const rt = makeRuntime();
+    const id = await seedDoc(rt, "occ-shape-read", { field: "f" }, [
+      { path: [], label: { confidentiality: ["root-covering"] } },
+      {
+        path: [],
+        label: { confidentiality: ["members-secret"] },
+        origin: "derived",
+        observes: "enumerate",
+      },
+      {
+        path: [],
+        label: { confidentiality: ["content-secret"] },
+        origin: "derived",
+        observes: "value",
+      },
+      {
+        path: ["field"],
+        label: { confidentiality: ["field-derived"] },
+        origin: "derived",
+      },
+    ]);
+    const join = await flowJoinOf(rt, "occ-shape-out", (tx) => {
+      tx.readOrThrow(readAddress(id, []), { nonRecursive: true });
+    });
+    expect(join).toEqual(["root-covering", "members-secret"]);
+  });
+
+  // The SC-8 widening (NOT parity — C0 §6 scopes it out deliberately): a
+  // standalone slot-pointer probe — a `linkResolutionProbe` read with no
+  // dereference trace covering the slot — observed WHICH reference sits at
+  // the slot. Pre-C1 this observation was skipped and the flow join stayed
+  // empty; it now consumes the pointer's link-origin label, and ONLY that:
+  // covering entries label content/shape a pointer observation never read.
+  it("standalone probes consume the link-origin pointer label (SC-8 widening, the new wider join)", async () => {
+    const rt = makeRuntime();
+    const id = await seedMixedDoc(rt, "occ-probe-read");
+    const join = await flowJoinOf(rt, "occ-probe-out", (tx) => {
+      tx.read(readAddress(id, ["slot"]), { meta: linkResolutionProbe });
+    });
+    expect(join).toEqual(["pointer-label"]);
+  });
+
+  // The relevance trigger widens with the reader: a tx whose only labeled
+  // contact is a standalone probe over a doc holding only a link-origin
+  // entry must auto-mark flow relevance at commit (no prepareCfc call).
+  it("standalone probes auto-mark flow relevance without an explicit prepareCfc", async () => {
+    const rt = makeRuntime();
+    const id = await seedDoc(rt, "occ-probe-relevance", {
+      slot: { "/": { "link@1": {} } },
+    }, [
+      {
+        path: ["slot"],
+        label: { confidentiality: ["pointer-label"] },
+        origin: "link",
+      },
+    ]);
+    const join = await flowJoinOf(rt, "occ-probe-relevance-out", (tx) => {
+      tx.read(readAddress(id, ["slot"]), { meta: linkResolutionProbe });
+    }, { autoRelevance: true });
+    expect(join).toEqual(["pointer-label"]);
+  });
+
+  // C0 §4's dereference row stays unchanged: a probe that belongs to a
+  // dereference this tx performed (a recorded trace source at-or-above the
+  // probed path) is resolution machinery, not a followRef observation — the
+  // taint of what was read arrives via ordinary reads of the target.
+  it("probes covered by a dereference trace are machinery: no followRef consumption", async () => {
+    const rt = makeRuntime();
+    const id = await seedMixedDoc(rt, "occ-deref-read");
+    const join = await flowJoinOf(rt, "occ-deref-out", (tx) => {
+      tx.read(readAddress(id, ["slot"]), { meta: linkResolutionProbe });
+      tx.recordCfcDereferenceTrace({
+        source: { space, id, scope: "space", path: ["slot"] },
+        target: {
+          space,
+          id: "of:target-doc",
+          scope: "space",
+          path: [],
+        },
+        kind: "value",
+      });
+    });
+    expect(join).toBeUndefined();
+  });
+
+  // Explicit `observes:"followRef"` entries behave like the implicit link
+  // carve-out: consumed by probes only, never as covering entries.
+  it("explicit followRef entries are consumed by probes only", async () => {
+    const rt = makeRuntime();
+    const seed = (cause: string) =>
+      seedDoc(rt, cause, { slot: { "/": { "link@1": {} } } }, [
+        {
+          path: ["slot"],
+          label: { confidentiality: ["ref-secret"] },
+          origin: "derived",
+          observes: "followRef",
+        },
+      ]);
+
+    const valueId = await seed("occ-explicit-followref-value");
+    const valueJoin = await flowJoinOf(rt, "occ-explicit-value-out", (tx) => {
+      tx.readOrThrow(readAddress(valueId, []));
+    });
+    expect(valueJoin).toBeUndefined();
+
+    const probeId = await seed("occ-explicit-followref-probe");
+    const probeJoin = await flowJoinOf(rt, "occ-explicit-probe-out", (tx) => {
+      tx.read(readAddress(probeId, ["slot"]), { meta: linkResolutionProbe });
+    });
+    expect(probeJoin).toEqual(["ref-secret"]);
+  });
+
+  // followRef observations contribute confidentiality only: the hereditary
+  // integrity meet quantifies over the transformation's content inputs
+  // (§8.9.3), so a standalone probe that resolves no label must not empty
+  // the meet and end certification propagation.
+  it("followRef observations do not participate in the hereditary integrity meet", async () => {
+    const rt = makeRuntime();
+    const certified = {
+      type: CFC_ATOM_TYPE.PolicyCertified,
+      policy: "p1",
+    };
+    const certifiedId = await seedDoc(rt, "occ-meet-certified", { n: 1 }, [
+      {
+        path: [],
+        label: {
+          confidentiality: ["certified-secret"],
+          integrity: [certified],
+        },
+      },
+    ]);
+    const bareId = await seedDoc(rt, "occ-meet-bare", {
+      slot: { "/": { "link@1": {} } },
+    }, []);
+
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(certifiedId, []));
+    // A standalone probe of an unlabeled slot: resolves no label. Letting it
+    // into the meet would empty it.
+    tx.read(readAddress(bareId, ["slot"]), { meta: linkResolutionProbe });
+    // Read-free write (`cell.set()` would journal an uncertified read of the
+    // output doc's prior value and rightly empty the meet on its own).
+    const out = rt.getCell(space, "occ-meet-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: outId, path: ["value"] },
+      { copied: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const derived = entriesOf(outId).find((e) => e.origin === "derived");
+    expect(derived).toBeDefined();
+    expect(derived!.label.integrity ?? []).toContainEqual(certified);
+  });
+
+  // The class axis survives persistence: canonicalization keeps `observes`
+  // (ordering per-class deterministically), and the persist region's
+  // carry-forward of untouched paths preserves it across unrelated writes.
+  it("canonicalization and carry-forward preserve the observes axis", async () => {
+    const canonical = canonicalizeCfcMetadata({
+      version: 1,
+      schemaHash: "h",
+      labelMap: {
+        version: 1,
+        entries: [
+          {
+            path: ["a"],
+            label: { confidentiality: ["s"] },
+            origin: "derived",
+            observes: "value",
+          },
+          {
+            path: ["a"],
+            label: { confidentiality: ["e"] },
+            origin: "derived",
+            observes: "shape",
+          },
+        ],
+      },
+    });
+    expect(canonical.labelMap.entries.map((e) => e.observes)).toEqual([
+      "shape",
+      "value",
+    ]);
+
+    const rt = makeRuntime();
+    const id = await seedDoc(rt, "occ-carry-forward", {
+      slot: { "/": { "link@1": {} } },
+      other: 1,
+    }, [
+      {
+        path: ["slot"],
+        label: { confidentiality: ["ref-secret"] },
+        origin: "derived",
+        observes: "followRef",
+      },
+    ]);
+
+    const tx = rt.edit();
+    const cell = rt.getCell(space, "occ-carry-forward", undefined, tx);
+    cell.key("other").set(2);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const entry = entriesOf(id).find((e) => e.path.join("/") === "slot");
+    expect(entry).toBeDefined();
+    expect(entry!.observes).toBe("followRef");
+  });
+});


### PR DESCRIPTION
Epic C stage C1 of `docs/plans/cfc-future-work-implementation.md` §4, per the C0 design (`docs/specs/cfc-observation-classes.md`, #4476) including the patched points from #4482 (link-origin carve-out, scoped parity, count→enumerate folding, two-regime rollout).

## What

A flow observation now consumes only the labelMap entries whose observation class matches what the read actually observed (spec §4.6.3):

- **`LabelMapEntry.observes?`** — new optional consumption axis (`value` | `shape` | `enumerate` | `followRef`), orthogonal to `origin`. Absent = covering for the content classes. **Carve-out (C0 §3, patched):** `origin:"link"` with absent `observes` is implicitly `observes:"followRef"` — consumed by followRef reads ONLY, never as a covering entry. `count` has no axis value: count-shaped reads (length) consume `enumerate` (C0 §4, patched).
- **`forEachFlowObservation`** classifies each read: recursive value read = `value+shape+enumerate`; `nonRecursive` = `shape+enumerate`; `linkResolutionProbe` = `followRef`. **Probes stop being skipped** — that exclusion was the SC-8 residual.
- **`effectiveReadLabel`** selects entries by class-compatibility; `excludeLinkOrigin` becomes class selection. The D2 write-gate keeps a deliberate class-blind `"all"` selection (over-inclusive is the fail-safe direction for a screen; per-class narrowing is C4).
- **`flowLabelWorkExists`** mirrors the class selection: probe-only transactions over link-labeled docs now auto-mark flow relevance.
- `canonicalizeCfcMetadata` and the persist-region carry-forward preserve `observes` (deterministic per-class ordering).

## Parity (scoped per C0 §6) and the intentional widening

- **Parity:** with only legacy covering entries, derived flow joins are **byte-identical** to today for value/shape/enumerate reads (asserted with exact-array equality in `cfc-observation-classes.test.ts`; these tests pass unchanged on pre-C1 code).
- **Widening (the SC-8 fix, asserted as the new wider join, not claimed as parity):** a standalone slot-pointer probe — no dereference — now consumes the pointer's link-origin label. Red→green: `standalone probes consume the link-origin pointer label`, `standalone probes auto-mark flow relevance`, `explicit followRef entries are consumed by probes only`, and the shape-class selection test all **fail on pre-C1 code** and pass here; the parity/machinery/meet tests pass on both sides.

## Refinements forced by code validation (recorded in C0 §6.1)

Implementing the naive readings broke the phase-B pointwise reader guarantees (`cfc-flow-pointwise.test.ts`); three refinements are now normative and documented:

1. **followRef reads consume only followRef-class entries** — covering entries label content; consuming them would taint every blind pass-through's terminal probe with the target's content label.
2. **The §4 row 3 / row 4 boundary is the dereference trace:** probes covered at-or-above by a same-tx trace source are resolution machinery (dereference, unchanged); only standalone probes are followRef observations. Without this, every traversal's own probes join each hop's pointer label and coordinator J re-smears pointwise flows.
3. **followRef observations contribute confidentiality only** — admitting them to the §8.9.3 hereditary meet (weakest-link) would empty it on virtually every transaction and silently end TransformedBy/PolicyCertified propagation.

## Rollout ordering (hard prerequisite, C0 §9)

C1 is the **reader-first half** of the followRef regime: the reader must understand observation classes **before any writer persists `observes:"followRef"` entries (C2)**. The fail-safe-by-construction claim does not hold for followRef — a class-unaware reader *drops* `origin:"link"` entries via `excludeLinkOrigin`, so writer-first would **under-taint** (not conservatively over-taint) on mixed versions. C2 must land after this PR is deployed, or gate followRef persistence behind a dial flipped only after readers understand it.

## Perf (plan §0 gate: both cfc benches, before/after — flat, within noise)

`cfc-label-sync-strategy.bench.ts` (M3 Max):

| benchmark | before | after |
|---|---|---|
| syncMetaLinkedDocs (warm) serial [old] | 108.2 ms | 108.8 ms |
| syncMetaLinkedDocs (warm) parallel batch | 3.4 ms | 3.4 ms |
| syncMetaLinkedDocs (warm) skip when present | 1.4 µs | 1.5 µs |
| getCfcLabel (warm) pure read [new] | 1.3 µs | 1.3 µs |
| syncMetaLinkedDocs (cold) serial [old] | 108.2 ms | 108.1 ms |
| syncMetaLinkedDocs (cold) skip when present [new] | 3.4 ms | 3.4 ms |

`cfc-canonicalize.bench.ts`:

| benchmark | before | after |
|---|---|---|
| preparedDigestFor — small | 13.5 µs | 13.2 µs |
| preparedDigestFor — large | 73.3 µs | 71.0 µs |
| canonicalizePreparedDigestInput — large | 3.8 µs | 3.7 µs |
| preparedDigestFor — tiebreak-heavy | 14.8 µs | 14.7 µs |
| preparedDigestFor — path-heavy | 70.4 µs | 67.6 µs |
| preparedDigestFor — large WARM | 72.5 µs | 72.6 µs |
| preparedDigestFor — path-heavy WARM | 55.1 µs | 54.5 µs |
| watchIdForEntry | 4.5 µs | 4.3 µs |

## Tests

- New `packages/runner/test/cfc-observation-classes.test.ts` (8 cases: scoped parity ×2, SC-8 widening ×2, deref-machinery, explicit followRef classes, hereditary-meet exclusion, observes persistence).
- Full `packages/runner` suite green: 747 passed / 0 failed (includes all 70 cfc test files and the phase-B pointwise suite unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds observation-class aware reads in CFC and ensures label coalescing preserves the `observes` class. Reads now only consume labels matching what was observed, and standalone probes consume pointer labels; deploy this reader before any writer persists `observes:"followRef"`.

- **New Features**
  - Added `observes` to `LabelMapEntry` (`value`, `shape`, `enumerate`, `followRef`). Legacy `origin:"link"` without `observes` is treated as `followRef` (probes only); covering entries apply to content classes only.
  - Classified reads in `forEachFlowObservation`: recursive = `value`; `nonRecursive` = `shape` (count folds into `enumerate`); standalone probe = `followRef`. Probes covered by a same-tx dereference trace are treated as machinery.
  - Replaced `excludeLinkOrigin` with class-based selection in `effectiveReadLabel`; D2 write-gate stays class-blind (`consumes:"all"`). `followRef` observations contribute confidentiality only.
  - `flowLabelWorkExists` mirrors class selection so probe-only transactions over link-labeled docs auto-mark relevance.
  - Canonicalization orders by `observes` and carry-forward preserves `observes`.

- **Bug Fixes**
  - Fixed `coalesceLabelEntries` to key by `(path, origin, observes)` and preserve `observes` in rebuilt entries, preventing class loss and unintended covering merges (e.g., `value`+`shape` siblings).
  - Strengthened carry-forward test to ensure metadata rewrites retain explicit `observes` (including `followRef`) and the persist-split pair remains separate.

<sup>Written for commit 66c529152d4d932081717ff087367ff78446e3c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

