### PR TITLE
fix(runner): ri-v2 — build resume-append fixture via legacy coordinator (filter flag-ON exit-leak)

### DIFF
--- a/packages/runner/test/resume-append-scenario.ts
+++ b/packages/runner/test/resume-append-scenario.ts
@@ -152,9 +152,21 @@ export interface AppendScenario {
 async function build(scenario: AppendScenario): Promise<void> {
   const { signer, space, server, program, cellId, items } = scenario;
   const sm = GatedStorageManager.make(signer, server);
+  // Build the durable aggregate through the LEGACY coordinator, even under the
+  // interpreter flag. The gate window this harness forces (below) holds each
+  // element's per-element RESULT document as it streams in on resume — but only
+  // the legacy coordinator persists those documents. The flag-on inline filter
+  // evaluates its predicates in-segment and keeps the ORIGINAL element
+  // references, so it never writes a streamable per-element result doc; a
+  // flag-on inline build would leave the gate with nothing to hold and
+  // `firstHeld` would never resolve (the same reason map is not gated here).
+  // The RESUME runtime keeps the ambient flag: the interpreter refuses resumed
+  // collections and falls back to the legacy coordinator, so the resume path —
+  // the actual subject of these tests — is still exercised flag-on.
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: sm,
+    experimental: { experimentalInterpreter: false },
   });
   const compiled = await rt.patternManager.compilePattern(program, { space });
   const tx0 = rt.edit();
@@ -176,9 +188,9 @@ async function build(scenario: AppendScenario): Promise<void> {
   expect(scenario.read(rc)).toEqual(scenario.buildExpected);
   rt.scheduler.dispose();
   await rt.dispose();
-  // Close the session too (sibling harnesses close their storage managers in
-  // afterEach): an inline-value element resolves to an argument-doc path
-  // whose watch keeps a transport promise pending past process end.
+  // Close the build session's storage manager (sibling harnesses close theirs in
+  // afterEach): a per-element result watch can otherwise keep a transport promise
+  // pending past process end, which the op sanitizer reports as a leak.
   await sm.close();
 }
 
@@ -217,14 +229,6 @@ export async function runResumeAppendScenario(
 
     const started = await rt2.start(rc2);
     expect(started).toBe(true);
-    // TEMP-DEBUG (ri2 leak isolation): stage bisect. 1=after start,
-    // 2=after firstHeld, 3=after release+settle.
-    const stopAt = Number(Deno.env.get("RI2_STOP_AT") ?? "0");
-    const fake = {
-      output: ["a", "b", "c", "d", "e"] as unknown[],
-      heldCount: 1,
-    };
-    if (stopAt === 1) return fake;
 
     // Standing effect so `idle()` drives the coordinator without `pull()`. While
     // the gate holds the per-element documents, `pull()` would block on the
@@ -243,13 +247,6 @@ export async function runResumeAppendScenario(
       // it into the resume batch instead, with no recovery.
       await gate.firstHeld;
       expect(gate.heldCount).toBeGreaterThan(0);
-      if (stopAt === 2) return fake;
-      if (stopAt === 3) {
-        gate.release();
-        await rc2.pull();
-        await rt2.settled();
-        return fake;
-      }
 
       // Append while the per-element results are held. The coordinator's
       // reconcile reads the still-stale sibling result cells, so its commit is


### PR DESCRIPTION
Follow-up to #4590. Fixes the residual `CF_EXPERIMENTAL_INTERPRETER=1` exit-leak in the **filter** variant of the resume-append regression (`resume-append-exclusion.test.ts`), which aborted the flag-ON process with `Promise resolution is still pending but the event loop has already resolved` even though every test passed on flag-OFF.

## Root cause — test harness, not the runtime

The shared harness `resume-append-scenario.ts` forces a deterministic "append during resume" window by holding each element's per-element **result document** in the transport (`/"path":\["element"/`) and blocking on `await gate.firstHeld` until the first is held. **Only the legacy list coordinator persists streamable per-element result docs.** The flag-ON **inline filter** evaluates predicates in-segment and keeps the *original element references*, so it never writes a per-element result doc that streams on resume → the gate holds nothing and `await gate.firstHeld` deadlocks forever. That hung promise is what Deno reports as the leak. (This is the same incompatibility the sibling test already documents for `map`.)

A no-gate probe confirms the flag-ON resume itself **converges correctly** (`[a,b,c,d]` then `[a,b,c,d,e]` after the append), identical to flag-OFF — so there is no runtime bug to drain. `trackUntilSettled` / `#crossSpacePromises` / watch views are all empty at teardown.

## Fix

Build the durable aggregate through the **legacy** coordinator (`experimental: { experimentalInterpreter: false }` on the first runtime only — a per-runtime instance field, not an ambient global), so the gated-window premise holds on both flags. The **resume** runtime keeps the ambient flag — the interpreter refuses resumed collections and falls back to legacy, so the resume path (the actual subject of these tests) is still exercised flag-on. flatMap is unaffected (already legacy at build).

Also removes the accidentally-committed `RI2_STOP_AT` debug toggle + its `fake` shortcut from the shared scenario, and corrects the now-stale build session-close comment.

## Verification (from `packages/runner`)

- filter flag-ON: **1 passed, exit 0** (was: deadlock + exit 1)
- filter flag-OFF: 1 passed, exit 0
- flatMap flag-ON / flag-OFF: 1 passed, exit 0
- `storage-close.test.ts` (the #4590 guard) flag-ON: 3 passed, exit 0
- resume/reload cluster (5 files) flag-ON: 6 passed, exit 0

`deno fmt` + `deno check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the exit leak in the resume-append filter test under `CF_EXPERIMENTAL_INTERPRETER=1` by building the pre-resume fixture via the legacy coordinator. Ensures the gated resume window works and the process exits cleanly while still exercising the flag-on resume path.

- **Bug Fixes**
  - Build the pre-resume aggregate with the legacy coordinator (`experimental: { experimentalInterpreter: false }`) so per-element result docs stream and the gate resolves.
  - Keep the resume runtime flag-on; resumed collections fall back to legacy, so resume logic is still covered under the interpreter flag.
  - Remove the `RI2_STOP_AT` debug toggle and its `fake` shortcut; update the stale session-close comment.
  - Verified in `packages/runner`: filter and flatMap pass on flag-ON and flag-OFF; no pending promises at teardown.

<sup>Written for commit 48d080b38115dea39d602ffb486fd4d0da5227d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

