### PR TITLE
fix(runner): freeze data:-URI reads + identity-stable parse cache (CT-1840, PR-A)

### DIFF
--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -397,10 +397,57 @@ function feedPlainObject(
 //
 
 /**
+ * Instrumentation counters for hash computation (CT-1840 benchmark support).
+ *
+ * `computeHashCalls` counts full (cache-missing) hash computations and is
+ * always on (a single integer increment). `bytesFed` measures the raw bytes
+ * fed through the hasher — the quantity the CT-1840 work drives down — but
+ * requires wrapping the hasher, so it is only collected when `enabled` is
+ * set (via `CF_HASH_STATS=1` or directly by tests/benchmarks).
+ */
+export const hashStats = {
+  enabled: (() => {
+    try {
+      return typeof Deno !== "undefined" &&
+        typeof Deno.env?.get === "function" &&
+        Deno.env.get("CF_HASH_STATS") === "1";
+    } catch {
+      return false;
+    }
+  })(),
+  computeHashCalls: 0,
+  bytesFed: 0,
+};
+
+/** Test/benchmark hook: zero the hash instrumentation counters. */
+export function resetHashStats(): void {
+  hashStats.computeHashCalls = 0;
+  hashStats.bytesFed = 0;
+}
+
+/** Wraps a hasher so every fed byte is counted in `hashStats.bytesFed`. */
+function instrumentedHasher(hasher: IncrementalHasher): IncrementalHasher {
+  return {
+    update(data: Uint8Array): void {
+      hashStats.bytesFed += data.length;
+      hasher.update(data);
+    },
+    digest: hasher.digest.bind(hasher) as IncrementalHasher["digest"],
+  };
+}
+
+/** Creates a hasher, instrumented when `hashStats.enabled` is set. */
+function createMeasuredHasher(): IncrementalHasher {
+  hashStats.computeHashCalls++;
+  const hasher = createHasher();
+  return hashStats.enabled ? instrumentedHasher(hasher) : hasher;
+}
+
+/**
  * Computes the hash of a value without consulting or populating any cache.
  */
 function computeHash(value: unknown): FabricHash {
-  const hasher = createHasher();
+  const hasher = createMeasuredHasher();
   feedValue(hasher, value);
   return new FabricHash(hasher.digest(), "fid1");
 }
@@ -410,7 +457,7 @@ function computeHash(value: unknown): FabricHash {
  * as `base64url`, rather than a hash object.
  */
 function computeHashAsString(value: unknown): string {
-  const hasher = createHasher();
+  const hasher = createMeasuredHasher();
   feedValue(hasher, value);
   return hasher.digest("base64url");
 }

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -1361,3 +1361,39 @@ describe("value-hash", () => {
     });
   });
 });
+
+describe("hashStats instrumentation (CT-1840)", () => {
+  it("counts compute calls, and bytes fed when enabled", async () => {
+    const { hashStats, resetHashStats } = await import("@/value-hash.ts");
+    const wasEnabled = hashStats.enabled;
+    try {
+      hashStats.enabled = true;
+      resetHashStats();
+      // Fresh mutable object: bypasses the frozen-object identity cache, so
+      // a full computation must run.
+      hashOf({ a: 1, b: "two" } as FabricValue);
+      expect(hashStats.computeHashCalls).toBeGreaterThan(0);
+      expect(hashStats.bytesFed).toBeGreaterThan(0);
+
+      const callsAfterFirst = hashStats.computeHashCalls;
+      const bytesAfterFirst = hashStats.bytesFed;
+      hashOf({ a: 1, b: "two" } as FabricValue);
+      // Another fresh mutable object: recomputed (not identity-cached).
+      expect(hashStats.computeHashCalls).toBeGreaterThan(callsAfterFirst);
+      expect(hashStats.bytesFed).toBeGreaterThan(bytesAfterFirst);
+
+      resetHashStats();
+      expect(hashStats.computeHashCalls).toBe(0);
+      expect(hashStats.bytesFed).toBe(0);
+
+      // Disabled: calls still counted, bytes not.
+      hashStats.enabled = false;
+      hashOf({ c: 3 } as FabricValue);
+      expect(hashStats.computeHashCalls).toBeGreaterThan(0);
+      expect(hashStats.bytesFed).toBe(0);
+    } finally {
+      hashStats.enabled = wasEnabled;
+      resetHashStats();
+    }
+  });
+});

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -34,6 +34,7 @@ import {
 import { type Cell, createCell, isCell } from "./cell.ts";
 import { type Action } from "./scheduler.ts";
 import { RetryImmediately } from "./scheduler/retry-immediately.ts";
+import { noteDependencyArm } from "./scheduler/dependency-arm-stats.ts";
 import {
   findAllWriteRedirectCells,
   unwrapOneLevelAndBindtoDoc,
@@ -3368,6 +3369,7 @@ export class Runner {
       : reads;
     const populateDependencies = reads.length > 0
       ? (depTx: IExtendedStorageTransaction, event: any) => {
+        noteDependencyArm("handlerDeclaredReads");
         this.populateDeclaredSchedulerReads(declaredSchedulerReads, depTx);
         this.populateHandlerEventSchedulerReads(
           module.argumentSchema,
@@ -3378,6 +3380,7 @@ export class Runner {
       }
       : module.argumentSchema
       ? (depTx: IExtendedStorageTransaction, event: any) => {
+        noteDependencyArm("handlerArgumentSchema");
         const eventInputs = {
           ...(inputs as Record<string, any>),
           $event: event,
@@ -3679,8 +3682,10 @@ export class Runner {
       logger.timeStart("action", "populateDependencies");
       try {
         if (reads.length > 0) {
+          noteDependencyArm("actionDeclaredReads");
           this.populateDeclaredSchedulerReads(reads, depTx);
         } else if (module.argumentSchema !== undefined) {
+          noteDependencyArm("actionArgumentSchema");
           const inputsCell = this.runtime.getImmutableCell(
             processCell.space,
             inputs,
@@ -4123,6 +4128,7 @@ export class Runner {
       try {
         // Capture read dependencies - use custom if provided, otherwise read all inputs
         if (builtinPopulateDependencies) {
+          noteDependencyArm("builtinCustom");
           if (typeof builtinPopulateDependencies === "function") {
             builtinPopulateDependencies(depTx);
           } else {
@@ -4133,6 +4139,7 @@ export class Runner {
           }
         } else {
           // Default: read all inputs
+          noteDependencyArm("builtinReadAllInputs");
           for (const input of inputCells) {
             this.runtime.getCellFromLink(input, undefined, depTx)?.get();
           }

--- a/packages/runner/src/scheduler/dependency-arm-stats.ts
+++ b/packages/runner/src/scheduler/dependency-arm-stats.ts
@@ -1,0 +1,62 @@
+import { getLogger } from "@commonfabric/utils/logger";
+
+const logger = getLogger("dependency-arm-stats", {
+  enabled: false,
+  level: "debug",
+});
+
+/**
+ * Dependency-collection arm accounting (CT-1840, critique F7).
+ *
+ * The CT-1840 fix bets that the `argumentSchema`-driven collection arm —
+ * which roots every traversal at a content-addressed `data:` URI cell and is
+ * therefore the beneficiary of frozen, identity-stable parse results —
+ * dominates dependency collection in production, versus the declared-reads
+ * arm (which never touches `getImmutableCell`). These counters make that
+ * attribution measurable instead of assumed: read them from a profile
+ * session (or the periodic debug log) to confirm which arm the workload
+ * actually exercises before crediting (or blaming) the freeze work.
+ *
+ * Counting is a single integer increment per collection — cheap enough to
+ * stay unconditionally on.
+ */
+export const dependencyArmStats = {
+  /** Action collections that used declared scheduler reads. */
+  actionDeclaredReads: 0,
+  /** Action collections that traversed the argument schema (data:-rooted). */
+  actionArgumentSchema: 0,
+  /** Event-handler collections that used declared scheduler reads. */
+  handlerDeclaredReads: 0,
+  /** Event-handler collections that traversed the argument schema. */
+  handlerArgumentSchema: 0,
+  /** Raw/builtin collections with a builtin-provided populate/log. */
+  builtinCustom: 0,
+  /** Raw/builtin collections that read all input cells. */
+  builtinReadAllInputs: 0,
+};
+
+export type DependencyArm = keyof typeof dependencyArmStats;
+
+/** Log a summary line every N collections (debug-gated, lazy). */
+const LOG_EVERY = 1000;
+let sinceLastLog = 0;
+
+/** Records one dependency collection through the given arm. */
+export function noteDependencyArm(arm: DependencyArm): void {
+  dependencyArmStats[arm]++;
+  if (++sinceLastLog >= LOG_EVERY) {
+    sinceLastLog = 0;
+    logger.debug("dependency-arms", () => [
+      "dependency-collection arm totals",
+      { ...dependencyArmStats },
+    ]);
+  }
+}
+
+/** Test/benchmark hook: zero all counters. */
+export function resetDependencyArmStats(): void {
+  for (const key of Object.keys(dependencyArmStats)) {
+    dependencyArmStats[key as DependencyArm] = 0;
+  }
+  sinceLastLog = 0;
+}

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -21,7 +21,8 @@ import type {
 } from "../interface.ts";
 import { unclaimed } from "@commonfabric/memory/fact";
 import { getLogger } from "@commonfabric/utils/logger";
-import { LRUCache } from "@commonfabric/utils/cache";
+import { WeightedLRUCache } from "@commonfabric/utils/cache";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { toTransactionDocumentValue } from "../v2-document.ts";
 
 const logger = getLogger("attestation", {
@@ -33,14 +34,52 @@ const cacheHitLogger = getLogger("attestation-hit", {
   enabled: false,
   level: "debug",
 });
+
+type LoadResult = Result<
+  IAttestation,
+  IInvalidDataURIError | IUnsupportedMediaTypeError
+>;
+
 /**
- * Cache for parsed data URIs to avoid redundant parsing.
- * Key format: `${address.id}::${address.type}`
+ * Cache for parsed data URIs, keyed by `address.id` (the id IS the content —
+ * `data:` URIs are content-addressed, so no other key component is needed).
+ *
+ * Identity stability is load-bearing here (CT-1840): every identity-keyed
+ * cache downstream — `frozenObjectHashCache`, `_schemaAtPathCache`, the
+ * schema seam memos — hangs off the object identity of the parse result. If
+ * this cache hands out a fresh parse for an id it has seen before, every one
+ * of those caches misses and the runner re-hashes/re-traverses the value
+ * from scratch. The previous 1000-ENTRY LRU did exactly that under >1000
+ * distinct data: URIs (Loom-scale workloads carry ~10k), cycling on every
+ * pass. Two layers fix it:
+ *
+ * - `dataURIRetention`: strong, byte-budgeted LRU (weight = id length, which
+ *   bounds the parse-result size too since the id embeds the content).
+ *   Retention proportional to memory, not entry count.
+ * - `dataURIInterns`: `Map<string, WeakRef>` + `FinalizationRegistry`
+ *   (precedent: schema interning in data-model/schema-hash.ts). Guarantees
+ *   that as long as a previously returned result is alive ANYWHERE, `load`
+ *   returns that same object — even after retention eviction. When nothing
+ *   references the result, the entry is collected and a later re-parse is
+ *   harmless: the downstream weak caches keyed on the dead identity are gone
+ *   too.
  */
-const dataURICache = new LRUCache<
-  string,
-  Result<IAttestation, IInvalidDataURIError | IUnsupportedMediaTypeError>
->({ capacity: 1000 });
+const DATA_URI_RETENTION_MAX_BYTES = 128 * 1024 * 1024;
+
+const dataURIRetention = new WeightedLRUCache<string, LoadResult>({
+  maxWeight: DATA_URI_RETENTION_MAX_BYTES,
+});
+
+const dataURIInterns = new Map<string, WeakRef<LoadResult>>();
+
+const dataURIFinalizer = new FinalizationRegistry<string>((id) => {
+  const ref = dataURIInterns.get(id);
+  // Guard against a NEWER result having been interned under the same id
+  // after the finalized one died: only delete if the ref is actually dead.
+  if (ref !== undefined && ref.deref() === undefined) {
+    dataURIInterns.delete(id);
+  }
+});
 
 export const InvalidDataURIError = (
   message: string,
@@ -225,17 +264,35 @@ export const resolve = (
 /**
  * Loads an attestation from a data URI address. Parses the data URI content
  * and returns an attestation with the parsed value.
- * Results are cached to avoid redundant parsing of the same data URIs.
+ *
+ * Results are cached to avoid redundant parsing, and the cache is
+ * identity-stable: repeated loads of the same id return the SAME result
+ * object (see the cache commentary above). The parsed value is deep-frozen —
+ * `data:` URIs are content-addressed, the id IS the content, so the value is
+ * immutable by definition; freezing both hardens the shared cache result
+ * against in-place mutation and lets the value pass the frozen-only gates on
+ * the identity-keyed schema/hash memos downstream (CT-1840).
  */
 export const load = (
   address: Omit<IMemoryAddress, "path">,
 ): Result<IAttestation, IInvalidDataURIError | IUnsupportedMediaTypeError> => {
-  // Check cache first
   const cacheKey = address.id;
-  const cached = dataURICache.get(cacheKey);
+
+  // Strong retention layer first (bumps recency).
+  const cached = dataURIRetention.get(cacheKey);
   if (cached) {
     cacheHitLogger.debug("cache-hit", "found cached result");
     return cached;
+  }
+
+  // Intern layer: a result evicted from retention but still referenced
+  // elsewhere MUST keep its identity. Re-admit it to retention on the way
+  // out (it is evidently hot again).
+  const interned = dataURIInterns.get(cacheKey)?.deref();
+  if (interned) {
+    cacheHitLogger.debug("cache-hit", "found interned result");
+    dataURIRetention.put(cacheKey, interned, cacheKey.length);
+    return interned;
   }
 
   logger.debug("storage-datauri-parse", () => ["Parsing data URI"]);
@@ -276,7 +333,7 @@ export const load = (
         if (mediaType === "application/json") {
           let value: FabricValue;
           try {
-            value = JSON.parse(content);
+            value = deepFreeze(JSON.parse(content));
             result = { ok: { address: { ...address, path: [] }, value } };
           } catch (error) {
             const reason = error as Error;
@@ -304,7 +361,9 @@ export const load = (
     };
   }
 
-  dataURICache.put(cacheKey, result);
+  dataURIRetention.put(cacheKey, result, cacheKey.length);
+  dataURIInterns.set(cacheKey, new WeakRef(result));
+  dataURIFinalizer.register(result, cacheKey);
 
   return result;
 };

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -34,7 +34,59 @@ import {
 } from "./attestation.ts";
 import { applyMutablePathWrite } from "./mutable-path-write.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import * as Edit from "./edit.ts";
+
+/**
+ * Debug-only invariant assertion (CT-1840): storage-sourced read results —
+ * `data:` URI parses and replica-backed attestations — must be deep-frozen.
+ * The frozen-only gates on the identity-keyed schema/hash memos depend on
+ * it; an unfrozen value silently bypasses every one of them and the runner
+ * re-hashes/re-traverses the value on each touch. Enable via
+ * `CF_ASSERT_FROZEN_READS=1` so the invariant can't rot unnoticed.
+ *
+ * Deliberately NOT applied to novelty-backed (working copy) reads: the
+ * working copy is mutable by design within a transaction.
+ */
+const ASSERT_FROZEN_READS_ENV: boolean = (() => {
+  try {
+    return typeof Deno !== "undefined" &&
+      typeof Deno.env?.get === "function" &&
+      Deno.env.get("CF_ASSERT_FROZEN_READS") === "1";
+  } catch {
+    return false;
+  }
+})();
+
+let assertFrozenReads = ASSERT_FROZEN_READS_ENV;
+
+/**
+ * Test hook: override (or restore, with `undefined`) the
+ * `CF_ASSERT_FROZEN_READS` debug assertion, which is otherwise fixed at
+ * module load.
+ */
+export const setAssertFrozenReadsForTesting = (
+  value: boolean | undefined,
+): void => {
+  assertFrozenReads = value ?? ASSERT_FROZEN_READS_ENV;
+};
+
+const assertFrozenReadValue = (
+  attestation: IAttestation | undefined,
+): void => {
+  if (!assertFrozenReads || attestation === undefined) {
+    return;
+  }
+  if (!isDeepFrozen(attestation.value)) {
+    throw new Error(
+      `CF_ASSERT_FROZEN_READS: storage read returned a value that is not ` +
+        `deep-frozen: ${attestation.address.id} (type ` +
+        `${attestation.address.type}, path [${
+          attestation.address.path.join(", ")
+        }])`,
+    );
+  }
+};
 
 /**
  * Mutating-write wrapper around `applyMutablePathWrite()` that mirrors
@@ -270,6 +322,7 @@ export class Chronicle {
       if (error) {
         return { error };
       } else {
+        assertFrozenReadValue(attestation);
         return read(attestation, address);
       }
     }
@@ -289,6 +342,9 @@ export class Chronicle {
     }
 
     const loaded = attest(state);
+    // Replica-backed values must arrive deep-frozen (materialization and
+    // confirmed-ingest both freeze); novelty overlays below are exempt.
+    assertFrozenReadValue(loaded);
     const { error, ok: invariant } = read(loaded, address);
     if (error) {
       // If the read failed because of path errors, this is still effectively a

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -53,6 +53,7 @@ import type { Cell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
 import {
@@ -2398,9 +2399,15 @@ class SpaceReplica implements ISpaceReplica {
       if (upsert.seq < record.confirmed.seq) {
         continue;
       }
+      // Deep-freeze at confirmed-ingest (CT-1840): wire-decoded docs are
+      // already deep-frozen at the codec boundary (JsonEncodingContext), so
+      // this is an O(1) WeakSet check there; it only pays on providers that
+      // hand over locally-constructed docs. Frozen confirmed values are what
+      // let embedded link schemas pass the frozen-only gates on the
+      // identity-keyed schema/hash memos downstream.
       record.confirmed = confirmedVersion(
         upsert.seq,
-        upsert.deleted === true ? undefined : upsert.doc,
+        upsert.deleted === true ? undefined : deepFreeze(upsert.doc),
       );
       record.materialized = undefined;
       this.#watchedIds.add(docKey(upsert.id as URI, upsert.scope));

--- a/packages/runner/test/dependency-arm-stats.test.ts
+++ b/packages/runner/test/dependency-arm-stats.test.ts
@@ -1,0 +1,41 @@
+/**
+ * CT-1840 (critique F7): the dependency-collection arm counters exist so the
+ * "schema arm dominates" attribution behind the data:-URI freeze work is
+ * measurable rather than assumed. Pin the counter mechanics here; the
+ * increments at the runner's populateDependencies closures are exercised by
+ * the pattern integration suites.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  dependencyArmStats,
+  noteDependencyArm,
+  resetDependencyArmStats,
+} from "../src/scheduler/dependency-arm-stats.ts";
+
+describe("dependencyArmStats (CT-1840 F7)", () => {
+  it("increments the named arm and resets to zero", () => {
+    resetDependencyArmStats();
+    noteDependencyArm("actionArgumentSchema");
+    noteDependencyArm("actionArgumentSchema");
+    noteDependencyArm("actionDeclaredReads");
+    expect(dependencyArmStats.actionArgumentSchema).toBe(2);
+    expect(dependencyArmStats.actionDeclaredReads).toBe(1);
+    expect(dependencyArmStats.handlerArgumentSchema).toBe(0);
+
+    resetDependencyArmStats();
+    expect(dependencyArmStats.actionArgumentSchema).toBe(0);
+    expect(dependencyArmStats.actionDeclaredReads).toBe(0);
+  });
+
+  it("tracks every declared arm key", () => {
+    resetDependencyArmStats();
+    for (const key of Object.keys(dependencyArmStats)) {
+      noteDependencyArm(key as keyof typeof dependencyArmStats);
+      expect(dependencyArmStats[key as keyof typeof dependencyArmStats])
+        .toBe(1);
+    }
+    resetDependencyArmStats();
+  });
+});

--- a/packages/runner/test/storage-attestation-freeze.test.ts
+++ b/packages/runner/test/storage-attestation-freeze.test.ts
@@ -19,16 +19,16 @@ import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import * as Transaction from "../src/storage/transaction.ts";
 import type {
-  FabricValue,
   ISpaceReplica,
   IStorageManager,
   MemorySpace,
   Signer,
 } from "../src/storage/interface.ts";
+import type { FabricValue } from "@commonfabric/api";
 import type { Cell } from "../src/cell.ts";
 
 // Mirrors Runtime.getImmutableCell's mint: percent-encoded JSON payload.
-const dataURI = (value: unknown): string =>
+const dataURI = (value: unknown): `${string}:${string}` =>
   `data:application/json,${encodeURIComponent(JSON.stringify(value))}`;
 
 describe("attestation.load freeze + identity stability (CT-1840)", () => {

--- a/packages/runner/test/storage-attestation-freeze.test.ts
+++ b/packages/runner/test/storage-attestation-freeze.test.ts
@@ -1,0 +1,283 @@
+/**
+ * CT-1840 contract pins: data:-URI reads return deep-frozen, identity-stable
+ * values.
+ *
+ * Every dependency-collection traversal of a pattern's argument closure is
+ * rooted at a `data:` URI cell. If `attestation.load` hands out unfrozen
+ * values, the embedded link schemas fail the frozen-only gates on the
+ * identity-keyed schema/hash memos and the runner re-hashes/re-traverses
+ * everything per touch. If it hands out a FRESH parse per call (the old
+ * 1000-entry LRU cycling under >1000 distinct URIs), every identity-keyed
+ * cache downstream misses the same way. These tests pin both properties.
+ */
+
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { load } from "../src/storage/transaction/attestation.ts";
+import { setAssertFrozenReadsForTesting } from "../src/storage/transaction/chronicle.ts";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
+import * as Transaction from "../src/storage/transaction.ts";
+import type {
+  FabricValue,
+  ISpaceReplica,
+  IStorageManager,
+  MemorySpace,
+  Signer,
+} from "../src/storage/interface.ts";
+import type { Cell } from "../src/cell.ts";
+
+// Mirrors Runtime.getImmutableCell's mint: percent-encoded JSON payload.
+const dataURI = (value: unknown): string =>
+  `data:application/json,${encodeURIComponent(JSON.stringify(value))}`;
+
+describe("attestation.load freeze + identity stability (CT-1840)", () => {
+  it("returns a deep-frozen parse result", () => {
+    const id = dataURI({
+      value: { name: "Alice", tags: ["a", "b"], nested: { n: 1 } },
+    });
+    const result = load({ id, type: "application/json" });
+    expect(result.ok).toBeDefined();
+    expect(isDeepFrozen(result.ok!.value)).toBe(true);
+    // Nested containers are frozen too, not just the root.
+    const root = result.ok!.value as Record<string, any>;
+    expect(Object.isFrozen(root.value)).toBe(true);
+    expect(Object.isFrozen(root.value.tags)).toBe(true);
+    expect(Object.isFrozen(root.value.nested)).toBe(true);
+  });
+
+  it("in-place mutation of a loaded value throws (strict mode)", () => {
+    const id = dataURI({ value: { name: "Alice" } });
+    const result = load({ id, type: "application/json" });
+    const root = result.ok!.value as Record<string, any>;
+    expect(() => {
+      "use strict";
+      root.value.name = "Mallory";
+    }).toThrow();
+    expect(root.value.name).toBe("Alice");
+  });
+
+  it("repeated loads return the SAME result object (identity-stable)", () => {
+    const id = dataURI({ value: { repeat: true, n: 42 } });
+    const first = load({ id, type: "application/json" });
+    const second = load({ id, type: "application/json" });
+    expect(second).toBe(first);
+    expect(second.ok!.value).toBe(first.ok!.value);
+  });
+
+  it("identity survives >1000 distinct interleaved URIs (F4 regression)", () => {
+    // The old cache was a 1000-ENTRY LRU: loading >1000 distinct data: URIs
+    // cycled it, so re-loading the first URI re-parsed and minted a fresh
+    // object identity — silently defeating every identity-keyed cache
+    // downstream. The byte-budgeted retention layer keeps all of these
+    // (they are tiny), so identity must hold.
+    const firstId = dataURI({ value: { marker: "first" } });
+    const first = load({ id: firstId, type: "application/json" });
+    for (let i = 0; i < 1500; i++) {
+      const filler = load({
+        id: dataURI({ value: { filler: i } }),
+        type: "application/json",
+      });
+      expect(filler.ok).toBeDefined();
+    }
+    const again = load({ id: firstId, type: "application/json" });
+    expect(again).toBe(first);
+    expect(again.ok!.value).toBe(first.ok!.value);
+  });
+
+  it("error results are still produced for invalid data URIs", () => {
+    const bad = load({
+      id: "data:application/json,{not json",
+      type: "application/json",
+    });
+    expect(bad.error).toBeDefined();
+    expect(bad.error!.name).toBe("InvalidDataURIError");
+
+    const wrongType = load({
+      id: "data:text/plain,hello",
+      type: "application/json",
+    });
+    expect(wrongType.error).toBeDefined();
+    expect(wrongType.error!.name).toBe("UnsupportedMediaTypeError");
+  });
+
+  it("defaults-injection-style clone leaves the shared cache result intact", () => {
+    // schema.ts's defaults-injection arm makes values mutable via
+    // cloneIfNecessary({ deep: false, frozen: false, force: false }) before
+    // writing default properties. Before the freeze, that call was a no-op
+    // for the (unfrozen) shared parse result, so defaults were written INTO
+    // the cache. Frozen, the same call must shallow-clone — pin that the
+    // cached value is never touched.
+    const id = dataURI({ value: { present: 1 } });
+    const cached = load({ id, type: "application/json" });
+    const root = cached.ok!.value as Record<string, any>;
+
+    const mutable = cloneIfNecessary(root.value as FabricValue, {
+      deep: false,
+      frozen: false,
+      force: false,
+    }) as Record<string, any>;
+    expect(mutable).not.toBe(root.value);
+    mutable.injectedDefault = "should not leak into the cache";
+
+    const reloaded = load({ id, type: "application/json" });
+    expect(reloaded).toBe(cached);
+    expect(
+      (reloaded.ok!.value as Record<string, any>).value.injectedDefault,
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CF_ASSERT_FROZEN_READS: chronicle-level invariant assertion
+// ---------------------------------------------------------------------------
+
+class MockReplica implements ISpaceReplica {
+  private data = new Map<string, any>();
+
+  constructor(private space: MemorySpace) {}
+
+  did() {
+    return this.space;
+  }
+
+  get(entry: { id: string; type?: string }) {
+    const key = `${entry.id}:${entry.type ?? "application/json"}`;
+    return this.data.get(key);
+  }
+
+  getDocument() {
+    return undefined;
+  }
+
+  commit() {
+    return Promise.resolve({ ok: {} as any });
+  }
+
+  setData(id: string, type: string, value: any) {
+    const key = `${id}:${type}`;
+    this.data.set(key, { the: type, of: id, is: value });
+  }
+}
+
+class MockStorageManager implements IStorageManager {
+  id = "test-storage";
+  replicas = new Map<MemorySpace, MockReplica>();
+  as = { did: () => "did:test:user" as const } as unknown as Signer;
+
+  open(space: MemorySpace) {
+    let replica = this.replicas.get(space);
+    if (!replica) {
+      replica = new MockReplica(space);
+      this.replicas.set(space, replica);
+    }
+    return { replica } as any;
+  }
+
+  edit() {
+    return Transaction.create(this);
+  }
+
+  synced() {
+    return Promise.resolve();
+  }
+
+  addCrossSpacePromise() {}
+
+  removeCrossSpacePromise() {}
+
+  trackUntilSettled() {}
+
+  syncCell<T>(cell: Cell<T>): Promise<Cell<T>> {
+    return Promise.resolve(cell);
+  }
+
+  subscribe() {}
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("CF_ASSERT_FROZEN_READS (CT-1840 invariant assertion)", () => {
+  const testSpace: MemorySpace = "did:test:space";
+
+  afterEach(() => {
+    setAssertFrozenReadsForTesting(undefined);
+  });
+
+  it("passes for data:-URI reads (frozen at parse)", () => {
+    setAssertFrozenReadsForTesting(true);
+    const storage = new MockStorageManager();
+    const tx = storage.edit();
+
+    const result = tx.read({
+      space: testSpace,
+      id: dataURI({ value: { ok: true } }),
+      type: "application/json",
+      path: ["value", "ok"],
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.ok?.value).toBe(true);
+  });
+
+  it("passes for frozen replica-backed reads", () => {
+    setAssertFrozenReadsForTesting(true);
+    const storage = new MockStorageManager();
+    const replica = storage.open(testSpace).replica as MockReplica;
+    replica.setData(
+      "doc:frozen",
+      "application/json",
+      Object.freeze({ value: Object.freeze({ name: "Alice" }) }),
+    );
+
+    const tx = storage.edit();
+    const result = tx.read({
+      space: testSpace,
+      id: "doc:frozen",
+      type: "application/json",
+      path: ["value", "name"],
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.ok?.value).toBe("Alice");
+  });
+
+  it("throws for an unfrozen replica-backed read when enabled", () => {
+    setAssertFrozenReadsForTesting(true);
+    const storage = new MockStorageManager();
+    const replica = storage.open(testSpace).replica as MockReplica;
+    // Deliberately mutable: simulates a storage path that skipped freezing.
+    replica.setData("doc:mutable", "application/json", {
+      value: { name: "Alice" },
+    });
+
+    const tx = storage.edit();
+    expect(() =>
+      tx.read({
+        space: testSpace,
+        id: "doc:mutable",
+        type: "application/json",
+        path: ["value", "name"],
+      })
+    ).toThrow(/CF_ASSERT_FROZEN_READS/);
+  });
+
+  it("is inert when disabled (default)", () => {
+    setAssertFrozenReadsForTesting(false);
+    const storage = new MockStorageManager();
+    const replica = storage.open(testSpace).replica as MockReplica;
+    replica.setData("doc:mutable", "application/json", {
+      value: { name: "Alice" },
+    });
+
+    const tx = storage.edit();
+    const result = tx.read({
+      space: testSpace,
+      id: "doc:mutable",
+      type: "application/json",
+      path: ["value", "name"],
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.ok?.value).toBe("Alice");
+  });
+});

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -170,3 +170,165 @@ export class LRUCache<K, V> implements Cache<K, V> {
     this.#removeNode(node);
   }
 }
+
+export interface WeightedCacheOptions {
+  /** Maximum total weight retained before least-recently-used eviction. */
+  maxWeight: number;
+}
+
+interface WeightedLRUNode<K, V> {
+  key: K;
+  value: V;
+  weight: number;
+  prev: WeightedLRUNode<K, V> | null;
+  next: WeightedLRUNode<K, V> | null;
+}
+
+/**
+ * LRU cache bounded by total entry *weight* rather than entry count.
+ *
+ * Motivation (CT-1840): an entry-count LRU is blind to what the entries
+ * cost. When entries vary from bytes to megabytes (e.g. parsed `data:` URIs,
+ * where the key IS the content), a count bound either cycles under many
+ * small entries — destroying identity stability for every identity-keyed
+ * cache downstream — or blows memory under a few huge ones. A weight bound
+ * (callers typically pass byte sizes) keeps retention proportional to
+ * actual memory.
+ *
+ * Entries heavier than `maxWeight` are NOT stored: admitting one would evict
+ * the entire cache for a single entry that can never be joined by another.
+ * Callers needing identity stability for such values should layer a
+ * `WeakRef` intern over this cache.
+ */
+export class WeightedLRUCache<K, V> {
+  #map = new Map<K, WeightedLRUNode<K, V>>();
+  #head: WeightedLRUNode<K, V> | null = null;
+  #tail: WeightedLRUNode<K, V> | null = null;
+  #maxWeight: number;
+  #totalWeight = 0;
+
+  constructor(options: WeightedCacheOptions) {
+    this.#maxWeight = Math.max(options.maxWeight, 1);
+  }
+
+  get size(): number {
+    return this.#map.size;
+  }
+
+  get totalWeight(): number {
+    return this.#totalWeight;
+  }
+
+  has(key: K): boolean {
+    return this.#map.has(key);
+  }
+
+  get(key: K): V | undefined {
+    const node = this.#map.get(key);
+    if (node === undefined) {
+      return undefined;
+    }
+    this.#moveToTail(node);
+    return node.value;
+  }
+
+  /**
+   * Inserts or refreshes an entry. `weight` must be a non-negative finite
+   * number; entries heavier than `maxWeight` are silently not stored (and an
+   * existing entry under that key is removed, since the caller has declared
+   * the value's current cost exceeds the whole budget).
+   */
+  put(key: K, value: V, weight: number): void {
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new Error(`WeightedLRUCache: invalid weight ${weight}`);
+    }
+
+    const existing = this.#map.get(key);
+    if (existing !== undefined) {
+      this.#map.delete(key);
+      this.#removeNode(existing);
+      this.#totalWeight -= existing.weight;
+    }
+
+    if (weight > this.#maxWeight) {
+      return;
+    }
+
+    const node: WeightedLRUNode<K, V> = {
+      key,
+      value,
+      weight,
+      prev: null,
+      next: null,
+    };
+    this.#map.set(key, node);
+    this.#addToTail(node);
+    this.#totalWeight += weight;
+
+    while (this.#totalWeight > this.#maxWeight && this.#head !== null) {
+      this.#evictHead();
+    }
+  }
+
+  delete(key: K): boolean {
+    const node = this.#map.get(key);
+    if (node === undefined) {
+      return false;
+    }
+    this.#map.delete(key);
+    this.#removeNode(node);
+    this.#totalWeight -= node.weight;
+    return true;
+  }
+
+  clear(): void {
+    this.#map.clear();
+    this.#head = null;
+    this.#tail = null;
+    this.#totalWeight = 0;
+  }
+
+  #removeNode(node: WeightedLRUNode<K, V>): void {
+    if (node.prev !== null) {
+      node.prev.next = node.next;
+    } else {
+      this.#head = node.next;
+    }
+    if (node.next !== null) {
+      node.next.prev = node.prev;
+    } else {
+      this.#tail = node.prev;
+    }
+    node.prev = null;
+    node.next = null;
+  }
+
+  #addToTail(node: WeightedLRUNode<K, V>): void {
+    if (this.#tail === null) {
+      this.#head = node;
+      this.#tail = node;
+    } else {
+      node.prev = this.#tail;
+      this.#tail.next = node;
+      this.#tail = node;
+    }
+  }
+
+  #moveToTail(node: WeightedLRUNode<K, V>): void {
+    if (node === this.#tail) {
+      return;
+    }
+    this.#removeNode(node);
+    this.#addToTail(node);
+  }
+
+  #evictHead(): void {
+    if (this.#head === null) {
+      return;
+    }
+    const node = this.#head;
+    this.#map.delete(node.key);
+    this.#removeNode(node);
+    this.#totalWeight -= node.weight;
+  }
+}

--- a/packages/utils/test/cache.test.ts
+++ b/packages/utils/test/cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { LRUCache } from "@commonfabric/utils/cache";
+import { LRUCache, WeightedLRUCache } from "@commonfabric/utils/cache";
 
 describe("LRUCache", () => {
   describe("basic operations", () => {
@@ -170,5 +170,115 @@ describe("LRUCache", () => {
       expect(cache.has("c")).toBe(true);
       expect(cache.has("d")).toBe(true);
     });
+  });
+});
+
+describe("WeightedLRUCache", () => {
+  it("stores and retrieves values, tracking total weight", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 10);
+    cache.put("b", 2, 20);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("b")).toBe(2);
+    expect(cache.size).toBe(2);
+    expect(cache.totalWeight).toBe(30);
+  });
+
+  it("evicts least-recently-used entries when over the weight budget", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("b", 2, 40);
+    cache.put("c", 3, 40); // exceeds 100: evicts "a"
+    expect(cache.has("a")).toBe(false);
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("c")).toBe(3);
+    expect(cache.totalWeight).toBe(80);
+  });
+
+  it("a heavy entry evicts as many light entries as needed", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 30);
+    cache.put("b", 2, 30);
+    cache.put("c", 3, 30);
+    cache.put("big", 4, 90); // evicts a, b, c
+    expect(cache.has("a")).toBe(false);
+    expect(cache.has("b")).toBe(false);
+    expect(cache.has("c")).toBe(false);
+    expect(cache.get("big")).toBe(4);
+    expect(cache.totalWeight).toBe(90);
+  });
+
+  it("get refreshes recency so hot entries survive eviction", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("b", 2, 40);
+    cache.get("a"); // "a" now most recent
+    cache.put("c", 3, 40); // evicts "b", not "a"
+    expect(cache.get("a")).toBe(1);
+    expect(cache.has("b")).toBe(false);
+    expect(cache.get("c")).toBe(3);
+  });
+
+  it("does not store entries heavier than the whole budget", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("huge", 2, 101);
+    expect(cache.has("huge")).toBe(false);
+    // Existing entries survive the refused insert.
+    expect(cache.get("a")).toBe(1);
+    expect(cache.totalWeight).toBe(40);
+  });
+
+  it("an oversize re-put removes the existing entry under that key", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("a", 2, 101);
+    expect(cache.has("a")).toBe(false);
+    expect(cache.totalWeight).toBe(0);
+  });
+
+  it("re-put under the same key replaces value and weight", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("a", 2, 60);
+    expect(cache.get("a")).toBe(2);
+    expect(cache.size).toBe(1);
+    expect(cache.totalWeight).toBe(60);
+  });
+
+  it("delete removes an entry and its weight", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("b", 2, 40);
+    expect(cache.delete("a")).toBe(true);
+    expect(cache.delete("a")).toBe(false);
+    expect(cache.has("a")).toBe(false);
+    expect(cache.totalWeight).toBe(40);
+  });
+
+  it("clear empties the cache", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 100 });
+    cache.put("a", 1, 40);
+    cache.put("b", 2, 40);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.totalWeight).toBe(0);
+    expect(cache.has("a")).toBe(false);
+  });
+
+  it("zero-weight entries are admitted and never trigger eviction", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 10 });
+    for (let i = 0; i < 100; i++) {
+      cache.put(`k${i}`, i, 0);
+    }
+    expect(cache.size).toBe(100);
+    expect(cache.totalWeight).toBe(0);
+  });
+
+  it("rejects invalid weights", () => {
+    const cache = new WeightedLRUCache<string, number>({ maxWeight: 10 });
+    expect(() => cache.put("a", 1, -1)).toThrow();
+    expect(() => cache.put("a", 1, Number.NaN)).toThrow();
+    expect(() => cache.put("a", 1, Infinity)).toThrow();
   });
 });


### PR DESCRIPTION
## Why

CT-1840: a 75-second production CPU profile of a Loom daemon shows the runner burning its scheduler loop on re-hashing and re-traversing values it has already seen — 44% of the profile inside `hashOf`, ~64% inclusive in `validateAndTransform` — starving storage push leases into 300s timeouts. The caches to prevent exactly this **already exist** (`frozenObjectHashCache`, `_schemaAtPathCache`, the schema seam memos, `hashSchema` memo keys): they are identity-keyed and gated on frozen inputs, and they are being **structurally bypassed** because the values that enter dependency collection are unfrozen.

The verified mechanism: every argument-schema-driven dependency collection is rooted at a `data:` URI cell (`Runtime.getImmutableCell` mints `data:application/json,...`), and `attestation.load` returned raw, unfrozen `JSON.parse` results. Unfrozen values fail `isMemoizableSchemaInput`, so every embedded link schema misses every seam memo and every hash cache, every time.

Worse, even freezing alone would not survive the target workload: the parse cache was a **1000-entry** LRU, and Loom-scale spaces carry ~10k distinct `data:` URIs (~47MB of inlined content). A traversal touching >1000 distinct URIs cycles the LRU, so each pass re-parses and mints a *fresh object identity* — silently defeating every identity-keyed cache downstream even with freezing in place.

This is PR-A of the three-PR series designed (and adversarially critiqued) for CT-1840: close the unfrozen-value entry points and make parse identity stable. PR-B (composite keys for `viewRefHash` / chronicle cause-ref memo) and PR-C (flagged version-validated dependency-log memo) follow.

## What Changed

- **`attestation.load` deep-freezes its parse result.** `data:` URIs are content-addressed — the id IS the content — so the value is immutable by definition and freezing is semantically free. This also converts a latent aliasing hazard into a clone: `schema.ts`'s defaults-injection arm makes values mutable via `cloneIfNecessary({deep:false, frozen:false, force:false})`, which is a no-op for unfrozen objects — it could previously write injected defaults **into the shared cached parse result**. Frozen, that call shallow-clones (pinned by test).
- **Identity-stable parse cache** replacing the 1000-entry LRU (critique F4):
  - a strong, **byte-budgeted** retention LRU (`WeightedLRUCache`, new in `@commonfabric/utils/cache`; weight = id length, 128MB budget) so retention is proportional to memory rather than entry count, and
  - a `Map<string, WeakRef>` intern layer with `FinalizationRegistry` cleanup (precedent: schema interning in `data-model/schema-hash.ts`) so a result evicted from retention keeps its identity as long as anything references it.
  - (Also fixes the stale comment claiming the cache key was `id::type`; it keys by `id`.)
- **Deep-freeze at replica confirmed-ingest** (`applySessionSync` upsert arm). Wire-decoded docs are already frozen at the codec boundary (`JsonEncodingContext`), so this is an O(1) WeakSet check there; it only pays on providers handing over locally-constructed docs. Belt-and-braces for the same invariant.
- **`CF_ASSERT_FROZEN_READS=1` debug assertion in `Chronicle.read`**: storage-sourced read results (data:-URI parses and replica-backed attestations) must be deep-frozen; novelty working copies are exempt (mutable by design within a tx). Keeps the invariant from silently rotting.
- **Dependency-collection arm counters** (critique F7): `dependencyArmStats` counts declared-reads vs argument-schema collections (action, handler, and builtin arms) so the "schema arm dominates" attribution behind this fix is measurable on a live workload instead of assumed, before betting PR-B/PR-C sizing on it.
- **`hashStats` instrumentation** in `value-hash.ts`: always-on `computeHashCalls` counter plus gated (`CF_HASH_STATS=1`) bytes-fed accounting, for the design's benchmark harness (full benchmark is PR-C territory; these are the counters it needs).

### In-place-mutation audit (freeze failure mode)

Code that mutated `data:`-read results in place would now throw (strict mode) or no-op. Audited:

- `schema.ts` defaults injection — already clones via `cloneIfNecessary` before writing (see above); pinned by test.
- Repo-wide grep for assignments into read/attestation values — no hits outside the by-design-mutable novelty working copy (writes to `data:` addresses were already rejected with `ReadOnlyAddressError` before this change).
- Memory engine docs are copy-on-write and deep-frozen at the `applyPatch` boundary and at `decodeMemoryBoundary`, so freezing at ingest cannot break engine-side mutation (there is none).
- `getJSONFromDataURI` (`uri-utils.ts`) is a separate, uncached parse path returning a fresh object per call — unaffected, and no shared-cache aliasing risk. Out of scope here.

### Drift notes (design pin 89c3607e7 → main HEAD)

The CT-1840 design + critique were verified against labs pin `89c3607e7` (the pin Loom runs). All target sites were re-located at main HEAD; none had been fixed upstream:

- `attestation.ts:279` raw `JSON.parse` and the 1000-entry `dataURICache` — unchanged at HEAD; fixed here.
- `v2.ts:2381-2384` confirmed-ingest — now `v2.ts:~2394-2406`; upstream added a seq-monotonicity guard (`upsert.seq < record.confirmed.seq → continue`) above the site; freeze applied to the upsert arm only (the other `confirmedVersion` sites take `undefined` or already-frozen materialized values).
- `runner.ts:3629-3637` `populateDependencies` — now `runner.ts:~3678-3703`; upstream formalized the declared-reads vs argument-schema arm split, which is exactly where the F7 counters now sit (plus the handler and builtin closures).
- `chronicle.ts:256-315` `read` — minor line drift only.
- `schema.ts:1310-1316` defaults injection — upstream already documents and uses the `cloneIfNecessary` mutable-before-inject pattern; behavior under frozen inputs verified and pinned.

## Test plan

- New `packages/runner/test/storage-attestation-freeze.test.ts`: parse results deep-frozen (root and nested); strict-mode mutation throws; repeated loads return the SAME object (design pin 1); **identity survives >1000 distinct interleaved URIs** (the F4 LRU-cycling regression); error results unchanged; defaults-injection-style clone leaves the shared cache untouched; `CF_ASSERT_FROZEN_READS` passes on frozen data:/replica reads, throws on an unfrozen replica value, inert by default.
- New `WeightedLRUCache` tests in `packages/utils/test/cache.test.ts` (weight-budget eviction, recency, oversize refusal, delete/clear, invalid weights).
- `hashStats` and `dependencyArmStats` counter mechanics tests.
- Full suites: runner **797 passed (4150 steps), 0 failed**; data-model 48 passed (1922 steps); utils 91 passed (503 steps). `deno check`, `deno lint`, `deno fmt` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze all storage-sourced `data:` URI reads and make the parse cache identity-stable to stop re-hashing and re-traversal in the runner for CT-1840. Adds a byte-budgeted cache with WeakRef interning and lightweight instrumentation to confirm impact.

- **Bug Fixes**
  - `attestation.load`: deep-freezes JSON parses and returns the same object identity per id; replaces the 1000-entry LRU with a 128MB weighted LRU + `WeakRef` interning to keep identities stable across evictions.
  - Replica ingest: deep-freezes confirmed docs in `v2` so storage-backed reads are frozen end-to-end.
  - Chronicle reads: optional `CF_ASSERT_FROZEN_READS=1` debug check to enforce the “frozen storage reads” invariant (novelty working copies exempt).

- **New Features**
  - `WeightedLRUCache` in `@commonfabric/utils/cache`: weight-based (byte) eviction for better memory-proportional retention.
  - Dependency stats: `dependencyArmStats` counters in the runner to measure declared-reads vs argument-schema arms.
  - Hash stats: `hashStats` in `@commonfabric/data-model/value-hash` with `CF_HASH_STATS=1` to track compute calls and bytes fed.

<sup>Written for commit 524595c4974967de8642aba1cbafb759aadb26f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

