### PR TITLE
perf(runner): defer boot-time source-map composition to first use (CT-1819, D3)

### DIFF
--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -83,7 +83,7 @@ const atSegmentEnd = (mappings: string, i: number): boolean =>
  * {@link SourceMapComposeError} — fail loud, no silent degradation.
  */
 function composeBundleSourceMapTextual(
-  modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
+  modules: ReadonlyArray<ComposeModuleEntry>,
   bundleFilename: string,
   startLineOffset = 0,
 ): SourceMap | undefined {
@@ -102,7 +102,12 @@ function composeBundleSourceMapTextual(
   let any = false;
   let lineOffset = startLineOffset;
 
-  for (const { body, map, source } of modules) {
+  for (const { body, bodyLineCount, map, source } of modules) {
+    if (body === undefined && bodyLineCount === undefined) {
+      throw new SourceMapComposeError(
+        "module entry needs body or bodyLineCount (line extent is required)",
+      );
+    }
     if (map) {
       if (typeof map.sourceRoot === "string" && map.sourceRoot !== "") {
         throw new SourceMapComposeError(
@@ -233,8 +238,11 @@ function composeBundleSourceMapTextual(
       }
     }
     // Lines this body occupies in the "\n"-joined bundle = (newlines in body)+1.
-    // Robust to trailing newlines, unlike split().length.
-    lineOffset += (body.match(/\n/g)?.length ?? 0) + 1;
+    // Robust to trailing newlines, unlike split().length. Callers that no
+    // longer hold the body pass the precomputed count instead (the lazy
+    // boot-path registration, CT-1819) — the count is the ONLY thing compose
+    // needs from the body text.
+    lineOffset += bodyLineCount ?? ((body!.match(/\n/g)?.length ?? 0) + 1);
   }
   if (!any) return undefined;
   const composed = {
@@ -264,13 +272,34 @@ function composeBundleSourceMapTextual(
  *
  * Returns `undefined` if no module contributed a map.
  */
+/**
+ * A module's contribution to a composed bundle map. Exactly one of `body` /
+ * `bodyLineCount` must describe the module's generated-line extent —
+ * composition only ever needs the LINE COUNT of the body, so callers that
+ * defer composition (the lazy boot-path registration, CT-1819) capture the
+ * precomputed count instead of retaining the body text.
+ */
+export type ComposeModuleEntry = {
+  body?: string;
+  bodyLineCount?: number;
+  map?: SourceMap;
+  source?: string;
+};
+
+// Tests-only observability: cold-boot laziness is asserted by counting
+// compositions (a profile-level claim otherwise only visible on the rig).
+let composeCallsForTesting = 0;
+export function getComposeBundleSourceMapCallsForTesting(): number {
+  return composeCallsForTesting;
+}
+
 export function composeBundleSourceMap(
   // `source`, when set, overrides the map's recorded source path for ALL of that
   // module's mappings. The per-module compiler maps record only the basename
   // (e.g. `main.tsx`), but the CFC verified-source set is keyed by the full
   // module path (e.g. `/<id>/dir/main.tsx`); overriding makes resolved
   // coordinates match the set so verified-source identity holds.
-  modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
+  modules: ReadonlyArray<ComposeModuleEntry>,
   bundleFilename: string,
   // Generated-line offset applied to the FIRST module. Use this when the
   // generated text is wrapped by a fixed prefix of N lines (e.g. the ESM
@@ -279,6 +308,7 @@ export function composeBundleSourceMap(
   // (1-based, relative to the eval'd string) map correctly.
   startLineOffset = 0,
 ): SourceMap | undefined {
+  composeCallsForTesting++;
   return composeBundleSourceMapTextual(
     modules,
     bundleFilename,
@@ -303,8 +333,16 @@ export function composeBundleSourceMap(
  * eval'd text under this load), so no positional information is invented — the
  * map only re-labels the bundle coordinate with the per-module source name.
  */
-export function identitySourceMap(body: string, source: string): SourceMap {
-  const lineCount = (body.match(/\n/g)?.length ?? 0) + 1;
+export function identitySourceMap(
+  // The compiled body, or its precomputed line count — the map is a fixed
+  // token per line, so the count is all the body contributes (lets the lazy
+  // boot-path registration avoid retaining body text, CT-1819).
+  body: string | number,
+  source: string,
+): SourceMap {
+  const lineCount = typeof body === "number"
+    ? body
+    : (body.match(/\n/g)?.length ?? 0) + 1;
   // Synthesized directly — the stream is a fixed token per line: line 1 maps
   // column 0 to source 0, line 1, column 0 (`AAAA`); every following line
   // advances only the original line by one (`AACA`). Byte-identical to what a
@@ -371,17 +409,44 @@ export class SourceMapParser {
     capacity: MAX_SOURCE_MAP_CACHE_SIZE,
   });
   private consumers = new WeakMap<SourceMap, SourceMapConsumer>();
+  // Deferred registrations (CT-1819): the boot path registers a PROVIDER
+  // instead of composing eagerly; the first lookup that needs the filename
+  // materializes it. One-shot — the provider is dropped as soon as it runs,
+  // so its captured inputs are released after first use.
+  private pendingProviders = new Map<string, () => SourceMap | undefined>();
 
   load(filename: string, sourceMap: SourceMap) {
+    // An explicit map supersedes any pending provider for the same name.
+    this.pendingProviders.delete(filename);
     this.sourceMaps.put(filename, sourceMap);
   }
 
   /**
-   * Clear all accumulated source maps and consumers.
+   * Register a deferred source map: `provider` runs (once) the first time a
+   * lookup needs `filename`. A provider returning `undefined` (nothing to
+   * compose) simply leaves the name unmapped, matching eager behavior.
+   */
+  loadLazy(filename: string, provider: () => SourceMap | undefined) {
+    this.pendingProviders.set(filename, provider);
+  }
+
+  private materialize(filename: string): void {
+    const provider = this.pendingProviders.get(filename);
+    if (provider === undefined) return;
+    this.pendingProviders.delete(filename);
+    const sourceMap = provider();
+    if (sourceMap !== undefined) {
+      this.sourceMaps.put(filename, sourceMap);
+    }
+  }
+
+  /**
+   * Clear all accumulated source maps, consumers, and pending providers.
    * Used for cleanup when the runtime is disposed.
    */
   clear(): void {
     this.sourceMaps.clear();
+    this.pendingProviders.clear();
   }
 
   // Fixes stack traces to use source map from eval. Strangely, both Deno and
@@ -433,6 +498,7 @@ export class SourceMapParser {
     const lineNum = parseInt(lineStr, 10);
     const columnNum = parseInt(colStr, 10);
 
+    this.materialize(filename);
     const sourceMap = this.sourceMaps.get(filename);
     if (!sourceMap) return originalLine;
 
@@ -464,6 +530,7 @@ export class SourceMapParser {
     line: number,
     column: number,
   ): MappedPosition | null {
+    this.materialize(filename);
     const sourceMap = this.sourceMaps.get(filename);
     if (!sourceMap) return null;
     const consumer = this.getConsumer(sourceMap);

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -412,8 +412,16 @@ export class SourceMapParser {
   // Deferred registrations (CT-1819): the boot path registers a PROVIDER
   // instead of composing eagerly; the first lookup that needs the filename
   // materializes it. One-shot — the provider is dropped as soon as it runs,
-  // so its captured inputs are released after first use.
-  private pendingProviders = new Map<string, () => SourceMap | undefined>();
+  // so its captured inputs are released after first use. LRU-bounded like
+  // `sourceMaps`: a provider whose filename is NEVER looked up (its eval never
+  // errored) would otherwise be retained until dispose — one per eval, an
+  // unbounded leak on long-lived runners — so cap it and evict the oldest.
+  // Evicting an unused provider only means a later error in that (old) eval
+  // goes unmapped, exactly as when the composed-map LRU evicts a stale entry.
+  private pendingProviders = new LRUCache<
+    string,
+    () => SourceMap | undefined
+  >({ capacity: MAX_SOURCE_MAP_CACHE_SIZE });
 
   load(filename: string, sourceMap: SourceMap) {
     // An explicit map supersedes any pending provider for the same name.
@@ -427,7 +435,12 @@ export class SourceMapParser {
    * compose) simply leaves the name unmapped, matching eager behavior.
    */
   loadLazy(filename: string, provider: () => SourceMap | undefined) {
-    this.pendingProviders.set(filename, provider);
+    this.pendingProviders.put(filename, provider);
+  }
+
+  /** Tests-only: count of still-deferred (not-yet-materialized) providers. */
+  pendingProviderCountForTesting(): number {
+    return this.pendingProviders.size;
   }
 
   private materialize(filename: string): void {

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -936,4 +936,27 @@ describe("deferred composition inputs and lazy registration (CT-1819)", () => {
     expect(parser.mapPosition("empty.js", 1, 0)).toBeNull();
     expect(calls).toBe(1);
   });
+
+  it("pendingProviders is LRU-bounded: never-looked-up providers don't accumulate (CT-1819 leak guard)", () => {
+    const parser = new SourceMapParser();
+    // The leak scenario: evaluations that never error, so their source maps are
+    // never looked up / materialized. Each registers a unique `${evalId}.js`
+    // provider; a plain Map would retain one per eval until dispose.
+    const register = (from: number, count: number) => {
+      for (let i = from; i < from + count; i++) {
+        parser.loadLazy(
+          `eval-${i}.js`,
+          () => identitySourceMap("a", "/id/x.tsx"),
+        );
+      }
+    };
+    register(0, 4096);
+    const afterFirst = parser.pendingProviderCountForTesting();
+    register(4096, 4096); // 4096 more, all unique, still never looked up
+    const afterSecond = parser.pendingProviderCountForTesting();
+    // Bounded far below the 8192 registered, and it plateaus (the second batch
+    // evicts rather than grows). A plain Map would give 4096 then 8192.
+    expect(afterFirst).toBeLessThan(4096);
+    expect(afterSecond).toBe(afterFirst);
+  });
 });

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -818,3 +818,122 @@ export const tag = "util";
     }
   });
 });
+
+// CT-1819: the boot path defers composition, capturing per-module LINE COUNTS
+// instead of bodies — pin that the count-shaped inputs are byte-equivalent to
+// the body-shaped ones, and that the parser's lazy slot has one-shot,
+// lookup-driven semantics.
+describe("deferred composition inputs and lazy registration (CT-1819)", () => {
+  const raw = (mappings: string, sources: string[] = ["a.ts"]): SourceMap =>
+    ({
+      version: 3,
+      file: "m.js",
+      sources,
+      names: [],
+      mappings,
+    }) as unknown as SourceMap;
+
+  it("bodyLineCount is byte-equivalent to body for composition", () => {
+    const bodies = ["a\nbb\nccc", "one", "x\n", ""];
+    const withBodies = composeBundleSourceMap(
+      bodies.map((body, i) => ({
+        body,
+        map: raw("AAAA;AACA", [`s${i}.ts`]),
+        source: `/id/s${i}.ts`,
+      })),
+      "bundle.js",
+    );
+    const withCounts = composeBundleSourceMap(
+      bodies.map((body, i) => ({
+        bodyLineCount: (body.match(/\n/g)?.length ?? 0) + 1,
+        map: raw("AAAA;AACA", [`s${i}.ts`]),
+        source: `/id/s${i}.ts`,
+      })),
+      "bundle.js",
+    );
+    expect(withCounts).toEqual(withBodies);
+  });
+
+  it("identitySourceMap accepts a line count in place of the body", () => {
+    for (const body of ["one line", "a\nb\nc", "trailing\n", ""]) {
+      const lineCount = (body.match(/\n/g)?.length ?? 0) + 1;
+      expect(identitySourceMap(lineCount, "/id/m.tsx")).toEqual(
+        identitySourceMap(body, "/id/m.tsx"),
+      );
+    }
+  });
+
+  it("an entry with neither body nor bodyLineCount throws", () => {
+    expect(() =>
+      composeBundleSourceMap(
+        [{ map: raw("AAAA") }],
+        "bundle.js",
+      )
+    ).toThrow(/body or bodyLineCount/);
+  });
+
+  it("loadLazy defers the provider until a lookup needs the filename", () => {
+    const parser = new SourceMapParser();
+    let calls = 0;
+    parser.loadLazy("lazy.js", () => {
+      calls++;
+      return identitySourceMap("a\nb", "/id/lazy.tsx");
+    });
+    expect(calls).toBe(0);
+    // A lookup for a DIFFERENT filename does not materialize it.
+    expect(parser.mapPosition("other.js", 1, 0)).toBeNull();
+    expect(calls).toBe(0);
+    // First matching lookup materializes (once) and resolves.
+    const pos = parser.mapPosition("lazy.js", 2, 0);
+    expect(calls).toBe(1);
+    expect(pos?.source).toBe("/id/lazy.tsx");
+    expect(pos?.line).toBe(2);
+    parser.mapPosition("lazy.js", 1, 0);
+    expect(calls).toBe(1); // one-shot: provider dropped after first use
+  });
+
+  it("parse() materializes pending providers for frames it maps", () => {
+    const parser = new SourceMapParser();
+    let calls = 0;
+    parser.loadLazy("lazy.js", () => {
+      calls++;
+      return identitySourceMap("a\nb\nc", "/id/lazy.tsx");
+    });
+    const mapped = parser.parse("    at fn (lazy.js:3:0)");
+    expect(calls).toBe(1);
+    expect(mapped).toContain("/id/lazy.tsx:3:0");
+  });
+
+  it("an explicit load supersedes a pending provider; clear drops both", () => {
+    const parser = new SourceMapParser();
+    let calls = 0;
+    parser.loadLazy("lazy.js", () => {
+      calls++;
+      return identitySourceMap("a", "/id/stale.tsx");
+    });
+    parser.load("lazy.js", identitySourceMap("a", "/id/fresh.tsx"));
+    expect(parser.mapPosition("lazy.js", 1, 0)?.source).toBe("/id/fresh.tsx");
+    expect(calls).toBe(0);
+
+    parser.loadLazy("dropped.js", () => {
+      calls++;
+      return identitySourceMap("a", "/id/dropped.tsx");
+    });
+    parser.clear();
+    expect(parser.mapPosition("dropped.js", 1, 0)).toBeNull();
+    expect(calls).toBe(0);
+  });
+
+  it("a provider returning undefined leaves the name unmapped", () => {
+    const parser = new SourceMapParser();
+    let calls = 0;
+    parser.loadLazy("empty.js", () => {
+      calls++;
+      return undefined;
+    });
+    expect(parser.mapPosition("empty.js", 1, 0)).toBeNull();
+    expect(calls).toBe(1);
+    expect(parser.mapPosition("empty.js", 1, 0)).toBeNull();
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -931,23 +931,52 @@ export class Engine extends EventTarget implements Harness {
       // re-labels the bundle frame with the canonical source name, so the
       // EXISTING verified-binding check passes for legitimately compiled modules
       // without weakening it.
-      const bundleSourceMap = composeBundleSourceMap(
-        [...graph.compiledBodies].map(([specifier, body]) => {
-          const source = sourceNameBySpecifier.get(specifier);
-          return {
-            body,
-            map: graph.moduleSourceMaps.get(specifier) ??
-              (source !== undefined
-                ? identitySourceMap(body, source)
-                : undefined),
-            source,
-          };
-        }),
-        `${evalId}.js`,
-      );
-      if (bundleSourceMap) {
-        this.getSESRuntime().loadSourceMap(`${evalId}.js`, bundleSourceMap);
+      // Composition + registration are DEFERRED (CT-1819): composing these
+      // maps is a per-segment VLQ transcode over every module (~16-22ms per
+      // cold boot post-#4455/#4460), while their only consumers are
+      // on-demand \u2014 error mapping (`parseStack`/`mapThrownError`) and debug
+      // `fn.src` resolution (`mapPosition`; eager only when
+      // EXPERIMENTAL_EAGER_SOURCE_ANNOTATION is on, i.e. dev shells, which
+      // then materialize these providers during boot and keep today's
+      // behavior). Identity no longer needs the maps at boot: scheduler and
+      // CFC verified-source are provenance-rooted (#4436/#4458). The
+      // CT-1754 fail-closed notes below explain why the REGISTRATION must
+      // exist at all \u2014 they are satisfied by lazy materialization, since the
+      // fail-closed check only runs when `fn.src` is resolved, which is
+      // itself what materializes the map. Providers capture per-module LINE
+      // COUNTS and raw maps, never compiled bodies, so the closures retain
+      // KBs, not the bundle text; each is one-shot and dropped after first
+      // use.
+      const lineCountBySpecifier = new Map<string, number>();
+      for (const [specifier, body] of graph.compiledBodies) {
+        lineCountBySpecifier.set(
+          specifier,
+          (body.match(/\n/g)?.length ?? 0) + 1,
+        );
       }
+      const moduleSourceMaps = graph.moduleSourceMaps;
+      const bundleEntries = [...graph.compiledBodies.keys()].map(
+        (specifier) => {
+          const source = sourceNameBySpecifier.get(specifier);
+          const bodyLineCount = lineCountBySpecifier.get(specifier)!;
+          return { specifier, source, bodyLineCount };
+        },
+      );
+      this.getSESRuntime().loadSourceMapLazy(
+        `${evalId}.js`,
+        () =>
+          composeBundleSourceMap(
+            bundleEntries.map(({ specifier, source, bodyLineCount }) => ({
+              bodyLineCount,
+              map: moduleSourceMaps.get(specifier) ??
+                (source !== undefined
+                  ? identitySourceMap(bodyLineCount, source)
+                  : undefined),
+              source,
+            })),
+            `${evalId}.js`,
+          ),
+      );
       // ALSO register each module's map under its eval `//# sourceURL` (its
       // sanitized source name). The browser surfaces the per-module eval frame
       // in `new Error().stack`, and `annotateFunctionDebugMetadata` resolves
@@ -970,15 +999,17 @@ export class Engine extends EventTarget implements Harness {
       // name, so the EXISTING verified-binding check passes for legitimately
       // compiled modules without weakening it.
       for (const [name, specifier] of graph.specifierByPath) {
-        const map = graph.moduleSourceMaps.get(specifier) ??
-          identitySourceMap(graph.compiledBodies.get(specifier) ?? "", name);
         const sourceUrl = name.replace(/[\r\n\u2028\u2029]/g, "_");
-        const moduleMap = composeBundleSourceMap(
-          [{ body: "", map, source: name }],
-          sourceUrl,
-          1, // the `(function (exports, require, module) {` wrapper line
-        );
-        if (moduleMap) this.getSESRuntime().loadSourceMap(sourceUrl, moduleMap);
+        const bodyLineCount = lineCountBySpecifier.get(specifier) ?? 1;
+        this.getSESRuntime().loadSourceMapLazy(sourceUrl, () => {
+          const map = moduleSourceMaps.get(specifier) ??
+            identitySourceMap(bodyLineCount, name);
+          return composeBundleSourceMap(
+            [{ bodyLineCount: 1, map, source: name }],
+            sourceUrl,
+            1, // the `(function (exports, require, module) {` wrapper line
+          );
+        });
       }
 
       const frame = pushFrame({

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -51,6 +51,10 @@ class SESInternals {
     this.sourceMaps.load(filename, sourceMap);
   }
 
+  loadSourceMapLazy(filename: string, provider: () => SourceMap | undefined) {
+    this.sourceMaps.loadLazy(filename, provider);
+  }
+
   mapPosition(
     filename: string,
     line: number,
@@ -232,6 +236,21 @@ export class SESRuntime extends EventTarget {
    */
   loadSourceMap(filename: string, sourceMap: SourceMap): void {
     this.internals.loadSourceMap(filename, sourceMap);
+  }
+
+  /**
+   * Deferred variant of {@link loadSourceMap}: `provider` runs (once) on the
+   * first lookup that needs `filename`. The ESM boot path registers its
+   * composed bundle/per-module maps this way — composition is a per-segment
+   * VLQ transcode over every module, and its only consumers (error mapping,
+   * debug `fn.src` resolution) are on-demand, so boots that never look up a
+   * frame never pay it (CT-1819).
+   */
+  loadSourceMapLazy(
+    filename: string,
+    provider: () => SourceMap | undefined,
+  ): void {
+    this.internals.loadSourceMapLazy(filename, provider);
   }
 
   parseStack(stack: string): string {

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { setEagerSourceAnnotation } from "../src/builder/module.ts";
+import { getComposeBundleSourceMapCallsForTesting } from "@commonfabric/js-compiler/source-map";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
@@ -109,5 +110,21 @@ describe("ESM loader: verified-source location resolution", () => {
     // normalization — they both gain the same leading slash).
     expect(r.src).toMatch(/^cf:module\//);
     expect(r.kind).toBe("verified");
+  });
+
+  // CT-1819: with source annotation OFF (the production default) nothing at
+  // boot consumes the maps, so nothing should COMPOSE them either — the eval
+  // registers lazy providers only. The debug-path test above is the other
+  // half of the pin: with annotation ON, the same providers materialize
+  // during eval and `.src` still resolves to the authored source, so the
+  // CT-1754 fail-closed behavior is unchanged for every consumer that
+  // actually looks.
+  it("evaluation composes no source maps when annotation is off", async () => {
+    setEagerSourceAnnotation(false);
+    makeRuntime();
+    const before = getComposeBundleSourceMapCallsForTesting();
+    const compiled = await runtime.patternManager.compilePattern(program);
+    expect(compiled).toBeDefined();
+    expect(getComposeBundleSourceMapCallsForTesting()).toBe(before);
   });
 });

--- a/packages/runner/test/ses-runtime-source-maps.test.ts
+++ b/packages/runner/test/ses-runtime-source-maps.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { SESRuntime } from "../src/sandbox/ses-runtime.ts";
+import { identitySourceMap } from "@commonfabric/js-compiler/source-map";
+
+// The runner-facing source-map surface of the SES runtime. The ESM boot path
+// now registers DEFERRED providers (CT-1819), but the eager chain stays
+// load-bearing: the AMD/isolate `execute` path registers per-script maps
+// directly, and an explicit registration must win over any pending provider
+// for the same name.
+describe("SESRuntime source-map registration", () => {
+  it("eager loads resolve immediately and supersede lazy providers", () => {
+    const runtime = new SESRuntime();
+    let providerCalls = 0;
+    runtime.loadSourceMapLazy("m.js", () => {
+      providerCalls++;
+      return identitySourceMap(3, "/id/stale.tsx");
+    });
+    runtime.loadSourceMap("m.js", identitySourceMap(3, "/id/fresh.tsx"));
+
+    const pos = runtime.mapPosition("m.js", 2, 0);
+    expect(pos?.source).toBe("/id/fresh.tsx");
+    expect(pos?.line).toBe(2);
+    // The pending provider was displaced without ever running.
+    expect(providerCalls).toBe(0);
+    // Stack parsing rides the same registry.
+    expect(runtime.parseStack("    at fn (m.js:3:0)")).toContain(
+      "/id/fresh.tsx:3:0",
+    );
+  });
+
+  it("lazy providers materialize once, on first lookup", () => {
+    const runtime = new SESRuntime();
+    let providerCalls = 0;
+    runtime.loadSourceMapLazy("lazy.js", () => {
+      providerCalls++;
+      return identitySourceMap(2, "/id/lazy.tsx");
+    });
+    expect(providerCalls).toBe(0);
+    expect(runtime.mapPosition("lazy.js", 1, 0)?.source).toBe("/id/lazy.tsx");
+    runtime.mapPosition("lazy.js", 2, 0);
+    expect(providerCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes the remaining piece orphaned from CT-1816: every record-graph evaluation eagerly composed + registered its bundle and per-module source maps — a per-segment VLQ transcode over every module — while the maps' only consumers are **on-demand**: error mapping (`parseStack`/`mapThrownError`) and debug `fn.src` resolution (`mapPosition`; eager only in dev shells via `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`).

**Preconditions (both verified on main):** identity no longer needs the maps at boot — scheduler identity and CFC verified-source are provenance-rooted (#4436/#4458; `verified-provenance.ts` is the explicit "`.src`-free replacement", `identityFromCanonicalSource(.src)` retired).

**The change.** `SourceMapParser.loadLazy(filename, provider)` — a one-shot deferred registration materialized by the first lookup that names the file (`mapPosition`/`parseStack`); explicit `load` supersedes; `clear` drops pending. The engine registers providers instead of composing. Providers capture per-module **line counts** and raw maps, never compiled bodies — composition only ever needs the body's line count, so `composeBundleSourceMap`/`identitySourceMap` accept a precomputed count in place of the body (byte-equivalent, differentially tested).

**CT-1754 fail-closed behavior is unchanged for every consumer that actually looks:** resolution is itself what materializes the map. The eager-annotation suite (`esm-source-location.test.ts`) now flows through the lazy path verbatim and still resolves `/main.tsx:line:col` + `verified`; dev shells materialize during boot and keep today's behavior exactly. (The `recordModuleProvenance` guard concern from the ticket resolves the same way — any on-demand reader triggers composition.)

**Measured (offset-12 rig, production shape, 2 cold boots):** the `#8 bundle-sourcemap-compose` bucket disappears from the profile entirely — zero samples (was ~6ms residual post-#4455/#4460; larger on bigger closures). Boots with no errors and no debugging now pay nothing for maps.

**Tests:** provider laziness/one-shot/supersede/clear semantics; `bodyLineCount` ≡ `body` byte-equivalence; missing-extent throw; engine-level pin that evaluation composes nothing when annotation is off. Full runner suite 783/0; js-compiler suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers source map composition at boot and composes on first lookup, with LRU-bounded deferred providers to prevent leaks on long-lived runners. Implements CT-1819 without changing error mapping, debug `.src`, dev shells, or AMD/isolate behavior.

- **New Features**
  - `@commonfabric/js-compiler`
    - Added `SourceMapParser.loadLazy(filename, provider)`: one-shot providers materialize on first `parse()`/`mapPosition()`; `load()` supersedes; `clear()` drops pending; providers may return `undefined`.
    - `composeBundleSourceMap`/`identitySourceMap` accept `bodyLineCount` (or a numeric count) and throw if neither body nor count is provided. Added `getComposeBundleSourceMapCallsForTesting()` and `pendingProviderCountForTesting()`.
  - `@commonfabric/runner`
    - Engine registers bundle and per-module maps via `loadSourceMapLazy`; providers capture line counts and raw maps only. With annotation off, evaluation composes nothing; dev shells still materialize during boot.
    - `SESRuntime` adds `loadSourceMapLazy`; eager `loadSourceMap` still takes precedence and remains used by the AMD/isolate path.

- **Bug Fixes**
  - `@commonfabric/js-compiler`: LRU-bounded the pending lazy provider map to avoid accumulating unused providers when evals never error; eviction matches composed-map LRU behavior.

<sup>Written for commit fc35f01adc2909d9361bd98bd450393bc35e3ffa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

**Bonus, observed CI-side:** pattern-unit test wall times DROPPED across the board on this branch — all 92 measured files faster than the adjacent main run, median ratio 0.58× (e.g. `lunch-stats` 15.8s → 5.4s, `shopping-list` 20.3s → 7.3s). The pattern-test harness's evals were paying eager composition constantly; deferring it is a substantial test-suite win, not just a boot-floor one.
