### PR TITLE
feat(cfc): concept-level integrity floors via trust closure (Epic D5)

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -77,6 +77,7 @@ import {
 } from "../cfc/types.ts";
 import {
   cfcConfidentialityForObservationNode,
+  type CfcFloorTrustContext,
   cfcIntegritySatisfiesFloor,
   cfcObservationFitsCeiling,
   type CfcObservationResult,
@@ -84,6 +85,7 @@ import {
   meetCfcObservationCeilings,
   uniqueCfcAtoms,
 } from "../cfc/observation.ts";
+import { createTrustResolver } from "../cfc/trust.ts";
 import { cfcSchemaToObject, resolveCfcSchemaRefs } from "../cfc/schema-refs.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
@@ -2042,6 +2044,7 @@ function toolInputRequiredIntegrityFailure(
   schema: unknown,
   value: unknown,
   path: string,
+  trust: CfcFloorTrustContext,
 ): string | undefined {
   if (!isRecord(schema)) {
     return undefined;
@@ -2052,8 +2055,10 @@ function toolInputRequiredIntegrityFailure(
     if (required.length > 0) {
       const integrity = toolInputValueIntegrity(runtime, space, value);
       // The single shared floor predicate (observation.ts) — the same
-      // membership the commit-boundary gates use; D5 upgrades it in one place.
-      const satisfied = cfcIntegritySatisfiesFloor(integrity, required);
+      // membership the commit-boundary gates use. `trust` carries the acting
+      // principal's closure so a CONCEPT-valued floor accepts any concrete
+      // atom above the concept (D5), consistently with the read/write gates.
+      const satisfied = cfcIntegritySatisfiesFloor(integrity, required, trust);
       if (!satisfied) {
         return `field "${path || "(root)"}" requires integrity the ` +
           `model-supplied value does not carry (pass an integrity-bearing ` +
@@ -2077,6 +2082,7 @@ function toolInputRequiredIntegrityFailure(
         childSchema,
         value[key],
         path ? `${path}.${key}` : key,
+        trust,
       );
       if (failure !== undefined) {
         return failure;
@@ -2093,6 +2099,7 @@ function toolInputRequiredIntegrityFailure(
         schema.items,
         value[index],
         `${path}[${index}]`,
+        trust,
       );
       if (failure !== undefined) {
         return failure;
@@ -2112,6 +2119,7 @@ function toolInputRequiredIntegrityFailure(
           branch,
           value,
           path,
+          trust,
         );
         if (failure !== undefined) {
           return failure;
@@ -2190,12 +2198,20 @@ async function executeToolCalls(
           CFC_ENFORCING_STRICTNESS
       ) {
         const gate = integrityGateTarget(resolved, part, toolCatalog);
+        // Acting principal's trust closure for CONCEPT-valued floors (D5),
+        // built from the runtime's frozen trust config + acting principal —
+        // the same inputs the tx-side gates use via cfcFloorTrustContext.
+        const trust: CfcFloorTrustContext = {
+          trustResolver: createTrustResolver(runtime.cfcTrustConfig),
+          actingPrincipal: runtime.trustSnapshotProvider()?.actingPrincipal,
+        };
         const integrityFailure = toolInputRequiredIntegrityFailure(
           runtime,
           space,
           gate.schema,
           gate.input,
           "",
+          trust,
         );
         if (integrityFailure !== undefined) {
           results.push({

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -303,8 +303,14 @@ export const instantiateAtomPattern = (
 export const conceptGuard = (
   pattern: unknown,
 ): { uri: string | undefined } | undefined => {
+  // `isRecord` admits arrays (`typeof [] === "object"`), and an array can carry
+  // own `type`/`uri` properties — exclude it explicitly so only the canonical
+  // OBJECT shape `{ type, uri }` can route to trust-closure satisfaction. A
+  // Concept-shaped array is not the canonical shape and fails closed to
+  // ordinary matching, in keeping with the discipline below.
   if (
-    !isRecord(pattern) || isAtomVarPlaceholder(pattern) ||
+    !isRecord(pattern) || Array.isArray(pattern) ||
+    isAtomVarPlaceholder(pattern) ||
     (pattern as { type?: unknown }).type !== CFC_ATOM_TYPE.Concept
   ) {
     return undefined;

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -279,6 +279,48 @@ export const instantiateAtomPattern = (
   bindings: AtomPatternBindings,
 ): { value: unknown } | null => instantiateValue(pattern, bindings);
 
+/**
+ * A concept-valued integrity guard (spec §4.4.5): a CONCRETE `Concept` atom
+ * pattern. Satisfied exclusively via the acting principal's trust closure —
+ * never by pool-matching a literal Concept atom (which carried integrity
+ * cannot legitimately contain; the mint gate strips it). Returns `undefined`
+ * for non-concept-shaped patterns (they route to ordinary pool matching) and
+ * `{ uri: undefined }` — a concept guard that is NEVER satisfied — for any
+ * `Concept`-typed pattern that is not the EXACT concrete two-field shape
+ * `{ type, uri: <non-empty string> }`.
+ *
+ * The exact-shape requirement is load-bearing (codex/cubic P2 on #4564):
+ * concept guards are checked ONLY on `type` + trust closure, so extra
+ * constraint fields (`{ type: Concept, uri, subject: … }`) or a smuggled
+ * `var` key would be silently ignored — an over-constrained guard the author
+ * wrote as narrow would fire as broadly as the bare concept. Anything but the
+ * canonical shape fails closed.
+ *
+ * Shared by the exchange-rule evaluator (B4 rule guards) and the integrity
+ * floors (D5, observation.ts): one recognizer, so a Concept-typed entry means
+ * the same thing in a rule precondition and a `requiredIntegrity` floor.
+ */
+export const conceptGuard = (
+  pattern: unknown,
+): { uri: string | undefined } | undefined => {
+  if (
+    !isRecord(pattern) || isAtomVarPlaceholder(pattern) ||
+    (pattern as { type?: unknown }).type !== CFC_ATOM_TYPE.Concept
+  ) {
+    return undefined;
+  }
+  const uri = (pattern as { uri?: unknown }).uri;
+  // Exactly `{ type, uri }`, uri a non-empty string. Extra fields (or a `var`
+  // key, which would push the key count past 2) → never satisfied.
+  if (
+    Object.keys(pattern).length !== 2 ||
+    typeof uri !== "string" || uri.length === 0
+  ) {
+    return { uri: undefined };
+  }
+  return { uri };
+};
+
 type ExpiresAtom = { type: string; timestamp: number };
 
 // Only the CANONICAL two-field `Expires` shape participates in timestamp

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -1,11 +1,9 @@
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isRecord } from "@commonfabric/utils/types";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 import {
   type AtomPatternBindings,
+  conceptGuard,
   instantiateAtomPattern,
-  isAtomVarPlaceholder,
   matchAtomPattern,
   matchAtomPatternAgainstAtoms,
 } from "./atom-pattern.ts";
@@ -83,44 +81,6 @@ export type ExchangeEvalResult = {
   readonly label: IFCLabel;
   readonly firings: readonly RuleFiring[];
   readonly exhausted: boolean;
-};
-
-/**
- * A concept-valued integrity guard (spec §4.4.5): a CONCRETE `Concept` atom
- * pattern. Satisfied exclusively via the acting principal's trust closure —
- * never by pool-matching a literal Concept atom (which carried integrity
- * cannot legitimately contain; the mint gate strips it). Returns `undefined`
- * for non-concept-shaped patterns (they route to ordinary pool matching) and
- * `{ uri: undefined }` — a concept guard that is NEVER satisfied — for any
- * `Concept`-typed pattern that is not the EXACT concrete two-field shape
- * `{ type, uri: <non-empty string> }`.
- *
- * The exact-shape requirement is load-bearing (codex/cubic P2 on #4564):
- * concept guards are checked ONLY on `type` + trust closure, so extra
- * constraint fields (`{ type: Concept, uri, subject: … }`) or a smuggled
- * `var` key would be silently ignored — an over-constrained guard the author
- * wrote as narrow would fire as broadly as the bare concept. Anything but the
- * canonical shape fails closed.
- */
-const conceptGuard = (
-  pattern: unknown,
-): { uri: string | undefined } | undefined => {
-  if (
-    !isRecord(pattern) || isAtomVarPlaceholder(pattern) ||
-    (pattern as { type?: unknown }).type !== CFC_ATOM_TYPE.Concept
-  ) {
-    return undefined;
-  }
-  const uri = (pattern as { uri?: unknown }).uri;
-  // Exactly `{ type, uri }`, uri a non-empty string. Extra fields (or a `var`
-  // key, which would push the key count past 2) → never satisfied.
-  if (
-    Object.keys(pattern).length !== 2 ||
-    typeof uri !== "string" || uri.length === 0
-  ) {
-    return { uri: undefined };
-  }
-  return { uri };
 };
 
 /**

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -153,6 +153,7 @@ export {
 export {
   CFC_LABEL_READ_FAILED_ATOM,
   cfcConfidentialityForObservationNode,
+  type CfcFloorTrustContext,
   cfcIntegritySatisfiesFloorCoherently,
   cfcIntegrityWitnessKey,
   cfcJsonPointerForPath,

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -1,4 +1,5 @@
 import type { ImmutableJSONValue, JSONSchema } from "@commonfabric/api";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
@@ -198,7 +199,18 @@ const integrityAtomSatisfies = (
 ): boolean => {
   const concept = conceptGuard(required);
   if (concept !== undefined) {
+    // A concept floor is satisfied ONLY by concrete evidence reaching the
+    // concept in the closure — NEVER by a literal Concept atom in carried
+    // integrity (spec §4.8: conceptual principals live in trust statements,
+    // not carried labels; the mint gate strips any Concept atom). Reject a
+    // Concept-typed `actual` locally, BEFORE the resolver, so a misconfigured
+    // trust statement whose `concrete` is itself Concept-shaped cannot let a
+    // smuggled `Concept` atom pool-match its way through — fail closed here
+    // rather than lean on the upstream mint gate. `isRecord` admits arrays, so
+    // this catches a Concept-typed array shape too.
     return concept.uri !== undefined &&
+      !(isRecord(actual) &&
+        (actual as { type?: unknown }).type === CFC_ATOM_TYPE.Concept) &&
       trust?.trustResolver !== undefined &&
       trust.trustResolver.conceptSatisfied(
         concept.uri,

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -6,7 +6,8 @@ import {
   cfcLabelPathPrefixMatches,
   type CfcLabelView,
 } from "./label-view-core.ts";
-import { atomEntails, matchAtomPattern } from "./atom-pattern.ts";
+import { atomEntails, conceptGuard, matchAtomPattern } from "./atom-pattern.ts";
+import type { TrustResolver } from "./trust.ts";
 import {
   clauseAlternatives,
   clausesEqual,
@@ -155,20 +156,59 @@ export const cfcObservationFitsCeiling = (
 };
 
 /**
+ * Trust context threaded through the floor predicates for CONCEPT-valued
+ * requirements (Epic D5). A concept floor is satisfied only via the acting
+ * principal's trust closure, so the predicates need the resolver plus who is
+ * acting. Optional throughout: absent it (every pre-D5 caller, and every
+ * plain-atom floor) concept requirements fail closed and plain atoms behave
+ * exactly as before — the change is invisible to concrete/pattern floors.
+ */
+export type CfcFloorTrustContext = {
+  readonly trustResolver?: TrustResolver;
+  readonly actingPrincipal?: string;
+};
+
+/**
  * Does carried atom `actual` satisfy floor requirement `required`
- * (§8.10.3)? The requirement is an ATOM PATTERN — `matchAtomPattern`'s
- * subset-field semantics let a floor name exactly the fields it demands
- * (`{type: CaveatScreened, verdict: "pass"}` accepts any trusted mint with
- * those fields) — with `atomEntails` layered for the ordered families.
- * Exact structural equality is the degenerate case of both, so floors
- * authored as concrete atoms keep their meaning. Concept-valued
- * requirements via the trust closure are D5 (this stays a pure predicate).
+ * (§8.10.3)? Three cases, in order:
+ *
+ * - A CONCEPT-valued requirement (`{type: Concept, uri}`, recognized by
+ *   `conceptGuard`) is satisfied iff `actual` — a CONCRETE atom — reaches the
+ *   concept in the acting principal's trust closure (spec §4.8.9, D5). It is
+ *   NEVER pool-matched as a literal: a concept pattern is not structural data,
+ *   and carried integrity cannot legitimately contain a Concept atom (the mint
+ *   gate strips it). Evaluated per single atom — `conceptSatisfied` over a set
+ *   is the ∃-over-atoms disjunction, and concept edges form a graph whose
+ *   reachability from a set is the union of per-atom reachability, so testing
+ *   one atom at a time gives the same answer AND tells us WHICH concrete atom
+ *   is the witness (keeping the coherence machinery below well-defined).
+ *   Fails closed on a malformed concept shape (`conceptGuard` → `{uri:
+ *   undefined}`) or an absent resolver.
+ * - Otherwise the requirement is an ATOM PATTERN — `matchAtomPattern`'s
+ *   subset-field semantics let a floor name exactly the fields it demands
+ *   (`{type: CaveatScreened, verdict: "pass"}` accepts any trusted mint with
+ *   those fields) — with `atomEntails` layered for the ordered families.
+ * - Exact structural equality is the degenerate case of both, so floors
+ *   authored as concrete atoms keep their meaning.
  */
 const integrityAtomSatisfies = (
   required: unknown,
   actual: unknown,
-): boolean =>
-  matchAtomPattern(required, actual) !== null || atomEntails(actual, required);
+  trust?: CfcFloorTrustContext,
+): boolean => {
+  const concept = conceptGuard(required);
+  if (concept !== undefined) {
+    return concept.uri !== undefined &&
+      trust?.trustResolver !== undefined &&
+      trust.trustResolver.conceptSatisfied(
+        concept.uri,
+        [actual],
+        trust.actingPrincipal,
+      );
+  }
+  return matchAtomPattern(required, actual) !== null ||
+    atomEntails(actual, required);
+};
 
 /**
  * Integrity-floor membership (§8.10.3 / §8.12.4.1): every required pattern
@@ -177,14 +217,17 @@ const integrityAtomSatisfies = (
  * the coherent form below), the write-side floor (`verifyWriteFloor`, Epic
  * D3), and the tool-input floor (llm-dialog, Epic D2), so D5's upgrade to
  * concept matching (`conceptSatisfied`) lands in ONE place instead of
- * diverging across three inlined copies.
+ * diverging across three inlined copies. `trust` carries the acting
+ * principal's closure for CONCEPT-valued requirements; omit it for plain
+ * (concrete/pattern) floors.
  */
 export const cfcIntegritySatisfiesFloor = (
   integrity: readonly unknown[],
   requiredIntegrity: readonly unknown[],
+  trust?: CfcFloorTrustContext,
 ): boolean =>
   requiredIntegrity.every((required) =>
-    integrity.some((actual) => integrityAtomSatisfies(required, actual))
+    integrity.some((actual) => integrityAtomSatisfies(required, actual, trust))
   );
 
 /**
@@ -198,8 +241,9 @@ export const cfcIntegritySatisfiesFloor = (
 export const cfcIntegrityWitnessKey = (
   required: unknown,
   actual: unknown,
+  trust?: CfcFloorTrustContext,
 ): string | null => {
-  if (!integrityAtomSatisfies(required, actual)) return null;
+  if (!integrityAtomSatisfies(required, actual, trust)) return null;
   if (
     isRecord(actual) && isRecord((actual as { scope?: unknown }).scope) &&
     (actual as { scope: { valueRef?: unknown } }).scope.valueRef !== undefined
@@ -221,18 +265,22 @@ export const cfcIntegrityWitnessKey = (
  * screened by someone" is not "the object was screened". The single-leaf
  * case reduces exactly to `cfcIntegritySatisfiesFloor`; an empty leaf set is
  * vacuously satisfied (nothing was consumed — the caller's quantification
- * decides whether the gate even runs).
+ * decides whether the gate even runs). For a CONCEPT-valued requirement the
+ * shared witness is the CONCRETE atom that reaches the concept (D5): two
+ * leaves each reaching the concept via a DIFFERENT concrete atom are
+ * incoherent, exactly as two different concrete screening atoms would be.
  */
 export const cfcIntegritySatisfiesFloorCoherently = (
   consumedIntegrity: readonly (readonly unknown[])[],
   requiredIntegrity: readonly unknown[],
+  trust?: CfcFloorTrustContext,
 ): boolean =>
   requiredIntegrity.every((required) => {
     let common: Set<string> | undefined;
     for (const integrity of consumedIntegrity) {
       const keys = new Set<string>();
       for (const actual of integrity) {
-        const key = cfcIntegrityWitnessKey(required, actual);
+        const key = cfcIntegrityWitnessKey(required, actual, trust);
         if (key !== null) keys.add(key);
       }
       if (keys.size === 0) return false;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -47,6 +47,7 @@ import { clauseAlternatives, isOrClause, normalizeClause } from "./clause.ts";
 import { externalIngestStamp } from "./external-ingest.ts";
 import {
   atomsOutsideCeiling,
+  type CfcFloorTrustContext,
   cfcIntegritySatisfiesFloor,
   cfcIntegritySatisfiesFloorCoherently,
   uniqueCfcAtoms,
@@ -2552,6 +2553,24 @@ const isProvenanceOnlyConsumedLabel = (label: IFCLabel): boolean => {
     integrity.every(isNonEndorsementProvenanceAtom);
 };
 
+// Trust context for CONCEPT-valued requiredIntegrity floors (Epic D5): the
+// deployment trust closure plus the acting principal, built from tx CFC state
+// exactly like `evaluateGatedConfidentiality` — SAME resolver, SAME acting
+// principal — so the floor gates and the exchange-rule guards agree on concept
+// satisfaction. A concept floor ("minted by a valid GPS measurement") then
+// accepts any concrete atom above the concept in THIS user's closure; plain
+// (concrete/pattern) floors ignore it (inv-11: concrete integrity portable,
+// concept satisfaction acting-principal scoped).
+const cfcFloorTrustContext = (
+  tx: IExtendedStorageTransaction,
+): CfcFloorTrustContext => {
+  const state = tx.getCfcState();
+  return {
+    trustResolver: createTrustResolver(state.trustConfig),
+    actingPrincipal: state.trustSnapshot?.actingPrincipal,
+  };
+};
+
 const verifyInputRequirements = (
   tx: IExtendedStorageTransaction,
   schema: JSONSchema,
@@ -2672,6 +2691,7 @@ const verifyInputRequirements = (
       const ok = cfcIntegritySatisfiesFloorCoherently(
         gatedReads.map((read) => read.label?.integrity ?? []),
         requiredIntegrity,
+        cfcFloorTrustContext(tx),
       );
       if (!ok) {
         return `requiredIntegrity failed at /${entry.path.join("/")}`;
@@ -3561,6 +3581,10 @@ const verifyWriteFloor = (
   },
 ): string[] => {
   const failures: string[] = [];
+  // Built once per verify (not per entry/contribution): the closure and acting
+  // principal are tx-wide. Concept floors on the written value resolve through
+  // it; plain floors ignore it (Epic D5).
+  const trust = cfcFloorTrustContext(tx);
   const entries = walkIfcSchema(schema);
   const entryLabels = new Map<string, IFCLabel>(
     entries.map((entry) => [pathKey(entry.path), entry.label]),
@@ -3698,7 +3722,7 @@ const verifyWriteFloor = (
     if (valueWritten) contributions.push(ctx.flowIntegrity);
 
     const misses = contributions.some((extra) =>
-      !cfcIntegritySatisfiesFloor([...base, ...extra], floor)
+      !cfcIntegritySatisfiesFloor([...base, ...extra], floor, trust)
     );
     if (misses) {
       failures.push(

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -15,6 +15,7 @@ import {
   type CfcTrustConfigInput,
   createTrustResolver,
 } from "../src/cfc/trust.ts";
+import { conceptGuard } from "../src/cfc/atom-pattern.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
 import { createLLMFriendlyLink } from "../src/link-types.ts";
@@ -163,6 +164,63 @@ describe("CFC concept-level integrity floors (D5)", () => {
       expect(cfcIntegritySatisfiesFloor(
         [concept(GPS_CONCEPT)],
         [concept(GPS_CONCEPT)],
+        trustCtx(signer.did()),
+      )).toBe(false);
+    });
+
+    it("rejects a Concept-typed carried atom even under a Concept-shaped concrete statement (cubic P2)", () => {
+      // Defense in depth (cubic review-run a177bba7): the previous version
+      // handed `actual` straight to the resolver, so a MISCONFIGURED trust
+      // statement whose `concrete` side is itself Concept-shaped would let a
+      // smuggled literal Concept atom pool-match its way to concept
+      // satisfaction. A concept floor is satisfied ONLY by concrete evidence
+      // (spec §4.8), so a Concept-typed carried atom must fail closed BEFORE
+      // the closure is consulted, independent of how the config is written.
+      const cfg = buildCfcTrustConfig({
+        // `concrete` is the concept atom itself — a config a careful operator
+        // would never write, but the predicate must not depend on that.
+        statements: [{
+          concrete: concept(GPS_CONCEPT),
+          implements: PRIVACY_CONCEPT,
+          verifier: AUDITOR,
+        }],
+        delegations: [{
+          delegator: signer.did(),
+          verifier: AUDITOR,
+          concepts: [PRIVACY_CONCEPT],
+        }],
+      });
+      const ctx = {
+        trustResolver: createTrustResolver(cfg),
+        actingPrincipal: signer.did(),
+      };
+      // Before the fix this returned true: `concept(GPS_CONCEPT)` matched the
+      // Concept-shaped concrete and reached PRIVACY_CONCEPT.
+      expect(cfcIntegritySatisfiesFloor(
+        [concept(GPS_CONCEPT)],
+        [concept(PRIVACY_CONCEPT)],
+        ctx,
+      )).toBe(false);
+    });
+
+    it("does not treat a Concept-shaped ARRAY as a concept guard (cubic P2)", () => {
+      // `isRecord` admits arrays (`typeof [] === "object"`), so an array
+      // carrying own `type`/`uri` properties previously routed to trust-closure
+      // satisfaction. The canonical Concept atom is an OBJECT; a Concept-shaped
+      // array is not the canonical shape and must fail closed to ordinary
+      // matching (cubic review-run a177bba7).
+      const arrayGuard = [] as unknown as Record<string, unknown>;
+      arrayGuard.type = concept(GPS_CONCEPT).type;
+      arrayGuard.uri = GPS_CONCEPT;
+      // Before the fix `conceptGuard` returned `{ uri }` here.
+      expect(conceptGuard(arrayGuard)).toBeUndefined();
+      // And through the floor: an array-shaped requirement is NOT a concept
+      // floor, so a valid measurement does not satisfy it via the closure —
+      // it falls through to structural matching, which an array requirement
+      // against a concrete object never meets.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [arrayGuard],
         trustCtx(signer.did()),
       )).toBe(false);
     });

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -1,0 +1,659 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { enableMockMode } from "@commonfabric/llm/client";
+import {
+  cfcIntegritySatisfiesFloor,
+  cfcIntegritySatisfiesFloorCoherently,
+  cfcIntegrityWitnessKey,
+} from "../src/cfc/observation.ts";
+import {
+  buildCfcTrustConfig,
+  type CfcTrustConfigInput,
+  createTrustResolver,
+} from "../src/cfc/trust.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
+import { createLLMFriendlyLink } from "../src/link-types.ts";
+import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
+import type { CfcEnforcementMode } from "../src/cfc/types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-concept-floor");
+enableMockMode();
+
+// Epic D5 (docs/plans/cfc-future-work-implementation.md §5; spec §4.8.9 /
+// §8.10.3 / §8.12.4.1): integrity-floor membership matches a CONCEPT-valued
+// requirement against carried CONCRETE integrity through the acting
+// principal's trust closure. A floor like "minted by a valid GPS measurement"
+// accepts ANY concrete atom above the concept for the acting user (inv-11:
+// concrete integrity is portable; concept satisfaction is acting-principal
+// scoped). Plain-atom floors keep their exact-match / pattern meaning.
+
+const GPS_CONCEPT = "https://commonfabric.org/cfc/concepts/gps-measurement";
+const PRIVACY_CONCEPT =
+  "https://commonfabric.org/cfc/concepts/privacy-preserving";
+const AUDITOR = "did:key:gps-auditor";
+const BOB = "did:key:bob";
+const GPS_TYPE = "https://example.com/atoms/GPSMeasurement";
+const APPROVED = { type: "https://example.com/atoms/Approved" };
+
+const concept = (uri: string) => cfcAtom.concept(uri);
+// A concrete measurement atom (device-scoped): two devices are SIBLINGS under
+// the concept — both above it, neither dominating the other.
+const gps = (device: string) => ({ type: GPS_TYPE, device });
+const unrelated = {
+  type: "https://example.com/atoms/Thermometer",
+  device: "T",
+};
+
+// Trust config binding any GPSMeasurement (family pattern on `type`) to the
+// GPS concept, delegated by `delegator` to AUDITOR. `delegator` defaults to
+// the runtime's acting principal (the signer) so the integration paths, whose
+// acting principal is the signer's DID, resolve the concept.
+const trustInput = (
+  overrides: Partial<CfcTrustConfigInput> = {},
+  delegator: string = signer.did(),
+): CfcTrustConfigInput => ({
+  statements: [{
+    concrete: { type: GPS_TYPE },
+    implements: GPS_CONCEPT,
+    verifier: AUDITOR,
+  }],
+  delegations: [{ delegator, verifier: AUDITOR, concepts: [GPS_CONCEPT] }],
+  ...overrides,
+});
+
+const trustCtx = (
+  actingPrincipal: string | undefined,
+  overrides: Partial<CfcTrustConfigInput> = {},
+) => ({
+  trustResolver: createTrustResolver(
+    buildCfcTrustConfig(trustInput(overrides)),
+  ),
+  actingPrincipal,
+});
+
+describe("CFC concept-level integrity floors (D5)", () => {
+  describe("shared predicate: cfcIntegritySatisfiesFloor", () => {
+    it("accepts a concrete atom above the concept in the acting closure", () => {
+      // RED before D5: a Concept-valued floor matched nothing (a concept
+      // pattern never structurally matches a GPSMeasurement atom), so a valid
+      // measurement wrongly failed the floor.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [concept(GPS_CONCEPT)],
+        trustCtx(signer.did()),
+      )).toBe(true);
+    });
+
+    it("rejects a below/unrelated atom for a concept floor", () => {
+      expect(cfcIntegritySatisfiesFloor(
+        [unrelated],
+        [concept(GPS_CONCEPT)],
+        trustCtx(signer.did()),
+      )).toBe(false);
+      expect(cfcIntegritySatisfiesFloor(
+        [],
+        [concept(GPS_CONCEPT)],
+        trustCtx(signer.did()),
+      )).toBe(false);
+    });
+
+    it("scopes concept satisfaction to the acting principal (inv-11)", () => {
+      // The SAME concrete atom is portable, but only the delegating principal's
+      // closure admits the concept. Bob never delegated to the auditor.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [concept(GPS_CONCEPT)],
+        trustCtx(signer.did()),
+      )).toBe(true);
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [concept(GPS_CONCEPT)],
+        trustCtx(BOB),
+      )).toBe(false);
+    });
+
+    it("fails closed with no trust resolver or no config", () => {
+      // No context at all (the pre-D5 2-arg callers): a concept floor never
+      // passes — concepts resolve ONLY through the trust closure.
+      expect(cfcIntegritySatisfiesFloor([gps("X")], [concept(GPS_CONCEPT)]))
+        .toBe(false);
+      // Context present but no resolver.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [concept(GPS_CONCEPT)],
+        { actingPrincipal: signer.did() },
+      )).toBe(false);
+      // Resolver from an empty (undefined) config fails closed.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [concept(GPS_CONCEPT)],
+        {
+          trustResolver: createTrustResolver(undefined),
+          actingPrincipal: signer.did(),
+        },
+      )).toBe(false);
+    });
+
+    it("never satisfies a malformed concept shape, even with a matching atom", () => {
+      // Extra field beyond {type, uri} → fail closed (the guard is checked on
+      // type + closure only; an over-constrained concept must not fire broadly).
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [{ ...concept(GPS_CONCEPT), subject: "extra" }],
+        trustCtx(signer.did()),
+      )).toBe(false);
+      // Missing uri → never satisfied.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [{ type: concept(GPS_CONCEPT).type }],
+        trustCtx(signer.did()),
+      )).toBe(false);
+    });
+
+    it("never pool-matches a literal Concept atom in carried integrity", () => {
+      // A literal Concept atom in the value's integrity (which the mint gate
+      // strips, but belt-and-suspenders here) does NOT satisfy a concept floor:
+      // it matches no trust statement's concrete side.
+      expect(cfcIntegritySatisfiesFloor(
+        [concept(GPS_CONCEPT)],
+        [concept(GPS_CONCEPT)],
+        trustCtx(signer.did()),
+      )).toBe(false);
+    });
+
+    it("satisfies a downstream concept floor transitively over concept edges", () => {
+      const ctx = trustCtx(signer.did(), {
+        conceptEdges: [{ from: GPS_CONCEPT, to: PRIVACY_CONCEPT }],
+      });
+      expect(
+        cfcIntegritySatisfiesFloor([gps("X")], [concept(PRIVACY_CONCEPT)], ctx),
+      )
+        .toBe(true);
+      // Reverse direction is not walked: a privacy-only carrier does not
+      // satisfy the upstream GPS floor.
+      expect(
+        cfcIntegritySatisfiesFloor([gps("X")], [concept(GPS_CONCEPT)], ctx),
+      )
+        .toBe(true);
+    });
+
+    it("preserves exact-match / pattern behavior for plain atoms (byte-compat)", () => {
+      // Trust context present but irrelevant: plain-atom requirements resolve
+      // exactly as before, ignoring the closure.
+      const ctx = trustCtx(signer.did());
+      expect(cfcIntegritySatisfiesFloor([APPROVED], [APPROVED], ctx)).toBe(
+        true,
+      );
+      expect(
+        cfcIntegritySatisfiesFloor([APPROVED], [{ type: APPROVED.type }], ctx),
+      )
+        .toBe(true);
+      expect(cfcIntegritySatisfiesFloor([APPROVED], [gps("X")], ctx)).toBe(
+        false,
+      );
+      // And the 2-arg plain-atom form is unchanged.
+      expect(cfcIntegritySatisfiesFloor([APPROVED], [APPROVED])).toBe(true);
+    });
+
+    it("conjunctively combines a concept requirement with a plain one", () => {
+      const ctx = trustCtx(signer.did());
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X"), APPROVED],
+        [concept(GPS_CONCEPT), APPROVED],
+        ctx,
+      )).toBe(true);
+      // Missing the plain requirement fails the whole floor.
+      expect(cfcIntegritySatisfiesFloor(
+        [gps("X")],
+        [concept(GPS_CONCEPT), APPROVED],
+        ctx,
+      )).toBe(false);
+    });
+  });
+
+  describe("shared predicate: concept coherence + witness key", () => {
+    it("keys a concept witness by the concrete atom that reaches it", () => {
+      const ctx = trustCtx(signer.did());
+      // The witness is the concrete measurement, not the concept.
+      expect(cfcIntegrityWitnessKey(concept(GPS_CONCEPT), gps("X"), ctx))
+        .not.toBeNull();
+      expect(cfcIntegrityWitnessKey(concept(GPS_CONCEPT), gps("X"), ctx))
+        .toBe(cfcIntegrityWitnessKey(concept(GPS_CONCEPT), gps("X"), ctx));
+      // Sibling measurements are DISTINCT witnesses.
+      expect(cfcIntegrityWitnessKey(concept(GPS_CONCEPT), gps("X"), ctx))
+        .not.toBe(cfcIntegrityWitnessKey(concept(GPS_CONCEPT), gps("Y"), ctx));
+      // A non-reaching atom has no witness key.
+      expect(cfcIntegrityWitnessKey(concept(GPS_CONCEPT), unrelated, ctx))
+        .toBeNull();
+    });
+
+    it("requires ONE shared concrete witness across all leaves for a concept floor", () => {
+      const ctx = trustCtx(signer.did());
+      const required = [concept(GPS_CONCEPT)];
+      // Same measurement in every leaf → coherent.
+      expect(cfcIntegritySatisfiesFloorCoherently(
+        [[gps("X")], [gps("X"), gps("Y")]],
+        required,
+        ctx,
+      )).toBe(true);
+      // Each leaf reaches the concept, but via DIFFERENT measurements →
+      // incoherent ("each part measured by some GPS" is not "the object
+      // measured by one GPS").
+      expect(cfcIntegritySatisfiesFloorCoherently(
+        [[gps("X")], [gps("Y")]],
+        required,
+        ctx,
+      )).toBe(false);
+      // A leaf reaching nothing fails outright.
+      expect(cfcIntegritySatisfiesFloorCoherently(
+        [[gps("X")], [unrelated]],
+        required,
+        ctx,
+      )).toBe(false);
+    });
+  });
+
+  describe("read-side gate integration (verifyInputRequirements)", () => {
+    const sourceSchema = (integrity: unknown[]) =>
+      ({
+        type: "string",
+        ifc: { confidentiality: ["s"], integrity },
+      }) as JSONSchema;
+
+    const runGate = async (
+      sources: unknown[][],
+      required: unknown,
+      trust?: CfcTrustConfigInput,
+    ): Promise<{ ok: boolean; message?: string }> => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        ...(trust ? { cfcTrustConfig: trust } : {}),
+      });
+      try {
+        for (const [index, integrity] of sources.entries()) {
+          const seed = runtime.edit();
+          runtime.getCell(
+            signer.did(),
+            `concept-src-${index}`,
+            sourceSchema(integrity),
+            seed,
+          ).set(`value-${index}`);
+          seed.prepareCfc();
+          expect((await seed.commit()).ok).toBeDefined();
+        }
+        const tx = runtime.edit();
+        for (const [index, integrity] of sources.entries()) {
+          runtime.getCell(
+            signer.did(),
+            `concept-src-${index}`,
+            sourceSchema(integrity),
+            tx,
+          ).get();
+        }
+        runtime.getCell(
+          signer.did(),
+          "concept-sink",
+          {
+            type: "object",
+            properties: {
+              out: { type: "string", ifc: { requiredIntegrity: [required] } },
+            },
+            required: ["out"],
+          } as JSONSchema,
+          tx,
+        ).set({ out: "derived" });
+        tx.prepareCfc();
+        const result = await tx.commit();
+        return {
+          ok: result.ok !== undefined,
+          message: (result.error as Error | undefined)?.message,
+        };
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    it("admits a concrete atom above the concept floor", async () => {
+      // RED before threading the trust context into the gate: the concept
+      // floor rejected the valid measurement and the commit failed.
+      const result = await runGate(
+        [[gps("X")]],
+        concept(GPS_CONCEPT),
+        trustInput(),
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects a concrete atom that is not above the concept", async () => {
+      const result = await runGate(
+        [[unrelated]],
+        concept(GPS_CONCEPT),
+        trustInput(),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("requiredIntegrity failed");
+    });
+
+    it("rejects a concept floor with no trust configured (fail closed)", async () => {
+      const result = await runGate([[gps("X")]], concept(GPS_CONCEPT));
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("requiredIntegrity failed");
+    });
+
+    it("rejects heterogeneous per-leaf witnesses for one concept requirement", async () => {
+      // Two reads each reach the concept, but via different measurements →
+      // concept coherence rejects, exactly like the concrete case.
+      const result = await runGate(
+        [[gps("X")], [gps("Y")]],
+        concept(GPS_CONCEPT),
+        trustInput(),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("requiredIntegrity failed");
+    });
+
+    it("still exact-matches a plain-atom floor with trust configured", async () => {
+      expect((await runGate([[APPROVED]], APPROVED, trustInput())).ok).toBe(
+        true,
+      );
+      expect((await runGate([[gps("X")]], APPROVED, trustInput())).ok).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("write-side floor integration (verifyWriteFloor)", () => {
+    const runWriteFloor = async (
+      addIntegrity: unknown[],
+      required: unknown,
+      trust?: CfcTrustConfigInput,
+    ): Promise<{ ok: boolean; message?: string }> => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        cfcWriteFloor: "enforce",
+        ...(trust ? { cfcTrustConfig: trust } : {}),
+      });
+      try {
+        const tx = runtime.edit();
+        runtime.getCell(
+          signer.did(),
+          "concept-write-sink",
+          {
+            type: "object",
+            properties: {
+              out: {
+                type: "string",
+                ifc: { requiredIntegrity: [required], addIntegrity },
+              },
+            },
+            required: ["out"],
+          } as JSONSchema,
+          tx,
+        ).set({ out: "written" });
+        tx.prepareCfc();
+        const result = await tx.commit();
+        return {
+          ok: result.ok !== undefined,
+          message: (result.error as Error | undefined)?.message,
+        };
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    it("passes when the minted concrete value is above the concept floor", async () => {
+      // RED before threading the trust context into the write floor: the
+      // minted GPSMeasurement did not satisfy the Concept floor.
+      const result = await runWriteFloor(
+        [gps("X")],
+        concept(GPS_CONCEPT),
+        trustInput(),
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects when the minted value is not above the concept floor", async () => {
+      const result = await runWriteFloor(
+        [unrelated],
+        concept(GPS_CONCEPT),
+        trustInput(),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("write floor failed");
+    });
+
+    it("rejects a concept write floor with no trust configured", async () => {
+      const result = await runWriteFloor([gps("X")], concept(GPS_CONCEPT));
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("write floor failed");
+    });
+  });
+
+  describe("tool-input floor integration (llm-dialog, Epic D2)", () => {
+    const KERNEL_CONCEPT_FLOOR = concept(GPS_CONCEPT);
+
+    async function setup(
+      cfcEnforcementMode: CfcEnforcementMode,
+      trust: CfcTrustConfigInput | undefined,
+    ) {
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode,
+        ...(trust ? { cfcTrustConfig: trust } : {}),
+      });
+      const tx = runtime.edit();
+      const { commonfabric } = createTrustedBuilder(runtime);
+      const { pattern, handler, Writable } = commonfabric;
+
+      const sendMailInputSchema = {
+        type: "object",
+        properties: {
+          recipient: {
+            type: "string",
+            ifc: { requiredIntegrity: [KERNEL_CONCEPT_FLOOR] },
+          },
+          body: { type: "string" },
+        },
+        required: ["recipient", "body"],
+        additionalProperties: false,
+      } as JSONSchema;
+
+      const sendMail = handler<
+        { recipient: string; body: string },
+        { emails: any }
+      >(
+        {
+          type: "object",
+          properties: {
+            recipient: { type: "string" },
+            body: { type: "string" },
+          },
+          required: ["recipient", "body"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            emails: {
+              type: "array",
+              items: { type: "object", additionalProperties: true },
+              asCell: ["cell"],
+            },
+          },
+          required: ["emails"],
+        },
+        ({ recipient, body }, { emails }) => {
+          emails.push({ recipient, body });
+        },
+      );
+
+      const resultSchema = {
+        type: "object",
+        properties: {
+          emails: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+          tools: true,
+        },
+        required: ["emails", "tools"],
+      } as const satisfies JSONSchema;
+
+      const testPattern = pattern(
+        () => {
+          const emails = Writable.of<{ recipient: string; body: string }[]>([]);
+          return {
+            emails,
+            tools: {
+              sendMail: {
+                description: "Send an email.",
+                inputSchema: sendMailInputSchema,
+                handler: sendMail({ emails }),
+              },
+            },
+          };
+        },
+        false,
+        resultSchema,
+      );
+
+      const resultCell = runtime.getCell(
+        space,
+        `concept-tool-${cfcEnforcementMode}-${trust ? "trust" : "notrust"}`,
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+
+      const catalog = llmToolExecutionHelpers.buildToolCatalog(
+        result.key("tools") as any,
+        false,
+      );
+
+      const sendCall = async (recipient: unknown) => {
+        await llmToolExecutionHelpers.executeToolCalls(
+          runtime,
+          space,
+          catalog,
+          [{
+            type: "tool-call",
+            toolCallId: "call-under-test",
+            toolName: "sendMail",
+            input: { recipient, body: "hi" },
+          }] as any,
+        );
+        await runtime.idle();
+      };
+
+      const sentRecipients = async () => {
+        const emails = (await result.key("emails").pull()) as
+          | { recipient: string }[]
+          | undefined;
+        return (emails ?? []).map((e) => e.recipient);
+      };
+
+      // Seed a value whose stored label carries a concrete measurement atom,
+      // returned as the by-reference form the model would pass.
+      const seedConcreteRecipient = async (name: string, value: string) => {
+        const seedTx = runtime.edit();
+        const cell = runtime.getCell(
+          space,
+          name,
+          {
+            type: "string",
+            ifc: { integrity: [gps("X")] },
+          } as const satisfies JSONSchema,
+          seedTx,
+        );
+        cell.set(value);
+        seedTx.prepareCfc();
+        expect((await seedTx.commit()).ok).toBeDefined();
+        await runtime.idle();
+        // Premise: the concrete atom really landed on the stored label.
+        const readTx = runtime.edit();
+        const view = cfcLabelViewForCell(
+          runtime.getCell(
+            space,
+            name,
+            { type: "string" } as JSONSchema,
+            readTx,
+          ),
+        );
+        expect(
+          (view?.entries ?? []).flatMap((e) => e.label.integrity ?? []),
+        ).toContainEqual(gps("X"));
+        readTx.commit();
+        return {
+          "@link": createLLMFriendlyLink(cell.getAsNormalizedFullLink(), space),
+        };
+      };
+
+      const dispose = async () => {
+        await runtime.dispose();
+        await storageManager.close();
+      };
+
+      return { sendCall, sentRecipients, seedConcreteRecipient, dispose };
+    }
+
+    it("allows a by-reference recipient whose concrete atom is above the concept floor", async () => {
+      // RED before threading the trust context into the tool-input gate: the
+      // concept floor rejected the referenced concrete measurement.
+      const t = await setup("enforce-explicit", trustInput());
+      try {
+        const ref = await t.seedConcreteRecipient(
+          "concept-ok",
+          "john@example.org",
+        );
+        await t.sendCall(ref);
+        expect(await t.sentRecipients()).toEqual(["john@example.org"]);
+      } finally {
+        await t.dispose();
+      }
+    });
+
+    it("refuses a plain-literal recipient against a concept floor", async () => {
+      const t = await setup("enforce-explicit", trustInput());
+      try {
+        await t.sendCall("bob@evil.org");
+        expect(await t.sentRecipients()).toEqual([]);
+      } finally {
+        await t.dispose();
+      }
+    });
+
+    it("refuses a concept floor when no trust is configured (fail closed)", async () => {
+      const t = await setup("enforce-explicit", undefined);
+      try {
+        const ref = await t.seedConcreteRecipient(
+          "concept-notrust",
+          "john@example.org",
+        );
+        await t.sendCall(ref);
+        expect(await t.sentRecipients()).toEqual([]);
+      } finally {
+        await t.dispose();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Epic D5 — concept-level integrity floors via trust closure

Swaps exact-match integrity-floor membership for **pattern + concept matching**, so a
floor like *"minted by a valid GPS measurement"* accepts any concrete atom that sits
above the concept in the **acting user's trust closure** — not just a byte-identical atom.

Ground truth: spec §4.8.9 (user-scoped trust closure) and invariant 11 (concrete
integrity is portable; concept satisfaction is acting-principal-scoped). Plan
`docs/plans/cfc-future-work-implementation.md` §5, Epic D5.

### The one place that changed

The upgrade lands in the **single shared predicate** `cfcIntegritySatisfiesFloor`
(`packages/runner/src/cfc/observation.ts`), deliberately extracted by D3 (#4479) as
THE predicate for all three floor consumers — no per-consumer forks:

- read-side gate — `verifyInputRequirements` (via the coherent form)
- write-side floor — `verifyWriteFloor` (dial `cfcWriteFloor`)
- D2 tool-input floor — `toolInputRequiredIntegrityFailure` (llm-dialog)

`integrityAtomSatisfies` now branches on `conceptGuard(required)` (shared out of
exchange-eval into `atom-pattern.ts`):

- **concept-valued requirement** → satisfied iff a carried **concrete** atom reaches the
  concept in the acting principal's closure (`TrustResolver.conceptSatisfied`). Evaluated
  **per single atom**: `conceptSatisfied` over a set is the ∃-over-atoms disjunction, and
  concept edges form a graph whose reachability from a set is the union of per-atom
  reachability — so per-atom evaluation gives the same answer *and* names WHICH concrete
  atom is the witness, keeping the coherence/witness-key machinery well-defined. A concept
  requirement is **never** pool-matched as literal data, and fails closed on a malformed
  concept shape or an absent resolver.
- **plain atom / pattern** → unchanged `matchAtomPattern` + `atomEntails` (B5). Exact
  structural equality remains the degenerate case, so concrete floors keep their meaning.

The trust context (`{ trustResolver, actingPrincipal }`) is threaded through all three
call sites from the tx CFC state / runtime. It is **optional** everywhere: pre-D5 callers
and every plain-atom floor are byte-for-byte unchanged (concept requirements just fail
closed without it). Concept-floor decisions are already covered by the prepared digest via
`TrustSnapshot.revision` (which folds the trust-config digest) — no new digest work.

### Coordination with B5

B5 (#4566) already upgraded the same predicate to `matchAtomPattern` + `atomEntails` at
the boundary (the consume-side twin). D5 adds the `conceptSatisfied` concept layer **on
top**, in the same predicate — not a duplicate.

### Tests (red-first, per consumer)

New `packages/runner/test/cfc-concept-floor.test.ts` (27 steps):

- **shared predicate** — concept accepts an above-the-concept concrete atom; below/unrelated
  fails; inv-11 acting-principal scoping; fail-closed with no resolver/config; malformed
  concept shape never satisfied; a literal `Concept` atom is never pool-matched; transitive
  over concept edges; plain-atom byte-compat preserved; concept ∧ plain conjunction.
- **coherence + witness key** — a concept witness is keyed by the concrete atom that reaches
  it; one shared concrete witness is required across all consumed leaves (heterogeneous
  per-leaf witnesses fail).
- **per-consumer integration** — read-side gate, write-side floor, and D2 tool-input floor
  each get: admits above-concept / rejects below / fails closed with no trust / plain-atom
  floor still exact-matches.

Full runner suite green (794 passed / 0 failed); `deno check` clean on all three modified
modules. Merged `origin/main` (D4 #4555 restructured `verifyInputRequirements` to a
per-write prefix `gating` set — the trust context rides that change cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds concept-level integrity floors: a `Concept` requirement is satisfied by any carried concrete atom that reaches the concept in the acting user’s trust closure, enforced consistently across read, write, and tool-input gates via a single predicate. Adds defense-in-depth to fail closed on `Concept`-typed carried atoms and Concept-shaped arrays.

- **New Features**
  - Upgraded `cfcIntegritySatisfiesFloor` to handle `Concept` requirements via `conceptGuard` and `TrustResolver.conceptSatisfied`, scoped to `actingPrincipal`; evaluated per atom and never pool-matches a literal `Concept`.
  - Threaded `CfcFloorTrustContext` through `verifyInputRequirements`, `verifyWriteFloor`, and the tool-input gate in `llm-dialog.ts` (via `createTrustResolver`); context is optional so plain floors and legacy callers remain unchanged.
  - Coherence: the witness key for a concept requirement is the concrete atom that reaches it, and all consumed leaves must share the same witness; supports transitive concept edges; malformed `{ type: Concept, uri }` shapes and missing trust fail closed.
  - Added `packages/runner/test/cfc-concept-floor.test.ts` covering the predicate, coherence, and per-consumer integration.

- **Bug Fixes**
  - `conceptGuard` now excludes arrays; only the canonical object shape `{ type, uri }` is recognized as a concept guard.
  - `integrityAtomSatisfies` rejects `Concept`-typed carried atoms before consulting the resolver, preventing misconfigured trust statements from satisfying concept floors via a literal `Concept`.

<sup>Written for commit 7a28e38c1b8b7da456c0d2bf31d6183cf4c1b841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

