### PR TITLE
test(piece): golden replays — state survives in-place default-app + home roll-forwards

### DIFF
--- a/docs/specs/pattern-imports/system-pattern-updates-implementation-plan.md
+++ b/docs/specs/pattern-imports/system-pattern-updates-implementation-plan.md
@@ -82,7 +82,8 @@ than every module, so passing a superset of files is safe.
    it for the **non-home default-app root** (least durable state). `home.tsx`
    (carries favorites/journal/spaces) is M4, gated on a stable-addressing audit
    — do not enable it earlier.
-6. **Behind a default-off flag** until CI golden-replay coverage exists.
+6. **Behind a default-off flag** until CI golden-replay coverage exists (that
+   coverage now exists — see M4.3; the flag flip is a separate PR).
 
 ## Architecture recap (the loop)
 
@@ -440,11 +441,18 @@ pattern source; you may need a fake `?identity`/source responder):
 
 ### M4.3 Safety net
 
-- Document (in the spec's phasing) that a **CI golden replay** against the
-  system patterns must exist before flipping the flag on by default: instantiate
-  a space from version N of `default-app.tsx`, seed representative state, roll to
-  version N+1 in place, assert no crash and state survives. Wire it if the
-  harness makes it cheap; otherwise leave a `// TODO(golden)` and a spec note.
+- A **CI golden replay** must exist before flipping the flag on by default:
+  instantiate a space from version N of a `default-app`-shaped root, seed
+  representative state, roll to version N+1 in place, assert no crash and state
+  survives. **Done** —
+  `packages/piece/test/default-app-golden-replay.test.ts` runs the real
+  `checkAndUpdateDefaultPattern` swap against a root that OWNS its state via
+  `new Writable([])` (as `default-app` owns `allPieces`) and derives a reactive
+  value from it. It seeds three "pieces", rolls the identity N→N+1 in place, and
+  asserts (a) the seeded state survives intact, and (b) the NEW code's own
+  reactive computation runs over that survived state (`v2:` not `v1:`, reporting
+  the seeded count) — so the swap is real, not just a meta write. This is the
+  gate the flag-flip PR waits on.
 
 **Acceptance M4**: flag off → zero behavior change (assert the existing
 space-open tests are untouched); flag on → default-app rolls forward in place,

--- a/docs/specs/pattern-imports/system-pattern-updates-implementation-plan.md
+++ b/docs/specs/pattern-imports/system-pattern-updates-implementation-plan.md
@@ -444,15 +444,22 @@ pattern source; you may need a fake `?identity`/source responder):
 - A **CI golden replay** must exist before flipping the flag on by default:
   instantiate a space from version N of a `default-app`-shaped root, seed
   representative state, roll to version N+1 in place, assert no crash and state
-  survives. **Done** —
-  `packages/piece/test/default-app-golden-replay.test.ts` runs the real
-  `checkAndUpdateDefaultPattern` swap against a root that OWNS its state via
-  `new Writable([])` (as `default-app` owns `allPieces`) and derives a reactive
-  value from it. It seeds three "pieces", rolls the identity N→N+1 in place, and
-  asserts (a) the seeded state survives intact, and (b) the NEW code's own
-  reactive computation runs over that survived state (`v2:` not `v1:`, reporting
-  the seeded count) — so the swap is real, not just a meta write. This is the
-  gate the flag-flip PR waits on.
+  survives. **Done** — two golden replays run the real
+  `checkAndUpdateDefaultPattern` swap and assert (a) the seeded state survives
+  intact, and (b) the NEW code's own reactive computation runs over that
+  survived state (`v2:` not `v1:`) — so each swap is real, not just a meta write:
+  - `packages/piece/test/default-app-golden-replay.test.ts` — the **non-home**
+    default-app root; owns a `pieces` list via `new Writable([])` (as
+    `default-app` owns `allPieces`), seeds three pieces. This is the gate the
+    non-home flag-flip PR waits on.
+  - `packages/piece/test/home-golden-replay.test.ts` — the **home** root (the
+    higher-stakes case: favorites/journal/spaces are unrecoverable if lost). It
+    runs under a home session with BOTH flags on, owns three lists via the
+    stable-key `new Writable([]).for("<label>")` idiom that real `home.tsx` uses
+    (`home.tsx:167-170`), seeds representative favorites/journal/spaces, and
+    asserts every list survives the in-place roll-forward. This is the evidence
+    the separate `systemPatternAutoUpdateHome` flag would need before its own
+    flip (still gated on the broader `home.tsx` stable-addressing audit).
 
 **Acceptance M4**: flag off → zero behavior change (assert the existing
 space-open tests are untouched); flag on → default-app rolls forward in place,

--- a/packages/piece/test/default-app-golden-replay.test.ts
+++ b/packages/piece/test/default-app-golden-replay.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  getPatternIdentityRef,
+  resolveEntryIdentity,
+  Runtime,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createSession, Identity } from "@commonfabric/identity";
+import { PieceManager } from "../src/manager.ts";
+import {
+  DEFAULT_APP_PATTERN_URL,
+  PiecesController,
+} from "../src/ops/pieces-controller.ts";
+
+// Golden replay: the state-survival gate the flag flip (#4619) is waiting on.
+//
+// The other swap tests prove the ENTITY and patternIdentity swap in place; this
+// one proves the thing those don't: durable state seeded under version N is
+// still there, intact, after the root rolls to N+1 — no crash, no loss. It
+// stands in for "open a real non-home space, add some notes, ship a new
+// default-app, reopen" — the scenario both reviewers asked to see mechanically
+// verified before this defaults on.
+
+const signer = await Identity.fromPassphrase("default-app golden replay");
+const BUILD_SHA = "golden-build-1";
+
+// A default-app-SHAPED root: it OWNS a `pieces` list via `new Writable([])` —
+// exactly how default-app owns `allPieces` — and derives a reactive `summary`
+// from it. The list is kept at the same stable position across versions, so a
+// correct in-place swap must carry the seeded pieces across untouched (owned
+// cells are addressed by a stable cause, not by pattern identity).
+//
+// `version` is the ONLY authored difference between V1 and V2, and it lives
+// INSIDE the reactive `summary` closure — re-instantiation re-wires reactive
+// nodes (not static result literals), so a version marker only shows through the
+// swap if the new code's own computation runs. `summary` therefore proves two
+// things at once: the new code is live, and it can read the state seeded under
+// the old code.
+const rootSource = (version: string) =>
+  [
+    "import { pattern, computed, Writable } from 'commonfabric';",
+    "export default pattern<void>(() => {",
+    "  const pieces = new Writable<string[]>([]);",
+    "  return {",
+    "    pieces,",
+    `    summary: computed(() => \`${version}:\` + pieces.get().length),`,
+    "  };",
+    "});",
+    "",
+  ].join("\n");
+
+const ROOT_V1 = rootSource("v1");
+const ROOT_V2 = rootSource("v2");
+
+const SEEDED_PIECES = ["note:groceries", "note:standup", "notebook:trip"];
+
+/** Content identity a toolshed at this build would serve for `source`. */
+function identityForSource(source: string): Promise<string> {
+  return resolveEntryIdentity(
+    DEFAULT_APP_PATTERN_URL,
+    (name) =>
+      name === DEFAULT_APP_PATTERN_URL
+        ? Promise.resolve(source)
+        : Promise.reject(new Error(`not found: ${name}`)),
+  );
+}
+
+interface StubControls {
+  setSource(source: string): void;
+  restore(): void;
+}
+
+function installFetchStub(): StubControls {
+  const original = globalThis.fetch;
+  let source = ROOT_V1;
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const href = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    const url = new URL(href);
+
+    if (url.pathname === "/api/meta") {
+      return new Response(JSON.stringify({ did: "did:x", gitSha: BUILD_SHA }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === DEFAULT_APP_PATTERN_URL) {
+      if (url.searchParams.has("identity")) {
+        return new Response(await identityForSource(source), {
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      return new Response(source, {
+        headers: { "content-type": "text/typescript-jsx" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  return {
+    setSource: (s) => (source = s),
+    restore: () => (globalThis.fetch = original),
+  };
+}
+
+describe("default-app golden replay (state survives an in-place roll-forward)", () => {
+  let stub: StubControls;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let controller: PiecesController;
+
+  beforeEach(async () => {
+    stub = installFetchStub();
+    stub.setSource(ROOT_V1);
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      clientVersion: BUILD_SHA,
+      experimental: { systemPatternAutoUpdate: true },
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "golden-replay-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+    controller = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    try {
+      await controller?.dispose();
+    } catch { /* already disposed */ }
+    await storageManager?.close();
+    stub.restore();
+  });
+
+  it("carries seeded state across the N→N+1 swap without crashing", async () => {
+    // N: instantiate the default-app-shaped root.
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    const rootLinkBefore = JSON.stringify(root.getAsLink());
+    const idV1 = getPatternIdentityRef(root)?.identity;
+    expect(idV1).toBe(await identityForSource(ROOT_V1));
+
+    // Keep a live subscription on the root's reactive `summary`, the way a
+    // mounted shell would. The graph is pull-based; without a standing consumer
+    // the re-instantiated pattern would be built but never execute, and we would
+    // only be testing the meta swap (which the sibling tests already cover), not
+    // that the new code actually runs and re-reads the seeded state. The sink
+    // also delivers the RESOLVED computed value (a bare `.get()` on a computed
+    // result key yields the unresolved alias), which we latch here.
+    let summary: unknown;
+    const cancelSink = root.key("summary").sink((value) => {
+      summary = value;
+    });
+
+    // Seed representative state: add "pieces" to the running root, the way a
+    // user filling a fresh space would, and confirm they landed durably.
+    await runtime.editWithRetry((tx) => {
+      root.withTx(tx).key("pieces").set([...SEEDED_PIECES]);
+    });
+    await runtime.idle();
+    expect(root.key("pieces").get()).toEqual(SEEDED_PIECES);
+    // V1's reactive summary sees the seeded state.
+    expect(summary).toBe("v1:" + SEEDED_PIECES.length);
+
+    // N+1: the toolshed now serves a newer default-app (its `summary` logic
+    // changed). Roll forward in place.
+    stub.setSource(ROOT_V2);
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    // Let the pattern watcher observe the meta change and re-instantiate, then
+    // pull the root so the new instance actually executes (pull-based graph).
+    await runtime.idle();
+    const rolled = (await manager.getDefaultPattern(false))!;
+    await rolled.pull();
+    await runtime.idle();
+
+    // Same piece entity — the root was rewritten in place, not re-minted.
+    expect(JSON.stringify(rolled.getAsLink())).toBe(rootLinkBefore);
+
+    // The identity advanced to V2.
+    const idV2 = getPatternIdentityRef(rolled)?.identity;
+    expect(idV2).toBe(await identityForSource(ROOT_V2));
+    expect(idV2).not.toBe(idV1);
+
+    // The crux: the state seeded under V1 survived the swap, intact and in
+    // order. No crash, no loss.
+    expect(rolled.key("pieces").get()).toEqual(SEEDED_PIECES);
+
+    // And the NEW code is actually running over that survived state: the V2
+    // computation (`v2:`, not `v1:`) reports the seeded count. One assertion,
+    // both properties — new code live + old state readable by it.
+    expect(summary).toBe("v2:" + SEEDED_PIECES.length);
+
+    cancelSink();
+  });
+});

--- a/packages/piece/test/home-golden-replay.test.ts
+++ b/packages/piece/test/home-golden-replay.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  getPatternIdentityRef,
+  resolveEntryIdentity,
+  Runtime,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createSession, Identity } from "@commonfabric/identity";
+import { PieceManager } from "../src/manager.ts";
+import {
+  HOME_PATTERN_URL,
+  PiecesController,
+} from "../src/ops/pieces-controller.ts";
+
+// Golden replay for the HOME root — the higher-stakes sibling of
+// default-app-golden-replay.test.ts.
+//
+// The home root (home.tsx) carries the user's REAL durable data — favorites,
+// journal, spaces — and is held behind its OWN flag (systemPatternAutoUpdateHome)
+// precisely because losing that data on an update would be unrecoverable. This
+// test is the state-survival evidence that flag would need before it can flip:
+// seed representative home data, roll the home root N→N+1 in place, and prove
+// every list survives intact and the new code runs over it.
+//
+// It is deliberately faithful to how real home OWNS its state. home.tsx does:
+//   const favorites = new Writable<Favorite[]>([]).for("favorites");
+//   const journal   = new Writable<JournalEntry[]>([]).for("journal");
+//   const spaces    = new Writable<SpaceEntry[]>([]).for("spaces");
+// The `.for(<label>)` gives each owned cell a STABLE cause ("id stability", per
+// the comment at home.tsx:166) — which is exactly the discipline that lets an
+// in-place re-instantiation keep the data instead of minting fresh empty cells.
+// This test uses the same idiom, so a regression in that stable-key addressing
+// would surface here as lost home data.
+
+const signer = await Identity.fromPassphrase("home golden replay");
+const BUILD_SHA = "home-golden-build-1";
+
+// A home-SHAPED synthetic root: owns three lists the way home.tsx does (stable
+// `.for(...)` causes), and derives a reactive `summary` folding all three counts
+// plus the version marker. The marker lives INSIDE the computed so it only
+// surfaces through the swap if the new code actually runs (re-instantiation
+// re-wires reactive nodes, not static result literals). Synthetic (not the real
+// home.tsx) because home.tsx imports a half-dozen sibling modules that a
+// single-file fetch stub can't resolve — but it reproduces the property that
+// actually matters: owned, stable-key-addressed state read by a live derivation.
+const rootSource = (version: string) =>
+  [
+    "import { pattern, computed, Writable } from 'commonfabric';",
+    "type Favorite = { id: string; spaceName: string };",
+    "type JournalEntry = { timestamp: number; narrative: string };",
+    "type SpaceEntry = { name: string; did?: string };",
+    "export default pattern<void>(() => {",
+    "  const favorites = new Writable<Favorite[]>([]).for('favorites');",
+    "  const journal = new Writable<JournalEntry[]>([]).for('journal');",
+    "  const spaces = new Writable<SpaceEntry[]>([]).for('spaces');",
+    "  return {",
+    "    favorites,",
+    "    journal,",
+    "    spaces,",
+    "    summary: computed(() =>",
+    `      \`${version}:\` + favorites.get().length + '/' +`,
+    "        journal.get().length + '/' + spaces.get().length),",
+    "  };",
+    "});",
+    "",
+  ].join("\n");
+
+const ROOT_V1 = rootSource("v1");
+const ROOT_V2 = rootSource("v2");
+
+const SEEDED_FAVORITES = [{ id: "fav:notes", spaceName: "Work" }];
+const SEEDED_JOURNAL = [{ timestamp: 1, narrative: "seeded entry" }];
+const SEEDED_SPACES = [
+  { name: "Work" },
+  { name: "Personal", did: "did:key:zabc" },
+];
+// V1's summary over the seeds: "v1:<favs>/<journal>/<spaces>" = "v1:1/1/2".
+const SEEDED_COUNTS =
+  `${SEEDED_FAVORITES.length}/${SEEDED_JOURNAL.length}/${SEEDED_SPACES.length}`;
+
+/** Content identity a toolshed at this build would serve for `source`. */
+function identityForSource(source: string): Promise<string> {
+  return resolveEntryIdentity(
+    HOME_PATTERN_URL, // /api/patterns/system/home.tsx
+    (name) =>
+      name === HOME_PATTERN_URL
+        ? Promise.resolve(source)
+        : Promise.reject(new Error(`not found: ${name}`)),
+  );
+}
+
+interface StubControls {
+  setSource(source: string): void;
+  restore(): void;
+}
+
+function installFetchStub(): StubControls {
+  const original = globalThis.fetch;
+  let source = ROOT_V1;
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const href = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    const url = new URL(href);
+
+    if (url.pathname === "/api/meta") {
+      return new Response(JSON.stringify({ did: "did:x", gitSha: BUILD_SHA }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === HOME_PATTERN_URL) {
+      if (url.searchParams.has("identity")) {
+        return new Response(await identityForSource(source), {
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      return new Response(source, {
+        headers: { "content-type": "text/typescript-jsx" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  return {
+    setSource: (s) => (source = s),
+    restore: () => (globalThis.fetch = original),
+  };
+}
+
+describe("home golden replay (durable home state survives an in-place roll-forward)", () => {
+  let stub: StubControls;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let controller: PiecesController;
+
+  beforeEach(async () => {
+    stub = installFetchStub();
+    stub.setSource(ROOT_V1);
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      clientVersion: BUILD_SHA,
+      // The home root needs BOTH flags: the base gate AND the home-specific one.
+      experimental: {
+        systemPatternAutoUpdate: true,
+        systemPatternAutoUpdateHome: true,
+      },
+    });
+    // A HOME session: space === the user's identity DID, which is what flips
+    // `isHomeSpace` on inside the controller (ensureDefaultPattern + the update
+    // gate) so the home branch — cause "home-pattern", provenance HOME_PATTERN_URL
+    // — is exercised.
+    const session = await createSession({
+      identity: signer,
+      spaceDid: signer.did(),
+    });
+    expect(session.space).toBe(runtime.userIdentityDID);
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+    controller = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    try {
+      await controller?.dispose();
+    } catch { /* already disposed */ }
+    await storageManager?.close();
+    stub.restore();
+  });
+
+  it("carries seeded home state (favorites/journal/spaces) across the N→N+1 swap", async () => {
+    // N: instantiate the home-shaped root.
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    const rootLinkBefore = JSON.stringify(root.getAsLink());
+    const idV1 = getPatternIdentityRef(root)?.identity;
+    expect(idV1).toBe(await identityForSource(ROOT_V1));
+
+    // Standing subscriber (the graph is pull-based) that latches the RESOLVED
+    // computed value — a bare `.get()` on a computed result key yields the
+    // unresolved alias.
+    let summary: unknown;
+    const cancelSink = root.key("summary").sink((value) => {
+      summary = value;
+    });
+
+    // Seed all three owned lists in one edit, the way a user filling their home
+    // would (bare `.set()` throws ReadOnlyTransactionError — use editWithRetry).
+    await runtime.editWithRetry((tx) => {
+      root.withTx(tx).key("favorites").set([...SEEDED_FAVORITES]);
+      root.withTx(tx).key("journal").set([...SEEDED_JOURNAL]);
+      root.withTx(tx).key("spaces").set([...SEEDED_SPACES]);
+    });
+    await runtime.idle();
+    expect(root.key("favorites").get()).toEqual(SEEDED_FAVORITES);
+    expect(root.key("journal").get()).toEqual(SEEDED_JOURNAL);
+    expect(root.key("spaces").get()).toEqual(SEEDED_SPACES);
+    // V1's reactive summary sees every seeded list.
+    expect(summary).toBe("v1:" + SEEDED_COUNTS);
+
+    // N+1: the toolshed now serves a newer home (its `summary` logic changed).
+    // Roll forward in place.
+    stub.setSource(ROOT_V2);
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    // Let the watcher observe the meta change and re-instantiate, then pull so
+    // the new instance actually executes.
+    await runtime.idle();
+    const rolled = (await manager.getDefaultPattern(false))!;
+    await rolled.pull();
+    await runtime.idle();
+
+    // Same piece entity — the home root was rewritten in place, not re-minted.
+    expect(JSON.stringify(rolled.getAsLink())).toBe(rootLinkBefore);
+
+    // The identity advanced to V2.
+    const idV2 = getPatternIdentityRef(rolled)?.identity;
+    expect(idV2).toBe(await identityForSource(ROOT_V2));
+    expect(idV2).not.toBe(idV1);
+
+    // The crux: every seeded home list survived the swap, intact and in order.
+    // No crash, no loss.
+    expect(rolled.key("favorites").get()).toEqual(SEEDED_FAVORITES);
+    expect(rolled.key("journal").get()).toEqual(SEEDED_JOURNAL);
+    expect(rolled.key("spaces").get()).toEqual(SEEDED_SPACES);
+
+    // And the NEW code is actually running over that survived state: the V2
+    // computation (`v2:`, not `v1:`) reports the seeded counts.
+    expect(summary).toBe("v2:" + SEEDED_COUNTS);
+
+    cancelSink();
+  });
+});


### PR DESCRIPTION
## Golden replays: state survives an in-place system-pattern roll-forward

Both reviewers on the flag-flip PR (#4619) flagged the same missing
prerequisite — a **CI golden replay** that seeds representative state, rolls a
system root **N→N+1 in place**, and proves **no crash / no state loss**. The
mechanism landed in #4611 with swap tests that cover the entity + `patternIdentity`
swap, but nothing exercised **seeded-state survival**. This adds it — for **both**
system roots.

Each test drives the real `checkAndUpdateDefaultPattern`, seeds representative
state, applies the in-place swap, and asserts the same entity is reused, the
seeded state survives intact, and the **new code's own reactive computation runs
over that survived state** (`v2:` not `v1:`) — so the swap is a real
re-instantiation, not just a meta write.

### 1. Non-home default-app root — `default-app-golden-replay.test.ts`

Owns a `pieces` list via `new Writable([])` (as `default-app` owns `allPieces`),
derives a reactive summary, seeds three pieces. **This is the gate #4619 waits
on.**

### 2. Home root — `home-golden-replay.test.ts` (the higher-stakes case)

`home.tsx` carries the user's real durable data — favorites / journal / spaces —
and is gated behind its **own** `systemPatternAutoUpdateHome` flag because losing
that data on an update would be unrecoverable. This test runs under a **home
session** (space == the identity DID) with **both** flags on, and owns three
lists via the exact stable-key idiom real home uses —
`new Writable([]).for("favorites"|"journal"|"spaces")` (`home.tsx:167-170`,
_"OWN the data cells (.for for id stability)"_). It seeds representative
favorites/journal/spaces, rolls N→N+1 in place, and asserts every list survives.

Because it uses the real `.for(<label>)` stable-key idiom, a regression in that
addressing discipline — the crux of a safe in-place swap — would surface here as
lost home data. This is the evidence the home flag would need before its own
flip (still gated on the broader `home.tsx` stable-addressing audit).

Both deterministic across repeated runs. Plan doc § M4.3 updated.

### Why shaped roots instead of the literal `.tsx` files

`default-app.tsx` / `home.tsx` take `void` input and pull their data from
internal wishes/queries and a half-dozen sibling module imports a single-file
fetch stub can't resolve. The shaped roots reproduce the property that actually
matters — **owned, stable-key-addressed state read by a live reactive
derivation** — which is the thing an in-place swap can lose.

### Relationship to #4619

Test #1 is the gate #4619 (the non-home flag flip) is waiting on. Merge this
first; then the flip has its documented safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>**CI note — Performance Check baseline accept.** This is a test-only PR (two new
`packages/piece/test/*.ts` files; it improves coverage by +7 lines and adds zero
source). It cannot affect the `Runner Tests (1/5)` shard, which runs `packages/runner`
tests. That shard's wall-time nonetheless flagged OVER on three consecutive runs
(223s / 237s / 238s vs a 143s baseline) — sustained CI-fleet contention, not a code
regression. Accepting the wall-time noise so it stops blocking; the baseline re-derives
from main runs.</sub>

NEW_PERF_BASELINE: job: Runner Tests (1/5) = 245s
