### PR TITLE
fix(ui): degrade unloadable mentionable members per-element, not wholesale (CT-1863)

### DIFF
--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1352,6 +1352,77 @@ describe("SchemaObjectTraverser array element validation fallback priority", () 
     expect(error).toBeDefined();
   });
 
+  // CT-1863: the mentionable/piece-list read shape. Each element is an object
+  // keyed by a required NAME; an unloadable member (deployed pattern source the
+  // current runtime refuses) resolves to an unmaterializable link and fails the
+  // object schema. These two tests pin the before/after: a non-nullable element
+  // schema voids the WHOLE list (blanking every loadable sibling — the bug),
+  // while wrapping the member schema in `anyOf` with null degrades only the bad
+  // member and keeps the rest (the fix, exactly what MentionableArraySchema
+  // now does).
+  const memberObjectSchema = {
+    type: "object",
+    properties: { $NAME: { type: "string" } },
+    required: ["$NAME"],
+  } as const;
+
+  function makeMemberListDoc() {
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const docUri = "of:doc-member-list" as URI;
+    const docEntity = docUri as Entity;
+    const missingUri = "of:unloadable-member" as URI;
+    const docValue = [
+      { $NAME: "Alpha" },
+      // Unloadable member: a link whose target never materializes (pattern
+      // source refused by this runtime), so the element fails memberObjectSchema.
+      { "/": { [LINK_V1_TAG]: { id: missingUri, path: [] } } },
+      { $NAME: "Gamma" },
+    ];
+    store.set(`${docEntity}/${type}`, {
+      the: type,
+      of: docEntity,
+      is: { value: docValue },
+      cause: hashOf({ the: type, of: docEntity }),
+      since: 1,
+    });
+    // Note: missingUri is deliberately absent from the store.
+    return { store, docUri, type, docValue };
+  }
+
+  it("degrades one unloadable member to null and keeps siblings (CT-1863 fix — anyOf null)", () => {
+    const { store, docUri, type, docValue } = makeMemberListDoc();
+    const schema = {
+      type: "array",
+      items: { anyOf: [{ type: "null" }, memberObjectSchema] },
+    } as JSONSchema;
+
+    const { ok: result } = getTraverser(store, { path: ["value"], schema })
+      .traverse({
+        address: { space: "did:null:null", id: docUri, type, path: ["value"] },
+        value: docValue as FabricValue[],
+      });
+
+    expect(result).toEqual([{ $NAME: "Alpha" }, null, { $NAME: "Gamma" }]);
+  });
+
+  it("voids the whole list when one member is unloadable and items are non-nullable (CT-1863 bug)", () => {
+    const { store, docUri, type, docValue } = makeMemberListDoc();
+    const schema = {
+      type: "array",
+      items: memberObjectSchema,
+    } as JSONSchema;
+
+    const { error } = getTraverser(store, { path: ["value"], schema })
+      .traverse({
+        address: { space: "did:null:null", id: docUri, type, path: ["value"] },
+        value: docValue as FabricValue[],
+      });
+
+    // One bad member blanks all three — the exact blast radius CT-1863 fixes.
+    expect(error).toBeDefined();
+  });
+
   it("does not silently replace a mismatched item with undefined when items schema is a $ref", () => {
     // Before the isValidType $ref fix, isValidType called with a schema of the
     // form { $ref: "...", $defs: {...} } would skip $ref resolution and fall

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -426,9 +426,12 @@ export class CFCodeEditor extends BaseElement {
 
     for (let i = 0; i < mentionableData.length; i++) {
       const mention = mentionableData[i];
-      const name = mention?.[NAME] ?? "";
+      // Skip degraded holes (CT-1863): a null slot has no name to match on,
+      // and an empty query would otherwise falsely "exact-match" it.
+      if (!mention) continue;
+      const name = mention[NAME] ?? "";
       if (name.toLowerCase() === queryLower) {
-        return [handle.key(i), i];
+        return [handle.key(i) as CellHandle<Mentionable>, i];
       }
     }
 

--- a/packages/ui/src/v2/core/mention-controller.test.ts
+++ b/packages/ui/src/v2/core/mention-controller.test.ts
@@ -134,6 +134,29 @@ describe("MentionController — filtering", () => {
     const ctrl = new MentionController(createMockHost());
     expect(ctrl.getFilteredMentions()).toEqual([]);
   });
+
+  it("skips degraded null holes and keeps loadable siblings (CT-1863)", () => {
+    // A member whose pattern can't load on this runtime is degraded to a null
+    // slot by MentionableArraySchema (rather than voiding the whole list). The
+    // controller must skip those holes — with an empty query especially, where
+    // the name check is short-circuited. Here the middle member is a hole.
+    const ctrl = new MentionController(createMockHost());
+    const items: MentionableArray = [
+      { [NAME]: "Alice" },
+      null,
+      { [NAME]: "Bob" },
+    ];
+    const cell = createMockCellHandle(items, {
+      id: "of:mentionables-with-hole" as any,
+      schema: { type: "array", items: { anyOf: [{ type: "null" }, { type: "object" }] } },
+    });
+    ctrl.setMentionable(cell);
+
+    const filtered = ctrl.getFilteredMentions();
+    expect(filtered.length).toBe(2);
+    expect(filtered[0].get()?.[NAME]).toBe("Alice");
+    expect(filtered[1].get()?.[NAME]).toBe("Bob");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -160,8 +160,15 @@ export class MentionController implements ReactiveController {
 
     const filtered: CellHandle<Mentionable>[] = [];
     for (let i = 0; i < mentionableArray.length; i++) {
-      // Use .key(i) to get Cell reference, preserving cell-ness
-      const mentionCell = handle.key(i);
+      // Skip degraded holes: a member whose pattern can't load on this runtime
+      // surfaces as a null slot (CT-1863 — see MentionableArraySchema) with no
+      // mentionable identity or name. Without this guard an empty query would
+      // push the hole (the `!query` branch below skips the name check).
+      if (mentionableArray[i] == null) continue;
+
+      // Use .key(i) to get Cell reference, preserving cell-ness. Non-null was
+      // just asserted above, so the slot is a real Mentionable.
+      const mentionCell = handle.key(i) as CellHandle<Mentionable>;
 
       // Only call .get() to read the name for filtering
       const name = mentionCell.get()?.[NAME];
@@ -387,7 +394,10 @@ export class MentionController implements ReactiveController {
     // Use .key(i) to preserve cell-ness of items
     const mentions: CellHandle<Mentionable>[] = [];
     for (let i = 0; i < mentionableArray.length; i++) {
-      const mentionCell = handle.key(i);
+      // Skip degraded holes (CT-1863): an unloadable member is a null slot,
+      // not a mentionable piece — don't hand callers a handle to nothing.
+      if (mentionableArray[i] == null) continue;
+      const mentionCell = handle.key(i) as CellHandle<Mentionable>;
       if (mentionCell) {
         mentions.push(mentionCell);
       }

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -5,7 +5,11 @@ export interface Mentionable {
   [key: string]: unknown;
 }
 
-export type MentionableArray = readonly Mentionable[];
+// A slot may be null: a member whose pattern can't load on this runtime can't
+// satisfy MentionableSchema, and the array read degrades it to `null` rather
+// than voiding every sibling (see MentionableArraySchema). Consumers skip the
+// null holes.
+export type MentionableArray = readonly (Mentionable | null)[];
 
 export const MentionableSchema = {
   type: "object",
@@ -20,5 +24,22 @@ export const MentionableSchema = {
 
 export const MentionableArraySchema = {
   type: "array",
-  items: MentionableSchema,
+  // Per-element degradation, not wholesale void (CT-1863). One space member
+  // whose deployed pattern source the current runtime can't load fails
+  // MentionableSchema (its NAME never resolves). With a non-nullable element
+  // schema the runtime's array traversal voids the ENTIRE read the moment one
+  // element fails — so three stranded pieces blanked all 24, emptying the
+  // #mention list and any piece view backed by it. Allowing `null` per element
+  // makes the existing per-element degradation path fire instead: the bad
+  // member becomes a `null` hole and every loadable sibling survives. The
+  // `anyOf` order (null first) mirrors the runtime's own nullable-array tests.
+  // NOTE: this fixes the mentionable read specifically; hardening the runtime's
+  // array traversal to never void wholesale on ANY schema-backed array is a
+  // deliberate, broader follow-up (it would change a core read invariant).
+  items: {
+    anyOf: [
+      { type: "null" },
+      MentionableSchema,
+    ],
+  },
 } as const satisfies JSONSchema;


### PR DESCRIPTION
## Why

A production space with 24 registered, fully-intact pieces rendered an empty
`#mention` autocomplete (and any piece view backed by it) because exactly 3
member pieces had deployed pattern sources the current pin's transformer
refuses. One unloadable member shouldn't hide the other 23 — but it did:
reading the mentionable array under `MentionableArraySchema` validates each
element against a non-nullable object schema (required NAME), and the runtime's
array traversal voids the *entire* read the moment one element fails. Three
stranded pieces blanked all 24.

This is the read-side blast radius of the "pin bump strands deployed sources"
class (CT-1838, CT-1864): spaces already carrying stranded sources get a
silently empty UI with zero user-facing explanation.

## What Changed

Option 1 — a targeted schema fix, with the grain of the existing runtime, which
already degrades a failing array element to `null` when the element schema
permits null and only voids wholesale when it does not:

- `MentionableArraySchema` items → `anyOf: [ { type: null }, MentionableSchema ]`.
  A member whose pattern can't load becomes a `null` hole; every loadable
  sibling survives.
- Consumers skip the holes. `cf-code-editor` was already defensive
  (`if (!pieceValue) continue`), so the schema and its consumers were simply out
  of sync — this realigns them. `mention-controller` now skips holes too (an
  empty query previously would have pushed one).

Scope notes (deliberately deferred — see the follow-up ticket):

- Hardening the runtime's `traverseArrayWithSchema` to never void wholesale on
  ANY schema-backed array changes a core read invariant relied on by many call
  sites; it warrants its own RFC.
- Surfacing an unloadable member as a *visible* "can't load — redeploy/upgrade"
  entry (vs a silent hole) needs identity-carrying degradation — a null hole
  carries no identity to render.

The transformer output confirms default-app's own `allPieces` read is
`items: true` (lenient, doesn't void) and the shell's `HeaderView._pieces`
already degrades per-element, so the wholesale-void was concentrated at the
mentionable read fixed here.

## Test plan

- UI suite green (127/0); runner traverse (24/0).
- `traverse.test.ts`: before/after for the exact schema shape — a non-nullable
  object-with-required array voids on one unloadable member; the `anyOf`-null
  variant degrades that member to `null` and keeps siblings.
- `mention-controller.test.ts`: holes are skipped, including the empty-query
  path.

Related: CT-1864 (the redeploy path for stranded sources), CT-1838.

Linear: https://linear.app/common-tools/issue/CT-1863

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty #mention lists when a few space members can’t load by degrading those entries to null slots instead of voiding the whole array. Loadable members now show up as expected. Linked to Linear CT-1863.

- **Bug Fixes**
  - Schema: `MentionableArraySchema` items now use `anyOf: [{ type: "null" }, MentionableSchema]` to degrade unloadable members per element.
  - UI: `mention-controller` and `cf-code-editor` skip null holes, including the empty-query path.
  - Tests: Added traversal tests to pin non-nullable vs `anyOf` behavior and a controller test to ensure holes are skipped.

<sup>Written for commit e7555dc1b3bbf0e078074666b8a2b8b67348bd57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

