### PR TITLE
fix(runner): give esm-verifier benches short, stable names

### DIFF
--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -209,12 +209,69 @@ console.error(
 );
 
 // ---------------------------------------------------------------------------
+// Bench naming: performance tracking keys each benchmark's timeline by the
+// origin file, group, and verbatim name, so groups and names must stay
+// stable across commits — no content hashes, byte counts, or module counts.
+// Volatile sizes go to stderr.
+// ---------------------------------------------------------------------------
+
+/** Basenames too vague to identify a module on their own. */
+const GENERIC_BASENAMES = new Set([
+  "mod.ts",
+  "mod.tsx",
+  "index.ts",
+  "index.tsx",
+]);
+
+/** Strips the whole-program `/<id>` prefix from a resolved module path. */
+function stripProgramPrefix(path: string, programId: string): string {
+  return path.startsWith(`/${programId}/`)
+    ? path.slice(programId.length + 2)
+    : path;
+}
+
+/**
+ * Short label for a module's source path: the basename, with the parent
+ * directory prepended when the basename is generic.
+ */
+function moduleLabel(path: string, programId: string): string {
+  const segments = stripProgramPrefix(path, programId).split("/");
+  const basename = segments[segments.length - 1];
+  return GENERIC_BASENAMES.has(basename) && segments.length > 1
+    ? segments.slice(-2).join("/")
+    : basename;
+}
+
+const parkingLabelBySpecifier = new Map<string, string>();
+{
+  const usedLabels = new Set<string>();
+  for (const [path, specifier] of parkingGraph.graph.specifierByPath) {
+    let label = moduleLabel(path, parkingGraph.id);
+    // On a label collision, use the prefix-stripped path so names stay
+    // unique and free of the whole-program hash.
+    if (usedLabels.has(label)) {
+      label = stripProgramPrefix(path, parkingGraph.id);
+    }
+    usedLabels.add(label);
+    parkingLabelBySpecifier.set(specifier, label);
+  }
+}
+
+function labelFor(specifier: string): string {
+  const label = parkingLabelBySpecifier.get(specifier);
+  if (label === undefined) {
+    throw new Error(`no label for module specifier ${specifier}`);
+  }
+  return label;
+}
+
+// ---------------------------------------------------------------------------
 // Benchmarks: small program
 // ---------------------------------------------------------------------------
 
 Deno.bench(
-  `ESM body verify (all bodies summed): small [${smallBodies.length} modules]`,
-  { group: "esm-verifier-small", baseline: true },
+  "body verify: small",
+  { group: "small", baseline: true },
   () => {
     for (const [specifier, body] of smallBodies) {
       verifyCompiledModuleBody(body, specifier);
@@ -223,8 +280,8 @@ Deno.bench(
 );
 
 Deno.bench(
-  `ESM graph verify: small [${smallRecords.size} records]`,
-  { group: "esm-verifier-small" },
+  "graph verify: small",
+  { group: "small" },
   () => {
     verifyModuleGraph(smallRecords, smallMainSpec);
   },
@@ -235,8 +292,8 @@ Deno.bench(
 // ---------------------------------------------------------------------------
 
 Deno.bench(
-  `ESM body verify (all bodies summed): parking-coordinator [${parkingBodies.length} modules]`,
-  { group: "esm-verifier-parking", baseline: true },
+  "body verify: parking",
+  { group: "parking", baseline: true },
   () => {
     for (const [specifier, body] of parkingBodies) {
       verifyCompiledModuleBody(body, specifier);
@@ -245,8 +302,8 @@ Deno.bench(
 );
 
 Deno.bench(
-  `ESM graph verify: parking-coordinator [${parkingRecords.size} records]`,
-  { group: "esm-verifier-parking" },
+  "graph verify: parking",
+  { group: "parking" },
   () => {
     verifyModuleGraph(parkingRecords, parkingMainSpec);
   },
@@ -258,12 +315,19 @@ Deno.bench(
 // pattern, the per-module numbers help pinpoint which module dominates).
 // ---------------------------------------------------------------------------
 
+console.error(
+  "parking-coordinator modules: " +
+    parkingBodies
+      .map(([specifier, body]) =>
+        `${labelFor(specifier)} (${body.length} bytes)`
+      )
+      .join(", "),
+);
+
 for (const [specifier, body] of parkingBodies) {
-  // Trim specifier to a readable label (last 12 hex chars of the hash)
-  const label = specifier.replace("cf:module/", "").slice(-12);
   Deno.bench(
-    `ESM body verify: module …${label} [${body.length} bytes]`,
-    { group: "esm-verifier-per-module" },
+    `body: ${labelFor(specifier)}`,
+    { group: "per-module" },
     () => {
       verifyCompiledModuleBody(body, specifier);
     },
@@ -284,17 +348,21 @@ const [dominantSpec, dominantBody] = parkingBodies.reduce((max, cur) =>
   cur[1].length > max[1].length ? cur : max
 );
 
+console.error(
+  `dominant module: ${labelFor(dominantSpec)} (${dominantBody.length} bytes)`,
+);
+
 Deno.bench(
-  `ESM body verify (current, two-pass): dominant module [${dominantBody.length} bytes]`,
-  { group: "esm-verifier-regression-delta", baseline: true },
+  "two-pass: dominant",
+  { group: "shadow-delta", baseline: true },
   () => {
     verifyCompiledModuleBody(dominantBody, dominantSpec);
   },
 );
 
 Deno.bench(
-  `ESM body verify (legacy single-pass, pre-shadow-detection): dominant module [${dominantBody.length} bytes]`,
-  { group: "esm-verifier-regression-delta" },
+  "single-pass: dominant",
+  { group: "shadow-delta" },
   () => {
     verifyCompiledModuleBodyLegacy(dominantBody, dominantSpec);
   },
@@ -302,8 +370,8 @@ Deno.bench(
 
 // Also run the regression delta over all parking bodies summed
 Deno.bench(
-  `ESM body verify (current, two-pass): parking all bodies [${parkingBodies.length} modules]`,
-  { group: "esm-verifier-regression-all", baseline: true },
+  "two-pass: parking",
+  { group: "shadow-delta-all", baseline: true },
   () => {
     for (const [specifier, body] of parkingBodies) {
       verifyCompiledModuleBody(body, specifier);
@@ -312,8 +380,8 @@ Deno.bench(
 );
 
 Deno.bench(
-  `ESM body verify (legacy single-pass): parking all bodies [${parkingBodies.length} modules]`,
-  { group: "esm-verifier-regression-all" },
+  "single-pass: parking",
+  { group: "shadow-delta-all" },
   () => {
     for (const [specifier, body] of parkingBodies) {
       verifyCompiledModuleBodyLegacy(body, specifier);


### PR DESCRIPTION
The esm-verifier benchmark names embedded three volatile values: the last twelve characters of each module's content-address hash, compiled body byte counts, and module/record counts. The hash follows the authored source, so commits touching the commonfabric/cfc type surface renamed the injected type-stub bench even though its compiled body is a constant 197-byte shell. The byte counts follow the compiler output, so js-compiler changes renamed the dominant-module benches. Performance tracking keys each benchmark's timeline by origin file, group, and verbatim name, so every rename orphaned the accumulated history and reset the baseline at exactly the commits most likely to change verifier cost. Over a recent two-week stretch of CI runs the name set changed six times.

Names now carry only stable labels, and are short enough to fit in benchmark UIs. Group-level benches are named for the program ("body verify: parking"); per-module benches are labelled by the module's source filename, derived from the compiled graph's specifierByPath with the whole-program id prefix stripped and the parent directory prepended for generic basenames like mod.ts; the regression-delta benches say "dominant" for whichever module is largest. The groups drop the esm-verifier- prefix, which the origin file name already carries. The sizes that used to live in the names are logged to stderr instead, which also keeps them out of the --json stdout that CI captures.

Two details keep the labels stable in edge cases: on a basename collision the label falls back to the prefix-stripped path rather than the resolved path, which embeds the whole-program content hash; and an unknown specifier makes labelFor throw rather than fall back to a content-hash suffix, so a refactor that breaks the label map fails the bench run loudly instead of silently reintroducing volatile names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `esm-verifier` bench names by dropping volatile hashes, sizes, and counts. Uses short, deterministic labels and moves size details to stderr to keep `--json` clean and CI timelines stable.

- **Bug Fixes**
  - Replace hash/byte/module-count names with stable labels; drop `esm-verifier-` group prefix to preserve history.
  - Groups are now "small", "parking", "per-module", "shadow-delta", and "shadow-delta-all". Per‑module labels come from source filenames (prepend parent dir for generic basenames); on collision use prefix‑stripped path; unknown specifier throws.
  - Print per‑module sizes and the dominant module to stderr; update baselines to match new names.

<sup>Written for commit bbfec193c1d1c681f999b41d3e1eacd30e387dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

