### PR TITLE
fix(wish): resolve favorites tag matches from the matched cell

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -225,6 +225,8 @@ type WishContext = {
 type BaseResolution = {
   cell: Cell<unknown>;
   pathPrefix?: readonly string[];
+  // When true, pathPrefix is the full path to resolve from cell.
+  pathConsumed?: boolean;
 };
 
 type SharedHashtagState = {
@@ -283,6 +285,18 @@ function resolvePath(
     current = current.key(segment);
   }
   return current.resolveAsCell();
+}
+
+function buildResolutionPath(
+  baseResolution: BaseResolution,
+  parsedPath: readonly string[],
+): readonly string[] {
+  if (baseResolution.pathConsumed) {
+    return baseResolution.pathPrefix ?? [];
+  }
+  return baseResolution.pathPrefix
+    ? [...baseResolution.pathPrefix, ...parsedPath]
+    : parsedPath;
 }
 
 function getHomeSpaceCell(ctx: WishContext): Cell<unknown> {
@@ -762,6 +776,7 @@ function resolveHomeSpaceTarget(
       return [{
         cell: match.cell,
         pathPrefix: parsed.path.slice(1),
+        pathConsumed: true,
       }];
     }
 
@@ -1051,9 +1066,10 @@ function createSharedHashtagResolver(
         queryKey,
         () =>
           baseResolutions.map((baseResolution) => {
-            const combinedPath = baseResolution.pathPrefix
-              ? [...baseResolution.pathPrefix, ...sharedParsed.path]
-              : sharedParsed.path;
+            const combinedPath = buildResolutionPath(
+              baseResolution,
+              sharedParsed.path,
+            );
             return resolvePath(baseResolution.cell, combinedPath);
           }),
       );
@@ -1969,9 +1985,10 @@ export function wish(
               queryKey,
               () =>
                 baseResolutions.map((baseResolution) => {
-                  const combinedPath = baseResolution.pathPrefix
-                    ? [...baseResolution.pathPrefix, ...activeParsed.path]
-                    : activeParsed.path;
+                  const combinedPath = buildResolutionPath(
+                    baseResolution,
+                    activeParsed.path,
+                  );
                   const resolvedCell = resolvePath(
                     baseResolution.cell,
                     combinedPath,

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2343,12 +2343,11 @@ describe("wish built-in", () => {
       expect((favorites as any[])[0].tag).toEqual("test favorite");
     });
 
-    // Helper: stand up the home space with a single favorite carrying the given
-    // discovery/user tags, then resolve `#favorites/<term>` against it.
     async function resolveFavoritesTerm(
       label: string,
       entry: { tags?: string[]; userTags?: string[] },
       term: string,
+      options?: { value?: unknown; path?: string[] },
     ) {
       const homeSpaceCell = runtime.getHomeSpaceCell(tx);
       const defaultPatternCell = runtime.getCell(
@@ -2364,7 +2363,7 @@ describe("wish built-in", () => {
         undefined,
         tx,
       );
-      favoriteItem.set({ name: "My Favorite", value: 42 });
+      favoriteItem.set(options?.value ?? { name: "My Favorite", value: 42 });
       favoritesCell.set([
         {
           cell: favoriteItem,
@@ -2379,7 +2378,11 @@ describe("wish built-in", () => {
       tx = runtime.edit();
 
       const wishPattern = pattern(() => {
-        return { result: wish({ query: `#favorites/${term}` }) };
+        return {
+          result: wish({
+            query: ["#favorites", term, ...(options?.path ?? [])].join("/"),
+          }),
+        };
       });
       const resultCell = runtime.getCell<{
         result?: { result?: unknown; error?: string };
@@ -2396,10 +2399,6 @@ describe("wish built-in", () => {
       return result.key("result").get();
     }
 
-    // A `#favorites/<term>` query finds a favorite whose discovery tag or user
-    // tag matches `term`. These tests assert the match decision (no "No favorite
-    // found" error when one matches; the error when none do) — that is the code
-    // path the favorite matchers own.
     it("matches a #favorites/<term> query by a structured discovery tag", async () => {
       const resolved = await resolveFavoritesTerm(
         "tag",
@@ -2418,6 +2417,32 @@ describe("wish built-in", () => {
       expect(resolved?.error).toBeUndefined();
     });
 
+    it("resolves #favorites/<term> to the matched favorite", async () => {
+      const resolved = await resolveFavoritesTerm(
+        "weather-value",
+        { userTags: ["weather"] },
+        "weather",
+        { value: { name: "My Favorite", value: 42 } },
+      );
+      expect(resolved?.result).toEqual({
+        name: "My Favorite",
+        value: 42,
+      });
+    });
+
+    it("resolves #favorites/<term>/<subpath> inside the matched favorite", async () => {
+      const resolved = await resolveFavoritesTerm(
+        "weather-subpath",
+        { userTags: ["weather"] },
+        "weather",
+        {
+          value: { name: "My Favorite", forecast: { temp: 72 } },
+          path: ["forecast", "temp"],
+        },
+      );
+      expect(resolved?.result).toBe(72);
+    });
+
     it("reports an error for #favorites/<term> when nothing matches", async () => {
       const resolved = await resolveFavoritesTerm(
         "nomatch",
@@ -2428,8 +2453,6 @@ describe("wish built-in", () => {
       expect(resolved?.error).toMatch(/No favorite found matching/);
     });
 
-    // Other well-known home-space targets resolve to fixed paths under the home
-    // default pattern.
     async function resolveHomeTarget(
       label: string,
       key: string,
@@ -2488,6 +2511,17 @@ describe("wish built-in", () => {
       );
       expect(resolved?.error).toBeUndefined();
       expect((resolved?.result as any)?.summary).toBe("a learned summary");
+    });
+
+    it("resolves #learnedSummary to the home learned summary", async () => {
+      const resolved = await resolveHomeTarget(
+        "learned-summary",
+        "learned",
+        { summary: "Known facts" },
+        "#learnedSummary",
+      );
+      expect(resolved?.error).toBeUndefined();
+      expect(resolved?.result).toBe("Known facts");
     });
 
     it("resolves well-known profile targets from the home default profile link", async () => {


### PR DESCRIPTION
Queries such as #favorites/weather first consume the tag term when they select a favorite. The previous resolver returned the matched favorite cell, but the main wish resolver still appended the full query path. That caused the tag term to be applied again as a child key, so #favorites/weather tried to read matchedFavorite.weather instead of the favorite value.

This change lets resolver results mark that their returned path already accounts for the query path. The #favorites/<term> branch uses that for the path after the matched tag, while existing home-space and space-scoped routes keep appending their query path as before. Regression tests cover the matched favorite, a nested path under it, and unchanged well-known targets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `#favorites/<term>` so the tag is consumed once and the query resolves from the matched favorite. Prevents cases where `#favorites/weather` tried to read `matchedFavorite.weather` instead of the favorite’s value.

- **Bug Fixes**
  - Added `pathConsumed` and a path builder to only append query segments when needed.
  - Marked the favorites-tag branch as consumed, enabling `#favorites/<term>` and nested paths like `#favorites/weather/forecast/temp`.
  - Expanded tests to cover resolving the matched favorite’s value, nested subpaths, and unchanged home-space routes like `#learnedSummary`.

<sup>Written for commit ebe4969447119edfdfa893f4c0f69f807ae53cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

