### PR TITLE
test: guard against new polling waitFor in integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -53,6 +53,9 @@ jobs:
       - name: 📄 Type-check docs code blocks
         run: deno task check-docs
 
+      - name: 🚧 Guard against new polling waitFor in integration tests
+        run: deno task check-no-waitfor
+
       - name: 🔎 Check generated commonfabric/cfc types are up to date
         working-directory: packages/static
         run: deno task check-cfc-types

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -42,6 +42,7 @@
   "tasks": {
     "check": "./tasks/check.sh",
     "check-docs": "deno run --allow-read --allow-write --allow-run --allow-env ./docs/check.ts",
+    "check-no-waitfor": "deno run --allow-read ./tasks/check-no-waitfor.ts",
     "cfcheck": "deno run -A ./tasks/cfcheck.ts",
     "check-skill-facts": "deno test --allow-read skills/cf-review/check-facts.ts",
     "cf": "deno run --allow-run --allow-env --allow-read ./packages/cli/launcher.ts",

--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -269,6 +269,12 @@ Each of the following is what `awaitViewSettled` replaces. They are either racy
 The shape is always: settle the view, click once, then wait for the effect —
 never poll-and-pray, and never re-click.
 
+A CI check enforces this for the polling `waitFor`: `deno task check-no-waitfor`
+fails when an integration test imports `waitFor` from
+`@commonfabric/integration`. See
+[`waitfor-migration.md`](./waitfor-migration.md) for the rationale, the full
+event-driven toolkit, and the allowlist of intentional exceptions.
+
 ## Best Practices
 
 1. **Use roles first**: `button`, `textbox`, `checkbox`, etc.

--- a/docs/development/waitfor-migration.md
+++ b/docs/development/waitfor-migration.md
@@ -110,6 +110,25 @@ Documentation:
   event-driven primitives instead of `waitFor`, and a stale reference to a
   non-existent `awaitRuntimeIdle` corrected to `waitForRuntimeIdle`.
 
+## Guard against new usage
+
+A check keeps new integration tests from importing the polling `waitFor` again.
+`tasks/check-no-waitfor.ts` scans the `.ts` files under any `integration/`
+directory beneath `packages/` (excluding the `@commonfabric/integration` package,
+which defines `waitFor`) and fails when one names `waitFor` in an import from
+`@commonfabric/integration` and is not on the check's allowlist. Run it with
+`deno task check-no-waitfor`; the CI "Check" job runs it on every pull request.
+The error names the offending file and points at `waitForCondition`,
+`awaitViewSettled`, the in-process `defer()` replacement, and this report.
+
+The allowlist inside `tasks/check-no-waitfor.ts` holds exactly the files listed
+as intentional exceptions below, and the check's own tests assert that the
+allowlist and the set of files still using the polling `waitFor` stay in step: a
+new offender fails the check, and an allowlisted file that later drops `waitFor`
+fails the tests until its entry is removed. When a new usage is genuinely one of
+the exception shapes below, add the file to the allowlist with a one-line reason
+and record it here.
+
 ## Intentional exceptions: `waitFor` usages left in place
 
 These are the usages where a bounded poll is the right tool. They are grouped by

--- a/docs/development/waitfor-migration.md
+++ b/docs/development/waitfor-migration.md
@@ -121,13 +121,24 @@ which defines `waitFor`) and fails when one names `waitFor` in an import from
 The error names the offending file and points at `waitForCondition`,
 `awaitViewSettled`, the in-process `defer()` replacement, and this report.
 
-The allowlist inside `tasks/check-no-waitfor.ts` holds exactly the files listed
-as intentional exceptions below, and the check's own tests assert that the
-allowlist and the set of files still using the polling `waitFor` stay in step: a
-new offender fails the check, and an allowlisted file that later drops `waitFor`
-fails the tests until its entry is removed. When a new usage is genuinely one of
-the exception shapes below, add the file to the allowlist with a one-line reason
-and record it here.
+The allowlist inside `tasks/check-no-waitfor.ts` covers only the exceptions the
+check can see: the integration-test files that import the shared `waitFor` from
+`@commonfabric/integration`. That is a subset of the exceptions listed below.
+The others fall outside the scan and are not on the allowlist — the in-process
+`test/` files that each define their own local `waitFor` poll loop (the check
+never reads a named import there), the `MultiRuntimeHarness.waitFor` method and
+its callers (a different `waitFor`), `packages/runner/integration/sqlite-cfc-commit-eval.test.ts`
+(which waits through a local helper rather than the shared import), and
+`packages/integration/shell-utils.ts` (inside the excluded package that defines
+`waitFor`). Do not add those to the allowlist: the check never scans them, so the
+stale-entry test would reject the entry.
+
+For the in-scope entries, the check's own tests assert that the allowlist and the
+set of integration-test files still importing the shared `waitFor` stay in step:
+a new offender fails the check, and an allowlisted file that later drops `waitFor`
+fails the tests until its entry is removed. When a new in-scope usage is genuinely
+one of the exception shapes below, add the file to the allowlist with a one-line
+reason and record it here.
 
 ## Intentional exceptions: `waitFor` usages left in place
 

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -1,10 +1,45 @@
 import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import {
   ALLOWLIST,
   importsPollingWaitFor,
   isIntegrationTestFile,
+  main,
   scan,
 } from "./check-no-waitfor.ts";
+
+// Writes a single integration test file with the given contents into a fresh
+// temp tree and returns its root. The caller removes the tree.
+async function fixtureTree(
+  fileName: string,
+  contents: string,
+): Promise<string> {
+  const root = await Deno.makeTempDir({ prefix: "check-no-waitfor-" });
+  const dir = join(root, "packages", "foo", "integration");
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(join(dir, fileName), contents);
+  return root;
+}
+
+// Runs `body` with console.log and console.error captured, returning what each
+// received. Restores the originals afterward.
+async function captureConsole(
+  body: () => Promise<void>,
+): Promise<{ out: string; err: string }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args) => out.push(args.map(String).join(" "));
+  console.error = (...args) => err.push(args.map(String).join(" "));
+  try {
+    await body();
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+  return { out: out.join("\n"), err: err.join("\n") };
+}
 
 Deno.test("importsPollingWaitFor detects a single-line named import", () => {
   assert(
@@ -103,6 +138,11 @@ Deno.test("isIntegrationTestFile excludes non-integration and non-ts files", () 
     isIntegrationTestFile("packages/patterns/integration/counter.tsx"),
     false,
   );
+  // Outside packages/ entirely.
+  assertEquals(
+    isIntegrationTestFile("docs/examples/integration/demo.ts"),
+    false,
+  );
 });
 
 // The following two tests run against the real repository tree. Together they
@@ -130,4 +170,43 @@ Deno.test("ALLOWLIST has no stale entries", async () => {
     "ALLOWLIST entries in tasks/check-no-waitfor.ts no longer import the polling " +
       "waitFor (or no longer exist). Remove them from the allowlist.",
   );
+});
+
+// The next two tests drive the command entry point over a temp fixture tree, so
+// they cover the clean and violation paths without depending on the real tree.
+
+Deno.test("main reports success and returns 0 on a clean tree", async () => {
+  const root = await fixtureTree(
+    "ok.test.ts",
+    'import { env } from "@commonfabric/integration";\n',
+  );
+  try {
+    let code = -1;
+    const { out } = await captureConsole(async () => {
+      code = await main(root);
+    });
+    assertEquals(code, 0);
+    assert(out.includes("No new polling waitFor"));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("main reports the offender and returns 1 on a violation", async () => {
+  const root = await fixtureTree(
+    "bad.test.ts",
+    'import { waitFor } from "@commonfabric/integration";\n',
+  );
+  try {
+    let code = -1;
+    const { err } = await captureConsole(async () => {
+      code = await main(root);
+    });
+    assertEquals(code, 1);
+    assert(err.includes("packages/foo/integration/bad.test.ts"));
+    assert(err.includes("waitForCondition"));
+    assert(err.includes("docs/development/waitfor-migration.md"));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
 });

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -1,0 +1,133 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  ALLOWLIST,
+  importsPollingWaitFor,
+  isIntegrationTestFile,
+  scan,
+} from "./check-no-waitfor.ts";
+
+Deno.test("importsPollingWaitFor detects a single-line named import", () => {
+  assert(
+    importsPollingWaitFor(
+      'import { env, waitFor } from "@commonfabric/integration";',
+    ),
+  );
+});
+
+Deno.test("importsPollingWaitFor detects a multi-line named import", () => {
+  const source = [
+    "import {",
+    "  env,",
+    "  Page,",
+    "  waitFor,",
+    "  waitForCondition,",
+    '} from "@commonfabric/integration";',
+  ].join("\n");
+  assert(importsPollingWaitFor(source));
+});
+
+Deno.test("importsPollingWaitFor detects an aliased import", () => {
+  assert(
+    importsPollingWaitFor(
+      'import { waitFor as poll } from "@commonfabric/integration";',
+    ),
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores waitFor-prefixed helpers", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      'import { waitForCondition, waitForText } from "@commonfabric/integration";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores a subpath specifier", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      'import { waitFor } from "@commonfabric/integration/shell-utils";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores a harness.waitFor member call", () => {
+  const source = [
+    'import { MultiRuntimeHarness } from "./multi-runtime-harness.ts";',
+    "await harness.waitFor(() => true);",
+  ].join("\n");
+  assertEquals(importsPollingWaitFor(source), false);
+});
+
+Deno.test("importsPollingWaitFor ignores a commented-out member", () => {
+  const source = [
+    "import {",
+    "  env,",
+    "  // waitFor,",
+    '} from "@commonfabric/integration";',
+  ].join("\n");
+  assertEquals(importsPollingWaitFor(source), false);
+});
+
+Deno.test("isIntegrationTestFile scopes to integration test files", () => {
+  assert(isIntegrationTestFile("packages/shell/integration/piece.test.ts"));
+  assert(
+    isIntegrationTestFile("packages/patterns/integration/counter.test.ts"),
+  );
+  assert(
+    isIntegrationTestFile(
+      "packages/patterns/google/core/integration/google-calendar-importer.test.ts",
+    ),
+  );
+});
+
+Deno.test("isIntegrationTestFile excludes the integration package itself", () => {
+  // packages/integration/ defines and re-exports waitFor.
+  assertEquals(
+    isIntegrationTestFile("packages/integration/utils.ts"),
+    false,
+  );
+  assertEquals(
+    isIntegrationTestFile("packages/integration/shell-utils.ts"),
+    false,
+  );
+});
+
+Deno.test("isIntegrationTestFile excludes non-integration and non-ts files", () => {
+  assertEquals(
+    isIntegrationTestFile("packages/runner/test/scheduler.test.ts"),
+    false,
+  );
+  assertEquals(
+    isIntegrationTestFile("packages/patterns/integration/counter.tsx"),
+    false,
+  );
+});
+
+// The following two tests run against the real repository tree. Together they
+// assert that the set of in-scope files importing the polling `waitFor` equals
+// the ALLOWLIST exactly.
+
+Deno.test("no un-allowlisted polling waitFor in integration tests", async () => {
+  const { violations } = await scan();
+  assertEquals(
+    violations,
+    [],
+    "New polling waitFor usage found in integration test(s). Migrate to " +
+      "waitForCondition / awaitViewSettled (see docs/development/waitfor-migration.md), " +
+      "or, for a genuine exception, add the file to ALLOWLIST in tasks/check-no-waitfor.ts.",
+  );
+});
+
+Deno.test("ALLOWLIST has no stale entries", async () => {
+  const { allowlisted } = await scan();
+  const seen = new Set(allowlisted);
+  const stale = [...ALLOWLIST].filter((path) => !seen.has(path)).sort();
+  assertEquals(
+    stale,
+    [],
+    "ALLOWLIST entries in tasks/check-no-waitfor.ts no longer import the polling " +
+      "waitFor (or no longer exist). Remove them from the allowlist.",
+  );
+});

--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -163,8 +163,9 @@ function reportViolations(violations: string[]): void {
   console.error(lines.join("\n"));
 }
 
-async function main(): Promise<number> {
-  const { violations } = await scan();
+/** Runs the check over `root`/packages, reports, and returns a process code. */
+export async function main(root: string = REPO_ROOT): Promise<number> {
+  const { violations } = await scan(root);
   if (violations.length > 0) {
     reportViolations(violations);
     return 1;

--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S deno run --allow-read
+//
+// Guards against new use of the polling `waitFor` helper in integration tests.
+//
+// `waitFor` (defined in packages/integration/utils.ts, exported from
+// "@commonfabric/integration") re-runs a predicate every 50 milliseconds — in a
+// browser test each tick is a DevTools Protocol round-trip — and throws once a
+// timeout elapses. An earlier change moved the browser suites off it and onto
+// event-driven waits (`waitForCondition`, `awaitViewSettled`, and the wrappers
+// in packages/patterns/integration/cfc-browser-helpers.ts). This check keeps new
+// tests from importing the polling helper again.
+//
+// A file is in scope when it lives under an `integration/` directory somewhere
+// beneath `packages/`, excluding the `@commonfabric/integration` package itself,
+// which defines and re-exports `waitFor`. An in-scope file fails the check when
+// it names `waitFor` in an import from "@commonfabric/integration" and is not on
+// the ALLOWLIST below.
+//
+// The ALLOWLIST holds the files that are exempt from this check; the reason for
+// each is recorded in the "Intentional exceptions" section of
+// docs/development/waitfor-migration.md.
+//
+// Usage: deno run --allow-read ./tasks/check-no-waitfor.ts
+
+import { walk } from "@std/fs/walk";
+import { dirname, fromFileUrl, relative, resolve } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+// Files exempt from this check: they keep the polling `waitFor` from
+// "@commonfabric/integration". Each entry is a repo-relative path; the reason
+// for each is documented under "Intentional exceptions" in
+// docs/development/waitfor-migration.md.
+export const ALLOWLIST: ReadonlySet<string> = new Set([
+  // Headless cell pull: no page to attach an in-page waiter to.
+  "packages/generated-patterns/integration/pattern-harness.ts",
+  // Off-page piece-result cell reads through the in-process controller.
+  "packages/patterns/integration/counter.test.ts",
+  "packages/patterns/integration/nested-counter.test.ts",
+  "packages/shell/integration/piece.test.ts",
+  // Cross-page joint condition: the wait spans two separate browser pages, which
+  // a single-page in-page waiter cannot express.
+  "packages/patterns/integration/lunch-poll-vote.test.ts",
+  // MockDoc rendered-HTML reads and fresh cell.sync() round-trips, with no
+  // completion callback the test can hook.
+  "packages/runtime-client/integration/client.test.ts",
+  // Instrumentation and profiling one-shots, shared button-click helpers used
+  // both wrapped and bare, and render/source-state probe waits.
+  "packages/patterns/integration/default-app.test.ts",
+  "packages/patterns/integration/reload/default-app-notebook.test.ts",
+  // Pre-existing OAuth end-to-end flow, predating the move to event-driven waits.
+  "packages/patterns/google/core/integration/google-calendar-importer.test.ts",
+  // Disabled tests: never run, so migrating them only churns dead code.
+  "packages/patterns/integration/cf-checkbox.test.disabled.ts",
+  "packages/patterns/integration/cf-code-editor.test.disabled.ts",
+  "packages/patterns/integration/cf-render.test.disabled.ts",
+]);
+
+// Matches an import from exactly "@commonfabric/integration" and captures the
+// named-imports clause between the braces. A leading default import and a
+// `type` modifier are tolerated. The closing quote right after `integration`
+// keeps subpath specifiers (".../shell-utils") from matching, and `[^}]*` keeps
+// the capture from bleeding past the end of the clause.
+const NAMED_IMPORT_RE =
+  /import\s+(?:[\w$]+\s*,\s*)?(?:type\s+)?\{([^}]*)\}\s*from\s*["']@commonfabric\/integration["']/g;
+
+// Removes `//` and `/* */` comments from a named-imports clause. Such a clause
+// holds only identifiers, `as`, `type`, and commas, so a `waitFor` inside a
+// comment is a commented-out member rather than a real import.
+function stripComments(clause: string): string {
+  return clause
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/[^\n]*/g, " ");
+}
+
+/**
+ * Returns true when `source` imports the polling `waitFor` as a named import
+ * from "@commonfabric/integration". `waitForCondition`, `waitForText`, and other
+ * `waitFor`-prefixed names do not count; a `waitFor` on a subpath specifier or a
+ * `harness.waitFor(...)` member call does not count either.
+ */
+export function importsPollingWaitFor(source: string): boolean {
+  for (const match of source.matchAll(NAMED_IMPORT_RE)) {
+    if (/\bwaitFor\b/.test(stripComments(match[1]))) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true when `relPath` (a repo-relative, forward-slash path) is an
+ * integration test in scope for this check: under `packages/`, inside an
+ * `integration/` directory, a `.ts` file, and not part of the
+ * `@commonfabric/integration` package that defines `waitFor`.
+ */
+export function isIntegrationTestFile(relPath: string): boolean {
+  const path = relPath.replaceAll("\\", "/");
+  if (!path.startsWith("packages/")) return false;
+  // The package that defines and re-exports `waitFor`.
+  if (path.startsWith("packages/integration/")) return false;
+  if (!path.includes("/integration/")) return false;
+  return path.endsWith(".ts");
+}
+
+export interface ScanResult {
+  /** In-scope files importing the polling `waitFor` that are not allowlisted. */
+  violations: string[];
+  /** In-scope files importing the polling `waitFor` that are allowlisted. */
+  allowlisted: string[];
+}
+
+/** Scans integration tests under `root`/packages for polling-`waitFor` use. */
+export async function scan(root: string = REPO_ROOT): Promise<ScanResult> {
+  const violations: string[] = [];
+  const allowlisted: string[] = [];
+  const packagesDir = resolve(root, "packages");
+  const walker = walk(packagesDir, {
+    includeDirs: false,
+    skip: [/\/node_modules\//, /\/dist\//, /\/\.cache\//, /\/coverage\//],
+  });
+  for await (const entry of walker) {
+    const rel = relative(root, entry.path).replaceAll("\\", "/");
+    if (!isIntegrationTestFile(rel)) continue;
+    const source = await Deno.readTextFile(entry.path);
+    if (!importsPollingWaitFor(source)) continue;
+    (ALLOWLIST.has(rel) ? allowlisted : violations).push(rel);
+  }
+  violations.sort();
+  allowlisted.sort();
+  return { violations, allowlisted };
+}
+
+function reportViolations(violations: string[]): void {
+  const lines = [
+    "",
+    'New use of the polling `waitFor` from "@commonfabric/integration" in ' +
+    "integration test(s):",
+    "",
+    ...violations.map((path) => `  ${path}`),
+    "",
+    "The polling `waitFor` re-runs a predicate every 50ms, and in a browser test",
+    "each tick is a DevTools round-trip, which makes tests slow and flaky. In a",
+    "browser test, use an event-driven wait instead:",
+    "",
+    "  - waitForCondition(page, predicate, opts) — resolves the instant the DOM",
+    "    reflects the new state.",
+    "  - awaitViewSettled(page) — resolves once the view is interactive.",
+    "  - waitForText / clickCfButton / clickCfButtonAndWaitForText / … in",
+    "    packages/patterns/integration/cfc-browser-helpers.ts.",
+    "",
+    "In a test with no page, resolve a defer() from a callback the test already",
+    "registers (a cell sink, a subscription's next, a scheduler onError) instead",
+    "of polling.",
+    "",
+    "See docs/development/waitfor-migration.md for the rationale and the full",
+    "toolkit.",
+    "",
+    "If an event-driven wait genuinely cannot express this (for example a",
+    "cross-page condition or a headless cell read), add the file to ALLOWLIST in",
+    "tasks/check-no-waitfor.ts with a one-line reason and record it under",
+    '"Intentional exceptions" in docs/development/waitfor-migration.md.',
+    "",
+  ];
+  console.error(lines.join("\n"));
+}
+
+async function main(): Promise<number> {
+  const { violations } = await scan();
+  if (violations.length > 0) {
+    reportViolations(violations);
+    return 1;
+  }
+  console.log(
+    `No new polling waitFor in integration tests ` +
+      `(${ALLOWLIST.size} allowlisted exception(s)).`,
+  );
+  return 0;
+}
+
+if (import.meta.main) Deno.exit(await main());


### PR DESCRIPTION
Migrating the browser integration suites off the polling `waitFor` helper (defined in `packages/integration/utils.ts`, exported from `@commonfabric/integration`) removed a pattern that re-runs a predicate from the test process every 50 milliseconds across a DevTools Protocol round-trip and gives up after a timeout. Nothing, however, stopped a new test from importing that helper again, which would silently reintroduce the same slowness and flakiness the migration set out to remove.

Add a small check that keeps the migration from regressing. `tasks/check-no-waitfor.ts` walks the `.ts` files under any `integration/` directory beneath `packages/` (excluding the `@commonfabric/integration` package itself, which defines the helper) and fails when one names `waitFor` in an import from `@commonfabric/integration` and is not on an allowlist. The allowlist holds the files where a bounded poll is deliberately kept — the headless cell reads, the cross-page and race checks, the disabled tests, and the other cases already recorded under "Intentional exceptions" in the migration report — so the check passes on the current tree unchanged and fails only on new usage.

Detection keys on the named import of `waitFor` from the exact `@commonfabric/integration` specifier. That distinguishes the polling helper from same-prefixed names such as `waitForCondition` and `waitForText`, from the `waitForState` method exported by the `shell-utils` subpath, and from the `MultiRuntimeHarness.waitFor` member method, none of which are the CDP poll this targets. Comments inside the import braces are stripped first, so a commented-out member does not trip the check. The failure message names the offending file and points at `waitForCondition`, `awaitViewSettled`, the higher-level browser helpers, the in-process `defer()` replacement, and the migration report.

The check runs as its own step in the CI "Check" job via `deno task check-no-waitfor`, and its colocated test additionally asserts that the allowlist and the set of files still importing the helper stay exactly in step, so a migrated-away file that is left on the allowlist is flagged as stale. The migration report and the UI testing guide both point at the new check.

NEW_COVERAGE_BASELINE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI guard to block new imports of the polling `waitFor` in integration tests. Clarifies that the allowlist covers only in-scope files and adds tests that drive the command entry to lock behavior.

- **New Features**
  - Added `tasks/check-no-waitfor.ts` to scan `packages/**/integration/**/*.ts` (excluding `packages/integration`) and fail on a named `waitFor` import from `@commonfabric/integration` unless allowlisted. Uses an exact match; ignores `waitForCondition`, subpaths, member calls, and commented imports.
  - Added an allowlist for intentional exceptions, plus tests that keep the allowlist and actual usages in sync and cover the command entry: `main` is exported, accepts an optional root, and is tested over temp trees for both clean and violation paths.
  - Wired into CI (`deno task check-no-waitfor`) and documented. The migration guide now clarifies the allowlist covers only in-scope imports and must not include out-of-scope shapes (local polls in `test/`, `MultiRuntimeHarness.waitFor`, subpaths, or files in `packages/integration`).

<sup>Written for commit 2b3018ed1579bbcd5e0b483af2811d0e06942804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



