### PR TITLE
docs(tutorial): refresh against current code — mergeable writes, CFC, ACLs, renamed internals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,13 +13,17 @@ signatures.
 This repository contains many packages that compose and stack to create the
 Common Fabric product.
 
-1. Foundation: api, runner, identity, memory
+1. Foundation: api, data-model, runner, identity, memory
 2. System: schema-generator, iframe-sandbox, ts-transformers, js-compiler
 3. Capabilities: piece, html, llm
-4. Operation: background-piece-service, cli
-5. Deployed Product: toolshed, shell
+4. Operation: background-piece-service, cli, fuse, state-inspector, cf-harness
+5. Deployed Product: toolshed, shell, lib-shell, runtime-client
 6. User Interface: ui
 7. End-User Programs: home-schemas, patterns
+
+Support and test packages (utils, test-support, deno-web-test, integration,
+generated-patterns, content-hash, leb128, felt, static, vendor-astral,
+fs-sync-example) sit outside the layer stack.
 
 ## Pattern Development
 

--- a/docs/common/capabilities/llm.md
+++ b/docs/common/capabilities/llm.md
@@ -107,11 +107,13 @@ If you get `TypeError: Cannot read properties of undefined (reading 'model')`, c
 
 ### Cache Busting for Regeneration
 
-For "respin" or "regenerate" features, set `cache: false` in the options:
+For "respin" or "regenerate" features, set `cache: false` in the options.
+Only `generateObject` accepts it (`generateText` is always cached per
+distinct input):
 
 ```typescript
 // Shown for illustration only.
-const result = generateText({
+const result = generateObject({
   prompt,
   cache: false,  // Forces fresh generation
 });

--- a/docs/tutorial/01-big-picture.md
+++ b/docs/tutorial/01-big-picture.md
@@ -71,10 +71,11 @@ your browser; your housemate is looking at the same list on their laptop.
    "remaining items" count, the list partition into active/completed — and
    re-runs exactly those. Your UI updates immediately (optimistically).
 3. **Sync.** The runtime's storage layer turns the transaction into a
-   *commit* — the operations plus a record of what was read, so the server
-   can detect conflicts — and sends it over a WebSocket to the server
-   (**Toolshed**), which validates it and appends it to the space's SQLite
-   log.
+   *commit* — the operations plus, for read-modify-write operations, a
+   record of what was read so the server can detect conflicts (a simple
+   toggle like this one ships as a last-write-wins write; Chapter 9) — and
+   sends it over a WebSocket to the server (**Toolshed**), which validates
+   it and appends it to the space's SQLite log.
 4. **Fan-out.** The server knows which sessions are watching queries that
    touch this document. It pushes a delta to your housemate's session.
 5. **Remote reactivity.** Their runtime integrates the delta into its local
@@ -92,11 +93,11 @@ the same stack with the *why* attached:
 
 | Layer | Packages | Why it has to exist |
 |---|---|---|
-| Foundation | `api`, `runner`, `identity`, `memory` | The cell/pattern abstractions, the scheduler that runs graphs, cryptographic identity, and the durable store. Everything else is expressed in these terms. |
+| Foundation | `api`, `data-model`, `runner`, `identity`, `memory` | The cell/pattern abstractions, the canonical value/link data model, the scheduler that runs graphs, cryptographic identity, and the durable store. Everything else is expressed in these terms. |
 | System | `schema-generator`, `ts-transformers`, `js-compiler`, `iframe-sandbox` | Patterns are authored as ordinary TypeScript, but the runtime needs *schemas* (to know what to subscribe to) and *graph nodes* (to schedule). A compiler pipeline extracts both. The sandbox exists because pattern code is untrusted. |
 | Capabilities | `piece`, `html`, `llm` | The things patterns can *do* beyond pure computation: be instantiated as pieces, render HTML, call LLMs. |
-| Operation | `background-piece-service`, `cli` | Run pieces with no browser open; drive the system from scripts and agents. |
-| Deployed product | `toolshed`, `shell` | The server (storage, sync, LLM proxy, blobs) and the browser app users actually open. |
+| Operation | `background-piece-service`, `cli`, `fuse`, `state-inspector`, `cf-harness` | Run pieces with no browser open; drive, mount, and inspect the system from scripts and agents. |
+| Deployed product | `toolshed`, `shell`, `lib-shell`, `runtime-client` | The server (storage, sync, LLM proxy, blobs), the browser app users actually open, and the shared shell logic and runtime-client seam that connect its UI thread to the worker-hosted runtime. |
 | UI | `ui` | The `cf-*` web-component library patterns build interfaces from. |
 | End-user programs | `patterns`, `home-schemas` | The patterns themselves — the point of the whole exercise. |
 

--- a/docs/tutorial/02-cells.md
+++ b/docs/tutorial/02-cells.md
@@ -42,15 +42,19 @@ deep:
   what a handler is allowed to touch. Declaring write intent in the type is
   declaring it to the runtime, not just to the compiler.
 
-The write-capable surface (`docs/common/concepts/writeable.md`):
+The write-capable surface (`docs/common/concepts/types-and-schemas/writable.md`):
 
 ```ts
 // Shown inside a pattern body.
 value.get()              // current value (inside computations: also subscribes)
-value.set(next)          // replace
+value.set(next)          // replace (last-write-wins)
 value.update({ k: v })   // shallow merge into an object
-items.push(item)         // append to an array
-items.remove(item)       // remove (by identity — see below)
+value.increment(1)       // add to a number — mergeable: concurrent increments sum
+items.push(item)         // append — mergeable: disjoint appends merge
+items.addUnique(item)    // append if not already present — mergeable
+items.remove(item)       // remove the first matching element
+items.removeByValue(item) // remove elements equal to a value — mergeable
+items.elementById("id")  // cell for one element, addressed by a stable key
 obj.key("field")         // navigate to a sub-cell: a Writable of one field
 ```
 
@@ -59,6 +63,14 @@ obj.key("field")         // navigate to a sub-cell: a Writable of one field
 `item.title` — which is exactly what you hand to a two-way-bound input
 (Chapter 4). Reactivity is path-granular: a computation that read only
 `item.title` does not re-run when `item.done` changes.
+
+The methods marked *mergeable* matter for collaboration: they commit the
+*intent* of the write (append this, add one) rather than the resulting
+value, so two users pushing to the same list — or incrementing the same
+counter — both land, merged by the server, instead of one clobbering the
+other. `writable.md` spells out the authoring contract, including when a
+write is *not* mergeable (a push whose value depends on reading the same
+list is a read-modify-write, and the compiler warns about it).
 
 ## Defaults: `Default<>`
 
@@ -187,12 +199,20 @@ mechanisms in Chapters 8 and 9:
   JSX expression, or a handler's reactive context re-runs that computation
   when the value changes — even if the change came from another machine.
 - **Writes are transactional.** All writes from one handler invocation go
-  into one transaction — which targets a single space — and commit
-  atomically, or not at all.
-- **Updates are optimistic but converge.** Your own writes apply locally and
-  instantly; if the server detects a conflict with someone else's commit,
-  your transaction is rolled back and retried against fresh state. You don't
-  write merge code; you may occasionally see your write "lose" and re-apply.
+  into one transaction — which by default targets a single space — and
+  commit atomically, or not at all. (A handler *can* end up writing a
+  second space, e.g. by instantiating a pattern there via a factory's
+  `.inSpace()`; such transactions commit per-space, sequentially, with no
+  cross-space atomicity.)
+- **Updates are optimistic and converge — by one of three routes.** Your
+  own writes always apply locally and instantly. What happens when two
+  users race depends on the kind of write: *mergeable* operations
+  (`push`, `addUnique`, `increment`, `removeByValue`) are merged by the
+  server, so concurrent writers all land; plain scalar `set`s — including
+  the writes two-way UI bindings make — are last-write-wins, the later
+  write simply sticks; and read-modify-write commits carry their read set,
+  so a genuine conflict rolls the loser back and retries it against fresh
+  state. In all three cases you don't write merge code.
 - **Durability is automatic.** There is no save button anywhere in this
   system. If it committed, it's in SQLite on the server.
 

--- a/docs/tutorial/03-patterns.md
+++ b/docs/tutorial/03-patterns.md
@@ -88,8 +88,8 @@ result of `computed()` is itself a reactive value you can pass to JSX, other
 computeds, or the return object.
 
 `lift()` is the lower-level primitive `computed()` is built on
-(`docs/common/concepts/lift.md`): it turns a pure function into a reusable
-reactive operator, and it must be declared at **module scope**:
+(`docs/common/concepts/computed/computed.md`): it turns a pure function into
+a reusable reactive operator, and it must be declared at **module scope**:
 
 ```ts
 // Shown inside a pattern body.
@@ -100,8 +100,8 @@ return { combined: addCells({ a, b }) };
 
 Rule of thumb from the docs: it's almost always better to use `computed()`.
 Reach for `lift()` only for a derivation you want to reuse across patterns
-or call several times. (You'll also see `derive()` in old code — deprecated,
-same meaning as `computed()`.)
+or call several times. (Old code and cautionary comments mention `derive()`;
+it has been removed from the API — use `computed()`.)
 
 One discipline: **`computed()` derives; it never writes.** Calling `.set()`
 on an upstream cell inside a computed creates a reactive cycle — the
@@ -132,7 +132,7 @@ at the call site:
 ```ts
 // Shown inside a pattern body.
 const increment = handler<void, { value: Writable<number> }>(
-  (_, { value }) => value.set(value.get() + 1),
+  (_, { value }) => value.increment(1),
 );
 
 // inside the pattern body:
@@ -187,7 +187,7 @@ interface CounterOutput {
 // Module-scope handler: reusable, bound to context at the call site.
 const increment = handler<void, { value: Writable<number> }>(
   (_, { value }) => {
-    value.set(value.get() + 1);
+    value.increment(1);
   },
 );
 
@@ -206,7 +206,7 @@ const Counter = pattern<CounterInput, CounterOutput>(({ value }) => {
 
   // Pattern-body action: preferred for single-use behavior.
   const decrement = action(() => {
-    value.set(value.get() - 1);
+    value.increment(-1);
   });
 
   // Derived values.
@@ -244,6 +244,10 @@ export default Counter;
 
 Things worth noticing:
 
+- `value.increment(1)`, not `value.set(value.get() + 1)`. `increment()` is a
+  *mergeable* write (Chapter 2): two users clicking at once both count,
+  because the server sums the increments instead of letting one
+  read-modify-write clobber the other.
 - `{value}` appears bare in JSX. No `.get()` — JSX expressions are reactive
   contexts, and the compiler wires the subscription (Chapter 7).
 - The pure helper `ordinal()` is called *inside* a `computed()`. The

--- a/docs/tutorial/04-ui.md
+++ b/docs/tutorial/04-ui.md
@@ -19,17 +19,20 @@ place to see real usage. The main families:
 - **Inputs:** `cf-button`, `cf-input`, `cf-textarea`, `cf-checkbox`,
   `cf-select`, `cf-slider`, `cf-switch`, `cf-toggle`, `cf-radio`,
   `cf-autocomplete`, `cf-tags`, `cf-picker`, `cf-calendar`,
-  `cf-message-input`, `cf-prompt-input`, `cf-image-input`, `cf-code-editor`
+  `cf-message-input`, `cf-submit-input`, `cf-prompt-input`,
+  `cf-image-input`, `cf-code-editor`
 - **Layout:** `cf-screen`, `cf-card`, `cf-vstack`/`cf-hstack`,
   `cf-vgroup`/`cf-hgroup`, `cf-vscroll`/`cf-hscroll`, `cf-grid`,
-  `cf-list-item`, `cf-modal`, `cf-tab-bar`, `cf-toolbar`
+  `cf-list-item`, `cf-modal`, `cf-tabs` (with `cf-tab`, `cf-tab-list`,
+  `cf-tab-panel`), `cf-tab-bar`, `cf-toolbar`
 - **Display:** `cf-heading`, `cf-text`, `cf-label`, `cf-chip`, `cf-badge`,
   `cf-markdown`, `cf-svg`, `cf-separator`, `cf-kbd`, `cf-copy-button`
 - **Feedback:** `cf-progress`, `cf-loader`, `cf-skeleton`, `cf-alert`,
   `cf-toast`
 - **Data viz:** `cf-chart` (with `cf-line-mark`, `cf-bar-mark`, ...), `cf-map`
 - **Composition:** `cf-render` (render another piece's UI from a cell —
-  bind with `$cell`), `cf-cell-context`
+  bind with `$cell`; `variant="full|chip|tile"` picks the piece's `[UI]`,
+  `[CHIP_UI]`, or `[TILE_UI]` output, with fallbacks), `cf-cell-context`
 
 Why a custom library instead of plain HTML? The next section is the answer.
 
@@ -75,7 +78,10 @@ Three conventions, all about exact spelling:
   (`onClick={decrement}`) or a closure (`onClick={() => stream.send(x)}`).
 - Component-specific events use `oncf-` + kebab-case: `oncf-send`
   (`cf-message-input`, payload `e.detail.message`), `oncf-change`,
-  `oncf-input`, `oncf-remove`, `oncf-keydown`.
+  `oncf-input`, `oncf-remove`, `oncf-keydown`. One exception to know:
+  `cf-submit-input` deliberately does *not* emit a `cf-send` event — it
+  submits via a real (trusted) button click, so you wire `onClick` and read
+  `event.target.value`.
 - Component *properties* are camelCase, exactly as typed in the catalog:
   `<cf-autocomplete allowCustom={true} />` works; `allow-custom` silently
   does not.
@@ -187,12 +193,12 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
     [UI]: (
       <cf-screen>
         <cf-vscroll flex showScrollbar fadeEdges>
-          <cf-vstack gap="2" style="padding: 1rem;">
+          <cf-vstack gap="2" padding="4">
             {itemCards}
             {ifElse(hasCompleted, <details>{/* completed section */}</details>, null)}
           </cf-vstack>
         </cf-vscroll>
-        <cf-hstack slot="footer" gap="2" style="padding: 1rem;">
+        <cf-hstack slot="footer" gap="2" padding="4">
           <cf-message-input
             placeholder="Add a todo item..."
             oncf-send={(e: { detail?: { message?: string } }) => {

--- a/docs/tutorial/05-composition-and-pieces.md
+++ b/docs/tutorial/05-composition-and-pieces.md
@@ -146,10 +146,11 @@ sentence is the product.
 
 A piece can keep working with no browser open. A pattern that exposes a
 `bgUpdater` stream (or registers via the `cf-updater` component) gets picked
-up by the **background piece service**, which polls registered pieces (every
-60 s by default) and sends to that stream server-side — same graph, same
-cells, headless executor (details in Chapter 11). This is how "summarize my
-feed every morning" works without anyone keeping a tab open.
+up by the **background piece service**, which re-runs each registered piece
+on a fixed cadence (every 60 s by default), sending to that stream
+server-side — same graph, same cells, headless executor (details in
+Chapter 11). This is how "summarize my feed every morning" works without
+anyone keeping a tab open.
 
 ---
 

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -18,7 +18,14 @@ deno task cf check pattern.tsx --verbose-errors     # more error context
 pattern once, so it catches both type errors and graph-construction errors
 ("reactive reference outside context", handlers in the wrong scope, ...).
 `--show-transformed` is your X-ray: when behavior is mysterious, look at
-what your source actually compiled into before theorizing.
+what your source actually compiled into before theorizing. The transformed
+output is dense — pipe it into `cf view`, an interactive syntax-aware pager
+that colors builders, schemas, and closures and lets you navigate the
+structure tree:
+
+```bash
+deno task cf check pattern.tsx --show-transformed --no-run | deno task cf view
+```
 
 ## Set up identity and server
 
@@ -124,9 +131,13 @@ deno task cf test packages/patterns/my-pattern/      # all tests in a directory
 Notice what makes the subject *testable*: dual type parameters on
 `pattern<Input, Output>()` and exported `Stream<T>` actions. That's why
 Chapter 3 insisted on them. Keep assertions deterministic — no
-`safeDateNow()` or randomness inside them. The guidance from the canonical
-guide: primary verification is still runtime behavior; write tests for
-logic that's awkward or expensive to verify by clicking.
+`safeDateNow()` or randomness inside them. Patterns that fetch external data
+(`fetchJson` and friends) can still be tested deterministically: export a
+module-scope `fetchMocks` array from the test file and the harness injects
+it as the runtime's fetch (worked examples in
+`packages/patterns/examples/fetch-mock.test.tsx`). The guidance from the
+canonical guide: primary verification is still runtime behavior; write
+tests for logic that's awkward or expensive to verify by clicking.
 
 ## The gotcha checklist
 
@@ -159,7 +170,10 @@ failures (each links to a full writeup under
 
 When something still goes wrong: `docs/development/debugging/` has the error
 reference, and the repo-local `pattern-critic` agent/skill reviews a pattern
-against the full rule list mechanically.
+against the full rule list mechanically. For storage-level surprises ("what
+is actually stored?", "who overwrote this?"), `cf inspect` performs an
+offline autopsy of a space's SQLite database — see the `state-inspector`
+skill.
 
 ---
 

--- a/docs/tutorial/07-compilation.md
+++ b/docs/tutorial/07-compilation.md
@@ -26,16 +26,17 @@ into explicit graph nodes, and harden the result.**
 
 ## The pipeline
 
-`packages/ts-transformers/src/cf-pipeline.ts` defines ~19 transformer stages
+`packages/ts-transformers/src/cf-pipeline.ts` defines ~20 transformer stages
 that run in strict order over the TypeScript AST. You don't need to know
 all of them; you need the five jobs they implement:
 
 **Validation** (early stages — `CastValidation`, `OpaqueGetValidation`,
-`PatternContextValidation`, ...): reject things that cannot work at
-runtime, at compile time — e.g. `.get()` calls in invalid positions, or
-malformed pattern context usage. Many "framework rules" from Part I are
-enforced here, which is why violations are compile errors rather than weird
-runtime behavior.
+`PatternContextValidation`, `MergeablePushValidation`, ...): reject things
+that cannot work at runtime, at compile time — e.g. `.get()` calls in
+invalid positions, malformed pattern context usage, or a mergeable `push`
+whose value was read from the same list (a hidden read-modify-write). Many
+"framework rules" from Part I are enforced here, which is why violations
+are compile errors rather than weird runtime behavior.
 
 **JSX lowering** (`JsxExpressionSiteRouter`, `LiftLowering`): every dynamic
 expression site in JSX is routed to a lowering strategy. A multi-value
@@ -48,8 +49,8 @@ closure's body logic stays plain JavaScript (only its captures are
 rewritten, as described next).
 
 **Closure reification** (`ClosureTransformer`,
-`PatternCallbackLowering`, `BuilderCallbackHoisting`,
-`BuilderCallHoisting`): callbacks that conceptually close over pattern
+`PatternCallbackLowering`, `BuilderCallHoisting`): callbacks that
+conceptually close over pattern
 state — `action()` bodies, `.map()` callbacks — are analyzed; their
 captured variables become explicit, schema-described inputs, and the
 callbacks are hoisted to module scope. A `.map()` over items becomes a
@@ -68,7 +69,8 @@ created.
 module-scope functions get `Object.freeze()` and the module is shaped for
 the SES sandbox.
 
-You can watch all of this on any file:
+You can watch all of this on any file (append `| deno task cf view` for a
+navigable, syntax-colored view of the dense output):
 
 ```bash
 deno task cf check pattern.tsx --show-transformed --no-run
@@ -85,7 +87,7 @@ one handles the branded wrapper types:
 | `number` | `{ type: "number" }` |
 | `Cell<T>` / `Writable<T>` | schema of `T` + `asCell: ["cell"]` |
 | `Stream<T>` | schema of `T` + `asCell: ["stream"]` |
-| `Reactive<T>` | schema of `T` + `asCell: ["opaque"]` |
+| `OpaqueCell<T>` | schema of `T` + `asCell: ["opaque"]` |
 | `T \| Default<V>` | schema of `T` + `default: V` |
 | `PerSpace<T>` / `PerUser<T>` / `PerSession<T>` | schema of `T` + `scope: "space" \| "user" \| "session"` (folded into the `asCell` entry when the inner type is cell-wrapped) |
 
@@ -143,7 +145,7 @@ Pattern {
 }
 Node {
   module: { type: "javascript" | "pattern" | "raw" | "isolated" | ...,
-            implementation, implementationRef, ... },
+            implementation, $implRef, ... },
   inputs, outputs,                // value trees containing cell links
 }
 ```
@@ -155,22 +157,24 @@ real data only flows later, when the scheduler executes nodes (Chapter 8).
 It's also why `if (count > 3)` in the body can't work — `count` is a
 placeholder, not a number.
 
-## Identity and caching: `implementationRef`
+## Identity and caching: `$implRef`
 
-Each node's code carries an `implementationRef` — a stable, content-derived
-identity for the implementation (minted from the function's source, kind,
-and position; trusted host functions get reserved refs). It serves three
-masters:
+Each node's code carries an `$implRef` — a stable, content-derived identity
+for the implementation: `{ identity, symbol }`, the defining module's
+content identity plus the artifact's export symbol
+(`packages/runner/src/builder/types.ts`). It is deliberately ordinal-free —
+where the function sits in the file doesn't participate, only its content.
+It serves three masters:
 
-- **Caching**: compiled functions are cached by ref
-  (`packages/runner/src/function-cache.ts`), so re-loading a piece doesn't
-  recompile unchanged nodes.
+- **Caching**: compiled implementations are resolved and cached by ref
+  (`packages/runner/src/harness/executable-registry.ts`, with compiled
+  records in `packages/runner/src/compilation-cache/`), so re-loading a
+  piece doesn't recompile unchanged nodes.
 - **Stable scheduling**: the scheduler identifies actions across re-runs by
-  a content-addressed implementation fingerprint (the implementation hash,
-  falling back to source location).
+  a content-addressed implementation fingerprint (the implementation hash).
 - **Provenance**: verified-source tracking ties running code back to the
-  exact source that produced it (this also feeds the CFC
-  confidential-computing work you'll see in `packages/patterns/cfc-*`).
+  exact source that produced it (this also feeds the CFC contextual
+  flow-control machinery in `packages/runner/src/cfc/` — Chapter 10).
 
 The `js-compiler` package does the actual TypeScript-to-JS emission in two
 modes: **bundle** (one AMD bundle — how pattern programs are packaged for

--- a/docs/tutorial/08-runtime-internals.md
+++ b/docs/tutorial/08-runtime-internals.md
@@ -19,7 +19,7 @@ Cell = {
 ```
 
 - `space` — the DID of the space the document lives in.
-- `id` — the entity id (`of:<hash>` URI) of the document.
+- `id` — the entity id (an `of:fid1:<hash>` URI) of the document.
 - `path` — a property path *within* the document (`["items", 2, "title"]`).
 - `schema` — the JSON schema (from Chapter 7) describing what's expected at
   that path — including `asCell`/`default`/`scope` annotations.
@@ -38,7 +38,9 @@ created by the same graph node gets the same id deterministically — which is
 what lets a server re-instantiate a piece and arrive at the same cells.
 
 **Links between documents** are stored as serializable references (sigil
-links: `{ "/": { "link@1": { id, path, space } } }`). When a read encounters
+links: `{ "/": { "link@1": { id, path, space } } }`; the modern cell
+representation holds these as atomic `FabricLink` values that serialize to
+that envelope). When a read encounters
 one, it resolves through to the target — transparently crossing documents
 and even spaces. This is the mechanism behind `cf piece link` (Chapter 5).
 Writes are subtler, and worth stating precisely: a write whose path
@@ -68,11 +70,12 @@ The runtime's event loop is the scheduler
    the scheduler doesn't care), the index marks the affected actions dirty
    and queues them.
 
-Two execution strategies exist (`scheduler/pull-execution.ts`,
-`push-execution.ts`): **push** re-runs anything dirty immediately; **pull**
-(the default) is lazy — only computations that something observable (a UI
-sink, an effect, an explicit `.pull()`) depends on get re-run, so an
-unobserved derived value costs nothing.
+Execution is **pull-based and lazy** (`scheduler/pull-execution.ts` and its
+sibling `pull-*` modules): only computations that something observable (a
+UI sink, an effect, an explicit `.pull()`) depends on get re-run, so an
+unobserved derived value costs nothing. (An eager "push" mode existed
+historically; it was removed in the scheduler-v2 rebuild — pull is now the
+only strategy.)
 
 Cycles and pathologies are contained by bounded iteration — an action that
 keeps dirtying itself (e.g. a `computed` that writes upstream, gotcha #2)
@@ -106,6 +109,17 @@ reactive actions a bounded number of times). This is the mechanism behind
 the Part I promise "optimistic but converge; you may see a write lose and
 re-apply."
 
+Not every write takes that compare-and-swap path, though. **Mergeable**
+operations (Chapter 2 — `push`, `addUnique`, `increment`, `removeByValue`)
+commit the *intent* of the write and drop their own incidental read of the
+container from the conflict set, so concurrent appends or increments merge
+on the server instead of conflicting
+(`packages/runner/src/storage/mergeable-ops.ts`). And plain scalar sets —
+notably the writes two-way UI bindings issue — are **blind**: their reads
+are recorded for reactivity but excluded from commit preconditions, making
+them last-write-wins. Revert-and-retry is the story for read-modify-write
+commits.
+
 Note the layering discipline: the scheduler only knows "transactions commit
 or conflict"; *how* conflicts are detected is entirely the storage layer's
 business (Chapter 9). That separation is what lets the same runtime run
@@ -120,8 +134,8 @@ the previous three sections together:
    where `default:` values materialize and `asCell` decides whether a node
    receives a value or a writable handle.
 2. Each `Node` in the graph becomes a scheduled action: `javascript` nodes
-   (lifts/computeds/handlers) wrap their compiled implementation (fetched
-   via the `implementationRef` function cache) and run in the SES sandbox;
+   (lifts/computeds/handlers) wrap their compiled implementation (resolved
+   via the `$implRef` executable registry) and run in the SES sandbox;
    `pattern` nodes recurse into sub-patterns; `ref`/`raw`/`passthrough`
    cover builtins and plumbing. (An `isolated` module type is declared in
    the API but not currently implemented by the runner.)

--- a/docs/tutorial/09-storage-and-sync.md
+++ b/docs/tutorial/09-storage-and-sync.md
@@ -6,24 +6,26 @@ without locks, how other clients hear about it, and what's actually on disk.
 The code is `packages/memory` (the store and protocol) plus
 `packages/runner/src/storage/` (the client side).
 
-> **Historical note, because you'll see it in the code.** The package
-> contains two generations. The original ("v1") modeled storage as a chain
-> of immutable *facts* `{the, of, is, cause}` with per-fact compare-and-swap
-> — its types still shape the public vocabulary (`URI`, `ConflictError`,
-> entity ids like `of:<hash>`). The current engine ("v2",
-> `packages/memory/v2/`) keeps the spirit — optimistic concurrency over
-> append-only history — but moves the unit of conflict from single facts to
-> **commits with read-set validation**, which is what's described below.
-> Toolshed and the runtime speak only v2.
+> **Historical note, because you'll see traces of it in the code.** The
+> original storage engine ("v1") modeled storage as a chain of immutable
+> *facts* `{the, of, is, cause}` with per-fact compare-and-swap. Its engine
+> has been removed; what survives is its type vocabulary (`URI`,
+> `ConflictError`, `MIME`, the fact shape in `interface.ts`/`fact.ts`),
+> reused by the current engine ("v2", `packages/memory/v2/`). V2 keeps the
+> spirit — optimistic concurrency over append-only history — but moves the
+> unit of conflict from single facts to **commits with read-set
+> validation**, which is what's described below. Toolshed and the runtime
+> speak only v2.
 
 ## The data model: documents in spaces
 
 The unit of storage is an **entity document**: a JSON document named by a
-hash id (`of:<hash>`, derived from the cell's creation context — the
-document itself mutates while its id stays stable), living in a space, with the cell's payload
-under its `value` field plus metadata (e.g. a `source` link to the owning
-piece). Cells (Chapter 8) address `(space, id, path)`; the path is resolved
-inside the document.
+hash id (`of:fid1:<hash>`, derived from the cell's creation context — the
+document itself mutates while its id stays stable), living in a space, with
+the cell's payload under its `value` field (the document shape reserves
+room for metadata fields such as `source`, but today the system produces
+and consumes only `value`). Cells (Chapter 8) address `(space, id, path)`;
+the path is resolved inside the document.
 
 Documents also carry a **scope key**. `PerUser`/`PerSession` cells
 (Chapter 2) aren't filtered by queries — the engine physically partitions
@@ -44,8 +46,22 @@ ClientCommit {
     pending:   [{ id, path, localSeq }], // "I read my own unconfirmed commit"
   },
   operations: [ set | patch | delete | sqlite ],
+  // (abridged — the real type also carries preconditions, scheduler
+  // observations, branch/merge fields, ...)
 }
 ```
+
+A `patch` operation is itself a small language: alongside the
+diff-generated ops (`replace`, `add`, `remove`, `move`, `splice`) it
+carries the **mergeable** ops from Chapter 2 — `append`, `add-unique`,
+`remove-by-value`, `increment` — which record the *intent* of a collection
+write rather than its result. The whole family is defined in one registry;
+see `docs/development/patch-operations.md`,
+`docs/development/mergeable-collection-writes.md` (including the trade-off:
+merging is add-wins, so a stale add landing after a remove resurrects the
+element), and `docs/development/keyed-collection-writes.md` (how
+`elementById` gives a list element a deterministic address so per-element
+edits decompose into these ops).
 
 The `reads` field is the concurrency-control token, built automatically from
 the transaction journal (Chapter 8). The protocol is *optimistic*: no locks,
@@ -59,9 +75,17 @@ transaction):
 2. **Read validation.** For each confirmed read, the engine checks whether
    any later revision touched it. Full-document `set`/`delete` conflicts
    with any read of that document; a `patch` conflicts **only if its patched
-   paths overlap the read path**. Two users patching disjoint fields of the
-   same document both succeed — this path-granular rule is what makes
-   field-level two-way bindings (Chapter 4) practical under concurrency.
+   paths overlap the read path** (a read can also be recorded as shape-only
+   — `nonRecursive` — conflicting only with writes at or above its path).
+   Two users patching disjoint fields of the same document both succeed —
+   this path-granular rule is what makes field-level two-way bindings
+   (Chapter 4) practical under concurrency. Mergeable ops go one step
+   further, on the client side: the op's own incidental read of the
+   container is dropped from the read set, so two concurrent `append`s or
+   `increment`s to the *same* collection both land, applied against durable
+   state — they merge rather than conflict. (A reader that explicitly
+   `.get()`s the list still records that read, and still
+   conflicts-and-retries.)
 3. **Pending resolution.** Pipelined commits (a client needn't wait for ack
    to keep committing) have their pending reads mapped to the server
    sequence numbers their dependencies actually landed at, then validated
@@ -99,7 +123,7 @@ result of a query defined by schemas*.)
 After every commit the server marks the written ids dirty and, on a
 debounced tick, re-walks only the affected graphs per session, diffs against
 what that session already has, and pushes a `session/effect` carrying a
-`SessionSync` — upserts (id, seq, document) and removals. The originating
+`SessionSync` — upserts (id, seq, doc) and removes. The originating
 session is skipped (it already applied the change optimistically). The
 client integrates the delta into its replica and notifies cell sinks —
 re-entering Chapter 8's trigger index, completing the loop from the
@@ -150,7 +174,9 @@ per-`(space, id)` database file. The design is asymmetric, deliberately:
 
 A server-side registry can also map a handle to an external on-disk
 database (`cf piece link sqlite:/abs/path <piece>/<field>`) — read-only —
-which is how local datasets get exposed to patterns.
+which is how local datasets get exposed to patterns. (Databases governed by
+the CFC flow-control layer additionally capture per-column provenance and
+apply read-time clearance to query results — Chapter 10.)
 
 ## The local/remote symmetry
 

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -27,7 +27,7 @@ registration step, no central registry: knowing the derivation inputs *is*
 knowing the space. Dev environments lean on this hard: named dev spaces
 derive from a well-known passphrase, which is why two local setups agree on
 what `did:key:...` a space name means. The same trick defines the **shared
-dev identity** `id derive "implicit trust"` — the DID the local toolshed
+dev identity** `cf id derive "implicit trust"` — the DID the local toolshed
 itself runs as in dev mode. Because it comes from a public string, *everyone*
 who derives it gets the identical keypair. That is a convenience on your own
 localhost (CLI, browser, and server can all act as one admin identity) and a
@@ -84,15 +84,18 @@ current (v2) protocol, authorization happens at **session open**
    partitions from Chapter 9. `PerUser` isolation is cryptographic
    identity, enforced in the storage engine.
 
-The package also contains a fuller capability system from the v1 design —
-UCAN-signed per-invocation proofs and per-space ACLs
-(`packages/memory/access.ts`, `acl.ts`, surfaced as `cf acl ...`). **An
-honest caveat for the current code:** in the v2 path as deployed, what's
-verified is the signature and principal binding; the v1-style space-level
-ACL check is not wired into the v2 server (the v2 session-open hook
-authenticates rather than authorizes against an ACL). Treat per-space
-access control as an evolving area and check the code before relying on a
-specific enforcement property.
+Beyond authentication, per-space **ACLs** are now wired into the v2 server
+itself. A space can carry an ACL document (its entity id is the space DID;
+types in `packages/memory/acl.ts`, managed by the runner's `ACLManager`
+and surfaced as `cf acl ...`) granting READ/WRITE/OWNER capabilities. The
+server evaluates them per message — session-open, queries, and watches
+need READ; `transact` needs WRITE; writing the ACL itself needs OWNER —
+and seeds the space's creator as owner on first open. Enforcement is a
+deployment dial (`MEMORY_ACL_MODE`: `off`/`observe`/`enforce`,
+`packages/memory/v2/server.ts`); the default is still `off`, and `enforce`
+additionally revokes live sessions that lose access. So the machinery
+exists, but check your deployment's mode before relying on a specific
+enforcement property.
 
 ## Running untrusted code: three rings
 
@@ -104,10 +107,7 @@ unworkable constructs; emitted module-scope functions are frozen; every
 handler/lift carries a schema that *declares* what it reads and writes. The
 schema is a capability manifest: the runtime passes a handler exactly the
 cells its context schema names — with write handles only where the schema
-says `asCell` — rather than ambient access to the space. (The
-`cfc-*` patterns and the verified-source `implementationRef` machinery
-extend this into data-classification policies — flow tracking of which code
-touched which classified data — beyond this tutorial's scope.)
+says `asCell` — rather than ambient access to the space.
 
 **Ring 2 — SES.** Compiled pattern code executes inside SES (Secure
 ECMAScript) compartments: hardened intrinsics, no ambient authority. This
@@ -129,10 +129,31 @@ IPC protocol mediated by the host (`src/ipc.ts`), which applies policy per
 request. The package README is candid that exfiltration hardening (e.g.
 covert channels via permitted fetches) is ongoing work.
 
+**Beyond the rings — Contextual Flow Control (CFC).** The rings bound what
+untrusted code *can do*; CFC (`packages/runner/src/cfc/`) tracks what data
+it *touched*. Every value can carry a label: **integrity atoms** recording
+who or what vouches for it (`PolicyCertified`, `InjectionSafe`,
+`LlmDerived`, `ExternalIngest`, ...) and **confidentiality clauses**
+(conjunctive normal form, including author-written disjunctions) saying who
+may observe it. The runtime derives a conservative flow join per
+transaction — LLM output is stamped `LlmDerived` at the store boundary;
+data arriving over vouched channels (OAuth, Plaid, the ingest endpoint of
+Chapter 11) gets a runtime-minted, unforgeable `ExternalIngest` provenance
+mark — and can refuse operations that would launder a label or fall below a
+required-integrity floor (e.g. tool inputs that demand certified data).
+Deployments dial it along four independent axes — enforcement mode
+(`disabled`/`observe`/`enforce-explicit`/`enforce-strict`), flow-label
+persistence (`off`/`observe`/`persist`), the write floor, and trigger-read
+gating; the shell today runs `enforce-explicit` with flow labels at
+`persist`. The verified-source `$implRef` machinery (Chapter 7) is what
+ties labels to the exact code that produced a value. Specs live in
+`docs/specs/cfc-*.md`; demo patterns in `packages/patterns/cfc-*`.
+
 The rings compose with the data layer: even code that breaks ergonomics
 rules still acts *as* its session's principal, inside one space's replica,
 through schema-bounded handles, with every commit journaled in the
-append-only history of Chapter 9. Damage is scoped and auditable by
+append-only history of Chapter 9 — and, with CFC, with the provenance of
+what it read and wrote labeled. Damage is scoped and auditable by
 construction.
 
 ---

--- a/docs/tutorial/11-deployed-system.md
+++ b/docs/tutorial/11-deployed-system.md
@@ -22,14 +22,19 @@ the product needs server-side. Its route groups (`app.ts`) tell the story:
   (`GET /api/patterns/:filename`).
 - `integrations/*` — OAuth flows (Google, Discord, ...) so pieces can hold
   third-party credentials server-side; `webhooks` for inbound events.
+- `ingest` — `POST /api/ingest/:id`: a bearer-token channel for external,
+  DID-less sources (a phone beacon, a webhook emitter) to durably append
+  records to a channel's cell; everything arriving here carries the
+  runtime-minted `ExternalIngest` provenance mark (Chapter 10).
+- `agent-tools/*` (web-search, web-read), `link-preview`, `sandbox/exec` —
+  server-mediated capabilities for patterns and agents.
 - `whoami`, `meta`, `health` — introspection; `shell` — serves the web app
   itself.
 
 It boots its own `Runtime` instance too — the server is also a client of the
 fabric, which is what server-side piece execution rides on. Configuration is
-environment-driven (`HOST`, `PORT`, `MEMORY_DIR`/`DB_PATH`, compilation
-cache toggles); `docs/development/LOCAL_DEV_SERVERS.md` covers running it
-locally.
+environment-driven (`HOST`, `PORT`, `MEMORY_DIR`/`DB_PATH`, `CACHE_DIR`,
+...); `docs/development/LOCAL_DEV_SERVERS.md` covers running it locally.
 
 ## Shell: the browser client
 
@@ -90,13 +95,18 @@ ran `cf piece link` long ago to feed the list into a dashboard piece.
    pull-execution re-runs them; UI sinks fire; the row moves to "Completed"
    in Alice's DOM — all before any network round trip.
 3. **Commit** (Ch. 9). The storage manager emits a `ClientCommit` — a
-   `patch` op on the item document plus the journal's read set — over the
-   session opened at login (signed `session.open`, Ch. 10). Toolshed's
-   engine validates the reads against the space's SQLite history inside one
-   write transaction, appends commit + revision rows, advances the head.
-   Had Bob concurrently patched the same item's `title`, both commits would
-   land — disjoint paths don't conflict; had he patched `done`, the loser
-   would revert and retry (Ch. 8/9).
+   `patch` op on the item document — over the session opened at login
+   (signed `session.open`, Ch. 10). A scalar binding write like this
+   checkbox is *blind* (last-write-wins): its reads are recorded for
+   reactivity, not as commit preconditions. Toolshed's engine validates
+   whatever reads a commit does carry against the space's SQLite history
+   inside one write transaction, appends commit + revision rows, advances
+   the head. Had Bob concurrently patched the same item's `title`, both
+   commits would land — disjoint paths never conflict. Had he toggled
+   `done` at the same instant, the later write would simply win;
+   revert-and-retry is reserved for read-modify-write commits, and
+   mergeable ops (a `push` of a new item) merge instead of racing
+   (Ch. 8/9).
 4. **Fan-out** (Ch. 9). The engine marks the item document dirty. The
    debounced refresh re-walks affected watch graphs per session — Bob's
    watch covers the list's documents via its schema selectors, as does the
@@ -125,6 +135,9 @@ Common Fabric.
   scheduler (`packages/runner/src/scheduler.ts`) and the v2 engine
   (`packages/memory/v2/engine.ts`) are the two files most worth reading
   end to end.
-- **Open questions to watch in the code**: v2 space-level access control
-  (Ch. 10 caveat), branches/merge in the storage engine (Ch. 9), and the
-  CFC data-classification work (`packages/patterns/cfc-*`).
+- **Areas to watch in the code**: per-space ACL enforcement recently landed
+  behind a default-off dial (`MEMORY_ACL_MODE`, Ch. 10); branch
+  infrastructure exists in the storage engine's schema while merge remains
+  open (Ch. 9); and the CFC flow-control layer is evolving quickly
+  (`packages/runner/src/cfc/`, specs in `docs/specs/cfc-*.md`, demo
+  patterns in `packages/patterns/cfc-*`).


### PR DESCRIPTION
## Why

The tutorial (`docs/tutorial/`) was written in mid-June; ~150 commits have landed since, and several of its load-bearing claims no longer matched the code. A chapter-by-chapter verification against the current tree found three substantive drifts and a handful of dead references:

- **The write model changed.** The tutorial taught a single write story (optimistic CAS with rollback-and-retry). The mergeable-writes work (#4245, #4370, #4452, #4464) split this into three: mergeable ops (`push`/`addUnique`/`increment`/`removeByValue`) that merge on the server, blind last-write-wins scalar UI-binding writes, and CAS only for read-modify-write. This invalidated the end-to-end traces in chapters 1 and 11, the chapter 2 guarantees contract, the counter example (the real file now uses `value.increment(1)`), and the chapter 8/9 conflict-protocol descriptions.
- **The security chapter's honest caveat went stale in the good direction.** Per-space ACLs are now wired into the v2 server behind `MEMORY_ACL_MODE` (default `off`), and CFC has grown from a parenthetical into a runtime subsystem the shell runs at `enforce-explicit`/`persist` — chapter 10 now describes both.
- **Renamed/removed internals.** `implementationRef` → `$implRef {identity, symbol}` (#4436), the push scheduler mode and `function-cache.ts` are gone, `derive()` was removed, `Reactive<T>` no longer emits `asCell: ["opaque"]` (`OpaqueCell<T>` does), and the v1 memory stack was deleted (#4236).

Also fixes a real contradiction in `docs/common/capabilities/llm.md` (showed `cache: false` on `generateText`; only `generateObject` accepts it) and adds the six unmapped product-stack packages (`data-model`, `runtime-client`, `lib-shell`, `fuse`, `state-inspector`, `cf-harness`) to the AGENTS.md pace layers, which the tutorial's chapter 1 table mirrors.

## What Changed

- All eleven tutorial chapters updated; new content includes the mergeable-write surface and authoring contract (ch2/3/8/9), `cf view` and `fetchMocks` test mocking (ch6), a real CFC treatment with the four deployment dials (ch10), and the new Toolshed route groups incl. `POST /api/ingest/:id` (ch11).
- `docs/common/capabilities/llm.md`: cache-busting example moved to `generateObject`.
- `AGENTS.md` + tutorial ch1 pace-layer table: six packages added to layers; support/test packages explicitly called out as outside the stack.

## Test plan

- `deno task check-docs tutorial` — all 23 checked code blocks pass.
- `deno task check-docs common/capabilities` — passes.
- Every factual correction was verified against the current source with file-level evidence before editing (six parallel read-only review passes, one per chapter group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the tutorial and related docs to match the current code: documents mergeable writes vs blind LWW vs CAS, adds CFC and per‑space ACLs, and updates renamed internals like `$implRef` and the pull-only scheduler. Also fixes an LLM docs contradiction and updates the product stack with `data-model`, `runtime-client`, `lib-shell`, `fuse`, `state-inspector`, `cf-harness`.

- **New Features**
  - Explains mergeable writes (`push`, `addUnique`, `increment`, `removeByValue`), blind scalar `set`s (LWW), and read‑modify‑write CAS; updates examples and conflict protocol.
  - Adds CFC overview with enforcement/persistence dials and provenance marks; describes per‑space ACLs with `MEMORY_ACL_MODE` and server evaluation.
  - Documents `cf view` for transformed output and `fetchMocks` for deterministic tests; notes Toolshed `POST /api/ingest/:id` and server‑mediated tools.
  - Updates internals in docs: `$implRef { identity, symbol }`, `OpaqueCell<T>`, pull‑only scheduler; removes `derive()`; clarifies link formats and blind binding writes.
  - Expands pace‑layer tables/AGENTS with `data-model`, `runtime-client`, `lib-shell`, `fuse`, `state-inspector`, `cf-harness`; marks support/test packages as outside the stack.

- **Bug Fixes**
  - Moves cache‑busting example to `generateObject` in LLM docs (was incorrectly shown on `generateText`).

<sup>Written for commit b63bb0df1bff128e2608683801bc302ce2b10b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

