### PR TITLE
fix(ui): make FormFieldController.commit() respect form context

### DIFF
--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -509,6 +509,11 @@ export class CFInput extends BaseElement {
    * completed before continuing. Does not surface a remote-commit rejection (the
    * underlying set() logs and swallows that). When the field is not bound to a
    * Cell, it falls back to the cell controller's setValue.
+   *
+   * This is for standalone inputs. Inside a cf-form the form owns durable writes
+   * and flushes every field atomically on submit, so commit() resolves without
+   * writing: the edit stays buffered for the form's submit rather than
+   * persisting on its own.
    */
   commit(): Promise<void> {
     return this._formField.commit();

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -506,4 +506,60 @@ describe("FormFieldController commit", () => {
 
     expect(cellSet).toBe("buffered");
   });
+
+  it("does not write out-of-band when inside a form context", async () => {
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    let flushed = false;
+    let cellSet: string | undefined;
+    let setValueArg: string | undefined;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "cell-value",
+      setValue: (v: string) => {
+        setValueArg = v;
+      },
+      flush: () => {
+        flushed = true;
+      },
+      getCell: () => ({
+        set: (v: string) => {
+          cellSet = v;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const formField = new FormFieldController(host, { cellController });
+
+    // Simulate being inside a cf-form: supply a form context to the controller's
+    // context consumer, plus a buffered edit as typing would produce, and an
+    // original baseline captured at registration.
+    const internals = formField as unknown as {
+      _formContextConsumer: { value: FormContext };
+      _buffer: string;
+      _hasBuffer: boolean;
+      _originalValue: string;
+    };
+    internals._formContextConsumer = { value: new MockFormContext() };
+    internals._buffer = "buffered";
+    internals._hasBuffer = true;
+    internals._originalValue = "original";
+
+    expect(formField.inFormContext).toBe(true);
+
+    await formField.commit();
+
+    // The form owns the atomic flush, so commit() writes nothing durable.
+    expect(cellSet).toBeUndefined();
+    expect(setValueArg).toBeUndefined();
+    expect(flushed).toBe(false);
+
+    // The edit stays buffered for the form to flush on submit.
+    expect(internals._hasBuffer).toBe(true);
+    expect(internals._buffer).toBe("buffered");
+
+    // Dirty tracking is not rebaselined: the buffered edit still counts as
+    // unsaved until the form submits.
+    expect(internals._originalValue).toBe("original");
+    expect(formField.isDirty()).toBe(true);
+  });
 });

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -169,16 +169,25 @@ export class FormFieldController<T> implements ReactiveController {
 
   /**
    * Flush the field's current value to the bound cell and await the set()
-   * round-trip. Uses the buffered value in a form context, otherwise the cell
-   * controller's value, draining any pending debounced/throttled write first.
-   * In a form context this commits the field immediately rather than waiting for
-   * the form's atomic submit, and rebaselines dirty/reset tracking to the
-   * committed value. Resolves once the local apply and the set() round-trip
-   * complete; it does not surface a remote-commit rejection (the underlying
-   * set() logs and swallows that). When no Cell is bound, it falls back to the
-   * cell controller's setValue, mirroring the form's flush.
+   * round-trip. This is for standalone fields: it drains any pending
+   * debounced/throttled write, then writes the current value (buffered value if
+   * present, otherwise the cell controller's value) to the bound cell, and
+   * rebaselines dirty/reset tracking to the committed value. Resolves once the
+   * local apply and the set() round-trip complete; it does not surface a
+   * remote-commit rejection (the underlying set() logs and swallows that). When
+   * no Cell is bound, it falls back to the cell controller's setValue.
+   *
+   * In a form context the form owns durable writes: each field buffers its edit
+   * and the form flushes them together on submit. So when this field is in a
+   * form, commit() returns without writing and without rebaselining; the edit
+   * stays in the buffer for the form to flush, and dirty tracking is unchanged
+   * so the value still counts as unsaved until the form submits.
    */
   async commit(): Promise<void> {
+    // In a form context the form owns durable writes via its atomic submit;
+    // leave the edit buffered and do not write or rebaseline here.
+    if (this._formContext) return;
+
     this._cellController.flush?.();
     const valueToFlush = this._hasBuffer
       ? this._buffer as T


### PR DESCRIPTION
FormFieldController.commit() flushes a field's pending edit and durably writes it to the bound cell. It is meant for standalone fields, and its only caller is cf-input.commit().

Inside a cf-form the form owns durable writes: each field buffers its edit and the form flushes every field together on submit, giving all-or-nothing form submission. commit() ignored that. When a field was inside a form it still wrote the cell directly (cell.set, or the cell controller's setValue when no cell was bound) and rebaselined the original-value baseline used for dirty and reset tracking. That write lands out of band: one field could be persisted before the user submits or while other fields are still buffered, defeating the atomic submit, and the premature rebaseline made a later isDirty()/reset() treat an uncommitted value as saved.

No caller triggers this today, since commit() is used only by cf-input as a standalone field, but it is a latent hazard once commit() gains a form-context caller.

Make commit() defer to the form when the field is in a form context: it returns early without writing and without rebaselining, leaving the edit in the buffer for the form to flush on submit. This loses nothing, because typing in a form context already routes setValue into the buffer synchronously, and the cell controller's debounce timer is only armed by its own setValue, which the buffered path never calls, so there is no pending write to drain. Dirty tracking is left untouched, so the value still counts as unsaved until the form submits.

Update the commit() doc comment to describe the standalone write path and the form-context no-op, and update cf-input.commit()'s doc, which had promised the set() round-trip completes before it resolves — untrue for a form-participating input. Add a test that drives commit() with a mocked form context and a buffered edit, asserting no cell write, no fallback setValue, no flush, the buffer preserved, the baseline unchanged, and the field still reported as dirty.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make FormFieldController.commit() respect form context so fields inside a cf-form no longer write out-of-band, preserving atomic submits and correct dirty/reset tracking. Standalone fields keep the previous commit behavior.

- **Bug Fixes**
  - In a form context, commit() returns without writing or rebaselining; the edit stays buffered for the form’s submit.
  - Standalone fields still flush pending writes to the cell and rebaseline on commit.
  - Updated commit() docs (including `cf-input.commit()`) and added a test covering the form-context no-op.

<sup>Written for commit 3adc7151d3cb09470add5abb87ed319e3ff4b5bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

