### PR TITLE
fix(runner): finish the fabric-safety deepEqual -> valueEqual swaps (CT-1770 tail)

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -11,6 +11,7 @@ import { emptySchemaObject } from "@commonfabric/data-model/schema-utils";
 import {
   cloneForMutation,
   type CloneForMutationResult,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
@@ -2601,12 +2602,20 @@ const writeInstallsInitialSchemaDefault = (
     return false;
   }
   const pathTarget = { ...target, path };
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); `schema.default` can hold a `FabricValue`, so this
-  // CFC write-policy check can compare wrong. Migrate to a `Fabric`-aware
-  // equality once available.
+  // `schema.default` can hold a `FabricValue` (a native `Uint8Array`/`Date`
+  // default interns to `FabricBytes`/`FabricEpoch*`), so this write-policy check
+  // must use `valueEqual`, the `Fabric`-aware content equality: `deepEqual`
+  // walks enumerable own-props, of which a `FabricPrimitive` has none, so it
+  // conflates every distinct same-class instance and would treat a write that
+  // differs from the default only in Fabric content as an initial-default
+  // install (CT-1770). The `default` is statically `ImmutableJSONValue` (a
+  // subset of `FabricValue`); the cast bridges the deeply-`readonly` JSON type
+  // to the `FabricValue` the comparison operates over.
   return previousWriteValueForTarget(tx, pathTarget) === undefined &&
-    deepEqual(writeValueForTarget(tx, pathTarget), schema.default);
+    valueEqual(
+      writeValueForTarget(tx, pathTarget),
+      schema.default as FabricValue,
+    );
 };
 
 const linkedWriteValueForPolicy = (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2602,14 +2602,10 @@ const writeInstallsInitialSchemaDefault = (
     return false;
   }
   const pathTarget = { ...target, path };
-  // `schema.default` can hold a `FabricValue` (a native `Uint8Array`/`Date`
-  // default interns to `FabricBytes`/`FabricEpoch*`), so this write-policy
-  // check compares with `valueEqual`, the `Fabric`-aware content equality that
-  // distinguishes `FabricPrimitive` values by content (state in private
-  // `#fields`, zero enumerable own-props). The cast is required: `default` is
-  // statically `ImmutableJSONValue`, whose deeply-`readonly`,
-  // `ArrayLike`-based JSON shape is not assignable to `FabricValue`, even
-  // though the runtime value is one.
+  // The cast is required: `default` is statically `ImmutableJSONValue`, whose
+  // deeply-`readonly`, `ArrayLike`-based JSON shape is not assignable to
+  // `FabricValue` -- though the runtime value is one (a native
+  // `Uint8Array`/`Date` default interns to a `FabricPrimitive`).
   return previousWriteValueForTarget(tx, pathTarget) === undefined &&
     valueEqual(
       writeValueForTarget(tx, pathTarget),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2603,14 +2603,13 @@ const writeInstallsInitialSchemaDefault = (
   }
   const pathTarget = { ...target, path };
   // `schema.default` can hold a `FabricValue` (a native `Uint8Array`/`Date`
-  // default interns to `FabricBytes`/`FabricEpoch*`), so this write-policy check
-  // must use `valueEqual`, the `Fabric`-aware content equality: `deepEqual`
-  // walks enumerable own-props, of which a `FabricPrimitive` has none, so it
-  // conflates every distinct same-class instance and would treat a write that
-  // differs from the default only in Fabric content as an initial-default
-  // install (CT-1770). The `default` is statically `ImmutableJSONValue` (a
-  // subset of `FabricValue`); the cast bridges the deeply-`readonly` JSON type
-  // to the `FabricValue` the comparison operates over.
+  // default interns to `FabricBytes`/`FabricEpoch*`), so this write-policy
+  // check compares with `valueEqual`, the `Fabric`-aware content equality that
+  // distinguishes `FabricPrimitive` values by content (state in private
+  // `#fields`, zero enumerable own-props). The cast is required: `default` is
+  // statically `ImmutableJSONValue`, whose deeply-`readonly`,
+  // `ArrayLike`-based JSON shape is not assignable to `FabricValue`, even
+  // though the runtime value is one.
   return previousWriteValueForTarget(tx, pathTarget) === undefined &&
     valueEqual(
       writeValueForTarget(tx, pathTarget),

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -15,12 +15,12 @@ export function setValueAtPath(
     parent = parent[key];
   }
 
-  // This no-op write gate uses `valueEqual`, the `Fabric`-aware content
-  // equality: `deepEqual` walks enumerable own-props, of which a
-  // `FabricPrimitive` has none, so it conflates every distinct same-class
-  // instance and would drop a real Fabric-value change as a no-op (CT-1770).
-  // Note `valueEqual` throws on a function or a non-`Fabric` class instance
-  // rather than reporting it unequal; both operands here are `FabricValue`s.
+  // No-op write gate: the existing and new values are compared with
+  // `valueEqual`, the `Fabric`-aware content equality, so a `FabricPrimitive`
+  // (state in private `#fields`, zero enumerable own-props) is compared by
+  // content rather than by its absent own-props. Note `valueEqual` throws on
+  // a function or a non-`Fabric` class instance rather than reporting it
+  // unequal; both operands here are `FabricValue`s by contract.
   if (valueEqual(parent[path[path.length - 1]], value)) return false;
 
   // We just set the values here. If you need to delete elements from an

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
 
 export function setValueAtPath(
@@ -15,12 +15,13 @@ export function setValueAtPath(
     parent = parent[key];
   }
 
-  // TODO(danfuzz): This no-op write gate compares the existing value against
-  // the new value with `deepEqual`, which mishandles `FabricValue` (same-class
-  // `FabricPrimitive`s compare equal regardless of value, since their state
-  // lives in private `#fields` with zero own-props), so a real Fabric-value
-  // change can be dropped as a no-op. Use a Fabric-aware equality.
-  if (deepEqual(parent[path[path.length - 1]], value)) return false;
+  // This no-op write gate uses `valueEqual`, the `Fabric`-aware content
+  // equality: `deepEqual` walks enumerable own-props, of which a
+  // `FabricPrimitive` has none, so it conflates every distinct same-class
+  // instance and would drop a real Fabric-value change as a no-op (CT-1770).
+  // Note `valueEqual` throws on a function or a non-`Fabric` class instance
+  // rather than reporting it unequal; both operands here are `FabricValue`s.
+  if (valueEqual(parent[path[path.length - 1]], value)) return false;
 
   // We just set the values here. If you need to delete elements from an
   // array or object, set it to another array or object without those elements.

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -15,12 +15,8 @@ export function setValueAtPath(
     parent = parent[key];
   }
 
-  // No-op write gate: the existing and new values are compared with
-  // `valueEqual`, the `Fabric`-aware content equality, so a `FabricPrimitive`
-  // (state in private `#fields`, zero enumerable own-props) is compared by
-  // content rather than by its absent own-props. Note `valueEqual` throws on
-  // a function or a non-`Fabric` class instance rather than reporting it
-  // unequal; both operands here are `FabricValue`s by contract.
+  // Note: `valueEqual()` throws on a function or a non-`Fabric` class
+  // instance; both operands here are `FabricValue`s by contract.
   if (valueEqual(parent[path[path.length - 1]], value)) return false;
 
   // We just set the values here. If you need to delete elements from an

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -44,11 +44,11 @@ export function mapsEqual(
   if (a.size !== b.size) return false;
   for (const [key, val] of a) {
     if (!b.has(key)) return false;
-    // `valueEqual` is the `Fabric`-aware content equality these stored
-    // read-value maps need: `deepEqual` walks enumerable own-props, of which a
-    // `FabricPrimitive` (`FabricBytes`/`FabricHash`/...) has none, so it
-    // conflates every distinct same-class instance and would mask a real value
-    // change (CT-1770).
+    // These are stored read-value maps, so values are compared with
+    // `valueEqual`, the `Fabric`-aware content equality: a `FabricPrimitive`
+    // (`FabricBytes`/`FabricHash`/...) keeps its state in private `#fields`
+    // with zero enumerable own-props, so only a content-aware comparison can
+    // tell two distinct same-class instances apart.
     if (!valueEqual(val, b.get(key))) return false;
   }
   return true;

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -1,4 +1,7 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import {
   arraysOverlap,
   nonRecursiveReadMayOverlapWrite,
@@ -35,18 +38,18 @@ export function collectTransitiveEffects(state: {
 }
 
 export function mapsEqual(
-  a: Map<string, unknown>,
-  b: Map<string, unknown>,
+  a: Map<string, FabricValue>,
+  b: Map<string, FabricValue>,
 ): boolean {
   if (a.size !== b.size) return false;
   for (const [key, val] of a) {
     if (!b.has(key)) return false;
-    // TODO(danfuzz): `mapsEqual` compares map values with `deepEqual`, which
-    // mishandles `FabricValue`; this helper is used on stored read-value maps,
-    // so two same-class `FabricPrimitive`s (state in private `#fields`, zero
-    // own-props) compare equal regardless of value. Use a Fabric-aware
-    // equality.
-    if (!deepEqual(val, b.get(key))) return false;
+    // `valueEqual` is the `Fabric`-aware content equality these stored
+    // read-value maps need: `deepEqual` walks enumerable own-props, of which a
+    // `FabricPrimitive` (`FabricBytes`/`FabricHash`/...) has none, so it
+    // conflates every distinct same-class instance and would mask a real value
+    // change (CT-1770).
+    if (!valueEqual(val, b.get(key))) return false;
   }
   return true;
 }

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -44,11 +44,6 @@ export function mapsEqual(
   if (a.size !== b.size) return false;
   for (const [key, val] of a) {
     if (!b.has(key)) return false;
-    // These are stored read-value maps, so values are compared with
-    // `valueEqual`, the `Fabric`-aware content equality: a `FabricPrimitive`
-    // (`FabricBytes`/`FabricHash`/...) keeps its state in private `#fields`
-    // with zero enumerable own-props, so only a content-aware comparison can
-    // tell two distinct same-class instances apart.
     if (!valueEqual(val, b.get(key))) return false;
   }
   return true;

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -134,9 +134,7 @@ export const attest = (
  * of the fact in the given replica otherwise function fails with
  * `IStorageTransactionInconsistent` error.
  *
- * Values are compared with `valueEqual`, the `Fabric`-aware content equality
- * (reference-identical operands settle immediately via its leading
- * `Object.is`, without hashing).
+ * Values are compared with `valueEqual()`.
  */
 export const claim = (
   { address, value: expected }: IAttestation,
@@ -154,13 +152,6 @@ export const claim = (
     )
     : read(source, address)?.ok?.value;
 
-  // Compare the stored document value (the read/attested value) with
-  // `valueEqual`, the `Fabric`-aware content equality: a `FabricPrimitive`
-  // keeps its state in private `#fields` with zero enumerable own-props, so
-  // only a content-aware comparison can detect the changed Fabric value this
-  // check exists to catch. `valueEqual` settles identical references via its
-  // leading `Object.is`, which is also why there is no `===` fast path here:
-  // `+0 === -0` is `true`, but they are distinct stored values.
   if (valueEqual(expected, actual)) {
     return { ok: state };
   } else {

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,8 +1,8 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   type FabricPlainObject,
   type FabricValue,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import type {
@@ -154,14 +154,14 @@ export const claim = (
     : read(source, address)?.ok?.value;
 
   // Fast path: reference equality check avoids expensive comparison
-  // when the replica state hasn't changed since the original read
-  // TODO(danfuzz): This compares a stored document value (the read/attested
-  // value) with `deepEqual`, which mishandles `FabricValue`: two same-class
-  // `FabricPrimitive` values (state in private `#fields`, zero own-props)
-  // compare equal regardless of value, so a changed Fabric value can be
-  // mis-detected as unchanged. Use a Fabric-aware equality for stored-value
-  // comparison.
-  if (expected === actual || deepEqual(expected, actual)) {
+  // when the replica state hasn't changed since the original read.
+  // Otherwise compare the stored document value (the read/attested value) with
+  // `valueEqual`, the `Fabric`-aware content equality: `deepEqual` walks
+  // enumerable own-props, of which a `FabricPrimitive` (state in private
+  // `#fields`) has none, so it conflates every distinct same-class instance and
+  // would mis-detect a changed Fabric value as unchanged (CT-1770), masking the
+  // very `StateInconsistency` this check exists to raise.
+  if (expected === actual || valueEqual(expected, actual)) {
     return { ok: state };
   } else {
     return {

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -134,8 +134,9 @@ export const attest = (
  * of the fact in the given replica otherwise function fails with
  * `IStorageTransactionInconsistent` error.
  *
- * Optimized to check reference equality before falling back to JSON.stringify
- * comparison, avoiding expensive hashing when the replica state is unchanged.
+ * Values are compared with `valueEqual`, the `Fabric`-aware content equality
+ * (reference-identical operands settle immediately via its leading
+ * `Object.is`, without hashing).
  */
 export const claim = (
   { address, value: expected }: IAttestation,
@@ -153,15 +154,14 @@ export const claim = (
     )
     : read(source, address)?.ok?.value;
 
-  // Fast path: reference equality check avoids expensive comparison
-  // when the replica state hasn't changed since the original read.
-  // Otherwise compare the stored document value (the read/attested value) with
-  // `valueEqual`, the `Fabric`-aware content equality: `deepEqual` walks
-  // enumerable own-props, of which a `FabricPrimitive` (state in private
-  // `#fields`) has none, so it conflates every distinct same-class instance and
-  // would mis-detect a changed Fabric value as unchanged (CT-1770), masking the
-  // very `StateInconsistency` this check exists to raise.
-  if (expected === actual || valueEqual(expected, actual)) {
+  // Compare the stored document value (the read/attested value) with
+  // `valueEqual`, the `Fabric`-aware content equality: a `FabricPrimitive`
+  // keeps its state in private `#fields` with zero enumerable own-props, so
+  // only a content-aware comparison can detect the changed Fabric value this
+  // check exists to catch. `valueEqual` settles identical references via its
+  // leading `Object.is`, which is also why there is no `===` fast path here:
+  // `+0 === -0` is `true`, but they are distinct stored values.
+  if (valueEqual(expected, actual)) {
     return { ok: state };
   } else {
     return {

--- a/packages/runner/test/attestation-claim-fabric.test.ts
+++ b/packages/runner/test/attestation-claim-fabric.test.ts
@@ -1,15 +1,15 @@
-// Covers the Fabric-aware consistency check in `claim()` (CT-1770). The check
-// compares a stored attested value (`expected`) against the replica's current
-// value (`actual`) to decide whether the state is unchanged. A `FabricPrimitive`
-// keeps its state in private `#fields` with zero enumerable own-props, so a
-// naive `deepEqual` reports two distinct same-class instances as equal --
-// masking a genuine change as consistent and swallowing the
-// `StorageTransactionInconsistent` error the check exists to raise.
+// Covers the consistency check in `claim()`: it compares a stored attested
+// value (`expected`) against the replica's current value (`actual`) with
+// `valueEqual`, the `Fabric`-aware content equality. A `FabricPrimitive`
+// keeps its state in private `#fields` with zero enumerable own-props, so
+// only a content-aware comparison can tell two distinct same-class instances
+// apart; these tests pin the verdicts that depend on that.
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { claim } from "../src/storage/transaction/attestation.ts";
 import type {
   IAttestation,
@@ -22,7 +22,7 @@ import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 // deliberately absent so `claim()` takes its `read`-based `actual` path (the
 // `typeof replica.getDocument === "function"` guard is false), reading the
 // stored value straight off the attested state rather than an entity document.
-const replicaHolding = (storedValue: FabricBytes): ISpaceReplica => {
+const replicaHolding = (storedValue: FabricValue): ISpaceReplica => {
   const state: State = {
     the: "application/json",
     of: "of:attest-claim-fabric",
@@ -59,15 +59,26 @@ describe("attestation claim(): Fabric-aware consistency check", () => {
 
   it("reports StateInconsistency when the Fabric value actually changed (CT-1770)", () => {
     // The attested value and the stored value are distinct `FabricBytes` that
-    // differ only in byte content. `deepEqual` sees two zero-own-prop instances
-    // of the same class and calls them equal, so the check masks the change and
-    // returns `{ ok }`; `valueEqual` compares by content hash and surfaces the
-    // `StorageTransactionInconsistent` error.
+    // differ only in their (private `#fields`) byte content: a genuine change,
+    // which must surface as the `StorageTransactionInconsistent` error the
+    // check exists to raise.
     const attestation: IAttestation = {
       address,
       value: new FabricBytes(new Uint8Array([1, 2, 3])),
     };
     const replica = replicaHolding(new FabricBytes(new Uint8Array([4, 5, 6])));
+
+    const result = claim(attestation, replica);
+    expect(result.error).toBeDefined();
+    expect(result.error?.name).toBe("StorageTransactionInconsistent");
+  });
+
+  it("treats +0 and -0 as distinct stored values (Object.is semantics)", () => {
+    // Stored values are compared with `Object.is` semantics (via
+    // `valueEqual`), under which `+0` and `-0` are distinct -- IEEE754 `===`,
+    // which conflates them, must play no part in this check.
+    const attestation: IAttestation = { address, value: 0 };
+    const replica = replicaHolding(-0);
 
     const result = claim(attestation, replica);
     expect(result.error).toBeDefined();

--- a/packages/runner/test/attestation-claim-fabric.test.ts
+++ b/packages/runner/test/attestation-claim-fabric.test.ts
@@ -1,0 +1,76 @@
+// Covers the Fabric-aware consistency check in `claim()` (CT-1770). The check
+// compares a stored attested value (`expected`) against the replica's current
+// value (`actual`) to decide whether the state is unchanged. A `FabricPrimitive`
+// keeps its state in private `#fields` with zero enumerable own-props, so a
+// naive `deepEqual` reports two distinct same-class instances as equal --
+// masking a genuine change as consistent and swallowing the
+// `StorageTransactionInconsistent` error the check exists to raise.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { claim } from "../src/storage/transaction/attestation.ts";
+import type {
+  IAttestation,
+  ISpaceReplica,
+  State,
+} from "../src/storage/interface.ts";
+import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+
+// A replica whose stored state carries `storedValue`. `getDocument` is
+// deliberately absent so `claim()` takes its `read`-based `actual` path (the
+// `typeof replica.getDocument === "function"` guard is false), reading the
+// stored value straight off the attested state rather than an entity document.
+const replicaHolding = (storedValue: FabricBytes): ISpaceReplica => {
+  const state: State = {
+    the: "application/json",
+    of: "of:attest-claim-fabric",
+    is: storedValue,
+    // A real cause hash is irrelevant to the value comparison under test.
+    cause: undefined as unknown as FabricHash,
+  } as State;
+  return {
+    did: () => "did:test:attest" as ReturnType<ISpaceReplica["did"]>,
+    get: () => state,
+  } as unknown as ISpaceReplica;
+};
+
+describe("attestation claim(): Fabric-aware consistency check", () => {
+  const address = {
+    id: "of:attest-claim-fabric" as const,
+    type: "application/json" as const,
+    path: [] as string[],
+  };
+
+  it("reports ok when the attested value matches the stored value", () => {
+    // Two distinct same-content `FabricBytes`: no real change, so the state is
+    // consistent.
+    const attestation: IAttestation = {
+      address,
+      value: new FabricBytes(new Uint8Array([1, 2, 3])),
+    };
+    const replica = replicaHolding(new FabricBytes(new Uint8Array([1, 2, 3])));
+
+    const result = claim(attestation, replica);
+    expect(result.ok).toBeDefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("reports StateInconsistency when the Fabric value actually changed (CT-1770)", () => {
+    // The attested value and the stored value are distinct `FabricBytes` that
+    // differ only in byte content. `deepEqual` sees two zero-own-prop instances
+    // of the same class and calls them equal, so the check masks the change and
+    // returns `{ ok }`; `valueEqual` compares by content hash and surfaces the
+    // `StorageTransactionInconsistent` error.
+    const attestation: IAttestation = {
+      address,
+      value: new FabricBytes(new Uint8Array([1, 2, 3])),
+    };
+    const replica = replicaHolding(new FabricBytes(new Uint8Array([4, 5, 6])));
+
+    const result = claim(attestation, replica);
+    expect(result.error).toBeDefined();
+    expect(result.error?.name).toBe("StorageTransactionInconsistent");
+  });
+});

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -828,6 +828,76 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("rejects a uiContract field whose Fabric write differs from its Fabric default (CT-1770)", async () => {
+    // The schema default and the written value are distinct `FabricBytes`
+    // (interned from the `Uint8Array`s) that differ only in byte content, so the
+    // write does NOT install the default -- it must be rejected exactly like the
+    // "not default" string case above. `deepEqual` sees two zero-own-prop
+    // instances of the same class and calls them equal, so the write-policy gate
+    // wrongly treats this as an initial-default install and lets the differing
+    // value through; `valueEqual` compares by content hash and rejects it.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      // A schema whose `savedBytes` default is a `Uint8Array` cannot be authored
+      // as a plain literal (schema interning deep-freezes it and a raw
+      // `Uint8Array` cannot be frozen). Instead, round-trip the schema through a
+      // cell read as a query result, which interns the native `Uint8Array`
+      // default into a `FabricBytes` -- the realistic way a Fabric value reaches
+      // `schema.default` (see query-result-proxy-fabric-primitive.test.ts).
+      const schemaSource = {
+        type: "object",
+        properties: {
+          argument: {
+            type: "object",
+            properties: {
+              savedBytes: {
+                default: new Uint8Array([1, 2, 3]),
+                ifc: {
+                  uiContract: {
+                    helper: "UiAction",
+                    action: "TrustedSave",
+                    trustedPattern: "TrustedSaveSurface",
+                  },
+                },
+              },
+            },
+            required: ["savedBytes"],
+          },
+        },
+      };
+
+      const schemaTx = runtime.edit();
+      const schemaCell = runtime.getCell(
+        signer.did(),
+        "cfc-ui-contract-fabric-schema-source",
+        undefined,
+        schemaTx,
+      );
+      schemaCell.set(schemaSource);
+      const schema = schemaCell.getAsQueryResult() as JSONSchema;
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-ui-contract-fabric-non-default-setup",
+        schema,
+        tx,
+      );
+      // Write bytes that DIFFER from the default's bytes.
+      cell.set({ argument: { savedBytes: new Uint8Array([4, 5, 6]) } });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain(
+        "missing trusted-event policy input",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("rejects relevant unprepared commits in enforcing modes", async () => {
     const { runtime, storageManager } = createRuntime();
     try {

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -830,12 +830,10 @@ describe("ExtendedStorageTransaction CFC gate", () => {
 
   it("rejects a uiContract field whose Fabric write differs from its Fabric default (CT-1770)", async () => {
     // The schema default and the written value are distinct `FabricBytes`
-    // (interned from the `Uint8Array`s) that differ only in byte content, so the
-    // write does NOT install the default -- it must be rejected exactly like the
-    // "not default" string case above. `deepEqual` sees two zero-own-prop
-    // instances of the same class and calls them equal, so the write-policy gate
-    // wrongly treats this as an initial-default install and lets the differing
-    // value through; `valueEqual` compares by content hash and rejects it.
+    // (interned from the `Uint8Array`s) that differ only in byte content, so
+    // the write does NOT install the default -- the write-policy gate's
+    // content comparison must reject it exactly like the "not default" string
+    // case above.
     const { runtime, storageManager } = createRuntime();
     try {
       // A schema whose `savedBytes` default is a `Uint8Array` cannot be authored

--- a/packages/runner/test/path-utils.test.ts
+++ b/packages/runner/test/path-utils.test.ts
@@ -49,10 +49,8 @@ describe("Path operations", () => {
 
     it("is Fabric-aware: a differing FabricBytes is a real change (CT-1770)", () => {
       // Two distinct `FabricBytes` differing only in their (private `#fields`)
-      // byte content. `deepEqual` walks enumerable own-props -- of which a
-      // `FabricPrimitive` has none -- so it wrongly reports the pair equal and
-      // drops the write as a no-op. `valueEqual` compares by content hash and
-      // sees the change: the write must happen and `true` be returned.
+      // byte content: a real change, not a no-op, so the write must happen and
+      // `true` be returned.
       const original = new FabricBytes(new Uint8Array([1, 2, 3]));
       const replacement = new FabricBytes(new Uint8Array([4, 5, 6]));
       const obj = { x: original };

--- a/packages/runner/test/path-utils.test.ts
+++ b/packages/runner/test/path-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   arrayEqual,
   getValueAtPath,
@@ -32,6 +33,32 @@ describe("Path operations", () => {
       const changed = setValueAtPath(obj, ["x", "y"], 1);
       expect(changed).toBe(false);
       expect(obj).toEqual({ x: { y: 1 } });
+    });
+
+    it("is Fabric-aware: an equal FabricBytes is a no-op", () => {
+      // Two distinct same-content `FabricBytes`: no real change, so the no-op
+      // gate must elide the write and return `false`.
+      const obj = { x: new FabricBytes(new Uint8Array([1, 2, 3])) };
+      const changed = setValueAtPath(
+        obj,
+        ["x"],
+        new FabricBytes(new Uint8Array([1, 2, 3])),
+      );
+      expect(changed).toBe(false);
+    });
+
+    it("is Fabric-aware: a differing FabricBytes is a real change (CT-1770)", () => {
+      // Two distinct `FabricBytes` differing only in their (private `#fields`)
+      // byte content. `deepEqual` walks enumerable own-props -- of which a
+      // `FabricPrimitive` has none -- so it wrongly reports the pair equal and
+      // drops the write as a no-op. `valueEqual` compares by content hash and
+      // sees the change: the write must happen and `true` be returned.
+      const original = new FabricBytes(new Uint8Array([1, 2, 3]));
+      const replacement = new FabricBytes(new Uint8Array([4, 5, 6]));
+      const obj = { x: original };
+      const changed = setValueAtPath(obj, ["x"], replacement);
+      expect(changed).toBe(true);
+      expect(obj.x).toBe(replacement);
     });
   });
 

--- a/packages/runner/test/topology-maps-equal.test.ts
+++ b/packages/runner/test/topology-maps-equal.test.ts
@@ -1,0 +1,50 @@
+// Covers the Fabric-aware equality of `mapsEqual` (CT-1770). The helper
+// compares stored read-value maps; a `FabricPrimitive` keeps its state in
+// private `#fields` with zero enumerable own-props, so a naive `deepEqual`
+// conflates every distinct same-class instance and reports maps that differ
+// only in a `FabricBytes` value as equal -- masking a real change.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { mapsEqual } from "../src/scheduler/topology.ts";
+
+describe("mapsEqual", () => {
+  it("treats maps equal when values are structurally equal", () => {
+    const a = new Map<string, FabricValue>([["k", 1]]);
+    const b = new Map<string, FabricValue>([["k", 1]]);
+    expect(mapsEqual(a, b)).toBe(true);
+  });
+
+  it("treats maps unequal when a plain value differs", () => {
+    const a = new Map<string, FabricValue>([["k", 1]]);
+    const b = new Map<string, FabricValue>([["k", 2]]);
+    expect(mapsEqual(a, b)).toBe(false);
+  });
+
+  it("is Fabric-aware: equal FabricBytes values keep the maps equal", () => {
+    const a = new Map<string, FabricValue>([
+      ["k", new FabricBytes(new Uint8Array([1, 2, 3]))],
+    ]);
+    const b = new Map<string, FabricValue>([
+      ["k", new FabricBytes(new Uint8Array([1, 2, 3]))],
+    ]);
+    expect(mapsEqual(a, b)).toBe(true);
+  });
+
+  it("is Fabric-aware: a differing FabricBytes value makes the maps unequal (CT-1770)", () => {
+    // The two maps differ only in the byte content of a `FabricBytes` value.
+    // `deepEqual` sees two zero-own-prop instances of the same class and calls
+    // them equal, so `mapsEqual` wrongly returns `true`; `valueEqual` compares
+    // by content hash and sees the difference.
+    const a = new Map<string, FabricValue>([
+      ["k", new FabricBytes(new Uint8Array([1, 2, 3]))],
+    ]);
+    const b = new Map<string, FabricValue>([
+      ["k", new FabricBytes(new Uint8Array([4, 5, 6]))],
+    ]);
+    expect(mapsEqual(a, b)).toBe(false);
+  });
+});

--- a/packages/runner/test/topology-maps-equal.test.ts
+++ b/packages/runner/test/topology-maps-equal.test.ts
@@ -1,8 +1,9 @@
-// Covers the Fabric-aware equality of `mapsEqual` (CT-1770). The helper
-// compares stored read-value maps; a `FabricPrimitive` keeps its state in
-// private `#fields` with zero enumerable own-props, so a naive `deepEqual`
-// conflates every distinct same-class instance and reports maps that differ
-// only in a `FabricBytes` value as equal -- masking a real change.
+// Covers the Fabric-aware equality of `mapsEqual`. The helper compares stored
+// read-value maps with `valueEqual`, the content equality: a `FabricPrimitive`
+// keeps its state in private `#fields` with zero enumerable own-props, so only
+// a content-aware comparison can tell two distinct same-class instances apart.
+// These tests pin that maps differing only in a `FabricBytes` value are
+// unequal, and equal-content ones equal.
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -35,10 +36,9 @@ describe("mapsEqual", () => {
   });
 
   it("is Fabric-aware: a differing FabricBytes value makes the maps unequal (CT-1770)", () => {
-    // The two maps differ only in the byte content of a `FabricBytes` value.
-    // `deepEqual` sees two zero-own-prop instances of the same class and calls
-    // them equal, so `mapsEqual` wrongly returns `true`; `valueEqual` compares
-    // by content hash and sees the difference.
+    // The two maps differ only in the (private `#fields`) byte content of a
+    // `FabricBytes` value: a real change, which the content comparison must
+    // report as unequal.
     const a = new Map<string, FabricValue>([
       ["k", new FabricBytes(new Uint8Array([1, 2, 3]))],
     ]);

--- a/packages/utils/src/deep-equal.ts
+++ b/packages/utils/src/deep-equal.ts
@@ -17,8 +17,8 @@ import { isRecord } from "./types.ts";
  * own-props, so two same-class `FabricPrimitive` values (state in private
  * `#fields`, zero own-props) compare equal regardless of value, and
  * `FabricInstance` values compare by internal slots rather than logical
- * contents. Use a `data-model`-aware equality (`valueEqual`, once it is itself
- * made `Fabric`-aware) for any `FabricValue` comparison.
+ * contents. Use the `data-model`-aware `valueEqual()` for any `FabricValue`
+ * comparison.
  */
 export function deepEqual(a: any, b: any): boolean {
   if (Object.is(a, b)) return true;


### PR DESCRIPTION
Completes the tail of the fabric-safety series: the four remaining marked `deepEqual` equality gates over `FabricValue`s are swapped to `valueEqual`, the `data-model`-aware content-hash equality. `deepEqual` compares class instances by enumerable own-props, and a `FabricPrimitive` (`FabricBytes`/`FabricHash`/`FabricEpoch*`/...) keeps its state in private `#fields` with zero own-props — so `deepEqual` wrongly reports every distinct same-class instance as equal, masking real value changes in no-op / change-detection / consistency gates. `deepEqual`'s legitimate non-Fabric uses are left in place; its doc comment is refreshed since `valueEqual` is now itself `Fabric`-aware.

Part of the fabric-safety series — tracking issue #4527.

### Markers resolved (each removed)

- topology.ts: `` TODO(danfuzz): `mapsEqual` compares map values with `deepEqual`, which mishandles `FabricValue`; this helper is used on stored read-value maps, so two same-class `FabricPrimitive`s (state in private `#fields`, zero own-props) compare equal regardless of value. Use a Fabric-aware equality. ``
- attestation.ts: `` TODO(danfuzz): This compares a stored document value (the read/attested value) with `deepEqual`, which mishandles `FabricValue`: two same-class `FabricPrimitive` values (state in private `#fields`, zero own-props) compare equal regardless of value, so a changed Fabric value can be mis-detected as unchanged. Use a Fabric-aware equality for stored-value comparison. ``
- prepare.ts: `` TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see `utils/deep-equal.ts`); `schema.default` can hold a `FabricValue`, so this CFC write-policy check can compare wrong. Migrate to a `Fabric`-aware equality once available. ``
- path-utils.ts: `` TODO(danfuzz): This no-op write gate compares the existing value against the new value with `deepEqual`, which mishandles `FabricValue` (same-class `FabricPrimitive`s compare equal regardless of value, since their state lives in private `#fields` with zero own-props), so a real Fabric-value change can be dropped as a no-op. Use a Fabric-aware equality. ``
- deep-equal.ts stale doc: `` Use a `data-model`-aware equality (`valueEqual`, once it is itself made `Fabric`-aware) for any `FabricValue` comparison. `` → refreshed.

### Per-site operand arguments (both operands are stored-form `FabricValue`s)

- **topology `mapsEqual`**: params tightened `Map<string, unknown>` → `Map<string, FabricValue>` to match the sole caller (`diagnosis.ts`'s `DiagnosisRecord.readValues`, already `Map<string, FabricValue>`); no cast. (The maps' sentinel `"[read-error]"` strings and `undefined` values are both handled by `valueEqual` without throwing.)
- **attestation `claim`**: `expected` is `IAttestation.value: Immutable<FabricValue>`; `actual` is `FabricValue`/`Immutable<FabricValue>` from `toTransactionDocumentValue` or `read().ok.value`; no cast.
- **prepare `writeInstallsInitialSchemaDefault`**: written side is `FabricValue`; `schema.default` is statically `ImmutableJSONValue` but interns a native `Uint8Array`/`Date` default to a `FabricPrimitive` at runtime (verified both operands arrive as `FabricBytes` at the gate); documented cast bridges the deeply-`readonly` JSON type.
- **path-utils `setValueAtPath`**: operands are `any`; both are `FabricValue` by convention (see droppable-commit note).

### ⚠️ Behavior notes

**The attestation swap UN-MASKS previously hidden `StorageTransactionInconsistent` errors.** Where a stored Fabric value genuinely changed but differed only in `FabricPrimitive` content, `claim` previously returned `{ ok }` (silent masking); it now correctly returns the `StateInconsistency` error the check exists to raise. This is the exact bug the marker names and is the desired behavior — but it is a behavior change that can surface inconsistencies that were being swallowed.

**`valueEqual` throw-semantics:** unlike `deepEqual` (which reports non-`Fabric` class instances and functions as merely unequal), `valueEqual` **throws** on a function or a non-`Fabric` class instance. Every operand at these four sites is argued to be a stored-form `FabricValue`, so this is not expected to fire — but it is a real semantic difference at each gate, most notably at the public `setValueAtPath` boundary.

**The final commit (`setValueAtPath`) is droppable — Dan's call.** `setValueAtPath` is re-exported from `runner/src/index.ts`, so the throw-on-non-Fabric semantics reach the runner's public surface. It is isolated as the last commit (marked `!`) so it can be dropped if the public-surface risk should wait.

### Verification

Red-first per site — a test using two distinct same-class `FabricBytes` (differing only in byte content) fails against the pre-swap code and passes after: `mapsEqual` → false; `claim` → `StateInconsistency`; the CFC write-policy check → rejection; `setValueAtPath` → writes and returns true. Gates: `deno fmt --check` + `lint` + `check` clean on all touched files (and package-wide); full `packages/runner` suite 769 passed / 0 failed; full `packages/utils` suite 86 passed / 0 failed.

### Needs Dan's judgment

1. Whether to land the droppable `setValueAtPath` public-surface commit now or defer it.
2. Confirmation that un-masking `StateInconsistency` in `attestation.claim` is wanted in this PR (it is the marker's intent, but it can surface real inconsistencies previously swallowed).
3. The prepare.ts `schema.default as FabricValue` cast — kept in the spirit of your diagnosis.ts documented casts, but a cleaner long-term fix might tighten the `default` typing or add a runtime `isFabricValue` guard.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finish swapping `deepEqual` → `valueEqual` for all remaining `FabricValue` comparisons in the runner to stop masking real changes in no-op and consistency checks. Completes CT-1770 and may surface inconsistencies that were previously hidden.

- **Bug Fixes**
  - `scheduler/topology.ts`: `mapsEqual` now uses `valueEqual` and is typed `Map<string, FabricValue>`.
  - `storage/transaction/attestation.ts`: `claim` compares via `valueEqual` only; removed the `===` fast path to avoid `+0/-0` conflation and updated docs.
  - `cfc/prepare.ts`: `writeInstallsInitialSchemaDefault` uses `valueEqual` (casts `schema.default` to `FabricValue`).
  - `path-utils.setValueAtPath`: no-op gate uses `valueEqual` (public surface).
  - Docs: `utils/deep-equal` points `FabricValue` comparisons to `valueEqual`; trimmed call-site comments to describe current behavior.
  - Added tests for each site, including `+0/-0` in `claim`, Fabric-aware map equality, CFC default-vs-write, and `setValueAtPath`.

- **Migration**
  - `attestation.claim` can now return `StorageTransactionInconsistent` when a `Fabric` primitive changed only in content; `+0` and `-0` are treated as distinct.
  - `setValueAtPath` now throws on functions or non-`Fabric` class instances; callers should pass `FabricValue`s.

<sup>Written for commit 333e886789e4edff76de0ae72443b39b28f87898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

