### PR TITLE
docs: build a central registry of experimental flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,12 @@ If you are developing runtime code, read the following documentation:
   layers
 - `docs/development/UI_TESTING.md` - How to work with shadow dom in our
   integration tests
+- `docs/development/EXPERIMENTAL_OPTIONS.md` - The central registry of every
+  experimental flag (runtime experimental options, CFC enforcement dials,
+  storage and memory-protocol capability flags, shell dogfood toggles): what
+  each gates, its default, its planned end state, and its removal path. Read it
+  before adding, changing, or removing any experimental flag, and update it in
+  the same change.
 - `docs/development/debugging/` - Runtime errors, type errors, and
   troubleshooting
 

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -247,6 +247,8 @@ Most shell config is **build-time**: esbuild injects defines in
 | `API_URL` | `$API_URL` | falls back to `location.origin` | Backend the shell calls. |
 | `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
+| `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | `EXPERIMENTAL.persistentSchedulerState` | _(unset)_ | See experimental flags. |
+| `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | `EXPERIMENTAL.eagerSourceAnnotation` | on in dev builds, off in production | See experimental flags. |
 | `SHELL_PORT` | _(server-only)_ | `5173` (from `ports.json`) | Dev server port. |
 
 ---
@@ -303,6 +305,8 @@ Passed before the CLI args; rarely needed:
 | `IDENTITY` | _(unset)_ | Path to keyfile; takes precedence over `OPERATOR_PASS`. |
 | `API_URL` | `http://localhost:8000` | Toolshed URL the service calls. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | _(unset)_ | See experimental flags. |
+| `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | _(unset)_ | See experimental flags. |
+| `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | _(unset)_ | See experimental flags. |
 
 ---
 

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -212,20 +212,26 @@ longer exist.
 
 ## Experimental flags
 
-See [`docs/development/EXPERIMENTAL_OPTIONS.md`](./EXPERIMENTAL_OPTIONS.md) for
-the full table, propagation paths (server / shell / bg-piece / CLI), and
-verification steps. Briefly:
+[`docs/development/EXPERIMENTAL_OPTIONS.md`](./EXPERIMENTAL_OPTIONS.md) is the
+central registry of every experimental flag: what each gates, who added it, its
+default, its planned end state, and its removal path, plus the propagation paths
+(server / shell / bg-piece / CLI) and verification steps. Briefly:
 
 - Server-side toggles take effect on restart.
 - Shell-side toggles are baked at build time — toggling requires a rebuild.
 - The same env var must be set everywhere the flag is read.
 
-Currently defined:
+The environment-backed flags (the only ones settable without editing code) are:
 
 | Flag | Env var |
 |---|---|
 | `modernCellRep` | `EXPERIMENTAL_MODERN_CELL_REP` |
-| `schedulerHistoricalMightWrite` | _(runtime-only; pass via `new Runtime({ experimental: { ... } })`)_ |
+| `persistentSchedulerState` | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` |
+| `eagerSourceAnnotation` | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` |
+
+The runtime-only flags (`commitPreconditions`, the CFC enforcement dials) and the
+storage, memory-protocol, and shell flags are documented in the registry. See it
+for the complete list.
 
 ---
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1,185 +1,586 @@
-# Experimental Options
+# Experimental Flags Registry
 
-`ExperimentalOptions` are feature flags that gate incremental rollout of
-various major features.
+This is the single central registry of experimental flags in the repository. An
+experimental flag is a toggle that gates the incremental rollout of an
+in-progress feature: it lets the new behavior ship in a dormant state, be
+enabled deliberately for testing or dogfooding, and be graduated to always-on
+(or removed) once the feature is finished.
 
-## Available Flags
+There is no single place in the code that enumerates every flag, because flags
+live in different layers (the runner, the memory protocol, the storage layer,
+and the shell). This document is the human-maintained index that ties them
+together. If you add, change, graduate, or remove a flag, update this document
+in the same change.
 
-| Flag | Env Var | Description |
-|------|---------|-------------|
-| `modernCellRep` | `EXPERIMENTAL_MODERN_CELL_REP` | Enables new "cell representation" classes |
-| `persistentSchedulerState` | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | Enables durable scheduler observations, dirty state, and scheduler rehydration through memory-v2. |
-| `schedulerHistoricalMightWrite` | n/a (`RuntimeOptions` only) | Preserves the scheduler's legacy cumulative write history for dependency scheduling instead of the default current-known write set. |
+> **Maintaining this document.** Each section records who added the flag, what
+> it gates, its current default, its intended end state, and the concrete path
+> to removing it. When you touch a flag, update its section and the summary
+> table, and move the date and status line forward. When you delete a flag,
+> move its section to [Appendix A: Removed and never-shipped
+> flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
+> record, so the history stays discoverable.
 
-All flags default to `undefined` which means they take on the default value
-defined for the flag. The default is generally `false` unless the flag is in the
-process of being "graduated." Setting any flag to `true` activates the
-corresponding experimental behavior, and setting it to `false` suppresses the
-experimental behavior (if it happened to be on by default).
+**Last reviewed:** 2026-07-08.
 
-Most flags are controlled by environment variables. Flags marked `n/a` in the
-table are internal runtime options and currently have to be passed through
-`new Runtime({ experimental: { ... } })`.
+## Summary table
 
-## Defining a new flag
+| Flag | Toggle via | Default today | Originally added by | Planned end state | Status (2026-07-08) |
+|------|-----------|---------------|---------------------|-------------------|---------------------|
+| [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
+| [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
+| [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (no env var) | off | Bernhard Seefeld (#4090) | graduate with scheduler-v2 speculation lineage | implemented, off by default |
+| [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
+| [`cfcEnforcementMode`](#cfcenforcementmode) | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse) | `enforce-explicit` | Bernhard Seefeld (#3263) | tighten default toward `enforce-strict` | active; ladder is permanent |
+| [`cfcFlowLabels`](#cfcflowlabels) | `RuntimeOptions.cfcFlowLabels` | `off` | Bernhard Seefeld (#4011) | move toward `persist` | implemented, staged rollout |
+| [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
+| [`cfcTriggerReadGating`](#cfctriggerreadgating) | `RuntimeOptions.cfcTriggerReadGating` | `false` | Bernhard Seefeld (#4488) | move toward `true` | implemented, staged rollout |
+| [`cfcPolicyEvaluation`](#cfcpolicyevaluation) | `RuntimeOptions.cfcPolicyEvaluation` | `off` | Bernhard Seefeld (#4566) | move toward `enforce` | implemented, staged rollout |
+| [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
+| [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
+| [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 
-Unfortunately, there is no single unified "source of truth" for the set of
-flags. You pretty much need to search the codebase for an existing flag, and
-tweak all the spots that turn up.
+Removed or never-shipped flags that documentation elsewhere still references are
+recorded in [Appendix A](#appendix-a-removed-and-never-shipped-flags). Toggles
+that look like flags but are operational, debugging, or test controls rather
+than experimental-feature gates are listed in [Appendix
+B](#appendix-b-related-toggles-that-are-not-experimental-flags).
 
-## Enabling Flags Locally
+---
 
-Set the corresponding environment variables before starting the server. The env
-vars must be present both when **building the shell** (for browser-side flags)
-and when **running the server** (for server-side flags):
+## Category 1: Runtime experimental options
+
+These four flags are the `ExperimentalOptions` interface in
+[`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
+are passed as `new Runtime({ experimental: { ... } })`. Three of them
+(`modernCellRep`, `persistentSchedulerState`, `eagerSourceAnnotation`) are also
+wired to environment variables so the deployed processes can set them; see [How
+flags propagate](#how-flags-propagate). Each flag defaults to `undefined`, which
+means "take the built-in default"; the built-in default is `false` for all four.
+
+### `modernCellRep`
+
+- **Toggle via.** `EXPERIMENTAL_MODERN_CELL_REP` environment variable (parsed in
+  toolshed, background piece service, and the shell build), or directly through
+  `RuntimeOptions.experimental.modernCellRep`. The ambient control point is
+  `setModernCellRepConfig` in
+  [`packages/data-model/src/cell-rep.ts`](../../packages/data-model/src/cell-rep.ts).
+- **Added by.** Dan Bornstein, in "Define a new 'modern cell representation'
+  experiment flag" (#3818, 2026-06-02).
+- **Purpose.** Switches the data model over to the new "cell representation"
+  classes and their serialized form. In the modern form a link serializes as a
+  `FabricHash`; in the legacy form it serializes as the older
+  `{ "/": "<tag>:<hash>" }` object. The flag lets both encodings coexist while
+  the format transition happens.
+- **Current default and planned end state.** Off by default. The plan is to
+  graduate it to always-on once every client and server produce and accept the
+  modern encoding, and then delete the flag along with the legacy object-form
+  code paths.
+- **Status on 2026-07-08.** Implemented and gated on both sides: the data-model
+  dispatch reads the ambient flag, and the memory wire protocol carries a
+  `modernCellRep` capability that peers must agree on
+  (`compatibleMemoryProtocolFlags` requires the two sides to match). Off by
+  default. The dedicated plumbing test
+  (`packages/runner/test/experimental-options.test.ts`) passes.
+- **Path to removal.** Turn the default on and let it soak; confirm every peer
+  in the fleet negotiates `modernCellRep` true; then delete the flag, the legacy
+  `{ "/" }` serialization branches in `cell-rep.ts`, and the protocol-capability
+  negotiation for it.
+
+### `persistentSchedulerState`
+
+- **Toggle via.** `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` environment variable,
+  or `RuntimeOptions.experimental.persistentSchedulerState`. The ambient control
+  point is `setPersistentSchedulerStateConfig` in
+  [`packages/memory/v2.ts`](../../packages/memory/v2.ts) (the runner owns the
+  feature, but the value has to be known at the memory client and server
+  handshake, so it lives beside the memory protocol flags).
+- **Added by.** Bernhard Seefeld, in "persist scheduler state for rehydration"
+  (#3646, 2026-05-28).
+- **Purpose.** Persists the scheduler's observations to durable storage through
+  memory-v2 and uses them to rehydrate scheduler state after a restart, instead
+  of rediscovering everything by re-running.
+- **Current default and planned end state.** Off by default. The scheduler-v2
+  design is persistence-first, so the intended end state is to graduate this to
+  always-on. The scheduler-observation protocol is an optional capability rather
+  than a data-model contract, so peers with different settings can still share
+  memory data; the server's setting controls whether scheduler rows are accepted
+  on a connection.
+- **Status on 2026-07-08.** Implemented; the durable tables, the rehydration
+  primitives, and the memory-protocol capability are wired. Off by default,
+  rollout in progress. See
+  [`docs/specs/persistent-scheduler-state.md`](../specs/persistent-scheduler-state.md)
+  and [`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) for the tracked
+  status.
+- **Path to removal.** Confirm rehydration falls back cleanly when observations
+  are absent or stale; graduate the default to on across the fleet; then fold
+  the behavior into the base scheduler and delete the flag.
+
+### `commitPreconditions`
+
+- **Toggle via.** `RuntimeOptions.experimental.commitPreconditions` only. There
+  is no environment variable for it today: the toolshed and background-piece
+  environment mappers do not forward it, so it can be enabled only by
+  constructing a `Runtime` with the flag set (which is what the tests do). The
+  ambient control point is `setCommitPreconditionsConfig` in
+  [`packages/memory/v2.ts`](../../packages/memory/v2.ts).
+- **Added by.** Bernhard Seefeld, in "speculation lineage for event-launched
+  work (scheduler-v2 E1)" (#4090, 2026-06-12).
+- **Purpose.** Attaches origin-committed preconditions to scheduler-v2 lineage
+  commits, so that event-launched follow-up work commits only against the state
+  it was speculated from.
+- **Current default and planned end state.** Off by default. It is meant to
+  graduate together with the rest of scheduler-v2 speculation lineage.
+- **Status on 2026-07-08.** Implemented and plumbed through the runner and the
+  memory protocol, behind the flag. Off by default and reachable only
+  programmatically.
+- **Path to removal.** This exists to serve scheduler-v2 speculation lineage; it
+  can be deleted only when lineage tracking becomes part of the base scheduler
+  semantics. At that point remove the flag, the precondition attach and check in
+  the storage transaction path, and the server-side precondition check in the
+  memory engine.
+
+### `eagerSourceAnnotation`
+
+- **Toggle via.** `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` environment variable, or
+  `RuntimeOptions.experimental.eagerSourceAnnotation`. The ambient control point
+  is `setEagerSourceAnnotation` in
+  [`packages/runner/src/builder/module.ts`](../../packages/runner/src/builder/module.ts).
+  Unlike the other three, the runtime propagates this one only when it is set
+  explicitly, because the ambient flag is also a test seam.
+- **Added by.** gideon, in "make fn.src lazy/debug-only — re-root identity off
+  .src" (#4458, 2026-07-06).
+- **Purpose.** Resolves the per-primitive debug source annotation (`fn.src`)
+  eagerly at module evaluation instead of lazily. Resolving it is a stack
+  capture plus a source-map walk for every primitive, which is the single
+  largest cost in the cold boot floor (on the order of eighty milliseconds or
+  more per cold piece boot). Identity never reads `.src`, so this is purely a
+  debugging convenience.
+- **Current default and planned end state.** Off in production. Shell
+  development builds turn it on so that per-primitive source locations keep
+  working while debugging; the build define in
+  [`packages/shell/felt.config.ts`](../../packages/shell/felt.config.ts)
+  supplies the value, and
+  [`packages/shell/src/lib/env.ts`](../../packages/shell/src/lib/env.ts)
+  defaults it to on when the environment is `development`. Unlike the flags
+  above, this one is not expected to graduate: it trades boot time for debug
+  fidelity and stays off in production by design.
+- **Status on 2026-07-08.** Implemented and wired across the shell, the toolshed,
+  and the runtime.
+- **Path to removal.** There is no planned removal. It would only be deleted if
+  the debug source-annotation mechanism itself were removed, which is unlikely
+  because `.src` is a public debugging surface.
+
+---
+
+## Category 2: Contextual Flow Control enforcement rollout dials
+
+Contextual Flow Control (CFC) is the label-propagation and egress-gating layer
+that decides which writes and outbound requests are allowed based on the
+confidentiality and integrity labels the values carry. It is being rolled out in
+stages, and each stage has its own dial on `RuntimeOptions` in
+[`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). The
+dial types live in
+[`packages/runner/src/cfc/types.ts`](../../packages/runner/src/cfc/types.ts).
+
+Unlike the Category 1 flags, most of these are not simple on/off booleans; they
+are staged dials, usually `off` then `observe` (evaluate and emit diagnostics
+but do not reject) then `enforce` (reject on a violation). They also are not
+wired to environment variables in the deployed processes: the toolshed, shell,
+and background-piece entrypoints do not set them, so in the product they take
+their constructor defaults. The interactive `cf-harness` and the `fuse` mount
+expose the enforcement mode through `CF_CFC_MODE` for testing. The staging plan
+is tracked in the CFC design docs under
+[`docs/specs/`](../specs/) (for example the S16 default-transition design and
+the per-epic implementation notes).
+
+### `cfcEnforcementMode`
+
+- **Toggle via.** `RuntimeOptions.cfcEnforcementMode`. The cf-harness and fuse
+  read `CF_CFC_MODE` as an override.
+- **Added by.** Bernhard Seefeld, in "Implement runner commit-boundary" (#3263,
+  2026-04-14).
+- **Purpose.** The master strictness ladder for commit-boundary CFC enforcement.
+  Values are `disabled`, `observe`, `enforce-explicit`, and `enforce-strict`,
+  in increasing strictness. `disabled` runs no gates; `observe` emits audit
+  diagnostics without rejecting; `enforce-explicit` rejects writes that violate
+  explicit labels; `enforce-strict` also rejects violations that come from
+  inferred taint.
+- **Current default and planned end state.** The type-level default constant
+  (`DEFAULT_CFC_ENFORCEMENT_MODE`) is `disabled`, but the `Runtime` constructor
+  raises the effective product default to `enforce-explicit`, so boundary
+  enforcement is on by default in the product. The content-addressed compilation
+  cache is also gated on this being anything other than `disabled`. Over time
+  the default is expected to tighten toward `enforce-strict`.
+- **Status on 2026-07-08.** Active. All four rungs of the ladder are
+  implemented; the ladder itself is a permanent part of the system rather than a
+  temporary flag.
+- **Path to removal.** The dial is not planned for removal. What changes over
+  time is the default rung; the `disabled` and `observe` rungs stay available
+  for local development and diagnostics.
+
+### `cfcFlowLabels`
+
+- **Toggle via.** `RuntimeOptions.cfcFlowLabels`.
+- **Added by.** Bernhard Seefeld, in "S16 default transition — flow-label
+  propagation" (#4011, 2026-06-10).
+- **Purpose.** Controls flow-label propagation at the commit boundary. Values are
+  `off`, `observe`, and `persist`. `observe` computes the conservative label
+  join and emits diagnostics but writes nothing; `persist` writes the derived
+  label components onto every value write target. Propagation runs only when the
+  enforcement mode is at least `observe`; it derives and stores labels but never
+  rejects on its own.
+- **Current default and planned end state.** `off` by default. The target is to
+  move toward `persist` as the downstream egress gates (render ceiling, sink
+  ceilings, and the LLM path) come online.
+- **Status on 2026-07-08.** Implemented and in staged rollout; the core
+  propagation work is done and further stages are tracked in the S16 design doc.
+- **Path to removal.** Flow-label propagation is load-bearing for the S16 audit
+  transition, so the dial is not expected to be removed; it will settle on
+  `persist` as its steady state.
+
+### `cfcWriteFloor`
+
+- **Toggle via.** `RuntimeOptions.cfcWriteFloor`.
+- **Added by.** Bernhard Seefeld, in "write-side requiredIntegrity floor (Epic
+  D3, SC-18)" (#4479, 2026-07-02).
+- **Purpose.** A write-side minimum-integrity check. Values are `off`,
+  `observe`, and `enforce`. `observe` evaluates the floor and emits diagnostics;
+  `enforce` records a rejection reason when a write's integrity falls below the
+  floor. The floor tests the integrity of the written value, not of the reads
+  that produced it.
+- **Current default and planned end state.** `off` by default. The target is to
+  move toward `enforce` once field testing confirms the floor does not
+  over-reject legitimate writes.
+- **Status on 2026-07-08.** Implemented and in staged rollout.
+- **Path to removal.** Once integrity propagation is complete and the floor is
+  proven safe, the check could fold into the base enforcement ladder and the
+  separate dial could be retired.
+
+### `cfcTriggerReadGating`
+
+- **Toggle via.** `RuntimeOptions.cfcTriggerReadGating` (a plain boolean).
+- **Added by.** Bernhard Seefeld, in "trigger-read gating on the enforcement
+  side (Epic H5, SC-3)" (#4488, 2026-07-02).
+- **Purpose.** Closes a residual side channel where a reactive rerun is triggered
+  by an invalidating write. When on, the addresses whose invalidating writes
+  scheduled the rerun join the consumed-read set that the egress ceiling and the
+  input-requirement gates quantify over, so the rerun cannot leak information
+  through the mere fact that it was triggered. It fails closed and costs extra
+  metadata resolution per commit prepare.
+- **Current default and planned end state.** `false` by default. The target is to
+  move toward `true` once the per-commit metadata resolution cost is acceptable.
+- **Status on 2026-07-08.** Implemented and in staged rollout.
+- **Path to removal.** Once the cost is acceptable (or metadata caching removes
+  it), the default could flip to `true` and the gating could become
+  unconditional, retiring the dial.
+
+### `cfcPolicyEvaluation`
+
+- **Toggle via.** `RuntimeOptions.cfcPolicyEvaluation`.
+- **Added by.** Bernhard Seefeld, in "boundary policy evaluation dial + coherent
+  requiredIntegrity matcher (Epic B, stage B5)" (#4566, 2026-07-07).
+- **Purpose.** Controls exchange-rule policy evaluation. Values are `off`,
+  `observe`, and `enforce`. `off` decides gates on the raw labels, byte-identical
+  to before the dial existed; `observe` evaluates the gated labels to a fixpoint
+  and emits diagnostics while still deciding on the un-rewritten label; `enforce`
+  decides on the rewritten label and fails closed when the evaluation runs out of
+  fuel.
+- **Current default and planned end state.** `off` by default. The target is to
+  move toward `enforce` once the policy rule sets and deployment policies are
+  stable.
+- **Status on 2026-07-08.** Implemented and in staged rollout.
+- **Path to removal.** Once policy evaluation is the norm, the dial could settle
+  on `enforce` and be retired.
+
+> The related `RuntimeOptions` fields `cfcSinkMaxConfidentiality`,
+> `cfcPolicyRecords`, and `cfcTrustConfig` are CFC *configuration inputs* (the
+> policy records, per-sink ceilings, and trust statements the dials evaluate
+> against), not on/off rollout dials, so they are not tracked as flags here.
+> They are validated and frozen at `Runtime` construction.
+
+---
+
+## Category 3: Storage and memory-protocol capability flags
+
+### `conflictAdmissionMode`
+
+- **Toggle via.** `CF_CONFLICT_ADMISSION` environment variable (read directly in
+  the storage layer, not through the toolshed environment schema), or
+  `setConflictAdmissionMode()` in
+  [`packages/runner/src/storage/v2.ts`](../../packages/runner/src/storage/v2.ts).
+  The legacy `setConflictAdmissionEnabled(true|false)` wrapper maps `true` to
+  `preempt` and `false` to `off`.
+- **Added by.** William Kelly, in "gate conflict retries on caught-up local seq"
+  (#4237, 2026-06-22).
+- **Purpose.** Chooses what the client does with a new commit whose reads land on
+  an identifier that is still catching up after an earlier conflict. Values are
+  `off`, `preempt`, and `hold`. `preempt` assumes the commit will conflict and
+  reverts and re-runs it locally without sending. `hold` waits for the catch-up,
+  re-runs the server's precondition check locally against the now-current
+  confirmed sequence numbers, reverts only the genuinely stale commits, and
+  sends the rest.
+- **Current default and planned end state.** `off` by default. Both non-default
+  modes were measured on the lunch-poll workload: `preempt` was net-negative
+  (it pre-empted commits that would have succeeded), and `hold` was neutral
+  (safe but no win, because the staleness there is only knowable on the server).
+  The code comment warns not to enable either mode without re-measuring on the
+  target workload.
+- **Status on 2026-07-08.** Implemented, off by default. It is a tuning dial that
+  has not shown a win on the workloads measured so far.
+- **Path to removal.** Either it finds a workload where a non-default mode pays
+  off and graduates into a documented tuning knob, or it is removed once the
+  underlying conflict-retry behavior is settled and the experiment is closed.
+
+### `syncSchemaTableV2`
+
+- **Toggle via.** `setSyncSchemaTableConfig()` in
+  [`packages/memory/v2.ts`](../../packages/memory/v2.ts). It is advertised as a
+  capability in the memory `hello` handshake and negotiated per connection, so a
+  peer only receives the compact form if it advertises support.
+- **Added by.** Ben Follington, in "intern schemas in sync frames" (#4292).
+- **Purpose.** A wire-size optimization: it packs the schemas in a sync payload
+  into a hash-keyed, frame-local schema table instead of repeating them inline.
+  It changes only the size of the payload, not its meaning. Peers that do not
+  advertise the capability keep receiving the historical fully-expanded
+  `SessionSync` shape.
+- **Current default and planned end state.** On by default. It is negotiated, so
+  it degrades safely against older peers. The end state is to retire the
+  negotiation and the expanded form once every peer in the fleet speaks the
+  compact form.
+- **Status on 2026-07-08.** Implemented and on by default.
+- **Path to removal.** Confirm no peer still needs the expanded payload, then
+  delete the negotiation and the expanded-form encoder and always send the
+  compact form.
+
+> Two neighbours in the same handshake are related but are not runtime-toggleable
+> experimental flags:
+>
+> - **`syncSchemaTable`** is the older, index-keyed predecessor of
+>   `syncSchemaTableV2`. It is hardwired to `false` in `getMemoryProtocolFlags`
+>   and has no config function; it is effectively dead and can be deleted from
+>   the protocol types once no peer negotiates it.
+> - **`sqliteCommitRowLabelEval`** is a build-inherent capability, hardwired to
+>   `true`, advertising that this build's engine evaluates row-label rules at
+>   commit time. It is not configuration: an older server that lacks the
+>   capability advertises it absent (parsed as `false`), and a newer runner then
+>   keeps its write gate failing closed. It was added by Bernhard Seefeld in
+>   "server-side commit-time row-label re-derivation (Epic E4, Phase 3.c)"
+>   (#4552). It is permanent.
+
+---
+
+## Category 4: Shell dogfood toggles
+
+### `cfcRenderCeiling`
+
+- **Toggle via.** The browser console command
+  `commonfabric.cfcRenderCeiling(enabled?)`, backed by the `cfcRenderCeiling`
+  key in `localStorage`. It is per browser profile. See
+  [`packages/shell/src/lib/render-ceiling.ts`](../../packages/shell/src/lib/render-ceiling.ts).
+  Because the ceiling crosses the worker boundary in the fixed initialization
+  data, flipping it takes effect on the next runtime (a reload or re-login),
+  not live.
+- **Added by.** Bernhard Seefeld, in "populate the render confidentiality ceiling
+  behind a shell dogfood flag (Epic H3a)" (#4550, 2026-07-07).
+- **Purpose.** Populates the CFC render confidentiality ceiling in the shell's
+  runtime. When on, display sinks admit only the acting user's own identity atom
+  plus allow-listed influence-class caveat kinds; everything else fails closed
+  and renders as a blocked placeholder, and author-supplied render-boundary
+  declassification is denied.
+- **Current default and planned end state.** Off by default. It changes what the
+  shell renders and is expected to over-block until exchange resolution (a later
+  CFC stage, Epic H3b) lands, so it is enabled deliberately per browser profile
+  for dogfooding. The end state is to graduate the ceiling on once exchange
+  resolution makes the blocking precise.
+- **Status on 2026-07-08.** Implemented, off by default, dogfood only.
+- **Path to removal.** Land exchange resolution so the ceiling stops
+  over-blocking, turn it on by default, and then remove the localStorage toggle
+  and make the ceiling unconditional.
+
+---
+
+## How flags propagate
+
+The environment-backed flags (`EXPERIMENTAL_MODERN_CELL_REP`,
+`EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`, `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`)
+reach the runtime through the deployed processes. The runtime-only flags
+(`commitPreconditions`, the CFC dials) reach it only through the `RuntimeOptions`
+passed to `new Runtime(...)`.
+
+### Server-side (Deno processes)
+
+Server-side propagation is straightforward: environment variables are parsed and
+passed directly into `new Runtime({ experimental: { ... } })`.
+
+```
+Server Process (Deno)
+  |
+  +-- ENV: EXPERIMENTAL_* = <value>
+  |
+  +-- toolshed/env.ts        --> Zod parses the env vars (tri-state: true / false / unset)
+  +-- toolshed/index.ts      --> new Runtime({ experimental: runtimeExperimentalOptions(env) })
+```
+
+The tri-state parse matters: an unset flag stays `undefined`, which the runtime
+reads as "use the built-in default", and that is different from an explicit
+`false`.
+
+### Browser-side (build-time injection)
+
+Browser-side flags are injected at build time and carried to the web worker that
+hosts the runtime.
+
+```
+Build Time (shell)
+  |
+  +-- ENV: EXPERIMENTAL_* = <value>
+  +-- felt.config.ts   --> esbuild define: $EXPERIMENTAL_*
+  +-- src/lib/env.ts   --> EXPERIMENTAL.<flag> = <value>
+  |
+Browser (main thread)
+  +-- shell/runtime.ts --> reads EXPERIMENTAL from env.ts
+  +-- RuntimeClient.initialize(transport, { ..., experimental: EXPERIMENTAL })
+        |  postMessage (IPC), InitializationData carries experimental
+        v
+Browser web worker
+  +-- new Runtime({ ..., experimental })
+```
+
+Because the shell bakes the flags into the bundle at build time, changing a
+browser-side flag requires rebuilding the shell. Server-side flags take effect
+on restart without a rebuild.
+
+### Background piece service
+
+```
+packages/background-piece-service/src/main.ts
+  --> new Runtime({ experimental }) (from env.ts)
+  --> SpaceManager --> WorkerController --> worker.ts initialize({ experimental })
+  --> new Runtime({ experimental })
+```
+
+Set the same `EXPERIMENTAL_*` variables when starting the background piece
+service.
+
+## Enabling flags locally
+
+Set the environment variables before building the shell (for browser-side flags)
+and before starting the server (for server-side flags):
 
 ```bash
-# Enable a single flag (build + run)
+# One flag, build and run.
 EXPERIMENTAL_EXAMPLE_NAME=true deno task dev
 
-# Enable multiple flags
+# Several flags.
 EXPERIMENTAL_EXAMPLE_NAME_1=true \
 EXPERIMENTAL_EXAMPLE_NAME_2=true \
 deno task dev
 ```
 
-The same env vars work for all entry points:
+For the runtime-only flags and the CFC dials there is no environment variable in
+the deployed processes; enable them by constructing the `Runtime` with the option
+set (which is how the tests exercise them), or, for the enforcement mode in the
+interactive tools, through `CF_CFC_MODE`.
 
-- **Toolshed server** (`packages/toolshed`): parsed via the Zod env schema in
-  `env.ts`.
-- **Shell build** (`packages/shell`): injected at build time via
-  `felt.config.ts` defines, read from globals in `src/lib/env.ts`.
-- **Background piece service** (`packages/background-piece-service`): parsed in
-  `src/env.ts` and threaded to worker processes via IPC.
-- **CF CLI** (`packages/cli`): the `cf` CLI reads experimental flags from the
-  environment when constructing its `Runtime` instance.
+## Verifying flags are working
 
-**Important:** Because the shell uses build-time injection, toggling flags for
-the browser requires rebuilding the shell. Server-side flags take effect
-immediately on restart without a rebuild.
-
-## How Flags Propagate
-
-### Server-side (Deno processes)
-
-Server-side propagation is straightforward: env vars are parsed and passed
-directly to `new Runtime({ experimental: { ... } })`.
+When any experimental flag is explicitly overridden, the `Runtime` constructor
+logs it on startup, for example:
 
 ```
-Server Process (Deno)
-  |
-  +-- ENV: EXPERIMENTAL_EXAMPLE_NAME_1=<value>
-  |        EXPERIMENTAL_EXAMPLE_NAME_2=<value>
-  |        ...
-  |
-  +-- toolshed/env.ts        --> Zod parses env vars
-  +-- toolshed/index.ts      --> new Runtime({ experimental: { ... } })
-                                    +-- setExperimentName1Config(...)
-                                    +-- setExperimentName2Config(...)
-                                    ...
+Experimental flag overrides: modernCellRep=true
 ```
 
-### Browser-side (build-time injection)
+- Server-side: look in the toolshed log.
+- Browser-side: look in the browser developer console (the message comes from the
+  web worker that hosts the runtime). You can also inspect the `EXPERIMENTAL`
+  export from `packages/shell/src/lib/env.ts` in the console to see the baked-in
+  values.
 
-Browser-side flags are injected at build time and carried to the Web Worker
-via the IPC protocol:
-
-```
-Build Time (shell)
-  |
-  +-- ENV: EXPERIMENTAL_EXAMPLE_NAME_1=<value>
-  |        EXPERIMENTAL_EXAMPLE_NAME_2=<value>
-  |        ...
-  |
-  +-- felt.config.ts          --> esbuild define: $EXPERIMENTAL_*
-  +-- src/lib/env.ts          --> EXPERIMENTAL.exampleName* = true
-  |
-Browser (Main Thread)
-  |
-  +-- shell/runtime.ts        --> reads EXPERIMENTAL from env.ts
-  |
-  +-- RuntimeClient.initialize(transport, { ..., experimental: EXPERIMENTAL })
-        |
-        | postMessage (IPC)
-        | InitializationData { ..., experimental: { exampleName*: true } }
-        |
-        v
-Browser Web Worker
-  |
-  +-- RuntimeProcessor.initialize(data)
-        +-- new Runtime({ ..., experimental: data.experimental })
-              +-- setExperimentName1Config(...)
-              +-- setExperimentName2Config(...)
-              ...
-```
-
-Key points:
-
-1. For env-backed flags, the **env vars** are the single source of truth. They
-   must be set at build time (for the shell) and at server start time (for
-   toolshed).
-2. The **shell build** bakes the flags into the JS bundle via esbuild defines.
-3. The **IPC protocol** carries the flags from the main thread to the Web Worker
-   via `InitializationData`.
-4. The **Runtime constructor** calls experiment configuration functions, which
-   collectively set up the ambient config for the system.
-
-## Background Piece Service
-
-The background piece service has its own propagation path:
-
-```
-packages/background-piece-service/src/main.ts
-  --> new Runtime({ experimental: { ... } }) (reads from env.ts)
-  --> BackgroundPieceService({ runtime })
-  --> SpaceManager({ experimental: runtime.experimental })
-  --> WorkerController({ experimental })
-  --> worker.ts initialize({ experimental })
-  --> new Runtime({ experimental })
-```
-
-Set the same `EXPERIMENTAL_*` env vars when starting the background piece
-service.
-
-## Verifying Flags Are Working
-
-### Check the logs
-
-When any experimental flags are explicitly overridden, the `Runtime`
-constructor logs them on startup. Look for a line like:
-
-```
-Experimental flag overrides: someFlag=true, someOtherFlag=false
-```
-
-- **Server-side (toolshed):** Check `packages/toolshed/local-dev-toolshed.log`.
-- **Client-side (shell):** Check the browser's developer console (the message
-  comes from the Web Worker that hosts the runtime).
-
-### Check the build output
-
-You can also inspect the `EXPERIMENTAL` export from `src/lib/env.ts` in the
-browser console to see the flag values baked into the shell build.
-
-### Run the experimental options tests
+The dedicated plumbing test checks that constructing and disposing a `Runtime`
+sets and resets the ambient flag state correctly:
 
 ```bash
 cd packages/runner
 deno test --allow-ffi --allow-env --allow-read test/experimental-options.test.ts
 ```
 
-These tests verify that `Runtime` construction correctly sets and resets the
-ambient config.
+This test passes as of 2026-07-08. It exercises the flag plumbing, not the full
+behavior of every feature under every flag combination; the per-feature test
+matrices live with each feature's specs (for example under
+[`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) and the CFC design docs).
 
-## Implementation Details
+## Implementation details
 
-The flags are defined in `packages/runner/src/runtime.ts` as the
-`ExperimentalOptions` interface. The `Runtime` constructor merges provided flags
-with defaults (all `false`) and stores the resolved result as
-`runtime.experimental` (type `Required<ExperimentalOptions>`).
+The Category 1 flags are declared as the `ExperimentalOptions` interface in
+[`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). The
+`Runtime` constructor merges the provided flags with the defaults (all `false`),
+propagates each one to its ambient control point, and then reads the effective
+state back so that `runtime.experimental.*` reflects what is actually in effect.
 
 - Only one set of experimental flags is active per JavaScript context at a time.
-- In the browser, the Web Worker is a separate JS context, so its flags are
-  independent of the main thread.
-- Creating a new `Runtime` overwrites the ambient config; disposing it resets
-  to defaults.
+- In the browser the web worker is a separate JavaScript context, so its flags
+  are independent of the main thread.
+- Creating a new `Runtime` overwrites the ambient config; disposing it resets to
+  the defaults.
+
+---
+
+## Appendix A: Removed and never-shipped flags
+
+These are recorded so that references to them elsewhere in the tree do not send a
+future reader hunting for a flag that no longer exists.
+
+### `schedulerHistoricalMightWrite` (removed)
+
+An `ExperimentalOptions` flag that preserved the scheduler's cumulative
+"historical might-write" tracking for dependency scheduling, instead of the
+current-known write set. It was confirmed deletable on 2026-06-11 and has been
+removed from the code; under scheduler-v2's static write surface the writer map
+is fixed at registration, so the discovered write history is obsolete. Several
+scheduler-v2 spec documents still mention it as part of their migration history.
+
+### `esmModuleLoader` / `CF_ESM_MODULE_LOADER` (removed)
+
+The flag that selected the ESM module-record loader over the older AMD bundle
+path during the content-addressed module-loading rollout. (An early draft of the
+plan called it `EXPERIMENTAL_ESM_MODULE_LOADER`.) It was defaulted on, and then
+the flag, the AMD bundle pipeline, and the AMD compilation cache were all
+removed; the ESM loader is now the only loader. See
+[`docs/specs/module-loading-implementation-plan.md`](../specs/module-loading-implementation-plan.md),
+whose status header records the removal.
+
+### `EXPERIMENTAL_MODERN_DATA_MODEL` (never implemented)
+
+Mentioned only in
+[`docs/specs/persistent-scheduler-state/implementation_notes.md`](../specs/persistent-scheduler-state/implementation_notes.md)
+as an example of how to plumb a flag through the runtime, shell, toolshed, and
+CLI. It was never built; the persistent-scheduler-state flag was built instead,
+following the same plumbing pattern.
+
+---
+
+## Appendix B: Related toggles that are not experimental flags
+
+The sweep that produced this registry also turned up toggles that look like flags
+but gate operational, debugging, build, or test behavior rather than the rollout
+of an in-progress feature. They are intentionally out of scope here; the general
+configuration reference is
+[`docs/development/CONFIGURATION.md`](./CONFIGURATION.md). Recorded so a future
+sweep does not mistake them for missing experimental flags:
+
+- **`CF_CFC_MODE`** — sets `cfcEnforcementMode` in the cf-harness and the fuse
+  mount. It is the way to drive the enforcement dial in those tools, not a
+  separate flag.
+- **Shell debugging and preference toggles** (localStorage): `forwardWorkerConsole`
+  (forward the web worker's console to the main thread), `telemetryEnabled`
+  (browser OpenTelemetry), `showDebuggerView`, `themePreference`.
+- **Runner diagnostics** (environment): `CF_TRAVERSE_CAPTURE`,
+  `CF_TRAVERSE_CAPTURE_MAX`, `CF_TRAVERSE_DIAGNOSTICS`.
+- **CLI controls** (environment): `CF_EXEC_SHEBANG`, `CF_CLI_TRACE_TIMINGS`,
+  `CF_PROFILE_DONE_MARKER`.
+- **Operational and build toggles**: `MEMORY_DUMP_ENABLED` (state-inspector dump
+  endpoint), `OTEL_ENABLED`, `PRODUCTION` (shell build mode).
+- **Test controls**: `TEST_LLM`, `TEST_HTTP`, and the integration-test
+  environment variables (`HEADLESS`, `PIPE_CONSOLE`, `CFC_BROWSER_PROFILE_COUNT`,
+  `CF_WAITFOR_DELAY_MS`).

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -28,7 +28,7 @@ in the same change.
 |------|-----------|---------------|---------------------|-------------------|---------------------|
 | [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
-| [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (no env var) | off | Bernhard Seefeld (#4090) | graduate with scheduler-v2 speculation lineage | implemented, off by default |
+| [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic-only — in the canonical env registry) | off | Bernhard Seefeld (#4090) | graduate with scheduler-v2 speculation lineage | implemented, off by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
 | [`cfcEnforcementMode`](#cfcenforcementmode) | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse) | `enforce-explicit` | Bernhard Seefeld (#3263) | tighten default toward `enforce-strict` | active; ladder is permanent |
 | [`cfcFlowLabels`](#cfcflowlabels) | `RuntimeOptions.cfcFlowLabels` | `off` | Bernhard Seefeld (#4011) | move toward `persist` | implemented, staged rollout |
@@ -49,20 +49,31 @@ B](#appendix-b-related-toggles-that-are-not-experimental-flags).
 
 ## Category 1: Runtime experimental options
 
-These four flags are the `ExperimentalOptions` interface in
+These flags make up the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
-are passed as `new Runtime({ experimental: { ... } })`. Three of them
-(`modernCellRep`, `persistentSchedulerState`, `eagerSourceAnnotation`) are also
-wired to environment variables so the deployed processes can set them; see [How
-flags propagate](#how-flags-propagate). Each flag defaults to `undefined`, which
-means "take the built-in default"; the built-in default is `false` for all four.
+are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
+`undefined`, which means "take the built-in default"; the built-in default is
+`false` for every one of them.
+
+The mapping from environment variable to flag is defined once, canonically, as
+`EXPERIMENTAL_ENV_VARS` in
+[`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts),
+and read by `experimentalOptionsFromEnv(envReader)`. The toolshed, the CLI, and
+the background piece service all go through that one mapping, so their wirings
+cannot drift; the shell reads the same variables from its build-time defines.
+Three flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
+`eagerSourceAnnotation`); `commitPreconditions` is deliberately mapped to `null`
+there, which records "not env-reachable" as a decision rather than an omission.
+The mapping accepts exactly `"true"` and `"false"`; any other value is ignored
+with a warning rather than coerced. See [How flags
+propagate](#how-flags-propagate).
 
 ### `modernCellRep`
 
-- **Toggle via.** `EXPERIMENTAL_MODERN_CELL_REP` environment variable (parsed in
-  toolshed, background piece service, and the shell build), or directly through
-  `RuntimeOptions.experimental.modernCellRep`. The ambient control point is
-  `setModernCellRepConfig` in
+- **Toggle via.** `EXPERIMENTAL_MODERN_CELL_REP` environment variable (through
+  the canonical mapping described in the category note above), or directly
+  through `RuntimeOptions.experimental.modernCellRep`. The ambient control point
+  is `setModernCellRepConfig` in
   [`packages/data-model/src/cell-rep.ts`](../../packages/data-model/src/cell-rep.ts).
 - **Added by.** Dan Bornstein, in "Define a new 'modern cell representation'
   experiment flag" (#3818, 2026-06-02).
@@ -88,8 +99,9 @@ means "take the built-in default"; the built-in default is `false` for all four.
 
 ### `persistentSchedulerState`
 
-- **Toggle via.** `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` environment variable,
-  or `RuntimeOptions.experimental.persistentSchedulerState`. The ambient control
+- **Toggle via.** `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` environment variable
+  (through the canonical mapping described in the category note above), or
+  `RuntimeOptions.experimental.persistentSchedulerState`. The ambient control
   point is `setPersistentSchedulerStateConfig` in
   [`packages/memory/v2.ts`](../../packages/memory/v2.ts) (the runner owns the
   feature, but the value has to be known at the memory client and server
@@ -117,11 +129,13 @@ means "take the built-in default"; the built-in default is `false` for all four.
 
 ### `commitPreconditions`
 
-- **Toggle via.** `RuntimeOptions.experimental.commitPreconditions` only. There
-  is no environment variable for it today: the toolshed and background-piece
-  environment mappers do not forward it, so it can be enabled only by
-  constructing a `Runtime` with the flag set (which is what the tests do). The
-  ambient control point is `setCommitPreconditionsConfig` in
+- **Toggle via.** `RuntimeOptions.experimental.commitPreconditions` only. It has
+  no environment variable today: it is mapped to `null` in the canonical
+  `EXPERIMENTAL_ENV_VARS` registry, which puts "not env-reachable" on the record
+  as a deliberate choice rather than leaving it absent from one wiring. Wiring an
+  environment variable is a one-line change there. Until then it can be enabled
+  only by constructing a `Runtime` with the flag set, which is what its tests do.
+  The ambient control point is `setCommitPreconditionsConfig` in
   [`packages/memory/v2.ts`](../../packages/memory/v2.ts).
 - **Added by.** Bernhard Seefeld, in "speculation lineage for event-launched
   work (scheduler-v2 E1)" (#4090, 2026-06-12).
@@ -164,8 +178,9 @@ means "take the built-in default"; the built-in default is `false` for all four.
   defaults it to on when the environment is `development`. Unlike the flags
   above, this one is not expected to graduate: it trades boot time for debug
   fidelity and stays off in production by design.
-- **Status on 2026-07-08.** Implemented and wired across the shell, the toolshed,
-  and the runtime.
+- **Status on 2026-07-08.** Implemented: reachable on the server through the
+  canonical environment mapping (like every env-backed flag), defaulted on in
+  shell development builds, and honored by the runtime.
 - **Path to removal.** There is no planned removal. It would only be deleted if
   the debug source-annotation mechanism itself were removed, which is unlikely
   because `.src` is a public debugging surface.
@@ -184,18 +199,32 @@ dial types live in
 
 Unlike the Category 1 flags, most of these are not simple on/off booleans; they
 are staged dials, usually `off` then `observe` (evaluate and emit diagnostics
-but do not reject) then `enforce` (reject on a violation). They also are not
-wired to environment variables in the deployed processes: the toolshed, shell,
-and background-piece entrypoints do not set them, so in the product they take
-their constructor defaults. The interactive `cf-harness` and the `fuse` mount
-expose the enforcement mode through `CF_CFC_MODE` for testing. The staging plan
-is tracked in the CFC design docs under
+but do not reject) then `enforce` (reject on a violation).
+
+They are not wired to environment variables. Instead, the first-party posture is
+set once in `coreOptions`, the shared core that every construction preset
+composes, in
+[`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts).
+`coreOptions` pins `cfcEnforcementMode` to `enforce-explicit`; the other CFC
+dials are deliberately left on their constructor defaults (`off` or none) there,
+with a comment marking `coreOptions` as the one place to flip a dial when a
+first-party rollout begins. So the place to advance a CFC rollout across the
+whole fleet is that one function, not each call site. A few presets accept
+per-environment overrides: `patternTest` and `unitTest` take a laxer
+`cfcEnforcementMode`, and `browserWorker` takes host-controlled
+`cfcEnforcementMode` and `cfcFlowLabels` from the shell's initialization data.
+The interactive `cf-harness` and the `fuse` mount expose the enforcement mode
+through `CF_CFC_MODE` for testing. Because these dials are keys of
+`RuntimeOptions`, the exhaustive `RUNTIME_OPTION_KEYS` registry in the same file
+makes adding a new one a compile error until it is classified across every
+preset. The staging plan is tracked in the CFC design docs under
 [`docs/specs/`](../specs/) (for example the S16 default-transition design and
 the per-epic implementation notes).
 
 ### `cfcEnforcementMode`
 
-- **Toggle via.** `RuntimeOptions.cfcEnforcementMode`. The cf-harness and fuse
+- **Toggle via.** `RuntimeOptions.cfcEnforcementMode`, pinned for first-party
+  processes in `coreOptions` (see the category note). The cf-harness and fuse
   read `CF_CFC_MODE` as an override.
 - **Added by.** Bernhard Seefeld, in "Implement runner commit-boundary" (#3263,
   2026-04-14).
@@ -206,11 +235,14 @@ the per-epic implementation notes).
   explicit labels; `enforce-strict` also rejects violations that come from
   inferred taint.
 - **Current default and planned end state.** The type-level default constant
-  (`DEFAULT_CFC_ENFORCEMENT_MODE`) is `disabled`, but the `Runtime` constructor
-  raises the effective product default to `enforce-explicit`, so boundary
-  enforcement is on by default in the product. The content-addressed compilation
-  cache is also gated on this being anything other than `disabled`. Over time
-  the default is expected to tighten toward `enforce-strict`.
+  (`DEFAULT_CFC_ENFORCEMENT_MODE`) is `disabled`, but both the `Runtime`
+  constructor and the shared `coreOptions` preset set `enforce-explicit`, so
+  boundary enforcement is on by default in the product. (The preset pins the same
+  value the constructor would default to, so that a future change to the
+  constructor default cannot silently relax first-party processes.) The
+  content-addressed compilation cache is also gated on this being anything other
+  than `disabled`. Over time the default is expected to tighten toward
+  `enforce-strict`.
 - **Status on 2026-07-08.** Active. All four rungs of the ladder are
   implemented; the ladder itself is a permanent part of the system rather than a
   temporary flag.
@@ -407,23 +439,30 @@ reach the runtime through the deployed processes. The runtime-only flags
 (`commitPreconditions`, the CFC dials) reach it only through the `RuntimeOptions`
 passed to `new Runtime(...)`.
 
-### Server-side (Deno processes)
+All first-party processes build their `RuntimeOptions` through a construction
+preset in
+[`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts),
+and the environment-backed flags reach the runtime through the one canonical
+mapping, `experimentalOptionsFromEnv`, in that same file. That mapping accepts
+exactly `"true"` and `"false"`: an unset variable stays `undefined`, which the
+runtime reads as "use the built-in default", and any other value is ignored with
+a warning. (The distinction between unset and an explicit `false` matters,
+because an explicit value overrides a built-in default that happens to be on.)
 
-Server-side propagation is straightforward: environment variables are parsed and
-passed directly into `new Runtime({ experimental: { ... } })`.
+### Server-side (Deno processes)
 
 ```
 Server Process (Deno)
   |
-  +-- ENV: EXPERIMENTAL_* = <value>
+  +-- ENV: EXPERIMENTAL_* = "true" | "false"
   |
-  +-- toolshed/env.ts        --> Zod parses the env vars (tri-state: true / false / unset)
-  +-- toolshed/index.ts      --> new Runtime({ experimental: runtimeExperimentalOptions(env) })
+  +-- runner/runtime-presets.ts  --> experimentalOptionsFromEnv(Deno.env.get)
+  +-- toolshed/runtime-options.ts --> runtimePresets.productionServer({ experimental, ... })
+  +-- toolshed/index.ts           --> new Runtime(toolshedRuntimeOptions(...))
 ```
 
-The tri-state parse matters: an unset flag stays `undefined`, which the runtime
-reads as "use the built-in default", and that is different from an explicit
-`false`.
+The background piece service and the CLI use the same mapping and the same
+presets, so the three server-side wirings agree on how a value parses.
 
 ### Browser-side (build-time injection)
 
@@ -440,27 +479,24 @@ Build Time (shell)
 Browser (main thread)
   +-- shell/runtime.ts --> reads EXPERIMENTAL from env.ts
   +-- RuntimeClient.initialize(transport, { ..., experimental: EXPERIMENTAL })
-        |  postMessage (IPC), InitializationData carries experimental
+        |  postMessage (IPC), InitializationData carries experimental + CFC dials
         v
 Browser web worker
-  +-- new Runtime({ ..., experimental })
+  +-- runtime-client/backends/runtime-processor.ts
+        --> new Runtime(runtimePresets.browserWorker({ experimental, cfcEnforcementMode, cfcFlowLabels, ... }))
 ```
 
 Because the shell bakes the flags into the bundle at build time, changing a
 browser-side flag requires rebuilding the shell. Server-side flags take effect
-on restart without a rebuild.
+on restart without a rebuild. The browser is also the one place a CFC dial is
+host-controlled at construction: the `browserWorker` preset takes
+`cfcEnforcementMode` and `cfcFlowLabels` from the shell's initialization data.
 
 ### Background piece service
 
-```
-packages/background-piece-service/src/main.ts
-  --> new Runtime({ experimental }) (from env.ts)
-  --> SpaceManager --> WorkerController --> worker.ts initialize({ experimental })
-  --> new Runtime({ experimental })
-```
-
-Set the same `EXPERIMENTAL_*` variables when starting the background piece
-service.
+The background piece service reads the same environment variables and builds its
+runtimes (the main process and each worker) through the `productionServer`
+preset, so set the same `EXPERIMENTAL_*` variables when starting it.
 
 ## Enabling flags locally
 
@@ -477,10 +513,17 @@ EXPERIMENTAL_EXAMPLE_NAME_2=true \
 deno task dev
 ```
 
-For the runtime-only flags and the CFC dials there is no environment variable in
-the deployed processes; enable them by constructing the `Runtime` with the option
-set (which is how the tests exercise them), or, for the enforcement mode in the
-interactive tools, through `CF_CFC_MODE`.
+Use exactly `true` or `false`. Values like `1`, `yes`, or `TRUE` used to be
+coerced (and, before the mapping was unified, in opposite directions in
+different processes); they are now ignored with a warning, leaving the built-in
+default in place.
+
+For the runtime-only flags and the CFC dials there is no environment variable;
+enable them by constructing the `Runtime` with the option set (which is how the
+tests exercise them). To advance a CFC dial for every first-party process at
+once, change its value in `coreOptions` in
+[`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts).
+For the enforcement mode in the interactive tools, use `CF_CFC_MODE`.
 
 ## Verifying flags are working
 
@@ -505,10 +548,17 @@ cd packages/runner
 deno test --allow-ffi --allow-env --allow-read test/experimental-options.test.ts
 ```
 
-This test passes as of 2026-07-08. It exercises the flag plumbing, not the full
-behavior of every feature under every flag combination; the per-feature test
-matrices live with each feature's specs (for example under
-[`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) and the CFC design docs).
+A second test, `packages/runner/test/runtime-presets.test.ts`, is a conformance
+golden: it pins the full `RuntimeOptions` each preset produces, including the
+`coreOptions` CFC pins, and the exact value each environment variable parses to
+through `experimentalOptionsFromEnv`. Any change to the fleet-wide posture or the
+env mapping shows up as a diff in that one file.
+
+Both tests pass as of 2026-07-08. They exercise the flag plumbing and the
+per-preset posture, not the full behavior of every feature under every flag
+combination; the per-feature test matrices live with each feature's specs (for
+example under [`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) and the CFC
+design docs).
 
 ## Implementation details
 
@@ -517,6 +567,22 @@ The Category 1 flags are declared as the `ExperimentalOptions` interface in
 `Runtime` constructor merges the provided flags with the defaults (all `false`),
 propagates each one to its ambient control point, and then reads the effective
 state back so that `runtime.experimental.*` reflects what is actually in effect.
+
+First-party construction config is centralized in
+[`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts),
+which is the place to touch when adding or changing a flag that construction
+config reaches:
+
+- `EXPERIMENTAL_ENV_VARS` is the single environment-variable mapping for
+  `ExperimentalOptions`, typed as `Record<keyof ExperimentalOptions, string |
+  null>`, so every flag must be listed there (a real env var name, or `null` for
+  "programmatic-only"). `experimentalOptionsFromEnv` reads it.
+- `RUNTIME_OPTION_KEYS` is an exhaustive, compile-checked registry of every
+  `RuntimeOptions` key (including the CFC dials). Adding a new option to
+  `RuntimeOptions` without registering it there is a compile error, which forces
+  a decision about how each preset treats it.
+- `coreOptions` holds the shared first-party posture (today, the CFC pins) that
+  every preset composes.
 
 - Only one set of experimental flags is active per JavaScript context at a time.
 - In the browser the web worker is a separate JavaScript context, so its flags

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -637,6 +637,9 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
   "no cell reconstruction at the memory boundary",
 );
 
+// These ambient flags and the memory protocol flags below are catalogued, with
+// their defaults and removal paths, in docs/development/EXPERIMENTAL_OPTIONS.md.
+// Update that registry when adding or removing one.
 let persistentSchedulerStateEnabled = false;
 let commitPreconditionsEnabled = false;
 let syncSchemaTableEnabled = true;

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -165,6 +165,10 @@ export type EnvReader = (name: string) => string | undefined;
  * `flagValue()` read anything but "false" as true, the CLI read anything but
  * "true" as false — so `EXPERIMENTAL_MODERN_CELL_REP=1` enabled the flag on
  * toolshed and disabled it under `cf test`.)
+ *
+ * Every experimental flag is catalogued in
+ * `docs/development/EXPERIMENTAL_OPTIONS.md`; update that registry when adding
+ * or removing an entry here.
  */
 export const EXPERIMENTAL_ENV_VARS = {
   modernCellRep: "EXPERIMENTAL_MODERN_CELL_REP",

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -193,6 +193,11 @@ export type VersionSkewHandler = (info: VersionSkewInfo) => void;
  * propagated to the memory layer as ambient config.
  *
  * See the formal spec at `docs/specs/space-model-formal-spec/`.
+ *
+ * Every experimental flag in the repository — these options, the CFC
+ * enforcement dials below, and the storage, memory-protocol, and shell flags —
+ * is catalogued in `docs/development/EXPERIMENTAL_OPTIONS.md`. Update that
+ * registry when adding, changing, or removing a flag.
  */
 export interface ExperimentalOptions {
   /** Enable the modern "cell representation" classes. */

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -196,6 +196,7 @@ const CONFLICT_READ_REPAIR_TIMEOUT_MS = 30_000;
 //     data its own later syncs have already superseded.
 //
 // Default off. Do NOT enable without re-measuring on the target workload.
+// Catalogued in docs/development/EXPERIMENTAL_OPTIONS.md (conflictAdmissionMode).
 type ConflictAdmissionMode = "off" | "preempt" | "hold";
 let conflictAdmissionModeOverride: ConflictAdmissionMode | undefined;
 export function setConflictAdmissionMode(

--- a/packages/shell/src/lib/render-ceiling.ts
+++ b/packages/shell/src/lib/render-ceiling.ts
@@ -12,6 +12,8 @@
  * which is fixed for a runtime's lifetime: unlike worker-console forwarding
  * there is no live apply — flipping the flag takes effect on the next
  * runtime (reload or re-login).
+ *
+ * Catalogued in docs/development/EXPERIMENTAL_OPTIONS.md (cfcRenderCeiling).
  */
 
 const STORAGE_KEY = "cfcRenderCeiling";


### PR DESCRIPTION
Experimental flags gate the incremental rollout of in-progress features, but they were scattered across several layers with no single place that enumerated them: the runner's experimental options, the Contextual Flow Control enforcement dials, a storage-layer conflict-admission mode, the memory wire-protocol capability flags, and a shell dogfood toggle. The one existing document listed only three flags, and one of those had already been removed from the code, so a reader could not tell from any single source which flags exist, what state they are in, or how they will eventually go away.

This turns docs/development/EXPERIMENTAL_OPTIONS.md into the central registry. It opens with a summary table and then gives one section per flag recording where the flag is toggled, who originally added it, what it gates, its current default, its planned eventual state, its status as of the review date, and the concrete path to removing it. The flags are grouped into runtime experimental options, CFC enforcement dials, storage and memory-protocol capability flags, and shell dogfood toggles. Two appendices keep the record honest: one lists flags that have been removed or were never shipped, so that lingering references elsewhere in the tree do not send a reader hunting for something that no longer exists; the other lists operational, debugging, and test toggles that look like feature flags but are deliberately out of scope.

The registry is only useful if it stays current, so the change also wires pointers to it from the places a future change is likely to start: the runtime development document list in AGENTS.md, the configuration reference, and a short comment at each flag's definition site (the experimental-options interface, the toolshed environment schema, the memory protocol flags, the conflict-admission mode, and the render-ceiling toggle). Each pointer asks that the registry be updated in the same change that touches a flag. The configuration reference also had a stale entry for a removed flag, which this corrects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build a single, accurate registry of all experimental flags and align it with the canonical `runtime-presets` env mapping so teams have one place to see what exists, how to toggle it, and how it will be removed. Updates docs and definition sites, and clarifies strict env parsing and defaults (e.g. `eagerSourceAnnotation` on in shell dev builds).

- **New Features**
  - Expand `docs/development/EXPERIMENTAL_OPTIONS.md` into the central registry with a summary table and per-flag sections across runtime options, CFC dials, storage/memory-protocol capabilities, and a shell dogfood toggle. Add appendices for removed/never-shipped flags and non-experimental toggles.
  - Document the single env mapping `EXPERIMENTAL_ENV_VARS` and strict parsing (`"true"`/`"false"` only) in `packages/runner/src/runtime-presets.ts`; mark `commitPreconditions` as programmatic-only (mapped to `null`).
  - Note fleet-wide CFC posture comes from `coreOptions` and is compile-checked via `RUNTIME_OPTION_KEYS`. Redraw server/browser propagation around presets and the canonical mapping.
  - Update `docs/development/CONFIGURATION.md` to point to the registry, list env-backed flags `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` and `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` (in shell and CLI tables), and document `eagerSourceAnnotation` defaults (on in dev builds, off in production).
  - Link the registry from `AGENTS.md`. Add inline pointers at definition sites to update it when flags change: `packages/runner/src/runtime.ts`, `packages/runner/src/runtime-presets.ts` (`EXPERIMENTAL_ENV_VARS`), `packages/memory/v2.ts`, `packages/runner/src/storage/v2.ts`, `packages/shell/src/lib/render-ceiling.ts`.

- **Migration**
  - When adding/changing/removing any flag: update `docs/development/EXPERIMENTAL_OPTIONS.md` and, if env-backed, `EXPERIMENTAL_ENV_VARS`.
  - For env-backed flags, set `EXPERIMENTAL_*` at shell build time and server start; use only `"true"` or `"false"`.

<sup>Written for commit 491bf667c55a73ee379478fb877a5f0c4eb4aedf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

