### PR TITLE
fix(runner): send benchmark diagnostics to stderr so --json stdout st…

### DIFF
--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -199,11 +199,11 @@ const parkingRecords = parkingGraph.graph.records;
 const parkingMainSpec = parkingGraph.mainSpecifier;
 
 // Log program sizes for reference
-console.log(
+console.error(
   `small: ${smallBodies.length} authored bodies, ` +
     `total body bytes: ${smallBodies.reduce((s, [, b]) => s + b.length, 0)}`,
 );
-console.log(
+console.error(
   `parking-coordinator: ${parkingBodies.length} authored bodies, ` +
     `total body bytes: ${parkingBodies.reduce((s, [, b]) => s + b.length, 0)}`,
 );

--- a/packages/runner/test/pattern-binding.bench.ts
+++ b/packages/runner/test/pattern-binding.bench.ts
@@ -223,7 +223,7 @@ function time(
   for (let i = 0; i < iters; i++) op(binding, links);
   const ms = performance.now() - t0;
   const nsPerOp = (ms * 1e6) / iters;
-  console.log(label.padEnd(44), `${nsPerOp.toFixed(0).padStart(9)} ns/op`);
+  console.error(label.padEnd(44), `${nsPerOp.toFixed(0).padStart(9)} ns/op`);
 }
 
 if (import.meta.main) {
@@ -232,7 +232,9 @@ if (import.meta.main) {
     ? [custom]
     : [1, 10, 30, 100, 300, 1000];
 
-  console.log("\n# scaling: ns/op and ns/alias (pathDepth=2, link schema on)");
+  console.error(
+    "\n# scaling: ns/op and ns/alias (pathDepth=2, link schema on)",
+  );
   for (const aliases of sizes) {
     const binding = makeUiBinding({ aliases, pathDepth: 2 });
     const iters = aliases >= 300 ? 2000 : 20000;
@@ -241,14 +243,14 @@ if (import.meta.main) {
     for (let i = 0; i < iters; i++) op(binding);
     const ms = performance.now() - t0;
     const nsPerOp = (ms * 1e6) / iters;
-    console.log(
+    console.error(
       `aliases=${String(aliases).padStart(5)}`,
       `${nsPerOp.toFixed(0).padStart(9)} ns/op`,
       `${(nsPerOp / Math.max(1, aliases)).toFixed(0).padStart(6)} ns/alias`,
     );
   }
 
-  console.log("\n# what drives it (aliases=100, 20000 iters each)");
+  console.error("\n# what drives it (aliases=100, 20000 iters each)");
   const N = 100;
   time(
     "baseline (depth2, link schema)",

--- a/packages/runner/test/traverse-replay.bench.ts
+++ b/packages/runner/test/traverse-replay.bench.ts
@@ -60,7 +60,7 @@ if (DIAGNOSTICS) {
 if (DIAGNOSTICS) {
   globalThis.addEventListener("unload", () => {
     for (const [name, m] of lastMetrics) {
-      console.log(
+      console.error(
         `[diagnostics] ${name}: invocations=${m.invocations} ` +
           `schemaCalls=${m.traverseWithSchemaCalls} ` +
           `pointer=${m.traversePointerCalls} array=${m.traverseArrayCalls} ` +
@@ -71,7 +71,7 @@ if (DIAGNOSTICS) {
       );
       const latency = lastLatency.get(name);
       if (latency !== undefined) {
-        console.log(`[diagnostics] ${name}: latency ${latency}`);
+        console.error(`[diagnostics] ${name}: latency ${latency}`);
       }
     }
   });


### PR DESCRIPTION
…ays clean

The Benchmarks CI job runs `deno bench --json` and redirects stdout to `bench-results/results.json`. `deno bench --json` writes its machine-readable report to stdout, but several benchmark files also printed human-readable diagnostics to stdout via `console.log`. That diagnostic text interleaved with (and in some cases preceded) the JSON report, so the saved file was not valid JSON — it began with a preamble such as `small: 3 authored bodies, ...`. Downstream consumers (the perf tooling in tasks/perf-lib.ts and tasks/perf-regression.ts, plus a dashboard benchmark tile) then had to parse around the noise by stripping everything before the first `{"version":`.

Move the diagnostic output to stderr, where human-readable diagnostics belong, by switching the offending `console.log` calls to `console.error`. Under `--json` this leaves stdout carrying only the benchmark report; the plain `deno bench` run is unaffected because it prints its own results table and the diagnostics simply appear on stderr instead of stdout. The benchmarks themselves are unchanged — only the output stream for the diagnostics moves.

Affected files: esm-verifier.bench.ts (program-size summary), pattern-binding.bench.ts (scaling / ns-per-op table), and traverse-replay.bench.ts (per-benchmark diagnostics).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route benchmark diagnostics to stderr so `deno bench --json` stdout stays clean and the saved results are valid JSON in CI. Swaps `console.log` to `console.error` in benchmark files without changing benchmark behavior.

- **Bug Fixes**
  - CI now writes valid JSON to `bench-results/results.json`; no interleaved diagnostics.
  - Updated: `packages/runner/test/esm-verifier.bench.ts`, `packages/runner/test/pattern-binding.bench.ts`, `packages/runner/test/traverse-replay.bench.ts`.
  - Plain `deno bench` unaffected; diagnostics now print on stderr.

<sup>Written for commit 4796252cc843525a0a07ad6d4c541afc72ac3c79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

