### PR TITLE
Stabilize CLI profiler help capture test

### DIFF
--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -1073,6 +1073,51 @@ describe("capture-deno-inspector-profile helpers", () => {
     });
   });
 
+  it("ignores profiler start markers after a stop signal", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      celestial.startError = new Error("WebSocket closed");
+      const logs: string[] = [];
+      const errors: string[] = [];
+      const resumed = Promise.withResolvers<void>();
+      const signalHandlers: Partial<Record<Deno.Signal, () => void>> = {};
+      const outputPath = `${tmpDir}/profile.cpuprofile`;
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${outputPath}`,
+          "--profile-start-pattern=Usage",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({
+          celestial,
+          logs,
+          errors,
+          resumed,
+          signalHandlers,
+        }),
+      );
+
+      await resumed.promise;
+      signalHandlers.SIGINT?.();
+      celestial.dispatchConsole({ value: "Usage:" });
+
+      assertEquals(await done, 1);
+      assertEquals(celestial.starts, 0);
+      assertEquals(
+        errors.some((line) => line.includes("Profiler.start failed")),
+        false,
+      );
+      assertStringIncludes(
+        errors.join("\n"),
+        "Profile start pattern was not observed: Usage",
+      );
+      assertStringIncludes(
+        await Deno.readTextFile(profileErrorOutputPath(outputPath)),
+        "Profile start pattern was not observed: Usage",
+      );
+    });
+  });
+
   it("fails when the inspector websocket closes before a required profile start marker", async () => {
     await withTempDir(async (tmpDir) => {
       const celestial = new FakeCelestial();

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -446,6 +446,10 @@ export async function captureDenoInspectorProfile(
     const text = detail.args
       .map((arg) => stringifyRemoteObject(arg))
       .join(" ");
+    if (stopReasonSent || profileStopState.ended) {
+      state.consoleMessages.push(text);
+      return;
+    }
     const profileMessage = recordConsoleProfileMessage(
       state,
       text,

--- a/packages/cli/support/profiling/cf-profile.test.ts
+++ b/packages/cli/support/profiling/cf-profile.test.ts
@@ -120,7 +120,6 @@ Deno.test("cf-profile captures a CPU profile for CLI help", async () => {
         "-A",
         scriptPath,
         `--profile-output=${profilePath}`,
-        "--profile-start-pattern=Usage",
         "--profile-stop-pattern=Usage",
         "--help",
       ],
@@ -142,7 +141,7 @@ Deno.test("cf-profile captures a CPU profile for CLI help", async () => {
     const meta = JSON.parse(await Deno.readTextFile(metaPath));
     assertEquals(meta.command, ["--help"]);
     assertEquals("profileDoneMarker" in meta, false);
-    assertEquals(meta.profileStartPattern, "Usage");
+    assertEquals("profileStartPattern" in meta, false);
     assertEquals(meta.profileStopPattern, "Usage");
     assertEquals(meta.cliStatus.success, true);
     assertEquals(meta.captureStatus.success, true);


### PR DESCRIPTION
The CLI profiler wrapper had a flaky help-command test that waited for the CLI help text before starting the inspector profiler. The help command can finish quickly enough that the wrapper asks the capture process to stop before the inspector console event for that help text has been processed. A later console event could then try to start the profiler while shutdown was already under way, which reports a closed inspector WebSocket and fails the test.

Start profiling before the help command is resumed by dropping the start marker from that end-to-end test. Keep the stop marker so the wrapper still exercises console-driven stop handling. Also ignore start-marker work after a capture stop has already been requested, while still recording the console text. Add a unit test that forces the stop-signal-then-late-marker order so the regression does not depend on scheduler timing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the CLI profiler help-capture path by starting profiling earlier and ignoring late start markers after a stop, removing a flaky closed-WebSocket error in the help test.

- **Bug Fixes**
  - Drop the `--profile-start-pattern` from the `cf-profile` help e2e test; keep the stop marker so stop handling is exercised.
  - Guard console handling to skip start logic after a stop is requested or capture has ended while still recording console text.
  - Add a unit test that sends SIGINT before a late start marker to ensure no start attempt occurs and a clear “start pattern not observed” message is emitted.
  - Update help test expectations: no `profileStartPattern` in metadata; `profileStopPattern` remains.

<sup>Written for commit b0c1614103832ba918916fc6e27a6e8749849def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

