### PR TITLE
test(cfc): pin the read-clearance result shape to the declared release (E3)

### DIFF
--- a/docs/plans/cfc-future-work-implementation.md
+++ b/docs/plans/cfc-future-work-implementation.md
@@ -648,7 +648,14 @@ release: require (a) declared in the query contract, (b) the table's governing
 policy permits it (a `rowLabel`-adjacent schema flag), (c) auditable (count of
 withheld rows in diagnostics). Never for aggregates. Tests: per-user mailbox
 view (each participant sees their rows only); the withheld-count is not
-observable in the result shape beyond the declared release.
+observable in the result shape beyond the declared release. Status: **LANDED
+(#4478/#4484)** — keep-mask/withheld semantics in
+`packages/runner/test/sqlite-row-label-read.test.ts`, per-user view +
+reader-isolated result cells in
+`packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts`;
+the same file's result-shape test pins the raw cleared result doc to exactly
+the declared surface (kept rows + `withheld` + pending/error + request
+bookkeeping — no placeholders, gaps, or ids of withheld rows).
 
 **E4 — Phase 3.c server-side commit-time re-derivation (independent of
 E1–E3).**

--- a/packages/patterns/integration/fixtures/sqlite-read-clearance/main.tsx
+++ b/packages/patterns/integration/fixtures/sqlite-read-clearance/main.tsx
@@ -55,11 +55,11 @@ export default pattern(() => {
       reader: "text",
       body: "text",
     },
-    // A BARE term (no all() list): a rule term LIST is an array of objects,
-    // which splits into per-element linked docs on the handle value — and a
-    // second runtime's schema-less deep read of the handle can see that link
-    // unresolved (null), destabilizing the request hash across runtimes. The
-    // bare term stays inline, so every runtime reads the identical rule.
+    // A bare term (no all() wrapper) — the simplest form for a single
+    // alternative. (Term LISTS used to split into per-element linked docs on
+    // the stored handle and destabilize the request hash across runtimes;
+    // fixed in #4509 — the handle is stored self-contained — and guarded by
+    // packages/runner/test/sqlite-handle-multi-runtime.test.ts.)
     (f) => ({
       confidentiality: principal("key", match(f.reader, KEY, { min: 1 })),
     }),

--- a/packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts
+++ b/packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts
@@ -198,4 +198,57 @@ describe("sqlite read-time clearance across runtimes", () => {
       "baseline request hash stays reader-blind",
     );
   });
+
+  it("releases nothing about withheld rows beyond the declared surface", async () => {
+    // §6 E3 (docs/plans/cfc-future-work-implementation.md): "the
+    // withheld-count is not observable in the result shape beyond the
+    // declared release". The raw stored doc — read with NO result-schema
+    // shaping, so it is the query's ENTIRE observable surface — must carry
+    // exactly the declared release: the kept rows, the withheld count, and
+    // the request bookkeeping. Withheld rows leave no artifacts: no
+    // placeholder slots, no index gaps, no ids, no content.
+    const bobRaw = await bob.readRaw(["qClear"]) as Record<string, unknown>;
+    assertEquals(
+      Object.keys(bobRaw).sort(),
+      ["pending", "requestHash", "result", "withheld"],
+      "the cleared result doc carries ONLY the declared surface",
+    );
+    const bobRows = bobRaw.result as unknown[];
+    assertEquals(bobRows.length, 1, "kept rows only — no per-withheld slots");
+    assert(
+      bobRows.every((r) => r !== null && r !== undefined),
+      "the kept-row array is dense — no placeholder gaps",
+    );
+    // Content opacity: nothing reachable in bob's raw doc mentions a
+    // withheld row (kept rows split into per-row link docs, so the doc
+    // itself holds no row content — a leak would surface right here).
+    const bobFlat = JSON.stringify(bobRaw);
+    for (const leaked of ["alice-1", "alice-2"]) {
+      assert(
+        !bobFlat.includes(leaked),
+        `withheld row content "${leaked}" leaked into bob's raw result doc`,
+      );
+    }
+
+    const aliceRaw = await alice.readRaw(["qClear"]) as Record<string, unknown>;
+    assertEquals(
+      Object.keys(aliceRaw).sort(),
+      ["pending", "requestHash", "result", "withheld"],
+      "the cleared result doc carries ONLY the declared surface",
+    );
+    assertEquals((aliceRaw.result as unknown[]).length, 2);
+    assert(
+      !JSON.stringify(aliceRaw).includes("bob-only"),
+      "withheld row content leaked into alice's raw result doc",
+    );
+
+    // The boundary in the other direction: a NON-clearance query result
+    // carries no clearance artifact at all — `withheld` is absent, not 0.
+    const allRaw = await alice.readRaw(["qAll"]) as Record<string, unknown>;
+    assertEquals(
+      Object.keys(allRaw).sort(),
+      ["pending", "requestHash", "result"],
+      "a non-clearance result must not carry a withheld field",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes out the two residuals from the E3 read-time-clearance work (#4478 / #4484):

**1. The missing §6 E3 test** (docs/plans/cfc-future-work-implementation.md): *"the withheld-count is not observable in the result shape beyond the declared release."*

New step in `packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts`: reads each reader's cleared result doc **raw** (no result-schema shaping — the query's entire observable surface) and asserts it carries exactly the declared release:

- top-level keys are exactly `{pending, requestHash, result, withheld}` — nothing else;
- `result` holds **kept rows only**, dense — no placeholder slots, index gaps, or ids where rows were withheld;
- no withheld-row content anywhere in the serialized raw doc;
- the reverse boundary: a non-clearance query result carries **no** `withheld` field at all (absent, not 0).

**Red-checked:** perturbing the builtin to emit an extra `withheldRowIds` field fails *only* the new step — the existing row-content/isolation assertions stay green, so the pin does work the prior assertions don't.

**2. The db-owner re-mint concern** from #4484's PR body needed no new work: it was fixed in #4506 (owner minted only when there is no prior committed handle, composed with #4509's self-contained raw write) with red-checked regression tests in both lanes (`packages/runner/test/sqlite-db-owner.test.ts`, `packages/patterns/integration/sqlite-db-owner-multi-runtime.test.ts`). Both verified green on this branch. The split-rule-term request-hash instability also noted there was fixed by #4509, so the fixture's bare-term workaround comment is stale — refreshed to point at the fix and its guard test (behavior unchanged).

Also marks E3's test line **LANDED** in the plan doc.

## Test plan

- `deno test -A integration/sqlite-read-clearance-multi-runtime.test.ts` — 3 steps green (new step red-checked as above)
- `deno test -A integration/sqlite-db-owner-multi-runtime.test.ts` — green
- `deno test test/sqlite-db-owner.test.ts` (runner) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a raw-result test to pin the E3 read-time clearance shape: cleared results contain only dense kept rows, the `withheld` count, and request bookkeeping, with no placeholders, index gaps, row IDs, or withheld-row content; non-clearance results omit `withheld`.

Refresh the inline comment in `packages/patterns/integration/fixtures/sqlite-read-clearance/main.tsx` to point to the request-hash fix, and mark E3 as LANDED in `docs/plans/cfc-future-work-implementation.md`.

<sup>Written for commit c7a103f12114a30d61c6fb542137ce2e6d5880b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

