### PR TITLE
feat(cfc): existence grows on overwrite + slot-pointer channel pin (Epic C, stage C3)

### DIFF
--- a/docs/specs/cfc-observation-classes.md
+++ b/docs/specs/cfc-observation-classes.md
@@ -150,6 +150,18 @@ stamps, which have always been confidentiality-only. Consequence: a
 confidentiality but no longer inherits content certification into the
 hereditary meet — an intended under-claim (SC-9's fail-safe direction).
 
+**C3 note (2026-07-03): the grow landed.** On overwrite the flow-clear folds
+the confidentiality of every dropped `derived` (any class, covering
+included — pre-C2 data) and `structure` entry into the covering written
+path's `observes:"shape"` entry: new J first, then the cleared atoms, so
+re-derivation stays byte-identical (SC-11). The grown entry is written even
+when the overwriting transaction consumed nothing (the red SC-4 case — a
+clean overwrite previously made the existence bit public). Cleared `link`
+entries are excluded (pointer labels; folding them into content shape would
+re-smear the pointer/content split), and cleared existence not covered by
+any stamp path (e.g. a link write replacing the slot) lands as a bare shape
+entry at the shallowest covering written path.
+
 ## 6. What `deriveFlowJoin` consumes per read shape
 
 `forEachFlowObservation` (`prepare.ts`) already visits each read with its

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3906,6 +3906,21 @@ export const prepareBoundaryCommit = (
       const entryPath = canonicalizeLogicalPath(entry.path);
       const key = pathKey(entryPath);
       if (persistedLabelEntryKeys.has(key) || currentLinkWritePaths.has(key)) {
+        // A link write replacing a previously content-labeled path drops
+        // the old derived/structure entries here (the link machinery owns
+        // the slot's label now) — their existence history still folds into
+        // the SC-4 pool like any other clear.
+        if (
+          flowPersist &&
+          currentLinkWritePaths.has(key) &&
+          (entry.origin === "derived" || entry.origin === "structure") &&
+          (entry.label.confidentiality?.length ?? 0) > 0
+        ) {
+          clearedExistence.push({
+            path: entryPath,
+            confidentiality: entry.label.confidentiality!,
+          });
+        }
         continue;
       }
       // A fresh ingest re-mints the ExternalIngest mark for this doc below, so

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1234,8 +1234,10 @@ const isPureLinkStructure = (value: unknown): boolean => {
 // node gets an exact-path `structure` stamp with the per-tx join. Bare
 // link leaves get nothing: a pointer read at the leaf's own path is blind
 // passing, and the link entry already carries the target's transport
-// label. `undefined` (a removal) gets nothing either — "this path was
-// cleared" stays in the SC-4 existence-channel residual.
+// label. `undefined` (a removal) mints no stamp of its own; if the removed
+// path carried labels, the SC-4 grow folds them into the written path's
+// existence entry (see `clearedExistence` in the persist region), so only
+// the removal of never-labeled paths stays unrecorded.
 const pureLinkContainerPaths = (
   value: unknown,
   path: readonly string[],
@@ -3887,6 +3889,19 @@ export const prepareBoundaryCommit = (
       linkWriteInputs.map((input) => pathKey(input.target.path)),
     );
     let flowCleared = false;
+    // SC-4 (C3): the existence channel never shrinks. When the flow-clear
+    // drops a derived or structure entry under a written path, its
+    // confidentiality is collected here and folded into the written path's
+    // `observes:"shape"` entry below — "this path was once written under J"
+    // reveals every historical writer, so the existence label GROWS across
+    // overwrites while the value label replaces (§8.12.8 stays a
+    // value-class rule; C0 §5). Link entries are excluded: they label the
+    // pointer, and folding them into content shape would re-smear the
+    // pointer/content split.
+    const clearedExistence: Array<{
+      path: readonly string[];
+      confidentiality: readonly unknown[];
+    }> = [];
     for (const entry of existing?.labelMap.entries ?? []) {
       const entryPath = canonicalizeLogicalPath(entry.path);
       const key = pathKey(entryPath);
@@ -3913,6 +3928,15 @@ export const prepareBoundaryCommit = (
         flowWrittenPaths.some((written) => isPrefix(written, entryPath))
       ) {
         flowCleared = true;
+        if (
+          entry.origin !== "link" &&
+          (entry.label.confidentiality?.length ?? 0) > 0
+        ) {
+          clearedExistence.push({
+            path: entryPath,
+            confidentiality: entry.label.confidentiality!,
+          });
+        }
         continue;
       }
       const schemaEntry = mergedSchemaEntrySchemas.get(key);
@@ -3972,7 +3996,7 @@ export const prepareBoundaryCommit = (
       }
     }
 
-    if (flowPersist && flowHasLabels) {
+    if (flowPersist && (flowHasLabels || clearedExistence.length > 0)) {
       // Attach the per-tx join at each written path. Within one tx every
       // write carries the same join, so deeper written paths are redundant
       // with a shallower written ancestor and are collapsed away (§4.6.4
@@ -4013,6 +4037,25 @@ export const prepareBoundaryCommit = (
         }
         derivedStampPaths.push(path);
       }
+      // SC-4 grow (C3): the confidentiality of every derived/structure
+      // entry the flow-clear dropped folds into the shape-channel entry of
+      // the stamp path covering it — new J first, then the cleared atoms,
+      // so re-deriving the same overwrite reproduces the same grown entry
+      // byte-for-byte (SC-11). Consumed pool indices are tracked so
+      // anything not covered by a stamp still lands below.
+      const attachedExistence = new Set<number>();
+      const grownConfidentialityFor = (
+        path: readonly string[],
+      ): unknown[] => {
+        const atoms: unknown[] = [...flowConfidentiality];
+        clearedExistence.forEach((cleared, index) => {
+          if (isPrefix(path, cleared.path)) {
+            attachedExistence.add(index);
+            atoms.push(...cleared.confidentiality);
+          }
+        });
+        return uniqueCfcAtoms(atoms);
+      };
       for (const path of derivedStampPaths) {
         // Deeper stamped paths are redundant with a stamped ancestor; only
         // collapse against paths that actually receive a covering entry.
@@ -4028,28 +4071,31 @@ export const prepareBoundaryCommit = (
         // entry carries the full J and keeps §8.12.8 replace-on-overwrite;
         // the `shape` (existence) entry carries confidentiality only —
         // existence is a confidentiality channel (SC-4: "this path was
-        // once written"), and integrity there would be joined by C3's
-        // grow-on-overwrite, which for integrity claims is an over-claim
-        // (integrity meets, never joins). Same conf atoms either way, so a
-        // class-unaware reader consuming both as covering entries sees
-        // exactly today's label — additively safe, no dial (C0 §9).
-        persistedLabelEntries.push({
-          path,
-          label: {
-            ...(flowConfidentiality.length > 0
-              ? { confidentiality: [...flowConfidentiality] }
-              : {}),
-            ...(flowIntegrity.length > 0
-              ? { integrity: [...flowIntegrity] }
-              : {}),
-          },
-          origin: "derived",
-          observes: "value",
-        });
-        if (flowConfidentiality.length > 0) {
+        // once written"), and integrity there would be joined by the
+        // grow-on-overwrite above, which for integrity claims is an
+        // over-claim (integrity meets, never joins). A class-unaware
+        // reader consuming both as covering entries sees today's label or
+        // a wider one — additively safe, no dial (C0 §9).
+        if (flowHasLabels) {
           persistedLabelEntries.push({
             path,
-            label: { confidentiality: [...flowConfidentiality] },
+            label: {
+              ...(flowConfidentiality.length > 0
+                ? { confidentiality: [...flowConfidentiality] }
+                : {}),
+              ...(flowIntegrity.length > 0
+                ? { integrity: [...flowIntegrity] }
+                : {}),
+            },
+            origin: "derived",
+            observes: "value",
+          });
+        }
+        const shapeConfidentiality = grownConfidentialityFor(path);
+        if (shapeConfidentiality.length > 0) {
+          persistedLabelEntries.push({
+            path,
+            label: { confidentiality: shapeConfidentiality },
             origin: "derived",
             observes: "shape",
           });
@@ -4070,10 +4116,51 @@ export const prepareBoundaryCommit = (
         // structure entries (absent `observes`) stay covering — unchanged
         // compat; the flow join is unaffected either way since value reads
         // consume the `shape` class too (C0 §4).
+        const structureConfidentiality = grownConfidentialityFor(path);
+        if (flowHasLabels || structureConfidentiality.length > 0) {
+          persistedLabelEntries.push({
+            path,
+            label: { confidentiality: structureConfidentiality },
+            origin: "structure",
+            observes: "shape",
+          });
+        }
+      }
+      // Cleared existence not covered by any stamp path (a link write
+      // replaced the slot, or the tx had no label of its own): the shallowest
+      // written path covering the cleared entry receives a bare shape entry
+      // so the existence history survives the overwrite regardless.
+      const leftoverByPath = new Map<
+        string,
+        { path: readonly string[]; atoms: unknown[] }
+      >();
+      clearedExistence.forEach((cleared, index) => {
+        if (attachedExistence.has(index)) {
+          return;
+        }
+        let shallowest: readonly string[] | undefined;
+        for (const written of flowWrittenPaths) {
+          if (
+            isPrefix(written, cleared.path) &&
+            (shallowest === undefined || written.length < shallowest.length)
+          ) {
+            shallowest = written;
+          }
+        }
+        if (shallowest === undefined) {
+          return;
+        }
+        const key = pathKey(shallowest);
+        const bucket = leftoverByPath.get(key) ??
+          { path: shallowest, atoms: [...flowConfidentiality] };
+        bucket.atoms.push(...cleared.confidentiality);
+        leftoverByPath.set(key, bucket);
+      });
+      for (const bucket of leftoverByPath.values()) {
         persistedLabelEntries.push({
-          path,
-          label: { confidentiality: [...flowConfidentiality] },
-          origin: "structure",
+          path: canonicalizeLogicalPath(bucket.path),
+          label: { confidentiality: uniqueCfcAtoms(bucket.atoms) },
+          origin: "derived",
           observes: "shape",
         });
       }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3906,13 +3906,13 @@ export const prepareBoundaryCommit = (
       const entryPath = canonicalizeLogicalPath(entry.path);
       const key = pathKey(entryPath);
       if (persistedLabelEntryKeys.has(key) || currentLinkWritePaths.has(key)) {
-        // A link write replacing a previously content-labeled path drops
-        // the old derived/structure entries here (the link machinery owns
-        // the slot's label now) — their existence history still folds into
+        // A link write replacing a previously content-labeled path — or a
+        // declared entry re-minting at the same path — drops the old
+        // derived/structure entries here, through a different skip than
+        // the flow-clear below; their existence history still folds into
         // the SC-4 pool like any other clear.
         if (
           flowPersist &&
-          currentLinkWritePaths.has(key) &&
           (entry.origin === "derived" || entry.origin === "structure") &&
           (entry.label.confidentiality?.length ?? 0) > 0
         ) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4142,9 +4142,11 @@ export const prepareBoundaryCommit = (
         }
       }
       // Cleared existence not covered by any stamp path (a link write
-      // replaced the slot, or the tx had no label of its own): the shallowest
-      // written path covering the cleared entry receives a bare shape entry
-      // so the existence history survives the overwrite regardless.
+      // replaced the slot, a declared entry re-minted at the path, or the
+      // tx had no label of its own): the shallowest written path covering
+      // the cleared entry — or, when none does (a declared re-mint without
+      // a write there), the entry's own path — receives a bare shape entry
+      // so the existence history survives regardless.
       const leftoverByPath = new Map<
         string,
         { path: readonly string[]; atoms: unknown[] }
@@ -4162,12 +4164,10 @@ export const prepareBoundaryCommit = (
             shallowest = written;
           }
         }
-        if (shallowest === undefined) {
-          return;
-        }
-        const key = pathKey(shallowest);
+        const anchor = shallowest ?? cleared.path;
+        const key = pathKey(anchor);
         const bucket = leftoverByPath.get(key) ??
-          { path: shallowest, atoms: [...flowConfidentiality] };
+          { path: anchor, atoms: [...flowConfidentiality] };
         bucket.atoms.push(...cleared.confidentiality);
         leftoverByPath.set(key, bucket);
       });

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+import type { LabelMapEntry } from "../src/cfc/types.ts";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-existence-channel");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// Epic C stage C3 — the two channel fixes (C0 §5, SC-4; C0 §4 row 3, SC-8).
+//
+// SC-4: §8.12.8 replace-on-overwrite is a VALUE-class rule. The existence
+// (shape) channel must never shrink: "this path was once written under J"
+// reveals every historical writer, so on overwrite the existence entry GROWS
+// (join of old and new confidentiality) — where before C3 the flow-clear
+// dropped it with the rest of the per-value components and a clean overwrite
+// made the existence bit public.
+describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const seedDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    entries: LabelMapEntry[],
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: { version: 1, entries },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const readAddress = (id: string, path: string[]) => ({
+    space,
+    scope: "space" as const,
+    id: id as `${string}:${string}`,
+    type: "application/json" as const,
+    path: ["value", ...path],
+  });
+
+  const uri = (id: string) => id as `${string}:${string}`;
+
+  // Root-writes `value` into a fresh doc while consuming `sourceId`,
+  // returning the new doc's id. Root writeOrThrow: leaf-diffing set() would
+  // not cover the stamped path on the later overwrite.
+  const writeTainted = async (
+    rt: Runtime,
+    sourceId: string | undefined,
+    outCause: string,
+    value: Record<string, unknown>,
+    writePath: string[] = [],
+  ): Promise<string> => {
+    const tx = rt.edit();
+    if (sourceId !== undefined) {
+      tx.readOrThrow(readAddress(sourceId, []));
+    }
+    const out = rt.getCell(space, outCause, undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", ...writePath] },
+      value,
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    return outId;
+  };
+
+  const shapeEntriesAt = (id: string, path: string[]): StoredEntry[] =>
+    entriesOf(id).filter((e) =>
+      e.observes === "shape" && e.path.join("/") === path.join("/")
+    );
+
+  // The SC-4 red case: a clean overwrite (nothing labeled read) previously
+  // erased the whole derived pair — the existence bit went public. The
+  // existence entry must survive, still carrying the old writer's J.
+  it("clean overwrite keeps the existence label (today it vanishes)", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    const outId = await writeTainted(rt, sourceId, "ec-clean-out", {
+      copied: true,
+    });
+    expect(shapeEntriesAt(outId, [])[0]?.label.confidentiality).toEqual([
+      "secret",
+    ]);
+
+    // Clean overwrite: reads nothing labeled, root-overwrites the doc.
+    const tx = rt.edit();
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { copied: false },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(outId, []);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality).toContainEqual("secret");
+    // The value channel legitimately lowered: no secret-carrying value
+    // entry survives the clean recomputation (§8.12.8 replace).
+    const valueEntries = entriesOf(outId).filter((e) => e.observes === "value");
+    for (const entry of valueEntries) {
+      expect(entry.label.confidentiality ?? []).not.toContainEqual("secret");
+    }
+  });
+
+  // A labeled overwrite: value replaces (precision win), existence grows
+  // (join of old and new — soundness fix).
+  it("labeled overwrite: value replaces, existence grows to the join", async () => {
+    const rt = makeRuntime();
+    const secretId = await seedDoc(rt, "ec-secret", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    const publicId = await seedDoc(rt, "ec-public", { n: 2 }, [
+      { path: [], label: { confidentiality: ["public-ish"] } },
+    ]);
+    const outId = await writeTainted(rt, secretId, "ec-grow-out", {
+      copied: true,
+    });
+
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(publicId, []));
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { copied: false },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const valueEntry = entriesOf(outId).find((e) => e.observes === "value");
+    expect(valueEntry?.label.confidentiality).toEqual(["public-ish"]);
+    const shape = shapeEntriesAt(outId, []);
+    expect(shape.length).toBe(1);
+    expect([...(shape[0].label.confidentiality ?? [])].sort()).toEqual([
+      "public-ish",
+      "secret",
+    ]);
+  });
+
+  // An ancestor overwrite clears derived descendants (§8.12.8) — but their
+  // existence folds UP into the written path's existence entry rather than
+  // vanishing.
+  it("ancestor overwrite folds descendant existence into the written path", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-child-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    // Create the doc first (clean tx, no stamps): a nested write on a
+    // MISSING doc records as a root creation and would stamp [] instead.
+    const outId = await writeTainted(rt, undefined, "ec-fold-out", {
+      child: {},
+    });
+    expect(entriesOf(outId)).toEqual([]);
+    // Derived pair lands at ["child"].
+    const tainted = rt.edit();
+    tainted.readOrThrow(readAddress(sourceId, []));
+    tainted.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", "child"] },
+      { deep: true },
+    );
+    tainted.prepareCfc();
+    expect((await tainted.commit()).ok).toBeDefined();
+    expect(shapeEntriesAt(outId, ["child"]).length).toBe(1);
+
+    // Clean ROOT overwrite: descendant pair cleared, existence folds to [].
+    const tx = rt.edit();
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { flat: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(shapeEntriesAt(outId, ["child"])).toEqual([]);
+    const rootShape = shapeEntriesAt(outId, []);
+    expect(rootShape.length).toBe(1);
+    expect(rootShape[0].label.confidentiality).toContainEqual("secret");
+  });
+
+  // Pre-C2 covering derived entries carried the existence channel too; a
+  // clean overwrite must fold their confidentiality into the new existence
+  // entry, not erase it (the same SC-4 leak on legacy data).
+  it("legacy covering derived entries feed the existence grow", async () => {
+    const rt = makeRuntime();
+    // Seed via a real flow write on a pre-C2-shaped doc: seed the covering
+    // entry raw, with a loadable schema (the persist region skips docs
+    // whose schemaHash does not resolve).
+    const sourceId = await seedDoc(rt, "ec-legacy-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["old-secret"] } },
+    ]);
+    const outId = await writeTainted(rt, sourceId, "ec-legacy-out", {
+      copied: true,
+    });
+    // Rewrite the stored metadata into the pre-C2 single-covering shape.
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): { cfc?: { labelMap?: { entries: unknown[] } } };
+    };
+    const stored = replica.getDocument(outId).cfc! as Record<
+      string,
+      unknown
+    >;
+    const legacy = rt.edit();
+    legacy.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["cfc"] },
+      {
+        ...stored,
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: { confidentiality: ["old-secret"] },
+            origin: "derived",
+          }],
+        },
+      },
+    );
+    expect((await legacy.commit()).ok).toBeDefined();
+
+    const tx = rt.edit();
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { copied: false },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(outId, []);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality).toContainEqual("old-secret");
+  });
+
+  // Structure stamps are the container-shape half of the same channel: an
+  // overwrite that replaces a labeled pure-link container with plain
+  // content must keep the membership history on the existence entry.
+  it("cleared structure stamps feed the existence grow", async () => {
+    const rt = makeRuntime();
+    const el0 = await seedDoc(rt, "ec-el-0", { n: 1 }, [
+      { path: [], label: { confidentiality: ["alice"] } },
+    ]);
+    const tx1 = rt.edit();
+    tx1.readOrThrow(readAddress(el0, []));
+    const el0Cell = rt.getCell(space, "ec-el-0", undefined, tx1);
+    const list = rt.getCell(space, "ec-list", {
+      type: "array",
+      items: { asCell: ["cell"] },
+    }, tx1);
+    list.set([el0Cell]);
+    tx1.prepareCfc();
+    expect((await tx1.commit()).ok).toBeDefined();
+    const listId = list.getAsNormalizedFullLink().id;
+    expect(
+      entriesOf(listId).some((e) => e.origin === "structure"),
+    ).toBe(true);
+
+    const tx2 = rt.edit();
+    tx2.writeOrThrow(
+      { space, scope: "space", id: uri(listId), path: ["value"] },
+      { replaced: true },
+    );
+    tx2.prepareCfc();
+    expect((await tx2.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(listId, []);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality).toContainEqual("alice");
+  });
+
+  // Idempotence stays per-class (SC-11): repeating the same clean overwrite
+  // must not churn the metadata — the grown existence entry re-derives
+  // identically.
+  it("the grown existence entry re-derives idempotently", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-idem-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    const outId = await writeTainted(rt, sourceId, "ec-idem-out", {
+      copied: true,
+    });
+
+    const overwrite = async (value: Record<string, unknown>) => {
+      const tx = rt.edit();
+      tx.writeOrThrow(
+        { space, scope: "space", id: uri(outId), path: ["value"] },
+        value,
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+    };
+    await overwrite({ copied: false });
+    const first = JSON.stringify(entriesOf(outId));
+    await overwrite({ copied: 3 });
+    expect(JSON.stringify(entriesOf(outId))).toEqual(first);
+  });
+});
+
+// SC-8, the pointer-identity channel (C0 §4 row 3). The consumption
+// mechanism landed with C1 (probes classified followRef, standalone probes
+// consume link-origin labels); this pins the channel end-to-end at the
+// resolution seam: observing WHICH reference sits at a slot — without
+// following it — taints the observer's flow join with the pointer's label.
+describe("CFC slot-pointer channel (C3, SC-8 end-to-end)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  it("resolving a slot link without following it taints with the pointer label", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    const seed = runtime.edit();
+    const holder = runtime.getCell(space, "sp-holder", undefined, seed);
+    const holderId = holder.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id: holderId, path: [] }, {
+      value: { slot: { "/": { "link@1": { id: "of:sp-target", path: [] } } } },
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["slot"],
+            label: { confidentiality: ["pointer-label"] },
+            origin: "link",
+          }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+
+    // Observe WHICH link sits at the slot without following it: lastNode
+    // "top" stops at the slot after probing it — the row-3 observation.
+    const tx = runtime.edit();
+    const slotLink: NormalizedFullLink = {
+      space,
+      id: holderId as `${string}:${string}`,
+      path: ["slot"],
+      scope: "space",
+    } as NormalizedFullLink;
+    resolveLink(runtime, tx, slotLink, "top");
+    const out = runtime.getCell(space, "sp-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      {
+        space,
+        scope: "space",
+        id: outId as `${string}:${string}`,
+        path: ["value"],
+      },
+      { observed: true },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const replica = storageManager.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    const derived = (replica.getDocument(outId)?.cfc?.labelMap?.entries ?? [])
+      .filter((e) => e.origin === "derived");
+    expect(
+      derived.flatMap((e) => e.label.confidentiality ?? []),
+    ).toContainEqual("pointer-label");
+  });
+});

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -420,6 +420,64 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     expect(shapeConf).toContainEqual("old-secret");
   });
 
+  // A declared re-mint can cover a path the transaction never wrote (the
+  // schema policy input names it while the write lands elsewhere): with no
+  // covering written path, the fold anchors at the cleared entry's OWN
+  // path instead of dropping the history.
+  it("declared re-mint without a covering write anchors existence at the entry's path", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-anchor-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["old-secret"] } },
+    ]);
+    const outId = await writeTainted(rt, undefined, "ec-anchor-out", {
+      secret: "seed",
+      other: 1,
+    });
+    const taint = rt.edit();
+    taint.readOrThrow(readAddress(sourceId, []));
+    taint.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", "secret"] },
+      "tainted",
+    );
+    taint.prepareCfc();
+    expect((await taint.commit()).ok).toBeDefined();
+    expect(shapeEntriesAt(outId, ["secret"]).length).toBe(1);
+
+    // The clean tx writes a DIFFERENT doc but records a schema input naming
+    // this doc's SECRET path: the declared entry re-mints at ["secret"]
+    // with no write to this doc at all — no written path can anchor the
+    // fold.
+    const declared = internSchema(
+      { type: "string", ifc: { confidentiality: ["base"] } } as JSONSchema,
+      true,
+    );
+    const elsewhereId = await writeTainted(rt, undefined, "ec-anchor-else", {
+      unrelated: 1,
+    });
+    const clean = rt.edit();
+    clean.writeValueOrThrow(
+      { space, scope: "space", id: uri(elsewhereId), path: ["value"] },
+      { unrelated: 2 },
+    );
+    clean.recordCfcWritePolicyInput({
+      kind: "schema",
+      target: {
+        space,
+        scope: "space",
+        id: uri(outId),
+        path: ["value", "secret"],
+      },
+      schemaHash: declared.taggedHashString,
+      schema: declared.schema,
+    });
+    clean.prepareCfc();
+    expect((await clean.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(outId, ["secret"]);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality).toContainEqual("old-secret");
+  });
+
   // Idempotence stays per-class (SC-11): repeating the same clean overwrite
   // must not churn the metadata — the grown existence entry re-derives
   // identically.

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -313,6 +313,43 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     expect(shape[0].label.confidentiality).toContainEqual("alice");
   });
 
+  // A link write replacing a labeled slot is skipped by the stamp loops
+  // (the link machinery owns that path), so the cleared existence lands as
+  // a bare shape entry at the written path — the leftover branch.
+  it("link overwrite of a labeled slot keeps existence as a bare shape entry", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-link-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    // Doc with a derived pair at ["slot"]: create clean, then taint the slot.
+    const outId = await writeTainted(rt, undefined, "ec-link-out", {
+      slot: 0,
+    });
+    const taint = rt.edit();
+    taint.readOrThrow(readAddress(sourceId, []));
+    taint.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", "slot"] },
+      { copied: true },
+    );
+    taint.prepareCfc();
+    expect((await taint.commit()).ok).toBeDefined();
+    expect(shapeEntriesAt(outId, ["slot"]).length).toBe(1);
+
+    // Replace the slot with a LINK (a clean tx): the link machinery owns
+    // the slot's label now, but the existence history must survive.
+    await seedDoc(rt, "ec-link-target", { n: 2 }, []);
+    const linkTx = rt.edit();
+    const outCell = rt.getCell(space, "ec-link-out", undefined, linkTx);
+    const otherCell = rt.getCell(space, "ec-link-target", undefined, linkTx);
+    outCell.key("slot").set(otherCell);
+    linkTx.prepareCfc();
+    expect((await linkTx.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(outId, ["slot"]);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality).toContainEqual("secret");
+  });
+
   // Idempotence stays per-class (SC-11): repeating the same clean overwrite
   // must not churn the metadata — the grown existence entry re-derives
   // identically.

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { resolveLink } from "../src/link-resolution.ts";
 import type { LabelMapEntry } from "../src/cfc/types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-existence-channel");
@@ -348,6 +350,74 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     const shape = shapeEntriesAt(outId, ["slot"]);
     expect(shape.length).toBe(1);
     expect(shape[0].label.confidentiality).toContainEqual("secret");
+  });
+
+  // A declared entry re-minting at the same path (a schema policy input
+  // covering the write) drops the old derived pair through a different
+  // carry-forward skip than the flow-clear — its existence must fold into
+  // the pool all the same (review finding on this PR).
+  it("declared re-mint at the same path still folds existence", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-declared-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["old-secret"] } },
+    ]);
+    const outId = await writeTainted(rt, undefined, "ec-declared-out", {
+      secret: "seed",
+    });
+    const taint = rt.edit();
+    taint.readOrThrow(readAddress(sourceId, []));
+    taint.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", "secret"] },
+      "tainted",
+    );
+    taint.prepareCfc();
+    expect((await taint.commit()).ok).toBeDefined();
+    expect(shapeEntriesAt(outId, ["secret"]).length).toBe(1);
+
+    // Clean overwrite that ALSO records a schema policy input covering the
+    // path: the declared entry re-mints at ["secret"], which drops the old
+    // derived pair via the persisted-entry skip, not the flow-clear.
+    const declared = internSchema(
+      {
+        type: "string",
+        ifc: { confidentiality: ["base"] },
+      } as JSONSchema,
+      true,
+    );
+    const clean = rt.edit();
+    clean.writeValueOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", "secret"] },
+      "fresh",
+    );
+    clean.recordCfcWritePolicyInput({
+      kind: "schema",
+      target: {
+        space,
+        scope: "space",
+        id: uri(outId),
+        path: ["value", "secret"],
+      },
+      schemaHash: declared.taggedHashString,
+      schema: declared.schema,
+    });
+    clean.prepareCfc();
+    expect((await clean.commit()).ok).toBeDefined();
+
+    const stored = entriesOf(outId);
+    // The declared entry re-minted…
+    expect(
+      stored.some((e) =>
+        e.path.join("/") === "secret" &&
+        (e.label.confidentiality ?? []).includes("base")
+      ),
+    ).toBe(true);
+    // …and the existence history survived at a covering path (the fold
+    // anchors at the written path, which may be a coarser ancestor —
+    // a sound over-approximation).
+    const shapeConf = stored
+      .filter((e) => e.observes === "shape")
+      .flatMap((e) => e.label.confidentiality ?? []);
+    expect(shapeConf).toContainEqual("old-secret");
   });
 
   // Idempotence stays per-class (SC-11): repeating the same clean overwrite

--- a/packages/runner/test/cfc-flow-labels.test.ts
+++ b/packages/runner/test/cfc-flow-labels.test.ts
@@ -267,7 +267,7 @@ describe("CFC flow labels (default transition)", () => {
   // path from a transaction that read nothing labeled replaces the derived
   // component, so the label tracks the current value (the old, tainted value
   // is gone; reads of it journaled its label at read time).
-  it("replaces the derived component when the value is overwritten by an untainted write", async () => {
+  it("untainted overwrite replaces the value channel and grows the existence channel", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -332,11 +332,14 @@ describe("CFC flow labels (default transition)", () => {
       ).toContainEqual("secret");
 
       // Untainted overwrite: a write whose journal contains no reads (raw
-      // root write). The derived component is replaced (cleared — this tx
-      // derived nothing), not unioned forever. Note that `cell.set()` is
-      // NOT such a write: it journals a read of the prior value, so a
-      // set-overwrite of a tainted doc conservatively re-derives the taint
-      // — by the journal it consumed the old value.
+      // root write). The VALUE channel is replaced (cleared — this tx
+      // derived nothing): §8.12.8 replace-on-overwrite is a value-class
+      // rule. The EXISTENCE (shape) channel grows instead of vanishing
+      // (SC-4, C3): "this path was once written under secret" must not
+      // become a public bit. Note that `cell.set()` is NOT an untainted
+      // write: it journals a read of the prior value, so a set-overwrite
+      // of a tainted doc conservatively re-derives the taint — by the
+      // journal it consumed the old value.
       const clean = runtime.edit();
       clean.writeOrThrow({
         space: signer.did(),
@@ -348,7 +351,17 @@ describe("CFC flow labels (default transition)", () => {
       expect((await clean.commit()).ok).toBeDefined();
 
       const entriesAfter = replicaEntries(storageManager, targetId);
-      expect(entriesAfter.find((e) => e.origin === "derived")).toBeUndefined();
+      const derivedAfter = entriesAfter.filter((e) => e.origin === "derived");
+      expect(
+        derivedAfter.filter((e) =>
+          (e as { observes?: string }).observes !== "shape"
+        ),
+      ).toEqual([]);
+      expect(derivedAfter.length).toBe(1);
+      expect((derivedAfter[0] as { observes?: string }).observes).toBe(
+        "shape",
+      );
+      expect(derivedAfter[0].label.confidentiality).toEqual(["secret"]);
     } finally {
       await runtime.dispose();
       await storageManager.close();


### PR DESCRIPTION
Epic C stage C3 of `docs/plans/cfc-future-work-implementation.md` §4 — the two red-first channel fixes (C0 §5 SC-4, C0 §4 row 3 SC-8), on top of C1 (#4507) and C2 (#4520).

## SC-4 — the existence channel never shrinks (red→green)

**The leak:** §8.12.8 replace-on-overwrite replaced the whole derived component, so a clean overwrite (a tx that consumed nothing) erased the label covering *existence* — "this path was once written under secret" became a public bit. Acknowledged in-code since S16 and pinned by an existing test asserting the vanish.

**The fix:** the flow-clear now collects the confidentiality of every dropped `derived` (any class — pre-C2 covering entries included) and `structure` entry, and folds it into the covering written path's `observes:"shape"` entry:

- **Grown, not replaced:** new J first, then the cleared atoms — so re-deriving the same overwrite reproduces the grown entry byte-for-byte (SC-11 idempotence holds, tested).
- **Written even on a clean overwrite** (the red case): the stamp block now runs when the cleared-existence pool is non-empty even if the tx derived no labels of its own; the `value` entry is only pushed when there is a J (replace semantics unchanged).
- **Link entries excluded:** pointer labels folding into content shape would re-smear the pointer/content split; a link's replacement discipline is the link machinery's.
- **Leftovers covered:** cleared existence under a link-covered write (no stamp path) lands as a bare shape entry at the shallowest covering written path.
- **Confidentiality only**, per the C2 §5 note — growing integrity would union certification claims (over-claim).

Red→green: 5 tests in `cfc-existence-channel.test.ts` fail on main (clean overwrite, labeled-overwrite grow, ancestor fold, legacy covering entries, structure stamps) and pass here; the pre-C3 contract test in `cfc-flow-labels.test.ts` ("replaces the derived component…") is updated to the channel-split contract: **value replaces, existence grows**.

## SC-8 — slot-pointer channel, end-to-end pin

The consumption mechanism landed in C1 (standalone probes consume `followRef`-class labels). C3 adds the end-to-end pin at the resolution seam: `resolveLink(…, "top")` — observing WHICH reference sits at a slot without following it — taints the observer's flow join with the pointer's label. (Green since C1 by construction; pinned so the channel can't silently regress.)

## Docs

C0 doc §5 gains a dated C3 note recording the landed grow semantics (fold sources, exclusions, leftover placement); the stale in-code SC-4 residual comment in `prepare.ts` is updated.

## Perf (plan §0 gate — both cfc benches, flat/within noise vs the C2 baseline)

The grow only does work on overwrites of labeled paths; the bench workloads are unchanged: label-sync warm parallel batch 3.7→3.7 ms, skip-when-present 1.5→1.5 µs, getCfcLabel 1.4→1.5 µs; canonicalize preparedDigestFor small 14.3→13.8 µs, large 78.3→74.6 µs, path-heavy 67.7→67.9 µs.

## Tests

- New `packages/runner/test/cfc-existence-channel.test.ts` (7 cases: 5 red-first SC-4, idempotence, SC-8 end-to-end).
- Full `packages/runner` suite green: 768 passed / 0 failed (all 78 cfc test files).

Next: C4 — consumer precision (LLM observation ceiling + render label views consume per-class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a confidentiality leak by growing the existence channel on overwrite and pins the slot‑pointer channel so pointer observations are labeled correctly. Adds a fallback to anchor cleared existence at the entry’s own path when no written path covers it; value labels still replace; performance unchanged.

- **Bug Fixes**
  - Existence channel: on overwrite, fold confidentiality from cleared `derived`/`structure` entries into the covering path’s `shape` entry; runs on clean overwrites; also collects when a link write replaces a labeled slot and when a declared entry re‑mints at the same path; excludes `link` entries; leftovers land at the shallowest written path or, if none covers, at the cleared entry’s own path; integrity is not grown.
  - Slot-pointer channel: `resolveLink(..., "top")` taints the join with the pointer’s label without following the link, pinning the end-to-end behavior.
  - Tests and docs: added `packages/runner/test/cfc-existence-channel.test.ts` (adds link-overwrite, declared re‑mint, and no‑write anchor cases), updated `packages/runner/test/cfc-flow-labels.test.ts` to “value replaces, existence grows,” and noted grow semantics in `docs/specs/cfc-observation-classes.md`; benches unchanged.

<sup>Written for commit 2d4042c9a5d9f6b4070a2b106bce7094e76f736a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

