### PR TITLE
ci: add a Test runner-size experiment with CPU-usage sampling

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -174,7 +174,7 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: 🧪 Run parallel workspace tests with CPU sampling
-        run: deno run --allow-read --allow-run --allow-env scripts/run-with-cpu-stats.ts deno task test
+        run: deno run --allow-all scripts/run-with-cpu-stats.ts deno task test
         env:
           DENO_COVERAGE_DIR: coverage/raw/workspace
           TEST_DISABLED_PACKAGES: runner

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -129,6 +129,54 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
+  # Experiment: run the same workload as the "test" job above on several runner
+  # sizes and report each one's wall time and the number of cores it actually
+  # drove (see scripts/run-with-cpu-stats.ts). This decides whether Test can
+  # leave the 32-core runner. It is additive and non-blocking: the real "test"
+  # job is untouched, nothing depends on this job, and continue-on-error means a
+  # slow or unschedulable size cannot fail the run. No coverage is uploaded; only
+  # timing and CPU usage matter here. Delete this job once the sizing is decided.
+  test-runner-experiment:
+    name: "Test Experiment (${{ matrix.runner }})"
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: true
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest: standard runner (free on this public repo).
+        # ubuntu-22.04-large: 4-core / 16 GB. ubuntu-24.04-32-core: the 32-core
+        # runner currently behind `group: labs`, for an apples-to-apples baseline
+        # and its core-saturation profile.
+        runner: [ubuntu-latest, ubuntu-22.04-large, ubuntu-24.04-32-core]
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 📦 Install Linux FUSE test dependencies
+        uses: ./.github/actions/apt-install
+        with:
+          packages: pkg-config gcc libfuse3-dev fuse3
+          cache-key: cfc-pattern-check
+
+      - name: 📥 Download Deno dependency binaries
+        run: deno task initialize-db
+
+      - name: 🛡️ Disable AppArmor for browser tests
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+      - name: 🧪 Run parallel workspace tests with CPU sampling
+        run: deno run --allow-read --allow-run --allow-env scripts/run-with-cpu-stats.ts deno task test
+        env:
+          DENO_COVERAGE_DIR: coverage/raw/workspace
+          TEST_DISABLED_PACKAGES: runner
+
   runner-test:
     name: "Runner Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -144,11 +144,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-latest: standard runner (free on this public repo).
-        # ubuntu-22.04-large: 4-core / 16 GB. ubuntu-24.04-32-core: the 32-core
-        # runner currently behind `group: labs`, for an apples-to-apples baseline
-        # and its core-saturation profile.
-        runner: [ubuntu-latest, ubuntu-22.04-large, ubuntu-24.04-32-core]
+        # ubuntu-latest: standard runner (free on this public repo; the CPU
+        # sampler reports its actual core count). ubuntu-24.04-32-core: the
+        # 32-core runner currently behind `group: labs`, for an apples-to-apples
+        # baseline and its core-saturation profile.
+        # The 4-core ubuntu-22.04-large runner lives in a runner group this
+        # public repo cannot schedule from, so it is left out.
+        runner: [ubuntu-latest, ubuntu-24.04-32-core]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7

--- a/scripts/run-with-cpu-stats.ts
+++ b/scripts/run-with-cpu-stats.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read --allow-run --allow-env
+#!/usr/bin/env -S deno run --allow-all
 
 // Run a command while sampling how much CPU the whole machine is using, then
 // print how many cores the command actually drove. On a dedicated CI runner
@@ -8,7 +8,12 @@
 // busy fraction into "cores busy" by multiplying by the core count. Reports the
 // average over the whole run plus the per-interval peak and percentiles, which
 // separates a job that pins many cores throughout from one that only spikes
-// briefly and is otherwise single-threaded.
+// briefly and is otherwise single-threaded. Also samples the 1-minute load
+// average, which unlike utilization can rise above the core count and so shows
+// when the command wants more cores than the runner has.
+//
+// Runs under --allow-all: Deno gates /proc/stat behind the all-access
+// permission, and the wrapped command brings its own permissions when spawned.
 //
 // Exits with the wrapped command's exit code, so it is a transparent prefix in
 // front of any command. On a platform without /proc/stat it still runs the
@@ -34,9 +39,9 @@ interface StatSample {
 // missing instead of guessing "no /proc/stat".
 let statError: string | null = null;
 
-// Read the first line of /proc/stat. procfs files report a size of 0, so a
-// size-hinted whole-file read can come back empty; read through an explicit
-// descriptor loop until the first newline instead.
+// Read the first line of /proc/stat through an explicit descriptor loop.
+// procfs files report a size of 0, so read until the first newline rather than
+// trusting a size-hinted whole-file read.
 function readProcStatFirstLine(): string | null {
   let file: Deno.FsFile;
   try {
@@ -87,18 +92,29 @@ function coresBusy(a: StatSample, b: StatSample): number | null {
   return (1 - dIdle / dTotal) * cores;
 }
 
+function loadavg1(): number | null {
+  try {
+    return Deno.loadavg()[0];
+  } catch {
+    return null;
+  }
+}
+
 const SAMPLE_INTERVAL_MS = 2000;
 const intervalCores: number[] = [];
+let peakLoad = loadavg1() ?? 0;
 let prev = readStat();
 const overallStart = prev;
 
-const timer = prev === null ? undefined : setInterval(() => {
+const timer = setInterval(() => {
   const cur = readStat();
   if (prev && cur) {
     const busy = coresBusy(prev, cur);
     if (busy !== null) intervalCores.push(busy);
   }
   prev = cur ?? prev;
+  const load = loadavg1();
+  if (load !== null) peakLoad = Math.max(peakLoad, load);
 }, SAMPLE_INTERVAL_MS);
 
 const startedAt = performance.now();
@@ -111,7 +127,9 @@ const child = new Deno.Command(command[0], {
 const status = await child.status;
 const wallSeconds = (performance.now() - startedAt) / 1000;
 const overallEnd = readStat();
-if (timer !== undefined) clearInterval(timer);
+const endLoad = loadavg1();
+if (endLoad !== null) peakLoad = Math.max(peakLoad, endLoad);
+clearInterval(timer);
 
 function fmt(n: number): string {
   return n.toFixed(2);
@@ -141,6 +159,12 @@ if (intervalCores.length) {
     `median / p90 cores busy: ${fmt(at(0.5))} / ${
       fmt(at(0.9))
     } (${intervalCores.length} samples)`,
+  );
+}
+if (peakLoad > 0) {
+  lines.push(
+    `peak 1-min load average: ${fmt(peakLoad)}` +
+      (peakLoad > cores ? ` (above ${cores} cores — wants more)` : ""),
   );
 }
 lines.push("=========================================================");

--- a/scripts/run-with-cpu-stats.ts
+++ b/scripts/run-with-cpu-stats.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-env
+
+// Run a command while sampling how much CPU the whole machine is using, then
+// print how many cores the command actually drove. On a dedicated CI runner
+// nothing else is running, so the system-wide figure is this job's usage.
+//
+// Reads the aggregate line of /proc/stat at a fixed interval and turns the
+// busy fraction into "cores busy" by multiplying by the core count. Reports the
+// average over the whole run plus the per-interval peak and percentiles, which
+// separates a job that pins many cores throughout from one that only spikes
+// briefly and is otherwise single-threaded.
+//
+// Exits with the wrapped command's exit code, so it is a transparent prefix in
+// front of any command. On a platform without /proc/stat it still runs the
+// command and simply reports the CPU figures as unavailable.
+//
+// Usage:
+//   run-with-cpu-stats.ts <command> [args...]
+
+const command = Deno.args;
+if (command.length === 0) {
+  console.error("usage: run-with-cpu-stats.ts <command> [args...]");
+  Deno.exit(2);
+}
+
+const cores = navigator.hardwareConcurrency;
+
+interface StatSample {
+  idle: number;
+  total: number;
+}
+
+// Parse the aggregate "cpu" line of /proc/stat into idle and total jiffies.
+// Fields after the label are: user nice system idle iowait irq softirq steal ...
+function readStat(): StatSample | null {
+  let line: string;
+  try {
+    line = Deno.readTextFileSync("/proc/stat").split("\n", 1)[0];
+  } catch {
+    return null;
+  }
+  const fields = line.trim().split(/\s+/).slice(1).map(Number);
+  if (fields.length < 5 || fields.some((n) => !Number.isFinite(n))) return null;
+  const idle = fields[3] + (fields[4] ?? 0); // idle + iowait
+  const total = fields.reduce((sum, n) => sum + n, 0);
+  return { idle, total };
+}
+
+// Convert the change between two samples into the average number of cores busy
+// over that window.
+function coresBusy(a: StatSample, b: StatSample): number | null {
+  const dTotal = b.total - a.total;
+  if (dTotal <= 0) return null;
+  const dIdle = b.idle - a.idle;
+  return (1 - dIdle / dTotal) * cores;
+}
+
+const SAMPLE_INTERVAL_MS = 2000;
+const intervalCores: number[] = [];
+let prev = readStat();
+const overallStart = prev;
+
+const timer = prev === null ? undefined : setInterval(() => {
+  const cur = readStat();
+  if (prev && cur) {
+    const busy = coresBusy(prev, cur);
+    if (busy !== null) intervalCores.push(busy);
+  }
+  prev = cur ?? prev;
+}, SAMPLE_INTERVAL_MS);
+
+const startedAt = performance.now();
+const child = new Deno.Command(command[0], {
+  args: command.slice(1),
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+}).spawn();
+const status = await child.status;
+const wallSeconds = (performance.now() - startedAt) / 1000;
+const overallEnd = readStat();
+if (timer !== undefined) clearInterval(timer);
+
+function fmt(n: number): string {
+  return n.toFixed(2);
+}
+
+const lines = [
+  "===== CPU stats (system-wide on a dedicated runner) =====",
+  `runner cores (nproc): ${cores}`,
+  `wall time: ${wallSeconds.toFixed(1)}s`,
+];
+if (overallStart && overallEnd) {
+  const avg = coresBusy(overallStart, overallEnd);
+  lines.push(
+    `average cores busy: ${avg === null ? "n/a" : fmt(avg)} of ${cores}`,
+  );
+} else {
+  lines.push("average cores busy: n/a (no /proc/stat)");
+}
+if (intervalCores.length) {
+  const sorted = [...intervalCores].sort((a, b) => a - b);
+  const at = (q: number) =>
+    sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))];
+  lines.push(
+    `peak cores busy (${SAMPLE_INTERVAL_MS / 1000}s intervals): ${
+      fmt(sorted[sorted.length - 1])
+    }`,
+    `median / p90 cores busy: ${fmt(at(0.5))} / ${
+      fmt(at(0.9))
+    } (${intervalCores.length} samples)`,
+  );
+}
+lines.push("=========================================================");
+console.error("\n" + lines.join("\n") + "\n");
+
+Deno.exit(status.code);

--- a/scripts/run-with-cpu-stats.ts
+++ b/scripts/run-with-cpu-stats.ts
@@ -30,17 +30,49 @@ interface StatSample {
   total: number;
 }
 
+// The first read failure, kept so the summary can explain why CPU stats are
+// missing instead of guessing "no /proc/stat".
+let statError: string | null = null;
+
+// Read the first line of /proc/stat. procfs files report a size of 0, so a
+// size-hinted whole-file read can come back empty; read through an explicit
+// descriptor loop until the first newline instead.
+function readProcStatFirstLine(): string | null {
+  let file: Deno.FsFile;
+  try {
+    file = Deno.openSync("/proc/stat", { read: true });
+  } catch (e) {
+    statError ??= `open /proc/stat: ${e instanceof Error ? e.message : e}`;
+    return null;
+  }
+  try {
+    const decoder = new TextDecoder();
+    const buf = new Uint8Array(8192);
+    let text = "";
+    while (!text.includes("\n")) {
+      const n = file.readSync(buf);
+      if (n === null || n === 0) break;
+      text += decoder.decode(buf.subarray(0, n), { stream: true });
+    }
+    return text.split("\n", 1)[0];
+  } catch (e) {
+    statError ??= `read /proc/stat: ${e instanceof Error ? e.message : e}`;
+    return null;
+  } finally {
+    file.close();
+  }
+}
+
 // Parse the aggregate "cpu" line of /proc/stat into idle and total jiffies.
 // Fields after the label are: user nice system idle iowait irq softirq steal ...
 function readStat(): StatSample | null {
-  let line: string;
-  try {
-    line = Deno.readTextFileSync("/proc/stat").split("\n", 1)[0];
-  } catch {
+  const line = readProcStatFirstLine();
+  if (line === null) return null;
+  const fields = line.trim().split(/\s+/).slice(1).map(Number);
+  if (fields.length < 5 || fields.some((n) => !Number.isFinite(n))) {
+    statError ??= `unexpected /proc/stat first line: ${JSON.stringify(line)}`;
     return null;
   }
-  const fields = line.trim().split(/\s+/).slice(1).map(Number);
-  if (fields.length < 5 || fields.some((n) => !Number.isFinite(n))) return null;
   const idle = fields[3] + (fields[4] ?? 0); // idle + iowait
   const total = fields.reduce((sum, n) => sum + n, 0);
   return { idle, total };
@@ -96,7 +128,7 @@ if (overallStart && overallEnd) {
     `average cores busy: ${avg === null ? "n/a" : fmt(avg)} of ${cores}`,
   );
 } else {
-  lines.push("average cores busy: n/a (no /proc/stat)");
+  lines.push(`average cores busy: n/a (${statError ?? "no /proc/stat"})`);
 }
 if (intervalCores.length) {
   const sorted = [...intervalCores].sort((a, b) => a - b);


### PR DESCRIPTION
The Test job runs on the 32-core "labs" runner group, which is billed at roughly thirteen times the standard Linux rate. Unlike Build Binaries, which is single-threaded, Test genuinely fans out: its runner starts one test subprocess per workspace package at once. So the question is not whether to move it to a two-core runner but how many cores it actually needs, and whether a smaller runner keeps its wall time acceptable given that the job's tail is gated by a single slow package.

To answer that with data rather than a guess, add a self-contained experiment that runs the same workload as the Test job on several runner sizes and reports, for each, the wall time and the number of cores it drove.

Two parts:

- scripts/run-with-cpu-stats.ts wraps any command, samples the aggregate line of /proc/stat at a fixed interval, and prints the core count, wall time, average cores busy over the whole run, and the per-interval peak and percentiles. On a dedicated CI runner the system-wide figure is the job's own usage. It exits with the wrapped command's exit code, so it is a transparent prefix, and it degrades to reporting the CPU figures as unavailable where /proc/stat is absent. This is reusable for sizing any other job later.

- A test-runner-experiment job runs the Test workload, wrapped in that sampler, across the standard runner, a four-core runner, and the 32-core runner, so one run yields a wall-time and core-usage comparison plus the 32-core saturation profile. It is additive and non-blocking: the real Test job is untouched, nothing depends on the experiment, and continue-on-error means a slow or unschedulable size cannot fail the run. It uploads no coverage; only timing and CPU usage matter. It is meant to be deleted once the sizing is decided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI experiment to measure how many CPU cores the Test workload uses and its wall time on different runner sizes. Fix Linux sampling, run under `--allow-all`, and add a load‑average signal to spot oversubscription; compare `ubuntu-latest` with `ubuntu-24.04-32-core` to decide if we can drop the 32‑core runner.

- **New Features**
  - Added `scripts/run-with-cpu-stats.ts`: wraps any command, samples `/proc/stat` every 2s, and reports runner cores, wall time, and avg/peak/percentile cores busy; also records peak 1‑min load average and flags when it exceeds core count; exits with the wrapped command’s status and degrades if `/proc/stat` is unavailable.
  - Introduced `test-runner-experiment` job: runs tests with the sampler on `ubuntu-latest` and `ubuntu-24.04-32-core`; non-blocking via `continue-on-error`, no coverage, temporary.

- **Bug Fixes**
  - Fixed CPU sampling by reading `/proc/stat` via a descriptor loop (procfs size=0 quirk), running under `--allow-all`, and surfacing real errors.
  - Removed `ubuntu-22.04-large` from the matrix because it cannot be scheduled from this public repo.

<sup>Written for commit fcbe8d2ae287b33df6492ca78da1138f43c2ee6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

