### PR TITLE
feat(cfc): stamp llm/generateText/generateObject model output LlmDerived (Epic D, stage D1b)

### DIFF
--- a/packages/runner/src/builtins/llm-schemas.ts
+++ b/packages/runner/src/builtins/llm-schemas.ts
@@ -1,4 +1,23 @@
+import type { JSONSchema } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { cfcAtom } from "@commonfabric/api/cfc";
+
+// Epic D1b (docs/plans/cfc-future-work-implementation.md): model output written
+// by the `llm`, `generateText`, and `generateObject` builtins carries an
+// explicit `LlmDerived` provenance stamp — the same mark D1 attaches to dialog
+// messages, so "model-derived" is explicit provenance rather than mere absence
+// of integrity. The stamp is applied AT the model-output writeback (llm.ts), not
+// on the shared result schemas: keeping it off the schema means the builtins'
+// control-state writes (the `pending`/`error` resets of the initial run and the
+// error path) stay CFC-inert — only the actual model bytes are stamped and made
+// CFC-relevant, mirroring D1's `pushModelMessages` (which stamps the model push,
+// not every message-cell write). The write is attributed to the builtin because
+// `LlmDerived` is a runtime-minted evidence family: the persist-time gate
+// (`gateRuntimeMintedIntegrity`, audit S4) admits it only from a builtin author,
+// which also stops pattern code from forging it.
+export const LLM_DERIVED_RESULT_STAMP_SCHEMA = internSchema(
+  { ifc: { addIntegrity: [cfcAtom.llmDerived()] } } as JSONSchema,
+);
 
 /** Runtime schema for {@link BuiltInLLMContent} (packages/api/index.ts). */
 export const LLMContentSchema = internSchema(
@@ -239,6 +258,9 @@ export const LLMResultSchema = internSchema(
     type: "object",
     properties: {
       pending: { type: "boolean", default: false },
+      // `result`/`partial` are model output; the `LlmDerived` stamp is applied
+      // at the writeback (llm.ts), not declared here — see
+      // {@link LLM_DERIVED_RESULT_STAMP_SCHEMA}.
       result: {
         anyOf: [
           { type: "string" },
@@ -270,6 +292,8 @@ export const GenerateTextResultSchema = internSchema(
     type: "object",
     properties: {
       pending: { type: "boolean", default: false },
+      // `result`/`partial` are model output; stamped at the writeback (llm.ts),
+      // not declared here — see {@link LLM_DERIVED_RESULT_STAMP_SCHEMA}.
       result: { type: "string" },
       error: { type: "string" },
       partial: { type: "string" },
@@ -296,6 +320,10 @@ export const GenerateObjectResultSchema = internSchema(
     type: "object",
     properties: {
       pending: { type: "boolean", default: false },
+      // `result` is model output; generateObject writes it through a (possibly
+      // custom user) `resultSchema` via `asSchema`, and merges the `LlmDerived`
+      // stamp into that schema's root at the write (`withLlmDerivedStamp` in
+      // llm.ts) — so it is not declared here.
       result: { type: "object" },
       messages: { type: "array", items: LLMMessageSchema },
       error: { type: "string" },

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -70,8 +70,11 @@ const PARTIAL_BATCH_MS = 66;
 // stamp their model-output writebacks with an explicit `LlmDerived` provenance
 // atom — the same mark D1 attaches to dialog messages. `llm`/`generateText`
 // write `result`/`partial` through {@link LLM_DERIVED_RESULT_STAMP_SCHEMA};
-// `generateObject` merges the stamp into the (possibly custom) resultSchema root
-// via `withLlmDerivedStamp`. Both apply the stamp at the WRITE, not on the shared
+// `generateObject` merges the stamp into EVERY node of the (possibly custom)
+// resultSchema via `withLlmDerivedStamp`, so it also rides split child-document
+// writes (`asCell` fields, ID-anchored array items) whose descent via
+// `getSchemaAtPath` would otherwise drop `ifc.addIntegrity`. Both apply the
+// stamp at the WRITE, not on the shared
 // result schema, so the builtins' control-state writes (initial-run / error-path
 // `pending`/`result=undefined` resets, and the transient streaming `partial`
 // batches) stay CFC-inert — only the final model bytes are stamped and made
@@ -112,30 +115,98 @@ function setStampedModelOutput(
   cell.withTx(tx).set(value);
 }
 
+/** Merge `LlmDerived` into one schema node's `ifc.addIntegrity`, idempotently. */
+function mergeLlmDerivedIntoNode(
+  node: Record<string, unknown>,
+): Record<string, unknown> {
+  const ifc = isRecord(node.ifc) ? node.ifc : {};
+  const addIntegrity = Array.isArray(ifc.addIntegrity) ? ifc.addIntegrity : [];
+  const stamp = cfcAtom.llmDerived();
+  const already = addIntegrity.some((atom) =>
+    isRecord(atom) && isRecord(stamp) && atom.type === stamp.type
+  );
+  return {
+    ...node,
+    ifc: {
+      ...ifc,
+      addIntegrity: already ? addIntegrity : [...addIntegrity, stamp],
+    },
+  };
+}
+
 /**
- * Merge the `LlmDerived` stamp into a generateObject result schema's ROOT
- * `ifc.addIntegrity`, so it rides the (possibly custom / injection-safe)
- * resultSchema write to wherever the object lands — inline at `["result"]` or a
- * split child doc — the way the InjectionSafe sanitizer's per-field annotations
- * already persist. An absent resultSchema defaults to a plain object schema.
+ * Deep-merge the `LlmDerived` stamp into a generateObject result schema's
+ * `ifc.addIntegrity` at EVERY node — the root AND every nested property / item /
+ * `$defs` / compound-branch node — so it rides the (possibly custom /
+ * injection-safe) resultSchema write to wherever the model bytes land, whether
+ * inline at `["result"]` or in a SPLIT CHILD DOCUMENT.
+ *
+ * A root-only merge is not enough: when a nested value redirects/splits into its
+ * own document (an `asCell` field, an ID-anchored array item), the child write
+ * descends via `runtime.cfc.getSchemaAtPath`, which carries ancestor
+ * confidentiality but NOT `ifc.addIntegrity`. The child doc that stores the
+ * model bytes would then persist as unstamped/ordinary output and the D1b
+ * provenance guarantee would be lost for structured results (codex P1). Stamping
+ * every node keeps `getSchemaAtPath` at any split-child path carrying the mark,
+ * so `walkIfcSchema` mints the `LlmDerived` labelMap entry on that child doc too.
+ *
+ * The merge is idempotent (an injection-safe schema that already carries the
+ * stamp on a node is left unchanged) and cycle-safe over recursive `$ref`
+ * schemas. An absent resultSchema defaults to a plain object schema.
  */
 function withLlmDerivedStamp(schema: JSONSchema | undefined): JSONSchema {
-  const base: Record<string, unknown> = isRecord(schema)
+  const seen = new Map<object, JSONSchema>();
+  const stampNode = (node: JSONSchema): JSONSchema => {
+    if (!isRecord(node)) return node;
+    const cached = seen.get(node);
+    if (cached !== undefined) return cached;
+    // Reserve the slot before recursing so a `$ref` cycle resolves to the same
+    // (in-progress) node rather than recursing forever. The placeholder is the
+    // stamped-but-not-yet-descended node; children are filled in below.
+    const stamped = mergeLlmDerivedIntoNode(node);
+    seen.set(node, stamped as JSONSchema);
+
+    const descend = (value: unknown): unknown => {
+      if (Array.isArray(value)) return value.map(descend);
+      if (isRecord(value)) return stampNode(value as JSONSchema);
+      return value;
+    };
+
+    for (
+      const key of [
+        "properties",
+        "$defs",
+        "patternProperties",
+      ]
+    ) {
+      const container = stamped[key];
+      if (isRecord(container)) {
+        stamped[key] = Object.fromEntries(
+          Object.entries(container).map(([k, v]) => [k, descend(v)]),
+        );
+      }
+    }
+    for (const key of ["items", "additionalProperties", "prefixItems"]) {
+      if (key in stamped) stamped[key] = descend(stamped[key]);
+    }
+    for (const key of ["anyOf", "oneOf", "allOf"]) {
+      if (Array.isArray(stamped[key])) stamped[key] = descend(stamped[key]);
+    }
+    return stamped as JSONSchema;
+  };
+
+  const base: JSONSchema = isRecord(schema)
     ? schema
-    : { type: "object" };
-  const ifc = isRecord(base.ifc) ? base.ifc : {};
-  const addIntegrity = Array.isArray(ifc.addIntegrity) ? ifc.addIntegrity : [];
-  return internSchema({
-    ...base,
-    ifc: { ...ifc, addIntegrity: [...addIntegrity, cfcAtom.llmDerived()] },
-  } as JSONSchema);
+    : { type: "object" } as JSONSchema;
+  return internSchema(stampNode(base));
 }
 
 /**
  * Write a generateObject model-output object through its (possibly custom)
- * resultSchema, with the `LlmDerived` stamp merged into the schema root. When
- * CFC is disabled, writes through the bare resultSchema so no metadata is minted
- * — keeping the disabled deployment CFC-inert.
+ * resultSchema, with the `LlmDerived` stamp merged into every schema node (so it
+ * lands on split child documents too). When CFC is disabled, writes through the
+ * bare resultSchema so no metadata is minted — keeping the disabled deployment
+ * CFC-inert.
  */
 function setStampedObjectResult(
   tx: IExtendedStorageTransaction,

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -73,11 +73,12 @@ const PARTIAL_BATCH_MS = 66;
 // `generateObject` merges the stamp into the (possibly custom) resultSchema root
 // via `withLlmDerivedStamp`. Both apply the stamp at the WRITE, not on the shared
 // result schema, so the builtins' control-state writes (initial-run / error-path
-// `pending`/`result=undefined` resets) stay CFC-inert — only the actual model
-// bytes are stamped and made CFC-relevant, mirroring D1's `pushModelMessages`.
-// The write is attributed to the builtin because `LlmDerived` is a runtime-minted
-// evidence family: the persist-time gate (`gateRuntimeMintedIntegrity`, audit S4)
-// admits it only from a builtin author, which also stops pattern code forging it.
+// `pending`/`result=undefined` resets, and the transient streaming `partial`
+// batches) stay CFC-inert — only the final model bytes are stamped and made
+// CFC-relevant, mirroring D1's `pushModelMessages`. The write is attributed to
+// the builtin because `LlmDerived` is a runtime-minted evidence family: the
+// persist-time gate (`gateRuntimeMintedIntegrity`, audit S4) admits it only from
+// a builtin author, which also stops pattern code forging it.
 
 /**
  * Attribute a model-output writeback tx to the builtin so the `LlmDerived` stamp
@@ -216,10 +217,6 @@ function createUpdatePartialCallback(
   runtime: Runtime,
   getCurrentRun: () => number,
   thisRun: number,
-  // D1b: builtin id for attributing the streaming `partial` writeback, so a
-  // `partial` field carrying the `LlmDerived` stamp keeps it during streaming
-  // (llm/generateText; omitted where the field carries no stamp).
-  builtinId?: string,
 ): { callback: (text: string) => void; cleanup: () => void } {
   let pendingText: string | null = null;
   let batchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -261,20 +258,8 @@ function createUpdatePartialCallback(
             return;
           }
           return runtime.editWithRetry((tx) => {
-            if (builtinId !== undefined) {
-              // D1b: attribute FIRST, then stamp — the streaming `partial` is
-              // model output too, so it carries `LlmDerived`.
-              attributeModelOutputWrite(tx, runtime, builtinId);
-              setStampedModelOutput(
-                tx,
-                runtime,
-                resultCell,
-                "partial",
-                textToWrite,
-              );
-            } else {
-              resultCell.key("partial").withTx(tx).set(textToWrite);
-            }
+            const partialCell = resultCell.key("partial").withTx(tx);
+            partialCell.set(textToWrite);
           });
         }).catch((e) => {
           console.warn("[LLM] Error writing partial update:", e);
@@ -711,7 +696,6 @@ export function llm(
         runtime,
         getRunForCancellation,
         thisRun,
-        "llm",
       );
 
     // Build tool catalog if tools are present, then start execution after the
@@ -1059,7 +1043,6 @@ export function generateText(
         runtime,
         getRunForCancellation,
         thisRun,
-        "generateText",
       );
 
     enqueuePostCommitLLMWork(
@@ -1459,7 +1442,6 @@ export function generateObject<T extends Record<string, unknown>>(
           runtime,
           queueName ? () => thisRun : () => currentRun,
           thisRun,
-          "generateObject",
         );
 
       // When queued, disable run cancellation — the queue manages lifecycle.

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -17,7 +17,10 @@ import {
   BuiltInLLMParams,
 } from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
+import type { JSONSchema } from "../builder/types.ts";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { cfcLabelViewForCellFailClosed } from "../cfc/label-view.ts";
@@ -39,6 +42,7 @@ import {
   GenerateObjectResultSchema,
   GenerateTextParamsSchema,
   GenerateTextResultSchema,
+  LLM_DERIVED_RESULT_STAMP_SCHEMA,
   LLMParamsSchema,
   LLMResultSchema,
   LLMToolSchema,
@@ -61,6 +65,92 @@ const client = new LLMClient();
 
 /** Batch interval for partial streaming updates (~15fps). */
 const PARTIAL_BATCH_MS = 66;
+
+// Epic D1b (docs/plans/cfc-future-work-implementation.md): the llm builtins
+// stamp their model-output writebacks with an explicit `LlmDerived` provenance
+// atom — the same mark D1 attaches to dialog messages. `llm`/`generateText`
+// write `result`/`partial` through {@link LLM_DERIVED_RESULT_STAMP_SCHEMA};
+// `generateObject` merges the stamp into the (possibly custom) resultSchema root
+// via `withLlmDerivedStamp`. Both apply the stamp at the WRITE, not on the shared
+// result schema, so the builtins' control-state writes (initial-run / error-path
+// `pending`/`result=undefined` resets) stay CFC-inert — only the actual model
+// bytes are stamped and made CFC-relevant, mirroring D1's `pushModelMessages`.
+// The write is attributed to the builtin because `LlmDerived` is a runtime-minted
+// evidence family: the persist-time gate (`gateRuntimeMintedIntegrity`, audit S4)
+// admits it only from a builtin author, which also stops pattern code forging it.
+
+/**
+ * Attribute a model-output writeback tx to the builtin so the `LlmDerived` stamp
+ * persists rather than being gate-stripped. Gated on CFC enforcement so a
+ * `disabled` deployment is a strict no-op (no identity, no stamp).
+ */
+function attributeModelOutputWrite(
+  tx: IExtendedStorageTransaction,
+  runtime: Runtime,
+  builtinId: string,
+): void {
+  if (runtime.cfcEnforcementMode === "disabled") return;
+  tx.setCfcImplementationIdentity({ kind: "builtin", builtinId });
+}
+
+/**
+ * Write a model-output field (`result`/`partial`) through the `LlmDerived` stamp
+ * schema, attributed to the builtin. A no-op stamp (plain write) when CFC is
+ * disabled, so the disabled deployment stores no CFC metadata.
+ */
+function setStampedModelOutput(
+  tx: IExtendedStorageTransaction,
+  runtime: Runtime,
+  resultCell: Cell<any>,
+  field: "result" | "partial",
+  value: unknown,
+): void {
+  const cell = runtime.cfcEnforcementMode === "disabled"
+    ? resultCell.key(field)
+    : resultCell.key(field).asSchema(LLM_DERIVED_RESULT_STAMP_SCHEMA);
+  cell.withTx(tx).set(value);
+}
+
+/**
+ * Merge the `LlmDerived` stamp into a generateObject result schema's ROOT
+ * `ifc.addIntegrity`, so it rides the (possibly custom / injection-safe)
+ * resultSchema write to wherever the object lands — inline at `["result"]` or a
+ * split child doc — the way the InjectionSafe sanitizer's per-field annotations
+ * already persist. An absent resultSchema defaults to a plain object schema.
+ */
+function withLlmDerivedStamp(schema: JSONSchema | undefined): JSONSchema {
+  const base: Record<string, unknown> = isRecord(schema)
+    ? schema
+    : { type: "object" };
+  const ifc = isRecord(base.ifc) ? base.ifc : {};
+  const addIntegrity = Array.isArray(ifc.addIntegrity) ? ifc.addIntegrity : [];
+  return internSchema({
+    ...base,
+    ifc: { ...ifc, addIntegrity: [...addIntegrity, cfcAtom.llmDerived()] },
+  } as JSONSchema);
+}
+
+/**
+ * Write a generateObject model-output object through its (possibly custom)
+ * resultSchema, with the `LlmDerived` stamp merged into the schema root. When
+ * CFC is disabled, writes through the bare resultSchema so no metadata is minted
+ * — keeping the disabled deployment CFC-inert.
+ */
+function setStampedObjectResult(
+  tx: IExtendedStorageTransaction,
+  runtime: Runtime,
+  resultCell: Cell<any>,
+  resultSchema: JSONSchema | undefined,
+  object: unknown,
+): void {
+  const disabled = runtime.cfcEnforcementMode === "disabled";
+  const target = disabled
+    ? (resultSchema === undefined
+      ? resultCell.key("result")
+      : resultCell.key("result").asSchema(resultSchema))
+    : resultCell.key("result").asSchema(withLlmDerivedStamp(resultSchema));
+  target.withTx(tx).set(object);
+}
 
 function logGenerateObject(stage: string, details: Record<string, unknown>) {
   console.warn("[generateObject]", stage, details);
@@ -126,6 +216,10 @@ function createUpdatePartialCallback(
   runtime: Runtime,
   getCurrentRun: () => number,
   thisRun: number,
+  // D1b: builtin id for attributing the streaming `partial` writeback, so a
+  // `partial` field carrying the `LlmDerived` stamp keeps it during streaming
+  // (llm/generateText; omitted where the field carries no stamp).
+  builtinId?: string,
 ): { callback: (text: string) => void; cleanup: () => void } {
   let pendingText: string | null = null;
   let batchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -167,8 +261,20 @@ function createUpdatePartialCallback(
             return;
           }
           return runtime.editWithRetry((tx) => {
-            const partialCell = resultCell.key("partial").withTx(tx);
-            partialCell.set(textToWrite);
+            if (builtinId !== undefined) {
+              // D1b: attribute FIRST, then stamp — the streaming `partial` is
+              // model output too, so it carries `LlmDerived`.
+              attributeModelOutputWrite(tx, runtime, builtinId);
+              setStampedModelOutput(
+                tx,
+                runtime,
+                resultCell,
+                "partial",
+                textToWrite,
+              );
+            } else {
+              resultCell.key("partial").withTx(tx).set(textToWrite);
+            }
           });
         }).catch((e) => {
           console.warn("[LLM] Error writing partial update:", e);
@@ -605,6 +711,7 @@ export function llm(
         runtime,
         getRunForCancellation,
         thisRun,
+        "llm",
       );
 
     // Build tool catalog if tools are present, then start execution after the
@@ -650,10 +757,24 @@ export function llm(
                   const groundingSources = extractGroundingSources(llmResult);
 
                   await runtime.editWithRetry((tx) => {
+                    // D1b: attribute FIRST, then stamp the model-output fields —
+                    // `result`/`partial` carry `LlmDerived`; the control-state
+                    // fields (pending/error/requestHash/grounding) do not.
+                    attributeModelOutputWrite(tx, runtime, "llm");
                     resultCell.key("pending").withTx(tx).set(false);
-                    resultCell.key("result").withTx(tx).set(llmResult.content);
+                    setStampedModelOutput(
+                      tx,
+                      runtime,
+                      resultCell,
+                      "result",
+                      llmResult.content,
+                    );
                     resultCell.key("error").withTx(tx).set(undefined);
-                    resultCell.key("partial").withTx(tx).set(
+                    setStampedModelOutput(
+                      tx,
+                      runtime,
+                      resultCell,
+                      "partial",
                       extractTextFromLLMResponse(llmResult),
                     );
                     resultCell.key("requestHash").withTx(tx).set(hash);
@@ -938,6 +1059,7 @@ export function generateText(
         runtime,
         getRunForCancellation,
         thisRun,
+        "generateText",
       );
 
     enqueuePostCommitLLMWork(
@@ -978,10 +1100,24 @@ export function generateText(
                   const groundingSources = extractGroundingSources(llmResult);
 
                   await runtime.editWithRetry((tx) => {
+                    // D1b: attribute FIRST, then stamp the model-output fields.
+                    attributeModelOutputWrite(tx, runtime, "generateText");
                     resultCell.key("pending").withTx(tx).set(false);
-                    resultCell.key("result").withTx(tx).set(textResult);
+                    setStampedModelOutput(
+                      tx,
+                      runtime,
+                      resultCell,
+                      "result",
+                      textResult,
+                    );
                     resultCell.key("error").withTx(tx).set(undefined);
-                    resultCell.key("partial").withTx(tx).set(textResult);
+                    setStampedModelOutput(
+                      tx,
+                      runtime,
+                      resultCell,
+                      "partial",
+                      textResult,
+                    );
                     resultCell.key("requestHash").withTx(tx).set(hash);
                     resultCell.key("groundingSources").withTx(tx).set(
                       groundingSources,
@@ -1323,6 +1459,7 @@ export function generateObject<T extends Record<string, unknown>>(
           runtime,
           queueName ? () => thisRun : () => currentRun,
           thisRun,
+          "generateObject",
         );
 
       // When queued, disable run cancellation — the queue manages lifecycle.
@@ -1522,18 +1659,25 @@ export function generateObject<T extends Record<string, unknown>>(
               await runtime.editWithRetry((tx) => {
                 // The InjectionSafe annotations on resultSchema are minted by
                 // the trusted sanitizer; attribute this write to the builtin so
-                // the persist-time evidence gate trusts them (audit S4).
+                // the persist-time evidence gate trusts them (audit S4). The
+                // same attribution keeps the D1b LlmDerived stamp merged into
+                // the result schema root below.
                 tx.setCfcImplementationIdentity({
                   kind: "builtin",
                   builtinId: "generateObject",
                 });
                 resultCell.key("pending").withTx(tx).set(false);
-                const resultTarget = objectResponse.resultSchema === undefined
-                  ? resultCell.key("result")
-                  : resultCell.key("result").asSchema(
-                    objectResponse.resultSchema,
-                  );
-                resultTarget.withTx(tx).set(objectResponse.object);
+                // D1b: write the model-produced object through the resultSchema
+                // with `LlmDerived` merged into its root, so the stamp rides to
+                // wherever the object lands (inline or a split child doc). This
+                // covers both a custom user resultSchema and the default.
+                setStampedObjectResult(
+                  tx,
+                  runtime,
+                  resultCell,
+                  objectResponse.resultSchema,
+                  objectResponse.object,
+                );
                 // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values
                 // on this `.get()`-path today, but will in the not-too-distant
                 // future; at that point this JSON round-trip silently loses any
@@ -1761,7 +1905,9 @@ export function generateObject<T extends Record<string, unknown>>(
               await runtime.editWithRetry((tx) => {
                 // The InjectionSafe annotations on resultSchema are minted by
                 // the trusted sanitizer; attribute this write to the builtin so
-                // the persist-time evidence gate trusts them (audit S4).
+                // the persist-time evidence gate trusts them (audit S4). The
+                // same attribution keeps the D1b LlmDerived stamp merged into
+                // the result schema root below.
                 tx.setCfcImplementationIdentity({
                   kind: "builtin",
                   builtinId: "generateObject",
@@ -1771,10 +1917,15 @@ export function generateObject<T extends Record<string, unknown>>(
                   content: JSON.stringify(response.object, null, 2),
                 };
                 resultCell.key("pending").withTx(tx).set(false);
-                const resultTarget = response.resultSchema === undefined
-                  ? resultCell.key("result")
-                  : resultCell.key("result").asSchema(response.resultSchema);
-                resultTarget.withTx(tx).set(response.object);
+                // D1b: write the model-produced object through the resultSchema
+                // with `LlmDerived` merged into its root (custom or default).
+                setStampedObjectResult(
+                  tx,
+                  runtime,
+                  resultCell,
+                  response.resultSchema,
+                  response.object,
+                );
                 // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values
                 // on this `.get()`-path today, but will in the not-too-distant
                 // future; at that point these JSON round-trips silently lose any

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -151,34 +151,22 @@ function mergeLlmDerivedIntoNode(
  * so `walkIfcSchema` mints the `LlmDerived` labelMap entry on that child doc too.
  *
  * The merge is idempotent (an injection-safe schema that already carries the
- * stamp on a node is left unchanged) and cycle-safe over recursive `$ref`
- * schemas. An absent resultSchema defaults to a plain object schema.
+ * stamp on a node is left unchanged). The recursion follows the finite, acyclic
+ * JSON-Schema tree — `$ref` is a string this function does not dereference, so a
+ * recursive `$defs` self-reference is a leaf here — and the result is interned.
+ * An absent resultSchema defaults to a plain object schema.
  */
 function withLlmDerivedStamp(schema: JSONSchema | undefined): JSONSchema {
-  const seen = new Map<object, JSONSchema>();
-  const stampNode = (node: JSONSchema): JSONSchema => {
-    if (!isRecord(node)) return node;
-    const cached = seen.get(node);
-    if (cached !== undefined) return cached;
-    // Reserve the slot before recursing so a `$ref` cycle resolves to the same
-    // (in-progress) node rather than recursing forever. The placeholder is the
-    // stamped-but-not-yet-descended node; children are filled in below.
+  const stampNode = (node: Record<string, unknown>): JSONSchema => {
     const stamped = mergeLlmDerivedIntoNode(node);
-    seen.set(node, stamped as JSONSchema);
 
     const descend = (value: unknown): unknown => {
       if (Array.isArray(value)) return value.map(descend);
-      if (isRecord(value)) return stampNode(value as JSONSchema);
+      if (isRecord(value)) return stampNode(value);
       return value;
     };
 
-    for (
-      const key of [
-        "properties",
-        "$defs",
-        "patternProperties",
-      ]
-    ) {
+    for (const key of ["properties", "$defs", "patternProperties"]) {
       const container = stamped[key];
       if (isRecord(container)) {
         stamped[key] = Object.fromEntries(
@@ -195,9 +183,9 @@ function withLlmDerivedStamp(schema: JSONSchema | undefined): JSONSchema {
     return stamped as JSONSchema;
   };
 
-  const base: JSONSchema = isRecord(schema)
+  const base: Record<string, unknown> = isRecord(schema)
     ? schema
-    : { type: "object" } as JSONSchema;
+    : { type: "object" };
   return internSchema(stampNode(base));
 }
 

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -12,6 +12,8 @@ import type { JSONSchema } from "../src/builder/types.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
+import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
+import { parseLink } from "../src/link-utils.ts";
 import type { Cell } from "../src/cell.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
@@ -46,6 +48,36 @@ function resultIntegrity(result: Cell<any>): unknown[] {
 /** The persisted integrity on a builtin's model-output `partial` field. */
 function partialIntegrity(result: Cell<any>): unknown[] {
   return integrityAtomsAt(result.key("partial").resolveAsCell());
+}
+
+/**
+ * The integrity persisted in the labelMap of the OWN document a child cell
+ * splits into (a schema `asCell` field / ID-anchored item lands the model bytes
+ * in a separate doc). Read the child doc's persisted metadata directly by its
+ * own id — this is the label a downstream integrity check (a `requiredIntegrity`
+ * floor, a cross-space read) sees for those bytes, independent of any ancestor
+ * entry on the parent document that a label view would rebase over the child.
+ */
+function childDocIntegrity(
+  runtime: Runtime,
+  childCell: Cell<any>,
+): unknown[] {
+  const rtx = runtime.edit();
+  try {
+    const raw = childCell.withTx(rtx).getRaw();
+    const link = parseLink(raw);
+    if (link?.id === undefined) return [];
+    const metadata = readStoredCfcMetadata(rtx, {
+      space: link.space ?? space,
+      id: link.id,
+      scope: link.scope === "inherit" ? undefined : link.scope,
+    });
+    return (metadata?.labelMap.entries ?? []).flatMap(
+      (entry) => entry.label.integrity ?? [],
+    );
+  } finally {
+    rtx.commit();
+  }
 }
 
 function waitForPendingToBecomeFalse(result: Cell<any>) {
@@ -361,6 +393,85 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
 
     expect(result.key("result").get()).toEqual({ verdict: "model-produced" });
     expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+  });
+
+  it("stamps a `generateObject` result whose schema splits model bytes into a child doc", async () => {
+    // Codex P1: when the resultSchema redirects/splits a nested value into its
+    // OWN document (here an `asCell` array item), the model-produced bytes land
+    // in that separate child doc. The D1b stamp is merged only into the schema
+    // ROOT (`withLlmDerivedStamp`); the child write descends via
+    // `runtime.cfc.getSchemaAtPath`, which carries ancestor confidentiality but
+    // NOT `ifc.addIntegrity`. So the child doc that actually stores the model
+    // bytes must still carry `LlmDerived` in its persisted labelMap — otherwise
+    // a later integrity check reading that child doc by its own id sees ordinary,
+    // unstamped output and the provenance guarantee is lost for structured
+    // results. A custom resultSchema only reaches the writeback with
+    // `schemaSanitizePromptInjection` on.
+    const testPrompt = "d1b-generateObject-child-doc-stamp";
+    const objectSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+            // Each item splits into its own entity document on write.
+            asCell: ["cell"],
+          },
+        },
+      },
+      required: ["items"],
+    };
+    addMockObjectResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ) && req.schema.type === "object",
+      {
+        object: { items: [{ name: "alpha" }, { name: "beta" }] },
+        id: "d1b-go-child-doc-1",
+      },
+    );
+
+    const testPattern = builder.pattern(() =>
+      builder.generateObject({
+        prompt: testPrompt,
+        schema: objectSchema,
+        schemaSanitizePromptInjection: true,
+      })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-generateObject-child-doc-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(result.key("result").get()).toEqual({
+      items: [{ name: "alpha" }, { name: "beta" }],
+    });
+
+    // Each item is its own document; read the model bytes' OWN persisted label.
+    const items = result.key("result").key("items") as unknown as Cell<any>;
+    const firstItem = items.key(0) as unknown as Cell<any>;
+    const secondItem = items.key(1) as unknown as Cell<any>;
+
+    // Sanity: the items really do split into their own documents.
+    expect(parseLink(firstItem.withTx().getRaw())?.id).toBeDefined();
+
+    expect(childDocIntegrity(runtime, firstItem)).toContainEqual(
+      LLM_DERIVED_ATOM,
+    );
+    expect(childDocIntegrity(runtime, secondItem)).toContainEqual(
+      LLM_DERIVED_ATOM,
+    );
   });
 
   it("does not stamp the `llm` result when CFC enforcement is disabled", async () => {

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -474,6 +474,121 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
     );
   });
 
+  it("stamps split child docs across anyOf branches and recursive `$ref` shapes", async () => {
+    // The stamp is deep-merged into EVERY node of the result schema so it
+    // survives `getSchemaAtPath` descent at any split point — exercising the
+    // compound (`anyOf`) and recursive-`$defs` shapes, not just a flat
+    // `properties`/`items` object. Each element below lands in its OWN document
+    // (array items with `asCell`), so its persisted labelMap must carry the
+    // stamp: `tagged[*]` splits through an `anyOf` item schema; the tree's
+    // `children[*]` splits through an item schema that is a `$ref` back into
+    // `$defs.node`.
+    const testPrompt = "d1b-generateObject-compound-recursive-stamp";
+    const objectSchema: JSONSchema = {
+      type: "object",
+      $defs: {
+        node: {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            children: {
+              type: "array",
+              // A `$ref` item that splits into its own document per element.
+              items: { $ref: "#/$defs/node", asCell: ["cell"] },
+            },
+          },
+          required: ["label"],
+          // A boolean schema keyword — the deep-stamp walk descends into it and
+          // passes it through untouched (a leaf that is neither object nor array).
+          additionalProperties: false,
+        },
+      },
+      properties: {
+        tagged: {
+          type: "array",
+          items: {
+            // Each item splits into its own document AND is a compound schema.
+            asCell: ["cell"],
+            anyOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+              },
+              {
+                type: "object",
+                properties: { b: { type: "number" } },
+                required: ["b"],
+              },
+            ],
+          },
+        },
+        tree: { $ref: "#/$defs/node" },
+      },
+      required: ["tagged", "tree"],
+    };
+    addMockObjectResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ) && req.schema.type === "object",
+      {
+        object: {
+          tagged: [{ a: "x" }, { b: 2 }],
+          tree: { label: "root", children: [{ label: "leaf", children: [] }] },
+        },
+        id: "d1b-go-compound-recursive-1",
+      },
+    );
+
+    const testPattern = builder.pattern(() =>
+      builder.generateObject({
+        prompt: testPrompt,
+        schema: objectSchema,
+        schemaSanitizePromptInjection: true,
+      })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-generateObject-compound-recursive-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(result.key("result").get()).toEqual({
+      tagged: [{ a: "x" }, { b: 2 }],
+      tree: { label: "root", children: [{ label: "leaf", children: [] }] },
+    });
+
+    const tagged = result.key("result").key("tagged") as unknown as Cell<any>;
+    const taggedFirst = tagged.key(0) as unknown as Cell<any>;
+    const taggedSecond = tagged.key(1) as unknown as Cell<any>;
+    const treeChild = ((result.key("result").key("tree") as unknown as Cell<any>)
+      .key("children") as unknown as Cell<any>).key(0) as unknown as Cell<any>;
+
+    // Sanity: every asserted element really split into its own document.
+    expect(parseLink(taggedFirst.withTx().getRaw())?.id).toBeDefined();
+    expect(parseLink(taggedSecond.withTx().getRaw())?.id).toBeDefined();
+    expect(parseLink(treeChild.withTx().getRaw())?.id).toBeDefined();
+
+    // anyOf-branch items carry the stamp on their own doc.
+    expect(childDocIntegrity(runtime, taggedFirst)).toContainEqual(
+      LLM_DERIVED_ATOM,
+    );
+    expect(childDocIntegrity(runtime, taggedSecond)).toContainEqual(
+      LLM_DERIVED_ATOM,
+    );
+    // Recursive-`$ref` item carries the stamp on its own doc.
+    expect(childDocIntegrity(runtime, treeChild)).toContainEqual(
+      LLM_DERIVED_ATOM,
+    );
+  });
+
   it("does not stamp the `llm` result when CFC enforcement is disabled", async () => {
     const disabledStorage = StorageManager.emulate({ as: signer });
     const disabledRuntime = new Runtime({

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -568,8 +568,11 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
     const tagged = result.key("result").key("tagged") as unknown as Cell<any>;
     const taggedFirst = tagged.key(0) as unknown as Cell<any>;
     const taggedSecond = tagged.key(1) as unknown as Cell<any>;
-    const treeChild = ((result.key("result").key("tree") as unknown as Cell<any>)
-      .key("children") as unknown as Cell<any>).key(0) as unknown as Cell<any>;
+    const treeChild =
+      ((result.key("result").key("tree") as unknown as Cell<any>)
+        .key("children") as unknown as Cell<any>).key(0) as unknown as Cell<
+          any
+        >;
 
     // Sanity: every asserted element really split into its own document.
     expect(parseLink(taggedFirst.withTx().getRaw())?.id).toBeDefined();

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import {
+  addMockObjectResponse,
+  addMockResponse,
+  clearMockResponses,
+  enableMockMode,
+} from "@commonfabric/llm/client";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
+import type { Cell } from "../src/cell.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { LLM_DERIVED_RESULT_STAMP_SCHEMA } from "../src/builtins/llm-schemas.ts";
+
+// Epic D1b (docs/plans/cfc-future-work-implementation.md): the `llm`,
+// `generateText`, and `generateObject` builtins stamp their MODEL-OUTPUT
+// writebacks with an explicit `LlmDerived` provenance atom — the same mark D1
+// (cfc-llm-derived-stamp.test.ts) attaches to dialog messages. These tests are
+// the D1b counterpart: for each builtin, real model output on the `result`
+// field carries `LlmDerived`; a pattern-authored copy of the stamp is stripped
+// by the runtime-minted evidence gate; and a `disabled` deployment is a no-op.
+
+const signer = await Identity.fromPassphrase("runner-cfc-llm-derived-builtins");
+const space = signer.did();
+
+const LLM_DERIVED_ATOM = cfcAtom.llmDerived();
+
+enableMockMode();
+
+/** Flatten every integrity atom the persisted label surfaces at a cell. */
+function integrityAtomsAt(cell: unknown): unknown[] {
+  const view = cfcLabelViewForCell(cell);
+  return (view?.entries ?? []).flatMap((entry) => entry.label.integrity ?? []);
+}
+
+/** The persisted integrity on a builtin's model-output `result` field. */
+function resultIntegrity(result: Cell<any>): unknown[] {
+  return integrityAtomsAt(result.key("result").resolveAsCell());
+}
+
+function waitForPendingToBecomeFalse(result: Cell<any>) {
+  const liveResult = result.withTx();
+  const timeoutMs = 5000;
+  return new Promise<void>((resolve, reject) => {
+    const start = Date.now();
+    const tick = async () => {
+      await liveResult.sync();
+      const pending = liveResult.key("pending").get() as unknown;
+      if (pending === false) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error("Timeout waiting for pending to become false"));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick().catch(reject);
+  });
+}
+
+describe("CFC LlmDerived stamping — result-field stamp mechanism", () => {
+  // The builtins write model output through LLM_DERIVED_RESULT_STAMP_SCHEMA.
+  // Prove the gate keys the stamp on the write's authoring identity at the
+  // result field-path: a builtin write stamps, a pattern write is stripped.
+  it("stamps a builtin write to the result field; strips a pattern write", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      // Model-output write: builtin identity + the stamp schema at ["result"].
+      const modelTx = runtime.edit();
+      modelTx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "llm",
+      });
+      const builtinResult = runtime.getCell(
+        space,
+        "llm-derived-builtin-result",
+        undefined,
+        modelTx,
+      );
+      builtinResult.key("result").asSchema(LLM_DERIVED_RESULT_STAMP_SCHEMA).set(
+        "model bytes",
+      );
+      modelTx.prepareCfc();
+      expect((await modelTx.commit()).ok).toBeDefined();
+
+      const readTx = runtime.edit();
+      const builtinRead = runtime.getCell(
+        space,
+        "llm-derived-builtin-result",
+        undefined,
+        readTx,
+      );
+      expect(integrityAtomsAt(builtinRead.key("result"))).toContainEqual(
+        LLM_DERIVED_ATOM,
+      );
+      readTx.commit();
+
+      // Pattern write through the SAME stamp schema: no builtin identity, so
+      // the runtime-minted gate strips the forged stamp.
+      const forgeTx = runtime.edit();
+      const forged = runtime.getCell(
+        space,
+        "llm-derived-forge-result",
+        undefined,
+        forgeTx,
+      );
+      forged.key("result").asSchema(LLM_DERIVED_RESULT_STAMP_SCHEMA).set(
+        "forged provenance",
+      );
+      forgeTx.prepareCfc();
+      expect((await forgeTx.commit()).ok).toBeDefined();
+
+      const forgeReadTx = runtime.edit();
+      const forgedRead = runtime.getCell(
+        space,
+        "llm-derived-forge-result",
+        undefined,
+        forgeReadTx,
+      );
+      expect(integrityAtomsAt(forgedRead.key("result"))).not.toContainEqual(
+        LLM_DERIVED_ATOM,
+      );
+      forgeReadTx.commit();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});
+
+describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let builder: ReturnType<typeof createTrustedBuilder>["commonfabric"];
+
+  beforeEach(() => {
+    clearMockResponses();
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    tx = runtime.edit();
+    ({ commonfabric: builder } = createTrustedBuilder(runtime));
+  });
+
+  afterEach(async () => {
+    clearMockResponses();
+    await runtime.idle();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("stamps the `llm` builtin's model-output result", async () => {
+    const testPrompt = "d1b-llm-stamp";
+    addMockResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ),
+      { role: "assistant", content: "hello from the model", id: "d1b-llm-1" },
+    );
+
+    const testPattern = builder.pattern(() =>
+      builder.llm({ messages: [{ role: "user", content: testPrompt }] })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-llm-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+  });
+
+  it("stamps the `generateText` builtin's model-output result", async () => {
+    const testPrompt = "d1b-generateText-stamp";
+    addMockResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ),
+      { role: "assistant", content: "text reply", id: "d1b-gt-1" },
+    );
+
+    const testPattern = builder.pattern(() =>
+      builder.generateText({ prompt: testPrompt })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-generateText-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(result.key("result").get()).toBe("text reply");
+    expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+  });
+
+  it("stamps the `generateObject` direct-path model-output result", async () => {
+    const testPrompt = "d1b-generateObject-direct-stamp";
+    const objectSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        summary: { type: "string" },
+      },
+      required: ["title", "summary"],
+    };
+    addMockObjectResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ) && req.schema.type === "object",
+      {
+        object: { title: "Model Title", summary: "Model summary" },
+        id: "d1b-go-direct-1",
+      },
+    );
+
+    const testPattern = builder.pattern(() =>
+      builder.generateObject({ prompt: testPrompt, schema: objectSchema })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-generateObject-direct-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(result.key("result").get()).toEqual({
+      title: "Model Title",
+      summary: "Model summary",
+    });
+    // The custom user resultSchema does not itself declare LlmDerived; the stamp
+    // is merged into its root at the write (withLlmDerivedStamp).
+    expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+  });
+
+  it("stamps the `generateObject` tools-path model-output result", async () => {
+    const testPrompt = "d1b-generateObject-tools-stamp";
+    const objectSchema: JSONSchema = {
+      type: "object",
+      properties: { verdict: { type: "string" } },
+      required: ["verdict"],
+    };
+    // A presentResult tool-call routes through the generateObject tools arm.
+    addMockResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ) && req.tools?.["presentResult"] !== undefined,
+      {
+        role: "assistant",
+        content: [{
+          type: "tool-call",
+          toolCallId: "call_present_1",
+          toolName: "presentResult",
+          input: { verdict: "model-produced" },
+        }],
+        id: "d1b-go-tools-1",
+      },
+    );
+
+    const dummyPattern = builder.pattern(() => ({}), { type: "object" });
+    const testPattern = builder.pattern(() =>
+      builder.generateObject({
+        prompt: testPrompt,
+        schema: objectSchema,
+        tools: {
+          dummy: {
+            description: "forces the tool-calling path",
+            pattern: dummyPattern,
+          },
+        },
+      })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-generateObject-tools-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(result.key("result").get()).toEqual({ verdict: "model-produced" });
+    expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+  });
+
+  it("does not stamp the `llm` result when CFC enforcement is disabled", async () => {
+    const disabledStorage = StorageManager.emulate({ as: signer });
+    const disabledRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: disabledStorage,
+      cfcEnforcementMode: "disabled",
+    });
+    const disabledTx = disabledRuntime.edit();
+    const { commonfabric } = createTrustedBuilder(disabledRuntime);
+
+    const testPrompt = "d1b-llm-disabled";
+    addMockResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ),
+      { role: "assistant", content: "no stamp here", id: "d1b-llm-disabled-1" },
+    );
+
+    try {
+      const testPattern = commonfabric.pattern(() =>
+        commonfabric.llm({ messages: [{ role: "user", content: testPrompt }] })
+      );
+      const resultCell = disabledRuntime.getCell(
+        space,
+        "d1b-llm-disabled-result",
+        testPattern.resultSchema,
+        disabledTx,
+      );
+      const result = disabledRuntime.run(
+        disabledTx,
+        testPattern,
+        {},
+        resultCell,
+      );
+      disabledTx.commit();
+
+      await expect(waitForPendingToBecomeFalse(result)).resolves
+        .toBeUndefined();
+      await disabledRuntime.idle();
+
+      expect(resultIntegrity(result)).not.toContainEqual(LLM_DERIVED_ATOM);
+    } finally {
+      await disabledRuntime.idle();
+      await disabledRuntime.dispose();
+      await disabledStorage.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -43,6 +43,11 @@ function resultIntegrity(result: Cell<any>): unknown[] {
   return integrityAtomsAt(result.key("result").resolveAsCell());
 }
 
+/** The persisted integrity on a builtin's model-output `partial` field. */
+function partialIntegrity(result: Cell<any>): unknown[] {
+  return integrityAtomsAt(result.key("partial").resolveAsCell());
+}
+
 function waitForPendingToBecomeFalse(result: Cell<any>) {
   const liveResult = result.withTx();
   const timeoutMs = 5000;
@@ -190,6 +195,42 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
     await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
     await runtime.idle();
 
+    // Both model-output fields carry the stamp.
+    expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+    expect(partialIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+  });
+
+  it("stamps the `llm` builtin's array-of-parts result", async () => {
+    // `llm` result is `anyOf: [string, array-of-parts]`; the array variant is
+    // stamped on the `result` field as a whole.
+    const testPrompt = "d1b-llm-array-stamp";
+    addMockResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "part one" }],
+        id: "d1b-llm-array-1",
+      },
+    );
+
+    const testPattern = builder.pattern(() =>
+      builder.llm({ messages: [{ role: "user", content: testPrompt }] })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "d1b-llm-array-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
     expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
   });
 
@@ -220,6 +261,7 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
 
     expect(result.key("result").get()).toBe("text reply");
     expect(resultIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
+    expect(partialIntegrity(result)).toContainEqual(LLM_DERIVED_ATOM);
   });
 
   it("stamps the `generateObject` direct-path model-output result", async () => {
@@ -362,6 +404,66 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
         .toBeUndefined();
       await disabledRuntime.idle();
 
+      expect(resultIntegrity(result)).not.toContainEqual(LLM_DERIVED_ATOM);
+    } finally {
+      await disabledRuntime.idle();
+      await disabledRuntime.dispose();
+      await disabledStorage.close();
+    }
+  });
+
+  it("does not stamp the `generateObject` result when CFC is disabled", async () => {
+    // Exercises setStampedObjectResult's disabled branch (writes through the
+    // bare resultSchema, minting no CFC metadata).
+    const disabledStorage = StorageManager.emulate({ as: signer });
+    const disabledRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: disabledStorage,
+      cfcEnforcementMode: "disabled",
+    });
+    const disabledTx = disabledRuntime.edit();
+    const { commonfabric } = createTrustedBuilder(disabledRuntime);
+
+    const testPrompt = "d1b-generateObject-disabled";
+    const objectSchema: JSONSchema = {
+      type: "object",
+      properties: { verdict: { type: "string" } },
+      required: ["verdict"],
+    };
+    addMockObjectResponse(
+      (req) =>
+        req.messages.some((m) =>
+          typeof m.content === "string" && m.content.includes(testPrompt)
+        ) && req.schema.type === "object",
+      { object: { verdict: "unstamped" }, id: "d1b-go-disabled-1" },
+    );
+
+    try {
+      const testPattern = commonfabric.pattern(() =>
+        commonfabric.generateObject({
+          prompt: testPrompt,
+          schema: objectSchema,
+        })
+      );
+      const resultCell = disabledRuntime.getCell(
+        space,
+        "d1b-generateObject-disabled-result",
+        testPattern.resultSchema,
+        disabledTx,
+      );
+      const result = disabledRuntime.run(
+        disabledTx,
+        testPattern,
+        {},
+        resultCell,
+      );
+      disabledTx.commit();
+
+      await expect(waitForPendingToBecomeFalse(result)).resolves
+        .toBeUndefined();
+      await disabledRuntime.idle();
+
+      expect(result.key("result").get()).toEqual({ verdict: "unstamped" });
       expect(resultIntegrity(result)).not.toContainEqual(LLM_DERIVED_ATOM);
     } finally {
       await disabledRuntime.idle();

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -23,7 +23,14 @@ import type { Cell, FactoryInput, JSONSchema } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import { INJECTION_SAFE_ATOM } from "../src/cfc/schema-sanitization.ts";
+
+// D1b (cfc-llm-derived-stamp-builtins.test.ts): generateObject stamps LlmDerived
+// on EVERY node of the result schema so the mark rides split child-document
+// writes too. So instruction-inert result paths carry [InjectionSafe, LlmDerived]
+// and non-inert paths carry [LlmDerived].
+const LLM_DERIVED_ATOM = cfcAtom.llmDerived();
 import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -2030,27 +2037,28 @@ describe("generateObject with tools", () => {
             path: ["action"],
             label: {
               confidentiality: [promptInfluence],
-              integrity: [INJECTION_SAFE_ATOM],
+              integrity: [INJECTION_SAFE_ATOM, LLM_DERIVED_ATOM],
             },
           },
           {
             path: ["approved"],
             label: {
               confidentiality: [promptInfluence],
-              integrity: [INJECTION_SAFE_ATOM],
+              integrity: [INJECTION_SAFE_ATOM, LLM_DERIVED_ATOM],
             },
           },
           {
             path: ["confidence"],
             label: {
               confidentiality: [promptInfluence],
-              integrity: [INJECTION_SAFE_ATOM],
+              integrity: [INJECTION_SAFE_ATOM, LLM_DERIVED_ATOM],
             },
           },
           {
             path: ["reasoning"],
             label: {
               confidentiality: [promptRisk, promptInfluence],
+              integrity: [LLM_DERIVED_ATOM],
             },
           },
         ]),


### PR DESCRIPTION
## What

Follow-up to **D1** (which stamps dialog messages `LlmDerived`). Extends the `LlmDerived` provenance stamp to the three model-output writebacks in `packages/runner/src/builtins/llm.ts`:

1. **`llm`** — `result` + `partial`
2. **`generateText`** — `result` + `partial`
3. **`generateObject`** — `result` (through its possibly-custom user `resultSchema`)

## Why

**Low-value / for completeness** — explicitness, not soundness. `requiredIntegrity` floors already fail on integrity *absence*, so this doesn't close a hole; it makes "model-derived" explicit positive provenance rather than a bare absence of integrity.

## Mechanism

The stamp is applied **at the writeback**, not on the shared result schemas. Keeping it off the schema means the builtins' control-state writes (initial-run and error-path `pending` / `result=undefined` resets) stay **CFC-inert** — only the actual model bytes are stamped and made CFC-relevant. This mirrors D1's `pushModelMessages` (which stamps the model push, not every message-cell write) and, importantly, keeps the raw-action outbox retry/scope tests unchanged (an earlier shared-schema variant made every result/partial write CFC-relevant and broke those direct-commit tests).

- `llm` / `generateText` write `result`/`partial` through `LLM_DERIVED_RESULT_STAMP_SCHEMA` (a bare `ifc.addIntegrity:[llmDerived()]` node).
- `generateObject` merges the stamp into its (custom or default) `resultSchema` root via `withLlmDerivedStamp`, so it rides to wherever the object lands (inline or a split child doc) — the same way the InjectionSafe sanitizer's per-field annotations already persist.
- Every path attributes the write to the builtin, because `LlmDerived` is a runtime-minted evidence family: the persist-time gate (`gateRuntimeMintedIntegrity`, audit S4) admits the atom only from a builtin author, which also strips any pattern-authored copy.
- Disabled deployments are a strict no-op (no identity, no stamp metadata).

## Tests

New `cfc-llm-derived-stamp-builtins.test.ts` mirrors `cfc-llm-derived-stamp` for each builtin:
- result-field stamp mechanism (builtin write stamps; a pattern write is stripped);
- e2e: `llm`, `generateText`, `generateObject` (direct + tools) model output carries `LlmDerived`;
- disabled enforcement = no stamp.

Full affected surface is green (all `llm`/`generate*` files + all 72 `cfc-*.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit `LlmDerived` provenance stamp to model output from `llm`, `generateText`, and `generateObject`, applied at writeback so only model-produced bytes are stamped. Streaming updates remain inert; the final write stamps both `result` and `partial`.

- **New Features**
  - `llm`/`generateText`: stamp final `result` and `partial` via `LLM_DERIVED_RESULT_STAMP_SCHEMA`; streaming partial batches are not stamped.
  - `generateObject`: deep-merge the stamp into every node of the (possibly custom) `resultSchema` with `withLlmDerivedStamp`, so inline values and split child docs carry `LlmDerived` (including `anyOf` branches and recursive `$ref`).
  - Writes are attributed to the builtin so the runtime gate admits the stamp and strips any pattern-authored copy; CFC disabled mode is a strict no-op.

- **Bug Fixes**
  - Ensure `generateObject` results that split into child documents persist `LlmDerived` on those child docs (label maps assert the stamp).
  - Drop unreachable cycle/non-record guards in the deep-stamp walk and add tests that cover compound (`anyOf`/`oneOf`/`allOf`) and recursive `$ref` shapes, array-of-parts results, and disabled-mode behavior.

<sup>Written for commit 0b632acb6cfbdc3658465c1f58506e4f9abb5954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

