### PR TITLE
Fix profiler capture signal race during cleanup

### DIFF
--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -67,6 +67,7 @@ class FakeCelestial {
   closeError: unknown;
   closePromise: Promise<void> | undefined;
   closeStarted: PromiseWithResolvers<void> | undefined;
+  closeThrow: unknown;
   starts = 0;
   stops = 0;
   removedListeners: string[] = [];
@@ -146,6 +147,7 @@ class FakeCelestial {
   close(): Promise<void> {
     this.calls.push("close");
     this.closeStarted?.resolve();
+    if (this.closeThrow) throw this.closeThrow;
     if (this.closeError) return Promise.reject(this.closeError);
     return this.closePromise ?? Promise.resolve();
   }
@@ -1262,6 +1264,35 @@ describe("capture-deno-inspector-profile helpers", () => {
       }
 
       assertEquals((caught as Error).message, "close failed");
+    });
+  });
+
+  it("reports inspector client close throws after successful capture", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      celestial.closeThrow = new Error("close threw");
+      const logs: string[] = [];
+      const resumed = Promise.withResolvers<void>();
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${tmpDir}/profile.cpuprofile`,
+          "--summary-pattern=done",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({ celestial, logs, resumed }),
+      );
+
+      await resumed.promise;
+      celestial.dispatchConsole({ value: "done" });
+
+      let caught: unknown;
+      try {
+        await done;
+      } catch (error) {
+        caught = error;
+      }
+
+      assertEquals((caught as Error).message, "close threw");
     });
   });
 

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -65,6 +65,8 @@ class FakeWebSocket {
 class FakeCelestial {
   calls: string[] = [];
   closeError: unknown;
+  closePromise: Promise<void> | undefined;
+  closeStarted: PromiseWithResolvers<void> | undefined;
   starts = 0;
   stops = 0;
   removedListeners: string[] = [];
@@ -143,8 +145,9 @@ class FakeCelestial {
 
   close(): Promise<void> {
     this.calls.push("close");
+    this.closeStarted?.resolve();
     if (this.closeError) return Promise.reject(this.closeError);
-    return Promise.resolve();
+    return this.closePromise ?? Promise.resolve();
   }
 
   dispatch(type: string, event: Event): void {
@@ -1316,6 +1319,47 @@ describe("capture-deno-inspector-profile helpers", () => {
       assertEquals(celestial.stops, 1);
       assertEquals(logs.includes("profile: signal-SIGTERM"), true);
       assertEquals(removed, ["SIGINT", "SIGTERM"]);
+    });
+  });
+
+  it("keeps signal handlers while the inspector client closes", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      const closeStarted = Promise.withResolvers<void>();
+      const logs: string[] = [];
+      const resumed = Promise.withResolvers<void>();
+      const signalHandlers: Partial<Record<Deno.Signal, () => void>> = {};
+      const removed: Deno.Signal[] = [];
+      celestial.closeStarted = closeStarted;
+      celestial.closePromise = new Promise<void>(() => {});
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${tmpDir}/profile.cpuprofile`,
+          "--summary-pattern=done",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({
+          celestial,
+          logs,
+          resumed,
+          signalHandlers,
+          removeSignalListener: (signal) => {
+            removed.push(signal);
+            delete signalHandlers[signal];
+          },
+        }),
+      );
+
+      await resumed.promise;
+      celestial.dispatchConsole({ value: "done" });
+      await closeStarted.promise;
+
+      assertEquals(typeof signalHandlers.SIGINT, "function");
+      signalHandlers.SIGINT?.();
+
+      assertEquals(await done, 0);
+      assertEquals(removed, ["SIGINT", "SIGTERM"]);
+      assertEquals(signalHandlers.SIGINT, undefined);
     });
   });
 

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -363,20 +363,6 @@ export async function captureDenoInspectorProfile(
   const profileStopPattern = parseArg(args, "profile-stop-pattern");
   const websocketUrl = requireArg(args, "websocket-url");
   const output = runtime.console ?? console;
-
-  const target = {
-    id: websocketUrl,
-    title: websocketUrl,
-    type: "node",
-    webSocketDebuggerUrl: websocketUrl,
-  };
-  output.log(`profile: target ${target.title ?? target.id}`);
-
-  const ws = runtime.createWebSocket(target.webSocketDebuggerUrl);
-  await waitForWebSocketOpen(ws);
-  output.log("profile: websocket open");
-
-  const celestial = runtime.createCelestial(ws);
   const summaryRegex = new RegExp(summaryPattern);
   const profileStartRegex = profileStartPattern
     ? new RegExp(profileStartPattern)
@@ -397,6 +383,20 @@ export async function captureDenoInspectorProfile(
   let pendingProfilerStopReason: string | undefined;
   let profilerStartError: string | undefined;
   let missingProfileStartError: string | undefined;
+
+  const target = {
+    id: websocketUrl,
+    title: websocketUrl,
+    type: "node",
+    webSocketDebuggerUrl: websocketUrl,
+  };
+  output.log(`profile: target ${target.title ?? target.id}`);
+
+  const ws = runtime.createWebSocket(target.webSocketDebuggerUrl);
+  await waitForWebSocketOpen(ws);
+  output.log("profile: websocket open");
+
+  const celestial = runtime.createCelestial(ws);
 
   const requestStop = (reason: string): void => {
     if (stopReasonSent) return;
@@ -463,15 +463,17 @@ export async function captureDenoInspectorProfile(
     }
   };
 
-  celestial.addEventListener(
-    "Runtime.consoleAPICalled",
-    handleConsoleApiCalled,
-  );
-
   const signalHandlers: Array<[Deno.Signal, () => void]> = [];
+  const cleanupSignal = Promise.withResolvers<void>();
+  let cleanupSignalSent = false;
+  let cleanupStarted = false;
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     try {
       const handler = () => {
+        if (cleanupStarted && !cleanupSignalSent) {
+          cleanupSignalSent = true;
+          cleanupSignal.resolve();
+        }
         requestProfilerStop(`signal-${signal}`);
       };
       if (runtime.addSignalListener) {
@@ -482,6 +484,15 @@ export async function captureDenoInspectorProfile(
       // Signals are best-effort here.
     }
   }
+  const removeSignalHandlers = (): void => {
+    for (const [signal, handler] of signalHandlers) {
+      try {
+        runtime.removeSignalListener?.(signal, handler);
+      } catch {
+        // Listener may already be gone.
+      }
+    }
+  };
 
   const stopProfile = async (reason: string): Promise<void> => {
     if (markProfileStoppedOnce(profileStopState, reason)) {
@@ -509,9 +520,16 @@ export async function captureDenoInspectorProfile(
   let caughtError: unknown;
   let cleanupError: unknown;
   let hasCaughtError = false;
+  let consoleListenerAdded = false;
   let websocketCloseListenerAdded = false;
   let stopResumeOnPause: (() => void) | undefined;
   try {
+    celestial.addEventListener(
+      "Runtime.consoleAPICalled",
+      handleConsoleApiCalled,
+    );
+    consoleListenerAdded = true;
+
     await celestial.Runtime.enable();
     output.log("profile: runtime enabled");
     await celestial.Console.enable();
@@ -548,43 +566,53 @@ export async function captureDenoInspectorProfile(
     hasCaughtError = true;
     caughtError = error;
   } finally {
-    for (const [signal, handler] of signalHandlers) {
-      try {
-        runtime.removeSignalListener?.(signal, handler);
-      } catch {
-        // Listener may already be gone.
-      }
-    }
-
     if (websocketCloseListenerAdded) {
       ws.removeEventListener("close", handleClose);
     }
     stopResumeOnPause?.();
-    celestial.removeEventListener(
-      "Runtime.consoleAPICalled",
-      handleConsoleApiCalled,
-    );
+    if (consoleListenerAdded) {
+      celestial.removeEventListener(
+        "Runtime.consoleAPICalled",
+        handleConsoleApiCalled,
+      );
+    }
+    cleanupStarted = true;
     try {
-      await celestial.close();
+      const closeResult = await Promise.race([
+        celestial.close().then(
+          () => ({ kind: "closed" as const }),
+          (error) => ({ kind: "error" as const, error }),
+        ),
+        cleanupSignal.promise.then(() => ({ kind: "interrupted" as const })),
+      ]);
+      if (closeResult.kind === "error" && !hasCaughtError) {
+        cleanupError = closeResult.error;
+      }
     } catch (error) {
       if (!hasCaughtError) cleanupError = error;
+    } finally {
+      cleanupStarted = false;
     }
   }
 
-  if (hasCaughtError) throw caughtError;
-  if (cleanupError !== undefined) throw cleanupError;
+  try {
+    if (hasCaughtError) throw caughtError;
+    if (cleanupError !== undefined) throw cleanupError;
 
-  output.log(
-    JSON.stringify(
-      {
-        reason: profileStopState.reason,
-        outputPath,
-        consoleMessages: state.consoleMessages.length,
-      },
-      null,
-      2,
-    ),
-  );
+    output.log(
+      JSON.stringify(
+        {
+          reason: profileStopState.reason,
+          outputPath,
+          consoleMessages: state.consoleMessages.length,
+        },
+        null,
+        2,
+      ),
+    );
 
-  return profilerStartError || missingProfileStartError ? 1 : 0;
+    return profilerStartError || missingProfileStartError ? 1 : 0;
+  } finally {
+    removeSignalHandlers();
+  }
 }

--- a/packages/cli/support/profiling/capture-deno-inspector-profile.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile.ts
@@ -8,5 +8,5 @@ if (import.meta.main) {
     createWebSocket: (url) => new WebSocket(url),
     removeSignalListener: Deno.removeSignalListener,
   });
-  if (exitCode !== 0) Deno.exit(exitCode);
+  Deno.exit(exitCode);
 }

--- a/packages/cli/support/profiling/cf-profile.test.ts
+++ b/packages/cli/support/profiling/cf-profile.test.ts
@@ -99,6 +99,13 @@ async function terminateChildProcess(
   return await child.status;
 }
 
+function profilingCaptureEnv(): Record<string, string> {
+  const env = profilingChildEnv();
+  const coverageDir = Deno.env.get("DENO_COVERAGE_DIR");
+  if (coverageDir) env.DENO_COVERAGE_DIR = coverageDir;
+  return env;
+}
+
 Deno.test("cf-profile captures a CPU profile for CLI help", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "cf-profile-test-" });
   try {
@@ -293,7 +300,7 @@ Deno.test("capture-deno-inspector-profile waits for profiler start before summar
         `--websocket-url=${await inspectorUrl.promise}`,
       ],
       clearEnv: true,
-      env: profilingChildEnv(),
+      env: profilingCaptureEnv(),
       stdout: "piped",
       stderr: "piped",
     }).spawn();
@@ -436,7 +443,7 @@ Deno.test("capture-deno-inspector-profile starts from a console marker", async (
         `--websocket-url=${await inspectorUrl.promise}`,
       ],
       clearEnv: true,
-      env: profilingChildEnv(),
+      env: profilingCaptureEnv(),
       stdout: "piped",
       stderr: "piped",
     }).spawn();


### PR DESCRIPTION
The CLI profiler wrapper can send SIGINT to the inspector capture process after the profiled command has already produced a profile stop marker. The capture process removed its signal handlers before closing the inspector client and before printing its final summary, so a late SIGINT could terminate Deno with exit code 130 even though the profile had been written successfully.

Keep the capture signal handlers installed through inspector cleanup and final reporting. A signal that arrives while the inspector client is closing now releases the cleanup wait, so a stalled close cannot hang the one-shot capture process. The capture entry point now exits explicitly with the returned status code so any abandoned inspector resources cannot keep the process alive after an interrupted cleanup.

Add a deterministic unit test that holds inspector close open, sends SIGINT during that window, and verifies the capture exits successfully and unregisters its handlers. This catches the cleanup race without changing the existing startup behavior before the inspector WebSocket opens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cleanup-time signal race in the CLI profiler capture that could exit with 130 after a successful profile. Ensures clean shutdown and correct exit codes even if a signal arrives during inspector teardown, and properly reports close errors.

- **Bug Fixes**
  - Keep SIGINT/SIGTERM handlers through inspector close and final reporting; late signals release cleanup wait and return success if the profile already stopped.
  - Propagate synchronous or async errors from inspector client close when no earlier error occurred.
  - Always call `Deno.exit(exitCode)` in `capture-deno-inspector-profile.ts` to avoid lingering resources.
  - Add deterministic tests for signal-during-close and sync close throws; preserve `DENO_COVERAGE_DIR` for capture subprocesses to record entrypoint coverage.

<sup>Written for commit 8a5c87656fc3daee61247af3b7c8d199ea9de3e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

