### PR TITLE
fix(patterns): match profile identity by space in picker default badge; drop vestigial resultIndex (CT-1843)

### DIFF
--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -1,16 +1,13 @@
 import {
   computed,
-  equals,
   ifElse,
   NAME,
   pattern,
   UI,
   type VNode,
-  type WishState,
   Writable,
 } from "commonfabric";
 import ProfileCreate, {
-  profileLinkListSchema,
   profileLinkSchema,
   setDefaultProfile,
   setMruProfile,
@@ -33,9 +30,9 @@ import type { ProfileHomeOutput } from "./profile-home.tsx";
 // trusted picker-surface actions (owner-protected; see profile-create); those
 // writes reorder the builtin's candidates, which is what flips `.result`.
 //
-// The `resultIndex`/`result` computeds below duplicate the builtin's ordering
-// and are VESTIGIAL — nothing reads them anymore; kept one release for
-// compatibility, then to be deleted (CT-1829 follow-up).
+// The picker output is only `[UI]` — it does NOT surface a `result` /
+// `candidates` (the wish builtin owns those); its former `resultIndex` / `result`
+// computeds were vestigial after CT-1829 (#4512) and are removed (CT-1843).
 
 type ProfilePickerInput = {
   profiles: Writable<ProfileHomeOutput[]>;
@@ -43,40 +40,59 @@ type ProfilePickerInput = {
   mru: Writable<ProfileHomeOutput[]>;
 };
 
+// Whether two profile cells name the SAME profile — compared by the profile's
+// own SPACE, NOT by `equals` / entity id (CT-1843; mirrors the runner-side
+// `sameProfileCell` in wish.ts landed by CT-1842 #4534).
+//
+// The `defaultProfile` link and a `profiles`-list entry for the SAME profile
+// reach it through DIFFERENT links — different entity `id` (and scope) WITHIN
+// that profile's own space (the list stores one cell, the default link another).
+// `equals` compares id (and scope), so it returns false cross-space and the
+// default badge is mislabeled/omitted. The stable per-profile identity is the
+// profile's own SPACE: each profile is a distinct anonymous
+// `ProfileHome.inSpace()` whose DID is unique per user and per creation event,
+// so equal space ⇒ same profile.
+//
+// `homeSpace` guards the degenerate case: the `profiles` / `defaultProfile` /
+// `mru` container links live in the home space, so an unmaterialized / invalid
+// entry that still resolves into the home space must never match.
+//
+// Uses `getAsNormalizedFullLink().space` via the `as any` escape hatch — the
+// pattern-facing surface has no typed space accessor (precedent:
+// home-ben.tsx). Defensive: any throw / missing space ⇒ no match.
+
+// A cell's own space DID, or undefined if it isn't a resolvable link. Module
+// scope (not pattern context), so the `as any` escape hatch + `?.` are fine.
+// deno-lint-ignore no-explicit-any
+const linkSpace = (cell: unknown): string | undefined => {
+  try {
+    return (cell as any)?.getAsNormalizedFullLink?.()?.space as
+      | string
+      | undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const sameProfileCell = (
+  a: unknown,
+  b: unknown,
+  homeSpace: string | undefined,
+): boolean => {
+  const spaceA = linkSpace(a);
+  const spaceB = linkSpace(b);
+  if (!spaceA || !spaceB) return false;
+  if (spaceA === homeSpace || spaceB === homeSpace) return false;
+  return spaceA === spaceB;
+};
+
 export default pattern<
   ProfilePickerInput,
-  WishState<ProfileHomeOutput> & { [UI]: VNode }
+  { [UI]: VNode }
 >(({ profiles, defaultProfile, mru }) => {
-  // Index (into `profiles`) of the profile the wish should resolve to.
-  // Reads links as cell refs (asCell) and matches by link identity via `equals`,
-  // so a cross-space profile not yet loaded here doesn't collapse the read to
-  // `undefined` (which would mis-resolve to index 0). See profileLinkSchema.
-  const resultIndex = computed(() => {
-    const list = ((profiles as any).asSchema(profileLinkListSchema()).get() ??
-      []) as ProfileHomeOutput[];
-    if (list.length === 0) return -1;
-    const def = (defaultProfile as any).asSchema(profileLinkSchema()).get() as
-      | ProfileHomeOutput
-      | undefined;
-    const mruList = ((mru as any).asSchema(profileLinkListSchema()).get() ??
-      []) as ProfileHomeOutput[];
-    const matchIndex = (target: ProfileHomeOutput | undefined) =>
-      target ? list.findIndex((entry) => equals(entry, target)) : -1;
-
-    // Default wins (matches headless #profile), then most-recently-used.
-    const defIdx = matchIndex(def);
-    if (defIdx >= 0) return defIdx;
-    const mruIdx = mruList.length > 0 ? matchIndex(mruList[0]) : -1;
-    if (mruIdx >= 0) return mruIdx;
-    return 0;
-  });
-
-  // Named computed so the CTS transformer leaves it intact in the return object
-  // and wish.ts can read the resolved profile via `.get()`.
-  const result = computed(() => {
-    const idx = resultIndex;
-    return idx >= 0 ? (profiles.key(idx) as any) : undefined;
-  });
+  // Home space of the `profiles`/`defaultProfile`/`mru` container links — used
+  // to reject entries that resolve into the home space (see sameProfileCell).
+  const homeSpace = linkSpace(profiles);
 
   const profileCreate = ProfileCreate({
     profiles: profiles as any,
@@ -85,8 +101,6 @@ export default pattern<
 
   return {
     [NAME]: "Choose a profile",
-    result,
-    candidates: profiles as any,
     [UI]: (
       <cf-vstack
         id="profile-picker"
@@ -108,10 +122,14 @@ export default pattern<
             </div>
             {ifElse(
               computed(() => {
+                // Read the default link as a cell REF (asCell) so a cross-space
+                // profile not yet loaded here doesn't collapse to `undefined`,
+                // then match by the profile's own SPACE (CT-1843) — `equals`
+                // returns false cross-space (different entity id + scope).
                 const def = (defaultProfile as any).asSchema(
                   profileLinkSchema(),
                 ).get();
-                return def ? equals(def, p) : false;
+                return def ? sameProfileCell(def, p, homeSpace) : false;
               }),
               <span style={{ color: "#0a7", fontSize: "12px" }}>default</span>,
               <cf-button


### PR DESCRIPTION
## Why

In real (cross-space) deployments the profile picker mislabels/omits the **default** badge: the interactive `[UI]` used `equals(def, p)` to decide which profile row shows "default". The `defaultProfile` link and the `profiles`-list entry for the SAME profile reach it through **different links** — different entity `id` (and scope) within that profile's own space — so `Cell.equals` (which compares id + scope) returns false, and the actual default never gets the badge.

This is the SAME class of bug as CT-1842 (#4534), which fixed the runner-side `#profile` MRU/default ordering by matching on the profile's own **space** instead of `Cell.equals`. This PR applies that idea in the picker **pattern**.

It also removes the vestigial `resultIndex` / `result` computeds that CT-1829 (#4512) left dead — the wish `.result` no longer flows through the picker (the wish builtin resolves `.result` itself), and nothing reads the picker's `result` / `candidates` anymore. Removing them also removes a second copy of this same latent `equals` bug.

Links: CT-1843, CT-1842 (#4534), CT-1829 (#4512).

## What

- Add module-scope helpers `linkSpace(cell)` (a cell's own space DID via `getAsNormalizedFullLink().space`, defensive) and `sameProfileCell(a, b, homeSpace)` — mirroring the runner's `sameProfileCell` (wish.ts, CT-1842): match two profile cells by their **space** (each profile is a distinct anonymous `ProfileHome.inSpace()`, so equal space ⇒ same profile), with a `homeSpace` guard rejecting entries that resolve into the home space.
- The pattern-facing API has **no typed space accessor**; the picker already uses the `(cell as any)` escape hatch for `.asSchema(...)`, and `home-ben.tsx` already calls `getAsNormalizedFullLink()` on a cell in pattern code — same precedent used here. Derive `homeSpace` from the `profiles` container link (which lives in the home space, matching how wish.ts sources its guard).
- Replace the `[UI]` default-badge `equals(def, p)` with `sameProfileCell(def, p, homeSpace)` (still reading `def` as a cell REF via `profileLinkSchema()` so a not-yet-loaded cross-space profile doesn't collapse to `undefined`).
- Delete the vestigial `resultIndex` / `result` computeds and drop `result` / `candidates` from the picker output; the picker output is now just `{ [UI]: VNode }`. Verified `home.tsx` (the only consumer) and `wish.ts` render only the picker's `[UI]`, never its `result` / `candidates`.

## Test / verification limits

- `deno fmt`, `deno lint`, and `cf check` are clean on `profile-picker.tsx` **and** on `home.tsx` (the consumer, whose picker output type changed). The transformer lifts `homeSpace = linkSpace(profiles)` and the badge condition into reactive computeds as expected.
- Runner `wish.test.ts` passes (unchanged; picker output-shape change is compatible — those tests read the picker's `[UI]` and the main wish `.result`, not the picker's own `result`/`candidates`).
- **No new pattern-unit test**: exercising the cross-space default badge requires two profiles in distinct `inSpace` spaces plus a `defaultProfile` link — a cross-space create the pattern-unit lane forbids (it trips the console-error gate via closure-replication-failed). The space-matching correctness therefore needs **browser verification**: with 2+ profiles and one set as default, confirm the default profile's row shows the "default" badge cross-space. The runner-side twin (`sameProfileCell` in wish.ts) is already covered by CT-1842's cross-space `wish.test.ts` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the profile picker so the “default” badge shows on the correct profile across spaces, and simplifies the picker API by removing unused `resultIndex`/`result`. Addresses CT-1843 by aligning the picker with the space-based matching used in CT-1842.

- **Bug Fixes**
  - Match profile identity by the profile’s own space DID instead of `equals`, via `linkSpace` and `sameProfileCell`.
  - Derive `homeSpace` from `profiles` and reject any entries that resolve into the home space.
  - Replace `equals(def, p)` with `sameProfileCell(def, p, homeSpace)` to render the default badge correctly across spaces.

- **Migration**
  - Picker output is now only `{ [UI]: VNode }`; `result` and `candidates` were removed. Update any consumer still reading them.

<sup>Written for commit 090347ac70823a3ef27ce6ce69cf72235b78ae1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

