### PR TITLE
fix(runner): pre-sync compile-cache write targets under a one-hop edge selector (CT-1848)

### DIFF
--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -449,6 +449,39 @@ export const SOURCE_DOC_SCHEMA = {
 } as const satisfies JSONSchema;
 
 /**
+ * One-hop selector for pre-syncing write-back targets (CT-1848). A stored
+ * source/compiled doc's `imports` array holds LIVE links to per-edge element
+ * docs (the cell layer hoists each `{specifier, link}` element into its own
+ * derived doc); the element doc's own `link` field is a *quoted* link — data,
+ * not a traversal edge — so this schema pulls exactly the doc plus its edge
+ * element docs and stops. A schema-less `sync()` normalizes to the rejecting
+ * selector and delivers only the root, leaving the element docs unknown to
+ * the replica — then the re-write touches them blind and the engine reveals
+ * the conflicts one per commit attempt (the CT-1824 loop; the write-back's
+ * retry budget converges it, one round per edge doc). With the element docs
+ * client-known up front, the re-write diffs against true state and commits
+ * on the first attempt. Recursion is deliberately omitted: the write-target
+ * pre-sync enumerates every module doc itself, so each doc only needs its
+ * own edges — nothing beyond the write set loads (the lazy-by-default
+ * posture for code docs is untouched).
+ */
+export const WRITE_TARGET_EDGE_SYNC_SCHEMA = {
+  type: "object",
+  properties: {
+    imports: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          specifier: { type: "string" },
+          link: true,
+        },
+      },
+    },
+  },
+} as const satisfies JSONSchema;
+
+/**
  * Write every emitted module as a `pattern:<identity>` cell into `space`, each
  * import a sigil link to its dependency cell (the entry additionally linking any
  * otherwise-unreachable module). Idempotent (content-addressed keys). The caller

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -35,6 +35,7 @@ import {
   ROOT_LINK_SPECIFIER,
   type SourceDoc,
   sourceDocKey,
+  WRITE_TARGET_EDGE_SYNC_SCHEMA,
   writeCompiledDocs,
   writeSourceDocs,
 } from "./compilation-cache/cell-cache.ts";
@@ -1398,13 +1399,25 @@ export class PatternManager {
     }
   }
 
+  // Write-target pre-syncs carry the one-hop edge selector (CT-1848): a
+  // schema-less sync delivers only the root doc, leaving the per-edge element
+  // docs unknown to the replica, so a re-write of pre-existing docs touches
+  // them blind and conflicts one engine round per edge (the CT-1824 loop).
+  // With the edge docs materialized up front the write-back diffs against
+  // true state and commits on the first attempt; the retry budget in
+  // writeBackCompileCache remains as a backstop. Same-microtask syncs batch
+  // into a single server round trip.
   private async syncSourceCacheWriteTargets(
     space: MemorySpace,
     modules: readonly CacheableModule[],
   ): Promise<void> {
     await Promise.all(
       modules.map((module) =>
-        this.runtime.getCell(space, sourceDocKey(module.identity)).sync()
+        this.runtime.getCell(
+          space,
+          sourceDocKey(module.identity),
+          WRITE_TARGET_EDGE_SYNC_SCHEMA,
+        ).sync()
       ),
     );
   }
@@ -1416,10 +1429,15 @@ export class PatternManager {
   ): Promise<void> {
     await Promise.all(
       modules.flatMap((module) => [
-        this.runtime.getCell(space, sourceDocKey(module.identity)).sync(),
+        this.runtime.getCell(
+          space,
+          sourceDocKey(module.identity),
+          WRITE_TARGET_EDGE_SYNC_SCHEMA,
+        ).sync(),
         this.runtime.getCell(
           space,
           compiledDocKey(opts.runtimeVersion, module.identity),
+          WRITE_TARGET_EDGE_SYNC_SCHEMA,
         ).sync(),
       ]),
     );

--- a/packages/runner/test/compile-cache-version.test.ts
+++ b/packages/runner/test/compile-cache-version.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  getCompileCacheRuntimeVersion,
+  resolveBakedCompileCacheRuntimeVersionForTesting,
+  setCompileCacheRuntimeVersionForTesting,
+} from "../src/compilation-cache/cell-cache.ts";
+import { SOURCE_COMPILE_CACHE_RUNTIME_VERSION } from "../src/compilation-cache/compile-cache-version.ts";
+
+type VersionGlobal = typeof globalThis & {
+  __cfCompileCacheRuntimeVersion?: unknown;
+};
+
+// The compile-cache runtimeVersion decides when deployed pieces recompile
+// (a version move sends every cold load through the recovery write-back —
+// the CT-1824 arc), so the resolution ladder is load-bearing:
+//   defined global override  >  baked build version  >  live compiler
+//   fingerprint (Deno dev runtime)  >  undefined (no fingerprint source).
+describe("compile-cache runtime-version resolution", () => {
+  it("a defined global version overrides everything", async () => {
+    const g = globalThis as VersionGlobal;
+    const previous = g.__cfCompileCacheRuntimeVersion;
+    g.__cfCompileCacheRuntimeVersion = "cf/esm-compile/defined-by-build";
+    try {
+      // Even an explicit baked version loses to the build-time define.
+      expect(
+        await resolveBakedCompileCacheRuntimeVersionForTesting("baked-v1"),
+      ).toBe("cf/esm-compile/defined-by-build");
+    } finally {
+      if (previous === undefined) {
+        delete g.__cfCompileCacheRuntimeVersion;
+      } else {
+        g.__cfCompileCacheRuntimeVersion = previous;
+      }
+    }
+  });
+
+  it("an empty or non-string define is ignored, falling to the baked version", async () => {
+    const g = globalThis as VersionGlobal;
+    const previous = g.__cfCompileCacheRuntimeVersion;
+    try {
+      g.__cfCompileCacheRuntimeVersion = "";
+      expect(
+        await resolveBakedCompileCacheRuntimeVersionForTesting("baked-v2"),
+      ).toBe("baked-v2");
+      g.__cfCompileCacheRuntimeVersion = 42;
+      expect(
+        await resolveBakedCompileCacheRuntimeVersionForTesting("baked-v2"),
+      ).toBe("baked-v2");
+    } finally {
+      if (previous === undefined) {
+        delete g.__cfCompileCacheRuntimeVersion;
+      } else {
+        g.__cfCompileCacheRuntimeVersion = previous;
+      }
+    }
+  });
+
+  it("a baked (non-source) version is returned verbatim", async () => {
+    expect(
+      await resolveBakedCompileCacheRuntimeVersionForTesting("cf/esm/v42"),
+    ).toBe("cf/esm/v42");
+  });
+
+  it("the source sentinel resolves the live compiler fingerprint under Deno", async () => {
+    // Dev runtimes carry the source sentinel; the ladder then computes the
+    // fingerprint from the compiler-relevant sources. This is the value whose
+    // movement makes deployed pieces stale, so pin its shape: defined,
+    // non-empty, not the sentinel itself, and stable across resolutions.
+    const first = await resolveBakedCompileCacheRuntimeVersionForTesting(
+      SOURCE_COMPILE_CACHE_RUNTIME_VERSION,
+    );
+    expect(typeof first).toBe("string");
+    expect((first as string).length).toBeGreaterThan(0);
+    expect(first).not.toBe(SOURCE_COMPILE_CACHE_RUNTIME_VERSION);
+    const second = await resolveBakedCompileCacheRuntimeVersionForTesting(
+      SOURCE_COMPILE_CACHE_RUNTIME_VERSION,
+    );
+    expect(second).toBe(first);
+  });
+
+  it("the test override stacks and restores like a scope", async () => {
+    // The conflict/healing tests lean on this seam to simulate version bumps;
+    // pin the restore discipline (LIFO, restores the PREVIOUS override, and
+    // the ambient resolution returns once the stack unwinds).
+    const ambient = await getCompileCacheRuntimeVersion();
+    const restoreOuter = setCompileCacheRuntimeVersionForTesting("outer-v");
+    try {
+      expect(await getCompileCacheRuntimeVersion()).toBe("outer-v");
+      const restoreInner = setCompileCacheRuntimeVersionForTesting("inner-v");
+      expect(await getCompileCacheRuntimeVersion()).toBe("inner-v");
+      restoreInner();
+      expect(await getCompileCacheRuntimeVersion()).toBe("outer-v");
+    } finally {
+      restoreOuter();
+    }
+    expect(await getCompileCacheRuntimeVersion()).toBe(ambient);
+  });
+});

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -5,7 +5,11 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
-import { setCompileCacheRuntimeVersionForTesting } from "../src/compilation-cache/cell-cache.ts";
+import {
+  setCompileCacheRuntimeVersionForTesting,
+  sourceDocKey,
+  WRITE_TARGET_EDGE_SYNC_SCHEMA,
+} from "../src/compilation-cache/cell-cache.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 // Shared-server helper (same shape as cell-cache.test.ts): several managers —
@@ -140,6 +144,130 @@ describe("compile-cache write-back after a runtime-version bump", () => {
       expect(warm).toBeDefined();
       expect(runtimeC.patternManager.getCompileCacheStats().byIdentityHits)
         .toBeGreaterThan(0);
+    } finally {
+      restoreVersion();
+      await runtimeC?.dispose();
+      await runtimeB?.dispose();
+      await runtimeA.dispose();
+      await smC?.close();
+      await smB?.close();
+      await smA.close();
+      await server.close();
+    }
+  });
+});
+
+// CT-1848: the write-target pre-sync carries the one-hop edge selector, so
+// the per-edge element docs (the derived docs the cell layer hoists each
+// `imports[i]` into) are client-known BEFORE the re-write. A schema-less
+// pre-sync normalizes to the rejecting selector and delivers only the root
+// doc; in the browser the re-write then touches the element docs blind and
+// the engine reveals the conflicts one per attempt (the CT-1824 loop,
+// converged only by the retry budget). NOTE: the blind-conflict itself does
+// not reproduce in-process (this fixture's flows warm the element docs some
+// other way — same limitation as the healing test above); the conflict-free
+// attempt-1 property is verified live on the browser rig. What IS pinned
+// here, differentially, is the selector semantics the fix rides on: the
+// edge-schema sync materializes the element docs into a cold replica, the
+// schema-less sync does not.
+describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
+  it("edge-schema sync delivers element docs to a cold replica; schema-less does not", async () => {
+    const server = newSharedServer();
+    const program = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern } from 'commonfabric';",
+            "import { double } from './dep.ts';",
+            "export default pattern<{ value: number }>(({ value }) => {",
+            "  return { result: double(value) };",
+            "});",
+          ].join("\n"),
+        },
+        {
+          name: "/dep.ts",
+          contents: [
+            "import { lift } from 'commonfabric';",
+            "export const double = lift((x: number) => x * 2);",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const restoreVersion = setCompileCacheRuntimeVersionForTesting(
+      "ct1848-version-A",
+    );
+    const smA = SharedServerStorageManager.connectTo(server, { as: signer });
+    const runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: smA,
+    });
+    let smB: SharedServerStorageManager | undefined;
+    let runtimeB: Runtime | undefined;
+    let smC: SharedServerStorageManager | undefined;
+    let runtimeC: Runtime | undefined;
+    try {
+      const txA = runtimeA.edit();
+      const compiled = await runtimeA.patternManager.compilePattern(program, {
+        space,
+        tx: txA,
+      });
+      const ref = runtimeA.patternManager.getArtifactEntryRef(compiled)!;
+      await runtimeA.patternManager.flushCompileCacheWrites();
+      await txA.commit();
+      await smA.synced();
+
+      // Arm 1 — COLD replica, sync the entry under the one-hop edge schema
+      // (what the write-target pre-sync now uses): the element docs arrive.
+      smB = SharedServerStorageManager.connectTo(server, { as: signer });
+      runtimeB = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smB,
+      });
+      const edgeCell = runtimeB.getCell(
+        space,
+        sourceDocKey(ref.identity),
+        WRITE_TARGET_EDGE_SYNC_SCHEMA,
+      );
+      await edgeCell.sync();
+      const parentUri = edgeCell.getAsNormalizedFullLink().id;
+      const providerB = smB.open(space);
+      // deno-lint-ignore no-explicit-any
+      const rawParent = (providerB as any).get(parentUri);
+      expect(rawParent).toBeDefined();
+      const importsRaw = rawParent?.value?.imports;
+      expect(Array.isArray(importsRaw)).toBe(true);
+      expect((importsRaw as unknown[]).length).toBeGreaterThan(0);
+      const elementIds: string[] = [];
+      for (
+        const el of importsRaw as { "/"?: { "link@1"?: { id?: string } } }[]
+      ) {
+        const id = el?.["/"]?.["link@1"]?.id;
+        expect(typeof id).toBe("string");
+        elementIds.push(id!);
+        // deno-lint-ignore no-explicit-any
+        expect((providerB as any).get(id)).toBeDefined();
+      }
+
+      // Arm 2 — another COLD replica, schema-less sync (the pre-fix
+      // behavior): the root arrives, the element docs do NOT. This is the
+      // differential that makes the edge selector load-bearing.
+      smC = SharedServerStorageManager.connectTo(server, { as: signer });
+      runtimeC = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smC,
+      });
+      const bareCell = runtimeC.getCell(space, sourceDocKey(ref.identity));
+      await bareCell.sync();
+      const providerC = smC.open(space);
+      // deno-lint-ignore no-explicit-any
+      expect((providerC as any).get(parentUri)).toBeDefined();
+      for (const id of elementIds) {
+        // deno-lint-ignore no-explicit-any
+        expect((providerC as any).get(id)).toBeUndefined();
+      }
     } finally {
       restoreVersion();
       await runtimeC?.dispose();


### PR DESCRIPTION
Implements Bernhard's CT-1824 design guidance (*"once we start loading one module file, we should load them all … expressing a nested schema and using sigil links"*) for the compile-cache write-back's pre-sync.

**Problem.** The write-target pre-syncs were schema-less, which `normalizeSyncSelector` maps to the rejecting selector: only the root doc arrives. A recovery re-write then touches the per-edge **element docs** (the derived docs the cell layer hoists each `imports[i]` into) blind, and the engine reveals those conflicts one per commit attempt — the CT-1824 loop class, converged only by the write-back's retry budget (#4495).

**Fix.** `WRITE_TARGET_EDGE_SYNC_SCHEMA` — a one-hop selector (doc → imports → element docs; the element's own `link` field is a *quoted* link, i.e. data, so the pull stops exactly there). Both write-target pre-syncs carry it. Nothing beyond the write set loads; the lazy-by-default posture for code docs is untouched. Same-microtask syncs still batch into one server round trip.

**Tests.** Differential, self-falsifying pair: a cold replica syncing under the edge schema receives the element docs; a cold replica syncing schema-less receives only the root (that arm *is* the pre-fix behavior, asserted absent). Full workspace suite green.

**Honest scope (live-verified on the browser rig).** The pre-sync materializes every *currently-linked* edge doc (in-worker probe: `known=N/N` per parent). The recovery loop's remaining conflicts are on **old-generation** element docs that current parent values no longer link — each historical write minted fresh cause-derived element ids and re-pointed, and the new write ends up asserting seq-0 on ids from an older generation that no pull of current state can discover. That residue is exactly the quasi-content-addressed *"either absent or identical"* class from the CT-1824 discussion (Q1): it stays converged by the #4495 retry budget and is the converge-op's territory. Mechanism notes and the remaining probe are on CT-1848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-syncs compile-cache write targets with a one-hop edge selector so source/compiled docs and their element docs load before write-back, eliminating per-edge conflict retries. Addresses CT-1848 and keeps the load limited to the write set.

- **Bug Fixes**
  - Added `WRITE_TARGET_EDGE_SYNC_SCHEMA` (doc + `imports` element docs; quoted inner links stop traversal).
  - Applied to source and compiled write-target pre-syncs in `PatternManager`; write-back now diffs true state and commits on the first attempt; same-microtask syncs still batch.
  - Tests: cold-replica differential asserting edge-schema loads element docs vs schema-less only root; new suite pinning compile-cache `runtimeVersion` resolution (defined global > baked > Deno fingerprint; empty/non-string ignored; test override stacks/restores).

<sup>Written for commit 8775de1adabab4a71b0aceb498ccea270b2c1b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

