### PR TITLE
fix(state-inspector): make discovery tests hermetic against real cf-inspect cache

### DIFF
--- a/packages/state-inspector/discover.ts
+++ b/packages/state-inspector/discover.ts
@@ -84,11 +84,19 @@ export function candidateRoots(cwd: string = Deno.cwd()): string[] {
   return roots;
 }
 
-/** Discover local space DBs. `dirs` are searched before the default roots. */
+/**
+ * Discover local space DBs. `dirs` are searched before the default roots.
+ * `defaultRoots: false` searches ONLY `dirs`, skipping env overrides, the
+ * remote-pull cache, and the cwd walk — tests need this to stay hermetic on
+ * machines whose real `~/.cache/cf-inspect` holds pulled DBs.
+ */
 export function discoverSpaceDbs(
-  opts: { dirs?: string[]; cwd?: string } = {},
+  opts: { dirs?: string[]; cwd?: string; defaultRoots?: boolean } = {},
 ): DiscoveredSpace[] {
-  const roots = [...(opts.dirs ?? []), ...candidateRoots(opts.cwd)];
+  const roots = [
+    ...(opts.dirs ?? []),
+    ...(opts.defaultRoots === false ? [] : candidateRoots(opts.cwd)),
+  ];
   const seen = new Set<string>();
   const out: DiscoveredSpace[] = [];
   for (const root of roots) {

--- a/packages/state-inspector/test/discover.test.ts
+++ b/packages/state-inspector/test/discover.test.ts
@@ -6,6 +6,7 @@ import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
 
 import {
+  candidateRoots,
   deriveSpaceDid,
   discoverSpaceDbs,
   quickStats,
@@ -70,6 +71,15 @@ Deno.test("discovery + resolution", async (t) => {
       assert(found.every((s) => s.sizeBytes > 0));
     });
 
+    await t.step("default roots find the DBs via the cwd walk", () => {
+      // No explicit dirs: the cwd walk must reach `<cwd>/cache/memory`. On a
+      // real machine the default roots may surface OTHER DBs too (env
+      // overrides, ~/.cache/cf-inspect), so assert superset, never counts.
+      const found = discoverSpaceDbs({ cwd: dir });
+      const dids = new Set(found.map((s) => s.did));
+      assert(dids.has(DID_1) && dids.has(DID_2));
+    });
+
     await t.step("resolveSpacePath matches by DID prefix", () => {
       const found = discoverSpaceDbs({
         dirs: [`${dir}/cache/memory`],
@@ -128,5 +138,35 @@ Deno.test("discovery + resolution", async (t) => {
     );
   } finally {
     await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("candidateRoots orders env overrides before caches and cwd walk", () => {
+  const saved = {
+    MEMORY_DIR: Deno.env.get("MEMORY_DIR"),
+    DB_PATH: Deno.env.get("DB_PATH"),
+  };
+  const restore = (k: keyof typeof saved) =>
+    saved[k] === undefined ? Deno.env.delete(k) : Deno.env.set(k, saved[k]!);
+  try {
+    Deno.env.set("MEMORY_DIR", "/env/memory");
+    Deno.env.set("DB_PATH", "/env/db/space.sqlite");
+    const roots = candidateRoots("/a/b");
+    // env overrides first (a .sqlite DB_PATH contributes its directory)…
+    assertEquals(roots[0], "/env/memory");
+    assertEquals(roots[1], "/env/db");
+    // …then the remote-pull cache…
+    assert(roots[2].endsWith("/.cache/cf-inspect"));
+    // …then both cache layouts at each level of the upward walk.
+    assert(roots.includes("/a/b/packages/toolshed/cache/memory"));
+    assert(roots.includes("/a/b/cache/memory"));
+    assert(roots.includes("/a/cache/memory"));
+
+    // A bare relative DB_PATH filename resolves to ".", not an empty root.
+    Deno.env.set("DB_PATH", "space.sqlite");
+    assert(candidateRoots("/a/b").includes("."));
+  } finally {
+    restore("MEMORY_DIR");
+    restore("DB_PATH");
   }
 });

--- a/packages/state-inspector/test/discover.test.ts
+++ b/packages/state-inspector/test/discover.test.ts
@@ -63,7 +63,7 @@ Deno.test("discovery + resolution", async (t) => {
     await t.step("discovers both DBs by walking the cache base", () => {
       const found = discoverSpaceDbs({
         dirs: [`${dir}/cache/memory`],
-        cwd: dir,
+        defaultRoots: false,
       });
       assertEquals(found.length, 2);
       assertEquals(new Set(found.map((s) => s.did)), new Set([DID_1, DID_2]));
@@ -73,7 +73,7 @@ Deno.test("discovery + resolution", async (t) => {
     await t.step("resolveSpacePath matches by DID prefix", () => {
       const found = discoverSpaceDbs({
         dirs: [`${dir}/cache/memory`],
-        cwd: dir,
+        defaultRoots: false,
       });
       const path = resolveSpacePath("zAlpha", found);
       assert(path.endsWith(`${DID_1}.sqlite`));
@@ -87,7 +87,7 @@ Deno.test("discovery + resolution", async (t) => {
     await t.step("ambiguous prefix throws", () => {
       const found = discoverSpaceDbs({
         dirs: [`${dir}/cache/memory`],
-        cwd: dir,
+        defaultRoots: false,
       });
       assertThrows(
         () => resolveSpacePath("did:key:z", found),
@@ -113,7 +113,7 @@ Deno.test("discovery + resolution", async (t) => {
         makeSpace(`${engine}/${did}.sqlite`, 1);
         const found = discoverSpaceDbs({
           dirs: [`${dir}/cache/memory`],
-          cwd: dir,
+          defaultRoots: false,
         });
 
         const byName = await resolveSpace(name, found);

--- a/packages/state-inspector/test/remote.test.ts
+++ b/packages/state-inspector/test/remote.test.ts
@@ -90,7 +90,7 @@ Deno.test("a pulled DB is discoverable and resolvable by full DID", async () => 
 
       // …so normal local discovery reports the real DID and resolves it by the
       // full DID a `pull` would have printed (the workflow Codex flagged).
-      const found = discoverSpaceDbs({ dirs: [cacheDir] });
+      const found = discoverSpaceDbs({ dirs: [cacheDir], defaultRoots: false });
       assertEquals(found.some((s) => s.did === SPACE), true);
       assertEquals(resolveSpacePath(SPACE, found), path);
     } finally {


### PR DESCRIPTION
## Problem

`packages/state-inspector/test/discover.test.ts` ("discovers both DBs by walking the cache base") fails on any machine where `~/.cache/cf-inspect` contains real pulled DBs (e.g. from `cf inspect --remote` usage).

The test already pointed discovery at a seeded temp dir via `dirs`, but `discoverSpaceDbs` unconditionally **appends** `candidateRoots()` — which includes the remote-pull cache (`~/.cache/cf-inspect`), `MEMORY_DIR`/`DB_PATH` env overrides, and an upward cwd walk. So the "exactly 2 discovered DBs" assertion counted whatever real cache contents exist on the machine.

## Fix

- `discoverSpaceDbs` gains a `defaultRoots?: boolean` option. `defaultRoots: false` searches **only** the explicit `dirs`, skipping env overrides, the remote-pull cache, and the cwd walk. The default (`true`) is unchanged, so CLI behavior and `resolveSpace`/`resolveSpacePath` defaults are untouched.
- `discover.test.ts`: all four `discoverSpaceDbs` calls pass `defaultRoots: false` (the now-unused `cwd: dir` dropped).
- `remote.test.ts`: same option on its one discovery call — its assertions were tolerant of extras, but it had the same latent leak.

## Verification

- `deno task test` in `packages/state-inspector`: 31 passed (71 steps), 0 failed — on a machine whose `~/.cache/cf-inspect` is populated with real host dirs.
- Reproduced the failure mode deliberately: with a poisoned default root (`MEMORY_DIR` → dir containing an extra `.sqlite`), the old test fails exactly as reported and the fixed test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `state-inspector` discovery tests hermetic by letting `discoverSpaceDbs` skip default roots and pointing tests at temp dirs. Also adds hermetic coverage for `candidateRoots` and the default-roots discovery path.

- **Bug Fixes**
  - Added `defaultRoots?: boolean` to `discoverSpaceDbs`; when false, search only `dirs` and skip env overrides, the remote-pull cache, and the cwd walk. Default stays true; CLI and `resolveSpace*` defaults unchanged.
  - Updated tests to pass `defaultRoots: false` and removed the unused `cwd`; added a superset-asserting default-roots discovery step and a `candidateRoots` unit test (env override ordering, cwd walk, bare relative `DB_PATH`).

<sup>Written for commit 221b4cd5ed4f4469b99fed3ce52fa391884e2e26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

