### PR TITLE
feat(runner): #profile wish resolves single result; picker becomes switcher (CT-1829)

### DIFF
--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -46,6 +46,15 @@ When multiple pieces match, a picker UI is rendered via `wishResult[UI]`. The
 user browses candidates and clicks "Confirm Selection". Until confirmed,
 `result` reactively reflects the currently highlighted candidate.
 
+> **Exception — well-known profile targets.** `wish({ query: "#profile" })` does
+> _not_ follow the "result reflects the highlighted candidate" rule. Its
+> `.result` is **always the single current profile** (default → MRU → first) in
+> every mode; the picker there is only a switching affordance, and selecting a
+> profile changes `.result` by reordering candidates (MRU/default writes), not by
+> a confirm gesture. See [Well-Known Profile Targets](#well-known-profile-targets)
+> (CT-1829). Generalizing this "single-best by default; picker opt-in" shape to
+> all wishes is a future step.
+
 You can render the built-in UI directly:
 
 ```tsx
@@ -106,26 +115,41 @@ wish({ query: "#portfolio", scope: ["profile"] })
 A user may have multiple profiles, stored on the home default pattern at
 `homeSpaceCell.defaultPattern.profiles` (a list), with `defaultProfile` and a
 recency-ordered `mru`. The well-known wishes enumerate that list and resolve,
-ordered **default first, then by MRU**:
+ordered **default first, then by MRU, then list order**:
 
 ```tsx
 // Shown at module scope.
-wish({ query: "#profile" }) // the default profile (headless); see [UI] below
+wish({ query: "#profile" }) // the single current profile; see [UI] below
 wish({ query: "#profileName" }) // default profile's initialNameApplied
 wish({ query: "#profileAvatar" }) // default profile's avatar
 wish({ query: "#profileBio" }) // default profile's bio (free-text description)
 wish({ query: "#profileSpace" }) // default profile's space cell
 ```
 
-Headless / single-profile callers get the default profile. The optional `[UI]`
+`wish({ query: "#profile" }).result` is **always the single current profile** —
+the best of the ordered candidates (default → MRU → first) — in **every** mode
+(interactive, headless, and the blessed read). It is never `undefined` while a
+profile exists, and it never depends on the picker sidecar pattern running, so
+consumers can gate on `.result` without stranding in the multi-profile case
+(CT-1829). The `candidates` array holds all ordered profiles.
+
+The picker is the **switching affordance**, not the source of `.result`:
+selection is _state_, not a channel. When the picker's "Use" writes `mru` or
+"Set default" writes `defaultProfile`, it reorders the candidates, so
+`ordered[0]` — and therefore `.result` — updates reactively. The optional `[UI]`
 for `wish({ query: "#profile" })`:
 
 - **0 profiles:** the trusted profile-create surface (same input as the home
   Profile tab). Submitting a name creates the viewer's first profile and leaves
-  the current view in place; the wish reacts once the link exists.
+  the current view in place; the wish reacts once the link exists. `.result` is
+  `undefined` and `error` is set until the first profile exists.
 - **1 profile:** a link to that profile.
-- **2+ profiles:** the **profile picker** (`profile-picker.tsx`) — lists
-  profiles, selects the default, stamps MRU, and creates more inline.
+- **2+ profiles, a valid default set:** a link to the default profile.
+- **2+ profiles, no valid default:** the **profile picker**
+  (`profile-picker.tsx`) — lists profiles, sets the default, stamps MRU, and
+  creates more inline — rendered purely as the switcher. `.result` still
+  resolves to the ordered best (MRU-or-first) immediately; picking a profile is
+  what changes it.
 
 When rendering profile data from a shared piece, use a user-scoped result schema
 for the rendered output so each viewer sees their own home profile projection.

--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -20,17 +20,22 @@ import ProfileCreate, {
 } from "./profile-create.tsx";
 import type { ProfileHomeOutput } from "./profile-home.tsx";
 
-// The profile picker launched by the #profile wish when the user has more than
-// one profile. It renders each profile natively (name + avatar + a link),
-// offers an inline "create another" affordance, lets the user pick a default,
-// and stamps most-recently-used (MRU) on selection. The chosen profile flows
-// back as the wish `result`:
-//   result = default (if set) ⟶ else most-recently-used ⟶ else first.
-// This default-first order matches headless `#profile` resolution
-// (wish.ts getProfileCandidateCells) so the "current profile" is the same
-// whether resolved headless or through the picker.
-// Selection writes MRU and the "set default" control writes `defaultProfile`,
-// both as trusted picker-surface actions (owner-protected; see profile-create).
+// The profile picker rendered as the `[UI]` of a #profile wish when the user
+// has 2+ profiles and no valid default. It renders each profile natively
+// (name + avatar + a link), offers an inline "create another" affordance, lets
+// the user pick a default, and stamps most-recently-used (MRU) on selection.
+//
+// The picker is purely the SWITCHING affordance (CT-1829): the wish `.result`
+// does NOT flow through this pattern. The wish builtin resolves `.result`
+// eagerly to the single best profile — default (if set) ⟶ else MRU head ⟶
+// else first (wish.ts getProfileCandidateCells) — in every mode. Selection
+// writes MRU and the "set default" control writes `defaultProfile`, both as
+// trusted picker-surface actions (owner-protected; see profile-create); those
+// writes reorder the builtin's candidates, which is what flips `.result`.
+//
+// The `resultIndex`/`result` computeds below duplicate the builtin's ordering
+// and are VESTIGIAL — nothing reads them anymore; kept one release for
+// compatibility, then to be deleted (CT-1829 follow-up).
 
 type ProfilePickerInput = {
   profiles: Writable<ProfileHomeOutput[]>;

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1723,6 +1723,18 @@ export function wish(
     });
   }
 
+  // The profile-picker sidecar rendered as a VNode, for the `[UI]` slot of a
+  // #profile wish with 2+ candidates and no valid default. `.result` rides the
+  // main wish state (ordered[0]) — the picker is only the switching affordance
+  // (CT-1829); its "Use" / "Set default" writes reorder candidates so the
+  // builtin's ordered[0] — and thus `.result` — flips reactively.
+  function profilePickerUI(ctx: WishContext): VNode {
+    return h("cf-render", {
+      "data-profile-picker-ui": "wish",
+      $cell: launchProfilePickerPattern(ctx, ctx.tx),
+    });
+  }
+
   // Launch the profile picker for #profile wishes with multiple profiles. Feeds
   // the home `profiles`/`defaultProfile`/`mru` cells (as sigil links) so the
   // picker can render natively, select (stamp MRU), set the default, and create
@@ -1777,15 +1789,36 @@ export function wish(
     if (!cachedProfilePickerPattern) {
       void profilePickerPatternCache.fetch(runtime).then(
         (pattern) => {
-          if (!cancelled && pattern && profilePickerPatternResultCell) {
+          if (cancelled || !profilePickerPatternResultCell) return;
+          if (pattern) {
             runSidecarInOwnTx(
               profilePickerPatternResultCell,
               pattern,
               pickerInputForTx,
             );
+          } else {
+            // Fetch/compile failed (createSidecarPatternCache swallows the
+            // error and resolves to undefined). Surface it as an error UI in the
+            // picker sidecar cell so the picker slot doesn't stay blank forever.
+            // `.result` is unaffected: under CT-1829 it rides the main wish state
+            // (ordered[0]), not this sidecar (a superseded fetch also resolves
+            // to undefined — a benign extra error UI on a since-replaced cell).
+            commitPatternErrorUI(
+              profilePickerPatternResultCell,
+              `Can't load profile-picker.tsx`,
+            );
           }
         },
-      );
+      ).catch((error) => {
+        // Defensive: a throw inside the `.then` body (or a truly-rejecting
+        // fetch) would otherwise be an unhandled rejection. Surface it too.
+        if (!cancelled && profilePickerPatternResultCell) {
+          commitPatternErrorUI(
+            profilePickerPatternResultCell,
+            errorMessage(error),
+          );
+        }
+      });
     } else if (!cancelled && profilePickerPatternResultCell) {
       runtime.run(
         tx,
@@ -1964,27 +1997,6 @@ export function wish(
               queryKey,
             );
 
-            // #profile with multiple profiles → launch the dedicated profile
-            // picker (native name/avatar/link rows, inline create, MRU/default
-            // writes). Headless / single-profile callers fall through to the
-            // fast path below and get the default profile directly.
-            if (
-              isProfilePersonaTarget(activeParsed) &&
-              !headless &&
-              uniqueResultCells.length > 1
-            ) {
-              measureWishPhase(
-                "send-profile-picker",
-                queryKey,
-                () =>
-                  sendResult(
-                    tx,
-                    launchProfilePickerPattern(ctx, tx),
-                  ),
-              );
-              return;
-            }
-
             // Unified shape: always return { result, candidates, [UI] }
             // For single result, use fast path (no picker needed)
             // For multiple results, launch suggestion pattern for picker
@@ -2000,6 +2012,43 @@ export function wish(
                   tx,
                 ),
             );
+
+            // #profile with 2+ candidates and no valid default (the only case
+            // that reaches here interactively; a valid default short-circuits to
+            // a single candidate in resolveWishTarget) → CT-1829: `.result` is
+            // always the single best profile (ordered default → MRU → first, i.e.
+            // uniqueResultCells[0]), sent eagerly on the main wish state exactly
+            // like the generic multi-match path does at wish.ts:2052. The picker
+            // sidecar becomes the `[UI]` switching affordance: its "Use" (MRU)
+            // and "Set default" writes reorder candidates so `.result` follows
+            // reactively. This removes the orphan-second-profile deadlock where
+            // the wish output was replaced by the picker's initially-empty (and
+            // forever-empty on fetch failure) result cell.
+            if (
+              isProfilePersonaTarget(activeParsed) &&
+              !headless &&
+              uniqueResultCells.length > 1
+            ) {
+              measureWishPhase(
+                "send-profile-picker",
+                queryKey,
+                () =>
+                  sendWishState(
+                    tx,
+                    {
+                      result: projectWishCellValue(
+                        uniqueResultCells[0],
+                        schema,
+                      ),
+                      candidates: candidatesCell,
+                      [UI]: profilePickerUI(ctx),
+                    },
+                    outputScope,
+                    schema,
+                  ),
+              );
+              return;
+            }
 
             if (uniqueResultCells.length === 1 || headless) {
               // Single result or headless mode - fast path with unified shape

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -3438,6 +3438,335 @@ describe("wish built-in", () => {
         expect("count" in pieceData).toBe(true);
       }
     });
+
+    // CT-1829: `wish("#profile").result` is ALWAYS the single best profile
+    // (ordered default → MRU → first) in every mode. The picker no longer owns
+    // `.result`; it is only the `[UI]` switching affordance. These tests pin the
+    // decided contract that Loom (loom PR #3627) binds to. This is a distinct
+    // describe from the "host embedding contract" block landing in PR #4502 — do
+    // not depend on that one.
+    describe("single-result #profile contract (CT-1829)", () => {
+      // Stand up N profiles in one profile space, wire the home default-pattern
+      // `profiles` list (and optionally `defaultProfile` / `mru`), run a
+      // `#profile` wish (interactive unless `headless`), and return the wish
+      // state cell so callers can read `.result` / `[UI]` and re-pull after
+      // writes.
+      async function setupProfiles(
+        label: string,
+        opts: {
+          names: string[];
+          defaultIndex?: number;
+          // Indices into `names`, most-recently-used first.
+          mruIndices?: number[];
+          // Point `defaultProfile` at a cell that is not in `profiles` (an
+          // invalid default link) so `defaultValid` is false.
+          invalidDefault?: boolean;
+          headless?: boolean;
+        },
+      ) {
+        const profileSpaceDid = (await Identity.fromPassphrase(
+          `ct1829-${label}-space`,
+        )).did();
+        const profileCells = opts.names.map((name, i) => {
+          const cell = runtime.getCell(
+            profileSpaceDid,
+            `ct1829-${label}-profile-${i}`,
+            undefined,
+            tx,
+          );
+          cell.set({
+            name,
+            initialNameApplied: name,
+            avatar: "",
+            bio: "",
+            elements: [],
+          });
+          return cell;
+        });
+
+        await tx.commit();
+        await runtime.idle();
+        tx = runtime.edit();
+
+        const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+        const homeDefaultCell = runtime.getCell(
+          userIdentity.did(),
+          `ct1829-${label}-home-default`,
+          undefined,
+          tx,
+        );
+        homeDefaultCell.key("profiles").set(profileCells);
+        if (opts.invalidDefault) {
+          // An invalid default link: points at a cell in the HOME space, which
+          // profileCellIsValid rejects (it requires the profile live in a
+          // non-home space). So `defaultValid` is false and the default is
+          // ignored — the next ordering rule (MRU) applies.
+          const orphan = runtime.getCell(
+            userIdentity.did(),
+            `ct1829-${label}-orphan-default`,
+            undefined,
+            tx,
+          );
+          orphan.set({
+            name: "Orphan",
+            initialNameApplied: "Orphan",
+            avatar: "",
+            bio: "",
+            elements: [],
+          });
+          homeDefaultCell.key("defaultProfile").set(orphan);
+        } else if (opts.defaultIndex !== undefined) {
+          homeDefaultCell.key("defaultProfile").set(
+            profileCells[opts.defaultIndex],
+          );
+        }
+        if (opts.mruIndices) {
+          homeDefaultCell.key("mru").set(
+            opts.mruIndices.map((i) => profileCells[i]),
+          );
+        }
+        (homeSpaceCell as any).key("defaultPattern").set(homeDefaultCell);
+
+        await tx.commit();
+        await runtime.idle();
+        tx = runtime.edit();
+
+        const wishPattern = pattern(() => ({
+          profile: wish(
+            opts.headless
+              ? { query: "#profile", headless: true }
+              : { query: "#profile" },
+          ),
+        }));
+        const resultCell = runtime.getCell<Record<string, any>>(
+          patternSpace.did(),
+          `ct1829-${label}-result`,
+          undefined,
+          tx,
+        );
+        const result = runtime.run(tx, wishPattern, {}, resultCell);
+        await tx.commit();
+        tx = runtime.edit();
+        await result.pull();
+
+        return { result, homeDefaultCell, profileCells };
+      }
+
+      it("0 profiles → result undefined, error set, create-surface UI", async () => {
+        const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+        const homeDefaultCell = runtime.getCell(
+          userIdentity.did(),
+          "ct1829-zero-home-default",
+          undefined,
+          tx,
+        );
+        (homeSpaceCell as any).key("defaultPattern").set(homeDefaultCell);
+        await tx.commit();
+        await runtime.idle();
+        tx = runtime.edit();
+
+        const wishPattern = pattern(() => ({
+          profile: wish({ query: "#profile" }),
+        }));
+        const resultCell = runtime.getCell<Record<string, any>>(
+          patternSpace.did(),
+          "ct1829-zero-result",
+          undefined,
+          tx,
+        );
+        const result = runtime.run(tx, wishPattern, {}, resultCell);
+        await tx.commit();
+        tx = runtime.edit();
+        await result.pull();
+
+        const state = result.key("profile").get();
+        const ui = result.key("profile").key(UI).get() as any;
+        expect(state?.result).toBeUndefined();
+        expect(String(state?.error)).toContain("profile");
+        expect(ui?.props?.["data-profile-create-ui"]).toBe("wish");
+      });
+
+      it("1 profile → result = it (interactive)", async () => {
+        const { result } = await setupProfiles("one-interactive", {
+          names: ["Solo"],
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Solo");
+      });
+
+      it("1 profile → result = it (headless)", async () => {
+        const { result } = await setupProfiles("one-headless", {
+          names: ["Solo"],
+          headless: true,
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Solo");
+      });
+
+      it("2+ with valid default → result = default (interactive)", async () => {
+        const { result } = await setupProfiles("default-interactive", {
+          names: ["First", "TheDefault"],
+          defaultIndex: 1,
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("TheDefault");
+      });
+
+      it("2+ with valid default → result = default (headless)", async () => {
+        const { result } = await setupProfiles("default-headless", {
+          names: ["First", "TheDefault"],
+          defaultIndex: 1,
+          headless: true,
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("TheDefault");
+      });
+
+      it("2+ no default → result = MRU head, INTERACTIVE (new behavior; no empty window)", async () => {
+        // The orphan-second-profile case: 2 profiles, no default, MRU lists the
+        // second first. Pre-CT-1829 this launched the picker and left `.result`
+        // undefined until the sidecar ran (undefined forever on fetch failure —
+        // which is exactly what happens here, the sidecar 404s against the test
+        // apiUrl). Now `.result` rides the main wish state and resolves eagerly.
+        const { result } = await setupProfiles("mru-interactive", {
+          names: ["Ada", "Grace"],
+          mruIndices: [1],
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Grace");
+      });
+
+      it("2+ no default → result = MRU head (headless)", async () => {
+        const { result } = await setupProfiles("mru-headless", {
+          names: ["Ada", "Grace"],
+          mruIndices: [1],
+          headless: true,
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Grace");
+      });
+
+      it("2+ no default, no MRU → result = first (interactive)", async () => {
+        const { result } = await setupProfiles("first-interactive", {
+          names: ["Ada", "Grace"],
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Ada");
+      });
+
+      it("2+ no default, no MRU → result = first (headless)", async () => {
+        const { result } = await setupProfiles("first-headless", {
+          names: ["Ada", "Grace"],
+          headless: true,
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Ada");
+      });
+
+      it("invalid default link → skipped, next rule (MRU) applies", async () => {
+        // defaultProfile points at a cell not in `profiles` → defaultValid is
+        // false, so the default is ignored and MRU order wins.
+        const { result } = await setupProfiles("invalid-default", {
+          names: ["Ada", "Grace"],
+          invalidDefault: true,
+          mruIndices: [1],
+        });
+        expect(result.key("profile").get()?.result?.name).toBe("Grace");
+      });
+
+      it("interactive 2+ no default renders the picker sidecar as [UI]", async () => {
+        const { result } = await setupProfiles("picker-ui", {
+          names: ["Ada", "Grace"],
+        });
+        const ui = result.key("profile").key(UI).get() as any;
+        expect(ui?.name).toBe("cf-render");
+        expect(ui?.props?.["data-profile-picker-ui"]).toBe("wish");
+        // And `.result` is populated even though the sidecar has not run.
+        expect(result.key("profile").get()?.result?.name).toBe("Ada");
+      });
+
+      it("MRU write flips result (the switcher contract: selection = MRU write → result changes)", async () => {
+        // Start with Ada as most-recently-used (no default) → result = Ada.
+        const { result, profileCells } = await setupProfiles(
+          "mru-flip",
+          { names: ["Ada", "Grace"], mruIndices: [0] },
+        );
+        expect(result.key("profile").get()?.result?.name).toBe("Ada");
+
+        // Simulate the picker's "Use" action: stamp Grace as most-recently-used.
+        // This is the trusted picker-surface write the switcher makes — it feeds
+        // the same MRU ordering the builtin reads, so `.result` (ordered[0])
+        // tracks the selection rather than the picker's confirm gesture.
+        const liveMru = runtime.getHomeSpaceCell(tx)
+          .key("defaultPattern")
+          .resolveAsCell()
+          .key("mru") as any;
+        liveMru.set([profileCells[1].withTx(tx)]);
+        await tx.commit();
+        await runtime.idle();
+        tx = runtime.edit();
+
+        // Resolve `#profile` after the selection write: ordered[0] — and thus
+        // `.result` — now follows the new MRU head. (A live picker sidecar drives
+        // this reactively through the scheduler graph; here we re-resolve to
+        // assert the ordering contract the write feeds.)
+        const wishPattern2 = pattern(() => ({
+          profile: wish({ query: "#profile" }),
+        }));
+        const rc2 = runtime.getCell<Record<string, any>>(
+          patternSpace.did(),
+          "ct1829-mru-flip-after-selection",
+          undefined,
+          tx,
+        );
+        const r2 = runtime.run(tx, wishPattern2, {}, rc2);
+        await tx.commit();
+        tx = runtime.edit();
+        await r2.pull();
+
+        expect(r2.key("profile").get()?.result?.name).toBe("Grace");
+      });
+
+      it("picker sidecar fetch failure → result still resolves; error surfaced in picker UI", async () => {
+        // Point the pattern environment at a host whose fetch fails, so the
+        // picker sidecar fetch rejects/404s. Under CT-1829 `.result` no longer
+        // rides the sidecar cell, so it must still resolve to ordered[0]; the
+        // fetch failure is surfaced as an error inside the picker `[UI]` cell,
+        // not as an unhandled rejection.
+        const originalFetch = globalThis.fetch;
+        const originalEnvironment = getPatternEnvironment();
+        setPatternEnvironment({
+          apiUrl: new URL("https://ct1829-picker-fail.test/"),
+        });
+        globalThis.fetch = ((input: Request | URL | string) => {
+          const url = input instanceof Request ? input.url : String(input);
+          if (url.includes("profile-picker.tsx")) {
+            return Promise.reject(new Error("picker fetch boom"));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch;
+
+        try {
+          const { result } = await setupProfiles("picker-fail", {
+            names: ["Ada", "Grace"],
+          });
+          // `.result` still resolves to the single best profile.
+          expect(result.key("profile").get()?.result?.name).toBe("Ada");
+
+          // The picker sidecar cell surfaces the fetch error: the sidecar cache
+          // swallows the fetch rejection and resolves to undefined, so the new
+          // undefined-pattern branch commits an error UI into the picker cell.
+          // Give the deferred fetch a moment to route through and commit.
+          const pickerCell = result.key("profile").key(UI).key("props")
+            .key("$cell").resolveAsCell();
+          const deadline = Date.now() + 5_000;
+          let errorNode: any;
+          while (Date.now() < deadline) {
+            await runtime.idle();
+            errorNode = pickerCell.key(UI).get() as any;
+            if (errorNode) break;
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          expect(errorNode).toBeDefined();
+        } finally {
+          globalThis.fetch = originalFetch;
+          setPatternEnvironment(originalEnvironment);
+          await runtime.idle();
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Why

The orphan-second-profile deadlock: a labs-shell tab can create a second profile without setting a default. In that 2+/no-default case, the interactive `#profile` wish replaced its output with the profile-picker sidecar pattern's **initially-empty** result cell — so `.result` was `undefined` for the whole sidecar fetch/compile window, and `undefined` **forever** if the fetch failed (the fetch chain had no failure surfacing; the sidecar cache swallows errors). Every consumer gating on `.result` (e.g. profile-group-chat's send guard) deadlocked, and headless/interactive answers diverged.

PR #4415 fixed the common case (2+ profiles **with** a default) and explicitly left this residual open. The design decision is recorded on Linear [CT-1829](https://linear.app/common-tools/issue/CT-1829) — **Option A: `wish("#profile").result` is always single; the picker becomes a switcher** — and is the contract Loom binds to (https://github.com/commontoolsinc/loom/pull/3627).

## What

- **`packages/runner/src/builtins/wish.ts`**
  - The `#profile` interactive multi-candidate branch no longer sends the picker sidecar's result cell as the wish output. It now sends the unified wish state eagerly — `result: ordered[0]` (candidates are already ordered default → MRU → first by `getProfileCandidateCells`), `candidates`, and `[UI]` = the picker sidecar rendered via `cf-render` (same idiom as `profileCreateUI`) — mirroring what the generic multi-match path already does.
  - **Switcher semantics:** the picker's existing "Use" (MRU stamp) and "Set default" trusted writes reorder the candidates, so `ordered[0]` — and therefore `.result` — flips reactively. Selection is state, not a channel.
  - Picker sidecar fetch failure now surfaces an error UI in the picker cell instead of leaving the slot blank forever (the sidecar cache resolves failed fetches to `undefined`; a defensive `.catch` also covers genuine rejections). `.result` is unaffected — it rides the main wish state.
  - Headless and single-candidate paths are untouched (they already returned `ordered[0]`).

- **`packages/runner/test/wish.test.ts`** — new `single-result #profile contract (CT-1829)` describe block (independent of the host-embedding-contract block landing in #4502): 0 profiles (create surface, error, undefined result), 1 profile (interactive + headless), 2+ with valid default (interactive + headless), 2+ no default → MRU head **interactive** (the new load-bearing case) + headless, 2+ no default no MRU → first (both modes), invalid default link skipped, picker rendered as `[UI]` with `.result` populated, MRU write flips result, and sidecar-fetch-failure resilience (`.result` still resolves; error surfaced in picker UI).

- **`docs/common/conventions/wish.md`** — "Well-Known Profile Targets" rewritten to the decided semantics (`.result` always the single current profile in every mode; picker = switching affordance; selection = MRU/default write → result updates). The general "multiple matches show a picker" section gains an explicit profile-exception note.

## Consumer check

All 13 `#profile` consumers surveyed; none need changes. Spot-checked the two most load-bearing:
- **profile-group-chat** send guard (`profileWish.result !== undefined`) — now enables in the orphan case instead of deadlocking.
- **group-chat-lobby** `{profileWish[UI]}` — still shows the picker when ambiguous (now via the `[UI]` slot).

## Follow-ups

- `profile-picker.tsx` keeps its own vestigial `result`/`resultIndex` computeds for one release; delete them once this lands and bakes (the builtin is the single source of ordering).
- `docs/development/HOST_EMBEDDING.md` (PR #4502, unmerged) carries a "pending CT-1829" marker — deliberately not touched here; it resolves in a follow-up once both PRs merge.
- Option C (generalizing single-best-by-default to all wishes, picker opt-in) is a separate future issue.

## Verification

- `deno test packages/runner/test/wish.test.ts` — 104 steps, 0 failed.
- Full `packages/runner` suite (`deno task test`) — 758 passed (3759 steps), 0 failed.
- `deno fmt` / `deno lint` / `deno task check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `wish("#profile").result` always resolve to a single current profile (default → MRU → first) in every mode. The picker now lives in `[UI]` as a switcher that updates `.result` via MRU/default writes, fixing the orphan second‑profile deadlock and aligning with CT-1829.

- **New Features**
  - `packages/runner/src/builtins/wish.ts`: Interactive 2+ profiles with no default send unified state early with `result = ordered[0]`, `candidates`, and `[UI]` rendering the profile picker via `cf-render`. Headless and single-candidate paths are unchanged.
  - Switcher semantics and docs: `docs/common/conventions/wish.md` documents the profile exception (`.result` is always single; picker is the switching affordance). Updated `packages/patterns/system/profile-picker.tsx` header comment to reflect switcher-only behavior and mark `result`/`resultIndex` as vestigial.

- **Bug Fixes**
  - `.result` no longer goes undefined during picker load or on picker fetch failure; errors are surfaced inside the picker cell instead.
  - `packages/runner/test/wish.test.ts`: Adds a suite that pins the new contract across 0/1/2+ profiles, default/MRU/first, invalid default, MRU flip, and sidecar fetch failure.

<sup>Written for commit 945056faaac228a917b524e730564a960abf58de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

