### PR TITLE
fix(runner): FabricPrimitive leafs, FabricInstance handled per-path in traverseDAG and schema defaults

### DIFF
--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -12,6 +12,10 @@ import {
   shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import {
+  FabricInstance,
+  FabricPrimitive,
+} from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   isNontrivialSchema,
@@ -675,6 +679,24 @@ export function processDefaultValue(
     }
   }
 
+  // A `FabricPrimitive` default is a fully-opaque leaf (state in private
+  // `#fields`, zero enumerable own-props): the object-type rebuild below
+  // would decompose it to `{}`. Return it as-is; it takes no back-to-cell
+  // annotation (see `annotateWithBackToCellSymbols`).
+  if (defaultValue instanceof FabricPrimitive) {
+    return defaultValue;
+  }
+  // A `FabricInstance` default is not a fully-opaque leaf: it can have
+  // model-visible outgoing references, so neither the object-type rebuild
+  // below nor returning it whole handles it correctly. Fail loudly until
+  // instances can be processed by their codec contents.
+  if (defaultValue instanceof FabricInstance) {
+    throw new Error(
+      `Cannot yet handle \`${defaultValue.constructor.name}\` (a ` +
+        "`FabricInstance`) as a schema default.",
+    );
+  }
+
   // Handle object type defaults
   if (
     resolvedSchema?.type === "object" && isRecord(defaultValue) &&
@@ -876,9 +898,27 @@ function annotateWithBackToCellSymbols(
   synced = false,
   cfcLabelView?: CfcLabelView,
 ) {
-  if (!isRecord(value) || isCell(value)) {
-    // We only possibly annotate objects or arrays that _aren't_ cells.
+  if (
+    !isRecord(value) || isCell(value) ||
+    value instanceof FabricPrimitive
+  ) {
+    // We only possibly annotate plain objects or arrays that _aren't_ cells.
+    // A `FabricPrimitive` is a fully-opaque leaf and takes no back-to-cell
+    // annotation, exactly like a plain `number` or `string` leaf: it is
+    // always frozen (`defineProperty` would throw "object is not
+    // extensible"), and cloning-or-freezing-to-annotate would misrepresent
+    // it. It passes through untouched.
     return value;
+  }
+  if (value instanceof FabricInstance) {
+    // Unlike a primitive, a `FabricInstance` can have model-visible outgoing
+    // references, so skipping annotation is not obviously right for it — and
+    // the generic record annotation below would be wrong. Fail loudly until
+    // the back-to-cell story for instances exists.
+    throw new Error(
+      `Cannot yet handle \`${value.constructor.name}\` (a ` +
+        "`FabricInstance`) in back-to-cell annotation.",
+    );
   }
 
   const extensible = Object.isExtensible(value);

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -679,17 +679,14 @@ export function processDefaultValue(
     }
   }
 
-  // A `FabricPrimitive` default is a fully-opaque leaf (state in private
-  // `#fields`, zero enumerable own-props): the object-type rebuild below
-  // would decompose it to `{}`. Return it as-is; it takes no back-to-cell
-  // annotation (see `annotateWithBackToCellSymbols`).
+  // A `FabricPrimitive` default is an opaque leaf; return it as-is ahead of
+  // the object-type rebuild below (it takes no back-to-cell annotation --
+  // see `annotateWithBackToCellSymbols`).
   if (defaultValue instanceof FabricPrimitive) {
     return defaultValue;
   }
-  // A `FabricInstance` default is not a fully-opaque leaf: it can have
-  // model-visible outgoing references, so neither the object-type rebuild
-  // below nor returning it whole handles it correctly. Fail loudly until
-  // instances can be processed by their codec contents.
+  // TODO(danfuzz): a `FabricInstance` default is not yet handled -- it needs
+  // processing by its codec contents. Fail loudly until that exists.
   if (defaultValue instanceof FabricInstance) {
     throw new Error(
       `Cannot yet handle \`${defaultValue.constructor.name}\` (a ` +
@@ -903,18 +900,14 @@ function annotateWithBackToCellSymbols(
     value instanceof FabricPrimitive
   ) {
     // We only possibly annotate plain objects or arrays that _aren't_ cells.
-    // A `FabricPrimitive` is a fully-opaque leaf and takes no back-to-cell
-    // annotation, exactly like a plain `number` or `string` leaf: it is
-    // always frozen (`defineProperty` would throw "object is not
-    // extensible"), and cloning-or-freezing-to-annotate would misrepresent
-    // it. It passes through untouched.
+    // A `FabricPrimitive` passes through untouched, exactly like a plain
+    // `number` or `string` leaf.
     return value;
   }
   if (value instanceof FabricInstance) {
-    // Unlike a primitive, a `FabricInstance` can have model-visible outgoing
-    // references, so skipping annotation is not obviously right for it — and
-    // the generic record annotation below would be wrong. Fail loudly until
-    // the back-to-cell story for instances exists.
+    // TODO(danfuzz): the back-to-cell story for a `FabricInstance` (which,
+    // unlike a primitive, can have model-visible outgoing references) does
+    // not exist yet. Fail loudly until it does.
     throw new Error(
       `Cannot yet handle \`${value.constructor.name}\` (a ` +
         "`FabricInstance`) in back-to-cell annotation.",

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -10,6 +10,8 @@ import {
 import type { JSONSchemaObj, SchemaPathSelector } from "@commonfabric/api";
 import type { MemorySpace, Result, Unit } from "@commonfabric/memory/interface";
 import {
+  FabricInstance,
+  FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
@@ -1514,6 +1516,23 @@ export abstract class BaseObjectTraverser {
         this.dagMemo.set(memoKey, arrayResult);
       }
       return arrayResult;
+    } else if (doc.value instanceof FabricPrimitive) {
+      // A `FabricPrimitive` is a fully-opaque leaf (state in private
+      // `#fields`, zero enumerable own-props): return it intact rather than
+      // letting it fall into the record branch below, whose `Object.entries`
+      // walk would decompose it to `{}`. Placed after the array arm so array
+      // reads skip the `instanceof`.
+      return doc.value;
+    } else if (doc.value instanceof FabricInstance) {
+      // A `FabricInstance` is not a fully-opaque leaf: it can have
+      // model-visible outgoing references, and correct traversal descends it
+      // by its codec contents -- which does not exist yet. Unlike the
+      // schema-`default` paths (which fail loudly), this path carries live
+      // instance traffic today -- the fetch builtins store a `FabricError`
+      // result value, which the query path reads back through here -- so it
+      // leafs the instance whole rather than throwing.
+      // TODO(danfuzz): descend by codec contents, not own-props.
+      return doc.value;
     } else if (isRecord(doc.value)) {
       // First, see if we need special handling
       if (isSigilLink(doc.value)) {
@@ -3500,12 +3519,12 @@ export class SchemaObjectTraverser<V extends FabricValue>
       });
       newValue.length = entries.length;
       return { ok: this.objectCreator.createObject(newLink, newValue) };
-      // TODO(danfuzz): a `FabricInstance` is walked by `Object.entries` over
-      // internal slots rather than descended by its codec contents; the same
-      // gap applies to the schema-`default` fallback path
-      // (`traverseDAG`/`applyDefault`), since a schema `default` can carry a
-      // `FabricValue`. A correct fix descends a `FabricInstance` by codec
-      // contents, not own-props.
+      // TODO(danfuzz): `FabricInstance` values (containers) are not yet
+      // handled by schema traversal: a correct fix descends one by its codec
+      // contents, not own-props. Separately, a `FabricPrimitive` stored as
+      // an array element under `items: true` still decomposes via
+      // `traverseArrayWithSchema`'s `createDataCellURI` path (pre-existing;
+      // not addressed here).
     } else if (doc.value instanceof FabricSpecialObject) {
       // A `FabricSpecialObject` (e.g. `FabricBytes`) is an opaque host value
       // the fabric type system treats like a primitive — always frozen,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1517,21 +1517,15 @@ export abstract class BaseObjectTraverser {
       }
       return arrayResult;
     } else if (doc.value instanceof FabricPrimitive) {
-      // A `FabricPrimitive` is a fully-opaque leaf (state in private
-      // `#fields`, zero enumerable own-props): return it intact rather than
-      // letting it fall into the record branch below, whose `Object.entries`
-      // walk would decompose it to `{}`. Placed after the array arm so array
-      // reads skip the `instanceof`.
+      // An opaque leaf: return it intact ahead of the record branch below.
+      // Placed after the array arm so array reads skip the `instanceof`.
       return doc.value;
     } else if (doc.value instanceof FabricInstance) {
-      // A `FabricInstance` is not a fully-opaque leaf: it can have
-      // model-visible outgoing references, and correct traversal descends it
-      // by its codec contents -- which does not exist yet. Unlike the
-      // schema-`default` paths (which fail loudly), this path carries live
-      // instance traffic today -- the fetch builtins store a `FabricError`
-      // result value, which the query path reads back through here -- so it
-      // leafs the instance whole rather than throwing.
-      // TODO(danfuzz): descend by codec contents, not own-props.
+      // TODO(danfuzz): a `FabricInstance` should be descended by its codec
+      // contents, which does not exist yet. This path carries live instance
+      // traffic today (the fetch builtins store a `FabricError` result value
+      // that is read back through here), so unlike the schema-`default`
+      // paths it cannot fail loudly yet: the instance leafs through whole.
       return doc.value;
     } else if (isRecord(doc.value)) {
       // First, see if we need special handling

--- a/packages/runner/test/traverse-fabric-primitive.test.ts
+++ b/packages/runner/test/traverse-fabric-primitive.test.ts
@@ -1,0 +1,310 @@
+// fabric-safety (#4527): a `FabricPrimitive` (state in private `#fields`,
+// zero enumerable own-props) must traverse as a fully-opaque leaf, while a
+// `FabricInstance` — which can have model-visible outgoing references — must
+// fail loudly rather than be silently rebuilt as a plain record (stripping
+// its class and codec identity) or leafed whole, until it can be descended
+// by its codec contents. Covers `traverseDAG`'s record branch and the
+// schema-`default` processing; the dispatch-path primitive cases double as
+// regression coverage for the value-type dispatch's leaf arm.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type {
+  Entity,
+  Revision,
+  State,
+  URI,
+} from "@commonfabric/memory/interface";
+import type { SchemaPathSelector } from "@commonfabric/api";
+
+import { Runtime } from "../src/runtime.ts";
+import { processDefaultValue } from "../src/schema.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import {
+  ManagedStorageTransaction,
+  SchemaObjectTraverser,
+} from "../src/traverse.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+
+const signer = await Identity.fromPassphrase("fabric-safety traverse leaf");
+const space = signer.did();
+
+describe("FabricPrimitive leaf routing in schema traversal", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("returns a stored FabricPrimitive intact through a typed-object schema read", async () => {
+    const schema = {
+      type: "object",
+      properties: { blob: { type: "object" } },
+    } as const satisfies JSONSchema;
+    const c = runtime.getCell<{ blob: Uint8Array }>(
+      space,
+      "typed-read",
+      schema,
+      tx,
+    );
+    // A native Uint8Array interns to FabricBytes on the write path.
+    c.set({ blob: new Uint8Array([1, 2, 3]) });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const got = c.withTx(tx).get() as Record<string, unknown>;
+    expect(got.blob).toBeInstanceOf(FabricBytes);
+    expect(
+      Array.from((got.blob as FabricBytes).slice()),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("keeps rejecting a FabricPrimitive where the schema type already rejected it", async () => {
+    // Under `{ type: "string" }` the pre-fix record branch failed the type
+    // gate for a FabricBytes; the leaf arm must preserve that verdict (the
+    // fix changes decomposition, not accept/reject outcomes).
+    const schema = {
+      type: "object",
+      properties: { blob: { type: "string" } },
+    } as const satisfies JSONSchema;
+    const c = runtime.getCell<{ blob: Uint8Array }>(
+      space,
+      "typed-reject",
+      schema,
+      tx,
+    );
+    c.set({ blob: new Uint8Array([1, 2, 3]) });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const got = c.withTx(tx).get() as Record<string, unknown>;
+    // Pre-fix observed behavior for a type-gate failure on a property read:
+    // the property is absent from the result. The leaf arm keeps it absent.
+    expect(got.blob).toBeUndefined();
+  });
+
+  it("surfaces a FabricPrimitive under an object schema with `required` (deliberate verdict change)", async () => {
+    // Pre-fix, the record branch enforced `required` against the primitive's
+    // spurious `{}` decomposition, so the property was REJECTED (dropped from
+    // the result). A `{}` could never satisfy `required` -- that rejection was
+    // a decomposition artifact, not schema intent -- so the leaf arm now
+    // surfaces the primitive intact. This pins the one deliberate
+    // accept/reject change this fix makes; see the PR's "Needs Dan's
+    // judgment".
+    const schema = {
+      type: "object",
+      properties: { blob: { type: "object", required: ["x"] } },
+    } as const satisfies JSONSchema;
+    const c = runtime.getCell<{ blob: Uint8Array }>(
+      space,
+      "typed-required",
+      schema,
+      tx,
+    );
+    c.set({ blob: new Uint8Array([1, 2, 3]) });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const got = c.withTx(tx).get() as Record<string, unknown>;
+    expect(got.blob).toBeInstanceOf(FabricBytes);
+  });
+
+  it("returns a FabricPrimitive schema-default intact (typed-object property)", async () => {
+    // Runtime reality (see #4529's cfc red): interned schemas can carry
+    // FabricPrimitive defaults (a native Uint8Array default interns to
+    // FabricBytes). The static JSONSchema `default` type is JSON-shaped, so
+    // the instance is placed via a cast here.
+    const blobDefault = new FabricBytes(new Uint8Array([7, 8]));
+    const schema = {
+      type: "object",
+      properties: {
+        blob: {
+          type: "object",
+          default: blobDefault,
+        },
+      },
+    } as unknown as JSONSchema;
+    const c = runtime.getCell<{ blob?: Uint8Array }>(
+      space,
+      "default-read",
+      schema,
+      tx,
+    );
+    c.set({});
+    await tx.commit();
+    tx = runtime.edit();
+
+    const got = c.withTx(tx).get() as Record<string, unknown>;
+    expect(got.blob).toBeInstanceOf(FabricBytes);
+    expect(
+      Array.from((got.blob as FabricBytes).slice()),
+    ).toEqual([7, 8]);
+  });
+
+  it("returns a FabricPrimitive inside a parent default under a `true` property schema intact", () => {
+    // The property schema is `true`, so the per-property default processing
+    // takes the non-record-schema path (annotateWithBackToCellSymbols), which
+    // must also treat a primitive as an atomic leaf.
+    const blobDefault = new FabricBytes(new Uint8Array([9, 9, 1]));
+    const schema = {
+      type: "object",
+      properties: { blob: true },
+      default: { blob: blobDefault },
+    } as unknown as JSONSchema;
+    // The cell is never written: reading a valueless cell applies the whole
+    // schema-level default, which is then processed per-property (blob's
+    // schema is `true`, so its default slice takes the non-record-schema
+    // path).
+    const c = runtime.getCell<{ blob?: Uint8Array }>(
+      space,
+      "default-true-read",
+      schema,
+      tx,
+    );
+
+    const got = c.withTx(tx).get() as Record<string, unknown>;
+    expect(got.blob).toBeInstanceOf(FabricBytes);
+    expect(
+      Array.from((got.blob as FabricBytes).slice()),
+    ).toEqual([9, 9, 1]);
+  });
+
+  it("traverseDAG returns a FabricPrimitive intact under a true schema (store-level)", () => {
+    // Mirrors traverse.test.ts's store-backed harness: this exercises the
+    // querySchema traverser (StandardObjectCreator), whose `traverseDAG`
+    // record branch rebuilds via Object.entries.
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const uri = "of:fabric-dag" as URI;
+    const entity = uri as Entity;
+    const value = {
+      blob: new FabricBytes(
+        new Uint8Array([4, 5, 6]),
+      ) as unknown as FabricValue,
+    };
+    store.set(`${entity}/${type}`, {
+      the: type,
+      of: entity,
+      is: { value },
+      cause: hashOf({ the: type, of: entity }),
+      since: 1,
+    });
+    const selector: SchemaPathSelector = { path: ["value"], schema: true };
+    const manager = new StoreObjectManager(store);
+    const managedTx = new ManagedStorageTransaction(manager);
+    const storeTx = new ExtendedStorageTransaction(managedTx);
+    const traverser = new SchemaObjectTraverser(storeTx, selector);
+
+    const { ok: result } = traverser.traverse({
+      address: {
+        space: "did:null:null",
+        id: uri,
+        type,
+        path: ["value"],
+      },
+      value,
+    });
+
+    expect((result as Record<string, unknown>).blob).toBeInstanceOf(
+      FabricBytes,
+    );
+  });
+
+  it("traverseDAG leafs a FabricInstance whole (deliberate back-off from fail-loud)", () => {
+    // A `FabricInstance` is not a fully-opaque leaf and correct traversal
+    // descends it by codec contents (not yet built). This path carries live
+    // instance traffic today -- the fetch builtins store a `FabricError`
+    // result value that the query path reads back through `traverseDAG` --
+    // so failing loudly here breaks fetch reactivity (uncaught rejection in
+    // the tracked-query refresh). Until codec-contents descent exists, the
+    // instance leafs through whole; this pins that deliberate back-off.
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const uri = "of:fabric-dag-instance" as URI;
+    const entity = uri as Entity;
+    const failure = FabricError.fromNativeError(new Error("leaf me"));
+    const value = { failure: failure as unknown as FabricValue };
+    store.set(`${entity}/${type}`, {
+      the: type,
+      of: entity,
+      is: { value },
+      cause: hashOf({ the: type, of: entity }),
+      since: 1,
+    });
+    const selector: SchemaPathSelector = { path: ["value"], schema: true };
+    const manager = new StoreObjectManager(store);
+    const managedTx = new ManagedStorageTransaction(manager);
+    const storeTx = new ExtendedStorageTransaction(managedTx);
+    const traverser = new SchemaObjectTraverser(storeTx, selector);
+
+    const { ok: result } = traverser.traverse({
+      address: {
+        space: "did:null:null",
+        id: uri,
+        type,
+        path: ["value"],
+      },
+      value,
+    });
+
+    expect((result as Record<string, unknown>).failure).toBe(failure);
+  });
+
+  it("fails loudly on a FabricInstance schema-default (not yet handled)", () => {
+    // Driven at the `processDefaultValue` layer directly: an interned schema
+    // cannot currently deliver a `FabricInstance` default to this layer
+    // end-to-end -- the intern-time canonicalization walk
+    // (`canonicalizeSchemaKeyOrder`) rebuilds one as a plain record first,
+    // stripping its class (recorded as a finding on #4527). A default
+    // reaching this layer intact must fail loudly rather than be rebuilt or
+    // silently leafed.
+    const failureDefault = FabricError.fromNativeError(new Error("nope"));
+    expect(() =>
+      processDefaultValue(runtime, tx, {
+        space,
+        id: "of:default-instance-unit" as URI,
+        scope: "space",
+        path: [],
+        schema: { type: "object" } as JSONSchema,
+      }, failureDefault)
+    ).toThrow(/Cannot yet handle/);
+  });
+
+  it("fails loudly on a FabricInstance default under a non-record schema (annotate path, not yet handled)", () => {
+    // A `true` schema routes `processDefaultValue` down its non-record-schema
+    // path (annotateWithBackToCellSymbols). Skipping annotation is right for
+    // a fully-opaque primitive but not obviously right for a
+    // `FabricInstance`, so that path fails loudly too.
+    const failureDefault = FabricError.fromNativeError(new Error("nope"));
+    expect(() =>
+      processDefaultValue(runtime, tx, {
+        space,
+        id: "of:default-instance-annotate-unit" as URI,
+        scope: "space",
+        path: [],
+        schema: true,
+      }, failureDefault)
+    ).toThrow(/Cannot yet handle/);
+  });
+});


### PR DESCRIPTION
**Reworked 2026-07-20 per danfuzz's review** (the first draft guarded the wider `FabricSpecialObject`): only `FabricPrimitive` is fully opaque, so the guards narrow to it, and the other direct subclass, `FabricInstance` — which can have model-visible outgoing references — gets its own branch per path: failing loudly where nothing routes instances today, and deliberately backing off where live traffic exists. Also rebased onto current main.

A `FabricPrimitive` is `typeof "object"` with its state in private `#fields` and zero enumerable own-props. It now materializes as a fully-opaque leaf on the three sibling paths the value-type dispatch's arm doesn't cover — `traverseDAG`'s record rebuild, `processDefaultValue`'s object-type rebuild, and the default-annotation gate (previously a live crash: `TypeError: Cannot define property Symbol(toCell), object is not extensible` on a frozen primitive default).

Part of the fabric-safety series — tracking issue #4527. Companion PR #4845 applies the same subclass split to the value-type dispatch arm and the plain-schema fast path.

### Shape — per-path subclass split (per review)

| path | `FabricPrimitive` | `FabricInstance` |
| --- | --- | --- |
| `traverseDAG` record rebuild | opaque leaf | **leafs whole — deliberate back-off, see below** |
| `processDefaultValue` object rebuild | opaque leaf (after the asCell block, as before) | **throws** `Cannot yet handle … as a schema default.` |
| `annotateWithBackToCellSymbols` | pass-through, exactly like a `number`/`string` leaf (the review's litmus) | **throws** `Cannot yet handle … in back-to-cell annotation.` |

**The traverseDAG back-off** (the review's "only back away from that if that causes real trouble now"): with the throw in place, the full runner suite surfaced real instance traffic — the fetch builtins store a `FabricError` result value, and the tracked-query refresh (memory v2 `loadFactsForDoc`) reads it back through `traverseDAG`. The throw became an uncaught rejection in the refresh loop and broke fetch reactivity (three test files, plus the `#now` interval wish stalling to timeout). The instance therefore leafs whole on that path, pinned by a test that documents the back-off. The other two paths keep their throws — the full suite is green with them in place.

### Findings recorded during the rework

- **Interning decomposes instance-valued schema defaults** (upstream of this PR; recorded on #4527): a `FabricError` default never reaches `processDefaultValue` as an instance — `canonicalizeSchemaKeyOrder` (the intern-time key-order workaround already slated for removal by its own TODO) rebuilds it as a plain record (its five enumerable own-props, key-sorted), stripping the class. The instance-default tests therefore pin `processDefaultValue` directly. A `FabricBytes` default survives interning only because zero own-props makes that walk identity-return it.
- **`FabricError` carries enumerable own-props** (`type`, `name`, `message`, `stack`, `cause`) — the "zero enumerable own-props" story is primitive-specific. Instances corrupt through generic walks by losing their class and codec identity (plain-record rebuild), not by `{}`-decomposition.

### Verification

- **Red-first:** the primitive cases fail without the guards (`{}` decomposition / the annotate crash), captured verbatim; the two fail-loud cases fail against the guard-less code (verified by stashing `schema.ts`); the dispatch-path primitive cases pass on main and remain regression coverage for #4510's arm, including the pin for its deliberate `required` verdict change (CT-1836's mechanism).
- **The back-off is evidence-based:** the failing fetch/interval runs with the traverseDAG throw in place are what forced it; the pinning test documents the traffic (fetch's stored `FabricError` read back by the query path).
- **Gates:** fmt/lint/`deno check` clean; full `packages/runner` suite **970 passed / 0 failed** on the rebased tree.

### Needs Dan's judgment

1. The traverseDAG back-off — leafing whole vs some other interim posture for the live instance traffic (fetch's stored `FabricError`s).
2. Whether the `processDefaultValue`/annotate throws should land now (nothing in the unit suite routes instances there; the pattern-integration suites are the broader canary — if they surface traffic, the same back-off applies).
3. Disposition of the interning finding (`canonicalizeSchemaKeyOrder` rebuilding instance defaults) — your TODO already slates the function for removal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
