### PR TITLE
fix(runner): drain in-flight commits on replica close() instead of aw…

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1374,25 +1374,6 @@ class SpaceReplica implements ISpaceReplica {
     await Promise.all([...this.#syncPromises, ...this.#commitPromises]);
   }
 
-  /**
-   * The durable half of `synced()`: flush scheduler observations and in-flight
-   * commits, but do NOT block on in-flight reads/watch refreshes.
-   *
-   * `close()` uses this instead of `synced()` because a watch's transport
-   * response can be withheld past dispose (e.g. a gate holding a doc), so a read
-   * pull promise may never settle on its own. Awaiting it before teardown would
-   * deadlock close(); teardown rejects the request instead, settling the read.
-   */
-  private async flushCommits(): Promise<void> {
-    if (
-      this.#schedulerObservationBatch.length > 0 ||
-      this.#schedulerObservationFlushPromise
-    ) {
-      await this.flushSchedulerObservationBatch();
-    }
-    await Promise.allSettled([...this.#commitPromises]);
-  }
-
   async sqliteQuery(
     db: SqliteDbRef,
     sql: string,
@@ -1444,13 +1425,18 @@ class SpaceReplica implements ISpaceReplica {
     // cannot outlive close(); `#closed` also makes refreshWatchSet fail closed
     // for any refresh already in flight.
     this.cancelQueuedWatchRefresh();
-    // Flush durable work (scheduler observations + in-flight commits). Unlike
-    // `synced()`, this does NOT wait on in-flight reads/watch refreshes: a
-    // watch's transport response can be withheld past dispose (e.g. a gate
-    // holding a doc), so awaiting it here would deadlock close(). The client
-    // teardown below rejects every in-flight request, which settles those read
-    // promises without waiting on a response that may never arrive.
-    await this.flushCommits();
+    // Send any batched scheduler observations so they reach the server, but do
+    // not await commit confirmation here. A commit whose response is withheld
+    // past dispose — the server holding it for a gated read that never arrives —
+    // never settles on its own, so awaiting it before the client teardown below
+    // would deadlock close(), just as awaiting an in-flight read would. Kicking
+    // the flush issues the observation commit into `#commitPromises`; the client
+    // teardown rejects every in-flight request, reads and commits alike, and the
+    // post-teardown drain settles them.
+    const observationFlush = (this.#schedulerObservationBatch.length > 0 ||
+        this.#schedulerObservationFlushPromise)
+      ? this.flushSchedulerObservationBatch()
+      : undefined;
     this.#watchView?.close();
     this.#watchView = null;
     // Also close the view the update consumer is bound to, in case it diverged
@@ -1480,9 +1466,14 @@ class SpaceReplica implements ISpaceReplica {
         await resolved.client.close();
       }
     }
-    // With the client closed, every in-flight read/watch pull has been rejected
-    // and now settles promptly. Awaiting them here can no longer hang and
-    // guarantees no transport promise is left pending when close() resolves.
+    // With the client closed, every in-flight commit and read/watch pull has
+    // been rejected and now settles promptly. Awaiting them here can no longer
+    // hang and guarantees no transport promise is left pending when close()
+    // resolves.
+    await Promise.allSettled([
+      ...(observationFlush ? [observationFlush] : []),
+      ...this.#commitPromises,
+    ]);
     await Promise.allSettled([...this.#syncPromises]);
     await Promise.allSettled([...this.#updatePromises]);
     this.#syncTasks.clear();

--- a/packages/runner/test/runtime-dispose-withheld-commit.test.ts
+++ b/packages/runner/test/runtime-dispose-withheld-commit.test.ts
@@ -1,0 +1,104 @@
+import { assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { Runtime } from "../src/runtime.ts";
+import type { SessionFactory } from "../src/storage/v2.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
+
+// A session whose transport delivers the handshake, reads and watches normally
+// but, once `withhold` is set, silently swallows every `transact` (commit) send
+// so its response never arrives. This mirrors the integration flake: a commit
+// whose server-side processing is withheld past dispose — the server holding
+// the commit while a gated read it depends on never arrives — so the commit
+// promise never settles on its own.
+class WithheldCommitSessionFactory implements SessionFactory {
+  withhold = false;
+  constructor(private readonly server: MemoryV2Server.Server) {}
+  async create(id: string, signer?: Signer) {
+    const base = MemoryV2Client.loopback(this.server);
+    const transport: MemoryV2Client.Transport = {
+      send: (payload: string) =>
+        this.withhold && payload.includes('"transact"')
+          ? Promise.resolve()
+          : base.send(payload),
+      close: () => base.close(),
+      setReceiver: (r) => base.setReceiver(r),
+      setCloseReceiver: (r) => base.setCloseReceiver?.(r),
+    };
+    const client = await MemoryV2Client.connect({ transport });
+    const session = await client.mount(
+      id as MemorySpace,
+      {},
+      testPrincipalSessionOpenAuthFactory(signer),
+    );
+    return { client, session };
+  }
+}
+
+function makeServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(m) {
+      const p = (m.authorization as { principal?: unknown })?.principal;
+      return typeof p === "string" ? p : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+}
+
+// runtime.dispose() tears down storage as part of shutdown. Storage teardown
+// used to flush in-flight commits — awaiting their confirmation — BEFORE closing
+// the client that would settle them. A commit whose response is withheld past
+// dispose never confirms on its own, so that pre-teardown flush deadlocked, and
+// dispose() hung. Teardown must reject in-flight commits (the way it already
+// rejects in-flight reads) rather than wait on a response that may never come.
+Deno.test("runtime.dispose() resolves while a commit is withheld in flight", async () => {
+  const signer = await Identity.fromPassphrase(
+    "runtime-dispose-withheld-commit",
+  );
+  const factory = new WithheldCommitSessionFactory(makeServer());
+  const storageManager = TestStorageManager.create(
+    { as: signer, memoryHost: new URL("memory://") },
+    factory,
+  );
+  const runtime = new Runtime({ apiUrl: new URL("memory://"), storageManager });
+
+  const cell = runtime.getCell<{ value: number }>(
+    signer.did(),
+    "runtime-dispose-withheld-commit",
+    { type: "object", properties: { value: { type: "number" } } } as const,
+  );
+
+  // From now on, any commit's transport response is withheld.
+  factory.withhold = true;
+  // Fire-and-forget write: its commit reaches the transport but never confirms,
+  // so a commit promise is in flight when we dispose. Teardown cancels it, so
+  // tolerate the cancellation.
+  const writeTx = runtime.edit();
+  cell.withTx(writeTx).set({ value: 1 });
+  writeTx.commit().catch(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  // Guard the precondition: if the commit is not actually in flight, dispose
+  // would not exercise the deadlock and the test would pass vacuously.
+  assertEquals(storageManager.hasPendingCommits(), true);
+
+  // dispose() must resolve without waiting on the withheld commit. A dispose
+  // that blocked on the in-flight commit would time out here.
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const result = await Promise.race([
+    runtime.dispose().then(() => "disposed" as const),
+    new Promise<"timed-out">((resolve) => {
+      timeout = setTimeout(() => resolve("timed-out"), 5000);
+      Deno.unrefTimer(timeout);
+    }),
+  ]).finally(() => {
+    if (timeout !== undefined) clearTimeout(timeout);
+  });
+
+  assertEquals(result, "disposed");
+});


### PR DESCRIPTION
…aiting them

SpaceReplica.close() flushed in-flight commits — awaiting their confirmation via flushCommits() — before closing the client that would settle them. A commit whose response is withheld past dispose never confirms on its own: the server can hold a commit while a gated read its server-side processing depends on never arrives, so the commit promise stays pending. Awaiting it before the client teardown deadlocked close(), and therefore runtime.dispose(), which calls storageManager.close() during shutdown. The test then passes but its teardown hangs until the outer timeout fires.

This is the same "response withheld past dispose" deadlock that an earlier fix addressed for reads: close() there was reordered to reject in-flight read pulls via the client teardown and drain them with allSettled afterwards, rather than awaiting a response that may never come. That fix left the commit half of the flush awaiting confirmation before teardown, so the deadlock persisted for commits.

Apply the same treatment to commits. close() now kicks the scheduler observation flush so batched observations reach the server, but does not await any commit confirmation before tearing down the client. Closing the client rejects every in-flight request — reads and commits alike — and the commit promises are drained with allSettled after teardown, alongside the read and update pulls. This matches runtime.dispose()'s documented contract that unawaited commits are canceled at teardown; callers that need commit durability await storageManager.synced() before disposing.

Add an integration-style unit test that withholds a commit's transport response and asserts runtime.dispose() still resolves. Without the fix the withheld commit keeps close() from ever returning and the test trips the op sanitizer with "Promise resolution is still pending"; with it dispose() resolves promptly. The test guards the precondition that the commit is actually in flight so it cannot pass vacuously.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shutdown deadlock where `runtime.dispose()` could hang if a commit response was withheld. `SpaceReplica.close()` now tears down the client first and drains in-flight commits after, instead of awaiting their confirmation.

- **Bug Fixes**
  - Reordered `SpaceReplica.close()` in `packages/runner/src/storage/v2.ts`: kick scheduler observation flush, do not await commit confirmation, close the client, then `Promise.allSettled` drain commits/reads/updates. This matches the contract that unawaited commits are canceled at teardown; use `storageManager.synced()` for durability before disposing.
  - Added `packages/runner/test/runtime-dispose-withheld-commit.test.ts` to withhold a commit response and verify `runtime.dispose()` resolves.

<sup>Written for commit 292795ab39f83e9978a692d07fd19e410694eada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

