### PR TITLE
Expand fixed-length tuple spreads to imported cell parameters

### DIFF
--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -501,7 +501,6 @@ function getFixedTupleElementCount(
   if (!checker.isTupleType(type)) return undefined;
   const target = (type as ts.TypeReference).target as ts.TupleType;
   const elementFlags = target.elementFlags;
-  if (!elementFlags) return undefined;
   for (const flag of elementFlags) {
     if (flag !== ts.ElementFlags.Required) return undefined;
   }

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -488,6 +488,26 @@ function isRestParameter(parameter: ts.Symbol | undefined): boolean {
     !!declaration.dotDotDotToken;
 }
 
+// A spread of a fixed-length tuple fills a statically known set of parameter
+// positions, so it can be expanded and matched positionally. Return the element
+// count for such a tuple, or undefined for anything whose length is not fixed at
+// compile time (a plain array, or a tuple with an optional, rest, or variadic
+// element such as `[A, ...B[]]`). Every element flag must be exactly
+// `Required`; any other flag admits a variable runtime length.
+function getFixedTupleElementCount(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): number | undefined {
+  if (!checker.isTupleType(type)) return undefined;
+  const target = (type as ts.TypeReference).target as ts.TupleType;
+  const elementFlags = target.elementFlags;
+  if (!elementFlags) return undefined;
+  for (const flag of elementFlags) {
+    if (flag !== ts.ElementFlags.Required) return undefined;
+  }
+  return elementFlags.length;
+}
+
 function isLiteralElement(
   expr: ts.Expression | undefined,
 ): expr is
@@ -2316,17 +2336,94 @@ export function analyzeFunctionCapabilities(
       const args = call.arguments;
       if (!args) return handled;
 
-      for (let index = 0; index < args.length; index++) {
+      // `index` walks the argument list; `paramIndex` walks parameter
+      // positions. The two diverge only when a fixed-length tuple spread expands
+      // into several positions, so the loop update advances `paramIndex` by one
+      // per argument and the tuple branch adds the remaining positions.
+      for (
+        let index = 0, paramIndex = 0;
+        index < args.length;
+        index++, paramIndex++
+      ) {
         const argument = args[index];
         if (!argument) continue;
 
-        const parameter = getParameterAtArgument(signature, index);
+        const parameter = getParameterAtArgument(signature, paramIndex);
         const isSpreadArgument = ts.isSpreadElement(argument);
-        // An array spread has unknown runtime length, so it cannot be matched to
-        // later fixed parameters; stop signature mapping there. A spread into a
-        // rest parameter is a collection of rest elements, recorded below at the
-        // representative array-item path.
-        if (isSpreadArgument && !isRestParameter(parameter)) break;
+        // An array spread into a fixed parameter has unknown runtime length, so
+        // it cannot be matched to later fixed parameters. A spread of a
+        // fixed-length tuple is the exception: its positions are statically
+        // known, so expand each tuple element to its corresponding parameter. A
+        // spread into a rest parameter is a collection of rest elements,
+        // recorded below at the representative array-item path.
+        if (isSpreadArgument && !isRestParameter(parameter)) {
+          const tupleLength = getFixedTupleElementCount(
+            checker.getTypeAtLocation(argument.expression),
+            checker,
+          );
+          if (tupleLength === undefined) break;
+
+          const spreadSource = resolveSourceRef(argument.expression);
+          // Suppress the ordinary read of the spread source only when the
+          // contract accounts for every tuple position: a dynamic source is
+          // wholly wildcarded, and a static source qualifies only if every
+          // element maps to a recognized cell wrapper. A tuple with a non-cell
+          // position leaves that position to conservative read tracking.
+          const suppressOrdinaryRead = () => {
+            handled.add(index);
+            signatureCapabilityArgumentUses.add(
+              unwrapExpressionUsageSite(argument.expression),
+            );
+          };
+          if (spreadSource) {
+            if (spreadSource.dynamic) {
+              markWildcard(spreadSource.root);
+              suppressOrdinaryRead();
+            } else {
+              let mappedCount = 0;
+              for (let element = 0; element < tupleLength; element++) {
+                const elementParameter = getParameterAtArgument(
+                  signature,
+                  paramIndex + element,
+                );
+                const elementCellKind = getParameterDeclaredCellKind(
+                  elementParameter,
+                  checker,
+                );
+                if (!elementCellKind) continue;
+                mappedCount++;
+                const elementPath = [...spreadSource.path, String(element)];
+                switch (elementCellKind) {
+                  case "cell":
+                    trackRead(spreadSource.root, elementPath);
+                    trackWrite(spreadSource.root, elementPath);
+                    break;
+                  case "readonly":
+                    trackRead(spreadSource.root, elementPath);
+                    break;
+                  case "writeonly":
+                    trackWrite(spreadSource.root, elementPath);
+                    break;
+                  case "comparable":
+                    recordComparablePath(spreadSource.root, elementPath, {
+                      cellLike: true,
+                    });
+                    break;
+                  case "opaque":
+                  case "stream":
+                  case "sqlite":
+                    recordOpaquePath(spreadSource.root, elementPath);
+                    break;
+                }
+              }
+              if (mappedCount === tupleLength) suppressOrdinaryRead();
+            }
+          }
+          // The loop update advances `paramIndex` by one; the tuple fills
+          // `tupleLength` positions, so add the rest here.
+          paramIndex += tupleLength - 1;
+          continue;
+        }
 
         const capabilityArgument = isSpreadArgument
           ? argument.expression

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -1718,6 +1718,189 @@ Deno.test(
 );
 
 Deno.test(
+  "Capability analysis stays conservative for a variadic tuple spread into fixed parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { variadic }: { variadic: [Writable<Auth>, ...Writable<Auth>[]] },
+        ) => {
+          client(...variadic);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // A tuple with a rest element has no statically fixed length, so signature
+    // mapping stops and the positions are not written.
+    assertEquals(state.writePaths.includes("variadic.0"), false);
+    assertEquals(state.writePaths.includes("variadic.1"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis wildcards a dynamically indexed fixed tuple spread",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          {
+            bag,
+            k,
+          }: {
+            bag: { [key: string]: [Writable<Auth>, Writable<Auth>] };
+            k: string;
+          },
+        ) => {
+          const local = bag;
+          client(...local[k]);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // The tuple is fixed-length, but the spread source is reached through a
+    // dynamic index, so the whole root is wildcarded rather than mapped to
+    // specific positions.
+    assert(state.wildcard);
+  },
+);
+
+Deno.test(
+  "Capability analysis maps writeonly, comparable, and opaque fixed tuple positions",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type {
+          ComparableCell,
+          OpaqueCell,
+          WriteonlyCell,
+        } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: WriteonlyCell<Auth>,
+          b: ComparableCell<Auth>,
+          c: OpaqueCell<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type {
+          ComparableCell,
+          OpaqueCell,
+          WriteonlyCell,
+        } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          {
+            triple,
+          }: {
+            triple: [
+              WriteonlyCell<Auth>,
+              ComparableCell<Auth>,
+              OpaqueCell<Auth>,
+            ];
+          },
+        ) => {
+          client(...triple);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // Element 0 is write-only (write, no passing read), element 1 is a
+    // comparable cell (identity-cell path), element 2 is opaque.
+    assert(state.writePaths.includes("triple.0"));
+    assertEquals(state.readPaths.includes("triple.0"), false);
+    assert(state.identityCellPaths.includes("triple.1"));
+    assert(state.opaquePaths.includes("triple.2"));
+  },
+);
+
+Deno.test(
+  "Capability analysis records nothing for a parenthesis-free imported construction",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export declare class Client {
+          constructor(auth: Writable<Auth>);
+        }
+      `,
+      "/test.ts": `
+        import { Client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { auth }: { auth: Writable<Auth> },
+        ) => {
+          new Client;
+          return auth;
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // A construction written without an argument list has no arguments to map,
+    // so the constructor's declared cell contract records no write for the
+    // separately-read cell.
+    assertEquals(state.writePaths.includes("auth"), false);
+    assert(state.readPaths.includes("auth"));
+  },
+);
+
+Deno.test(
   "Capability analysis shrinks a root cell to readonly for a ReadonlyCell parameter",
   () => {
     const { program, sourceFile } = createProgramWithFiles({

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -1474,6 +1474,250 @@ Deno.test(
 );
 
 Deno.test(
+  "Capability analysis expands a fixed tuple spread into imported fixed parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { pair }: { pair: [Writable<Auth>, Writable<Auth>] },
+        ) => {
+          client(...pair);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assert(state.writePaths.includes("pair.0"));
+    assert(state.writePaths.includes("pair.1"));
+  },
+);
+
+Deno.test(
+  "Capability analysis maps each fixed tuple spread element to its own parameter capability",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { ReadonlyCell, Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: ReadonlyCell<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { ReadonlyCell, Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { pair }: { pair: [Writable<Auth>, ReadonlyCell<Auth>] },
+        ) => {
+          client(...pair);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // Element 0 flows to a Writable parameter (read and write); element 1 flows
+    // to a ReadonlyCell parameter (read only, no write).
+    assert(state.writePaths.includes("pair.0"));
+    assertEquals(state.writePaths.includes("pair.1"), false);
+    assert(state.readPaths.includes("pair.1"));
+  },
+);
+
+Deno.test(
+  "Capability analysis does not expand a variable-length array spread into imported fixed parameters",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { pair }: { pair: Writable<Auth>[] },
+        ) => {
+          client(...pair);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assertEquals(state.writePaths.includes("pair.0"), false);
+    assertEquals(state.writePaths.includes("pair.1"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis keeps a tuple spread with a non-cell position conservatively read",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: number,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          { pair }: { pair: [Writable<Auth>, number] },
+        ) => {
+          client(...pair);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // Element 0 maps to a Writable parameter, so its write is recorded. Element
+    // 1 is a plain value with no cell contract, so the spread source is not
+    // suppressed and its ordinary read is tracked conservatively.
+    assert(state.writePaths.includes("pair.0"));
+    assert(state.readPaths.includes("pair"));
+  },
+);
+
+Deno.test(
+  "Capability analysis maps a leading fixed argument before a fixed tuple spread",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          first: Writable<Auth>,
+          a: Writable<Auth>,
+          b: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          {
+            first,
+            pair,
+          }: {
+            first: Writable<Auth>;
+            pair: [Writable<Auth>, Writable<Auth>];
+          },
+        ) => {
+          client(first, ...pair);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    assert(state.writePaths.includes("first"));
+    assert(state.writePaths.includes("pair.0"));
+    assert(state.writePaths.includes("pair.1"));
+  },
+);
+
+Deno.test(
+  "Capability analysis advances past a single-element tuple spread to a trailing argument",
+  () => {
+    const { program, sourceFile } = createProgramWithFiles({
+      "/client.d.ts": `
+        import type { Writable } from "commonfabric";
+
+        export type Auth = { token: string };
+        export function client(
+          a: Writable<Auth>,
+          b: Writable<Auth>,
+        ): void;
+      `,
+      "/test.ts": `
+        import { client, type Auth } from "client";
+        import type { Writable } from "commonfabric";
+
+        const fn = (
+          _event: unknown,
+          {
+            single,
+            tail,
+          }: {
+            single: [Writable<Auth>];
+            tail: Writable<Auth>;
+          },
+        ) => {
+          client(...single, tail);
+        };
+      `,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const state = getPaths(summary, "__param1");
+
+    // The single tuple element fills parameter 0, so the trailing argument must
+    // map to parameter 1 rather than colliding on parameter 0.
+    assert(state.writePaths.includes("single.0"));
+    assert(state.writePaths.includes("tail"));
+  },
+);
+
+Deno.test(
   "Capability analysis shrinks a root cell to readonly for a ReadonlyCell parameter",
   () => {
     const { program, sourceFile } = createProgramWithFiles({


### PR DESCRIPTION
The capability analysis reads write and read intent from an out-of-file callee's declared Common Fabric cell-wrapper parameter types, recovering intent that body analysis cannot see across an import boundary. When an argument was a spread into a fixed parameter, the analysis stopped mapping there, because an array spread's runtime length is unknown and later fixed parameters cannot be positionally matched.

A spread whose static type is a fixed-length tuple is the exception: its positions are known at compile time, so each tuple element can be matched to its corresponding fixed parameter. This change detects that case and expands it. Each tuple element index maps to the parameter at that position and records the declared capability (read, write, comparable, or opaque) at the spread source path extended by the element index, mirroring how the rest parameter case records at a representative array-item path.

A separate parameter cursor walks parameter positions independently of the argument index, so a tuple spread that fills several positions still leaves arguments after it mapped to the correct parameters. The detection is strict: only a tuple whose every element is a required, fixed position expands. A plain array, or a tuple carrying an optional, rest, or variadic element, has a length that is not fixed at compile time and keeps the existing conservative behavior of stopping the mapping.

The ordinary read of the spread source is suppressed only when the contract accounts for every tuple position. A dynamic source is wholly wildcarded, and a static source qualifies only when every element maps to a recognized cell wrapper. A tuple with a non-cell position leaves that position to conservative read tracking, so a partially recognized tuple does not drop the read of its unaccounted positions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands capability analysis to handle spreads of fixed-length tuples into imported parameters, mapping each element to its parameter and recording the correct capability. Keeps conservative behavior for arrays or non-fixed tuples and only suppresses the spread source’s ordinary read when all elements map to a recognized `commonfabric` cell wrapper; dynamically indexed tuple sources are wildcarded.

- New Features
  - Expands fixed-length tuple spreads and uses a separate parameter cursor so trailing arguments map to the right parameters.
  - Records per-element capabilities at the spread source with indexed paths (including `writeonly`, `comparable`, and `opaque`); treats variadic/optional tuples or any non-cell element conservatively, and records nothing for parenthesis-free imported constructions.

<sup>Written for commit 01d1c08dbbd7fd21e15abfa430cc43fee58ece0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

