### PR TITLE
feat(cfc): persist the flow join as per-class entries (Epic C, stage C2)

### DIFF
--- a/docs/specs/cfc-observation-classes.md
+++ b/docs/specs/cfc-observation-classes.md
@@ -138,6 +138,18 @@ This is the crux of SC-4: separating the two classes lets `value` replace (the
 precision win) while `shape` grows (the soundness fix), where today one label
 does both and the existence bit leaks.
 
+**C2 note (2026-07-03): existence entries carry confidentiality only.** "The
+join of the old and new derivation's flow labels" above is a
+confidentiality-channel rule. The persisted `observes:"shape"` entry does not
+carry J's integrity: integrity composes by meet, never join, so growing an
+existence entry's integrity across writers would *union* certification claims
+— an over-claim. The `value` entry keeps the full J (confidentiality +
+integrity, replace-on-overwrite); this matches the existing `structure`
+stamps, which have always been confidentiality-only. Consequence: a
+`nonRecursive` (shape) read of a split-labeled path taints with the existence
+confidentiality but no longer inherits content certification into the
+hereditary meet — an intended under-claim (SC-9's fail-safe direction).
+
 ## 6. What `deriveFlowJoin` consumes per read shape
 
 `forEachFlowObservation` (`prepare.ts`) already visits each read with its

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4023,6 +4023,16 @@ export const prepareBoundaryCommit = (
         ) {
           continue;
         }
+        // C2 persist split (C0 §5/§8): the per-tx join lands as two
+        // per-class entries instead of one covering entry. The `value`
+        // entry carries the full J and keeps §8.12.8 replace-on-overwrite;
+        // the `shape` (existence) entry carries confidentiality only —
+        // existence is a confidentiality channel (SC-4: "this path was
+        // once written"), and integrity there would be joined by C3's
+        // grow-on-overwrite, which for integrity claims is an over-claim
+        // (integrity meets, never joins). Same conf atoms either way, so a
+        // class-unaware reader consuming both as covering entries sees
+        // exactly today's label — additively safe, no dial (C0 §9).
         persistedLabelEntries.push({
           path,
           label: {
@@ -4034,7 +4044,16 @@ export const prepareBoundaryCommit = (
               : {}),
           },
           origin: "derived",
+          observes: "value",
         });
+        if (flowConfidentiality.length > 0) {
+          persistedLabelEntries.push({
+            path,
+            label: { confidentiality: [...flowConfidentiality] },
+            origin: "derived",
+            observes: "shape",
+          });
+        }
       }
       for (const path of structureStampPaths) {
         // A covering derived stamp at-or-above already labels the shape;
@@ -4047,10 +4066,15 @@ export const prepareBoundaryCommit = (
         ) {
           continue;
         }
+        // C2: structure stamps state their class explicitly. Pre-C2
+        // structure entries (absent `observes`) stay covering — unchanged
+        // compat; the flow join is unaffected either way since value reads
+        // consume the `shape` class too (C0 §4).
         persistedLabelEntries.push({
           path,
           label: { confidentiality: [...flowConfidentiality] },
           origin: "structure",
+          observes: "shape",
         });
       }
     }

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -301,9 +301,12 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
-    const derived = entriesOf(outId).find((e) => e.origin === "derived");
-    expect(derived).toBeDefined();
-    expect(derived!.label.integrity ?? []).toContainEqual(certified);
+    // C2 splits the derived stamp into a value + shape pair (integrity
+    // rides the value entry) — collect across the pair.
+    const derived = entriesOf(outId).filter((e) => e.origin === "derived");
+    expect(derived.length).toBeGreaterThan(0);
+    expect(derived.flatMap((e) => e.label.integrity ?? []))
+      .toContainEqual(certified);
   });
 
   // The class axis survives persistence: canonicalization keeps `observes`

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
+import type { LabelMapEntry } from "../src/cfc/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-persist-split");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// Epic C stage C2 (docs/specs/cfc-observation-classes.md §5/§8): the persist
+// region writes the per-tx flow join as per-class entries — an
+// `observes:"value"` derived entry carrying the full J plus an
+// `observes:"shape"` (existence) entry carrying confidentiality only — and
+// `structure` stamps state `observes:"shape"` explicitly.
+//
+// Rollout (C0 §9): additively safe, no dial. A class-unaware reader treats
+// both split entries as covering and sees exactly today's atoms; the C1
+// class-aware reader joins them back identically for value reads. No
+// `observes:"followRef"` entry is newly persisted here — link-origin entries
+// already carry that class implicitly.
+describe("CFC observation classes (C2 persist split)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const seedDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    entries: LabelMapEntry[],
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: { version: 1, entries },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const rawDocOf = (
+    id: string,
+  ): { cfc?: { labelMap?: { entries: StoredEntry[] } } } | undefined => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id);
+  };
+
+  const entriesOf = (id: string): StoredEntry[] =>
+    rawDocOf(id)?.cfc?.labelMap?.entries ?? [];
+
+  const readAddress = (id: string, path: string[]) => ({
+    space,
+    scope: "space" as const,
+    id: id as `${string}:${string}`,
+    type: "application/json" as const,
+    path: ["value", ...path],
+  });
+
+  // Copies a labeled value into a fresh output doc and returns the output's
+  // stored entries.
+  const launder = async (
+    rt: Runtime,
+    sourceId: string,
+    outCause: string,
+  ): Promise<{ id: string; entries: StoredEntry[] }> => {
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(sourceId, []));
+    const out = rt.getCell(space, outCause, undefined, tx);
+    out.set({ copied: true });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    const id = out.getAsNormalizedFullLink().id;
+    return { id, entries: entriesOf(id) };
+  };
+
+  // The core split: a derived flow stamp lands as an `observes:"value"`
+  // entry carrying the full J (confidentiality + integrity) plus an
+  // `observes:"shape"` existence entry carrying confidentiality only.
+  it("persists the flow join as a value + shape entry pair", async () => {
+    const rt = makeRuntime();
+    const certified = { type: CFC_ATOM_TYPE.PolicyCertified, policy: "p1" };
+    const sourceId = await seedDoc(rt, "ps-source", { n: 1 }, [
+      {
+        path: [],
+        label: { confidentiality: ["secret"], integrity: [certified] },
+      },
+    ]);
+
+    // Read-free output write so the hereditary meet keeps the certification
+    // and the value entry demonstrably carries integrity.
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(sourceId, []));
+    const out = rt.getCell(space, "ps-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: outId, path: ["value"] },
+      { copied: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const derived = entriesOf(outId).filter((e) => e.origin === "derived");
+    expect(derived.map((e) => e.observes).sort()).toEqual(["shape", "value"]);
+    const valueEntry = derived.find((e) => e.observes === "value")!;
+    const shapeEntry = derived.find((e) => e.observes === "shape")!;
+    expect(valueEntry.label.confidentiality).toEqual(["secret"]);
+    expect(valueEntry.label.integrity).toContainEqual(certified);
+    // The existence channel carries confidentiality only: integrity there
+    // would be joined by C3's grow-on-overwrite, an over-claim.
+    expect(shapeEntry.label.confidentiality).toEqual(["secret"]);
+    expect(shapeEntry.label.integrity).toBeUndefined();
+    expect(shapeEntry.path).toEqual(valueEntry.path);
+  });
+
+  // Structure stamps (pure-link-structure writes) now state their class.
+  it('structure stamps carry observes:"shape"', async () => {
+    const rt = makeRuntime();
+    const el0 = await seedDoc(rt, "ps-el-0", { n: 1 }, [
+      { path: [], label: { confidentiality: ["alice"] } },
+    ]);
+
+    // A tx that reads labeled content and writes a pure-link container: the
+    // container gets an exact-path structure stamp with J.
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(el0, []));
+    const el0Cell = rt.getCell(space, "ps-el-0", undefined, tx);
+    const list = rt.getCell(space, "ps-list", {
+      type: "array",
+      items: { asCell: ["cell"] },
+    }, tx);
+    list.set([el0Cell]);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const listId = list.getAsNormalizedFullLink().id;
+    const structure = entriesOf(listId).filter((e) => e.origin === "structure");
+    expect(structure.length).toBeGreaterThan(0);
+    for (const entry of structure) {
+      expect(entry.observes).toBe("shape");
+      expect(entry.label.confidentiality).toEqual(["alice"]);
+    }
+  });
+
+  // SC-11 idempotence per class: re-deriving an unchanged label must not
+  // rewrite the ["cfc"] doc — the split pair must canonicalize identically
+  // across re-derivations.
+  it("keeps re-derivation idempotent per class (SC-11)", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ps-idem-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    const first = await launder(rt, sourceId, "ps-idem-out");
+    const before = JSON.stringify(rawDocOf(first.id)?.cfc);
+
+    // Same read, same write, same derivation → the metadata write must be
+    // skipped (canonically identical), not re-split or duplicated.
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(sourceId, []));
+    const out = rt.getCell(space, "ps-idem-out", undefined, tx);
+    out.set({ copied: true });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const after = JSON.stringify(rawDocOf(first.id)?.cfc);
+    expect(after).toEqual(before);
+    const derived = entriesOf(first.id).filter((e) => e.origin === "derived");
+    expect(derived.map((e) => e.observes).sort()).toEqual(["shape", "value"]);
+  });
+
+  // Reader parity across the split: a class-aware value read of split
+  // entries derives the same downstream join a single covering entry
+  // produced.
+  it("value-read flow joins over split entries match the covering join", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ps-parity-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    const first = await launder(rt, sourceId, "ps-parity-mid");
+    // Second hop reads the split-labeled doc and copies onward.
+    const second = await launder(rt, first.id, "ps-parity-out");
+    const derived = second.entries.filter((e) => e.origin === "derived");
+    expect(derived.map((e) => e.observes).sort()).toEqual(["shape", "value"]);
+    for (const entry of derived) {
+      expect(entry.label.confidentiality).toEqual(["secret"]);
+    }
+  });
+
+  // Per-class consumption refinement (intended, fail-safe): a nonRecursive
+  // (shape) read of a split-labeled path consumes the existence
+  // confidentiality but no longer inherits the value entry's content
+  // certification into the hereditary meet — shape observations are not
+  // content inputs (SC-9: under-claim, never over-claim).
+  it("shape reads over split entries taint without inheriting content certification", async () => {
+    const rt = makeRuntime();
+    const certified = { type: CFC_ATOM_TYPE.PolicyCertified, policy: "p1" };
+    const sourceId = await seedDoc(rt, "ps-shape-source", { n: 1 }, [
+      {
+        path: [],
+        label: { confidentiality: ["secret"], integrity: [certified] },
+      },
+    ]);
+    const first = await launder(rt, sourceId, "ps-shape-mid");
+
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(first.id, []), { nonRecursive: true });
+    const out = rt.getCell(space, "ps-shape-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: outId, path: ["value"] },
+      { counted: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const derived = entriesOf(outId).filter((e) => e.origin === "derived");
+    const valueEntry = derived.find((e) => e.observes === "value")!;
+    expect(valueEntry.label.confidentiality).toEqual(["secret"]);
+    // No PolicyCertified inherited through a shape-only observation.
+    expect(
+      (valueEntry.label.integrity ?? []).filter((atom) =>
+        (atom as { type?: string }).type === CFC_ATOM_TYPE.PolicyCertified
+      ),
+    ).toEqual([]);
+  });
+
+  // Overwrite discipline at C2: the value entry is replaced by the new
+  // derivation (§8.12.8). The shape entry's replace-vs-grow is deliberately
+  // NOT pinned here — C3 upgrades it to grow (SC-4).
+  it("overwrite replaces the value entry with the new derivation", async () => {
+    const rt = makeRuntime();
+    const secretId = await seedDoc(rt, "ps-ow-secret", { n: 1 }, [
+      { path: [], label: { confidentiality: ["old-secret"] } },
+    ]);
+    const publicId = await seedDoc(rt, "ps-ow-public", { n: 2 }, [
+      { path: [], label: { confidentiality: ["public-ish"] } },
+    ]);
+    const first = await launder(rt, secretId, "ps-ow-out");
+    expect(
+      first.entries.find((e) => e.observes === "value")?.label.confidentiality,
+    ).toEqual(["old-secret"]);
+
+    // A ROOT overwrite (whole-value write at the stamped path) — a leaf
+    // write below the stamp must NOT clear it, so `out.set({...})`'s
+    // leaf-diffing would not exercise replace-on-overwrite.
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(publicId, []));
+    tx.writeOrThrow(
+      {
+        space,
+        scope: "space",
+        id: first.id as `${string}:${string}`,
+        path: ["value"],
+      },
+      { copied: false },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const valueEntry = entriesOf(first.id).find((e) =>
+      e.origin === "derived" && e.observes === "value"
+    );
+    expect(valueEntry?.label.confidentiality).toEqual(["public-ish"]);
+    expect(valueEntry?.label.confidentiality).not.toContainEqual("old-secret");
+  });
+
+  // Wire-compat (C0 §9, the plan's mixed-version discipline): a
+  // class-UNAWARE reader — one that ignores `observes` entirely and treats
+  // every entry as covering — resolves exactly today's atoms from the split
+  // pair: same confidentiality, and the integrity still present via the
+  // value entry. More restrictive is allowed, less is not.
+  it("split entries read as covering by a class-unaware reader lose nothing", async () => {
+    const rt = makeRuntime();
+    const certified = { type: CFC_ATOM_TYPE.PolicyCertified, policy: "p1" };
+    const sourceId = await seedDoc(rt, "ps-compat-source", { n: 1 }, [
+      {
+        path: [],
+        label: { confidentiality: ["secret"], integrity: [certified] },
+      },
+    ]);
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(sourceId, []));
+    const out = rt.getCell(space, "ps-compat-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: outId, path: ["value"] },
+      { copied: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    // Legacy resolution: union every entry's atoms regardless of class.
+    const derived = entriesOf(outId).filter((e) => e.origin === "derived");
+    const legacyConfidentiality = [
+      ...new Set(derived.flatMap((e) => e.label.confidentiality ?? [])),
+    ];
+    const legacyIntegrity = derived.flatMap((e) => e.label.integrity ?? []);
+    expect(legacyConfidentiality).toEqual(["secret"]);
+    expect(legacyIntegrity).toContainEqual(certified);
+  });
+
+  // The SC-8 probe consumption composes with the split: standalone probes
+  // still consume only followRef-class entries — never the new value/shape
+  // pair.
+  it("standalone probes do not consume the split value/shape entries", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ps-probe-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    const first = await launder(rt, sourceId, "ps-probe-mid");
+
+    const tx = rt.edit();
+    tx.read(readAddress(first.id, []), { meta: linkResolutionProbe });
+    const out = rt.getCell(space, "ps-probe-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: outId, path: ["value"] },
+      { probed: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(entriesOf(outId).filter((e) => e.origin === "derived")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Epic C stage C2 of `docs/plans/cfc-future-work-implementation.md` §4, on top of C1 (#4507, the class-aware reader). The persist region now writes the per-tx derived flow join as per-class entries instead of one covering entry (C0 §5/§8).

## What

- **`observes:"value"` derived entry** — carries the full J (confidentiality + integrity), keeps the §8.12.8 replace-on-overwrite discipline.
- **`observes:"shape"` (existence) entry** — same path, confidentiality only. **Design note (recorded in the C0 doc §5):** existence is a confidentiality channel (SC-4: "this path was once written"); carrying J's integrity there would be *joined* by C3's grow-on-overwrite, and integrity composes by meet, never join — growing it would union certification claims, an over-claim. This matches the `structure` stamps, which have always been confidentiality-only.
- **Structure stamps** now state `observes:"shape"` explicitly. Pre-C2 structure entries (absent `observes`) stay covering — unchanged compat.
- No `observes:"followRef"` entry is newly persisted — link-origin entries already carry that class implicitly (C0 §3 carve-out), so the SC-8 reader-first prerequisite from #4507 is untouched.

## Rollout (C0 §9): additively safe, no dial

- A **class-unaware (old) reader** treats both split entries as covering and resolves exactly today's atoms — same confidentiality (both entries carry the same atoms), integrity via the value entry. Pinned by the `split entries read as covering by a class-unaware reader lose nothing` test (the plan's mixed-version discipline).
- The **C1 class-aware reader** joins the pair back identically for value reads (parity test across a two-hop launder chain).
- **Intended refinement** (fail-safe direction): a `nonRecursive` (shape) read of a split-labeled path taints with the existence confidentiality but no longer inherits content certification into the hereditary meet — shape observations are not content inputs (SC-9: under-claim, never over-claim). Pinned by its own test and documented in the C0 §5 note.
- SC-4's replace-on-overwrite behavior for the shape entry is deliberately **not pinned** — C3 upgrades it to grow (red-first there).

## Red→green

All six persistence-shape tests in `packages/runner/test/cfc-persist-split.test.ts` fail on main and pass here (split pair, structure class, SC-11 per class, value-read parity, shape-read refinement, root-overwrite replace); the two invariant tests (class-unaware compat, probe non-consumption) hold on both sides by construction. One C1 test updated its entry selector (integrity now rides the value entry of the pair).

## SC-11 idempotence per class

Re-deriving an unchanged label produces a canonically identical split pair — the `["cfc"]` doc write is skipped, no metadata churn (test: `keeps re-derivation idempotent per class`).

## Perf (plan §0 gate — both cfc benches before/after on this machine, flat/within noise)

| `cfc-label-sync-strategy` | before | after |
|---|---|---|
| syncMetaLinkedDocs (warm) parallel batch | 3.7 ms | 3.8 ms |
| syncMetaLinkedDocs (warm) skip when present | 1.5 µs | 1.4 µs |
| getCfcLabel (warm) pure read | 1.4 µs | 1.3 µs |
| syncMetaLinkedDocs (cold) skip when present | 3.7 ms | 3.8 ms |

| `cfc-canonicalize` | before | after |
|---|---|---|
| preparedDigestFor — small | 14.3 µs | 13.0 µs |
| preparedDigestFor — large | 78.3 µs | 71.6 µs |
| preparedDigestFor — tiebreak-heavy | 15.1 µs | 14.3 µs |
| preparedDigestFor — path-heavy | 67.7 µs | 65.1 µs |
| preparedDigestFor — large WARM | 73.8 µs | 70.9 µs |
| watchIdForEntry | 4.3 µs | 4.3 µs |

LabelMap growth is bounded at +1 entry per derived-stamped path (only when the flow join has confidentiality), not a blanket 2×: link entries, declared entries, and structure stamps are unchanged.

## Tests

- New `packages/runner/test/cfc-persist-split.test.ts` (8 cases).
- Full `packages/runner` suite green: 764 passed / 0 failed (all 76 cfc test files).

Next: C3 — the two red-first channel fixes (SC-4 grow-on-overwrite for the existence entry; SC-8 formal slot-pointer taint tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the derived flow join as split per-class entries to enable class-aware semantics without breaking old readers. Structure stamps now explicitly use `observes:"shape"`, and shape reads taint with confidentiality only.

- **New Features**
  - Persistence: write two derived entries per path — `observes:"value"` carries confidentiality+integrity and keeps replace-on-overwrite; `observes:"shape"` carries confidentiality only; no `observes:"followRef"` is persisted.
  - Structure stamps: now include `observes:"shape"`; pre-C2 stamps (without `observes`) remain covering and fully compatible.
  - Reader behavior: class-unaware readers resolve the same atoms; C1 value reads join identically; `nonRecursive` shape reads taint with existence confidentiality only; SC-11 idempotence holds per class (no metadata churn).

<sup>Written for commit 8c35b8fc67e6b423c2d19235151cb3f0c2e6a3c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

