### PR TITLE
fix(runner): array-diff shrink emits explicit slot deletes (clears stale per-slot link labels)

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -991,6 +991,26 @@ export function normalizeAndDiff(
       const childSchema = (lub !== undefined)
         ? { type: "number", ifc: { confidentiality: lub } } as JSONSchema
         : { type: "number" } as JSONSchema;
+      // Slots truncated by a shrink are removed, not merely out of range:
+      // emit explicit deletes (the direct `length`-write path's idiom) so
+      // write-detail consumers — notably the flow-label carry-forward that
+      // must drop the removed slots' stale per-slot link entries — see the
+      // removal. Ordered BEFORE the length change: once the length write
+      // has truncated the array, a delete at a now-absent slot is a no-op
+      // the write layer elides from the journal. Growth needs nothing
+      // here — the element loop above already visited every new slot.
+      for (let i = newValue.length; i < currentValue.length; i++) {
+        if (!(i in currentValue)) continue; // hole: nothing to remove
+        changes.push({
+          location: {
+            ...link,
+            path: [...link.path, i.toString()],
+            schema: runtime.cfc.getSchemaAtPath(link.schema, [i.toString()]),
+          },
+          value: undefined,
+          delete: true,
+        });
+      }
       changes.push({
         location: {
           ...link,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -923,6 +923,32 @@ export function normalizeAndDiff(
     // Get current array for precomputing child values (if it was an array)
     const currentArray = Array.isArray(currentValue) ? currentValue : undefined;
 
+    // On GROWTH the length change must precede the element writes: applying
+    // a slot write beyond the current end auto-extends the array, turning a
+    // later length write into a no-op the write layer elides from the
+    // journal — write-detail consumers (flow-label clear/re-stamp of the
+    // ["length"] entries) would never see the length change, fossilizing
+    // its labels at whatever join first stamped them. The shrink direction
+    // is the opposite (deletes first, length last) — see below.
+    if (
+      Array.isArray(currentValue) && newValue.length > currentValue.length
+    ) {
+      const lub = (link.schema !== undefined)
+        ? runtime.cfc.lubSchema(link.schema)
+        : undefined;
+      const lengthSchema = (lub !== undefined)
+        ? { type: "number", ifc: { confidentiality: lub } } as JSONSchema
+        : { type: "number" } as JSONSchema;
+      changes.push({
+        location: {
+          ...link,
+          path: [...link.path, "length"],
+          schema: lengthSchema,
+        },
+        value: newValue.length,
+      });
+    }
+
     for (let i = 0; i < newValue.length; i++) {
       const inNew = i in newValue;
       const inCur = currentArray ? i in currentArray : false;
@@ -981,8 +1007,9 @@ export function normalizeAndDiff(
       changes.push(...nestedChanges);
     }
 
-    // Handle array length changes
-    if (Array.isArray(currentValue) && currentValue.length != newValue.length) {
+    // Handle array SHRINK (growth emitted its length change above, before
+    // the element writes)
+    if (Array.isArray(currentValue) && currentValue.length > newValue.length) {
       // We need to add the schema here, since the array may be secret, so the length should be too
       const lub = (link.schema !== undefined)
         ? runtime.cfc.lubSchema(link.schema)

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -79,6 +79,14 @@ describe("CFC: array shrink clears truncated slots' link labels", () => {
       )
       .flatMap((e) => e.label.confidentiality ?? []);
 
+  const lengthValueConfidentiality = (id: string): string[] =>
+    entriesOf(id)
+      .filter((e) =>
+        e.origin === "derived" && e.observes === "value" &&
+        e.path.length === 1 && e.path[0] === "length"
+      )
+      .flatMap((e) => e.label.confidentiality ?? []);
+
   it("drops the truncated slot's link entry on shrink; survivors keep theirs", async () => {
     storageManager = StorageManager.emulate({ as: signer });
     runtime = new Runtime({
@@ -124,10 +132,22 @@ describe("CFC: array shrink clears truncated slots' link labels", () => {
     // no residue of the departed member to re-import via followRef.
     const growTx = runtime.edit();
     const el2 = runtime.getCell(space, "shrink-el-2", undefined, growTx);
+    el2.get(); // a content read: carol joins the growing tx's flow join
     const lc2 = runtime.getCell(space, "shrink-list", listSchema, growTx);
     lc2.set([el0, el2]);
     expect((await growTx.commit()).ok).toBeDefined();
 
     expect(linkConfidentialityAt(listId, "1")).toEqual(["carol-secret"]);
+
+    // The grow-side twin of the shrink bug: element writes auto-extend the
+    // array, so a trailing length change no-ops and is elided from the
+    // journal — the ["length"] derived entries would then never be cleared
+    // or re-stamped, fossilizing the join that first minted them (which
+    // here was the SHRINK tx's join, containing bob). With the length
+    // change emitted before the element writes, the grow tx re-stamps
+    // ["length"] from its own join: carol present, and not the pure
+    // fossil that lacks her.
+    const lengthConf = lengthValueConfidentiality(listId);
+    expect(lengthConf).toContainEqual("carol-secret");
   });
 });

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-shrink-slot-labels");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// An array-diff shrink truncates slots by writing `length` alone; without an
+// explicit delete write per truncated slot, the removed slots' per-slot link
+// entries survive in the labelMap. Any later read/diff of such a slot (e.g. a
+// list growing back) consumes the stale entry as a followRef observation
+// (SC-8) and re-imports the departed member's taint into the reader's flow
+// join — the echo behind the #4525 probe's A3 step. The diff layer now emits
+// the same explicit slot deletes the direct `length`-write path always has,
+// and the flow-clear drops the stale entries like any other covered write.
+describe("CFC: array shrink clears truncated slots' link labels", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const seedLabeledDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    atom: string,
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({
+      space,
+      scope: "space",
+      id,
+      path: [],
+    }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: {
+          version: 1,
+          entries: [{ path: [], label: { confidentiality: [atom] } }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica!.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const linkConfidentialityAt = (id: string, slot: string): string[] =>
+    entriesOf(id)
+      .filter((e) =>
+        e.origin === "link" && e.path.length === 1 &&
+        e.path[0] === slot
+      )
+      .flatMap((e) => e.label.confidentiality ?? []);
+
+  it("drops the truncated slot's link entry on shrink; survivors keep theirs", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    await seedLabeledDoc(runtime, "shrink-el-0", { n: 1 }, "alice-secret");
+    await seedLabeledDoc(runtime, "shrink-el-1", { n: 2 }, "bob-secret");
+    await seedLabeledDoc(runtime, "shrink-el-2", { n: 3 }, "carol-secret");
+
+    const listSchema = {
+      type: "array",
+      items: { asCell: ["cell"] },
+    } as const;
+
+    const setup = runtime.edit();
+    const el0 = runtime.getCell(space, "shrink-el-0", undefined, setup);
+    const el1 = runtime.getCell(space, "shrink-el-1", undefined, setup);
+    const listCell = runtime.getCell(space, "shrink-list", listSchema, setup);
+    listCell.set([el0, el1]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const listId = listCell.getAsNormalizedFullLink().id;
+    // Precondition: both slots carry their element's link label.
+    expect(linkConfidentialityAt(listId, "0")).toEqual(["alice-secret"]);
+    expect(linkConfidentialityAt(listId, "1")).toEqual(["bob-secret"]);
+
+    // Shrink: bob's slot is truncated by the array diff (a `length` write —
+    // slot 1 itself is not overwritten by any surviving element).
+    const shrinkTx = runtime.edit();
+    const lc = runtime.getCell(space, "shrink-list", listSchema, shrinkTx);
+    lc.set([el0]);
+    expect((await shrinkTx.commit()).ok).toBeDefined();
+
+    expect(linkConfidentialityAt(listId, "0")).toEqual(["alice-secret"]);
+    // The truncated slot's stale entry is the echo carrier — it must go.
+    expect(linkConfidentialityAt(listId, "1")).toEqual([]);
+
+    // Growth re-uses the slot: its label is the new occupant's alone, with
+    // no residue of the departed member to re-import via followRef.
+    const growTx = runtime.edit();
+    const el2 = runtime.getCell(space, "shrink-el-2", undefined, growTx);
+    const lc2 = runtime.getCell(space, "shrink-list", listSchema, growTx);
+    lc2.set([el0, el2]);
+    expect((await growTx.commit()).ok).toBeDefined();
+
+    expect(linkConfidentialityAt(listId, "1")).toEqual(["carol-secret"]);
+  });
+});

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -315,14 +315,25 @@ describe("data-updating", () => {
       const current = testCell.key("items").getAsNormalizedFullLink();
       const changes = normalizeAndDiff(runtime, tx, current, [1, 2]);
 
-      expect(changes.length).toBe(1);
+      // A shrink is explicit deletes of the truncated slots PLUS a length
+      // change — deletes first, so they hit still-present slots (a delete
+      // after truncation is a no-op the write layer elides).
+      expect(changes.length).toBe(2);
       expect(
         areNormalizedLinksSame(
           changes[0].location,
+          testCell.key("items").key("2").getAsNormalizedFullLink(),
+        ),
+      ).toBe(true);
+      expect(changes[0].value).toBe(undefined);
+      expect(changes[0].delete).toBe(true);
+      expect(
+        areNormalizedLinksSame(
+          changes[1].location,
           testCell.key("items").key("length").getAsNormalizedFullLink(),
         ),
       ).toBe(true);
-      expect(changes[0].value).toBe(2);
+      expect(changes[1].value).toBe(2);
     });
 
     it("should generate correct paths when setting array length to 0", () => {

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -336,6 +336,37 @@ describe("data-updating", () => {
       expect(changes[1].value).toBe(2);
     });
 
+    it("should emit the length change before element writes on growth", () => {
+      const testCell = runtime.getCell<{ items: number[] }>(
+        space,
+        "normalizeAndDiff array growth ordering",
+        undefined,
+        tx,
+      );
+      testCell.set({ items: [1, 2] });
+      const current = testCell.key("items").getAsNormalizedFullLink();
+      const changes = normalizeAndDiff(runtime, tx, current, [1, 2, 3]);
+
+      // Length first: a slot write beyond the current end auto-extends the
+      // array, which would turn a trailing length write into a no-op the
+      // write layer elides from the journal.
+      expect(changes.length).toBe(2);
+      expect(
+        areNormalizedLinksSame(
+          changes[0].location,
+          testCell.key("items").key("length").getAsNormalizedFullLink(),
+        ),
+      ).toBe(true);
+      expect(changes[0].value).toBe(3);
+      expect(
+        areNormalizedLinksSame(
+          changes[1].location,
+          testCell.key("items").key("2").getAsNormalizedFullLink(),
+        ),
+      ).toBe(true);
+      expect(changes[1].value).toBe(3);
+    });
+
     it("should generate correct paths when setting array length to 0", () => {
       const testCell = runtime.getCell<{ items: number[] }>(
         space,


### PR DESCRIPTION
## Why

An array-diff shrink (`cell.set([...fewer])`) emits only the `length` change — the truncated slots are never written. Their per-slot `origin:"link"` labelMap entries therefore survive in storage after the slots themselves are gone. Since C1 (#4507), any later read or diff that touches such a slot — most simply, the list growing back over it — consumes the stale entry as a followRef observation (SC-8) and re-imports the **departed** element's confidentiality into the reader's flow join. For membership labels that §8.12.8 says *replace-from-criteria* (#4546), this manufactures accumulation the discipline forbids: it is the bridge behind the A3 step of the probe on #4525, where a member two membership-changes gone kept re-appearing in a filter container's `enumerate` label.

This is a bug independent of any coordinator: it needs only a list of labeled links and a shrink. (The filter/flatMap work in #4391 makes it *visible* on membership stamps, but the stale entries exist either way.)

## The fix

The diff layer already has the right idiom: a **direct** `length` write emits explicit per-slot deletes for the removed range. The array-diff branch now does the same for a shrink — with the deletes ordered **before** the length change, because once the length write has truncated the array, a delete at a now-absent slot is a no-op the write layer elides from the journal (verified via write details; this ordering is why the naive "same idiom, same order" version silently changed nothing).

With the removal visible as a write, the flow-label carry-forward drops the stale entries through the **existing** written-path clear — no label-layer changes at all. Growth needs nothing: the element loop already visits every new slot.

## Verification

- **Red-first:** `cfc-array-shrink-slot-labels.test.ts` — on main, the truncated slot's link entry survives the shrink (`["bob-secret"]`); with the fix it is cleared, the survivor keeps its label, and a regrown slot carries only its new occupant (no departed-member residue for followRef to re-import).
- The pinned diff contract in `data-updating.test.ts` ("array length changes") updates from `[length]` to `[delete, length]`, matching the direct-length-write path's shipped contract.
- Blast radius: cfc + list-builtin + cell + resume + data-updating suites — 136 files / 1044 steps, 0 failed. Full runner suite green (see checks).

## Relation to open work

#4391's rebase onto #4546 composes with this: the shrink probe's A-scenario converges once the stale-slot bridge is gone (one reconcile of hysteresis remains — the shrink reconcile itself genuinely observes the departing slot's pointer — which is SC-8-consistent). Details on that thread.

*Analysis, fix, and tests by Claude Fable 5; PR by @mathpirate.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix array-diff shrink and growth ordering to clear stale per-slot link labels and ensure ["length"] labels re-stamp correctly. Shrinks now emit per-slot deletes before the length write; growth emits the length change before element writes.

- **Bug Fixes**
  - Shrink: emit delete ops for each truncated slot before the `length` write; holes are skipped. Clears stale per-slot `origin: "link"` labels and matches the direct `length`-write path.
  - Growth: emit the `length` change before element writes to prevent elision, ensuring the `["length"]` value entry is cleared/re-stamped from the current tx’s join.
  - Tests: added `cfc-array-shrink-slot-labels.test.ts`; updated `data-updating.test.ts` with shrink `[delete, length]` and growth `[length, element]` ordering, plus a `["length"]` value-label re-stamp assertion.

<sup>Written for commit 867afe87f6dfde095f6cbf7e85fef4fe9e386112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

