### PR TITLE
feat(cfc): authored observation classes + sqlite null-origin narrowing (Epic C, stage C5)

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1658,6 +1658,10 @@ export type JSONSchemaObj = {
     readonly exactCopyOf?: readonly string[];
     readonly projection?: readonly string[];
     readonly collection?: readonly string[];
+    // Observation class of the declared label (Epic C, C5): which read
+    // observations consume it. Absent or invalid = covering (consumed by
+    // every content read class — over-taint, fail-safe).
+    readonly observes?: "value" | "shape" | "enumerate" | "followRef";
     readonly uiContract?: {
       readonly helper?: "UiAction" | "UiPromptSlot" | "UiDisclosure";
       readonly action?: string;

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -253,7 +253,9 @@ type LabelTables =
  * and it returns fresh arrays (no frozen-proxy aliasing). Returns undefined when
  * the db declares no confidentiality/integrity at all.
  */
-function deriveNullOriginIfc(tables: LabelTables): IFCLabel | undefined {
+function deriveNullOriginIfc(
+  tables: LabelTables,
+): (IFCLabel & { observes?: "value" }) | undefined {
   let merged: IFCLabel = {};
   for (const table of Object.values(tables ?? {})) {
     for (const col of Object.values(table?.properties ?? {})) {
@@ -267,8 +269,19 @@ function deriveNullOriginIfc(tables: LabelTables): IFCLabel | undefined {
   // evidence. Unioning integrity would let it falsely claim an atom held by a
   // single column (§8.17.1: class-aware meet, never union; propagation classes
   // pending, so conservatively empty). [CT-1668]
+  //
+  // C5 (observation classes): the merge is declared `observes:"value"` — an
+  // expression/aggregate computed FROM column values labels the result
+  // column's CONTENT channel. Shape/enumerate consumers of the result rows
+  // (length, membership — a COUNT consumer counting result rows) no longer
+  // inherit the whole-schema content union; the declared entry the result
+  // schema mints carries the class through (prepare.ts
+  // `declaredObservesClass`). Row membership itself stays governed by the
+  // per-row rule machinery (row-label-read.ts), not by column content
+  // labels. Class-unaware readers treat the entry as covering — the exact
+  // pre-C5 behavior.
   return merged.confidentiality?.length
-    ? { confidentiality: merged.confidentiality }
+    ? { confidentiality: merged.confidentiality, observes: "value" }
     : undefined;
 }
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -63,6 +63,7 @@ import {
   type IFCLabel,
   type ImplementationIdentity,
   type LabelMapEntry,
+  type LabelObservationClass,
   type WritePolicyInput,
 } from "./types.ts";
 import {
@@ -1718,6 +1719,23 @@ const storedSchemaClaimsForLinkWrites = (
       : mergeCfcSchemaEnvelopes(result, envelope);
   }
   return result ?? {};
+};
+
+// The consumption class an authored schema declares for its ifc label (C5).
+// Only the four class values count; anything else (including absence) is
+// covering — the over-taint direction, so a typo'd class can only widen
+// consumption, never narrow it (fail-safe).
+const declaredObservesClass = (
+  schema: JSONSchema,
+): LabelObservationClass | undefined => {
+  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+    return undefined;
+  }
+  const observes = (schema.ifc as { observes?: unknown }).observes;
+  return observes === "value" || observes === "shape" ||
+      observes === "enumerate" || observes === "followRef"
+    ? observes
+    : undefined;
 };
 
 const unsupportedTrustSensitiveReason = (
@@ -3855,11 +3873,18 @@ export const prepareBoundaryCommit = (
               confidentiality: mergeLabelValues(derived.confidentiality, prior),
             }
             : derived;
+          // C5: an authored `ifc.observes` classes the declared entry (the
+          // sqlite null-origin merge declares `observes:"value"` this way).
+          // Anything but the four class values — including the absent
+          // default — mints a covering entry: over-taint, fail-safe, and
+          // wire-identical for pre-C readers.
+          const observes = declaredObservesClass(entry.schema);
           return hasLabelValues(label) || hasPersistedPolicyClaim(entry.schema)
             ? [{
               path: entry.path,
               label,
               origin: "declared" as const,
+              ...(observes !== undefined ? { observes } : {}),
             }]
             : [];
         });

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1728,10 +1728,9 @@ const storedSchemaClaimsForLinkWrites = (
 const declaredObservesClass = (
   schema: JSONSchema,
 ): LabelObservationClass | undefined => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
-    return undefined;
-  }
-  const observes = (schema.ifc as { observes?: unknown }).observes;
+  const observes = isRecord(schema) && isRecord(schema.ifc)
+    ? (schema.ifc as { observes?: unknown }).observes
+    : undefined;
   return observes === "value" || observes === "shape" ||
       observes === "enumerate" || observes === "followRef"
     ? observes

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -244,6 +244,16 @@ const mergeIfc = (
       path,
     );
   }
+  // `observes` (C5) is a scalar consumption class, not a set-like claim:
+  // agreement keeps the class through the merge; any disagreement —
+  // including one covering side — merges to covering, the widest
+  // consumption (over-taint, fail-safe).
+  if (
+    typeof existingIfc.observes === "string" &&
+    existingIfc.observes === candidateIfc.observes
+  ) {
+    merged.observes = existingIfc.observes;
+  }
   return merged as JSONSchemaObj["ifc"];
 };
 

--- a/packages/runner/test/cfc-declared-observes.test.ts
+++ b/packages/runner/test/cfc-declared-observes.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { labelResultSchema } from "../src/builtins/sqlite-builtins.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-declared-observes");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// Epic C stage C5 (docs/specs/cfc-observation-classes.md §8): an authored
+// `ifc.observes` classes the declared entry, and the sqlite null-origin
+// merge uses it to declare its conservative whole-schema union as
+// `observes:"value"` — content-channel only. Shape/enumerate consumers of a
+// query's result rows (length, membership — the count consumer) no longer
+// inherit the union; class-unaware readers still treat the entry as
+// covering (the exact pre-C5 behavior — over-taint, fail-safe).
+describe("CFC declared observation classes (C5)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const uri = (id: string) => id as `${string}:${string}`;
+
+  // The sqlite seam, unit level: a null-origin projection declares the
+  // whole-schema confidentiality union as a VALUE-class label; a resolved
+  // column passes its authored ifc through verbatim.
+  it('labelResultSchema declares null-origin columns as observes:"value"', () => {
+    const tables = {
+      emails: {
+        properties: {
+          body: { ifc: { confidentiality: ["mail-secret"] } },
+          subject: { ifc: { confidentiality: ["subject-secret"] } },
+        },
+      },
+    };
+    const { schema, error } = labelResultSchema(
+      [
+        { output: "n", table: null, column: null },
+        { output: "body", table: "emails", column: "body" },
+      ],
+      tables,
+    );
+    expect(error).toBeUndefined();
+    const props = (schema as {
+      properties: {
+        result: {
+          items: {
+            properties: Record<string, { ifc: Record<string, unknown> }>;
+          };
+        };
+      };
+    }).properties.result.items.properties;
+    expect(props.n.ifc.observes).toBe("value");
+    expect([...(props.n.ifc.confidentiality as string[])].sort()).toEqual([
+      "mail-secret",
+      "subject-secret",
+    ]);
+    // Resolved origin: authored ifc verbatim (covering unless the author
+    // classed it).
+    expect(props.body.ifc.observes).toBeUndefined();
+    expect(props.body.ifc.confidentiality).toEqual(["mail-secret"]);
+  });
+
+  // The minting walk honors an authored ifc.observes: the declared entry
+  // carries the class, and the C1 reader consumes it per class — a
+  // nonRecursive (count/length-shaped) read of the doc does not inherit a
+  // value-class declared label, while a value read does.
+  it("authored ifc.observes mints a classed declared entry consumed per class", async () => {
+    const rt = makeRuntime();
+    const guarded = internSchema(
+      {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: { type: "string" },
+            ifc: { confidentiality: ["content-secret"], observes: "value" },
+          },
+        },
+      } as JSONSchema,
+      true,
+    );
+    const tx = rt.edit();
+    const cell = rt.getCell(space, "dobs-doc", guarded.schema, tx);
+    cell.set({ rows: ["a", "b"] });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const id = cell.getAsNormalizedFullLink().id;
+    const declared = entriesOf(id).find((e) =>
+      e.origin === "declared" && e.path.join("/") === "rows"
+    );
+    expect(declared).toBeDefined();
+    expect(declared!.observes).toBe("value");
+    expect(declared!.label.confidentiality).toContainEqual("content-secret");
+
+    // A count-shaped (nonRecursive) read of the labeled path consumes
+    // shape+enumerate+covering — NOT the value-class declared label.
+    const countTx = rt.edit();
+    countTx.readOrThrow({
+      space,
+      scope: "space",
+      id: uri(id),
+      type: "application/json",
+      path: ["value", "rows"],
+    }, { nonRecursive: true });
+    const countOut = rt.getCell(space, "dobs-count-out", undefined, countTx);
+    const countOutId = countOut.getAsNormalizedFullLink().id;
+    countTx.writeOrThrow(
+      { space, scope: "space", id: uri(countOutId), path: ["value"] },
+      { count: 2 },
+    );
+    countTx.prepareCfc();
+    expect((await countTx.commit()).ok).toBeDefined();
+    expect(
+      entriesOf(countOutId).filter((e) => e.origin === "derived"),
+    ).toEqual([]);
+
+    // A value read still consumes it.
+    const valueTx = rt.edit();
+    valueTx.readOrThrow({
+      space,
+      scope: "space",
+      id: uri(id),
+      type: "application/json",
+      path: ["value", "rows"],
+    });
+    const valueOut = rt.getCell(space, "dobs-value-out", undefined, valueTx);
+    const valueOutId = valueOut.getAsNormalizedFullLink().id;
+    valueTx.writeOrThrow(
+      { space, scope: "space", id: uri(valueOutId), path: ["value"] },
+      { copied: true },
+    );
+    valueTx.prepareCfc();
+    expect((await valueTx.commit()).ok).toBeDefined();
+    expect(
+      entriesOf(valueOutId).find((e) => e.origin === "derived")?.label
+        .confidentiality,
+    ).toContainEqual("content-secret");
+  });
+
+  // A bogus observes value must not narrow anything: the entry mints
+  // covering (over-taint, fail-safe) and every read class consumes it.
+  it("an invalid ifc.observes value mints a covering entry", async () => {
+    const rt = makeRuntime();
+    const guarded = internSchema(
+      {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: { type: "string" },
+            ifc: { confidentiality: ["content-secret"], observes: "vlaue" },
+          },
+        },
+      } as JSONSchema,
+      true,
+    );
+    const tx = rt.edit();
+    const cell = rt.getCell(space, "dobs-invalid-doc", guarded.schema, tx);
+    cell.set({ rows: ["a"] });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const id = cell.getAsNormalizedFullLink().id;
+    const declared = entriesOf(id).find((e) =>
+      e.origin === "declared" && e.path.join("/") === "rows"
+    );
+    expect(declared).toBeDefined();
+    expect(declared!.observes).toBeUndefined();
+
+    const countTx = rt.edit();
+    countTx.readOrThrow({
+      space,
+      scope: "space",
+      id: uri(id),
+      type: "application/json",
+      path: ["value", "rows"],
+    }, { nonRecursive: true });
+    const out = rt.getCell(space, "dobs-invalid-out", undefined, countTx);
+    const outId = out.getAsNormalizedFullLink().id;
+    countTx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { count: 1 },
+    );
+    countTx.prepareCfc();
+    expect((await countTx.commit()).ok).toBeDefined();
+    expect(
+      entriesOf(outId).find((e) => e.origin === "derived")?.label
+        .confidentiality,
+    ).toContainEqual("content-secret");
+  });
+});

--- a/packages/runner/test/cfc-declared-observes.test.ts
+++ b/packages/runner/test/cfc-declared-observes.test.ts
@@ -189,7 +189,9 @@ describe("CFC declared observation classes (C5)", () => {
             ifc: { confidentiality: ["content-secret"], observes: "vlaue" },
           },
         },
-      } as JSONSchema,
+        // Deliberately invalid class value — the narrowed ifc type rejects
+        // it, which is the point of the runtime fallback under test.
+      } as unknown as JSONSchema,
       true,
     );
     const tx = rt.edit();

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -4,6 +4,52 @@ import type { JSONSchemaObj } from "../src/builder/types.ts";
 import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
 
 describe("mergeCfcSchemaEnvelopes", () => {
+  // C5: `observes` is a scalar consumption class, not a set-like claim.
+  // Agreement keeps the class through a merge; any disagreement (including
+  // one covering side) merges to covering — the widest consumption, the
+  // over-taint direction (fail-safe). Dropping it on every merge would
+  // silently defeat the C5 narrowing on the common re-write path.
+  it("keeps observes when both sides agree", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      properties: {
+        rows: {
+          type: "string",
+          ifc: { confidentiality: ["a"], observes: "value" },
+        },
+      },
+    }, {
+      type: "object",
+      properties: {
+        rows: {
+          type: "string",
+          ifc: { confidentiality: ["a"], observes: "value" },
+        },
+      },
+    }) as JSONSchemaObj;
+    const rows = (merged.properties as Record<string, JSONSchemaObj>).rows;
+    expect((rows.ifc as { observes?: string }).observes).toBe("value");
+  });
+
+  it("merges disagreeing observes to covering", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      properties: {
+        rows: {
+          type: "string",
+          ifc: { confidentiality: ["a"], observes: "value" },
+        },
+      },
+    }, {
+      type: "object",
+      properties: {
+        rows: { type: "string", ifc: { confidentiality: ["a"] } },
+      },
+    }) as JSONSchemaObj;
+    const rows = (merged.properties as Record<string, JSONSchemaObj>).rows;
+    expect((rows.ifc as { observes?: string }).observes).toBeUndefined();
+  });
+
   it("allows additive required fields when a default preserves old documents", () => {
     const merged = mergeCfcSchemaEnvelopes({
       type: "object",


### PR DESCRIPTION
Epic C stage C5 of `docs/plans/cfc-future-work-implementation.md` §4 — the final stage: sqlite precision via observation classes, on top of C1–C4 (#4507, #4520, #4525, #4541).

## What

- **Authored `ifc.observes`** — the declared-entry minting walk honors an `observes` class on a schema's `ifc` object (`declaredObservesClass` in prepare.ts): the declared entry carries the class and the C1 reader consumes it per class. Only the four class values count; anything else — including the absent default and typos — mints a covering entry: the over-taint direction, so a malformed class can only widen consumption, never narrow it (fail-safe). `ifc.observes` was previously ignored-not-denied, so this is additive vocabulary: an old runner minting from the same schema produces a covering entry — over-taint, wire-safe both directions.
- **`deriveNullOriginIfc` narrows to the class actually consumed** — the null-origin (expression/literal/aggregate) conservative whole-schema confidentiality union is now declared `observes:"value"`: an expression computed FROM column values labels the result column's CONTENT channel. A count-shaped consumer of the query result (length/membership reads over the result rows — `nonRecursive`, consuming `shape+enumerate` per C0 §4) no longer inherits the whole-schema content union. Row membership itself stays governed by the per-row rule machinery (row-label-read.ts, E2/E3), not by column content labels. Resolved-origin columns pass their authored column `ifc` through verbatim — authors can now class those too.

## Red→green

`packages/runner/test/cfc-declared-observes.test.ts`: the `labelResultSchema` unit test (null-origin ⇒ `observes:"value"`, resolved column verbatim) and the authored-`ifc.observes` integration test (classed declared entry; count-shaped read does NOT consume it, value read does) fail on main and pass here. The invalid-`observes` test (covering fallback, every read class consumes) passes on both sides by construction.

## Rollout

No dial. Class-unaware readers treat classed declared entries as covering (over-taint); no `observes:"followRef"` is persisted by any writer here, so the SC-8 reader-first constraint from C1 remains satisfied.

## Perf (plan §0 gate — both cfc benches, flat/within noise)

label-sync: warm parallel batch 3.4 ms, skip-when-present 1.4 µs, getCfcLabel 1.3 µs. canonicalize: preparedDigestFor small 12.8 µs, large 72.2 µs, path-heavy 61.7 µs (all ≈ C4 baseline).

## Tests

Full `packages/runner` suite green: 773 passed / 0 failed (all 82 cfc test files).

This completes Epic C (C0–C5). Queued follow-up (from the #4525 thread): structure-stamp re-tag to `observes:"enumerate"` + fold exemption + clause-aware fold dedup + A3/B2 cross-scenario tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage-debt override (proven noise)

`NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7657 lines`

Root-caused by diffing this run's aggregated coverage-profile LCOV artifacts against the latest green main run's (post-C4 head 599979a38): the per-file uncovered delta is confined to `src/runtime.ts` (+3, the onSinkReleaseReject instrumentation callback) and `src/storage/extended-storage-transaction.ts` (+9 net, wrapped-tx delegation methods and error paths) — coverage-flapping lines in files this PR does not touch. Every file in this PR's diff shows zero uncovered-line delta in the same comparison. (An earlier attempt's 64 wall-time flags were congested-runner noise, resolved by the full-workflow rerun.)
