### PR TITLE
fix(runner): drain in-flight watch long-poll on replica close()

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1322,6 +1322,25 @@ class SpaceReplica implements ISpaceReplica {
     await Promise.all([...this.#syncPromises, ...this.#commitPromises]);
   }
 
+  /**
+   * The durable half of `synced()`: flush scheduler observations and in-flight
+   * commits, but do NOT block on in-flight reads/watch refreshes.
+   *
+   * `close()` uses this instead of `synced()` because a watch's transport
+   * response can be withheld past dispose (e.g. a gate holding a doc), so a read
+   * pull promise may never settle on its own. Awaiting it before teardown would
+   * deadlock close(); teardown rejects the request instead, settling the read.
+   */
+  private async flushCommits(): Promise<void> {
+    if (
+      this.#schedulerObservationBatch.length > 0 ||
+      this.#schedulerObservationFlushPromise
+    ) {
+      await this.flushSchedulerObservationBatch();
+    }
+    await Promise.allSettled([...this.#commitPromises]);
+  }
+
   async sqliteQuery(
     db: SqliteDbRef,
     sql: string,
@@ -1369,8 +1388,17 @@ class SpaceReplica implements ISpaceReplica {
     this.#closed = true;
     this.resetConflictAdmissionState();
     this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
-    await this.synced();
+    // Settle any queued (not-yet-sent) watch refresh first so its pull promise
+    // cannot outlive close(); `#closed` also makes refreshWatchSet fail closed
+    // for any refresh already in flight.
     this.cancelQueuedWatchRefresh();
+    // Flush durable work (scheduler observations + in-flight commits). Unlike
+    // `synced()`, this does NOT wait on in-flight reads/watch refreshes: a
+    // watch's transport response can be withheld past dispose (e.g. a gate
+    // holding a doc), so awaiting it here would deadlock close(). The client
+    // teardown below rejects every in-flight request, which settles those read
+    // promises without waiting on a response that may never arrive.
+    await this.flushCommits();
     this.#watchView?.close();
     this.#watchView = null;
     // Also close the view the update consumer is bound to, in case it diverged
@@ -1393,9 +1421,17 @@ class SpaceReplica implements ISpaceReplica {
         resolved = undefined;
       }
       if (resolved !== undefined) {
+        // Closing the client rejects every in-flight request (pulls/watch
+        // refreshes) with a ConnectionError and closes the session's watch
+        // view — the generic drain for any open watch, not just the two views
+        // tracked above.
         await resolved.client.close();
       }
     }
+    // With the client closed, every in-flight read/watch pull has been rejected
+    // and now settles promptly. Awaiting them here can no longer hang and
+    // guarantees no transport promise is left pending when close() resolves.
+    await Promise.allSettled([...this.#syncPromises]);
     await Promise.allSettled([...this.#updatePromises]);
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
@@ -1470,6 +1506,9 @@ class SpaceReplica implements ISpaceReplica {
         // The session never opened cleanly; there is nothing to close.
       });
     }
+    // The fire-and-forget client.close() above rejects in-flight requests; drain
+    // their read pulls too so no transport promise is left pending.
+    void Promise.allSettled([...this.#syncPromises]);
     void Promise.allSettled([...this.#updatePromises]);
     this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -4,9 +4,14 @@ import type { SchemaPathSelector } from "@commonfabric/api";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
 import type { CellScope } from "@commonfabric/memory/v2";
 import type { Result, Unit } from "../src/storage/interface.ts";
-import type * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { SessionFactory } from "../src/storage/v2.ts";
-import { TestStorageManager } from "./memory-v2-test-utils.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
 
 class PendingSessionFactory implements SessionFactory {
   create(_space: MemorySpace, _signer?: Signer): Promise<{
@@ -14,6 +19,45 @@ class PendingSessionFactory implements SessionFactory {
     session: MemoryV2Client.SpaceSession;
   }> {
     return new Promise(() => {});
+  }
+}
+
+function makeServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(m) {
+      const p = (m.authorization as { principal?: unknown })?.principal;
+      return typeof p === "string" ? p : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+}
+
+// A session whose transport delivers the handshake and commits normally but
+// silently swallows every `session.watch.add`, so the watch request the pull
+// issues is left in flight — its response never arrives. This mirrors the
+// regression's mechanism: a transport gate holding a watched doc past dispose,
+// so the storage layer is left with an open watch whose long-poll never
+// settles on its own.
+class WithheldWatchSessionFactory implements SessionFactory {
+  constructor(private readonly server: MemoryV2Server.Server) {}
+  async create(id: string, signer?: Signer) {
+    const base = MemoryV2Client.loopback(this.server);
+    const transport: MemoryV2Client.Transport = {
+      send: (payload: string) =>
+        payload.includes("session.watch.add")
+          ? Promise.resolve()
+          : base.send(payload),
+      close: () => base.close(),
+      setReceiver: (r) => base.setReceiver(r),
+      setCloseReceiver: (r) => base.setCloseReceiver?.(r),
+    };
+    const client = await MemoryV2Client.connect({ transport });
+    const session = await client.mount(
+      id as MemorySpace,
+      {},
+      testPrincipalSessionOpenAuthFactory(signer),
+    );
+    return { client, session };
   }
 }
 
@@ -102,4 +146,38 @@ Deno.test("Provider.destroyNow force-closes after destroy is already pending", a
 
   assertEquals(result, "closed");
   assertEquals(closeNowCalls, 1);
+});
+
+Deno.test("StorageManager.close drains a watch long-poll still in flight", async () => {
+  const signer = await Identity.fromPassphrase("storage-close-watch-inflight");
+  const storage = TestStorageManager.create(
+    { as: signer, memoryHost: new URL("memory://") },
+    new WithheldWatchSessionFactory(makeServer()),
+  );
+
+  const provider = storage.open(signer.did());
+  // Open a watch by pulling a doc. Its `watch.add` response is withheld, so the
+  // request stays in flight when we tear down — the exact state that used to
+  // leave a transport promise pending past close() and trip the op sanitizer
+  // with "Promise resolution is still pending...".
+  void provider.sync("of:storage-close-watch-inflight" as URI);
+  // Let the pull reach the transport before closing.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  // close() must resolve without waiting on the withheld watch response: a
+  // close() that blocked on the in-flight read would deadlock here. The default
+  // op sanitizer additionally fails this test if close() leaves any transport
+  // promise pending — the actual regression it guards.
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const result = await Promise.race([
+    storage.close().then(() => "closed" as const),
+    new Promise<"timed-out">((resolve) => {
+      timeout = setTimeout(() => resolve("timed-out"), 1000);
+      Deno.unrefTimer(timeout);
+    }),
+  ]).finally(() => {
+    if (timeout !== undefined) clearTimeout(timeout);
+  });
+
+  assertEquals(result, "closed");
 });


### PR DESCRIPTION
## Problem

`SpaceReplica.close()` awaited `synced()` — which blocks on in-flight **read/watch pulls** — **before** tearing down the client that would settle them. When a watch's transport response is withheld past dispose (the reactive-interpreter resume path opens an argument-doc watch whose response a transport gate holds), that read pull never settles on its own. `close()` then either deadlocks or leaves a transport promise pending, and Deno's default op sanitizer aborts the (flag-ON) test process with:

> Promise resolution is still pending but the event loop has already resolved

…**after the test itself passes** — i.e. process-exit hygiene, not a test failure.

Repro (from `packages/runner`, before this change):

```
CF_EXPERIMENTAL_INTERPRETER=1 ENV=test deno test --allow-ffi --allow-env \
  --allow-read --allow-write=/tmp,/var/folders --allow-run=git \
  test/resume-append-exclusion.test.ts
```

Flag-OFF is clean, so **CI (which runs flag-OFF) is unaffected today** — but it blocks local flag-ON runs and would break CI the day the interpreter flag flips default-on.

## Fix (generic, storage-layer)

`packages/runner/src/storage/v2.ts` — reorder `close()` into a generic drain rather than matching the interpreter's doc shape:

1. Cancel queued (not-yet-sent) watch refreshes.
2. Flush only **durable** work (scheduler observations + commits) via a new `flushCommits()` — no longer block on in-flight reads.
3. Close the watch views, then close the client. `client.close()` rejects **every** in-flight request with a `ConnectionError` — the generic teardown for *any* open watch, not just the two views the replica tracks.
4. Then `await Promise.allSettled([...#syncPromises])` — safe now that the requests are already rejected, guaranteeing no transport promise outlives `close()`.

`closeNow()` gets the same `#syncPromises` drain for symmetry. `flushCommits()` uses `allSettled` (not `Promise.all`) so a rejected commit during teardown can't throw out of `close()` and skip the client teardown (which would re-leak).

## Guard (red→green)

`storage-close.test.ts` adds a test whose transport withholds every `session.watch.add` response, leaving the pull's watch in flight, then closes the manager. Verified by stashing the src fix: **without** it the test hangs and the op sanitizer fails the process; **with** it, `close()` resolves clean.

## Verification

- Exclusion tests (`resume-append-exclusion` + `-list`), flag-ON **and** flag-OFF: clean, exit 0.
- Full runner suite both flags (`deno task test` / `CF_EXPERIMENTAL_INTERPRETER=1 deno task test`): **803 passed / 0 failed / exit 0 / 0 op-sanitizer errors** each.
- `deno fmt` + `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shutdown hangs by draining in-flight watch long‑polls when closing replicas. Reorders `SpaceReplica.close()` so reads are rejected by client teardown and do not outlive close.

- **Bug Fixes**
  - Added `flushCommits()` to flush scheduler observations and commit promises without waiting on reads/watch refreshes.
  - `close()` now: cancels queued watch refreshes, calls `flushCommits()`, closes watch views, closes the client to reject all in-flight requests, then awaits `Promise.allSettled` on sync/update promises.
  - Mirrored the sync drain in `closeNow()` to avoid leaving pending transport promises.
  - New test in `packages/runner/test/storage-close.test.ts` that withholds `session.watch.add` responses to verify `close()` resolves cleanly and no promises remain pending.

<sup>Written for commit d47eb153f5e3fb0abe9efde0a236be5ae581334c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

