### PR TITLE
fix(runner): classify terminal commit-rule rejections as non-retryable (Epic E4 follow-up)

### DIFF
--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -466,6 +466,15 @@ statement bound), a read-back/count mismatch, and any evaluator `{error}`.
 DELETE and rule-less target tables keep the plain write path; rule-less dbs
 pay nothing.
 
+A rolled-back commit is a **terminal** rejection: the server preserves the
+`RowLabelCommitError` name over the wire (it is not collapsed into a generic
+`TransactionError`), and the runner classifies it non-retryable
+([`storage/rejection.ts`](../../../packages/runner/src/storage/rejection.ts)
+`isTerminalRejection`). Re-running the identical handler would recompute the
+identical refused write, so the doomed handler stops immediately rather than
+consuming its retry budget — its per-attempt speculative rev bumps would only
+starve concurrent sibling commits that share reactive state.
+
 Trust note: `op.db.owner` is client-supplied like the rest of the db ref. A
 forged owner can only turn an ABSENT `dbOwner()` resolution into a present
 one — every structural failure the evaluator enforces (strict-if-present,

--- a/packages/memory/test/v2-sqlite-protocol-test.ts
+++ b/packages/memory/test/v2-sqlite-protocol-test.ts
@@ -8,6 +8,7 @@ import { expect } from "@std/expect";
 import { Server } from "../v2/server.ts";
 import { connect, loopback } from "../v2/client.ts";
 import { cfLink, table } from "../v2/sqlite/schema.ts";
+import { all, match, principal } from "../v2/sqlite/row-label.ts";
 import type { SqliteDbRef } from "../v2.ts";
 import {
   testSessionOpenAuthFactory,
@@ -225,6 +226,54 @@ describe("sqlite protocol verbs (loopback)", () => {
     await seedRows(goodDb, "INSERT INTO messages (body) VALUES (?)", ["ok"]);
     const r = await session.sqliteQuery(goodDb, "SELECT body FROM messages");
     expect(r.rows).toEqual([{ body: "ok" }]);
+  });
+
+  it("surfaces a row-label commit violation as a terminal RowLabelCommitError (name preserved over the wire)", async () => {
+    // A folded write whose committed row violates the table's row-label rule
+    // (Phase 3.c commit-time re-derivation, sqlite/commit-eval.ts) is TERMINAL:
+    // re-running recomputes the identical refused write. The server MUST
+    // serialize the class name UNCHANGED so the runner classifies it
+    // non-retryable (runner storage/rejection.ts `isTerminalRejection`).
+    // Collapsing it into a generic TransactionError (the pre-fix behavior) would
+    // let the doomed handler burn its retry budget and starve concurrent
+    // siblings — this asserts the exact server-side serialization the runner
+    // integration test otherwise only covers end-to-end.
+    const ADDR = /[^\s<>,;"]+@[^\s<>,;"]+/g;
+    const ruleDb: SqliteDbRef = {
+      id: `of:rowlabel-terminal-${crypto.randomUUID()}`,
+      owner: SPACE,
+      tables: {
+        // A required-anchor sender rule: a from_addr with no address-shaped
+        // match fails closed (strict-if-present) when re-derived at commit.
+        emails: table(
+          { id: "integer primary key", from_addr: "text", body: "text" },
+          (f) => ({
+            confidentiality: all(
+              principal("mailto", match(f.from_addr, ADDR, { min: 1 })),
+            ),
+          }),
+        ),
+      },
+    };
+    let name: string | undefined;
+    try {
+      await session.transact({
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          {
+            op: "sqlite",
+            db: ruleDb,
+            sql: "INSERT INTO emails (from_addr, body) VALUES (?, ?)",
+            params: ["not an address", "boom"],
+          },
+        ],
+      });
+    } catch (error) {
+      name = (error as { name?: string }).name;
+    }
+    // Not "TransactionError": the terminal identity survived the wire.
+    expect(name).toBe("RowLabelCommitError");
   });
 
   it("rolls back the whole commit when a folded sqlite op fails", async () => {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -54,6 +54,7 @@ import {
   ensureTables,
 } from "./sqlite/exec.ts";
 import { assertReadOnly } from "./sqlite/guard.ts";
+import { RowLabelCommitError } from "./sqlite/commit-eval.ts";
 import type { TableSchema } from "./sqlite/schema.ts";
 import { DiskSourceRegistry } from "./sqlite/disk-source.ts";
 import { ReadConnectionPool } from "./sqlite/read-pool.ts";
@@ -1745,6 +1746,15 @@ export class Server {
               ? "ConflictError"
               : error instanceof Engine.ProtocolError
               ? "ProtocolError"
+              // A RowLabelCommitError (Phase 3.c commit-time row-label refusal,
+              // sqlite/commit-eval.ts) is TERMINAL: re-running recomputes the
+              // identical refused write, so the client must not retry it.
+              // Preserve the class name unchanged — the runner classifies by it
+              // (storage/rejection.ts `isTerminalRejection`); collapsing it into
+              // a generic TransactionError would let the doomed handler burn its
+              // retry budget and starve concurrent siblings.
+              : error instanceof RowLabelCommitError
+              ? "RowLabelCommitError"
               : "TransactionError",
             messageText,
           );

--- a/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
+++ b/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
@@ -54,17 +54,13 @@ async function runTest(base: URL) {
     const send = (key: string) =>
       runtime.editWithRetry((tx) => result.key(key).withTx(tx).send({}));
 
-    // A handler whose commit the server REFUSES re-runs through the
-    // scheduler's bounded retry budget before giving up loudly (~1s of
-    // requeue timers `settled()` cannot see). Drain that churn before
-    // sending the next handler, so the doomed re-runs' speculative rev bumps
-    // don't contend with — and starve — the successor's commit.
-    const drainDoomed = async () => {
-      for (let round = 0; round < 12; round++) {
-        await runtime.settled();
-        await new Promise((r) => setTimeout(r, 250));
-      }
-    };
+    // NOTE: a handler whose commit the server refuses (a RowLabelCommitError)
+    // is now classified as a TERMINAL rejection and runs exactly once — it does
+    // NOT re-run through the scheduler's retry budget (storage/rejection.ts
+    // `isTerminalRejection`; server preserves the class name). So the next
+    // handler can be sent immediately: there are no doomed re-runs whose
+    // speculative rev bumps would starve the successor's commit, and no drain is
+    // needed between sends. If this test flakes, that classification regressed.
 
     const dumpQ = (k: string) => ({
       pending: result.key(k).key("pending").getRaw(),
@@ -119,7 +115,6 @@ async function runTest(base: URL) {
       // advertised 3.c); the server evaluates the two committed rows, the
       // violating one refuses, and the WHOLE statement rolls back. ---
       await send("copyBad");
-      await drainDoomed();
       // The failed commit rolls back the db-handle rev bump too, so `q` does
       // not re-run for it; the next SUCCESSFUL write re-queries server truth.
       await send("copyGood");
@@ -143,7 +138,6 @@ async function runTest(base: URL) {
       // --- Upsert, violating post-image: row 2's sender flips to junk ->
       // the server re-derives the post-image, refuses, rolls back. ---
       await send("upsertBad");
-      await drainDoomed();
       // --- Upsert, valid post-image: row 1's sender flips to carol2. Its
       // successful commit bumps the handle rev, forcing a FRESH query cycle
       // against server truth (no dependency on rolled-back speculation). ---

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -175,21 +175,27 @@ export function watchReactiveActionCommit(state: {
       return;
     }
 
+    // Permanent (precondition) and terminal (deterministic commit-rule refusal —
+    // `isTerminalRejection`) rejections are never retried: re-running recomputes
+    // the identical refused write, and the doomed re-runs would starve
+    // concurrent siblings. Skip BEFORE charging the retry budget — a no-retry
+    // outcome must not consume it, or an action that later re-runs on changed
+    // inputs and then hits a genuinely transient failure would start from the
+    // accumulated count and skip its own bounded retries. Resubscribe still
+    // happens (finalizeReactiveActionCommit), so a real input change re-triggers.
+    if (isPermanentRejection(error) || isTerminalRejection(error)) {
+      return;
+    }
+
     // Non-conflict failures are NOT re-triggered by reader-dirty — a transient
     // transport error, or the path-blind local StorageTransactionInconsistent
     // guard that fires before the engine's granular matcher — so they still
-    // warrant a bounded retry. Permanent (precondition) and terminal
-    // (deterministic commit-rule refusal — `isTerminalRejection`) rejections are
-    // never retried: re-running recomputes the identical refused write, and the
-    // doomed re-runs would starve concurrent siblings. On every attempt we still
-    // resubscribe, so even after the budget is exhausted (or a terminal skip)
-    // the action is re-triggered when its input data changes.
+    // warrant a bounded retry. On every attempt we still resubscribe, so even
+    // after the budget is exhausted the action is re-triggered when its input
+    // data changes.
     const retries = (state.retries.get(state.action) ?? 0) + 1;
     state.retries.set(state.action, retries);
-    if (
-      retries < MAX_RETRIES_FOR_REACTIVE && !isPermanentRejection(error) &&
-      !isTerminalRejection(error)
-    ) {
+    if (retries < MAX_RETRIES_FOR_REACTIVE) {
       // Resubscribe sets up dependencies/triggers from the log so the action
       // re-runs when its inputs change. The run still exists only because of the
       // consumed trigger reads (§8.9.2), so restore them for its tx.

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -178,12 +178,15 @@ export function watchReactiveActionCommit(state: {
     // Permanent (precondition) and terminal (deterministic commit-rule refusal —
     // `isTerminalRejection`) rejections are never retried: re-running recomputes
     // the identical refused write, and the doomed re-runs would starve
-    // concurrent siblings. Skip BEFORE charging the retry budget — a no-retry
-    // outcome must not consume it, or an action that later re-runs on changed
-    // inputs and then hits a genuinely transient failure would start from the
-    // accumulated count and skip its own bounded retries. Resubscribe still
-    // happens (finalizeReactiveActionCommit), so a real input change re-triggers.
+    // concurrent siblings. This definitively ENDS the current retry sequence, so
+    // clear the counter — exactly like the success path above — before returning:
+    // a later re-run triggered by changed inputs is a fresh sequence that must
+    // keep its full bounded budget for a genuinely transient failure, not inherit
+    // a count accumulated by earlier transient attempts or the terminal one.
+    // Resubscribe still happens (finalizeReactiveActionCommit), so a real input
+    // change re-triggers.
     if (isPermanentRejection(error) || isTerminalRejection(error)) {
+      state.retries.delete(state.action);
       return;
     }
 

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -11,6 +11,7 @@ import type {
 import {
   isConflictRejection,
   isPermanentRejection,
+  isTerminalRejection,
 } from "../storage/rejection.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import {
@@ -177,12 +178,18 @@ export function watchReactiveActionCommit(state: {
     // Non-conflict failures are NOT re-triggered by reader-dirty — a transient
     // transport error, or the path-blind local StorageTransactionInconsistent
     // guard that fires before the engine's granular matcher — so they still
-    // warrant a bounded retry. Permanent (precondition) rejections are never
-    // retried. On every attempt we still resubscribe, so even after the budget
-    // is exhausted the action is re-triggered when its input data changes.
+    // warrant a bounded retry. Permanent (precondition) and terminal
+    // (deterministic commit-rule refusal — `isTerminalRejection`) rejections are
+    // never retried: re-running recomputes the identical refused write, and the
+    // doomed re-runs would starve concurrent siblings. On every attempt we still
+    // resubscribe, so even after the budget is exhausted (or a terminal skip)
+    // the action is re-triggered when its input data changes.
     const retries = (state.retries.get(state.action) ?? 0) + 1;
     state.retries.set(state.action, retries);
-    if (retries < MAX_RETRIES_FOR_REACTIVE && !isPermanentRejection(error)) {
+    if (
+      retries < MAX_RETRIES_FOR_REACTIVE && !isPermanentRejection(error) &&
+      !isTerminalRejection(error)
+    ) {
       // Resubscribe sets up dependencies/triggers from the log so the action
       // re-runs when its inputs change. The run still exists only because of the
       // consumed trigger reads (§8.9.2), so restore them for its tx.

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -17,6 +17,7 @@ import {
   isConflictRejection,
   isPermanentRejection,
   isStorageTransactionInconsistent,
+  isTerminalRejection,
 } from "../storage/rejection.ts";
 import { getDirectTransactionMergeableOpAddresses } from "../storage/transaction-inspection.ts";
 import {
@@ -770,6 +771,7 @@ export async function dispatchQueuedEvent(state: {
           ? { retryAttempt: disposition.attempts, terminal: "convergence" }
           : {}),
         ...(disposition.kind === "permanent" ? { terminal: "permanent" } : {}),
+        ...(disposition.kind === "terminal" ? { terminal: "rule" } : {}),
       });
 
       switch (disposition.kind) {
@@ -805,6 +807,20 @@ export async function dispatchQueuedEvent(state: {
             disposition.attempts,
             disposition.deadline,
             disposition.runAt,
+          );
+          return;
+        case "terminal":
+          // A deterministic commit-rule refusal: run the final callback and
+          // stop. No retry (would recompute the identical refused write) and no
+          // handleError — the rejection is observable via the commit telemetry
+          // marker (`terminal: "rule"`), mirroring the permanent path; surfacing
+          // a scheduler error here is reserved for non-deterministic failures.
+          runFinalCommitCallback();
+          logger.warn(
+            "scheduler",
+            "Event handler commit terminally rejected (deterministic refusal); " +
+              "not retrying",
+            { error: result.error, handlerId },
           );
           return;
         case "permanent":
@@ -922,6 +938,7 @@ function transactionHasMergeableOps(tx: IExtendedStorageTransaction): boolean {
 type CommitDisposition =
   | { kind: "success" }
   | { kind: "permanent" }
+  | { kind: "terminal" }
   | {
     kind: "backoff";
     attempts: number;
@@ -938,6 +955,10 @@ type CommitDisposition =
  *
  *  - success: nothing more to do.
  *  - permanent: a precondition failure; never retried.
+ *  - terminal: a deterministic server-side refusal of the committed data
+ *    (a CFC row-label commit-rule violation, `isTerminalRejection`); never
+ *    retried — re-running recomputes the identical refused write, and the
+ *    doomed re-runs' speculative rev bumps would starve concurrent siblings.
  *  - backoff / convergence-failed: a stale-basis ConflictError under
  *    contention, or a stale-basis StorageTransactionInconsistent on a commit
  *    that carries a mergeable op. It backs off and retries until it lands or the
@@ -967,6 +988,13 @@ function classifyCommitDisposition(
   }
   if (isPermanentRejection(error)) {
     return { kind: "permanent" };
+  }
+  // A deterministic commit-rule refusal is terminal BEFORE the retry-budget /
+  // windowing logic: it is neither a stale-read conflict (retry cannot converge)
+  // nor a transient error (re-running recomputes the identical refused write),
+  // so it must not consume the retry budget or back off — it stops now.
+  if (isTerminalRejection(error)) {
+    return { kind: "terminal" };
   }
   const windowed = isConflictRejection(error) ||
     (hasMergeableOps && isStorageTransactionInconsistent(error));

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -10,6 +10,41 @@ export function isPermanentRejection(
 }
 
 /**
+ * The wire names of terminal commit rejections: a server-side commit-time
+ * evaluation that DETERMINISTICALLY refused the committed data itself, so
+ * re-running the identical handler recomputes the identical refused write and
+ * can NEVER converge. Today: `RowLabelCommitError` — a CFC per-row label
+ * commit-rule violation (memory/v2/sqlite/commit-eval.ts, evaluated inside
+ * `applyCommitTransaction`, rolls back the whole commit). The memory server
+ * MUST serialize the class name unchanged (memory/v2/server.ts transact catch);
+ * the runner keeps it through normalization (storage/v2.ts `toRejectedError`).
+ * Keep the two in sync — the sqlite-cfc-commit-eval integration test exercises
+ * the real server→runner path and fails if the name is dropped or renamed.
+ */
+const TERMINAL_REJECTION_NAMES: ReadonlySet<string> = new Set([
+  "RowLabelCommitError",
+]);
+
+/**
+ * A terminal rejection is a deterministic, data-caused commit refusal that
+ * retrying can never resolve (see {@link TERMINAL_REJECTION_NAMES}). It is
+ * terminal like a {@link isPermanentRejection}, but classified separately: a
+ * permanent rejection is an idempotency/lineage precondition
+ * (`origin-committed`/`receipt-exists`), whereas a terminal rejection is the
+ * server refusing the committed rows on their own merits. Both must stop the
+ * handler immediately: a doomed handler that keeps re-running through its retry
+ * budget produces speculative rev bumps on each attempt that starve concurrent
+ * sibling commits sharing reactive state. Unlike a stale-read
+ * {@link isConflictRejection} (retry against fresh state can converge), a
+ * terminal rejection is NOT retryable.
+ */
+export function isTerminalRejection(
+  error: { name?: string } | undefined | null,
+): boolean {
+  return error?.name !== undefined && TERMINAL_REJECTION_NAMES.has(error.name);
+}
+
+/**
  * A conflict rejection is a stale-read / pending-dependency commit failure
  * (normalized to `ConflictError`, see storage/v2.ts): the authoritative version
  * is ahead of this replica. A reactive compute or effect recovers from one by

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2907,6 +2907,21 @@ const toRejectedError = (
     return rejected;
   }
 
+  // A terminal commit rejection (a deterministic server-side refusal of the
+  // committed data — today `RowLabelCommitError`, storage/rejection.ts
+  // `isTerminalRejection`): preserve the wire name so the scheduler classifies
+  // it as non-retryable instead of collapsing it into a generic, bounded-retry
+  // TransactionError. Re-running the identical handler recomputes the identical
+  // refused write, so the doomed re-runs would only starve sibling commits.
+  if (name === "RowLabelCommitError") {
+    return {
+      name,
+      message,
+      cause: { name: "SystemError", message, code: 500 },
+      transaction: commit as Transaction,
+    } as unknown as TransactionError;
+  }
+
   return {
     name: "TransactionError",
     message,

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -178,9 +178,10 @@ export type RuntimeTelemetryMarker = {
   /**
    * Set when the commit reached a terminal outcome: `permanent` for a
    * never-retried precondition failure, `convergence` for a transient conflict
-   * that exhausted the retry window and surfaced a terminal error.
+   * that exhausted the retry window and surfaced a terminal error, `rule` for a
+   * deterministic server-side commit-rule refusal (never retried).
    */
-  terminal?: "permanent" | "convergence";
+  terminal?: "permanent" | "convergence" | "rule";
 } | {
   type: "scheduler.event.preflight";
   handlerId: string;

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -395,6 +395,73 @@ describe("committed-write backpressure", () => {
   );
 
   it(
+    "does not retry a terminal commit-rule rejection (RowLabelCommitError) and stops after one run",
+    async () => {
+      // A server-side commit-time row-label violation (E4 Phase 3.c,
+      // memory/v2/sqlite/commit-eval.ts `RowLabelCommitError`) rolls back the
+      // whole commit and can NEVER succeed on retry: re-running the identical
+      // handler recomputes the identical refused write. Unlike a stale-read
+      // ConflictError, it must not consume the retry budget — each doomed
+      // re-run's speculative rev bumps starve concurrent sibling commits that
+      // share reactive state (the E4 3.c integration test masked this with a
+      // between-sends drain). It must therefore run exactly once, like a
+      // permanent rejection.
+      const piece = buildCounterPiece(
+        runtime,
+        tx,
+        "backpressure-terminal-root",
+      );
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const terminalErrors: ErrorWithContext[] = [];
+      runtime.scheduler.onError((error) => terminalErrors.push(error));
+      const commitTelemetry = collectEventCommitMarkers(runtime);
+
+      const injector = rejectServerTransacts(storageManager, Infinity, {
+        name: "RowLabelCommitError",
+        message:
+          "sqlite commit refused: rowLabel rule rejected committed row " +
+          '(rowid 1) of table "emails"',
+      });
+
+      try {
+        piece.queueAdd(
+          4,
+          "evt:backpressure-terminal:0:backpressure-terminal-root",
+        );
+
+        await waitFor(
+          runtime,
+          () => commitTelemetry.markers.length >= 1,
+          "terminal rejection never reported a commit marker",
+        );
+        // Give any erroneous retry a generous chance to run (a bounded-retry
+        // misclassification would re-run the handler up to
+        // DEFAULT_RETRIES_FOR_EVENTS more times), then confirm none did.
+        await runtime.idle();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        await runtime.idle();
+
+        // The doomed handler ran exactly once — no retry budget consumed.
+        expect(piece.invocations()).toBe(1);
+        // The refused write did not land.
+        expect(piece.total()).toBe(0);
+        // A terminal deterministic refusal is reported, not silently dropped.
+        expect(
+          commitTelemetry.markers.some((marker) =>
+            (marker as { terminal?: string }).terminal === "rule"
+          ),
+        ).toBe(true);
+      } finally {
+        injector.restore();
+        commitTelemetry.dispose();
+      }
+    },
+  );
+
+  it(
     "surfaces a terminal error when a transient conflict never converges",
     async () => {
       await disposeSchedulerTestRuntime({ storageManager, runtime, tx });

--- a/packages/runner/test/scheduler-rejection-taxonomy.test.ts
+++ b/packages/runner/test/scheduler-rejection-taxonomy.test.ts
@@ -1,7 +1,10 @@
 // Integration coverage for no-retry behavior lands in work orders 03/04,
 // where the engine can actually emit precondition failures.
 import { describe, expect, it } from "./scheduler-test-utils.ts";
-import { isPermanentRejection } from "../src/storage/rejection.ts";
+import {
+  isPermanentRejection,
+  isTerminalRejection,
+} from "../src/storage/rejection.ts";
 
 describe("scheduler rejection taxonomy", () => {
   it("classifies precondition failures as permanent", () => {
@@ -18,5 +21,33 @@ describe("scheduler rejection taxonomy", () => {
 
   it("does not classify missing errors as permanent", () => {
     expect(isPermanentRejection(undefined)).toBe(false);
+  });
+
+  it("classifies a row-label commit refusal as terminal", () => {
+    // A deterministic commit-rule refusal (memory/v2/sqlite/commit-eval.ts):
+    // re-running recomputes the identical refused write, so it must never retry.
+    expect(isTerminalRejection({
+      name: "RowLabelCommitError",
+    })).toBe(true);
+  });
+
+  it("does not classify retryable/transient rejections as terminal", () => {
+    // A stale-read conflict CAN converge on retry; a generic transient error
+    // keeps its bounded retry budget — neither is terminal.
+    expect(isTerminalRejection({ name: "ConflictError" })).toBe(false);
+    expect(isTerminalRejection({ name: "TransactionError" })).toBe(false);
+    expect(isTerminalRejection({ name: "PreconditionFailedError" })).toBe(
+      false,
+    );
+    expect(isTerminalRejection(undefined)).toBe(false);
+  });
+
+  it("keeps permanent and terminal as distinct categories", () => {
+    // Both stop the handler, but they are different provenance (idempotency
+    // precondition vs. deterministic data refusal) and must not be conflated.
+    expect(isPermanentRejection({ name: "RowLabelCommitError" })).toBe(false);
+    expect(isTerminalRejection({ name: "PreconditionFailedError" })).toBe(
+      false,
+    );
   });
 });

--- a/packages/runner/test/scheduler-retries.test.ts
+++ b/packages/runner/test/scheduler-retries.test.ts
@@ -15,8 +15,10 @@ import {
 import type {
   Action,
   IExtendedStorageTransaction,
+  ReactivityLog,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import { watchReactiveActionCommit } from "../src/scheduler/action-run.ts";
 
 describe("reactive retries", () => {
   let storageManager: SchedulerTestStorageManager;
@@ -82,6 +84,81 @@ describe("reactive retries", () => {
       await runtime.idle();
 
       expect(attempts).toBe(11);
+    },
+  );
+
+  // Directly exercise the reactive commit-result classification
+  // (`watchReactiveActionCommit`): a whole-runtime commit injector would churn
+  // every commit and re-trigger the action externally, confounding the retry
+  // count, so drive the watcher with a resolved commit result instead.
+  const runWatcher = async (
+    errorName: string | undefined,
+    initialRetries: number,
+  ) => {
+    const action = (() => {}) as unknown as Action;
+    const retries = new WeakMap<Action, number>();
+    if (initialRetries > 0) retries.set(action, initialRetries);
+    let queued = 0;
+    let resubscribed = 0;
+    const error = errorName === undefined
+      ? undefined
+      : { name: errorName, message: `injected ${errorName}` };
+    const commitPromise = Promise.resolve({ error }) as unknown as ReturnType<
+      IExtendedStorageTransaction["commit"]
+    >;
+    watchReactiveActionCommit({
+      action,
+      tx: {} as IExtendedStorageTransaction,
+      log: {} as ReactivityLog,
+      retries,
+      pending: new Set<Action>(),
+      commitPromise,
+      resubscribe: () => {
+        resubscribed++;
+      },
+      markDirectDirty: () => {},
+      queueExecution: () => {
+        queued++;
+      },
+      restoreCfcTriggerReads: () => {},
+    });
+    await commitPromise;
+    await new Promise((r) => setTimeout(r, 0));
+    return { queued, resubscribed, retries, action };
+  };
+
+  it(
+    "does not retry a terminal reactive rejection and clears the retry budget",
+    async () => {
+      // A deterministic commit-rule refusal (RowLabelCommitError) can never
+      // converge; re-running recomputes the identical refused write and its
+      // speculative rev bumps starve concurrent siblings. It must not re-queue,
+      // and — since the sequence has ended — must clear any accumulated count so
+      // a later input-triggered run keeps its full budget for a transient
+      // failure. (Contrast the abort case above, which retries to the limit.)
+      const r = await runWatcher("RowLabelCommitError", 3);
+      expect(r.queued).toBe(0);
+      expect(r.retries.has(r.action)).toBe(false);
+    },
+  );
+
+  it(
+    "does not retry a permanent reactive rejection and clears the retry budget",
+    async () => {
+      const r = await runWatcher("PreconditionFailedError", 3);
+      expect(r.queued).toBe(0);
+      expect(r.retries.has(r.action)).toBe(false);
+    },
+  );
+
+  it(
+    "retries a transient reactive rejection within the bounded budget",
+    async () => {
+      // A generic transient error keeps the bounded retry path: it re-queues and
+      // charges the counter (proving terminal/permanent are the exceptions).
+      const r = await runWatcher("TransactionError", 0);
+      expect(r.queued).toBe(1);
+      expect(r.retries.get(r.action)).toBe(1);
     },
   );
 


### PR DESCRIPTION
## Problem

After a **terminal** commit rejection — one that will never succeed on retry — the runtime kept re-running the doomed handler through its bounded retry budget, and each doomed re-run's speculative rev bumps starved concurrent sibling commits that share reactive state.

Epic E4 (#4552) made this reachable: a `RowLabelCommitError` (Phase 3.c server-side row-label re-derivation, `memory/v2/sqlite/commit-eval.ts`) is thrown inside `applyCommitTransaction`, rolls back the whole commit, and can never converge — re-running the identical handler recomputes the identical refused write. But nothing classified it as terminal, so it fell into the ordinary bounded-retry bucket. The 3.c integration test masked the resulting starvation with a `drainDoomed()` between sends (that drain was a symptom, not a fix).

## Root cause (both wire halves)

1. **Server dropped the identity.** `memory/v2/server.ts` serialized a thrown commit error's name as only `ConflictError` / `ProtocolError` / else `TransactionError` — so `RowLabelCommitError` was collapsed to a generic `TransactionError` at the wire.
2. **Runner had no terminal classification.** `toRejectedError` normalized that to a generic error, and the scheduler (`classifyCommitDisposition`, event path; `watchReactiveActionCommit`, reactive path) treated it as `bounded-retry`, re-running the handler up to `DEFAULT_RETRIES_FOR_EVENTS` (6 total) / `MAX_RETRIES_FOR_REACTIVE` times.

## Fix

- **Server** preserves the `RowLabelCommitError` name unchanged (it is the source of truth for terminality).
- **`isTerminalRejection`** (`storage/rejection.ts`) — a new classifier, distinct from the idempotency/lineage `isPermanentRejection`: a deterministic *data* refusal, not a precondition. `toRejectedError` keeps the name through normalization.
- Wired into both scheduler paths: a new `terminal` event disposition (run the final callback, warn, do not retry; telemetry `terminal: "rule"`) and a reactive-path skip. Resubscribe still happens, so a later input change re-triggers the action.

The existing rollback/revert already invalidates the failed commit's own speculative state; stopping the doomed re-runs is what removes the starvation.

## Tests (red→green, verified)

- `scheduler-commit-backpressure` — a terminal rejection runs the handler **exactly once** (was **6** before the fix; asserted RED→GREEN).
- `scheduler-rejection-taxonomy` — unit coverage that terminal is distinct from permanent / conflict / transient.
- `v2-sqlite-protocol` (memory, loopback wire) — a row-label-violating folded commit surfaces to the client as `RowLabelCommitError`, **not** `TransactionError`. Verified it fails when the server's name-preservation branch is removed (guards the exact serialization the integration test only covers end-to-end).
- **Removed the `drainDoomed` workaround** from the 3.c integration test — now **10/10 deterministic, ~0.85s/run** (was flaky ~1/5, ~7s with the drain's blind sleeps).

## Verification

Full runner unit suite (788 files / 4078 steps ✓), memory sqlite+server suite (73 ✓), both sqlite integration tests ✓, `deno fmt`/`lint` clean.

## Known follow-up (not in this PR)

`runtime.editWithRetry` retries on *any* commit error while `maxRetries > 0` — it consults no rejection taxonomy, so a terminal/permanent rejection driven directly through it loops its budget. Lower severity (a caller's own awaited call, not a scheduler-queued handler starving siblings) and out of scope here; the same short-circuit would make it coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops retrying terminal commit-rule rejections by preserving `RowLabelCommitError` over the wire and classifying it as non-retryable in the runner. Also clears reactive retry counters on terminal/permanent outcomes, preventing starvation and making CFC 3.c tests deterministic.

- **Bug Fixes**
  - Server preserves `RowLabelCommitError` instead of collapsing to `TransactionError`.
  - Runner adds `isTerminalRejection` (distinct from `isPermanentRejection`) and wires it into both scheduler paths: no retries, final callback runs, telemetry sets `terminal: "rule"`.
  - Reactive path no longer charges the retry budget for no-retry outcomes and clears any accumulated retry count; resubscribe still happens so real input changes re-trigger.
  - `toRejectedError` keeps the error name so classification survives normalization.
  - CFC spec documents terminal classification and behavior.

- **Tests**
  - New loopback protocol test asserts the error name is preserved as `RowLabelCommitError`.
  - Scheduler tests verify a terminal rejection runs exactly once, does not land the write, and emits `terminal: "rule"`.
  - Reactive retry tests cover no re-queue and clearing the counter on terminal/permanent outcomes; transient errors still re-queue within budget.
  - Removed the between-sends drain from the 3.c integration test; runs are now deterministic and faster.

<sup>Written for commit 0d26e7302da1d7a76626826da15f61a6853328a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

