### PR TITLE
test(patterns): drop cross-space-sync workaround from home profile cr…

### DIFF
--- a/packages/patterns/integration/home-profile.test.ts
+++ b/packages/patterns/integration/home-profile.test.ts
@@ -8,7 +8,6 @@ import {
   fillCfInput,
   submitViaEnter,
   waitForRuntimeIdle,
-  waitForRuntimeSynced,
   waitForText,
 } from "./cfc-browser-helpers.ts";
 
@@ -69,13 +68,6 @@ async function createProfile(
   { viaEnter = false }: { viaEnter?: boolean } = {},
 ) {
   await ensureProfileTabActive(page);
-  // Each profile lives in its own `inSpace` child space, so appending one is a
-  // cross-space commit. `waitForRuntimeIdle` returns once the scheduler queue
-  // drains; `waitForRuntimeSynced` additionally awaits every opened space to
-  // reconcile. Settle fully before submitting so the append does not interleave
-  // with commits still in flight from a prior navigation's rehydration, and
-  // again after so it reconciles before the caller navigates or appends again.
-  await waitForRuntimeSynced(page);
   await fillCfInput(page, "#wish-profile-picker-name-input", name);
   // Submit either by clicking the trusted "Create profile" button or by
   // pressing Enter in the field. Both ride a trusted gesture that carries the
@@ -85,7 +77,12 @@ async function createProfile(
   } else {
     await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
   }
-  await waitForRuntimeSynced(page);
+  // Each profile lives in its own `inSpace` child space, so appending one is a
+  // cross-space commit issued fire-and-forget by the event handler.
+  // `waitForRuntimeIdle` now includes commit durability: it awaits the storage
+  // manager's pending-commit barrier as well as scheduler quiescence, so the
+  // append is server-confirmed before the caller navigates or appends again.
+  await waitForRuntimeIdle(page);
 }
 
 // Regression coverage for creating a profile directly from the home space's


### PR DESCRIPTION
…eate

The `createProfile` helper in the home-profile integration test bracketed every create with two `waitForRuntimeSynced` (rt.allSynced) calls: one before submitting and one after. That workaround was added back when the client-facing idle guaranteed only reactive quiescence, not commit durability. A profile append is a cross-space commit issued fire-and-forget by the event handler, and `waitForRuntimeIdle` used to return while that commit was still travelling to the server, so the append could be reverted by a prior navigation's rehydration churn or dropped before the next step. `waitForRuntimeSynced` papered over both by additionally awaiting every opened space to reconcile.

The idle-durability fix (#4453) folded the storage manager's pending-commit barrier into the client-facing idle: `waitForRuntimeIdle` now awaits `idleWithPendingCommits`, which re-checks `hasPendingCommits()` in the same convergence loop as reactive quiescence, and the pending set is registered synchronously as each commit is issued. So the durability half of the workaround is now redundant. The pre-submit reconciliation is covered too: the helper's `ensureProfileTabActive` already ends with `waitForRuntimeIdle` on every path, and that idle now waits on the rehydration commits, so the append lands against reconciled state without a separate `allSynced`.

The remaining question was the rendering half. Each profile's name is written into its own `inSpace` child space, and the picker renders it via a `cf-cell-link` that reads the name back out of that child space — a cross-space read, which idle deliberately excludes (the pending-commit barrier is kept distinct from the cross-space read set so unconfirmed writes, not link loads, gate idle). Dropping `allSynced` could therefore have left a profile row rendering with a blank name. It does not here, because these assertions read in the same session that created the profile: the create leaves the child space open and subscribed, so the reactive read resolves from already-open state and the name reaches the DOM, waking the mutation-driven `waitForText`. This is why the sibling reload-durability test, which reads after a full reload that tears the worker down, still needs its own settle-and-sync for that read.

`createProfile` now simply ends with `waitForRuntimeIdle`, mirroring the reload-durability test's helper. Verified by running the test file five times with a fresh identity each run; all three cases (single create, multi-profile append against a home already holding a persisted profile, and keyboard submit) stayed green with every rendered-name assertion passing and no timeouts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the home-profile integration test by removing the `waitForRuntimeSynced` pre/post waits in `createProfile` and relying on `waitForRuntimeIdle`, which now includes commit durability. This drops an unnecessary cross-space sync, reduces flakiness, and keeps the rendered profile name stable within the same session.

<sup>Written for commit 43ee86670713000964f7d2d555370e558ef50dbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

