### PR TITLE
refactor(runner): guard three value-rebuild walks against FabricPrimitive corruption

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import {
   emptySchemaObject,
   schemaForValueType,
@@ -117,6 +118,14 @@ export function toJSONWithLegacyAliases(
     );
   }
 
+  // A `FabricPrimitive` is an atomic value whose state lives in private fields
+  // (zero enumerable own-props). The `for...in` copy branch below would flatten
+  // it to `{}`, so return it unchanged here — after the cell / alias / array
+  // handling above, which must still win for those forms.
+  if (value instanceof BaseFabricPrimitive) {
+    return value as unknown as JSONValue;
+  }
+
   // If this is an object or a pattern, process each key recursively.
   if (isRecord(value) || isPattern(value)) {
     // Guard against circular object references (e.g. schema objects with
@@ -139,11 +148,13 @@ export function toJSONWithLegacyAliases(
       : (value as Record<string, any>);
 
     const result: any = {};
-    // TODO(danfuzz): This `isRecord`-gated `for...in` walk has no
-    // `FabricSpecialObject` guard, so a `FabricPrimitive` (state in private
-    // fields, zero enumerable own-props) flattens to `{}` and a
-    // `FabricInstance` is walked by its internal slots instead of its codec
-    // contents.
+    // TODO(danfuzz): A `FabricPrimitive` is now returned atomically above, but
+    // the other special-object type, `FabricInstance` (a container), still
+    // reaches this `for...in` copy and is walked by its internal slots (zero
+    // enumerable own-props) instead of its codec contents. Unlike a primitive it
+    // *does* need descending into — but by its actual contents, which this walk
+    // won't do correctly. This site will need attention once FabricInstances see
+    // real use.
     for (const key in valueToProcess as any) {
       const jsonValue = toJSONWithLegacyAliases(
         valueToProcess[key],

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
+import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import {
   emptySchemaObject,
   schemaForValueType,
@@ -122,7 +122,7 @@ export function toJSONWithLegacyAliases(
   // (zero enumerable own-props). The `for...in` copy branch below would flatten
   // it to `{}`, so return it unchanged here — after the cell / alias / array
   // handling above, which must still win for those forms.
-  if (value instanceof BaseFabricPrimitive) {
+  if (value instanceof FabricPrimitive) {
     return value as unknown as JSONValue;
   }
 

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
+import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import { type FactoryInput, isPattern, isReactive } from "./types.ts";
 import { noteDerivedCopy } from "./pattern-metadata.ts";
 import { isCell } from "../cell.ts";
@@ -13,7 +13,7 @@ import { isCellResultForDereferencing } from "../query-result-proxy.ts";
  * @returns Transformed value
  *
  * TODO(danfuzz): The `isRecord`-gated `Object.entries`/`Array.map` descent
- * below now leaves `FabricPrimitive` values atomic (a `BaseFabricPrimitive`
+ * below now leaves `FabricPrimitive` values atomic (an `instanceof` check
  * short-circuits the descent condition), but the other special-object type,
  * `FabricInstance` (a container), is still walked by its internal slots instead
  * of its codec contents. Unlike a primitive it *does* need descending into —
@@ -44,7 +44,7 @@ export function traverseValue(
     !isReactive(value) &&
     !isCell(value) &&
     !isCellResultForDereferencing(value) &&
-    !((value as object) instanceof BaseFabricPrimitive) &&
+    !((value as object) instanceof FabricPrimitive) &&
     (isRecord(value) || isPattern(value))
   ) {
     if (Array.isArray(value)) {

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import { type FactoryInput, isPattern, isReactive } from "./types.ts";
 import { noteDerivedCopy } from "./pattern-metadata.ts";
 import { isCell } from "../cell.ts";
@@ -11,11 +12,14 @@ import { isCellResultForDereferencing } from "../query-result-proxy.ts";
  * @param fn - The function to apply to each value, which can return a new value
  * @returns Transformed value
  *
- * TODO(danfuzz): This `isRecord`-gated walk has no `FabricSpecialObject` guard
- * before its `Object.entries`/`Array.map` descent, so it recurses into
- * `FabricPrimitive` values (decomposing them to their empty enumerable props)
- * and walks `FabricInstance` values by their internal slots instead of their
- * codec contents.
+ * TODO(danfuzz): The `isRecord`-gated `Object.entries`/`Array.map` descent
+ * below now leaves `FabricPrimitive` values atomic (a `BaseFabricPrimitive`
+ * short-circuits the descent condition), but the other special-object type,
+ * `FabricInstance` (a container), is still walked by its internal slots instead
+ * of its codec contents. Unlike a primitive it *does* need descending into —
+ * but by its actual contents, which the generic enumerable-prop traversal won't
+ * do correctly. This site will need attention once FabricInstances see real
+ * use.
  */
 export function traverseValue(
   unprocessedValue: FactoryInput<any>,
@@ -31,11 +35,16 @@ export function traverseValue(
   if (isRecord(result)) seen.add(result);
   else if (isRecord(unprocessedValue)) seen.add(unprocessedValue);
 
-  // Traverse value
+  // Traverse value. A `FabricPrimitive` is an atomic value whose state lives in
+  // private fields (zero enumerable own-props); descending into one would
+  // rebuild it as `{}`, corrupting it. It has already been shown to `fn` above
+  // like any other leaf — here we just decline to descend, so the original
+  // instance passes through intact.
   if (
     !isReactive(value) &&
     !isCell(value) &&
     !isCellResultForDereferencing(value) &&
+    !((value as object) instanceof BaseFabricPrimitive) &&
     (isRecord(value) || isPattern(value))
   ) {
     if (Array.isArray(value)) {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1,4 +1,5 @@
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import {
   DEFAULT_MODEL_NAME,
   LLMClient,
@@ -770,9 +771,13 @@ function traverseAndSerialize(
  * @param value - The value to traverse and cellify
  * @returns The cellified value
  *
- * TODO(danfuzz): This `Object.fromEntries(Object.entries(...))` walk has no
- * `FabricSpecialObject` guard; a `FabricPrimitive` flattens to `{}` (its state
- * is private) and a `FabricInstance` is walked by internal slots.
+ * TODO(danfuzz): A `FabricPrimitive` is now returned atomically, but the other
+ * special-object type, `FabricInstance` (a container), still reaches the
+ * `Object.fromEntries(Object.entries(...))` walk and is flattened by its
+ * internal slots (zero enumerable own-props) instead of its codec contents.
+ * Unlike a primitive it *does* need descending into — but by its actual
+ * contents, which this walk won't do correctly. This site will need attention
+ * once FabricInstances see real use.
  */
 function traverseAndCellify(
   runtime: Runtime,
@@ -811,6 +816,11 @@ function traverseAndCellify(
   if (Array.isArray(value)) {
     return value.map((v) => traverseAndCellify(runtime, space, v));
   }
+  // A `FabricPrimitive` is an atomic value whose state lives in private fields
+  // (zero enumerable own-props). It is not a link, so the `Object.fromEntries(
+  // Object.entries(...))` rebuild below would flatten it to `{}`; leave it
+  // intact as an atomic leaf, like any string or number.
+  if (value instanceof BaseFabricPrimitive) return value;
   if (isRecord(value)) {
     return Object.fromEntries(
       Object.entries(value).map((

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1,5 +1,7 @@
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
+import {
+  FabricPrimitive,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import {
   DEFAULT_MODEL_NAME,
   LLMClient,
@@ -820,7 +822,7 @@ function traverseAndCellify(
   // (zero enumerable own-props). It is not a link, so the `Object.fromEntries(
   // Object.entries(...))` rebuild below would flatten it to `{}`; leave it
   // intact as an atomic leaf, like any string or number.
-  if (value instanceof BaseFabricPrimitive) return value;
+  if (value instanceof FabricPrimitive) return value;
   if (isRecord(value)) {
     return Object.fromEntries(
       Object.entries(value).map((

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -4,6 +4,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 import {
   createJsonSchema,
@@ -772,6 +773,18 @@ describe("json-utils", () => {
           scope: "space",
         },
       });
+    });
+
+    it("passes a nested FabricPrimitive through as an atomic value", () => {
+      // A `FabricBytes` (a `FabricPrimitive`) keeps its state in private fields
+      // and exposes zero enumerable own-props, so the `for...in` copy branch
+      // flattens it to `{}`, silently dropping its bytes. It is atomic and must
+      // pass through unchanged.
+      const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+      const result = toJSONWithLegacyAliases({ payload: bytes } as any) as any;
+
+      expect(result.payload).toBe(bytes);
     });
   });
 });

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/builtins/llm-dialog.ts";
 import { schemaWithInjectionSafeAnnotations } from "../src/cfc/schema-sanitization.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 const {
   buildAvailableCellsDocumentation,
@@ -530,6 +531,28 @@ Deno.test("traverseAndCellify converts LLM-friendly links inside strings and obj
   assertEquals(nested.list[0].kind, "cell");
   assertEquals(nested.malformed, '{"@link":');
   assertEquals(parsedLinks.length, 2);
+});
+
+Deno.test("traverseAndCellify passes a nested FabricPrimitive through intact", () => {
+  // A `FabricBytes` (a `FabricPrimitive`) keeps its state in private fields and
+  // exposes zero enumerable own-props, so the `Object.fromEntries(Object.
+  // entries(...))` rebuild flattens it to `{}`, silently dropping its bytes. It
+  // is atomic (no link, no descent) and must pass through as the same instance,
+  // just like a string or number leaf does.
+  const runtime = {
+    getCellFromLink() {
+      throw new Error("should not be called for a FabricPrimitive");
+    },
+  };
+  const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+  const result = traverseAndCellify(
+    runtime as any,
+    "did:test:cellify",
+    { payload: bytes },
+  ) as any;
+
+  assert(result.payload === bytes, "FabricBytes instance must survive intact");
 });
 
 Deno.test("buildToolCatalog normalizes dynamic legacy tools", () => {

--- a/packages/runner/test/traverse-utils.test.ts
+++ b/packages/runner/test/traverse-utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { traverseValue } from "../src/builder/traverse-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -115,5 +116,51 @@ describe("traverseValue with query result proxies", () => {
     expect(result[2]).toBe(mixedArray[2]); // Query result proxy preserved
     expect(result[3]).toEqual({ nested: { values: [10, 20] } });
     expect(result[4]).toEqual([100, 200, 300]);
+  });
+});
+
+describe("traverseValue with FabricPrimitive values", () => {
+  it("passes a nested FabricPrimitive through as an atomic leaf", () => {
+    // A `FabricBytes` (a `FabricPrimitive`) keeps its state in private fields
+    // and exposes zero enumerable own-props. Descending into it via
+    // `Object.entries`/`Object.fromEntries` decomposes it to `{}`, silently
+    // corrupting the value. It must be left intact as an atomic leaf.
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+    const structure = { name: "test", payload: bytes };
+
+    const result = traverseValue(structure, () => undefined);
+
+    // Same instance passes through: it is not rebuilt, so its private state
+    // survives.
+    expect(result.payload).toBe(bytes);
+    // Siblings are still traversed normally.
+    expect(result.name).toBe("test");
+  });
+
+  it("still applies `fn` to a nested FabricPrimitive", () => {
+    // The guard belongs in the descent condition, not as a pre-`fn` early
+    // return: a primitive is still a value `fn` should get to see (and
+    // optionally replace), exactly like a string or number leaf. Only the
+    // rebuild-descent must be skipped.
+    const bytes = new FabricBytes(new Uint8Array([4, 5, 6]));
+    const seen: unknown[] = [];
+
+    traverseValue({ payload: bytes }, (v) => {
+      seen.push(v);
+      return undefined;
+    });
+
+    expect(seen).toContain(bytes);
+  });
+
+  it("lets `fn` replace a nested FabricPrimitive", () => {
+    const bytes = new FabricBytes(new Uint8Array([7, 8, 9]));
+
+    const result = traverseValue(
+      { payload: bytes },
+      (v) => (v instanceof FabricBytes ? "replaced" : undefined),
+    );
+
+    expect(result.payload).toBe("replaced");
   });
 });


### PR DESCRIPTION
Three builder/builtin walks rebuild records via generic enumerable-prop copies (`Object.entries`/`Object.fromEntries` or `for...in`). A `FabricPrimitive` (`FabricBytes`, `FabricEpochNsec`, …) keeps its state in private `#fields` and exposes zero enumerable own-props, so each walk silently decomposed such a value to `{}` — observably corrupting it. This applies Dan's #4238 guard shape (a `BaseFabricPrimitive` short-circuits to an atomic leaf before the generic record branch) to the three remaining walks that observably rebuild values.

Part of the fabric-safety series — tracking issue #4527.

### Markers narrowed

Each site carried a `TODO(danfuzz)` (from #4253 / #4289) naming both the `FabricPrimitive` *and* `FabricInstance` defects. This PR resolves the `FabricPrimitive` half only and rewrites each marker, narrowed to the remaining `FabricInstance` half (mirroring #4238's residual-TODO style):

- **`traverseValue` (traverse-utils.ts)** — before: *"…has no `FabricSpecialObject` guard before its `Object.entries`/`Array.map` descent, so it recurses into `FabricPrimitive` values … and walks `FabricInstance` values by their internal slots…"* → after: *"…now leaves `FabricPrimitive` values atomic …, but … `FabricInstance` (a container) is still walked by its internal slots instead of its codec contents. … This site will need attention once FabricInstances see real use."*
- **`toJSONWithLegacyAliases` (json-utils.ts)** — before: *"…has no `FabricSpecialObject` guard, so a `FabricPrimitive` … flattens to `{}` and a `FabricInstance` is walked by its internal slots…"* → after: *"A `FabricPrimitive` is now returned atomically above, but … `FabricInstance` (a container) still reaches this `for...in` copy and is walked by its internal slots… once FabricInstances see real use."*
- **`traverseAndCellify` (llm-dialog.ts)** — before: *"…has no `FabricSpecialObject` guard; a `FabricPrimitive` flattens to `{}` … and a `FabricInstance` is walked by internal slots."* → after: *"A `FabricPrimitive` is now returned atomically, but … `FabricInstance` (a container) still reaches the `Object.fromEntries(Object.entries(...))` walk … once FabricInstances see real use."*

(The sibling `serializeForLLMObservation` marker in llm-dialog.ts is deliberately untouched — it needs a rendering decision and is listed under "needs your design decision" in #4527.)

### Shape

- **`toJSONWithLegacyAliases` / `traverseAndCellify`**: early-return the primitive unchanged before the record-rebuild branch — atomic-leaf, exactly like #4238's `if (obj instanceof BaseFabricPrimitive) return obj`. Placed after the cell / alias / link / array handling that must still win.
- **`traverseValue` placement (deliberately different)**: this function applies `fn` to *every* value — leaves included — before descending, then rebuilds records. A `FabricPrimitive` should still be **seen by `fn`** like any string/number leaf; only the rebuild-descent must be skipped. So the guard is added to the **descent condition** (alongside the existing `isReactive`/`isCell`/`isCellResultForDereferencing` leaf-outs), *not* as a pre-`fn` early return. Two companion tests lock this in: `fn` still sees the primitive, and `fn` can still replace it — both pass **against the pre-fix code**, validating the placement. (The `instanceof` LHS is cast `as object` because the exclusion chain narrows `value` to a union TS rejects as a bare `instanceof` operand; harmless at runtime.)
- **Honesty:** the markers (Dan's own, from #4253/#4289) state the defect; the *fix-shape* here is **inferred from #4238**, not independently re-derived. The `BaseFabricPrimitive` chokepoint and atomic-leaf treatment are Dan's; applied mechanically to the three flagged walks.
- **Derived-byte churn:** `toJSONWithLegacyAliases` feeds builder serialization (its four call sites are in `builder/pattern.ts`, building `pattern.nodes`), which feeds derived, content-addressed artifacts. Fixing the flattening changes the serialized form of any pattern that embeds a `FabricPrimitive`, hence its derived ids — but, as in #4238, *"they are not widely used yet, so the storage-key churn is acceptable (fresh-db caveat)."* The other two sites (`traverseValue`, `traverseAndCellify`) are in-memory transforms with no persisted-id impact.

### Verification

- **Red-first, per site, against unmodified code:** each site's nested `FabricBytes` came out as `{}` (`-{} / +FabricBytes {}`, or an identity assertion for `traverseAndCellify`); failing output captured. For `traverseValue`, the two `fn`-behavior tests passed *before* the fix, validating the descent-condition placement.
- **Green:** all three site tests pass after the fix.
- **Gates:** `deno fmt`/`lint`/`check` clean on all touched files (and package-wide typecheck); **full `packages/runner` suite: 769 passed / 0 failed**.
- **Downstream independently verified** (adversarial review pass): the intact primitive reaching codec-aware consumers (value-hash dispatches `FabricBytes` via its native tag; cell writes normalize via `shallowFabricFromNativeValue`) is a strict improvement — pre-fix, `{}` collapsed all distinct primitives to one hash. The two `JSON.stringify` consumers downstream produce `{}` for a `FabricBytes` either way (no `toJSON`, zero enumerable props), identical to pre-fix — no regression.

### Needs Dan's judgment

1. **`traverseValue` `as object` cast** — cast the `instanceof` LHS because the leaf-out exclusion chain narrows `value` away from `any` (unlike #4238's `obj: any`). Acceptable, or would you prefer typing the residual differently / a small `isFabricPrimitive` predicate to match the sibling type-guards?
2. **`FabricInstance` residual** — left unhandled at all three sites per your #4238 precedent (needs correct *descent* by codec contents, not the generic walk). Confirm that's still the intended posture and the narrowed TODOs read the way you'd want.
3. **Derived-byte churn scope** — the fresh-db caveat is invoked only for `toJSONWithLegacyAliases` (the serialization path). Please confirm no currently-shipping pattern embeds a `FabricPrimitive` in a way that would make this churn more than theoretical.
4. **`traverseAndCellify` = identity contract** — asserted the *same instance* survives (its leaf case is `return value`). If you'd rather the contract guarantee only content-intactness (allowing a future codec round-trip), say so and the assertion relaxes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards three rebuild paths to keep `FabricPrimitive` values atomic instead of flattening to `{}`. Fixes silent corruption across traversal, JSON serialization, and LLM cellification; adds targeted tests. Part of #4527.

- **Bug Fixes**
  - `toJSONWithLegacyAliases`: early-return primitives before the `for...in` copy; residual TODO narrowed to `FabricInstance`.
  - `traverseValue`: guard the descent so `BaseFabricPrimitive` leaves are not rebuilt; `fn` still sees and can replace them; residual TODO narrowed to `FabricInstance`.
  - `traverseAndCellify`: early-return primitives before the `Object.fromEntries` rebuild; residual TODO narrowed to `FabricInstance`.
  - Added regression tests for all three sites (pass-through as same instance; `fn` visibility/replacement where applicable).

- **Migration**
  - Builder serialization now preserves embedded `FabricPrimitive` values, which can change derived, content-addressed IDs for affected patterns. Fresh DB recommended if this path is in use. Other sites are in-memory only.

<sup>Written for commit 41056802160a2a7022b8c2a9f4a3e52ad4e42bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

