### PR TITLE
Remove post restart test sleeps

### DIFF
--- a/docs/development/waitfor-migration.md
+++ b/docs/development/waitfor-migration.md
@@ -240,9 +240,21 @@ low-value tail:
   and `piece.test.ts` (see the exceptions above) can each become a `defer()`
   resolved in the existing `resultCell.sink(...)`.
 
-## Also noticed (out of scope)
+## Also noticed, since cleaned up
 
-Two bare sleeps sit next to migrated waits and deserve their own cleanup:
-`packages/runner/integration/reconnection.test.ts` sleeps 100ms after restarting
-the server, and `packages/toolshed/routes/storage/memory/memory.test.ts` does the
-same. Both race server readiness rather than awaiting it.
+Three bare sleeps sat next to migrated waits, one in
+`packages/runner/integration/reconnection.test.ts` and two in
+`packages/toolshed/routes/storage/memory/memory.test.ts`. Each restarted the
+server on the same port and then slept a fixed 100 milliseconds before writing
+the value a subscriber was waiting for, racing server readiness rather than
+awaiting it.
+
+All three are gone. Each test already blocked on a `defer()` that its
+subscription sink resolves when the post-restart value arrives, so the sleep only
+added latency ahead of a wait that already covered the reconnection.
+`Deno.serve` binds and starts accepting connections synchronously before it
+returns, so the writer runtime created after the restart connects to an
+already-listening server, and on reconnect the subscriber re-issues its watch
+against the fresh server, which reads current committed state — so the update is
+delivered whether the write lands before or after the reconnect completes. The
+sleeps were removed with no replacement wait.

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -68,7 +68,6 @@ Deno.test(
 
       await server.shutdown();
       server = Deno.serve({ port }, app.fetch);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       const writerRuntime = createRuntime(identity, base);
       const writerCell = writerRuntime.getCell(

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1070,7 +1070,6 @@ serialTest(
 
       await server.shutdown();
       server = Deno.serve({ port }, app.fetch);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       const runtime2 = createRuntime(identity, base);
       const counterWriter = runtime2.getCell(
@@ -1222,7 +1221,6 @@ serialTest(
 
       await server.shutdown();
       server = Deno.serve({ port }, app.fetch);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       const runtime2 = createRuntime(identity, base);
       const targetCell2 = runtime2.getCell(


### PR DESCRIPTION
## Problem

Three integration tests restart a server on the same port and then sleep a fixed 100 milliseconds before writing the value a subscriber is waiting for:

- `packages/runner/integration/reconnection.test.ts` — one sleep, labelled "let the client reconnect".
- `packages/toolshed/routes/storage/memory/memory.test.ts` — two sleeps, in the counter-cell reconnect test and the alias-derived-schema reconnect test.

Each sleep races server readiness instead of awaiting it: too short and the test flakes, too long and every run pays the delay for nothing. They were flagged during the waitFor migration (#4596) in the "Also noticed (out of scope)" section of `docs/development/waitfor-migration.md`.

## Fix

Delete all three sleeps with no replacement wait. Each test already blocks on a `defer()` that its subscription sink resolves when the post-restart value arrives, so the test cannot finish until the subscriber has reconnected and its subscription has delivered the new value — the sleep only added latency ahead of a wait that already covered the reconnection.

The removal is sound because:

- `Deno.serve` binds and starts accepting connections synchronously before it returns, so the writer runtime created after the restart connects to an already-listening server with nothing to wait for. (The test already relies on this: it reads `server.addr.port` on the line right after `Deno.serve`.)
- On reconnect the subscriber re-issues its watch against the fresh server, and the server evaluates that watch against current committed state, emitting an upsert for the current value. So the update is delivered whether the write lands before or after the subscriber finishes reconnecting — there is no interleaving where it is missed.
- `await server.shutdown()` fully releases the port before it resolves, so the same-port rebind never throws.

This follows the repo guideline to avoid timeouts, retry loops, and sleeps in tests; no replacement sleep or poll is introduced.

## Commits

- `test(runner)` — remove the reconnection-test sleep.
- `test(toolshed)` — remove both memory reconnect-test sleeps.
- `docs` — update the waitFor migration report's "Also noticed" section to record the cleanup (and correct the count: toolshed held two sleeps, not one).

## Verification

Both affected files pass, and the reconnection/race paths were re-run to check stability:

- `deno test -A packages/runner/integration/reconnection.test.ts` — 1 passed (dropped from a 100ms-floored run to ~55ms).
- `deno test -A packages/toolshed/routes/storage/memory/memory.test.ts` — 19 passed.
- Both files re-run three additional times: green every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed fixed 100ms post-restart sleeps in three integration tests to cut flakiness and speed up runs; updated docs to reflect the cleanup. Tests now rely on existing `defer()` synchronization instead of arbitrary waits.

- **Refactors**
  - Deleted the sleeps in `packages/runner/integration/reconnection.test.ts` (1) and `packages/toolshed/routes/storage/memory/memory.test.ts` (2).
  - Tests already block on a `defer()` resolved by the subscription sink when the post-restart value arrives; no replacement waits added. `Deno.serve` accepts connections before returning, `await server.shutdown()` frees the port, and reconnect re-issues the watch to emit the current value.
  - Updated `docs/development/waitfor-migration.md` to record the removals and rationale.

<sup>Written for commit f0b791c4079df87d332f8186927d1cb0dfbf45d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

