### PR TITLE
fix(cfc): anchor creation membership stamps at the canonical path

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1181,11 +1181,25 @@ const valueWriteTargets = (
       ) {
         continue;
       }
+      // A document-root write carries the RAW envelope ({value, source, …}):
+      // writeOrThrow's missing-doc retry materializes the whole document in
+      // one write at storage path []. `writePath` is already logical, so the
+      // recorded value must be too — the envelope's `value` member. Keeping
+      // the raw envelope would let `pureLinkContainerPaths` walk through the
+      // `value` wrapper and emit it as a stamp path, persisting membership
+      // anchored at ["value"] where no canonical-path read consumes it; the
+      // envelope's other members (`source`, `cfc`) are the runtime surfaces
+      // the raw-path exclusions above keep out of flow labeling.
+      const writtenValue = rawPath.length === 0
+        ? (isRecord(write.value)
+          ? (write.value as { value?: unknown }).value
+          : undefined)
+        : write.value;
       const key = targetKey(write.address);
       const existing = result.get(key);
       if (existing !== undefined) {
         existing.paths.push(writePath);
-        existing.valuesByPath.set(pathKey(writePath), write.value);
+        existing.valuesByPath.set(pathKey(writePath), writtenValue);
       } else {
         result.set(key, {
           space: write.address.space,
@@ -1193,7 +1207,7 @@ const valueWriteTargets = (
           id: write.address.id as URI,
           type: (write.address.type ?? "application/json") as MediaType,
           paths: [writePath],
-          valuesByPath: new Map([[pathKey(writePath), write.value]]),
+          valuesByPath: new Map([[pathKey(writePath), writtenValue]]),
         });
       }
     }

--- a/packages/runner/test/cfc-creation-membership-anchor.test.ts
+++ b/packages/runner/test/cfc-creation-membership-anchor.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-creation-anchor");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// A document-creating write lands at the RAW document root: writeOrThrow's
+// missing-doc retry constructs the envelope `{value: ...}` and writes it at
+// storage path []. `valueWriteTargets` canonicalizes the write PATH but used
+// to keep the RAW envelope as the written value, so the pure-link container
+// walk descended through the `value` wrapper key and emitted raw-projected
+// container paths — the membership stamp (origin:"structure",
+// observes:"enumerate") then persisted anchored at ["value"] instead of the
+// canonical container path []. Consumption compares stored anchors against
+// canonical read paths, so nothing at the canonical path consumed the
+// membership label until the next write's carry-forward re-anchored it; the
+// window was only masked by the co-minted frozen existence entry carrying
+// the same creating join. These tests pin the canonical anchoring at
+// creation itself.
+describe("CFC: creation anchors membership at the canonical container path", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const seedLabeledDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    atom: string,
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({
+      space,
+      scope: "space",
+      id,
+      path: [],
+    }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: {
+          version: 1,
+          entries: [{ path: [], label: { confidentiality: [atom] } }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica!.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const createList = async (): Promise<string> => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    await seedLabeledDoc(runtime, "anchor-el-0", { n: 1 }, "alice-secret");
+    await seedLabeledDoc(runtime, "anchor-el-1", { n: 2 }, "bob-secret");
+
+    const listSchema = {
+      type: "array",
+      items: { asCell: ["cell"] },
+    } as const;
+
+    // The creating transaction: a content read (alice joins the flow join)
+    // plus the pure-link array write that creates the list document.
+    const setup = runtime.edit();
+    const el0 = runtime.getCell(space, "anchor-el-0", undefined, setup);
+    const el1 = runtime.getCell(space, "anchor-el-1", undefined, setup);
+    el0.get();
+    const listCell = runtime.getCell(space, "anchor-list", listSchema, setup);
+    listCell.set([el0, el1]);
+    expect((await setup.commit()).ok).toBeDefined();
+    return listCell.getAsNormalizedFullLink().id;
+  };
+
+  it("mints the structure/enumerate membership entry at [] in the creating tx", async () => {
+    const listId = await createList();
+
+    // The membership stamp must anchor at the canonical container path
+    // immediately after the creating commit — not at the raw storage
+    // projection ["value"], which no canonical-path read would consume.
+    const membership = entriesOf(listId).filter((e) =>
+      e.origin === "structure" && e.observes === "enumerate"
+    );
+    expect(membership.map((e) => e.path)).toEqual([[]]);
+    expect(membership[0].label.confidentiality).toEqual(["alice-secret"]);
+
+    // The general form of the same invariant: no persisted entry may sit at
+    // a raw storage path. A leading "value" segment in a stored anchor is
+    // the raw document projection leaking into logical space (a user field
+    // actually named "value" would live at raw ["value","value"] and
+    // canonicalize to logical ["value"] — stored anchors here come from
+    // canonical mint paths, so a leading "value" can only be the leak).
+    expect(
+      entriesOf(listId).filter((e) => e.path[0] === "value"),
+    ).toEqual([]);
+  });
+
+  it("a shape read at the canonical container path consumes the creating join", async () => {
+    const listId = await createList();
+
+    // A nonRecursive (shape) read at the container observes membership and
+    // existence: the creating join must arrive in the reader's flow join
+    // and stamp its output. (During the mis-anchored window this held only
+    // by coincidence — the frozen existence entry carried the same atoms —
+    // so this is the consumption guard for the canonical anchoring above.)
+    const readTx = runtime!.edit();
+    readTx.readOrThrow({
+      space,
+      scope: "space",
+      id: listId as `${string}:${string}`,
+      type: "application/json",
+      path: ["value"],
+    }, { nonRecursive: true });
+    const out = runtime!.getCell(space, "anchor-out", undefined, readTx);
+    out.set({ copied: true });
+    expect((await readTx.commit()).ok).toBeDefined();
+
+    const outDerived = entriesOf(out.getAsNormalizedFullLink().id).find((e) =>
+      e.origin === "derived" && e.observes === "value"
+    );
+    expect(outDerived?.label.confidentiality).toEqual(["alice-secret"]);
+  });
+});


### PR DESCRIPTION
A document-creating transaction that writes a pure-link array mints its membership stamp (`origin:"structure"`, `observes:"enumerate"`) at the raw storage path `["value"]` instead of the canonical logical container path `[]`. Observed empirically (plain list cell under `cfcFlowLabels:"persist"`): after the creating commit the stored labelMap holds `["value"] structure/enumerate` beside `[] structure/shape`; the next write's carry-forward re-anchors it to `[]`.

## Root cause

1. A doc-creating write lands at the **raw document root**: `writeOrThrow`'s missing-doc retry materializes the whole document as one write of the envelope `{value: …}` at storage path `[]` (`extended-storage-transaction.ts`).
2. `valueWriteTargets` canonicalizes the write **path** but recorded the **raw envelope** as the written value — path and value disagree about which space they live in.
3. `pureLinkContainerPaths` walks that envelope and emits two container stamp paths: `[]` (the envelope record — a phantom; it is not a logical container) and `["value"]` (the actual array).
4. The membership stamp mints at both; `coalesceLabelEntries` merges them under one canonical pathKey but keeps the **last** entry's path → the stored anchor is `["value"]`. The frozen existence entry survives at `[]` only because `hasFrozenExistence` dedups via the canonicalizing `pathKey`.

Consumption compares stored anchors against canonical read paths (`labelAtPath`'s prefix resolution; the C4 exact-path node consumption), so nothing reading at the canonical container path consumes the mis-anchored membership label until carry-forward re-anchors it one commit later.

## Fix

Record the envelope's logical `value` member in `valueWriteTargets` instead of the raw envelope, so the recorded path and value agree in logical space. Membership now mints once, at `[]`. This also keeps the envelope's runtime surfaces (`source`, `cfc`) out of pure-link classification — a source-only creation no longer mints a phantom container stamp — consistent with the raw-path exclusions immediately above, which exist to keep those surfaces out of flow labeling.

Deliberately **not** fixed by canonicalizing entry paths at the coalesce/persist chokepoint: `canonicalizeLogicalPath` strips a leading `"value"` from any path, so applying it to already-logical stored paths is unsound for a user field literally named `value` — that hazard exists at three current call sites (empirically verified: one unrelated commit re-anchors a `["value","secret"]` entry to `["secret"]`) and is filed as [CT-1859](https://linear.app/common-tools/issue/CT-1859/cfc-canonicalizelogicalpath-double-strips-stored-logical-paths-user) with a staged fix proposal.

## Why the window didn't leak

At creation the membership stamp and the frozen existence entry co-mint with the same atoms (membership = J; existence = J plus cleared-existence absorb ⊇ J), and every consumer class that consumes `enumerate` also consumes `shape`. So during the one-commit window the flow join stayed correct by coincidence. The defect is the canonical-anchor invariant violation, the digest/store divergence it creates (`canonicalizeCfcMetadata` digests the entry at `[]` while the store said `["value"]`), and fragility against anything that decouples the two entries (e.g. Epic F range-scoped entries).

## Rollout

No migration needed: mis-anchored entries in existing stores self-heal on the document's next write via carry-forward re-anchoring (the behavior observed empirically).

## Testing

- Red-first: `cfc-creation-membership-anchor.test.ts` fails on unpatched main with the enumerate entry at `["value"]` (byte-identical to the field observation), passes with the fix. Pins: the enumerate entry sits at `[]` immediately after the creating commit; no stored entry sits at a raw `["value", …]` path; a shape read at the canonical container path consumes the creating join.
- Full runner suite on this branch: 784 passed (3910 steps), 0 failed. fmt/lint/check clean.

Context threads: #4546 (settled channel disciplines), #4525 probe discussion. Independent of #4556 (array-diff write-visibility) — different layer and mechanism, same probe constellation.

## CI note: coverage-debt override

The Performance Check's `packages/runner` coverage ratchet reports +2/+3 uncovered lines, which is baseline wobble, not debt from this diff: local V8 coverage over the full runner suite shows every added/modified line hot (the new ternary's lines all carry count 11382 — the LCOV converter smears a statement's count across its lines, so no test can move them), the coverage bot itself reported it could not tie the regression to any file in the diff, and the same run shows untouched groups drifting (`packages/memory` +7). A check-only re-run moved the *baseline* (7646→7645) while the current side stayed pinned at 7648 (re-runs reuse the uploaded LCOV artifacts). Narrow per-metric override below, per convention.

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7648 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
