### PR TITLE
feat: computed-cell identity — kind-tagged ids and ack-and-drop conflict semantics

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -9,6 +9,7 @@ various major features.
 |------|---------|-------------|
 | `modernCellRep` | `EXPERIMENTAL_MODERN_CELL_REP` | Enables new "cell representation" classes |
 | `persistentSchedulerState` | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | Enables durable scheduler observations, dirty state, and scheduler rehydration through memory-v2. |
+| `computedCellIds` | `EXPERIMENTAL_COMPUTED_CELL_IDS` | Mints kind-tagged entity ids (`fid2:computed:`) for internal cells provably written only by compute nodes. Gates minting only; readers accept both forms. See `docs/specs/computed-cell-identity.md`. |
 | `schedulerHistoricalMightWrite` | n/a (`RuntimeOptions` only) | Preserves the scheduler's legacy cumulative write history for dependency scheduling instead of the default current-known write set. |
 
 All flags default to `undefined` which means they take on the default value

--- a/docs/development/handlers/invocation-outside-pattern.md
+++ b/docs/development/handlers/invocation-outside-pattern.md
@@ -43,7 +43,7 @@ await runtime.idle();
 
 ## Why it works
 
-The `{ asStream: true }` in the schema tells the cell that this property is a stream. When you call `.send()` on a stream-marked cell, it internally uses `scheduler.queueEvent()` which triggers the registered handler.
+The `{ asCell: ["stream"] }` in the schema tells the cell that this property is a stream. When you call `.send()` on a stream-marked cell, it internally uses `scheduler.queueEvent()` which triggers the registered handler.
 
 ## What doesn't work
 

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -2,12 +2,19 @@
 
 ## Status
 
-Phase 1 (minting) implemented behind `EXPERIMENTAL_COMPUTED_CELL_IDS`:
-`createRef`/`FabricHash` kind support (preimage + `fid2:computed:` format),
-conservative builder classifier, kind-aware descriptor/manifest matching.
-Server-side conflict policy (phases 2-4) not started. Derived from a design
-discussion on 2026-06-30/07-01 about avoiding needless commit conflicts when
-multiple clients recompute the same derived values.
+Phases 1-3 implemented. Phase 1 (minting), behind
+`EXPERIMENTAL_COMPUTED_CELL_IDS`: `createRef`/`FabricHash` kind support
+(preimage + `fid2:computed:` format), conservative builder classifier,
+kind-aware descriptor/manifest matching. Phase 2 (server policy): the
+memory-v2 engine acknowledges-and-drops stale all-computed commits — a
+zero-revision commit row keeps replay dedupe, dependent pending reads, and
+origin-committed preconditions working — and the storage client reverts the
+optimistic pending value on a `droppedComputed` ack instead of promoting it
+(promotion would shadow the authoritative value behind the monotonic seq
+guard). Phase 3 (lineage) is verified by engine tests. Value-equality dedupe
+(phase 4) and the server-side action runner (phase 5) are not started.
+Derived from a design discussion on 2026-06-30/07-01 about avoiding needless
+commit conflicts when multiple clients recompute the same derived values.
 
 ## Summary
 

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -209,6 +209,20 @@ only a missed optimization; tagging state as computed means the server
 silently drops user writes. The classifier may start extremely narrow and
 widen as capability analysis improves.
 
+One widening is implemented: a handle-bearing argument schema (`asCell`
+entries) disqualifies only when the module's capture writes are UNVERIFIED.
+The transformer emits `captureWritesAnalyzed` on lowered computeds whose
+capability analysis saw every capture (no wildcard escape, no recursion
+short-circuit, and no unrecognized method call on a cell-like receiver —
+the writer-method list is closed but the Cell API is not, so unknown
+cell-methods fail closed), making `materializerWriteInputPaths` an
+exhaustive record of writes through captures — `.send()` included, since it
+is a write (`Stream.send()` delegates to `set()`). For such modules, possession of a
+handle is not use: a computed may embed event streams in the JSX it produces
+and still classify as a pure derivation. Hand-written `lift()`s with
+`asCell` schemas carry no such provenance and stay under the conservative
+rule.
+
 ### Server conflict policy
 
 At commit-apply time the engine classifies each semantic operation by

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -1,0 +1,364 @@
+# Computed Cell Identity And Write Conflict Policy
+
+## Status
+
+Proposal. No implementation yet. Derived from a design discussion on
+2026-06-30/07-01 about avoiding needless commit conflicts when multiple
+clients recompute the same derived values.
+
+## Summary
+
+When a pattern is instantiated, the runner materializes internal cells whose
+contents are, in many cases, pure functions of the pattern's inputs: any
+runtime holding the same inputs recomputes the same values. Today the memory
+server treats writes to those cells exactly like writes to authoritative
+state. When two clients recompute concurrently, or when one client commits a
+recompute against inputs that another client has just advanced, the server
+rejects the stale commit, the losing client's action re-runs, and it commits
+again — protocol churn that exists purely to converge on a value both sides
+would have derived anyway.
+
+This proposal makes the derived/authoritative distinction visible to the
+memory server by embedding a role in the entity id of computed internal
+cells, and relaxes the server's conflict handling for writes that target
+those entities: a computed write whose reads are stale is acknowledged and
+dropped instead of rejected, because reactivity guarantees the writer
+recomputes from the newer inputs once they sync down. Clients keep sending
+every commit — the database stays current for tools like `cf inspect`,
+`localSeq`-based read resolution keeps working, and speculation lineage
+preconditions stay satisfiable. Only the server's *response* to staleness
+changes, and only for entities whose ids carry the computed role.
+
+## Goals
+
+- Eliminate reject/re-run/recommit churn for concurrent or stale writes to
+  purely derived internal cells, without weakening conflict detection for
+  authoritative state.
+- Make the derived/authoritative classification of an entity immutable,
+  client-independent, and readable by the server (and by offline tools)
+  without protocol shape changes or side-channel registries.
+- Keep every commit flowing to the server so the durable store remains a
+  complete, inspectable materialization of all values.
+- Preserve the semantics of `PendingRead.localSeq` references and
+  `origin-committed` commit preconditions.
+- Lay the classification groundwork the future server-side action runner
+  needs to know which entities it is licensed to regenerate.
+
+## Non-goals
+
+- Do not skip sending recompute commits from clients. (An earlier variant of
+  this idea did; it was rejected because later commits' pending reads
+  reference the `localSeq` of prior local commits, `origin-committed`
+  preconditions name origin commits by `localSeq`, and non-runtime readers
+  such as `cf inspect` would lose visibility.)
+- Do not make the memory server execute pattern code. The server compares
+  read watermarks; it never computes values. A server-side action runner is
+  future work that this proposal feeds but does not include.
+- Do not change conflict semantics for authoritative state cells, stream
+  cells, or builtin result cells (`fetch`, `llm`, `generateText`, …). Their
+  writes are not re-derivable and keep strict semantics.
+- Do not retrofit visible role tags onto existing roles. Stream cells
+  already carry `$kind: "stream"` in their id preimage but not in their
+  visible form; adding a visible tag would re-identify every existing stream
+  cell. Visible role tags apply to newly introduced roles only.
+- Do not treat the role tag as a security boundary. Conflict semantics are a
+  convergence mechanism; authorization is unchanged.
+
+## Current System Overview
+
+### Internal cell identity
+
+The pattern builder assigns each internal root cell a `partialCause` —
+the cell's declared name, or an anonymous `{ $generated: N }` counter, with
+`$kind: "stream"` mixed in for stream cells
+(`packages/runner/src/builder/pattern.ts`). At instantiation the runner
+mints the entity id from the piece's result cell and that partial cause:
+
+```ts
+createRef({}, { parent, type: "internal", cause: descriptor.partialCause })
+```
+
+(`packages/runner/src/link-utils.ts`, `getDerivedInternalCellLink`). The
+result is a `FabricHash`: hash bytes plus an algorithm tag, stringified as
+`<tag>:<base64urlHash>`, e.g. `fid1:abc…`
+(`packages/data-model/src/fabric-primitives/FabricHash.ts`). The hash is
+opaque: nothing about the preimage — including `type: "internal"` or the
+partial cause — is recoverable from the id. `hashOf` mints the `fid1` tag at
+a single chokepoint (`packages/data-model/src/value-hash.ts`).
+
+The manifest of materialized internal cells is stored in result-cell
+metadata and matched by `deepEqual(partialCause)`
+(`packages/runner/src/runner.ts`, `materializeDerivedInternalCells`).
+
+### Transaction provenance
+
+The runner already distinguishes recompute transactions from event-handler
+transactions, but only in process memory:
+
+- Reactive action runs open their transaction with a `changeGroup` and set
+  `tx.tx.sourceAction` (`packages/runner/src/scheduler/action-run.ts`).
+- Event dispatch sets `tx.dispatchedEventId` and `tx.tx.immediate`
+  (`packages/runner/src/scheduler/events.ts`).
+
+Behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`, reactive runs attach a
+`SchedulerActionObservation` to their commit with
+`actionKind: "computation" | "effect"`; the event path attaches no
+observation, so the `"event-handler"` kind is currently never produced.
+
+### Commit conflict handling
+
+`ClientCommit` (`packages/memory/v2.ts`) carries `localSeq`, a read set
+(confirmed reads with sequence watermarks, pending reads referencing prior
+local commits by `localSeq`), operations, and optional preconditions. A
+commit whose reads are stale relative to the space head is rejected; the
+client's scheduler re-runs the action against the newer inputs and commits
+again. The persistent-scheduler-state work already performs per-entry
+keep/drop decisions on exactly this read-watermark basis for no-op
+observation batches, recording dropped replay rows rather than surfacing
+conflicts.
+
+## Problem Statement
+
+For a purely derived internal cell, a conflict between two clients is never
+meaningful: if their inputs matched, their values match; if their inputs
+differed, one client was stale and will recompute when the newer input
+arrives. The reject-and-retry cycle spends protocol round-trips and commit
+log entries converging on a value the system was always going to reach.
+Worse, as more clients share spaces, the probability of two runtimes
+recomputing the same node concurrently grows, so the churn scales with
+exactly the deployments we want to work well.
+
+The server cannot currently tell derived writes from authoritative ones. The
+in-process provenance markers do not cross the wire, the observation
+`actionKind` is an optional blob behind an experimental flag and absent on
+the event path (so absence is not a safe discriminator), and the entity id
+is an opaque hash.
+
+## Proposed Model
+
+### Role-tagged entity ids
+
+Embed the role in the id's visible tag segment. The current parser
+(`FabricHash.fromString`) splits at the **first** colon and base64url-decodes
+the remainder, so a literal three-segment `fid1:computed:<hash>` form fails
+to parse. Instead, fold the role into the tag with a non-colon separator:
+
+```
+fid1+computed:<base64urlHash>
+```
+
+This is drop-in compatible: `fromString`, `toString`, the `{tag, hash}`
+codec, and the `of:` URI layer round-trip it unchanged, and nothing in the
+codebase asserts specific tag values. The `tag` field's meaning widens from
+"algorithm identifier" to "format tag" (algorithm + role); this spec is the
+documentation of that widening.
+
+Alternative considered: segment-aware parsing for a true three-part form.
+Rejected for version 1 because every independent parser of the string form
+(client, memory engine, offline SQLite readers) would need to agree on the
+new grammar simultaneously; the folded tag requires no coordination.
+
+Rules:
+
+- **The role is also minted into the hash preimage.** `createRef` gains a
+  role input that is injected into the cause (following the
+  `$kind: "stream"` precedent) *and* selects the visible tag suffix, from
+  the same argument at the same call. The two representations cannot
+  diverge, and two cells identical except for role differ in hash bytes as
+  well as string form — so code paths that compare by `hashString` or raw
+  bytes rather than the full tagged form cannot alias a computed cell with
+  a state cell.
+- **Identity keys are the full tagged string form.** `fid1+computed:H` and
+  `fid1:H` are distinct entities everywhere, unconditionally.
+- **Absence means strict.** Untagged ids — every existing entity — keep
+  authoritative conflict semantics. There is no migration; only newly minted
+  computed cells get the new form, and the server's conservative default
+  covers everything it cannot classify.
+
+### Builder-side classification
+
+The builder tags a cell `computed` only when it can prove the cell is
+written solely by compute nodes:
+
+- the cell is the output of a `lift`/`computed`/derive node, and
+- the cell is not handed writable into any handler binding, and
+- the cell is not a stream, and
+- the cell is not the result cell of a non-replayable builtin (`fetch`,
+  `llm`, `generateText`, `llmDialog`, `streamData`, …), and
+- the cell is not exposed writable through the pattern's result/argument
+  surface.
+
+Everything else defaults to untagged (strict). The misclassification
+asymmetry drives this conservatism: tagging a computed cell as state costs
+only a missed optimization; tagging state as computed means the server
+silently drops user writes. The classifier may start extremely narrow and
+widen as capability analysis improves.
+
+### Server conflict policy
+
+At commit-apply time the engine classifies each semantic operation by
+parsing the role from its entity id string. Policy:
+
+- **All-computed commits** (every semantic operation targets a
+  computed-tagged entity):
+  - Reads current → accept normally. Optionally dedupe value-equal writes
+    (see Open Questions).
+  - Reads stale → **acknowledge and drop.** No rejection is signaled, no
+    retry is expected. The client's own scheduler re-runs the action when
+    the winning input syncs down; convergence is unchanged, churn is
+    eliminated.
+  - Two current commits racing on the same computed entity: first wins.
+    Determinism says the values should be identical; if they differ, that is
+    a nondeterminism bug surfacing, and first-wins still converges because
+    the losing client is corrected on sync-down.
+- **Mixed commits** (computed and non-computed operations together): strict
+  semantics for the whole commit. Atomicity is preserved; partial
+  application of a commit is never introduced. Pure recompute transactions
+  write only their computed output cells, so the all-computed case is the
+  common one.
+- **Non-computed commits**: unchanged.
+
+An acknowledged-and-dropped commit is indistinguishable from an accepted one
+for bookkeeping purposes: it consumes its `localSeq`, satisfies
+`origin-committed` preconditions that name it, and resolves
+`PendingRead.localSeq` references from later commits (the referenced read
+resolves against the value that actually won, which is the value the reader
+will observe after sync-down; if that read is thereby stale, the *reading*
+commit's own policy applies). This is the invariant that lets clients keep
+their existing commit pipeline untouched.
+
+### Client behavior
+
+None required beyond minting. The drop is invisible: the client applied its
+write optimistically, the server acks, and the authoritative value arrives
+through the normal subscription path exactly as a lost conflict does today —
+minus the rejection, the action re-run, and the second commit.
+
+### Role flips across pattern versions
+
+A cell whose role changes between pattern versions (e.g. a `computed(...)`
+refactored into handler-managed state) mints a different partial cause and
+therefore a different entity id. This is semantically correct, not a
+migration problem: in the computed→state direction the orphaned value was
+derived garbage; in the state→computed direction the old value is superseded
+by derivation. Either way the old contents are meaningless under the new
+role, and the manifest's `deepEqual(partialCause)` matching materializes the
+new cell and drops the stale entry naturally.
+
+Internal-cell identity is already refactor-fragile — anonymous cells re-mint
+on reorder via the `$generated` counter, named cells on rename — so role
+flips add a trigger to an existing hazard class (durable cross-piece links
+pointing at an orphaned entity), not a new class.
+
+### Trust model
+
+The role tag is client-asserted; the server cannot verify purity without
+executing code. What the design guarantees instead:
+
+- **Immutability.** The role is part of identity. There is no retag
+  operation, no migration case, and no surface where a buggy or malicious
+  client demotes an existing state cell to computed to get its writes
+  stale-dropped: changing the tag necessarily changes the id, i.e. names a
+  different entity.
+- **Blast-radius containment.** A client that mints a computed-tagged id and
+  writes non-derived data through it only relaxes conflict semantics for
+  entities it created itself. It gains no ability to affect the conflict
+  handling of anyone else's data.
+- **Honest tagging by construction.** The tag originates in the builder's
+  structural analysis, never in pattern-author-controlled values.
+
+## Relationship To Persistent Scheduler State
+
+The two workstreams are complementary, with the dependency pointing from
+this proposal onto persistent-scheduler-state:
+
+- The server-side machinery this policy needs — comparing a payload's read
+  watermarks against heads and making per-entry keep/drop decisions with
+  dropped-replay bookkeeping — already exists for no-op observation batches.
+  Implementing this policy is largely extending that mechanism from
+  observation rows to semantic operations on computed-tagged entities.
+- In return, this proposal de-risks persistent-scheduler-state's hardest
+  open problem: rehydration trust. For the computed subset of entities,
+  acting on a stale or invalid persisted observation degrades from a
+  correctness cliff to a performance cost — a wrong write is dropped and
+  recomputed — so the conservative fallback can be less conservative exactly
+  where data is replayable, even while action-identity fingerprints remain
+  version-1 placeholders.
+- Together they form the knowledge layer for the future server-side action
+  runner: persistent-scheduler-state supplies the dependency graph, read and
+  write surfaces, and dirty state; computed-tagged ids supply the set of
+  entities the server is licensed to regenerate; `ClientCommit.codeCID`
+  supplies code identity. Execution remains the missing (and out-of-scope)
+  half.
+
+## Correctness Invariants
+
+- A write to a non-computed entity is never dropped, deduped, or otherwise
+  relaxed by this policy.
+- A commit is either applied whole or dropped whole; mixed commits are never
+  partially applied.
+- An acknowledged-and-dropped commit satisfies every bookkeeping obligation
+  an accepted commit satisfies: `localSeq` consumption, `origin-committed`
+  preconditions, `PendingRead` resolution.
+- For deterministic computations, all clients converge on identical values
+  and identical entity ids without any client observing a conflict on a
+  computed entity.
+- For a nondeterministic computation mistakenly tagged computed, the system
+  still converges (first-wins plus sync-down correction); the failure mode
+  is value flapping, never divergence or data loss.
+- Existing entities and untagged ids behave exactly as before the change.
+
+## Phased Plan
+
+1. **Minting.** Thread a role input through `createRef`/`hashOf` (preimage +
+   visible tag from one argument). Builder classifier, starting with the
+   narrowest provable-pure rule. Gate minting behind an experimental flag in
+   the `EXPERIMENTAL_MODERN_DATA_MODEL` mold — new-form ids are a data
+   compatibility event, so the flag controls id creation, and readers accept
+   both forms unconditionally from the start.
+2. **Server policy, drop-on-stale.** Engine-side role parse at commit-apply;
+   ack-and-drop for all-computed stale commits, with dropped-replay rows for
+   inspectability, reusing the persistent-scheduler-state keep/drop path.
+3. **Lineage integration.** Verify `origin-committed` and
+   `PendingRead.localSeq` semantics against dropped commits under the
+   speculation test suites.
+4. **Value-equality dedupe** for current-read computed commits, if the
+   measured commit-log savings justify the comparison cost.
+5. **Later:** server-side action runner consumes the tags (separate spec).
+
+## Test Strategy
+
+- Unit: `FabricHash` round-trips of the folded tag through string, URI, and
+  codec forms; full-form identity keying (computed and untagged ids with
+  equal hash bytes are distinct everywhere).
+- Builder: classifier coverage for each exclusion (handler-writable, stream,
+  builtin result, result-surface exposure); a pattern refactor that flips a
+  cell's role mints a new id and re-materializes via the manifest.
+- Engine: all-computed stale commit is acked, dropped, recorded as a dropped
+  replay row, satisfies a dependent `origin-committed` precondition, and
+  resolves a later commit's pending read; mixed commit keeps strict
+  semantics; race of two current computed commits is first-wins.
+- Integration: two-client scenario where both recompute the same node —
+  assert convergence with zero conflict-driven action re-runs; `cf inspect`
+  shows the computed value and the drop bookkeeping.
+
+## Open Questions
+
+- Do builtin result cells flow through nodes the scheduler already marks as
+  effects, or as computations? The classifier's exclusion list must be
+  grounded in what the graph actually reports, not the builtin registry
+  alone.
+- Exact separator and vocabulary for the tag segment (`fid1+computed` vs
+  `fid1.computed`; whether the role set is a closed registry from day one).
+- Should the engine cache per-entity role or parse per operation? Parsing a
+  string prefix is likely cheap enough to skip the cache.
+- Is value-equality dedupe on current-read commits worth the comparison
+  cost, or does drop-on-stale capture nearly all of the win?
+- How should dropped commits surface in telemetry and `cf inspect` so that
+  a misclassified cell (state writes being silently dropped) is diagnosable
+  rather than mysterious?
+- Interaction with multi-space commits (`enableMultiSpaceWrites`): per-space
+  commits classify independently, but the partial-failure contract needs
+  re-reading against ack-and-drop.
+- Whether CFC flow-label derivation needs to observe dropped writes, or is
+  indifferent to them.

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -2,9 +2,12 @@
 
 ## Status
 
-Proposal. No implementation yet. Derived from a design discussion on
-2026-06-30/07-01 about avoiding needless commit conflicts when multiple
-clients recompute the same derived values.
+Phase 1 (minting) implemented behind `EXPERIMENTAL_COMPUTED_CELL_IDS`:
+`createRef`/`FabricHash` kind support (preimage + `fid2:computed:` format),
+conservative builder classifier, kind-aware descriptor/manifest matching.
+Server-side conflict policy (phases 2-4) not started. Derived from a design
+discussion on 2026-06-30/07-01 about avoiding needless commit conflicts when
+multiple clients recompute the same derived values.
 
 ## Summary
 
@@ -19,7 +22,7 @@ again — protocol churn that exists purely to converge on a value both sides
 would have derived anyway.
 
 This proposal makes the derived/authoritative distinction visible to the
-memory server by embedding a role in the entity id of computed internal
+memory server by embedding a kind in the entity id of computed internal
 cells, and relaxes the server's conflict handling for writes that target
 those entities: a computed write whose reads are stale is acknowledged and
 dropped instead of rejected, because reactivity guarantees the writer
@@ -27,7 +30,7 @@ recomputes from the newer inputs once they sync down. Clients keep sending
 every commit — the database stays current for tools like `cf inspect`,
 `localSeq`-based read resolution keeps working, and speculation lineage
 preconditions stay satisfiable. Only the server's *response* to staleness
-changes, and only for entities whose ids carry the computed role.
+changes, and only for entities whose ids carry the computed kind.
 
 ## Goals
 
@@ -57,11 +60,11 @@ changes, and only for entities whose ids carry the computed role.
 - Do not change conflict semantics for authoritative state cells, stream
   cells, or builtin result cells (`fetch`, `llm`, `generateText`, …). Their
   writes are not re-derivable and keep strict semantics.
-- Do not retrofit visible role tags onto existing roles. Stream cells
+- Do not retrofit visible kind tags onto existing kinds. Stream cells
   already carry `$kind: "stream"` in their id preimage but not in their
   visible form; adding a visible tag would re-identify every existing stream
-  cell. Visible role tags apply to newly introduced roles only.
-- Do not treat the role tag as a security boundary. Conflict semantics are a
+  cell. Visible kind tags apply to newly introduced kinds only.
+- Do not treat the kind tag as a security boundary. Conflict semantics are a
   convergence mechanism; authorization is unchanged.
 
 ## Current System Overview
@@ -136,39 +139,44 @@ is an opaque hash.
 
 ## Proposed Model
 
-### Role-tagged entity ids
+### Kind-tagged entity ids
 
-Embed the role in the id's visible tag segment. The current parser
-(`FabricHash.fromString`) splits at the **first** colon and base64url-decodes
-the remainder, so a literal three-segment `fid1:computed:<hash>` form fails
-to parse. Instead, fold the role into the tag with a non-colon separator:
+Embed the kind as a proper segment of a **versioned** id format:
 
 ```
-fid1+computed:<base64urlHash>
+fid2:computed:<base64urlHash>
 ```
 
-This is drop-in compatible: `fromString`, `toString`, the `{tag, hash}`
-codec, and the `of:` URI layer round-trip it unchanged, and nothing in the
-codebase asserts specific tag values. The `tag` field's meaning widens from
-"algorithm identifier" to "format tag" (algorithm + role); this spec is the
-documentation of that widening.
+`fid1:<hash>` remains the untagged form. `fid2` is a format version, not a
+new hash algorithm — the bytes are produced by the same fid1 hashing — and
+the version bump exists so the first segment stays a pure format
+discriminator: a parser that only knows fid1 fails loudly on a kinded id
+instead of silently mis-handling it.
 
-Alternative considered: segment-aware parsing for a true three-part form.
-Rejected for version 1 because every independent parser of the string form
-(client, memory engine, offline SQLite readers) would need to agree on the
-new grammar simultaneously; the folded tag requires no coordination.
+Parsing: `FabricHash.fromString` splits at the **last** colon. The hash
+segment is base64url and never contains a colon, so this is unambiguous,
+parses every existing two-segment id identically, and yields
+`tag = "fid2:<kind>"` for kinded ids. The `{tag, hash}` codec and the `of:`
+URI layer round-trip the form unchanged, and nothing in the codebase asserts
+specific tag values.
+
+Alternative considered: folding the kind into the tag with a non-colon
+separator (`fid1+computed:<hash>`), which keeps first-colon parsing working
+untouched. Rejected because it overloads `fid1` — the format-version
+identifier should stay clean before the first colon, and version-dispatching
+parsers get the failure-on-unknown-format property for free.
 
 Rules:
 
-- **The role is also minted into the hash preimage.** `createRef` gains a
-  role input that is injected into the cause (following the
-  `$kind: "stream"` precedent) *and* selects the visible tag suffix, from
+- **The kind is also minted into the hash preimage.** `createRef` gains a
+  kind input that is injected into the cause (following the
+  `$kind: "stream"` precedent) *and* selects the visible tag, from
   the same argument at the same call. The two representations cannot
-  diverge, and two cells identical except for role differ in hash bytes as
+  diverge, and two cells identical except for kind differ in hash bytes as
   well as string form — so code paths that compare by `hashString` or raw
   bytes rather than the full tagged form cannot alias a computed cell with
   a state cell.
-- **Identity keys are the full tagged string form.** `fid1+computed:H` and
+- **Identity keys are the full tagged string form.** `fid2:computed:H` and
   `fid1:H` are distinct entities everywhere, unconditionally.
 - **Absence means strict.** Untagged ids — every existing entity — keep
   authoritative conflict semantics. There is no migration; only newly minted
@@ -197,7 +205,7 @@ widen as capability analysis improves.
 ### Server conflict policy
 
 At commit-apply time the engine classifies each semantic operation by
-parsing the role from its entity id string. Policy:
+parsing the kind from its entity id string. Policy:
 
 - **All-computed commits** (every semantic operation targets a
   computed-tagged entity):
@@ -234,28 +242,28 @@ write optimistically, the server acks, and the authoritative value arrives
 through the normal subscription path exactly as a lost conflict does today —
 minus the rejection, the action re-run, and the second commit.
 
-### Role flips across pattern versions
+### Kind flips across pattern versions
 
-A cell whose role changes between pattern versions (e.g. a `computed(...)`
+A cell whose kind changes between pattern versions (e.g. a `computed(...)`
 refactored into handler-managed state) mints a different partial cause and
 therefore a different entity id. This is semantically correct, not a
 migration problem: in the computed→state direction the orphaned value was
 derived garbage; in the state→computed direction the old value is superseded
 by derivation. Either way the old contents are meaningless under the new
-role, and the manifest's `deepEqual(partialCause)` matching materializes the
+kind, and the manifest's `deepEqual(partialCause)` matching materializes the
 new cell and drops the stale entry naturally.
 
 Internal-cell identity is already refactor-fragile — anonymous cells re-mint
-on reorder via the `$generated` counter, named cells on rename — so role
+on reorder via the `$generated` counter, named cells on rename — so kind
 flips add a trigger to an existing hazard class (durable cross-piece links
 pointing at an orphaned entity), not a new class.
 
 ### Trust model
 
-The role tag is client-asserted; the server cannot verify purity without
+The kind tag is client-asserted; the server cannot verify purity without
 executing code. What the design guarantees instead:
 
-- **Immutability.** The role is part of identity. There is no retag
+- **Immutability.** The kind is part of identity. There is no retag
   operation, no migration case, and no surface where a buggy or malicious
   client demotes an existing state cell to computed to get its writes
   stale-dropped: changing the tag necessarily changes the id, i.e. names a
@@ -310,13 +318,13 @@ this proposal onto persistent-scheduler-state:
 
 ## Phased Plan
 
-1. **Minting.** Thread a role input through `createRef`/`hashOf` (preimage +
+1. **Minting.** Thread a kind input through `createRef`/`hashOf` (preimage +
    visible tag from one argument). Builder classifier, starting with the
    narrowest provable-pure rule. Gate minting behind an experimental flag in
    the `EXPERIMENTAL_MODERN_DATA_MODEL` mold — new-form ids are a data
    compatibility event, so the flag controls id creation, and readers accept
    both forms unconditionally from the start.
-2. **Server policy, drop-on-stale.** Engine-side role parse at commit-apply;
+2. **Server policy, drop-on-stale.** Engine-side kind parse at commit-apply;
    ack-and-drop for all-computed stale commits, with dropped-replay rows for
    inspectability, reusing the persistent-scheduler-state keep/drop path.
 3. **Lineage integration.** Verify `origin-committed` and
@@ -333,7 +341,7 @@ this proposal onto persistent-scheduler-state:
   equal hash bytes are distinct everywhere).
 - Builder: classifier coverage for each exclusion (handler-writable, stream,
   builtin result, result-surface exposure); a pattern refactor that flips a
-  cell's role mints a new id and re-materializes via the manifest.
+  cell's kind mints a new id and re-materializes via the manifest.
 - Engine: all-computed stale commit is acked, dropped, recorded as a dropped
   replay row, satisfies a dependent `origin-committed` precondition, and
   resolves a later commit's pending read; mixed commit keeps strict
@@ -348,9 +356,9 @@ this proposal onto persistent-scheduler-state:
   effects, or as computations? The classifier's exclusion list must be
   grounded in what the graph actually reports, not the builtin registry
   alone.
-- Exact separator and vocabulary for the tag segment (`fid1+computed` vs
-  `fid1.computed`; whether the role set is a closed registry from day one).
-- Should the engine cache per-entity role or parse per operation? Parsing a
+- Whether the kind vocabulary is a closed registry from day one (the format
+  question itself is resolved: `fid2:<kind>:<hash>`, last-colon parsing).
+- Should the engine cache per-entity kind or parse per operation? Parsing a
   string prefix is likely cheap enough to skip the cache.
 - Is value-equality dedupe on current-read commits worth the comparison
   cost, or does drop-on-stale capture nearly all of the win?
@@ -362,3 +370,12 @@ this proposal onto persistent-scheduler-state:
   re-reading against ack-and-drop.
 - Whether CFC flow-label derivation needs to observe dropped writes, or is
   indifferent to them.
+- Preimage embedding shape: the current implementation wraps the preimage in
+  a `{ entityKind, inner }` envelope inside `createRef` (guaranteeing an
+  untagged preimage — which always has a top-level `causal` key — can never
+  collide bytes-for-bytes with a kind-tagged one). An alternative is to bake
+  `$kind: "computed"` into the `partialCause` itself, mirroring the existing
+  `$kind: "stream"` convention for generated stream cells; that would also
+  let manifest matching collapse back to plain `deepEqual(partialCause)`
+  instead of the current `(partialCause, kind)` pair. Deferred for now; the
+  envelope approach stands.

--- a/packages/background-piece-service/src/env.ts
+++ b/packages/background-piece-service/src/env.ts
@@ -56,6 +56,7 @@ const envSchema = z.object({
   // other boolean env vars in this file have the same latent bug.
   EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
+  EXPERIMENTAL_COMPUTED_CELL_IDS: flagValue(),
   // Background Piece Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
   //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -51,6 +51,7 @@ export function createRuntime(env: EnvVars, identity: Identity): Runtime {
     experimental: {
       modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
       persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
+      computedCellIds: env.EXPERIMENTAL_COMPUTED_CELL_IDS,
     },
   });
 }

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -29,6 +29,7 @@ export function experimentalOptionsFromEnv(): ExperimentalOptions {
     persistentSchedulerState: read(
       "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
     ),
+    computedCellIds: read("EXPERIMENTAL_COMPUTED_CELL_IDS"),
   };
 
   // Log any overridden experimental flags.

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -109,10 +109,13 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 
   /**
    * Parses an instance from its string representation
-   * (`<tag>:<base64urlHash>`).
+   * (`<tag>:<base64urlHash>`). Splits at the LAST colon: the hash segment is
+   * base64url and never contains one, while the tag segment may (entity-kind
+   * formats such as `fid2:computed:<hash>` carry the kind inside the tag; see
+   * `entity-kind.ts`).
    */
   static fromString(source: string): FabricHash {
-    const colonIndex = source.indexOf(":");
+    const colonIndex = source.lastIndexOf(":");
     if (colonIndex === -1) {
       throw new ReferenceError(`Invalid content hash string: ${source}`);
     }

--- a/packages/data-model/src/fabric-primitives/entity-kind.ts
+++ b/packages/data-model/src/fabric-primitives/entity-kind.ts
@@ -1,0 +1,95 @@
+import { FabricHash } from "./FabricHash.ts";
+
+/**
+ * Entity kinds version a `FabricHash`'s format tag: `fid2:computed:<hash>`
+ * names an entity whose contents are a pure function of its pattern's
+ * inputs, re-derivable by any runtime holding the same inputs. The kind
+ * participates in identity — it is minted into the hash preimage AND the
+ * visible tag from the same argument (`createRef`'s `kind` option), so the
+ * two representations cannot diverge and a kind change necessarily names a
+ * different entity.
+ *
+ * `fid1:<hash>` remains the untagged form with strict, authoritative
+ * semantics. `fid2` is a FORMAT version, not a new hash algorithm: the bytes
+ * are produced by the same fid1 hashing, and the version bump exists so the
+ * first segment stays a pure format discriminator — a parser that only knows
+ * fid1 fails loudly on a kinded id instead of silently mis-handling it.
+ * `FabricHash.fromString` splits at the last colon (the hash segment is
+ * base64url and never contains one), so the parsed `tag` of a kinded id is
+ * `"fid2:<kind>"`.
+ *
+ * See `docs/specs/computed-cell-identity.md`.
+ */
+export type EntityKind = "computed";
+
+/** The format tag prefix of kind-tagged entity ids (`fid2:<kind>:<hash>`). */
+export const KINDED_ID_TAG_PREFIX = "fid2:";
+
+/** The format tag of untagged entity ids, which kinded minting upgrades. */
+const UNKINDED_ID_TAG = "fid1";
+
+const KNOWN_ENTITY_KINDS: ReadonlySet<string> = new Set(["computed"]);
+
+export function isEntityKind(value: unknown): value is EntityKind {
+  return typeof value === "string" && KNOWN_ENTITY_KINDS.has(value);
+}
+
+/**
+ * Returns a `FabricHash` with the same bytes whose format tag carries `kind`
+ * (`fid1` → `fid2:<kind>`). Throws on any other input tag: kinds are minted
+ * exactly once, at id creation, and only on top of the fid1 format.
+ */
+export function withEntityKind(hash: FabricHash, kind: EntityKind): FabricHash {
+  if (hash.tag !== UNKINDED_ID_TAG) {
+    throw new Error(
+      `Cannot mint a kind onto tag "${hash.tag}"; kinds are minted once, ` +
+        `onto ${UNKINDED_ID_TAG} hashes only`,
+    );
+  }
+  return new FabricHash(
+    hash.bytes,
+    `${KINDED_ID_TAG_PREFIX}${kind}`,
+  );
+}
+
+/**
+ * Parses the kind from a format tag (e.g. `"fid2:computed"` → `"computed"`).
+ * Unknown kind suffixes return `undefined` — callers must treat unrecognized
+ * kinds as strict/authoritative, never relaxed.
+ */
+export function entityKindOfTag(tag: string): EntityKind | undefined {
+  if (!tag.startsWith(KINDED_ID_TAG_PREFIX)) return undefined;
+  const kind = tag.slice(KINDED_ID_TAG_PREFIX.length);
+  return isEntityKind(kind) ? kind : undefined;
+}
+
+/**
+ * Parses the kind from an id string in tagged-hash form
+ * (`fid2:computed:<hash>`) or `of:`-prefixed URI form. Non-entity URIs
+ * (e.g. `data:`) and untagged ids return `undefined`.
+ */
+export function entityKindOfIdString(id: string): EntityKind | undefined {
+  const start = id.startsWith("of:") ? 3 : 0;
+  const lastColon = id.lastIndexOf(":");
+  if (lastColon <= start) return undefined;
+  return entityKindOfTag(id.slice(start, lastColon));
+}
+
+let computedCellIdsEnabled = false;
+
+/**
+ * Ambient runtime flag gating the MINTING of kind-tagged computed-cell ids.
+ * Readers accept both forms unconditionally regardless of this flag — new-form
+ * ids are a data-compatibility event, so only creation is gated.
+ */
+export function setComputedCellIdsConfig(enabled?: boolean): void {
+  computedCellIdsEnabled = enabled ?? false;
+}
+
+export function getComputedCellIdsConfig(): boolean {
+  return computedCellIdsEnabled;
+}
+
+export function resetComputedCellIdsConfig(): void {
+  computedCellIdsEnabled = false;
+}

--- a/packages/data-model/src/fabric-primitives/index.ts
+++ b/packages/data-model/src/fabric-primitives/index.ts
@@ -6,6 +6,16 @@ import { FabricHash } from "./FabricHash.ts";
 import { FabricRegExp } from "./FabricRegExp.ts";
 
 export { BaseFabricPrimitive } from "./BaseFabricPrimitive.ts";
+export {
+  type EntityKind,
+  entityKindOfIdString,
+  entityKindOfTag,
+  getComputedCellIdsConfig,
+  isEntityKind,
+  resetComputedCellIdsConfig,
+  setComputedCellIdsConfig,
+  withEntityKind,
+} from "./entity-kind.ts";
 export { FabricBytes } from "./FabricBytes.ts";
 export { FabricRegExp } from "./FabricRegExp.ts";
 export { FabricHash } from "./FabricHash.ts";

--- a/packages/data-model/test/fabric-primitives/entity-kind.test.ts
+++ b/packages/data-model/test/fabric-primitives/entity-kind.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import {
+  entityKindOfIdString,
+  entityKindOfTag,
+  getComputedCellIdsConfig,
+  isEntityKind,
+  resetComputedCellIdsConfig,
+  setComputedCellIdsConfig,
+  withEntityKind,
+} from "@/fabric-primitives/entity-kind.ts";
+import { hashOf } from "@/value-hash.ts";
+
+describe("entity-kind", () => {
+  const base = hashOf({ probe: "entity-kind" });
+
+  it("versions the tag to fid2:<kind> with the same bytes", () => {
+    const kinded = withEntityKind(base, "computed");
+    expect(kinded.tag).toBe("fid2:computed");
+    expect(kinded.hashString).toBe(base.hashString);
+    expect(kinded.taggedHashString).toBe(`fid2:computed:${base.hashString}`);
+  });
+
+  it("round-trips a kind-tagged hash through the string form", () => {
+    const kinded = withEntityKind(base, "computed");
+    const parsed = FabricHash.fromString(kinded.toString());
+    expect(parsed.tag).toBe("fid2:computed");
+    expect(parsed.hashString).toBe(base.hashString);
+    expect(parsed.toString()).toBe(kinded.toString());
+  });
+
+  it("keeps kind-tagged and untagged forms distinct identities", () => {
+    const kinded = withEntityKind(base, "computed");
+    expect(kinded.toString()).not.toBe(base.toString());
+  });
+
+  it("refuses to mint a kind twice or onto non-fid1 tags", () => {
+    const kinded = withEntityKind(base, "computed");
+    expect(() => withEntityKind(kinded, "computed")).toThrow(
+      /kinds are minted once/,
+    );
+    expect(() =>
+      withEntityKind(new FabricHash(base.bytes, "legacy"), "computed")
+    )
+      .toThrow(/kinds are minted once/);
+  });
+
+  it("parses kinds from tags, treating unknown kinds as absent", () => {
+    expect(entityKindOfTag("fid2:computed")).toBe("computed");
+    expect(entityKindOfTag("fid1")).toBeUndefined();
+    expect(entityKindOfTag("legacy")).toBeUndefined();
+    // Unknown kind suffixes must read as strict/authoritative.
+    expect(entityKindOfTag("fid2:future")).toBeUndefined();
+  });
+
+  it("parses kinds from id strings and of: URIs", () => {
+    const kinded = withEntityKind(base, "computed");
+    expect(entityKindOfIdString(kinded.toString())).toBe("computed");
+    expect(entityKindOfIdString(`of:${kinded.toString()}`)).toBe("computed");
+    expect(entityKindOfIdString(base.toString())).toBeUndefined();
+    expect(entityKindOfIdString(`of:${base.toString()}`)).toBeUndefined();
+    expect(entityKindOfIdString("data:application/json,{}")).toBeUndefined();
+    expect(entityKindOfIdString("no-colon")).toBeUndefined();
+  });
+
+  it("recognizes only known kinds", () => {
+    expect(isEntityKind("computed")).toBe(true);
+    expect(isEntityKind("state")).toBe(false);
+    expect(isEntityKind(undefined)).toBe(false);
+  });
+
+  it("exposes the ambient minting flag with a false default", () => {
+    expect(getComputedCellIdsConfig()).toBe(false);
+    setComputedCellIdsConfig(true);
+    expect(getComputedCellIdsConfig()).toBe(true);
+    resetComputedCellIdsConfig();
+    expect(getComputedCellIdsConfig()).toBe(false);
+  });
+});

--- a/packages/memory/test/v2-computed-drop-test.ts
+++ b/packages/memory/test/v2-computed-drop-test.ts
@@ -1,0 +1,394 @@
+/**
+ * Engine tests for the computed-cell ack-and-drop conflict policy
+ * (docs/specs/computed-cell-identity.md): a commit whose semantic operations
+ * ALL target computed-kind entities (`fid2:computed:` ids) is acknowledged as
+ * committed but its operations dropped when its reads are stale, instead of
+ * being rejected. The dropped commit still consumes its localSeq and — via
+ * its zero-revision commit row — satisfies replay dedupe, dependent pending
+ * reads, and origin-committed preconditions. Mixed and untagged commits keep
+ * strict conflict semantics.
+ */
+
+import { assertEquals, assertExists, assertThrows } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import {
+  applyCommit,
+  close,
+  ConflictError,
+  type Engine,
+  open,
+} from "../v2/engine.ts";
+import { type EntityDocument, toDocumentPath } from "../v2.ts";
+import type { FabricValue } from "@commonfabric/api";
+
+const toEntityDocument = (value: FabricValue): EntityDocument => ({ value });
+
+const createEngine = async (): Promise<{ engine: Engine; path: string }> => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  return { engine, path };
+};
+
+const INPUT_ID = "of:fid1:input";
+const COMPUTED_ID = "of:fid2:computed:out";
+const OTHER_COMPUTED_ID = "of:fid2:computed:other";
+const STATE_ID = "of:fid1:state";
+
+const revisionCount = (engine: Engine, id: string): number =>
+  (engine.database.prepare(
+    `SELECT count(*) AS count FROM revision WHERE id = :id`,
+  ).get({ id }) as { count: number }).count;
+
+// seq 1: session:a writes the input. seq 2: session:b overwrites it — any
+// read of the input at seq 1 is now stale.
+const seedStaleInput = (engine: Engine): void => {
+  applyCommit(engine, {
+    sessionId: "session:a",
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: INPUT_ID,
+        value: toEntityDocument({ count: 1 }),
+      }],
+    },
+  });
+  applyCommit(engine, {
+    sessionId: "session:b",
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: INPUT_ID,
+        value: toEntityDocument({ count: 2 }),
+      }],
+    },
+  });
+};
+
+const staleComputedCommit = (localSeq: number) => ({
+  sessionId: "session:a",
+  commit: {
+    localSeq,
+    reads: {
+      confirmed: [{
+        id: INPUT_ID,
+        path: toDocumentPath(["value", "count"]),
+        seq: 1,
+      }],
+      pending: [],
+    },
+    operations: [{
+      op: "set" as const,
+      id: COMPUTED_ID,
+      value: toEntityDocument({ doubled: 2 }),
+    }],
+  },
+});
+
+Deno.test("stale all-computed commit is acknowledged and dropped", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    const applied = applyCommit(engine, staleComputedCommit(2));
+
+    assertEquals(applied.droppedComputed, "stale-confirmed-read");
+    assertEquals(applied.revisions, []);
+    // A real commit row exists (localSeq consumed) but no revision was
+    // written and the entity remains untouched.
+    assertEquals(applied.seq, 3);
+    assertEquals(revisionCount(engine, COMPUTED_ID), 0);
+
+    // The engine stays writable past the dropped commit.
+    const next = applyCommit(engine, {
+      sessionId: "session:b",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: STATE_ID,
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+    assertEquals(next.seq, 4);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("replaying a dropped commit is idempotent and keeps the marker", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    const first = applyCommit(engine, staleComputedCommit(2));
+    const replayed = applyCommit(engine, staleComputedCommit(2));
+
+    assertEquals(replayed.seq, first.seq);
+    assertEquals(replayed.revisions, []);
+    assertEquals(replayed.droppedComputed, "stale-confirmed-read");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("dropped commit satisfies a dependent origin-committed precondition", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    applyCommit(engine, staleComputedCommit(2));
+
+    const dependent = applyCommit(engine, {
+      sessionId: "session:a",
+      commit: {
+        localSeq: 3,
+        reads: { confirmed: [], pending: [] },
+        preconditions: [{ kind: "origin-committed", originLocalSeq: 2 }],
+        operations: [{
+          op: "set",
+          id: STATE_ID,
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+    assertEquals(dependent.droppedComputed, undefined);
+    assertEquals(dependent.revisions.length, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("dropped commit resolves a dependent pending read", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    applyCommit(engine, staleComputedCommit(2));
+
+    // Reads the dropped commit's output pending its resolution. The dropped
+    // commit row resolves the localSeq; the computed entity has no revisions
+    // after that seq, so the read is current and the commit applies.
+    const dependent = applyCommit(engine, {
+      sessionId: "session:a",
+      commit: {
+        localSeq: 3,
+        reads: {
+          confirmed: [],
+          pending: [{
+            id: COMPUTED_ID,
+            path: toDocumentPath(["value"]),
+            localSeq: 2,
+          }],
+        },
+        operations: [{
+          op: "set",
+          id: OTHER_COMPUTED_ID,
+          value: toEntityDocument({ derived: true }),
+        }],
+      },
+    });
+    assertEquals(dependent.droppedComputed, undefined);
+    assertEquals(dependent.revisions.length, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("all-computed commit with current reads applies normally", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    const applied = applyCommit(engine, {
+      sessionId: "session:a",
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [{
+            id: INPUT_ID,
+            path: toDocumentPath(["value", "count"]),
+            seq: 2,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: COMPUTED_ID,
+          value: toEntityDocument({ doubled: 4 }),
+        }],
+      },
+    });
+    assertEquals(applied.droppedComputed, undefined);
+    assertEquals(applied.revisions.length, 1);
+    assertEquals(revisionCount(engine, COMPUTED_ID), 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("mixed commit keeps strict conflict semantics", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:a",
+          commit: {
+            localSeq: 2,
+            reads: {
+              confirmed: [{
+                id: INPUT_ID,
+                path: toDocumentPath(["value", "count"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [
+              {
+                op: "set",
+                id: COMPUTED_ID,
+                value: toEntityDocument({ doubled: 2 }),
+              },
+              {
+                op: "set",
+                id: STATE_ID,
+                value: toEntityDocument({ ok: true }),
+              },
+            ],
+          },
+        }),
+      ConflictError,
+      "stale confirmed read",
+    );
+    assertEquals(revisionCount(engine, COMPUTED_ID), 0);
+    assertEquals(revisionCount(engine, STATE_ID), 0);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("untagged commit keeps strict conflict semantics", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:a",
+          commit: {
+            localSeq: 2,
+            reads: {
+              confirmed: [{
+                id: INPUT_ID,
+                path: toDocumentPath(["value", "count"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: STATE_ID,
+              value: toEntityDocument({ ok: true }),
+            }],
+          },
+        }),
+      ConflictError,
+      "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("all-computed commit with a missing pending dependency is dropped", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    const applied = applyCommit(engine, {
+      sessionId: "session:a",
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [],
+          // localSeq 99 was never committed (e.g. a rejected mixed commit).
+          pending: [{
+            id: INPUT_ID,
+            path: toDocumentPath(["value"]),
+            localSeq: 99,
+          }],
+        },
+        operations: [{
+          op: "set",
+          id: COMPUTED_ID,
+          value: toEntityDocument({ doubled: 2 }),
+        }],
+      },
+    });
+    assertEquals(applied.droppedComputed, "pending-read-missing");
+    assertEquals(applied.revisions, []);
+    assertEquals(revisionCount(engine, COMPUTED_ID), 0);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("unknown kinds stay strict", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:a",
+          commit: {
+            localSeq: 2,
+            reads: {
+              confirmed: [{
+                id: INPUT_ID,
+                path: toDocumentPath(["value", "count"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              // A future kind this engine does not know must not relax.
+              id: "of:fid2:future:mystery",
+              value: toEntityDocument({ q: 1 }),
+            }],
+          },
+        }),
+      ConflictError,
+      "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("head advances past a dropped commit", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    seedStaleInput(engine);
+    const dropped = applyCommit(engine, staleComputedCommit(2));
+    assertExists(dropped.droppedComputed);
+    const head = (engine.database.prepare(
+      `SELECT head_seq FROM branch WHERE name = ''`,
+    ).get() as { head_seq: number } | undefined)?.head_seq;
+    assertEquals(head, dropped.seq);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1,5 +1,6 @@
 import { Database } from "@db/sqlite";
 import type { FabricValue } from "@commonfabric/api";
+import { entityKindOfIdString } from "@commonfabric/data-model/fabric-primitives";
 import { runWrite } from "./sqlite/exec.ts";
 import {
   applyPatch,
@@ -749,16 +750,29 @@ export interface AppliedSchedulerObservationResult {
   localSeq: number;
   status: "kept" | "dropped";
   schedulerObservationId?: number;
-  reason?:
-    | "stale-confirmed-read"
-    | "stale-pending-read"
-    | "pending-read-missing";
+  reason?: CommitReadDropReason;
 }
+
+export type CommitReadDropReason =
+  | "stale-confirmed-read"
+  | "stale-pending-read"
+  | "pending-read-missing";
 
 export interface AppliedCommit {
   seq: number;
   branch: BranchName;
   revisions: AppliedRevision[];
+  /**
+   * Set when the commit was acknowledged-as-committed but its operations were
+   * DROPPED under the computed-cell conflict policy: every semantic operation
+   * targeted a computed-kind entity (`fid2:computed:` id) and the commit's
+   * reads were stale, so reactivity guarantees the writer recomputes from the
+   * newer inputs — no rejection, no retry, no revisions. The commit still
+   * consumes its localSeq and satisfies dependent pending reads and
+   * origin-committed preconditions. See
+   * `docs/specs/computed-cell-identity.md`.
+   */
+  droppedComputed?: CommitReadDropReason;
   schedulerObservationId?: number;
   schedulerObservationResults?: AppliedSchedulerObservationResult[];
   schedulerDirtiedReaders?: SchedulerReaderIndexEntry[];
@@ -3143,10 +3157,15 @@ const applyCommitTransaction = (
         `commit replay mismatch for session ${sessionId} localSeq ${commit.localSeq}`,
       );
     }
+    const storedResolution = decodeMemoryBoundary(
+      existing.resolution,
+    ) as { droppedComputed?: CommitReadDropReason } | undefined;
     return {
       seq: existing.seq,
       branch: existing.branch,
       revisions: selectCommitRevisions(engine, existing.seq),
+      ...(storedResolution?.droppedComputed !== undefined &&
+        { droppedComputed: storedResolution.droppedComputed }),
     };
   }
 
@@ -3179,6 +3198,30 @@ const applyCommitTransaction = (
       localSeq: commit.localSeq,
       reads: commit.reads,
       schedulerObservation,
+    });
+  }
+
+  // Computed-cell conflict policy (docs/specs/computed-cell-identity.md): a
+  // commit whose semantic operations ALL target computed-kind entities is
+  // acknowledged-as-committed but DROPPED when its reads are stale, instead
+  // of rejected. The values are re-derivable — the writer's own scheduler
+  // recomputes from the newer inputs once they sync down — so rejection would
+  // only buy retry churn. The dropped commit still consumes its localSeq and
+  // (via its commit row) satisfies dependent pending reads and
+  // origin-committed preconditions, exactly like an applied commit.
+  const computedDropReason = commitComputedDropReason(engine, {
+    sessionKey,
+    sessionId,
+    principal,
+    branch,
+    commit,
+  });
+  if (computedDropReason !== undefined) {
+    return applyDroppedComputedCommit(engine, {
+      sessionKey,
+      branch,
+      commit,
+      reason: computedDropReason,
     });
   }
 
@@ -3686,6 +3729,111 @@ const schedulerObservationReadDropReason = (
   }
 
   return undefined;
+};
+
+/**
+ * The computed-cell drop policy's gate: returns a drop reason iff the commit
+ * carries at least one semantic operation, EVERY semantic operation targets a
+ * computed-kind entity (`fid2:computed:` id), and the commit's reads are
+ * stale. Any non-computed or sqlite operation disqualifies the whole commit —
+ * mixed commits keep strict all-or-nothing conflict semantics, preserving
+ * atomicity. Unknown kinds parse as no-kind and therefore stay strict.
+ *
+ * Cost note: an all-computed commit with current reads validates its reads
+ * here AND in the throwing validators afterwards. Correctness first; the two
+ * checks share `findConflictSeq`, so a divergence bug is not possible.
+ */
+const commitComputedDropReason = (
+  engine: Engine,
+  {
+    sessionKey,
+    sessionId,
+    principal,
+    branch,
+    commit,
+  }: {
+    sessionKey: string;
+    sessionId: SessionId;
+    principal: string | undefined;
+    branch: BranchName;
+    commit: ClientCommit;
+  },
+): CommitReadDropReason | undefined => {
+  const { operations } = commit;
+  if (operations.length === 0) return undefined;
+  const allComputed = operations.every((operation) =>
+    operation.op !== "sqlite" &&
+    entityKindOfIdString(operation.id) === "computed"
+  );
+  if (!allComputed) return undefined;
+  return schedulerObservationReadDropReason(engine, {
+    sessionKey,
+    sessionId,
+    principal,
+    branch,
+    reads: commit.reads,
+  });
+};
+
+/**
+ * Acknowledge-and-drop an all-computed stale commit. Inserts a real commit
+ * row with ZERO revisions: replay dedupe (`selectExistingCommit`), dependent
+ * pending reads, and origin-committed preconditions (`selectPendingResolution`)
+ * all key on `(session_id, local_seq)`, so the row makes a dropped commit
+ * indistinguishable from an applied one for every bookkeeping purpose — the
+ * spec's invariant. No revisions, no snapshot materialization, no scheduler
+ * dirty-marking: nothing changed. A `schedulerObservation` riding on the
+ * commit is deliberately NOT persisted — its reads are the same stale reads,
+ * and persistent-scheduler-state semantics drop stale observations, leaving
+ * the prior snapshot and dirty state untouched.
+ */
+const applyDroppedComputedCommit = (
+  engine: Engine,
+  {
+    sessionKey,
+    branch,
+    commit,
+    reason,
+  }: {
+    sessionKey: string;
+    branch: BranchName;
+    commit: ClientCommit;
+    reason: CommitReadDropReason;
+  },
+): AppliedCommit => {
+  const seq = (engine.statements.selectNextSeq.get() as { seq: number }).seq;
+  const invocationRef = engine.legacyCommitMetadataRefsRequired
+    ? LEGACY_EMPTY_INVOCATION_REF
+    : null;
+  const authorizationRef = engine.legacyCommitMetadataRefsRequired
+    ? LEGACY_EMPTY_AUTHORIZATION_REF
+    : null;
+  if (engine.legacyCommitMetadataRefsRequired) {
+    engine.statements.insertAuthorization.run({
+      ref: LEGACY_EMPTY_AUTHORIZATION_REF,
+      authorization: encodeMemoryBoundary(LEGACY_EMPTY_AUTHORIZATION),
+    });
+    engine.statements.insertInvocation.run({
+      ref: LEGACY_EMPTY_INVOCATION_REF,
+      iss: LEGACY_EMPTY_INVOCATION.iss,
+      aud: LEGACY_EMPTY_INVOCATION.aud ?? null,
+      cmd: LEGACY_EMPTY_INVOCATION.cmd,
+      sub: LEGACY_EMPTY_INVOCATION.sub,
+      invocation: encodeMemoryBoundary(LEGACY_EMPTY_INVOCATION),
+    });
+  }
+  engine.statements.insertCommit.run({
+    seq,
+    branch,
+    session_id: sessionKey,
+    local_seq: commit.localSeq,
+    invocation_ref: invocationRef,
+    authorization_ref: authorizationRef,
+    original: encodeMemoryBoundary(commit),
+    resolution: encodeMemoryBoundary({ seq, droppedComputed: reason }),
+  });
+  engine.statements.updateBranchHead.run({ branch, seq });
+  return { seq, branch, revisions: [], droppedComputed: reason };
 };
 
 const replayedSchedulerObservationResult = (

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1655,25 +1655,30 @@ export class Server {
           message.sessionId,
         );
       }
-      await this.runPostCommitSchedulerSideEffects(
-        message.space,
-        commit,
-        schedulerObservations,
-        previousReadSpaces,
-        session,
-      );
-      this.markSpaceDirty(
-        message.space,
-        message.commit.operations
-          .filter((operation) => operation.op !== "sqlite")
-          .map((operation) =>
-            toDirtyKey(operation.id, declaredScope(operation.scope))
-          ),
-        {
-          sessionId: message.sessionId,
-          seq: commit.seq,
-        },
-      );
+      // An acknowledged-but-dropped computed commit wrote no revisions:
+      // nothing to broadcast to other sessions, and its scheduler observation
+      // was deliberately not persisted, so there are no side effects to run.
+      if (commit.droppedComputed === undefined) {
+        await this.runPostCommitSchedulerSideEffects(
+          message.space,
+          commit,
+          schedulerObservations,
+          previousReadSpaces,
+          session,
+        );
+        this.markSpaceDirty(
+          message.space,
+          message.commit.operations
+            .filter((operation) => operation.op !== "sqlite")
+            .map((operation) =>
+              toDirtyKey(operation.id, declaredScope(operation.scope))
+            ),
+          {
+            sessionId: message.sessionId,
+            seq: commit.seq,
+          },
+        );
+      }
       return {
         type: "response",
         requestId: message.requestId,

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -364,11 +364,21 @@ export function lift<T, R>(
     ...(options?.materializerWriteInputPaths
       ? { materializerWriteInputPaths: options.materializerWriteInputPaths }
       : {}),
+    ...(options?.captureWritesAnalyzed === true
+      ? { captureWritesAnalyzed: true }
+      : {}),
   });
 }
 
 interface DeriveSchedulerOptions {
   materializerWriteInputPaths?: readonly (readonly string[])[];
+  /**
+   * Transformer-emitted assertion that capability analysis ran over the
+   * callback with no capture escaping tracking, so
+   * `materializerWriteInputPaths` is an EXHAUSTIVE record of writes through
+   * captures. See `docs/specs/computed-cell-identity.md`.
+   */
+  captureWritesAnalyzed?: boolean;
 }
 
 export function byRef<T, R>(ref: string): ModuleFactory<T, R> {

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -710,6 +710,13 @@ function assignComputedCellKinds(
   // its own inputs. (Handlers never appear as writers — their `outputs` is
   // `{}` — but ref builtins, sub-patterns, raw/isolated modules, and effects
   // do, and none of their outputs are replayable.)
+  //
+  // Handle-bearing argument schemas (asCell entries) disqualify only when the
+  // module's capture writes are UNVERIFIED: when the transformer's capability
+  // analysis vouches for the callback (`captureWritesAnalyzed`, emitted only
+  // with no wildcard escape and no recursion short-circuit, with `.send()`
+  // counted as a write), possession of a handle is not use — a computed may
+  // embed event streams in its JSX output and still be a pure derivation.
   const writerQualifies = (module: NodeRef["module"]): boolean =>
     isModule(module) &&
     module.type === "javascript" &&
@@ -717,7 +724,8 @@ function assignComputedCellKinds(
     module.isEffect !== true &&
     (module.materializerWriteInputPaths?.length ?? 0) === 0 &&
     module.writableProxy !== true &&
-    !schemaGrantsWritableHandles(module.argumentSchema);
+    (module.captureWritesAnalyzed === true ||
+      !schemaGrantsWritableHandles(module.argumentSchema));
 
   const writersByRoot = new Map<OpaqueCell<any>, NodeRef["module"][]>();
   const disqualified = new Set<OpaqueCell<any>>();

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -4,9 +4,11 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
   type CellScope,
+  type DerivedInternalCellDescriptor,
   type FactoryInput,
   type Frame,
   type ICell,
+  isModule,
   isReactive,
   JSONObject,
   type JSONSchema,
@@ -50,6 +52,7 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { isCell, setCellUnlinkedSpace } from "../cell.ts";
+import { getComputedCellIdsConfig } from "@commonfabric/data-model/fabric-primitives";
 import { createRef } from "../create-ref.ts";
 import { toURI } from "../uri-utils.ts";
 import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
@@ -513,6 +516,15 @@ function factoryFromPattern<T, R>(
     true,
   )!;
 
+  if (getComputedCellIdsConfig()) {
+    assignComputedCellKinds(
+      allNodes,
+      derivedInternalPartialCausesByRoot,
+      derivedInternalCells,
+      result,
+    );
+  }
+
   const argumentSchema: JSONSchema = argumentSchemaArg ?? true;
 
   const resultSchema =
@@ -616,6 +628,147 @@ function factoryFromPattern<T, R>(
   const patternFactory = makePatternFactory();
 
   return patternFactory;
+}
+
+/**
+ * `asCell` kinds that provably cannot write through the handle. Everything
+ * else — "cell", "writeonly", "stream", "sqlite", and any kind this code does
+ * not recognize — counts as write-capable for classification.
+ */
+const READ_ONLY_CELL_KINDS: ReadonlySet<string> = new Set([
+  "opaque",
+  "comparable",
+  "readonly",
+]);
+
+/**
+ * Recursively true if a schema grants a write-capable cell handle anywhere in
+ * its subtree (an `asCell` entry whose kind is not provably read-only). For
+ * computed-kind classification any occurrence disqualifies — deliberately
+ * over-broad (a value coincidentally containing an `asCell` key inside a
+ * `default` also trips it); the failure direction is only a missed
+ * optimization.
+ */
+function schemaGrantsWritableHandles(schema: unknown): boolean {
+  if (Array.isArray(schema)) return schema.some(schemaGrantsWritableHandles);
+  if (!isRecord(schema)) return false;
+  if (Array.isArray(schema.asCell)) {
+    for (const entry of schema.asCell) {
+      const kind = typeof entry === "string"
+        ? entry
+        : isRecord(entry)
+        ? entry.kind
+        : undefined;
+      if (typeof kind !== "string" || !READ_ONLY_CELL_KINDS.has(kind)) {
+        return true;
+      }
+    }
+  }
+  return Object.values(schema).some(schemaGrantsWritableHandles);
+}
+
+/**
+ * Marks derived internal cells with `kind: "computed"` when the serialized
+ * graph proves they are written ONLY by pure compute nodes, so their ids are
+ * minted kind-tagged (`fid2:computed:`) and the memory server may apply
+ * relaxed conflict semantics to their writes. Classification must be
+ * conservative: tagging a computed cell as state costs a missed optimization,
+ * tagging state as computed silently drops user writes. See
+ * `docs/specs/computed-cell-identity.md`.
+ *
+ * A cell qualifies iff:
+ * - every node writing it (listing its root under `node.outputs`) is a plain
+ *   javascript compute module — not a handler wrapper, not an effect, not a
+ *   builtin/pattern/raw node — with no writable-input markers of its own
+ *   (`materializerWriteInputPaths`, `writableProxy`, or an argument schema
+ *   granting cell handles), and there is at least one such writer;
+ * - its root never appears in the INPUTS of any node that could write through
+ *   them (handlers capture their whole closure under `$ctx`; materializers,
+ *   effects, builtins, and sub-patterns may write inputs — any appearance
+ *   disqualifies, even a read-only capture);
+ * - it is not a stream; and
+ * - the result surface never exposes it through an alias whose schema still
+ *   grants a cell handle (a consumer could write through the handle).
+ */
+function assignComputedCellKinds(
+  allNodes: Set<NodeRef>,
+  partialCausesByRoot: Map<OpaqueCell<any>, JSONValue>,
+  derivedInternalCells: DerivedInternalCellDescriptor[],
+  serializedResult: JSONValue,
+): void {
+  const collectCellRoots = (value: unknown): Set<OpaqueCell<any>> => {
+    const roots = new Set<OpaqueCell<any>>();
+    traverseValue(value as FactoryInput<unknown>, (item) => {
+      if (isCellResultForDereferencing(item)) item = getCellOrThrow(item);
+      if (isCell(item)) roots.add(item.export().cell);
+      return item;
+    });
+    return roots;
+  };
+
+  // A writer we can vouch for: a plain compute that also cannot write through
+  // its own inputs. (Handlers never appear as writers — their `outputs` is
+  // `{}` — but ref builtins, sub-patterns, raw/isolated modules, and effects
+  // do, and none of their outputs are replayable.)
+  const writerQualifies = (module: NodeRef["module"]): boolean =>
+    isModule(module) &&
+    module.type === "javascript" &&
+    module.wrapper !== "handler" &&
+    module.isEffect !== true &&
+    (module.materializerWriteInputPaths?.length ?? 0) === 0 &&
+    module.writableProxy !== true &&
+    !schemaGrantsWritableHandles(module.argumentSchema);
+
+  const writersByRoot = new Map<OpaqueCell<any>, NodeRef["module"][]>();
+  const disqualified = new Set<OpaqueCell<any>>();
+  allNodes.forEach((node) => {
+    collectCellRoots(node.outputs).forEach((root) => {
+      const writers = writersByRoot.get(root) ?? [];
+      writers.push(node.module);
+      writersByRoot.set(root, writers);
+    });
+    if (!writerQualifies(node.module)) {
+      collectCellRoots(node.inputs).forEach((root) => disqualified.add(root));
+    }
+  });
+
+  // Result aliases that still grant a cell handle expose the cell writable to
+  // consumers; collect their partial causes for disqualification.
+  const handleExposedPartialCauses: JSONValue[] = [];
+  const collectHandleExposures = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(collectHandleExposures);
+      return;
+    }
+    if (!isRecord(value)) return;
+    const alias = (value as LegacyAlias).$alias;
+    if (
+      isRecord(alias) && alias.partialCause !== undefined &&
+      schemaGrantsWritableHandles(alias.schema)
+    ) {
+      handleExposedPartialCauses.push(alias.partialCause);
+    }
+    Object.values(value).forEach(collectHandleExposures);
+  };
+  collectHandleExposures(serializedResult);
+
+  partialCausesByRoot.forEach((partialCause, root) => {
+    const writers = writersByRoot.get(root);
+    if (writers === undefined || writers.length === 0) return;
+    if (!writers.every(writerQualifies)) return;
+    if (disqualified.has(root)) return;
+    const { value } = root.export();
+    if (isRecord(value) && value.$stream === true) return;
+    if (
+      handleExposedPartialCauses.some((cause) => deepEqual(cause, partialCause))
+    ) {
+      return;
+    }
+    const descriptor = derivedInternalCells.find((candidate) =>
+      deepEqual(candidate.partialCause, partialCause)
+    );
+    if (descriptor !== undefined) descriptor.kind = "computed";
+  });
 }
 
 /**

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import type { EntityKind } from "@commonfabric/data-model/fabric-primitives";
 import type { PatternBuilder } from "./pattern.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
 
@@ -242,6 +243,14 @@ export type DerivedInternalCellDescriptor = {
   partialCause: JSONValue;
   schema?: JSONSchema;
   scope?: CellScope;
+  /**
+   * Entity kind minted into the cell's id (preimage + visible tag). Set to
+   * `"computed"` only when the builder proves the cell is written solely by
+   * compute nodes. Participates in manifest matching: a kind change
+   * re-materializes the cell under a new id. See
+   * `docs/specs/computed-cell-identity.md`.
+   */
+  kind?: EntityKind;
 };
 
 declare module "@commonfabric/api" {

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -220,6 +220,14 @@ declare module "@commonfabric/api" {
     materializerWriteEnvelopes?: readonly NormalizedFullLink[];
     /** Input paths whose writable cells should become materializer envelopes */
     materializerWriteInputPaths?: readonly (readonly string[])[];
+    /**
+     * Transformer assertion that capability analysis ran over this module's
+     * callback and no capture escaped tracking, making
+     * `materializerWriteInputPaths` an exhaustive record of capture writes
+     * (`.send()` included). Lets the computed-cell classifier accept
+     * handle-bearing argument schemas when no writes were observed.
+     */
+    captureWritesAnalyzed?: boolean;
     /** Run this module's result in a specific space. */
     targetSpace?: MemorySpace;
   }

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,7 +1,9 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import {
   BaseFabricPrimitive,
+  type EntityKind,
   FabricHash,
+  withEntityKind,
 } from "@commonfabric/data-model/fabric-primitives";
 import {
   type EntityRef,
@@ -39,6 +41,19 @@ export function entityIdFrom(hash: string | FabricHash): EntityId {
 }
 
 /**
+ * Options for {@link createRef}.
+ */
+export type CreateRefOptions = {
+  /**
+   * Entity kind minted into BOTH the hash preimage and the visible tag
+   * (`fid2:computed:<hash>`), so the two representations cannot diverge and
+   * a kind change necessarily names a different entity. See
+   * `docs/specs/computed-cell-identity.md`.
+   */
+  kind?: EntityKind;
+};
+
+/**
  * Generates an entity ID.
  *
  * Derivation inputs must resolve: a Cell with no entityId or a Reactive with
@@ -48,6 +63,7 @@ export function entityIdFrom(hash: string | FabricHash): EntityId {
  *
  * @param source - The source object.
  * @param cause - Optional causal source. If omitted, a random id is minted.
+ * @param options - Optional kind; see {@link CreateRefOptions}.
  */
 export function createRef(
   source: Record<string | number | symbol, any> = {},
@@ -58,6 +74,7 @@ export function createRef(
     );
     return crypto.randomUUID();
   })(),
+  options?: CreateRefOptions,
 ): EntityId {
   const seen = new Set<any>();
 
@@ -140,7 +157,17 @@ export function createRef(
     else return obj;
   }
 
-  return entityIdFrom(hashOf(traverse({ ...source, causal: cause })));
+  const kind = options?.kind;
+  // The kind changes the preimage SHAPE, not just a key: an untagged preimage
+  // always carries a top-level `causal` key, while the kind envelope never
+  // does, so no untagged id can collide bytes-for-bytes with a kind-tagged one
+  // (guards code paths that compare `hashString`/bytes instead of the full
+  // tagged form).
+  const preimage = kind === undefined
+    ? { ...source, causal: cause }
+    : { entityKind: kind, inner: { ...source, causal: cause } };
+  const hash = hashOf(traverse(preimage));
+  return entityIdFrom(kind === undefined ? hash : withEntityKind(hash, kind));
 }
 
 /**

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -761,11 +761,15 @@ export function getDerivedInternalCellLink(
   const parent = resultCell.entityId ?? resultCell;
   return {
     space: resultCellLink.space,
-    id: toURI(createRef({}, {
-      parent,
-      type: "internal",
-      cause: descriptor.partialCause,
-    })),
+    id: toURI(createRef(
+      {},
+      {
+        parent,
+        type: "internal",
+        cause: descriptor.partialCause,
+      },
+      descriptor.kind !== undefined ? { kind: descriptor.kind } : undefined,
+    )),
     path: [],
     scope: descriptor.scope ?? resultCellLink.scope,
     ...(descriptor.schema !== undefined && { schema: descriptor.schema }),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4,6 +4,7 @@ import {
   nativeFromFabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import { getPersistentSchedulerStateConfig } from "@commonfabric/memory/v2";
+import type { EntityKind } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import {
   toCompactDebugString,
@@ -126,6 +127,12 @@ const EAGER_RESULT_BUILTIN_REFS = new Set([
 
 type InternalCellDescriptor = {
   partialCause: JSONValue;
+  /**
+   * Entity kind of the materialized cell's id. Part of the manifest match
+   * key alongside `partialCause`: a kind flip across pattern versions must
+   * re-materialize the cell under its new id rather than reuse the old link.
+   */
+  kind?: EntityKind;
   link: SigilLink;
 };
 
@@ -910,7 +917,8 @@ export class Runner {
         tx,
       );
       const manifestMatch = existingManifest.findIndex((existingDescriptor) =>
-        deepEqual(existingDescriptor.partialCause, descriptor.partialCause)
+        deepEqual(existingDescriptor.partialCause, descriptor.partialCause) &&
+        existingDescriptor.kind === descriptor.kind
       );
       if (manifestMatch === -1) {
         // this cell isn't in our manifest yet. Create it, and add it to the manifest
@@ -920,6 +928,7 @@ export class Runner {
         });
         manifest.push({
           partialCause: descriptor.partialCause,
+          ...(descriptor.kind !== undefined && { kind: descriptor.kind }),
           link: derivedSigilLink,
         });
         setResultCell(derivedCell, resultCell.asSchema(pattern.resultSchema));

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -20,6 +20,11 @@ import {
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import {
+  getComputedCellIdsConfig,
+  resetComputedCellIdsConfig,
+  setComputedCellIdsConfig,
+} from "@commonfabric/data-model/fabric-primitives";
+import {
   getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
   resetCommitPreconditionsConfig,
@@ -172,6 +177,13 @@ export interface ExperimentalOptions {
   persistentSchedulerState?: boolean | undefined;
   /** Attach origin-committed preconditions to scheduler-v2 lineage commits. */
   commitPreconditions?: boolean | undefined;
+  /**
+   * Mint kind-tagged entity ids (`fid2:computed:`) for internal cells the
+   * builder proves are written only by compute nodes. Gates minting only;
+   * readers accept both forms unconditionally. See
+   * `docs/specs/computed-cell-identity.md`.
+   */
+  computedCellIds?: boolean | undefined;
 }
 
 /**
@@ -428,6 +440,7 @@ export class Runtime {
       modernCellRep: undefined,
       persistentSchedulerState: undefined,
       commitPreconditions: undefined,
+      computedCellIds: undefined,
       ...options.experimental,
     };
 
@@ -455,6 +468,8 @@ export class Runtime {
       getPersistentSchedulerStateConfig();
     setCommitPreconditionsConfig(this.experimental.commitPreconditions);
     this.experimental.commitPreconditions = getCommitPreconditionsConfig();
+    setComputedCellIdsConfig(this.experimental.computedCellIds);
+    this.experimental.computedCellIds = getComputedCellIdsConfig();
 
     this.commitBackpressure = resolveCommitBackpressure(
       options.commitBackpressure,
@@ -715,6 +730,7 @@ export class Runtime {
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
+    resetComputedCellIdsConfig();
 
     // Clear the current runtime reference
     // Removed setCurrentRuntime call - no longer using singleton pattern

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2098,6 +2098,9 @@ class SpaceReplica implements ISpaceReplica {
       }
       const { session } = await this.sessionHandle();
       const applied = await session.transact(commit);
+      if (applied.droppedComputed !== undefined) {
+        return this.finalizeDroppedComputed(localSeq, operations, source);
+      }
       this.confirmPending(localSeq, operations, applied);
       return { ok: {} };
     } catch (error) {
@@ -2127,6 +2130,70 @@ class SpaceReplica implements ISpaceReplica {
         rejection,
       );
     }
+  }
+
+  // Success tail for a commit the server acknowledged-as-committed but
+  // DROPPED under the computed-cell conflict policy (its reads were stale and
+  // every operation targeted a computed-kind entity). The commit SUCCEEDED
+  // for bookkeeping — localSeq consumed, dependents satisfied — but no
+  // revision was written, so the optimistic pending value must NOT be
+  // promoted into confirmed state: confirmPending would stamp it at the acked
+  // commit seq, and the monotonic guard in applySessionSync would then shadow
+  // the server's authoritative value indefinitely. Instead drop the pending
+  // write (confirmed keeps the entity's real seq) and emit a revert
+  // notification. No retry is scheduled: the newer input revisions that made
+  // the reads stale arrive through the normal watch flow, dirty the reader,
+  // and the recompute writes a fresh commit — re-running now would only
+  // reproduce the same stale write. See docs/specs/computed-cell-identity.md.
+  private finalizeDroppedComputed(
+    localSeq: number,
+    operations: NativeCommitOperation[],
+    source: IStorageTransaction | undefined,
+  ): Result<Unit, StorageTransactionRejected> {
+    const touched = operations.map((operation) => ({
+      id: operation.id,
+      scope: operation.scope,
+    }));
+    const hasSemanticOperations = operations.length > 0;
+    const shouldNotifySubscribers = hasSemanticOperations &&
+      this.hasNotificationSubscribers();
+    const shouldNotifySinks = hasSemanticOperations &&
+      this.hasSinkSubscribers(touched);
+    const before = shouldNotifySubscribers
+      ? Differential.checkout(
+        this,
+        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+      )
+      : undefined;
+    this.dropPending(localSeq);
+    logger.debug("commit-dropped-computed", () => [
+      `computed commit acknowledged-and-dropped (stale reads)`,
+      { localSeq, operations: operations.length },
+    ]);
+    if (before !== undefined) {
+      const changes = before.compare(this);
+      this.#subscription.next({
+        type: "revert",
+        space: this.#space,
+        changes,
+        // Not a conflict (isConflictRejection is false by name), so no
+        // consumer schedules a retry off this notification; same synthetic
+        // cast idiom as toRejectedError's TransactionError fallback.
+        reason: {
+          name: "DroppedComputedCommit",
+          message:
+            "computed commit acknowledged and dropped: reads were stale; " +
+            "recompute from the newer inputs supersedes this write",
+        } as unknown as StorageTransactionRejected,
+        source,
+      });
+      if (shouldNotifySinks) {
+        this.notifySinks(changes);
+      }
+    } else if (shouldNotifySinks) {
+      this.notifySinksForIds(touched);
+    }
+    return { ok: {} };
   }
 
   // Shared rejection tail for both real conflicts and pre-empted commits: wait

--- a/packages/runner/test/computed-cell-kinds.test.ts
+++ b/packages/runner/test/computed-cell-kinds.test.ts
@@ -150,8 +150,62 @@ describe("computed cell kinds", () => {
         return { out: writeThrough({ c: st }) };
       });
       for (const descriptor of testPattern.derivedInternalCells ?? []) {
-        // Neither the captured cell (possibly written through the handle)
-        // nor the writer's own output qualifies.
+        // Without capability-analysis provenance, possession of a handle is
+        // indistinguishable from use: neither the captured cell nor the
+        // writer's own output qualifies.
+        expect(descriptor.kind).toBeUndefined();
+      }
+    });
+
+    it("accepts handle-bearing lifts when capture writes are analyzed", () => {
+      // The transformer emits captureWritesAnalyzed for lowered computeds
+      // whose capability analysis saw every capture (no wildcard escape):
+      // materializerWriteInputPaths is then exhaustive, so an empty one
+      // proves the handle is embedded, not written through.
+      const embedsHandle = lift(
+        (_input: unknown) => 0,
+        {
+          type: "object",
+          properties: { c: { type: "number", asCell: ["cell"] } },
+        } as const,
+        { type: "number" } as const,
+        { captureWritesAnalyzed: true },
+      );
+      const testPattern = pattern<{ x: number }>(() => {
+        const st = reactive<number>(5);
+        (st as any).for("st");
+        return { out: embedsHandle({ c: st }) };
+      });
+      const outDescriptor = testPattern.derivedInternalCells?.find((
+        descriptor,
+      ) => descriptor.partialCause === "out");
+      expect(outDescriptor?.kind).toBe("computed");
+      // The captured state cell still has no compute writer — untagged.
+      const stateDescriptor = testPattern.derivedInternalCells?.find((
+        descriptor,
+      ) => descriptor.partialCause === "st");
+      expect(stateDescriptor?.kind).toBeUndefined();
+    });
+
+    it("keeps analyzed lifts with observed capture writes disqualified", () => {
+      const writesThrough = lift(
+        (_input: unknown) => 0,
+        {
+          type: "object",
+          properties: { c: { type: "number", asCell: ["cell"] } },
+        } as const,
+        { type: "number" } as const,
+        {
+          captureWritesAnalyzed: true,
+          materializerWriteInputPaths: [["c"]],
+        },
+      );
+      const testPattern = pattern<{ x: number }>(() => {
+        const st = reactive<number>(5);
+        (st as any).for("st");
+        return { out: writesThrough({ c: st }) };
+      });
+      for (const descriptor of testPattern.derivedInternalCells ?? []) {
         expect(descriptor.kind).toBeUndefined();
       }
     });

--- a/packages/runner/test/computed-cell-kinds.test.ts
+++ b/packages/runner/test/computed-cell-kinds.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type Frame } from "../src/builder/types.ts";
+import { byRef, handler, lift } from "../src/builder/module.ts";
+import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { reactive } from "../src/builder/reactive.ts";
+import { createRef } from "../src/create-ref.ts";
+import { getDerivedInternalCellLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Identity } from "@commonfabric/identity";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("computed cell kinds", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let frame: Frame;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { computedCellIds: true },
+    });
+    frame = pushFrame({
+      space,
+      generatedIdCounter: 0,
+      reactives: new Set(),
+      runtime,
+    });
+  });
+
+  afterEach(async () => {
+    popFrame(frame);
+    // Disposal resets the ambient computed-cell-ids config to its default.
+    await runtime?.dispose();
+  });
+
+  describe("createRef kind option", () => {
+    it("mints a kind-tagged id with distinct bytes", () => {
+      const cause = { the: "cause" };
+      const untagged = createRef({}, cause);
+      const kinded = createRef({}, cause, { kind: "computed" });
+      expect(kinded.tag).toBe("fid2:computed");
+      expect(untagged.tag).toBe("fid1");
+      // The kind is in the preimage too, so even the bytes differ — code
+      // comparing bare hashStrings can never alias the two.
+      expect(kinded.hashString).not.toBe(untagged.hashString);
+    });
+
+    it("mints deterministically", () => {
+      const cause = { the: "cause" };
+      expect(createRef({}, cause, { kind: "computed" }).toString()).toBe(
+        createRef({}, cause, { kind: "computed" }).toString(),
+      );
+    });
+  });
+
+  describe("builder classification", () => {
+    it("tags a pure lift output as computed", () => {
+      const double = lift((x: number) => x * 2);
+      const testPattern = pattern<{ x: number }>(({ x }) => ({
+        doubled: double(x),
+      }));
+      expect(testPattern.derivedInternalCells).toEqual([
+        { partialCause: "doubled", kind: "computed" },
+      ]);
+    });
+
+    it("tags intermediate lift outputs as computed", () => {
+      const increment = lift((x: number) => x + 1);
+      const double = lift((x: number) => x * 2);
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const intermediate = increment(x);
+        return { doubled: double(intermediate) };
+      });
+      expect(testPattern.derivedInternalCells).toEqual([
+        { partialCause: { $generated: 0 }, kind: "computed" },
+        { partialCause: "doubled", kind: "computed" },
+      ]);
+    });
+
+    it("leaves state cells (no compute writer) untagged", () => {
+      const double = lift(({ x }: { x: number }) => x * 2);
+      const testPattern = pattern<{ x: number }>(() => {
+        const x = reactive<number>(1);
+        (x as any).for("x");
+        return { double: double({ x }) };
+      });
+      expect(testPattern.derivedInternalCells).toEqual([
+        { partialCause: "double", kind: "computed" },
+        // `x` is seeded state with no compute writer — never tagged.
+        { partialCause: "x", schema: { default: 1 } },
+      ]);
+    });
+
+    it("disqualifies cells captured by a handler, even read-only", () => {
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: { target: { type: "number" } },
+        } as const,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, onBump: bump({ target: doubled }) };
+      });
+      const doubledDescriptor = testPattern.derivedInternalCells?.find((
+        descriptor,
+      ) => descriptor.partialCause === "doubled");
+      expect(doubledDescriptor).toBeDefined();
+      expect(doubledDescriptor!.kind).toBeUndefined();
+      // The handler's stream output is not tagged either.
+      for (const descriptor of testPattern.derivedInternalCells ?? []) {
+        if (descriptor.partialCause === "doubled") continue;
+        expect(descriptor.kind).toBeUndefined();
+      }
+    });
+
+    it("disqualifies outputs of non-javascript (ref) nodes", () => {
+      const rawNode = byRef<number, number>("someRawTarget");
+      const testPattern = pattern<{ x: number }>(({ x }) => ({
+        out: rawNode(x),
+      }));
+      const outDescriptor = testPattern.derivedInternalCells?.find((
+        descriptor,
+      ) => descriptor.partialCause === "out");
+      expect(outDescriptor).toBeDefined();
+      expect(outDescriptor!.kind).toBeUndefined();
+    });
+
+    it("disqualifies lifts whose argument schema grants cell handles", () => {
+      const writeThrough = lift(
+        (_input: unknown) => 0,
+        {
+          type: "object",
+          properties: { c: { type: "number", asCell: ["cell"] } },
+        } as const,
+        { type: "number" } as const,
+      );
+      const testPattern = pattern<{ x: number }>(() => {
+        const st = reactive<number>(5);
+        (st as any).for("st");
+        return { out: writeThrough({ c: st }) };
+      });
+      for (const descriptor of testPattern.derivedInternalCells ?? []) {
+        // Neither the captured cell (possibly written through the handle)
+        // nor the writer's own output qualifies.
+        expect(descriptor.kind).toBeUndefined();
+      }
+    });
+
+    it("mints nothing when the flag is off", async () => {
+      // Replace the flag-on runtime from beforeEach with a default one.
+      popFrame(frame);
+      await runtime.dispose();
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      frame = pushFrame({
+        space,
+        generatedIdCounter: 0,
+        reactives: new Set(),
+        runtime,
+      });
+
+      const double = lift((x: number) => x * 2);
+      const testPattern = pattern<{ x: number }>(({ x }) => ({
+        doubled: double(x),
+      }));
+      expect(testPattern.derivedInternalCells).toEqual([
+        { partialCause: "doubled" },
+      ]);
+    });
+  });
+
+  describe("derived internal cell links", () => {
+    it("mints kind-tagged ids for computed descriptors", () => {
+      const resultCell = runtime.getCell(space, "computed-kind-link-test");
+      const kinded = getDerivedInternalCellLink(resultCell, {
+        partialCause: "d",
+        kind: "computed",
+      });
+      const untagged = getDerivedInternalCellLink(resultCell, {
+        partialCause: "d",
+      });
+      expect(kinded.id.startsWith("of:fid2:computed:")).toBe(true);
+      expect(untagged.id.startsWith("of:fid1:")).toBe(true);
+      expect(kinded.id).not.toBe(untagged.id);
+    });
+  });
+});

--- a/packages/runner/test/computed-drop-storage.test.ts
+++ b/packages/runner/test/computed-drop-storage.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Storage-level tests for the client side of the computed-cell ack-and-drop
+ * policy (docs/specs/computed-cell-identity.md): when the server acknowledges
+ * an all-computed commit but drops its operations (stale reads), the commit
+ * must SUCCEED from the transaction's point of view while the optimistic
+ * pending value is reverted — never promoted into confirmed state, where it
+ * would shadow the authoritative value behind the monotonic seq guard.
+ *
+ * Runs against the real memory-v2 server inside the emulated storage manager;
+ * staleness is made deterministic by capturing the transaction's read before
+ * a remote session advances the input on the server.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createRef } from "../src/create-ref.ts";
+import { toURI } from "../src/uri-utils.ts";
+import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("computed-drop-storage");
+const space = signer.did();
+
+describe("computed-cell ack-and-drop (storage client)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let remoteClient: MemoryV2Client.Client;
+  let remoteSession: MemoryV2Client.SpaceSession;
+  let remoteLocalSeq: number;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const candidate = storageManager as unknown as {
+      server?: () => MemoryV2Server;
+    };
+    if (typeof candidate.server !== "function") {
+      throw new Error("Expected a memory/v2 emulated storage manager");
+    }
+    remoteClient = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(candidate.server()),
+    });
+    remoteSession = await remoteClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
+    remoteLocalSeq = 1;
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await remoteClient.close();
+    await storageManager.close();
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  });
+
+  it("acks a stale all-computed commit, reverts the optimistic value, and converges on recompute", async () => {
+    const input = runtime.getCell<number>(space, "computed-drop-input");
+    const computedLink = {
+      space,
+      id: toURI(createRef({}, "computed-drop-out", { kind: "computed" })),
+      path: [],
+      scope: "space",
+    } as const;
+    const out = runtime.getCellFromLink<number>(computedLink);
+
+    // Seed the input and let it reach the server.
+    const seedTx = runtime.edit();
+    input.withTx(seedTx).set(1);
+    const seedResult = await seedTx.commit();
+    expect(seedResult.error).toBeUndefined();
+    await runtime.storageManager.synced();
+
+    // Open the computing transaction and capture its read of the input
+    // BEFORE the remote write advances it: the commit's confirmed read is
+    // now pinned to the old seq.
+    const computeTx = runtime.edit();
+    const seen = input.withTx(computeTx).get();
+    expect(seen).toBe(1);
+
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: input.getAsNormalizedFullLink().id,
+        value: { value: 5 },
+      }],
+    });
+
+    // Commit the (now stale) computed write. The server acknowledges and
+    // drops it: the transaction reports SUCCESS, no conflict retry.
+    out.withTx(computeTx).set(seen * 2);
+    const result = await computeTx.commit();
+    expect(result.error).toBeUndefined();
+
+    // The optimistic value was reverted, not promoted: nothing pins seq
+    // ahead of the authoritative state, so the entity reads as unwritten.
+    expect(out.getRaw()).toBeUndefined();
+
+    // Convergence: once the newer input arrives, a fresh recompute against
+    // it commits cleanly (current reads — no drop).
+    await input.pull();
+    expect(input.get()).toBe(5);
+    const recomputeTx = runtime.edit();
+    const current = input.withTx(recomputeTx).get();
+    out.withTx(recomputeTx).set(current * 2);
+    const recomputeResult = await recomputeTx.commit();
+    expect(recomputeResult.error).toBeUndefined();
+    await runtime.storageManager.synced();
+    expect(out.get()).toBe(10);
+  });
+
+  it("keeps strict conflict semantics for stale writes to untagged cells", async () => {
+    const input = runtime.getCell<number>(space, "strict-input");
+    const state = runtime.getCell<number>(space, "strict-state-out");
+
+    const seedTx = runtime.edit();
+    input.withTx(seedTx).set(1);
+    const seedResult = await seedTx.commit();
+    expect(seedResult.error).toBeUndefined();
+    await runtime.storageManager.synced();
+
+    const computeTx = runtime.edit();
+    const seen = input.withTx(computeTx).get();
+    expect(seen).toBe(1);
+
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: input.getAsNormalizedFullLink().id,
+        value: { value: 5 },
+      }],
+    });
+
+    state.withTx(computeTx).set(seen * 2);
+    const result = await computeTx.commit();
+    expect(result.error).toBeDefined();
+    expect((result.error as { name?: string }).name).toBe("ConflictError");
+  });
+});

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -8,6 +8,10 @@ import {
   resetModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import {
+  getComputedCellIdsConfig,
+  resetComputedCellIdsConfig,
+} from "@commonfabric/data-model/fabric-primitives";
+import {
   getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
   resetCommitPreconditionsConfig,
@@ -26,6 +30,7 @@ describe("ExperimentalOptions", () => {
     resetModernCellRepConfig();
     resetCommitPreconditionsConfig();
     resetPersistentSchedulerStateConfig();
+    resetComputedCellIdsConfig();
   });
 
   describe("Runtime construction", () => {
@@ -42,6 +47,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        computedCellIds: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -60,6 +66,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        computedCellIds: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -76,6 +83,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        computedCellIds: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -128,6 +136,23 @@ describe("ExperimentalOptions", () => {
       expect(getCommitPreconditionsConfig()).toBe(true);
 
       await runtime.dispose();
+      await sm.close();
+    });
+
+    it("constructing Runtime with computedCellIds sets global config", async () => {
+      const sm = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: sm,
+        experimental: {
+          computedCellIds: true,
+        },
+      });
+
+      expect(getComputedCellIdsConfig()).toBe(true);
+
+      await runtime.dispose();
+      expect(getComputedCellIdsConfig()).toBe(false);
       await sm.close();
     });
 

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -49,6 +49,9 @@ const config: Config = {
       "$EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE": Deno.env.get(
         "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
       ),
+      "$EXPERIMENTAL_COMPUTED_CELL_IDS": Deno.env.get(
+        "EXPERIMENTAL_COMPUTED_CELL_IDS",
+      ),
       "globalThis.__cfCompileCacheRuntimeVersion":
         COMPILE_CACHE_RUNTIME_VERSION,
     },

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -4,6 +4,7 @@ declare global {
   var $COMMIT_SHA: string | undefined;
   var $EXPERIMENTAL_MODERN_CELL_REP: string | undefined;
   var $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: string | undefined;
+  var $EXPERIMENTAL_COMPUTED_CELL_IDS: string | undefined;
 }
 
 const ENVIRONMENT_DEFINE = typeof $ENVIRONMENT === "string"
@@ -20,6 +21,10 @@ const EXPERIMENTAL_MODERN_CELL_REP_DEFINE =
 const EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE =
   typeof $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE === "string"
     ? $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE
+    : undefined;
+const EXPERIMENTAL_COMPUTED_CELL_IDS_DEFINE =
+  typeof $EXPERIMENTAL_COMPUTED_CELL_IDS === "string"
+    ? $EXPERIMENTAL_COMPUTED_CELL_IDS
     : undefined;
 
 export const ENVIRONMENT: "development" | "production" =
@@ -45,4 +50,5 @@ export const EXPERIMENTAL = {
   persistentSchedulerState: flagValue(
     EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE,
   ),
+  computedCellIds: flagValue(EXPERIMENTAL_COMPUTED_CELL_IDS_DEFINE),
 };

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -259,6 +259,7 @@ export const EnvSchema = z.object({
   // ===========================================================================
   EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
+  EXPERIMENTAL_COMPUTED_CELL_IDS: flagValue(),
 
   // Git SHA of the deployed commit. Set at deploy time; takes priority over
   // the build-baked SHA (see lib/build-info.ts).

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -28,6 +28,7 @@ const initializeRuntime = () => {
       experimental: {
         modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
         persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
+        computedCellIds: env.EXPERIMENTAL_COMPUTED_CELL_IDS,
       },
     });
     console.log("Runtime initialized successfully");

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -124,29 +124,51 @@ function getFirstParameterCapabilitySummary(
   callback: ts.ArrowFunction | ts.FunctionExpression,
   checker: ts.TypeChecker,
   typeRegistry?: WeakMap<ts.Node, ts.Type>,
-): CapabilityParamSummary | undefined {
-  const summary = analyzeFunctionCapabilities(callback, {
+): {
+  summary: CapabilityParamSummary | undefined;
+  recursive: boolean;
+} {
+  const functionSummary = analyzeFunctionCapabilities(callback, {
     checker,
     typeRegistry,
     includeNestedCallbacks: true,
   });
   const parameter = callback.parameters[0];
-  if (!parameter) return undefined;
+  const recursive = functionSummary.recursive === true;
+  if (!parameter) return { summary: undefined, recursive };
   const parameterName = ts.isIdentifier(parameter.name)
     ? parameter.name.text
     : "__param0";
-  return summary.params.find((param) => param.name === parameterName);
+  return {
+    summary: functionSummary.params.find((param) =>
+      param.name === parameterName
+    ),
+    recursive,
+  };
 }
 
 function createDeriveSchedulerOptions(
   inputParamSummary: CapabilityParamSummary | undefined,
+  recursive: boolean,
   factory: ts.NodeFactory,
 ): ts.ObjectLiteralExpression | undefined {
   const writePaths = inputParamSummary?.writePaths ?? [];
-  if (writePaths.length === 0) return undefined;
+  // `captureWritesAnalyzed` asserts writePaths are an EXHAUSTIVE record of
+  // writes through captures: analysis ran, no capture escaped tracking
+  // (wildcard), no unrecognized method was called on a cell-like receiver
+  // (hasUnverifiedCellUse — the writer-method list is closed but the Cell API
+  // is not), and analysis was not short-circuited (recursive). The
+  // computed-cell classifier keys its relaxation off this — an unverified
+  // callback stays under the conservative has-a-handle rule.
+  const captureWritesAnalyzed = inputParamSummary !== undefined &&
+    inputParamSummary.wildcard !== true &&
+    inputParamSummary.hasUnverifiedCellUse !== true &&
+    !recursive;
+  if (writePaths.length === 0 && !captureWritesAnalyzed) return undefined;
 
-  return factory.createObjectLiteralExpression([
-    factory.createPropertyAssignment(
+  const properties: ts.ObjectLiteralElementLike[] = [];
+  if (writePaths.length > 0) {
+    properties.push(factory.createPropertyAssignment(
       "materializerWriteInputPaths",
       factory.createArrayLiteralExpression(
         writePaths.map((path) =>
@@ -157,8 +179,15 @@ function createDeriveSchedulerOptions(
         ),
         false,
       ),
-    ),
-  ], false);
+    ));
+  }
+  if (captureWritesAnalyzed) {
+    properties.push(factory.createPropertyAssignment(
+      "captureWritesAnalyzed",
+      factory.createTrue(),
+    ));
+  }
+  return factory.createObjectLiteralExpression(properties, false);
 }
 
 /**
@@ -542,11 +571,12 @@ export function transformLiftAppliedCall(
     captureNameMap,
     hadZeroParameters,
   );
-  const inputParamSummary = getFirstParameterCapabilitySummary(
-    newCallback,
-    checker,
-    options.state?.typeRegistry,
-  );
+  const { summary: inputParamSummary, recursive } =
+    getFirstParameterCapabilitySummary(
+      newCallback,
+      checker,
+      options.state?.typeRegistry,
+    );
   if (inputParamSummary) {
     inputTypeNode = applyShrinkAndWrap(
       inputParamSummary,
@@ -568,6 +598,7 @@ export function transformLiftAppliedCall(
   }
   const schedulerOptions = createDeriveSchedulerOptions(
     inputParamSummary,
+    recursive,
     factory,
   );
 

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -44,6 +44,12 @@ export interface CapabilityParamSummary {
   readonly opaquePaths?: readonly (readonly string[])[];
   readonly passthrough: boolean;
   readonly wildcard: boolean;
+  /**
+   * An unrecognized method was called on a cell-like receiver rooted in this
+   * parameter — `writePaths` may be incomplete. Consumers asserting write
+   * exhaustiveness (`captureWritesAnalyzed`) must treat this like `wildcard`.
+   */
+  readonly hasUnverifiedCellUse?: boolean;
   readonly identityOnly?: boolean;
   readonly identityPaths?: readonly (readonly string[])[];
   readonly identityCellPaths?: readonly (readonly string[])[];

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -76,6 +76,13 @@ interface MutableCapabilityState {
   hasIdentityUse: boolean;
   hasNonIdentityUse: boolean;
   hasNonIdentityRootUse: boolean;
+  /**
+   * An unrecognized method was called on a cell-like receiver rooted in this
+   * parameter. The call could be a mutator this analysis does not know, so
+   * `writes` cannot be treated as exhaustive (fail-closed for
+   * `captureWritesAnalyzed`); recognized reads/derivations are unaffected.
+   */
+  hasUnverifiedCellUse: boolean;
 }
 
 interface ObservedCapabilityUsage {
@@ -85,6 +92,7 @@ interface ObservedCapabilityUsage {
   readonly opaquePaths: readonly (readonly string[])[];
   readonly passthrough: boolean;
   readonly wildcard: boolean;
+  readonly hasUnverifiedCellUse: boolean;
   readonly identityOnly: boolean;
   readonly identityPaths: readonly (readonly string[])[];
   readonly identityCellPaths: readonly (readonly string[])[];
@@ -147,9 +155,14 @@ const PARAMETER_SUMMARY_PREFIX = "__param";
 const mergeableMethods = (kind: MergeableOpMethodKind): string[] =>
   MERGEABLE_OP_METHODS.filter((op) => op.kind === kind).map((op) => op.method);
 
+// `send` is a write: at runtime Stream.send() delegates to set() (an event
+// enqueue is a write to the stream cell). Classifying it here keeps
+// writePaths an exhaustive record of capture writes, which the computed-cell
+// classifier relies on (docs/specs/computed-cell-identity.md).
 const WRITER_METHODS = new Set([
   "set",
   "update",
+  "send",
   ...mergeableMethods("scalar-writer"),
 ]);
 const ARRAY_IDENTITY_WRITER_METHODS = new Set([
@@ -1325,6 +1338,7 @@ function normalizeObservedCapabilityUsage(
     opaquePaths,
     passthrough: state.passthrough,
     wildcard: state.wildcard,
+    hasUnverifiedCellUse: state.hasUnverifiedCellUse,
     identityOnly: identityPaths.some((path) => path.length === 0) &&
       !state.hasNonIdentityUse &&
       state.reads.size === 0 &&
@@ -1430,6 +1444,7 @@ export function analyzeFunctionCapabilities(
           hasIdentityUse: false,
           hasNonIdentityUse: false,
           hasNonIdentityRootUse: false,
+          hasUnverifiedCellUse: false,
         };
         states.set(name, state);
       }
@@ -1469,6 +1484,15 @@ export function analyzeFunctionCapabilities(
       const state = ensureState(name);
       state.wildcard = true;
       state.hasNonIdentityUse = true;
+    };
+
+    // Unlike markWildcard this does NOT change shrinking or identity
+    // classification — it only poisons write-exhaustiveness, so
+    // `captureWritesAnalyzed` is withheld while everything else behaves as
+    // before.
+    const markUnverifiedCellUse = (name: string): void => {
+      const state = ensureState(name);
+      state.hasUnverifiedCellUse = true;
     };
 
     const markPassthrough = (
@@ -2814,6 +2838,9 @@ export function analyzeFunctionCapabilities(
               markWildcard(source.root);
               continue;
             }
+            if (paramSummary.hasUnverifiedCellUse) {
+              markUnverifiedCellUse(source.root);
+            }
 
             for (const readPath of paramSummary.readPaths) {
               trackRead(source.root, [...source.path, ...readPath]);
@@ -3004,7 +3031,19 @@ export function analyzeFunctionCapabilities(
                 markOpaqueUse(receiver.root, receiver.path);
               }
             } else {
-              // Unknown method call over a tracked source reads at least the receiver path.
+              // Unknown method call over a tracked source reads at least the
+              // receiver path. On a CELL-LIKE receiver the unknown method
+              // could be a mutator this analysis does not recognize (the
+              // writer sets are a closed list against an evolving Cell API),
+              // so write-exhaustiveness is poisoned — fail closed. Value
+              // receivers (e.g. array methods on a `.get()` snapshot) cannot
+              // write through the cell and stay reads.
+              if (
+                !checker ||
+                isCellLikeExpression(node.expression.expression)
+              ) {
+                markUnverifiedCellUse(receiver.root);
+              }
               if (shouldTrackFullShape) {
                 trackFullShapeReadRef(receiver);
               } else if (directReceiver) {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -45,7 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["values"]
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: pattern-two-schemas
 // Verifies: pattern with both input and output schemas already present preserves them
 //   pattern<Input, Result>(fn, inputSchema, outputSchema) → pattern(fn, inputSchema, outputSchema) (schemas kept)

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["input"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: pattern-with-name-and-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["input"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: pattern-with-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -60,7 +60,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["card"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": [false, true, ""]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: action-in-ternary-branch
 // Verifies: action() result used in a ternary branch alongside computed() keeps
 //   local JSX rewrites instead of forcing a whole-branch lift-applied computation

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -82,7 +82,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: action-in-ternary-with-explicit-computed
 // Verifies: action() referenced inside an explicit computed() in JSX is captured in the lift-applied wrapper
 //   action(() => ...) → handler(...)({ isEditing })

--- a/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "numLiteral", "floatLiteral", "boolLiteral", "strLiteral"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // Test that all literal types are widened in closure captures
 // FIXTURE: computed-all-literal-types
 // Verifies: literal values (number, string, boolean, float) are captured and their types widened in schemas

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "factors"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-array-element-access
 // Verifies: an array variable accessed by index inside a computed is captured as a whole array
 //   computed(() => expr) → lift(schema, schema)({ value, factors })

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
@@ -45,7 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["allPieces"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     allPieces: {
         length: number;
@@ -66,7 +66,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["allPieces"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const piece = __cf_pattern_input.key("element");
     return (<li>{piece.key("name")}</li>);

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-basic-capture
 // Verifies: computed(() => expr) with two cell captures is closure-extracted into a lift-applied computation
 //   computed(() => value.get() * multiplier.get()) → lift(({ value, multiplier }) => value.get() * multiplier.get())({ value, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
@@ -36,7 +36,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["multiplier", "value"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-collision-property
 // Verifies: a captured cell named the same as a returned object property does not rename the property
 //   computed(() => ({ multiplier: multiplier.get(), value: ... })) → lift(...)({ multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
@@ -43,7 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["value", "data"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-collision-shorthand
 // Verifies: a shorthand property `{ multiplier }` over a captured cell expands correctly
 //   computed(() => ({ value, data: { multiplier } })) → lift(...)({ multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b", "c"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-complex-expression
 // Verifies: computed(() => expr) with three cell captures in an arithmetic expression
 //   computed(() => (a.get() * b.get() + c.get()) / 2) → lift(({ a, b, c }) => ...)({ a, b, c })

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "threshold", "a", "b"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-conditional-expression
 // Verifies: computed(() => expr) with four cell captures in a ternary expression
 //   computed(() => value.get() > threshold.get() ? a.get() : b.get()) → lift(({ value, threshold, a, b }) => ...)({ value, threshold, a, b })

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -74,7 +74,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     result: { tasks: Item[]; view: string; };
 }, __cfHelpers.JSXElement[]>(({ result }) => {
@@ -140,7 +140,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-destructured-map
 // Verifies: .map() on a destructured property of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const { tasks } = result; return tasks.map(fn) }) → lift(({ result }) => { const { tasks } = result; return tasks.map(fn) })(...)

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-destructured-param
 // Verifies: a captured cell works alongside destructuring inside the computed body
 //   computed(() => { const { x, y } = point.get(); ... }) → lift(...)({ point, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -57,7 +57,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-filter-map-chain
 // Verifies: .filter() and .map() inside computed() are NOT transformed
 // Context: Inside computed(), Reactive auto-unwraps to plain array, so

--- a/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>

--- a/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-jsx-local-function
 // Verifies: computed() with a locally-defined function inside the callback is closure-extracted
 //   computed(() => { const format = ...; return <span>{format(count)}</span> }) → lift(({ count }) => { ... })({ count })

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -62,7 +62,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "price"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     filtered: {
         name: string;
@@ -113,7 +113,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-local-var-map
 // Verifies: .map() on a local variable assigned from a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const localVar = filtered; return localVar.map(fn) }) → lift(({ filtered }) => { const localVar = filtered; return localVar.map(fn) })(...)

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
@@ -37,7 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b", "c"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-local-variable
 // Verifies: callback-local variables are not captured, but outer cells are
 //   computed(() => { const sum = a.get() + b.get(); return sum * c.get() }) → lift(...)({ a, b, c })

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         required: ["name", "rank", "isFirst"]
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
 }, number>(({ people }) => people.get().length, {
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["people"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-map-in-derived-branch
 // Verifies: moving a reactive computation out of a JSX slot forces the whole
 //   branch into derive(), so nested maps run in compute context and stay plain

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         required: ["name", "rank", "isFirst"]
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
 }, number>(({ people }) => people.get().length, {
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["people"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     return (<span>{person.key("name")}</span>);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
@@ -54,7 +54,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-map-input-no-captures
 // Verifies: a computed over a captured cell array uses a plain .map() (not .mapWithPattern)
 //   computed(() => items.get().map(...).length) → lift(...)({ items })

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     view: string[];
 }, string | undefined>(({ view }) => view[0], {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.unless({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -57,7 +57,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         required: ["done"]
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-method-call-capture
 // Verifies: a deep property access on a captured object is restructured into a nested capture object
 //   computed(() => value.get() + state.counter.value) → lift(...)({ value, state: { counter: { value } } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -37,7 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b", "c"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-multiple-captures
 // Verifies: computed() with a multi-statement body capturing three cells is closure-extracted
 //   computed(() => { const sum = a.get() + b.get(); return sum * c.get() }) → lift(({ a, b, c }) => { ... })({ a, b, c })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-nested-callback
 // Verifies: capture extraction works with a nested .map() over a captured cell's array value
 //   computed(() => numbers.get().map(n => n * multiplier.get())) → lift(...)({ numbers, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -33,7 +33,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["counter"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-nested-property
 // Verifies: computed() capturing a cell with an object value and accessing a nested property
 //   computed(() => { const current = counter.get(); return current.count * 2 }) → lift(({ counter }) => { ... })({ counter })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     sum: number;
 }, number>(({ sum }) => sum * 2, {
@@ -42,7 +42,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["sum"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-nested
 // Verifies: chained computed() calls where the second captures the result of the first
 //   computed(() => a.get() + b.get()) → lift(({ a, b }) => a.get() + b.get())({ a, b })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -45,7 +45,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["topQuestion"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     topQuestion: Question | null;
 }, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.question, {
@@ -79,7 +79,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_4 = __cfHelpers.lift<{
     topQuestion: {
         category: string;
@@ -104,7 +104,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["topQuestion"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_5 = __cfHelpers.lift<{
     topQuestion: Question | null;
 }, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.category, {
@@ -138,7 +138,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-nullable-optional-chain
 // Verifies: computed() capturing a nullable computed result preserves anyOf [type, null] in schema
 //   computed(() => topQuestion?.question || "") → lift(({ topQuestion }) => topQuestion?.question || "")({ topQuestion })

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-optional-chaining
 // Verifies: computed() with optional chaining and nullish coalescing on captured cells
 //   computed(() => value.get() * (config.get()?.multiplier ?? 1)) → lift(({ value, config }) => ...)({ value, config })

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config", "offset", "threshold"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-pattern-param-mixed
 // Verifies: computed() capturing a mix of cells, pattern params, and plain locals
 //   computed(() => (value.get() + config.base + offset) * config.multiplier + threshold.get()) → lift(...)({ value, config: { base, multiplier }, offset, threshold })

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -36,7 +36,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-pattern-param
 // Verifies: computed() inside a pattern captures the pattern parameter as a structured object
 //   computed(() => value.get() * config.multiplier) → lift(({ value, config }) => ...)({ value, config: { multiplier: config.key("multiplier") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-pattern-typed
 // Verifies: computed() inside a typed pattern with destructured params is closure-extracted
 //   computed(() => value.get() * multiplier) → lift(({ value, multiplier }) => value.get() * multiplier)({ value, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -74,7 +74,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     result: {
         tasks: {
@@ -132,7 +132,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-property-access-map
 // Verifies: .map() on a property access of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => result.tasks.map(fn)) → lift(({ result }) => result.tasks.map(fn))({ result: { tasks: result.key("tasks") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "__cf_reserved"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-reserved-names
 // Verifies: variables with __cf_ prefixed names are captured without special treatment
 //   computed(() => value.get() * __cf_reserved.get()) → lift(...)({ value, __cf_reserved })

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["count", "total"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     stats: {
         count: number;
@@ -90,7 +90,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["stats"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-result-in-derive-captures
 // Verifies: computed() result properties captured in a subsequent lift-applied computation use .key() access
 //   computed(() => `${stats.count} of ${stats.total} done`) → lift(({ stats }) => ...)({ stats: { count: stats.key("count"), total: stats.key("total") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -43,7 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     summary: {
         length: number;
@@ -64,7 +64,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["summary"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-result-property-in-return
 // Verifies: .length on a computed() string result is captured via .key("length") in a subsequent lift-applied computation
 //   computed(() => summary.length) → lift(({ summary }) => summary.length)({ summary: { length: summary.key("length") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["token"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     token: string;
 }, { headers: { Authorization: string; }; }>(({ token }) => ({
@@ -50,7 +50,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     },
     required: ["headers"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // CT-1334: computed() with template literal capturing pattern parameter.
 // The `token` from pattern destructuring must be captured as an explicit
 // input to the lift-applied call, so the callback receives the

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["prefix", "value"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-template-literal
 // Verifies: captured cells used inside a template literal expression are extracted
 //   computed(() => `${prefix.get()}${value.get()}`) → lift(...)({ value, prefix })

--- a/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-type-assertion
 // Verifies: a type assertion (`as number`) in the callback body is preserved after capture extraction
 //   computed(() => (value.get() * multiplier.get()) as number) → lift(...)({ value, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-union-undefined
 // Verifies: captured properties with `number | undefined` union types produce correct schemas
 //   computed(() => ...) → lift(...)({ value, config: { required, unionUndefined } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-with-closed-over-cell-map
 // Verifies: .map() on a closed-over Cell inside computed() IS transformed to .mapWithPattern()
 //   computed(() => numbers.map(n => n * multiplier.get())) → lift(({ numbers, multiplier }) => numbers.mapWithPattern(pattern(fn, ...), { multiplier }))({ numbers, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
@@ -51,7 +51,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
-} as const satisfies __cfHelpers.JSONSchema, { materializerWriteInputPaths: [["processed"]] });
+} as const satisfies __cfHelpers.JSONSchema, { materializerWriteInputPaths: [["processed"]], captureWritesAnalyzed: true });
 // FIXTURE: computed-write-capability-materializer
 // Verifies: a computed() that WRITES to a captured cell (`.set(...)`) produces a
 //   write-capability capture, which the lift-applied strategy emits with a

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -86,7 +86,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: inline-action-in-ternary-branch
 // Verifies: inline arrow handler inside explicit computed() in a ternary branch is extracted and captured in a lift-applied computation
 //   computed(() => <cf-button onClick={() => state.isEditing.set(true)} />) → lift(..., handler(...)(...))({ state: { isEditing: asCell } })

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: lift-result-type-cf-ref-normalized
 // Verifies: a synthesized lift's RESULT type argument that is a commonfabric
 // type (here JSXElement, the type of the returned JSX) is emitted as the

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -68,7 +68,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["emoji"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -127,10 +127,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
-        boundCastVote: {
-            $ref: "#/$defs/VoteEvent",
-            asCell: ["stream"]
-        },
         item: {
             type: "object",
             properties: {
@@ -139,9 +135,13 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["id"]
+        },
+        boundCastVote: {
+            $ref: "#/$defs/VoteEvent",
+            asCell: ["stream"]
         }
     },
-    required: ["boundCastVote", "item"],
+    required: ["item", "boundCastVote"],
     $defs: {
         VoteEvent: {
             type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -60,7 +60,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state", "personName"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         removePersonConfirmTarget: string | null;
@@ -89,7 +89,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state", "personName"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         spots: {
@@ -146,7 +146,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         },
         required: ["label", "value"]
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_4 = __cfHelpers.lift<{
     activeSpotOpts: {
         length: number;

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -78,7 +78,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -75,7 +75,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -48,7 +48,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
@@ -67,7 +67,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -116,7 +116,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_5 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -165,7 +165,7 @@ const __cfLift_6 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_7 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -222,7 +222,7 @@ const __cfLift_9 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_10 = __cfHelpers.lift<{
     item: {
         length: number;
@@ -309,7 +309,7 @@ const __cfLift_12 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_13 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
@@ -328,7 +328,7 @@ const __cfLift_13 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_14 = __cfHelpers.lift<{
     item: {
         length: number;
@@ -415,7 +415,7 @@ const __cfLift_16 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: map-regains-reactive-aliases
 // Verifies: compute-owned aliases that still resolve to reactive array roots
 // are rewritten back to mapWithPattern/filterWithPattern when used in pattern

--- a/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
@@ -53,7 +53,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["id"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span data-inline-id={item.key("id")}>{item.key("id")}</span>;
@@ -136,7 +136,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["id"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-cast-id={item.key("id")}>{item.key("id")}</span>);
@@ -219,7 +219,7 @@ const __cfLift_3 = __cfHelpers.lift<{
             required: ["id"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-satisfies-id={item.key("id")}>{item.key("id")}</span>);

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         tags: {
@@ -79,7 +79,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const showInactive = __cf_pattern_input.key("params", "showInactive");

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["background"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     secondToggle: __cfHelpers.ReadonlyCell<boolean>;
 }, { background: string; }>(({ secondToggle }) => {
@@ -68,7 +68,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     },
     required: ["background"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: nested-computed-in-ifelse
 // Verifies: computed() inside ifElse branches transforms to the lift-applied form without double-wrapping .get()
 //   computed(() => { secondToggle.get(); ... }) → lift(({ secondToggle }) => { secondToggle.get(); ... })({ secondToggle })

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -90,6 +90,15 @@ const __cfLift_1 = __cfHelpers.lift<{
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        p: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
         setAssign: {
             type: "object",
             properties: {
@@ -99,18 +108,9 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
             },
             required: ["name"],
             asCell: ["stream"]
-        },
-        p: {
-            type: "object",
-            properties: {
-                name: {
-                    type: "string"
-                }
-            },
-            required: ["name"]
         }
     },
-    required: ["setAssign", "p"]
+    required: ["p", "setAssign"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }));
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const p = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-reactive-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-reactive-map.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: pattern-computed-reactive-map
 // Verifies: .map() on a Reactive inside computed() is NOT transformed to mapWithPattern
 //   computed(() => items.map((n) => n * 2)) → lift(({ items }) => items.map((n) => n * 2))({ items })

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     i: number;
     item: {
@@ -75,7 +75,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["i", "item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const i = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -26,7 +26,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["messages"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     result?: any;
 }, any>(({ result }) => result?.title ?? "Untitled", {

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["req"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: pattern-optional-destructured-capture
 // Verifies: an optional pattern input (`opt?`) destructured and captured in a
 //   closure is emitted optional in the derived lift's input schema (so it does

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     query: string;
     content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["language"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     content: string;
 }, string>(({ content }) => content, {
@@ -44,7 +44,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["content"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     genResult: {
         pending: boolean;
@@ -73,7 +73,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["genResult"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     language: string;
     content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     value: number;
 }) => {

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     query: string;
     content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "offset"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     value: number;
     offset: number;

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
@@ -64,7 +64,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: readonly-capture-named-alias-nested-cell
 // Verifies (BEHAVIOR LOCK): a by-reference, read-only-used capture of a bare
 //   `Cell<EntriesValue>` (EntriesValue = Entry[] | Default<[]>, Entry has a

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -26,7 +26,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["limit"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{item.key("name")}</span>;
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: authored-ifelse-jsx-branches
 // Verifies: authored ifElse in JSX lowers both conditions and reactive branches correctly
 //   ifElse(limit > 0, items.map(...), <span>Hidden</span>) → derived condition + pattern-lowered map branch

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["showHistory", "messageCount", "dismissedIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // Reproduction of bug: .get() called on Cell inside ifElse predicate
 // The transformer wraps predicates in a lift-applied computation, which unwraps Cells,
 // but fails to remove the .get() calls

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["bar"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["B", "C"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: computed-boundary-nested-ternaries
 // Verifies: outer branch lowering does not structurally lower nested ternaries inside computed callbacks
 //   show ? computed(() => bar ? "B" : "C") : "D" → outer branch lowers, inner ternary stays authored
@@ -88,7 +88,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["foo", "bar"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["A", "B", "C"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 export const AuthoredIfElse = pattern((__cf_pattern_input) => {
     const show = __cf_pattern_input.key("show");
     const foo = __cf_pattern_input.key("foo");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -79,7 +79,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     itemsWithAisles: { aisle: string; item: Item; }[];
 }, Record<string, Assignment[]>>(({ itemsWithAisles }) => {
@@ -162,7 +162,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
 }, string[]>(({ groupedByAisle }) => Object.keys(groupedByAisle).sort(), {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -152,6 +152,15 @@ const __cfLift_3 = __cfHelpers.lift<{
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
         pushPath: {
             type: "object",
             properties: {
@@ -161,18 +170,9 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
             },
             required: ["name"],
             asCell: ["stream"]
-        },
-        entry: {
-            type: "object",
-            properties: {
-                name: {
-                    type: "string"
-                }
-            },
-            required: ["name"]
         }
     },
-    required: ["pushPath", "entry"]
+    required: ["entry", "pushPath"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, entry }) => pushPath.send({ name: entry.name }));
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -204,6 +204,15 @@ const __cfLift_2 = __cfHelpers.lift<{
 const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
         handleNavigateInto: {
             type: "object",
             properties: {
@@ -213,24 +222,18 @@ const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
             },
             required: ["name"],
             asCell: ["stream"]
-        },
-        item: {
-            type: "object",
-            properties: {
-                name: {
-                    type: "string"
-                }
-            },
-            required: ["name"]
         }
     },
-    required: ["handleNavigateInto", "item"]
+    required: ["item", "handleNavigateInto"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { handleNavigateInto, item }) => handleNavigateInto.send({
     name: item.name,
 }));
 const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        item: {
+            $ref: "#/$defs/Entry"
+        },
         handleOpenFile: {
             type: "object",
             properties: {
@@ -240,12 +243,9 @@ const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
             },
             required: ["item"],
             asCell: ["stream"]
-        },
-        item: {
-            $ref: "#/$defs/Entry"
         }
     },
-    required: ["handleOpenFile", "item"],
+    required: ["item", "handleOpenFile"],
     $defs: {
         Entry: {
             type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -227,6 +227,15 @@ const __cfLift_3 = __cfHelpers.lift<{
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
         pushPath: {
             type: "object",
             properties: {
@@ -236,18 +245,9 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
             },
             required: ["name"],
             asCell: ["stream"]
-        },
-        item: {
-            type: "object",
-            properties: {
-                name: {
-                    type: "string"
-                }
-            },
-            required: ["name"]
         }
     },
-    required: ["pushPath", "item"]
+    required: ["item", "pushPath"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, item }) => pushPath.send({ name: item.name }));
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["pending", "result"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     result: string;
 }, boolean>(({ result }) => !!result, {
@@ -40,7 +40,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["result"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // Tests ifElse where ifTrue is explicitly undefined
 // This pattern is common: ifElse(pending, undefined, { result })
 // The transformer must handle this correctly - the undefined is a VALUE, not a missing argument

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
@@ -58,7 +58,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         price: number;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
@@ -249,7 +249,7 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: jsx-conditional-rendering-no-name
 // Verifies: same conditional rendering transforms work when pattern has no NAME export
 //   cond ? a : b             → ifElse(schema..., cond, a, b)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
@@ -249,7 +249,7 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: jsx-conditional-rendering
 // Verifies: ternary expressions and ifElse() calls in JSX are transformed to reactive ifElse()
 //   cond ? a : b             → ifElse(schema, schema, schema, schema, cond, a, b)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -96,7 +96,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["author", "body"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     message: {
         author: string;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -357,7 +357,7 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         names: string[];

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -84,7 +84,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             type: "boolean",
             "enum": [false]
         }]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const bar = __cf_pattern_input.key("bar");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-cell-map.expected.jsx
@@ -159,16 +159,16 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["cellRef"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     piece: any;
-}, any>(({ piece }) => piece[__cfHelpers.NAME], {
+}, any>(({ piece }) => piece[NAME], {
     type: "object",
     properties: {
         piece: true
     },
     required: ["piece"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const piece = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["show"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: safe-context-and-jsx
 // Verifies: && and || with JSX inside handler callbacks are transformed to when()/unless()
 //   computed(() => show) && <span> → when(computed(() => show), <span>)
@@ -140,7 +140,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }, {
             type: "null"
         }]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // Test: || with JSX inside handler callback should transform to unless()
 const MyHandler2 = handler({
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -81,7 +81,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "value"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: {
@@ -110,7 +110,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     state: any;
 }, boolean>(({ state }) => state.recentEvents.length === 0, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -69,7 +69,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "value"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: {
@@ -98,7 +98,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: ternary-hoisted-compute-plain-map-branch
 // Verifies: once a ternary JSX branch is wholly compute-wrapped, compute-owned
 // array maps inside that branch stay plain Array.map() calls.

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -179,7 +179,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["allowMultiple"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         collapsed?: boolean | undefined;
@@ -203,7 +203,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["entry"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
@@ -231,7 +231,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     },
     required: ["fontWeight"]
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_4 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
@@ -251,7 +251,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["entry"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_5 = __cfHelpers.lift<{
     isExpanded: boolean;
 }, boolean>(({ isExpanded }) => !isExpanded, {

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -114,7 +114,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["text", "active"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     memberIndex: number;
 }, boolean>(({ memberIndex }) => memberIndex === 0, {
@@ -351,7 +351,7 @@ visibleProjects.map((project, projectIndex) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
 export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -219,7 +219,7 @@ state.threads.map((thread, outerIndex) => ({
             required: ["id", "title", "muted", "comments"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     visibleComments: Comment[];
 }, Comment[]>(({ visibleComments }) => visibleComments, {
@@ -284,7 +284,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["id", "text", "flagged", "reactions"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     reboundIndex: number;
     outerIndex: number;
@@ -716,7 +716,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_8 = __cfHelpers.lift<{
     labelIndex: number;
 }, boolean>(({ labelIndex }) => labelIndex === 0, {

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -87,7 +87,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     task: {
         note?: string | undefined;
@@ -107,7 +107,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["task"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     tagIndex: number;
     taskIndex: number;
@@ -124,7 +124,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["tagIndex", "taskIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const tagIndex = __cf_pattern_input.key("index");
@@ -448,7 +448,7 @@ section.tasks.length > 0
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const section = __cf_pattern_input.key("element");
     const sectionIndex = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["summary"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: context-lift-result-property-projection-shorthand
 // Verifies: shorthand object returns preserve the projected computed() result type
 //   return { difference } → result schema difference: number

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["summary"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: context-lift-result-property-projection
 // Verifies: a reactive builder preserves projected property schemas when the captured
 // input comes from a typed lift() result rather than falling back to unknown

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     items: {
         label: string | (string & { readonly [DEFAULT_MARKER]: ""; });
@@ -88,7 +88,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     items: {
         rank: number | (number & { readonly [DEFAULT_MARKER]: 7; });
@@ -113,7 +113,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_4 = __cfHelpers.lift<{
     boxes: {
         note: string | (string & { readonly [DEFAULT_MARKER]: "n/a"; });
@@ -138,7 +138,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["boxes"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const boxes = __cf_pattern_input.key("boxes");

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
@@ -52,7 +52,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["settings"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     settings: {
         count: number | (number & { readonly [DEFAULT_MARKER]: 3; });
@@ -74,7 +74,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["settings"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_3 = __cfHelpers.lift<{
     settings: {
         enabled: boolean | (false & { readonly [DEFAULT_MARKER]: true; }) | (true & { readonly [DEFAULT_MARKER]: true; });
@@ -96,7 +96,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["settings"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 export default pattern((__cf_pattern_input) => {
     const settings = __cf_pattern_input.key("settings");
     const noteIsUnset = __cfLift_1({ settings: {

--- a/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
@@ -47,7 +47,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 const __cfLift_2 = __cfHelpers.lift<{
     items: {
         label: string;
@@ -71,7 +71,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Extras key: only exists on some elements; must shrink to `priority?`.

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["result", "prompt"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { captureWritesAnalyzed: true });
 // FIXTURE: pattern-any-result-override
 // Verifies: explicit Output type parameter overrides inferred `any` return type for schema generation
 //   pattern<Input, string>() → output schema { type: "string" } instead of inferred any


### PR DESCRIPTION
## Summary

Implements phases 1–3 of `docs/specs/computed-cell-identity.md` (spec included in this PR): internal cells that are pure functions of their pattern's inputs get identity-level classification, and the memory server relaxes conflict semantics for their writes — eliminating reject/re-run/recommit churn when multiple clients recompute the same derived values.

Everything is gated behind `EXPERIMENTAL_COMPUTED_CELL_IDS` (minting side); the server policy and readers activate only on ids that carry the new format.

### Kind-tagged entity ids (minting)

- New versioned id format `fid2:computed:<hash>`; `fid1:<hash>` stays the untagged, strict-semantics form. `FabricHash.fromString` now splits at the **last** colon (the hash segment is base64url and never contains one), so existing ids parse identically and fid1-only parsers fail loudly on kinded ids instead of silently mis-handling them.
- `createRef` mints the kind into BOTH the hash preimage (shape-disjoint envelope — kinded and untagged ids can never collide bytes-for-bytes) and the visible tag, from one argument, so the representations cannot diverge and a kind flip necessarily names a different entity.
- Conservative builder classifier (`assignComputedCellKinds`): a cell qualifies only when every writer is a plain javascript compute module with no writable-input markers, it is never captured in a non-qualifying node's inputs, is not a stream, and is not exposed via a write-capable handle in the result surface. Kind participates in descriptor/manifest matching, so a kind flip re-materializes under the new id.

### Ack-and-drop conflict policy (server + client)

- A commit whose semantic operations ALL target computed-kind entities is **acknowledged-as-committed but dropped** when its reads are stale, instead of rejected: recompute from the newer inputs supersedes the write, so rejection would only buy retry churn. The dropped commit inserts a zero-revision commit row, which keeps replay dedupe, dependent pending reads, and `origin-committed` preconditions intact for free.
- The storage client reverts the optimistic pending value on a `droppedComputed` ack rather than promoting it (promotion would pin the stale value behind the monotonic seq guard in `applySessionSync`, shadowing the authoritative value indefinitely). No retry is scheduled — the newer inputs arrive through the normal watch flow, dirty the reader, and the recompute writes a fresh commit.
- Mixed, sqlite-bearing, unknown-kind, and untagged commits keep strict all-or-nothing conflict semantics.

### Verified capture writes (classifier widening)

- `send` added to the capability analysis writer methods (`Stream.send()` delegates to `set()` — it is a write).
- The transformer emits `captureWritesAnalyzed` on lowered computeds whose analysis saw every capture: no wildcard escape, no recursion short-circuit, and no unrecognized method call on a cell-like receiver (new `hasUnverifiedCellUse` — the writer-method list is closed but the Cell API is not, so unknown cell-methods fail closed).
- For verified modules `materializerWriteInputPaths` is an exhaustive record of capture writes, so the classifier accepts handle-bearing argument schemas when it is empty: a computed embedding event streams in its JSX output (the canonical UI derivation, e.g. habit-tracker's `habitCards`) now classifies as pure. Hand-written lifts carry no provenance and stay conservative.

### Measured impact

Census over 18 real patterns (exemplars + system/home + default-app), 483 internal cells: **109 computed / 243 standard / 131 streams — 31.0% of data cells classify computed** (27.6% before the widening). Computed cells are the high-churn ones (rewritten on every input change), so their share of commit traffic — and of multi-client conflict churn — is substantially higher than their share of cells.

## Test plan

- `packages/data-model`: entity-kind round-trips (string/URI/codec), mint-once/fid1-only guards, unknown kinds read as strict
- `packages/runner`: classifier coverage per disqualification rule + the verified-capture relaxation; flag-off byte-identical output; kind-tagged link minting; storage-client ack-and-drop (real in-process server): stale computed commit acked → optimistic value reverted → recompute converges; strict-semantics control for untagged cells
- `packages/memory`: drop + marker, replay idempotency, origin-committed satisfaction, pending-read resolution against a dropped commit, current-reads apply, mixed/untagged/unknown-kind stay strict, head advancement
- `packages/ts-transformers`: full suite (999) including regenerated goldens — audited as marker insertions plus balanced schema-property moves only
- Full `deno task check` and package suites green; census script used for the impact numbers

Remaining (not in this PR): value-equality dedupe for current-read computed commits (phase 4), server-side action runner (phase 5), handler write facts for further classifier widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce kind‑tagged computed cell ids and an “ack‑and‑drop” server policy for stale writes to computed cells, behind `EXPERIMENTAL_COMPUTED_CELL_IDS`. This reduces multi‑client conflict churn while keeping commit bookkeeping intact.

- **New Features**
  - Mint `fid2:computed:<hash>` for internal cells proven to be pure; `fid1:<hash>` stays strict.
  - `createRef` supports a `kind`; kind is embedded in the hash preimage and visible tag; manifest matching now includes kind. `FabricHash.fromString` splits at the last colon so existing ids parse unchanged.
  - Conservative computed classifier added, widened by verified capture‑writes (`captureWritesAnalyzed`) and treating `.send()` as a write; embedding event streams in JSX no longer disqualifies pure computeds.
  - Memory‑v2 acknowledges and drops stale commits whose ops all target computed‑kind ids; writes a zero‑revision commit row for dedupe and preconditions. Client reverts the optimistic value on `droppedComputed`; mixed/unknown/sqlite/untagged commits keep strict reject‑on‑stale.
  - New flag `EXPERIMENTAL_COMPUTED_CELL_IDS` wired through runtime, CLI, shell, toolshed, and background service; spec and docs updated.

- **Migration**
  - Opt‑in by setting `EXPERIMENTAL_COMPUTED_CELL_IDS=true` (or `experimental.computedCellIds` in `Runtime` options). Readers accept both `fid1` and `fid2` forms.
  - Enabling can re‑materialize internal cells due to kind‑sensitive ids; this is expected.
  - If you parse Fabric ids outside the SDK, split on the last colon and accept `fid2:computed:`.

<sup>Written for commit e634ddfe7dc021acca84eb757d0c4e09864da401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

