### PR TITLE
feat(lunch-poll): profile-first join with manual-name fallback

### DIFF
--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -12,6 +12,13 @@ export default pattern(() => {
     adminName,
   });
 
+  // Profile-first UI fires `joinAs.send({})` (no name) for the "Join as <name>"
+  // button. With no profile resolved and no typed name, that must be a safe
+  // no-op — never enrolling a blank participant.
+  const action_join_empty = action(() => {
+    participantIdentity.joinAs.send({});
+  });
+
   const action_join_as_alex = action(() => {
     participantIdentity.joinAs.send({ name: "Alex" });
   });
@@ -39,6 +46,12 @@ export default pattern(() => {
     participantIdentity.me === "" &&
     participantIdentity.isJoined === false &&
     participantIdentity.isAdmin === false
+  );
+
+  const assert_empty_send_noop = computed(() =>
+    users.get().length === 0 &&
+    participantIdentity.me === "" &&
+    participantIdentity.isJoined === false
   );
 
   const assert_joined_as_alex = computed(() => {
@@ -76,6 +89,8 @@ export default pattern(() => {
   return {
     tests: [
       { assertion: assert_initial },
+      { action: action_join_empty },
+      { assertion: assert_empty_send_noop },
       { action: action_join_as_alex },
       { assertion: assert_joined_as_alex },
       { action: action_try_rejoin_as_alex_two },

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -83,6 +83,13 @@ const claimHost = handler<ClaimHostEvent, {
  * taking over admin duties. The resolved identity outputs (`me`, `isJoined`,
  * and `isAdmin`) are intended for downstream sub-patterns such as per-option
  * cards.
+ *
+ * Joining is profile-first: when `#profileName` resolves, the surface offers a
+ * one-click "Join as <name>" (carrying the profile name and avatar) with a
+ * "Use a different name" escape hatch. The manual name input is the FALLBACK,
+ * shown by default only when no profile resolves. This keeps the shared profile
+ * — not a hand-typed name — the primary identity, so avatars aren't dropped and
+ * viewers aren't asked to retype who they already are.
  */
 
 /**
@@ -154,6 +161,21 @@ export default pattern<
     });
     const boundClaimHost = claimHost({ myName, adminName });
 
+    // The join name/avatar default to the viewer's shared profile; the manual
+    // input is only a fallback for when no profile resolves (or the viewer
+    // deliberately wants a one-off name). `useCustomName` reveals that input
+    // even when a profile IS present.
+    const useCustomName = Writable.perSession.of<boolean>(false);
+    const profileDisplayName = computed(() =>
+      trimmedName(profileNameWish.result ?? "")
+    );
+    const hasProfile = computed(() =>
+      trimmedName(profileNameWish.result ?? "") !== ""
+    );
+    const showManualEntry = computed(() =>
+      trimmedName(profileNameWish.result ?? "") === "" || useCustomName.get()
+    );
+
     const me = computed(() => trimmedName(myName.get()));
     const isJoined = computed(() => trimmedName(myName.get()) !== "");
     const isAdmin = computed(() => {
@@ -205,29 +227,75 @@ export default pattern<
               >
                 {joinHint}
               </div>
-              <div
-                style={{
-                  display: "flex",
-                  gap: "8px",
-                  alignItems: "center",
-                }}
-              >
-                <cf-input
-                  id="lp-join-name"
-                  $value={joinName}
-                  placeholder="Your name…"
-                  aria-label="Your name"
-                  timing-strategy="immediate"
-                  style="flex:1"
-                />
-                <cf-button
-                  id="lp-join-button"
-                  aria-label="Join the poll"
-                  onClick={() => boundJoin.send({})}
-                >
-                  Join
-                </cf-button>
-              </div>
+              {showManualEntry
+                ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "8px",
+                      alignItems: "center",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <cf-input
+                      id="lp-join-name"
+                      $value={joinName}
+                      placeholder="Your name…"
+                      aria-label="Your name"
+                      timing-strategy="immediate"
+                      style="flex:1"
+                    />
+                    <cf-button
+                      id="lp-join-button"
+                      aria-label="Join the poll"
+                      onClick={() => boundJoin.send({})}
+                    >
+                      Join
+                    </cf-button>
+                    {hasProfile
+                      ? (
+                        <cf-button
+                          variant="ghost"
+                          size="sm"
+                          aria-label="Use my profile name instead"
+                          onClick={() => {
+                            useCustomName.set(false);
+                            joinName.set("");
+                          }}
+                        >
+                          Cancel
+                        </cf-button>
+                      )
+                      : null}
+                  </div>
+                )
+                : (
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "8px",
+                      alignItems: "center",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <cf-button
+                      id="lp-join-button"
+                      variant="primary"
+                      aria-label="Join the poll with your profile name"
+                      onClick={() => boundJoin.send({})}
+                    >
+                      Join as {profileDisplayName}
+                    </cf-button>
+                    <cf-button
+                      variant="ghost"
+                      size="sm"
+                      aria-label="Use a different name"
+                      onClick={() => useCustomName.set(true)}
+                    >
+                      Use a different name
+                    </cf-button>
+                  </div>
+                )}
             </div>
           )}
 


### PR DESCRIPTION
## Why

The lunch-poll join surface always rendered a "Your name…" text input, so every viewer typed a name to join. But the join handler treats a typed name as an **override** — it discards the viewer's shared profile name and snapshots an empty avatar. The consequence, visible on live polls: rosters full of hand-typed, avatar-less participants even when everyone has a resolvable `#profile`, and viewers asked to retype an identity the system already knows.

The profile path already existed in the handler (`joinAs.send({})` with no name uses `#profileName`/`#profileAvatar`), but nothing in the UI ever offered it, so it was effectively dead. This surfaced while debugging why a shared poll showed a stale/typed identity rather than the viewer's profile — the identity plumbing was correct; the card just never gave the profile a way in.

## What Changed

`participant-identity-card.tsx` — join is now profile-first:

- When `#profileName` resolves, the card shows a one-click **"Join as \<name\>"** (primary) that carries the profile name and avatar through the **unchanged** join handler, plus a **"Use a different name"** ghost button.
- The manual name input becomes the **fallback**, shown by default only when no profile resolves. When shown by choice (profile present, user opted in), a **"Cancel"** returns to the profile-first button and clears the draft.
- Branch selection is a per-session `useCustomName` toggle plus reactive `hasProfile` / `showManualEntry` computeds reading the profile wish. No change to the join handler, the pattern's inputs/outputs, or `main.tsx`.

## Test plan

- `deno task cf test packages/patterns/lunch-poll/participant-identity-card.test.tsx` — 6 passed, 0 failed. Added an empty-send (`joinAs.send({})`) no-op assertion: the profile-first button firing before any profile or typed name resolves must never enrol a blank participant.
- `deno task cf check … --no-run` — clean (only the two pre-existing `push`-mergeability transform warnings, unchanged by this diff).
- `--show-transformed` confirms the new computeds lower to reactive lifts off the wish result and both conditional sites lower to `ifElse(...)` (not const-folded), so the branch flips reactively when the profile resolves.
- Not yet driven in a live browser (profile resolution is home-space-backed and the bare pattern-test harness can't seed `#profileName`). The reactive branch idiom is identical to existing in-file usage (`isJoined`/`canClaimHost`) and `main.tsx` (`resetConfirmPending`). Already-deployed polls are snapshots and need a redeploy to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make joining lunch polls use your profile by default, preserving your name and avatar. Manual name entry is now a fallback when no profile is available or you choose to use a different name.

- **New Features**
  - Show a one-click "Join as <name>" when a profile resolves; passes the profile name and avatar through the existing join handler.
  - Add "Use a different name" to reveal manual entry; "Cancel" returns to the profile option and clears the draft.
  - Add a safety test to ensure `joinAs.send({})` is a no-op when neither a profile nor a typed name is present.

<sup>Written for commit e571f99f5b84fcfe60ad6b2d4b21a9660c934b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

