### PR TITLE
ci: run Build Binaries on a standard runner instead of the 32-core group

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -186,8 +186,7 @@ jobs:
 
   build-binaries:
     name: "Build Binaries"
-    runs-on:
-      group: labs
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: 📥 Checkout repository


### PR DESCRIPTION
The Build Binaries job compiles the toolshed, background-piece-service, and cf binaries (plus the shell assets) and then hands the results to every downstream integration and unit test job. It ran on the "labs" runner group, which is a GitHub-hosted 32-core larger runner billed at roughly thirteen times the standard Linux rate. Larger-runner minutes are billed even for public repositories, so this job is one of only four that actually cost money; the rest of the workflow runs on standard runners that are free for a public repository.

The build does not use those extra cores. It is a sequential chain: build the shell in development mode, then production mode, then compile each binary one after another, each step a single build subprocess that is essentially single-threaded. A local measurement of the same task averaged about 1.2 cores over the whole run, with a peak resident set under 2 GB. On the 32-core machine that leaves roughly thirty cores idle for the duration.

Because the work is single-threaded and disk-bound rather than core-bound, a standard two-core runner should complete it in about the same wall time. Build Binaries sits at the root of the tier-1 dependency chain, so the concern with moving it is whether it would delay everything that waits on it. Since its duration is set by single-core speed and I/O, not by core count, its wall time and therefore the overall critical path should be unchanged, while its cost on the billed 32-core runner drops to zero.

Memory headroom is ample: the peak resident set observed locally is well under a standard runner's available memory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Build Binaries CI job on a standard `ubuntu-latest` runner instead of the 32‑core `labs` group. This removes larger-runner costs without increasing wall time, since the build is single‑threaded (~1.2 cores, <2 GB RAM) and downstream outputs remain the same.

<sup>Written for commit 3ca73959a9efa5e724b4d44436cc54f6480d7039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

