### PR TITLE
ci: run Attest and Upload Binaries on a standard runner instead of th…

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -817,8 +817,7 @@ jobs:
   attest-binaries:
     name: "Attest and Upload Binaries"
     if: github.ref == 'refs/heads/main'
-    runs-on:
-      group: labs
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs:
       [


### PR DESCRIPTION
…e 32-core group

The Attest and Upload Binaries job takes the compiled binaries, hashes and signs them, generates and verifies build-provenance attestations, combines the per-job coverage reports, and uploads the signed tarball to Cloud Storage. It ran on the "labs" runner group, a GitHub-hosted 32-core larger runner billed at roughly thirteen times the standard Linux rate and, unlike standard runners on a public repository, billed rather than free. It is one of only a handful of jobs that actually cost money.

None of the work benefits from extra cores. Hashing, openssl signing, tar, attestation generation and verification, and the Cloud Storage uploads are I/O and network bound; they run on one core and wait on disk and the network. The 32 cores sit idle for the duration.

The job also sits off the pull-request critical path. It runs only on the main branch after every test job, and it gates the staging deploys rather than any check a pull request waits on. Its duration is set by signing and upload time, not by core count, so a standard two-core runner completes it in about the same wall time and the deploy that follows is not meaningfully delayed, while its cost on the billed larger runner drops to zero.

This is the companion change to moving Build Binaries to a standard runner: both are single-threaded or I/O-bound jobs that were paying for 32 cores they did not use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the "Attest and Upload Binaries" job on a standard `ubuntu-latest` runner instead of the paid 32‑core "labs" group to cut CI cost with no runtime impact. The job is I/O‑bound and runs only on `main`, so PR checks and deploy timing are unaffected.

<sup>Written for commit 3cf6a3230858f532775396bd7bdc3341c5835e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

