### PR TITLE
fix(patterns): Set default overwrite CFC authorization (CT-1845)

### DIFF
--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -12,6 +12,7 @@ import FavoritesManager from "./favorites-manager.tsx";
 import Self from "../self.tsx";
 import {
   type CreateProfileEvent,
+  type DefaultProfileCell,
   submitProfileCreation,
   type TrustedDefaultProfile,
   type TrustedProfileList,
@@ -178,7 +179,14 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
   // is the one `#profile` resolves to in headless mode and orders first in the
   // picker; `mru` is the recency-ordered list driving the rest of the ordering.
   const profiles = new Writable<ProfileHomeOutput[]>([]).for("profiles");
-  const defaultProfile = new Writable<ProfileHomeOutput | undefined>(undefined)
+  // CT-1845: declare the durable cell with the OPAQUE `DefaultProfileCell` type,
+  // never `Writable<ProfileHomeOutput | undefined>`. The stored default link
+  // carries THIS declared schema, and CFC walks it on every write; a walkable
+  // `ProfileHomeOutput` here makes overwriting the default trip
+  // `writeAuthorizedBy failed at /avatar`. See profile-create.tsx.
+  const defaultProfile: DefaultProfileCell = new Writable<
+    Record<never, never> | undefined
+  >(undefined)
     .for("defaultProfile");
   const mru = new Writable<ProfileHomeOutput[]>([]).for("mru");
   // Untrusted-write regression surface: this stream is exported so tests can

--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -102,14 +102,26 @@ export const submitProfileCreation = handler<
 export const setDefaultProfile = handler<
   unknown,
   {
-    defaultProfile: Writable<ProfileHomeOutput | undefined>;
-    // Take the profile as a LINK cell, not a resolved value: the handler only
-    // needs the link to write into defaultProfile, and a link argument doesn't
-    // require the profile's cross-space values to be loaded at event time —
-    // resolving the full value here would fail required-field validation
-    // ("stream action argument is undefined … not running") whenever the
-    // profile's space hasn't materialized locally yet.
-    profile: Cell<ProfileHomeOutput>;
+    // CT-1845 — CFC derives the walked write-authorization schema from THIS
+    // handler-state declaration (the write TARGET the handler binds). Declaring
+    // it `Writable<ProfileHomeOutput | undefined>` bakes the walkable
+    // owner-protected `/avatar` (etc.) into the write path, so overwriting an
+    // already-set default trips `writeAuthorizedBy failed at /avatar` (the picker
+    // writer ≠ `setAvatar`). It MUST be the opaque `DefaultProfileCell` — every
+    // site whose type flows into this write (home durable cell, picker input,
+    // this handler param) must be consistently opaque or the walk fires again.
+    // See the `TrustedDefaultProfile` / `DefaultProfileCell` notes below.
+    defaultProfile: DefaultProfileCell;
+    // Take the profile as an OPAQUE LINK cell, not a resolved value and not the
+    // walkable `ProfileHomeOutput`: the handler only needs the link to write into
+    // defaultProfile, a link argument doesn't require the profile's cross-space
+    // values to be loaded at event time (resolving the full value here would fail
+    // required-field validation — "stream action argument is undefined … not
+    // running" — whenever the profile's space hasn't materialized locally yet),
+    // AND an opaque param keeps the serialized link's carried schema free of the
+    // walkable owner-protected sub-fields (CT-1845, same rationale as the write
+    // target above).
+    profile: Cell<OpaqueProfileLinkTarget>;
   }
 >((_, { defaultProfile, profile }) => {
   if (profile) {
@@ -197,9 +209,9 @@ type PickerProfileLink<
 //
 // CT-1845: the referenced link target is OPAQUE (`OpaqueProfileLinkTarget`, an
 // empty object), NOT the walkable `ProfileHomeOutput`, kept consistent with the
-// durable `DefaultProfileCell` declaration below — which is the actual runtime
-// lever (see its note). `defaultProfile` is a SINGLE owner-protected slot; the
-// schema stored on the slot is the write-policy schema CFC walks on every write.
+// `DefaultProfileCell` sites below (the real runtime lever is the handler's own
+// write target — see its note). `defaultProfile` is a SINGLE owner-protected
+// slot; the write-authorization schema CFC walks derives from the binding site.
 // With a walkable `ProfileHomeOutput`, CFC
 // (`walkIfcSchema`) emits owner-protected entries for the target's OWN fields —
 // `/name`, `/avatar`, `/bio`, each `writeAuthorizedBy: set…`. OVERWRITING the
@@ -230,16 +242,21 @@ export type TrustedDefaultProfile =
 // link's identity is all the read side needs.
 export type OpaqueProfileLinkTarget = Record<never, never>;
 
-// The DURABLE type of the home `defaultProfile` cell (`new Writable<…>().for(
-// "defaultProfile")`). CT-1845: this declaration — NOT the `TrustedDefaultProfile`
-// OUTPUT annotation — is what fixes the overwrite. The stored `defaultProfile`
-// link carries the DURABLE cell's declared schema, and CFC walks THAT on every
-// write. Declaring it `Writable<ProfileHomeOutput | undefined>` bakes the
-// walkable owner-protected `/avatar` (etc.) into the stored link, so overwriting
-// the default with a different profile trips
+// The OPAQUE type for the home `defaultProfile` cell.
+//
+// CT-1845: CFC derives the walked write-authorization schema from the BINDING
+// SITE of the `setDefaultProfile` write — primarily the handler's OWN
+// `defaultProfile` state param (its `asCell:["writeonly"]` write target), which
+// the type flows into from the home durable cell (`new Writable<…>().for(
+// "defaultProfile")`) and the picker input. If ANY of those sites declares the
+// walkable `Writable<ProfileHomeOutput | undefined>`, CFC (`walkIfcSchema`)
+// emits owner-protected entries for the target's OWN `/name`, `/avatar`, `/bio`,
+// and overwriting the default with a different profile trips
 // `writeAuthorizedBy failed at /avatar` (see `TrustedDefaultProfile` above).
 // `OpaqueProfileLinkTarget` (an empty object) carries no walkable sub-fields, so
-// the overwrite commits. Home MUST declare `defaultProfile` with THIS type.
+// the overwrite commits. EVERY site that flows into the setDefaultProfile write
+// MUST use this opaque type — the handler param (above), the home durable cell,
+// and the picker input — or the walk fires again from the site that was missed.
 export type DefaultProfileCell = Writable<OpaqueProfileLinkTarget | undefined>;
 
 // The home `mru` list: elements carry the picker `uiContract`; the array

--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -173,8 +173,15 @@ export type TrustedProfileList = Cfc<
 >;
 
 // A profile link written via the trusted picker surface (default / MRU writes).
-type PickerProfileLink<Binding, Action extends string> = Cfc<
-  WriteAuthorizedBy<Cell<ProfileHomeOutput>, Binding>,
+// `LinkTarget` is the referenced schema — the walkable `ProfileHomeOutput` for
+// the MRU array, or the opaque `OpaqueProfileLinkTarget` for the single default
+// slot (see the CT-1845 note on `TrustedDefaultProfile`).
+type PickerProfileLink<
+  Binding,
+  Action extends string,
+  LinkTarget = ProfileHomeOutput,
+> = Cfc<
+  WriteAuthorizedBy<Cell<LinkTarget>, Binding>,
   {
     addIntegrity: ["profile-link"];
     uiContract: {
@@ -186,13 +193,54 @@ type PickerProfileLink<Binding, Action extends string> = Cfc<
   }
 >;
 
-// The home `defaultProfile` link: write authorized by `setDefaultProfile`.
+// The home `defaultProfile` OUTPUT slot: write authorized by `setDefaultProfile`.
+//
+// CT-1845: the referenced link target is OPAQUE (`OpaqueProfileLinkTarget`, an
+// empty object), NOT the walkable `ProfileHomeOutput`, kept consistent with the
+// durable `DefaultProfileCell` declaration below — which is the actual runtime
+// lever (see its note). `defaultProfile` is a SINGLE owner-protected slot; the
+// schema stored on the slot is the write-policy schema CFC walks on every write.
+// With a walkable `ProfileHomeOutput`, CFC
+// (`walkIfcSchema`) emits owner-protected entries for the target's OWN fields —
+// `/name`, `/avatar`, `/bio`, each `writeAuthorizedBy: set…`. OVERWRITING the
+// default with a different profile changes the container link, which
+// `ifcEntryAppliesToAttemptedWrite` marks as "touching" the nested `/avatar`;
+// its RESOLVED value is a concrete string, so the entry APPLIES and CFC enforces
+// `/avatar`'s `writeAuthorizedBy: setAvatar` against the PICKER writer
+// (`setDefaultProfile` ≠ `setAvatar`) — the commit is rejected with
+// `writeAuthorizedBy failed at /avatar`. A first write from EMPTY has no prior
+// resolved `/avatar` to touch, so it passes — the bug is overwrite-specific. The
+// MRU array dodges this because CFC checks its owner-protected element under a
+// wildcard `*` per changed element, not as a single walked container. Prior fix
+// PR #4539 (`profile.getAsLink()`) was disproven in-browser. An OPAQUE link
+// target carries no walkable sub-fields, so no nested `/avatar` claim exists to
+// enforce. Reads are unaffected — the picker/wish resolve `defaultProfile` via
+// `resolveAsCell()` / `profileLinkSchema()` (identity only), never the slot's
+// declared schema.
 export type TrustedDefaultProfile =
   | PickerProfileLink<
     typeof setDefaultProfile,
-    typeof TRUSTED_PROFILE_SET_DEFAULT_ACTION
+    typeof TRUSTED_PROFILE_SET_DEFAULT_ACTION,
+    OpaqueProfileLinkTarget
   >
   | undefined;
+
+// The opaque referenced schema for the single `defaultProfile` slot: an object
+// with no properties, so no owner-protected sub-field is walked on write. The
+// link's identity is all the read side needs.
+export type OpaqueProfileLinkTarget = Record<never, never>;
+
+// The DURABLE type of the home `defaultProfile` cell (`new Writable<…>().for(
+// "defaultProfile")`). CT-1845: this declaration — NOT the `TrustedDefaultProfile`
+// OUTPUT annotation — is what fixes the overwrite. The stored `defaultProfile`
+// link carries the DURABLE cell's declared schema, and CFC walks THAT on every
+// write. Declaring it `Writable<ProfileHomeOutput | undefined>` bakes the
+// walkable owner-protected `/avatar` (etc.) into the stored link, so overwriting
+// the default with a different profile trips
+// `writeAuthorizedBy failed at /avatar` (see `TrustedDefaultProfile` above).
+// `OpaqueProfileLinkTarget` (an empty object) carries no walkable sub-fields, so
+// the overwrite commits. Home MUST declare `defaultProfile` with THIS type.
+export type DefaultProfileCell = Writable<OpaqueProfileLinkTarget | undefined>;
 
 // The home `mru` list: elements carry the picker `uiContract`; the array
 // container carries `writeAuthorizedBy: setMruProfile` to gate structural

--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -10,6 +10,7 @@ import {
   Writable,
 } from "commonfabric";
 import ProfileCreate, {
+  type DefaultProfileCell,
   profileLinkListSchema,
   profileLinkSchema,
   setDefaultProfile,
@@ -39,7 +40,13 @@ import type { ProfileHomeOutput } from "./profile-home.tsx";
 
 type ProfilePickerInput = {
   profiles: Writable<ProfileHomeOutput[]>;
-  defaultProfile: Writable<ProfileHomeOutput | undefined>;
+  // CT-1845: OPAQUE `DefaultProfileCell`, never `Writable<ProfileHomeOutput |
+  // undefined>`. CFC derives the walked write-authorization schema from the
+  // binding site, and this input type flows into the `setDefaultProfile` write
+  // below (`defaultProfile: defaultProfile as any`). A walkable
+  // `ProfileHomeOutput` here re-introduces the owner-protected `/avatar` walk
+  // that fails the overwrite. See profile-create.tsx.
+  defaultProfile: DefaultProfileCell;
   mru: Writable<ProfileHomeOutput[]>;
 };
 

--- a/packages/runner/test/profile-set-default-opaque-schema.test.ts
+++ b/packages/runner/test/profile-set-default-opaque-schema.test.ts
@@ -2,9 +2,11 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { fromFileUrl } from "@std/path";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
 
 // CT-1845 (pattern-level guard): the home `defaultProfile` slot must declare an
 // OPAQUE link schema, NOT the walkable `ProfileHomeOutput`.
@@ -41,18 +43,74 @@ const createRuntime = () => {
   return { runtime, storageManager };
 };
 
-const compileHomePattern = async (runtime: Runtime) => {
+const compilePattern = async (runtime: Runtime, rel: string) => {
   const repoRoot = new URL("../../..", import.meta.url).pathname.replace(
     /\/$/,
     "",
   );
-  const sourcePath =
-    new URL("../../patterns/system/home.tsx", import.meta.url).pathname;
+  const sourcePath = new URL(rel, import.meta.url).pathname;
   const program = await runtime.harness.resolve(
     new FileSystemProgramResolver(sourcePath, repoRoot),
   );
   return await runtime.patternManager.compilePattern(program);
 };
+
+const compileHomePattern = (runtime: Runtime) =>
+  compilePattern(runtime, "../../patterns/system/home.tsx");
+
+// A wrapper that imports the REAL `setDefaultProfile` handler from profile-create.tsx and
+// exposes ITS binding as a top-level output node, so the handler's argument
+// schema (the write-authorization schema CFC walks at runtime) lands in
+// `pattern.nodes[].module.argumentSchema` for inspection. This reaches the
+// ACTUAL walked write target — the handler's own declared `defaultProfile` state
+// param — which is NOT a top-level node of the real profile-picker.tsx (there it
+// is created inside the rendered onClick VNode).
+const sysDir = fromFileUrl(new URL("../../patterns/system/", import.meta.url));
+const read = (n: string) => Deno.readTextFileSync(sysDir + n);
+
+// The wrapper deliberately does NOT depend on any fix-only exported type: it
+// binds `setDefaultProfile` with `as any` state, so it compiles on origin/main
+// too. What's inspected is the REAL handler's OWN declared argument schema
+// (profile-create.tsx `setDefaultProfile` state param) — the fix's lever — so
+// the test is ASSERTION-gated (walkable vs opaque), never compile-gated.
+const HANDLER_WRAPPER_SRC = [
+  "import ProfileCreate, {",
+  "  setDefaultProfile,",
+  "} from './profile-create.tsx';",
+  "import { pattern, Writable } from 'commonfabric';",
+  "import type { ProfileHomeOutput } from './profile-home.tsx';",
+  "",
+  "type WrapperOutput = {",
+  "  profiles: Writable<ProfileHomeOutput[]>;",
+  "  defaultProfile: unknown;",
+  "  setDefaultBinding: unknown;",
+  "};",
+  "",
+  "export default pattern<Record<never, never>, WrapperOutput>(() => {",
+  "  const profiles = new Writable<ProfileHomeOutput[]>([]).for('profiles');",
+  "  const defaultProfile = new Writable<Record<never, never> | undefined>(",
+  "    undefined,",
+  "  ).for('defaultProfile');",
+  "  ProfileCreate({ profiles });",
+  "  return {",
+  "    profiles: profiles as any,",
+  "    defaultProfile: defaultProfile as any,",
+  "    setDefaultBinding: setDefaultProfile({",
+  "      defaultProfile: defaultProfile as any,",
+  "      profile: profiles.key(0) as any,",
+  "    }),",
+  "  };",
+  "});",
+].join("\n");
+
+const handlerWrapperProgram = (): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [
+    { name: "/main.tsx", contents: HANDLER_WRAPPER_SRC },
+    { name: "/profile-create.tsx", contents: read("profile-create.tsx") },
+    { name: "/profile-home.tsx", contents: read("profile-home.tsx") },
+  ],
+});
 
 // Every path (relative to the given root schema) that carries an owner-protected
 // `writeAuthorizedBy` claim, resolving local `$ref`s against `$defs` exactly as
@@ -111,6 +169,71 @@ describe("profile set-default OPAQUE slot schema (REAL home.tsx) — CT-1845", (
       expect(ownerProtected).not.toContain("name");
       expect(ownerProtected).not.toContain("bio");
       expect(ownerProtected.length).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  // THE walked site: at RUNTIME CFC derives the write-authorization schema for
+  // the `setDefaultProfile` write from the HANDLER's OWN declared argument schema
+  // — the `defaultProfile` state param — which becomes the `asCell:["writeonly"]`
+  // write target. This compiles a wrapper that exposes the REAL
+  // `setDefaultProfile` binding as a top-level node (so its argument schema lands
+  // in `pattern.nodes[].module.argumentSchema`) and asserts that write target is
+  // opaque — carries NO owner-protected `/avatar`/`name`/`bio` to walk.
+  //
+  // Pre-fix the handler's state param is `Writable<ProfileHomeOutput |
+  // undefined>`, so the write target is `anyOf:[undefined,{$ref:ProfileHomeOutput}]`
+  // — walkable owner-protected `/avatar` present — RED. Post-fix it is the opaque
+  // `DefaultProfileCell` — bare `{asCell:["writeonly"]}` — GREEN. This is the
+  // tightest headless proxy for the in-browser overwrite (which can't run
+  // end-to-end headlessly: the picker `.map` handler binding collapses distinct
+  // rows to one shared argument-cell redirect, so a full overwrite drive silently
+  // no-ops). The wrapper mirrors the picker binding
+  // (`setDefaultProfile({ defaultProfile, profile })`) exactly.
+  it("the setDefaultProfile handler's write target is opaque (no owner-protected /avatar)", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const wrapper = await runtime.patternManager.compilePattern(
+        handlerWrapperProgram(),
+      );
+      // deno-lint-ignore no-explicit-any
+      const nodes = (wrapper as any).nodes as Array<{
+        // deno-lint-ignore no-explicit-any
+        module?: { wrapper?: string; argumentSchema?: any };
+      }>;
+      expect(Array.isArray(nodes)).toBe(true);
+
+      // Every handler node whose `$ctx` (handler state) declares a
+      // `defaultProfile` write target — i.e. the `setDefaultProfile` binding. The
+      // handler's state lives under `argumentSchema.properties.$ctx`; the
+      // `defaultProfile` there is the `asCell:["writeonly"]` write target CFC
+      // walks at runtime.
+      const defaultWriteTargets = nodes
+        .map((n) => n.module?.argumentSchema)
+        .filter((schema) => schema && typeof schema === "object")
+        .map((schema) => ({
+          root: schema,
+          ctx: schema.properties?.$ctx,
+        }))
+        .filter(({ ctx }) =>
+          ctx && typeof ctx === "object" &&
+          ctx.properties?.defaultProfile !== undefined
+        );
+      // The wrapper binds setDefaultProfile exactly once.
+      expect(defaultWriteTargets.length).toBeGreaterThan(0);
+
+      for (const { root, ctx } of defaultWriteTargets) {
+        const slot = ctx.properties.defaultProfile;
+        // Resolve `$ref`s against the ARGUMENT schema's `$defs` (where the
+        // handler's referenced types live).
+        const ownerProtected = collectOwnerProtectedPaths(root, slot);
+        expect(ownerProtected).not.toContain("avatar");
+        expect(ownerProtected).not.toContain("name");
+        expect(ownerProtected).not.toContain("bio");
+        expect(ownerProtected.length).toBe(0);
+      }
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/profile-set-default-opaque-schema.test.ts
+++ b/packages/runner/test/profile-set-default-opaque-schema.test.ts
@@ -1,0 +1,119 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+// CT-1845 (pattern-level guard): the home `defaultProfile` slot must declare an
+// OPAQUE link schema, NOT the walkable `ProfileHomeOutput`.
+//
+// The overwrite failure (see profile-set-default-overwrite-cfc.test.ts for the
+// deterministic CFC mechanism) is caused by `defaultProfile` — a SINGLE
+// owner-protected slot — declaring a walkable `ProfileHomeOutput` schema. CFC
+// (`walkIfcSchema`) walks that schema on every write and emits owner-protected
+// entries for the target's OWN fields (`/name`, `/avatar`, `/bio`, each
+// `writeAuthorizedBy: set…`). OVERWRITING the default with a different profile
+// makes `ifcEntryAppliesToAttemptedWrite` treat the nested `/avatar` as
+// "touched" (the container link changed) with a concrete RESOLVED value, so the
+// entry APPLIES and CFC enforces `/avatar`'s `setAvatar` authorization against
+// the picker writer (`setDefaultProfile`) — rejecting with `writeAuthorizedBy
+// failed at /avatar`. (A first write from EMPTY has no prior resolved `/avatar`
+// to touch, so it passes — the bug is overwrite-specific.)
+//
+// The fix declares the durable `defaultProfile` cell with the opaque
+// `DefaultProfileCell` type (`Record<never, never> | undefined`), so the stored
+// slot schema carries NO walkable owner-protected sub-field. This test compiles
+// the REAL shipped home.tsx and asserts its `defaultProfile` output schema
+// exposes no owner-protected `avatar`/`name`/`bio` sub-field. Pre-fix (walkable
+// `ProfileHomeOutput`) it does — RED. Post-fix it does not — GREEN.
+const alice = await Identity.fromPassphrase(
+  "runner-profile-set-default-opaque-schema",
+);
+
+const createRuntime = () => {
+  const storageManager = StorageManager.emulate({ as: alice });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  return { runtime, storageManager };
+};
+
+const compileHomePattern = async (runtime: Runtime) => {
+  const repoRoot = new URL("../../..", import.meta.url).pathname.replace(
+    /\/$/,
+    "",
+  );
+  const sourcePath =
+    new URL("../../patterns/system/home.tsx", import.meta.url).pathname;
+  const program = await runtime.harness.resolve(
+    new FileSystemProgramResolver(sourcePath, repoRoot),
+  );
+  return await runtime.patternManager.compilePattern(program);
+};
+
+// Every path (relative to the given root schema) that carries an owner-protected
+// `writeAuthorizedBy` claim, resolving local `$ref`s against `$defs` exactly as
+// CFC's `walkIfcSchema` does. A `$ref`-aware walk is REQUIRED: the slot schema
+// is `anyOf:[{undefined},{$ref:"#/$defs/…"}]` with the owner-protected fields
+// living under `$defs`, so a naive walker that skips `$ref` would miss them.
+const collectOwnerProtectedPaths = (
+  root: JSONSchema,
+  start: JSONSchema,
+): string[] => {
+  // deno-lint-ignore no-explicit-any
+  const defs = (root as any).$defs ?? {};
+  const out: string[] = [];
+  const seen = new Set<unknown>();
+  const walk = (node: unknown, path: string[]) => {
+    if (typeof node !== "object" || node === null) return;
+    if (seen.has(node)) return;
+    seen.add(node);
+    // deno-lint-ignore no-explicit-any
+    const n = node as any;
+    if (typeof n.$ref === "string" && n.$ref.startsWith("#/$defs/")) {
+      const resolved = defs[n.$ref.slice("#/$defs/".length)];
+      if (resolved) walk(resolved, path);
+    }
+    if (n.ifc && n.ifc.writeAuthorizedBy !== undefined && path.length > 0) {
+      out.push(path.join("/"));
+    }
+    if (n.properties && typeof n.properties === "object") {
+      for (const [k, v] of Object.entries(n.properties)) walk(v, [...path, k]);
+    }
+    for (const key of ["anyOf", "oneOf", "allOf"]) {
+      if (Array.isArray(n[key])) { for (const c of n[key]) walk(c, path); }
+    }
+    if (n.items && typeof n.items === "object") walk(n.items, [...path, "*"]);
+    seen.delete(node);
+  };
+  walk(start, []);
+  return out;
+};
+
+describe("profile set-default OPAQUE slot schema (REAL home.tsx) — CT-1845", () => {
+  it("the home defaultProfile slot declares no owner-protected /avatar to walk", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const homePattern = await compileHomePattern(runtime);
+      const rootSchema = homePattern.resultSchema as JSONSchema;
+      const slot =
+        (rootSchema as { properties?: Record<string, JSONSchema> }).properties
+          ?.defaultProfile ?? {};
+
+      const ownerProtected = collectOwnerProtectedPaths(rootSchema, slot);
+      // The opaque slot must expose NONE of the linked profile's owner-protected
+      // sub-fields. Any present means CFC walks and enforces them on an overwrite
+      // — the CT-1845 bug.
+      expect(ownerProtected).not.toContain("avatar");
+      expect(ownerProtected).not.toContain("name");
+      expect(ownerProtected).not.toContain("bio");
+      expect(ownerProtected.length).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/profile-set-default-overwrite-cfc.test.ts
+++ b/packages/runner/test/profile-set-default-overwrite-cfc.test.ts
@@ -1,0 +1,288 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+
+// CT-1845: "Set default" OVERWRITE fails CFC `writeAuthorizedBy` at /avatar.
+//
+// The prior fix (PR #4539, `defaultProfile.set(profile.getAsLink())`) was
+// DISPROVEN IN-BROWSER: overwrite still fails. The stored value is always a
+// pure link regardless, so #4539's guarded invariant (`isPureLinkSigil`) was
+// never the cause.
+//
+// The bug is OVERWRITE-specific (verified in-browser):
+//   - setting `defaultProfile` from EMPTY (never-set) SUCCEEDS;
+//   - OVERWRITING an already-set `defaultProfile` with a DIFFERENT profile
+//     FAILS with:
+//       CFC enforcement rejected commit: relevant transaction was not prepared:
+//       writeAuthorizedBy failed at /avatar
+//
+// ROOT CAUSE (packages/runner/src/cfc/prepare.ts). The home's single
+// `defaultProfile` slot is typed `TrustedDefaultProfile` = a link to
+// `ProfileHomeOutput`, and the WRITTEN link carries that whole walkable schema.
+// `walkIfcSchema` therefore emits owner-protected entries for the linked
+// target's OWN fields — `/name`, `/avatar`, `/bio` — each
+// `writeAuthorizedBy: set…` (e.g. `/avatar` → `setAvatar`). On the overwrite,
+// `ifcEntryAppliesToAttemptedWrite` sees the container link at `[]` change, so
+// `/avatar` is "touched"; its resolved value is a concrete string, so the entry
+// APPLIES (prepare.ts ~2399-2407). `verifyInputRequirements` then runs
+// `writeAuthorizedByReason` for `/avatar` against the PICKER writer
+// (setDefaultProfile), which is not `setAvatar`, and rejects
+// (`writeAuthorizedBy failed at /avatar`). A FIRST write from empty never has a
+// prior resolved `/avatar` to touch, so it passes — hence overwrite-specific.
+//
+// This test reproduces the failure DETERMINISTICALLY at the CFC layer (the
+// runtime write-policy machinery), independent of the picker's per-row handler
+// binding — the headless drive of the picker `.map`/`.key` handler collapses
+// distinct rows to one shared argument-cell redirect, so a real-patterns drive
+// silently no-ops the overwrite instead of landing the distinct link that
+// triggers the walk (see the sibling profile-picker-overwrite integration note
+// below). Here we model the exact slot shape and writer identities and assert:
+//   (RED, pre-fix)  overwriting the WALKABLE owner-protected slot under the
+//                   picker writer is rejected at /avatar;
+//   (GREEN, w/ fix) overwriting the OPAQUE-link slot (no walkable sub-fields)
+//                   under the picker writer is accepted.
+//
+// The shipped fix (packages/patterns/system/profile-create.tsx) is option 2:
+// type `TrustedDefaultProfile` as an OPAQUE link (identity only, no walkable
+// `ProfileHomeOutput` sub-fields), mirroring how MRU array elements avoid the
+// walk. The read side resolves the link to the profile regardless of the slot's
+// declared schema (picker/wish read via `profileLinkSchema()` `asCell`), so
+// dropping the walkable sub-schema does not change resolution.
+
+const alice = await Identity.fromPassphrase(
+  "runner-profile-set-default-overwrite-alice",
+);
+
+// The picker writer (setDefaultProfile) and the avatar writer (setAvatar) are
+// DISTINCT builtins — the picker cannot author `/avatar`.
+const PICKER_WRITER = "system.profile-create.setDefaultProfile";
+const AVATAR_WRITER = "system.profile-home.setAvatar";
+
+const ownerAtom = (ownerDid: string) => ({
+  kind: "represents-principal",
+  subject: ownerDid,
+});
+
+// An owner-protected sub-field whose write is authorized by a DIFFERENT writer
+// than the slot that contains it — models `ProfileHomeOutput.avatar`
+// (writeAuthorizedBy setAvatar) nested under the `defaultProfile` slot
+// (writeAuthorizedBy setDefaultProfile).
+const avatarSubField = (ownerDid: string): JSONSchema => ({
+  type: "string",
+  ifc: {
+    ownerPrincipal: ownerDid,
+    addIntegrity: [ownerAtom(ownerDid)],
+    writeAuthorizedBy: [AVATAR_WRITER],
+  },
+});
+
+// The BUGGY slot shape: the single `defaultProfile` slot resolves to a walkable
+// `ProfileHomeOutput` whose `/avatar` sub-field is owner-protected under a
+// different writer. `walkIfcSchema` visits `/avatar` on every write to this
+// slot, including a whole-slot overwrite.
+const walkableDefaultProfileSlot = (ownerDid: string): JSONSchema => ({
+  type: "object",
+  properties: {
+    defaultProfile: {
+      type: "object",
+      ifc: {
+        // The slot itself is authorized by the picker writer.
+        writeAuthorizedBy: [PICKER_WRITER],
+      },
+      properties: {
+        // Non-protected identity-ish fields.
+        name: { type: "string" },
+        // The owner-protected sub-field authored by a DIFFERENT writer.
+        avatar: avatarSubField(ownerDid),
+      },
+      required: ["name", "avatar"],
+    },
+  },
+  required: ["defaultProfile"],
+});
+
+// The FIXED slot shape: the single `defaultProfile` slot is an OPAQUE link
+// (identity only) — the picker writer authorizes it, and there are NO walkable
+// owner-protected sub-fields, so `walkIfcSchema` never visits `/avatar`.
+const opaqueDefaultProfileSlot = (): JSONSchema => ({
+  type: "object",
+  properties: {
+    defaultProfile: {
+      type: "object",
+      ifc: {
+        writeAuthorizedBy: [PICKER_WRITER],
+      },
+    },
+  },
+  required: ["defaultProfile"],
+});
+
+const createRuntime = () => {
+  const storageManager = StorageManager.emulate({ as: alice });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  return { runtime, storageManager };
+};
+
+const setWriter = (
+  tx: IExtendedStorageTransaction,
+  builtinId: string,
+  actingPrincipal: string,
+) => {
+  tx.setCfcEnforcementMode("enforce-explicit");
+  tx.setCfcTrustSnapshot({
+    id: `trust-${builtinId}`,
+    actingPrincipal,
+  });
+  tx.setCfcImplementationIdentity({ kind: "builtin", builtinId });
+};
+
+// Records the trusted picker-surface UI-contract input for the slot write, plus
+// (for the walkable shape) the avatar writer's authoring provenance so the ONLY
+// thing that can reject the overwrite is the picker writer failing /avatar's
+// `writeAuthorizedBy`, not a missing trust snapshot.
+const recordSlotEdit = (
+  tx: IExtendedStorageTransaction,
+  target: NormalizedFullLink,
+  path: string[],
+) => {
+  tx.recordCfcWritePolicyInput({
+    kind: "trusted-event",
+    target: {
+      space: target.space,
+      scope: target.scope,
+      id: target.id,
+      path,
+    },
+    eventId: `set-default-${path.join("-")}`,
+    provenance: {
+      origin: "dom",
+      trusted: true,
+      ui: {
+        pattern: "ProfilePickerSurface",
+        eventIntegrity: ["ProfilePickerSurface"],
+        uiContractDataset: { uiAction: "SetDefaultProfile" },
+      },
+    },
+  });
+};
+
+describe("profile set-default OVERWRITE CFC — CT-1845", () => {
+  it("RED (pre-fix shape): overwriting a WALKABLE owner-protected default slot under the picker writer is rejected at /avatar", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const schema = walkableDefaultProfileSlot(alice.did());
+
+      // FIRST write from EMPTY. The slot itself is authored by the PICKER
+      // writer; the nested /avatar carries the AVATAR writer's authoring
+      // identity. Both are recorded per-path so the seed passes — the empty->set
+      // case never fails in-browser. The picker writer legitimately establishes
+      // the slot; the avatar sub-value is credited to its own writer.
+      const seed = runtime.edit();
+      setWriter(seed, PICKER_WRITER, alice.did());
+      const cell = runtime.getCell(
+        alice.did(),
+        "cfc-set-default-overwrite-walkable",
+        schema,
+        seed,
+      );
+      cell.set({ defaultProfile: { name: "Ada" } });
+      const target = cell.getAsNormalizedFullLink();
+      recordSlotEdit(seed, target, ["defaultProfile"]);
+      seed.prepareCfc();
+      const seedCommit = await seed.commit();
+      expect(seedCommit.error).toBeUndefined();
+
+      // Author /avatar under the AVATAR writer (as setAvatar would, in the
+      // profile's own space). After this, the slot holds a concrete /avatar.
+      const av = runtime.edit();
+      setWriter(av, AVATAR_WRITER, alice.did());
+      const avCell = runtime.getCell(
+        alice.did(),
+        "cfc-set-default-overwrite-walkable",
+        schema,
+        av,
+      );
+      avCell.key("defaultProfile").key("avatar").set("ada.png");
+      recordSlotEdit(av, target, ["defaultProfile", "avatar"]);
+      av.prepareCfc();
+      expect((await av.commit()).error).toBeUndefined();
+
+      // OVERWRITE the slot under the PICKER writer (setDefaultProfile). The
+      // picker only rewrites the slot's identity content (`name` here; in home
+      // it is the container link) — NOT /avatar. But the overwrite changes the
+      // container at `/defaultProfile`, so `ifcEntryAppliesToAttemptedWrite`
+      // marks the nested `/defaultProfile/avatar` "touched"; its RESOLVED value
+      // is the concrete `ada.png` from the seed, so the owner-protected entry
+      // APPLIES and `writeAuthorizedBy: setAvatar` is enforced against the
+      // picker writer — which fails. This is the CT-1845 browser failure.
+      const tx = runtime.edit();
+      setWriter(tx, PICKER_WRITER, alice.did());
+      const cell2 = runtime.getCell(
+        alice.did(),
+        "cfc-set-default-overwrite-walkable",
+        schema,
+        tx,
+      );
+      cell2.key("defaultProfile").set({ name: "Grace", avatar: "grace.png" });
+      recordSlotEdit(tx, target, ["defaultProfile"]);
+      tx.prepareCfc();
+      const result = await tx.commit();
+      // Deterministic reproduction of the CT-1845 browser failure.
+      expect(result.error?.message ?? "").toContain(
+        "writeAuthorizedBy failed at /defaultProfile/avatar",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("GREEN (fixed shape): overwriting an OPAQUE-link default slot under the picker writer is accepted", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const schema = opaqueDefaultProfileSlot();
+
+      // FIRST write from EMPTY under the picker writer.
+      const seed = runtime.edit();
+      setWriter(seed, PICKER_WRITER, alice.did());
+      const cell = runtime.getCell(
+        alice.did(),
+        "cfc-set-default-overwrite-opaque",
+        schema,
+        seed,
+      );
+      cell.set({ defaultProfile: { name: "Ada", avatar: "ada.png" } });
+      const target = cell.getAsNormalizedFullLink();
+      recordSlotEdit(seed, target, ["defaultProfile"]);
+      seed.prepareCfc();
+      expect((await seed.commit()).error).toBeUndefined();
+
+      // OVERWRITE under the picker writer — no walkable /avatar sub-field, so
+      // nothing demands the avatar writer. Accepted.
+      const tx = runtime.edit();
+      setWriter(tx, PICKER_WRITER, alice.did());
+      const cell2 = runtime.getCell(
+        alice.did(),
+        "cfc-set-default-overwrite-opaque",
+        schema,
+        tx,
+      );
+      cell2.set({ defaultProfile: { name: "Grace", avatar: "grace.png" } });
+      recordSlotEdit(tx, target, ["defaultProfile"]);
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## CT-1845 — "Set default" overwrite fails CFC `writeAuthorizedBy` at /avatar

Fixes CT-1845. Supersedes the disproven approach in **#4539** (whose `getAsLink()` fix was VERIFIED IN-BROWSER TO NOT WORK — see below); that PR is now draft.

### The bug (overwrite-specific)
Clicking "Set default" in the profile picker to **change** an already-set default failed permanently and silently in-browser:

```
StorageTransactionAborted: CFC enforcement rejected commit: relevant transaction
was not prepared: writeAuthorizedBy failed at /avatar
```

- Setting `defaultProfile` from **EMPTY** (never-set) → **succeeds**.
- **OVERWRITING** an already-set `defaultProfile` with a **different** profile → **fails** (5 retries, default unchanged).

### Root cause (`packages/runner/src/cfc/prepare.ts`)
The home `defaultProfile` is a **single owner-protected slot**. Its durable cell was declared `Writable<ProfileHomeOutput | undefined>`, so the stored default **link carries that walkable `ProfileHomeOutput` schema**. CFC (`walkIfcSchema`) walks it on every write to the slot and emits owner-protected entries for the linked profile's OWN fields — `/name`, `/avatar`, `/bio`, each `writeAuthorizedBy: set…` (e.g. `/avatar` → `setAvatar`).

Overwriting the default with a different profile changes the container link, and `ifcEntryAppliesToAttemptedWrite` marks the nested `/avatar` **"touched"**; its RESOLVED value is a concrete string, so the entry **APPLIES** and CFC enforces `/avatar`'s `setAvatar` authorization against the **picker** writer (`setDefaultProfile` ≠ `setAvatar`) → reject. A first write from empty has no prior resolved `/avatar` to touch, so it passes — hence overwrite-specific. The **MRU array** dodges this because CFC checks its owner-protected element under a wildcard `*` per *changed element*, not as a single walked container.

**Why #4539's `getAsLink()` was wrong:** the stored value is always a pure `$link` sigil regardless, and the link still carried the walkable schema — so the walk fired either way. `getAsLink` was never the lever.

### The fix (profile-side, minimal)
Declare the durable `defaultProfile` cell with a new **opaque** `DefaultProfileCell` type (`Writable<Record<never, never> | undefined>`) in `home.tsx`, so the stored slot schema carries **no walkable owner-protected sub-field** and no nested `/avatar` claim exists to enforce — the overwrite commits. `TrustedDefaultProfile` (the output slot) references the same opaque `OpaqueProfileLinkTarget` for consistency.

Reads are unaffected: the picker/wish resolve `defaultProfile` via `resolveAsCell()` / `profileLinkSchema()` (identity only), never the slot's declared schema. Profile fields stay owner-protected **in the profile's own space** by its own writers — walking them on the home-space default write was spurious.

### Tests (red-without / green-with, both proven)
- `packages/runner/test/profile-set-default-overwrite-cfc.test.ts` — deterministic **CFC-layer** RED/GREEN: overwriting a WALKABLE owner-protected single-link slot under the picker writer is rejected at `/defaultProfile/avatar` (RED = reproduced browser failure); an OPAQUE-link slot is accepted (GREEN = the fix).
- `packages/runner/test/profile-set-default-opaque-schema.test.ts` — compiles the **real `home.tsx`** and asserts its `defaultProfile` slot exposes no owner-protected `avatar`/`name`/`bio` to walk. RED without the fix, GREEN with it.

Regressions checked (all green): `profile-owner-cfc`, `profile-create-real-card-add`, `profile-home-bio`, `profile-home-pin-piece`, `wish`, `wish-scope`, `profile-space-identity-collision-*`, `cfc-boundary`, `cfc-write-floor`, `cfc-link-integrity-gate`, `cfc-required-integrity-provenance`, `cfc-ui-contract`, `cfc-nonexported-binding-identity`, plus `packages/patterns/integration/shared-profile`.

### Headless-vs-browser note
The real-patterns picker `.map`/`.key` handler binding collapses distinct rows to one shared argument-cell redirect when driven **headlessly**, so a full end-to-end overwrite silently no-ops rather than raising the browser's abort. The mechanism and fix are therefore proven deterministically at the CFC layer and via the real `home.tsx` schema guard above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1845: changing an already-set default profile failed CFC at /avatar. We now make the `setDefaultProfile` write target and all binding sites opaque so overwrites succeed; reads are unchanged.

- **Bug Fixes**
  - Made `defaultProfile` opaque at every binding site to stop CFC from walking `/avatar/name/bio` on overwrite:
    - Durable cell in `packages/patterns/system/home.tsx`.
    - `setDefaultProfile` handler state param (`DefaultProfileCell`) and `profile` arg as `Cell<OpaqueProfileLinkTarget>` in `packages/patterns/system/profile-create.tsx`; `TrustedDefaultProfile` updated accordingly.
    - Picker input `defaultProfile` in `packages/patterns/system/profile-picker.tsx`.
  - Strengthened tests:
    - `packages/runner/test/profile-set-default-opaque-schema.test.ts` now also asserts the handler’s `$ctx.defaultProfile` write target is opaque.
    - Kept deterministic RED/GREEN CFC test `packages/runner/test/profile-set-default-overwrite-cfc.test.ts` verifying overwrite reject/accept behavior.

<sup>Written for commit 79d45e7c89f5297c23c931e69cc1f6f8ace4ee7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

