### PR TITLE
feat(ts-transformers): keep cf-disable-transform column-zero-only, warn on indented lookalikes (CT-1815)

### DIFF
--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -1,4 +1,7 @@
 import type ts from "typescript";
+// Typescript-free contract module (see engine.ts) — safe to import eagerly
+// without pulling the compiler stack onto this module's graph.
+import { sourceHasIgnoredDisableDirective } from "@commonfabric/ts-transformers/runtime-contract";
 import { compilerStack } from "./deferred-compiler-stack.ts";
 import { RuntimeProgram } from "./types.ts";
 
@@ -22,14 +25,28 @@ export function transformInjectHelperModule(
   const { transformCfDirective } = compilerStack();
   return {
     main: program.main,
-    files: program.files.map((source) => ({
-      name: source.name,
-      contents: source.name.endsWith(".d.ts")
-        ? source.contents
-        : normalizeMixedModuleImports(
+    files: program.files.map((source) => {
+      if (source.name.endsWith(".d.ts")) {
+        return { name: source.name, contents: source.contents };
+      }
+      // `/// <cf-disable-transform />` disables the transform only at column
+      // zero (matching TypeScript's triple-slash directives). An indented
+      // first-line lookalike is silently ignored — the file transforms as
+      // usual — so warn an author who meant to opt this file out.
+      if (sourceHasIgnoredDisableDirective(source.contents)) {
+        console.warn(
+          `${source.name}: an indented "/// <cf-disable-transform />" is ` +
+            `ignored; the directive disables the transform only at column ` +
+            `zero. Move it to the start of the line to opt this file out.`,
+        );
+      }
+      return {
+        name: source.name,
+        contents: normalizeMixedModuleImports(
           transformCfDirective(source.contents, source.name),
         ),
-    })),
+      };
+    }),
     mainExport: program.mainExport,
   };
 }

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -98,6 +98,27 @@ Deno.test("transformInjectHelperModule warns only on an indented (ignored) cf-di
   assertEquals(columnZero.warnings.length, 0);
 });
 
+Deno.test("transformInjectHelperModule passes .d.ts files through untouched", () => {
+  const declarations = "export declare const value: number;\n";
+  const transformed = transformInjectHelperModule({
+    main: "/main.tsx",
+    files: [
+      { name: "/main.tsx", contents: "export default 1;" },
+      { name: "/types.d.ts", contents: declarations },
+    ],
+  });
+
+  const main = transformed.files.find((file) => file.name === "/main.tsx")!;
+  const types = transformed.files.find((file) => file.name === "/types.d.ts")!;
+
+  // A declaration file is types-only, so it bypasses the transform entirely:
+  // injecting the `__cfHelpers` value import would be invalid in a .d.ts. It is
+  // passed through byte-identical, while an ordinary source still gets helpers.
+  assertMatch(main.contents, /import \{ __cfHelpers \} from "commonfabric";/);
+  assertEquals(types.contents, declarations);
+  assertNotMatch(types.contents, /__cfHelpers/);
+});
+
 Deno.test("transformInjectHelperModule injects JS-syntax helpers into .js sources", () => {
   const program: RuntimeProgram = {
     main: "/main.tsx",

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -54,6 +54,50 @@ Deno.test("transformInjectHelperModule transforms by default and respects cf-dis
   assertNotMatch(plain.contents, /cf-disable-transform/);
 });
 
+Deno.test("transformInjectHelperModule warns only on an indented (ignored) cf-disable-transform", () => {
+  const run = (name: string, contents: string) => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      const out = transformInjectHelperModule({
+        main: name,
+        files: [{ name, contents }],
+      });
+      return { warnings, contents: out.files[0]!.contents };
+    } finally {
+      console.warn = originalWarn;
+    }
+  };
+
+  // Indented directive: not honored, so the file is transformed as usual —
+  // and the author is warned, by file name, that it was ignored.
+  const indented = run(
+    "/indented.tsx",
+    ["  /// <cf-disable-transform />", "export const value = 1;"].join("\n"),
+  );
+  assertMatch(
+    indented.contents,
+    /import \{ __cfHelpers \} from "commonfabric";/,
+  );
+  assertEquals(indented.warnings.length, 1);
+  assertMatch(indented.warnings[0]!, /\/indented\.tsx/);
+  assertMatch(indented.warnings[0]!, /column zero/);
+
+  // Column-zero directive: honored (transform disabled) and no warning.
+  const columnZero = run(
+    "/plain.tsx",
+    ["/// <cf-disable-transform />", "export const value = 1;"].join("\n"),
+  );
+  assertNotMatch(
+    columnZero.contents,
+    /import \{ __cfHelpers \} from "commonfabric";/,
+  );
+  assertEquals(columnZero.warnings.length, 0);
+});
+
 Deno.test("transformInjectHelperModule injects JS-syntax helpers into .js sources", () => {
   const program: RuntimeProgram = {
     main: "/main.tsx",

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -159,6 +159,7 @@ export class CFHelpers {
 export {
   findFirstContentLineIndex,
   sourceDisablesCfTransform,
+  sourceHasIgnoredDisableDirective,
 } from "./runtime-contract.ts";
 import {
   findFirstContentLineIndex,

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -232,5 +232,6 @@ export {
   injectCfDataHelper,
   injectCfHelpers,
   sourceDisablesCfTransform,
+  sourceHasIgnoredDisableDirective,
   transformCfDirective,
 } from "./cf-helpers.ts";

--- a/packages/ts-transformers/src/core/runtime-contract.ts
+++ b/packages/ts-transformers/src/core/runtime-contract.ts
@@ -14,15 +14,43 @@
  */
 export const PATTERN_COVERAGE_GLOBAL = "__cfPatternCoverage";
 
+// A `/// <cf-disable-transform />` directive is honored only at column zero.
+// This is intentional and mirrors TypeScript's own triple-slash directives
+// (`/// <reference ... />`), which are likewise recognized only at the very
+// start of a line, ahead of any statement. Leading blank lines before the
+// directive are fine — `findFirstContentLineIndex` skips them — but leading
+// whitespace *on* the directive line is not: an indented directive is ignored
+// and the file transforms normally (see `sourceHasIgnoredDisableDirective`).
 const CF_DISABLE_TRANSFORM_DIRECTIVE_RE =
   /^\/\/\/\s*<cf-disable-transform\s*\/>/m;
 
-/** True when the source's first content line is the disable directive. */
+/**
+ * True when the source's first content line is the disable directive at column
+ * zero — see {@link CF_DISABLE_TRANSFORM_DIRECTIVE_RE} for why column zero is
+ * required. Read on the runtime boot path, so it stays a cheap string scan.
+ */
 export function sourceDisablesCfTransform(source: string): boolean {
   const lines = source.split("\n");
   const firstContentLineIndex = findFirstContentLineIndex(lines);
   return firstContentLineIndex !== null &&
     isCFTransformDisabled(lines[firstContentLineIndex]!);
+}
+
+/**
+ * True when the source's first content line is an *indented* disable directive:
+ * a `/// <cf-disable-transform />` that would disable the transform but for its
+ * leading whitespace, so it is silently ignored under the column-zero rule.
+ * A compile-time caller can use this to warn the author instead of transforming
+ * a file they meant to opt out. The runtime boot path never needs it —
+ * {@link sourceDisablesCfTransform} alone decides behavior.
+ */
+export function sourceHasIgnoredDisableDirective(source: string): boolean {
+  const lines = source.split("\n");
+  const firstContentLineIndex = findFirstContentLineIndex(lines);
+  if (firstContentLineIndex === null) return false;
+  const line = lines[firstContentLineIndex]!;
+  return !isCFTransformDisabled(line) &&
+    isCFTransformDisabled(line.trimStart());
 }
 
 function isCFTransformDisabled(line: string) {

--- a/packages/ts-transformers/src/mod.ts
+++ b/packages/ts-transformers/src/mod.ts
@@ -15,6 +15,7 @@ export {
   PATTERN_COVERAGE_GLOBAL,
   Pipeline,
   sourceDisablesCfTransform,
+  sourceHasIgnoredDisableDirective,
   transformCfDirective,
   Transformer,
 } from "./core/mod.ts";

--- a/packages/ts-transformers/test/core/cf-helpers.test.ts
+++ b/packages/ts-transformers/test/core/cf-helpers.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";
 import {
   sourceDisablesCfTransform,
+  sourceHasIgnoredDisableDirective,
   transformCfDirective,
 } from "../../src/mod.ts";
 
@@ -31,4 +32,47 @@ Deno.test("transformCfDirective strips cf-disable-transform without helpers", ()
   assertEquals(transformed.split("\n")[0], "");
   assertNotMatch(transformed, /import \{ __cfHelpers \} from "commonfabric";/);
   assertNotMatch(transformed, /cf-disable-transform/);
+});
+
+// The disable directive is honored only at column zero (matching TypeScript's
+// own triple-slash directive convention). An indented directive-lookalike as
+// the first content line is intentionally NOT honored: the file transforms as
+// usual and the directive line is left untouched.
+Deno.test("transformCfDirective does not honor an indented cf-disable-transform", () => {
+  const source = [
+    "  /// <cf-disable-transform />",
+    'export const value = "plain";',
+  ].join("\n");
+
+  assertEquals(sourceDisablesCfTransform(source), false);
+
+  const transformed = transformCfDirective(source);
+  assertMatch(transformed, /import \{ __cfHelpers \} from "commonfabric";/);
+  // The indented directive line is preserved, not stripped.
+  assertMatch(transformed, /\/\/\/ <cf-disable-transform \/>/);
+});
+
+// `sourceHasIgnoredDisableDirective` names the compile-time signal for warning
+// an author: it flags exactly the indented first-content-line lookalikes, and
+// nothing that is honored (column zero, with any leading blank lines) or absent.
+Deno.test("sourceHasIgnoredDisableDirective flags only indented directive-lookalikes", () => {
+  const spaceIndented = "  /// <cf-disable-transform />\nexport const x = 1;";
+  const tabIndented = "\t/// <cf-disable-transform />\nexport const x = 1;";
+  const columnZero = "/// <cf-disable-transform />\nexport const x = 1;";
+  const blanksThenColumnZero =
+    "\n\n/// <cf-disable-transform />\nexport const x = 1;";
+  const absent = "export const x = 1;";
+
+  // Indented lookalikes are flagged as ignored...
+  assertEquals(sourceHasIgnoredDisableDirective(spaceIndented), true);
+  assertEquals(sourceHasIgnoredDisableDirective(tabIndented), true);
+  // ...while none of these are: two are honored, one has no directive.
+  assertEquals(sourceHasIgnoredDisableDirective(columnZero), false);
+  assertEquals(sourceHasIgnoredDisableDirective(blanksThenColumnZero), false);
+  assertEquals(sourceHasIgnoredDisableDirective(absent), false);
+
+  // "Honored" is exactly the column-zero cases; leading blank lines are fine.
+  assertEquals(sourceDisablesCfTransform(columnZero), true);
+  assertEquals(sourceDisablesCfTransform(blanksThenColumnZero), true);
+  assertEquals(sourceDisablesCfTransform(spaceIndented), false);
 });


### PR DESCRIPTION
## What this does

`/// <cf-disable-transform />` opts a file out of the CF transform **only** when
it is the first content line and begins at **column zero**. This makes that
column-zero rule intentional and self-consistent (it previously lived
implicitly in the directive regex) and warns an author whose directive is
indented — and therefore silently ignored.

Resolves CT-1815 (surfaced by cubic on #4459). Decision: keep column-zero,
matching TypeScript's own triple-slash directive convention; do not tolerate
leading whitespace.

## Changes

- **`runtime-contract.ts`** — documents the column-zero rule and adds
  `sourceHasIgnoredDisableDirective`: a typescript-free predicate that flags an
  indented first-content-line lookalike (a directive that would opt the file
  out but for its leading whitespace). `sourceDisablesCfTransform` is unchanged.
- **`pretransform.ts`** (runner) — warns, with the file name, when a file has an
  ignored indented directive. The helper is imported from the boot-safe
  `@commonfabric/ts-transformers/runtime-contract` subpath, so no compiler stack
  is pulled onto the module graph.
- **Tests** — pin the semantics: an indented directive is ignored (the file
  transforms, the author is warned); a column-zero directive is honored, with
  leading blank lines allowed.

## No compilation-behavior change

Honored directives are exactly the column-zero ones they were before — emitted
output is identical. The only new behavior is the advisory `console.warn` on the
previously-silent indented case.

## Why not tolerate leading whitespace

Honoring an indented directive would be a compilation-behavior change: any
existing source whose first content line is an indented directive-lookalike
would start skipping the transform, changing emitted bytes (and cached compiled
docs). Column-zero keeps that blast radius at zero, while the warning removes
the silent surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `/// <cf-disable-transform />` effective only when it’s the first content line at column zero, and warn when an indented lookalike is found. Aligns with CT-1815: keep the column‑zero rule; do not allow leading whitespace.

- **New Features**
  - Added `sourceHasIgnoredDisableDirective` in `@commonfabric/ts-transformers/runtime-contract` to detect indented first-content-line directives.
  - Runner `pretransform` now warns with the filename when such a directive is ignored; `.d.ts` files bypass the transform unchanged.
  - Re-exported the helper via `cf-helpers`, `core/mod`, and the package root `mod`; documented the rule.
  - Tests pin behavior: column‑zero is honored (blank lines allowed); indented is ignored with a warning; indented lines are preserved; `.d.ts` passthrough is covered.
  - No change to emitted output.

<sup>Written for commit f3924e170030ea5ecbcb7a85d07712b31498dc22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

