### PR TITLE
fix(runner): make compile-cache source writeback a blind writer (CT-1864)

### DIFF
--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -453,6 +453,11 @@ export const SOURCE_DOC_SCHEMA = {
  * import a sigil link to its dependency cell (the entry additionally linking any
  * otherwise-unreachable module). Idempotent (content-addressed keys). The caller
  * owns the transaction's commit.
+ *
+ * Pure blind writer: it reads nothing, so it adds no commit read-preconditions.
+ * Product annotations to preserve on the entry doc must be read by the caller
+ * OUTSIDE this transaction and passed via `entryAnnotations` — reading them here
+ * would reintroduce the aged-space forever-conflict (CT-1864); see the body.
  */
 export function writeSourceDocs(
   runtime: Runtime,
@@ -460,6 +465,7 @@ export function writeSourceDocs(
   modules: readonly CacheableModule[],
   entryIdentity: string,
   tx: IExtendedStorageTransaction,
+  entryAnnotations?: Record<string, unknown>,
 ): void {
   assertNoUnpinnedFabricImports(modules);
   const docs = buildSourceDocs(modules, entryIdentity);
@@ -472,12 +478,20 @@ export function writeSourceDocs(
       undefined,
       tx,
     );
-    // Preserve product annotations on the entry doc only. Annotations are only
-    // written there; reading every dependency doc here turns unrelated stale
-    // cache cells into writeback conflict preconditions.
-    const existingAnnotations = identity === entryIdentity
-      ? cell.get()?.annotations
-      : undefined;
+    // Product annotations live on the entry doc only, and are supplied by the
+    // caller — this function NEVER reads an existing doc, so it is a pure blind
+    // writer with no read preconditions. Reading the current entry doc inside
+    // this write tx (as an earlier version did, to preserve annotations) makes
+    // it — and, on aged spaces, whatever old-era quote-cell indirection doc its
+    // `imports` links transitively resolve to — a commit read-precondition.
+    // When that linked doc is persisted in a shape the current pin cannot
+    // rematerialize, the writing session pins the read at seq 0 while the store
+    // holds a higher seq, so `editWithRetry` conflicts forever and the deploy
+    // hard-fails even though the compile itself succeeded (CT-1864). Callers
+    // that want to preserve annotations read them OUTSIDE this tx (see
+    // PatternManager.readEntrySourceAnnotations) and pass them via
+    // `entryAnnotations`; a blind `set()` has no precondition to poison.
+    const annotations = identity === entryIdentity ? entryAnnotations : undefined;
     cell.set({
       kind: "source",
       identity,
@@ -488,9 +502,7 @@ export function writeSourceDocs(
         link: runtime.getCell(space, sourceDocKey(imp.identity), undefined, tx)
           .getAsLink(),
       })),
-      ...(isRecord(existingAnnotations)
-        ? { annotations: existingAnnotations }
-        : {}),
+      ...(isRecord(annotations) ? { annotations } : {}),
     } as StoredSourceDoc);
   }
 }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -422,8 +422,23 @@ export class PatternManager {
         ]),
       });
     }
+    // Carry any product annotations already on the destination's entry doc
+    // (read OUTSIDE the write tx — an in-tx read would poison the commit on
+    // aged spaces, see writeSourceDocs / CT-1864). Fresh replicas simply have
+    // none, matching the prior behaviour.
+    const entryAnnotations = this.readEntrySourceAnnotations(
+      toSpace,
+      entryIdentity,
+    );
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(this.runtime, toSpace, modules, entryIdentity, tx);
+      writeSourceDocs(
+        this.runtime,
+        toSpace,
+        modules,
+        entryIdentity,
+        tx,
+        entryAnnotations,
+      );
       if (runtimeVersion !== undefined) {
         writeCompiledDocs(
           this.runtime,
@@ -1332,6 +1347,43 @@ export class PatternManager {
     }
   }
 
+  /**
+   * Best-effort read of the entry source doc's product annotations, on a
+   * throwaway read transaction that is immediately aborted — so it can NEVER
+   * become a precondition on a write-back's commit.
+   *
+   * Preserving annotations across an idempotent recompile means reading the
+   * existing entry doc, but doing that read inside the write tx is exactly what
+   * conflicts forever on aged spaces (CT-1864 — see {@link writeSourceDocs}).
+   * Reading here keeps preservation best-effort: a healthy space returns its
+   * annotations; an aged space whose entry doc (or an old-era indirection it
+   * links to) cannot rematerialize simply yields `undefined`, and the rewrite
+   * overwrites without them rather than failing the deploy. The read is
+   * untyped and guarded because a partially-unreadable aged doc must degrade to
+   * `undefined`, not throw.
+   */
+  private readEntrySourceAnnotations(
+    space: MemorySpace,
+    entryIdentity: string,
+  ): Record<string, unknown> | undefined {
+    const readTx = this.runtime.edit();
+    try {
+      const annotations = this.runtime
+        .getCell<{ annotations?: Record<string, unknown> }>(
+          space,
+          sourceDocKey(entryIdentity),
+          undefined,
+          readTx,
+        )
+        .get()?.annotations;
+      return isRecord(annotations) ? annotations : undefined;
+    } catch {
+      return undefined;
+    } finally {
+      readTx.abort?.("read-entry-source-annotations complete");
+    }
+  }
+
   private async writeBackSourceCache(
     space: MemorySpace,
     modules: CacheableModule[],
@@ -1339,8 +1391,19 @@ export class PatternManager {
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncSourceCacheWriteTargets(space, modules);
+    const entryAnnotations = this.readEntrySourceAnnotations(
+      space,
+      entryIdentity,
+    );
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
+      writeSourceDocs(
+        this.runtime,
+        space,
+        modules,
+        entryIdentity,
+        tx,
+        entryAnnotations,
+      );
     });
     logger.time(writebackStart, "compile-cache", "source-writeback");
     if (error) {
@@ -1368,6 +1431,10 @@ export class PatternManager {
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncCompileCacheWriteTargets(space, modules, opts);
+    const entryAnnotations = this.readEntrySourceAnnotations(
+      space,
+      entryIdentity,
+    );
     // The write-back re-writes source docs whose values carry quote-cell
     // indirections (one derived doc per import edge). On a cold replica those
     // derived docs are unknown, and each commit attempt discovers exactly ONE
@@ -1385,7 +1452,14 @@ export class PatternManager {
     const importEdges = modules.reduce((n, m) => n + m.imports.length, 0);
     const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
+      writeSourceDocs(
+        this.runtime,
+        space,
+        modules,
+        entryIdentity,
+        tx,
+        entryAnnotations,
+      );
       writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
     }, writebackMaxRetries);
     logger.time(writebackStart, "compile-cache", "writeback");

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -490,6 +490,41 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     expect(afterClobber?.get(entryIdentity)?.annotations).toBeUndefined();
   });
 
+  it("readEntrySourceAnnotations recovers existing annotations off the write tx (CT-1864 healthy path)", async () => {
+    // The write-back reads annotations to preserve via this helper, which runs
+    // on a throwaway tx OUTSIDE editWithRetry (so it can't poison the commit).
+    // Guard that it still recovers them on a healthy space — otherwise every
+    // redeploy would silently drop annotations, not just aged ones.
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const tx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, modules, entryIdentity, tx);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const pm = runtime.patternManager as unknown as {
+      readEntrySourceAnnotations(
+        space: typeof spaceA,
+        id: string,
+      ): Record<string, unknown> | undefined;
+    };
+
+    // No annotation yet → undefined, so a rewrite overwrites cleanly rather
+    // than resurrecting anything stale.
+    expect(pm.readEntrySourceAnnotations(spaceA, entryIdentity)).toBeUndefined();
+
+    await runtime.patternManager.annotatePattern(
+      entryIdentity,
+      spaceA,
+      "name",
+      { "/": "name-doc-link" },
+    );
+
+    // Present → recovered, so a healthy redeploy re-supplies and preserves them.
+    expect(pm.readEntrySourceAnnotations(spaceA, entryIdentity)).toEqual({
+      name: { "/": "name-doc-link" },
+    });
+  });
+
   it("is empty for an entry that was never written", async () => {
     const tx = runtime.edit();
     const loaded = await loadSourceClosure(

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -440,9 +440,23 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     });
 
     // A re-write of the identical source (idempotent recompile) preserves the
-    // annotation rather than clobbering it.
+    // annotation when the caller supplies it. `writeSourceDocs` is a pure blind
+    // writer that never reads the existing doc (that read is what conflicts
+    // forever on aged spaces — CT-1864), so annotation preservation is the
+    // caller's responsibility: it reads them OUTSIDE the write tx and passes
+    // them in. Here we thread through the annotation loaded above.
+    const preserved = verified?.get(entryIdentity)?.annotations as
+      | Record<string, unknown>
+      | undefined;
     const rewriteTx = runtime.edit();
-    writeSourceDocs(runtime, spaceA, modules, entryIdentity, rewriteTx);
+    writeSourceDocs(
+      runtime,
+      spaceA,
+      modules,
+      entryIdentity,
+      rewriteTx,
+      preserved,
+    );
     runtime.prepareTxForCommit(rewriteTx);
     await rewriteTx.commit();
     const afterRewriteTx = runtime.edit();
@@ -455,6 +469,25 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     expect(afterRewrite?.get(entryIdentity)?.annotations).toEqual({
       name: { "/": "name-doc-link" },
     });
+
+    // And a re-write that does NOT re-supply the annotation clobbers it — the
+    // writer holds no memory of its own, by design. This is the CT-1864
+    // regression guard: if `writeSourceDocs` ever reads the existing entry doc
+    // again to self-preserve annotations, that read is what conflicts forever
+    // on aged spaces — and this assertion (annotation survives without being
+    // re-supplied) would flip and fail.
+    const clobberTx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, modules, entryIdentity, clobberTx);
+    runtime.prepareTxForCommit(clobberTx);
+    await clobberTx.commit();
+    const afterClobberTx = runtime.edit();
+    const afterClobber = await loadVerifiedSourceClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      afterClobberTx,
+    );
+    expect(afterClobber?.get(entryIdentity)?.annotations).toBeUndefined();
   });
 
   it("is empty for an entry that was never written", async () => {


### PR DESCRIPTION
## Why

Redeploying already-deployed source into an aged space — one whose deployed
sources were stranded by a pin bump, i.e. exactly the users who most need to
redeploy (see CT-1863) — hard-failed forever:

    [ERROR][pattern-manager] compile-cache-writeback-failed entry=…
    stale confirmed read: of:fid1:… at seq 0 conflicted with seq 171616

The compile itself succeeds; only the cache writeback dies, so a byte-identical
fixed source can never be redeployed into the space that needs it.

Root cause: `writeSourceDocs` read the existing entry doc *inside* the
`editWithRetry` write transaction to preserve product annotations. Materializing
that doc follows its `imports` links, and on an aged space one resolves to an
old-era quote-cell indirection doc (`{"value":{"link":{"/quote":…}}}`) that the
current pin can't rematerialize. The writing session pins that read at seq 0
while the store holds a higher seq, so `editWithRetry`'s catch-up pull never
converges — it conflicts on every attempt. (`writeCompiledDocs` was already a
blind `set()`; the annotations `cell.get()` was the sole poison read.)

## What Changed

- `writeSourceDocs` is now a **pure blind writer**: it reads nothing, so it adds
  no commit read-preconditions and cannot be poisoned by an unmaterializable
  existing doc. Annotations to preserve are passed in by the caller.
- New `PatternManager.readEntrySourceAnnotations`: best-effort annotation read on
  a throwaway, immediately-aborted read tx (so it can never become a commit
  precondition). Healthy space → returns them; aged/unreadable doc → `undefined`
  and the rewrite overwrites, rather than failing the deploy.
- All three writeback paths updated (source cache, compile cache, closure
  replication).

## Test plan

- Runner suite green (`deno task test`, 799/0).
- `cell-cache.test.ts`:
  - annotation preserve-when-supplied + **clobber-when-not** — the clobber
    assertion is the regression guard: it can only pass if the in-tx read is
    gone.
  - `readEntrySourceAnnotations` recovers annotations on a healthy space
    (undefined when none; the exact annotation when present) — so hoisting the
    read never silently drops annotations on ordinary redeploys.

A faithful "conflicts forever" repro needs synthesizing the aged quote-cell
persisted shape; live acceptance is loom-side against the real space. Related:
CT-1863 (the read-side blast radius), CT-1838 (stored-source sibling class).

Linear: https://linear.app/common-tools/issue/CT-1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the compile-cache source writeback a pure blind writer to stop endless commit conflicts on aged spaces, so redeploys of previously deployed sources succeed. Moves product-annotation reads out of the write transaction and makes them best-effort, addressing Linear CT-1864.

- **Bug Fixes**
  - `writeSourceDocs` no longer reads existing docs; accepts optional `entryAnnotations` and performs blind `set()` writes.
  - Added PatternManager.readEntrySourceAnnotations to read annotations on a throwaway aborted read tx, avoiding commit preconditions; returns undefined on unreadable aged docs so redeploys proceed.
  - Updated all writeback paths (source cache, compile cache, closure replication) to pass annotations; added tests for preserve-when-supplied, clobber-when-not, and healthy-path recovery.

<sup>Written for commit b3bd687b7001bf0921d49521730ae690bb6ab34c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

