### PR TITLE
fix(runner): materialize FabricSpecialObject values as leaves in schema traversal (CT-1836)

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3187,23 +3187,23 @@ export class SchemaObjectTraverser<V extends FabricValue>
       });
       newValue.length = entries.length;
       return { ok: this.objectCreator.createObject(newLink, newValue) };
-      // TODO(danfuzz): a `FabricInstance` is still walked by `Object.entries`
-      // over internal slots rather than descended by its codec contents; the
-      // same gap applies to the schema-`default` fallback path
+      // TODO(danfuzz): a `FabricInstance` is walked by `Object.entries` over
+      // internal slots rather than descended by its codec contents; the same
+      // gap applies to the schema-`default` fallback path
       // (`traverseDAG`/`applyDefault`), since a schema `default` can carry a
       // `FabricValue`. A correct fix descends a `FabricInstance` by codec
       // contents, not own-props.
     } else if (doc.value instanceof FabricSpecialObject) {
-      // A `FabricSpecialObject` (e.g. `FabricBytes`) is an opaque host value:
-      // the fabric type system treats it like a primitive — always frozen,
-      // passes through conversion unchanged. Without this arm it fell into
-      // the record branch below and was decomposed by `Object.entries` over
-      // its (empty) own props, so it failed structural schemas — e.g. the
-      // schema-generator's object schema for `FetchBinaryResult.bytes` — and
-      // the containing field was silently dropped from the materialized
-      // value, permanently gating every lift consuming a `fetchBinary`
-      // result (CT-1836). Validate as "object" (the shape the generator
-      // emits for these types today) and pass the value through as a leaf.
+      // A `FabricSpecialObject` (e.g. `FabricBytes`) is an opaque host value
+      // the fabric type system treats like a primitive — always frozen,
+      // passing through conversion unchanged — so it materializes as a LEAF:
+      // its `typeof` is "object", so this arm must precede the record branch
+      // below, which would otherwise decompose it via `Object.entries` over
+      // its own props (empty for e.g. `FabricBytes`, whose surface lives on
+      // the prototype). Type-validate as "object" — the shape the
+      // schema-generator emits for these types today — but do not consult
+      // the schema's structural details: leaves are not property-walked
+      // (CT-1836).
       return this.isValidType(schemaObj, "object") !== TypeValidity.False
         ? { ok: this.traversePrimitive(doc, schemaObj) }
         : fail(TRAVERSE_FAILURES.invalidType);

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -9,7 +9,10 @@ import {
 } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchemaObj, SchemaPathSelector } from "@commonfabric/api";
 import type { MemorySpace, Result, Unit } from "@commonfabric/memory/interface";
-import { type FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  FabricSpecialObject,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 // TODO(@ubik2): Ideally this would import from "@commonfabric/utils/types",
@@ -3184,14 +3187,26 @@ export class SchemaObjectTraverser<V extends FabricValue>
       });
       newValue.length = entries.length;
       return { ok: this.objectCreator.createObject(newLink, newValue) };
-      // TODO(danfuzz): The value-type dispatch above has no `FabricSpecialObject`
-      // arm: a `FabricPrimitive` (`typeof "object"`) never reaches the leaf
-      // `traversePrimitive` and falls into this record branch (decomposed); a
-      // `FabricInstance` is walked by `Object.entries` over internal slots rather
-      // than descended by its codec contents. The same gap applies to the
-      // schema-`default` fallback path (`traverseDAG`/`applyDefault`), since a
-      // schema `default` can carry a `FabricValue`. A correct fix descends a
-      // `FabricInstance` by codec contents, not own-props.
+      // TODO(danfuzz): a `FabricInstance` is still walked by `Object.entries`
+      // over internal slots rather than descended by its codec contents; the
+      // same gap applies to the schema-`default` fallback path
+      // (`traverseDAG`/`applyDefault`), since a schema `default` can carry a
+      // `FabricValue`. A correct fix descends a `FabricInstance` by codec
+      // contents, not own-props.
+    } else if (doc.value instanceof FabricSpecialObject) {
+      // A `FabricSpecialObject` (e.g. `FabricBytes`) is an opaque host value:
+      // the fabric type system treats it like a primitive — always frozen,
+      // passes through conversion unchanged. Without this arm it fell into
+      // the record branch below and was decomposed by `Object.entries` over
+      // its (empty) own props, so it failed structural schemas — e.g. the
+      // schema-generator's object schema for `FetchBinaryResult.bytes` — and
+      // the containing field was silently dropped from the materialized
+      // value, permanently gating every lift consuming a `fetchBinary`
+      // result (CT-1836). Validate as "object" (the shape the generator
+      // emits for these types today) and pass the value through as a leaf.
+      return this.isValidType(schemaObj, "object") !== TypeValidity.False
+        ? { ok: this.traversePrimitive(doc, schemaObj) }
+        : fail(TRAVERSE_FAILURES.invalidType);
     } else if (isRecord(doc.value)) {
       if (isSigilLink(doc.value)) {
         this.tx.read(doc.address, READ_FOR_SCHEDULING);

--- a/packages/runner/test/fetch-binary-schema-materialization.test.ts
+++ b/packages/runner/test/fetch-binary-schema-materialization.test.ts
@@ -82,7 +82,9 @@ describe("fetchBinary consumer materialization (CT-1836)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      // Deterministic binary response; no network (CT-1768 seam).
+      // `RuntimeOptions.fetch` overrides the outbound fetch for this runtime
+      // instance, so the builtin resolves against this deterministic binary
+      // response instead of the network.
       fetch: () =>
         Promise.resolve(
           new Response(TINY_PNG_BYTES, {

--- a/packages/runner/test/fetch-binary-schema-materialization.test.ts
+++ b/packages/runner/test/fetch-binary-schema-materialization.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+/**
+ * Regression for CT-1836: a lift consuming a `fetchBinary` result was
+ * permanently gated because schema-query materialization DROPPED the
+ * `FabricBytes`-bearing `result` field.
+ *
+ * Mechanism: `SchemaObjectTraverser`'s value dispatch had no
+ * `FabricSpecialObject` arm, so a `FabricBytes` fell into the record branch
+ * and was decomposed by `Object.entries` over its (empty) own props. That
+ * failed the schema-generator's structural object schema for
+ * `FetchBinaryResult.bytes`, the traversal dropped the containing `result`
+ * field entirely (`required` unmet), the consumer's argument stayed invalid,
+ * and its body never ran — freezing every downstream consumer, at any
+ * nesting depth. (`fetchJson` consumers were unaffected: plain JSON values.)
+ * The collateral: the consumers' crippled read logs also never registered
+ * the forward dependents edges the post-writeback wake relies on.
+ *
+ * The fix treats `FabricSpecialObject` values as opaque leaves (the fabric
+ * type system's documented contract: frozen, pass through conversion
+ * unchanged).
+ *
+ * This test runs the WHOLE chain — mocked binary fetch (via the injectable
+ * `RuntimeOptions.fetch`, CT-1768) → `FabricBytes` result → consumer lifts
+ * reading `result.mediaType` and re-encoding `result.bytes` — and asserts
+ * the consumers actually materialize. Fails without the traverse fix (both
+ * outputs stay empty forever); passes with it.
+ */
+
+const signer = await Identity.fromPassphrase("fetch-binary-materialization");
+const space = signer.did();
+
+// 1×1 transparent PNG.
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+const TINY_PNG_BYTES = Uint8Array.from(
+  atob(TINY_PNG_BASE64),
+  (c) => c.charCodeAt(0),
+);
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { computed, fetchBinary, pattern } from 'commonfabric';",
+        "export default pattern(() => {",
+        "  const art = fetchBinary({ url: 'https://mock.test/img' });",
+        "  const mediaType = computed(() => art.result?.mediaType ?? '');",
+        "  const dataUrl = computed(() => {",
+        "    const bytes = art.result?.bytes;",
+        "    const mt = art.result?.mediaType;",
+        "    if (!bytes || !mt) return '';",
+        "    const raw = bytes.slice();",
+        "    let binary = '';",
+        "    for (let i = 0; i < raw.length; i++) {",
+        "      binary += String.fromCharCode(raw[i]);",
+        "    }",
+        "    return `data:${mt};base64,${btoa(binary)}`;",
+        "  });",
+        "  return { mediaType, dataUrl };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+describe("fetchBinary consumer materialization (CT-1836)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      // Deterministic binary response; no network (CT-1768 seam).
+      fetch: () =>
+        Promise.resolve(
+          new Response(TINY_PNG_BYTES, {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+        ),
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("lifts reading a FabricBytes-bearing fetch result materialize and run", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    const resultCell = runtime.getCell<{ mediaType: string; dataUrl: string }>(
+      space,
+      "fetch-binary-consumer",
+      compiled.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, compiled, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const cancelSink = result.sink(() => {});
+    // `settled()` awaits the async fetch work and its writeback; a follow-up
+    // `idle()` drains the consumer re-runs the writeback triggers.
+    await runtime.settled();
+    await runtime.idle();
+
+    expect(await result.key("mediaType").pull()).toBe("image/png");
+    expect(await result.key("dataUrl").pull()).toBe(
+      `data:image/png;base64,${TINY_PNG_BASE64}`,
+    );
+    cancelSink();
+  });
+});

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -9,6 +9,7 @@ import type {
   URI,
 } from "@commonfabric/memory/interface";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
@@ -996,6 +997,87 @@ describe("SchemaObjectTraverser boolean type handling", () => {
 
     // boolean doesn't match string schema
     expect(error).toBeDefined();
+  });
+});
+
+describe("SchemaObjectTraverser FabricSpecialObject type handling", () => {
+  it("materializes a FabricSpecialObject value as an opaque leaf", () => {
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const docUri = "of:doc-fabric-bytes" as URI;
+    const docEntity = docUri as Entity;
+
+    const docValue = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+    const docRevision: Revision<State> = {
+      the: type,
+      of: docEntity,
+      is: { value: docValue },
+      cause: hashOf({ the: type, of: docEntity }),
+      since: 1,
+    };
+    store.set(`${docRevision.of}/${docRevision.the}`, docRevision);
+
+    // The structural shape the schema-generator emits for these types today
+    // (CT-1836): own props can never satisfy it — `length` lives on the
+    // prototype. A leaf is not property-walked, so it must not matter.
+    const schema = {
+      type: "object",
+      properties: { length: { type: "number" } },
+      required: ["length"],
+    } as const satisfies JSONSchema;
+
+    const traverser = getTraverser(store, { path: ["value"], schema });
+
+    const { ok: result } = traverser.traverse({
+      address: {
+        space: "did:null:null",
+        id: docUri,
+        type,
+        path: ["value"],
+      },
+      value: docValue,
+    });
+
+    // The same frozen instance passes through — not an `Object.entries`
+    // decomposition of its (empty) own props.
+    expect(result).toBe(docValue);
+  });
+
+  it("rejects a FabricSpecialObject value where the schema cannot be an object", () => {
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const docUri = "of:doc-fabric-bytes-reject" as URI;
+    const docEntity = docUri as Entity;
+
+    const docValue = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+    const docRevision: Revision<State> = {
+      the: type,
+      of: docEntity,
+      is: { value: docValue },
+      cause: hashOf({ the: type, of: docEntity }),
+      since: 1,
+    };
+    store.set(`${docRevision.of}/${docRevision.the}`, docRevision);
+
+    const schema = { type: "string" } as const satisfies JSONSchema;
+
+    const traverser = getTraverser(store, { path: ["value"], schema });
+
+    const { error } = traverser.traverse({
+      address: {
+        space: "did:null:null",
+        id: docUri,
+        type,
+        path: ["value"],
+      },
+      value: docValue,
+    });
+
+    // A special object validates as "object" and nothing else: it is
+    // rejected here, not decomposed against the mismatched schema.
+    expect(error?.code).toBe("INVALID_TYPE");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes **CT-1836**: every lift consuming a `fetchBinary` result — at any nesting depth — was permanently gated, because schema-query materialization silently **dropped the `FabricBytes`-bearing `result` field**. One traversal arm fixes it; an end-to-end regression (mocked binary fetch → consumer lifts) pins it.

## Root cause

`SchemaObjectTraverser`'s value dispatch had no `FabricSpecialObject` arm — a gap its own `TODO(danfuzz)` comment already recorded. A `FabricBytes` (typeof `"object"`, no enumerable own props — `length` is a prototype getter) fell into the record branch and was decomposed by `Object.entries` into `{}`, failing the schema-generator's structural object schema for `FetchBinaryResult.bytes` (`{type:"object", properties:{length…}}`). The traversal then dropped the containing `result` field entirely (`required` unmet), so:

- the consumer lift's argument stayed invalid forever → its **body never ran** (`readJavaScriptArgument` → `isValidArgument` gate), freezing `fetchState`/downstream consumers/UI overlays;
- the consumers' crippled read logs also never registered the forward `dependents` edges the post-writeback wake walks, which is why the freeze looked like a scheduler defect for several investigation rounds (full falsification trail on CT-1836 — six instrumented rounds);
- `fetchJson` consumers were unaffected (plain JSON values), which disguised the regression: it arrived with the fetchData→fetchBinary split (#4206), so **every `fetchBinary` consumer since then has been frozen**, e.g. the lunch-poll generated art.

## The fix

A `FabricSpecialObject` leaf arm in the dispatch, before the record branch: validate loosely as `"object"` (the shape the schema-generator emits for these types today) and pass the value through unchanged via `traversePrimitive` — which is the fabric type system's documented contract for `FabricPrimitive` ("always frozen, passes through conversion unchanged"). The pre-existing TODO is narrowed to the remaining `FabricInstance` codec-descent design.

Verified chain after the fix (probes on the lunch-poll art flow): binary fetch completes → `FabricBytes` result materializes through schema queries → consumer bodies run → base64 re-encode works → **cross-boundary reads of fetch-derived sub-pattern outputs work** (`art.imageDataUrl` readable from a parent — the CT-1811-family "sub-pattern with fetch + computed outputs" gap this closes).

## Regression test

`runner/test/fetch-binary-schema-materialization.test.ts` — the whole chain, self-contained via the injectable `RuntimeOptions.fetch` (CT-1768): mocked PNG response → `fetchBinary` → consumer lifts reading `result.mediaType` and re-encoding `result.bytes` to a data URL → asserts both materialize. **Fails without the fix** (validated by stash-revert: `0 passed, 1 failed`), passes with it.

## Related (documented on CT-1836, deliberately not in this PR)

- A scheduler hardening (wake a general pass when mark-dirty finds no forward effects) was drafted and probe-validated during the investigation; this fix removes its known trigger (the crippled read logs), so it's parked on the ticket rather than shipped.
- The lunch-poll `art-sync.test.tsx` canary (branch `gideon/lunch-poll-art-readd`) pins the pre-fix behavior and will go RED when this lands — flipping it to the full persist contract is the follow-up there (the card's notify idiom also gets simplified: cross-boundary reads work now, and send-inside-computed is fatal in the current runtime — kills the harness worker silently, observed during round 7).

## Verification

| Gate | Result |
| -- | -- |
| New regression (fails-without / passes-with) | ✅ |
| runner full suite | 759 passed / 0 failed |
| cli full suite | 913 passed / 0 failed |
| Repo-wide `deno task check` | ✅ |
| fmt · lint | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1836 by treating `FabricSpecialObject` values (e.g., `FabricBytes`) as leaves in schema traversal so `fetchBinary` results materialize and consumer lifts run. Adds an end-to-end regression and unit tests to pin the behavior.

- **Bug Fixes**
  - Root cause: no `FabricSpecialObject` arm; `FabricBytes` was decomposed to `{}`, the `result` field was dropped, and consumers stayed gated.
  - Fix: add a `FabricSpecialObject` leaf branch before record handling, validate as "object", and pass the value through unchanged.
  - Tests: new `fetch-binary-schema-materialization.test.ts` (e2e) and `traverse.test.ts` (unit accept/reject) cover the contract; comments updated to describe current behavior.

<sup>Written for commit c8b418e8c6e657a9bcee34b0f4051e8462d26c39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

