### PR TITLE
fix(ci): drop migrated files from the check-no-waitfor allowlist

### DIFF
--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -35,8 +35,6 @@ export const ALLOWLIST: ReadonlySet<string> = new Set([
   // Headless cell pull: no page to attach an in-page waiter to.
   "packages/generated-patterns/integration/pattern-harness.ts",
   // Off-page piece-result cell reads through the in-process controller.
-  "packages/patterns/integration/counter.test.ts",
-  "packages/patterns/integration/nested-counter.test.ts",
   "packages/shell/integration/piece.test.ts",
   // Cross-page joint condition: the wait spans two separate browser pages, which
   // a single-page in-page waiter cannot express.


### PR DESCRIPTION
## What

Remove two stale entries from the `check-no-waitfor` ALLOWLIST in `tasks/check-no-waitfor.ts`:

- `packages/patterns/integration/counter.test.ts`
- `packages/patterns/integration/nested-counter.test.ts`

## Why

`main` is currently red. These two files were migrated off the polling `waitFor` helper (they now use `waitForText` / `page.waitForSelector`, not the `waitFor` re-exported from `@commonfabric/integration`) as part of the waitFor migration (#4596 / #4605), but they were left in the ALLOWLIST. The guard's own `ALLOWLIST has no stale entries` test then fails with *"…no longer import the polling waitFor. Remove them from the allowlist."* — taking down the `Check` and `Test (3/6)` jobs on `main` and on every PR rebased onto it.

`packages/shell/integration/piece.test.ts` (grouped under the same comment) still uses the polling helper, so it stays.

## Verification

- `deno test --no-check --allow-read --allow-write --allow-env --allow-run tasks/` → **200 passed / 0 failed**
- `deno task check-no-waitfor` → `No new polling waitFor in integration tests (10 allowlisted exception(s)).`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two migrated tests from the `check-no-waitfor` ALLOWLIST to fix the stale-entry guard and unblock CI on `main`.

- **Bug Fixes**
  - Removed from ALLOWLIST in `tasks/check-no-waitfor.ts`: `packages/patterns/integration/counter.test.ts`, `packages/patterns/integration/nested-counter.test.ts`.

<sup>Written for commit a85f2819a88d0f60c310a17330223f77146bf711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

