### PR TITLE
perf(ci): shorten workspace test tail

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -62,6 +62,37 @@ Jobs and steps for a run:
 `GET /repos/commontoolsinc/labs/actions/runs/<run-id>/jobs?per_page=100` — each
 job and step carries `started_at` and `completed_at`.
 
+## Root Test Job Shape
+
+The `Test` job in `.github/workflows/deno.yml` runs the root `deno task test`
+with `TEST_DISABLED_PACKAGES=runner`. The runner package has its own sharded CI
+job, so the root job skips it. The root task still collects workspace coverage
+with `DENO_COVERAGE_DIR`.
+
+The root task is `tasks/test.ts`. It reads the workspace list from
+`deno.jsonc`, starts `deno task test` in every enabled package at the same time,
+and waits for all packages to finish. Its wall time is set by the slowest
+package test task, plus the fixed setup and coverage report steps around it.
+
+When this job becomes the long pole, start with the `Package timings:` block
+printed by `tasks/test.ts`. A slow package may simply be running many independent
+test modules serially. Deno's `--parallel` mode can reduce that package's wall
+time, but only after checking for tests that share process-wide state.
+
+Known serial CLI tests:
+
+- `test/fuse.test.ts`, `test/inspect-remote.test.ts`,
+  `test/log-level.test.ts`, `test/main-command.test.ts`,
+  `test/test-runner-compile-byte-cache.test.ts`, and
+  `test/test-runner-pattern-coverage.test.ts` mutate shared process state.
+- `test/view-mod-gate.test.ts` changes into a removed directory to test the
+  missing-current-directory fallback.
+- `test/view-pager-pty.test.ts` drives a real pseudo-terminal and is sensitive
+  to heavy workspace contention.
+
+The CLI package keeps those tests in a serial group and runs the rest of its
+test modules with `--parallel`.
+
 ## Coverage Debt Baselines
 
 Performance Check also tracks coverage debt as uncovered source lines. See

--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -3,7 +3,7 @@
   "tasks": {
     "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.jsonc --cli-entrypoint ./mod.ts --",
     "cli-no-pwd-override": "CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
-    "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env --allow-net=127.0.0.1 test/*.test.ts support",
+    "test": "deno run --allow-read --allow-run --allow-env test/run-tests.ts",
     "integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/integration.sh",
     "fuse-integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/fuse-exec.sh",
     "acl-integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/acl.sh"

--- a/packages/cli/test/run-tests.ts
+++ b/packages/cli/test/run-tests.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-env
+import { join } from "@std/path";
+
+const PERMISSIONS = [
+  "--allow-ffi",
+  "--allow-read",
+  "--allow-write",
+  "--allow-run",
+  "--allow-env",
+  "--allow-net=127.0.0.1",
+];
+
+const SERIAL_TESTS = [
+  "test/fuse.test.ts",
+  "test/inspect-remote.test.ts",
+  "test/log-level.test.ts",
+  "test/main-command.test.ts",
+  "test/test-runner-compile-byte-cache.test.ts",
+  "test/test-runner-pattern-coverage.test.ts",
+  "test/view-mod-gate.test.ts",
+  "test/view-pager-pty.test.ts",
+];
+
+function slashPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+async function collectTests(dir: string): Promise<string[]> {
+  const tests: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    const path = slashPath(join(dir, entry.name));
+    if (entry.isDirectory) {
+      tests.push(...await collectTests(path));
+    } else if (entry.isFile && path.endsWith(".test.ts")) {
+      tests.push(path);
+    }
+  }
+  return tests;
+}
+
+async function run(
+  label: string,
+  options: string[],
+  files: string[],
+): Promise<void> {
+  if (files.length === 0) {
+    console.log(`Skipping ${label} (0 files)`);
+    return;
+  }
+
+  console.log(`Running ${label} (${files.length} files)`);
+  const result = await new Deno.Command(Deno.execPath(), {
+    args: ["test", ...PERMISSIONS, ...options, ...files],
+    stdout: "inherit",
+    stderr: "inherit",
+  }).spawn().status;
+  if (!result.success) {
+    Deno.exit(result.code);
+  }
+}
+
+const tests = (await Promise.all(["test", "support"].map(collectTests)))
+  .flat()
+  .sort();
+const serial = new Set(SERIAL_TESTS);
+const missingSerialTests = SERIAL_TESTS.filter((test) => !tests.includes(test));
+if (missingSerialTests.length > 0) {
+  console.error(
+    `Serial CLI test file(s) not found: ${missingSerialTests.join(", ")}`,
+  );
+  Deno.exit(1);
+}
+
+const parallelTests = tests.filter((test) => !serial.has(test));
+const denoTestArgs = Deno.args[0] === "--" ? Deno.args.slice(1) : Deno.args;
+
+await run("parallel CLI tests", ["--parallel", ...denoTestArgs], parallelTests);
+await run("serial CLI tests", denoTestArgs, SERIAL_TESTS);

--- a/packages/schema-generator/deno.jsonc
+++ b/packages/schema-generator/deno.jsonc
@@ -14,7 +14,7 @@
     "typescript": "npm:typescript"
   },
   "tasks": {
-    "test": "deno test --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK test/**/*.test.ts",
+    "test": "deno test --parallel --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK test/**/*.test.ts",
     "test:check": "deno test --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK test/**/*.test.ts",
     "check": "deno check src/**/*.ts test/**/*.ts",
     "fmt": "deno fmt src/ test/",

--- a/packages/ts-transformers/deno.jsonc
+++ b/packages/ts-transformers/deno.jsonc
@@ -13,7 +13,7 @@
     "typescript": "npm:typescript"
   },
   "tasks": {
-    "test": "deno test --allow-read --allow-write --allow-env test/**/*.test.ts",
+    "test": "deno test --parallel --allow-read --allow-write --allow-env test/**/*.test.ts",
     "check": "deno check src/**/*.ts",
     "fmt": "deno fmt src/ test/**/*.test.ts",
     "lint": "deno lint src/ test/"


### PR DESCRIPTION
The CI Test job runs the root workspace test task with coverage enabled and the runner package disabled. That root task starts package test tasks together and then waits for the slowest package. Recent timing data showed that the Test job had become the long pole, and local measurements showed that cli, ts-transformers, and schema-generator were the packages setting the tail.

Run the ts-transformers and schema-generator test modules with Deno parallelism. Replace the CLI package test command with a small Deno runner that keeps tests with shared process state in a serial group and runs the remaining CLI test modules with Deno parallelism. The runner still uses deno test for both groups, forwards extra deno test arguments, and fails if a known serial test file disappears.

Document the root Test job shape and the known CLI serial tests in the CI performance guide so future timing investigations have a durable starting point.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens the CI workspace test tail by parallelizing safe package tests and splitting `cli` tests into parallel and serial groups. Speeds up the Test job without changing test coverage or behavior.

- **Refactors**
  - Enable `deno test --parallel` in `ts-transformers` and `schema-generator`.
  - Replace `cli` test task with `test/run-tests.ts` that runs safe tests in parallel, keeps known serial files separate, forwards extra `deno test` args, and fails if a serial file disappears.
  - Document the root `Test` job shape and the known `cli` serial tests in `docs/development/CI_PERFORMANCE.md`.

<sup>Written for commit fc04c289e55ccd857537a7eb1fb310308cb56e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

