### PR TITLE
fix(runner): store the SqliteDb handle self-contained (multi-runtime shared-query hash stability)

### DIFF
--- a/docs/specs/sqlite-builtin/03-database-sources.md
+++ b/docs/specs/sqlite-builtin/03-database-sources.md
@@ -34,6 +34,15 @@ to creation and opaque to the pattern. The handle cell reads back
 [`packages/runner/src/builtins/sqlite-builtins.ts`](../../../packages/runner/src/builtins/sqlite-builtins.ts)
 `sqliteDatabase`).
 
+- The handle value is stored **self-contained** (one raw inline write, no
+  linked sub-documents). A rowLabel rule's term lists are arrays of objects,
+  which an ordinary cell write would split into per-element linked docs that no
+  schema-driven sync loads — a second runtime would deep-resolve them to
+  `null`, hash a DIFFERENT request for the same shared query result cell, and
+  the two runtimes would re-issue against each other's hashes forever.
+  Self-containment keeps the request identity equal across every client of a
+  shared db; `db.exec`'s rev bump is a leaf write for the same reason (a
+  whole-value rewrite from a handler frame would re-split the term lists).
 - There is **no way to point the database at an arbitrary cell**. A pattern
   cannot pass "some other cell" as the database's identity; doing so would
   re-introduce ambient authority (a pattern naming a cell it was never granted).

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -38,10 +38,15 @@ import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
 import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import {
+  fabricFromNativeValue,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
+import {
   entityRefToString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
 import { columnDeclaresIfc } from "@commonfabric/memory/v2";
+import { validateRowLabelSpec } from "@commonfabric/memory/sqlite/row-label";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 type SqliteDbRef = {
@@ -55,6 +60,11 @@ type SqliteDbRef = {
   // once at handle creation (CFC Phase 3: resolves the row rule's dbOwner()
   // and the ceiling's __ctDbOwner placeholder; never the acting reader).
   owner?: string;
+  // db.exec's optimistic-concurrency revision (bumped per write, cell.ts). A
+  // handle re-derivation must carry it forward: deleting it changes the handle
+  // value, which every consumer hashing the handle (e.g. sqliteQuery's
+  // reactOn) sees as "new inputs".
+  rev?: number;
 };
 type WireParams = readonly unknown[] | Record<string, unknown> | undefined;
 
@@ -99,10 +109,11 @@ function readDbRef(value: unknown): SqliteDbRef {
     const ref = value as SqliteDbRef;
     return {
       id: ref.id,
-      // Materialize to plain JSON: a rowLabel rule's term LISTS (arrays of
-      // objects) split into per-element entity docs when the handle value is
-      // stored, so the stored form holds doc LINKS — the wire (server
-      // provenance gate) and every local consumer need the resolved spec.
+      // Materialize to plain JSON: sqliteDatabase stores the handle value
+      // inline (self-contained), but a handle written before that fix (or a
+      // proxy-carried read) can still hold doc LINKS where the rule's AST
+      // nodes should be — the wire (server provenance gate) and every local
+      // consumer need the resolved spec.
       tables: ref.tables
         ? cloneIfNecessary(
           ref.tables as Parameters<typeof cloneIfNecessary>[0],
@@ -116,6 +127,33 @@ function readDbRef(value: unknown): SqliteDbRef {
     };
   }
   throw new TypeError("sqlite: invalid database handle");
+}
+
+/**
+ * Whether a materialized `tables` value is fully RESOLVED in this runtime — no
+ * table (or rule) read through a not-yet-loaded linked doc. A rowLabel rule's
+ * term LIST (array of objects) splits into per-element entity docs wherever it
+ * passes through a builder-frame write (e.g. pattern static data), and no
+ * schema-driven sync loads those splits, so a runtime that merely LOADED the
+ * pattern can deep-resolve them to `null` (the #3830 class). Materializing
+ * that read would bake `allOf: [null]` into the handle — a different value
+ * (and request hash) than the creator wrote. Validation is the resolution
+ * probe: a resolved rule always validates; a null-riddled one never does.
+ */
+function dbTablesResolved(
+  tables: Record<string, unknown> | undefined,
+): boolean {
+  if (tables === undefined) return true;
+  for (const t of Object.values(tables)) {
+    if (!t || typeof t !== "object") return false; // an unresolved table doc
+    const spec = (t as { rowLabel?: unknown }).rowLabel;
+    if (spec === undefined) continue;
+    const columns = Object.keys(
+      (t as { properties?: Record<string, unknown> }).properties ?? {},
+    );
+    if (validateRowLabelSpec(spec, columns) !== undefined) return false;
+  }
+  return true;
 }
 
 /** Union of the per-column (Phase 2) confidentiality atoms a labeled result
@@ -493,13 +531,44 @@ export function sqliteDatabase(
       // a column's read label or widen its write ceiling (audit S8). First
       // creation (no prior) passes the declared tables through unchanged.
       const prior = handle.withTx(tx).get() as SqliteDbRef | undefined;
-      const tables = growOnlyMergeDbTables(prior?.tables, options?.tables);
-      handle.withTx(tx).set({
-        id,
-        tables,
-        scope,
-        ...(owner !== undefined && { owner }),
-      });
+      const merged = growOnlyMergeDbTables(prior?.tables, options?.tables);
+      // Materialize to plain JSON: the stored handle must be SELF-CONTAINED.
+      // A raw `set` of the inputs proxy would capture `tables` as a LINK into
+      // this pattern's doc graph — whose rule-term splits no schema-driven
+      // sync loads — so a second runtime deep-resolves parts of it to null and
+      // hashes a DIFFERENT request for the same shared query cell: each
+      // runtime sees the other's hash as "new inputs" and re-issues forever.
+      // Inline, every runtime that can read the handle doc has the full spec.
+      const tables = merged !== undefined
+        ? cloneIfNecessary(
+          merged as Parameters<typeof cloneIfNecessary>[0],
+          { frozen: false },
+        ) as Record<string, unknown>
+        : undefined;
+      // Fail closed on an UNRESOLVED materialization (this runtime loaded the
+      // pattern but not every linked doc under `tables`): writing it would
+      // bake nulls over a good prior value. The prior handle stays; a runtime
+      // that resolves fully (the creator, at least) writes the inline form.
+      if (prior === undefined || dbTablesResolved(tables)) {
+        // RAW write, not `.set()`: this first action run can execute inside
+        // the pattern's builder frame, where `set` [ID]-anchors every object
+        // in an array — splitting a rule's term list into per-element entity
+        // docs (the very shape the materialization above exists to avoid).
+        // The raw write stores the subtree verbatim; `onlyIfDifferent` keeps
+        // an unchanged re-derivation write-free (no hash churn per runtime).
+        handle.withTx(tx).setRawUntyped(
+          fabricFromNativeValue({
+            id,
+            ...(tables !== undefined && { tables }),
+            scope,
+            ...(owner !== undefined && { owner }),
+            // Carry db.exec's write revision forward — dropping it would make
+            // this re-derivation look like "new inputs" to every handle hasher.
+            ...(typeof prior?.rev === "number" && { rev: prior.rev }),
+          }) as FabricValue,
+          true,
+        );
+      }
       sendResult(tx, handle);
       initialized = true;
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1125,11 +1125,12 @@ export class CellImpl<T extends FabricValue>
         ".exec() is only available on a SqliteDb cell (invalid database handle)",
       );
     }
-    // Materialize `tables` through a RESOLVING read: a rowLabel rule's term
-    // lists (arrays of objects) split into per-element entity docs when the
-    // handle value is stored, so `getRaw` sees doc LINKS where the rule's AST
-    // nodes should be. The permissive schema bypasses the SqliteDb shape (no
-    // declared properties) that would shape `get()` down to `{}`.
+    // Materialize `tables` through a RESOLVING read: sqliteDatabase now
+    // stores the handle inline (self-contained), but a handle written before
+    // that fix can still hold doc LINKS where the rule's AST nodes should be,
+    // so `getRaw` alone would see links. The permissive schema bypasses the
+    // SqliteDb shape (no declared properties) that would shape `get()` down
+    // to `{}`.
     const materialized = this.asSchema(
       { type: "object", additionalProperties: true } as JSONSchema,
     ).withTx(this.tx).get() as { tables?: unknown } | undefined;
@@ -1209,9 +1210,14 @@ export class CellImpl<T extends FabricValue>
     //  - it serializes concurrent writers: each does a read-modify-write of
     //    `rev`, so two in-flight `db.exec` commits conflict on this cell's
     //    revision (optimistic-concurrency mutex) and one retries.
+    // A LEAF write, not a whole-value set of `{...handle, rev}`: exec runs
+    // inside a handler frame, where a whole-value `.set()` [ID]-anchors every
+    // object-in-array and would split the handle's inline rule term lists
+    // back into per-element linked docs — the split sqliteDatabase stores the
+    // handle raw specifically to avoid (a second runtime can't load those).
     const rev = ((handle as { rev?: unknown }).rev as number | undefined) ?? 0;
-    this.withTx(this.tx).set(
-      { ...(handle as Record<string, unknown>), rev: rev + 1 } as unknown as T,
+    (this.withTx(this.tx) as unknown as Cell<{ rev: number }>).key("rev").set(
+      rev + 1,
     );
   }
 

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -1,0 +1,359 @@
+// Multi-runtime stability of the SqliteDb handle (CFC Phase 3 rule-bearing
+// dbs). A rowLabel rule's term LIST (`all(a, b, …)` — an array of objects)
+// used to split into per-element entity docs when the handle value was stored
+// (Cell.set assigns [ID] to every object-in-array). Those term docs are not
+// reachable through any schema-driven sync, so a SECOND runtime deep-resolved
+// the links to `null` and `sqliteQuery` hashed `allOf: [null]` while the
+// creator runtime hashed the resolved AST — two request hashes fighting over
+// ONE shared (space-scoped) result cell, each runtime seeing the other's hash
+// as "new inputs" and re-issuing forever (the query never settles).
+//
+// Guarded contract: the stored handle value is SELF-CONTAINED (no linked
+// docs), so every runtime that can read the handle doc has the full resolved
+// spec — one request hash per logical query, shared result-cell dedup works.
+//
+// The harness runs two real Runtimes with SEPARATE storage managers over one
+// in-process memory server (separate heaps are the point: the bug only shows
+// when a doc can exist server-side but not in the reading runtime's heap; the
+// single-StorageManager emulate() setup would mask it).
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { SqliteTableSchemas } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createCell } from "../src/cell.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { isSigilLink } from "../src/link-utils.ts";
+
+// Fresh identity per RUN: the server derives the on-disk cell-db file from the
+// (causal) db id, so a fixed passphrase would reuse a stale $TMPDIR db across
+// test runs (the classic same-file repro trap).
+const signer = await Identity.fromPassphrase(
+  `sqlite handle multi runtime ${crypto.randomUUID()}`,
+);
+const space = signer.did();
+
+// ---------------------------------------------------------------------------
+// Two storage managers, ONE server — the emulated loopback session factory
+// (mirrors v2-emulate.ts) against a caller-owned server, so each manager has
+// its own heap/replica while sharing the durable state.
+// ---------------------------------------------------------------------------
+
+class LoopbackSessionFactory implements SessionFactory {
+  constructor(private readonly server: MemoryV2Server.Server) {}
+
+  async create(space: MemorySpace, signer?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(this.server),
+    });
+    const session = await client.mount(
+      space,
+      {},
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: { principal: signer?.did() },
+      }),
+    );
+    return { client, session };
+  }
+}
+
+class SharedServerStorageManager extends StorageManager {
+  static overServer(
+    options: Omit<Options, "memoryHost">,
+    server: MemoryV2Server.Server,
+  ): SharedServerStorageManager {
+    return new SharedServerStorageManager(
+      // Placeholder: the loopback session factory never resolves an address.
+      { ...options, memoryHost: new URL("memory://") },
+      new LoopbackSessionFactory(server),
+    );
+  }
+}
+
+function newServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-runner-shared-server-test",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The pattern under test: a rule-bearing db whose rule is a term LIST
+// (`all(sender, recipients)` — the mailbox shape), plus a shared query.
+// Rebuilt per runtime (each has its own trusted builder); the causal ids
+// derive from the shared result cell, so both runtimes address the same docs.
+// ---------------------------------------------------------------------------
+
+const RESULT_CAUSE = "sqlite-handle-multi-runtime";
+
+// The tables flow through the pattern ARGUMENT (a real doc, like a compiled
+// pattern's static data) rather than a builder literal: that is the shape
+// where the handle write used to capture `tables` as a LINK into the pattern's
+// doc graph — whose term-list splits a second runtime never loads.
+function makeTables(
+  cf: ReturnType<typeof createTrustedBuilder>["commonfabric"],
+) {
+  const { table, all, principal, match } = cf.cfSqlite;
+  const ADDR = /[^\s<>,;"]+@[^\s<>,;"]+/g;
+  return {
+    emails: table(
+      {
+        id: "integer primary key",
+        from_addr: "text",
+        to_addrs: "text",
+      },
+      (f) => ({
+        confidentiality: all(
+          principal("mailto", match(f.from_addr, ADDR, { min: 1 })),
+          principal("mailto", match(f.to_addrs, ADDR)),
+        ),
+      }),
+    ),
+    // Rule-less sibling: its INSERT creates the on-disk cell-db (a fresh,
+    // never-written db reads back `{ rows: [] }` with NO column provenance,
+    // which a rule-bearing read refuses fail-closed).
+    notes: table({ id: "integer primary key", body: "text" }),
+  };
+}
+
+/** Fold one INSERT into `notes` through db.exec so the cell-db file exists. */
+async function seedDbFile(
+  runtime: Runtime,
+  resultCell: ReturnType<Runtime["getCell"]>,
+) {
+  const handleLink = resultCell.key("db").resolveAsCell()
+    .getAsNormalizedFullLink();
+  const tx = runtime.edit();
+  const db = createCell(
+    runtime,
+    { ...handleLink, schema: undefined },
+    tx,
+    false,
+    "sqlite",
+  ) as unknown as { exec(sql: string, params?: readonly unknown[]): void };
+  db.exec("INSERT INTO notes (body) VALUES (?)", ["seed"]);
+  const res = await tx.commit();
+  expect(res.error).toBeUndefined();
+}
+
+function makePattern(
+  cf: ReturnType<typeof createTrustedBuilder>["commonfabric"],
+) {
+  return cf.pattern<{ tables: SqliteTableSchemas }>(({ tables }) => {
+    const db = cf.sqliteDatabase({ tables });
+    const q = cf.sqliteQuery({
+      db,
+      sql: "SELECT id, from_addr, to_addrs FROM emails",
+      reactOn: db,
+    });
+    return { db, q };
+  });
+}
+
+type QueryState = {
+  pending?: boolean;
+  error?: unknown;
+  requestHash?: string;
+  result?: unknown[];
+};
+
+/** Run the pattern and return schema-less cells for the handle and query docs. */
+function runPattern(runtime: Runtime) {
+  const { commonfabric: cf } = createTrustedBuilder(runtime);
+  const pattern = makePattern(cf);
+  const tx = runtime.edit();
+  const resultCell = runtime.getCell(space, RESULT_CAUSE, undefined, tx);
+  runtime.run(tx, pattern, { tables: makeTables(cf) }, resultCell);
+  const commit = tx.commit();
+  return { resultCell, commit };
+}
+
+async function waitUntil<T>(
+  runtime: Runtime,
+  cell: { sink: (f: () => void) => () => void; get: () => unknown },
+  pred: (v: T) => boolean,
+  iterations = 400,
+): Promise<T> {
+  const cancel = cell.sink(() => {});
+  try {
+    for (let i = 0; i < iterations; i++) {
+      await runtime.idle();
+      const v = cell.get() as T;
+      if (pred(v)) return v;
+      await new Promise((r) => setTimeout(r, 15));
+    }
+    throw new Error("timeout waiting for sqlite result");
+  } finally {
+    cancel?.();
+  }
+}
+
+/** All sigil links reachable in a RAW stored value (never descends into one). */
+function collectSigilLinks(value: unknown, out: unknown[] = []): unknown[] {
+  if (isSigilLink(value)) {
+    out.push(value);
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) collectSigilLinks(v, out);
+    return out;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const v of Object.values(value)) collectSigilLinks(v, out);
+    return out;
+  }
+  return out;
+}
+
+describe("sqlite handle across runtimes (rule term lists)", () => {
+  let server: MemoryV2Server.Server;
+  let runtimeA: Runtime;
+  let runtimeB: Runtime | undefined;
+
+  beforeEach(() => {
+    server = newServer();
+    runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: SharedServerStorageManager.overServer(
+        { as: signer },
+        server,
+      ),
+    });
+    runtimeB = undefined;
+  });
+
+  afterEach(async () => {
+    // Drain in-flight async builtin work (the query RPC + write-back) before
+    // dispose — Client.close rejects pending requests, which would otherwise
+    // surface as uncaught rejections and cancel the rest of the suite. Bounded
+    // so a genuinely fighting (bug-state) pair cannot hang teardown forever.
+    const grace = new Promise((r) => setTimeout(r, 3000));
+    await Promise.race([
+      Promise.allSettled([runtimeA.settled(), runtimeB?.settled()]),
+      grace,
+    ]);
+    runtimeB?.scheduler.dispose();
+    runtimeA.scheduler.dispose();
+    await Promise.allSettled([
+      runtimeB?.storageManager.synced(),
+      runtimeA.storageManager.synced(),
+    ]);
+    await runtimeB?.dispose();
+    await runtimeA.dispose();
+    await server.close();
+  });
+
+  it("stores the handle value self-contained (term list stays inline)", async () => {
+    const { resultCell, commit } = runPattern(runtimeA);
+    await commit;
+    await runtimeA.idle();
+
+    const handle = resultCell.key("db").resolveAsCell();
+    const raw = handle.getRaw() as Record<string, unknown>;
+    expect(raw).toBeDefined();
+    // The rule survived storage (still a 2-term conjunction)…
+    const rowLabel = (handle.key("tables").key("emails") as unknown as {
+      get: () => { rowLabel?: { confidentiality?: { allOf?: unknown[] } } };
+    }).get()?.rowLabel;
+    expect(rowLabel?.confidentiality?.allOf?.length).toBe(2);
+    // …and nothing in the stored handle value is a link to another doc: a
+    // split-out term doc is unreachable by schema-driven sync, so a second
+    // runtime would resolve it to null and destabilize the request hash.
+    expect(collectSigilLinks(raw)).toEqual([]);
+
+    // db.exec's rev bump must keep it self-contained too: it writes from a
+    // handler frame, where a whole-value set would [ID]-split the term list
+    // right back into linked docs. Only the `rev` leaf may change.
+    await seedDbFile(runtimeA, resultCell);
+    await runtimeA.idle();
+    const afterExec = handle.getRaw() as Record<string, unknown>;
+    expect((afterExec as { rev?: number }).rev).toBe(1);
+    expect(collectSigilLinks(afterExec)).toEqual([]);
+  });
+
+  it("a second runtime adopts the settled shared query instead of re-issuing", async () => {
+    const a = runPattern(runtimeA);
+    await a.commit;
+    await runtimeA.idle();
+    await seedDbFile(runtimeA, a.resultCell);
+    const qCellA = a.resultCell.key("q").resolveAsCell();
+    const qA = await waitUntil<QueryState>(
+      runtimeA,
+      qCellA,
+      (v) => v?.pending === false && v?.error === undefined,
+    );
+    expect(qA.error).toBeUndefined();
+    const hashA = qA.requestHash;
+    expect(typeof hashA).toBe("string");
+    await runtimeA.storageManager.synced();
+
+    // Second runtime, separate heap, same server: HYDRATES the same piece
+    // (no inputs re-provided — a pure loader, like a second tab).
+    runtimeB = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: SharedServerStorageManager.overServer(
+        { as: signer },
+        server,
+      ),
+    });
+    // Count B's server reads: with a stable request hash B must DEDUP against
+    // the settled shared result, never issue its own request. (The red failure
+    // mode: B's sqliteDatabase re-init rewrote the handle — dropping `rev`,
+    // re-deriving `tables` — so BOTH runtimes saw "new inputs", each write
+    // invalidating the other's hash on the ONE shared result cell.)
+    const providerB = runtimeB.storageManager.open(space) as unknown as {
+      sqliteQuery: (...a: unknown[]) => Promise<unknown>;
+    };
+    const originalB = providerB.sqliteQuery.bind(providerB);
+    let issuesFromB = 0;
+    providerB.sqliteQuery = (...args) => {
+      issuesFromB++;
+      return originalB(...args);
+    };
+
+    const { commonfabric: cfB } = createTrustedBuilder(runtimeB);
+    const resultCellB = runtimeB.getCell(space, RESULT_CAUSE, undefined);
+    await runtimeB.runSynced(resultCellB, makePattern(cfB));
+    const qCellB = resultCellB.key("q").resolveAsCell();
+    // Same piece ⇒ same shared query result doc in both runtimes.
+    expect(qCellB.getAsNormalizedFullLink().id).toBe(
+      qCellA.getAsNormalizedFullLink().id,
+    );
+
+    const qB = await waitUntil<QueryState>(
+      runtimeB!,
+      qCellB,
+      (v) => v?.pending === false && v?.requestHash === hashA,
+    );
+    expect(qB.error).toBeUndefined();
+
+    // Stability: B adopted the settled result (no re-issue), and A's hash
+    // survived B's hydration untouched.
+    await runtimeB!.settled();
+    await runtimeA.settled();
+    expect(issuesFromB).toBe(0);
+    const settledA = qCellA.get() as QueryState;
+    expect(settledA.requestHash).toBe(hashA);
+    expect(settledA.pending).toBe(false);
+    expect(settledA.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

A shared (space-scoped) sqlite query result cell ping-pongs indefinitely between two runtimes when the db's rowLabel rule uses a term LIST (e.g. `all(a, b, c)`).

Mechanism: the SqliteDb handle value was not stored **self-contained**. `sqliteDatabase`'s first action run can execute inside the pattern's builder frame, where `Cell.set` [ID]-anchors every object-in-array — splitting a rule's term list into per-element entity docs — and a proxy-carried `tables` read stores as a LINK into the pattern's doc graph. No schema-driven sync ever loads those linked docs, so a second runtime deep-resolves them to `null` (the #3830 class) and `sqliteQuery` hashes `rowLabel.confidentiality.allOf: [null]` while the creator hashes the resolved AST. Two request hashes on ONE shared result cell → each runtime sees the other's hash as "new inputs" and re-issues forever; the query never settles (~400 action re-runs in seconds) and nothing ever loads the term docs in the second runtime.

This affects any real multi-client use of a rule-bearing db whose rule has 2+ terms — e.g. `packages/patterns/cfc-row-label-mailbox` (`all(sender, recipients, dbOwner())`).

## Fix

Make the stored handle **self-contained**, and its re-derivation inert:

- **`sqliteDatabase` writes the handle RAW and inline** (`setRawUntyped(fabricFromNativeValue(...), onlyIfDifferent)`) after materializing the merged `tables` to plain JSON. No [ID] splits, no proxy→link capture: every runtime that can read the handle doc has the full resolved spec, so request hashes agree by construction.
- **Fail closed on an unresolved materialization**: a loader runtime that deep-reads `null` through a not-yet-loaded linked doc must not overwrite a good prior value with a null-riddled rule. `validateRowLabelSpec` doubles as the resolution probe (a resolved rule always validates; a null-riddled one never does) — the prior handle value stands.
- **The re-derivation carries `db.exec`'s `rev` forward** — it used to delete it, which every handle hasher (`reactOn: db`) saw as "new inputs": one spurious re-issue of the shared query per runtime init.
- **`db.exec` bumps `rev` as a LEAF write** instead of rewriting the whole handle value — the whole-value `.set()` ran inside the handler frame and re-split the inline term lists on the first write.

Old handles (split/link form) self-heal: the next runtime that fully resolves them rewrites the inline form; `readDbRef` / `db.exec` keep their materializing reads for the transition.

## Red-green

`packages/runner/test/sqlite-handle-multi-runtime.test.ts` — two real Runtimes with **separate storage managers over one in-process memory server** (separate heaps; the single-manager `emulate()` setup shares the heap and masks the bug).

- *"stores the handle value self-contained"*: pre-fix the term list stores as linked docs (`allOf: [<link>, <link>]`), and `db.exec` re-splits it; post-fix the raw handle contains no links, before and after an exec.
- *"a second runtime adopts the settled shared query instead of re-issuing"*: pre-fix a hydrating second runtime rewrites the handle and re-issues the settled query under a new hash (invalidating the first runtime's hash); post-fix it issues **zero** `sqliteQuery` RPCs and both runtimes hold one unchanged request hash.

Both steps verified red against unfixed source (stash/run/pop) and green with the fix. Full `packages/runner` suite: 748 passed, 0 failed.

## Notes

- Spec updated: `docs/specs/sqlite-builtin/03-database-sources.md` now records the self-containment contract.
- Follow-up for #4484: once this lands, the `sqlite-read-clearance` fixture can flip back from its bare confidentiality term to the natural term-list rule (its comment tracks this issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a multi-runtime ping-pong where shared `sqliteQuery` results kept re-issuing due to linked rule term lists. The `SqliteDb` handle is now stored self-contained, so request hashes stay stable across runtimes.

- Bug Fixes
  - Store the handle inline via a raw write after materializing `tables` to plain JSON, preventing link capture and [ID]-splits of rowLabel term lists; all runtimes hash the same inputs.
  - Fail closed on unresolved materialization to avoid overwriting a good handle with `null`-riddled rules; use `validateRowLabelSpec` to detect resolution before writing.
  - Keep `rev` stable: carry it forward during re-derivation and bump it via a leaf write in `db.exec` to avoid hash churn and re-splitting. Also added a multi-runtime test to confirm zero new `sqliteQuery` RPCs and updated the spec to document the self-containment contract.

<sup>Written for commit ae2eca963a5f1af0b09b8a073825a0ad3e2e4c78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


- Overlaps textually with #4506 (owner re-mint fix) in the same `sqliteDatabase` hunk; the two compose semantically. Whichever lands second resolves the conflict by keeping #4506's `owner = prior !== undefined ? prior.owner : actingPrincipal` derivation AND this PR's raw inline write (the derived `owner` just feeds the written object).
