### PR TITLE
fix(cfc): drop duplicate trigger-read loop defeating the cid: defense in depth

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1373,36 +1373,17 @@ const forEachFlowObservation = (
   // "dep changed" leaks one bit per change through the timing/existence of
   // writes the rerun makes. Runtime-surface addresses were already dropped
   // by `addCfcTriggerReads` (which sees the raw notification path before
-  // canonicalization and applies `flowReadExcluded`); the `cid:` check
-  // stays as defense in depth for trigger entries that arrive by other
-  // construction paths.
+  // canonicalization and applies `flowReadExcluded`). The path half of that
+  // exclusion cannot be rechecked here — stored paths are canonical, where
+  // a user `value.source` is indistinguishable from the raw `["source"]`
+  // surface — but the id-based `cid:` check stays as defense in depth for
+  // trigger entries that arrive by other construction paths: `cid:` docs
+  // sit on an unverified write path any same-space writer can reach (audit
+  // S5), so a poisoned labelMap on one must not join the flow derivation.
   for (const trigger of tx.getCfcState().triggerReads) {
     if (trigger.id.startsWith("cid:")) {
       continue;
     }
-    if (
-      consume(
-        trigger.space,
-        trigger.id as URI,
-        normalizeCellScope(trigger.scope),
-        "application/json",
-        trigger.path,
-        { shape: "value", nonRecursive: false },
-      )
-    ) {
-      return true;
-    }
-  }
-  // Trigger reads (§8.9.2): the addresses whose invalidating writes
-  // scheduled this run. The decision to run now was influenced by their
-  // values even when this run's branch never re-reads them — without this,
-  // "dep changed" leaks one bit per change through the timing/existence of
-  // writes the rerun makes. Runtime-surface addresses were already dropped
-  // by `addCfcTriggerReads` (which sees the raw notification path before
-  // canonicalization), so no `flowReadExcluded` check here — the stored
-  // path is canonical, where a user `value.source` is indistinguishable
-  // from the raw `["source"]` surface.
-  for (const trigger of tx.getCfcState().triggerReads) {
     if (
       consume(
         trigger.space,

--- a/packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts
+++ b/packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { parseLink } from "../src/link-utils.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-trigger-cid");
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+};
+
+const replicaEntries = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+): StoredEntry[] => {
+  const replica = storageManager.open(signer.did()).replica as unknown as {
+    getDocument(id: string): {
+      cfc?: { labelMap?: { entries: StoredEntry[] } };
+    } | undefined;
+  };
+  return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+};
+
+// §8.9.2 trigger reads name runtime-surface documents only by accident or
+// forgery: `addCfcTriggerReads` drops them at ingest (`flowReadExcluded` on
+// the raw notification path), and `forEachFlowObservation` keeps an id-based
+// `cid:` skip as defense in depth for entries that arrive by other
+// construction paths. That second layer matters because `cid:` schema docs
+// live on an unverified write path any same-space writer can reach (audit
+// S5): a poisoned labelMap on one must not join the flow derivation through
+// a smuggled trigger entry.
+describe("CFC trigger reads: cid: exclusion", () => {
+  it("keeps cid: trigger reads out of the flow derivation even when they bypass ingest filtering", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+    try {
+      // A legitimately labeled user doc — its trigger read SHOULD join, which
+      // proves the derivation machinery ran (the cid: assertion below is not
+      // vacuously green).
+      const seed = runtime.edit();
+      const sourceId = parseLink(
+        runtime.getCell(
+          signer.did(),
+          "cfc-trigger-cid-source",
+          { type: "object", properties: { secret: { type: "string" } } },
+        ).getAsLink(),
+      ).id!;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: sourceId,
+        path: [],
+      }, {
+        value: { secret: "s3cr3t" },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { confidentiality: ["secret"] },
+            }],
+          },
+        },
+      });
+      // A cid: doc carrying a labelMap — writable by any same-space
+      // principal, so its label is attacker-controlled and must stay out of
+      // flow joins.
+      const cidId = "cid:trigger-read-poison" as typeof sourceId;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: cidId,
+        path: [],
+      }, {
+        value: { secret: "poisoned" },
+        cfc: {
+          version: 1,
+          schemaHash: "poison-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { confidentiality: ["cid-secret"] },
+            }],
+          },
+        },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      // Ingest layer: `addCfcTriggerReads` drops the cid: address, keeps the
+      // user doc's.
+      tx.addCfcTriggerReads([
+        {
+          space: signer.did(),
+          id: sourceId,
+          type: "application/json",
+          path: ["value", "secret"],
+        },
+        {
+          space: signer.did(),
+          id: cidId,
+          type: "application/json",
+          path: ["value", "secret"],
+        },
+      ]);
+      expect(tx.getCfcState().triggerReads.length).toBe(1);
+      expect(tx.getCfcState().triggerReads[0].id).toBe(sourceId);
+
+      // Derivation layer: smuggle a cid: trigger entry past ingest, the way
+      // a divergent construction path (or a bug in one) would. Stored
+      // entries are canonical, so push the canonical form.
+      (tx.getCfcState().triggerReads as unknown as {
+        space: string;
+        id: string;
+        scope: string;
+        path: string[];
+      }[]).push({
+        space: signer.did(),
+        id: cidId,
+        scope: "space",
+        path: ["secret"],
+      });
+
+      // The transaction reads nothing — only the triggers connect it to the
+      // labeled docs.
+      const out = runtime.getCell(
+        signer.did(),
+        "cfc-trigger-cid-out",
+        undefined,
+        tx,
+      );
+      out.set({ flag: 1 });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const outId = out.getAsNormalizedFullLink().id;
+      const entries = replicaEntries(storageManager, outId);
+      const derived = entries.find((e) => e.origin === "derived");
+      // The legitimate trigger joined…
+      expect(derived).toBeDefined();
+      expect(derived!.label.confidentiality).toContainEqual("secret");
+      // …the poisoned cid: trigger did not — on ANY entry of the out doc.
+      for (const entry of entries) {
+        expect(entry.label.confidentiality ?? []).not.toContainEqual(
+          "cid-secret",
+        );
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`forEachFlowObservation` in `packages/runner/src/cfc/prepare.ts` consumed `tx.getCfcState().triggerReads` **twice**. PR #4022 (pointwise flow precision) replaced the old `dereferenceTraces` loop with a trigger-reads loop that carries a `cid:` skip and a "defense in depth" comment — but the pre-existing trigger-reads loop directly below it survived the diff as unchanged context.

Double consumption is idempotent for the confidentiality join (atoms dedup), so this was invisible. The **behavioral** bug is that the surviving second loop had **no `cid:` check**, so it consumed exactly the `cid:` trigger reads the first loop deliberately skips — defeating the defense-in-depth filter.

Why that filter matters: `cid:` schema documents sit on an unverified write path any same-space writer can reach (audit S5 — see `loadSchemaDocument`, which re-derives and rejects a poisoned hash on read). A same-space principal can attach a poisoned `labelMap` to a `cid:` doc; the surviving loop would join that attacker-controlled label into the flow derivation of any run whose trigger entry named it. `addCfcTriggerReads` filters the normal ingest path, but the in-loop `cid:` check is the backstop for entries arriving by other construction paths.

## Fix

- Keep the single loop **with** the `cid:` skip; remove the duplicate.
- Merge both comment blocks' rationale into the survivor: the id-based `cid:` check is defense in depth, and the path half of `flowReadExcluded` genuinely can't be rechecked here (stored paths are canonical, where a user `value.source` is indistinguishable from the raw `["source"]` runtime surface).

## Test (red-first)

New `packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts`:

- Seeds a legitimately labeled `of:` doc **and** a `cid:` doc with a poisoned `labelMap`.
- Asserts `addCfcTriggerReads` drops the `cid:` address at ingest (1 trigger survives).
- Injects the `cid:` trigger directly into `cfcState.triggerReads` (simulating a bypassing construction path) and commits a write-only transaction.
- Asserts the derived label contains the **legitimate** atom (proving the derivation ran — the exclusion isn't vacuously green) but **not** the poisoned `cid:` atom on any entry.

Against the unfixed code the derived label came out `[secret, cid-secret]` (red); after removing the duplicate loop it's `[secret]` (green).

## Verification

- New test + full `cfc-*` runner suite (76 files, 450 steps) + scheduler trigger-read tests + trigger-read gating suite all pass.
- `deno fmt --check` and `deno lint` clean on both touched files.
- Catch-up merged `origin/main` before pushing; CFC suite re-run green post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in CFC flow derivation where a duplicate trigger-read loop re-consumed triggers without the `cid:` check, allowing attacker-controlled `cid:` labels to join. Removes the duplicate loop and adds a regression test to enforce the defense-in-depth filter.

- **Bug Fixes**
  - Keep a single trigger-reads loop with the `cid:` skip; remove the second loop that bypassed it in `packages/runner/src/cfc/prepare.ts`.
  - Clarify comments: the id-based `cid:` check is defense in depth; path-based `flowReadExcluded` can’t be rechecked post-canonicalization.
  - Add `packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts` to verify `addCfcTriggerReads` drops `cid:` and that injected `cid:` triggers are ignored; derived labels include only legitimate atoms.

<sup>Written for commit baf7c79ecf41edbc506cc55c5398c52c5f530d48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

