### PR TITLE
feat(patterns): profile-embed presentation pattern for host embedding (CT-1833)

### DIFF
--- a/packages/patterns/system/profile-embed.test.tsx
+++ b/packages/patterns/system/profile-embed.test.tsx
@@ -1,0 +1,106 @@
+import { action, computed, pattern } from "commonfabric";
+import ProfileEmbed from "./profile-embed.tsx";
+import ProfileHome from "./profile-home.tsx";
+
+/**
+ * Lane-2 tests for the CT-1833 profile-embed presentation pattern.
+ *
+ * WISH LIMITATION (documented): `ProfileEmbed` resolves the viewer's profile via
+ * `wish({ query: "#profile" })`. The lane-2 test harness only seeds the
+ * `#default` pattern (allPieces/recentPieces), never a `profiles` roster, and a
+ * valid profile MUST live in its own (cross-)space — seeding one would drive the
+ * exact cross-space create surface the pattern-unit lane forbids (it fails a
+ * file on ANY console error). So `#profile` stays unresolved here and we test:
+ *   (1) the fallback branch — `result ?? fallback` — via the exported
+ *       `hasProfile` / `isEditing` signals when no profile resolves; and
+ *   (2) the amend-in-place CONTRACT the pattern depends on, exercised against a
+ *       REAL `ProfileHome` instance the way the pattern's save handlers do:
+ *       dispatch into the profile's exported owner-protected `setName` /
+ *       `setAvatar` / `setBio` streams, with empty sends suppressed for
+ *       name/avatar and allowed for bio (CT-1828). The rendered badge/bio
+ *       presentation and edit affordance are verified in the browser.
+ */
+export default pattern(() => {
+  // (1) Fallback branch: with no profile resolvable in lane-2, the embed reports
+  // no profile and is not in edit mode; the `[UI]` renders the wish fallback.
+  const embed = ProfileEmbed({});
+  const assert_no_profile_in_harness = computed(() =>
+    embed.hasProfile === false
+  );
+  const assert_not_editing_by_default = computed(() =>
+    embed.isEditing === false
+  );
+
+  // (2) Amend contract: a real profile the embed's save handlers write through.
+  const profile = ProfileHome({ initialName: "Ada Lovelace" });
+
+  // The embed's "Save name" is: read the draft, suppress empty, send { name }
+  // into the profile's exported setName stream. Reproduce that call shape.
+  const action_amend_name = action(() => {
+    const draft = "Grace Hopper";
+    if (draft.trim()) profile.setName.send({ name: draft });
+  });
+  // Empty/whitespace amends must be suppressed by the embed before dispatch
+  // (mirrors saveName's guard) — the canonical name must survive.
+  const action_amend_name_empty = action(() => {
+    const draft = "   ";
+    if (draft.trim()) profile.setName.send({ name: draft });
+  });
+
+  const action_amend_avatar = action(() => {
+    const draft = "GH";
+    if (draft.trim()) profile.setAvatar.send({ avatar: draft });
+  });
+  const action_amend_avatar_empty = action(() => {
+    const draft = "";
+    if (draft.trim()) profile.setAvatar.send({ avatar: draft });
+  });
+
+  // Bio is deliberately clearable (unlike name/avatar); the embed sends the
+  // trimmed draft unconditionally.
+  const action_amend_bio = action(() => {
+    profile.setBio.send({ bio: "Countess of computing." });
+  });
+  const action_amend_bio_clear = action(() => {
+    profile.setBio.send({ bio: "" });
+  });
+
+  const assert_initial_name = computed(() =>
+    profile.initialNameApplied === "Ada Lovelace"
+  );
+  const assert_name_amended = computed(() =>
+    profile.initialNameApplied === "Grace Hopper"
+  );
+  const assert_name_survives_empty = computed(() =>
+    profile.initialNameApplied === "Grace Hopper"
+  );
+  const assert_avatar_amended = computed(() => profile.avatar === "GH");
+  const assert_avatar_survives_empty = computed(() => profile.avatar === "GH");
+  const assert_bio_amended = computed(() =>
+    profile.bio === "Countess of computing."
+  );
+  const assert_bio_cleared = computed(() => profile.bio === "");
+
+  return {
+    tests: [
+      // (1) Fallback branch — no profile resolves in the harness.
+      { assertion: assert_no_profile_in_harness },
+      { assertion: assert_not_editing_by_default },
+      // (2) Amend-in-place contract through the exported streams.
+      { assertion: assert_initial_name },
+      { action: action_amend_name },
+      { assertion: assert_name_amended },
+      // Empty/whitespace name amend is suppressed (CT-1828 + embed guard).
+      { action: action_amend_name_empty },
+      { assertion: assert_name_survives_empty },
+      { action: action_amend_avatar },
+      { assertion: assert_avatar_amended },
+      { action: action_amend_avatar_empty },
+      { assertion: assert_avatar_survives_empty },
+      { action: action_amend_bio },
+      { assertion: assert_bio_amended },
+      { action: action_amend_bio_clear },
+      { assertion: assert_bio_cleared },
+    ],
+  };
+});

--- a/packages/patterns/system/profile-embed.tsx
+++ b/packages/patterns/system/profile-embed.tsx
@@ -1,0 +1,316 @@
+import {
+  computed,
+  handler,
+  ifElse,
+  NAME,
+  pattern,
+  Stream,
+  UI,
+  wish,
+  Writable,
+} from "commonfabric";
+import type {
+  ProfileHomeOutput,
+  SetProfileAvatarEvent,
+  SetProfileBioEvent,
+  SetProfileNameEvent,
+} from "./profile-home.tsx";
+
+/**
+ * Profile embed (CT-1833) — a clean, host-embeddable presentation of the
+ * VIEWER's own profile.
+ *
+ * Mechanism decision (Ben): this is a SEPARATE labs-owned presentation pattern,
+ * NOT a new UI-variant kind, NOT a Lit context, NOT a wish-query extension. UI
+ * variants (chip/tile) stay a pure size spectrum; "which chrome" is expressed by
+ * choosing which pattern a host mounts. A host (e.g. Loom's "Your Profile")
+ * instantiates this pattern standalone and mounts it at a known location; it can
+ * also be linked from the main profile surface later.
+ *
+ * The pattern takes NO profile input — it wishes `#profile` itself and renders
+ * the viewer's profile. The profile it renders is always the viewer's own
+ * (`#profile` resolves the viewer's default profile), so "owner" reduces to
+ * "profile resolved": once `result` is present the viewer is the owner and gets
+ * the amend-in-place edit affordance. Visitors never reach this pattern with
+ * someone else's profile — there is no profile input to point elsewhere.
+ *
+ * Presentation is deliberately minimal and theme-token compliant: a
+ * `<cf-profile-badge variant="hero">` bound to the REAL live profile cell (the
+ * blessed identity idiom — bind the cell, not a snapshot) plus a bio paragraph.
+ * Pinned elements / "Pin a piece" developer chrome are HIDDEN in this v1 (it is
+ * a presentation of upstream-owned data, not a second source of truth).
+ *
+ * Editing is amend-in-place: prefilled draft cells (seeded from the current
+ * values when the viewer enters edit mode) write back through the profile's
+ * EXPORTED owner-protected streams (`setName` / `setAvatar` / `setBio`) on the
+ * wish `result`. Cross-pattern stream dispatch is the sanctioned path; this
+ * pattern owns NO copy of name/avatar/bio beyond those transient drafts.
+ * CT-1828's empty-string guards make an accidental empty submit safe, and the
+ * UI additionally avoids sending empty names.
+ */
+
+// The wish `result` for `#profile` is the profile-home pattern's output: it
+// carries the readable `name`/`avatar`/`bio` fields AND the exported
+// owner-protected write streams we amend through.
+type ProfileResult = ProfileHomeOutput;
+
+const trimmed = (value?: string): string => (value ?? "").trim();
+
+/**
+ * Enter edit mode and seed the draft inputs from the current profile values so
+ * the viewer amends (not retypes from blank). Seeding is done here — at the
+ * transition into edit mode — rather than with a two-way `$value` onto the
+ * upstream (owner-protected) cells, which CFC would reject.
+ */
+const startEditing = handler<
+  void,
+  {
+    editing: Writable<boolean>;
+    nameDraft: Writable<string>;
+    avatarDraft: Writable<string>;
+    bioDraft: Writable<string>;
+    currentName?: string;
+    currentAvatar?: string;
+    currentBio?: string;
+  }
+>((_event, state) => {
+  state.nameDraft.set(trimmed(state.currentName));
+  state.avatarDraft.set(trimmed(state.currentAvatar));
+  state.bioDraft.set(trimmed(state.currentBio));
+  state.editing.set(true);
+});
+
+const stopEditing = handler<void, { editing: Writable<boolean> }>(
+  (_event, state) => {
+    state.editing.set(false);
+  },
+);
+
+/**
+ * Amend the profile name: reads the draft and dispatches into the profile's
+ * exported `setName` stream (the one owner-authorized writer). Empty/whitespace
+ * sends are suppressed here too so the UI never asks the upstream guard to
+ * reject — a name is never intentionally cleared.
+ */
+const saveName = handler<
+  void,
+  { draft: Writable<string>; setName?: Stream<SetProfileNameEvent> }
+>((_event, state) => {
+  const name = trimmed(state.draft.get());
+  if (!name) return;
+  state.setName?.send({ name });
+});
+
+const saveAvatar = handler<
+  void,
+  { draft: Writable<string>; setAvatar?: Stream<SetProfileAvatarEvent> }
+>((_event, state) => {
+  const avatar = trimmed(state.draft.get());
+  if (!avatar) return;
+  state.setAvatar?.send({ avatar });
+});
+
+const saveBio = handler<
+  void,
+  { draft: Writable<string>; setBio?: Stream<SetProfileBioEvent> }
+>((_event, state) => {
+  // Bio is deliberately clearable (unlike name/avatar), so an empty draft is a
+  // valid amend. CT-1828's guards keep this safe upstream.
+  state.setBio?.send({ bio: trimmed(state.draft.get()) });
+});
+
+export type ProfileEmbedInput = Record<string, never>;
+
+export type ProfileEmbedOutput = {
+  [NAME]: string;
+  [UI]: unknown;
+  // Whether the viewer's profile has resolved (a profile exists). When false the
+  // wish fallback (the trusted create surface) is rendered.
+  hasProfile: boolean;
+  // Raw edit-mode toggle state (the viewer's intent).
+  isEditing: boolean;
+};
+
+export default pattern<ProfileEmbedInput, ProfileEmbedOutput>(() => {
+  // Resolve the viewer's own profile. `result` is undefined at zero profiles or
+  // while resolution is pending; `[UI]` is the wish's fallback surface (the
+  // trusted create surface when empty). We render `result ?? fallback`.
+  const profileWish = wish<ProfileResult>({ query: "#profile" });
+
+  // Transient local drafts backing the amend inputs. Not a second source of
+  // truth — seeded from the live values on entering edit mode, cleared/written
+  // through the exported streams on save.
+  const nameDraft = new Writable("").for("nameDraft");
+  const avatarDraft = new Writable("").for("avatarDraft");
+  const bioDraft = new Writable("").for("bioDraft");
+  // View toggle: presentation by default, amend form when the owner opts in.
+  const editing = new Writable<boolean>(false).for("editing");
+
+  const hasProfile = computed(() => profileWish.result !== undefined);
+  const isEditing = computed(() => editing.get() === true);
+  const showEditForm = computed(() =>
+    profileWish.result !== undefined && editing.get() === true
+  );
+  const showPresentation = computed(() =>
+    profileWish.result !== undefined && editing.get() !== true
+  );
+
+  const bio = computed(() => trimmed(profileWish.result?.bio as string));
+  const hasBio = computed(() =>
+    trimmed(profileWish.result?.bio as string).length > 0
+  );
+
+  const displayName = computed(() => {
+    const name = trimmed(profileWish.result?.name as string);
+    return name.length > 0 ? name : "Profile";
+  });
+
+  return {
+    [NAME]: displayName,
+    hasProfile,
+    isEditing,
+    [UI]: (
+      <cf-screen data-ui-pattern="ProfileEmbed">
+        <cf-vstack gap="4" style={{ padding: "16px", maxWidth: "560px" }}>
+          {
+            /* No profile yet (or pending): render the wish fallback — the
+              trusted create surface at zero profiles. `result ?? fallback`. */
+          }
+          {ifElse(
+            hasProfile,
+            null,
+            <div data-ui-region="profile-embed-fallback">
+              {profileWish[UI]}
+            </div>,
+          )}
+
+          {
+            /* Clean presentation: hero badge bound to the REAL live profile cell
+              (the wish result) + bio. Elements / "Pin a piece" chrome hidden. */
+          }
+          {ifElse(
+            showPresentation,
+            <cf-vstack gap="4" data-ui-region="profile-embed-presentation">
+              <cf-profile-badge
+                id="profile-embed-badge"
+                variant="hero"
+                $profile={profileWish.result}
+                size="xl"
+                noNavigate
+              />
+
+              {ifElse(
+                hasBio,
+                <p
+                  data-ui-region="profile-embed-bio"
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    color: "var(--cf-theme-color-text-secondary)",
+                  }}
+                >
+                  {bio}
+                </p>,
+                null,
+              )}
+
+              <cf-hstack>
+                <cf-button
+                  variant="ghost"
+                  size="sm"
+                  onClick={startEditing({
+                    editing,
+                    nameDraft,
+                    avatarDraft,
+                    bioDraft,
+                    currentName: profileWish.result?.name,
+                    currentAvatar: profileWish.result?.avatar,
+                    currentBio: profileWish.result?.bio,
+                  })}
+                >
+                  Edit profile
+                </cf-button>
+              </cf-hstack>
+            </cf-vstack>,
+            null,
+          )}
+
+          {
+            /* Amend-in-place: prefilled drafts write back through the profile's
+              exported owner-protected streams. No developer chrome. */
+          }
+          {ifElse(
+            showEditForm,
+            <cf-vstack gap="4" data-ui-region="profile-embed-edit">
+              <cf-vstack gap="2">
+                <label>Name</label>
+                <cf-input $value={nameDraft} placeholder="Your name" />
+                <cf-hstack>
+                  <cf-button
+                    size="sm"
+                    onClick={saveName({
+                      draft: nameDraft,
+                      setName: profileWish.result?.setName,
+                    })}
+                  >
+                    Save name
+                  </cf-button>
+                </cf-hstack>
+              </cf-vstack>
+
+              <cf-vstack gap="2">
+                <label>Avatar</label>
+                <cf-input
+                  $value={avatarDraft}
+                  placeholder="Avatar URL or text"
+                />
+                <cf-hstack>
+                  <cf-button
+                    size="sm"
+                    onClick={saveAvatar({
+                      draft: avatarDraft,
+                      setAvatar: profileWish.result?.setAvatar,
+                    })}
+                  >
+                    Save avatar
+                  </cf-button>
+                </cf-hstack>
+              </cf-vstack>
+
+              <cf-vstack gap="2">
+                <label>Bio</label>
+                <cf-textarea
+                  $value={bioDraft}
+                  placeholder="A short bio…"
+                  style="width: 100%;"
+                />
+                <cf-hstack>
+                  <cf-button
+                    size="sm"
+                    onClick={saveBio({
+                      draft: bioDraft,
+                      setBio: profileWish.result?.setBio,
+                    })}
+                  >
+                    Save bio
+                  </cf-button>
+                </cf-hstack>
+              </cf-vstack>
+
+              <cf-hstack>
+                <cf-button
+                  variant="ghost"
+                  size="sm"
+                  onClick={stopEditing({ editing })}
+                >
+                  Done
+                </cf-button>
+              </cf-hstack>
+            </cf-vstack>,
+            null,
+          )}
+        </cf-vstack>
+      </cf-screen>
+    ),
+  };
+});


### PR DESCRIPTION
## Why

Embedders (starting with Loom's "Your Profile", loom#3627) need a clean,
theme-token-compliant presentation of the viewer's profile — name/avatar/bio —
without the developer chrome that profile-home ships in its edit surface (the
raw-DID "Pin a piece" form, pinned-element grid, retype-from-blank inputs).

The mechanism decision is recorded on Linear CT-1833 (by Ben): ship a **separate
labs-owned presentation pattern**, NOT a new UI-variant kind, NOT a Lit context,
NOT a wish-query extension. This keeps UI variants (`chip`/`tile`) a pure size
spectrum; "which chrome" is expressed by choosing which pattern a host mounts.

- Linear: CT-1833
- Loom: https://github.com/commontoolsinc/loom/pull/3627

## What

New pattern `packages/patterns/system/profile-embed.tsx` (+ colocated
`profile-embed.test.tsx`):

- Takes **no profile input** — it `wish({ query: "#profile" })`s itself and
  renders the viewer's own profile. A host can instantiate it standalone and
  mount it at a known location; it can also be linked from the main profile
  surface later.
- Robust to `result` undefined (zero profiles / pending): renders the wish
  `[UI]` fallback (the trusted create surface at zero profiles) via the
  `result ?? fallback` idiom. Works whether or not sibling CT-1829 lands.
- **Presentation** (theme tokens only): `cf-profile-badge variant="hero"` bound
  to the REAL live profile cell (the blessed identity idiom — the cell, not a
  snapshot) + a bio paragraph. Pinned elements / "Pin a piece" chrome are
  **hidden** in v1.
- **Editing (amend-in-place)**: since the pattern always renders the viewer's
  own profile, "owner" reduces to "profile resolved". Entering edit mode seeds
  prefilled draft cells from the current values (amend, not retype-from-blank);
  Save handlers dispatch the drafts into the profile's **exported
  owner-protected streams** `setName` / `setAvatar` / `setBio` on the wish
  `result` (cross-pattern stream dispatch is the sanctioned path; the actual
  writes stay CFC-owner-protected upstream). Empty name/avatar sends are
  suppressed in the UI; bio is deliberately clearable. Safe alongside CT-1828's
  empty-string guards.
- Owns **no** copy of name/avatar/bio beyond the transient drafts — it is a
  presentation of upstream-owned data, not a second source of truth.

## How Loom uses it

Loom instantiates this pattern like any piece creation, mounts it at a known
slug/location in the space, and renders it via `cf-render`. It self-resolves the
profile through the `#profile` wish — no profile needs to be passed in, and no
`wish.result`-vs-wish-`[UI]` routing dance is required on the host side (that
subtlety is what this separate pattern removes: the wish `[UI]` for a resolved
profile is a chip, whereas this pattern's own `[UI]` is the full clean
presentation + editor).

## Tests

`profile-embed.test.tsx` (lane-2, passes the pattern-unit console-error gate):

- Fallback branch — asserts the exported `hasProfile === false` /
  `isEditing === false` when no profile resolves in the harness.
- Amend-in-place contract — drives a real `ProfileHome`'s exported
  `setName`/`setAvatar`/`setBio` streams exactly as the embed's save handlers do,
  verifying name/avatar amends apply, empty/whitespace sends are suppressed, and
  bio amends (including clear) apply.

**Wish limitation (documented in the test):** the lane-2 harness only seeds the
`#default` pattern, never a `profiles` roster, and a valid profile must live in
its own space — seeding one would drive the exact cross-space create surface the
lane forbids. So `#profile` stays unresolved in-harness and the badge/bio
presentation + edit affordance are verified in the browser; the test covers the
fallback branch and the amend contract the pattern depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone `profile-embed` pattern that self-resolves the viewer’s `#profile` and shows a clean hero badge + bio with simple edit, ready for host embedding without developer chrome. Aligns with Linear CT-1833 and leaves UI variants (`chip`/`tile`) as-is.

- **New Features**
  - New `packages/patterns/system/profile-embed.tsx`: no inputs; uses `wish({ query: "#profile" })` and renders `result ?? fallback` (shows the trusted create surface when no profile exists).
  - Presentation only: `cf-profile-badge` `variant="hero"` + optional bio; hides pinned elements and “Pin a piece” chrome.
  - Amend-in-place editing: seeds drafts from current values; saves via the profile’s exported `setName`, `setAvatar`, `setBio`; suppresses empty/whitespace for name/avatar; bio is clearable; no secondary data source.
  - Exposes `hasProfile` and `isEditing` for host state if needed.

- **Migration**
  - Hosts mount the pattern directly via `cf-render`; no props or profile objects required.
  - Ideal for Loom’s “Your Profile” page; the pattern handles resolution, fallback, and editing internally.

<sup>Written for commit 547a6b49104d882a94f9d997f93573dcfb09cee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

