### PR TITLE
fix(shell): make login view scrollable on short viewports (CT-1866)

### DIFF
--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -45,10 +45,9 @@ export class XLoginView extends BaseView {
   static override styles = css`
     :host {
       display: flex;
-      align-items: center;
-      justify-content: center;
       width: 100%;
       height: 100%;
+      overflow-y: auto;
       font-family: var(--font-primary);
     }
 
@@ -56,6 +55,12 @@ export class XLoginView extends BaseView {
       display: flex;
       flex-direction: column;
       align-items: center;
+      /* Auto margins center the card when it fits but — unlike
+        align-items/justify-content centering — keep the overflow
+        reachable by scrolling when the viewport is shorter than
+        the card (e.g. the recovery-phrase screen on mobile). */
+      margin: auto;
+      padding: 1rem 0;
     }
 
     .auth-action-container {

--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -43,6 +43,15 @@ const AUTH_EVENT = "auth-event";
 
 export class XLoginView extends BaseView {
   static override styles = css`
+    /* The document-level border-box reset doesn't pierce the shadow root;
+      without this, width: 100% + padding (.auth-action-container) overflows
+      the viewport horizontally on mobile. */
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
     :host {
       display: flex;
       width: 100%;
@@ -98,7 +107,6 @@ export class XLoginView extends BaseView {
       color: var(--font-color);
       border: var(--border-width, 2px) solid var(--border-color, #000);
       background: var(--shell-surface);
-      box-sizing: border-box;
     }
 
     textarea {


### PR DESCRIPTION
## Summary

On mobile, the registration flow's "Your Secret Recovery Phrase" screen could not be scrolled: the CF logo was clipped off the top and the "🔒 I've Saved It - Continue" button was pushed below the fold with no way to reach it, making registration impossible on phones.

Fixes [CT-1866](https://linear.app/common-tools/issue/CT-1866/mobile-recovery-phrase-registration-screen-cant-scroll-continue-button).

## Root cause (confirmed by DOM probing at 375×568)

- There is no scroll container anywhere in the ancestor chain: `html`/`body` are fixed at `100dvh`, `x-root-view` is `overflow: hidden`, and `x-app-view`'s `.content-area` is `overflow: hidden`. Probing showed `.content-area` with `scrollHeight 626 > clientHeight 596` and `window.scrollTo` a no-op.
- `x-login-view` centered its card with `align-items: center; justify-content: center` in a `height: 100%` host, so when the card (~656px) is taller than the visible viewport (~550–660px on phones) the overflow spills **both above and below** and is clipped at both ends (measured: logo top = −12px, Continue bottom = 610px in a 568px viewport).
- The mnemonic textarea covering most of the screen consumes touch drags, and `body { overscroll-behavior: none }` suppresses the rubber-band cue, so the page feels completely dead to touch.

## Fix

Make the `x-login-view` host a scroll container (`overflow-y: auto`) and center `.login-container` with `margin: auto` instead of flex alignment — auto margins center the card when it fits but, unlike `align-items`/`justify-content` centering, keep overflowed content reachable by scrolling.

## Verification

- Playwright at 375×568: login host is scrollable, Continue button fully visible after scrolling to bottom, logo fully visible at top.
- Desktop 1280×800: card remains centered on both axes, no scrollbar.
- `packages/shell` tests: 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the login view scrollable on short screens and fix horizontal overflow on mobile so the recovery-phrase screen works. Addresses CT-1866 by keeping the header and Continue button reachable and the card within the viewport width.

- **Bug Fixes**
  - Made `XLoginView` host a scroll container with `overflow-y: auto`.
  - Centered the card with `margin: auto` instead of flex alignment to preserve scroll.
  - Applied `box-sizing: border-box` within the shadow root to prevent horizontal overflow; removed redundant per-element declarations.

<sup>Written for commit e5bd27ef195788b62f12ba131e629a51cc6fcac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

