### PR TITLE
feat(storage): cascade pending-dependency drops client-side; record full pending-stack dependencies in commit reads

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -610,9 +610,12 @@ the per-epic implementation notes).
 >   scalarizes each dependency array to its top-of-stack element before sending
 >   (`scalarizePendingReadStacks` in
 >   [`packages/runner/src/storage/v2.ts`](../../packages/runner/src/storage/v2.ts)),
->   which keeps wire compatibility while knowingly forgoing the lower-layer
->   dependency check on that server — the client-side drop cascade still covers
->   those edges locally. Added on CT-1872 (PR #4606). Path to removal: retire
+>   and HOLDS the send until every omitted lower dependency has settled — a
+>   dropped one dooms the commit locally before it reaches the wire; once all
+>   are accepted the scalar shape is sound. (Sending while an omitted
+>   dependency is unsettled would let the old server durably accept a commit
+>   the client cascade-rejects — a split-brain where the caller sees a
+>   conflict for a write that landed.) Added on CT-1872 (PR #4606). Path to removal: retire
 >   the scalarization fallback once every server in the fleet advertises the
 >   capability; the flag itself then reads as permanent documentation of the
 >   wire shape, and the successor design is tracked as CT-1910.

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -615,7 +615,10 @@ the per-epic implementation notes).
 >   are accepted the scalar shape is sound. (Sending while an omitted
 >   dependency is unsettled would let the old server durably accept a commit
 >   the client cascade-rejects — a split-brain where the caller sees a
->   conflict for a write that landed.) Added on CT-1872 (PR #4606). Path to removal: retire
+>   conflict for a write that landed.) Scheduler observations degrade instead
+>   of holding: a multi-layer observation is dropped client-side (flag-off
+>   semantics), so the flush that semantic commits await never waits on
+>   verdicts. Added on CT-1872 (PR #4606). Path to removal: retire
 >   the scalarization fallback once every server in the fleet advertises the
 >   capability; the flag itself then reads as permanent documentation of the
 >   wire shape, and the successor design is tracked as CT-1910.

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -602,6 +602,20 @@ the per-epic implementation notes).
 >   keeps its write gate failing closed. It was added by Bernhard Seefeld in
 >   "server-side commit-time row-label re-derivation (Epic E4, Phase 3.c)"
 >   (#4552). It is permanent.
+> - **`pendingReadStacks`** is a build-inherent capability, hardwired to `true`,
+>   advertising that this build's engine resolves array-`localSeq` pending reads
+>   (the full-stack dependency sets of CT-1872 1c; `resolvePendingReads` in
+>   [`packages/memory/v2/engine.ts`](../../packages/memory/v2/engine.ts)). It is
+>   not configuration: against a server that advertises it absent, the client
+>   scalarizes each dependency array to its top-of-stack element before sending
+>   (`scalarizePendingReadStacks` in
+>   [`packages/runner/src/storage/v2.ts`](../../packages/runner/src/storage/v2.ts)),
+>   which keeps wire compatibility while knowingly forgoing the lower-layer
+>   dependency check on that server — the client-side drop cascade still covers
+>   those edges locally. Added on CT-1872 (PR #4606). Path to removal: retire
+>   the scalarization fallback once every server in the fleet advertises the
+>   capability; the flag itself then reads as permanent documentation of the
+>   wire shape, and the successor design is tracked as CT-1910.
 
 ### `experimentalConcurrentWatchRefresh`
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -211,9 +211,14 @@ set/delete check false-conflicts with the reader's own stack.
 The array form is a negotiated capability (`pendingReadStacks` in the hello
 flags). Toward a server that does not advertise it, the client MUST send
 scalar reads, collapsing each array to its top-of-stack element — the
-pre-capability wire shape. The lower-layer dependency check is knowingly
-absent on such servers; the client-side drop cascade still covers those
-edges locally.
+pre-capability wire shape. Because the omitted lower layers are then
+invisible to the server, the client MUST NOT send such a commit while any
+omitted dependency is unsettled: the server could durably accept a commit
+the client is about to cascade-reject, and the caller would observe a
+conflict for a write that landed. The client holds the send until every
+omitted dependency settles — a dropped one dooms the commit locally before
+it reaches the wire, and all-accepted makes the scalar shape sound (each
+omitted layer's resolution is already durable).
 
 ## 3.6 Server Validation
 
@@ -258,14 +263,23 @@ function validatePendingReads(
   serverState: ServerState,
 ): ValidationResult {
   for (const read of commit.reads.pending) {
-    const resolution = serverState.resolveLocalSeq(sessionId, read.localSeq);
+    const layers = Array.isArray(read.localSeq)
+      ? read.localSeq
+      : [read.localSeq];
 
-    if (resolution === null) {
-      return pendingDependency(read.localSeq);
-    }
+    // Every listed layer must resolve to an ACCEPTED commit. The staleness
+    // check (§3.6.1/§3.6.2) then runs once per read, based at the HIGHEST
+    // element's resolution — the reader's top-of-stack layer (§3.5).
+    for (const localSeq of layers) {
+      const resolution = serverState.resolveLocalSeq(sessionId, localSeq);
 
-    if (resolution.rejected) {
-      return cascadedRejection(read.localSeq);
+      if (resolution === null) {
+        return pendingDependency(localSeq);
+      }
+
+      if (resolution.rejected) {
+        return cascadedRejection(localSeq);
+      }
     }
   }
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -153,6 +153,11 @@ interface PendingRead {
   id: EntityId;
   path: ReadPath;
   localSeq: number;
+  // Existence-only dependency record: asserts that `localSeq` resolved to an
+  // accepted commit, without carrying a staleness precondition of its own.
+  // Emitted for the layers UNDER the staleness-bearing top-of-stack read when
+  // a read observes a value through a stack of pending commits (§3.5).
+  resolutionOnly?: boolean;
 }
 ```
 
@@ -178,6 +183,17 @@ If `C1` is later confirmed, the server resolves `C2`'s pending read to that
 confirmed commit. If `C1` is rejected, `C2` is invalid and must be rejected as
 well. Rejection therefore cascades through the stack of dependent pending
 commits.
+
+The cascade cannot rely on each pending layer reading the layer beneath it:
+zero-read operations (mergeable collection writes) legally interleave into a
+stack without any read edge. A commit that reads through a pending stack
+therefore records its FULL dependency set directly — the top-of-stack layer as
+the ordinary (staleness-bearing) pending read, and every lower layer at or
+under the read path as a `resolutionOnly` existence read. The client mirrors
+the server cascade at drop time: when a pending commit's optimistic writes are
+dropped, every queued or in-flight commit whose recorded dependency set names
+the dropped `localSeq` is locally rejected without waiting for the server's
+per-commit verdict.
 
 ## 3.6 Server Validation
 
@@ -240,6 +256,17 @@ function validatePendingReads(
 If a referenced `localSeq` is not resolved yet, the server MAY hold the commit
 in the session queue until the dependency resolves. If the dependency resolves
 to rejection, the queued commit is rejected immediately.
+
+A `resolutionOnly` pending read participates in this resolution requirement
+exactly like an ordinary pending read — an unresolved or rejected dependency
+rejects the commit — but carries no staleness precondition of its own: the
+overlap validation of §3.6.1/§3.6.2 applies only to the staleness-bearing
+reads. The staleness scan for a pending read starts at the NAMED layer's
+resolution seq; writes landing between the reader's confirmed basis and that
+seq are not scanned through pending reads today (tracked as the pending-read
+basis over-advance follow-up on CT-1872 — the planned repair validates the
+full interval from the reader's confirmed basis, excluding only the reader's
+own resolved session stack).
 
 ### 3.6.4 Conflict Response
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -195,6 +195,15 @@ dropped, every queued or in-flight commit whose recorded dependency set names
 the dropped `localSeq` is locally rejected without waiting for the server's
 per-commit verdict.
 
+The recorded dependency set MUST include the document's top-of-stack pending
+layer below the reader, and the staleness-bearing read MUST name that top
+layer: the staleness basis is always the stack top. Any narrowing of the
+dependency set (for example, pruning layers whose write footprint provably
+cannot influence the read path) may drop only NON-top layers. Basing the
+staleness scan at a lower layer is unsound, not merely conservative: the
+session's own newer stacked commits then land inside the scan interval, where
+the path-blind set/delete check false-conflicts with the reader's own stack.
+
 ## 3.6 Server Validation
 
 When the server receives a commit, it validates all read dependencies before
@@ -256,6 +265,16 @@ function validatePendingReads(
 If a referenced `localSeq` is not resolved yet, the server MAY hold the commit
 in the session queue until the dependency resolves. If the dependency resolves
 to rejection, the queued commit is rejected immediately.
+
+Holding is queueing, not reordering: within a logical session, commits are
+resolved (accepted or rejected) in increasing `localSeq` order, and a held
+commit MUST NOT be leapfrogged by a later same-session commit. A commit's
+resolution seq is therefore monotonic in its `localSeq` within a session —
+the property that makes the top-of-stack pending read a sound staleness basis
+(§3.5): every own-session layer below the reader resolves at or before the
+basis layer's seq, so the scan interval past the basis contains no own-session
+commits. (The current implementation rejects rather than holds, which
+preserves this ordering trivially.)
 
 A `resolutionOnly` pending read participates in this resolution requirement
 exactly like an ordinary pending read — an unresolved or rejected dependency

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -218,7 +218,11 @@ the client is about to cascade-reject, and the caller would observe a
 conflict for a write that landed. The client holds the send until every
 omitted dependency settles — a dropped one dooms the commit locally before
 it reaches the wire, and all-accepted makes the scalar shape sound (each
-omitted layer's resolution is already durable).
+omitted layer's resolution is already durable). Scheduler observations,
+being droppable bookkeeping, degrade instead of holding: an observation
+whose read sat on more than one pending layer is dropped client-side
+(flag-off semantics — the resume re-runs fresh) rather than delaying the
+flush that semantic commits await.
 
 ## 3.6 Server Validation
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -152,12 +152,15 @@ interface ConfirmedRead {
 interface PendingRead {
   id: EntityId;
   path: ReadPath;
-  localSeq: number;
-  // Existence-only dependency record: asserts that `localSeq` resolved to an
-  // accepted commit, without carrying a staleness precondition of its own.
-  // Emitted for the layers UNDER the staleness-bearing top-of-stack read when
-  // a read observes a value through a stack of pending commits (§3.5).
-  resolutionOnly?: boolean;
+  // The dependency set: every pending layer the read's materialized view
+  // sat on. Each element must have resolved to an ACCEPTED commit for this
+  // commit to be applicable; the staleness check (§3.6.1) runs once, based
+  // at the resolution of the HIGHEST element — the document's top-of-stack
+  // layer below the reader, which the array MUST include (§3.5). A scalar
+  // is the single-layer form, and the only form a client may send to a
+  // server that has not advertised the `pendingReadStacks` capability in
+  // the hello exchange.
+  localSeq: number | number[];
 }
 ```
 
@@ -187,22 +190,30 @@ commits.
 The cascade cannot rely on each pending layer reading the layer beneath it:
 zero-read operations (mergeable collection writes) legally interleave into a
 stack without any read edge. A commit that reads through a pending stack
-therefore records its FULL dependency set directly — the top-of-stack layer as
-the ordinary (staleness-bearing) pending read, and every lower layer at or
-under the read path as a `resolutionOnly` existence read. The client mirrors
-the server cascade at drop time: when a pending commit's optimistic writes are
-dropped, every queued or in-flight commit whose recorded dependency set names
-the dropped `localSeq` is locally rejected without waiting for the server's
-per-commit verdict.
+therefore records its FULL dependency set directly: the read's `localSeq`
+array names every pending layer of the document below the reader, in
+ascending order. Each element imposes a resolution requirement; the highest
+element — the document's top-of-stack layer — is the staleness basis. The
+client mirrors the server cascade at drop time: when a pending commit's
+optimistic writes are dropped, every queued or in-flight commit whose
+recorded dependency set names the dropped `localSeq` is locally rejected
+without waiting for the server's per-commit verdict.
 
-The recorded dependency set MUST include the document's top-of-stack pending
-layer below the reader, and the staleness-bearing read MUST name that top
-layer: the staleness basis is always the stack top. Any narrowing of the
-dependency set (for example, pruning layers whose write footprint provably
-cannot influence the read path) may drop only NON-top layers. Basing the
-staleness scan at a lower layer is unsound, not merely conservative: the
-session's own newer stacked commits then land inside the scan interval, where
-the path-blind set/delete check false-conflicts with the reader's own stack.
+The dependency array MUST include the document's top-of-stack pending layer
+below the reader: the staleness basis is always the stack top (implicitly,
+the array's highest element). Any narrowing of the dependency set (for
+example, pruning layers whose write footprint provably cannot influence the
+read path) may drop only NON-top layers. Basing the staleness scan at a
+lower layer is unsound, not merely conservative: the session's own newer
+stacked commits then land inside the scan interval, where the path-blind
+set/delete check false-conflicts with the reader's own stack.
+
+The array form is a negotiated capability (`pendingReadStacks` in the hello
+flags). Toward a server that does not advertise it, the client MUST send
+scalar reads, collapsing each array to its top-of-stack element — the
+pre-capability wire shape. The lower-layer dependency check is knowingly
+absent on such servers; the client-side drop cascade still covers those
+edges locally.
 
 ## 3.6 Server Validation
 
@@ -276,16 +287,15 @@ basis layer's seq, so the scan interval past the basis contains no own-session
 commits. (The current implementation rejects rather than holds, which
 preserves this ordering trivially.)
 
-A `resolutionOnly` pending read participates in this resolution requirement
-exactly like an ordinary pending read — an unresolved or rejected dependency
-rejects the commit — but carries no staleness precondition of its own: the
-overlap validation of §3.6.1/§3.6.2 applies only to the staleness-bearing
-reads. The staleness scan for a pending read starts at the NAMED layer's
-resolution seq; writes landing between the reader's confirmed basis and that
-seq are not scanned through pending reads today (tracked as the pending-read
-basis over-advance follow-up on CT-1872 — the planned repair validates the
-full interval from the reader's confirmed basis, excluding only the reader's
-own resolved session stack).
+Every element of an array `localSeq` participates in this resolution
+requirement — one unresolved or rejected element rejects the commit — but
+only the highest element carries the staleness precondition: the overlap
+validation of §3.6.1/§3.6.2 runs once per read, based at the highest
+element's resolution seq. Writes landing between the reader's confirmed
+basis and that seq are not scanned through pending reads today (tracked as
+CT-1910, the pending-read basis over-advance — the planned repair validates
+the full interval from the reader's confirmed basis, excluding only the
+reader's own resolved session stack, and supersedes the max-basis rule).
 
 ### 3.6.4 Conflict Response
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -2522,6 +2522,155 @@ Deno.test("memory v2 engine resolves pending reads and rejects stale pending rea
   }
 });
 
+// CT-1872 1c: a resolutionOnly pending read asserts only that its dependency
+// localSeq resolved to a durable commit (a lower layer of the reader's pending
+// stack exists). It is exempt from the staleness check — that stays with the
+// top-of-stack pending read — so a later overlapping foreign write must NOT
+// reject it, while an unresolved dependency still must.
+Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but still require resolution", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({ foo: 0 }),
+        }],
+      },
+    });
+
+    // The dependency: localSeq 2 commits durably (seq 2).
+    const dependency = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{ op: "replace", path: "/value/foo", value: 1 }],
+        }],
+      },
+    });
+    assertEquals(dependency.seq, 2);
+
+    // A LATER overlapping foreign write to the same doc (a whole-doc set is
+    // path-blind, so it overlaps ANY read of entity:source): a normal pending
+    // read via localSeq 2 is now stale.
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({ foo: 2 }),
+        }],
+      },
+    });
+
+    // resolutionOnly + resolved dependency ⇒ ACCEPTED despite the later
+    // overlapping write: only existence of the seq-2 commit row is asserted.
+    const accepted = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(3),
+      authorization,
+      commit: {
+        localSeq: 3,
+        reads: {
+          confirmed: [],
+          pending: [{
+            id: "entity:source",
+            path: toDocumentPath([]),
+            localSeq: 2,
+            resolutionOnly: true,
+          }],
+        },
+        operations: [{
+          op: "set",
+          id: "entity:target",
+          value: toEntityDocument({ derived: true }),
+        }],
+      },
+    });
+    assertEquals(accepted.seq, 4);
+
+    // resolutionOnly does NOT waive resolution itself: a dependency that was
+    // never committed still rejects.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(4),
+          authorization,
+          commit: {
+            localSeq: 4,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:source",
+                path: toDocumentPath([]),
+                localSeq: 99,
+                resolutionOnly: true,
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:unresolved",
+              value: toEntityDocument({ ok: false }),
+            }],
+          },
+        }),
+      ConflictError,
+      "pending dependency not resolved",
+    );
+
+    // Control: the SAME shape without the flag is stale — the flag, not the
+    // scenario, is what admitted the commit above.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(5),
+          authorization,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:source",
+                path: toDocumentPath([]),
+                localSeq: 2,
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:control",
+              value: toEntityDocument({ ok: false }),
+            }],
+          },
+        }),
+      ConflictError,
+      "stale pending read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine reconstructs state across delete boundaries", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -2661,6 +2661,63 @@ Deno.test("memory v2 engine: array pending reads scan at the highest layer and r
       "pending dependency not resolved",
     );
 
+    // Malformed dependency sets are protocol violations, not conflicts: an
+    // empty array names no layer at all…
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(7),
+          authorization,
+          commit: {
+            localSeq: 7,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:source",
+                path: toDocumentPath([]),
+                localSeq: [],
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:malformed-empty",
+              value: toEntityDocument({ ok: false }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "names no localSeq",
+    );
+
+    // …and a non-integer element is not a localSeq.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(8),
+          authorization,
+          commit: {
+            localSeq: 8,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:source",
+                path: toDocumentPath([]),
+                localSeq: [1.5],
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:malformed-float",
+              value: toEntityDocument({ ok: false }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "non-integer localSeq",
+    );
+
     // Control: based at the LOWER layer alone (scalar 2), the foreign seq-3
     // write is inside the scan interval — the max-basis rule, not the
     // scenario, is what admitted the commit above.

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -2679,6 +2679,179 @@ Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but sti
   }
 });
 
+// CT-1872 1c, end to end at the engine: a fabricated composite must die on
+// the resolution edge, because no staleness scan can catch it.
+//
+//   base:  D = { items: [] }                                  (seq 1)
+//   T1  (localSeq 10): items = ["A"]  — REJECTED (stale read on title)
+//   T1.5 (localSeq 11): blind append "B", zero reads — APPLIED → items ["B"]
+//   T2  (localSeq 12): observed items ["A","B"] through the client stack
+//
+// T2's observation is not STALE — ["A","B"] never existed at any seq; "A"
+// lived only in the client's optimistic layer for a commit the server
+// refused. An under-declared T2 (pre-#4606 client: top-of-stack read only)
+// passes both resolution (T1.5 has a commit row) and the staleness scan
+// (nothing touched items after seq(T1.5)) and is durably ACCEPTED with a
+// phantom premise. The full-stack shape (#4606) names T1 as a
+// resolutionOnly dependency, and the missing commit row rejects it.
+Deno.test("memory v2 engine: full-stack dependency recording rejects a fabricated composite an under-declared commit smuggles through", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:seed",
+      invocation: invocationFor(1, { actor: "seed" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:D",
+          value: toEntityDocument({ items: [], title: "t0" }),
+        }],
+      },
+    });
+
+    // Foreign write (seq 2) bumps title so T1's confirmed read goes stale.
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:D",
+          patches: [{
+            op: "replace",
+            path: "/value/title",
+            value: "t-foreign",
+          }],
+        }],
+      },
+    });
+
+    // T1: REJECTED — its items=["A"] write is discarded everywhere.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(10),
+          authorization,
+          commit: {
+            localSeq: 10,
+            reads: {
+              confirmed: [{
+                id: "entity:D",
+                path: toDocumentPath(["value", "title"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "patch",
+              id: "entity:D",
+              patches: [{
+                op: "replace",
+                path: "/value/items",
+                value: ["A"],
+              }],
+            }],
+          },
+        }),
+      ConflictError,
+      "stale confirmed read",
+    );
+
+    // T1.5: blind append, zero reads — applies onto the T1-less base.
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(11),
+      authorization,
+      commit: {
+        localSeq: 11,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:D",
+          patches: [{ op: "add", path: "/value/items/-", value: "B" }],
+        }],
+      },
+    });
+
+    // Under-declared shape (pre-#4606 client): top-of-stack read only.
+    // ACCEPTED — resolution and staleness both legitimately pass, and the
+    // phantom ["A","B"] premise lands durably. This pins WHY the full-stack
+    // shape below is load-bearing (and stays reachable via version skew).
+    const smuggled = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(12),
+      authorization,
+      commit: {
+        localSeq: 12,
+        reads: {
+          confirmed: [],
+          pending: [{
+            id: "entity:D",
+            path: toDocumentPath(["value", "items"]),
+            localSeq: 11,
+          }],
+        },
+        operations: [{
+          op: "set",
+          id: "entity:phantom",
+          value: toEntityDocument({ observedItems: ["A", "B"] }),
+        }],
+      },
+    });
+    assertEquals(smuggled.seq, 4);
+    const durable = read(engine, { id: "entity:D" });
+    assertEquals(
+      (durable as { value?: { items?: unknown } } | null)?.value?.items,
+      ["B"],
+    );
+
+    // Full-stack shape (#4606): the same observation also names T1, whose
+    // commit row does not exist — rejected on the resolution edge.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(13),
+          authorization,
+          commit: {
+            localSeq: 13,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:D",
+                path: toDocumentPath(["value", "items"]),
+                localSeq: 11,
+              }, {
+                id: "entity:D",
+                path: toDocumentPath([]),
+                localSeq: 10,
+                resolutionOnly: true,
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:caught",
+              value: toEntityDocument({ observedItems: ["A", "B"] }),
+            }],
+          },
+        }),
+      ConflictError,
+      "pending dependency not resolved: 10",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine reconstructs state across delete boundaries", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -2522,20 +2522,19 @@ Deno.test("memory v2 engine resolves pending reads and rejects stale pending rea
   }
 });
 
-// CT-1872 1c: a resolutionOnly pending read asserts only that its dependency
-// localSeq resolved to a durable commit (a lower layer of the reader's pending
-// stack exists). It is exempt from the staleness check — that stays with the
-// top-of-stack pending read — so a later overlapping foreign write must NOT
-// reject it, while an unresolved dependency still must.
+// CT-1872 1c: an array localSeq names every pending layer the read sat on.
+// Non-highest elements impose resolution ONLY (the dependency must have an
+// accepted commit row) — staleness is based at the HIGHEST element, so a
+// foreign write that lands before the highest element's resolution must NOT
+// reject the read, while an unresolved element still must.
 //
-// NOTE: this pins main's de-facto lower-layer semantics made explicit on the
-// wire, not an endorsement of the scan interval. The staleness scan for a
-// pending read starts at the NAMED layer's resolution seq (with or without
-// resolutionOnly), so foreign writes in (reader's confirmed basis,
-// top-layer resolution] go unscanned — a pre-existing gap tracked as the
-// "pending-read basis over-advance" follow-up on CT-1872, whose fix
-// (own-session exclusion + true-basis validation) supersedes this exemption.
-Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but still require resolution", async () => {
+// NOTE: this pins main's de-facto basis semantics made explicit on the wire,
+// not an endorsement of the scan interval. The staleness scan starts at the
+// highest layer's resolution seq, so foreign writes in (reader's confirmed
+// basis, that resolution] go unscanned — a pre-existing gap tracked as
+// CT-1910 (pending-read basis over-advance), whose fix (own-session
+// exclusion + true-basis validation) supersedes the max-basis rule.
+Deno.test("memory v2 engine: array pending reads scan at the highest layer and require every layer to resolve", async () => {
   const { engine, path } = await createEngine();
 
   try {
@@ -2589,21 +2588,39 @@ Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but sti
       },
     });
 
-    // resolutionOnly + resolved dependency ⇒ ACCEPTED despite the later
-    // overlapping write: only existence of the seq-2 commit row is asserted.
-    const accepted = applyCommit(engine, {
+    // A newer same-session blind layer (localSeq 3, zero reads) lands AFTER
+    // the foreign write: the doc's stack top below the reader.
+    const top = applyCommit(engine, {
       sessionId: "session:1",
       invocation: invocationFor(3),
       authorization,
       commit: {
         localSeq: 3,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{ op: "add", path: "/value/blind", value: true }],
+        }],
+      },
+    });
+    assertEquals(top.seq, 4);
+
+    // Array [2, 3]: staleness is based at the HIGHEST layer (3 → seq 4), so
+    // the foreign seq-3 write is outside the scan; element 2 imposes
+    // resolution only ⇒ ACCEPTED.
+    const accepted = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(4),
+      authorization,
+      commit: {
+        localSeq: 4,
         reads: {
           confirmed: [],
           pending: [{
             id: "entity:source",
             path: toDocumentPath([]),
-            localSeq: 2,
-            resolutionOnly: true,
+            localSeq: [2, 3],
           }],
         },
         operations: [{
@@ -2613,25 +2630,24 @@ Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but sti
         }],
       },
     });
-    assertEquals(accepted.seq, 4);
+    assertEquals(accepted.seq, 5);
 
-    // resolutionOnly does NOT waive resolution itself: a dependency that was
-    // never committed still rejects.
+    // The array does NOT waive resolution for any element: one uncommitted
+    // member rejects the whole read.
     assertThrows(
       () =>
         applyCommit(engine, {
           sessionId: "session:1",
-          invocation: invocationFor(4),
+          invocation: invocationFor(5),
           authorization,
           commit: {
-            localSeq: 4,
+            localSeq: 5,
             reads: {
               confirmed: [],
               pending: [{
                 id: "entity:source",
                 path: toDocumentPath([]),
-                localSeq: 99,
-                resolutionOnly: true,
+                localSeq: [2, 99],
               }],
             },
             operations: [{
@@ -2645,16 +2661,17 @@ Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but sti
       "pending dependency not resolved",
     );
 
-    // Control: the SAME shape without the flag is stale — the flag, not the
+    // Control: based at the LOWER layer alone (scalar 2), the foreign seq-3
+    // write is inside the scan interval — the max-basis rule, not the
     // scenario, is what admitted the commit above.
     assertThrows(
       () =>
         applyCommit(engine, {
           sessionId: "session:1",
-          invocation: invocationFor(5),
+          invocation: invocationFor(6),
           authorization,
           commit: {
-            localSeq: 5,
+            localSeq: 6,
             reads: {
               confirmed: [],
               pending: [{
@@ -2689,11 +2706,12 @@ Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but sti
 //
 // T2's observation is not STALE — ["A","B"] never existed at any seq; "A"
 // lived only in the client's optimistic layer for a commit the server
-// refused. An under-declared T2 (pre-#4606 client: top-of-stack read only)
-// passes both resolution (T1.5 has a commit row) and the staleness scan
-// (nothing touched items after seq(T1.5)) and is durably ACCEPTED with a
-// phantom premise. The full-stack shape (#4606) names T1 as a
-// resolutionOnly dependency, and the missing commit row rejects it.
+// refused. An under-declared T2 (scalar top-of-stack read: what a client
+// emits toward a server without the `pendingReadStacks` flag) passes both
+// resolution (T1.5 has a commit row) and the staleness scan (nothing touched
+// items after seq(T1.5)) and is durably ACCEPTED with a phantom premise.
+// The full-stack array shape (#4606) also names T1, and the missing commit
+// row rejects it.
 Deno.test("memory v2 engine: full-stack dependency recording rejects a fabricated composite an under-declared commit smuggles through", async () => {
   const { engine, path } = await createEngine();
 
@@ -2813,8 +2831,8 @@ Deno.test("memory v2 engine: full-stack dependency recording rejects a fabricate
       ["B"],
     );
 
-    // Full-stack shape (#4606): the same observation also names T1, whose
-    // commit row does not exist — rejected on the resolution edge.
+    // Full-stack array shape (#4606): the same observation also names T1,
+    // whose commit row does not exist — rejected on the resolution edge.
     assertThrows(
       () =>
         applyCommit(engine, {
@@ -2828,12 +2846,7 @@ Deno.test("memory v2 engine: full-stack dependency recording rejects a fabricate
               pending: [{
                 id: "entity:D",
                 path: toDocumentPath(["value", "items"]),
-                localSeq: 11,
-              }, {
-                id: "entity:D",
-                path: toDocumentPath([]),
-                localSeq: 10,
-                resolutionOnly: true,
+                localSeq: [10, 11],
               }],
             },
             operations: [{

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -2527,6 +2527,14 @@ Deno.test("memory v2 engine resolves pending reads and rejects stale pending rea
 // stack exists). It is exempt from the staleness check — that stays with the
 // top-of-stack pending read — so a later overlapping foreign write must NOT
 // reject it, while an unresolved dependency still must.
+//
+// NOTE: this pins main's de-facto lower-layer semantics made explicit on the
+// wire, not an endorsement of the scan interval. The staleness scan for a
+// pending read starts at the NAMED layer's resolution seq (with or without
+// resolutionOnly), so foreign writes in (reader's confirmed basis,
+// top-layer resolution] go unscanned — a pre-existing gap tracked as the
+// "pending-read basis over-advance" follow-up on CT-1872, whose fix
+// (own-session exclusion + true-basis validation) supersedes this exemption.
 Deno.test("memory v2 engine: resolutionOnly pending reads skip staleness but still require resolution", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -795,6 +795,124 @@ Deno.test("memory v2 accepts batched no-op scheduler observations", async () => 
   }
 });
 
+// CT-1872 1c parity for observations: an observation's pending read carries
+// the same array dependency set as an ordinary commit read — every element
+// must resolve (else the observation drops), and staleness is based at the
+// HIGHEST element, so a foreign write before the top layer's resolution does
+// not drop it (the same max-basis rule, and the same CT-1908/CT-1910 basis
+// caveat, as resolvePendingReads).
+Deno.test("memory v2 scheduler observations resolve array pending reads at the highest layer", async () => {
+  const { engine, path } = await createEngine();
+  const sessionId = "session:scheduler-array-reads";
+
+  try {
+    // Layer 1 (accepted): creates the doc the observation read sits on.
+    applyCommit(engine, {
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:sched-doc",
+          value: { value: { x: 1 } },
+        }],
+      },
+    });
+
+    // Foreign write between the layers: inside layer 1's scan interval,
+    // outside layer 2's.
+    applyCommit(engine, {
+      sessionId: "session:scheduler-array-foreign",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:sched-doc",
+          value: { value: { x: 2 } },
+        }],
+      },
+    });
+
+    // Layer 2 (accepted, blind): the session's top-of-stack for the doc.
+    applyCommit(engine, {
+      sessionId,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:sched-doc",
+          patches: [{ op: "add", path: "/value/y", value: 3 }],
+        }],
+      },
+    });
+
+    const result = applyCommit(engine, {
+      sessionId,
+      commit: {
+        localSeq: 100,
+        reads: { confirmed: [], pending: [] },
+        operations: [],
+        schedulerObservationBatch: [
+          {
+            // Array read via [1, 2]: kept — element 1 resolves, staleness
+            // scans after layer 2's resolution, past the foreign write.
+            localSeq: 101,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:sched-doc",
+                path: toDocumentPath([]),
+                localSeq: [1, 2],
+              }],
+            },
+            schedulerObservation: observationForAction(
+              "pattern.tsx:array-read:kept",
+            ),
+          },
+          {
+            // An unresolved element drops the observation, exactly like the
+            // ordinary-commit resolution requirement.
+            localSeq: 102,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:sched-doc",
+                path: toDocumentPath([]),
+                localSeq: [1, 99],
+              }],
+            },
+            schedulerObservation: observationForAction(
+              "pattern.tsx:array-read:unresolved",
+            ),
+          },
+        ],
+      },
+    });
+
+    assertEquals(
+      result.schedulerObservationResults?.map((entry) => ({
+        localSeq: entry.localSeq,
+        status: entry.status,
+        reason: entry.reason,
+      })),
+      [
+        { localSeq: 101, status: "kept", reason: undefined },
+        {
+          localSeq: 102,
+          status: "dropped",
+          reason: "pending-read-missing",
+        },
+      ],
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 namespaces scheduler mirrors by owner space", async () => {
   const { engine, path } = await createEngine();
   const ownerA = "did:key:scheduler-owner-a";

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -142,6 +142,7 @@ describe("memory v2 flags", () => {
       syncSchemaTable: false,
       // Build-inherent capability, not configuration: always advertised.
       sqliteCommitRowLabelEval: true,
+      pendingReadStacks: true,
       syncSchemaTableV2: false,
     });
 
@@ -156,6 +157,7 @@ describe("memory v2 flags", () => {
       commitPreconditions: true,
       syncSchemaTable: false,
       sqliteCommitRowLabelEval: true,
+      pendingReadStacks: true,
       syncSchemaTableV2: true,
     });
 
@@ -174,6 +176,7 @@ describe("memory v2 flags", () => {
         syncSchemaTable: true,
         syncSchemaTableV2: true,
         sqliteCommitRowLabelEval: true,
+        pendingReadStacks: true,
       },
       {
         modernCellRep: true,
@@ -185,6 +188,7 @@ describe("memory v2 flags", () => {
         // compatible — the capability only gates the runner's write-gate
         // relaxation, never the connection.
         sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
       },
     ));
   });
@@ -199,6 +203,7 @@ describe("parseMemoryProtocolFlags", () => {
       syncSchemaTable: false,
       syncSchemaTableV2: false,
       sqliteCommitRowLabelEval: false,
+      pendingReadStacks: false,
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
@@ -207,6 +212,7 @@ describe("parseMemoryProtocolFlags", () => {
       syncSchemaTable: false,
       syncSchemaTableV2: false,
       sqliteCommitRowLabelEval: false,
+      pendingReadStacks: false,
     });
   });
 
@@ -222,6 +228,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
       },
     );
   });
@@ -238,6 +245,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
       },
     );
   });
@@ -254,6 +262,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: true,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
       },
     );
   });
@@ -270,6 +279,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: true,
         sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
       },
     );
   });
@@ -286,12 +296,34 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: true,
+        pendingReadStacks: false,
+      },
+    );
+  });
+
+  it("accepts the pendingReadStacks capability key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({
+        pendingReadStacks: true,
+      }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: false,
+        syncSchemaTable: false,
+        syncSchemaTableV2: false,
+        sqliteCommitRowLabelEval: false,
+        pendingReadStacks: true,
       },
     );
   });
 
   it("rejects values that are not a recognizable flags shape", () => {
     assertEquals(parseMemoryProtocolFlags(null), null);
+    assertEquals(
+      parseMemoryProtocolFlags({ pendingReadStacks: "true" }),
+      null,
+    );
     assertEquals(parseMemoryProtocolFlags(undefined), null);
     assertEquals(parseMemoryProtocolFlags("modernCellRep"), null);
     assertEquals(parseMemoryProtocolFlags([true]), null);

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -169,6 +169,16 @@ export interface PendingRead {
   localSeq: number;
   /** See {@link ConfirmedRead.nonRecursive}. */
   nonRecursive?: boolean;
+  /**
+   * When true, this read asserts ONLY that `localSeq` resolved to a durable
+   * commit — i.e. a lower layer of the reader's pending stack exists — and is
+   * exempt from the staleness (conflict) check entirely. Emitted for the
+   * non-top layers of a stacked pending read: the top-of-stack pending read
+   * carries the full path and remains staleness-bearing, so path staleness is
+   * still checked exactly once per read. Absent/false ⇒ full pending read
+   * (the historical behavior: resolution AND staleness).
+   */
+  resolutionOnly?: boolean;
 }
 
 export interface SchedulerObservationCommit {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -166,19 +166,19 @@ export interface PendingRead {
   id: EntityId;
   scope?: CellScope;
   path: ReadPath;
-  localSeq: number;
+  /**
+   * The reader's pending-stack dependency set for this document. An array
+   * lists EVERY pending layer the read's materialized view sat on; each
+   * element must have resolved to an accepted commit for this commit to be
+   * applicable, and the staleness (conflict) check runs exactly once, based
+   * at the resolution of the HIGHEST element — the document's top-of-stack
+   * layer below the reader, which the array MUST include. A scalar is the
+   * degenerate single-layer form (also what pre-`pendingReadStacks` peers
+   * emit: top-of-stack only, carrying no lower-layer dependencies).
+   */
+  localSeq: number | number[];
   /** See {@link ConfirmedRead.nonRecursive}. */
   nonRecursive?: boolean;
-  /**
-   * When true, this read asserts ONLY that `localSeq` resolved to a durable
-   * commit — i.e. a lower layer of the reader's pending stack exists — and is
-   * exempt from the staleness (conflict) check entirely. Emitted for the
-   * non-top layers of a stacked pending read: the top-of-stack pending read
-   * carries the full path and remains staleness-bearing, so path staleness is
-   * still checked exactly once per read. Absent/false ⇒ full pending read
-   * (the historical behavior: resolution AND staleness).
-   */
-  resolutionOnly?: boolean;
 }
 
 export interface SchedulerObservationCommit {
@@ -271,6 +271,17 @@ export interface MemoryProtocolFlags {
    * (not configuration), so a server of this version always advertises it.
    */
   sqliteCommitRowLabelEval: boolean;
+  /**
+   * Server capability (CT-1872 1c): pending reads may carry an ARRAY
+   * `localSeq` naming every pending layer the read sat on (resolution
+   * required for each element; staleness based at the highest — see
+   * `PendingRead.localSeq`). A client that sees this absent (an older
+   * server) falls back to scalar top-of-stack emission, keeping wire compat
+   * at the cost of the lower-layer dependency check on that server (the
+   * client-side drop cascade still applies locally). Inherent to the build,
+   * so a server of this version always advertises it.
+   */
+  pendingReadStacks: boolean;
 }
 
 /**
@@ -283,6 +294,7 @@ export type WireMemoryProtocolFlags = {
   syncSchemaTable?: boolean;
   syncSchemaTableV2?: boolean;
   sqliteCommitRowLabelEval?: boolean;
+  pendingReadStacks?: boolean;
 };
 
 export interface HelloMessage {
@@ -750,6 +762,10 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   // advertises the fact. Peers that see it absent (an older server) keep their
   // write gate failing closed.
   sqliteCommitRowLabelEval: true,
+  // Likewise build-inherent: this build's engine resolves array-localSeq
+  // pending reads (resolvePendingReads), so it always advertises it. Clients
+  // that see it absent scalarize to top-of-stack before sending.
+  pendingReadStacks: true,
   syncSchemaTableV2: getSyncSchemaTableConfig(),
 });
 
@@ -823,6 +839,14 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
+  const pendingReadStacks = value.pendingReadStacks;
+  if (
+    pendingReadStacks !== undefined &&
+    typeof pendingReadStacks !== "boolean"
+  ) {
+    return null;
+  }
+
   return {
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
@@ -832,6 +856,9 @@ export const parseMemoryProtocolFlags = (
     // Absent (an older peer) parses to false: the capability must be
     // POSITIVELY advertised for the runner to relax its write gate.
     sqliteCommitRowLabelEval: sqliteCommitRowLabelEval === true,
+    // Absent (an older server) parses to false: clients scalarize pending
+    // reads to top-of-stack unless the array capability is advertised.
+    pendingReadStacks: pendingReadStacks === true,
   };
 };
 
@@ -847,6 +874,7 @@ export const wireMemoryProtocolFlags = (
   syncSchemaTable: flags.syncSchemaTable,
   syncSchemaTableV2: flags.syncSchemaTableV2,
   sqliteCommitRowLabelEval: flags.sqliteCommitRowLabelEval,
+  pendingReadStacks: flags.pendingReadStacks,
 });
 
 /**

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -276,10 +276,11 @@ export interface MemoryProtocolFlags {
    * `localSeq` naming every pending layer the read sat on (resolution
    * required for each element; staleness based at the highest — see
    * `PendingRead.localSeq`). A client that sees this absent (an older
-   * server) falls back to scalar top-of-stack emission, keeping wire compat
-   * at the cost of the lower-layer dependency check on that server (the
-   * client-side drop cascade still applies locally). Inherent to the build,
-   * so a server of this version always advertises it.
+   * server) falls back to scalar top-of-stack emission, and MUST hold each
+   * such send until every omitted lower dependency has settled — otherwise
+   * the old server could durably accept a commit the client cascade-rejects
+   * (03-commit-model.md §3.5). Inherent to the build, so a server of this
+   * version always advertises it.
    */
   pendingReadStacks: boolean;
 }

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5462,6 +5462,11 @@ const resolvePendingReads = (
       resolutions.set(read.localSeq, resolution);
     }
 
+    // A resolutionOnly read asserts only that the dependency localSeq resolved
+    // to a durable commit (a lower layer of the reader's pending stack
+    // exists); the staleness check belongs to the top-of-stack pending read.
+    if (read.resolutionOnly === true) continue;
+
     const conflictSeq = findConflictSeq(
       engine,
       branch,
@@ -5583,6 +5588,11 @@ const schedulerObservationReadDropReason = (
       };
       resolutions.set(read.localSeq, resolution);
     }
+
+    // Same exemption as resolvePendingReads: a resolutionOnly read only
+    // requires the dependency to have resolved (checked above); staleness is
+    // the top-of-stack read's job.
+    if (read.resolutionOnly === true) continue;
 
     const conflictSeq = findConflictSeq(
       engine,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5444,41 +5444,54 @@ const resolvePendingReads = (
   const resolutions = new Map<number, { localSeq: number; seq: number }>();
 
   for (const read of commit.reads.pending) {
-    let resolution = resolutions.get(read.localSeq);
-    if (!resolution) {
-      const row = engine.statements.selectPendingResolution.get({
-        session_id: sessionKey,
-        local_seq: read.localSeq,
-      }) as { seq: number } | undefined;
-      if (!row) {
-        throw new ConflictError(
-          `pending dependency not resolved: ${read.localSeq}`,
-        );
-      }
-      resolution = {
-        localSeq: read.localSeq,
-        seq: row.seq,
-      };
-      resolutions.set(read.localSeq, resolution);
+    // An array localSeq names EVERY pending layer the read's view sat on:
+    // each element must have resolved to an accepted commit, and staleness
+    // is checked exactly once, based at the HIGHEST element — the document's
+    // top-of-stack layer below the reader, which the array MUST include
+    // (03-commit-model.md §3.5). A scalar is the single-layer form.
+    const layers = Array.isArray(read.localSeq)
+      ? read.localSeq
+      : [read.localSeq];
+    if (layers.length === 0) {
+      throw new ProtocolError(
+        `pending read on ${read.id} names no localSeq`,
+      );
     }
-
-    // A resolutionOnly read asserts only that the dependency localSeq resolved
-    // to a durable commit (a lower layer of the reader's pending stack
-    // exists); the staleness check belongs to the top-of-stack pending read.
-    if (read.resolutionOnly === true) continue;
+    let basis: { localSeq: number; seq: number } | undefined;
+    for (const localSeq of layers) {
+      let resolution = resolutions.get(localSeq);
+      if (!resolution) {
+        const row = engine.statements.selectPendingResolution.get({
+          session_id: sessionKey,
+          local_seq: localSeq,
+        }) as { seq: number } | undefined;
+        if (!row) {
+          throw new ConflictError(
+            `pending dependency not resolved: ${localSeq}`,
+          );
+        }
+        resolution = { localSeq, seq: row.seq };
+        resolutions.set(localSeq, resolution);
+      }
+      if (basis === undefined || localSeq > basis.localSeq) {
+        basis = resolution;
+      }
+    }
 
     const conflictSeq = findConflictSeq(
       engine,
       branch,
       read.id,
       resolveScopeKey(read.scope, { principal, sessionId }),
-      resolution.seq,
+      basis!.seq,
       read.path,
       read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       throw new ConflictError(
-        `stale pending read: ${read.id} via localSeq ${read.localSeq} conflicted with seq ${conflictSeq}`,
+        `stale pending read: ${read.id} via localSeq ${
+          basis!.localSeq
+        } conflicted with seq ${conflictSeq}`,
       );
     }
   }
@@ -5573,33 +5586,39 @@ const schedulerObservationReadDropReason = (
 
   const resolutions = new Map<number, { localSeq: number; seq: number }>();
   for (const read of reads.pending) {
-    let resolution = resolutions.get(read.localSeq);
-    if (!resolution) {
-      const row = engine.statements.selectPendingResolution.get({
-        session_id: sessionKey,
-        local_seq: read.localSeq,
-      }) as { seq: number } | undefined;
-      if (!row) {
-        return "pending-read-missing";
-      }
-      resolution = {
-        localSeq: read.localSeq,
-        seq: row.seq,
-      };
-      resolutions.set(read.localSeq, resolution);
+    // Same contract as resolvePendingReads: every listed layer must have
+    // resolved; staleness is checked once, based at the highest layer.
+    const layers = Array.isArray(read.localSeq)
+      ? read.localSeq
+      : [read.localSeq];
+    if (layers.length === 0) {
+      return "pending-read-missing";
     }
-
-    // Same exemption as resolvePendingReads: a resolutionOnly read only
-    // requires the dependency to have resolved (checked above); staleness is
-    // the top-of-stack read's job.
-    if (read.resolutionOnly === true) continue;
+    let basis: { localSeq: number; seq: number } | undefined;
+    for (const localSeq of layers) {
+      let resolution = resolutions.get(localSeq);
+      if (!resolution) {
+        const row = engine.statements.selectPendingResolution.get({
+          session_id: sessionKey,
+          local_seq: localSeq,
+        }) as { seq: number } | undefined;
+        if (!row) {
+          return "pending-read-missing";
+        }
+        resolution = { localSeq, seq: row.seq };
+        resolutions.set(localSeq, resolution);
+      }
+      if (basis === undefined || localSeq > basis.localSeq) {
+        basis = resolution;
+      }
+    }
 
     const conflictSeq = findConflictSeq(
       engine,
       branch,
       read.id,
       resolveScopeKey(read.scope, { principal, sessionId }),
-      resolution.seq,
+      basis!.seq,
       read.path,
       read.nonRecursive ?? false,
     );

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5433,6 +5433,29 @@ const validateConfirmedReads = (
   }
 };
 
+// Shared normalization/validation for a pending read's dependency set: a
+// non-empty array (or scalar) of integer localSeqs. Malformed shapes are a
+// protocol violation regardless of which validator (ordinary commit or
+// scheduler observation) encounters them.
+const pendingReadLayers = (
+  read: { id: string; localSeq: number | number[] },
+): number[] => {
+  const layers = Array.isArray(read.localSeq) ? read.localSeq : [read.localSeq];
+  if (layers.length === 0) {
+    throw new ProtocolError(
+      `pending read on ${read.id} names no localSeq`,
+    );
+  }
+  for (const layer of layers) {
+    if (!Number.isInteger(layer)) {
+      throw new ProtocolError(
+        `pending read on ${read.id} names a non-integer localSeq`,
+      );
+    }
+  }
+  return layers;
+};
+
 const resolvePendingReads = (
   engine: Engine,
   sessionKey: string,
@@ -5449,14 +5472,7 @@ const resolvePendingReads = (
     // is checked exactly once, based at the HIGHEST element — the document's
     // top-of-stack layer below the reader, which the array MUST include
     // (03-commit-model.md §3.5). A scalar is the single-layer form.
-    const layers = Array.isArray(read.localSeq)
-      ? read.localSeq
-      : [read.localSeq];
-    if (layers.length === 0) {
-      throw new ProtocolError(
-        `pending read on ${read.id} names no localSeq`,
-      );
-    }
+    const layers = pendingReadLayers(read);
     let basis: { localSeq: number; seq: number } | undefined;
     for (const localSeq of layers) {
       let resolution = resolutions.get(localSeq);
@@ -5587,13 +5603,10 @@ const schedulerObservationReadDropReason = (
   const resolutions = new Map<number, { localSeq: number; seq: number }>();
   for (const read of reads.pending) {
     // Same contract as resolvePendingReads: every listed layer must have
-    // resolved; staleness is checked once, based at the highest layer.
-    const layers = Array.isArray(read.localSeq)
-      ? read.localSeq
-      : [read.localSeq];
-    if (layers.length === 0) {
-      return "pending-read-missing";
-    }
+    // resolved; staleness is checked once, based at the highest layer. A
+    // malformed dependency set throws the same ProtocolError as on the
+    // ordinary-commit path rather than degrading to a drop reason.
+    const layers = pendingReadLayers(read);
     let basis: { localSeq: number; seq: number } | undefined;
     for (const localSeq of layers) {
       let resolution = resolutions.get(localSeq);

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -14,14 +14,16 @@ const ignoreReadForSchedulingMarker: unique symbol = Symbol(
 // carries NO value-equality concurrency precondition: read() does not mark its
 // document `validated` (so the client validate()/claim() pass skips it), and
 // buildReads DOWNGRADES it — rather than dropping the read outright, it replaces
-// it with a nonRecursive existence read at the entity ROOT. Set transaction-wide
+// it with a nonRecursive existence read at the cell's PARENT path (the
+// structural target threaded from handleCellSet). Set transaction-wide
 // by the UI-input blind-leaf-write mode (see markUiInputBlindWriteTx) so a scalar
 // `$value` overwrite is a last-write-wins write on its leaf value (removing the
-// own-write-race "stale confirmed read" conflict: a deep same-leaf patch sits
-// below the root read, so TIER-2 nonRecursive overlap does not fire) while still
-// failing fast on a concurrent WHOLE-DOC delete/replace (TIER-1 set/delete is
-// path-blind, so the structural read yields a clean ConflictError instead of a
-// raw "missing path" throw at patch read-materialization). Orthogonal to
+// own-write-race "stale confirmed read" conflict: a write to the cell's own
+// value sits below the parent read, so TIER-2 nonRecursive overlap does not
+// fire) while still failing fast on a concurrent WHOLE-DOC delete/replace
+// (TIER-1 set/delete is path-blind) or a reshape of the parent or any ancestor
+// (TIER-2 fires at-or-above the read path) — a clean ConflictError instead of a
+// raw "missing path" throw at patch read-materialization. Orthogonal to
 // scheduling: reactivity/subscriptions are unaffected (only ignoreReadForScheduling
 // gates those).
 const ignoreReadForCommitMarker: unique symbol = Symbol(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -315,6 +315,16 @@ type PendingCommitRead = {
   path: DocumentPath;
   localSeq: number;
   nonRecursive?: boolean;
+  /**
+   * Client mirror of the wire flag: this read asserts only that `localSeq`
+   * resolved to a durable commit (a lower layer of the reader's pending
+   * stack), and is exempt from the staleness check. The top-of-stack pending
+   * read carries staleness for the doc; these existence-only reads are what
+   * make the server's pending-dependency check (and the client cascade)
+   * cover EVERY layer the read's materialized view sat on, not just the
+   * nearest one (CT-1872 1c).
+   */
+  resolutionOnly?: boolean;
 };
 
 const pendingVersion = (
@@ -1641,6 +1651,48 @@ type SchedulerObservationBatchEntry = {
   pending: PromiseWithResolvers<Result<Unit, StorageTransactionRejected>>;
 };
 
+/**
+ * A commit that has been issued (optimistic write applied, verdict not yet
+ * settled) and that carries PENDING reads — i.e. its read set depends on
+ * another in-flight commit's optimistic state. Tracked in `#inFlightCommits`
+ * so that when a dependency's optimistic writes are dropped (`dropPending`),
+ * the dependants can be rejected locally instead of waiting for the server's
+ * inevitable "pending dependency not resolved" (CT-1872 1b).
+ *
+ * Commits with NO pending reads are deliberately never registered: a
+ * zero-read mergeable/blind commit is DESIGNED to survive a parent drop (the
+ * server materializes its spine via createMissing — CT-1872 1a), and the
+ * scheduler-observation batch wrapper carries no reads at all. Cascading
+ * either would break intended semantics.
+ */
+type InFlightCommit = {
+  readonly localSeq: number;
+  /**
+   * The unique localSeqs named by `commit.reads.pending` — every in-flight
+   * commit this one's read view sits on (resolution-only lower-layer reads
+   * carry the same `localSeq` field, so they contribute here too).
+   */
+  readonly dependencies: ReadonlySet<number>;
+  readonly operations: NativeCommitOperation[];
+  readonly source?: IStorageTransaction;
+  readonly commit: ClientCommit;
+  /**
+   * Resolves when a rejection is fabricated locally for this commit (a
+   * pending dependency was dropped, or the replica reset). Raced against the
+   * server verdict in `pushCommit`.
+   */
+  readonly localRejection: PromiseWithResolvers<StorageTransactionRejected>;
+  /**
+   * Set synchronously BEFORE `localRejection` resolves, so `pushCommit`'s
+   * pre-send checkpoints can observe the rejection without racing the
+   * microtask queue. `undefined` means "not locally rejected".
+   */
+  localRejectionValue?: StorageTransactionRejected;
+  /** True once `pushCommit`'s finally ran — the outcome is finalized and the
+   * entry can no longer be cascaded. */
+  settled: boolean;
+};
+
 const docKey = (id: URI, scope?: CellScope): string =>
   `${normalizeCellScope(scope)}\0${id}`;
 
@@ -1663,6 +1715,16 @@ class SpaceReplica implements ISpaceReplica {
   readonly #commitPromises = new Set<
     Promise<Result<Unit, StorageTransactionRejected>>
   >();
+  // Issued-but-unsettled commits that carry pending reads, keyed by localSeq.
+  // Scanned by cascadeDroppedDependency when a dependency's optimistic writes
+  // are dropped. See the InFlightCommit doc for why zero-pending-read commits
+  // are never registered.
+  readonly #inFlightCommits = new Map<number, InFlightCommit>();
+  // Server verdict promises superseded by a local rejection. Kept OUT of
+  // #commitPromises so synced() never blocks on a verdict the server may
+  // withhold indefinitely; close()/closeNow() drain the set after client
+  // teardown rejects every in-flight request.
+  readonly #suppressedVerdicts = new Set<Promise<void>>();
   readonly #schedulerObservationBatch: SchedulerObservationBatchEntry[] = [];
   #schedulerObservationFlushScheduled = false;
   #schedulerObservationFlushPromise:
@@ -1910,10 +1972,12 @@ class SpaceReplica implements ISpaceReplica {
     // With the client closed, every in-flight commit and read/watch pull has
     // been rejected and now settles promptly. Awaiting them here can no longer
     // hang and guarantees no transport promise is left pending when close()
-    // resolves.
+    // resolves. Suppressed verdicts (server responses superseded by a local
+    // rejection) live outside #commitPromises and join the same drain.
     await Promise.allSettled([
       ...(observationFlush ? [observationFlush] : []),
       ...this.#commitPromises,
+      ...this.#suppressedVerdicts,
     ]);
     await Promise.allSettled([...this.#syncPromises]);
     await Promise.allSettled([...this.#updatePromises]);
@@ -1991,9 +2055,11 @@ class SpaceReplica implements ISpaceReplica {
       });
     }
     // The fire-and-forget client.close() above rejects in-flight requests; drain
-    // their read pulls too so no transport promise is left pending.
+    // their read pulls too so no transport promise is left pending. Suppressed
+    // verdicts settle off the same teardown rejection.
     void Promise.allSettled([...this.#syncPromises]);
     void Promise.allSettled([...this.#updatePromises]);
+    void Promise.allSettled([...this.#suppressedVerdicts]);
     this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
@@ -2205,6 +2271,17 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   reset(): void {
+    // Every unsettled in-flight commit's optimistic pending write is about to
+    // be wiped by #docs.clear(); locally reject each so its pushCommit
+    // finalizes promptly instead of waiting on a server verdict for state
+    // that no longer exists. readyToRetry resolves immediately (nothing to
+    // repair — the replica is being rebuilt from scratch).
+    for (const entry of [...this.#inFlightCommits.values()]) {
+      this.rejectInFlightCommitLocally(
+        entry,
+        this.makeLocalRejection(entry.commit, "memory replica reset"),
+      );
+    }
     this.#docs.clear();
     this.#watchedIds.clear();
     this.resetConflictAdmissionState();
@@ -2636,38 +2713,174 @@ class SpaceReplica implements ISpaceReplica {
     return result;
   }
 
+  /**
+   * Register a commit in `#inFlightCommits` so a dropped dependency can
+   * reject it locally. Returns undefined — no registration — when the commit
+   * has no pending reads: with nothing read from another commit's optimistic
+   * state there is no dependency to cascade on, and this is the natural
+   * exemption for zero-read/mergeable/blind commits and the
+   * scheduler-observation batch wrapper (all DESIGNED to survive a parent
+   * drop; see the InFlightCommit doc).
+   */
+  private registerInFlightCommit(
+    localSeq: number,
+    operations: NativeCommitOperation[],
+    commit: ClientCommit,
+    source?: IStorageTransaction,
+  ): InFlightCommit | undefined {
+    if (commit.reads.pending.length === 0) {
+      return undefined;
+    }
+    const dependencies = new Set<number>();
+    for (const read of commit.reads.pending) {
+      dependencies.add(read.localSeq);
+    }
+    const entry: InFlightCommit = {
+      localSeq,
+      dependencies,
+      operations,
+      source,
+      commit,
+      localRejection: Promise.withResolvers<StorageTransactionRejected>(),
+      settled: false,
+    };
+    this.#inFlightCommits.set(localSeq, entry);
+    return entry;
+  }
+
+  /**
+   * Mark a commit's outcome as finalized and remove it from the cascade scan
+   * set. Idempotent — pushCommit's finally may run after reset() already
+   * signalled a local rejection for the same entry.
+   */
+  private settleInFlightCommit(localSeq: number): void {
+    const entry = this.#inFlightCommits.get(localSeq);
+    if (entry === undefined) {
+      return;
+    }
+    entry.settled = true;
+    this.#inFlightCommits.delete(localSeq);
+  }
+
+  /**
+   * Signal a locally-fabricated rejection for an in-flight commit. Invariant
+   * holder: `localRejectionValue` must be observable synchronously BEFORE
+   * `localRejection` resolves — pushCommit's pre-send checkpoints read the
+   * field directly; the promise only feeds the transact race.
+   */
+  private rejectInFlightCommitLocally(
+    entry: InFlightCommit,
+    rejection: StorageTransactionRejected,
+  ): void {
+    if (entry.settled || entry.localRejectionValue !== undefined) {
+      return;
+    }
+    entry.localRejectionValue = rejection;
+    entry.localRejection.resolve(rejection);
+  }
+
+  /**
+   * A server verdict superseded by a local rejection: consume it off the
+   * books. Late reject is the expected outcome (the server eventually agrees
+   * the dependency never resolved) and is swallowed. Late ACCEPT is
+   * deterministically impossible once resolution-only pending reads are
+   * emitted — the server cannot accept a commit whose pending dependency has
+   * no commit row — so it warns to flag a bug; the write is NOT promoted
+   * (its pending entries were already dropped by finalizeRejection).
+   */
+  private suppressLateVerdict(
+    verdict: Promise<AppliedCommit>,
+    localSeq: number,
+  ): void {
+    const settled = verdict.then(() => {
+      logger.warn("cascade-late-accept", () => [
+        "server accepted a commit after its local rejection; write not promoted",
+        { localSeq },
+      ]);
+    }, (error) => {
+      logger.debug("cascade-late-reject", () => [
+        `late server verdict after local rejection: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { localSeq },
+      ]);
+    }).finally(() => {
+      this.#suppressedVerdicts.delete(settled);
+    });
+    this.#suppressedVerdicts.add(settled);
+  }
+
   private async pushCommit(
     localSeq: number,
     operations: NativeCommitOperation[],
     commit: ClientCommit,
     source?: IStorageTransaction,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    // Strategy 1: a commit whose read set lands on a still-catching-up id.
-    const admissionMode = conflictAdmissionMode();
-    if (admissionMode !== "off") {
-      const threshold = this.preemptThreshold(commit);
-      if (threshold !== undefined) {
-        if (admissionMode === "hold") {
-          const rejection = this.makePreemptRejection(commit, threshold);
-          // Precise mode: hold until the catch-up is applied, then run the
-          // server's stale-read check locally. Revert only the genuinely stale
-          // commits; fall through to send the ones whose reads still hold.
-          try {
-            await this.waitForCaughtUpLocalSeq(threshold);
-          } catch {
-            // Session/replica closing or reset: do not open/send a new session
-            // while shutdown is in progress. Finalize the held rejection so the
-            // optimistic write is dropped and close can drain promptly.
-            return await this.finalizeRejection(
-              localSeq,
-              operations,
-              source,
-              rejection,
-            );
-          }
-          if (!this.#closed && this.commitReadsStaleLocally(commit)) {
-            logger.debug("commit-held-revert", () => [
-              `held commit reverted (locally stale) at caughtUpLocalSeq>=${threshold}`,
+    // Register BEFORE any await: commitOperations calls pushCommit
+    // synchronously after applyPending, so registration is atomic with the
+    // optimistic write — a dependency drop can never slip between the two.
+    const inFlight = this.registerInFlightCommit(
+      localSeq,
+      operations,
+      commit,
+      source,
+    );
+    try {
+      // Strategy 1: a commit whose read set lands on a still-catching-up id.
+      const admissionMode = conflictAdmissionMode();
+      if (admissionMode !== "off") {
+        const threshold = this.preemptThreshold(commit);
+        if (threshold !== undefined) {
+          if (admissionMode === "hold") {
+            const rejection = this.makePreemptRejection(commit, threshold);
+            // Precise mode: hold until the catch-up is applied, then run the
+            // server's stale-read check locally. Revert only the genuinely stale
+            // commits; fall through to send the ones whose reads still hold.
+            try {
+              await this.waitForCaughtUpLocalSeq(threshold);
+            } catch {
+              // Session/replica closing or reset: do not open/send a new session
+              // while shutdown is in progress. Finalize the held rejection so the
+              // optimistic write is dropped and close can drain promptly.
+              return await this.finalizeRejection(
+                localSeq,
+                operations,
+                source,
+                rejection,
+              );
+            }
+            if (inFlight?.localRejectionValue !== undefined) {
+              // A pending dependency was dropped while we held for catch-up;
+              // the commit is provably doomed — finalize without sending.
+              return await this.finalizeRejection(
+                localSeq,
+                operations,
+                source,
+                inFlight.localRejectionValue,
+              );
+            }
+            if (!this.#closed && this.commitReadsStaleLocally(commit)) {
+              logger.debug("commit-held-revert", () => [
+                `held commit reverted (locally stale) at caughtUpLocalSeq>=${threshold}`,
+                { localSeq, operations: operations.length },
+              ]);
+              return await this.finalizeRejection(
+                localSeq,
+                operations,
+                source,
+                rejection,
+              );
+            }
+            logger.debug("commit-held-sent", () => [
+              `held commit sent after catch-up (reads still valid)`,
+              { localSeq, operations: operations.length },
+            ]);
+            // fall through to send
+          } else {
+            // Coarse mode: assume conflict and pre-empt without sending.
+            const rejection = this.makePreemptRejection(commit, threshold);
+            logger.debug("commit-preempted", () => [
+              `commit preempted: stale until caughtUpLocalSeq>=${threshold}`,
               { localSeq, operations: operations.length },
             ]);
             return await this.finalizeRejection(
@@ -2677,93 +2890,131 @@ class SpaceReplica implements ISpaceReplica {
               rejection,
             );
           }
-          logger.debug("commit-held-sent", () => [
-            `held commit sent after catch-up (reads still valid)`,
-            { localSeq, operations: operations.length },
-          ]);
-          // fall through to send
-        } else {
-          // Coarse mode: assume conflict and pre-empt without sending.
-          const rejection = this.makePreemptRejection(commit, threshold);
-          logger.debug("commit-preempted", () => [
-            `commit preempted: stale until caughtUpLocalSeq>=${threshold}`,
-            { localSeq, operations: operations.length },
-          ]);
+        }
+      }
+      // The push marker window covers observation flush + (re)dial + send +
+      // confirm: the full client-side cost of durably landing this commit.
+      // (space.did, commit.local_seq) joins to the server's memory.transact span.
+      const telemetry = this.#getTelemetry();
+      const pushOpId = `push:${this.#space}:${localSeq}`;
+      telemetry?.submit({
+        type: "storage.push.start",
+        id: pushOpId,
+        operation: "transact",
+        localSeq,
+        spaceDid: this.#space,
+      });
+      try {
+        if (
+          operations.length > 0 &&
+          (this.#schedulerObservationBatch.length > 0 ||
+            this.#schedulerObservationFlushPromise)
+        ) {
+          const flushResult = await this.flushSchedulerObservationBatch();
+          const rejection = flushResult.error;
+          if (rejection !== undefined) {
+            const error = new Error(rejection.message);
+            error.name = rejection.name ?? "TransactionError";
+            throw error;
+          }
+        }
+        const { session } = await this.sessionHandle();
+        if (inFlight?.localRejectionValue !== undefined) {
+          // A pending dependency was dropped while we awaited the scheduler
+          // batch flush or the session handshake — do not send a commit whose
+          // doom is already provable.
+          telemetry?.submit({
+            type: "storage.push.error",
+            id: pushOpId,
+            sessionId: session.sessionId,
+            error: inFlight.localRejectionValue.name ?? "TransactionError",
+          });
           return await this.finalizeRejection(
             localSeq,
             operations,
             source,
-            rejection,
+            inFlight.localRejectionValue,
           );
         }
-      }
-    }
-    // The push marker window covers observation flush + (re)dial + send +
-    // confirm: the full client-side cost of durably landing this commit.
-    // (space.did, commit.local_seq) joins to the server's memory.transact span.
-    const telemetry = this.#getTelemetry();
-    const pushOpId = `push:${this.#space}:${localSeq}`;
-    telemetry?.submit({
-      type: "storage.push.start",
-      id: pushOpId,
-      operation: "transact",
-      localSeq,
-      spaceDid: this.#space,
-    });
-    try {
-      if (
-        operations.length > 0 &&
-        (this.#schedulerObservationBatch.length > 0 ||
-          this.#schedulerObservationFlushPromise)
-      ) {
-        const flushResult = await this.flushSchedulerObservationBatch();
-        const rejection = flushResult.error;
-        if (rejection !== undefined) {
-          const error = new Error(rejection.message);
-          error.name = rejection.name ?? "TransactionError";
-          throw error;
+        if (inFlight === undefined) {
+          // No pending reads → no dependency that can be dropped from under
+          // this commit; keep the direct await.
+          const applied = await session.transact(commit);
+          this.confirmPending(localSeq, operations, applied);
+          telemetry?.submit({
+            type: "storage.push.complete",
+            id: pushOpId,
+            sessionId: session.sessionId,
+          });
+          return { ok: {} };
         }
+        // Race the server verdict against a locally-fabricated rejection (a
+        // dependency dropped mid-flight, or a replica reset). A server
+        // rejection wins the race by REJECTING it, landing in the catch below.
+        const verdict = session.transact(commit);
+        const outcome = await Promise.race([
+          verdict.then((applied) => ({ applied })),
+          inFlight.localRejection.promise.then((rejection) => ({ rejection })),
+        ]);
+        if ("rejection" in outcome) {
+          // Local rejection won: the eventual server verdict is moot. Do NOT
+          // recordStaleFloor — a locally fabricated rejection carries no server
+          // catch-up point (parity with the preempt path above).
+          this.suppressLateVerdict(verdict, localSeq);
+          telemetry?.submit({
+            type: "storage.push.error",
+            id: pushOpId,
+            sessionId: session.sessionId,
+            error: outcome.rejection.name ?? "TransactionError",
+          });
+          return await this.finalizeRejection(
+            localSeq,
+            operations,
+            source,
+            outcome.rejection,
+          );
+        }
+        this.confirmPending(localSeq, operations, outcome.applied);
+        telemetry?.submit({
+          type: "storage.push.complete",
+          id: pushOpId,
+          sessionId: session.sessionId,
+        });
+        return { ok: {} };
+      } catch (error) {
+        const rejection = toRejectedError(error, commit, this.#space);
+        telemetry?.submit({
+          type: "storage.push.error",
+          id: pushOpId,
+          error: rejection.name ?? "TransactionError",
+        });
+        this.attachProviderReadyToRetry(rejection, localSeq);
+        if (admissionMode !== "off" && rejection.name === "ConflictError") {
+          this.recordStaleFloor(commit, localSeq);
+        }
+        // Counted (even while silent) so multi-writer churn can be read back via
+        // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
+        // drops only the optimistic pending write and re-derives from confirmed
+        // state; a non-falling count under load means conflicts ratchet rather
+        // than storm.
+        logger.debug(
+          rejection.name === "ConflictError"
+            ? "commit-conflict"
+            : "commit-rejected",
+          () => [
+            `commit ${rejection.name ?? "rejected"}: ${rejection.message}`,
+            { localSeq, operations: operations.length },
+          ],
+        );
+        return await this.finalizeRejection(
+          localSeq,
+          operations,
+          source,
+          rejection,
+        );
       }
-      const { session } = await this.sessionHandle();
-      const applied = await session.transact(commit);
-      this.confirmPending(localSeq, operations, applied);
-      telemetry?.submit({
-        type: "storage.push.complete",
-        id: pushOpId,
-        sessionId: session.sessionId,
-      });
-      return { ok: {} };
-    } catch (error) {
-      const rejection = toRejectedError(error, commit, this.#space);
-      telemetry?.submit({
-        type: "storage.push.error",
-        id: pushOpId,
-        error: rejection.name ?? "TransactionError",
-      });
-      this.attachProviderReadyToRetry(rejection, localSeq);
-      if (admissionMode !== "off" && rejection.name === "ConflictError") {
-        this.recordStaleFloor(commit, localSeq);
-      }
-      // Counted (even while silent) so multi-writer churn can be read back via
-      // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
-      // drops only the optimistic pending write and re-derives from confirmed
-      // state; a non-falling count under load means conflicts ratchet rather
-      // than storm.
-      logger.debug(
-        rejection.name === "ConflictError"
-          ? "commit-conflict"
-          : "commit-rejected",
-        () => [
-          `commit ${rejection.name ?? "rejected"}: ${rejection.message}`,
-          { localSeq, operations: operations.length },
-        ],
-      );
-      return await this.finalizeRejection(
-        localSeq,
-        operations,
-        source,
-        rejection,
-      );
+    } finally {
+      this.settleInFlightCommit(localSeq);
     }
   }
 
@@ -2793,6 +3044,11 @@ class SpaceReplica implements ISpaceReplica {
       : undefined;
     await this.waitForConflictReadRepair(rejection);
     this.dropPending(localSeq);
+    // Every drop funnels through here (server conflict, preempt, cascade,
+    // reset — this is dropPending's only call site), so scanning right after
+    // the drop catches every dependant; transitivity emerges from recursion
+    // (a victim's own finalizeRejection lands back here with its localSeq).
+    this.cascadeDroppedDependency(localSeq);
     if (before !== undefined) {
       const changes = before.compare(this);
       // The revert snapshots CURRENT confirmed state (which already includes
@@ -2824,6 +3080,10 @@ class SpaceReplica implements ISpaceReplica {
   ) {
     const confirmed: ConfirmedCommitRead[] = [];
     const pending: PendingCommitRead[] = [];
+    // Dedup for the existence-only reads on lower pending layers: a commit
+    // can read the same doc many times, and a pending stack can hold several
+    // entries per localSeq.
+    const seenExistenceDeps = new Set<string>();
     if (!source) {
       return { confirmed, pending };
     }
@@ -2854,12 +3114,32 @@ class SpaceReplica implements ISpaceReplica {
       confirmedSeq?: number,
     ) => {
       const record = this.#docs.get(docKey(id, scope));
-      const pendingLocalSeq = record?.pending
-        .filter((version) => version.localSeq < localSeq)
-        .at(-1)?.localSeq;
+      const lower = record?.pending
+        .filter((version) => version.localSeq < localSeq) ?? [];
+      const pendingLocalSeq = lower.at(-1)?.localSeq;
       const shape = nonRecursive ? { nonRecursive: true } : {};
       if (pendingLocalSeq !== undefined) {
         pending.push({ id, scope, path, localSeq: pendingLocalSeq, ...shape });
+        // The read's materialized view sat on EVERY lower pending layer, not
+        // just the nearest one. Emit an existence-only dependency per other
+        // unique layer so a dropped deeper layer still dooms this commit
+        // (server: pending-dependency resolution; client: cascade). These
+        // must not carry the read path: staleness stays with the top read —
+        // a full-path read on a lower layer would false-conflict with the
+        // session's own later stacked writes (CT-1872 1c).
+        for (const version of lower) {
+          if (version.localSeq === pendingLocalSeq) continue;
+          const depKey = `${docKey(id, scope)}\0${version.localSeq}`;
+          if (seenExistenceDeps.has(depKey)) continue;
+          seenExistenceDeps.add(depKey);
+          pending.push({
+            id,
+            scope,
+            path: toDocumentPath([]),
+            localSeq: version.localSeq,
+            resolutionOnly: true,
+          });
+        }
       } else {
         confirmed.push({
           id,
@@ -3169,6 +3449,84 @@ class SpaceReplica implements ISpaceReplica {
       // to wrap, so we do NOT call attachProviderReadyToRetry here).
       readyToRetry: () => this.waitForCaughtUpLocalSeq(threshold),
     };
+  }
+
+  // Locally-fabricated rejection for a commit whose doom is provable
+  // client-side (dropped pending dependency, or replica reset). Modeled on
+  // makePreemptRejection. readyToRetry resolves immediately: the PRIMARY
+  // rejection's finalizeRejection already awaited its read repair (or reset
+  // wiped the replica outright), so a cascaded victim adds no wait of its own.
+  private makeLocalRejection(
+    commit: ClientCommit,
+    message: string,
+  ): StorageTransactionRejected {
+    let firstId: URI | undefined;
+    for (const operation of commit.operations) {
+      if (operation.op !== "sqlite") {
+        firstId = operation.id as URI;
+        break;
+      }
+    }
+    return {
+      name: "ConflictError",
+      message,
+      transaction: commit as unknown as Transaction,
+      conflict: {
+        space: this.#space,
+        the: DOCUMENT_MIME,
+        of: firstId ?? "of:unknown",
+        expected: null,
+        actual: null,
+        existsInHistory: false,
+        history: [],
+      },
+      readyToRetry: () => Promise.resolve(),
+    };
+  }
+
+  private makeCascadeRejection(
+    entry: InFlightCommit,
+    droppedLocalSeq: number,
+  ): StorageTransactionRejected {
+    return this.makeLocalRejection(
+      entry.commit,
+      `pending dependency dropped locally: localSeq=${droppedLocalSeq}`,
+    );
+  }
+
+  /**
+   * CT-1872 1b: when a commit's optimistic writes are dropped, every
+   * in-flight commit whose pending reads name that localSeq is provably
+   * doomed — the dropped commit will never gain a commit row in the
+   * per-session commit table, so the server would reject each dependant with
+   * "pending dependency not resolved" only after a full round trip (a window
+   * of up to 30s+ per commit). Fabricate that rejection locally instead.
+   *
+   * Commits with no pending reads never enter `#inFlightCommits`, so
+   * zero-read mergeable/blind commits are structurally exempt — they are
+   * DESIGNED to survive a parent drop (the server materializes their spine
+   * via createMissing). Resolving the promises here queues the victims'
+   * continuations on later microtasks; each victim snapshots its own revert
+   * Differential before its own drop, so the scan itself never re-enters.
+   */
+  private cascadeDroppedDependency(droppedLocalSeq: number): void {
+    for (const entry of [...this.#inFlightCommits.values()]) {
+      if (
+        entry.settled ||
+        entry.localRejectionValue !== undefined ||
+        !entry.dependencies.has(droppedLocalSeq)
+      ) {
+        continue;
+      }
+      this.rejectInFlightCommitLocally(
+        entry,
+        this.makeCascadeRejection(entry, droppedLocalSeq),
+      );
+      logger.debug("commit-cascade-rejected", () => [
+        `commit locally rejected: pending dependency localSeq=${droppedLocalSeq} was dropped`,
+        { localSeq: entry.localSeq, operations: entry.operations.length },
+      ]);
+    }
   }
 
   private attachProviderReadyToRetry(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2643,7 +2643,36 @@ class SpaceReplica implements ISpaceReplica {
       if (client.serverFlags?.persistentSchedulerState !== true) {
         return { ok: {} };
       }
-      return await this.pushCommit(localSeq, [], commit, undefined);
+      // Same fail-closed degradation for the OTHER capability gap: against a
+      // server without `pendingReadStacks`, an observation whose read sat on
+      // MORE than one pending layer cannot be expressed soundly — the scalar
+      // wire would omit lower layers, and the old server could persist an
+      // observation that observed a dropped write (data commits get the
+      // pushCommit hold instead; observations are droppable bookkeeping, so
+      // dropping beats holding — a held envelope would chain verdict latency
+      // into every semantic commit awaiting this flush). Resolve the dropped
+      // entries {ok} and send the rest.
+      let wireEntries = entries;
+      if (client.serverFlags?.pendingReadStacks !== true) {
+        const expressible = (entry: SchedulerObservationBatchEntry): boolean =>
+          entry.commit.reads.pending.every((read) =>
+            !Array.isArray(read.localSeq) || read.localSeq.length <= 1
+          );
+        wireEntries = entries.filter(expressible);
+        for (const entry of entries) {
+          if (!expressible(entry)) {
+            entry.pending.resolve({ ok: {} });
+          }
+        }
+        if (wireEntries.length === 0) {
+          return { ok: {} };
+        }
+      }
+      const wireBatch: ClientCommit = wireEntries === entries ? commit : {
+        ...commit,
+        schedulerObservationBatch: wireEntries.map((entry) => entry.commit),
+      };
+      return await this.pushCommit(localSeq, [], wireBatch, undefined);
     })()
       .then((result) => {
         for (const entry of entries) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -320,8 +320,9 @@ type PendingCommitRead = {
    * the doc's top-of-stack layer below the reader, which the array always
    * includes (CT-1872 1c; 03-commit-model.md §3.5). Scalarized to the
    * top-of-stack element at send time when the server does not advertise
-   * `pendingReadStacks` — the pre-stack wire shape, which keeps compat at
-   * the cost of the lower-layer dependency check on that server.
+   * `pendingReadStacks` — the pre-stack wire shape — and in that case the
+   * send is HELD until every omitted lower dependency settles, so the old
+   * server can never durably accept a commit the client cascade-rejects.
    */
   localSeq: number | number[];
   nonRecursive?: boolean;
@@ -742,8 +743,10 @@ const toCommitReadPath = (
 // including those inside batched scheduler observations — to its
 // top-of-stack element (the highest localSeq, i.e. the staleness basis).
 // The lower-layer dependency check is lost against such servers by design
-// (CT-1872 1c stays open there); the client-side drop cascade still covers
-// those edges locally.
+// (CT-1872 1c stays open there). pushCommit compensates by HOLDING the send
+// until every omitted lower dependency settles — without the hold, the old
+// server could durably accept a commit the client cascade-rejects (a
+// split-brain: caller sees ConflictError for a write that landed).
 const scalarizeLocalSeq = (localSeq: number | number[]): number =>
   Array.isArray(localSeq) ? Math.max(...localSeq) : localSeq;
 
@@ -1785,6 +1788,14 @@ class SpaceReplica implements ISpaceReplica {
   // are dropped. See the InFlightCommit doc for why zero-pending-read commits
   // are never registered.
   readonly #inFlightCommits = new Map<number, InFlightCommit>();
+  // Every unsettled commit's outcome promise, keyed by localSeq (a superset
+  // of #inFlightCommits: zero-read commits appear here too). The old-server
+  // scalarization hold awaits these for the OMITTED lower dependencies —
+  // entries are removed on settlement, so an absent key means "settled".
+  readonly #commitOutcomeBySeq = new Map<
+    number,
+    Promise<unknown>
+  >();
   // Server verdict promises superseded by a local rejection. Kept OUT of
   // #commitPromises so synced() never blocks on a verdict the server may
   // withhold indefinitely; close()/closeNow() drain the set after client
@@ -2773,6 +2784,16 @@ class SpaceReplica implements ISpaceReplica {
         ),
     );
     this.#commitPromises.add(promise);
+    // Keyed registration for the old-server scalarization hold: a later
+    // stacked commit awaits its omitted lower dependencies' outcomes here.
+    // Removed on settlement (absent key = settled); the .catch keeps the
+    // tracking copy from surfacing as an unhandled rejection.
+    this.#commitOutcomeBySeq.set(
+      localSeq,
+      promise.catch(() => {}).finally(() => {
+        this.#commitOutcomeBySeq.delete(localSeq);
+      }),
+    );
     const result = await promise;
     this.#commitPromises.delete(promise);
     return result;
@@ -2996,6 +3017,33 @@ class SpaceReplica implements ISpaceReplica {
         const wireCommit = client.serverFlags?.pendingReadStacks === true
           ? commit
           : scalarizePendingReadStacks(commit);
+        if (wireCommit !== commit && inFlight !== undefined) {
+          // Old-server hold (split-brain guard): the scalarized wire omits
+          // the lower layers, so the server could durably ACCEPT a commit
+          // this client is about to cascade-reject — the caller would see a
+          // ConflictError for a write that landed. Do not send until every
+          // omitted dependency settles: a dropped one trips the doom
+          // checkpoint below before anything reaches the wire, and
+          // all-accepted makes the scalar shape sound (their resolution is
+          // already durable). Verdicts arrive in submission order, so this
+          // adds at most roughly one verdict round-trip, only against
+          // pre-`pendingReadStacks` servers, only for stacked commits.
+          const waits: Promise<unknown>[] = [];
+          for (const read of commit.reads.pending) {
+            if (!Array.isArray(read.localSeq)) continue;
+            const top = scalarizeLocalSeq(read.localSeq);
+            for (const layer of read.localSeq) {
+              if (layer === top) continue;
+              const outcome = this.#commitOutcomeBySeq.get(layer);
+              if (outcome !== undefined) {
+                waits.push(outcome);
+              }
+            }
+          }
+          if (waits.length > 0) {
+            await Promise.all(waits);
+          }
+        }
         if (inFlight?.localRejectionValue !== undefined) {
           // A pending dependency was dropped while we awaited the scheduler
           // batch flush or the session handshake — do not send a commit whose

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -313,18 +313,18 @@ type PendingCommitRead = {
   id: URI;
   scope?: CellScope;
   path: DocumentPath;
-  localSeq: number;
-  nonRecursive?: boolean;
   /**
-   * Client mirror of the wire flag: this read asserts only that `localSeq`
-   * resolved to a durable commit (a lower layer of the reader's pending
-   * stack), and is exempt from the staleness check. The top-of-stack pending
-   * read carries staleness for the doc; these existence-only reads are what
-   * make the server's pending-dependency check (and the client cascade)
-   * cover EVERY layer the read's materialized view sat on, not just the
-   * nearest one (CT-1872 1c).
+   * Every pending layer the read's materialized view sat on, as an array —
+   * each must resolve to an accepted commit (server pending-dependency
+   * check; client cascade), and staleness is based at the HIGHEST element,
+   * the doc's top-of-stack layer below the reader, which the array always
+   * includes (CT-1872 1c; 03-commit-model.md §3.5). Scalarized to the
+   * top-of-stack element at send time when the server does not advertise
+   * `pendingReadStacks` — the pre-stack wire shape, which keeps compat at
+   * the cost of the lower-layer dependency check on that server.
    */
-  resolutionOnly?: boolean;
+  localSeq: number | number[];
+  nonRecursive?: boolean;
 };
 
 const pendingVersion = (
@@ -609,6 +609,11 @@ const comparePath = (left: readonly string[], right: readonly string[]) => {
   return 0;
 };
 
+// Canonical grouping/sort key for a pending read's dependency set: arrays
+// are ascending, so the join is order-stable per identical stack.
+const localSeqKey = (localSeq: number | number[]): string =>
+  Array.isArray(localSeq) ? localSeq.join(",") : String(localSeq);
+
 const compactCommitReads = <
   Read extends ConfirmedCommitRead | PendingCommitRead,
 >(
@@ -630,11 +635,12 @@ const compactCommitReads = <
       return left.seq - right.seq;
     }
 
-    if (
-      "localSeq" in left && "localSeq" in right &&
-      left.localSeq !== right.localSeq
-    ) {
-      return left.localSeq - right.localSeq;
+    if ("localSeq" in left && "localSeq" in right) {
+      const leftKey = localSeqKey(left.localSeq);
+      const rightKey = localSeqKey(right.localSeq);
+      if (leftKey !== rightKey) {
+        return leftKey < rightKey ? -1 : 1;
+      }
     }
 
     if (left.nonRecursive !== right.nonRecursive) {
@@ -653,9 +659,9 @@ const compactCommitReads = <
       ? `confirmed:${
         normalizeCellScope(candidate.scope)
       }:${candidate.id}:${candidate.seq}`
-      : `pending:${
-        normalizeCellScope(candidate.scope)
-      }:${candidate.id}:${candidate.localSeq}`;
+      : `pending:${normalizeCellScope(candidate.scope)}:${candidate.id}:${
+        localSeqKey(candidate.localSeq)
+      }`;
     let group = grouped.get(dependencyKey);
     if (!group) {
       group = {
@@ -711,11 +717,12 @@ const compactCommitReads = <
       return left.seq - right.seq;
     }
 
-    if (
-      "localSeq" in left && "localSeq" in right &&
-      left.localSeq !== right.localSeq
-    ) {
-      return left.localSeq - right.localSeq;
+    if ("localSeq" in left && "localSeq" in right) {
+      const leftKey = localSeqKey(left.localSeq);
+      const rightKey = localSeqKey(right.localSeq);
+      if (leftKey !== rightKey) {
+        return leftKey < rightKey ? -1 : 1;
+      }
     }
 
     if (left.nonRecursive !== right.nonRecursive) {
@@ -729,6 +736,64 @@ const compactCommitReads = <
 const toCommitReadPath = (
   path: readonly (string | number)[],
 ): DocumentPath => toDocumentPath(path.map(String));
+
+// Wire-compat downgrade for servers that do not advertise the
+// `pendingReadStacks` hello flag: collapse every array dependency set —
+// including those inside batched scheduler observations — to its
+// top-of-stack element (the highest localSeq, i.e. the staleness basis).
+// The lower-layer dependency check is lost against such servers by design
+// (CT-1872 1c stays open there); the client-side drop cascade still covers
+// those edges locally.
+const scalarizeLocalSeq = (localSeq: number | number[]): number =>
+  Array.isArray(localSeq) ? Math.max(...localSeq) : localSeq;
+
+const scalarizePendingReadStacks = (commit: ClientCommit): ClientCommit => {
+  const hasStack = (reads: { localSeq: number | number[] }[]): boolean =>
+    reads.some((read) => Array.isArray(read.localSeq));
+  const scalarizeReads = <Read extends { localSeq: number | number[] }>(
+    reads: Read[],
+  ): Read[] =>
+    reads.map((read) =>
+      Array.isArray(read.localSeq)
+        ? { ...read, localSeq: scalarizeLocalSeq(read.localSeq) }
+        : read
+    );
+  const needsCommit = hasStack(commit.reads.pending);
+  const needsBatch =
+    commit.schedulerObservationBatch?.some((entry) =>
+      hasStack(entry.reads.pending)
+    ) === true;
+  if (!needsCommit && !needsBatch) {
+    return commit;
+  }
+  return {
+    ...commit,
+    ...(needsCommit
+      ? {
+        reads: {
+          confirmed: commit.reads.confirmed,
+          pending: scalarizeReads(commit.reads.pending),
+        },
+      }
+      : {}),
+    ...(needsBatch
+      ? {
+        schedulerObservationBatch: commit.schedulerObservationBatch!.map(
+          (entry) =>
+            hasStack(entry.reads.pending)
+              ? {
+                ...entry,
+                reads: {
+                  confirmed: entry.reads.confirmed,
+                  pending: scalarizeReads(entry.reads.pending),
+                },
+              }
+              : entry,
+        ),
+      }
+      : {}),
+  };
+};
 
 export class StorageManager implements IStorageManager {
   readonly id: string;
@@ -2733,7 +2798,13 @@ class SpaceReplica implements ISpaceReplica {
     }
     const dependencies = new Set<number>();
     for (const read of commit.reads.pending) {
-      dependencies.add(read.localSeq);
+      if (Array.isArray(read.localSeq)) {
+        for (const layer of read.localSeq) {
+          dependencies.add(layer);
+        }
+      } else {
+        dependencies.add(read.localSeq);
+      }
     }
     const entry: InFlightCommit = {
       localSeq,
@@ -2918,7 +2989,13 @@ class SpaceReplica implements ISpaceReplica {
             throw error;
           }
         }
-        const { session } = await this.sessionHandle();
+        const { client, session } = await this.sessionHandle();
+        // Wire-compat: only a server advertising `pendingReadStacks` can
+        // resolve array dependency sets — otherwise collapse each to its
+        // top-of-stack element before sending.
+        const wireCommit = client.serverFlags?.pendingReadStacks === true
+          ? commit
+          : scalarizePendingReadStacks(commit);
         if (inFlight?.localRejectionValue !== undefined) {
           // A pending dependency was dropped while we awaited the scheduler
           // batch flush or the session handshake — do not send a commit whose
@@ -2939,7 +3016,7 @@ class SpaceReplica implements ISpaceReplica {
         if (inFlight === undefined) {
           // No pending reads → no dependency that can be dropped from under
           // this commit; keep the direct await.
-          const applied = await session.transact(commit);
+          const applied = await session.transact(wireCommit);
           this.confirmPending(localSeq, operations, applied);
           telemetry?.submit({
             type: "storage.push.complete",
@@ -2951,7 +3028,7 @@ class SpaceReplica implements ISpaceReplica {
         // Race the server verdict against a locally-fabricated rejection (a
         // dependency dropped mid-flight, or a replica reset). A server
         // rejection wins the race by REJECTING it, landing in the catch below.
-        const verdict = session.transact(commit);
+        const verdict = session.transact(wireCommit);
         const outcome = await Promise.race([
           verdict.then((applied) => ({ applied })),
           inFlight.localRejection.promise.then((rejection) => ({ rejection })),
@@ -3080,10 +3157,6 @@ class SpaceReplica implements ISpaceReplica {
   ) {
     const confirmed: ConfirmedCommitRead[] = [];
     const pending: PendingCommitRead[] = [];
-    // Dedup for the existence-only reads on lower pending layers: a commit
-    // can read the same doc many times, and a pending stack can hold several
-    // entries per localSeq.
-    const seenExistenceDeps = new Set<string>();
     if (!source) {
       return { confirmed, pending };
     }
@@ -3114,32 +3187,29 @@ class SpaceReplica implements ISpaceReplica {
       confirmedSeq?: number,
     ) => {
       const record = this.#docs.get(docKey(id, scope));
-      const lower = record?.pending
-        .filter((version) => version.localSeq < localSeq) ?? [];
-      const pendingLocalSeq = lower.at(-1)?.localSeq;
+      // The read's materialized view sat on EVERY lower pending layer, not
+      // just the nearest one: name them ALL (ascending; the last element is
+      // the doc's top-of-stack below this commit) so a dropped deeper layer
+      // still dooms this commit (server: pending-dependency resolution;
+      // client: cascade). Staleness is based at the highest element only —
+      // a staleness basis on a lower layer would false-conflict with the
+      // session's own later stacked writes (CT-1872 1c).
+      const layers = [
+        ...new Set(
+          record?.pending
+            .filter((version) => version.localSeq < localSeq)
+            .map((version) => version.localSeq) ?? [],
+        ),
+      ].sort((left, right) => left - right);
       const shape = nonRecursive ? { nonRecursive: true } : {};
-      if (pendingLocalSeq !== undefined) {
-        pending.push({ id, scope, path, localSeq: pendingLocalSeq, ...shape });
-        // The read's materialized view sat on EVERY lower pending layer, not
-        // just the nearest one. Emit an existence-only dependency per other
-        // unique layer so a dropped deeper layer still dooms this commit
-        // (server: pending-dependency resolution; client: cascade). These
-        // must not carry the read path: staleness stays with the top read —
-        // a full-path read on a lower layer would false-conflict with the
-        // session's own later stacked writes (CT-1872 1c).
-        for (const version of lower) {
-          if (version.localSeq === pendingLocalSeq) continue;
-          const depKey = `${docKey(id, scope)}\0${version.localSeq}`;
-          if (seenExistenceDeps.has(depKey)) continue;
-          seenExistenceDeps.add(depKey);
-          pending.push({
-            id,
-            scope,
-            path: toDocumentPath([]),
-            localSeq: version.localSeq,
-            resolutionOnly: true,
-          });
-        }
+      if (layers.length > 0) {
+        pending.push({
+          id,
+          scope,
+          path,
+          localSeq: layers.length === 1 ? layers[0] : layers,
+          ...shape,
+        });
       } else {
         confirmed.push({
           id,

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -99,14 +99,22 @@ type ScriptedOutcome =
     kind: "accept";
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
+    /**
+     * Skip validateReads for this commit. Forces the "impossible" late
+     * accept — a server verdict resolving a pending dependency the client
+     * already dropped — so the cascade's late-verdict suppression can be
+     * pinned (the real server can never produce it once resolution-only
+     * pending reads are emitted).
+     */
+    skipReadValidation?: true;
   }
   | {
     kind: "rejectConflict";
     message?: string;
-    remoteInterleave?: RemoteCommit;
-    responseGate?: Promise<void>;
     /** See {@link RejectionError.retryAfterSeq}. */
     retryAfterSeq?: number;
+    remoteInterleave?: RemoteCommit;
+    responseGate?: Promise<void>;
   }
   | {
     kind: "dropThenReplayAccept";
@@ -204,7 +212,10 @@ class ScriptedServerModel {
       ? scripted.retryAfterSeq
       : undefined;
 
-    const readError = this.validateReads(commit);
+    const readError =
+      scripted.kind === "accept" && scripted.skipReadValidation === true
+        ? null
+        : this.validateReads(commit);
     if (readError) {
       return this.reject(
         commit,
@@ -250,6 +261,15 @@ class ScriptedServerModel {
           name: "ConflictError",
           message: `pending dependency localSeq=${read.localSeq}`,
         };
+      }
+      // A resolutionOnly read asserts only that the dependency resolved to a
+      // durable commit (a lower layer of the reader's pending stack exists);
+      // staleness stays with the top-of-stack read. Scanning it for overlap
+      // would false-conflict with the session's own later stacked writes —
+      // the exact hazard the flag exists to avoid (mirrors
+      // resolvePendingReads in packages/memory/v2/engine.ts).
+      if (read.resolutionOnly === true) {
+        continue;
       }
       for (const accepted of this.applied.values()) {
         if (accepted.applied.seq <= dependency.applied.seq) {
@@ -881,7 +901,11 @@ const topPendingSurface = (
     10_000,
   );
   return new Map(
-    reads.pending.map((read) => [read.id as URI, read.localSeq]),
+    reads.pending
+      // Existence-only reads on lower pending layers are dependency records,
+      // not the staleness-bearing surface this helper reports.
+      .filter((read) => read.resolutionOnly !== true)
+      .map((read) => [read.id as URI, read.localSeq]),
   );
 };
 
@@ -1106,6 +1130,12 @@ const runStressSeed = async (seed: number) => {
       pending.delete(localSeq);
     }
 
+    // A cascade-settled commit's promise resolves before the transport's
+    // queued transact callback books the (suppressed) late verdict. Drain
+    // those callbacks so the server-side bookkeeping below is final — it also
+    // makes the accepted-despite-client-error check meaningful.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
     assertEquals(
       topPendingSurface(harness).size,
       0,
@@ -1119,10 +1149,29 @@ const runStressSeed = async (seed: number) => {
           applied,
           `seed=${seed} result ${localSeq} expected applied`,
         );
-      } else {
-        assertExists(
-          rejected,
-          `seed=${seed} result ${localSeq} expected rejection`,
+      } else if (rejected === undefined) {
+        // The pending-dependency cascade settles a provably-doomed commit
+        // client-side, so a client-errored commit may lack a server rejection
+        // row in exactly two shapes: it carries the cascade's fabricated
+        // conflict message, or it was rejected at a pre-send checkpoint and
+        // never reached the server at all. Anything else — in particular a
+        // client error for a sent commit — still demands a rejection row.
+        const cascaded = result.message?.includes(
+          "pending dependency dropped locally",
+        ) === true;
+        const sent = harness.model.transactLocalSeqs.includes(localSeq);
+        assert(
+          cascaded || !sent,
+          `seed=${seed} result ${localSeq} expected rejection ` +
+            `(message=${result.message})`,
+        );
+        // Never acceptable: the server durably ACCEPTED a commit the client
+        // settled as a conflict.
+        assertEquals(
+          applied,
+          undefined,
+          `seed=${seed} result ${localSeq} settled as a client conflict but ` +
+            `the server accepted it`,
         );
       }
     }
@@ -1813,16 +1862,436 @@ Deno.test("memory v2 stacked commits: pending-read compaction keeps localSeq bou
     );
 
     assertEquals(reads.confirmed, []);
+    // The top-of-stack read carries staleness (and the read path); every
+    // lower pending layer the read's view sat on is recorded as one
+    // existence-only (resolutionOnly) dependency at the document root so a
+    // dropped lower layer still dooms the commit (CT-1872 1c). Two source
+    // reads over the same stack still emit a single dependency per layer.
     assertEquals(
       reads.pending.map((read) => ({
         id: read.id,
         localSeq: read.localSeq,
+        path: [...read.path],
+        resolutionOnly: read.resolutionOnly ?? false,
       })),
-      [{ id: DOCS.A, localSeq: 2 }],
+      [
+        { id: DOCS.A, localSeq: 1, path: [], resolutionOnly: true },
+        { id: DOCS.A, localSeq: 2, path: ["value"], resolutionOnly: false },
+      ],
     );
     await assertResultOk(c1.promise);
     await assertResultOk(c2.promise);
   } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: reading through the session's own two-deep stack does not self-conflict", async () => {
+  const harness = await createHarness();
+  try {
+    const c1 = beginSet(harness, DOCS.A, valueFor("c1"));
+    harness.model.setOutcome(c1.localSeq, { kind: "accept" });
+    const c2 = beginSet(harness, DOCS.A, valueFor("c2"));
+    harness.model.setOutcome(c2.localSeq, { kind: "accept" });
+    // c3's read view sits on the session's OWN stack [c1 set A, c2 set A].
+    // The lower layer (c1) must be an existence-only dependency: a
+    // staleness-bearing read naming c1 would false-conflict with our own c2.
+    const c3 = beginSet(
+      harness,
+      DOCS.A,
+      valueFor("c3"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(c3.localSeq, { kind: "accept" });
+
+    await assertResultOk(c1.promise);
+    await assertResultOk(c2.promise);
+    // ACCEPTED — this is the regression guard for the resolutionOnly design.
+    await assertResultOk(c3.promise);
+    expectVisible(harness, { A: valueFor("c3") });
+
+    // The wire commit really carried the two-layer read set (the scenario
+    // that would have false-conflicted without resolutionOnly).
+    const sent = harness.model.applied.get(c3.localSeq);
+    assertExists(sent);
+    assertEquals(
+      sent.commit.reads.pending
+        .map((read) => ({
+          localSeq: read.localSeq,
+          resolutionOnly: read.resolutionOnly ?? false,
+        }))
+        .sort((left, right) => left.localSeq - right.localSeq),
+      [
+        { localSeq: c1.localSeq, resolutionOnly: true },
+        { localSeq: c2.localSeq, resolutionOnly: false },
+      ],
+    );
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: dropped dependency locally rejects the in-flight dependant before its server verdict", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  try {
+    const t1 = beginBatch(harness, [
+      { op: "set", id: DOCS.A, value: valueFor("t1-a") },
+      { op: "set", id: DOCS.B, value: valueFor("t1-b") },
+    ]);
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      message: "synthetic conflict on T1",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "accept",
+      responseGate: g2.promise,
+    });
+
+    expectVisible(harness, {
+      A: valueFor("t1-a"),
+      B: valueFor("t1-b"),
+      D: valueFor("t2-d"),
+    });
+    // Let both commits reach the wire; T2's verdict stays gated so only the
+    // client-side cascade can settle it.
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t2.localSeq),
+      "t2 to reach the wire",
+    );
+
+    g1.resolve();
+    await assertConflict(t1.promise, "synthetic conflict on T1");
+    // T2 settles from T1's drop alone — its own verdict is still gated.
+    await assertConflict(
+      t2.promise,
+      `pending dependency dropped locally: localSeq=${t1.localSeq}`,
+    );
+    // Settled client-side: T2 WAS sent, but the server never judged it.
+    assert(harness.model.transactLocalSeqs.includes(t2.localSeq));
+    assertEquals(harness.model.rejected.has(t2.localSeq), false);
+    assertEquals(harness.model.applied.has(t2.localSeq), false);
+    // T2's optimistic write is reverted along with T1's.
+    expectVisible(harness, { A: undefined, B: undefined, D: undefined });
+
+    // Late verdict: consumed off the books, state stays put.
+    g2.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expectVisible(harness, { A: undefined, B: undefined, D: undefined });
+    assertEquals(harness.model.applied.has(t2.localSeq), false);
+  } finally {
+    g1.resolve();
+    g2.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: dependency drop cascades transitively through chained pending reads", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  const g3 = Promise.withResolvers<void>();
+  try {
+    const t1 = beginBatch(harness, [
+      { op: "set", id: DOCS.A, value: valueFor("t1-a") },
+      { op: "set", id: DOCS.B, value: valueFor("t1-b") },
+    ]);
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "accept",
+      responseGate: g2.promise,
+    });
+    // T3 reads D's pending state, which only exists via T2.
+    const t3 = beginSet(
+      harness,
+      DOCS.C,
+      valueFor("t3-c"),
+      sourceFromReads([{ id: DOCS.D }]),
+    );
+    harness.model.setOutcome(t3.localSeq, {
+      kind: "accept",
+      responseGate: g3.promise,
+    });
+
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t3.localSeq),
+      "t3 to reach the wire",
+    );
+
+    // One gate release topples the whole chain: T1's drop dooms T2, T2's
+    // drop dooms T3 — each victim's message names ITS dropped dependency.
+    g1.resolve();
+    await assertConflict(t1.promise);
+    await assertConflict(
+      t2.promise,
+      `pending dependency dropped locally: localSeq=${t1.localSeq}`,
+    );
+    await assertConflict(
+      t3.promise,
+      `pending dependency dropped locally: localSeq=${t2.localSeq}`,
+    );
+    expectVisible(harness, {
+      A: undefined,
+      B: undefined,
+      C: undefined,
+      D: undefined,
+    });
+  } finally {
+    g1.resolve();
+    g2.resolve();
+    g3.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: zero-read patch is not cascaded when an earlier batch drops", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g3 = Promise.withResolvers<void>();
+  try {
+    await seedAccepted(harness, DOCS.A, { count: 0 });
+
+    const t1 = beginBatch(harness, [
+      { op: "set", id: DOCS.A, value: { count: 1 } },
+      { op: "set", id: DOCS.B, value: valueFor("t1-b") },
+    ]);
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    // beginPatch goes straight to the replica, bypassing the harness
+    // dispatch counter: on the wire it is localSeq 3 (seed=1, t1=2).
+    const patchLocalSeq = 3;
+    harness.model.setOutcome(patchLocalSeq, {
+      kind: "accept",
+      responseGate: g3.promise,
+    });
+    let patchSettled = false;
+    const patch = beginPatch(
+      harness,
+      DOCS.A,
+      [{ op: "replace", path: "/value/count", value: 5 }],
+      { count: 5 },
+    ).finally(() => {
+      patchSettled = true;
+    });
+
+    expectVisible(harness, { A: { count: 5 } });
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(patchLocalSeq),
+      "patch to reach the wire",
+    );
+
+    g1.resolve();
+    await assertConflict(t1.promise);
+    // The patch carried no pending reads, so it never entered the cascade
+    // scan set: still in flight after T1's drop, its optimistic write
+    // re-derived on top of confirmed state (intended CT-1872 1a semantics).
+    assertEquals(patchSettled, false);
+    expectVisible(harness, { A: { count: 5 }, B: undefined });
+
+    g3.resolve();
+    await assertResultOk(patch);
+    assertEquals(harness.model.applied.has(patchLocalSeq), true);
+    expectVisible(harness, { A: { count: 5 } });
+  } finally {
+    g1.resolve();
+    g3.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: each cascaded victim emits one revert with its own doc ids", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  const g3 = Promise.withResolvers<void>();
+  try {
+    const t1 = beginBatch(harness, [
+      { op: "set", id: DOCS.A, value: valueFor("t1-a") },
+      { op: "set", id: DOCS.B, value: valueFor("t1-b") },
+    ]);
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "accept",
+      responseGate: g2.promise,
+    });
+    const t3 = beginSet(
+      harness,
+      DOCS.C,
+      valueFor("t3-c"),
+      sourceFromReads([{ id: DOCS.D }]),
+    );
+    harness.model.setOutcome(t3.localSeq, {
+      kind: "accept",
+      responseGate: g3.promise,
+    });
+
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t3.localSeq),
+      "t3 to reach the wire",
+    );
+    g1.resolve();
+    await assertConflict(t1.promise);
+    await assertConflict(t2.promise, "pending dependency dropped locally");
+    await assertConflict(t3.promise, "pending dependency dropped locally");
+
+    // One revert per victim, each scoped to the docs THAT commit touched —
+    // the primary first, then each cascaded victim in dependency order.
+    assertEquals(
+      changedIdsFor(harness.notifications.notifications, "revert"),
+      [
+        [DOCS.A, DOCS.B],
+        [DOCS.D],
+        [DOCS.C],
+      ],
+    );
+  } finally {
+    g1.resolve();
+    g2.resolve();
+    g3.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: late server reject after a cascade is swallowed without a second revert", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  try {
+    const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "rejectConflict",
+      message: "late server verdict for t2",
+      responseGate: g2.promise,
+    });
+
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t2.localSeq),
+      "t2 to reach the wire",
+    );
+    g1.resolve();
+    await assertConflict(t1.promise);
+    // The cascade won: the client's result carries the fabricated message,
+    // not the scripted server one.
+    await assertConflict(
+      t2.promise,
+      `pending dependency dropped locally: localSeq=${t1.localSeq}`,
+    );
+    assertEquals(
+      changedIdsFor(harness.notifications.notifications, "revert"),
+      [[DOCS.A], [DOCS.D]],
+    );
+
+    // The late server reject lands, is swallowed, and changes nothing: no
+    // second settle is possible and no second revert may be emitted.
+    g2.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assertEquals(harness.model.rejected.has(t2.localSeq), true);
+    assertEquals(
+      changedIdsFor(harness.notifications.notifications, "revert"),
+      [[DOCS.A], [DOCS.D]],
+    );
+    expectVisible(harness, { A: undefined, D: undefined });
+  } finally {
+    g1.resolve();
+    g2.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: impossible late accept after a cascade does not promote the write", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  try {
+    const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    // skipReadValidation forces the verdict the real server can never
+    // produce (accepting a commit whose pending dependency has no commit
+    // row) to pin the suppression path's failure mode.
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "accept",
+      skipReadValidation: true,
+      responseGate: g2.promise,
+    });
+
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t2.localSeq),
+      "t2 to reach the wire",
+    );
+    g1.resolve();
+    await assertConflict(t1.promise);
+    await assertConflict(
+      t2.promise,
+      `pending dependency dropped locally: localSeq=${t1.localSeq}`,
+    );
+    expectVisible(harness, { A: undefined, D: undefined });
+    assertEquals(currentSeq(harness, DOCS.D), 0);
+    const notificationsAtSettle = notificationLog(
+      harness.notifications.notifications,
+    );
+
+    // The server durably accepts the doomed commit — the client warns
+    // ("cascade-late-accept") and must NOT promote the already-dropped write
+    // to confirmed: the promise settled as a conflict long ago.
+    g2.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assertEquals(harness.model.applied.has(t2.localSeq), true);
+    expectVisible(harness, { A: undefined, D: undefined });
+    assertEquals(currentSeq(harness, DOCS.D), 0);
+    assertEquals(
+      notificationLog(harness.notifications.notifications),
+      notificationsAtSettle,
+    );
+  } finally {
+    g1.resolve();
+    g2.resolve();
     await harness.close();
   }
 });

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -3601,3 +3601,102 @@ for (
     await runStressSeed(seed);
   });
 }
+
+// Integrated from PR #4961 (Hixie's repro for the cf-render counter flake):
+// a foreground editWithRetry write that reads documents the scheduler is
+// concurrently writing declares pending reads on still-unconfirmed optimistic
+// writes. When one of those is rejected, the dependant is doomed — its
+// pending read names a localSeq that will never become a confirmed seq — and
+// a client without the cascade leaves it in flight awaiting its own verdict,
+// burning editWithRetry's bounded retry budget and surfacing the raw
+// "pending dependency not resolved" ConflictError to the caller.
+//
+// Distinct from the basic cascade test above: T2's OWN verdict stays gated
+// for the whole test, so the ONLY thing that can settle it is the client-side
+// cascade off T1's drop — pinning that the settle is entirely local (the
+// server never judges T2 at all). Adapted from the original's 2s wall-clock
+// absence bound to a settled-flag + microtask drain: the clock preload
+// freezes test-file timers, and the cascade path is pure promise flow, so a
+// missing cascade surfaces within microtasks as a failed assertion instead
+// of a hang.
+Deno.test("memory v2 stacked commits: a dependant stranded by a dropped optimistic sibling is rejected off the drop alone, without its own server verdict", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  try {
+    // T1 optimistically writes A and B. It is destined to be rejected, but
+    // its verdict is gated on g1 so T2 is built and put on the wire while T1
+    // is still in flight.
+    const t1 = beginBatch(harness, [
+      { op: "set", id: DOCS.A, value: valueFor("t1-a") },
+      { op: "set", id: DOCS.B, value: valueFor("t1-b") },
+    ]);
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      message: "synthetic conflict on T1",
+      responseGate: g1.promise,
+    });
+
+    // T2 writes D but READS A, so its commit declares a pending read on T1's
+    // still-unconfirmed optimistic write. T2's verdict gate (g2) is NEVER
+    // resolved until teardown.
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "accept",
+      responseGate: g2.promise,
+    });
+    let settledFromDropAlone = false;
+    void t2.promise.then(() => {
+      settledFromDropAlone = true;
+    });
+
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t2.localSeq),
+      "t2 to reach the wire",
+    );
+
+    // Drop T1. T2 is now provably doomed: its pending read names T1's
+    // dropped optimistic write, which can never become a confirmed seq.
+    g1.resolve();
+    await assertConflict(t1.promise, "synthetic conflict on T1");
+
+    // The cascade fires synchronously inside T1's drop and T2's settle is
+    // pure promise flow from there — give the microtask queue ample turns,
+    // then require the settle. A cascade-less client leaves T2 pending here.
+    for (let turn = 0; turn < 32; turn += 1) {
+      await Promise.resolve();
+    }
+    assert(
+      settledFromDropAlone,
+      "the doomed dependant was NOT rejected by a client-side " +
+        "pending-dependency cascade; it stayed in flight awaiting its own " +
+        "server verdict. On the real editWithRetry path this is exactly what " +
+        "makes a foreground piece.result.set() burn its bounded retry budget " +
+        'and surface "pending dependency not resolved".',
+    );
+
+    const t2Result = await t2.promise;
+    assertExists(t2Result.error);
+    assertEquals(t2Result.error.name, "ConflictError");
+    assert(
+      String(t2Result.error.message).includes(
+        `dropped locally: localSeq=${t1.localSeq}`,
+      ),
+      `unexpected dependant rejection message: ${
+        JSON.stringify(t2Result.error.message)
+      }`,
+    );
+    // The server never judged T2: it was settled entirely client-side.
+    assertEquals(harness.model.rejected.has(t2.localSeq), false);
+    assertEquals(harness.model.applied.has(t2.localSeq), false);
+  } finally {
+    g1.resolve();
+    g2.resolve();
+    await harness.close();
+  }
+});

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2017,6 +2017,110 @@ Deno.test("memory v2 stacked commits: a server without pendingReadStacks receive
   }
 });
 
+Deno.test("memory v2 stacked commits: old-server hold — a dropped omitted dependency dooms the commit before it is ever sent", async () => {
+  const harness = await createHarness({
+    transport: (model) => new PreStackTransport(model),
+  });
+  const g1 = Promise.withResolvers<void>();
+  try {
+    // The reviewer's split-brain shape: lower layer rejects, blind top layer
+    // accepts, and the dependant WOULD be accepted by the old server (its
+    // scalar wire read names only the accepted top). The hold must keep the
+    // dependant off the wire until c1 settles, so the server never gets the
+    // chance to accept what the client cascade-rejects.
+    const c1 = beginSet(harness, DOCS.A, valueFor("c1"));
+    harness.model.setOutcome(c1.localSeq, {
+      kind: "rejectConflict",
+      message: "c1 loses",
+      responseGate: g1.promise,
+    });
+    const c2 = beginSet(harness, DOCS.A, valueFor("c2"));
+    harness.model.setOutcome(c2.localSeq, { kind: "accept" });
+    const c3 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("c3-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(c3.localSeq, {
+      kind: "accept",
+      skipReadValidation: true,
+    });
+
+    // The blind top layer settles while c1's verdict is still gated…
+    await assertResultOk(c2.promise);
+    // …and c3 must be HELD off the wire (its omitted dependency c1 is
+    // unsettled). A send would surface within microtasks of the hold being
+    // wrongly absent.
+    for (let turn = 0; turn < 32; turn += 1) {
+      await Promise.resolve();
+    }
+    assertEquals(harness.model.transactLocalSeqs.includes(c3.localSeq), false);
+
+    // c1 drops: the cascade dooms c3 at the pre-send checkpoint. Nothing
+    // ever reaches the server, so a durable accept of a client-rejected
+    // commit — the split-brain — is structurally impossible.
+    g1.resolve();
+    await assertConflict(c1.promise, "c1 loses");
+    await assertConflict(
+      c3.promise,
+      `pending dependency dropped locally: localSeq=${c1.localSeq}`,
+    );
+    assertEquals(harness.model.transactLocalSeqs.includes(c3.localSeq), false);
+    assertEquals(harness.model.applied.has(c3.localSeq), false);
+  } finally {
+    g1.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: old-server hold releases once every omitted dependency is accepted", async () => {
+  const harness = await createHarness({
+    transport: (model) => new PreStackTransport(model),
+  });
+  const g1 = Promise.withResolvers<void>();
+  try {
+    const c1 = beginSet(harness, DOCS.A, valueFor("c1"));
+    harness.model.setOutcome(c1.localSeq, {
+      kind: "accept",
+      responseGate: g1.promise,
+    });
+    const c2 = beginSet(harness, DOCS.A, valueFor("c2"));
+    harness.model.setOutcome(c2.localSeq, { kind: "accept" });
+    const c3 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("c3-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(c3.localSeq, {
+      kind: "accept",
+      skipReadValidation: true,
+    });
+
+    await assertResultOk(c2.promise);
+    for (let turn = 0; turn < 32; turn += 1) {
+      await Promise.resolve();
+    }
+    assertEquals(harness.model.transactLocalSeqs.includes(c3.localSeq), false);
+
+    // c1 accepts: every omitted dependency is durable, the scalar shape is
+    // sound, and the held send proceeds.
+    g1.resolve();
+    await assertResultOk(c1.promise);
+    await assertResultOk(c3.promise);
+    const sent = harness.model.applied.get(c3.localSeq);
+    assertExists(sent);
+    assertEquals(
+      sent.commit.reads.pending.map((read) => read.localSeq),
+      [c2.localSeq],
+    );
+  } finally {
+    g1.resolve();
+    await harness.close();
+  }
+});
+
 Deno.test("memory v2 stacked commits: dropped dependency locally rejects the in-flight dependant before its server verdict", async () => {
   const harness = await createHarness();
   const g1 = Promise.withResolvers<void>();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -14,6 +14,7 @@ import type { FabricValue } from "@commonfabric/api";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
   type EntityDocument,
+  getMemoryProtocolFlags,
   type PatchOp,
   resetPersistentSchedulerStateConfig,
   type SessionSync,
@@ -157,6 +158,11 @@ type ResultRecord = {
   message?: string;
 };
 
+// The staleness-bearing top of a pending read's dependency set: the highest
+// listed layer (scalar reads are their own top).
+const localSeqTop = (read: { localSeq: number | number[] }): number =>
+  Array.isArray(read.localSeq) ? Math.max(...read.localSeq) : read.localSeq;
+
 class ScriptedServerModel {
   connectionCount = 0;
   transactLocalSeqs: number[] = [];
@@ -259,30 +265,43 @@ class ScriptedServerModel {
     commit: ClientCommit,
   ): RejectionError | null {
     for (const read of commit.reads.pending) {
-      const dependency = this.applied.get(read.localSeq);
-      if (!dependency) {
+      // Mirrors resolvePendingReads in packages/memory/v2/engine.ts: every
+      // element of an array localSeq must have resolved to an accepted
+      // commit, and staleness is scanned once, based at the HIGHEST element
+      // (the doc's top-of-stack below the reader). Scanning lower layers
+      // would false-conflict with the session's own later stacked writes —
+      // the exact hazard the max-basis rule exists to avoid.
+      const layers = Array.isArray(read.localSeq)
+        ? read.localSeq
+        : [read.localSeq];
+      let basis: AppliedRecord | undefined;
+      let unresolved: number | undefined;
+      for (const layer of layers) {
+        const dependency = this.applied.get(layer);
+        if (!dependency) {
+          unresolved = layer;
+          break;
+        }
+        if (
+          basis === undefined || dependency.applied.seq > basis.applied.seq
+        ) {
+          basis = dependency;
+        }
+      }
+      if (unresolved !== undefined || basis === undefined) {
         return {
           name: "ConflictError",
-          message: `pending dependency localSeq=${read.localSeq}`,
+          message: `pending dependency localSeq=${unresolved}`,
         };
       }
-      // A resolutionOnly read asserts only that the dependency resolved to a
-      // durable commit (a lower layer of the reader's pending stack exists);
-      // staleness stays with the top-of-stack read. Scanning it for overlap
-      // would false-conflict with the session's own later stacked writes —
-      // the exact hazard the flag exists to avoid (mirrors
-      // resolvePendingReads in packages/memory/v2/engine.ts).
-      if (read.resolutionOnly === true) {
-        continue;
-      }
       for (const accepted of this.applied.values()) {
-        if (accepted.applied.seq <= dependency.applied.seq) {
+        if (accepted.applied.seq <= basis.applied.seq) {
           continue;
         }
         if (accepted.touched.some((write) => readOverlapsWrite(read, write))) {
           return {
             name: "ConflictError",
-            message: `stale pending read localSeq=${read.localSeq}`,
+            message: `stale pending read localSeq=${localSeqTop(read)}`,
           };
         }
       }
@@ -531,9 +550,14 @@ type PushSyncOptions = {
 
 type Harness = ReturnType<typeof createHarness>;
 
-const createHarness = () => {
+const createHarness = (
+  options: {
+    transport?: (model: ScriptedServerModel) => ScriptedModelTransport;
+  } = {},
+) => {
   const model = new ScriptedServerModel();
-  const transport = new ScriptedModelTransport(model);
+  const transport = options.transport?.(model) ??
+    new ScriptedModelTransport(model);
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
@@ -932,11 +956,9 @@ const topPendingSurface = (
     10_000,
   );
   return new Map(
-    reads.pending
-      // Existence-only reads on lower pending layers are dependency records,
-      // not the staleness-bearing surface this helper reports.
-      .filter((read) => read.resolutionOnly !== true)
-      .map((read) => [read.id as URI, read.localSeq]),
+    // Lower layers in an array localSeq are dependency records; the
+    // staleness-bearing surface this helper reports is the top element.
+    reads.pending.map((read) => [read.id as URI, localSeqTop(read)]),
   );
 };
 
@@ -1893,21 +1915,18 @@ Deno.test("memory v2 stacked commits: pending-read compaction keeps localSeq bou
     );
 
     assertEquals(reads.confirmed, []);
-    // The top-of-stack read carries staleness (and the read path); every
-    // lower pending layer the read's view sat on is recorded as one
-    // existence-only (resolutionOnly) dependency at the document root so a
+    // One read per path, carrying the FULL dependency array (ascending; the
+    // last element is the doc's top-of-stack, the staleness basis) so a
     // dropped lower layer still dooms the commit (CT-1872 1c). Two source
-    // reads over the same stack still emit a single dependency per layer.
+    // reads over the same stack compact to a single entry.
     assertEquals(
       reads.pending.map((read) => ({
         id: read.id,
         localSeq: read.localSeq,
         path: [...read.path],
-        resolutionOnly: read.resolutionOnly ?? false,
       })),
       [
-        { id: DOCS.A, localSeq: 1, path: [], resolutionOnly: true },
-        { id: DOCS.A, localSeq: 2, path: ["value"], resolutionOnly: false },
+        { id: DOCS.A, localSeq: [1, 2], path: ["value"] },
       ],
     );
     await assertResultOk(c1.promise);
@@ -1925,8 +1944,8 @@ Deno.test("memory v2 stacked commits: reading through the session's own two-deep
     const c2 = beginSet(harness, DOCS.A, valueFor("c2"));
     harness.model.setOutcome(c2.localSeq, { kind: "accept" });
     // c3's read view sits on the session's OWN stack [c1 set A, c2 set A].
-    // The lower layer (c1) must be an existence-only dependency: a
-    // staleness-bearing read naming c1 would false-conflict with our own c2.
+    // The lower layer (c1) must impose resolution only: a staleness basis at
+    // c1 would false-conflict with our own c2 (max-basis rule, spec §3.5).
     const c3 = beginSet(
       harness,
       DOCS.A,
@@ -1937,25 +1956,61 @@ Deno.test("memory v2 stacked commits: reading through the session's own two-deep
 
     await assertResultOk(c1.promise);
     await assertResultOk(c2.promise);
-    // ACCEPTED — this is the regression guard for the resolutionOnly design.
+    // ACCEPTED — this is the regression guard for the max-basis rule.
     await assertResultOk(c3.promise);
     expectVisible(harness, { A: valueFor("c3") });
 
-    // The wire commit really carried the two-layer read set (the scenario
-    // that would have false-conflicted without resolutionOnly).
+    // The wire commit really carried the two-layer dependency array (the
+    // scenario that would have false-conflicted under a lower basis).
     const sent = harness.model.applied.get(c3.localSeq);
     assertExists(sent);
     assertEquals(
-      sent.commit.reads.pending
-        .map((read) => ({
-          localSeq: read.localSeq,
-          resolutionOnly: read.resolutionOnly ?? false,
-        }))
-        .sort((left, right) => left.localSeq - right.localSeq),
-      [
-        { localSeq: c1.localSeq, resolutionOnly: true },
-        { localSeq: c2.localSeq, resolutionOnly: false },
-      ],
+      sent.commit.reads.pending.map((read) => read.localSeq),
+      [[c1.localSeq, c2.localSeq]],
+    );
+  } finally {
+    await harness.close();
+  }
+});
+
+// An "older server": advertises every current capability EXCEPT the array
+// dependency sets.
+class PreStackTransport extends ScriptedModelTransport {
+  protected override helloFlags() {
+    return { ...getMemoryProtocolFlags(), pendingReadStacks: false };
+  }
+}
+
+Deno.test("memory v2 stacked commits: a server without pendingReadStacks receives scalar top-of-stack reads", async () => {
+  const harness = await createHarness({
+    transport: (model) => new PreStackTransport(model),
+  });
+  try {
+    const c1 = beginSet(harness, DOCS.A, valueFor("c1"));
+    harness.model.setOutcome(c1.localSeq, { kind: "accept" });
+    const c2 = beginSet(harness, DOCS.A, valueFor("c2"));
+    harness.model.setOutcome(c2.localSeq, { kind: "accept" });
+    const c3 = beginSet(
+      harness,
+      DOCS.A,
+      valueFor("c3"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(c3.localSeq, { kind: "accept" });
+
+    await assertResultOk(c1.promise);
+    await assertResultOk(c2.promise);
+    await assertResultOk(c3.promise);
+
+    // The wire commit was scalarized to the top-of-stack element — the
+    // pre-stack shape an old server can resolve. The lower-layer dependency
+    // (c1) is NOT on the wire (the 1c check is knowingly absent against
+    // such servers); the client-side cascade still recorded it locally.
+    const sent = harness.model.applied.get(c3.localSeq);
+    assertExists(sent);
+    assertEquals(
+      sent.commit.reads.pending.map((read) => read.localSeq),
+      [c2.localSeq],
     );
   } finally {
     await harness.close();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2017,6 +2017,62 @@ Deno.test("memory v2 stacked commits: a server without pendingReadStacks receive
   }
 });
 
+Deno.test("memory v2 stacked commits: old-server flush drops multi-layer observations client-side and sends the rest", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = await createHarness({
+    transport: (model) => new PreStackTransport(model),
+  });
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  try {
+    // Two pending layers on A: an observation reading A carries the array
+    // [t1, t2], which a pre-`pendingReadStacks` server cannot receive
+    // soundly (the scalar wire would omit t1 — if t1 drops, the old server
+    // would persist an observation that observed a dropped write).
+    const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "accept",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(harness, DOCS.A, valueFor("t2"));
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "accept",
+      responseGate: g2.promise,
+    });
+    const multiLayer = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:multi-layer"),
+    }, sourceFromReads([{ id: DOCS.A }]));
+    const zeroRead = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:zero-read"),
+    });
+
+    // The multi-layer entry resolves {ok} from the client-side drop alone —
+    // BEFORE t1/t2 settle (their gates are still held): flag-off semantics
+    // for that observation, not a wait.
+    assertEquals(await multiLayer, { ok: {} });
+    assertEquals(await zeroRead, { ok: {} });
+
+    // The wire batch carried only the expressible entry.
+    const batches = [...harness.model.applied.values()].filter((record) =>
+      record.commit.schedulerObservationBatch !== undefined
+    );
+    assertEquals(batches.length, 1);
+    assertEquals(
+      batches[0].commit.schedulerObservationBatch?.map((entry) =>
+        (entry.schedulerObservation as { actionId: string }).actionId
+      ),
+      ["action:zero-read"],
+    );
+  } finally {
+    g1.resolve();
+    g2.resolve();
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
 Deno.test("memory v2 stacked commits: old-server hold — a dropped omitted dependency dooms the commit before it is ever sent", async () => {
   const harness = await createHarness({
     transport: (model) => new PreStackTransport(model),

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2068,9 +2068,20 @@ Deno.test("memory v2 stacked commits: dropped dependency locally rejects the in-
     // T2's optimistic write is reverted along with T1's.
     expectVisible(harness, { A: undefined, B: undefined, D: undefined });
 
-    // Late verdict: consumed off the books, state stays put.
+    // Late verdict: consumed off the books, state stays put. Releasing the
+    // gate lets the model judge t2 — whose read of dropped t1 now fails
+    // validation, so the late verdict is a REJECT and its swallow is the
+    // "cascade-late-reject" count moving.
+    const lateRejectBaseline = getLoggerCountsBreakdown()["storage.v2"]
+      ?.["cascade-late-reject"]?.debug ?? 0;
     g2.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await harness.transport.drainVerdicts();
+    await waitForCondition(
+      () =>
+        (getLoggerCountsBreakdown()["storage.v2"]?.["cascade-late-reject"]
+          ?.debug ?? 0) > lateRejectBaseline,
+      "the late server verdict to be swallowed",
+    );
     expectVisible(harness, { A: undefined, B: undefined, D: undefined });
     assertEquals(harness.model.applied.has(t2.localSeq), false);
   } finally {

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -20,7 +20,10 @@ import {
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
 import type {
   ClientCommit,
   ConfirmedRead,
@@ -39,6 +42,7 @@ import type {
   IStorageProviderWithReplica,
   StorageNotification,
 } from "../src/storage/interface.ts";
+import { setConflictAdmissionMode } from "../src/storage/v2.ts";
 import {
   NotificationRecorder,
   ScriptedSessionTransport,
@@ -435,27 +439,54 @@ class ScriptedModelTransport extends ScriptedSessionTransport {
         const responseGate = this.model.scripted.get(
           commit.localSeq,
         )?.responseGate;
-        setTimeout(() => {
-          void (async () => {
-            await responseGate;
-            const response = this.model.transact(commit);
-            if (response.type === "drop") {
-              this.disconnect(new Error("disconnect"));
-              return;
-            }
-            this.respond({
-              type: "response",
-              requestId: message.requestId!,
-              ...(response.type === "accept"
-                ? { ok: response.applied }
-                : { error: response.error }),
-            });
-          })();
-        }, 0);
+        const verdictTask = new Promise<void>((resolveVerdict) => {
+          setTimeout(() => {
+            void (async () => {
+              try {
+                await responseGate;
+                const response = this.model.transact(commit);
+                if (response.type === "drop") {
+                  this.disconnect(new Error("disconnect"));
+                  return;
+                }
+                this.respond({
+                  type: "response",
+                  requestId: message.requestId!,
+                  ...(response.type === "accept"
+                    ? { ok: response.applied }
+                    : { error: response.error }),
+                });
+              } finally {
+                resolveVerdict();
+              }
+            })();
+          }, 0);
+        });
+        this.#verdictTasks.add(verdictTask);
+        void verdictTask.finally(() => this.#verdictTasks.delete(verdictTask));
         break;
       }
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+  }
+
+  // Verdict callbacks queued by `handle`'s transact case but not yet booked
+  // into the model (their responseGate may still be held). `drainVerdicts`
+  // awaits them so tests can assert on final server-side bookkeeping without
+  // a wall-clock sleep.
+  readonly #verdictTasks = new Set<Promise<void>>();
+
+  /**
+   * Resolve once every transact callback queued SO FAR (including any queued
+   * while draining) has booked its verdict and sent its response. Only the
+   * transport's side is drained: client-side settlement of those responses
+   * is still subject to the caller awaiting the affected commit promises or
+   * an observable event (e.g. a logger count).
+   */
+  async drainVerdicts(): Promise<void> {
+    while (this.#verdictTasks.size > 0) {
+      await Promise.all([...this.#verdictTasks]);
     }
   }
 
@@ -1134,7 +1165,7 @@ const runStressSeed = async (seed: number) => {
     // queued transact callback books the (suppressed) late verdict. Drain
     // those callbacks so the server-side bookkeeping below is final — it also
     // makes the accepted-despite-client-error check meaningful.
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await harness.transport.drainVerdicts();
 
     assertEquals(
       topPendingSurface(harness).size,
@@ -2184,6 +2215,11 @@ Deno.test("memory v2 stacked commits: late server reject after a cascade is swal
   const harness = await createHarness();
   const g1 = Promise.withResolvers<void>();
   const g2 = Promise.withResolvers<void>();
+  // Debug level so the lazy log closures on the cascade/suppression paths
+  // actually format their messages (they are counted either way).
+  const storageLogger = getLogger("storage.v2");
+  const previousLevel = storageLogger.level;
+  storageLogger.level = "debug";
   try {
     const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
     harness.model.setOutcome(t1.localSeq, {
@@ -2220,9 +2256,20 @@ Deno.test("memory v2 stacked commits: late server reject after a cascade is swal
     );
 
     // The late server reject lands, is swallowed, and changes nothing: no
-    // second settle is possible and no second revert may be emitted.
+    // second settle is possible and no second revert may be emitted. The
+    // swallow itself is observable: "cascade-late-reject" is counted in
+    // suppressLateVerdict's rejection handler, so once the count moves the
+    // late verdict has demonstrably been consumed off the books.
+    const lateRejectBaseline = getLoggerCountsBreakdown()["storage.v2"]
+      ?.["cascade-late-reject"]?.debug ?? 0;
     g2.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await harness.transport.drainVerdicts();
+    await waitForCondition(
+      () =>
+        (getLoggerCountsBreakdown()["storage.v2"]?.["cascade-late-reject"]
+          ?.debug ?? 0) > lateRejectBaseline,
+      "the late server reject to be swallowed",
+    );
     assertEquals(harness.model.rejected.has(t2.localSeq), true);
     assertEquals(
       changedIdsFor(harness.notifications.notifications, "revert"),
@@ -2230,6 +2277,7 @@ Deno.test("memory v2 stacked commits: late server reject after a cascade is swal
     );
     expectVisible(harness, { A: undefined, D: undefined });
   } finally {
+    storageLogger.level = previousLevel;
     g1.resolve();
     g2.resolve();
     await harness.close();
@@ -2240,6 +2288,11 @@ Deno.test("memory v2 stacked commits: impossible late accept after a cascade doe
   const harness = await createHarness();
   const g1 = Promise.withResolvers<void>();
   const g2 = Promise.withResolvers<void>();
+  // Warn stays visible at the default level; drop to debug anyway so every
+  // lazy closure on this path formats (coverage of the message builders).
+  const storageLogger = getLogger("storage.v2");
+  const previousLevel = storageLogger.level;
+  storageLogger.level = "debug";
   try {
     const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
     harness.model.setOutcome(t1.localSeq, {
@@ -2279,9 +2332,18 @@ Deno.test("memory v2 stacked commits: impossible late accept after a cascade doe
 
     // The server durably accepts the doomed commit — the client warns
     // ("cascade-late-accept") and must NOT promote the already-dropped write
-    // to confirmed: the promise settled as a conflict long ago.
+    // to confirmed: the promise settled as a conflict long ago. The warn
+    // count moving is the event that the late verdict has been consumed.
+    const lateAcceptBaseline = getLoggerCountsBreakdown()["storage.v2"]
+      ?.["cascade-late-accept"]?.warn ?? 0;
     g2.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await harness.transport.drainVerdicts();
+    await waitForCondition(
+      () =>
+        (getLoggerCountsBreakdown()["storage.v2"]?.["cascade-late-accept"]
+          ?.warn ?? 0) > lateAcceptBaseline,
+      "the late server accept to be suppressed",
+    );
     assertEquals(harness.model.applied.has(t2.localSeq), true);
     expectVisible(harness, { A: undefined, D: undefined });
     assertEquals(currentSeq(harness, DOCS.D), 0);
@@ -2290,8 +2352,259 @@ Deno.test("memory v2 stacked commits: impossible late accept after a cascade doe
       notificationsAtSettle,
     );
   } finally {
+    storageLogger.level = previousLevel;
     g1.resolve();
     g2.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: replica reset locally rejects in-flight dependents exactly once", async () => {
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const g2 = Promise.withResolvers<void>();
+  const storageLogger = getLogger("storage.v2");
+  const previousLevel = storageLogger.level;
+  storageLogger.level = "debug";
+  try {
+    const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "accept",
+      responseGate: g1.promise,
+    });
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(t2.localSeq, {
+      kind: "rejectConflict",
+      message: "late server verdict for t2",
+      responseGate: g2.promise,
+    });
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t2.localSeq),
+      "t2 to reach the wire",
+    );
+
+    // reset() sweeps the in-flight registry: t2 (pending read on t1's doc)
+    // is locally rejected; t1 (no pending reads, never registered) is not.
+    // A second sweep in the same tick must be a no-op — the entry already
+    // carries its local rejection (the rejectInFlightCommitLocally guard).
+    const resettable = harness.replica as unknown as { reset(): void };
+    resettable.reset();
+    resettable.reset();
+    await assertConflict(t2.promise, "memory replica reset");
+
+    // t1 was never locally rejected: its verdict resolves normally even
+    // though the replica was wiped underneath it.
+    g1.resolve();
+    await assertResultOk(t1.promise);
+
+    // t2's late server verdict is consumed off the books, exactly once.
+    const lateRejectBaseline = getLoggerCountsBreakdown()["storage.v2"]
+      ?.["cascade-late-reject"]?.debug ?? 0;
+    g2.resolve();
+    await harness.transport.drainVerdicts();
+    await waitForCondition(
+      () =>
+        (getLoggerCountsBreakdown()["storage.v2"]?.["cascade-late-reject"]
+          ?.debug ?? 0) > lateRejectBaseline,
+      "the late server verdict to be swallowed after reset",
+    );
+    assertEquals(harness.model.rejected.has(t2.localSeq), true);
+  } finally {
+    storageLogger.level = previousLevel;
+    g1.resolve();
+    g2.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: a dependency dropped during the scheduler-batch flush finalizes at the pre-send checkpoint", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  const gObs = Promise.withResolvers<void>();
+  try {
+    // localSeqs are the client's own counter, so drive commitNative directly:
+    // t1 = 1, the observation commit = 2, t2 = 3.
+    const t1 = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.A,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("t1") },
+      }],
+    });
+    harness.model.setOutcome(1, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(1),
+      "t1 to reach the wire",
+    );
+
+    // The observation commit enters the scheduler batch (consuming localSeq
+    // 2); t2 takes 3; the flush then MINTS its own commit as localSeq 4.
+    // Gating 4 deterministically parks t2 on the flush await.
+    const observation = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:doomed-window"),
+    });
+    harness.model.setOutcome(4, {
+      kind: "accept",
+      responseGate: gObs.promise,
+    });
+    const t2 = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.D,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("t2-d") },
+      }],
+    }, sourceFromReads([{ id: DOCS.A }]));
+
+    // While t2 waits on the flush, its dependency drops: the cascade books
+    // the local rejection on the registered in-flight entry.
+    g1.resolve();
+    await assertConflict(t1);
+
+    // Release the flush: t2 resumes at the pre-send checkpoint, sees its
+    // provable doom, and finalizes WITHOUT ever sending its own transact —
+    // only t1 (1) and the batch flush commit (4) ever reached the wire.
+    gObs.resolve();
+    await assertConflict(
+      t2,
+      "pending dependency dropped locally: localSeq=1",
+    );
+    await assertResultOk(observation);
+    assertEquals(harness.model.transactLocalSeqs.includes(3), false);
+    assertEquals(harness.model.transactLocalSeqs.includes(4), true);
+  } finally {
+    g1.resolve();
+    gObs.resolve();
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
+Deno.test("memory v2 stacked commits: a rejected scheduler-batch flush rejects the waiting write pre-send", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = await createHarness();
+  try {
+    // The observation entry consumes localSeq 1 and the write takes 2, but
+    // the batch flush MINTS its own commit as localSeq 3 — scripting THAT to
+    // reject makes the semantic write waiting on the flush surface the
+    // rejection without ever sending its own commit.
+    const observation = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:rejected-batch"),
+    });
+    harness.model.setOutcome(3, {
+      kind: "rejectConflict",
+      message: "observation batch rejected",
+    });
+    const write = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.A,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("write") },
+      }],
+    });
+    await assertConflict(write, "observation batch rejected");
+    await assertConflict(observation, "observation batch rejected");
+    assertEquals(harness.model.transactLocalSeqs, [3]);
+  } finally {
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
+// The admission-control override reaches into the replica the same way the
+// subscription tests do (recordStaleFloor/noteCaughtUpLocalSeq are private).
+type AdmissionReplica = {
+  recordStaleFloor(commit: unknown, localSeq: number): void;
+  noteCaughtUpLocalSeq(localSeq: number | undefined): void;
+};
+
+Deno.test("memory v2 stacked commits: hold-mode admission finalizes a dependency-dropped commit without sending", async () => {
+  setConflictAdmissionMode("hold");
+  const harness = await createHarness();
+  const g1 = Promise.withResolvers<void>();
+  try {
+    const t1 = beginSet(harness, DOCS.A, valueFor("t1"));
+    harness.model.setOutcome(t1.localSeq, {
+      kind: "rejectConflict",
+      responseGate: g1.promise,
+    });
+    await waitForCondition(
+      () => harness.model.transactLocalSeqs.includes(t1.localSeq),
+      "t1 to reach the wire",
+    );
+
+    // Floor A above the current caught-up seq: t2's read of A (a pending
+    // read through t1's optimistic layer) parks it in the hold.
+    const replica = harness.replica as unknown as AdmissionReplica;
+    replica.recordStaleFloor({
+      localSeq: 50,
+      reads: { confirmed: [{ id: DOCS.A, path: [], seq: 0 }], pending: [] },
+      operations: [],
+    }, 50);
+    const t2 = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t2-d"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+
+    // The dependency drops while t2 is held; releasing the hold must land on
+    // the post-hold doom checkpoint — finalize without sending.
+    g1.resolve();
+    await assertConflict(t1.promise);
+    replica.noteCaughtUpLocalSeq(50);
+    await assertConflict(
+      t2.promise,
+      `pending dependency dropped locally: localSeq=${t1.localSeq}`,
+    );
+    assertEquals(harness.model.transactLocalSeqs.includes(t2.localSeq), false);
+  } finally {
+    setConflictAdmissionMode(undefined);
+    g1.resolve();
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: preempt-mode admission rejects a floored commit without sending", async () => {
+  setConflictAdmissionMode("preempt");
+  const harness = await createHarness();
+  const storageLogger = getLogger("storage.v2");
+  const previousLevel = storageLogger.level;
+  storageLogger.level = "debug";
+  try {
+    const replica = harness.replica as unknown as AdmissionReplica;
+    replica.recordStaleFloor({
+      localSeq: 50,
+      reads: { confirmed: [{ id: DOCS.A, path: [], seq: 0 }], pending: [] },
+      operations: [],
+    }, 50);
+    const t = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("t"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    // The preempt rejection carries readyToRetry(threshold), so the repair
+    // gate holds the revert until the catch-up seq is observed.
+    replica.noteCaughtUpLocalSeq(50);
+    await assertConflict(t.promise, "preempted");
+    assertEquals(harness.model.transactLocalSeqs.includes(t.localSeq), false);
+  } finally {
+    storageLogger.level = previousLevel;
+    setConflictAdmissionMode(undefined);
     await harness.close();
   }
 });
@@ -2358,7 +2671,15 @@ Deno.test("memory v2 stacked commits: conflict rejection delivered before the wi
           ?.debug ?? 0) > conflictBaseline,
       "the conflict rejection to reach the runner",
     );
-    await clock.tick(30);
+    // If the gate were broken, the wrongful settle would arrive within
+    // microtasks of the catch (finalizeRejection past a non-waiting gate is
+    // pure promise flow — the only timer on this path is the 30s repair
+    // timeout). Drain the transport, then give the microtask queue ample
+    // turns; no wall-clock wait can make the non-event more certain.
+    await harness.transport.drainVerdicts();
+    for (let turn = 0; turn < 32; turn += 1) {
+      await Promise.resolve();
+    }
 
     // Rejection processed-but-held: the commit promise must not settle, the
     // optimistic value stays visible, and no revert is emitted before the

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -157,6 +157,12 @@ export abstract class ScriptedSessionTransport
   /** Called for each hello before hello.ok goes out (e.g. count connections). */
   protected onHello(_helloCount: number): void {}
 
+  /** Flags advertised on hello.ok — override to script an older server
+   * (e.g. one without `pendingReadStacks`). */
+  protected helloFlags(): ReturnType<typeof getMemoryProtocolFlags> {
+    return getMemoryProtocolFlags();
+  }
+
   /** Wire codec seams — override together when a harness needs a specific
    * reconstruction context. */
   protected decode(payload: string): ScriptedTransportMessage {
@@ -183,7 +189,7 @@ export abstract class ScriptedSessionTransport
         this.respond({
           type: "hello.ok",
           protocol: "memory",
-          flags: getMemoryProtocolFlags(),
+          flags: this.helloFlags(),
           sessionOpen: this.#sessionOpen,
         });
         return;


### PR DESCRIPTION
Closes CT-1872 classes **1b** and **1c** (stale-base replay escape hatches). Originally stacked on #4604 (the read-repair-gate replication test and its harness), which has since merged; this PR is now against `main`.

## Problem

**1b — the transient dependant window.** When commit T1 is rejected, `dropPending` removes its optimistic writes on every doc it touched — but in-flight commits that *read* T1's optimistic state stayed pending, replaying over a base missing their structural premise until the server rejected each one individually (`pending dependency not resolved`, a per-session commit-table lookup) plus each one's own read-repair wait. Their doom is provable client-side: T1 will never have a commit row, and the server check is deterministic.

**1c — incomplete dependency attachment (soundness hole).** `pushCommitRead` named only the **top-of-stack** pending localSeq. A read through dropped-T1's container sitting beneath an unrelated accepted T1.5 carried only a T1.5 dependency — which resolved — so the server durably **accepted** a commit whose read view included dropped data (the "phantom `["A","B"]`" engine regression pins this end to end).

Explicitly *not* changed (CT-1872 **1a**): zero-read mergeable ops (addUnique/append/increment) and blind UI writes are designed to survive parent drops — the server materializes their spine via `createMissing` on purpose. They carry no pending reads, so they are exempt from the cascade by construction, and a regression test pins that.

## Fix

**1c first** (it makes the cascade scan complete): a pending read's `localSeq` is now an **array** naming every pending layer of the doc below the reader, ascending. Each element imposes a resolution requirement (the dependency must have an accepted commit row); the staleness scan runs once per read, based at the **highest** element — the doc's top-of-stack, which the array must include. The load-bearing design point: basing staleness at a lower layer would false-conflict with the session's *own* later stacked writes (`findConflictSeq` has no own-commit exclusion and tier-1 conflicts are path-blind), so lower layers impose resolution only. Specced in `03-commit-model.md` §3.4/§3.5/§3.6.3, including the top-of-stack MUST and the same-session resolution-ordering clause ("holding is queueing, not reordering") that makes the max-basis rule sound.

**The wire capability**: the array form is negotiated via a new build-inherent `pendingReadStacks` hello flag (catalogued in EXPERIMENTAL_OPTIONS.md). Against a server that does not advertise it, the client scalarizes each array to its top-of-stack element at send time — including reads inside batched scheduler observations — which is exactly the pre-fix wire shape. Because the omitted lower layers are invisible to such a server, the client **holds the send until every omitted dependency has settled**: a dropped one dooms the commit at the pre-send checkpoint (it never reaches the wire, so the server can never durably accept a commit the client cascade-rejects), and all-accepted makes the scalar shape sound. The 1c hole otherwise remains knowingly open against pre-flag servers.

**1b — the cascade**: a new in-flight commit registry retains each read-carrying commit's flattened dependency set until it settles. `finalizeRejection`, immediately after `dropPending`, scans the registry and locally rejects every commit whose dependencies name the dropped localSeq — same ConflictError/revert/scheduler-retry path as a server rejection, with `readyToRetry` resolving immediately (the primary rejection already performed read repair). Transitivity emerges from recursion (a victim's own finalizeRejection re-enters the scan). `pushCommit` races `session.transact` against the local-rejection signal; a superseded late server verdict is suppressed (late *reject* is the expected agreement and is swallowed; late *accept* is deterministically impossible once the full dependency array is emitted, so it warns as a bug flag and is never promoted).

## Tests

- Engine: array max-basis/per-element-resolution/lower-basis-control triple; the fabricated-composite regression pins both the under-declared scalar shape being accepted (the version-skew exposure) and the array shape rejecting on the missing commit row.
- Emission: one read per path carrying the full ascending layer array; compaction keeps dependency-set boundaries; no-self-conflict over the session's own two-deep stack; `PreStackTransport` tests pin the scalarized wire shape against a server without the flag AND the old-server hold in both branches (dropped omitted dependency → never sent; all-accepted → held send proceeds with the scalar top).
- Cascade: basic (local rejection before the gated server verdict; sent-but-unrejected proven via receipt-time bookkeeping), transitive chains, one revert per victim with its own doc ids, late-reject swallowed (event-driven via the `cascade-late-reject` count), impossible late-accept not promoted, `reset()` sweep with idempotent double-rejection, pre-send doom checkpoints (scheduler-batch flush window, hold-mode admission, preempt mode).
- 1a exemption: zero-read patch not cascaded, then accepted, no resurrection.
- Protocol: `pendingReadStacks` parse/advertise coverage in `v2-test.ts`.

Suites green: stacked-commit 65/65 (incl. stress seeds), memory package 429 passed, full runner `test/*.test.ts` suite passed, `check-docs` 518/518. All waits in the new tests are event-driven (verdict drain barrier + logger-count conditions) per `waiting-in-tests.md`.

## Notes for reviewers

- **Version skew is now explicit, not incidental**: emission is gated on the negotiated flag; old servers get the old shape. The residual 1c exposure against pre-flag servers is a deliberate trade recorded in the spec and EXPERIMENTAL_OPTIONS entry.
- **Known, pre-existing, out of scope**: the pending-read basis over-advance (staleness scan starts at the top layer's resolution seq, leaving `(reader's confirmed basis, that seq]` unscanned) predates this PR and is unchanged by it — see the review thread repro. Tracked as **CT-1910** together with the successor design (server-inferred dependencies + true-basis validation), which retires the max-basis rule entirely.
- The admission-control experiment (`CF_CONFLICT_ADMISSION`, default off) composes: a held commit whose dependency drops mid-hold is finalized locally instead of being sent (now pinned).
- PR #4405 touches adjacent v2.ts regions (pending replay); conflicts are textual only, and its no-resurrection concern is complementary (this PR shortens the very window that replay bridges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cascades client-side rejection of in‑flight commits that depend on dropped pending writes and records full pending‑stack dependencies in commit reads. Holds scalarized sends to older servers until omitted dependencies settle; drops multi‑layer scheduler observations client‑side against pre‑flag servers so old servers can’t persist reads of dropped data. Addresses CT‑1872 1b/1c and stays wire‑compatible with servers without `pendingReadStacks`.

- **New Features**
  - Local cascade: reject dependent in‑flight commits when a parent’s pending writes drop; transitive and race‑safe; drains on close and `reset`; zero‑read mergeable/blind writes stay exempt.
  - Full pending‑stack reads: `localSeq` is `number | number[]`; all elements must resolve; staleness checks once at the highest element; applies to scheduler observations too. Negotiated via `pendingReadStacks`. When absent, data commits are scalarized and HELD until omitted lower dependencies settle (pre‑send doom if any drop); scheduler observations with multiple layers are DROPPED client‑side and resolved ok (rest of batch proceeds).

- **Bug Fixes**
  - CT‑1872 1b: remove the transient dependent window by settling doomed commits locally instead of waiting for server verdicts.
  - CT‑1872 1c: attach every lower pending layer so no commit that observed dropped data can be accepted; on servers without `pendingReadStacks`, server‑side lower‑layer checks are skipped, but held sends (for data commits), observation drops, and the local cascade prevent unsound acceptance.
  - Protocol validation: shared `pendingReadLayers` check rejects empty or non‑integer dependency arrays for both ordinary commits and scheduler observations.
  - Stranded dependant: regression test proves a dependant with a gated server verdict is still locally rejected by the cascade.

<sup>Written for commit 44bd679e6e02987013ca5c617a24de3a27719f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

