### PR TITLE
feat(cfc): spec-settled channel disciplines — membership replaces, existence freezes

### DIFF
--- a/docs/specs/cfc-observation-classes.md
+++ b/docs/specs/cfc-observation-classes.md
@@ -150,17 +150,33 @@ stamps, which have always been confidentiality-only. Consequence: a
 confidentiality but no longer inherits content certification into the
 hereditary meet — an intended under-claim (SC-9's fail-safe direction).
 
-**C3 note (2026-07-03): the grow landed.** On overwrite the flow-clear folds
-the confidentiality of every dropped `derived` (any class, covering
-included — pre-C2 data) and `structure` entry into the covering written
-path's `observes:"shape"` entry: new J first, then the cleared atoms, so
-re-derivation stays byte-identical (SC-11). The grown entry is written even
-when the overwriting transaction consumed nothing (the red SC-4 case — a
-clean overwrite previously made the existence bit public). Cleared `link`
-entries are excluded (pointer labels; folding them into content shape would
-re-smear the pointer/content split), and cleared existence not covered by
-any stamp path (e.g. a link write replacing the slot) lands as a bare shape
-entry at the shallowest covering written path.
+**C3 note (2026-07-03, superseded 2026-07-06): grow shipped, then the
+discipline was settled with the spec as freeze-at-creation.** C3's interim
+fix grew the existence entry on every overwrite; running the open questions
+against the spec (§8.12.8 as amended on specs branch
+`cfc/existence-freeze-at-creation`) settled the final disciplines:
+
+- **`observes:"shape"` (existence) entries FREEZE at creation**: minted
+  once with the creating attempt's join (legacy pre-class entries are
+  absorbed at the one-time migration, conservatively over-attributed to
+  the first labeled stamping), never cleared and never grown by overwrites
+  of a still-existing path. Soundness: a writer conditional on existence
+  journals that observation itself (§8.10.1/§8.9.2). Residual: deletion
+  leaves the frozen entry (over-taint) and re-creation keeps it instead of
+  re-minting at the re-creating join — re-mint-on-recreation needs
+  per-path previousValue plumbing.
+- **`origin:"structure"` membership stamps are `observes:"enumerate"`**,
+  replace-from-criteria per §8.12.8 (normative — its rationale names and
+  rejects accumulate-forever). Axis-mapping note: the labs `observes` axis
+  is read-op shaped, so labs `enumerate` at a container approximates the
+  spec's container-level `iterate.{order,count}` label classes; the
+  spec's per-child `shape` encoding of membership is a recorded residual
+  (see SC note in `cfc-spec-changes.md`: a static per-child existence
+  probe does not consume the container-anchored stamp).
+- Cleared `link` entries never fold (pointer labels; folding them into
+  content shape would re-smear the pointer/content split). Legacy
+  migration conf not covered by any stamp path lands as a frozen shape
+  entry at the shallowest covering written path, or the entry's own path.
 
 ## 6. What `deriveFlowJoin` consumes per read shape
 

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -105,6 +105,18 @@ Minimal needed now: reading an array whose items resolve to references _without
 dereferencing_ consumes container enumeration + per-item shape only — not
 element `value`. (This is what makes SC-7's coordinator taint well-defined.) A
 fuller table can come with the observation-class implementation.
+(Container-membership encoding residual, found 2026-07-06 during the C3
+follow-up's spec ground-truthing: the spec encodes membership as per-child
+`shape` entries plus container-level `iterate` (§8.5.6.1); the runner's
+container-anchored structure stamp is an undefined compaction with a known
+under-taint — a static per-child existence probe ("is `/items/3` present?")
+is a `shape` read at the child (§8.10.1.1) and does not consume the
+exact-path container stamp. The spec-conforming fix is per-slot shape
+entries, at the per-row entry-count cost (#3998); recorded here until an
+implementation decides to pay it. Existence-entry update discipline settled
+as freeze-at-creation — spec §8.12.8 amendment on branch
+`cfc/existence-freeze-at-creation`.)
+
 (Design settled 2026-07-02, C0 #4476 + follow-up patches:
 `docs/specs/cfc-observation-classes.md` — the §4 read-API → class table, the
 §5 SC-4 grow-vs-replace split, the §3 `origin:"link"` ⇒ implicit

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3899,31 +3899,62 @@ export const prepareBoundaryCommit = (
       linkWriteInputs.map((input) => pathKey(input.target.path)),
     );
     let flowCleared = false;
-    // SC-4 (C3): the existence channel never shrinks. When the flow-clear
-    // drops a derived or structure entry under a written path, its
-    // confidentiality is collected here and folded into the written path's
-    // `observes:"shape"` entry below — "this path was once written under J"
-    // reveals every historical writer, so the existence label GROWS across
-    // overwrites while the value label replaces (§8.12.8 stays a
-    // value-class rule; C0 §5). Link entries are excluded: they label the
-    // pointer, and folding them into content shape would re-smear the
-    // pointer/content split.
+    // SC-4 (C3, disciplines settled with the spec 2026-07-06 — freeze-at-
+    // creation, specs branch cfc/existence-freeze-at-creation): existence
+    // never shrinks, but it does not grow either. When a clear drops a
+    // DERIVED entry under a written path, its confidentiality is collected
+    // here and folded into the written path's `observes:"shape"` entry —
+    // the departed subtree's existence history. MEMBERSHIP stamps
+    // (`origin:"structure"`, `observes:"enumerate"`) are exempt:
+    // §8.12.8's replace-on-overwrite is normative for recomputed
+    // membership, and pooling them re-imports the label creep it rejects.
+    // Frozen existence entries (`origin:"structure"`, `observes:"shape"`)
+    // are never cleared at all (handled before the clears below). Legacy
+    // covering structure entries (pre-C2: membership and existence
+    // conflated) still pool once — the migration freeze absorbs them into
+    // the container's frozen existence entry, conservatively. Link entries
+    // are excluded: they label the pointer, and folding them into content
+    // shape would re-smear the pointer/content split.
     const clearedExistence: Array<{
       path: readonly string[];
       confidentiality: readonly unknown[];
     }> = [];
+    // Only pre-class LEGACY entries (no `observes`) pool: they conflated
+    // existence with content/membership, and the one-time migration absorb
+    // below freezes their accumulated confidentiality into the path's
+    // shape entry. Post-C2 entries never pool — value/enumerate replace,
+    // shape freezes.
+    const poolsExistence = (entry: LabelMapEntry): boolean =>
+      entry.observes === undefined &&
+      (entry.origin === "derived" || entry.origin === "structure");
     for (const entry of existing?.labelMap.entries ?? []) {
       const entryPath = canonicalizeLogicalPath(entry.path);
       const key = pathKey(entryPath);
+      // Shape-class (existence) entries survive every overwrite of a
+      // still-existing path (freeze-at-creation): not the flow-clear, not
+      // a link write replacing the slot, not a declared re-mint. Known
+      // residual: deletion leaves the frozen entry in place (over-taint)
+      // and re-creation keeps it instead of re-minting at the re-creating
+      // join — re-mint-on-recreation needs per-path previousValue
+      // plumbing.
+      if (entry.observes === "shape") {
+        persistedLabelEntries.push({
+          path: entryPath,
+          label: cloneLabel(entry.label),
+          ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
+          observes: "shape",
+        });
+        continue;
+      }
       if (persistedLabelEntryKeys.has(key) || currentLinkWritePaths.has(key)) {
         // A link write replacing a previously content-labeled path — or a
         // declared entry re-minting at the same path — drops the old
-        // derived/structure entries here, through a different skip than
-        // the flow-clear below; their existence history still folds into
-        // the SC-4 pool like any other clear.
+        // derived entries here, through a different skip than the
+        // flow-clear below; their existence history still folds into the
+        // SC-4 pool like any other clear.
         if (
           flowPersist &&
-          (entry.origin === "derived" || entry.origin === "structure") &&
+          poolsExistence(entry) &&
           (entry.label.confidentiality?.length ?? 0) > 0
         ) {
           clearedExistence.push({
@@ -3954,7 +3985,7 @@ export const prepareBoundaryCommit = (
       ) {
         flowCleared = true;
         if (
-          entry.origin !== "link" &&
+          poolsExistence(entry) &&
           (entry.label.confidentiality?.length ?? 0) > 0
         ) {
           clearedExistence.push({
@@ -4062,12 +4093,12 @@ export const prepareBoundaryCommit = (
         }
         derivedStampPaths.push(path);
       }
-      // SC-4 grow (C3): the confidentiality of every derived/structure
-      // entry the flow-clear dropped folds into the shape-channel entry of
-      // the stamp path covering it — new J first, then the cleared atoms,
-      // so re-deriving the same overwrite reproduces the same grown entry
-      // byte-for-byte (SC-11). Consumed pool indices are tracked so
-      // anything not covered by a stamp still lands below.
+      // SC-4, freeze-at-creation form: a path's shape (existence) entry is
+      // minted ONCE — at creation, or at the one-time migration of legacy
+      // pre-class entries (whose accumulated confidentiality is absorbed
+      // here, conservatively over-attributed to this first stamping) — and
+      // is carried verbatim ever after. Consumed pool indices are tracked
+      // so legacy conf not covered by a stamp still lands below.
       const attachedExistence = new Set<number>();
       // Clause-aware dedup: the fold is where STORED bytes (a peer may have
       // persisted {anyOf:["B","A"]}) meet this tx's normalized derivation
@@ -4077,7 +4108,7 @@ export const prepareBoundaryCommit = (
       // normalizeClause each clause first; non-clause atoms pass through.
       const foldedUnique = (atoms: readonly unknown[]): unknown[] =>
         uniqueCfcAtoms(atoms.map((atom) => normalizeClause(atom)));
-      const grownConfidentialityFor = (
+      const frozenConfidentialityFor = (
         path: readonly string[],
       ): unknown[] => {
         const atoms: unknown[] = [...flowConfidentiality];
@@ -4124,14 +4155,24 @@ export const prepareBoundaryCommit = (
             observes: "value",
           });
         }
-        const shapeConfidentiality = grownConfidentialityFor(path);
-        if (shapeConfidentiality.length > 0) {
-          persistedLabelEntries.push({
-            path,
-            label: { confidentiality: shapeConfidentiality },
-            origin: "derived",
-            observes: "shape",
-          });
+        // Freeze-at-creation: mint the existence entry only when the path
+        // has none (creation / legacy migration); a carried frozen entry
+        // pushed above wins, and later writes to a still-existing path add
+        // no existence information (a writer conditional on existence
+        // journals that observation itself, §8.10.1/§8.9.2).
+        const hasShapeEntry = persistedLabelEntries.some((entry) =>
+          entry.observes === "shape" && pathKey(entry.path) === pathKey(path)
+        );
+        if (!hasShapeEntry) {
+          const shapeConfidentiality = frozenConfidentialityFor(path);
+          if (shapeConfidentiality.length > 0) {
+            persistedLabelEntries.push({
+              path,
+              label: { confidentiality: shapeConfidentiality },
+              origin: "derived",
+              observes: "shape",
+            });
+          }
         }
       }
       for (const path of structureStampPaths) {
@@ -4149,22 +4190,49 @@ export const prepareBoundaryCommit = (
         // structure entries (absent `observes`) stay covering — unchanged
         // compat; the flow join is unaffected either way since value reads
         // consume the `shape` class too (C0 §4).
-        const structureConfidentiality = grownConfidentialityFor(path);
-        if (flowHasLabels || structureConfidentiality.length > 0) {
+        // MEMBERSHIP stamp: the container's current selection, recomputed
+        // from this attempt's journal — §8.12.8 replace-on-overwrite is
+        // normative for it, so it carries the current J only, never the
+        // pool. Labs-axis mapping note: the `observes` axis is read-op
+        // shaped, so "enumerate" here approximates the spec's container-
+        // level `iterate.{order,count}` classes; the spec's per-child
+        // shape encoding of membership remains a recorded residual.
+        if (flowHasLabels && flowConfidentiality.length > 0) {
           persistedLabelEntries.push({
             path,
-            label: { confidentiality: structureConfidentiality },
+            label: { confidentiality: [...flowConfidentiality] },
             origin: "structure",
-            observes: "shape",
+            observes: "enumerate",
           });
         }
+        // FROZEN existence entry (freeze-at-creation, spec branch
+        // cfc/existence-freeze-at-creation): minted once — at the first
+        // labeled stamping of this container (creation, or migration of
+        // pre-existing data, over-attributing conservatively) — carrying
+        // the creating attempt's join plus any cleared legacy covering
+        // structure confidentiality at-or-below (the one-time migration
+        // absorb). Never grown, never cleared; a carried entry above wins.
+        const hasFrozenExistence = persistedLabelEntries.some((entry) =>
+          entry.observes === "shape" && pathKey(entry.path) === pathKey(path)
+        );
+        if (!hasFrozenExistence) {
+          const frozen = frozenConfidentialityFor(path);
+          if (frozen.length > 0) {
+            persistedLabelEntries.push({
+              path,
+              label: { confidentiality: frozen },
+              origin: "structure",
+              observes: "shape",
+            });
+          }
+        }
       }
-      // Cleared existence not covered by any stamp path (a link write
+      // Legacy migration conf not absorbed by any stamp path (a link write
       // replaced the slot, a declared entry re-minted at the path, or the
       // tx had no label of its own): the shallowest written path covering
-      // the cleared entry — or, when none does (a declared re-mint without
-      // a write there), the entry's own path — receives a bare shape entry
-      // so the existence history survives regardless.
+      // the cleared legacy entry — or, when none does (a declared re-mint
+      // without a write there), the entry's own path — receives the frozen
+      // shape entry so the existence history survives the migration.
       const leftoverByPath = new Map<
         string,
         { path: readonly string[]; atoms: unknown[] }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3930,14 +3930,21 @@ export const prepareBoundaryCommit = (
     for (const entry of existing?.labelMap.entries ?? []) {
       const entryPath = canonicalizeLogicalPath(entry.path);
       const key = pathKey(entryPath);
-      // Shape-class (existence) entries survive every overwrite of a
-      // still-existing path (freeze-at-creation): not the flow-clear, not
-      // a link write replacing the slot, not a declared re-mint. Known
-      // residual: deletion leaves the frozen entry in place (over-taint)
-      // and re-creation keeps it instead of re-minting at the re-creating
-      // join — re-mint-on-recreation needs per-path previousValue
-      // plumbing.
-      if (entry.observes === "shape") {
+      // RUNTIME-MINTED shape-class (existence) entries survive every
+      // overwrite of a still-existing path (freeze-at-creation): not the
+      // flow-clear, not a link write replacing the slot, not a declared
+      // re-mint. Origin-scoped to derived/structure: a DECLARED
+      // observes:"shape" entry is policy, not measurement — it keeps the
+      // declared component's own discipline (grow-only re-mint through
+      // the schema walk) and must not be captured by the freeze carry
+      // (review on this PR). Known residual: deletion leaves the frozen
+      // entry in place (over-taint) and re-creation keeps it instead of
+      // re-minting at the re-creating join — re-mint-on-recreation needs
+      // per-path previousValue plumbing.
+      if (
+        (entry.origin === "derived" || entry.origin === "structure") &&
+        entry.observes === "shape"
+      ) {
         persistedLabelEntries.push({
           path: entryPath,
           label: cloneLabel(entry.label),
@@ -4160,7 +4167,12 @@ export const prepareBoundaryCommit = (
         // pushed above wins, and later writes to a still-existing path add
         // no existence information (a writer conditional on existence
         // journals that observation itself, §8.10.1/§8.9.2).
+        // Only a runtime-minted existence entry suppresses the mint: a
+        // DECLARED observes:"shape" entry is store policy for the shape
+        // channel, not a record that creation happened — both coexist as
+        // separate components (review on this PR).
         const hasShapeEntry = persistedLabelEntries.some((entry) =>
+          (entry.origin === "derived" || entry.origin === "structure") &&
           entry.observes === "shape" && pathKey(entry.path) === pathKey(path)
         );
         if (!hasShapeEntry) {
@@ -4213,6 +4225,7 @@ export const prepareBoundaryCommit = (
         // structure confidentiality at-or-below (the one-time migration
         // absorb). Never grown, never cleared; a carried entry above wins.
         const hasFrozenExistence = persistedLabelEntries.some((entry) =>
+          (entry.origin === "derived" || entry.origin === "structure") &&
           entry.observes === "shape" && pathKey(entry.path) === pathKey(path)
         );
         if (!hasFrozenExistence) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4069,6 +4069,14 @@ export const prepareBoundaryCommit = (
       // byte-for-byte (SC-11). Consumed pool indices are tracked so
       // anything not covered by a stamp still lands below.
       const attachedExistence = new Set<number>();
+      // Clause-aware dedup: the fold is where STORED bytes (a peer may have
+      // persisted {anyOf:["B","A"]}) meet this tx's normalized derivation
+      // ({anyOf:["A","B"]}). uniqueCfcAtoms is deepEqual-based, so byte-
+      // permuted forms of one clause would both survive — a doubled clause
+      // list and one spurious envelope rewrite (the SC-11 churn class).
+      // normalizeClause each clause first; non-clause atoms pass through.
+      const foldedUnique = (atoms: readonly unknown[]): unknown[] =>
+        uniqueCfcAtoms(atoms.map((atom) => normalizeClause(atom)));
       const grownConfidentialityFor = (
         path: readonly string[],
       ): unknown[] => {
@@ -4079,7 +4087,7 @@ export const prepareBoundaryCommit = (
             atoms.push(...cleared.confidentiality);
           }
         });
-        return uniqueCfcAtoms(atoms);
+        return foldedUnique(atoms);
       };
       for (const path of derivedStampPaths) {
         // Deeper stamped paths are redundant with a stamped ancestor; only
@@ -4184,7 +4192,7 @@ export const prepareBoundaryCommit = (
       for (const bucket of leftoverByPath.values()) {
         persistedLabelEntries.push({
           path: canonicalizeLogicalPath(bucket.path),
-          label: { confidentiality: uniqueCfcAtoms(bucket.atoms) },
+          label: { confidentiality: foldedUnique(bucket.atoms) },
           origin: "derived",
           observes: "shape",
         });

--- a/packages/runner/test/cfc-declared-observes.test.ts
+++ b/packages/runner/test/cfc-declared-observes.test.ts
@@ -175,6 +175,70 @@ describe("CFC declared observation classes (C5)", () => {
     ).toContainEqual("content-secret");
   });
 
+  // A declared observes:"shape" label must neither suppress the runtime's
+  // frozen existence stamp (different component: declared = policy,
+  // derived = measurement — review on the freeze follow-up) nor be
+  // captured by the freeze carry out of its declared-policy discipline.
+  it("declared shape labels coexist with the frozen existence stamp", async () => {
+    const rt = makeRuntime();
+    const secretId = await (async () => {
+      const seed = rt.edit();
+      const cell = rt.getCell(space, "dobs-shape-secret", undefined, seed);
+      const id = cell.getAsNormalizedFullLink().id;
+      seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+        value: { n: 1 },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [{ path: [], label: { confidentiality: ["secret"] } }],
+          },
+        },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+      return id;
+    })();
+
+    const guarded = internSchema(
+      {
+        type: "object",
+        ifc: { confidentiality: ["declared-members"], observes: "shape" },
+      } as JSONSchema,
+      true,
+    );
+    const tx = rt.edit();
+    tx.readOrThrow({
+      space,
+      scope: "space",
+      id: uri(secretId),
+      type: "application/json",
+      path: ["value"],
+    });
+    const out = rt.getCell(space, "dobs-shape-out", guarded.schema, tx);
+    out.set({ created: true });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const outId = out.getAsNormalizedFullLink().id;
+    const entries = entriesOf(outId);
+    const declaredShape = entries.find((e) =>
+      e.origin === "declared" && e.observes === "shape"
+    );
+    expect(declaredShape).toBeDefined();
+    expect(declaredShape!.label.confidentiality).toContainEqual(
+      "declared-members",
+    );
+    // The runtime existence stamp is NOT suppressed by the declared entry:
+    // creation under secret influence must be recorded (SC-4).
+    const frozen = entries.find((e) =>
+      (e.origin === "derived" || e.origin === "structure") &&
+      e.observes === "shape"
+    );
+    expect(frozen).toBeDefined();
+    expect(frozen!.label.confidentiality).toContainEqual("secret");
+  });
+
   // A bogus observes value must not narrow anything: the entry mints
   // covering (over-taint, fail-safe) and every read class consumes it.
   it("an invalid ifc.observes value mints a covering entry", async () => {

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -19,15 +19,17 @@ type StoredEntry = {
   observes?: string;
 };
 
-// Epic C stage C3 — the two channel fixes (C0 §5, SC-4; C0 §4 row 3, SC-8).
+// Epic C stage C3 + follow-up — the existence channel (C0 §5, SC-4) and
+// the slot-pointer channel (C0 §4 row 3, SC-8).
 //
-// SC-4: §8.12.8 replace-on-overwrite is a VALUE-class rule. The existence
-// (shape) channel must never shrink: "this path was once written under J"
-// reveals every historical writer, so on overwrite the existence entry GROWS
-// (join of old and new confidentiality) — where before C3 the flow-clear
-// dropped it with the rest of the per-value components and a clean overwrite
-// made the existence bit public.
-describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
+// SC-4, settled with the spec (freeze-at-creation, §8.12.8 as amended on
+// specs branch cfc/existence-freeze-at-creation): the existence (shape)
+// entry is minted at the path's CREATION carrying the creating attempt's
+// join, is never cleared and never grown by overwrites of a still-existing
+// path (a writer conditional on existence journals that observation
+// itself), and legacy pre-class entries are absorbed once at migration.
+// C3's interim grow-on-overwrite is superseded by this discipline.
+describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -154,9 +156,10 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     }
   });
 
-  // A labeled overwrite: value replaces (precision win), existence grows
-  // (join of old and new — soundness fix).
-  it("labeled overwrite: value replaces, existence grows to the join", async () => {
+  // A labeled overwrite of a still-existing path: value replaces
+  // (§8.12.8), existence stays FROZEN at the creation join — the second
+  // writer adds no existence information.
+  it("labeled overwrite: value replaces, existence stays frozen at creation", async () => {
     const rt = makeRuntime();
     const secretId = await seedDoc(rt, "ec-secret", { n: 1 }, [
       { path: [], label: { confidentiality: ["secret"] } },
@@ -181,16 +184,14 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     expect(valueEntry?.label.confidentiality).toEqual(["public-ish"]);
     const shape = shapeEntriesAt(outId, []);
     expect(shape.length).toBe(1);
-    expect([...(shape[0].label.confidentiality ?? [])].sort()).toEqual([
-      "public-ish",
-      "secret",
-    ]);
+    expect(shape[0].label.confidentiality).toEqual(["secret"]);
   });
 
-  // An ancestor overwrite clears derived descendants (§8.12.8) — but their
-  // existence folds UP into the written path's existence entry rather than
-  // vanishing.
-  it("ancestor overwrite folds descendant existence into the written path", async () => {
+  // An ancestor overwrite clears derived VALUE descendants (§8.12.8) —
+  // but a descendant's frozen existence entry survives at its own path
+  // (never cleared), and the root mints no entry of its own from a clean
+  // overwrite.
+  it("ancestor overwrite leaves descendant existence frozen in place", async () => {
     const rt = makeRuntime();
     const sourceId = await seedDoc(rt, "ec-child-source", { n: 1 }, [
       { path: [], label: { confidentiality: ["secret"] } },
@@ -221,16 +222,23 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
-    expect(shapeEntriesAt(outId, ["child"])).toEqual([]);
-    const rootShape = shapeEntriesAt(outId, []);
-    expect(rootShape.length).toBe(1);
-    expect(rootShape[0].label.confidentiality).toContainEqual("secret");
+    const childShape = shapeEntriesAt(outId, ["child"]);
+    expect(childShape.length).toBe(1);
+    expect(childShape[0].label.confidentiality).toEqual(["secret"]);
+    // No value-class entry survives the clean recomputation anywhere.
+    for (const entry of entriesOf(outId)) {
+      if (entry.observes === "value") {
+        expect(entry.label.confidentiality ?? []).not.toContainEqual(
+          "secret",
+        );
+      }
+    }
   });
 
   // Pre-C2 covering derived entries carried the existence channel too; a
   // clean overwrite must fold their confidentiality into the new existence
   // entry, not erase it (the same SC-4 leak on legacy data).
-  it("legacy covering derived entries feed the existence grow", async () => {
+  it("legacy covering derived entries freeze into the migrated existence entry", async () => {
     const rt = makeRuntime();
     // Seed via a real flow write on a pre-C2-shaped doc: seed the covering
     // entry raw, with a loadable schema (the persist region skips docs
@@ -282,7 +290,7 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
   // Structure stamps are the container-shape half of the same channel: an
   // overwrite that replaces a labeled pure-link container with plain
   // content must keep the membership history on the existence entry.
-  it("cleared structure stamps feed the existence grow", async () => {
+  it("cleared legacy structure stamps freeze into the container existence entry", async () => {
     const rt = makeRuntime();
     const el0 = await seedDoc(rt, "ec-el-0", { n: 1 }, [
       { path: [], label: { confidentiality: ["alice"] } },
@@ -550,10 +558,62 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     expect(JSON.stringify(entriesOf(outId))).toEqual(before);
   });
 
+  // The A3 cross-scenario shape from the #4525 probe: membership changes
+  // across labeled re-stamps of a pure-link container. The MEMBERSHIP
+  // (enumerate) stamp is replaced from the current criteria each time —
+  // bob's atom does not survive his element leaving (§8.12.8 normative,
+  // no accumulate-forever) — while the frozen existence (shape) entry
+  // keeps the CREATION join only, untouched by later re-stamps.
+  it("membership replaces per criteria while frozen existence keeps the creation join (A3)", async () => {
+    const rt = makeRuntime();
+    const alice = await seedDoc(rt, "ec-a3-alice", { n: 1 }, [
+      { path: [], label: { confidentiality: ["alice"] } },
+    ]);
+    const bob = await seedDoc(rt, "ec-a3-bob", { n: 2 }, [
+      { path: [], label: { confidentiality: ["bob"] } },
+    ]);
+
+    const stampList = async (readIds: string[], members: string[]) => {
+      const tx = rt.edit();
+      for (const id of readIds) tx.readOrThrow(readAddress(id, []));
+      const cells = members.map((cause) =>
+        rt.getCell(space, cause, undefined, tx)
+      );
+      const list = rt.getCell(space, "ec-a3-list", {
+        type: "array",
+        items: { asCell: ["cell"] },
+      }, tx);
+      list.set(cells);
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+      return list.getAsNormalizedFullLink().id;
+    };
+
+    // A1: created under alice's influence, members [alice].
+    const listId = await stampList([alice], ["ec-a3-alice"]);
+    // A2: re-stamped under bob's influence, members [alice, bob].
+    await stampList([bob], ["ec-a3-alice", "ec-a3-bob"]);
+    // A3: re-stamped under alice's influence again, members [alice].
+    await stampList([alice], ["ec-a3-alice"]);
+
+    const structure = entriesOf(listId).filter((e) => e.origin === "structure");
+    const enumerateConf = structure
+      .filter((e) => e.observes === "enumerate")
+      .flatMap((e) => e.label.confidentiality ?? []);
+    const shapeConf = structure
+      .filter((e) => e.observes === "shape")
+      .flatMap((e) => e.label.confidentiality ?? []);
+    // Current membership: alice's criteria only — bob's atom left with his
+    // element (no unshrinkable accumulation).
+    expect(enumerateConf).toEqual(["alice"]);
+    // Frozen existence: the creation join only — untouched by A2/A3.
+    expect(shapeConf).toEqual(["alice"]);
+  });
+
   // Idempotence stays per-class (SC-11): repeating the same clean overwrite
   // must not churn the metadata — the grown existence entry re-derives
   // identically.
-  it("the grown existence entry re-derives idempotently", async () => {
+  it("the frozen existence entry re-derives idempotently", async () => {
     const rt = makeRuntime();
     const sourceId = await seedDoc(rt, "ec-idem-source", { n: 1 }, [
       { path: [], label: { confidentiality: ["secret"] } },

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -478,6 +478,78 @@ describe("CFC existence channel (C3, SC-4 grow-on-overwrite)", () => {
     expect(shape[0].label.confidentiality).toContainEqual("old-secret");
   });
 
+  // SC-11, clause-aware: a stored existence clause in a byte-permuted form
+  // (a peer wrote {anyOf:["B","A"]}) meeting this tx's normalized
+  // derivation ({anyOf:["A","B"]}) must collapse to ONE clause — deepEqual
+  // dedup alone doubles the clause list and rewrites the envelope once.
+  it("folds byte-permuted clause forms without doubling (SC-11)", async () => {
+    const rt = makeRuntime();
+    const orClause = { anyOf: ["reader-a", "reader-b"] };
+    const sourceId = await seedDoc(rt, "ec-clause-source", { n: 1 }, [
+      { path: [], label: { confidentiality: [orClause] } },
+    ]);
+    const outId = await writeTainted(rt, sourceId, "ec-clause-out", {
+      copied: true,
+    });
+
+    // Flip the stored existence clause to the reversed byte form, as a
+    // peer's view merge could have persisted it.
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): { cfc?: Record<string, unknown> };
+    };
+    const stored = replica.getDocument(outId).cfc! as {
+      labelMap: { entries: StoredEntry[] };
+    };
+    const flipped = {
+      ...stored,
+      labelMap: {
+        version: 1,
+        entries: stored.labelMap.entries.map((e) =>
+          e.observes === "shape"
+            ? {
+              ...e,
+              label: { confidentiality: [{ anyOf: ["reader-b", "reader-a"] }] },
+            }
+            : e
+        ),
+      },
+    };
+    const flip = rt.edit();
+    flip.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["cfc"] },
+      flipped as never,
+    );
+    expect((await flip.commit()).ok).toBeDefined();
+
+    // Re-derive: reads the source again (normalized clause) and overwrites
+    // the root — the fold meets the reversed stored form.
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(sourceId, []));
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { copied: false },
+    );
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(outId, []);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality?.length).toBe(1);
+
+    // And the re-derivation is now canonically idempotent: repeating the
+    // same overwrite leaves the stored metadata byte-identical.
+    const before = JSON.stringify(entriesOf(outId));
+    const again = rt.edit();
+    again.readOrThrow(readAddress(sourceId, []));
+    again.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { copied: 2 },
+    );
+    again.prepareCfc();
+    expect((await again.commit()).ok).toBeDefined();
+    expect(JSON.stringify(entriesOf(outId))).toEqual(before);
+  });
+
   // Idempotence stays per-class (SC-11): repeating the same clean overwrite
   // must not churn the metadata — the grown existence entry re-derives
   // identically.

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -610,6 +610,104 @@ describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
     expect(shapeConf).toEqual(["alice"]);
   });
 
+  // Legacy migration through the OTHER carry-forward skips: a pre-class
+  // covering entry at a slot replaced by a LINK write pools through the
+  // link-path skip and lands as a frozen shape entry at its own path (the
+  // leftover anchor — link-covered paths get no stamps).
+  it("legacy entry at a link-replaced slot freezes via the leftover anchor", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-legacy-link-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["old-secret"] } },
+    ]);
+    const outId = await writeTainted(rt, undefined, "ec-legacy-link-out", {
+      slot: 0,
+    });
+    const taint = rt.edit();
+    taint.readOrThrow(readAddress(sourceId, []));
+    taint.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value", "slot"] },
+      { copied: true },
+    );
+    taint.prepareCfc();
+    expect((await taint.commit()).ok).toBeDefined();
+    // Rewrite stored metadata: ONE legacy covering derived entry at the slot.
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): { cfc?: Record<string, unknown> };
+    };
+    const stored = replica.getDocument(outId).cfc! as Record<string, unknown>;
+    const legacy = rt.edit();
+    legacy.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["cfc"] },
+      {
+        ...stored,
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["slot"],
+            label: { confidentiality: ["old-secret"] },
+            origin: "derived",
+          }],
+        },
+      },
+    );
+    expect((await legacy.commit()).ok).toBeDefined();
+
+    // Replace the slot with a LINK in a clean tx: the legacy entry pools
+    // through the link-path skip; no stamp path covers a link write, so
+    // the leftover anchors the frozen shape entry at the slot itself.
+    await seedDoc(rt, "ec-legacy-link-target", { n: 2 }, []);
+    const linkTx = rt.edit();
+    const outCell = rt.getCell(space, "ec-legacy-link-out", undefined, linkTx);
+    const otherCell = rt.getCell(
+      space,
+      "ec-legacy-link-target",
+      undefined,
+      linkTx,
+    );
+    outCell.key("slot").set(otherCell);
+    linkTx.prepareCfc();
+    expect((await linkTx.commit()).ok).toBeDefined();
+
+    const shape = shapeEntriesAt(outId, ["slot"]);
+    expect(shape.length).toBe(1);
+    expect(shape[0].label.confidentiality).toContainEqual("old-secret");
+  });
+
+  // A mixed write — plain content at the root and a pure-link container in
+  // the same transaction — collapses the container's membership stamp
+  // against the covering derived ancestor (exact-path structure stamps
+  // only collapse against derived ancestors-or-equal).
+  it("structure stamps collapse under a derived ancestor stamp", async () => {
+    const rt = makeRuntime();
+    const sourceId = await seedDoc(rt, "ec-mixed-source", { n: 1 }, [
+      { path: [], label: { confidentiality: ["secret"] } },
+    ]);
+    await seedDoc(rt, "ec-mixed-el", { n: 2 }, []);
+
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(sourceId, []));
+    const out = rt.getCell(space, "ec-mixed-out", undefined, tx);
+    const outId = out.getAsNormalizedFullLink().id;
+    tx.writeOrThrow(
+      { space, scope: "space", id: uri(outId), path: ["value"] },
+      { text: "x" },
+    );
+    const el = rt.getCell(space, "ec-mixed-el", undefined, tx);
+    out.key("list").withTx(tx).set([el]);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const entries = entriesOf(outId);
+    expect(
+      entries.some((e) => e.origin === "derived" && e.path.join("/") === ""),
+    ).toBe(true);
+    expect(
+      entries.filter((e) =>
+        e.origin === "structure" && e.observes === "enumerate"
+      ),
+    ).toEqual([]);
+  });
+
   // Idempotence stays per-class (SC-11): repeating the same clean overwrite
   // must not churn the metadata — the grown existence entry re-derives
   // identically.

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -149,8 +149,13 @@ describe("CFC observation classes (C2 persist split)", () => {
     expect(shapeEntry.path).toEqual(valueEntry.path);
   });
 
-  // Structure stamps (pure-link-structure writes) now state their class.
-  it('structure stamps carry observes:"shape"', async () => {
+  // Structure stamps (pure-link-structure writes) split per channel: the
+  // MEMBERSHIP stamp is observes:"enumerate" (replace-from-criteria,
+  // §8.12.8 — labs-axis approximation of the spec's container-level
+  // iterate classes) and the container's EXISTENCE is a separate frozen
+  // observes:"shape" entry minted at creation (freeze-at-creation, spec
+  // branch cfc/existence-freeze-at-creation).
+  it("structure stamps split into enumerate membership + frozen shape existence", async () => {
     const rt = makeRuntime();
     const el0 = await seedDoc(rt, "ps-el-0", { n: 1 }, [
       { path: [], label: { confidentiality: ["alice"] } },
@@ -172,8 +177,9 @@ describe("CFC observation classes (C2 persist split)", () => {
     const listId = list.getAsNormalizedFullLink().id;
     const structure = entriesOf(listId).filter((e) => e.origin === "structure");
     expect(structure.length).toBeGreaterThan(0);
+    const classes = [...new Set(structure.map((e) => e.observes))].sort();
+    expect(classes).toEqual(["enumerate", "shape"]);
     for (const entry of structure) {
-      expect(entry.observes).toBe("shape");
       expect(entry.label.confidentiality).toEqual(["alice"]);
     }
   });


### PR DESCRIPTION
Follow-up to Epic C committed on the #4525 thread ([context](https://github.com/commontoolsinc/labs/pull/4525#issuecomment-4890955902)): the structure-stamp taxonomy question raised by @mathpirate's probe, the clause-dedup SC-11 gap, and the existence-discipline question — all resolved by ground-truthing against the CFC spec and settling the one genuinely-unspecified point with a spec amendment.

## Spec ground-truth (drives everything below)

- **Membership update discipline is replace-from-criteria, spec-normatively** (§8.12.8 rejects accumulate-forever by name; §8.5.4.3 scopes membership taint to the per-attempt journal). #4391's decision 2 is the spec's position.
- **`enumerate` is a read op, not a storable class** — the spec stores `shape`/`value`/`iterate{order,count}`, with membership encoded per-child + container `iterate`. Our container-anchored stamp is a compaction; its one identified under-taint (static per-child existence probes miss it) is recorded as a residual in `cfc-spec-changes.md`.
- **Existence discipline across overwrites was unspecified → settled as freeze-at-creation**, now normative in the spec (branch `cfc/existence-freeze-at-creation`, commit `53c84e64`): minted at the path's creation with the creating attempt's join; never modified by overwrites of a still-existing path (a writer conditional on existence journals that observation itself, §8.10.1/§8.9.2); re-minted on delete/re-create.

## What changes

1. **Membership stamps re-tagged `observes:"enumerate"`** (labs-axis approximation of spec `iterate.*`; mapping documented), carrying the current attempt's J only — replace-from-criteria, exempt from any fold. The A3 probe shape is pinned: bob's atom leaves when his element does.
2. **Existence entries freeze at creation** — for derived paths and containers alike. Shape-class entries are never cleared by any of the three carry-forward drop sites and are minted only when absent (creation, or the one-time migration of legacy pre-class entries, whose accumulated confidentiality is absorbed conservatively). C3's interim grow-on-overwrite is superseded; the fold machinery reduces to the legacy-migration absorb. Known residual (documented): deletion leaves the frozen entry (over-taint) and re-creation keeps it rather than re-minting — needs per-path previousValue plumbing.
3. **Clause-aware migration dedup (SC-11)**: the absorb normalizes each clause before dedup, so a peer's byte-permuted stored clause meeting this tx's normalized derivation folds to one clause — no doubled lists, no spurious envelope rewrite (red-first: reversed-anyOf test).
4. **Superseded C3 contracts flipped with citations**: "existence grows to the join" → stays frozen at creation; "descendant existence folds up" → survives frozen at its own path. The clean-overwrite SC-4 red case still holds (frozen entry survives — trivially, since nothing clears it).
5. **Docs**: C0 §5 note superseded with the settled disciplines + axis mapping; per-child-probe under-taint recorded as an SC residual in `cfc-spec-changes.md`.

## Composition with #4391

With replace as the normative discipline, #4391's no-write re-stamp splice needs no pool routing — it IS the discipline. The frozen existence entry is orthogonal to the splice (never touched after creation). @mathpirate — this should make the reconciliation on your side a no-op or nearly so.

## Tests

Red→green: clause-permuted fold (SC-11), A3 cross-scenario (membership replaces / existence freezes). Contract flips are cited to the spec amendment in-test. Full `packages/runner` suite green (774 passed / 0 failed); all 83 cfc test files green. Coverage pre-checked: every added line covered. Benches (plan §0): label-sync warm parallel batch 3.4 ms / getCfcLabel 1.3 µs; canonicalize preparedDigestFor small 12.7 µs, large 69.9 µs — flat vs the C5 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns CFC channel behavior with the spec: membership replaces from current criteria, and existence freezes at creation. Also fixes declared `observes:"shape"` labels so they neither suppress nor mingle with the runtime existence stamp.

- **New Features**
  - Membership stamps are `origin:"structure"`, `observes:"enumerate"` and replace per attempt; no pooling.
  - Existence (`observes:"shape"`) freezes at creation for paths and containers; minted once (or during legacy migration), never grown or cleared. Docs and tests updated (A3 scenario, legacy leftover anchoring, structure-stamp collapse).

- **Bug Fixes**
  - Clause-aware dedup in the existence fold (SC-11): normalize clauses before de-dup to avoid doubled entries and rewrite churn (reversed-anyOf test).
  - Declared `observes:"shape"` labels are policy-only: freeze logic is origin-scoped to derived/structure so declared labels coexist with the frozen creation stamp and are not captured by the carry.

<sup>Written for commit a4c39d512131b43895cdd598179ce640fcf6d8a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

