### PR TITLE
fix(cli): project cf wish object output to plain data, drop stream-handle graph (CT-1844)

### DIFF
--- a/packages/cli/commands/wish.ts
+++ b/packages/cli/commands/wish.ts
@@ -6,7 +6,7 @@ import { render } from "../lib/render.ts";
 import { getDidFromFile } from "../lib/identity.ts";
 import { absPath } from "../lib/utils.ts";
 import { normalizeApiUrl, setQuietMode } from "./piece.ts";
-import { readWish } from "../lib/wish.ts";
+import { projectWishValue, readWish } from "../lib/wish.ts";
 
 /** Options the `cf wish` action receives (cliffy-parsed flags + env). */
 export interface WishCommandOptions {
@@ -91,7 +91,12 @@ export async function wishAction(
     return; // Reached only when a test injects a non-terminating exit.
   }
 
-  render(result, { json: true });
+  // Project away stream/cell handles before serializing. An object target
+  // (#profile) otherwise drags its pattern's stream handles — and through them
+  // the whole runtime object graph — into JSON (~50KB of noise). Scalar targets
+  // (#profileName etc.) and the null / --allow-empty result pass through
+  // unchanged. See projectWishValue (CT-1844).
+  render(projectWishValue(result), { json: true });
 }
 
 const description = cliText(

--- a/packages/cli/lib/wish.ts
+++ b/packages/cli/lib/wish.ts
@@ -155,8 +155,13 @@ export async function readWish(
   });
 }
 
-/** Marker substituted for a stream/handle-valued key in projected output. */
+/** Base marker substituted for a stream/handle-valued node in projected output. */
 export const WISH_STREAM_MARKER = "[stream]";
+
+/** Marker for a stripped handle, optionally tagged with the key it hung off. */
+function streamMarker(key?: string): string {
+  return key === undefined ? WISH_STREAM_MARKER : `[stream:${key}]`;
+}
 
 /**
  * Project a resolved wish value to plain, serializable data for output (CT-1844).
@@ -170,27 +175,51 @@ export const WISH_STREAM_MARKER = "[stream]";
  * exists for.
  *
  * This walks the value and replaces every stream/cell/function-valued node with
- * {@link WISH_STREAM_MARKER}, keeping all plain data (including nested arrays
- * like `elements` and the `$UI` VNode tree) intact. Scalar results (a bare
- * string/number/etc. from `#profileName` and friends) pass straight through
- * unchanged, so only the object-target output shape is affected.
+ * a `[stream]` / `[stream:<key>]` marker, keeping all plain data (including
+ * nested arrays like `elements` and the `$UI` VNode tree) intact. Scalar results
+ * (a bare string/number/etc. from `#profileName` and friends) pass straight
+ * through unchanged, so only the object-target output shape is affected.
+ *
+ * The walk memoizes the PROJECTED result per input node in a `Map` (with an
+ * in-progress sentinel so genuine cycles terminate rather than recurse forever).
+ * That is load-bearing correctness, not just efficiency: a plain object reached
+ * by two different paths (a DAG "diamond") must be projected on BOTH — a bare
+ * "already seen → return raw" dedup would leak any handle nested under the
+ * shared subtree on the second path, re-exposing exactly the graph this strips.
  */
-export function projectWishValue(
+export function projectWishValue(value: unknown): unknown {
+  return projectNode(value, undefined, new Map<object, unknown>());
+}
+
+/** In-progress sentinel: a node currently being projected higher in the stack. */
+const IN_PROGRESS = Symbol("wish-projection-in-progress");
+
+function projectNode(
   value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
+  key: string | undefined,
+  memo: Map<object, unknown>,
 ): unknown {
   if (isCell(value) || isStream(value) || typeof value === "function") {
-    return WISH_STREAM_MARKER;
+    return streamMarker(key);
   }
   if (value === null || typeof value !== "object") return value;
-  if (seen.has(value)) return value; // let downstream stringify flag circularity
-  seen.add(value);
-  if (Array.isArray(value)) {
-    return value.map((item) => projectWishValue(item, seen));
+
+  const cached = memo.get(value);
+  if (cached === IN_PROGRESS) {
+    // A genuine cycle: this node is an ancestor of itself. Break it so the walk
+    // terminates; downstream stringify would otherwise flag the same loop.
+    return "[circular]";
   }
-  const out: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(value)) {
-    out[key] = projectWishValue(val, seen);
-  }
-  return out;
+  if (cached !== undefined) return cached; // diamond: reuse the SAME projection.
+
+  memo.set(value, IN_PROGRESS);
+  const projected: unknown = Array.isArray(value)
+    ? value.map((item, i) => projectNode(item, String(i), memo))
+    : Object.fromEntries(
+      Object.entries(value).map((
+        [k, val],
+      ) => [k, projectNode(val, k, memo)]),
+    );
+  memo.set(value, projected);
+  return projected;
 }

--- a/packages/cli/lib/wish.ts
+++ b/packages/cli/lib/wish.ts
@@ -1,6 +1,8 @@
 import type { DID } from "@commonfabric/identity";
 import {
   createBuilder,
+  isCell,
+  isStream,
   type JSONSchema,
   type MemorySpace,
   type Runtime,
@@ -151,4 +153,44 @@ export async function readWish(
     schema: config.schema,
     scope: config.scope,
   });
+}
+
+/** Marker substituted for a stream/handle-valued key in projected output. */
+export const WISH_STREAM_MARKER = "[stream]";
+
+/**
+ * Project a resolved wish value to plain, serializable data for output (CT-1844).
+ *
+ * A `#profile` object result is a materialized pattern result: alongside the
+ * data fields (`$NAME`, `name`, `avatar`, `bio`, `elements`, `isEditing`, …) it
+ * carries the pattern's stream handles (`addElement`, `setName`, `setAvatar`,
+ * …). Those handles are live `Cell`/`Stream` objects; JSON-serializing them
+ * drags in the entire runtime object graph (scheduler, circular refs) — ~50KB
+ * of noise that defeats the agent/script/offline-cache audience this read path
+ * exists for.
+ *
+ * This walks the value and replaces every stream/cell/function-valued node with
+ * {@link WISH_STREAM_MARKER}, keeping all plain data (including nested arrays
+ * like `elements` and the `$UI` VNode tree) intact. Scalar results (a bare
+ * string/number/etc. from `#profileName` and friends) pass straight through
+ * unchanged, so only the object-target output shape is affected.
+ */
+export function projectWishValue(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): unknown {
+  if (isCell(value) || isStream(value) || typeof value === "function") {
+    return WISH_STREAM_MARKER;
+  }
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return value; // let downstream stringify flag circularity
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => projectWishValue(item, seen));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    out[key] = projectWishValue(val, seen);
+  }
+  return out;
 }

--- a/packages/cli/test/wish-command.test.ts
+++ b/packages/cli/test/wish-command.test.ts
@@ -216,6 +216,47 @@ describe("cf wish command action", () => {
     });
   });
 
+  it("projects an object result to plain data, dropping handle-valued keys (CT-1844)", async () => {
+    // A materialized #profile object carries the pattern's stream handles
+    // alongside its data. render() must not serialize those (they drag in the
+    // whole runtime graph). Here a function stands in for a handle: it triggers
+    // the same projection branch (isStream/isCell/function → marker) without a
+    // live runtime, and asserts the data fields survive.
+    const { deps, exits } = stubDeps({
+      result: {
+        $NAME: "Ada",
+        name: "Ada",
+        avatar: "",
+        bio: "First programmer.",
+        isEditing: false,
+        elements: [{ title: "Note" }],
+        setName: () => {},
+        addElement: () => {},
+        toggleEditing: () => {},
+      },
+    });
+    const out = await captureStdout(() =>
+      wishAction({ ...BASE_OPTIONS, quiet: true }, "#profile", deps)
+    );
+    const parsed = JSON.parse(out);
+
+    // Data fields present and intact (including the nested elements array).
+    expect(parsed.name).toBe("Ada");
+    expect(parsed.bio).toBe("First programmer.");
+    expect(parsed.isEditing).toBe(false);
+    expect(parsed.elements).toEqual([{ title: "Note" }]);
+
+    // Handle-valued keys are replaced by the stable marker, not omitted, and
+    // carry none of the runtime object graph.
+    expect(parsed.setName).toBe("[stream]");
+    expect(parsed.addElement).toBe("[stream]");
+    expect(parsed.toggleEditing).toBe("[stream]");
+    expect(out).not.toContain("scheduler");
+    expect(out).not.toContain("circular reference");
+    expect(out.length).toBeLessThan(600);
+    expect(exits).toEqual([]);
+  });
+
   it("--allow-empty prints null and does not exit on an empty result", async () => {
     const { deps, exits } = stubDeps({
       result: null,

--- a/packages/cli/test/wish-command.test.ts
+++ b/packages/cli/test/wish-command.test.ts
@@ -246,11 +246,11 @@ describe("cf wish command action", () => {
     expect(parsed.isEditing).toBe(false);
     expect(parsed.elements).toEqual([{ title: "Note" }]);
 
-    // Handle-valued keys are replaced by the stable marker, not omitted, and
+    // Handle-valued keys are replaced by a key-tagged marker, not omitted, and
     // carry none of the runtime object graph.
-    expect(parsed.setName).toBe("[stream]");
-    expect(parsed.addElement).toBe("[stream]");
-    expect(parsed.toggleEditing).toBe("[stream]");
+    expect(parsed.setName).toBe("[stream:setName]");
+    expect(parsed.addElement).toBe("[stream:addElement]");
+    expect(parsed.toggleEditing).toBe("[stream:toggleEditing]");
     expect(out).not.toContain("scheduler");
     expect(out).not.toContain("circular reference");
     expect(out.length).toBeLessThan(600);

--- a/packages/cli/test/wish.test.ts
+++ b/packages/cli/test/wish.test.ts
@@ -184,8 +184,8 @@ describe("cf wish headless read (resolveWish)", () => {
     expect(projected.elements).toEqual([{ title: "Note" }]);
     expect(projected.$UI).toEqual({ type: "vnode", name: "cf-screen" });
 
-    // The stream handle is replaced by a stable marker — no runtime graph.
-    expect(projected.setName).toBe(WISH_STREAM_MARKER);
+    // The stream handle is replaced by a key-tagged marker — no runtime graph.
+    expect(projected.setName).toBe("[stream:setName]");
 
     // The serialized output stays small and free of the runtime object graph.
     const json = safeStringify(projected);
@@ -195,12 +195,75 @@ describe("cf wish headless read (resolveWish)", () => {
     expect(json).not.toContain("runtime");
   });
 
+  it("strips handles nested in a shared DAG subtree on BOTH paths (CT-1844)", () => {
+    // A "diamond": one plain object referenced by two keys of the result, with a
+    // real stream handle nested inside it. A naive already-seen-return-raw dedup
+    // would project the shared subtree on the first path but return it RAW on
+    // the second — leaking the handle. The memo must project it on both.
+    const tx = runtime.edit();
+    const cell = runtime.getCell<
+      { shared: { label: string; setName: { $stream: boolean } } }
+    >(userIdentity.did(), "ct1844-diamond-fixture", undefined, tx);
+    cell.set({
+      shared: { label: "shared", setName: { $stream: true } },
+    });
+    const schema = {
+      type: "object",
+      properties: {
+        shared: {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            setName: { type: "object", asCell: ["stream"] },
+          },
+        },
+      },
+    } as const satisfies JSONSchema;
+    const shared = cell.asSchema(schema).get().shared;
+    if (!shared) throw new Error("fixture: shared subtree missing");
+    expect(isStream(shared.setName)).toBe(true);
+
+    // Alias the SAME object under two keys — this is the diamond.
+    const value = { left: shared, right: shared };
+    const projected = projectWishValue(value) as {
+      left: Record<string, unknown>;
+      right: Record<string, unknown>;
+    };
+
+    // Data survives on both branches...
+    expect(projected.left.label).toBe("shared");
+    expect(projected.right.label).toBe("shared");
+    // ...and the nested handle is stripped on BOTH (would leak on `right` under
+    // a raw already-seen dedup).
+    expect(projected.left.setName).toBe("[stream:setName]");
+    expect(projected.right.setName).toBe("[stream:setName]");
+
+    const json = safeStringify(projected);
+    expect(json).not.toContain("scheduler");
+    expect(json).not.toContain("runtime");
+  });
+
+  it("terminates on a genuine cycle without infinite recursion (CT-1844)", () => {
+    // A self-referential plain object (a real cycle, not a diamond) must not
+    // recurse forever; the in-progress sentinel breaks it with a marker.
+    const node: Record<string, unknown> = { name: "loop" };
+    node.self = node;
+
+    const projected = projectWishValue(node) as Record<string, unknown>;
+    expect(projected.name).toBe("loop");
+    expect(projected.self).toBe("[circular]");
+    // Serializes cleanly (no throw, no runaway).
+    expect(safeStringify(projected)).toContain("[circular]");
+  });
+
   it("projectWishValue passes scalar targets through unchanged (CT-1844)", () => {
     // #profileName and friends resolve to a bare scalar — untouched.
     expect(projectWishValue("Ada Lovelace")).toBe("Ada Lovelace");
     expect(projectWishValue(42)).toBe(42);
     expect(projectWishValue(true)).toBe(true);
     expect(projectWishValue(null)).toBe(null);
+    // A handle with no owning key falls back to the untagged base marker.
+    expect(projectWishValue(() => {})).toBe(WISH_STREAM_MARKER);
   });
 
   it("readWish connects through the injected manager and resolves", async () => {

--- a/packages/cli/test/wish.test.ts
+++ b/packages/cli/test/wish.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
+import { isStream, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { readWish, resolveWish } from "../lib/wish.ts";
+import {
+  projectWishValue,
+  readWish,
+  resolveWish,
+  WISH_STREAM_MARKER,
+} from "../lib/wish.ts";
+import { safeStringify } from "../lib/render.ts";
 
 // Exercises the headless wish read core (`resolveWish`) against an emulated
 // runtime — no live server. The full `readWish` (which adds a session-backed
@@ -128,6 +134,73 @@ describe("cf wish headless read (resolveWish)", () => {
     });
     expect(error).toBeUndefined();
     expect((result as { name?: string })?.name).toBe("Ada Lovelace");
+  });
+
+  it("projectWishValue strips stream handles but keeps profile data (CT-1844)", () => {
+    // Build a profile-shaped result carrying a REAL stream handle alongside its
+    // data fields, exactly as a materialized #profile object does.
+    const tx = runtime.edit();
+    const cell = runtime.getCell<{
+      name: string;
+      avatar: string;
+      bio: string;
+      isEditing: boolean;
+      elements: { title: string }[];
+      $UI: { type: string; name: string };
+      setName: { $stream: boolean };
+    }>(userIdentity.did(), "ct1844-projection-fixture", undefined, tx);
+    cell.set({
+      name: "Ada Lovelace",
+      avatar: "ada.png",
+      bio: "Mathematician & first programmer.",
+      isEditing: false,
+      elements: [{ title: "Note" }],
+      $UI: { type: "vnode", name: "cf-screen" },
+      setName: { $stream: true },
+    });
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        avatar: { type: "string" },
+        bio: { type: "string" },
+        isEditing: { type: "boolean" },
+        elements: { type: "array" },
+        $UI: { type: "object" },
+        setName: { type: "object", asCell: ["stream"] },
+      },
+    } as const satisfies JSONSchema;
+    const value = cell.asSchema(schema).get();
+    // Sanity: the raw value really does carry a live stream handle.
+    expect(isStream(value.setName)).toBe(true);
+
+    const projected = projectWishValue(value) as Record<string, unknown>;
+
+    // Data fields survive, including the nested `elements` array and $UI VNode.
+    expect(projected.name).toBe("Ada Lovelace");
+    expect(projected.avatar).toBe("ada.png");
+    expect(projected.bio).toBe("Mathematician & first programmer.");
+    expect(projected.isEditing).toBe(false);
+    expect(projected.elements).toEqual([{ title: "Note" }]);
+    expect(projected.$UI).toEqual({ type: "vnode", name: "cf-screen" });
+
+    // The stream handle is replaced by a stable marker — no runtime graph.
+    expect(projected.setName).toBe(WISH_STREAM_MARKER);
+
+    // The serialized output stays small and free of the runtime object graph.
+    const json = safeStringify(projected);
+    expect(json.length).toBeLessThan(2000);
+    expect(json).not.toContain("scheduler");
+    expect(json).not.toContain("circular reference");
+    expect(json).not.toContain("runtime");
+  });
+
+  it("projectWishValue passes scalar targets through unchanged (CT-1844)", () => {
+    // #profileName and friends resolve to a bare scalar — untouched.
+    expect(projectWishValue("Ada Lovelace")).toBe("Ada Lovelace");
+    expect(projectWishValue(42)).toBe(42);
+    expect(projectWishValue(true)).toBe(true);
+    expect(projectWishValue(null)).toBe(null);
   });
 
   it("readWish connects through the injected manager and resolves", async () => {


### PR DESCRIPTION
## What

`cf wish '#profile'` resolved correctly but printed ~58KB of JSON. The profile result **object** exposes the pattern's stream/handle keys (`addElement`, `addPiece`, `removeElement`, `setName`, `setAvatar`, `setBio`, `toggleEditing`) alongside its data keys (`$NAME`, `name`, `avatar`, `bio`, `elements`, `isEditing`, …). Those handles are live `Cell`/`Stream` objects, so JSON-serializing them dragged in the whole runtime object graph (scheduler, circular refs) — `addElement` alone was 28KB.

This projects the resolved value to plain, serializable data before output: every stream/cell/function-valued node is replaced with a stable `"[stream]"` marker; all genuine data (including the nested `elements` array and the `$UI` VNode tree) is kept intact.

## Why

The stated audience for this read path (CT-1834, #4513) is agents / scripts / offline profile caches. 58KB of runtime noise defeats that. Scalar targets (`#profileName`, `#profileAvatar`, `#profileBio`, `#profileSpace`) were already clean and are **unchanged** — a bare scalar passes straight through the projection.

## Mechanism

Grepped for a canonical "value → plain serializable" util first (anti-duplication). `convertCellsToLinks` exists but converts cells to *link refs* (different intent — it would still emit handle objects); `safeStringify` only guards circularity/depth. There is no existing "drop handles to plain data" helper, so this adds a small recursive `projectWishValue` in `lib/wish.ts` that keys off the runner's canonical `isCell`/`isStream` guards (exported from `@commonfabric/runner`) rather than hand-rolling structural detection. Applied in the CLI render path (`wishAction`) so only the object-target output shape changes.

## Before / after (live, a home space with a profile)

- `#profile`: **58560 → 1462 bytes**; data fields present (`name`, `bio`, `elements`, `$UI`, …), the 7 stream handles now render as `"[stream]"`.
- `#profileName` / `#profileBio`: unchanged (bare JSON scalar).

## Tests

`packages/cli/test/wish.test.ts`
- `projectWishValue strips stream handles but keeps profile data (CT-1844)` — builds a profile-shaped result carrying a **real** stream handle (via an `asCell: ["stream"]` schema), asserts data survives, the handle becomes `[stream]`, and the serialized output is small with no `scheduler`/`runtime`/`circular reference`.
- `projectWishValue passes scalar targets through unchanged (CT-1844)`.

`packages/cli/test/wish-command.test.ts`
- `projects an object result to plain data, dropping handle-valued keys (CT-1844)` — drives `wishAction` end-to-end through `render`, asserts data fields intact and handle keys marked.

All pre-existing scalar / zero-profile / `--allow-empty` tests pass unchanged. `deno fmt`/`lint`/`check` clean on cli.

Refs CT-1844 (follows CT-1834 / #4513).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes excessive JSON from `cf wish` object targets by projecting results to plain data and replacing stream/cell/function handles with markers like "[stream:setName]". Scalars pass through unchanged. Addresses CT-1844.

- **Bug Fixes**
  - Added `projectWishValue` to replace `Cell`/`Stream`/function nodes (via `isCell`/`isStream` from `@commonfabric/runner`) with key-tagged markers; memoizes projections so handles in shared subtrees are stripped on all paths and breaks real cycles as "[circular]".
  - Applied in `wishAction` so object results serialize to plain data; `#profile` drops from ~58KB to ~1.5KB while keeping fields like `name`, `bio`, `elements`, and `$UI`. Tests cover projection, key-tagged markers, DAG diamond, and cycle handling.

<sup>Written for commit 2252be1b7cf3b591724f2d306956e858c6420329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

