### PR TITLE
fix(tasks): merge per-instance lcov records in the coverage-debt metric (CT-1861)

### DIFF
--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -28,6 +28,38 @@ Deno.test("parseLcov accumulates hits per source line", () => {
   assertEquals(countUncoveredProfileLines(file!), 1);
 });
 
+Deno.test("parseLcov merges per-instance records of the same physical file", () => {
+  // Deno's coverage emits one record per module INSTANCE — the same file
+  // appears plain and as `?testRun=<uuid>` once per importing test file.
+  // Instances must merge so a line counts covered when ANY instance executed
+  // it; otherwise the debt metric counts the same physical line once per
+  // instance that skipped it, flapping with test order and punishing added
+  // tests (CT-1861).
+  const coverage = parseLcov([
+    "SF:/repo/packages/example/src/mod.ts",
+    "DA:1,1",
+    "DA:2,0",
+    "end_of_record",
+    "SF:/repo/packages/example/src/mod.ts?testRun=aaaa-1111",
+    "DA:1,0",
+    "DA:2,2",
+    "DA:3,0",
+    "end_of_record",
+    "SF:/repo/packages/example/src/mod.ts?testRun=bbbb-2222",
+    "DA:3,0",
+    "end_of_record",
+  ].join("\n"));
+
+  assertEquals(coverage.size, 1);
+  const file = coverage.get("/repo/packages/example/src/mod.ts");
+  // Line 1 covered by the plain instance, line 2 by testRun aaaa; line 3 by
+  // neither — the ONLY genuinely uncovered line.
+  assertEquals(file?.lineHits.get(1), 1);
+  assertEquals(file?.lineHits.get(2), 2);
+  assertEquals(file?.lineHits.get(3), 0);
+  assertEquals(countUncoveredProfileLines(file!), 1);
+});
+
 Deno.test("countTrackedSourceLines ignores blank and comment-only lines", () => {
   assertEquals(
     countTrackedSourceLines([

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -11,6 +11,7 @@ import {
   shouldTrackSourceFile,
   trackedSourceLineNumbers,
 } from "./coverage-metrics.ts";
+import { normalizeLcovInstancePaths } from "./write-coverage-lcov.ts";
 
 Deno.test("parseLcov accumulates hits per source line", () => {
   const coverage = parseLcov([
@@ -28,14 +29,16 @@ Deno.test("parseLcov accumulates hits per source line", () => {
   assertEquals(countUncoveredProfileLines(file!), 1);
 });
 
-Deno.test("parseLcov merges per-instance records of the same physical file", () => {
+Deno.test("instance-suffix normalization merges records of the same physical file", () => {
   // Deno's coverage emits one record per module INSTANCE — the same file
-  // appears plain and as `?testRun=<uuid>` once per importing test file.
-  // Instances must merge so a line counts covered when ANY instance executed
-  // it; otherwise the debt metric counts the same physical line once per
-  // instance that skipped it, flapping with test order and punishing added
-  // tests (CT-1861).
-  const coverage = parseLcov([
+  // appears plain and as `?testRun=<uuid>` once per cache-busting import.
+  // The suffix is stripped at LCOV GENERATION (normalizeLcovInstancePaths,
+  // applied by write-coverage-lcov.ts and the local lcovFromCoverageProfile
+  // path) so every consumer sees one record set per physical file, and a
+  // line counts covered when ANY instance executed it. Without this the debt
+  // metric counted the same physical line once per instance that skipped it,
+  // flapping with test order and punishing added tests (CT-1861).
+  const normalized = normalizeLcovInstancePaths([
     "SF:/repo/packages/example/src/mod.ts",
     "DA:1,1",
     "DA:2,0",
@@ -49,6 +52,7 @@ Deno.test("parseLcov merges per-instance records of the same physical file", () 
     "DA:3,0",
     "end_of_record",
   ].join("\n"));
+  const coverage = parseLcov(normalized);
 
   assertEquals(coverage.size, 1);
   const file = coverage.get("/repo/packages/example/src/mod.ts");

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
 import * as path from "@std/path";
+import { normalizeLcovInstancePaths } from "./write-coverage-lcov.ts";
 
 export const COVERAGE_PROFILE_ARTIFACT_PREFIX = "coverage-profile-";
 export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
@@ -273,16 +274,12 @@ export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
 
   for (const line of lcov.split(/\r?\n/)) {
     if (line.startsWith("SF:")) {
-      // Strip any query suffix before keying: Deno's coverage emits a
-      // separate record per module INSTANCE (e.g. `foo.ts?testRun=<uuid>`
-      // per importing test file), and keying on the raw path counted the
-      // same physical line as debt once per instance that didn't execute
-      // it. That made the debt metric flap ±1-5 lines with test order and
-      // timing — and made ADDING a test able to increase "uncovered lines"
-      // (its fresh instances carry red lines for whatever they don't
-      // execute). Merging instances measures real per-file coverage: a line
-      // is covered when ANY instance executed it (CT-1861).
-      currentPath = path.normalize(line.slice(3).split("?")[0]);
+      // Per-instance suffixes (`?testRun=<uuid>` cache-busting imports) are
+      // normalized away at LCOV GENERATION (write-coverage-lcov.ts,
+      // `normalizeLcovInstancePaths` — CT-1861), so records arriving here
+      // already share one path per physical file; duplicate `SF:` sections
+      // accumulate into the same entry below.
+      currentPath = path.normalize(line.slice(3));
       if (!files.has(currentPath)) {
         files.set(currentPath, { lineHits: new Map() });
       }
@@ -346,7 +343,9 @@ export async function lcovFromCoverageProfile(
       throw new Error(`deno coverage failed: ${stderr.trim()}`);
     }
 
-    return await Deno.readTextFile(outputPath);
+    // Same generation-point normalization the CI artifact writer applies
+    // (write-coverage-lcov.ts) — this is the LOCAL generation path.
+    return normalizeLcovInstancePaths(await Deno.readTextFile(outputPath));
   } finally {
     try {
       await Deno.remove(tmpDir, { recursive: true });

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -273,7 +273,16 @@ export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
 
   for (const line of lcov.split(/\r?\n/)) {
     if (line.startsWith("SF:")) {
-      currentPath = path.normalize(line.slice(3));
+      // Strip any query suffix before keying: Deno's coverage emits a
+      // separate record per module INSTANCE (e.g. `foo.ts?testRun=<uuid>`
+      // per importing test file), and keying on the raw path counted the
+      // same physical line as debt once per instance that didn't execute
+      // it. That made the debt metric flap ±1-5 lines with test order and
+      // timing — and made ADDING a test able to increase "uncovered lines"
+      // (its fresh instances carry red lines for whatever they don't
+      // execute). Merging instances measures real per-file coverage: a line
+      // is covered when ANY instance executed it (CT-1861).
+      currentPath = path.normalize(line.slice(3).split("?")[0]);
       if (!files.has(currentPath)) {
         files.set(currentPath, { lineHits: new Map() });
       }

--- a/tasks/write-coverage-lcov.ts
+++ b/tasks/write-coverage-lcov.ts
@@ -1,6 +1,24 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
 import * as path from "@std/path";
 
+/**
+ * Normalize per-instance source paths in an LCOV report to their physical
+ * file. A handful of tests deliberately import modules with a cache-busting
+ * query (`foo.ts?testRun=<uuid>`) to get fresh module-scoped state per test;
+ * V8 then reports each such import as a separate script, and
+ * `deno coverage --lcov` emits a separate record per instance under the
+ * suffixed path. Downstream consumers (the coverage-debt metric, the
+ * combined IDE report) must see one record set per physical file — a line is
+ * covered when ANY instance executed it — so the suffix is stripped here, at
+ * generation, rather than taught to every consumer (CT-1861). Records are
+ * left separate; LCOV consumers accumulate duplicate `SF:` sections.
+ */
+export function normalizeLcovInstancePaths(lcov: string): string {
+  return lcov.split(/\r?\n/).map((line) =>
+    line.startsWith("SF:") ? `SF:${line.slice(3).split("?")[0]}` : line
+  ).join("\n");
+}
+
 async function collectCoverageProfileFiles(dir: string): Promise<string[]> {
   const files: string[] = [];
   try {
@@ -92,6 +110,11 @@ async function main(): Promise<void> {
     }
     throw new Error(`deno coverage failed: ${stderr.trim()}`);
   }
+
+  await Deno.writeTextFile(
+    outputPath,
+    normalizeLcovInstancePaths(await Deno.readTextFile(outputPath)),
+  );
 
   console.log(`Wrote LCOV coverage report to ${outputPath}`);
 }


### PR DESCRIPTION
Deno's coverage emits one record per module **instance** — the same file appears plain and as `?testRun=<uuid>` once per importing test file — and `parseLcov` keyed records on the raw `SF:` path. The same physical line therefore counted as debt once per instance that didn't execute it, which made the coverage-debt ratchet structurally noisy:

- the metric **flapped ±1–5 lines** run-to-run on unchanged code (baselines carry n=2 samples after main moves, so one flap trips the gate);
- changes that move execution timing (e.g. eager→lazy deferral) **reshuffled the count with zero real coverage change** — verified from CI's own lcov artifacts, line-shift-adjusted against base runs, on both #4557 and #4560;
- **adding a test file could *increase* "uncovered lines"** — its fresh instances carry red lines for whatever they don't execute (observed +3 from adding a test whose target module measured 100% covered).

CT-1861 carries the full three-PR evidence trail from 2026-07-06/07.

**Fix:** strip the query suffix before keying, so instances of the same physical file merge and a line counts covered when **any** instance executed it — the metric measures real per-file coverage. Unit test pins the merge semantics (three instances, hits summed, only the line no instance executed counts uncovered).

**Transition:** no flag day. This PR's own gate computes merged (lower) values against old-style baselines — large apparent reductions — and post-merge main runs re-baseline downward once; subsequent PRs compare consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes coverage-debt noise by merging Deno’s per-instance LCOV records into a single per-file profile, preventing flapping and false increases when adding tests. Addresses CT-1861.

- **Bug Fixes**
  - Normalize instance suffixes at LCOV generation via `normalizeLcovInstancePaths` in `write-coverage-lcov.ts`, applied in both the CI artifact writer and local `lcovFromCoverageProfile`; all consumers (e.g. IDE report) now see one record per physical file, and `parseLcov` simply accumulates duplicate `SF:` sections.
  - Add a unit test that exercises normalize → parse and pins uncovered-line calculation.

- **Migration**
  - No action needed. The gate already compares merged values to old baselines; main will re-baseline lower once after merge.

<sup>Written for commit d2b74a693034e7c9ed6c6591a7576e8ec4fdeb87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

