### PR TITLE
test: finish migrating default-app and piece-result waits off polling waitFor

### DIFF
--- a/docs/development/waitfor-migration.md
+++ b/docs/development/waitfor-migration.md
@@ -84,6 +84,24 @@ Browser tests, moved to `waitForCondition` / `waitForText` / `awaitViewSettled`:
   `waitForRuntimeSynced`, the `waitFor(() => helper(page))` wrappers dropped to
   bare awaits, the `app.serialize()` reads moved into `waitForCondition`, and the
   standalone view-settle waits changed to gate-then-settle.
+- `packages/patterns/integration/default-app.test.ts`,
+  `reload/default-app-notebook.test.ts`, and `nested-counter.test.ts` — the
+  shared button-click helpers (`clickButtonWithText` / `clickButtonWithExactText`
+  / `clickButtonWithTitle`, and `nested-counter.test.ts`'s `clickNthButton`,
+  which clicked the nth `[data-cf-button]` in a retry loop) were reshaped to the
+  `clickCfButton` form: a `waitForCondition` predicate finds the first visible
+  matching (or nth) button and marks its click target, then the test dispatches
+  a single trusted click. This replaced both the `waitFor(() => helper(...))`
+  presence loops and the bare find-and-click, so the button-appearance wait is
+  event-driven and the click fires once.
+- `packages/patterns/integration/default-app.test.ts` and
+  `reload/default-app-notebook.test.ts` — the `collectNoteTitlesInList` /
+  `collectNotebookRenderState` / `collectNotebookSourceState` waits moved into
+  `waitForCondition` predicates that inline each probe's in-page collection (the
+  rendered-title scan, the piece-cell read for `isNotebook` / `noteCount` /
+  rendered chips, and the argument/internal read with manifest resolution). The
+  standalone probe functions were kept where a later line still reads them for a
+  one-shot assertion or diagnostics.
 
 In-process tests, moved to a `defer()` resolved inside a callback the test
 already registers (a cell `sink`/`subscribe`, a subscription's notification
@@ -99,6 +117,13 @@ counter):
 - piece: `pull-materialization.test.ts`.
 - runtime-client: `client.test.ts` — the cell-subscribe, console, and navigation
   waits (the render-driven `MockDoc` waits stay; see below).
+- patterns / shell: `counter.test.ts`, `nested-counter.test.ts`, and
+  `shell/integration/piece.test.ts` — the polls that read a piece's committed
+  `result` value through the in-process controller now resolve a `defer()` from
+  the result-cell `sink()` the tests already register to keep the piece
+  reactive. The sink records the latest committed value and resolves a pending
+  waiter when its target lands, with a fast path for a value already at the
+  target (a re-set to the same value commits no change).
 
 A handful of now-dead poll loops that followed an already-awaited
 `provider.sync(...)` were dropped outright, since sync resolving already implies
@@ -130,13 +155,12 @@ boundary the test can await without adding one to production code.
 - `packages/generated-patterns/integration/pattern-harness.ts` pulls a runtime
   `Cell` value and compares it, headless. No page; polling the pull until it
   converges is the honest wait.
-- The `waitFor` calls in `counter.test.ts`, `nested-counter.test.ts`, and
-  `piece.test.ts` that read a piece's committed `result` cell through the
-  in-process controller. These observe an off-page cell and are convertible by
-  resolving a `defer()` inside the `resultCell.sink(...)` the tests already
-  register; they were left because the browser+CLI suites they sit in verify the
-  browser interaction, and the cell-read waits are a small residual of that
-  larger flow rather than the CDP poll this effort targets.
+- `packages/shell/integration/piece.test.ts` — the one poll that reads a freshly
+  reloaded piece (`cc.get(pieceId, true)`), which has no registered sink, stays a
+  bounded poll on its own sync round trip. The sink-backed result-cell reads in
+  this file (and every such read in `counter.test.ts` and
+  `nested-counter.test.ts`) were converted to a `defer()` resolved from the
+  existing `resultCell.sink(...)`.
 
 ### Race, backpressure, and convergence tests
 
@@ -216,29 +240,6 @@ inside an in-page predicate for no reduction in flakiness.
 `cf-code-editor.test.disabled.ts`, `cf-render.test.disabled.ts`, and
 `cf-checkbox.test.disabled.ts` hold many `waitFor` calls but never run.
 Migrating them only churns dead code.
-
-## Remaining migratable work (not yet done)
-
-The clean conversions above are done. What is left is a small residual that is
-convertible but was held back because it changes shared helper semantics or is a
-low-value tail:
-
-- **Shared button-click helpers in the default-app tests.**
-  `clickButtonWithText` / `clickButtonWithTitle` / `clickButtonWithExactText` in
-  `default-app.test.ts` and the notebook reload test are used both wrapped in
-  `waitFor` (to wait for presence) and bare (their success is asserted directly).
-  Converting them to a settle-then-single-click helper (like the `clickCfButton`
-  shape) would touch every caller at once, so it wants its own focused change
-  rather than riding along here. The same goes for the `clickNthButton` helper in
-  `nested-counter.test.ts`.
-- **Render/source-state probe waits in the default-app tests.** The
-  `collectNoteTitlesInList` / `collectNotebookRenderState` /
-  `collectNotebookSourceState` waits poll a `page.evaluate` probe. They can move
-  into `waitForCondition` by inlining each probe's in-page collection, one probe
-  at a time.
-- **The piece-result cell reads** in `counter.test.ts`, `nested-counter.test.ts`,
-  and `piece.test.ts` (see the exceptions above) can each become a `defer()`
-  resolved in the existing `resultCell.sink(...)`.
 
 ## Also noticed, since cleaned up
 

--- a/packages/patterns/integration/counter.test.ts
+++ b/packages/patterns/integration/counter.test.ts
@@ -1,4 +1,4 @@
-import { env, waitFor } from "@commonfabric/integration";
+import { env } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
@@ -11,6 +11,7 @@ import {
   PiecesController,
 } from "./pieces-controller.ts";
 import { waitForText } from "./cfc-browser-helpers.ts";
+import { defer, type Deferred } from "@commonfabric/utils/defer";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -22,6 +23,22 @@ describe("counter direct operations test", () => {
   let cc: PiecesController;
   let piece: PieceController;
   let pieceSinkCancel: (() => void) | undefined;
+  // The piece's committed result value, tracked by the result-cell sink below,
+  // and a one-shot waiter the sink resolves when the value reaches a target.
+  let latestResultValue: number | undefined;
+  let resultWaiter: { target: number; deferred: Deferred } | undefined;
+
+  // Resolve once the piece's committed result value equals `target`. The sink
+  // fires with the current value on registration and on every committed change,
+  // so a value already at the target resolves immediately; otherwise the sink
+  // resolves the waiter when the target lands. A fresh deferred per call keeps
+  // the sequential value checks independent.
+  const awaitResultValue = (target: number): Promise<void> => {
+    if (latestResultValue === target) return Promise.resolve();
+    const deferred = defer();
+    resultWaiter = { target, deferred };
+    return deferred.promise;
+  };
 
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
@@ -46,9 +63,17 @@ describe("counter direct operations test", () => {
     );
 
     // In pull mode, create a sink to keep the piece reactive when inputs change.
-    // Without this, setting values won't trigger pattern re-computation.
+    // Without this, setting values won't trigger pattern re-computation. The
+    // sink also drives awaitResultValue: it records the latest committed value
+    // and resolves a pending waiter when its target is reached.
     const resultCell = cc.manager().getResult(piece.getCell());
-    pieceSinkCancel = resultCell.sink(() => {});
+    pieceSinkCancel = resultCell.sink((value) => {
+      latestResultValue = (value as { value?: number } | undefined)?.value;
+      if (resultWaiter && latestResultValue === resultWaiter.target) {
+        resultWaiter.deferred.resolve();
+        resultWaiter = undefined;
+      }
+    });
   });
 
   afterAll(async () => {
@@ -85,7 +110,7 @@ describe("counter direct operations test", () => {
     await waitForText(page, "#counter-result", "Counter is the 42nd number");
 
     // Verify we can also read the value back
-    await waitFor(async () => (await piece.result.get(["value"]) === 42));
+    await awaitResultValue(42);
   });
 
   it("should update counter value and verify after page refresh", async () => {
@@ -93,7 +118,7 @@ describe("counter direct operations test", () => {
 
     console.log("Setting counter value to 42 via direct operation");
     await piece.result.set(42, ["value"]);
-    await waitFor(async () => (await piece.result.get(["value"]) === 42));
+    await awaitResultValue(42);
 
     // Now refresh the page by navigating to the same URL
     console.log("Refreshing the page...");

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -3241,10 +3241,13 @@ async function ensureCapturedConsole(page: Page): Promise<boolean> {
 // cfc-browser-helpers.ts.
 const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
 
-// Serialized into the page by waitForCondition: find the first visible
+// Serialized into the page by waitForCondition: find the first rendered
 // button/link whose text or title matches, scroll it into view, and stamp its
-// inner click target with `token`. Returns false until a match exists, so the
-// wait re-checks on the next DOM mutation instead of the caller retrying a
+// inner click target with `token`. "Rendered" means laid out and not
+// display:none/visibility:hidden — the same elements the innerText scan the
+// poll used could see — and is viewport-independent, so a match below the fold
+// is scrolled in rather than skipped. Returns false until a match exists, so
+// the wait re-checks on the next DOM mutation instead of the caller retrying a
 // bare find-and-click loop.
 const markNoteButton = async (
   probe: ProbeApi,
@@ -3254,8 +3257,14 @@ const markNoteButton = async (
   token: string,
   attr: string,
 ): Promise<boolean> => {
+  const isRendered = (element: Element): boolean => {
+    const style = globalThis.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
   const target = probe.collect(selector).find((element) => {
-    if (!probe.isVisible(element)) return false;
+    if (!isRendered(element)) return false;
     if (match === "title") return element.getAttribute("title") === needle;
     const text = (element.textContent ?? "").trim();
     return match === "exact" ? text === needle : text.includes(needle);

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -487,9 +487,8 @@ describe("default-app flow test", () => {
       await waitForRuntimeIdle(page);
 
       console.log(`Wait for note count to increase (note ${noteIndex})...`);
-      await waitFor(async () => {
-        const noteTitles = await collectNoteTitlesInList(page);
-        return noteTitles.length > noteCountBefore;
+      await waitForCondition(page, noteTitlesExceed, {
+        args: [noteCountBefore],
       });
 
       const noteTitlesAfter = await collectNoteTitlesInList(page);
@@ -675,9 +674,26 @@ describe("default-app flow test", () => {
       await clickButtonWithText(page, "Notes");
       await clickButtonWithText(page, "New Notebook");
       try {
-        await waitFor(async () => {
-          const state = await collectNotebookRenderState(page);
-          return state.isNotebook;
+        await waitForCondition(page, async () => {
+          const commonfabric = globalThis.commonfabric as
+            | { readCell?: (options: { id: string }) => Promise<unknown> }
+            | undefined;
+          const view = globalThis.app?.serialize?.()?.view;
+          const pieceId = view && typeof view === "object" &&
+              "pieceId" in view && typeof view.pieceId === "string"
+            ? view.pieceId
+            : undefined;
+          if (!pieceId || !commonfabric?.readCell) return false;
+          let current: unknown;
+          const originalLog = console.log;
+          try {
+            console.log = () => {};
+            current = await commonfabric.readCell({ id: pieceId });
+          } finally {
+            console.log = originalLog;
+          }
+          return (current as { isNotebook?: unknown } | undefined)
+            ?.isNotebook === true;
         });
       } catch (error) {
         console.log(
@@ -721,12 +737,8 @@ describe("default-app flow test", () => {
       );
 
       try {
-        await waitFor(async () => {
-          const state = await collectNotebookSourceState(page);
-          return state.argumentNotesLength === noteCreates &&
-            state.noteCount === noteCreates &&
-            state.showNewNotePrompt === false &&
-            state.usedCreateAnotherNote === false;
+        await waitForCondition(page, notebookSourceStateMatches, {
+          args: [noteCreates],
         });
         await waitForRuntimeSynced(page);
       } catch (_) {
@@ -1562,7 +1574,7 @@ async function waitForHomePageReady(
   }, { args: [options.spaceName] });
 
   if (options.expectNoteInList) {
-    await waitFor(() => findNoteInList(page));
+    await waitForCondition(page, noteTitlesExceed, { args: [0] });
   }
 
   await waitForRuntimeIdle(page);
@@ -1664,6 +1676,88 @@ async function collectNotebookSourceState(page: Page): Promise<{
     };
   });
 }
+
+// Serialized into the page by waitForCondition: read the notebook's argument
+// and internal cells and report whether the rapidly created notes have all
+// landed — `expectedCount` notes present, the new-note prompt closed, and the
+// "create another" flag cleared. Inlines the collection that
+// collectNotebookSourceState performs so the wait resolves the instant the
+// source state converges rather than on a polling tick.
+const notebookSourceStateMatches = async (
+  _probe: ProbeApi,
+  expectedCount: number,
+): Promise<boolean> => {
+  const api = globalThis.commonfabric as {
+    readCell?: (options: {
+      id: string;
+      path?: string[];
+      meta?: "argument" | "internal";
+    }) => Promise<unknown>;
+  } | undefined;
+
+  const view = globalThis.app?.serialize?.()?.view;
+  const notebookEntityId = view && typeof view === "object" &&
+      "pieceId" in view && typeof view.pieceId === "string"
+    ? view.pieceId
+    : undefined;
+  if (!notebookEntityId || !api?.readCell) return false;
+
+  const resolveInternalManifest = async (
+    manifest: unknown,
+  ): Promise<Record<string, unknown>> => {
+    const resolved: Record<string, unknown> = {};
+    if (!Array.isArray(manifest)) return resolved;
+    for (const entry of manifest) {
+      if (entry === null || typeof entry !== "object") continue;
+      const { partialCause, link } = entry as {
+        partialCause?: unknown;
+        link?: { sync?: () => Promise<unknown> };
+      };
+      const key = typeof partialCause === "string"
+        ? partialCause
+        : JSON.stringify(partialCause) ?? String(partialCause);
+      if (link && typeof link.sync === "function") {
+        resolved[key] = await link.sync();
+      }
+    }
+    return resolved;
+  };
+
+  let notebookArgument: unknown;
+  let notebookInternalManifest: unknown;
+  const originalLog = console.log;
+  try {
+    console.log = () => {};
+    notebookArgument = await api.readCell({
+      id: notebookEntityId,
+      meta: "argument",
+    });
+    notebookInternalManifest = await api.readCell({
+      id: notebookEntityId,
+      meta: "internal",
+    });
+  } finally {
+    console.log = originalLog;
+  }
+  const notebookInternal = await resolveInternalManifest(
+    notebookInternalManifest,
+  );
+
+  const argumentNotes = (notebookArgument as { notes?: unknown[] } | undefined)
+    ?.notes;
+  const argumentNotesLength = Array.isArray(argumentNotes)
+    ? argumentNotes.length
+    : undefined;
+  const internal = notebookInternal as {
+    noteCount?: unknown;
+    showNewNotePrompt?: unknown;
+    usedCreateAnotherNote?: unknown;
+  };
+  return argumentNotesLength === expectedCount &&
+    internal.noteCount === expectedCount &&
+    internal.showNewNotePrompt === false &&
+    internal.usedCreateAnotherNote === false;
+};
 
 async function collectHomeLoadSummaryFromFreshPage(
   shell: ShellIntegration,
@@ -3464,6 +3558,23 @@ async function clickPieceLinkWithText(
 async function findNoteInList(page: Page): Promise<boolean> {
   return (await collectNoteTitlesInList(page)).length > 0;
 }
+
+// Serialized into the page by waitForCondition: count the unique rendered
+// "📝 New Note #<hash>" titles across the document and every shadow root and
+// report whether more than `minCount` are present. Inlines the collection that
+// collectNoteTitlesInList performs so the wait resolves the instant the list
+// grows rather than on a polling tick.
+const noteTitlesExceed = (probe: ProbeApi, minCount: number): boolean => {
+  const titles = new Set<string>();
+  for (const element of probe.collect("*")) {
+    const text = element.textContent;
+    if (!text) continue;
+    for (const match of text.matchAll(/📝 New Note #[A-Za-z0-9_-]+/g)) {
+      titles.add(match[0]);
+    }
+  }
+  return titles.size > minCount;
+};
 
 async function collectNoteTitlesInList(page: Page): Promise<string[]> {
   try {

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -3,6 +3,7 @@ import {
   CdpWorkerProfiler,
   env,
   Page,
+  type ProbeApi,
   renderProfileReport,
   waitFor,
   waitForCondition,
@@ -386,15 +387,11 @@ describe("default-app flow test", () => {
       }
 
       console.log(`Click notes drop down (note ${noteIndex})...`);
-      await waitFor(async () => {
-        return !!(await clickButtonWithText(page, "Notes"));
-      });
+      await clickButtonWithText(page, "Notes");
 
       const noteCreateStartedAt = performance.now();
       console.log(`Click 'New Note' (note ${noteIndex})...`);
-      await waitFor(async () => {
-        return !!(await clickButtonWithText(page, "New Note"));
-      });
+      await clickButtonWithText(page, "New Note");
 
       console.log(`Wait for note view (note ${noteIndex})...`);
       await waitForCondition(page, () => {
@@ -675,12 +672,8 @@ describe("default-app flow test", () => {
     await waitForRuntimeIdle(page);
 
     try {
-      await waitFor(async () => {
-        return !!(await clickButtonWithText(page, "Notes"));
-      });
-      await waitFor(async () => {
-        return !!(await clickButtonWithText(page, "New Notebook"));
-      });
+      await clickButtonWithText(page, "Notes");
+      await clickButtonWithText(page, "New Notebook");
       try {
         await waitFor(async () => {
           const state = await collectNotebookRenderState(page);
@@ -3148,26 +3141,129 @@ async function ensureCapturedConsole(page: Page): Promise<boolean> {
 }
 
 // Helper to find and click a button by text using piercing selectors
+// Marker attribute a click predicate stamps on the button it resolved, so the
+// test can then resolve that exact element and dispatch a single trusted click
+// on it. Mirrors the CLICK_TARGET_ATTR flow of clickCfButton in
+// cfc-browser-helpers.ts.
+const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
+
+// Serialized into the page by waitForCondition: find the first visible
+// button/link whose text or title matches, scroll it into view, and stamp its
+// inner click target with `token`. Returns false until a match exists, so the
+// wait re-checks on the next DOM mutation instead of the caller retrying a
+// bare find-and-click loop.
+const markNoteButton = async (
+  probe: ProbeApi,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+  token: string,
+  attr: string,
+): Promise<boolean> => {
+  const target = probe.collect(selector).find((element) => {
+    if (!probe.isVisible(element)) return false;
+    if (match === "title") return element.getAttribute("title") === needle;
+    const text = (element.textContent ?? "").trim();
+    return match === "exact" ? text === needle : text.includes(needle);
+  }) as HTMLElement | undefined;
+  if (!target) return false;
+  target.scrollIntoView({ block: "center", inline: "center" });
+  await new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  );
+  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+    | HTMLElement
+    | null) ?? target;
+  clickTarget.setAttribute(attr, token);
+  return true;
+};
+
+// Remove every element carrying `attr=token`, descending through shadow roots.
+async function clearNoteButtonMark(
+  page: Page,
+  token: string,
+): Promise<void> {
+  await page.evaluate((targetToken, targetAttr) => {
+    function collect(root: Document | ShadowRoot, result: Element[]): void {
+      for (const element of root.querySelectorAll("*")) {
+        if (element.getAttribute(targetAttr) === targetToken) {
+          result.push(element);
+        }
+        if (element.shadowRoot) collect(element.shadowRoot, result);
+      }
+    }
+    const matches: Element[] = [];
+    collect(document, matches);
+    for (const element of matches) element.removeAttribute(targetAttr);
+  }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
+}
+
+// Wait for a matching button to be present and interactive, then dispatch a
+// single trusted click on it. Throws if no matching button becomes clickable.
+async function settleAndClickNoteButton(
+  page: Page,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+): Promise<void> {
+  const token = `cfc-note-button-${crypto.randomUUID()}`;
+  try {
+    await waitForCondition(page, markNoteButton, {
+      args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
+    });
+  } catch (cause) {
+    throw new Error(
+      `Unable to find a ${
+        match === "title" ? "button titled" : "button matching"
+      } "${needle}" to click`,
+      { cause },
+    );
+  }
+  try {
+    const clickTarget = await page.waitForSelector(
+      `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
+      { strategy: "pierce" },
+    );
+    await clickTarget.click();
+  } finally {
+    await clearNoteButtonMark(page, token);
+  }
+}
+
+// The click helpers resolve `true` once the single click has landed (they throw
+// otherwise), so the call sites that assert the click succeeded keep reading.
 async function clickButtonWithText(
   page: Page,
   searchText: string,
 ): Promise<boolean> {
-  const button = await findButtonWithText(page, searchText);
-  if (!button) return false;
-  try {
-    await button.click();
-    return true;
-  } catch (_) {
-    return await page.evaluate((searchText: string) => {
-      for (const el of document.querySelectorAll("cf-button, button, a")) {
-        if (el.textContent?.trim().includes(searchText)) {
-          (el as HTMLElement).click();
-          return true;
-        }
-      }
-      return false;
-    }, { args: [searchText] });
-  }
+  await settleAndClickNoteButton(
+    page,
+    "cf-button, button, a",
+    "includes",
+    searchText,
+  );
+  return true;
+}
+
+async function clickButtonWithExactText(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(
+    page,
+    "cf-button, button, a",
+    "exact",
+    searchText,
+  );
+  return true;
+}
+
+async function clickButtonWithTitle(
+  page: Page,
+  title: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(page, "cf-button, button", "title", title);
+  return true;
 }
 
 async function findButtonWithText(
@@ -3188,75 +3284,6 @@ async function findButtonWithText(
     return null;
   } catch (_) {
     return null;
-  }
-}
-
-async function clickButtonWithExactText(
-  page: Page,
-  searchText: string,
-): Promise<boolean> {
-  try {
-    const buttons = await page.$$("cf-button, button, a", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const text = await button.innerText();
-      if (text?.trim() === searchText) {
-        try {
-          await button.click();
-          return true;
-        } catch (_) {
-          return await page.evaluate((searchText: string) => {
-            for (
-              const el of document.querySelectorAll(
-                "cf-button, button, a",
-              )
-            ) {
-              if (el.textContent?.trim() === searchText) {
-                (el as HTMLElement).click();
-                return true;
-              }
-            }
-            return false;
-          }, { args: [searchText] });
-        }
-      }
-    }
-    return false;
-  } catch (_) {
-    return false;
-  }
-}
-
-async function clickButtonWithTitle(
-  page: Page,
-  title: string,
-): Promise<boolean> {
-  try {
-    const buttons = await page.$$("cf-button, button", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const actualTitle = await button.getAttribute("title");
-      if (actualTitle === title) {
-        try {
-          await button.click();
-          return true;
-        } catch (_) {
-          return await page.evaluate((title: string) => {
-            const el = document.querySelector(
-              `cf-button[title="${title}"], button[title="${title}"]`,
-            );
-            if (!el) return false;
-            (el as HTMLElement).click();
-            return true;
-          }, { args: [title] });
-        }
-      }
-    }
-    return false;
-  } catch (_) {
-    return false;
   }
 }
 

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -2,7 +2,6 @@ import {
   env,
   Page,
   type ProbeApi,
-  waitFor,
   waitForCondition,
 } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
@@ -17,6 +16,7 @@ import {
   PieceController,
   PiecesController,
 } from "./pieces-controller.ts";
+import { defer, type Deferred } from "@commonfabric/utils/defer";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -28,6 +28,22 @@ describe("nested counter integration test", () => {
   let cc: PiecesController;
   let piece: PieceController;
   let pieceSinkCancel: (() => void) | undefined;
+  // The piece's committed result value, tracked by the result-cell sink below,
+  // and a one-shot waiter the sink resolves when the value reaches a target.
+  let latestResultValue: number | undefined;
+  let resultWaiter: { target: number; deferred: Deferred } | undefined;
+
+  // Resolve once the piece's committed result value equals `target`. The sink
+  // fires with the current value on registration and on every committed change,
+  // so a value already at the target resolves immediately; otherwise the sink
+  // resolves the waiter when the target lands. A fresh deferred per call keeps
+  // the sequential value checks independent.
+  const awaitResultValue = (target: number): Promise<void> => {
+    if (latestResultValue === target) return Promise.resolve();
+    const deferred = defer();
+    resultWaiter = { target, deferred };
+    return deferred.promise;
+  };
 
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
@@ -54,8 +70,16 @@ describe("nested counter integration test", () => {
     );
 
     // In pull mode, create a sink to keep the piece reactive when inputs change.
+    // The sink also drives awaitResultValue: it records the latest committed
+    // value and resolves a pending waiter when its target is reached.
     const resultCell = cc.manager().getResult(piece.getCell());
-    pieceSinkCancel = resultCell.sink(() => {});
+    pieceSinkCancel = resultCell.sink((value) => {
+      latestResultValue = (value as { value?: number } | undefined)?.value;
+      if (resultWaiter && latestResultValue === resultWaiter.target) {
+        resultWaiter.deferred.resolve();
+        resultWaiter = undefined;
+      }
+    });
   });
 
   afterAll(async () => {
@@ -84,13 +108,10 @@ describe("nested counter integration test", () => {
     const page = shell.page();
 
     // Click increment button (second button - first is decrement)
-    // Use retry logic to handle unstable box model during page settling
     await clickNthButton(page, "[data-cf-button]", 1);
 
-    // Wait for piece result update
-    await waitFor(async () => {
-      return await await piece.result.get(["value"]) === 1;
-    });
+    // Wait for the piece result to reflect the increment.
+    await awaitResultValue(1);
     await waitForCounter(page, "Counter is the 1st number");
   });
 

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -1,6 +1,7 @@
 import {
   env,
   Page,
+  type ProbeApi,
   waitFor,
   waitForCondition,
 } from "@commonfabric/integration";
@@ -135,22 +136,61 @@ async function waitForCounter(page: Page, text: string) {
   await waitForText(page, "#counter-result", text);
 }
 
-// Clicks the nth button matching selector, retrying if the element lacks a stable box model.
-// This handles timing issues where the element is found but the page
-// is still settling (re-renders, layout shifts, hydration).
-function clickNthButton(
+// Clicks the nth button matching selector: wait until that button is present
+// and interactive (scrolled into view with a stable box model), then dispatch a
+// single trusted click on it. The wait re-checks on each DOM mutation while the
+// page settles (re-renders, layout shifts, hydration) rather than re-clicking.
+const NTH_BUTTON_CLICK_TARGET_ATTR = "data-cfc-nth-button-target";
+
+async function clickNthButton(
   page: Page,
   selector: string,
   index: number,
 ): Promise<void> {
-  return waitFor(async () => {
-    const buttons = await page.$$(selector, { strategy: "pierce" });
-    if (buttons.length <= index) return false;
-    try {
-      await buttons[index].click();
+  const token = `cfc-nth-button-${crypto.randomUUID()}`;
+  try {
+    await waitForCondition(page, async (
+      probe: ProbeApi,
+      sel: string,
+      idx: number,
+      tok: string,
+      attr: string,
+    ) => {
+      const target = probe.collect(sel)[idx];
+      if (!target) return false;
+      target.scrollIntoView({ block: "center", inline: "center" });
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      );
+      if (!probe.isVisible(target)) return false;
+      target.setAttribute(attr, tok);
       return true;
-    } catch (_) {
-      return false;
-    }
-  });
+    }, { args: [selector, index, token, NTH_BUTTON_CLICK_TARGET_ATTR] });
+  } catch (cause) {
+    throw new Error(
+      `Unable to find button #${index} matching "${selector}"`,
+      { cause },
+    );
+  }
+  try {
+    const clickTarget = await page.waitForSelector(
+      `[${NTH_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
+      { strategy: "pierce" },
+    );
+    await clickTarget.click();
+  } finally {
+    await page.evaluate((targetToken, targetAttr) => {
+      function collect(root: Document | ShadowRoot, result: Element[]): void {
+        for (const element of root.querySelectorAll("*")) {
+          if (element.getAttribute(targetAttr) === targetToken) {
+            result.push(element);
+          }
+          if (element.shadowRoot) collect(element.shadowRoot, result);
+        }
+      }
+      const matches: Element[] = [];
+      collect(document, matches);
+      for (const element of matches) element.removeAttribute(targetAttr);
+    }, { args: [token, NTH_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
+  }
 }

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -408,10 +408,13 @@ const notebookReloadRendered = async (
 // cfc-browser-helpers.ts.
 const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
 
-// Serialized into the page by waitForCondition: find the first visible
+// Serialized into the page by waitForCondition: find the first rendered
 // button/link whose text or title matches, scroll it into view, and stamp its
-// inner click target with `token`. Returns false until a match exists, so the
-// wait re-checks on the next DOM mutation instead of the caller retrying a
+// inner click target with `token`. "Rendered" means laid out and not
+// display:none/visibility:hidden — the same elements the innerText scan the
+// poll used could see — and is viewport-independent, so a match below the fold
+// is scrolled in rather than skipped. Returns false until a match exists, so
+// the wait re-checks on the next DOM mutation instead of the caller retrying a
 // bare find-and-click loop.
 const markNoteButton = async (
   probe: ProbeApi,
@@ -421,8 +424,14 @@ const markNoteButton = async (
   token: string,
   attr: string,
 ): Promise<boolean> => {
+  const isRendered = (element: Element): boolean => {
+    const style = globalThis.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
   const target = probe.collect(selector).find((element) => {
-    if (!probe.isVisible(element)) return false;
+    if (!isRendered(element)) return false;
     if (match === "title") return element.getAttribute("title") === needle;
     const text = (element.textContent ?? "").trim();
     return match === "exact" ? text === needle : text.includes(needle);

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -53,9 +53,26 @@ describe("default-app notebook reload integration test", () => {
     await waitForRuntimeIdle(page);
     await clickButtonWithText(page, "Notes");
     await clickButtonWithText(page, "New Notebook");
-    await waitFor(async () => {
-      const state = await collectNotebookRenderState(page);
-      return state.isNotebook;
+    await waitForCondition(page, async () => {
+      const commonfabric = globalThis.commonfabric as
+        | { readCell?: (options: { id: string }) => Promise<unknown> }
+        | undefined;
+      const view = globalThis.app?.serialize?.()?.view;
+      const pieceId = view && typeof view === "object" && "pieceId" in view &&
+          typeof view.pieceId === "string"
+        ? view.pieceId
+        : undefined;
+      if (!pieceId || !commonfabric?.readCell) return false;
+      let current: unknown;
+      const originalLog = console.log;
+      try {
+        console.log = () => {};
+        current = await commonfabric.readCell({ id: pieceId });
+      } finally {
+        console.log = originalLog;
+      }
+      return (current as { isNotebook?: unknown } | undefined)
+        ?.isNotebook === true;
     });
 
     await waitForCondition(
@@ -85,14 +102,10 @@ describe("default-app notebook reload integration test", () => {
       "Expected final Create click to succeed",
     );
 
-    await waitFor(async () => {
-      await waitForRuntimeIdle(page);
-      const state = await collectNotebookSourceState(page);
-      return state.argumentNotesLength === noteCreates &&
-        state.noteCount === noteCreates &&
-        state.showNewNotePrompt === false &&
-        state.usedCreateAnotherNote === false;
-    }, { timeout: NOTEBOOK_RELOAD_TIMEOUT_MS });
+    await waitForCondition(page, notebookSourceStateMatches, {
+      args: [noteCreates],
+      timeout: NOTEBOOK_RELOAD_TIMEOUT_MS,
+    });
 
     await waitForRuntimeSynced(page, { timeout: NOTEBOOK_RELOAD_TIMEOUT_MS });
 
@@ -101,12 +114,10 @@ describe("default-app notebook reload integration test", () => {
     await page.applyConsoleFormatter();
     await shell.login(identity);
 
-    await waitFor(async () => {
-      const state = await collectNotebookRenderState(page);
-      return state.isNotebook &&
-        state.noteCount === noteCreates &&
-        state.renderedNoteChips === noteCreates;
-    }, { timeout: NOTEBOOK_RELOAD_TIMEOUT_MS });
+    await waitForCondition(page, notebookReloadRendered, {
+      args: [noteCreates],
+      timeout: NOTEBOOK_RELOAD_TIMEOUT_MS,
+    });
     await waitForRuntimeIdle(page, { timeout: NOTEBOOK_RELOAD_TIMEOUT_MS });
 
     const reloadRenderState = await collectNotebookRenderState(page);
@@ -268,103 +279,128 @@ async function resetEventInvocationTrace(page: Page): Promise<boolean> {
   });
 }
 
-async function collectNotebookSourceState(page: Page): Promise<{
-  notebookEntityId?: string;
-  argumentNotesLength?: number;
-  noteCount?: number;
-  showNewNotePrompt?: boolean;
-  usedCreateAnotherNote?: boolean;
-}> {
-  return await page.evaluate(async () => {
-    const api = globalThis.commonfabric as {
-      rt?: { idle?: () => Promise<void> };
-      readCell?: (options: {
-        id: string;
-        path?: string[];
-        meta?: "argument" | "internal";
-      }) => Promise<unknown>;
-    } | undefined;
-    await api?.rt?.idle?.();
+// Serialized into the page by waitForCondition: drain the worker, read the
+// notebook's argument and internal cells, and report whether the rapidly
+// created notes have all landed — `expectedCount` notes present, the new-note
+// prompt closed, and the "create another" flag cleared. Inlines the collection
+// that collectNotebookSourceState performs (including its runtime idle) so the
+// wait resolves the instant the source state converges rather than on a poll.
+const notebookSourceStateMatches = async (
+  _probe: ProbeApi,
+  expectedCount: number,
+): Promise<boolean> => {
+  const api = globalThis.commonfabric as {
+    rt?: { idle?: () => Promise<void> };
+    readCell?: (options: {
+      id: string;
+      path?: string[];
+      meta?: "argument" | "internal";
+    }) => Promise<unknown>;
+  } | undefined;
+  await api?.rt?.idle?.();
 
-    const appState = globalThis.app?.serialize?.();
-    const view = appState?.view;
-    const notebookEntityId = view && typeof view === "object" &&
-        "pieceId" in view && typeof view.pieceId === "string"
-      ? view.pieceId
-      : undefined;
-    if (!notebookEntityId || !api?.readCell) {
-      return { notebookEntityId };
-    }
+  const view = globalThis.app?.serialize?.()?.view;
+  const notebookEntityId = view && typeof view === "object" &&
+      "pieceId" in view && typeof view.pieceId === "string"
+    ? view.pieceId
+    : undefined;
+  if (!notebookEntityId || !api?.readCell) return false;
 
-    const resolveInternalManifest = async (
-      manifest: unknown,
-    ): Promise<Record<string, unknown>> => {
-      const resolved: Record<string, unknown> = {};
-      if (!Array.isArray(manifest)) return resolved;
-
-      for (const entry of manifest) {
-        if (entry === null || typeof entry !== "object") continue;
-        const { partialCause, link } = entry as {
-          partialCause?: unknown;
-          link?: { sync?: () => Promise<unknown> };
-        };
-        const key = typeof partialCause === "string"
-          ? partialCause
-          : JSON.stringify(partialCause) ?? String(partialCause);
-        if (link && typeof link.sync === "function") {
-          resolved[key] = await link.sync();
-        }
+  const resolveInternalManifest = async (
+    manifest: unknown,
+  ): Promise<Record<string, unknown>> => {
+    const resolved: Record<string, unknown> = {};
+    if (!Array.isArray(manifest)) return resolved;
+    for (const entry of manifest) {
+      if (entry === null || typeof entry !== "object") continue;
+      const { partialCause, link } = entry as {
+        partialCause?: unknown;
+        link?: { sync?: () => Promise<unknown> };
+      };
+      const key = typeof partialCause === "string"
+        ? partialCause
+        : JSON.stringify(partialCause) ?? String(partialCause);
+      if (link && typeof link.sync === "function") {
+        resolved[key] = await link.sync();
       }
-      return resolved;
-    };
-
-    let notebookArgument: unknown;
-    let notebookInternalManifest: unknown;
-    const originalLog = console.log;
-    try {
-      console.log = () => {};
-      notebookArgument = await api.readCell({
-        id: notebookEntityId,
-        meta: "argument",
-      });
-      notebookInternalManifest = await api.readCell({
-        id: notebookEntityId,
-        meta: "internal",
-      });
-    } finally {
-      console.log = originalLog;
     }
-    const notebookInternal = await resolveInternalManifest(
-      notebookInternalManifest,
-    );
+    return resolved;
+  };
 
-    return {
-      notebookEntityId,
-      argumentNotesLength: Array.isArray(
-          (notebookArgument as { notes?: unknown[] } | undefined)?.notes,
-        )
-        ? (notebookArgument as { notes: unknown[] }).notes.length
-        : undefined,
-      noteCount:
-        typeof (notebookInternal as { noteCount?: unknown } | undefined)
-            ?.noteCount === "number"
-          ? (notebookInternal as { noteCount: number }).noteCount
-          : undefined,
-      showNewNotePrompt:
-        typeof (notebookInternal as { showNewNotePrompt?: unknown } | undefined)
-            ?.showNewNotePrompt === "boolean"
-          ? (notebookInternal as { showNewNotePrompt: boolean })
-            .showNewNotePrompt
-          : undefined,
-      usedCreateAnotherNote: typeof (
-          notebookInternal as { usedCreateAnotherNote?: unknown } | undefined
-        )?.usedCreateAnotherNote === "boolean"
-        ? (notebookInternal as { usedCreateAnotherNote: boolean })
-          .usedCreateAnotherNote
-        : undefined,
-    };
-  });
-}
+  let notebookArgument: unknown;
+  let notebookInternalManifest: unknown;
+  const originalLog = console.log;
+  try {
+    console.log = () => {};
+    notebookArgument = await api.readCell({
+      id: notebookEntityId,
+      meta: "argument",
+    });
+    notebookInternalManifest = await api.readCell({
+      id: notebookEntityId,
+      meta: "internal",
+    });
+  } finally {
+    console.log = originalLog;
+  }
+  const notebookInternal = await resolveInternalManifest(
+    notebookInternalManifest,
+  );
+
+  const argumentNotes = (notebookArgument as { notes?: unknown[] } | undefined)
+    ?.notes;
+  const argumentNotesLength = Array.isArray(argumentNotes)
+    ? argumentNotes.length
+    : undefined;
+  const internal = notebookInternal as {
+    noteCount?: unknown;
+    showNewNotePrompt?: unknown;
+    usedCreateAnotherNote?: unknown;
+  };
+  return argumentNotesLength === expectedCount &&
+    internal.noteCount === expectedCount &&
+    internal.showNewNotePrompt === false &&
+    internal.usedCreateAnotherNote === false;
+};
+
+// Serialized into the page by waitForCondition: report whether the reloaded
+// notebook has rehydrated to `expectedCount` notes — the piece cell reads back
+// as a notebook with that noteCount, and that many "📝 New Note" chips are
+// rendered across the document and every shadow root. Inlines the readCell and
+// cf-chip collection that collectNotebookRenderState performs.
+const notebookReloadRendered = async (
+  probe: ProbeApi,
+  expectedCount: number,
+): Promise<boolean> => {
+  const commonfabric = globalThis.commonfabric as
+    | { readCell?: (options: { id: string }) => Promise<unknown> }
+    | undefined;
+  const view = globalThis.app?.serialize?.()?.view;
+  const pieceId = view && typeof view === "object" && "pieceId" in view &&
+      typeof view.pieceId === "string"
+    ? view.pieceId
+    : undefined;
+  if (!pieceId || !commonfabric?.readCell) return false;
+  let current: { isNotebook?: unknown; noteCount?: unknown } | undefined;
+  const originalLog = console.log;
+  try {
+    console.log = () => {};
+    current = await commonfabric.readCell({ id: pieceId }) as typeof current;
+  } finally {
+    console.log = originalLog;
+  }
+  if (current?.isNotebook !== true || current.noteCount !== expectedCount) {
+    return false;
+  }
+  const renderedNoteChips = probe.collect("cf-chip").filter((element) => {
+    const label = String(
+      (element as { label?: unknown }).label ??
+        element.getAttribute("label") ?? "",
+    ).trim();
+    return label.startsWith("📝 New Note");
+  }).length;
+  return renderedNoteChips === expectedCount;
+};
 
 // Marker attribute a click predicate stamps on the button it resolved, so the
 // test can then resolve that exact element and dispatch a single trusted click

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -2,6 +2,7 @@ import {
   awaitViewSettled,
   env,
   Page,
+  type ProbeApi,
   waitFor,
   waitForCondition,
 } from "@commonfabric/integration";
@@ -50,10 +51,8 @@ describe("default-app notebook reload integration test", () => {
     });
 
     await waitForRuntimeIdle(page);
-    await waitFor(async () => !!(await clickButtonWithText(page, "Notes")));
-    await waitFor(async () =>
-      !!(await clickButtonWithText(page, "New Notebook"))
-    );
+    await clickButtonWithText(page, "Notes");
+    await clickButtonWithText(page, "New Notebook");
     await waitFor(async () => {
       const state = await collectNotebookRenderState(page);
       return state.isNotebook;
@@ -367,26 +366,129 @@ async function collectNotebookSourceState(page: Page): Promise<{
   });
 }
 
+// Marker attribute a click predicate stamps on the button it resolved, so the
+// test can then resolve that exact element and dispatch a single trusted click
+// on it. Mirrors the CLICK_TARGET_ATTR flow of clickCfButton in
+// cfc-browser-helpers.ts.
+const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
+
+// Serialized into the page by waitForCondition: find the first visible
+// button/link whose text or title matches, scroll it into view, and stamp its
+// inner click target with `token`. Returns false until a match exists, so the
+// wait re-checks on the next DOM mutation instead of the caller retrying a
+// bare find-and-click loop.
+const markNoteButton = async (
+  probe: ProbeApi,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+  token: string,
+  attr: string,
+): Promise<boolean> => {
+  const target = probe.collect(selector).find((element) => {
+    if (!probe.isVisible(element)) return false;
+    if (match === "title") return element.getAttribute("title") === needle;
+    const text = (element.textContent ?? "").trim();
+    return match === "exact" ? text === needle : text.includes(needle);
+  }) as HTMLElement | undefined;
+  if (!target) return false;
+  target.scrollIntoView({ block: "center", inline: "center" });
+  await new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  );
+  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+    | HTMLElement
+    | null) ?? target;
+  clickTarget.setAttribute(attr, token);
+  return true;
+};
+
+// Remove every element carrying `attr=token`, descending through shadow roots.
+async function clearNoteButtonMark(
+  page: Page,
+  token: string,
+): Promise<void> {
+  await page.evaluate((targetToken, targetAttr) => {
+    function collect(root: Document | ShadowRoot, result: Element[]): void {
+      for (const element of root.querySelectorAll("*")) {
+        if (element.getAttribute(targetAttr) === targetToken) {
+          result.push(element);
+        }
+        if (element.shadowRoot) collect(element.shadowRoot, result);
+      }
+    }
+    const matches: Element[] = [];
+    collect(document, matches);
+    for (const element of matches) element.removeAttribute(targetAttr);
+  }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
+}
+
+// Wait for a matching button to be present and interactive, then dispatch a
+// single trusted click on it. Throws if no matching button becomes clickable.
+async function settleAndClickNoteButton(
+  page: Page,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+): Promise<void> {
+  const token = `cfc-note-button-${crypto.randomUUID()}`;
+  try {
+    await waitForCondition(page, markNoteButton, {
+      args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
+    });
+  } catch (cause) {
+    throw new Error(
+      `Unable to find a ${
+        match === "title" ? "button titled" : "button matching"
+      } "${needle}" to click`,
+      { cause },
+    );
+  }
+  try {
+    const clickTarget = await page.waitForSelector(
+      `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
+      { strategy: "pierce" },
+    );
+    await clickTarget.click();
+  } finally {
+    await clearNoteButtonMark(page, token);
+  }
+}
+
+// The click helpers resolve `true` once the single click has landed (they throw
+// otherwise), so the call sites that assert the click succeeded keep reading.
 async function clickButtonWithText(
   page: Page,
   searchText: string,
 ): Promise<boolean> {
-  const button = await findButtonWithText(page, searchText);
-  if (!button) return false;
-  try {
-    await button.click();
-    return true;
-  } catch (_) {
-    return await page.evaluate((searchText: string) => {
-      for (const el of document.querySelectorAll("cf-button, button, a")) {
-        if (el.textContent?.trim().includes(searchText)) {
-          (el as HTMLElement).click();
-          return true;
-        }
-      }
-      return false;
-    }, { args: [searchText] });
-  }
+  await settleAndClickNoteButton(
+    page,
+    "cf-button, button, a",
+    "includes",
+    searchText,
+  );
+  return true;
+}
+
+async function clickButtonWithExactText(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(
+    page,
+    "cf-button, button, a",
+    "exact",
+    searchText,
+  );
+  return true;
+}
+
+async function clickButtonWithTitle(
+  page: Page,
+  title: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(page, "cf-button, button", "title", title);
+  return true;
 }
 
 async function findButtonWithText(
@@ -404,75 +506,6 @@ async function findButtonWithText(
     return null;
   } catch (_) {
     return null;
-  }
-}
-
-async function clickButtonWithExactText(
-  page: Page,
-  searchText: string,
-): Promise<boolean> {
-  try {
-    const buttons = await page.$$("cf-button, button, a", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const text = await button.innerText();
-      if (text?.trim() === searchText) {
-        try {
-          await button.click();
-          return true;
-        } catch (_) {
-          return await page.evaluate((searchText: string) => {
-            for (
-              const el of document.querySelectorAll(
-                "cf-button, button, a",
-              )
-            ) {
-              if (el.textContent?.trim() === searchText) {
-                (el as HTMLElement).click();
-                return true;
-              }
-            }
-            return false;
-          }, { args: [searchText] });
-        }
-      }
-    }
-    return false;
-  } catch (_) {
-    return false;
-  }
-}
-
-async function clickButtonWithTitle(
-  page: Page,
-  title: string,
-): Promise<boolean> {
-  try {
-    const buttons = await page.$$("cf-button, button", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const actualTitle = await button.getAttribute("title");
-      if (actualTitle === title) {
-        try {
-          await button.click();
-          return true;
-        } catch (_) {
-          return await page.evaluate((title: string) => {
-            const el = document.querySelector(
-              `cf-button[title="${title}"], button[title="${title}"]`,
-            );
-            if (!el) return false;
-            (el as HTMLElement).click();
-            return true;
-          }, { args: [title] });
-        }
-      }
-    }
-    return false;
-  } catch (_) {
-    return false;
   }
 }
 

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -7,6 +7,7 @@ import { Identity } from "@commonfabric/identity";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { clickPierce } from "./shadow-dom.ts";
 import { expect } from "@std/expect";
+import { defer, type Deferred } from "@commonfabric/utils/defer";
 
 const { API_URL, SPACE_NAME, FRONTEND_URL } = env;
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
@@ -123,6 +124,18 @@ describe("shell piece tests", () => {
     let piece: PieceController | undefined;
     let pieceSinkCancel: (() => void) | undefined;
     let identityPath: string | undefined;
+    // The piece's committed result value, tracked by the result-cell sink set
+    // up below, and a one-shot waiter the sink resolves when the value reaches
+    // a target. A fresh deferred per call keeps the sequential checks (0, then
+    // -1, then -2) independent.
+    let latestResultValue: number | undefined;
+    let resultWaiter: { target: number; deferred: Deferred } | undefined;
+    const awaitResultValue = (target: number): Promise<void> => {
+      if (latestResultValue === target) return Promise.resolve();
+      const deferred = defer();
+      resultWaiter = { target, deferred };
+      return deferred.promise;
+    };
     const logDebugSnapshot = async (label: string) => {
       console.log(label, {
         shellState: await shell.state(),
@@ -214,11 +227,17 @@ describe("shell piece tests", () => {
       piece = currentPiece;
 
       const resultCell = cc.manager().getResult(currentPiece.getCell());
-      pieceSinkCancel = resultCell.sink(() => {});
+      pieceSinkCancel = resultCell.sink((value) => {
+        latestResultValue = (value as { value?: number } | undefined)?.value;
+        if (resultWaiter && latestResultValue === resultWaiter.target) {
+          resultWaiter.deferred.resolve();
+          resultWaiter = undefined;
+        }
+      });
 
-      await waitFor(async () =>
-        (await currentPiece.result.get(["value"])) === 0
-      );
+      await awaitResultValue(0);
+      // A fresh reload of the piece has no sink; poll until its own sync round
+      // trip reads the committed value back.
       await waitFor(async () => {
         const reloadedPiece = await cc.get(pieceId, true);
         return (await reloadedPiece.result.get(["value"])) === 0;
@@ -270,19 +289,13 @@ describe("shell piece tests", () => {
 
       await waitForActivePattern();
 
-      await waitFor(async () =>
-        (await currentPiece.result.get(["value"])) === 0
-      );
+      await awaitResultValue(0);
 
       await clickPierce(page, "#counter-decrement");
-      await waitFor(async () =>
-        (await currentPiece.result.get(["value"])) === -1
-      );
+      await awaitResultValue(-1);
 
       await clickPierce(page, "#counter-decrement");
-      await waitFor(async () =>
-        (await currentPiece.result.get(["value"])) === -2
-      );
+      await awaitResultValue(-2);
 
       // Compilation-cache contract: the piece's cold compile above was written
       // back to the IDB-backed CachedCompiler. A FRESH worker must then load
@@ -343,9 +356,7 @@ describe("shell piece tests", () => {
         );
       }
 
-      await waitFor(async () =>
-        (await currentPiece.result.get(["value"])) === -2
-      );
+      await awaitResultValue(-2);
     } catch (error) {
       if (piece) {
         await logDebugSnapshot("shell piece test debug");


### PR DESCRIPTION
## What

Finishes the "Remaining migratable work" left by #4596 — the three residual polling `waitFor` uses that were held back there because they change shared helper semantics or read off-page state. Each residual item is its own commit, and a follow-up commit applies a self-review fix.

### 1. Shared button-click helpers → settle-then-single-click

`clickButtonWithText` / `clickButtonWithExactText` / `clickButtonWithTitle` (shared by `default-app.test.ts` and the notebook reload test) and `clickNthButton` (`nested-counter.test.ts`) were used both wrapped in a polling `waitFor` (retry until the button appears) and called bare with their boolean result asserted. They were reshaped to the `clickCfButton` form: a `waitForCondition` predicate finds the first rendered matching (or nth) button, scrolls it into view, and stamps its inner click target; the test then resolves exactly that element and dispatches a single trusted click. The button-appearance wait is now event-driven and the click fires once instead of in a retry loop. The helpers resolve `true` on success and throw a descriptive error otherwise, so the call sites that assert the click succeeded keep their assertions.

### 2. Render / source-state probe waits → `waitForCondition`

The `collectNoteTitlesInList` / `collectNotebookRenderState` / `collectNotebookSourceState` polls in the default-app tests moved into `waitForCondition` predicates. Because the predicate is serialized and runs in the page, each probe's in-page collection is inlined into the predicate (the rendered-title scan, the piece-cell read for `isNotebook` / `noteCount` / rendered chips, and the argument/internal read with manifest resolution). The standalone probe functions are kept where a later line still reads them for a one-shot assertion or diagnostics; the reload test's now-unused `collectNotebookSourceState` is removed.

### 3. Piece-result cell reads → `defer()` in the existing sink

`counter.test.ts`, `nested-counter.test.ts`, and `shell/integration/piece.test.ts` polled a piece's committed `result` value through the in-process controller (`waitFor(async () => (await piece.result.get(["value"])) === N)`). Each test already registers a `resultCell.sink(...)` to keep the piece reactive in pull mode; that sink now records the latest committed value and resolves a one-shot `defer()` when a target is reached. A small `awaitResultValue` helper resolves immediately when the value is already at the target (the sink fires with the current value on registration, and a re-set to the same value commits no change), and otherwise awaits the next matching notification. In the shell piece test the one poll that reads a freshly reloaded piece (which has no registered sink) stays a bounded poll on its own sync round trip.

### 4. Self-review fix

A self-review flagged that the note button-click predicate filtered candidates through the shared `isVisible` probe (which includes a viewport test) before scrolling, so a laid-out button below the fold was never scrolled in and the wait could spin to timeout. The final commit replaces that with a viewport-independent "rendered" check (laid out, not `display:none` / `visibility:hidden`), matching the reach of the `innerText` scan the poll used and the scroll-then-act shape of the other click helpers.

The migration note (`docs/development/waitfor-migration.md`) is updated to move these items out of "Remaining migratable work" and record only the freshly reloaded (sink-less) piece read as a remaining intentional poll.

## Verification

All four affected browser suites pass (via the integration runner, which starts the servers):

- `deno task integration patterns default-app` — 2 passed
- `deno task integration patterns-reload` — 1 passed
- `deno task integration patterns counter` (counter + nested-counter) — 2 passed
- `deno task integration shell piece` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes migrating default-app and piece tests from polling `waitFor` to event-driven waits and single, settled clicks to reduce flakiness and timeouts.

- **Refactors**
  - Converted shared button-click helpers and `clickNthButton` to settle-then-single-click via `waitForCondition`; removed retry loops.
  - Moved default-app and reload notebook render/source-state waits into in-page predicates (title scan, piece cell `isNotebook`/`noteCount` and chip count, argument/internal reads with manifest resolution); removed the reload test’s unused `collectNotebookSourceState`.
  - Replaced piece-result polls in `counter`, `nested-counter`, and `shell piece` with `defer()` resolved by `resultCell.sink()`; kept a bounded poll only for the freshly reloaded, sink-less piece read.
  - Updated `docs/development/waitfor-migration.md` to record these conversions and drop the “Remaining migratable work” section.

- **Bug Fixes**
  - Made the note-button click predicate viewport-independent (“rendered” before scroll) so below-the-fold buttons are clicked reliably.

<sup>Written for commit 701f015ed74c618fd3b5cd033e0a704df1c2b394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

