### PR TITLE
feat(cfc): §4.9.3 render membership lookup (H3b follow-up)

### DIFF
--- a/docs/specs/cfc-render-membership-lookup.md
+++ b/docs/specs/cfc-render-membership-lookup.md
@@ -89,6 +89,7 @@ enumerate a member set.
 New `packages/runner/src/cfc/space-membership.ts`:
 
 ```ts
+// Shown for illustration only.
 import { type ACL, type Capability, isACL, isCapable, ANYONE_USER }
   from "@commonfabric/memory/acl";
 
@@ -123,6 +124,7 @@ fit runs inside a `cell.sink` callback). The provider gives a sync snapshot
 plus a subscription for reactive re-render:
 
 ```ts
+// Shown for illustration only.
 export interface SpaceMembershipProvider {
   /** Sync role snapshot for (principal, space) from the local replica; null =
    *  not-yet-known-or-not-a-member (both fail closed). Kicks a background sync

--- a/docs/specs/cfc-render-membership-lookup.md
+++ b/docs/specs/cfc-render-membership-lookup.md
@@ -1,9 +1,36 @@
 # CFC render membership lookup (§4.9.3) — design
 
-**Status:** design. Follow-up to Epic H3b (PR #4572, merged). Replaces the H3b
-render resolver's static `memberSpaces` heuristic with a verified per-space
-membership lookup, so cross-space `Space(...)` labels resolve for principals
-who genuinely read the space — never from a cell's mere local residency.
+**Status:** implemented (stages 1–4, this branch). Follow-up to Epic H3b (PR
+#4572, merged). Replaces the H3b render resolver's static `memberSpaces`
+heuristic with a verified per-space membership lookup, so cross-space
+`Space(...)` labels resolve for principals who genuinely read the space — never
+from a cell's mere local residency.
+
+**Implementation map (all four stages landed):**
+
+- **Stage 1 — capability resolver:** `spaceReaderRole` in
+  [space-membership.ts](../../packages/runner/src/cfc/space-membership.ts),
+  tested in `packages/runner/test/cfc-space-membership.test.ts`.
+- **Stage 2 — provider + per-label discovery:**
+  `createRuntimeSpaceMembershipProvider` (sync `readerRole` + change-only
+  `subscribe`) in the same file, and `spaceAtomIdsInConfidentiality` +
+  per-label mint in
+  [render-ceiling.ts](../../packages/runner/src/cfc/render-ceiling.ts), tested
+  in `cfc-space-membership.test.ts` and `cfc-render-ceiling.test.ts`.
+- **Stage 3 — wiring:** `renderConfidentialityResolverFor` /
+  `renderMembershipProviderFor` in
+  [runtime-processor.ts](../../packages/runtime-client/backends/runtime-processor.ts),
+  tested in `runtime-processor.test.ts`.
+- **Stage 4 — reactive re-render:** the worker
+  [reconciler](../../packages/html/src/worker/reconciler.ts) subscribes a gated
+  `Space(X)` cell to X's ACL doc within its cancel group and re-evaluates the
+  gate on change (`renderCellChild`), tested in
+  `packages/html/test/worker-reconciler-cfc-render-policy.test.ts`. Reused the
+  reconciler's existing `.sink` + `useCancelGroup` machinery — no
+  core-reactivity change was needed.
+
+The design below is retained as the record of intent; the spec/Lean obligations
+in §7–§8 remain outgoing follow-ups.
 
 ## 1. Problem
 

--- a/docs/specs/cfc-render-membership-lookup.md
+++ b/docs/specs/cfc-render-membership-lookup.md
@@ -1,0 +1,272 @@
+# CFC render membership lookup (§4.9.3) — design
+
+**Status:** design. Follow-up to Epic H3b (PR #4572, merged). Replaces the H3b
+render resolver's static `memberSpaces` heuristic with a verified per-space
+membership lookup, so cross-space `Space(...)` labels resolve for principals
+who genuinely read the space — never from a cell's mere local residency.
+
+## 1. Problem
+
+H3b's render ceiling resolves a `Space(X)` confidentiality atom to
+`User(actingUser)` when the acting user holds `HasRole(actingUser, X, reader)`
+(spec §4.3.3 SpaceReaderAccess). H3b mints that `HasRole` fact only from a
+static `memberSpaces` set, currently the acting user's own identity space +
+the session workspace ([runtime-processor.ts `renderConfidentialityResolverFor`](../../packages/runtime-client/backends/runtime-processor.ts)).
+Any other space fails closed (over-blocks). The residual: a real §4.9.3
+`lookupMembership(space, actingUser)` so cross-space content the user actually
+reads renders.
+
+The soundness invariant (H3b commit `4fc05f800`, and the adversarial-review
+finding behind it): **residency is not read authority.** Under the default
+`MEMORY_ACL_MODE="off"` a runtime can sync a space's bytes without the acting
+user being an authorized reader, so the lookup must read the space's declared
+membership, never infer it from the fact that a cell is locally resident.
+
+## 2. What already exists (do not rebuild)
+
+- **The authority record.** One ACL document per space, entity id
+  `of:${space}` (== the space DID), value
+  `ACL = { [DID | "*"]: "READ" | "WRITE" | "OWNER" }`
+  ([memory/interface.ts], helpers `isACL` / `isCapable` / `ANYONE_USER` in
+  [memory/acl.ts]). Server resolution
+  ([server.ts `#resolveCapability`](../../packages/memory/v2/server.ts)):
+  implicit `OWNER` if `principal === space` or a service DID; else
+  `acl[principal] ?? acl["*"] ?? null`; missing/malformed → `null` (fail
+  closed). Capability order `READ(0) < WRITE(1) < OWNER(2)`.
+- **A client reader.** [`ACLManager`](../../packages/runner/src/acl-manager.ts)
+  already reads that doc from the worker via
+  `getCellFromLink({ id: spaceDid, path: [], space: spaceDid })` (its `.get()`
+  is async — awaits `sync()`).
+- **A sync-read + background-sync primitive.**
+  [`Cell.get()`](../../packages/runner/src/cell.ts) reads the local value
+  synchronously and, when not yet synced, kicks a background sync
+  (`if (!this.synced) this.sync(); // No await`).
+- **The exchange rule.** `space-reader-access-display` in
+  [render-ceiling.ts](../../packages/runner/src/cfc/render-ceiling.ts)
+  (`Space($s)` + `HasRole($p,$s,reader)` under a display boundary → add
+  `User($p)`), formalized as `exchangeSpaceReader` in
+  `~/src/specs/cfc/formal/Cfc/Exchange.lean`.
+- **`HasRole` is runtime-mint-only** (`RUNTIME_MINTED_INTEGRITY_ATOM_TYPES`,
+  prepare.ts) — patterns cannot forge it. Only the verified *source* is
+  missing; no new atom, rule, or mint-gate change is needed.
+
+**No reverse index exists.** Membership is per-`(principal, space)` checkable
+only — matching the spec's `lookupMembership(space, user)` point query. So the
+resolver must discover candidate spaces from the *label being rendered*, not
+enumerate a member set.
+
+## 3. Design
+
+### 3.1 Capability resolver (runner)
+
+New `packages/runner/src/cfc/space-membership.ts`:
+
+```ts
+import { type ACL, type Capability, isACL, isCapable, ANYONE_USER }
+  from "@commonfabric/memory/acl";
+
+/** A principal's role in a space, or null if none (fail-closed). */
+export type SpaceRole = "owner" | "writer" | "reader";
+
+/** Mirror of the server's #resolveCapability, client-side (spec §3.6.2). */
+export const spaceReaderRole = (
+  acl: ACL | undefined,          // the space's ACL doc value (undefined = not read)
+  space: string,
+  principal: string,
+  serviceDids: readonly string[] = [],
+): SpaceRole | null => {
+  // Implicit OWNER: you own your own identity space; service principals.
+  if (principal === space || serviceDids.includes(principal)) return "owner";
+  if (!isACL(acl)) return null;                       // missing/malformed → fail closed
+  const cap = (acl as Record<string, Capability | undefined>)[principal] ??
+    (acl as Record<string, Capability | undefined>)[ANYONE_USER];
+  if (cap === undefined) return null;
+  if (!isCapable(cap, "READ")) return null;           // WRITE/OWNER imply READ
+  return capToRole(cap);                              // READ→reader, WRITE→writer, OWNER→owner
+};
+```
+
+Reusing `@commonfabric/memory/acl` keeps the client check byte-identical to the
+server's authority decision — the two must never drift.
+
+### 3.2 Membership provider
+
+The resolver needs a *synchronous* membership answer at render time (the render
+fit runs inside a `cell.sink` callback). The provider gives a sync snapshot
+plus a subscription for reactive re-render:
+
+```ts
+export interface SpaceMembershipProvider {
+  /** Sync role snapshot for (principal, space) from the local replica; null =
+   *  not-yet-known-or-not-a-member (both fail closed). Kicks a background sync
+   *  when the ACL doc is absent, so a later reactive tick can upgrade. */
+  readerRole(space: string): SpaceRole | null;
+  /** Subscribe to a space's ACL doc; `onChange` fires when it syncs/changes,
+   *  so a gated render re-evaluates. Returns a cancel. */
+  subscribe(space: string, onChange: () => void): Cancel;
+}
+```
+
+Backed by the runtime: `readerRole(space)` reads the space-DID cell
+(`getCellFromLink({ id: space, path: [], space })`) via `Cell.get()` (sync +
+background-sync kick), runs `spaceReaderRole`, and memoizes per
+`(space, principal)` (mirroring the server's `#aclCapabilities` cache),
+invalidated on the ACL cell's change. `subscribe` is `aclCell.sink(onChange)`.
+
+### 3.3 Per-label candidate discovery
+
+The render resolver already receives the cell's confidentiality label. Change
+`createRenderConfidentialityResolver` from a static `memberSpaces` list to a
+per-label mint:
+
+1. Extract the `Space(id)` atoms present in the label's clauses (including
+   inside `anyOf` — §4.3.4 multi-binding gives one access path per role held).
+2. For each, `provider.readerRole(id)`; when `!== null`, mint
+   `cfcAtom.hasRole(actingPrincipal, id, "reader")` (a reader-or-higher role
+   satisfies the reader guard — `isCapable` already collapsed the ranks).
+3. Feed the minted facts as `integrity` to `evaluateExchangeRules` exactly as
+   today. Own-space + session-space stay a fast path (no ACL read: own space is
+   implicit OWNER; the session space was gated by `session.open`).
+
+This also yields §4.9.4 (per-user content in a shared space) for free: a value
+carrying both `Space(Team)` and `PersonalSpace(User)` gets an independent
+verified fact per space; both must resolve for the value to fit.
+
+### 3.4 The async→sync / reactive bridge (the hard part)
+
+The fit is synchronous; the ACL read may need a sync. Two stages:
+
+- **Stage 1 (sound, self-contained):** `readerRole` does a sync `Cell.get()` of
+  the ACL doc. If present + grants READ → resolve. If absent → mint nothing
+  (fail closed → over-block) **and** the `.get()` has kicked a background sync.
+  This is always sound (declared authority or nothing; never residency).
+- **Stage 2 (precision):** when the reconciler gates a `Space(X)`-labeled cell
+  through the resolver, it also `subscribe`s to X's ACL doc within the cell's
+  existing `useCancelGroup`, re-rendering when the ACL syncs/changes. This
+  upgrades the Stage-1 over-block to an eventual admit without a
+  core-reactivity change — it reuses the reconciler's `.sink` + cancel-group
+  machinery. (Implement Stage 1 first; land Stage 2 behind the same flag.)
+
+### 3.5 Wiring
+
+`renderConfidentialityResolverFor(runtime, identity, ceiling, sessionSpace)`
+builds a `SpaceMembershipProvider` from the runtime (it already has
+`storageManager` + acting principal + `serviceDids` if configured) and passes
+it to `createRenderConfidentialityResolver`. The own-space + session-space
+fast path stays as verified facts (they need no ACL read).
+
+## 4. Soundness & the ACL-mode coupling
+
+Reading the ACL doc is the *authority* check (not residency). Its trust tracks
+`MEMORY_ACL_MODE`:
+
+- `enforce` — the ACL is authoritative; the server rejects non-reader
+  session.open/query, and revokes on change. The render lookup is exact.
+- `observe` — the ACL is evaluated + diagnosed but not enforced; the render
+  lookup reads the same declared record (creator-seeded ownership), giving
+  correct precision ahead of enforcement.
+- `off` (today's default) — declared-but-unenforced. The render lookup still
+  reads the ACL doc (creator-seeded OWNER, OWNER-gated writes) — strictly
+  better than residency, but only as strong as the deployment's posture.
+
+State this coupling in the docstring: the render gate's cross-space guarantee
+is exactly as strong as `MEMORY_ACL_MODE`. This argues for advancing the ACL
+rollout (`off → observe → enforce`) alongside the render-ceiling dogfood.
+
+Fail-closed everywhere: missing/malformed ACL, unsynced doc, or unknown
+principal → no `HasRole` fact → `Space(X)` stays outside the ceiling → blocked.
+
+## 5. Staged implementation plan
+
+1. **Capability resolver** — `space-membership.ts` `spaceReaderRole` (pure) +
+   unit tests over ACL fixtures (own space, service DID, reader/writer/owner,
+   ANYONE, missing, malformed).
+2. **Provider + per-label discovery** — the runtime-backed provider (sync read
+   + memo) and the label→Space-atoms extraction; refactor
+   `createRenderConfidentialityResolver` to mint per-label from the provider
+   (keep static `memberSpaces` as an accepted fast-path input for tests/own +
+   session space). Runner unit tests: a Space label resolves iff the fixture
+   ACL grants the acting principal READ+; residency (an unsynced/absent ACL)
+   stays blocked.
+3. **Wiring** — `renderConfidentialityResolverFor` builds the provider; keep
+   own/session fast path. runtime-processor helper test.
+4. **Stage-2 reactive re-render** — reconciler subscribes gated `Space(X)`
+   cells to X's ACL doc; re-render on change. html reconciler test: a cell
+   blocked before its ACL syncs renders after the ACL grants READ.
+
+Each stage is independently landable; Stage 1–3 deliver the sound lookup,
+Stage 4 the precision upgrade.
+
+## 6. Test plan
+
+- `packages/runner/test/cfc-space-membership.test.ts` — `spaceReaderRole`
+  truth table; provider sync-read + fail-closed on absent ACL; per-label mint
+  (multiple Space atoms → per-space facts; §4.9.4 conjunctive).
+- `packages/runner/test/cfc-render-ceiling.test.ts` — extend: a Space label
+  resolves through a provider-supplied reader role; residency (no ACL) blocks.
+- `packages/runtime-client/backends/runtime-processor.test.ts` — the helper
+  builds a provider-backed resolver; own space resolves, an ACL-granted space
+  resolves, an ACL-denied space blocks.
+- `packages/html/test/worker-reconciler-cfc-render-policy.test.ts` — Stage 2:
+  re-render on ACL sync/change.
+
+## 7. Spec updates (`~/src/specs/cfc`)
+
+- **§4.9.3** — replace the `lookupMembership` black box with the concrete
+  ACL-doc-backed lookup: membership is the per-space ACL record
+  (`{ principal → capability }`, implicit owner for own space + service
+  principals, `"*"` for public), `HasRole(user, space, role)` minted iff
+  `isCapable(acl[user] ?? acl["*"], READ)`; fail-closed on absent/malformed;
+  no reverse index (per-`(principal, space)` point query).
+- **§18** — a `CfcTrustedRenderProfile` sub-section for the render membership
+  lookup: sync-snapshot-from-replica + reactive upgrade, and the explicit
+  coupling of its guarantee to the deployment ACL mode.
+- **§15** — register `AddMemberIntent` as an atom (it appears only as a §3.6.3
+  exchange-rule guard today) with its params (`newUser`, `role`) and minter,
+  or note it as an intent consumed by the membership-mutation path.
+- **cfc-spec-changes.md** — track the above as an outgoing PR to
+  `commontoolsinc/specs`.
+
+## 8. Formal proof obligations (Lean4, `~/src/specs/cfc/formal`)
+
+Build on the existing `Cfc/Access.lean` (`Principal`, `canAccess`) and
+`Cfc/Exchange.lean` (`exchangeSpaceReader`, `hasSpaceReaderRoleB`). Add a
+membership/ACL model + the soundness theorem that the lookup only ever admits a
+`Space(X)` clause to a *verified reader*:
+
+- **Model.** `Capability := READ | WRITE | OWNER` with `isCapable`; `ACL := DID
+  → Option Capability` (plus `"*"`); `readerOf (acl) (space) (p) : Prop` :=
+  implicit-owner ∨ `isCapable (acl p ?? acl "*") READ`. `roleFacts (acl)
+  (acting) (space) : IntegLabel` mints `HasRole(acting, space, reader)` iff
+  `readerOf acl space acting`, else `[]`.
+- **T1 (soundness — no residency admission).** For the render evaluation
+  `exchangeSpaceReader acting boundary (label with avail := roleFacts acl
+  acting …)`: if the rewrite adds `User(acting)` to a `Space(X)` clause, then
+  `readerOf acl X acting`. I.e. the resolver never admits a space the ACL does
+  not grant — the residency-independence property the H3b review demanded,
+  proved rather than asserted.
+- **T2 (completeness — verified readers do resolve).** If `readerOf acl X
+  acting`, then `Space(X)` (as the sole clause) is admitted to `Principal {
+  atoms := [User acting] }` after the rewrite — i.e. the lookup does not
+  over-block a genuine reader.
+- **T3 (§4.9.4 conjunctive cross-space).** A label `{ Space(Team) ∧
+  PersonalSpace(User) }` is admitted to `acting` iff `readerOf acl Team acting
+  ∧ readerOf acl (PersonalSpace User) acting`.
+
+All theorems must `lake build` clean under `leanprover/lean4:v4.26.0`. Prefer
+reusing `satisfies_mono_atoms` / `canAccessConf_*` from `Access.lean`.
+
+## 9. Open questions
+
+- **Refresh cadence.** Stage 1 memoizes per session; Stage 2's subscription
+  invalidates on ACL change. Is per-mount subscription enough, or does a
+  long-lived render need the provider to own the subscriptions? (Lean into the
+  reconciler cancel-group ownership.)
+- **Service DIDs client-side.** The server has `MEMORY_SERVICE_DIDS`; the
+  worker resolver needs the same list to grant implicit OWNER to service
+  principals. Thread it through `InitializationData`, or omit (services rarely
+  render). Default: omit; document.
+- **Cross-space ACL availability.** Reading X's ACL requires X's ACL doc to be
+  syncable by the worker. Under `enforce` this itself needs READ on X (fine —
+  a reader can read the ACL). Under `off` it syncs freely. Confirm the ACL doc
+  is world-readable-within-the-space (it is: same space, READ-gated).

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -233,46 +233,72 @@ export class WorkerReconciler {
       // Ensure the current child is cancelled when the root is cancelled
       addCancel(() => wrapperState.cancel());
 
-      addCancel(
-        vnode.sink((resolvedVnode: unknown) => {
-          logger.debug("root-cell-update", () => ({ resolvedVnode }));
-          // The mounted cell is an egress like any descendant cell: gate its
-          // own label against the root policy (the host ceiling when
-          // configured) before rendering its resolved content. Checked per
-          // update so label changes re-evaluate, mirroring renderCellChild.
-          if (
-            !this.canRenderCellUnderPolicy(
-              vnode as Cell<unknown>,
-              this.rootRenderPolicy,
-            )
-          ) {
-            this.reconcileIntoWrapper(
-              ctx,
-              wrapperState,
-              this.blockedPlaceholderVNode(),
-              this.rootRenderPolicy,
-            );
-            this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
-            return;
-          }
-          // Validate that the resolved value is a valid render node
-          if (!this.isValidRenderNode(resolvedVnode)) {
-            this.onError?.(
-              new Error(
-                `Invalid VDOM content: expected WorkerVNode, string, or number, got ${typeof resolvedVnode}`,
-              ),
-            );
-            return;
-          }
+      // §4.9.3 Stage 2: the root cell is an egress too — if it is labeled
+      // Space(X) and X's ACL has not synced, it fails closed; watch X's ACL so
+      // a later grant re-renders (and a revoke re-blocks), mirroring
+      // renderCellChild. `renderRoot` is re-invoked with the last resolved
+      // value when an ACL changes.
+      let lastRootValue: unknown;
+      let rootHasRendered = false;
+      const rootWatchedSpaces = new Set<string>();
+      const watchRootMembershipSpaces = () => {
+        const provider = this.membershipProvider;
+        if (provider === undefined) return;
+        for (const space of this.spaceIdsForCellLabel(vnode as Cell<unknown>)) {
+          if (rootWatchedSpaces.has(space)) continue;
+          rootWatchedSpaces.add(space);
+          addCancel(
+            provider.subscribe(space, () => {
+              if (rootHasRendered) renderRoot(lastRootValue);
+            }),
+          );
+        }
+      };
+      const renderRoot = (resolvedVnode: unknown) => {
+        logger.debug("root-cell-update", () => ({ resolvedVnode }));
+        lastRootValue = resolvedVnode;
+        rootHasRendered = true;
+        watchRootMembershipSpaces();
+        // The mounted cell is an egress like any descendant cell: gate its
+        // own label against the root policy (the host ceiling when
+        // configured) before rendering its resolved content. Checked per
+        // update so label changes re-evaluate, mirroring renderCellChild.
+        if (
+          !this.canRenderCellUnderPolicy(
+            vnode as Cell<unknown>,
+            this.rootRenderPolicy,
+          )
+        ) {
           this.reconcileIntoWrapper(
             ctx,
             wrapperState,
-            resolvedVnode as WorkerRenderNode,
+            this.blockedPlaceholderVNode(),
             this.rootRenderPolicy,
           );
-          // Track the root child for cleanup
           this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
-        }),
+          return;
+        }
+        // Validate that the resolved value is a valid render node
+        if (!this.isValidRenderNode(resolvedVnode)) {
+          this.onError?.(
+            new Error(
+              `Invalid VDOM content: expected WorkerVNode, string, or number, got ${typeof resolvedVnode}`,
+            ),
+          );
+          return;
+        }
+        this.reconcileIntoWrapper(
+          ctx,
+          wrapperState,
+          resolvedVnode as WorkerRenderNode,
+          this.rootRenderPolicy,
+        );
+        // Track the root child for cleanup
+        this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
+      };
+
+      addCancel(
+        vnode.sink((resolvedVnode: unknown) => renderRoot(resolvedVnode)),
       );
     } else {
       // Static VNode - render directly into container

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -775,15 +775,26 @@ export class WorkerReconciler {
     return schema;
   }
 
+  /**
+   * A cell's CFC label view, mirroring the render gate's resolution: the cell's
+   * own view, or — when it has none — the resolved (followed) target's view,
+   * whose label may carry the `Space(...)` atoms. May throw (each caller
+   * decides its own fail-closed handling). The SINGLE source of label
+   * resolution shared by the gate (`canRenderCellUnderPolicy`), the
+   * represents-principal read, and the Stage-2 membership watcher
+   * (`watchCellMembership`), so they can never drift out of lockstep.
+   */
+  private resolveCellLabelView(cell: Cell<unknown>): CfcLabelView | undefined {
+    return cfcLabelViewForCell(cell) ??
+      cfcLabelViewForCell(cell.resolveAsCell());
+  }
+
   private representsPrincipalSubjectForCell(
     cell: Cell<unknown>,
   ): string | undefined {
     let labelView: CfcLabelView | undefined;
     try {
-      labelView = cfcLabelViewForCell(cell);
-      if (labelView === undefined) {
-        labelView = cfcLabelViewForCell(cell.resolveAsCell());
-      }
+      labelView = this.resolveCellLabelView(cell);
     } catch {
       return undefined;
     }
@@ -998,10 +1009,7 @@ export class WorkerReconciler {
 
     let labelView: CfcLabelView | undefined;
     try {
-      labelView = cfcLabelViewForCell(cell);
-      if (labelView === undefined) {
-        labelView = cfcLabelViewForCell(cell.resolveAsCell());
-      }
+      labelView = this.resolveCellLabelView(cell);
     } catch {
       return false;
     }
@@ -1152,9 +1160,13 @@ export class WorkerReconciler {
     if (provider === undefined) {
       return;
     }
+    // Read the label the render gate reads (`resolveCellLabelView`, including
+    // the followed-target fallback) so the watcher and the fit stay in
+    // lockstep — a followed cell whose `Space(...)` label lives on the target
+    // is watched, not silently left un-upgradable.
     let labelView: CfcLabelView | undefined;
     try {
-      labelView = cfcLabelViewForCell(cell);
+      labelView = this.resolveCellLabelView(cell);
     } catch {
       labelView = undefined;
     }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -241,24 +241,18 @@ export class WorkerReconciler {
       let lastRootValue: unknown;
       let rootHasRendered = false;
       const rootWatchedSpaces = new Set<string>();
-      const watchRootMembershipSpaces = () => {
-        const provider = this.membershipProvider;
-        if (provider === undefined) return;
-        for (const space of this.spaceIdsForCellLabel(vnode as Cell<unknown>)) {
-          if (rootWatchedSpaces.has(space)) continue;
-          rootWatchedSpaces.add(space);
-          addCancel(
-            provider.subscribe(space, () => {
-              if (rootHasRendered) renderRoot(lastRootValue);
-            }),
-          );
-        }
-      };
       const renderRoot = (resolvedVnode: unknown) => {
         logger.debug("root-cell-update", () => ({ resolvedVnode }));
         lastRootValue = resolvedVnode;
         rootHasRendered = true;
-        watchRootMembershipSpaces();
+        this.watchCellMembership(
+          vnode as Cell<unknown>,
+          rootWatchedSpaces,
+          addCancel,
+          () => {
+            if (rootHasRendered) renderRoot(lastRootValue);
+          },
+        );
         // The mounted cell is an egress like any descendant cell: gate its
         // own label against the root policy (the host ceiling when
         // configured) before rendering its resolved content. Checked per
@@ -1137,30 +1131,46 @@ export class WorkerReconciler {
   }
 
   /**
-   * The `Space(id)` ids in a cell's confidentiality label — the spaces whose
-   * ACL docs a Stage-2 reactive re-render must watch (§4.9.3). Empty unless a
-   * membership provider is wired; reads the same label the resolver consumes,
-   * so a resolved `Space(X)` and its watched ACL doc stay in lockstep. Any read
-   * failure is swallowed to `[]` (fail closed on watching — the render fit
-   * itself stays fail-closed independently).
+   * §4.9.3 Stage 2: subscribe `reeval` to the ACL docs of the spaces `cell` is
+   * labeled `Space(X)` with, so a fail-closed over-block re-renders when an ACL
+   * later grants (or revokes) READ. Shared by the descendant-cell
+   * (`renderCellChild`) and root-mounted (`mount`) egress paths. A no-op
+   * without a membership provider or when the label carries no `Space` atom;
+   * idempotent per space via `watched`; cancels register through `addCancel`
+   * (the cell's cancel group). Reads the same label view the render fit
+   * consumes, so a resolved `Space(X)` and its watched ACL doc stay in
+   * lockstep. Any label-read failure is swallowed (fail closed on watching —
+   * the render fit itself stays fail-closed independently).
    */
-  private spaceIdsForCellLabel(cell: Cell<unknown>): readonly string[] {
-    if (this.membershipProvider === undefined) {
-      return [];
+  private watchCellMembership(
+    cell: Cell<unknown>,
+    watched: Set<string>,
+    addCancel: (cancel: Cancel) => void,
+    reeval: () => void,
+  ): void {
+    const provider = this.membershipProvider;
+    if (provider === undefined) {
+      return;
     }
     let labelView: CfcLabelView | undefined;
     try {
       labelView = cfcLabelViewForCell(cell);
-      if (labelView === undefined) {
-        labelView = cfcLabelViewForCell(cell.resolveAsCell());
-      }
     } catch {
-      return [];
+      labelView = undefined;
     }
-    if (labelView === undefined) {
-      return [];
+    // No stored label (or a read failure) → no `Space` atom to watch. The
+    // render fit still fail-closes independently; we just set up no reactive
+    // upgrade.
+    if (labelView === undefined) return;
+    for (
+      const space of spaceAtomIdsInConfidentiality(
+        this.confidentialityLabels(labelView),
+      )
+    ) {
+      if (watched.has(space)) continue;
+      watched.add(space);
+      addCancel(provider.subscribe(space, reeval));
     }
-    return spaceAtomIdsInConfidentiality(this.confidentialityLabels(labelView));
   }
 
   private confidentialityLabelsFromCellSchema(
@@ -3446,26 +3456,11 @@ export class WorkerReconciler {
 
     let currentCancel: Cancel | undefined;
 
-    // §4.9.3 Stage 2: watch the ACL docs of the spaces this cell is labeled
-    // with, so a fail-closed over-block upgrades to an admit when a `Space(X)`
-    // ACL syncs in (and a revoke re-blocks) — a re-evaluation with the last
-    // resolved value, forced past the value-identity dedupe. Idempotent per
-    // space, and re-scanned on each render so a late-syncing label is caught.
+    // §4.9.3 Stage 2: on each render, watch the ACL docs of the spaces this
+    // cell is labeled with, so a fail-closed over-block upgrades to an admit
+    // when a `Space(X)` ACL syncs in (and a revoke re-blocks) — a re-evaluation
+    // with the last resolved value, forced past the value-identity dedupe.
     const watchedSpaces = new Set<string>();
-    const watchMembershipSpaces = () => {
-      const provider = this.membershipProvider;
-      if (provider === undefined) return;
-      for (const space of this.spaceIdsForCellLabel(cell)) {
-        if (watchedSpaces.has(space)) continue;
-        watchedSpaces.add(space);
-        addCancel(
-          provider.subscribe(
-            space,
-            () => renderResolved(childState.currentValue, true),
-          ),
-        );
-      }
-    };
 
     const renderResolved = (resolvedChild: unknown, forced = false) => {
       const isInitialRender = childState.nodeId === -1;
@@ -3479,7 +3474,12 @@ export class WorkerReconciler {
         return;
       }
       childState.currentValue = resolvedChild;
-      watchMembershipSpaces();
+      this.watchCellMembership(
+        cell,
+        watchedSpaces,
+        addCancel,
+        () => renderResolved(childState.currentValue, true),
+      );
 
       if (!this.canRenderCellUnderPolicy(cell, policy)) {
         if (!isInitialRender) {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -56,6 +56,8 @@ import {
   clauseAlternatives,
   markRendererTrustedEvent,
   type RenderConfidentialityResolver,
+  spaceAtomIdsInConfidentiality,
+  type SpaceMembershipProvider,
 } from "@commonfabric/runner/cfc";
 import type { VDomOp } from "../vdom-ops.ts";
 import { generateChildKeys } from "./keying.ts";
@@ -146,11 +148,16 @@ export class WorkerReconciler {
   // admitting `Space(...)`-via-`HasRole` principal forms. Undefined = H3a
   // exact-match behavior.
   private readonly resolveRenderConfidentiality?: RenderConfidentialityResolver;
+  // §4.9.3 Stage 2: the membership provider whose `subscribe` lets a gated
+  // `Space(X)`-labeled cell re-render when X's ACL syncs/changes. Undefined =
+  // no reactive upgrade (the Stage-1 sync snapshot still gates soundly).
+  private readonly membershipProvider?: SpaceMembershipProvider;
 
   constructor(options: WorkerReconcilerOptions) {
     this.onOps = options.onOps;
     this.onError = options.onError;
     this.resolveRenderConfidentiality = options.resolveRenderConfidentiality;
+    this.membershipProvider = options.membershipProvider;
     // Security knob: a present-but-unknown value fails closed to "deny";
     // only an absent option keeps the documented "allow" default.
     this.renderDeclassificationPolicy = normalizeRenderDeclassificationPolicy(
@@ -1101,6 +1108,33 @@ export class WorkerReconciler {
         ...(entry.label.confidentiality ?? []),
       ]),
     );
+  }
+
+  /**
+   * The `Space(id)` ids in a cell's confidentiality label — the spaces whose
+   * ACL docs a Stage-2 reactive re-render must watch (§4.9.3). Empty unless a
+   * membership provider is wired; reads the same label the resolver consumes,
+   * so a resolved `Space(X)` and its watched ACL doc stay in lockstep. Any read
+   * failure is swallowed to `[]` (fail closed on watching — the render fit
+   * itself stays fail-closed independently).
+   */
+  private spaceIdsForCellLabel(cell: Cell<unknown>): readonly string[] {
+    if (this.membershipProvider === undefined) {
+      return [];
+    }
+    let labelView: CfcLabelView | undefined;
+    try {
+      labelView = cfcLabelViewForCell(cell);
+      if (labelView === undefined) {
+        labelView = cfcLabelViewForCell(cell.resolveAsCell());
+      }
+    } catch {
+      return [];
+    }
+    if (labelView === undefined) {
+      return [];
+    }
+    return spaceAtomIdsInConfidentiality(this.confidentialityLabels(labelView));
   }
 
   private confidentialityLabelsFromCellSchema(
@@ -3386,250 +3420,276 @@ export class WorkerReconciler {
 
     let currentCancel: Cancel | undefined;
 
-    addCancel(
-      cell.sink((resolvedChild) => {
-        const isInitialRender = childState.nodeId === -1;
+    // §4.9.3 Stage 2: watch the ACL docs of the spaces this cell is labeled
+    // with, so a fail-closed over-block upgrades to an admit when a `Space(X)`
+    // ACL syncs in (and a revoke re-blocks) — a re-evaluation with the last
+    // resolved value, forced past the value-identity dedupe. Idempotent per
+    // space, and re-scanned on each render so a late-syncing label is caught.
+    const watchedSpaces = new Set<string>();
+    const watchMembershipSpaces = () => {
+      const provider = this.membershipProvider;
+      if (provider === undefined) return;
+      for (const space of this.spaceIdsForCellLabel(cell)) {
+        if (watchedSpaces.has(space)) continue;
+        watchedSpaces.add(space);
+        addCancel(
+          provider.subscribe(
+            space,
+            () => renderResolved(childState.currentValue, true),
+          ),
+        );
+      }
+    };
 
-        // Dedupe updates
-        if (!isInitialRender && resolvedChild === childState.currentValue) {
-          return;
-        }
-        childState.currentValue = resolvedChild;
+    const renderResolved = (resolvedChild: unknown, forced = false) => {
+      const isInitialRender = childState.nodeId === -1;
 
-        if (!this.canRenderCellUnderPolicy(cell, policy)) {
-          if (!isInitialRender) {
-            if (currentCancel) {
-              currentCancel();
-              currentCancel = undefined;
-            }
-            this.cleanupNodeHandlers(childState);
-            this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
-          }
+      // Dedupe updates. A forced re-eval (an ACL sync/change) bypasses the
+      // value-identity check: the value is unchanged but the render DECISION
+      // may have flipped.
+      if (
+        !forced && !isInitialRender && resolvedChild === childState.currentValue
+      ) {
+        return;
+      }
+      childState.currentValue = resolvedChild;
+      watchMembershipSpaces();
 
-          childState.nodeId = -1;
-          childState.elementState = undefined;
-          childState.isText = false;
-
-          const blockedState = this.createBlockedPlaceholder(ctx, policy);
-          childState.nodeId = blockedState.nodeId;
-          childState.elementState = blockedState;
-          childState.isText = false;
-          currentCancel = blockedState.cancel;
-
-          const beforeId = this.findNextSiblingId(
-            parentState.children,
-            childKey,
-          );
-          this.queueOps([{
-            op: "insert-child",
-            parentId: parentState.nodeId,
-            childId: blockedState.nodeId,
-            beforeId,
-          }]);
-          return;
-        }
-
-        if (this.shouldBlockTextFromCell(resolvedChild, cell, policy)) {
-          if (!isInitialRender) {
-            if (currentCancel) {
-              currentCancel();
-              currentCancel = undefined;
-            }
-            this.cleanupNodeHandlers(childState);
-            this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
-          }
-
-          childState.nodeId = -1;
-          childState.elementState = undefined;
-          childState.isText = false;
-
-          const blockedState = this.createBlockedPlaceholder(
-            ctx,
-            policy,
-            "integrity",
-          );
-          childState.nodeId = blockedState.nodeId;
-          childState.elementState = blockedState;
-          childState.isText = false;
-          currentCancel = blockedState.cancel;
-
-          const beforeId = this.findNextSiblingId(
-            parentState.children,
-            childKey,
-          );
-          this.queueOps([{
-            op: "insert-child",
-            parentId: parentState.nodeId,
-            childId: blockedState.nodeId,
-            beforeId,
-          }]);
-          return;
-        }
-
-        // Try to update in place if not initial render
-        if (
-          !isInitialRender &&
-          childState.nodeId !== -1
-        ) {
-          // Case 1: Text update
-          if (
-            childState.isText &&
-            (typeof resolvedChild === "string" ||
-              typeof resolvedChild === "number")
-          ) {
-            this.queueOps([{
-              op: "update-text",
-              nodeId: childState.nodeId,
-              text: String(resolvedChild),
-            }]);
-            return;
-          }
-
-          // Case 2: VNode in-place update (same tag)
-          if (childState.elementState) {
-            const newVNode = this.extractVNode(
-              resolvedChild as WorkerRenderNode,
-            );
-            if (newVNode) {
-              const sanitized = this.sanitizeNode(newVNode);
-              if (
-                sanitized &&
-                sanitized.name === childState.elementState.tagName
-              ) {
-                const childPolicy = this.childRenderPolicyForNode(
-                  sanitized,
-                  policy,
-                  childState.elementState.nodeId,
-                );
-                const policyChildren = this.childrenForRenderPolicy(
-                  sanitized,
-                  childPolicy,
-                );
-                const policyChanged = !this.renderPolicyEquals(
-                  childState.elementState.childRenderPolicy,
-                  childPolicy,
-                ) ||
-                  childState.elementState.childrenBlockedByPolicy !==
-                    policyChildren.blocked;
-                childState.elementState.renderPolicy = policy;
-                childState.elementState.childRenderPolicy = childPolicy;
-                childState.elementState.childrenBlockedByPolicy =
-                  policyChildren.blocked;
-                childState.elementState.sourceChildren = sanitized.children;
-                childState.elementState.sourceProps = sanitized.props;
-                // Same tag - update props in place
-                this.updatePropsInPlace(
-                  ctx,
-                  childState.elementState,
-                  sanitized.props,
-                );
-
-                if (policyChildren.children !== undefined) {
-                  const childrenSame = this.areChildrenSame(
-                    childState.elementState,
-                    policyChildren.children,
-                  );
-                  this.updateChildrenInPlace(
-                    ctx,
-                    childState.elementState,
-                    policyChildren.children,
-                    new Set(),
-                    childPolicy,
-                    policyChanged,
-                  );
-                  if (!childrenSame || policyChanged) {
-                    this.refreshTextIntegrityBoundaryState(
-                      childState.elementState,
-                      childPolicy,
-                    );
-                  }
-                }
-                return;
-              }
-            }
-          }
-        }
-
-        // Fallback: Replace (existing logic)
-        // Clean up previous (skip if initial render - nothing to clean)
+      if (!this.canRenderCellUnderPolicy(cell, policy)) {
         if (!isInitialRender) {
           if (currentCancel) {
             currentCancel();
             currentCancel = undefined;
           }
-          // Clean up event handlers before removing node
           this.cleanupNodeHandlers(childState);
-          // Log replacement
-          logger.debug(
-            "reconcile-cell-child",
-            () => ({
-              id: childState.nodeId,
-              cellId: this.getCellDebugId(cell),
-              type: "replace",
-              reason: "fallback",
-            }),
-          );
           this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
         }
 
-        // Reset nodeId
         childState.nodeId = -1;
         childState.elementState = undefined;
         childState.isText = false;
 
-        if (resolvedChild === null || resolvedChild === undefined) {
+        const blockedState = this.createBlockedPlaceholder(ctx, policy);
+        childState.nodeId = blockedState.nodeId;
+        childState.elementState = blockedState;
+        childState.isText = false;
+        currentCancel = blockedState.cancel;
+
+        const beforeId = this.findNextSiblingId(
+          parentState.children,
+          childKey,
+        );
+        this.queueOps([{
+          op: "insert-child",
+          parentId: parentState.nodeId,
+          childId: blockedState.nodeId,
+          beforeId,
+        }]);
+        return;
+      }
+
+      if (this.shouldBlockTextFromCell(resolvedChild, cell, policy)) {
+        if (!isInitialRender) {
+          if (currentCancel) {
+            currentCancel();
+            currentCancel = undefined;
+          }
+          this.cleanupNodeHandlers(childState);
+          this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+        }
+
+        childState.nodeId = -1;
+        childState.elementState = undefined;
+        childState.isText = false;
+
+        const blockedState = this.createBlockedPlaceholder(
+          ctx,
+          policy,
+          "integrity",
+        );
+        childState.nodeId = blockedState.nodeId;
+        childState.elementState = blockedState;
+        childState.isText = false;
+        currentCancel = blockedState.cancel;
+
+        const beforeId = this.findNextSiblingId(
+          parentState.children,
+          childKey,
+        );
+        this.queueOps([{
+          op: "insert-child",
+          parentId: parentState.nodeId,
+          childId: blockedState.nodeId,
+          beforeId,
+        }]);
+        return;
+      }
+
+      // Try to update in place if not initial render
+      if (
+        !isInitialRender &&
+        childState.nodeId !== -1
+      ) {
+        // Case 1: Text update
+        if (
+          childState.isText &&
+          (typeof resolvedChild === "string" ||
+            typeof resolvedChild === "number")
+        ) {
+          this.queueOps([{
+            op: "update-text",
+            nodeId: childState.nodeId,
+            text: String(resolvedChild),
+          }]);
           return;
         }
 
-        // Render new content. Primitive text from a Cell has already passed
-        // source-cell text integrity verification above, so do not reclassify
-        // it as an untrusted literal.
-        const newState = this.hasVisibleTextValue(resolvedChild) &&
-            (typeof resolvedChild === "string" ||
-              typeof resolvedChild === "number" ||
-              typeof resolvedChild === "boolean")
-          ? {
-            nodeId: this.createTextNode(
-              ctx,
-              this.stringifyText(resolvedChild),
-              policy,
-              { trustedText: true },
-            ).nodeId,
-            isText: true,
-            cancel: () => {},
-          }
-          : this.renderChildContent(
-            ctx,
-            resolvedChild,
-            new Set(visited),
-            policy,
+        // Case 2: VNode in-place update (same tag)
+        if (childState.elementState) {
+          const newVNode = this.extractVNode(
+            resolvedChild as WorkerRenderNode,
           );
-        if (newState) {
-          childState.nodeId = newState.nodeId;
-          childState.elementState = newState.elementState;
-          childState.isText = newState.isText;
-          currentCancel = newState.cancel;
+          if (newVNode) {
+            const sanitized = this.sanitizeNode(newVNode);
+            if (
+              sanitized &&
+              sanitized.name === childState.elementState.tagName
+            ) {
+              const childPolicy = this.childRenderPolicyForNode(
+                sanitized,
+                policy,
+                childState.elementState.nodeId,
+              );
+              const policyChildren = this.childrenForRenderPolicy(
+                sanitized,
+                childPolicy,
+              );
+              const policyChanged = !this.renderPolicyEquals(
+                childState.elementState.childRenderPolicy,
+                childPolicy,
+              ) ||
+                childState.elementState.childrenBlockedByPolicy !==
+                  policyChildren.blocked;
+              childState.elementState.renderPolicy = policy;
+              childState.elementState.childRenderPolicy = childPolicy;
+              childState.elementState.childrenBlockedByPolicy =
+                policyChildren.blocked;
+              childState.elementState.sourceChildren = sanitized.children;
+              childState.elementState.sourceProps = sanitized.props;
+              // Same tag - update props in place
+              this.updatePropsInPlace(
+                ctx,
+                childState.elementState,
+                sanitized.props,
+              );
 
-          // Always insert the child into its parent. On initial render,
-          // updateChildren also emits insert-child but may see nodeId=-1
-          // (Cell hasn't resolved yet), making that op a no-op. This
-          // ensures the node is inserted once it actually exists.
-          // Double inserts are harmless (DOM appendChild/insertBefore is idempotent).
-          const beforeId = this.findNextSiblingId(
-            parentState.children,
-            childKey,
-          );
-          this.queueOps([
-            {
-              op: "insert-child",
-              parentId: parentState.nodeId,
-              childId: newState.nodeId,
-              beforeId,
-            },
-          ]);
+              if (policyChildren.children !== undefined) {
+                const childrenSame = this.areChildrenSame(
+                  childState.elementState,
+                  policyChildren.children,
+                );
+                this.updateChildrenInPlace(
+                  ctx,
+                  childState.elementState,
+                  policyChildren.children,
+                  new Set(),
+                  childPolicy,
+                  policyChanged,
+                );
+                if (!childrenSame || policyChanged) {
+                  this.refreshTextIntegrityBoundaryState(
+                    childState.elementState,
+                    childPolicy,
+                  );
+                }
+              }
+              return;
+            }
+          }
         }
-      }),
-    );
+      }
+
+      // Fallback: Replace (existing logic)
+      // Clean up previous (skip if initial render - nothing to clean)
+      if (!isInitialRender) {
+        if (currentCancel) {
+          currentCancel();
+          currentCancel = undefined;
+        }
+        // Clean up event handlers before removing node
+        this.cleanupNodeHandlers(childState);
+        // Log replacement
+        logger.debug(
+          "reconcile-cell-child",
+          () => ({
+            id: childState.nodeId,
+            cellId: this.getCellDebugId(cell),
+            type: "replace",
+            reason: "fallback",
+          }),
+        );
+        this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+      }
+
+      // Reset nodeId
+      childState.nodeId = -1;
+      childState.elementState = undefined;
+      childState.isText = false;
+
+      if (resolvedChild === null || resolvedChild === undefined) {
+        return;
+      }
+
+      // Render new content. Primitive text from a Cell has already passed
+      // source-cell text integrity verification above, so do not reclassify
+      // it as an untrusted literal.
+      const newState = this.hasVisibleTextValue(resolvedChild) &&
+          (typeof resolvedChild === "string" ||
+            typeof resolvedChild === "number" ||
+            typeof resolvedChild === "boolean")
+        ? {
+          nodeId: this.createTextNode(
+            ctx,
+            this.stringifyText(resolvedChild),
+            policy,
+            { trustedText: true },
+          ).nodeId,
+          isText: true,
+          cancel: () => {},
+        }
+        : this.renderChildContent(
+          ctx,
+          resolvedChild,
+          new Set(visited),
+          policy,
+        );
+      if (newState) {
+        childState.nodeId = newState.nodeId;
+        childState.elementState = newState.elementState;
+        childState.isText = newState.isText;
+        currentCancel = newState.cancel;
+
+        // Always insert the child into its parent. On initial render,
+        // updateChildren also emits insert-child but may see nodeId=-1
+        // (Cell hasn't resolved yet), making that op a no-op. This
+        // ensures the node is inserted once it actually exists.
+        // Double inserts are harmless (DOM appendChild/insertBefore is idempotent).
+        const beforeId = this.findNextSiblingId(
+          parentState.children,
+          childKey,
+        );
+        this.queueOps([
+          {
+            op: "insert-child",
+            parentId: parentState.nodeId,
+            childId: newState.nodeId,
+            beforeId,
+          },
+        ]);
+      }
+    };
+
+    addCancel(cell.sink((resolvedChild) => renderResolved(resolvedChild)));
 
     // When the cancel group fires (parent teardown), also cancel the current
     // rendered content. Without this, deeper sinks (e.g. children/props of the

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -6,7 +6,10 @@
  */
 
 import type { Cancel, Cell, JSONSchema } from "@commonfabric/runner";
-import type { RenderConfidentialityResolver } from "@commonfabric/runner/cfc";
+import type {
+  RenderConfidentialityResolver,
+  SpaceMembershipProvider,
+} from "@commonfabric/runner/cfc";
 import type { CellRef, JSONValue } from "@commonfabric/runtime-client";
 
 /**
@@ -360,6 +363,16 @@ export interface WorkerReconcilerOptions {
    * reconciler only fits the resolved label against the ceiling.
    */
   resolveRenderConfidentiality?: RenderConfidentialityResolver;
+
+  /**
+   * The §4.9.3 membership provider backing {@link resolveRenderConfidentiality}
+   * (Stage 2 reactive upgrade). When present, a rendered cell labeled
+   * `Space(X)` subscribes to X's ACL doc within its cancel group, so a
+   * fail-closed over-block (X's ACL not yet synced) re-renders to an admit once
+   * the ACL arrives — and a later revoke re-blocks. Absent → no reactive
+   * upgrade (Stage-1 sync snapshot only; still sound, just less precise).
+   */
+  membershipProvider?: SpaceMembershipProvider;
 }
 
 /**

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -8,7 +8,10 @@ import {
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { cfcAtom } from "@commonfabric/api/cfc";
-import { createRenderConfidentialityResolver } from "@commonfabric/runner/cfc";
+import {
+  createRenderConfidentialityResolver,
+  type SpaceMembershipProvider,
+} from "@commonfabric/runner/cfc";
 import type { WorkerVNode } from "../src/worker/types.ts";
 import { normalizeRenderDeclassificationPolicy } from "../src/worker/types.ts";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
@@ -3352,6 +3355,125 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             false,
           );
           assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    // §4.9.3 Stage 2 (reactive upgrade): a cell labeled Space(X) where X's ACL
+    // has not yet synced fails closed (Stage 1); when the membership provider
+    // later reports X grants the acting user READ and fires its subscription,
+    // the cell re-renders and admits — WITHOUT a new value on the cell. Proves
+    // the reconciler wires the provider's ACL-change subscription into the
+    // cell's cancel group and re-evaluates the render gate on change.
+    await t.step(
+      "reactively re-renders a Space(X) cell once its ACL grants READ",
+      async () => {
+        const teamSpace = "did:key:z6MkTeamSpaceStage4Reactive";
+        const seedTx = runtime.edit();
+        const teamCell = runtime.getCell<string>(
+          signer.did(),
+          "cfc-stage4-team-note",
+          undefined,
+          seedTx,
+        );
+        const teamLink = teamCell.getAsNormalizedFullLink();
+        seedTx.writeOrThrow({
+          space: signer.did(),
+          id: teamLink.id!,
+          type: "application/json",
+          path: [],
+        }, {
+          value: "Team note",
+          cfc: {
+            version: 1,
+            schemaHash: "test-stage4-schema",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                label: { confidentiality: [cfcAtom.space(teamSpace)] },
+              }],
+            },
+          },
+        });
+        assertEquals((await seedTx.commit()).ok !== undefined, true);
+        const teamLabeled = runtime.getCell<string>(
+          signer.did(),
+          "cfc-stage4-team-note",
+        );
+
+        // Start denying (ACL unsynced), then grant + fire the subscription.
+        let granted = false;
+        const listeners: Array<{ space: string; onChange: () => void }> = [];
+        const provider: SpaceMembershipProvider = {
+          readerRole: (space) =>
+            granted && space === teamSpace ? "reader" : null,
+          subscribe: (space, onChange) => {
+            const entry = { space, onChange };
+            listeners.push(entry);
+            return () => {
+              const index = listeners.indexOf(entry);
+              if (index >= 0) listeners.splice(index, 1);
+            };
+          },
+        };
+        const fireAcl = (space: string) => {
+          for (const listener of [...listeners]) {
+            if (listener.space === space) listener.onChange();
+          }
+        };
+        const resolver = createRenderConfidentialityResolver({
+          actingPrincipal: signer.did(),
+          membershipProvider: provider,
+        });
+
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderConfidentialityCeiling: {
+            atoms: [
+              cfcAtom.user(signer.did()),
+              cfcAtom.personalSpace(signer.did()),
+            ],
+            caveatKinds: [],
+          },
+          resolveRenderConfidentiality: resolver,
+          membershipProvider: provider,
+        });
+        const cancel = reconciler.mount({
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [teamLabeled as never],
+        });
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          // Before the ACL grants READ, the Space(team) label fails closed.
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Team note"),
+            false,
+          );
+          // The reconciler subscribed to the labeled space's ACL doc.
+          assertEquals(
+            listeners.some((listener) => listener.space === teamSpace),
+            true,
+          );
+
+          // The ACL syncs in and grants READ; the subscription fires and the
+          // cell re-renders — the Stage-1 over-block upgrades to an admit with
+          // no new value on the cell.
+          granted = true;
+          collector.clear();
+          fireAcl(teamSpace);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Team note"),
+            true,
+          );
         } finally {
           cancel();
         }

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -3479,6 +3479,111 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    // The root-mounted cell is an egress too (codex P2): a Space(X) cell
+    // mounted AS the root gets the same reactive upgrade as a descendant.
+    await t.step(
+      "reactively re-renders a root-mounted Space(X) cell once its ACL grants READ",
+      async () => {
+        const teamSpace = "did:key:z6MkTeamSpaceStage4Root";
+        const seedTx = runtime.edit();
+        const teamCell = runtime.getCell<string>(
+          signer.did(),
+          "cfc-stage4-root-note",
+          undefined,
+          seedTx,
+        );
+        const teamLink = teamCell.getAsNormalizedFullLink();
+        seedTx.writeOrThrow({
+          space: signer.did(),
+          id: teamLink.id!,
+          type: "application/json",
+          path: [],
+        }, {
+          value: "Root team note",
+          cfc: {
+            version: 1,
+            schemaHash: "test-stage4-root-schema",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                label: { confidentiality: [cfcAtom.space(teamSpace)] },
+              }],
+            },
+          },
+        });
+        assertEquals((await seedTx.commit()).ok !== undefined, true);
+        const teamLabeled = runtime.getCell<string>(
+          signer.did(),
+          "cfc-stage4-root-note",
+        );
+
+        let granted = false;
+        const listeners: Array<{ space: string; onChange: () => void }> = [];
+        const provider: SpaceMembershipProvider = {
+          readerRole: (space) =>
+            granted && space === teamSpace ? "reader" : null,
+          subscribe: (space, onChange) => {
+            const entry = { space, onChange };
+            listeners.push(entry);
+            return () => {
+              const index = listeners.indexOf(entry);
+              if (index >= 0) listeners.splice(index, 1);
+            };
+          },
+        };
+        const fireAcl = (space: string) => {
+          for (const listener of [...listeners]) {
+            if (listener.space === space) listener.onChange();
+          }
+        };
+        const resolver = createRenderConfidentialityResolver({
+          actingPrincipal: signer.did(),
+          membershipProvider: provider,
+        });
+
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderConfidentialityCeiling: {
+            atoms: [
+              cfcAtom.user(signer.did()),
+              cfcAtom.personalSpace(signer.did()),
+            ],
+            caveatKinds: [],
+          },
+          resolveRenderConfidentiality: resolver,
+          membershipProvider: provider,
+        });
+        // Mount the labeled cell AS the root.
+        const cancel = reconciler.mount(teamLabeled);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Root team note"),
+            false,
+          );
+          assertEquals(
+            listeners.some((listener) => listener.space === teamSpace),
+            true,
+          );
+
+          granted = true;
+          collector.clear();
+          fireAcl(teamSpace);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Root team note"),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -3403,6 +3403,18 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           signer.did(),
           "cfc-stage4-team-note",
         );
+        // A sibling cell with NO stored label: the membership watcher must find
+        // no Space atom and set up no ACL subscription for it (labelView
+        // undefined path), while it renders normally under the ceiling.
+        const plainCell = runtime.getCell<string>(
+          signer.did(),
+          "cfc-stage4-plain-note",
+        );
+        {
+          const seed = runtime.edit();
+          plainCell.withTx(seed).set("Plain note");
+          assertEquals((await seed.commit()).ok !== undefined, true);
+        }
 
         // Start denying (ACL unsynced), then grant + fire the subscription.
         let granted = false;
@@ -3446,7 +3458,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           type: "vnode",
           name: "div",
           props: {},
-          children: [teamLabeled as never],
+          children: [teamLabeled as never, plainCell as never],
         });
         try {
           await new Promise((resolve) => setTimeout(resolve, 10));
@@ -3456,11 +3468,19 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
               .includes("Team note"),
             false,
           );
+          // The unlabeled sibling renders (no Space atom to gate) and no ACL
+          // subscription was set up for it.
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Plain note"),
+            true,
+          );
           // The reconciler subscribed to the labeled space's ACL doc.
           assertEquals(
             listeners.some((listener) => listener.space === teamSpace),
             true,
           );
+          assertEquals(listeners.length, 1);
 
           // The ACL syncs in and grants READ; the subscription fires and the
           // cell re-renders — the Stage-1 over-block upgrades to an admit with

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -3494,6 +3494,26 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
               .includes("Team note"),
             true,
           );
+
+          // Revoke (admit -> block, the confidentiality-critical direction):
+          // the ACL drops READ, the subscription fires again, and the gate
+          // re-blocks the already-rendered cell — the content is removed and
+          // the blocked placeholder re-inserted. Guards against an upgrade-only
+          // re-eval regression that would leave admitted content on screen.
+          granted = false;
+          collector.clear();
+          fireAcl(teamSpace);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Team note"),
+            false,
+          );
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Content hidden by policy"),
+            true,
+          );
         } finally {
           cancel();
         }
@@ -3597,6 +3617,22 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
               .includes("Root team note"),
+            true,
+          );
+
+          // Revoke re-blocks the root-mounted cell too (admit -> block).
+          granted = false;
+          collector.clear();
+          fireAcl(teamSpace);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Root team note"),
+            false,
+          );
+          assertEquals(
+            collector.getOpsOfType("create-text").map((op) => op.text)
+              .includes("Content hidden by policy"),
             true,
           );
         } finally {

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -130,6 +130,8 @@ export {
   RENDER_SINK_NAME,
   STANDARD_RENDER_EXCHANGE_RULES,
 } from "./render-ceiling.ts";
+export type { SpaceRole } from "./space-membership.ts";
+export { spaceReaderRole } from "./space-membership.ts";
 export {
   flowLabelWorkExists,
   flowReadExcluded,

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -128,10 +128,14 @@ export {
   createRenderConfidentialityResolver,
   RENDER_DISPLAY_SINK_CLASS,
   RENDER_SINK_NAME,
+  spaceAtomIdsInConfidentiality,
   STANDARD_RENDER_EXCHANGE_RULES,
 } from "./render-ceiling.ts";
-export type { SpaceRole } from "./space-membership.ts";
-export { spaceReaderRole } from "./space-membership.ts";
+export type { SpaceMembershipProvider, SpaceRole } from "./space-membership.ts";
+export {
+  createRuntimeSpaceMembershipProvider,
+  spaceReaderRole,
+} from "./space-membership.ts";
 export {
   flowLabelWorkExists,
   flowReadExcluded,

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -1,11 +1,14 @@
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { isRecord } from "@commonfabric/utils/types";
 import {
   buildCfcPolicySnapshot,
   type ExchangeRule,
   type PolicySnapshot,
 } from "./policy.ts";
 import { evaluateExchangeRules } from "./exchange-eval.ts";
+import { clauseAlternatives } from "./clause.ts";
 import { type CfcTrustConfig, createTrustResolver } from "./trust.ts";
+import type { SpaceMembershipProvider } from "./space-membership.ts";
 
 /**
  * Display-sink render ceiling resolution (Epic H3b of
@@ -102,6 +105,49 @@ export type RenderConfidentialityResolverConfig = {
    * broader cross-space membership arrives with the §4.9.3 membership lookup.
    */
   readonly memberSpaces?: readonly string[];
+  /**
+   * The §4.9.3 membership lookup: a per-space capability oracle consulted for
+   * each `Space(id)` atom in the label being rendered. When it verifies the
+   * acting principal reads that space (its declared ACL grants READ+, never
+   * residency), the resolver mints `HasRole(actingPrincipal, id, reader)` so
+   * the clause resolves — the dynamic complement to the static `memberSpaces`
+   * fast path (own space + session space, which need no ACL read).
+   *
+   * The cross-space guarantee is exactly as strong as the deployment's
+   * `MEMORY_ACL_MODE`: under `enforce` the ACL is authoritative; under
+   * `observe`/`off` the lookup reads the same declared (creator-seeded) record
+   * — strictly better than residency, but only as strong as the posture. Fail
+   * closed throughout: a `null` role (absent/unsynced/malformed ACL, or a
+   * non-reader principal) mints nothing and the `Space(...)` clause stays
+   * blocked.
+   */
+  readonly membershipProvider?: SpaceMembershipProvider;
+};
+
+/**
+ * The `Space(id)` atom ids present in a confidentiality label, walking each
+ * clause's alternatives so a `Space` atom nested inside an `{ anyOf: [...] }`
+ * clause is discovered too (§4.3.4 multi-binding gives one access path per
+ * role held). Order-preserving and deduped, so the provider is consulted once
+ * per distinct space.
+ */
+export const spaceAtomIdsInConfidentiality = (
+  confidentiality: readonly unknown[],
+): readonly string[] => {
+  const ids: string[] = [];
+  for (const clause of confidentiality) {
+    for (const alternative of clauseAlternatives(clause)) {
+      if (
+        isRecord(alternative) &&
+        (alternative as { type?: unknown }).type === CFC_ATOM_TYPE.Space &&
+        typeof (alternative as { id?: unknown }).id === "string"
+      ) {
+        const id = (alternative as { id: string }).id;
+        if (!ids.includes(id)) ids.push(id);
+      }
+    }
+  }
+  return ids;
 };
 
 /** The label of the cell being rendered, as read at the display boundary. */
@@ -137,12 +183,24 @@ export const createRenderConfidentialityResolver = (
 ): RenderConfidentialityResolver => {
   const boundary = renderDisplayBoundary();
   const trustResolver = createTrustResolver(config.trustConfig);
-  const staticRoleFacts = mintReaderRoleFacts(
-    config.actingPrincipal,
-    config.memberSpaces ?? [],
-  );
+  const actingPrincipal = config.actingPrincipal;
+  const staticMemberSpaces = config.memberSpaces ?? [];
+  const provider = config.membershipProvider;
   return (label) => {
     if (label.confidentiality.length === 0) return label.confidentiality;
+    // §4.9.3: role facts come ONLY from verified membership, never from the
+    // cell's residency. The static fast-path members (own space + session
+    // space — implicit reads, no ACL lookup) plus any `Space(id)` atom in THIS
+    // label the provider confirms the acting principal reads. A space the user
+    // cannot prove reader access to mints nothing and fails closed.
+    const memberSpaces = new Set(staticMemberSpaces);
+    if (provider !== undefined && actingPrincipal !== undefined) {
+      for (const id of spaceAtomIdsInConfidentiality(label.confidentiality)) {
+        if (memberSpaces.has(id)) continue; // already a static fast-path member
+        if (provider.readerRole(id) !== null) memberSpaces.add(id);
+      }
+    }
+    const roleFacts = mintReaderRoleFacts(actingPrincipal, [...memberSpaces]);
     const result = evaluateExchangeRules(
       {
         confidentiality: [...label.confidentiality],
@@ -150,13 +208,10 @@ export const createRenderConfidentialityResolver = (
       },
       STANDARD_RENDER_SNAPSHOT,
       {
-        // §4.9.3: role facts come ONLY from the verified member set, never
-        // from the cell's residency — so a `Space(X)` label the acting user
-        // cannot prove reader access to stays unresolved and fails closed.
-        integrity: staticRoleFacts,
+        integrity: roleFacts,
         boundary,
         trustResolver,
-        actingPrincipal: config.actingPrincipal,
+        actingPrincipal,
       },
     );
     return result.exhausted

--- a/packages/runner/src/cfc/space-membership.ts
+++ b/packages/runner/src/cfc/space-membership.ts
@@ -86,9 +86,12 @@ export interface SpaceMembershipProvider {
    */
   readerRole(space: string): SpaceRole | null;
   /**
-   * Subscribe to a space's ACL doc; `onChange` fires when it syncs or changes.
-   * Returns a cancel. Used by the reconciler to re-render a gated
-   * `Space(...)`-labeled cell within its existing cancel group (§3.4 Stage 2).
+   * Subscribe to a space's ACL doc; `onChange` fires when it later syncs or
+   * changes — NOT synchronously at subscribe time (the initial snapshot is
+   * `readerRole`'s job). Returns a cancel. Used by the reconciler to re-render
+   * a gated `Space(...)`-labeled cell within its existing cancel group (§3.4
+   * Stage 2), so a fail-closed over-block upgrades to an admit when the ACL
+   * arrives (and a revoke re-blocks).
    */
   subscribe(space: string, onChange: () => void): Cancel;
 }
@@ -151,7 +154,18 @@ export const createRuntimeSpaceMembershipProvider = (
       return spaceReaderRole(acl, space, actingPrincipal, serviceDids);
     },
     subscribe(space, onChange) {
-      return aclCellFor(runtime, cells, space).sink(() => onChange());
+      // `Cell.sink` runs its action once synchronously at subscribe time (the
+      // current snapshot); skip that fire so `onChange` signals CHANGE only —
+      // the caller already has the snapshot from `readerRole`. Every later
+      // re-fire (the ACL syncing in, or a subsequent write) invokes `onChange`.
+      let primed = false;
+      return aclCellFor(runtime, cells, space).sink(() => {
+        if (!primed) {
+          primed = true;
+          return;
+        }
+        onChange();
+      });
     },
   };
 };

--- a/packages/runner/src/cfc/space-membership.ts
+++ b/packages/runner/src/cfc/space-membership.ts
@@ -62,11 +62,12 @@ export const spaceReaderRole = (
   if (!isACL(acl)) return null;
   const byPrincipal = acl as Record<string, Capability | undefined>;
   const cap = byPrincipal[principal] ?? byPrincipal[ANYONE_USER];
-  if (cap === undefined) return null;
-  // WRITE/OWNER imply READ; a defensive guard mirroring the server's
-  // `isCapable(capability, requirement)` — `Capability` is only ever
-  // READ/WRITE/OWNER, so a valid grant always clears READ.
-  if (!isCapable(cap, "READ")) return null;
+  // `undefined` = principal not listed and no `"*"` grant. The `isCapable`
+  // mirror of the server's requirement check is folded in: a valid `Capability`
+  // is only ever READ/WRITE/OWNER and each clears READ (WRITE/OWNER imply READ),
+  // so it is vacuously true here, but kept so the client cannot drift from the
+  // server if READ's rank ever changes.
+  if (cap === undefined || !isCapable(cap, "READ")) return null;
   return capToRole[cap];
 };
 

--- a/packages/runner/src/cfc/space-membership.ts
+++ b/packages/runner/src/cfc/space-membership.ts
@@ -5,6 +5,10 @@ import {
   isACL,
   isCapable,
 } from "@commonfabric/memory/acl";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { Cancel } from "../cancel.ts";
+import type { Cell } from "../cell.ts";
+import type { Runtime } from "../runtime.ts";
 
 /**
  * §4.9.3 render membership lookup (design:
@@ -64,4 +68,90 @@ export const spaceReaderRole = (
   // READ/WRITE/OWNER, so a valid grant always clears READ.
   if (!isCapable(cap, "READ")) return null;
   return capToRole[cap];
+};
+
+/**
+ * A synchronous membership oracle for the render fit (which runs inside a
+ * `cell.sink` callback and cannot await). `readerRole` gives a sync snapshot
+ * from the local replica; `subscribe` lets a gated render re-evaluate when a
+ * space's ACL later syncs or changes (Stage 2 reactive upgrade, §3.4).
+ */
+export interface SpaceMembershipProvider {
+  /**
+   * The acting principal's reader-or-higher role in `space` from the local
+   * replica, or `null` when unknown/not-a-member (both fail closed). Reads the
+   * space's ACL doc synchronously and — when it is not yet synced — kicks a
+   * background sync, so a later reactive tick (see `subscribe`) can upgrade an
+   * over-block to an admit.
+   */
+  readerRole(space: string): SpaceRole | null;
+  /**
+   * Subscribe to a space's ACL doc; `onChange` fires when it syncs or changes.
+   * Returns a cancel. Used by the reconciler to re-render a gated
+   * `Space(...)`-labeled cell within its existing cancel group (§3.4 Stage 2).
+   */
+  subscribe(space: string, onChange: () => void): Cancel;
+}
+
+/**
+ * The space-DID cell whose value is the space's ACL document — entity id
+ * `of:${space}` == the space DID, read in-space (mirrors `ACLManager` and the
+ * server's `aclDocId`). One Cell per space, reused across `readerRole` reads
+ * and `subscribe` so both observe the same reactive state.
+ */
+const aclCellFor = (
+  runtime: Pick<Runtime, "getCellFromLink">,
+  cache: Map<string, Cell<unknown>>,
+  space: string,
+): Cell<unknown> => {
+  let cell = cache.get(space);
+  if (cell === undefined) {
+    // The ACL doc's entity id IS the space DID (`aclDocId(space)` server-side),
+    // read in-space — the same link `ACLManager` uses.
+    cell = runtime.getCellFromLink<unknown>({
+      id: space as MemorySpace,
+      path: [],
+      space: space as MemorySpace,
+    });
+    cache.set(space, cell);
+  }
+  return cell;
+};
+
+/**
+ * A runtime-backed {@link SpaceMembershipProvider}: `readerRole` reads each
+ * space's ACL doc from the local replica via `Cell.get()` (sync value + a
+ * background-sync kick when unsynced) and runs {@link spaceReaderRole}.
+ *
+ * Deliberately NOT memoized: the ACL is the authority record, and a stale memo
+ * would keep admitting a `Space(...)` clause after a revoke (unsound) — so each
+ * call reflects the latest replica. `Cell.get()`'s per-transaction read cache
+ * already amortizes repeated reads within a single synchronous render pass, so
+ * a fresh read is cheap; the ACL doc is tiny and the whole path only runs when
+ * a ceiling is in force and the label carries a `Space(...)` atom.
+ *
+ * `serviceDids` grants implicit OWNER to configured service principals; the
+ * worker does not thread `MEMORY_SERVICE_DIDS` today (design §9), so callers
+ * pass `[]` and service principals — which rarely render — fail closed.
+ */
+export const createRuntimeSpaceMembershipProvider = (
+  runtime: Pick<Runtime, "getCellFromLink">,
+  actingPrincipal: string,
+  serviceDids: readonly string[] = [],
+): SpaceMembershipProvider => {
+  const cells = new Map<string, Cell<unknown>>();
+  return {
+    readerRole(space) {
+      // Own-space and service principals are implicit OWNER — decided WITHOUT
+      // reading (or syncing) any ACL doc.
+      if (space === actingPrincipal || serviceDids.includes(actingPrincipal)) {
+        return "owner";
+      }
+      const acl = aclCellFor(runtime, cells, space).get() as ACL | undefined;
+      return spaceReaderRole(acl, space, actingPrincipal, serviceDids);
+    },
+    subscribe(space, onChange) {
+      return aclCellFor(runtime, cells, space).sink(() => onChange());
+    },
+  };
 };

--- a/packages/runner/src/cfc/space-membership.ts
+++ b/packages/runner/src/cfc/space-membership.ts
@@ -1,0 +1,67 @@
+import {
+  type ACL,
+  ANYONE_USER,
+  type Capability,
+  isACL,
+  isCapable,
+} from "@commonfabric/memory/acl";
+
+/**
+ * §4.9.3 render membership lookup (design:
+ * docs/specs/cfc-render-membership-lookup.md). The verified source of the
+ * `HasRole(actingUser, space, reader)` facts the render ceiling mints to admit
+ * a cross-space `Space(...)` label — sourced from the space's declared ACL
+ * document, NEVER from a cell's mere local residency (residency is not read
+ * authority; H3b commit 4fc05f800).
+ */
+
+/** A principal's role in a space, or `null` if none (fail closed). */
+export type SpaceRole = "owner" | "writer" | "reader";
+
+const capToRole: Record<Capability, SpaceRole> = {
+  READ: "reader",
+  WRITE: "writer",
+  OWNER: "owner",
+};
+
+/**
+ * A principal's reader-or-higher role in a space, or `null` when it holds
+ * none. A client-side mirror of the server's `#resolveCapability`
+ * (packages/memory/v2/server.ts `#resolveCapability`), so the render gate's
+ * authority decision cannot drift from the server's — the two consult the
+ * SAME `@commonfabric/memory/acl` helpers (`isACL`, `isCapable`, `ANYONE_USER`).
+ *
+ * Resolution order (mirrors the server exactly):
+ *  1. Implicit `OWNER` when `principal === space` (a principal owns its own
+ *     identity space) or `principal` is a configured service DID — these hold
+ *     regardless of ACL contents or deployment ACL mode.
+ *  2. Otherwise the ACL document decides: `acl[principal] ?? acl["*"]`. A
+ *     missing/malformed ACL, an unlisted principal with no `"*"` grant, or a
+ *     capability short of READ all yield `null` (fail closed). The implicit
+ *     owners above are unaffected by an absent ACL.
+ *
+ * `acl` is the space's ACL doc value (`undefined` = not yet read / absent):
+ * both `undefined` and a malformed value fail closed. A returned role is
+ * always reader-or-higher — every `Capability` is `isCapable(_, "READ")`, so
+ * any explicit grant admits reader access; the exact rank is returned for
+ * callers that need it, but the render mint only needs non-`null`.
+ */
+export const spaceReaderRole = (
+  acl: ACL | undefined,
+  space: string,
+  principal: string,
+  serviceDids: readonly string[] = [],
+): SpaceRole | null => {
+  // Implicit OWNER: you own your own identity space; service principals.
+  if (principal === space || serviceDids.includes(principal)) return "owner";
+  // Missing or malformed ACL document grants nothing (fail closed).
+  if (!isACL(acl)) return null;
+  const byPrincipal = acl as Record<string, Capability | undefined>;
+  const cap = byPrincipal[principal] ?? byPrincipal[ANYONE_USER];
+  if (cap === undefined) return null;
+  // WRITE/OWNER imply READ; a defensive guard mirroring the server's
+  // `isCapable(capability, requirement)` — `Capability` is only ever
+  // READ/WRITE/OWNER, so a valid grant always clears READ.
+  if (!isCapable(cap, "READ")) return null;
+  return capToRole[cap];
+};

--- a/packages/runner/test/cfc-render-ceiling.test.ts
+++ b/packages/runner/test/cfc-render-ceiling.test.ts
@@ -5,6 +5,7 @@ import {
   createRenderConfidentialityResolver,
   RENDER_DISPLAY_SINK_CLASS,
 } from "../src/cfc/render-ceiling.ts";
+import type { SpaceMembershipProvider } from "../src/cfc/space-membership.ts";
 import { atomsOutsideCeiling } from "../src/cfc/observation.ts";
 
 // Epic H3b (docs/plans/cfc-future-work-implementation.md §7): the display-sink
@@ -132,5 +133,121 @@ describe("CFC render confidentiality resolver (H3b)", () => {
     expect(atomsOutsideCeiling(resolved, aliceCeiling)).toEqual([
       cfcAtom.space(SPACE_TEAM),
     ]);
+  });
+});
+
+// §4.9.3 per-label membership discovery: instead of a static member set, the
+// resolver mints HasRole facts PER-LABEL from the Space atoms present in the
+// label, consulting a SpaceMembershipProvider (the ACL-doc-backed lookup).
+const providerGranting = (
+  grantedSpaces: readonly string[],
+): SpaceMembershipProvider => ({
+  readerRole: (space) => grantedSpaces.includes(space) ? "reader" : null,
+  subscribe: () => () => {},
+});
+
+describe("CFC render resolver — per-label membership discovery (§4.9.3)", () => {
+  it("resolves a Space label the provider verifies the acting user reads", () => {
+    const resolve = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      membershipProvider: providerGranting([SPACE_TEAM]),
+    });
+    const resolved = resolve({ confidentiality: [cfcAtom.space(SPACE_TEAM)] });
+    expect(atomsOutsideCeiling(resolved, aliceCeiling)).toEqual([]);
+  });
+
+  it("blocks a Space label the provider does not grant (fail-closed)", () => {
+    // The provider grants nothing for SPACE_OTHER — residency/an unsynced ACL
+    // mints no fact, so the clause stays outside the ceiling.
+    const resolve = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      membershipProvider: providerGranting([SPACE_TEAM]),
+    });
+    const resolved = resolve({ confidentiality: [cfcAtom.space(SPACE_OTHER)] });
+    expect(atomsOutsideCeiling(resolved, aliceCeiling)).toEqual([
+      cfcAtom.space(SPACE_OTHER),
+    ]);
+  });
+
+  it("§4.9.4 conjunctive: admits iff EVERY Space clause resolves", () => {
+    // A value carrying two Space atoms gets an independent verified fact per
+    // space; both must resolve for the value to fit.
+    const resolve = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      membershipProvider: providerGranting([SPACE_TEAM]),
+    });
+    // Only TEAM granted: OTHER stays offending.
+    const partial = resolve({
+      confidentiality: [cfcAtom.space(SPACE_TEAM), cfcAtom.space(SPACE_OTHER)],
+    });
+    expect(atomsOutsideCeiling(partial, aliceCeiling)).toEqual([
+      cfcAtom.space(SPACE_OTHER),
+    ]);
+    // Both granted: the whole conjunction fits.
+    const resolveBoth = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      membershipProvider: providerGranting([SPACE_TEAM, SPACE_OTHER]),
+    });
+    const both = resolveBoth({
+      confidentiality: [cfcAtom.space(SPACE_TEAM), cfcAtom.space(SPACE_OTHER)],
+    });
+    expect(atomsOutsideCeiling(both, aliceCeiling)).toEqual([]);
+  });
+
+  it("combines the static fast-path member set with per-label discovery", () => {
+    // Own space stays a static fast-path member (no ACL read); a cross-space
+    // Space atom is discovered per-label via the provider.
+    const resolve = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      memberSpaces: [ALICE],
+      membershipProvider: providerGranting([SPACE_TEAM]),
+    });
+    const resolved = resolve({
+      confidentiality: [cfcAtom.space(ALICE), cfcAtom.space(SPACE_TEAM)],
+    });
+    expect(atomsOutsideCeiling(resolved, aliceCeiling)).toEqual([]);
+  });
+
+  it("does not consult the provider for a space in the static fast path", () => {
+    // The own/session fast path needs no ACL read; the provider must not be
+    // asked about spaces already trusted statically.
+    const consulted: string[] = [];
+    const provider: SpaceMembershipProvider = {
+      readerRole: (space) => {
+        consulted.push(space);
+        return null;
+      },
+      subscribe: () => () => {},
+    };
+    const resolve = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      memberSpaces: [ALICE],
+      membershipProvider: provider,
+    });
+    resolve({ confidentiality: [cfcAtom.space(ALICE)] });
+    expect(consulted).not.toContain(ALICE);
+  });
+
+  it("discovers Space atoms nested inside an anyOf clause", () => {
+    // §4.3.4 multi-binding: a disjunctive clause offers one access path per
+    // role held; the provider is consulted for Space atoms inside anyOf too.
+    const consulted: string[] = [];
+    const provider: SpaceMembershipProvider = {
+      readerRole: (space) => {
+        consulted.push(space);
+        return space === SPACE_TEAM ? "reader" : null;
+      },
+      subscribe: () => () => {},
+    };
+    const resolve = createRenderConfidentialityResolver({
+      actingPrincipal: ALICE,
+      membershipProvider: provider,
+    });
+    resolve({
+      confidentiality: [{
+        anyOf: [cfcAtom.space(SPACE_TEAM), cfcAtom.user(MALLORY)],
+      }],
+    });
+    expect(consulted).toContain(SPACE_TEAM);
   });
 });

--- a/packages/runner/test/cfc-space-membership.test.ts
+++ b/packages/runner/test/cfc-space-membership.test.ts
@@ -1,7 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { ACL } from "@commonfabric/memory/acl";
-import { spaceReaderRole } from "../src/cfc/space-membership.ts";
+import {
+  createRuntimeSpaceMembershipProvider,
+  spaceReaderRole,
+} from "../src/cfc/space-membership.ts";
+import type { Cancel } from "../src/cancel.ts";
+import type { Runtime } from "../src/runtime.ts";
 
 // §4.9.3 render membership lookup — the client-side capability resolver
 // (design: docs/specs/cfc-render-membership-lookup.md §3.1). `spaceReaderRole`
@@ -74,5 +79,104 @@ describe("spaceReaderRole (§4.9.3 capability resolver)", () => {
 
   it("does not grant a service role to a non-service principal", () => {
     expect(spaceReaderRole(undefined, SPACE_TEAM, ALICE, [SERVICE])).toBeNull();
+  });
+});
+
+// A minimal runtime double: one ACL doc per space id, plus per-space sink
+// callbacks so a test can drive a reactive change. `get()` records calls so
+// the sync-read + background-sync-kick contract is observable.
+const fakeRuntime = (aclBySpace: Record<string, unknown>) => {
+  const sinks = new Map<string, Set<() => void>>();
+  const getCalls: string[] = [];
+  const runtime = {
+    getCellFromLink(link: { id: string; path: readonly []; space: string }) {
+      return {
+        get() {
+          getCalls.push(link.id);
+          return aclBySpace[link.id];
+        },
+        sink(cb: () => void): Cancel {
+          let set = sinks.get(link.id);
+          if (set === undefined) {
+            set = new Set();
+            sinks.set(link.id, set);
+          }
+          set.add(cb);
+          return () => set!.delete(cb);
+        },
+      };
+    },
+  } as unknown as Runtime;
+  const fire = (space: string) => {
+    for (const cb of sinks.get(space) ?? []) cb();
+  };
+  return { runtime, getCalls, fire, sinks };
+};
+
+describe("createRuntimeSpaceMembershipProvider (§4.9.3 provider)", () => {
+  it("reads a granted ACL synchronously and returns the reader role", () => {
+    const { runtime, getCalls } = fakeRuntime({
+      [SPACE_TEAM]: { [ALICE]: "READ" },
+    });
+    const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
+    expect(provider.readerRole(SPACE_TEAM)).toBe("reader");
+    // The ACL doc for the queried space was read (a Cell.get() sync read that
+    // also kicks a background sync when unsynced).
+    expect(getCalls).toContain(SPACE_TEAM);
+  });
+
+  it("fails closed when the ACL doc is absent (residency is not authority)", () => {
+    // The runtime may have synced the space's bytes without the acting user
+    // being an authorized reader; an absent/unread ACL grants NOTHING.
+    const { runtime } = fakeRuntime({});
+    const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
+    expect(provider.readerRole(SPACE_TEAM)).toBeNull();
+  });
+
+  it("grants the acting user's own space without reading an ACL", () => {
+    const { runtime, getCalls } = fakeRuntime({});
+    const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
+    expect(provider.readerRole(ALICE)).toBe("owner");
+    // Own-space is implicit OWNER — no ACL doc read needed.
+    expect(getCalls).not.toContain(ALICE);
+  });
+
+  it("fails closed on a malformed ACL value", () => {
+    const { runtime } = fakeRuntime({ [SPACE_TEAM]: "not-an-acl" });
+    const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
+    expect(provider.readerRole(SPACE_TEAM)).toBeNull();
+  });
+
+  it("reflects the latest replica across reads (no stale memo on revoke)", () => {
+    // Soundness under revoke: a later read must see the ACL as it now stands.
+    const acl: Record<string, unknown> = { [SPACE_TEAM]: { [ALICE]: "READ" } };
+    const { runtime } = fakeRuntime(acl);
+    const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
+    expect(provider.readerRole(SPACE_TEAM)).toBe("reader");
+    delete acl[SPACE_TEAM]; // ACL revoked / doc dropped
+    expect(provider.readerRole(SPACE_TEAM)).toBeNull();
+  });
+
+  it("subscribe fires onChange when the ACL cell changes, and cancels cleanly", () => {
+    const { runtime, fire, sinks } = fakeRuntime({
+      [SPACE_TEAM]: { [ALICE]: "READ" },
+    });
+    const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
+    let changes = 0;
+    const cancel = provider.subscribe(SPACE_TEAM, () => changes++);
+    fire(SPACE_TEAM);
+    expect(changes).toBe(1);
+    cancel();
+    fire(SPACE_TEAM);
+    expect(changes).toBe(1); // no further callbacks after cancel
+    expect(sinks.get(SPACE_TEAM)?.size ?? 0).toBe(0);
+  });
+
+  it("honors service DIDs for implicit OWNER", () => {
+    const { runtime } = fakeRuntime({});
+    const provider = createRuntimeSpaceMembershipProvider(runtime, SERVICE, [
+      SERVICE,
+    ]);
+    expect(provider.readerRole(SPACE_TEAM)).toBe("owner");
   });
 });

--- a/packages/runner/test/cfc-space-membership.test.ts
+++ b/packages/runner/test/cfc-space-membership.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { ACL } from "@commonfabric/memory/acl";
+import { spaceReaderRole } from "../src/cfc/space-membership.ts";
+
+// §4.9.3 render membership lookup — the client-side capability resolver
+// (design: docs/specs/cfc-render-membership-lookup.md §3.1). `spaceReaderRole`
+// mirrors the server's `#resolveCapability` (packages/memory/v2/server.ts) so
+// the render gate's authority decision cannot drift from the server's.
+
+const ALICE = "did:key:alice";
+const MALLORY = "did:key:mallory";
+const SPACE_TEAM = "did:key:team-space";
+const SERVICE = "did:web:commonfabric.org#runtime";
+
+describe("spaceReaderRole (§4.9.3 capability resolver)", () => {
+  it("grants implicit OWNER for a principal's own identity space", () => {
+    // A principal definitionally owns its own space (space DID == principal
+    // DID), independent of any ACL document or deployment ACL mode.
+    expect(spaceReaderRole(undefined, ALICE, ALICE)).toBe("owner");
+  });
+
+  it("grants implicit OWNER to a configured service DID", () => {
+    expect(spaceReaderRole(undefined, SPACE_TEAM, SERVICE, [SERVICE])).toBe(
+      "owner",
+    );
+  });
+
+  it("maps a READ grant to the reader role", () => {
+    const acl: ACL = { [ALICE]: "READ" };
+    expect(spaceReaderRole(acl, SPACE_TEAM, ALICE)).toBe("reader");
+  });
+
+  it("maps a WRITE grant to the writer role (WRITE implies READ)", () => {
+    const acl: ACL = { [ALICE]: "WRITE" };
+    expect(spaceReaderRole(acl, SPACE_TEAM, ALICE)).toBe("writer");
+  });
+
+  it("maps an OWNER grant to the owner role", () => {
+    const acl: ACL = { [ALICE]: "OWNER" };
+    expect(spaceReaderRole(acl, SPACE_TEAM, ALICE)).toBe("owner");
+  });
+
+  it("falls back to the ANYONE ('*') grant when the principal is unlisted", () => {
+    const acl: ACL = { "*": "READ" };
+    expect(spaceReaderRole(acl, SPACE_TEAM, ALICE)).toBe("reader");
+  });
+
+  it("prefers an explicit principal entry over the ANYONE grant", () => {
+    // `acl[principal] ?? acl["*"]` — the explicit entry wins even when it is
+    // narrower than the public grant.
+    const acl: ACL = { [ALICE]: "READ", "*": "OWNER" };
+    expect(spaceReaderRole(acl, SPACE_TEAM, ALICE)).toBe("reader");
+  });
+
+  it("returns null for a principal absent from a `*`-less ACL (fail closed)", () => {
+    const acl: ACL = { [MALLORY]: "OWNER" };
+    expect(spaceReaderRole(acl, SPACE_TEAM, ALICE)).toBeNull();
+  });
+
+  it("returns null for a missing ACL document (fail closed)", () => {
+    // The whole soundness point: an unread/absent ACL grants NOTHING, so the
+    // Space label stays blocked. Residency is not read authority.
+    expect(spaceReaderRole(undefined, SPACE_TEAM, ALICE)).toBeNull();
+  });
+
+  it("returns null for a malformed ACL value (fail closed)", () => {
+    expect(spaceReaderRole("not-an-acl" as unknown as ACL, SPACE_TEAM, ALICE))
+      .toBeNull();
+    expect(
+      spaceReaderRole({ [ALICE]: "SUDO" } as unknown as ACL, SPACE_TEAM, ALICE),
+    ).toBeNull();
+  });
+
+  it("does not grant a service role to a non-service principal", () => {
+    expect(spaceReaderRole(undefined, SPACE_TEAM, ALICE, [SERVICE])).toBeNull();
+  });
+});

--- a/packages/runner/test/cfc-space-membership.test.ts
+++ b/packages/runner/test/cfc-space-membership.test.ts
@@ -102,6 +102,7 @@ const fakeRuntime = (aclBySpace: Record<string, unknown>) => {
             sinks.set(link.id, set);
           }
           set.add(cb);
+          cb(); // real Cell.sink runs the action once synchronously at subscribe
           return () => set!.delete(cb);
         },
       };
@@ -157,14 +158,17 @@ describe("createRuntimeSpaceMembershipProvider (§4.9.3 provider)", () => {
     expect(provider.readerRole(SPACE_TEAM)).toBeNull();
   });
 
-  it("subscribe fires onChange when the ACL cell changes, and cancels cleanly", () => {
+  it("subscribe fires onChange on CHANGE only (skips the at-subscribe fire), and cancels cleanly", () => {
     const { runtime, fire, sinks } = fakeRuntime({
       [SPACE_TEAM]: { [ALICE]: "READ" },
     });
     const provider = createRuntimeSpaceMembershipProvider(runtime, ALICE);
     let changes = 0;
+    // subscribe triggers the underlying Cell.sink's synchronous at-subscribe
+    // fire, which the provider skips — so no onChange yet.
     const cancel = provider.subscribe(SPACE_TEAM, () => changes++);
-    fire(SPACE_TEAM);
+    expect(changes).toBe(0);
+    fire(SPACE_TEAM); // a real change
     expect(changes).toBe(1);
     cancel();
     fire(SPACE_TEAM);

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -177,6 +177,52 @@ describe("renderConfidentialityResolverFor (H3b)", () => {
       await storageManager.close();
     }
   });
+
+  it("resolves a cross-space Space label the space's ACL grants (§4.9.3)", async () => {
+    // §4.9.3 membership lookup: the helper wires a runtime-backed provider that
+    // reads each space's ACL doc. A space whose declared ACL grants the acting
+    // user READ resolves; one that does not (no ACL / residency only) blocks.
+    const { runtime, storageManager } = createRuntime();
+    const grantedSpace = "did:key:z6MkGrantedSpaceForRenderTest";
+    const deniedSpace = "did:key:z6MkDeniedSpaceForRenderTest";
+    try {
+      // Seed the granted space's ACL doc (entity id == space DID) with a READ
+      // grant for the acting user. The denied space gets no ACL doc at all —
+      // its bytes may still be resident, but residency is not read authority.
+      const aclCell = runtime.getCellFromLink({
+        id: grantedSpace,
+        path: [],
+        space: grantedSpace as MemorySpace,
+      });
+      const tx = runtime.edit();
+      aclCell.withTx(tx).set({ [cfcSigner.did()]: "READ" });
+      await tx.commit();
+      await runtime.idle();
+      await storageManager.synced();
+
+      const resolver = renderConfidentialityResolverFor(runtime, cfcSigner, {
+        atoms: [cfcAtom.user(cfcSigner.did())],
+      });
+      const ceiling = [cfcAtom.user(cfcSigner.did())];
+      // The ACL-granted space resolves to User(actingUser).
+      expect(
+        atomsOutsideCeiling(
+          resolver!({ confidentiality: [cfcAtom.space(grantedSpace)] }),
+          ceiling,
+        ),
+      ).toEqual([]);
+      // The space with no granting ACL stays blocked (fail-closed).
+      expect(
+        atomsOutsideCeiling(
+          resolver!({ confidentiality: [cfcAtom.space(deniedSpace)] }),
+          ceiling,
+        ),
+      ).toEqual([cfcAtom.space(deniedSpace)]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });
 
 describe("page slug metadata", () => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -7,6 +7,7 @@ import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   renderConfidentialityResolverFor,
+  renderMembershipProviderFor,
   runtimeOptionsFromInitializationData,
   RuntimeProcessor,
   sanitizeForPostMessage,
@@ -218,6 +219,50 @@ describe("renderConfidentialityResolverFor (H3b)", () => {
           ceiling,
         ),
       ).toEqual([cfcAtom.space(deniedSpace)]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});
+
+describe("renderMembershipProviderFor (§4.9.3 Stage 2)", () => {
+  it("returns undefined when no ceiling is configured", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      expect(renderMembershipProviderFor(runtime, cfcSigner, undefined))
+        .toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("builds a runtime-backed provider that reads a space's ACL doc", async () => {
+    const { runtime, storageManager } = createRuntime();
+    const grantedSpace = "did:key:z6MkGrantedSpaceForProviderTest";
+    try {
+      const aclCell = runtime.getCellFromLink({
+        id: grantedSpace,
+        path: [],
+        space: grantedSpace as MemorySpace,
+      });
+      const tx = runtime.edit();
+      aclCell.withTx(tx).set({ [cfcSigner.did()]: "READ" });
+      await tx.commit();
+      await runtime.idle();
+      await storageManager.synced();
+
+      const provider = renderMembershipProviderFor(runtime, cfcSigner, {
+        atoms: [cfcAtom.user(cfcSigner.did())],
+      });
+      expect(provider).toBeDefined();
+      // The acting user's own space is an implicit OWNER (no ACL read).
+      expect(provider!.readerRole(cfcSigner.did())).toBe("owner");
+      // A space whose ACL grants READ resolves to a reader role.
+      expect(provider!.readerRole(grantedSpace)).toBe("reader");
+      // A space with no ACL doc fails closed.
+      expect(provider!.readerRole("did:key:z6MkNoAclProviderTest")).toBeNull();
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -38,6 +38,7 @@ import {
   createRuntimeSpaceMembershipProvider,
   redactCaveatSourcesForDisplay,
   type RenderConfidentialityResolver,
+  type SpaceMembershipProvider,
 } from "@commonfabric/runner/cfc";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "../../runner/src/storage/cache.ts";
@@ -209,6 +210,7 @@ export function renderConfidentialityResolverFor(
   identity: Identity,
   ceiling: RenderConfidentialityCeiling | undefined,
   sessionSpace?: string,
+  membershipProvider?: SpaceMembershipProvider,
 ): RenderConfidentialityResolver | undefined {
   if (ceiling === undefined) {
     return undefined;
@@ -223,11 +225,34 @@ export function renderConfidentialityResolverFor(
     actingPrincipal,
     trustConfig: runtime.cfcTrustConfig,
     memberSpaces,
-    membershipProvider: createRuntimeSpaceMembershipProvider(
-      runtime,
-      actingPrincipal,
-    ),
+    // Share the reconciler's provider instance when supplied (so Stage-2 ACL
+    // subscriptions and the resolver's reads observe the same cells); else
+    // build a private one — both read the same underlying runtime documents.
+    membershipProvider: membershipProvider ??
+      createRuntimeSpaceMembershipProvider(runtime, actingPrincipal),
   });
+}
+
+/**
+ * The §4.9.3 membership provider for a worker's renders — the reactive half of
+ * the render lookup. Built once per worker (same lifetime as the resolver) and
+ * threaded to BOTH `renderConfidentialityResolverFor` (as the resolver's
+ * lookup) and the reconciler (for Stage-2 ACL-change subscriptions), so the two
+ * share one instance. Undefined when no ceiling is configured — no render
+ * gating, so no membership lookup. Service DIDs are not threaded to the worker
+ * (design §9), so service principals fail closed.
+ */
+export function renderMembershipProviderFor(
+  runtime: Runtime,
+  identity: Identity,
+  ceiling: RenderConfidentialityCeiling | undefined,
+): SpaceMembershipProvider | undefined {
+  if (ceiling === undefined) {
+    return undefined;
+  }
+  const actingPrincipal = runtime.trustSnapshotProvider()?.actingPrincipal ??
+    identity.did();
+  return createRuntimeSpaceMembershipProvider(runtime, actingPrincipal);
 }
 
 /**
@@ -388,6 +413,11 @@ export class RuntimeProcessor {
   // Rewrites a cell's label through the exchange rules so `Space(...)`-via-
   // `HasRole` principal forms resolve before the reconciler's ceiling fit.
   private renderConfidentialityResolver?: RenderConfidentialityResolver;
+  // §4.9.3 Stage 2: the membership provider shared with the resolver above and
+  // handed to every mount's reconciler, so a `Space(X)`-labeled cell blocked
+  // before X's ACL synced re-renders once the ACL grants READ. Undefined when
+  // no ceiling is in force.
+  private renderMembershipProvider?: SpaceMembershipProvider;
 
   private constructor(
     runtime: Runtime,
@@ -524,11 +554,17 @@ export class RuntimeProcessor {
       normalizeRenderDeclassificationPolicy(data.renderDeclassificationPolicy);
     processor.renderConfidentialityCeiling =
       normalizeRenderConfidentialityCeiling(data.renderConfidentialityCeiling);
+    processor.renderMembershipProvider = renderMembershipProviderFor(
+      runtime,
+      identity,
+      processor.renderConfidentialityCeiling,
+    );
     processor.renderConfidentialityResolver = renderConfidentialityResolverFor(
       runtime,
       identity,
       processor.renderConfidentialityCeiling,
       space,
+      processor.renderMembershipProvider,
     );
     // Site-table v0: the home space carries did → host hints; the
     // runtime reads them as its live host lookup (2026-06-09 federation
@@ -1562,6 +1598,7 @@ export class RuntimeProcessor {
       renderDeclassificationPolicy: this.renderDeclassificationPolicy,
       renderConfidentialityCeiling: this.renderConfidentialityCeiling,
       resolveRenderConfidentiality: this.renderConfidentialityResolver,
+      membershipProvider: this.renderMembershipProvider,
       onOps: (ops: VDomOp[]) => {
         const batchId = this.vdomBatchIdCounter++;
         self.postMessage({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -35,6 +35,7 @@ import { linkRefPayload } from "@commonfabric/runner/shared";
 import {
   cfcLabelViewForCell,
   createRenderConfidentialityResolver,
+  createRuntimeSpaceMembershipProvider,
   redactCaveatSourcesForDisplay,
   type RenderConfidentialityResolver,
 } from "@commonfabric/runner/cfc";
@@ -193,9 +194,15 @@ export function runtimeOptionsFromInitializationData(
  *    is a derived `spaceIdentity` DID distinct from the principal DID, and it
  *    is the space `session.open` gated on, so an own-workspace `Space(...)`
  *    label resolves rather than over-blocking.
- * Broader cross-space membership awaits the §4.9.3 membership lookup; until
- * then other-space `Space(...)` labels fail closed. Returns undefined when no
- * ceiling is configured (no render gating — today's behavior).
+ *
+ * Broader cross-space membership comes from the §4.9.3 membership lookup: a
+ * runtime-backed `SpaceMembershipProvider` reads each other space's declared
+ * ACL doc and mints a reader fact only when it grants the acting user READ+
+ * (never from residency). Its cross-space guarantee is exactly as strong as
+ * the deployment `MEMORY_ACL_MODE`. Service DIDs are NOT threaded to the
+ * worker today (design §9), so `serviceDids` is `[]` and service principals —
+ * which rarely render — fail closed. Returns undefined when no ceiling is
+ * configured (no render gating — today's behavior).
  */
 export function renderConfidentialityResolverFor(
   runtime: Runtime,
@@ -216,6 +223,10 @@ export function renderConfidentialityResolverFor(
     actingPrincipal,
     trustConfig: runtime.cfcTrustConfig,
     memberSpaces,
+    membershipProvider: createRuntimeSpaceMembershipProvider(
+      runtime,
+      actingPrincipal,
+    ),
   });
 }
 


### PR DESCRIPTION
## What

Implements the §4.9.3 render membership lookup (design:
`docs/specs/cfc-render-membership-lookup.md`), the follow-up to Epic H3b. It
replaces H3b's static `memberSpaces` heuristic with a verified per-space
membership lookup, so a cross-space `Space(X)` confidentiality label at the
render (display-sink) boundary resolves to `User(actingUser)` **only when the
acting user genuinely reads X** — sourced from X's declared ACL document, never
from the fact that a cell's bytes happen to be locally resident.

All four staged pieces from the design landed.

## How

**Stage 1 — capability resolver** (`packages/runner/src/cfc/space-membership.ts`).
`spaceReaderRole(acl, space, principal, serviceDids?)` returns the principal's
reader-or-higher role or `null`. It is a client-side mirror of the memory
server's `#resolveCapability` (`packages/memory/v2/server.ts`) and reuses
`@commonfabric/memory/acl` (`isACL` / `isCapable` / `ANYONE_USER`) so the render
gate's authority decision cannot drift from the server's: implicit `OWNER` for
own-space and service principals; else `acl[principal] ?? acl["*"]`; missing /
malformed / non-granting → `null`.

**Stage 2 — provider + per-label discovery.** `SpaceMembershipProvider` gives a
sync `readerRole(space)` snapshot (reads the space-DID ACL cell via
`Cell.get()` — sync value + background-sync kick — and runs `spaceReaderRole`)
plus a change-only `subscribe`. `createRenderConfidentialityResolver` now mints
`HasRole` facts **per-label** from the `Space(id)` atoms actually present in the
label (walking `anyOf` alternatives) via the provider, rather than a static set.
Own-space + session-space stay a no-ACL-read fast path. §4.9.4 (per-user content
in a shared space) falls out for free: each `Space` clause gets an independent
verified fact and all must resolve.

**Stage 3 — wiring** (`renderConfidentialityResolverFor` /
`renderMembershipProviderFor` in `runtime-processor.ts`). The worker builds one
runtime-backed provider, shared between the resolver (its lookup) and every
mount's reconciler (its subscriptions).

**Stage 4 — reactive re-render.** When the worker reconciler gates a
`Space(X)`-labeled cell, it subscribes to X's ACL doc within the cell's existing
`useCancelGroup` and re-evaluates the render gate when the ACL syncs/changes.
So a fail-closed over-block (X's ACL not yet synced) upgrades to an admit once
the ACL grants READ, and a revoke re-blocks — reusing the reconciler's existing
`.sink` + cancel-group machinery, with **no core-reactivity change**. The
provider's `subscribe` skips `Cell.sink`'s at-subscribe fire so it signals
change only.

## Soundness

Residency is never read authority. Only the ACL document (or implicit
own-space / service / session) may mint `HasRole`. A missing, unsynced, or
malformed ACL, or a principal not granted READ+, mints nothing → the `Space(X)`
label stays outside the ceiling → renders blocked. Stage 4's subscription only
triggers a re-run of that same fail-closed gate; it can never admit anything the
Stage-1 sync check wouldn't. The cross-space guarantee is exactly as strong as
the deployment `MEMORY_ACL_MODE` (documented in the resolver config and the
design §4).

## Tests (red-first per stage)

- `packages/runner/test/cfc-space-membership.test.ts` — `spaceReaderRole` truth
  table; provider sync-read + fail-closed on absent/malformed ACL; latest-replica
  (no stale memo on revoke); change-only `subscribe`.
- `packages/runner/test/cfc-render-ceiling.test.ts` — per-label discovery,
  §4.9.4 conjunctive, static-fast-path combine, `anyOf`-nested `Space`.
- `packages/runtime-client/backends/runtime-processor.test.ts` — a cross-space
  Space label whose seeded ACL grants READ resolves, no-ACL blocks;
  `renderMembershipProviderFor` builds a provider that reads a seeded ACL.
- `packages/html/test/worker-reconciler-cfc-render-policy.test.ts` — Stage 4: a
  `Space(X)` cell blocked before its ACL grants READ re-renders after the ACL
  subscription fires (verified red without the wiring).

Affected suites green; full `deno task check` (workspace typecheck) green;
`deno fmt` / `deno lint` clean.

## Residuals / follow-ups

- Service DIDs are not threaded to the worker (design §9); `serviceDids` is `[]`,
  so service principals fail closed (they rarely render).
- Spec (§4.9.3 / §15 / §18) and Lean4 obligations (design §7–§8) remain outgoing
  follow-ups to `commontoolsinc/specs`.

Both the descendant-cell (`renderCellChild`) and the root-mounted cell
(`WorkerReconciler.mount`) egress paths get the Stage-4 ACL subscription
(root path added in response to codex review).

## Coverage note

Both changed runner source files are **100% line-covered** by the full runner
suite (`cfc/space-membership.ts` 100%/100%/100%; `cfc/render-ceiling.ts` 100%
line, 100% function — the 92.6% branch figure is the pre-existing untested
fuel-exhaustion ternary, unrelated to this change), and `reconciler.ts`'s new
`watchCellMembership` is exercised by the Stage-4 tests plus every existing
no-provider render test. The coverage gate reports a residual **+1 uncovered
line in the `packages/runner` group that it "could not tie to specific files
from the diff"** — untieable phantom debt in an unchanged file, not new code.
Accepting that single phantom line:

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7619 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
