### PR TITLE
feat(ci): retro-classify unstamped runs + fingerprint fallback for missing cache-state artifacts

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -254,12 +254,18 @@ The comparison rules follow from the tagging:
 - The coverage-debt ratchet uses the latest non-cold main sample, so a cold
   main run cannot lower the baseline that warm PRs are held to.
 
-Runs with unknown cache state — anything before this mechanism rolled out, and
-backfill-derived runs — behave exactly as before: their samples are kept and
-their metrics gate normally.
+Runs without a recorded state — anything before this mechanism rolled out,
+backfill-derived runs, and runs whose cache-state artifacts failed — are
+retro-classified from the compile fingerprint (`tasks/perf-cache-state.ts`
+mirrors the `cc-*` key globs, drift-guarded by a test that parses the
+workflow): if the fingerprint paths changed against the run's predecessor,
+every family is treated as cold; if unchanged, warm. The same fingerprint
+inference backstops the current run when its cache-state artifacts are
+missing. Fingerprint inference cannot see non-fingerprint cold causes (cache
+eviction, cache-service outages) — runs cold for those reasons and lacking a
+recorded state stay unknown: kept and gated normally, exactly as before this
+mechanism.
 
-Two gaps remain. Cold compile duration itself is not gated, so a regression
+One gap remains: cold compile duration itself is not gated, so a regression
 that only shows up on a cold cache passes unnoticed; a dedicated cold-compile
-bench could cover that later. And cold main runs from before the rollout stay
-unknown, so they can still skew baselines until they age out of the 20-run
-baseline window.
+bench could cover that later.

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -254,18 +254,16 @@ The comparison rules follow from the tagging:
 - The coverage-debt ratchet uses the latest non-cold main sample, so a cold
   main run cannot lower the baseline that warm PRs are held to.
 
-Runs without a recorded state — anything before this mechanism rolled out,
-backfill-derived runs, and runs whose cache-state artifacts failed — are
+A run without a recorded cache state — an artifact carrying no stamp, a
+backfill-derived run, or a run whose cache-state artifact failed to upload — is
 retro-classified from the compile fingerprint (`tasks/perf-cache-state.ts`
-mirrors the `cc-*` key globs, drift-guarded by a test that parses the
-workflow): if the fingerprint paths changed against the run's predecessor,
-every family is treated as cold; if unchanged, warm. The same fingerprint
-inference backstops the current run when its cache-state artifacts are
-missing. Fingerprint inference cannot see non-fingerprint cold causes (cache
-eviction, cache-service outages) — runs cold for those reasons and lacking a
-recorded state stay unknown: kept and gated normally, exactly as before this
-mechanism.
+mirrors the `cc-*` key globs, drift-guarded by a test that parses the workflow):
+if the fingerprint paths changed against the run's predecessor, every family is
+treated as cold; if unchanged, warm. The same fingerprint inference backstops
+the current run when its cache-state artifact is missing. Fingerprint inference
+cannot see non-fingerprint cold causes (cache eviction, cache-service outages):
+a run cold for those reasons and lacking a recorded state stays unknown, so its
+samples are kept and gate normally.
 
-One gap remains: cold compile duration itself is not gated, so a regression
-that only shows up on a cold cache passes unnoticed; a dedicated cold-compile
-bench could cover that later.
+Cold compile duration itself is not gated, so a regression that shows up only on
+a cold cache passes unnoticed; a dedicated cold-compile bench would cover it.

--- a/tasks/perf-cache-state.test.ts
+++ b/tasks/perf-cache-state.test.ts
@@ -1,12 +1,31 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   changedPathsOf,
   classifyCacheKeyState,
   classifyRunAgainstPredecessor,
   COMPILE_CACHE_KEY_GLOBS,
+  fillMissingFamiliesFromFingerprint,
+  inferCurrentRunFallbackState,
+  matcherForGlob,
   pathTouchesCompileCacheKey,
+  recordUnstampedBaselineRunState,
   uniformCacheStates,
 } from "./perf-cache-state.ts";
+import type { CompileCacheStates } from "./perf-lib.ts";
+
+async function captureLogs(fn: () => void | Promise<void>): Promise<string[]> {
+  const logs: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return logs;
+}
 
 Deno.test("pathTouchesCompileCacheKey matches directory-tree globs", () => {
   assert(
@@ -144,4 +163,192 @@ Deno.test("changedPathsOf surfaces both sides of a rename", () => {
   // A rename OUT of the key set still rotated the fingerprint: the file
   // left a hashed directory even though its new path matches nothing.
   assertEquals(classifyCacheKeyState(paths), "cold");
+});
+
+Deno.test("matcherForGlob interprets tree and exact-file globs and refuses others", () => {
+  const tree = matcherForGlob("packages/api/**");
+  assert(tree("packages/api/index.ts"));
+  assert(!tree("packages/runner/index.ts"));
+
+  const exact = matcherForGlob("deno.lock");
+  assert(exact("deno.lock"));
+  assert(!exact("packages/toolshed/deno.lock"));
+
+  // A shape that is neither a directory tree nor an exact file is refused
+  // rather than silently mis-matched: a new glob shape in the workflow has to
+  // extend matcherForGlob (and the drift guard) deliberately.
+  assertThrows(
+    () => matcherForGlob("packages/*/deno.lock"),
+    Error,
+    "Unsupported compile-cache key glob shape",
+  );
+});
+
+Deno.test("inferCurrentRunFallbackState reads a PR's own changed files", async () => {
+  const mustNotFetch = () => {
+    throw new Error("a PR run must not fetch a baseline sha");
+  };
+  // Touching the key set is cold; touching nothing in it is warm — both read
+  // the PR's file list directly, never the predecessor compare.
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      isPullRequestRun: true,
+      prFiles: [{ filename: "packages/schema-generator/src/mod.ts" }],
+      headSha: "head",
+      fetchLatestBaselineSha: mustNotFetch,
+    }),
+    "cold",
+  );
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      isPullRequestRun: true,
+      prFiles: [{ filename: "docs/notes.md" }],
+      headSha: "head",
+      fetchLatestBaselineSha: mustNotFetch,
+    }),
+    "warm",
+  );
+  // A PR whose file list did not load cannot be classified — fail open.
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      isPullRequestRun: true,
+      prFiles: [],
+      headSha: "head",
+      fetchLatestBaselineSha: mustNotFetch,
+    }),
+    "unknown",
+  );
+});
+
+Deno.test("inferCurrentRunFallbackState compares a main push against the latest baseline", async () => {
+  const base = { isPullRequestRun: false, prFiles: [], headSha: "head" };
+  // Cold: the compare against the latest baseline run touches the key set.
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      ...base,
+      fetchLatestBaselineSha: () => Promise.resolve("prev"),
+      fetchChanged: (b, h) => {
+        assertEquals([b, h], ["prev", "head"]);
+        return Promise.resolve(["deno.lock"]);
+      },
+    }),
+    "cold",
+  );
+  // Warm: the compare touches nothing in the key set.
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      ...base,
+      fetchLatestBaselineSha: () => Promise.resolve("prev"),
+      fetchChanged: () => Promise.resolve(["docs/readme.md"]),
+    }),
+    "warm",
+  );
+});
+
+Deno.test("inferCurrentRunFallbackState fails open when the baseline is missing or unfetchable", async () => {
+  const base = { isPullRequestRun: false, prFiles: [], headSha: "head" };
+  // No prior baseline run (empty history): nothing to compare against.
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      ...base,
+      fetchLatestBaselineSha: () => Promise.resolve(undefined),
+      fetchChanged: () => {
+        throw new Error("must not compare without a predecessor");
+      },
+    }),
+    "unknown",
+  );
+  // The baseline-sha lookup itself failing (rate limit, outage).
+  assertEquals(
+    await inferCurrentRunFallbackState({
+      ...base,
+      fetchLatestBaselineSha: () => Promise.reject(new Error("rate limited")),
+    }),
+    "unknown",
+  );
+});
+
+Deno.test("fillMissingFamiliesFromFingerprint fills only unknown families, only when cold", async () => {
+  // Recorded states win: an already-recorded family (even warm) is untouched;
+  // only families with no recorded state are filled cold.
+  const recorded: CompileCacheStates = { "pattern-unit": "warm" };
+  let filled = -1;
+  const logs = await captureLogs(() => {
+    filled = fillMissingFamiliesFromFingerprint(recorded, "cold");
+  });
+
+  assertEquals(recorded["pattern-unit"], "warm");
+  assertEquals(recorded["pattern-integration"], "cold");
+  assertEquals(recorded["generated-patterns"], "cold");
+
+  const allFamilies = Object.keys(uniformCacheStates("cold")).sort();
+  assertEquals(Object.keys(recorded).sort(), allFamilies);
+  assertEquals(filled, allFamilies.length - 1);
+  // A non-zero fill is announced in the transcript, with the count.
+  assertEquals(logs.length, 1);
+  assert(logs[0]!.includes(String(filled)));
+  assert(logs[0]!.includes("treated as cold"));
+});
+
+Deno.test("fillMissingFamiliesFromFingerprint is a no-op (and silent) for warm and unknown verdicts", async () => {
+  for (const verdict of ["warm", "unknown"] as const) {
+    const recorded: CompileCacheStates = { "pattern-unit": "warm" };
+    let filled = -1;
+    const logs = await captureLogs(() => {
+      filled = fillMissingFamiliesFromFingerprint(recorded, verdict);
+    });
+    assertEquals(filled, 0);
+    assertEquals(recorded, { "pattern-unit": "warm" });
+    assertEquals(logs.length, 0);
+  }
+});
+
+Deno.test("recordUnstampedBaselineRunState retro-classifies against the predecessor and logs only cold", async () => {
+  // Cold: the compare against the predecessor touches the key set → every
+  // family recorded cold, with a transcript line naming the run.
+  const cold = new Map<number, CompileCacheStates>();
+  const coldLogs = await captureLogs(() =>
+    recordUnstampedBaselineRunState(
+      cold,
+      { id: 42, head_sha: "head" },
+      "prev",
+      "PR #4586",
+      (base, head) => {
+        assertEquals([base, head], ["prev", "head"]);
+        return Promise.resolve(["deno.lock"]);
+      },
+    )
+  );
+  assertEquals(cold.get(42), uniformCacheStates("cold"));
+  assertEquals(coldLogs.length, 1);
+  assert(coldLogs[0]!.includes("42"));
+  assert(coldLogs[0]!.includes("PR #4586"));
+  assert(coldLogs[0]!.includes("retro-classified cold"));
+
+  // Warm: the compare touches nothing in the key set → uniform-warm, no log.
+  const warm = new Map<number, CompileCacheStates>();
+  const warmLogs = await captureLogs(() =>
+    recordUnstampedBaselineRunState(
+      warm,
+      { id: 7, head_sha: "head" },
+      "prev",
+      "abc1234",
+      () => Promise.resolve(["docs/readme.md"]),
+    )
+  );
+  assertEquals(warm.get(7), uniformCacheStates("warm"));
+  assertEquals(warmLogs.length, 0);
+
+  // Unknown: no predecessor → records nothing, and never runs the compare.
+  const unknown = new Map<number, CompileCacheStates>();
+  await recordUnstampedBaselineRunState(
+    unknown,
+    { id: 9, head_sha: "head" },
+    undefined,
+    "def5678",
+    () => {
+      throw new Error("must not compare without a predecessor");
+    },
+  );
+  assertEquals(unknown.size, 0);
 });

--- a/tasks/perf-cache-state.test.ts
+++ b/tasks/perf-cache-state.test.ts
@@ -1,0 +1,128 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  classifyCacheKeyState,
+  classifyRunAgainstPredecessor,
+  COMPILE_CACHE_KEY_GLOBS,
+  pathTouchesCompileCacheKey,
+  uniformCacheStates,
+} from "./perf-cache-state.ts";
+
+Deno.test("pathTouchesCompileCacheKey matches directory-tree globs", () => {
+  assert(
+    pathTouchesCompileCacheKey(
+      "packages/ts-transformers/src/policy/capability-analysis.ts",
+    ),
+  );
+  assert(pathTouchesCompileCacheKey("packages/api/index.ts"));
+  assert(!pathTouchesCompileCacheKey("packages/runner/src/runner.ts"));
+  assert(!pathTouchesCompileCacheKey("packages/patterns/counter/main.tsx"));
+});
+
+Deno.test("pathTouchesCompileCacheKey matches exact-file entries exactly", () => {
+  assert(pathTouchesCompileCacheKey("deno.lock"));
+  assert(pathTouchesCompileCacheKey("deno.jsonc"));
+  assert(
+    pathTouchesCompileCacheKey("packages/runner/src/pattern-coverage.ts"),
+  );
+  // hashFiles('deno.lock') matches only the workspace-root file, and an
+  // exact-file entry must not swallow name-prefixed siblings.
+  assert(!pathTouchesCompileCacheKey("packages/toolshed/deno.lock"));
+  assert(
+    !pathTouchesCompileCacheKey("packages/runner/src/pattern-coverage.test.ts"),
+  );
+});
+
+Deno.test("classifyCacheKeyState is cold iff a changed file touches the key set", () => {
+  assertEquals(
+    classifyCacheKeyState(["packages/runner/src/cell.ts", "docs/notes.md"]),
+    "warm",
+  );
+  assertEquals(
+    classifyCacheKeyState([
+      "packages/runner/src/cell.ts",
+      "packages/schema-generator/src/mod.ts",
+    ]),
+    "cold",
+  );
+  assertEquals(classifyCacheKeyState([]), "warm");
+});
+
+Deno.test("uniformCacheStates covers every compile-cache family", () => {
+  const cold = uniformCacheStates("cold");
+  assertEquals(Object.values(cold), Object.keys(cold).map(() => "cold"));
+  assert(Object.keys(cold).includes("pattern-unit"));
+  assert(Object.keys(cold).includes("pattern-integration"));
+  assert(Object.keys(cold).includes("generated-patterns"));
+});
+
+Deno.test("classifyRunAgainstPredecessor classifies via changed files", async () => {
+  assertEquals(
+    await classifyRunAgainstPredecessor("headsha", "basesha", (base, head) => {
+      assertEquals(base, "basesha");
+      assertEquals(head, "headsha");
+      return Promise.resolve(["deno.lock"]);
+    }),
+    "cold",
+  );
+  assertEquals(
+    await classifyRunAgainstPredecessor(
+      "headsha",
+      "basesha",
+      () => Promise.resolve(["docs/readme.md"]),
+    ),
+    "warm",
+  );
+});
+
+Deno.test("classifyRunAgainstPredecessor fails open to unknown", async () => {
+  const mustNotFetch = () => {
+    throw new Error("should not fetch without a predecessor");
+  };
+  assertEquals(
+    await classifyRunAgainstPredecessor("headsha", undefined, mustNotFetch),
+    "unknown",
+  );
+  assertEquals(
+    await classifyRunAgainstPredecessor("samesha", "samesha", mustNotFetch),
+    "unknown",
+  );
+  assertEquals(
+    await classifyRunAgainstPredecessor(
+      "headsha",
+      "basesha",
+      () => Promise.reject(new Error("rate limited")),
+    ),
+    "unknown",
+  );
+});
+
+// The drift guard: COMPILE_CACHE_KEY_GLOBS mirrors the FIRST hashFiles(...)
+// argument list of every cc-* compile-cache key in the workflow. If this
+// fails, update the constant and the workflow together (and matcherForGlob
+// if a new glob shape appeared).
+Deno.test("COMPILE_CACHE_KEY_GLOBS matches the cc-* cache keys in deno.yml", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL("../.github/workflows/deno.yml", import.meta.url),
+  );
+  const keyLines = workflow.split("\n").filter((line) =>
+    line.includes("cc-") && line.includes("hashFiles(")
+  );
+  assert(
+    keyLines.length >= 3,
+    `expected at least 3 cc-* cache key lines in deno.yml, found ${keyLines.length}`,
+  );
+
+  const expected = [...COMPILE_CACHE_KEY_GLOBS].sort();
+  for (const line of keyLines) {
+    const firstGroup = line.match(/hashFiles\(([^)]*)\)/);
+    assert(firstGroup, `no hashFiles(...) group in: ${line.trim()}`);
+    const globs = [...firstGroup[1].matchAll(/'([^']+)'/g)]
+      .map((match) => match[1])
+      .sort();
+    assertEquals(
+      globs,
+      expected,
+      `compile-cache key inputs drifted from COMPILE_CACHE_KEY_GLOBS in:\n${line.trim()}`,
+    );
+  }
+});

--- a/tasks/perf-cache-state.test.ts
+++ b/tasks/perf-cache-state.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import {
+  changedPathsOf,
   classifyCacheKeyState,
   classifyRunAgainstPredecessor,
   COMPILE_CACHE_KEY_GLOBS,
@@ -125,4 +126,22 @@ Deno.test("COMPILE_CACHE_KEY_GLOBS matches the cc-* cache keys in deno.yml", asy
       `compile-cache key inputs drifted from COMPILE_CACHE_KEY_GLOBS in:\n${line.trim()}`,
     );
   }
+});
+
+Deno.test("changedPathsOf surfaces both sides of a rename", () => {
+  const paths = changedPathsOf([
+    {
+      filename: "packages/runner/src/moved.ts",
+      previous_filename: "packages/api/moved.ts",
+    },
+    { filename: "docs/notes.md" },
+  ]);
+  assertEquals(paths, [
+    "packages/runner/src/moved.ts",
+    "packages/api/moved.ts",
+    "docs/notes.md",
+  ]);
+  // A rename OUT of the key set still rotated the fingerprint: the file
+  // left a hashed directory even though its new path matches nothing.
+  assertEquals(classifyCacheKeyState(paths), "cold");
 });

--- a/tasks/perf-cache-state.ts
+++ b/tasks/perf-cache-state.ts
@@ -59,7 +59,7 @@ type PathMatcher = (path: string) => boolean;
  * glob shape in the workflow must extend this and the drift test together
  * rather than silently mis-matching.
  */
-function matcherForGlob(glob: string): PathMatcher {
+export function matcherForGlob(glob: string): PathMatcher {
   if (glob.endsWith("/**")) {
     const prefix = glob.slice(0, -"**".length);
     return (path) => path.startsWith(prefix);
@@ -163,4 +163,101 @@ export function uniformCacheStates(
     states[family] = state;
   }
   return states;
+}
+
+/**
+ * The current run's fallback fingerprint verdict, used only to fill families
+ * that have no recorded cache state. A PR run reads its own changed-file list;
+ * a main-push run compares its head against the latest prior baseline run.
+ * A fetch failure — or a PR whose file list did not load — yields "unknown", so
+ * the caller fills nothing and every family gates on its recorded state alone.
+ *
+ * `fetchLatestBaselineSha` and `fetchChanged` are injected so the selection is
+ * exercised without the GitHub API.
+ */
+export async function inferCurrentRunFallbackState(opts: {
+  isPullRequestRun: boolean;
+  prFiles: readonly { filename: string; previous_filename?: string }[];
+  headSha: string;
+  fetchLatestBaselineSha: () => Promise<string | undefined>;
+  fetchChanged?: (baseSha: string, headSha: string) => Promise<string[]>;
+}): Promise<CacheKeyState | "unknown"> {
+  if (opts.isPullRequestRun) {
+    return opts.prFiles.length > 0
+      ? classifyCacheKeyState(changedPathsOf(opts.prFiles))
+      : "unknown";
+  }
+  let predecessorSha: string | undefined;
+  try {
+    predecessorSha = await opts.fetchLatestBaselineSha();
+  } catch {
+    return "unknown";
+  }
+  return classifyRunAgainstPredecessor(
+    opts.headSha,
+    predecessorSha,
+    opts.fetchChanged,
+  );
+}
+
+/**
+ * Fill families with no recorded cache state from a run-level fingerprint
+ * verdict, mutating `states`. Recorded states are ground truth and always win,
+ * so only families absent from `states` are touched. A "cold" verdict fills
+ * those families "cold"; "warm" and "unknown" fill nothing — a family with no
+ * recorded state already gates normally, so a warm fill would be a no-op.
+ * Returns the number of families newly filled, and logs a non-zero fill for the
+ * CI transcript.
+ */
+export function fillMissingFamiliesFromFingerprint(
+  states: CompileCacheStates,
+  inferred: CacheKeyState | "unknown",
+): number {
+  if (inferred !== "cold") return 0;
+  let filled = 0;
+  for (const family of COMPILE_CACHE_FAMILIES) {
+    if (!(family in states)) {
+      states[family] = "cold";
+      filled++;
+    }
+  }
+  if (filled > 0) {
+    console.log(
+      `Compile fingerprint changed in this run; ${filled} unknown famil${
+        filled === 1 ? "y" : "ies"
+      } treated as cold.`,
+    );
+  }
+  return filled;
+}
+
+/**
+ * Retro-classify an unstamped baseline run — one whose artifacts carry no
+ * recorded stamp — from the compile fingerprint against its predecessor, and
+ * record the result in `cacheStatesByRunId` keyed by run id. A "cold"/"warm"
+ * verdict applies to every family at once (the shared key prefix); "unknown"
+ * (no predecessor, or an unreadable compare) records nothing, leaving the run
+ * to gate on its kept samples like any run whose cache state cannot be
+ * determined. A cold retro-classification is logged for the CI transcript.
+ * `fetchChanged` is injected so the classification is testable offline.
+ */
+export async function recordUnstampedBaselineRunState(
+  cacheStatesByRunId: Map<number, CompileCacheStates>,
+  run: { id: number; head_sha: string },
+  predecessorSha: string | undefined,
+  label: string,
+  fetchChanged?: (baseSha: string, headSha: string) => Promise<string[]>,
+): Promise<void> {
+  const inferred = await classifyRunAgainstPredecessor(
+    run.head_sha,
+    predecessorSha,
+    fetchChanged,
+  );
+  if (inferred === "unknown") return;
+  cacheStatesByRunId.set(run.id, uniformCacheStates(inferred));
+  if (inferred === "cold") {
+    console.log(
+      `  Baseline run ${run.id} (${label}) retro-classified cold: compile fingerprint changed vs predecessor.`,
+    );
+  }
 }

--- a/tasks/perf-cache-state.ts
+++ b/tasks/perf-cache-state.ts
@@ -1,0 +1,148 @@
+/**
+ * Compile-cache key state derivation for perf-check.
+ *
+ * The pattern-test jobs restore a compile byte cache under keys whose PREFIX
+ * hashes a transformer-adjacent path set (the `cc-*` cache keys in
+ * .github/workflows/deno.yml). The restore-keys prefix includes that hash, so
+ * a run whose commit changes any file in the set gets no cache fallback at
+ * all: every pattern compiles cold, and compile-dominated wall times inflate
+ * roughly 1.6-1.9x. Gating such a run against warm baselines is a false
+ * positive by construction — and the first main-branch run after such a merge
+ * is equally cold, polluting the baseline history the same way (observed as
+ * the recurring "single-test outlier" spikes).
+ *
+ * Only the prefix inputs matter for coldness: each job's key suffix (its
+ * pattern sources) still restores through the prefix restore-key when it
+ * changes, so suffix churn recompiles incrementally rather than from scratch.
+ *
+ * A run is cold exactly when the hashFiles digest of the prefix set differs
+ * from the commit whose cache it would restore — equivalently, when any file
+ * in the set changed between the two commits. That makes the state derivable
+ * from changed-file lists alone (the PR's file list, or the compare API for
+ * adjacent main pushes), with no cooperation needed from the pattern jobs.
+ */
+
+import {
+  COMPILE_CACHE_FAMILIES,
+  type CompileCacheState,
+  type CompileCacheStates,
+  githubGet,
+  REPO,
+} from "./perf-lib.ts";
+
+/** Run-level fingerprint verdict; "unknown" must fail open (keep + gate). */
+export type CacheKeyState = "cold" | "warm";
+
+/**
+ * Mirror of the FIRST hashFiles(...) argument list of every `cc-*` compile
+ * cache key in .github/workflows/deno.yml. perf-cache-state.test.ts parses
+ * the workflow and asserts set equality, so the two cannot drift silently.
+ */
+export const COMPILE_CACHE_KEY_GLOBS = [
+  "packages/ts-transformers/**",
+  "packages/js-compiler/**",
+  "packages/runner/src/harness/**",
+  "packages/runner/src/pattern-coverage.ts",
+  "packages/runner/src/sandbox/**",
+  "packages/schema-generator/**",
+  "packages/api/**",
+  "packages/static/assets/types/**",
+  "deno.jsonc",
+  "deno.lock",
+] as const;
+
+type PathMatcher = (path: string) => boolean;
+
+/**
+ * The key globs are deliberately simple (directory trees and exact files), so
+ * this interprets just those two shapes and refuses anything fancier — a new
+ * glob shape in the workflow must extend this and the drift test together
+ * rather than silently mis-matching.
+ */
+function matcherForGlob(glob: string): PathMatcher {
+  if (glob.endsWith("/**")) {
+    const prefix = glob.slice(0, -"**".length);
+    return (path) => path.startsWith(prefix);
+  }
+  if (!glob.includes("*")) {
+    return (path) => path === glob;
+  }
+  throw new Error(
+    `Unsupported compile-cache key glob shape: ${glob}`,
+  );
+}
+
+const KEY_PATH_MATCHERS: readonly PathMatcher[] = COMPILE_CACHE_KEY_GLOBS.map(
+  matcherForGlob,
+);
+
+export function pathTouchesCompileCacheKey(path: string): boolean {
+  return KEY_PATH_MATCHERS.some((matches) => matches(path));
+}
+
+export function classifyCacheKeyState(
+  changedFiles: readonly string[],
+): CacheKeyState {
+  return changedFiles.some(pathTouchesCompileCacheKey) ? "cold" : "warm";
+}
+
+/**
+ * Changed files between two commits via the compare API. GitHub caps the
+ * file list at 300 entries; adjacent main pushes stay far below that, and a
+ * capped list can only under-report (misread cold as warm), which degrades
+ * to today's behavior rather than wrongly waiving a gate.
+ */
+export async function fetchChangedFilesBetween(
+  baseSha: string,
+  headSha: string,
+): Promise<string[]> {
+  const data = await githubGet<{ files?: { filename: string }[] }>(
+    `/repos/${REPO}/compare/${encodeURIComponent(baseSha)}...${
+      encodeURIComponent(headSha)
+    }`,
+  );
+  return (data.files ?? []).map((file) => file.filename);
+}
+
+/**
+ * Classify a run against the run whose cache it would have restored
+ * (its predecessor on main). "unknown" — no predecessor available, or the
+ * compare failed — must be treated like "warm" by consumers: gate normally
+ * and keep the samples, i.e. fail open to today's behavior.
+ */
+export async function classifyRunAgainstPredecessor(
+  headSha: string,
+  predecessorSha: string | undefined,
+  fetchChanged: (
+    baseSha: string,
+    headSha: string,
+  ) => Promise<string[]> = fetchChangedFilesBetween,
+): Promise<CacheKeyState | "unknown"> {
+  if (!predecessorSha || predecessorSha === headSha) return "unknown";
+  try {
+    return classifyCacheKeyState(await fetchChanged(predecessorSha, headSha));
+  } catch (error) {
+    console.warn(
+      `  Warning: could not classify compile-cache state for ${
+        headSha.slice(0, 8)
+      }: ${error}`,
+    );
+    return "unknown";
+  }
+}
+
+/**
+ * Expand a run-level fingerprint verdict to per-family states: a fingerprint
+ * rotation colds every family at once (the shared key prefix), and a
+ * fingerprint-stable run restored (at least) via restore-keys everywhere.
+ * Used to retro-classify runs whose artifacts predate the recorded stamp.
+ */
+export function uniformCacheStates(
+  state: CompileCacheState,
+): CompileCacheStates {
+  const states: CompileCacheStates = {};
+  for (const family of COMPILE_CACHE_FAMILIES) {
+    states[family] = state;
+  }
+  return states;
+}

--- a/tasks/perf-cache-state.ts
+++ b/tasks/perf-cache-state.ts
@@ -96,12 +96,30 @@ export async function fetchChangedFilesBetween(
   baseSha: string,
   headSha: string,
 ): Promise<string[]> {
-  const data = await githubGet<{ files?: { filename: string }[] }>(
+  const data = await githubGet<
+    { files?: { filename: string; previous_filename?: string }[] }
+  >(
     `/repos/${REPO}/compare/${encodeURIComponent(baseSha)}...${
       encodeURIComponent(headSha)
     }`,
   );
-  return (data.files ?? []).map((file) => file.filename);
+  return changedPathsOf(data.files ?? []);
+}
+
+/**
+ * Both sides of every change: a file renamed OUT of the key set appears only
+ * under its new path, but the rename removed it from a hashed directory —
+ * the fingerprint rotated all the same. Deletions already surface under
+ * `filename`; renames need `previous_filename` too.
+ */
+export function changedPathsOf(
+  files: readonly { filename: string; previous_filename?: string }[],
+): string[] {
+  return files.flatMap((file) =>
+    file.previous_filename
+      ? [file.filename, file.previous_filename]
+      : [file.filename]
+  );
 }
 
 /**

--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -22,6 +22,7 @@ import {
   fetchArtifactsForRunBestEffort,
   fetchBaselineRunsForCheck,
   fetchCommitsBehindMain,
+  fetchLatestBaselineRunSha,
   fetchMainHeadSha,
   fetchPRForCommitWithError,
   formatBaselineSourceRunAge,
@@ -448,6 +449,31 @@ Deno.test("fetchMainHeadSha reads the main branch commit", async () => {
   );
 
   assertEquals(result, SHA_A);
+});
+
+Deno.test("fetchLatestBaselineRunSha reads the newest baseline run's head", async () => {
+  const result = await withMockFetch(
+    (input) => {
+      // The one-run baseline query against the workflow's successful main pushes.
+      assertStringIncludes(String(input), "/actions/workflows/");
+      assertStringIncludes(String(input), "per_page=1");
+      return new Response(
+        JSON.stringify({ workflow_runs: [{ head_sha: SHA_A }] }),
+      );
+    },
+    () => fetchLatestBaselineRunSha(),
+  );
+
+  assertEquals(result, SHA_A);
+});
+
+Deno.test("fetchLatestBaselineRunSha is undefined when no baseline run exists", async () => {
+  const result = await withMockFetch(
+    () => new Response(JSON.stringify({ workflow_runs: [] })),
+    () => fetchLatestBaselineRunSha(),
+  );
+
+  assertEquals(result, undefined);
 });
 
 Deno.test("fetchBaselineRunsForCheck fetches main head and baseline runs", async () => {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -84,6 +84,11 @@ import {
   writePerfMetricsBackfillFile,
   writePerfMetricsFile,
 } from "./perf-lib.ts";
+import {
+  classifyCacheKeyState,
+  classifyRunAgainstPredecessor,
+  uniformCacheStates,
+} from "./perf-cache-state.ts";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
@@ -1422,6 +1427,46 @@ export async function main() {
     `Compile cache states: ${formatCompileCacheStates(currentCacheStates)}`,
   );
 
+  // Fallback for families with no recorded state (artifact missing, upload
+  // or download failed): infer the run-level state from the compile
+  // fingerprint — the PR's changed files, or the compare against the
+  // previous main run. Recorded states are ground truth and win; the fill
+  // only applies to UNKNOWN families and only when the fingerprint rotated
+  // (a warm fill would change nothing — unknown already gates normally).
+  const inferredRunState = prNumber
+    ? (prFiles.length > 0
+      ? classifyCacheKeyState(prFiles.map((file) => file.filename))
+      : "unknown")
+    : await (async () => {
+      try {
+        const recent = await githubGet<{ workflow_runs: WorkflowRun[] }>(
+          workflowRunsPathForBaseline(1),
+        );
+        return await classifyRunAgainstPredecessor(
+          currentRunInfo.head_sha,
+          recent.workflow_runs[0]?.head_sha,
+        );
+      } catch {
+        return "unknown" as const;
+      }
+    })();
+  if (inferredRunState === "cold") {
+    let filled = 0;
+    for (const [family, state] of Object.entries(uniformCacheStates("cold"))) {
+      if (!(family in currentCacheStates)) {
+        currentCacheStates[family as keyof typeof currentCacheStates] = state;
+        filled++;
+      }
+    }
+    if (filled > 0) {
+      console.log(
+        `Compile fingerprint changed in this run; ${filled} unknown famil${
+          filled === 1 ? "y" : "ies"
+        } treated as cold.`,
+      );
+    }
+  }
+
   // Extract per-test metrics from JUnit artifacts
   try {
     // Newest per name: a re-run of a flagged test job must refresh its metric.
@@ -1570,6 +1615,21 @@ export async function main() {
     );
   }
 
+  // For each baseline run, its predecessor in the (newest-first) baseline
+  // list — the run whose saved compile cache it would have restored. Fuels
+  // retro-classification of runs whose artifacts predate the recorded stamp;
+  // once stamped artifacts fill the window this map goes unused.
+  const runsNewestFirst = [...baselineRuns].sort((a, b) =>
+    b.created_at.localeCompare(a.created_at) || b.id - a.id
+  );
+  const predecessorShaByRunId = new Map<number, string>();
+  for (let i = 0; i < runsNewestFirst.length - 1; i++) {
+    predecessorShaByRunId.set(
+      runsNewestFirst[i].id,
+      runsNewestFirst[i + 1].head_sha,
+    );
+  }
+
   await githubApiOrSkip(
     "building baseline timelines",
     () =>
@@ -1591,10 +1651,30 @@ export async function main() {
           timelines,
           artifacts,
         );
-        if (artifactResult.added) {
-          if (artifactResult.compileCacheStates) {
-            cacheStatesByRunId.set(run.id, artifactResult.compileCacheStates);
+        if (artifactResult.added && artifactResult.compileCacheStates) {
+          cacheStatesByRunId.set(run.id, artifactResult.compileCacheStates);
+        } else {
+          // Unstamped run (pre-rollout artifact, backfill, or live
+          // extraction): retro-infer the run-level state from the compile
+          // fingerprint diff against its predecessor and apply it to every
+          // family — a fingerprint rotation colds them all at once. Runs
+          // that were cold for other reasons (eviction) stay unknown and are
+          // kept, exactly as before this mechanism.
+          const inferred = await classifyRunAgainstPredecessor(
+            run.head_sha,
+            predecessorShaByRunId.get(run.id),
+          );
+          if (inferred !== "unknown") {
+            cacheStatesByRunId.set(run.id, uniformCacheStates(inferred));
           }
+          if (inferred === "cold") {
+            const pretty = pr ? `PR #${pr.number}` : run.head_sha.slice(0, 8);
+            console.log(
+              `  Baseline run ${run.id} (${pretty}) retro-classified cold: compile fingerprint changed vs predecessor.`,
+            );
+          }
+        }
+        if (artifactResult.added) {
           return;
         }
 

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -85,6 +85,7 @@ import {
   writePerfMetricsFile,
 } from "./perf-lib.ts";
 import {
+  changedPathsOf,
   classifyCacheKeyState,
   classifyRunAgainstPredecessor,
   uniformCacheStates,
@@ -1435,7 +1436,7 @@ export async function main() {
   // (a warm fill would change nothing — unknown already gates normally).
   const inferredRunState = prNumber
     ? (prFiles.length > 0
-      ? classifyCacheKeyState(prFiles.map((file) => file.filename))
+      ? classifyCacheKeyState(changedPathsOf(prFiles))
       : "unknown")
     : await (async () => {
       try {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -85,10 +85,9 @@ import {
   writePerfMetricsFile,
 } from "./perf-lib.ts";
 import {
-  changedPathsOf,
-  classifyCacheKeyState,
-  classifyRunAgainstPredecessor,
-  uniformCacheStates,
+  fillMissingFamiliesFromFingerprint,
+  inferCurrentRunFallbackState,
+  recordUnstampedBaselineRunState,
 } from "./perf-cache-state.ts";
 import * as path from "@std/path";
 import {
@@ -222,6 +221,19 @@ export async function fetchMainHeadSha(): Promise<string> {
     `/repos/${REPO}/branches/main`,
   );
   return branch.commit.sha;
+}
+
+/**
+ * The head SHA of the latest prior baseline run — the run whose compile cache
+ * the current main push would have restored. Used to fingerprint-classify a
+ * main push that carries no recorded cache state. Undefined when there is no
+ * prior baseline run (e.g. an empty run history).
+ */
+export async function fetchLatestBaselineRunSha(): Promise<string | undefined> {
+  const recent = await githubGet<{ workflow_runs: WorkflowRun[] }>(
+    workflowRunsPathForBaseline(1),
+  );
+  return recent.workflow_runs[0]?.head_sha;
 }
 
 function pluralize(value: number, unit: string): string {
@@ -1428,45 +1440,19 @@ export async function main() {
     `Compile cache states: ${formatCompileCacheStates(currentCacheStates)}`,
   );
 
-  // Fallback for families with no recorded state (artifact missing, upload
-  // or download failed): infer the run-level state from the compile
-  // fingerprint — the PR's changed files, or the compare against the
-  // previous main run. Recorded states are ground truth and win; the fill
-  // only applies to UNKNOWN families and only when the fingerprint rotated
-  // (a warm fill would change nothing — unknown already gates normally).
-  const inferredRunState = prNumber
-    ? (prFiles.length > 0
-      ? classifyCacheKeyState(changedPathsOf(prFiles))
-      : "unknown")
-    : await (async () => {
-      try {
-        const recent = await githubGet<{ workflow_runs: WorkflowRun[] }>(
-          workflowRunsPathForBaseline(1),
-        );
-        return await classifyRunAgainstPredecessor(
-          currentRunInfo.head_sha,
-          recent.workflow_runs[0]?.head_sha,
-        );
-      } catch {
-        return "unknown" as const;
-      }
-    })();
-  if (inferredRunState === "cold") {
-    let filled = 0;
-    for (const [family, state] of Object.entries(uniformCacheStates("cold"))) {
-      if (!(family in currentCacheStates)) {
-        currentCacheStates[family as keyof typeof currentCacheStates] = state;
-        filled++;
-      }
-    }
-    if (filled > 0) {
-      console.log(
-        `Compile fingerprint changed in this run; ${filled} unknown famil${
-          filled === 1 ? "y" : "ies"
-        } treated as cold.`,
-      );
-    }
-  }
+  // Fallback for families with no recorded state (artifact missing, upload or
+  // download failed): infer the run-level state from the compile fingerprint —
+  // the PR's changed files, or the compare against the previous main run — and
+  // fill only the families with no recorded state. Recorded states are ground
+  // truth and win (see inferCurrentRunFallbackState /
+  // fillMissingFamiliesFromFingerprint).
+  const inferredRunState = await inferCurrentRunFallbackState({
+    isPullRequestRun: !!prNumber,
+    prFiles,
+    headSha: currentRunInfo.head_sha,
+    fetchLatestBaselineSha: fetchLatestBaselineRunSha,
+  });
+  fillMissingFamiliesFromFingerprint(currentCacheStates, inferredRunState);
 
   // Extract per-test metrics from JUnit artifacts
   try {
@@ -1655,25 +1641,16 @@ export async function main() {
         if (artifactResult.added && artifactResult.compileCacheStates) {
           cacheStatesByRunId.set(run.id, artifactResult.compileCacheStates);
         } else {
-          // Unstamped run (pre-rollout artifact, backfill, or live
-          // extraction): retro-infer the run-level state from the compile
-          // fingerprint diff against its predecessor and apply it to every
-          // family — a fingerprint rotation colds them all at once. Runs
-          // that were cold for other reasons (eviction) stay unknown and are
-          // kept, exactly as before this mechanism.
-          const inferred = await classifyRunAgainstPredecessor(
-            run.head_sha,
+          // Unstamped run (an artifact carrying no recorded stamp — a backfill
+          // or a live extraction): retro-classify it from the compile
+          // fingerprint against its predecessor (see
+          // recordUnstampedBaselineRunState).
+          await recordUnstampedBaselineRunState(
+            cacheStatesByRunId,
+            run,
             predecessorShaByRunId.get(run.id),
+            pr ? `PR #${pr.number}` : run.head_sha.slice(0, 8),
           );
-          if (inferred !== "unknown") {
-            cacheStatesByRunId.set(run.id, uniformCacheStates(inferred));
-          }
-          if (inferred === "cold") {
-            const pretty = pr ? `PR #${pr.number}` : run.head_sha.slice(0, 8);
-            console.log(
-              `  Baseline run ${run.id} (${pretty}) retro-classified cold: compile fingerprint changed vs predecessor.`,
-            );
-          }
         }
         if (artifactResult.added) {
           return;

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -304,6 +304,8 @@ export interface PRInfo {
 
 export interface PRFile {
   filename: string;
+  /** Old path for renamed files; the fingerprint classifier needs both. */
+  previous_filename?: string;
   /** Unified diff for this file. Absent for binary or oversized changes. */
   patch?: string;
 }


### PR DESCRIPTION
Two additions on top of #4579 (now merged), closing the baseline-skew gap its
docs flagged. Built independently as a twin of #4579's base mechanism; once
#4579 landed, this rebased down to exactly these two additions — the shared
base (file-presence cold detection, the override-ordering / poison-on-unreadable
fix) is #4579's now and was dropped here as redundant. Ground truth beats
inference: a recorded cache state always wins; the fingerprint inference below
only fills where a recorded state is absent.

- **Retro-classification of unstamped baseline runs**: runs without a recorded
  state (pre-rollout artifacts, backfills, live extraction) are classified
  from the compile fingerprint — if the cc-* key paths changed vs the run's
  predecessor (compare API), every family is cold. This de-pollutes the
  existing 20-run window immediately (including the #4505/#4543-class cold
  samples) instead of waiting for stamped history to accumulate; once it does,
  the inference goes unused.
- **Fingerprint fallback for the current run**: families with no recorded
  state (artifact missing/failed) fill from the same inference, cold-only —
  recorded states win, and a warm fill would be a no-op.

`tasks/perf-cache-state.ts` mirrors the workflow's cc-* key globs with a
drift-guard test that parses deno.yml. Inference cannot see eviction/outage
colds — those stay unknown and behave exactly as today (fail-open).

Full tasks suite: 239 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retro-classifies unstamped baseline runs and adds a compile-fingerprint fallback when cache-state artifacts are missing. This cleans the 20-run baseline window and avoids false gates when the compile cache rotates.

- New Features
  - Baselines: For runs without a recorded state, compare changed files vs predecessor using the `cc-*` key globs; if any changed, mark all families cold; else warm.
  - Current run: Unknown families fall back to the same fingerprint inference (cold-only). Recorded states win; non-fingerprint causes (eviction/outage) stay unknown and gate normally.
  - Added `tasks/perf-cache-state.ts` and tests: mirrors `deno.yml` `cc-*` key globs with a drift-guard test; exposes `classifyRunAgainstPredecessor`, `classifyCacheKeyState`, `changedPathsOf`, and `uniformCacheStates`.
  - Docs: Updated CI performance guide to cover retro-classification and the fallback.

- Bug Fixes
  - Renames out of the fingerprint set are now classified cold by considering both `filename` and `previous_filename` from PR and compare APIs.

<sup>Written for commit 58a2cc1595d411baa9bdc69a0adb53083aacbb2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


