### PR TITLE
test(cfc): guard the B5×D4 enforcement seam (empty-gating skip + prefix-narrowed witness)

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3880,7 +3880,7 @@ export const prepareBoundaryCommit = (
   // attempt log, built once for the whole boundary pass. Each protected
   // write's input checks quantify over the reads in ITS prefix (see
   // verifyInputRequirements); the egress ceiling deliberately does not
-  // (collectConsumedConfidentiality stays transaction-global).
+  // (collectConsumedLabel stays transaction-global).
   const prefixBounds = buildWritePrefixBounds(tx);
   // A write to a document's ["cfc"] label-map path made outside the runtime's
   // privileged persistence scope forges the metadata that drives CFC derivation

--- a/packages/runner/test/cfc-policy-boundary.test.ts
+++ b/packages/runner/test/cfc-policy-boundary.test.ts
@@ -374,6 +374,34 @@ describe("CFC policy evaluation at boundaries (B5)", () => {
       return result;
     };
 
+    // The B5×D4 seam: identical to readThenWrite but with the ORDER inverted —
+    // write the ceiling-protected path FIRST, then read the confidential cell.
+    // The read's activity-clock position is now at/after the write's D4 bound
+    // (the last write attempt overlapping /out), so it is excluded from the
+    // write's read prefix. `maxConfidentiality` quantifies over that prefix
+    // (`gating`), which is empty, so the ceiling check is SKIPPED — a read that
+    // cannot have fed the committed value is not a consumed input here. With
+    // the pre-D4 transaction-global quantification this same read would sit in
+    // the gate and reject.
+    const writeThenRead = (
+      runtime: Runtime,
+      id: string,
+    ): { reasons: readonly string[]; diagnostics: readonly string[] } => {
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), `${id}-sink`, sinkSchema, tx)
+        .set({ out: "derived" });
+      const cell = runtime.getCell(signer.did(), id, SECRET_SCHEMA.schema, tx);
+      expect(cell.key("secret").get()).toBe("rosebud");
+      tx.prepareCfc();
+      const state = tx.getCfcState();
+      const reasons = state.prepare.status === "invalidated"
+        ? [...state.prepare.reasons]
+        : [];
+      const result = { reasons, diagnostics: [...state.diagnostics] };
+      tx.abort();
+      return result;
+    };
+
     it("off: rejects on the raw label", async () => {
       await withRuntime(
         { policyEvaluation: "off", policyRecords: unguardedPolicy },
@@ -420,6 +448,31 @@ describe("CFC policy evaluation at boundaries (B5)", () => {
               reason.includes("maxConfidentiality failed")
             ),
           ).toBe(true);
+        },
+      );
+    });
+
+    it("enforce: an empty gating prefix skips the ceiling (write-first read excluded by bound)", async () => {
+      // The D4 seam guard, dual to input-boundary-guarded above: SAME runtime
+      // (enforce, network-guarded POLICY that cannot rewrite [Space] at a
+      // write gate) and SAME confidential input, but the read now lands AFTER
+      // the protected write. It is therefore past the write's D4 bound and
+      // drops out of `gating`; with an empty gating set the `maxConfidentiality`
+      // check is skipped entirely and the write commits — even though [Space]
+      // is outside the [User(alice)] ceiling. This is intended delegation, not
+      // a hole: a read that could not have fed the value is not a consumed
+      // input. Flipping the gate's quantification back to the transaction-
+      // global consumed set re-admits this read and re-rejects (verified in
+      // the PR); the admission here is the regression guard for the skip.
+      await withRuntime(
+        { policyEvaluation: "enforce" }, // POLICY requires sinkClass network
+        async (runtime) => {
+          await seedSpaceLabeledCell(runtime, "input-empty-gating", {
+            confidentiality: [SPACE_ATOM],
+            integrity: [ROLE_ALICE],
+          });
+          const { reasons } = writeThenRead(runtime, "input-empty-gating");
+          expect(reasons).toEqual([]);
         },
       );
     });

--- a/packages/runner/test/cfc-required-integrity-coherence.test.ts
+++ b/packages/runner/test/cfc-required-integrity-coherence.test.ts
@@ -211,4 +211,116 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
       expect(result.message).toContain("requiredIntegrity failed");
     });
   });
+
+  // Epic D4 (docs/specs/cfc-write-prefix-provenance.md): the coherent floor
+  // quantifies over each write's READ PREFIX, not the transaction-global
+  // consumed set. A labeled read whose activity-clock position is at/after the
+  // last write attempt overlapping the protected path provably did not feed
+  // the committed value, so it is excluded from the witness set the floor is
+  // judged over. The read-side integration tests above keep BOTH reads in the
+  // prefix (they read then write), so they never exercise the prefix's effect
+  // on witness coverage; these do, by interleaving a read past the write.
+  describe("D4 read-prefix narrows the coherent-witness set", () => {
+    const sourceSchema = (id: string) =>
+      ({
+        type: "string",
+        ifc: {
+          confidentiality: ["s"],
+          integrity: [reviewedBy(id)],
+        },
+      }) as JSONSchema;
+
+    const sinkSchema = {
+      type: "object",
+      properties: {
+        out: {
+          type: "string",
+          ifc: { requiredIntegrity: [{ type: REVIEWED }] },
+        },
+      },
+      required: ["out"],
+    } as JSONSchema;
+
+    // Seed two labeled sources (witnesses A and B), then run one tx that reads
+    // A, WRITES the floored sink, and reads B. When `readBAfterWrite`, read B's
+    // clock position lands past the sink write's bound, so D4 drops it from
+    // /out's read prefix — the floor sees only leaf {A}. Otherwise both reads
+    // precede the write and both are in the prefix (the pre-D4 shape).
+    const runInterleaved = async (
+      witnessA: string,
+      witnessB: string,
+      readBAfterWrite: boolean,
+    ): Promise<{ ok: boolean; message?: string }> => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+      });
+      try {
+        for (const [index, witness] of [witnessA, witnessB].entries()) {
+          const seed = runtime.edit();
+          runtime.getCell(
+            signer.did(),
+            `prefix-src-${index}`,
+            sourceSchema(witness),
+            seed,
+          ).set(`value-${index}`);
+          seed.prepareCfc();
+          expect((await seed.commit()).ok).toBeDefined();
+        }
+
+        const tx = runtime.edit();
+        const readB = () =>
+          runtime.getCell(
+            signer.did(),
+            "prefix-src-1",
+            sourceSchema(witnessB),
+            tx,
+          ).get();
+        runtime.getCell(
+          signer.did(),
+          "prefix-src-0",
+          sourceSchema(witnessA),
+          tx,
+        )
+          .get();
+        if (!readBAfterWrite) readB();
+        runtime.getCell(signer.did(), "prefix-coherence-sink", sinkSchema, tx)
+          .set({ out: "derived" });
+        if (readBAfterWrite) readB();
+        tx.prepareCfc();
+        const result = await tx.commit();
+        return {
+          ok: result.ok !== undefined,
+          message: (result.error as Error | undefined)?.message,
+        };
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    it("admits a heterogeneous witness pair when the second read is past the write bound", async () => {
+      // r1 and r2 both match { type: REVIEWED } but via DIFFERENT atoms — the
+      // exact shape the coherence upgrade REJECTS when both reads are in the
+      // prefix (control below). Here read B (r2) lands after the sink write, so
+      // D4 excludes it: the floor is judged over the in-prefix leaf {r1} alone,
+      // a single coherent witness, and the write commits. The excluded read is
+      // neither demanded (its heterogeneity no longer forces a failure) nor
+      // counted as a satisfying witness.
+      const result = await runInterleaved("r1", "r2", true);
+      expect(result.ok).toBe(true);
+    });
+
+    it("control: the same heterogeneous pair rejects when both reads precede the write", async () => {
+      // Identical witnesses and sink, but read B stays in the prefix — so the
+      // floor sees leaves {r1},{r2} with no shared witness and rejects. This
+      // pins the admission above to the prefix narrowing, not to any change in
+      // witness matching.
+      const result = await runInterleaved("r1", "r2", false);
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("requiredIntegrity failed");
+    });
+  });
 });


### PR DESCRIPTION
Follow-up hardening from PR #4555 (Epic D4 "per-write read-prefix provenance", merged as `067388d16`). An adversarial review confirmed the B5×D4 reconciliation in `packages/runner/src/cfc/prepare.ts` (`verifyInputRequirements`) is **sound**, but flagged two untested paths at the new seam plus one stale comment. **These lock in already-correct behavior — no production behavior changes** (one comment word aside).

## The seam

`verifyInputRequirements`'s Epic-B5 enforcement — the coherent `requiredIntegrity` floor (`cfcIntegritySatisfiesFloorCoherently`) and the `maxConfidentiality` ceiling — now quantifies over D4's per-write prefix `gating` set (reads with `journalIndex < bound` for the protected path) instead of the transaction-global `gatedReads`. When `gating` is empty, **both** the floor and ceiling checks are skipped. This is sound: a read at/after the last overlapping value-write provably cannot have fed the committed value.

The existing tests never exercise the empty-`gating` path — their helpers always read *before* writing, so the read is always in-prefix.

## Changes

1. **`cfc-policy-boundary.test.ts` — empty-`gating` ceiling skip under enforce.** New `writeThenRead` helper (inverse of `readThenWrite`) writes the ceiling-protected `/out` first, then reads the confidential `[Space]` cell, so its `journalIndex >= bound` and it drops out of `gating`. Asserts the commit **admits** under `maxConfidentiality` enforce even though `[Space]` is outside the `[User(alice)]` ceiling — confirming the skip is intended delegation, not a hole. Dual to the existing read-first `input-boundary-guarded` reject test (same runtime/config), which doubles as the regression control.

2. **`cfc-required-integrity-coherence.test.ts` — D4 prefix narrows the coherent-witness set.** New `D4 read-prefix narrows the coherent-witness set` describe: a heterogeneous integrity witness read pushed **past** the write bound is excluded, so the floor is judged over the in-prefix leaf alone (single coherent witness) and **admits** — the excluded read neither satisfies nor is demanded. A companion **control** asserts the same `r1`/`r2` pair **rejects** when both reads precede the write, pinning the admission to the prefix narrowing.

3. **`prepare.ts` — cosmetic.** Fix the stale comment at ~line 3883: `collectConsumedConfidentiality` → `collectConsumedLabel` (the helper's current name).

## Verification

- Relevant runner CFC suites green: `cfc-write-prefix-provenance`, `cfc-policy-boundary`, `cfc-required-integrity-coherence`, `cfc-writer-fit`.
- **Regression-checked empirically**: temporarily reverting the gate to the transaction-global quantification (dropping `read.journalIndex < bound`) flips **both** admit-guards to reject (`maxConfidentiality failed` / `requiredIntegrity failed`) while the control stays reject; restored afterward.
- `deno fmt` / `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds targeted tests to harden the B5×D4 seam in CFC enforcement. Confirms empty per-write `gating` correctly skips `maxConfidentiality` and that D4 read-prefix narrowing affects `requiredIntegrity` witnesses; no runtime behavior changes.

- New Tests
  - `packages/runner/test/cfc-policy-boundary.test.ts`: write-then-read path shows empty `gating` skips the ceiling under enforce; read-first control still rejects.
  - `packages/runner/test/cfc-required-integrity-coherence.test.ts`: interleaved reads exclude the post-bound witness, admitting on a single coherent leaf; control rejects when both reads precede the write.

- Refactors
  - `packages/runner/src/cfc/prepare.ts`: fix stale comment name (`collectConsumedConfidentiality` → `collectConsumedLabel`).

<sup>Written for commit fb9c21fa3561d53647edd178f7a8795c5db3a4aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

