### PR TITLE
fix(ui): keep pending local edits over stale bound state in CellController

### DIFF
--- a/packages/ui/src/v2/core/cell-controller.test.ts
+++ b/packages/ui/src/v2/core/cell-controller.test.ts
@@ -810,6 +810,62 @@ describe("CellController — pending local edits vs stale bound state", () => {
     expect(ctrl.getValue()).toBe("Bob");
   });
 
+  it("shows an authoritative remote clear-to-undefined instead of the last known value", () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cell = createMockCellHandle<string>("Alice");
+    ctrl.bind(cell);
+    expect(ctrl.getValue()).toBe("Alice");
+
+    // The backend clears the cell. Unlike a fresh rebound handle's initial
+    // no-delivery state, this undefined is authoritative and must repaint the
+    // normal empty fallback.
+    pushUpdate(cell, undefined as unknown as string);
+    expect(ctrl.getValue()).toBe("");
+  });
+
+  it("does not resurrect the previous value on a same-cell rebind after a remote clear", () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cell = createMockCellHandle<string>("Alice");
+    ctrl.bind(cell);
+    pushUpdate(cell, undefined as unknown as string); // authoritative clear
+    expect(ctrl.getValue()).toBe("");
+
+    // A label-view drift rebind hands over a fresh unhydrated handle; the
+    // cleared value must not come back.
+    const rebound = createMockCellHandle<string>(undefined, {
+      cfcLabelView: DRIFTED_LABEL_VIEW,
+    });
+    ctrl.bind(rebound);
+    expect(ctrl.getValue()).toBe("");
+  });
+
+  it("releases a settled-but-unconverged edit when an authoritative clear arrives", async () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const initial = createMockCellHandle<string>("");
+    ctrl.bind(initial);
+
+    ctrl.setValue("Alice");
+    // Rebind swaps in a pre-write snapshot, so the write settles unconverged.
+    const rebound = createMockCellHandle<string>("", {
+      cfcLabelView: DRIFTED_LABEL_VIEW,
+    });
+    ctrl.bind(rebound);
+    await settleWrites();
+    expect(ctrl.getValue()).toBe("Alice");
+
+    // The write was lost and the cell cleared: the post-settle delivery is
+    // authoritative even when it is undefined — the edit must not be shown
+    // forever.
+    pushUpdate(rebound, undefined as unknown as string);
+    expect(ctrl.getValue()).toBe("");
+  });
+
   it("drops local-edit protection when rebinding to a different cell", () => {
     const ctrl = new StringCellController(createMockHost(), {
       timing: { strategy: "immediate" },
@@ -823,6 +879,170 @@ describe("CellController — pending local edits vs stale bound state", () => {
     });
     ctrl.bind(cellB);
     expect(ctrl.getValue()).toBe("other");
+  });
+
+  it("lets a genuinely newer remote value supersede a settled-but-unconverged edit", async () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const initial = createMockCellHandle<string>("");
+    ctrl.bind(initial);
+
+    ctrl.setValue("Alice");
+    const rebound = createMockCellHandle<string>("", {
+      cfcLabelView: DRIFTED_LABEL_VIEW,
+    });
+    ctrl.bind(rebound);
+    await settleWrites();
+
+    // Deliveries after settle reflect post-write state: a third value means a
+    // newer remote edit won and must repaint without waiting for our echo.
+    pushUpdate(rebound, "Zed");
+    expect(ctrl.getValue()).toBe("Zed");
+  });
+
+  it("a write settling after a rebind to a different cell does not release its edit", async () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cellA = createMockCellHandle<string>("", { id: "of:cell-a" as any });
+    ctrl.bind(cellA);
+    ctrl.setValue("typed"); // write in flight against cell A
+
+    const cellB = createMockCellHandle<string>("b-val", {
+      id: "of:cell-b" as any,
+    });
+    ctrl.bind(cellB);
+    ctrl.setValue("fresh-edit"); // pending edit on cell B
+
+    // Cell A's write settles now; it must not touch cell B's pending edit.
+    await settleWrites();
+    expect(ctrl.getValue()).toBe("fresh-edit");
+    pushUpdate(cellB, "fresh-edit"); // echo confirms on B
+    expect(ctrl.getValue()).toBe("fresh-edit");
+  });
+
+  it("cancel() abandons the pending edit and bound state repaints", () => {
+    const time = new FakeTime();
+    try {
+      const ctrl = new StringCellController(createMockHost(), {
+        timing: { strategy: "debounce", delay: 300 },
+      });
+      const cell = createMockCellHandle<string>("orig");
+      ctrl.bind(cell);
+
+      ctrl.setValue("temp");
+      expect(ctrl.getValue()).toBe("temp"); // pending edit shows
+      ctrl.cancel();
+      expect(ctrl.getValue()).toBe("orig"); // bound state authoritative again
+      time.tick(300);
+      expect(cell.get()).toBe("orig"); // and the write never landed
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("confirms an array edit structurally when the echo arrives on a rebound handle", () => {
+    const ctrl = new ArrayCellController<string | { k: string }>(
+      createMockHost(),
+    );
+    const initial = createMockCellHandle<(string | { k: string })[]>([]);
+    ctrl.bind(initial);
+
+    ctrl.setValue(["x", { k: "v" }]);
+    const rebound = createMockCellHandle<(string | { k: string })[]>(
+      undefined,
+      { cfcLabelView: DRIFTED_LABEL_VIEW },
+    );
+    ctrl.bind(rebound);
+    expect(ctrl.getValue()).toEqual(["x", { k: "v" }]);
+
+    // The echo is a fresh deserialized instance — equal by structure, not
+    // identity — and must still confirm (and release) the edit.
+    pushUpdate(rebound, ["x", { k: "v" }]);
+    expect(ctrl.getValue()).toEqual(["x", { k: "v" }]);
+    pushUpdate(rebound, ["x"]);
+    expect(ctrl.getValue()).toEqual(["x"]);
+  });
+
+  it("drops local-edit protection when rebinding to a different scope of the same doc", () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    // Same id/space/path, user scope: a scoped cell is partitioned storage.
+    const userScoped = createMockCellHandle<string>("", { scope: "user" });
+    ctrl.bind(userScoped);
+    ctrl.setValue("typed");
+
+    // Rebind to the space-scoped cell at the same address (plus label-view
+    // drift so equals() is false): a different cell — no edit carry-over.
+    const spaceScoped = createMockCellHandle<string>("shared", {
+      scope: "space",
+      cfcLabelView: DRIFTED_LABEL_VIEW,
+    });
+    ctrl.bind(spaceScoped);
+    expect(ctrl.getValue()).toBe("shared");
+  });
+
+  it("treats a delivery holding a different cell link as not confirming the edit", () => {
+    const ctrl = new CellController<unknown>(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cell = createMockCellHandle<unknown>("plain");
+    ctrl.bind(cell);
+
+    const linkA = createMockCellHandle("a", { id: "of:link-a" as any });
+    const linkB = createMockCellHandle("b", { id: "of:link-b" as any });
+    ctrl.setValue(linkA);
+    // A stale delivery carrying a DIFFERENT link must not read as the echo of
+    // our edit (links compare by identity, not structure).
+    pushUpdate(cell, linkB);
+    expect(ctrl.getValue()).toBe(linkA);
+  });
+
+  it("does not confirm on structurally different partial echoes (array and object)", () => {
+    const arrCtrl = new ArrayCellController<string>(createMockHost());
+    const arrCell = createMockCellHandle<string[]>([]);
+    arrCtrl.bind(arrCell);
+    arrCtrl.setValue(["a", "b"]);
+    // Shorter partial echo of an earlier state must not confirm or repaint.
+    pushUpdate(arrCell, ["a"]);
+    expect(arrCtrl.getValue()).toEqual(["a", "b"]);
+
+    const objCtrl = new CellController<{ k: string }>(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const objCell = createMockCellHandle<{ k: string }>({ k: "" });
+    objCtrl.bind(objCell);
+    objCtrl.setValue({ k: "v" });
+    // Extra keys make it a different value — not our echo.
+    pushUpdate(objCell, { k: "v", extra: 1 } as unknown as { k: string });
+    expect(objCtrl.getValue()).toEqual({ k: "v" });
+  });
+
+  it("manual transaction strategy still routes the write through the setter", () => {
+    const ctrl = new CellController<string>(createMockHost(), {
+      timing: { strategy: "immediate" },
+      transactionStrategy: "manual",
+    });
+    const cell = createMockCellHandle<string>("before");
+    ctrl.bind(cell);
+    ctrl.setValue("after");
+    expect(cell.get()).toBe("after");
+    expect(ctrl.getValue()).toBe("after");
+  });
+
+  it("setValue on a plain (non-cell) binding leaves the value to the host property system", () => {
+    const changes: Array<[string, string]> = [];
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+      onChange: (n, o) => changes.push([n, o]),
+    });
+    ctrl.bind("plain" as unknown as CellHandle<string>);
+    ctrl.setValue("next");
+    // No cell to write; the controller only reports the change.
+    expect(ctrl.getValue()).toBe("plain");
+    expect(changes).toContainEqual(["next", "plain"]);
   });
 });
 

--- a/packages/ui/src/v2/core/cell-controller.test.ts
+++ b/packages/ui/src/v2/core/cell-controller.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FakeTime } from "@std/testing/time";
 import type { ReactiveControllerHost } from "lit";
-import { CellHandle, isCellHandle } from "@commonfabric/runtime-client";
+import {
+  CellHandle,
+  type CellRef,
+  isCellHandle,
+} from "@commonfabric/runtime-client";
 import {
   createMockCellHandle,
   pushUpdate,
@@ -634,6 +638,191 @@ describe("CellController — timing integration", () => {
     ctrl.onFocus();
     ctrl.onBlur();
     expect(events).toEqual(["focus", "blur"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CellController — pending local edits vs stale bound state
+//
+// Regression coverage for the cf-input early-boot wipe: a user types before
+// the cell's initial echo/subscription has settled; the worker re-renders and
+// the applicator hands the element a FRESH CellHandle for the same cell
+// (cfcLabelView drift during CFC settling makes `equals()` false), whose value
+// has not hydrated yet. The controller used to adopt that handle's stale/empty
+// state, and the next repaint wiped the user's typed text until the backend
+// echo restored it. The local edit must win until the echo confirms it or a
+// genuinely newer remote value arrives.
+// ---------------------------------------------------------------------------
+
+/**
+ * A cfcLabelView that differs from the (absent) label view on the default mock
+ * ref. `CellHandle.equals()` compares cfcLabelView, so a rebind with this ref
+ * replaces the bound handle — the production wipe vector (the applicator's
+ * `setBinding` makes a fresh, value-less handle whenever the authored link's
+ * label view drifts during early CFC settling).
+ */
+const DRIFTED_LABEL_VIEW: CellRef["cfcLabelView"] = {
+  version: 1,
+  entries: [{ path: [], label: { confidentiality: ["did:key:z-someone"] } }],
+};
+
+/** Let in-flight CellHandle.set() round-trips settle (mock resolves async). */
+const settleWrites = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("CellController — pending local edits vs stale bound state", () => {
+  it("keeps a settled local edit when a same-cell rebind delivers a not-yet-hydrated handle", async () => {
+    // The confirmed lunch-poll trace: commit() resolved (write durable), THEN
+    // the host re-render swapped in a fresh handle with no value yet.
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const initial = createMockCellHandle<string>("");
+    ctrl.bind(initial);
+
+    ctrl.setValue("Alice"); // user types; optimistic write
+    await settleWrites(); // the set() round-trip completes
+
+    const rebound = createMockCellHandle<string>(undefined, {
+      cfcLabelView: DRIFTED_LABEL_VIEW,
+    });
+    ctrl.bind(rebound);
+    // The typed value must survive the rebind — there is no newer remote
+    // value, only a handle that has not hydrated yet.
+    expect(ctrl.getValue()).toBe("Alice");
+
+    // The durable echo hydrates the fresh handle.
+    pushUpdate(rebound, "Alice");
+    expect(ctrl.getValue()).toBe("Alice");
+
+    // Once hydrated, remote updates (including a clear) apply normally.
+    pushUpdate(rebound, "");
+    expect(ctrl.getValue()).toBe("");
+  });
+
+  it("suppresses a stale pre-write value delivered by a same-cell rebind until the echo confirms", async () => {
+    const changes: Array<string | undefined> = [];
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+      onChange: (newValue) => changes.push(newValue),
+    });
+    const initial = createMockCellHandle<string>("");
+    ctrl.bind(initial);
+
+    ctrl.setValue("Alice");
+    changes.length = 0;
+
+    // A re-render-driven rebind hands over a handle still holding the
+    // pre-write snapshot.
+    const rebound = createMockCellHandle<string>("", {
+      cfcLabelView: DRIFTED_LABEL_VIEW,
+    });
+    ctrl.bind(rebound);
+    expect(ctrl.getValue()).toBe("Alice");
+    // The stale "" must not be announced as a change either — the UI never
+    // showed it.
+    expect(changes).not.toContain("");
+    await settleWrites();
+    expect(ctrl.getValue()).toBe("Alice");
+
+    // Echo confirms; later remote edits apply normally.
+    pushUpdate(rebound, "Alice");
+    expect(ctrl.getValue()).toBe("Alice");
+    pushUpdate(rebound, "Bob");
+    expect(ctrl.getValue()).toBe("Bob");
+  });
+
+  it("keeps the latest keystroke when a partial echo of an earlier write arrives", () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cell = createMockCellHandle<string>("");
+    ctrl.bind(cell);
+
+    ctrl.setValue("Al");
+    ctrl.setValue("Alice");
+    // The echo of the first keystroke arrives after the second was typed.
+    pushUpdate(cell, "Al");
+    expect(ctrl.getValue()).toBe("Alice");
+
+    pushUpdate(cell, "Alice");
+    expect(ctrl.getValue()).toBe("Alice");
+  });
+
+  it("keeps the typed value when a late initial hydration arrives during a debounce window", async () => {
+    const time = new FakeTime();
+    try {
+      const ctrl = new StringCellController(createMockHost(), {
+        timing: { strategy: "debounce", delay: 300 },
+      });
+      // Early boot: the cell has not hydrated at bind time.
+      const cell = createMockCellHandle<string>(undefined);
+      ctrl.bind(cell);
+
+      ctrl.setValue("Al"); // user typing; write still debounced
+      pushUpdate(cell, ""); // late initial hydration (pre-write snapshot)
+      expect(ctrl.getValue()).toBe("Al");
+
+      time.tick(300); // debounced write lands
+      expect(cell.get()).toBe("Al");
+      await time.runMicrotasks();
+      expect(ctrl.getValue()).toBe("Al");
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("keeps an uncommitted edit over a remote update while using the blur strategy", () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "blur" },
+    });
+    const cell = createMockCellHandle<string>("");
+    ctrl.bind(cell);
+
+    ctrl.setValue("Ali"); // typed, not yet committed (commits on blur)
+    pushUpdate(cell, "remote-edit");
+    // The in-progress local edit wins; the blur-time write will overwrite the
+    // remote value anyway (last-write-wins set).
+    expect(ctrl.getValue()).toBe("Ali");
+
+    ctrl.onBlur(); // commits the edit
+    expect(cell.get()).toBe("Ali");
+  });
+
+  it("accepts remote updates — including a clear back to the pre-edit value — once the write settled", async () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cell = createMockCellHandle<string>("");
+    ctrl.bind(cell);
+
+    ctrl.setValue("Alice");
+    await settleWrites();
+
+    // A genuinely newer remote value must repaint...
+    pushUpdate(cell, "Bob");
+    expect(ctrl.getValue()).toBe("Bob");
+
+    ctrl.setValue("Carol");
+    await settleWrites();
+
+    // ...and so must a remote clear that matches the pre-edit baseline.
+    pushUpdate(cell, "Bob");
+    expect(ctrl.getValue()).toBe("Bob");
+  });
+
+  it("drops local-edit protection when rebinding to a different cell", () => {
+    const ctrl = new StringCellController(createMockHost(), {
+      timing: { strategy: "immediate" },
+    });
+    const cellA = createMockCellHandle<string>("a", { id: "of:cell-a" as any });
+    ctrl.bind(cellA);
+    ctrl.setValue("typed");
+
+    const cellB = createMockCellHandle<string>("other", {
+      id: "of:cell-b" as any,
+    });
+    ctrl.bind(cellB);
+    expect(ctrl.getValue()).toBe("other");
   });
 });
 

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -135,6 +135,15 @@ export class CellController<T> implements ReactiveController {
   // replacement handle that has not hydrated yet (get() still undefined)
   // does not repaint emptiness over it.
   private _lastKnownValue: T | undefined;
+  // Whether the current subscription has received a real (asynchronous)
+  // delivery. subscribe()'s synchronous initial callback merely echoes the
+  // handle's local cache — for a freshly minted rebound handle that is
+  // "no information yet", NOT an authoritative undefined. Once any real
+  // delivery arrives, an undefined value is an authoritative clear and must
+  // repaint (it may not be masked by _lastKnownValue).
+  private _bindingHydrated = false;
+  // True only while subscribe() runs its synchronous initial callback.
+  private _subscribeEcho = false;
   // Bumped when binding to a different persistent cell, so settle callbacks
   // from writes against a previous binding cannot release the new one.
   private _bindEpoch = 0;
@@ -185,6 +194,7 @@ export class CellController<T> implements ReactiveController {
         this._localEdit = undefined;
         this._settledAwaitingRelease = false;
         this._lastKnownValue = undefined;
+        this._bindingHydrated = false;
       }
       this._cleanupCellSubscription();
       // Only apply the component's schema when the CellHandle doesn't already
@@ -218,8 +228,11 @@ export class CellController<T> implements ReactiveController {
     }
     // A same-cell rebind can install a handle that has not hydrated yet
     // (get() still undefined). Keep showing the last known value until its
-    // first delivery arrives instead of repainting emptiness.
+    // first real delivery arrives instead of repainting emptiness. Once the
+    // subscription has delivered, an undefined value is an authoritative
+    // clear and must show the component's normal empty fallback.
     if (
+      !this._bindingHydrated &&
       isCellHandle(this._currentValue) &&
       (this._currentValue as CellHandle<T>).get() === undefined &&
       this._lastKnownValue !== undefined
@@ -407,26 +420,33 @@ export class CellController<T> implements ReactiveController {
   private _setupCellSubscription(): void {
     if (isCellHandle(this._currentValue)) {
       let previousValue: T | undefined;
-      this._cellUnsubscribe = this._currentValue.subscribe((newValue) => {
-        // Call onChange when the cell value changes from the backend
-        // This ensures components like cf-select can update their DOM state
-        const typedNewValue = newValue as T | undefined;
-        const suppressed = this._classifyDelivery(typedNewValue);
-        if (!suppressed && typedNewValue !== previousValue) {
-          const oldValue = previousValue;
-          previousValue = typedNewValue;
-          if (oldValue !== undefined || typedNewValue !== undefined) {
-            this.options.onChange(typedNewValue as T, oldValue as T);
+      this._bindingHydrated = false;
+      this._subscribeEcho = true;
+      try {
+        this._cellUnsubscribe = this._currentValue.subscribe((newValue) => {
+          // Call onChange when the cell value changes from the backend
+          // This ensures components like cf-select can update their DOM state
+          const typedNewValue = newValue as T | undefined;
+          if (!this._subscribeEcho) this._bindingHydrated = true;
+          const suppressed = this._classifyDelivery(typedNewValue);
+          if (!suppressed && typedNewValue !== previousValue) {
+            const oldValue = previousValue;
+            previousValue = typedNewValue;
+            if (oldValue !== undefined || typedNewValue !== undefined) {
+              this.options.onChange(typedNewValue as T, oldValue as T);
+            }
+          } else if (suppressed) {
+            // Keep the raw-stream bookkeeping coherent without announcing a
+            // value the UI never showed.
+            previousValue = typedNewValue;
           }
-        } else if (suppressed) {
-          // Keep the raw-stream bookkeeping coherent without announcing a
-          // value the UI never showed.
-          previousValue = typedNewValue;
-        }
-        if (this.options.triggerUpdate) {
-          this.host.requestUpdate();
-        }
-      });
+          if (this.options.triggerUpdate) {
+            this.host.requestUpdate();
+          }
+        });
+      } finally {
+        this._subscribeEcho = false;
+      }
     }
   }
 
@@ -437,7 +457,14 @@ export class CellController<T> implements ReactiveController {
    */
   private _classifyDelivery(value: T | undefined): boolean {
     if (this._localEdit === undefined) {
-      if (value !== undefined) this._lastKnownValue = value;
+      if (value !== undefined) {
+        this._lastKnownValue = value;
+      } else if (this._bindingHydrated) {
+        // An authoritative clear (a real delivery of undefined, not the
+        // no-information initial echo of a fresh handle): forget the last
+        // known value so a later same-cell rebind cannot resurrect it.
+        this._lastKnownValue = undefined;
+      }
       return false;
     }
     if (this._applyingLocalWrite) {
@@ -454,10 +481,15 @@ export class CellController<T> implements ReactiveController {
       this._lastKnownValue = value;
       return false;
     }
-    if (this._settledAwaitingRelease && value !== undefined) {
+    if (
+      this._settledAwaitingRelease &&
+      (value !== undefined || this._bindingHydrated)
+    ) {
       // Writes settled without converging; deliveries are FIFO, so this one
-      // reflects post-write state (e.g. a genuinely newer remote edit) and
-      // supersedes the local edit.
+      // reflects post-write state and supersedes the local edit — whether a
+      // genuinely newer remote edit or an authoritative clear (the edit was
+      // lost). A fresh rebound handle's initial undefined echo carries no
+      // information and does not release.
       this._localEdit = undefined;
       this._settledAwaitingRelease = false;
       this._lastKnownValue = value;
@@ -478,15 +510,17 @@ export class CellController<T> implements ReactiveController {
 }
 
 /**
- * Whether two refs address the same persistent cell (same document, space and
- * path), ignoring schema and cfcLabelView — the ref parts that drift across
- * re-renders while CFC label views settle. `CellHandle.equals()` is stricter
- * (it compares cfcLabelView), which is exactly why a drift-driven rebind
- * replaces the bound handle; local-edit continuity must follow the persistent
- * cell instead.
+ * Whether two refs address the same persistent cell (same document, space,
+ * scope and path), ignoring schema and cfcLabelView — the ref parts that
+ * drift across re-renders while CFC label views settle. `CellHandle.equals()`
+ * is stricter (it compares cfcLabelView), which is exactly why a drift-driven
+ * rebind replaces the bound handle; local-edit continuity must follow the
+ * persistent cell instead. Scope matters: user-/session-scoped cells are
+ * partitioned storage, so a same-id ref with a different scope is a
+ * different cell.
  */
 function sameCellDoc(a: CellRef, b: CellRef): boolean {
-  return a.id === b.id && a.space === b.space &&
+  return a.id === b.id && a.space === b.space && a.scope === b.scope &&
     a.path.length === b.path.length &&
     a.path.every((segment, index) => segment === b.path[index]);
 }

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -1,6 +1,7 @@
 import { ReactiveController, ReactiveControllerHost } from "lit";
 import {
   CellHandle,
+  type CellRef,
   isCellHandle,
   type JSONSchema,
 } from "@commonfabric/runtime-client";
@@ -113,6 +114,31 @@ export class CellController<T> implements ReactiveController {
   private _cellUnsubscribe: (() => void) | null = null;
   private _inputTiming?: InputTimingController;
 
+  // --- Pending-local-edit tracking (early-boot wipe guard) -----------------
+  // A locally-edited value that bound state has not yet confirmed. While set,
+  // it wins over stale bound state in getValue(), so a re-render cannot
+  // repaint a pre-write snapshot over what the user just typed. Released when
+  // the echo confirms it (a delivery equal to the edit), when a post-settle
+  // delivery supersedes it, or when the binding moves to a different cell.
+  private _localEdit: { value: T } | undefined;
+  // Number of in-flight cell writes started by the default setter.
+  private _inFlightWrites = 0;
+  // Re-entrancy marker: a subscription delivery firing synchronously from our
+  // own optimistic set() (as opposed to a backend push). A local echo must not
+  // release the edit — only durable/bound state catching up may.
+  private _applyingLocalWrite = false;
+  // All writes settled but bound state never converged (e.g. a rebind swapped
+  // in a pre-write snapshot first): deliveries are FIFO, so the next one
+  // reflects post-write state and is authoritative.
+  private _settledAwaitingRelease = false;
+  // Last authoritative user-visible value. Survives same-cell rebinds so a
+  // replacement handle that has not hydrated yet (get() still undefined)
+  // does not repaint emptiness over it.
+  private _lastKnownValue: T | undefined;
+  // Bumped when binding to a different persistent cell, so settle callbacks
+  // from writes against a previous binding cannot release the new one.
+  private _bindEpoch = 0;
+
   constructor(
     host: ReactiveControllerHost,
     options: CellControllerOptions<T> = {},
@@ -146,6 +172,20 @@ export class CellController<T> implements ReactiveController {
       !(this._currentValue instanceof CellHandle &&
         this._currentValue.equals(value))
     ) {
+      // equals() compares cfcLabelView, so early-boot CFC settling hands us a
+      // *fresh* handle for the same persistent cell (with a stale or
+      // not-yet-hydrated snapshot). Local-edit continuity must follow the
+      // persistent cell, not the handle: keep the tracking across a same-cell
+      // rebind, drop it when the binding moves to a different cell.
+      const samePersistentCell = this._currentValue instanceof CellHandle &&
+        value instanceof CellHandle &&
+        sameCellDoc(this._currentValue.ref(), value.ref());
+      if (!samePersistentCell) {
+        this._bindEpoch++;
+        this._localEdit = undefined;
+        this._settledAwaitingRelease = false;
+        this._lastKnownValue = undefined;
+      }
       this._cleanupCellSubscription();
       // Only apply the component's schema when the CellHandle doesn't already
       // have one. Pattern-compiled $bindings (e.g. $images, $files) arrive with
@@ -168,8 +208,23 @@ export class CellController<T> implements ReactiveController {
    * Get the current value from CellHandle<T> | T
    */
   getValue(): Readonly<T> {
+    // A pending local edit wins over bound state until it is confirmed or
+    // superseded — a re-render in that window must not repaint stale state.
+    if (this._localEdit !== undefined) {
+      return this._localEdit.value as Readonly<T>;
+    }
     if (this._currentValue === undefined || this._currentValue === null) {
       return undefined as T;
+    }
+    // A same-cell rebind can install a handle that has not hydrated yet
+    // (get() still undefined). Keep showing the last known value until its
+    // first delivery arrives instead of repainting emptiness.
+    if (
+      isCellHandle(this._currentValue) &&
+      (this._currentValue as CellHandle<T>).get() === undefined &&
+      this._lastKnownValue !== undefined
+    ) {
+      return this._lastKnownValue as Readonly<T>;
     }
     return this.options.getValue(this._currentValue);
   }
@@ -182,12 +237,34 @@ export class CellController<T> implements ReactiveController {
 
     const oldValue = this.getValue();
 
+    if (isCellHandle(this._currentValue)) {
+      // Track the edit so stale bound-state deliveries (late hydration,
+      // partial echoes of earlier keystrokes, pre-write snapshots on rebound
+      // handles) cannot repaint over it while the write is pending.
+      this._localEdit = { value: newValue };
+      this._settledAwaitingRelease = false;
+      this._lastKnownValue = newValue;
+    }
+
     const performUpdate = () => {
-      if (this.options.transactionStrategy === "auto") {
-        this.options.setValue(this._currentValue!, newValue, oldValue);
-      } else {
-        // For manual/batch strategies, just call setValue without transaction handling
-        this.options.setValue(this._currentValue!, newValue, oldValue);
+      this._applyingLocalWrite = true;
+      try {
+        if (this.options.transactionStrategy === "auto") {
+          this.options.setValue(this._currentValue!, newValue, oldValue);
+        } else {
+          // For manual/batch strategies, just call setValue without transaction handling
+          this.options.setValue(this._currentValue!, newValue, oldValue);
+        }
+      } finally {
+        this._applyingLocalWrite = false;
+      }
+
+      // A custom setter gives no in-flight signal, so the local apply is all
+      // the confirmation we will get — release the edit right away (status
+      // quo behavior for such components). The default setter tracks its
+      // write and releases on settle instead.
+      if (this._inFlightWrites === 0) {
+        this._localEdit = undefined;
       }
 
       // Call custom change handler
@@ -233,6 +310,10 @@ export class CellController<T> implements ReactiveController {
    */
   cancel(): void {
     this._inputTiming?.cancel();
+    // A cancelled pending write abandons its local edit; bound state is
+    // authoritative again.
+    this._localEdit = undefined;
+    this._settledAwaitingRelease = false;
   }
 
   /**
@@ -288,11 +369,38 @@ export class CellController<T> implements ReactiveController {
     _oldValue: T,
   ): void {
     if (isCellHandle(value)) {
-      value.set(newValue);
+      const epoch = this._bindEpoch;
+      this._inFlightWrites++;
+      // set() resolves once the write round-trip completes (it never rejects;
+      // failures are logged and swallowed inside set()).
+      value.set(newValue).finally(() => {
+        this._inFlightWrites--;
+        if (epoch !== this._bindEpoch || this._inFlightWrites > 0) return;
+        this._releaseLocalEditAfterSettle();
+      });
     } else {
       // For non-Cell values, we can't directly modify them
       // This should be handled by the component's property system
       // The caller should update their property and trigger re-render
+    }
+  }
+
+  /**
+   * All in-flight writes settled: release the pending local edit if bound
+   * state converged on it. If it did not (a same-cell rebind may have swapped
+   * in a pre-write snapshot first), keep the edit but mark that the next
+   * delivery is authoritative — deliveries are FIFO, so anything arriving
+   * after the write settled reflects post-write state.
+   */
+  private _releaseLocalEditAfterSettle(): void {
+    if (this._localEdit === undefined) return;
+    const raw = isCellHandle(this._currentValue)
+      ? (this._currentValue as CellHandle<T>).get()
+      : undefined;
+    if (raw !== undefined && deepValueEqual(raw, this._localEdit.value)) {
+      this._localEdit = undefined;
+    } else {
+      this._settledAwaitingRelease = true;
     }
   }
 
@@ -303,12 +411,17 @@ export class CellController<T> implements ReactiveController {
         // Call onChange when the cell value changes from the backend
         // This ensures components like cf-select can update their DOM state
         const typedNewValue = newValue as T | undefined;
-        if (typedNewValue !== previousValue) {
+        const suppressed = this._classifyDelivery(typedNewValue);
+        if (!suppressed && typedNewValue !== previousValue) {
           const oldValue = previousValue;
           previousValue = typedNewValue;
           if (oldValue !== undefined || typedNewValue !== undefined) {
             this.options.onChange(typedNewValue as T, oldValue as T);
           }
+        } else if (suppressed) {
+          // Keep the raw-stream bookkeeping coherent without announcing a
+          // value the UI never showed.
+          previousValue = typedNewValue;
         }
         if (this.options.triggerUpdate) {
           this.host.requestUpdate();
@@ -317,12 +430,92 @@ export class CellController<T> implements ReactiveController {
     }
   }
 
+  /**
+   * Decide how a subscription delivery interacts with a pending local edit.
+   * Returns true when the delivery is a stale snapshot that must neither
+   * repaint nor be announced over the user's pending edit.
+   */
+  private _classifyDelivery(value: T | undefined): boolean {
+    if (this._localEdit === undefined) {
+      if (value !== undefined) this._lastKnownValue = value;
+      return false;
+    }
+    if (this._applyingLocalWrite) {
+      // Our own optimistic apply echoing back synchronously. Deliver it as
+      // before, but a local echo does not confirm the edit — only bound state
+      // catching up (below) or the write settling may release it.
+      if (value !== undefined) this._lastKnownValue = value;
+      return false;
+    }
+    if (value !== undefined && deepValueEqual(value, this._localEdit.value)) {
+      // Bound state caught up with the edit — the echo confirmed it.
+      this._localEdit = undefined;
+      this._settledAwaitingRelease = false;
+      this._lastKnownValue = value;
+      return false;
+    }
+    if (this._settledAwaitingRelease && value !== undefined) {
+      // Writes settled without converging; deliveries are FIFO, so this one
+      // reflects post-write state (e.g. a genuinely newer remote edit) and
+      // supersedes the local edit.
+      this._localEdit = undefined;
+      this._settledAwaitingRelease = false;
+      this._lastKnownValue = value;
+      return false;
+    }
+    // Stale pre-write snapshot: late hydration, the partial echo of an
+    // earlier keystroke, or a rebound handle's initial state. The local edit
+    // wins until the echo confirms or a post-settle value supersedes it.
+    return true;
+  }
+
   private _cleanupCellSubscription(): void {
     if (this._cellUnsubscribe) {
       this._cellUnsubscribe();
       this._cellUnsubscribe = null;
     }
   }
+}
+
+/**
+ * Whether two refs address the same persistent cell (same document, space and
+ * path), ignoring schema and cfcLabelView — the ref parts that drift across
+ * re-renders while CFC label views settle. `CellHandle.equals()` is stricter
+ * (it compares cfcLabelView), which is exactly why a drift-driven rebind
+ * replaces the bound handle; local-edit continuity must follow the persistent
+ * cell instead.
+ */
+function sameCellDoc(a: CellRef, b: CellRef): boolean {
+  return a.id === b.id && a.space === b.space &&
+    a.path.length === b.path.length &&
+    a.path.every((segment, index) => segment === b.path[index]);
+}
+
+/**
+ * Structural equality for confirming a local edit against a delivered cell
+ * value (plain JSON-ish data; CellHandles compare by identity only).
+ */
+function deepValueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a instanceof CellHandle || b instanceof CellHandle) return false;
+  if (
+    a === null || b === null || typeof a !== "object" || typeof b !== "object"
+  ) {
+    return false;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, index) => deepValueEqual(item, b[index]));
+  }
+  const aKeys = Object.keys(a);
+  const bObj = b as Record<string, unknown>;
+  if (aKeys.length !== Object.keys(bObj).length) return false;
+  return aKeys.every((key) =>
+    Object.hasOwn(bObj, key) &&
+    deepValueEqual((a as Record<string, unknown>)[key], bObj[key])
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

A cell-bound `cf-input` transiently wipes typed text when the user types early in a page's life, before the cell's initial echo/subscription has settled. Reproduced with the lunch-poll join-name field (`<cf-input $value={joinName} timing-strategy="immediate">`) driven by `lunch-poll-vote.test.ts` against a fast-booting stack: type "Alice" → `commit()` resolves (~27 ms, write durable) → the next host re-render repaints the inner input from stale bound state, wiping the text → the cell echo restores it moments later. A real user in that window sees keystrokes vanish and reappear. (The integration waiter's 500 ms re-poll backstop, f2741b74a, masks the symptom in tests; the UX race itself was unfixed.)

## Root cause

`CellHandle.set()` applies optimistically **per handle instance**. During early CFC settling the authored `$value` link's `cfcLabelView` drifts, and both dedup guards compare it:

- `cellRefToKey` in the applicator's `setBinding` → the element's `value` property is re-assigned a **fresh `CellHandle` with no hydrated value** (`#value = undefined`) for the same persistent cell;
- `cellRefsEqual` behind `CellHandle.equals()` → `CellController.bind()` sees "different cell" and swaps out the handle holding the optimistic local value.

cf-input's `updated()` forced sync (`input.value = getValue()`) then paints `""`, bypassing Lit's dirty-check. `commit()` resolving does not close the window — the write being durable in the worker doesn't mean the freshly-minted main-thread handle has hydrated.

## Fix

`CellController` now tracks pending local edits and the last known authoritative value, keyed to the **persistent cell** (id/space/path) rather than handle identity, so the tracking survives drift-driven same-cell rebinds:

- **Pending-edit overlay** — from `setValue()` until confirmed, `getValue()` returns the user's edit, so no repaint can see a stale snapshot. Stale deliveries (late hydration, partial echoes of earlier keystrokes, a rebound handle's pre-write state) are suppressed and not announced via `onChange`.
- **Last-known-value fallback** — after release, a same-cell rebind to a not-yet-hydrated handle (`get()` still `undefined`) keeps showing the last known value instead of repainting emptiness. This alone covers the confirmed repro timeline (wipe after `commit()` resolved).
- **Release rules** — the edit clears when bound state converges on it, when all in-flight writes settle converged, or (settled-but-unconverged, e.g. a rebind swapped in a pre-write snapshot first) on the next delivery — deliveries are FIFO, so anything arriving after settle reflects post-write state and a genuinely newer remote value always wins. The same-handle optimistic sync echo deliberately does **not** confirm the edit; only bound state catching up may. Rebinding to a different cell drops all tracking; suppressing concurrent remote values while a write is in flight matches eventual state under blind last-write-wins `CellSet`.

All components sharing the controller (`cf-input`, `cf-textarea`, `cf-checkbox`, `cf-switch`, `cf-code-editor`, …) inherit the guard. Components with a custom `setValue` (none in-tree) keep status-quo behavior via an immediate release after the local apply.

## Tests

Seven new unit tests in `cell-controller.test.ts` (red before the fix, green after):

- keeps a settled local edit across a same-cell rebind to a not-yet-hydrated handle (the repro shape);
- suppresses a stale pre-write rebind snapshot until the echo confirms, without emitting `onChange` for the value the UI never showed;
- keeps the latest keystroke over a partial echo of an earlier write;
- keeps the typed value when late initial hydration arrives mid-debounce;
- keeps an uncommitted edit over a remote update under the blur strategy;
- **guards**: post-settle remote updates — including a clear back to the pre-edit baseline — still apply, and rebinding to a different cell drops protection (both green before and after).

Verified: full `packages/ui` suite (127 tests / 741 steps) and the two-browser `deno task integration patterns lunch-poll-vote` run green on fresh port-offset servers with the fix live in the dev-served shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the early-boot text wipe in cell-bound inputs by keeping pending local edits over stale bound state. Adds hydration-aware fallback and scope-aware cell identity so real clears repaint and cross-scope rebinds don’t carry edits.

- **Bug Fixes**
  - Track pending local edits keyed to the persistent cell; `getValue()` returns the edit until the bound state confirms it.
  - Hydration gating: use the last known value only before the first real delivery; an authoritative clear (`undefined` after hydration) repaints empty, forgets the last value, and can release an unconverged edit.
  - Same-cell rebinds to unhydrated handles keep showing the last known value; stale deliveries (late hydration, partial echoes, rebound pre-write snapshots) are suppressed; newer remote values always win.
  - Rebinder guard: scope-aware cell identity prevents edit carry-over across `user`/`space` scopes; bind-epoch isolates settles from previous cells; rebinding to a different cell resets tracking; `cancel()` drops the edit; custom setters release immediately.

- **Tests**
  - Added cases for authoritative clears and no resurrection on rebinds, newer-remote supersedes after settle, and bind-epoch isolation.
  - Covered scope-change rebinds, structural confirmation/rejection (arrays/objects), and link-identity non-confirmation.
  - Included `blur`/`debounce` timing, late hydration, manual transaction strategy, plain-value bindings, and `cancel()` behavior.

<sup>Written for commit 07da6f38b0104bd749bb95013889bdca28ec27ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

