### PR TITLE
fix(runner): resolve #profile MRU/default ordering by link identity, not Cell.equals (CT-1842)

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -382,8 +382,11 @@ function subscribeProfileName(cell: Cell<unknown>): void {
 /**
  * Enumerate the user's profile candidate cells from the home `profiles` list,
  * ordered: default first, then by most-recently-used (MRU), then remaining list
- * order. Identity is by link equality (`Cell.equals`); there is no synthetic
- * key. Returns [] when no valid profile exists yet.
+ * order. Identity is by the profile's own SPACE — each profile is a distinct
+ * `ProfileHome.inSpace()` space, so the `defaultProfile` / `mru` links are
+ * matched to candidates by space, not `Cell.equals` (see `sameProfileCell`;
+ * CT-1842). There is no synthetic key. Returns [] when no valid profile exists
+ * yet.
  */
 function getProfileCandidateCells(
   ctx: WishContext,

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -320,6 +320,33 @@ function profileCellIsValid(
 }
 
 /**
+ * Whether two profile cells name the SAME profile, compared by durable link
+ * identity (entity id + space + path) — NOT `Cell.equals`.
+ *
+ * CT-1842: the `#profile` ordering matches candidates (from the home `profiles`
+ * list) against the `defaultProfile` link and the `mru` list. Those name the
+ * same profiles but reach them through different links — a candidate is read
+ * straight from `profiles`, while an `mru`/`defaultProfile` entry is a link
+ * written by the picker surface (`setMruProfile` / `setDefaultProfile`), which
+ * can carry a write-redirect overwrite flag and its own schema. `Cell.equals`
+ * (`areNormalizedLinksSame`) also compares `scope` and does not collapse those
+ * representation differences, so it returns false for the same profile across
+ * spaces and the MRU/default ordering silently degrades to `profiles`-list
+ * (creation) order. Normalizing both sides with `getAsNormalizedFullLink()`
+ * resolves each link the same way and compares the profile's durable identity
+ * (its own-space entity id), which is stable regardless of how the link was
+ * stored. Reading each cell's normalized link also keeps the ordering reactive
+ * to `mru`/`defaultProfile` changes.
+ */
+function sameProfileCell(a: Cell<unknown>, b: Cell<unknown>): boolean {
+  const la = a.getAsNormalizedFullLink();
+  const lb = b.getAsNormalizedFullLink();
+  return la.id === lb.id && la.space === lb.space &&
+    la.path.length === lb.path.length &&
+    la.path.every((p, i) => p === lb.path[i]);
+}
+
+/**
  * Subscribe to a profile cell's live name so the wish re-runs once a
  * freshly-created profile's name materializes across the space boundary.
  */
@@ -391,16 +418,17 @@ function getProfileCandidateCells(
   for (let j = 0; j < mruLength; j++) {
     mruCells.push(mruCell.key(j).resolveAsCell());
   }
+  // Match by durable link identity, not `Cell.equals` — see sameProfileCell.
   const mruRank = (cell: Cell<unknown>): number => {
-    const idx = mruCells.findIndex((m) => m.equals(cell));
+    const idx = mruCells.findIndex((m) => sameProfileCell(m, cell));
     return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
   };
 
   const ordered = [...candidates];
   ordered.sort((a, b) => {
     if (defaultValid) {
-      const aDef = defaultCell.equals(a);
-      const bDef = defaultCell.equals(b);
+      const aDef = sameProfileCell(defaultCell, a);
+      const bDef = sameProfileCell(defaultCell, b);
       if (aDef && !bDef) return -1;
       if (bDef && !aDef) return 1;
     }

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -320,30 +320,43 @@ function profileCellIsValid(
 }
 
 /**
- * Whether two profile cells name the SAME profile, compared by durable link
- * identity (entity id + space + path) — NOT `Cell.equals`.
+ * Whether a `mru` / `defaultProfile` entry names the SAME profile as a candidate
+ * from the home `profiles` list — compared by the profile's own SPACE, NOT by
+ * `Cell.equals` or by entity id.
  *
- * CT-1842: the `#profile` ordering matches candidates (from the home `profiles`
- * list) against the `defaultProfile` link and the `mru` list. Those name the
- * same profiles but reach them through different links — a candidate is read
- * straight from `profiles`, while an `mru`/`defaultProfile` entry is a link
- * written by the picker surface (`setMruProfile` / `setDefaultProfile`), which
- * can carry a write-redirect overwrite flag and its own schema. `Cell.equals`
- * (`areNormalizedLinksSame`) also compares `scope` and does not collapse those
- * representation differences, so it returns false for the same profile across
- * spaces and the MRU/default ordering silently degrades to `profiles`-list
- * (creation) order. Normalizing both sides with `getAsNormalizedFullLink()`
- * resolves each link the same way and compares the profile's durable identity
- * (its own-space entity id), which is stable regardless of how the link was
- * stored. Reading each cell's normalized link also keeps the ordering reactive
- * to `mru`/`defaultProfile` changes.
+ * CT-1842: the `#profile` ordering matches candidates (from `profiles`) against
+ * the `defaultProfile` link and the `mru` list. Those name the same profiles but
+ * reach them through DIFFERENT links. Two distinct differences defeat a naive
+ * comparison, both observed on live data:
+ *   - `scope` skew — `Cell.equals` (`areNormalizedLinksSame`) compares `scope`,
+ *     which the two sides don't always agree on; and
+ *   - DIFFERENT entity `id` — the `mru`/`defaultProfile` link and the `profiles`
+ *     link for the SAME profile point at different cells WITHIN that profile's
+ *     space (e.g. the picker stores the profile pattern's result cell while the
+ *     list stores the pattern cell). So even id+space+path comparison fails.
+ *
+ * The stable per-profile identity is the profile's own SPACE. Each profile is a
+ * distinct anonymous `ProfileHome.inSpace()` (see submitProfileCreation), whose
+ * DID is unique per user AND per creation event, and `profileCellIsValid`
+ * guarantees every valid candidate lives in its OWN non-home space. No two
+ * distinct valid profiles ever share a space, so equal space ⇒ same profile.
+ * Reading each cell's normalized link keeps the ordering reactive to
+ * `mru`/`defaultProfile` changes.
+ *
+ * `homeSpace` guards the degenerate case: a `mru`/`defaultProfile` entry that
+ * still resolves into the home space (an unmaterialized / invalid link) must
+ * never match — candidates are never in the home space, but the guard makes the
+ * intent explicit and defends against a future home-space candidate slipping in.
  */
-function sameProfileCell(a: Cell<unknown>, b: Cell<unknown>): boolean {
-  const la = a.getAsNormalizedFullLink();
-  const lb = b.getAsNormalizedFullLink();
-  return la.id === lb.id && la.space === lb.space &&
-    la.path.length === lb.path.length &&
-    la.path.every((p, i) => p === lb.path[i]);
+function sameProfileCell(
+  a: Cell<unknown>,
+  b: Cell<unknown>,
+  homeSpace: Cell<unknown>["space"],
+): boolean {
+  const spaceA = a.getAsNormalizedFullLink().space;
+  const spaceB = b.getAsNormalizedFullLink().space;
+  if (spaceA === homeSpace || spaceB === homeSpace) return false;
+  return spaceA === spaceB;
 }
 
 /**
@@ -418,17 +431,18 @@ function getProfileCandidateCells(
   for (let j = 0; j < mruLength; j++) {
     mruCells.push(mruCell.key(j).resolveAsCell());
   }
-  // Match by durable link identity, not `Cell.equals` — see sameProfileCell.
+  // Match by the profile's own space, not `Cell.equals` — see sameProfileCell.
+  const homeSpace = homeSpaceCell.space;
   const mruRank = (cell: Cell<unknown>): number => {
-    const idx = mruCells.findIndex((m) => sameProfileCell(m, cell));
+    const idx = mruCells.findIndex((m) => sameProfileCell(m, cell, homeSpace));
     return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
   };
 
   const ordered = [...candidates];
   ordered.sort((a, b) => {
     if (defaultValid) {
-      const aDef = sameProfileCell(defaultCell, a);
-      const bDef = sameProfileCell(defaultCell, b);
+      const aDef = sameProfileCell(defaultCell, a, homeSpace);
+      const bDef = sameProfileCell(defaultCell, b, homeSpace);
       if (aDef && !bDef) return -1;
       if (bDef && !aDef) return 1;
     }

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2605,15 +2605,11 @@ describe("wish built-in", () => {
       // every pattern that wishes for "the viewer's active profile" (e.g.
       // profile-group-chat's send guard). With a default set, `#profile` must
       // resolve to it directly as a single result.
-      const profileSpaceDid = (await Identity.fromPassphrase(
-        "wish-profile-default-among-many",
+      // Each profile in its OWN space — space DID is the identity (CT-1842).
+      const spaceA = (await Identity.fromPassphrase(
+        "wish-profile-default-among-many-a",
       )).did();
-      const profileA = runtime.getCell(
-        profileSpaceDid,
-        "profile-a",
-        undefined,
-        tx,
-      );
+      const profileA = runtime.getCell(spaceA, "profile-a", undefined, tx);
       profileA.set({
         name: "Default Della",
         initialNameApplied: "Default Della",
@@ -2621,12 +2617,13 @@ describe("wish built-in", () => {
         bio: "",
         elements: [],
       });
-      const profileB = runtime.getCell(
-        profileSpaceDid,
-        "profile-b",
-        undefined,
-        tx,
-      );
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+      const spaceB = (await Identity.fromPassphrase(
+        "wish-profile-default-among-many-b",
+      )).did();
+      const profileB = runtime.getCell(spaceB, "profile-b", undefined, tx);
       profileB.set({
         name: "Other Otto",
         initialNameApplied: "Other Otto",
@@ -2970,30 +2967,25 @@ describe("wish built-in", () => {
     });
 
     it("resolves headless #profile to the default profile (ordered first)", async () => {
-      // Both profiles live in one (non-home) space so the home write opens a
-      // single cross-space writer; the real create flow appends one space per
-      // transaction.
-      const profileSpaceDid = (await Identity.fromPassphrase(
-        "wish-multi-profile-space",
+      // Each profile lives in its OWN (non-home) space — its space DID is its
+      // identity (CT-1842). Commit per space (single-space-writer per tx).
+      const p1Space = (await Identity.fromPassphrase(
+        "wish-multi-profile-space-1",
       )).did();
-      const p1 = runtime.getCell(
-        profileSpaceDid,
-        "multi-profile-1",
-        undefined,
-        tx,
-      );
+      const p1 = runtime.getCell(p1Space, "multi-profile-1", undefined, tx);
       p1.set({
         name: "Ada",
         initialNameApplied: "Ada",
         avatar: "ada.png",
         elements: [],
       });
-      const p2 = runtime.getCell(
-        profileSpaceDid,
-        "multi-profile-2",
-        undefined,
-        tx,
-      );
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+      const p2Space = (await Identity.fromPassphrase(
+        "wish-multi-profile-space-2",
+      )).did();
+      const p2 = runtime.getCell(p2Space, "multi-profile-2", undefined, tx);
       p2.set({
         name: "Grace",
         initialNameApplied: "Grace",
@@ -3044,27 +3036,24 @@ describe("wish built-in", () => {
     });
 
     it("orders headless #profile by MRU when no default is set", async () => {
-      const profileSpaceDid = (await Identity.fromPassphrase(
-        "wish-mru-profile-space",
+      // Each profile in its OWN space — space DID is the identity (CT-1842).
+      const p1Space = (await Identity.fromPassphrase(
+        "wish-mru-profile-space-1",
       )).did();
-      const p1 = runtime.getCell(
-        profileSpaceDid,
-        "mru-profile-1",
-        undefined,
-        tx,
-      );
+      const p1 = runtime.getCell(p1Space, "mru-profile-1", undefined, tx);
       p1.set({
         name: "Ada",
         initialNameApplied: "Ada",
         avatar: "",
         elements: [],
       });
-      const p2 = runtime.getCell(
-        profileSpaceDid,
-        "mru-profile-2",
-        undefined,
-        tx,
-      );
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+      const p2Space = (await Identity.fromPassphrase(
+        "wish-mru-profile-space-2",
+      )).did();
+      const p2 = runtime.getCell(p2Space, "mru-profile-2", undefined, tx);
       p2.set({
         name: "Grace",
         initialNameApplied: "Grace",
@@ -3498,10 +3487,15 @@ describe("wish built-in", () => {
           headless?: boolean;
         },
       ) {
-        const profileSpaceDid = (await Identity.fromPassphrase(
-          `ct1829-${label}-space`,
-        )).did();
-        const profileCells = opts.names.map((name, i) => {
+        // Each profile lives in its OWN space (an anonymous
+        // `ProfileHome.inSpace()` in production) — the profile's own space DID is
+        // its stable identity (CT-1842). Commit per space: a single tx can only
+        // open one space writer at a time.
+        const profileCells: Array<ReturnType<Runtime["getCell"]>> = [];
+        for (let i = 0; i < opts.names.length; i++) {
+          const profileSpaceDid = (await Identity.fromPassphrase(
+            `ct1829-${label}-space-${i}`,
+          )).did();
           const cell = runtime.getCell(
             profileSpaceDid,
             `ct1829-${label}-profile-${i}`,
@@ -3509,18 +3503,17 @@ describe("wish built-in", () => {
             tx,
           );
           cell.set({
-            name,
-            initialNameApplied: name,
+            name: opts.names[i],
+            initialNameApplied: opts.names[i],
             avatar: "",
             bio: "",
             elements: [],
           });
-          return cell;
-        });
-
-        await tx.commit();
-        await runtime.idle();
-        tx = runtime.edit();
+          await tx.commit();
+          await runtime.idle();
+          tx = runtime.edit();
+          profileCells.push(cell);
+        }
 
         const homeSpaceCell = runtime.getHomeSpaceCell(tx);
         const homeDefaultCell = runtime.getCell(
@@ -3801,37 +3794,44 @@ describe("wish built-in", () => {
         }
       });
 
-      // CT-1842: In real deployments each profile lives in its OWN space and the
-      // `mru` / `defaultProfile` links resolve with a DIFFERENT `scope` than the
-      // `profiles` candidates for the same profile (the picker surface stamps its
-      // own scope; the home `profiles` list carries another). `Cell.equals`
-      // (`areNormalizedLinksSame`) compares `scope`, so the MRU/default match
-      // returned false for every candidate and the ordering silently collapsed to
-      // `profiles`-list (creation) order — the switcher was a no-op cross-space.
-      // The builtin now matches by durable link identity (id + space + path), so
-      // the scope skew no longer defeats the match.
-      describe("cross-space scope skew (CT-1842)", () => {
+      // CT-1842: In real deployments each profile lives in its OWN space (an
+      // anonymous `ProfileHome.inSpace()`), and the `mru` / `defaultProfile` link
+      // and the `profiles` candidate for the SAME profile point at DIFFERENT
+      // cells WITHIN that profile's space — same space, DIFFERENT entity id (the
+      // picker stores the profile pattern's result cell; the list stores the
+      // pattern cell). So neither `Cell.equals` nor an id-based comparison matches
+      // them; the MRU/default match returned false for every candidate and the
+      // ordering silently collapsed to `profiles`-list (creation) order — the
+      // switcher was a no-op cross-space. The builtin now matches by the profile's
+      // own SPACE (the stable per-profile identity), so the id difference no
+      // longer defeats the match. Verified against live data (switchtest
+      // identity): mru[0].space == profiles[1].space for the same profile, while
+      // the ids differ.
+      describe("cross-space id skew (CT-1842)", () => {
         // Stand up N profiles, each in its OWN space (real cross-space), wire the
-        // home `profiles` list, and OPTIONALLY write `mru` / `defaultProfile` as
-        // links whose stored `scope` differs from the candidate scope — the exact
-        // shape that made `Cell.equals` return false for the same profile.
+        // home `profiles` list from the profiles' CANONICAL cells, and write
+        // `mru` / `defaultProfile` as links pointing at a DIFFERENT cell in the
+        // SAME profile space (a distinct entity id) — the exact production shape
+        // that made id/equals comparison return false for the same profile.
         async function setupCrossSpace(
           label: string,
           opts: {
             names: string[];
-            // Indices into `names`, most-recently-used first. Written with a
-            // `scope` that differs from the profiles-list candidate scope.
+            // Indices into `names`, most-recently-used first.
             mruIndices?: number[];
-            // Index into `names` to set as default, with a differing scope.
+            // Index into `names` to set as default.
             defaultIndex?: number;
-            skewScope?: "user" | "session";
           },
         ) {
-          const scope = opts.skewScope ?? "user";
           // Each profile in a DISTINCT space; commit per space (a single tx can
-          // only open one space writer at a time).
+          // only open one space writer at a time). We create TWO cells per
+          // profile space: the canonical profile cell (goes in `profiles`) and a
+          // sibling "alias" cell with a DIFFERENT id but the SAME `name` (what the
+          // mru/default links point at) — mirroring production's list-cell vs
+          // picker-result-cell id divergence within one profile space.
+          const profileSpaces: string[] = [];
           const profileCells: Array<ReturnType<Runtime["getCell"]>> = [];
-          const links: Array<
+          const aliasLinks: Array<
             ReturnType<
               ReturnType<Runtime["getCell"]>["getAsNormalizedFullLink"]
             >
@@ -3840,35 +3840,47 @@ describe("wish built-in", () => {
             const spaceDid = (await Identity.fromPassphrase(
               `ct1842-${label}-space-${i}`,
             )).did();
+            profileSpaces.push(spaceDid);
+            const value = {
+              name: opts.names[i],
+              initialNameApplied: opts.names[i],
+              avatar: "",
+              bio: "",
+              elements: [],
+            };
             const cell = runtime.getCell(
               spaceDid,
               `ct1842-${label}-profile-${i}`,
               undefined,
               tx,
             );
-            cell.set({
-              name: opts.names[i],
-              initialNameApplied: opts.names[i],
-              avatar: "",
-              bio: "",
-              elements: [],
-            });
+            cell.set(value);
+            // Sibling cell in the SAME space, DIFFERENT id — the mru/default link
+            // target.
+            const alias = runtime.getCell(
+              spaceDid,
+              `ct1842-${label}-profile-${i}-alias`,
+              undefined,
+              tx,
+            );
+            alias.set(value);
             await tx.commit();
             await runtime.idle();
             tx = runtime.edit();
             profileCells.push(cell);
-            links.push(cell.getAsNormalizedFullLink());
+            aliasLinks.push(alias.getAsNormalizedFullLink());
           }
 
-          // A scope-skewed sigil link to the same profile entity — the shape a
-          // cross-space `mru` / `defaultProfile` entry resolves to in production.
-          const skewedSigil = (i: number) => ({
+          // A sigil link to the SIBLING cell (same profile space, different id) —
+          // the shape a cross-space `mru` / `defaultProfile` entry resolves to in
+          // production.
+          const aliasSigil = (i: number) => ({
             "/": {
               [LINK_V1_TAG]: {
-                id: links[i].id,
-                space: links[i].space,
+                id: aliasLinks[i].id,
+                space: aliasLinks[i].space,
                 path: [],
-                scope,
+                scope: aliasLinks[i].scope,
               },
             },
           });
@@ -3884,13 +3896,13 @@ describe("wish built-in", () => {
           if (opts.mruIndices) {
             homeDefaultCell.key("mru").setRawUntyped(
               // deno-lint-ignore no-explicit-any
-              opts.mruIndices.map((i) => skewedSigil(i)) as any,
+              opts.mruIndices.map((i) => aliasSigil(i)) as any,
             );
           }
           if (opts.defaultIndex !== undefined) {
             homeDefaultCell.key("defaultProfile").setRawUntyped(
               // deno-lint-ignore no-explicit-any
-              skewedSigil(opts.defaultIndex) as any,
+              aliasSigil(opts.defaultIndex) as any,
             );
           }
           // deno-lint-ignore no-explicit-any
@@ -3916,35 +3928,36 @@ describe("wish built-in", () => {
           return { result };
         }
 
-        it("MRU head resolves cross-space despite scope-skewed mru links (fails on unfixed code)", async () => {
+        it("MRU head resolves cross-space despite different-id mru links (fails on unfixed code)", async () => {
           // Two profiles in two spaces, no default. MRU lists the SECOND-created
-          // profile first, written with a scope that differs from the candidate
-          // scope. Pre-fix, `Cell.equals` rejects every mru↔candidate match, so
-          // ordering falls back to creation order and `.result` = first-created
-          // (Ada). With the identity-based match, `.result` = MRU head (Grace).
-          const { result } = await setupCrossSpace("mru-scope-skew", {
+          // profile first, via a link whose entity id differs from the candidate's
+          // (but shares the profile space). Pre-fix, id/equals matching rejects
+          // every mru↔candidate pair, so ordering falls back to creation order and
+          // `.result` = first-created (Ada). With space-based matching, `.result`
+          // = MRU head (Grace).
+          const { result } = await setupCrossSpace("mru-id-skew", {
             names: ["Ada", "Grace"],
             mruIndices: [1],
           });
           expect(result.key("profile").get()?.result?.name).toBe("Grace");
         });
 
-        it("default resolves cross-space despite scope-skewed default link (guards the default-match fix)", async () => {
-          // defaultProfile points at the SECOND profile via a scope-skewed link.
+        it("default resolves cross-space despite different-id default link (guards the default-match fix)", async () => {
+          // defaultProfile points at the SECOND profile via a different-id link.
           // Pre-fix the default-match (`defaultCell.equals(candidate)`) fails the
           // same way, so the default is ignored; with the fix it resolves to the
           // chosen default.
-          const { result } = await setupCrossSpace("default-scope-skew", {
+          const { result } = await setupCrossSpace("default-id-skew", {
             names: ["Ada", "Grace"],
             defaultIndex: 1,
           });
           expect(result.key("profile").get()?.result?.name).toBe("Grace");
         });
 
-        it("default outranks MRU even under scope skew", async () => {
-          // Default = Ada (index 0), MRU head = Grace (index 1), both skewed.
+        it("default outranks MRU even under id skew", async () => {
+          // Default = Ada (index 0), MRU head = Grace (index 1), both different-id.
           // Default must win.
-          const { result } = await setupCrossSpace("default-over-mru-skew", {
+          const { result } = await setupCrossSpace("default-over-mru-id-skew", {
             names: ["Ada", "Grace"],
             defaultIndex: 0,
             mruIndices: [1],

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -3800,6 +3800,158 @@ describe("wish built-in", () => {
           await runtime.idle();
         }
       });
+
+      // CT-1842: In real deployments each profile lives in its OWN space and the
+      // `mru` / `defaultProfile` links resolve with a DIFFERENT `scope` than the
+      // `profiles` candidates for the same profile (the picker surface stamps its
+      // own scope; the home `profiles` list carries another). `Cell.equals`
+      // (`areNormalizedLinksSame`) compares `scope`, so the MRU/default match
+      // returned false for every candidate and the ordering silently collapsed to
+      // `profiles`-list (creation) order — the switcher was a no-op cross-space.
+      // The builtin now matches by durable link identity (id + space + path), so
+      // the scope skew no longer defeats the match.
+      describe("cross-space scope skew (CT-1842)", () => {
+        // Stand up N profiles, each in its OWN space (real cross-space), wire the
+        // home `profiles` list, and OPTIONALLY write `mru` / `defaultProfile` as
+        // links whose stored `scope` differs from the candidate scope — the exact
+        // shape that made `Cell.equals` return false for the same profile.
+        async function setupCrossSpace(
+          label: string,
+          opts: {
+            names: string[];
+            // Indices into `names`, most-recently-used first. Written with a
+            // `scope` that differs from the profiles-list candidate scope.
+            mruIndices?: number[];
+            // Index into `names` to set as default, with a differing scope.
+            defaultIndex?: number;
+            skewScope?: "user" | "session";
+          },
+        ) {
+          const scope = opts.skewScope ?? "user";
+          // Each profile in a DISTINCT space; commit per space (a single tx can
+          // only open one space writer at a time).
+          const profileCells: Array<ReturnType<Runtime["getCell"]>> = [];
+          const links: Array<
+            ReturnType<
+              ReturnType<Runtime["getCell"]>["getAsNormalizedFullLink"]
+            >
+          > = [];
+          for (let i = 0; i < opts.names.length; i++) {
+            const spaceDid = (await Identity.fromPassphrase(
+              `ct1842-${label}-space-${i}`,
+            )).did();
+            const cell = runtime.getCell(
+              spaceDid,
+              `ct1842-${label}-profile-${i}`,
+              undefined,
+              tx,
+            );
+            cell.set({
+              name: opts.names[i],
+              initialNameApplied: opts.names[i],
+              avatar: "",
+              bio: "",
+              elements: [],
+            });
+            await tx.commit();
+            await runtime.idle();
+            tx = runtime.edit();
+            profileCells.push(cell);
+            links.push(cell.getAsNormalizedFullLink());
+          }
+
+          // A scope-skewed sigil link to the same profile entity — the shape a
+          // cross-space `mru` / `defaultProfile` entry resolves to in production.
+          const skewedSigil = (i: number) => ({
+            "/": {
+              [LINK_V1_TAG]: {
+                id: links[i].id,
+                space: links[i].space,
+                path: [],
+                scope,
+              },
+            },
+          });
+
+          const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+          const homeDefaultCell = runtime.getCell(
+            userIdentity.did(),
+            `ct1842-${label}-home-default`,
+            undefined,
+            tx,
+          );
+          homeDefaultCell.key("profiles").set(profileCells);
+          if (opts.mruIndices) {
+            homeDefaultCell.key("mru").setRawUntyped(
+              // deno-lint-ignore no-explicit-any
+              opts.mruIndices.map((i) => skewedSigil(i)) as any,
+            );
+          }
+          if (opts.defaultIndex !== undefined) {
+            homeDefaultCell.key("defaultProfile").setRawUntyped(
+              // deno-lint-ignore no-explicit-any
+              skewedSigil(opts.defaultIndex) as any,
+            );
+          }
+          // deno-lint-ignore no-explicit-any
+          (homeSpaceCell as any).key("defaultPattern").set(homeDefaultCell);
+
+          await tx.commit();
+          await runtime.idle();
+          tx = runtime.edit();
+
+          const wishPattern = pattern(() => ({
+            profile: wish({ query: "#profile", headless: true }),
+          }));
+          const resultCell = runtime.getCell<Record<string, any>>(
+            patternSpace.did(),
+            `ct1842-${label}-result`,
+            undefined,
+            tx,
+          );
+          const result = runtime.run(tx, wishPattern, {}, resultCell);
+          await tx.commit();
+          tx = runtime.edit();
+          await result.pull();
+          return { result };
+        }
+
+        it("MRU head resolves cross-space despite scope-skewed mru links (fails on unfixed code)", async () => {
+          // Two profiles in two spaces, no default. MRU lists the SECOND-created
+          // profile first, written with a scope that differs from the candidate
+          // scope. Pre-fix, `Cell.equals` rejects every mru↔candidate match, so
+          // ordering falls back to creation order and `.result` = first-created
+          // (Ada). With the identity-based match, `.result` = MRU head (Grace).
+          const { result } = await setupCrossSpace("mru-scope-skew", {
+            names: ["Ada", "Grace"],
+            mruIndices: [1],
+          });
+          expect(result.key("profile").get()?.result?.name).toBe("Grace");
+        });
+
+        it("default resolves cross-space despite scope-skewed default link (guards the default-match fix)", async () => {
+          // defaultProfile points at the SECOND profile via a scope-skewed link.
+          // Pre-fix the default-match (`defaultCell.equals(candidate)`) fails the
+          // same way, so the default is ignored; with the fix it resolves to the
+          // chosen default.
+          const { result } = await setupCrossSpace("default-scope-skew", {
+            names: ["Ada", "Grace"],
+            defaultIndex: 1,
+          });
+          expect(result.key("profile").get()?.result?.name).toBe("Grace");
+        });
+
+        it("default outranks MRU even under scope skew", async () => {
+          // Default = Ada (index 0), MRU head = Grace (index 1), both skewed.
+          // Default must win.
+          const { result } = await setupCrossSpace("default-over-mru-skew", {
+            names: ["Ada", "Grace"],
+            defaultIndex: 0,
+            mruIndices: [1],
+          });
+          expect(result.key("profile").get()?.result?.name).toBe("Ada");
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Why

In real (cross-space) deployments the `#profile` MRU switcher was a no-op: picking a profile via the picker's **Use** button stamped MRU but `#profile` / `#profileName` kept resolving to the *first-created* profile instead of the MRU head. Verified live against the switchtest identity (profiles Grace + Alan, `mru = [Alan, Grace]`): `#profileName` returned "Grace" persistently; after this fix it returns "Alan".

Pre-existing since #3830 (2026-06-09); CT-1829 (#4512) relies on this ordering for the picker-as-switcher and exposed it. This unblocks CT-1829's switcher.

Fixes CT-1842.

## Root cause

`getProfileCandidateCells` in `packages/runner/src/builtins/wish.ts` orders profile candidates default → MRU → first, matching candidates (from the home `profiles` list) against the `defaultProfile` link and the `mru` list with `Cell.equals`.

Those lists name the same profiles but reach them through **different links**. On live data the `mru`/`defaultProfile` link and the `profiles` link for the SAME profile point at **different cells within that profile's own space — same space, DIFFERENT entity id** (the picker stores one cell, e.g. the profile pattern's result cell; the list stores another). `Cell.equals` (`areNormalizedLinksSame`) compares `id` (and `scope`), so it returns false for every candidate. Every candidate then ranks `MAX_SAFE_INTEGER`, the MRU sort is a no-op, and `#profile` falls back to `profiles`-list (creation) order.

Hard evidence (switchtest identity):

```
mru[0]  space …Ubj5gsae (Alan)    profiles[1] space …Ubj5gsae (Alan)   — same space, different id
mru[1]  space …WwikkTRr (Grace)   profiles[0] space …WwikkTRr (Grace)  — same space, different id
```

The default-match (`defaultCell.equals(a)`) shared the exact same bug and is fixed too.

## Fix

Match by the profile's own **space DID**, not `Cell.equals` and not entity id. Each profile is a distinct anonymous `ProfileHome.inSpace()` (see `submitProfileCreation`), whose DID is unique per user AND per creation event; `profileCellIsValid` guarantees every valid candidate lives in its own non-home space; no two distinct valid profiles ever share a space. So equal space ⇒ same profile, and the different-id / scope differences no longer defeat the match. A `homeSpace` guard rejects any entry that still resolves into the home space (an unmaterialized/invalid link).

New `sameProfileCell(a, b, homeSpace)` helper compares normalized-link `space`; applied to both the MRU rank and the default match. Ordering contract (default → MRU → first) unchanged; only the matching mechanism changed. Reading each cell's normalized link keeps the ordering reactive to `mru`/`defaultProfile` changes.

## Test (fails without the fix)

- **Live acceptance:** ran this branch's CLI against the local dev server with the switchtest identity — `#profileName` and `#profile` both resolve to **"Alan"** (MRU head), not "Grace".
- **New unit tests** — `cross-space id skew (CT-1842)` in `wish.test.ts`: profiles each in their own space; `mru`/`defaultProfile` links point at a **different cell in the same profile space** (different entity id) — the real production shape.
  - `MRU head resolves cross-space despite different-id mru links` — **red on unfixed code** (resolves first-created).
  - `default resolves cross-space despite different-id default link` — **red on unfixed code** (default ignored).
  - `default outranks MRU even under id skew`.
  Confirmed red-without-fix by temporarily reverting to `Cell.equals`.
- **Migrated existing ordering tests** (CT-1829 `setupProfiles` and the standalone default/MRU tests) from same-space-multiple-profiles to **one-space-per-profile** — the real invariant. All CT-1829 single-result contract tests stay green.

Verification: `wish.test.ts`, `profile-create-real-card-add.test.ts`, `wish-scope.test.ts`, `wish-shared-hashtag.test.ts`, `cross-space-value-read.test.ts` all pass (11 tests / 115 steps); `deno fmt` / `deno lint` / `deno task check` clean.

## Note on same-space matching

Space-based identity is only wrong if two distinct valid profiles ever share a space — which `submitProfileCreation` (anonymous per-event `inSpace()`) prevents. The previously same-space test setups were a test fiction, now corrected. A single profile resolves via `ordered[0]` regardless of matching, so single-profile identities are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)