### PR TITLE
docs(cfc): residual design docs — value-level provenance, label-metadata confidentiality, persisted declassification

### DIFF
--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -1,0 +1,239 @@
+# CFC label-metadata confidentiality (invariant 12 / SC-14) — design
+
+_Design for enforcing spec invariant 12 ("labels are not public payload by
+default") in the runner: the cross-space carried-label exposure the spec
+records as a known gap (`04-label-representation.md` §4.6.4.1), the
+`inspectConfLabel` observation profile (§4.6.4.1–.2), and the read-side gating
+SC-6 promised to revisit. Grounded in the shipped envelope machinery
+(`cfc/prepare.ts`, `cfc/label-view-core.ts`) and the audit item
+"`Caveat.source` redaction is display-only" (inv-12; SC-14). Written
+2026-07-09 at owner request._
+
+## 1. The exposure, measured against the code (not the audit sentence)
+
+What a destination space's **readers** — every client that syncs the doc, not
+just its runtime — can observe today when a label derived from space-A reads
+persists into a space-B document:
+
+| Persisted field | Names A-side principals/spaces? | Consumer that needs it |
+|---|---|---|
+| `User{subject}`, `Space{id}`, `PersonalSpace{owner}` clause atoms | **yes — DIDs** | read gating (equality), §4.9.3 ACL point query (`Space.id` dereference) |
+| `Caveat{kind, source, by}` | **yes** — `source` is a full nested atom | evidence binding (inv-10: discharge must bind the same caveat source) |
+| `LinkReference{source:{space,id,path}, target:{…}}` | **yes** — space DID + doc id + path | provenance display; S7 exemption keys on atom *type* only |
+| `TransformedBy{identity}` | code identity: `moduleIdentity`, `sourceFile`, `bindingPath`, `codeHash` | trust statements (B3 pattern match) |
+| `HasRole`, `UserSurfaceInput`, `ExternalIngest`, `authored-by`/`represents-principal` | **yes — DIDs** | role guards; authorship UI (product feature) |
+| sigil-link `cfcLabelView` **inside `value`** | same atom set, second copy | link-carried enforcement at B |
+| `cfc.schemaHash` + replicated schema doc (`ensureSchemaDocument`) | policy structure, field names | schema-driven enforcement |
+
+Two corrections to the audit item's inherited wording: `Origin` URIs have **no
+mint site** in the runner (nothing persists them), and **policy names are never
+persisted** (B2a policy ids reach the prepared digest only; label-carried
+`Policy(...)` is B2b, unbuilt). The live leak set is the DID-bearing rows
+above.
+
+Three structural facts shape everything below:
+
+1. **The replica is the disclosure.** Envelopes ride the doc JSON
+   (`EntityDocumentWithCfc`); memory access is per-space session partitioning
+   with no sub-document ACL. Any space-B session holds the bytes. A
+   view-transform at an API seam (the shipped `Caveat.source` display
+   redaction) cannot protect what sync already delivered.
+2. **Enforcement is local-first.** B's *runtime* legitimately evaluates these
+   labels — read gating, ceiling fit, exchange rules, evidence binding. There
+   is no trusted-server-only evaluation point that could hold plaintext while
+   clients receive redacted copies. So protection must live in the **persisted
+   representation** itself, per atom field, chosen so enforcement still works.
+3. **Some identities are public by design.** `represents-principal` /
+   `authored-by` subjects feed the authorship badge; blanket source-field
+   redaction breaks the product. Classification, not blanket redaction.
+
+## 2. Design: three representation classes per atom field
+
+At the cross-space persist seam (`prepareBoundaryCommit`'s envelope write plus
+the sigil `cfcLabelView` attachment), every source-bearing atom field is
+persisted in one of three forms, per a classification table owned alongside
+the atom registry:
+
+- **`public`** — verbatim. For fields whose disclosure is the feature
+  (authorship subjects where the author chose attribution) and for
+  non-identifying fields (`kind`, `type`, `Expires.timestamp`,
+  `Builtin.name`, `LlmDerived.model`).
+- **`commitment`** — the field value is replaced by its unsalted canonical
+  digest (`hashStringOf`), same idiom as the shipped `valueDigest` /
+  `evidenceDigest` atom fields. Preserves: equality matching (read gating
+  computes `H(reader)` and compares; evidence binding compares digests;
+  SC-11 idempotence — the transform is deterministic). Loses: dereference
+  (no §4.9.3 ACL lookup from a digested `Space.id`) and variable-binding
+  pattern matches over the field. Privacy honesty: digests of DIDs are
+  **probe-able** (an adversary can hash candidate DIDs and test) — this form
+  hides identities from casual observation, not from targeted enumeration.
+  It is the pragmatic middle, and the spec's fallback posture ("SHOULD prefer
+  atom forms whose payloads are not themselves sensitive") upgraded to a
+  mechanism.
+- **`reference`** — the strong form. The destination envelope stores an
+  opaque back-reference (`{space: A, entry: <content address>}`) to the label
+  entry in the **source space**; no atom payload crosses. Resolution happens
+  at evaluation time under **A's read authority**: a reader whose session can
+  read A resolves and evaluates; one who cannot gets the spec's
+  `notAvailable` collapse — the clause is unsatisfiable and the protected
+  value stays closed. This makes inv-12's "source identity confidentiality"
+  literal: *the label's readability is the source's own read authority.*
+  Fail-closed by construction; availability-coupled (A unreachable ⇒ B's
+  protected values unreadable even for legitimate readers) — mitigated by
+  per-reader local materialization after a successful resolve (cache the
+  resolved entry under the reader's own session, revalidated by content
+  address).
+
+Default assignments (initial table, revisable per family):
+
+| Field | Class | Rationale |
+|---|---|---|
+| `Caveat.source`, nested caveat sources | commitment | consumed by equality-shaped evidence binding; the audit's named leak |
+| `User.subject` / `PersonalSpace.owner` in confidentiality clauses | commitment | gating is pure equality against the acting reader |
+| `Space.id` in clauses | **public** (initially) | §4.9.3 must dereference it for the ACL point query; a commitment breaks membership-based release. Space DIDs identify a *container*, not a person; revisit under `reference` when cross-space resolution ships |
+| `LinkReference.source/target` | commitment (paths), public (space? no — commitment) | display/provenance only; nothing dereferences the persisted copy |
+| `TransformedBy.identity.sourceFile/bindingPath` | commitment | human-readable code layout is the leak; trust statements should bind the content-addressed `moduleIdentity` (public) instead |
+| `authored-by` / `represents-principal` `.subject` | public | product-displayed attribution, minted under the acting principal's own authority |
+| `HasRole` / `UserSurfaceInput.user` / `ExternalIngest.audience` | commitment | evidence families; equality-consumed |
+
+The classification is enforced where atoms are already canonicalized
+(`canonicalizeCfcMetadata` / the persist loop), applies **identically to the
+envelope entries and the sigil-link `cfcLabelView`** (one transform, two
+sinks — missing the in-`value` copy voids the whole design), and only fires
+for **cross-space** persistence: a label whose observations all originate in
+the destination space persists verbatim (nothing foreign to protect, and
+same-space tooling keeps full fidelity).
+
+Same-form matching keeps enforcement sound: a clause atom in commitment form
+is satisfied by digesting the candidate before comparison; an exchange-rule
+`appliesTo` in commitment form matches commitment atoms. Rules that need
+plaintext variables over a committed field simply do not fire at B — the
+fail-closed direction (a release that cannot be evaluated does not happen).
+
+## 3. The read side: label metadata becomes an observation
+
+Representation limits what B's replicas contain; inv-12 additionally requires
+that *observing* label metadata is itself a labeled observation. Today the
+read side has no channel at all: `["cfc"]` reads are excluded from flow/PC
+(`flowReadExcluded`), runtime reads go through `INTERNAL_VERIFIER_META`, and
+one **raw unredacted IPC seam is open** — `handleCellGet` with `meta: "cfc"`
+returns the raw envelope (`runtime-processor.ts` `getMetaRaw`; zero live
+callers). SC-6 records the exclusion as "a profile decision that must be
+revisited when invariant 12 is implemented." This is that revisit:
+
+1. **Close the raw seam.** `meta: "cfc"` over IPC either returns the same
+   redacted view as `getCfcLabel` or is removed (no callers today — remove).
+2. **`inspectConfLabel` is the only pattern-facing surface**, implemented per
+   §4.6.4.1: equality predicates only; result is a runtime-labeled value
+   whose label joins the consumed metadata observations + query-input
+   confidentiality + PC; `notAvailable` normalization for unobservable /
+   missing / matching-but-unreadable (the `reference`-form resolution failure
+   maps onto exactly this outcome — no new case).
+3. **Population profile (§4.6.4.2), staged.** Full per-field
+   `PathLabelTemplate` entries under `/cfc/labels/...` are the end state and
+   overlap the SC-4/SC-8 envelope-population design (same machinery — build
+   once). The interim rule, implementable now without new persisted metadata:
+   a source-bearing field's observation label = the source identity's
+   confidentiality when known, else the source value's **effective
+   confidentiality** (the label the entry itself guards), else fail closed —
+   computable from the entry in hand. `type`/`kind`/presence stay public per
+   the default profile.
+4. **Runtime enforcement reads stay outside the consumed set** (verifier
+   reads are not observations — §8.10.1), unchanged. What changes is that
+   *application-visible* projections of label metadata always pass through
+   (2)'s labeling.
+
+The shipped display redaction (`redactCaveatSourcesForDisplay` at the three
+IPC response sites) remains as defense-in-depth for same-space views, and
+extends to the sigil `cfcLabelView` copies in `handleCellGet`/`subscribe`
+value payloads — main-thread application code has no enforcement need for
+them (worker-side enforcement consumes the unredacted view).
+
+## 4. What this deliberately does not do
+
+- **No label-of-label recursion.** First-layer only, per §4.6.4.1; the
+  population profile's labels are runtime-enforced metadata, not
+  introspectable payload.
+- **No cryptographic audience encryption.** Encrypting envelope fields to the
+  clause's reader set would give strong privacy *and* offline evaluation, but
+  imports key distribution and revocation machinery the runtime does not
+  have; the `reference` form achieves the same authority semantics through
+  the existing session/ACL layer. Recorded as the upgrade path if probe-able
+  commitments prove insufficient.
+- **No existence hiding.** "This path carries *a* label entry" stays
+  observable (the spec: "the bare existence of a label entry is usually less
+  revealing than the source identities inside it"). SC-4's existence channel
+  is a payload-label concern, tracked separately.
+- **Schema replication stays.** Content-addressed schema docs continue to
+  cross spaces; `ifc` annotations reveal policy *structure*, accepted (they
+  are code, not data). Noted so the boundary is explicit.
+
+## 5. Staging
+
+- **Stage 0 (now, no representation change):** remove/redact the `meta:"cfc"`
+  IPC seam; extend display redaction to sigil `cfcLabelView` in IPC value
+  payloads; add the classification table as data (no transform yet). Each is
+  small and independently shippable.
+- **Stage 1 (representation):** the cross-space persist transform
+  (commitment/public per §2's table) behind a dial
+  (`cfcLabelMetadataProtection: off | observe | enforce` — observe computes
+  the transformed form and diagnoses divergence without persisting it, the
+  established rollout idiom). Migration: transformed and verbatim envelopes
+  coexist (entries are self-describing; a commitment field carries a marker
+  wrapper `{digestOf: <hash>}` so consumers dispatch on shape, and SC-11
+  equality is computed post-transform).
+- **Stage 2 (observation):** `inspectConfLabel` + interim population rule +
+  the label-metadata observation channel (SC-6 revisit).
+- **Stage 3 (strong form):** `reference`-form carried labels + per-reader
+  materialization; entry criteria: a concrete deployment whose threat model
+  includes targeted DID probing, and cross-space resolution latency measured
+  acceptable on the shared-profile / group-chat flows.
+
+Dependencies: none on Epics B/D/E remainder; Stage 2's full population
+profile co-builds with the SC-4/SC-8 envelope design. The D4 value-level
+provenance design (`cfc-value-level-provenance.md`) independently *shrinks*
+this disclosure surface — a pointwise flow join stamps each written path with
+only the atoms that fed it, so fewer A-side atoms reach B's envelopes at all
+(today's per-tx global `J` is a broader-than-necessary disclosure, its §1
+tension 8).
+
+## 6. Spec-change queue
+
+- §4.6.4.1's known-exposure paragraph upgrades from posture ("MUST treat as
+  visible … SHOULD prefer atom forms") to the normative representation rule:
+  cross-space persistence of source-bearing fields MUST use a
+  classification-governed form (public / commitment / reference), with
+  same-form matching semantics and the reference form's `notAvailable`
+  collapse.
+- §4.6.4.2 gains the interim population rule (effective-confidentiality
+  fallback computed from the entry in hand) as a sanctioned partial profile.
+- SC-6's exclusion text gets its revisit note discharged (label-metadata
+  reads become observations at the introspection surface; verifier reads
+  unchanged).
+- New SC entry in `cfc-spec-changes.md` recording the classification table's
+  initial assignments and the `Space.id`-stays-public-for-§4.9.3 exception.
+
+## Provenance
+
+Runner seams: envelope persist loop + `ensureSchemaDocument`
+(`cfc/prepare.ts`), `derivePersistedLinkLabel` + `LinkReference` mint
+(`cfc/prepare.ts`), flow join `deriveFlowJoin` (`cfc/prepare.ts`),
+`redactCaveatSourceAtom`/`redactCaveatSourcesForDisplay` + the
+keep-source-intact scope comment (`cfc/label-view-core.ts`), the three IPC
+redaction sites + the open `meta:"cfc"` raw seam
+(`runtime-client/backends/runtime-processor.ts`), sigil label views
+(`cfc/link-label-view.ts`, `cell.ts` `convertCellsToLinks`),
+`flowReadExcluded` + S18 write guard (`cfc/prepare.ts`),
+`CFC_LABEL_READ_FAILED_ATOM` ungrantable marker (`cfc/observation.ts`),
+digest idiom (`cfc/canonical.ts`, `UserSurfaceInput.valueDigest` et al.),
+session partitioning (`memory/v2/session-open-auth.ts`), ACL point query
+(`runner/src/acl-manager.ts`, `cfc/space-membership.ts`). Spec:
+`10-safety-invariants.md` inv-12, `04-label-representation.md` §4.6.4–.5
+(storage profile, observation profile, population profile, known-exposure
+paragraph), `08-10-validation-at-boundaries.md` §8.10.6 (redacted placeholder
+discloses neither value nor label payloads) and §8.10.5 (evidence binding
+needs the source), merged §4.9.3 (ACL point query). Labs-side:
+[SC-6, SC-14](./cfc-spec-changes.md), audit item 28b and the shipped display
+redaction (#4052), Epic C observation classes
+([`cfc-observation-classes.md`](./cfc-observation-classes.md), which this
+design extends to label metadata).

--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -147,10 +147,21 @@ revisited when invariant 12 is implemented." This is that revisit:
    (2)'s labeling.
 
 The shipped display redaction (`redactCaveatSourcesForDisplay` at the three
-IPC response sites) remains as defense-in-depth for same-space views, and
-extends to the sigil `cfcLabelView` copies in `handleCellGet`/`subscribe`
-value payloads — main-thread application code has no enforcement need for
-them (worker-side enforcement consumes the unredacted view).
+IPC response sites) remains as defense-in-depth for same-space views.
+Extending it to the sigil `cfcLabelView` copies in `handleCellGet`/
+`subscribe` value payloads is **not safe by itself**: those views round-trip
+— `CellHandle.deserialize` preserves the view on the `CellRef`,
+`mapCellRefsToSigilLinks` sends it back to the worker, and
+`prepareBoundaryCommit` persists `input.cfcLabelView` entries as link-origin
+labels — so response-side redaction would persist redacted, under-labeled
+views on copy-forward/link writes. The prerequisite (independently
+motivated: a round-tripped view is main-thread-influenceable, and today it
+is gated only for runtime-minted-integrity forgery) is **re-derivation at
+the persist seam**: the worker treats an inbound `cfcLabelView` as an
+untrusted display artifact and persists link-origin labels only from its own
+authoritative sources (stored source metadata / the worker-side label-view
+state), never from the round-tripped copy. Once persistence no longer
+consumes inbound views, redacting the outbound copies is safe.
 
 ## 4. What this deliberately does not do
 
@@ -174,9 +185,12 @@ them (worker-side enforcement consumes the unredacted view).
 ## 5. Staging
 
 - **Stage 0 (now, no representation change):** remove/redact the `meta:"cfc"`
-  IPC seam; extend display redaction to sigil `cfcLabelView` in IPC value
-  payloads; add the classification table as data (no transform yet). Each is
-  small and independently shippable.
+  IPC seam; make the persist seam re-derive link-origin labels from
+  worker-authoritative sources instead of the round-tripped `cfcLabelView`
+  (the §3 prerequisite — a hardening on its own); then extend display
+  redaction to sigil `cfcLabelView` in IPC value payloads; add the
+  classification table as data (no transform yet). Each is small and
+  independently shippable, in that order.
 - **Stage 1 (representation):** the cross-space persist transform
   (commitment/public per §2's table) behind a dial
   (`cfcLabelMetadataProtection: off | observe | enforce` — observe computes

--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -134,10 +134,13 @@ revisited when invariant 12 is implemented." This is that revisit:
    overlap the SC-4/SC-8 envelope-population design (same machinery — build
    once). The interim rule, implementable now without new persisted metadata:
    a source-bearing field's observation label = the source identity's
-   confidentiality when known, else the source value's **effective
-   confidentiality** (the label the entry itself guards), else fail closed —
-   computable from the entry in hand. `type`/`kind`/presence stay public per
-   the default profile.
+   confidentiality when known, else — **for derived-component entries only** —
+   the entry's own effective confidentiality (sound because the §8.9.2
+   conservative join already contains each influencing source's
+   confidentiality; declared/authored entries carry no such containment
+   guarantee and stay fail-closed), else fail closed. Computable from the
+   entry in hand, no cross-space resolution. `type`/`kind`/presence stay
+   public per the default profile.
 4. **Runtime enforcement reads stay outside the consumed set** (verifier
    reads are not observations — §8.10.1), unchanged. What changes is that
    *application-visible* projections of label metadata always pass through

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -1,0 +1,251 @@
+# CFC persisted declassification — grants, and the rewrite event
+
+_Design for the thing Epic B scoped out (decision 1: "rewritten labels are
+never persisted; store-label rewrite as a declassification event is out of
+scope for this epic"). Spec ground: `08-12-store-label-monotonicity.md`
+§8.12.7's three sanctioned widening routes, worked example §13.4.3, merged
+§4.9.3 (ACL point query), `06-events-and-intents.md` §6.5. Grounded in the
+shipped Epic B evaluator (`cfc/exchange-eval.ts`, `cfc/policy.ts`).
+Written 2026-07-09 at owner request._
+
+## 1. The spec names one route; its example is a different one
+
+§8.12.7 sanctions three routes to post-hoc widening of a stored label:
+access-time exchange rules (1), "an explicit store-label rewrite as a
+declassification event: an intent-gated, policy-guarded operation (the shape
+of §13.4.3's persistent share-policy update), never an ordinary write" (2),
+and a new value carrying the wider label (3).
+
+But §13.4.3 — route 2's own cited shape — does **not** rewrite a label. It
+persists a `ShareGrant` record (`{owner, resourceRef, recipient, scope,
+grantedAt, sourceIntentId}`) to policy state; "the grant is then consulted on
+later reads." §13.4.4 then shows the consuming exchange rule (`guard:
+{policyState: [{kind:"ShareGrant", …}]}` adding `User($recipient)`). The
+worked-examples summary table blurs the two ("persistent policy state / label
+rewrite"). These are different artifacts:
+
+- A **grant record** is a durable *input to evaluation*: the stored label
+  keeps its clauses; a route-1 rule consults the grant at access time. The
+  label stays honest, monotonicity is never touched, and revocation is the
+  grant's lifecycle.
+- A **rewrite event** is a durable *output of evaluation*: the declared
+  component itself widens, once, attributably. Reads thereafter need no
+  policy evaluation — the widening survives export beyond the
+  policy-evaluation domain.
+
+This design: build **grants** as the standard persisted-declassification
+mechanism (§2–3); specify the **rewrite event** precisely but keep it
+unscheduled behind hard entry criteria (§4–5), because every piece of
+substrate it needs is unbuilt and grants cover all but one use class.
+
+## 2. Grant records (build this)
+
+### 2.1 Shape and precedents
+
+Two artifacts of exactly this kind already exist or are specced:
+
+- The **space ACL document** (merged §4.9.3; `acl-manager.ts`,
+  `memory/v2/server.ts`): one doc per space at a reserved address (entity id
+  = the space DID), owner-gated writes, consulted at access time by a
+  fail-closed point query, feeding runtime-minted `HasRole` facts into
+  exchange evaluation. It *is* a durable audience grant.
+- The **ShareGrant** (§13.4.3): per-resource, minted by a trusted policy
+  writer after verifying intent evidence (rendered-state match, trusted
+  surface concept, share authority).
+
+A grant generalizes both: a content-addressed record at a reserved space-root
+path (the B2b storage discipline: "content-addressed records verified on
+read, read under `internalVerifierRead` so policy lookups never taint"),
+written only by a trusted policy writer, shaped
+
+```ts
+type CfcGrant = {
+  kind: string;                    // "ShareGrant", …  — matched by policyState guards
+  owner: DID;                      // whose release authority this spends
+  resource: Reference | AtomPattern; // what it releases (doc ref or label-pattern scope)
+  audience: unknown[];             // principal-like atoms, §3.1.8-validated
+  grantedAt: number;
+  expiresAt?: number;
+  sourceIntentId?: Reference;      // §6 attribution when the intent substrate exists
+  revoked?: { at: number; by: DID };
+};
+```
+
+### 2.2 Consumption: the `policyState` guard kind
+
+Shipped `ExchangeRule.preCondition` admits `confidentiality | integrity |
+boundary` guards only — §13.4.4's `policyState` guard kind is unimplementable
+in B2a. The extension: a `policyState` guard names a grant `kind` plus field
+patterns; at evaluation the runtime resolves matching, unexpired, unrevoked
+grants from the governing space's grant path (point query per candidate, the
+§4.9.3 discipline: fail-closed on absent/malformed/unsynced; discovered from
+atoms in the label under evaluation, never enumerated) and binds guard
+variables from the grant's fields. Everything downstream is the shipped
+evaluator: the fired rule adds the grant's audience as alternatives to the
+matched clause, clause-locally (invariant 11), evaluation-time only.
+
+Properties inherited for free:
+
+- **Monotonicity**: untouched — the stored label never changes.
+- **Revocation**: delete/expire/mark the grant; rules stop firing on next
+  evaluation. "Disjunctions arise at access time" stays true.
+- **Attribution**: the grant doc is written under the policy writer's
+  verified identity with `writeAuthorizedBy`, carries `owner` +
+  `sourceIntentId`; the policy-snapshot digest already binds *which rules*
+  could consume it (B5's `PreparedDigestInput.policySnapshot`).
+- **Audit**: grants are ordinary docs — enumerable per space at the reserved
+  path, with history.
+- **Single-use releases**: a grant consumed at a commit point claims a §6.5
+  consumed cell (`refer({grantConsumed: {grantId}})`) — the attempt-cell
+  contract verbatim, when that substrate ships; standing grants simply never
+  consume.
+
+### 2.3 Soundness conditions (each red-first-testable)
+
+1. **Write gate**: grant docs are writable only by the trusted policy-writer
+   identity (reserved-path guard, same class as the S18 `["cfc"]` write
+   guard); `audience` entries pass the §3.1.8 principal-like validation
+   (`disallowedAuthoredClauseReason` — no Caveat/Expires alternatives); the
+   writer verifies the granting principal's release authority over
+   `resource` (inv-7: an audience is mintable only over content within the
+   granter's own authority).
+2. **Read non-taint**: grant lookups ride `internalVerifierRead` — they must
+   not enter the consumed set or PC (the §4.9.3 point-query discipline;
+   otherwise every gated read of a shared doc taints with the grant doc).
+3. **Digest binding**: the resolved grant set joins the evaluation's
+   identity. Cheapest sound form: fold each consulted grant's content address
+   into the prepared digest input alongside `policySnapshot.digest` (same
+   invalidation discipline — a grant changed between prepare and commit
+   invalidates).
+4. **Clause locality**: a grant releases only the clause(s) its consuming
+   rule matched — inherited from the evaluator, but the B2b home-clause
+   constraint (CT-1874) applies identically when grants are discovered from
+   label-carried atoms: a grant referenced from clause k must not widen
+   clause j ≠ k.
+5. **Cross-space representation**: a grant names DIDs; when its *existence*
+   crosses spaces it is label-adjacent metadata and the inv-12 classification
+   applies ([`cfc-label-metadata-confidentiality.md`](./cfc-label-metadata-confidentiality.md)).
+   Same-space grants (the normal case) persist verbatim.
+
+### 2.4 What grants cannot do
+
+A grant is live state: it works only where the evaluator runs *and* the grant
+doc is reachable. Three consequences — the exact residual that motivates the
+rewrite event:
+
+- **Export/publish**: a value released "to everyone, forever" (publishing)
+  should not depend on a grant lookup succeeding for eternity.
+- **Cross-deployment portability**: a doc synced into a deployment without
+  the source's policy writer/grant path re-closes.
+- **Read-path cost**: every gated read pays evaluation + point queries.
+
+## 3. Build order for grants
+
+1. `policyState` guard kind + grant resolution in `exchange-eval.ts`
+   (evaluator change is additive; guards default-absent).
+2. Reserved grant path + trusted-writer gate + §3.1.8 validation (storage
+   discipline shared with B2b's policy docs — build once).
+3. Digest binding of consulted grants.
+4. ShareGrant end-to-end: share UI → (until §6 intents ship) a
+   trusted-builtin writer verifying authority directly → grant → release on
+   read; the §13.4.3 verification list minus the intent-evidence rows, which
+   strengthen when intents land.
+5. Single-use grants (blocked on §6.5 consumed-cell substrate).
+
+Dependency note: (1)+(2) are B2b-adjacent — the same reserved-path,
+content-addressed, verify-on-read machinery. If B2b is built first, grants
+are a second record kind on the same substrate; if grants go first, B2b
+inherits the substrate. Either order, with CT-1874's home-clause gate in the
+shared selection layer.
+
+## 4. The rewrite event (specify now, build later)
+
+When a widening must survive without evaluation (§2.4), route 2 proper: an
+in-place widening of the **declared** component, executed as a
+declassification event. Contract, if and when built:
+
+1. **Intent-gated**: requires a consumed `IntentOnce` (§6.5) whose parameters
+   (target doc, clause, added audience) carry integrity per §3.8.4 robust
+   declassification — release scope/destination/audience are
+   integrity-sensitive parameters. **Hard dependency: the intent substrate,
+   which does not exist in the runner today.**
+2. **Policy-guarded**: the acting principal's authority over the target
+   clause verified exactly as a grant writer would (inv-7), plus §8.10.5.2 —
+   a broader audience is a new release judgment with its own evidence.
+3. **A new monotonicity gate**: today no runtime `canUpdateStoreLabel` check
+   exists (declared entries evolve only via the schema-walk re-mint). The
+   event is the *sanctioned exception* to a gate that must first exist —
+   build the gate (reject non-monotone declared-component changes outside an
+   event) before the exception, or the "never an ordinary write" clause is
+   unenforced prose.
+4. **The event record**, adjacent to but not inside the `["cfc"]` envelope
+   (SC-11 keeps envelopes churn-free and version-neutral; an event wants an
+   ordered, revision-bumping ledger): a content-addressed record at the
+   reserved path, `{doc, path, clauseDigest, priorLabelDigest,
+   newLabelDigest, actingPrincipal, intentId, at}` — clause identity by
+   canonical clause digest (clause *indices* are evaluation-ephemeral; the
+   shipped `RuleFiring.clauseIndex` is explicitly firing-time-only and
+   under-records for this purpose).
+5. **Tighten-back is legal, un-widening is not retroactive**: a later
+   monotone tightening (§8.12.5) may re-narrow the label, but reads served
+   between event and tightening were released — the event is a real
+   declassification, stated plainly.
+
+**Considered and rejected — mechanized route 3** (rewrite = copy-forward with
+a wider authored label + alias swap): sidesteps monotonicity entirely and
+reuses the shipped authoring path (the B6 sanitizer already persists loosened
+labels onto new values), but changes document identity — every inbound link,
+sync client, and history consumer sees a different doc. Identity-preserving
+widening is the whole point of route 2; if identity may change, route 3
+already works today with no new machinery.
+
+## 5. Entry criteria
+
+Build **grants** when a product surface needs durable sharing (the share UI,
+group-membership beyond space ACLs) — B2b-adjacent, no blockers beyond the
+evaluator extension. Build the **rewrite event** only when all hold: (a) a
+real export/publish/portability requirement that grants demonstrably cannot
+serve; (b) the §6.5 intent substrate exists (IntentOnce + consumed cells);
+(c) the declared-component monotonicity gate (§4.3) has shipped and soaked.
+Until then, "publish" is served by route 3 (copy-forward), which is honest
+about being a new value.
+
+## 6. Spec-change queue
+
+- **§8.12.7 route 2 splits** into 2a (durable grant records consumed by
+  access-time rules — the §13.4.3/§13.4.4 shape, generalizing the §4.9.3 ACL
+  document) and 2b (the in-place rewrite event proper, with the §4 contract:
+  intent-gated, authority-verified, gate-first, event record with
+  clause-digest identity, ledger outside the envelope). "Right when the
+  widening is a durable owner decision" refines to: 2a when revocable or
+  policy-derived; 2b only when the widening must survive without evaluation.
+- **§13 worked-examples summary table**: "persistent policy state / label
+  rewrite" unconflates into the two rows.
+- **§6.8 cell-ID table** gains `grantConsumed` (single-use grants) when the
+  §6.5 substrate is specced for the runner.
+- **`policyState` guard kind** documented next to the exchange-rule grammar
+  (§4.3.3 vicinity), with the §4.9.3-style fail-closed resolution rules and
+  the CT-1874 home-clause constraint for label-carried discovery.
+
+## Provenance
+
+Runner seams: `exchange-eval.ts` (`RuleFiring` under-recording, guard kinds,
+fuel/fail-closed), `policy.ts` (`PolicyRecord`/`PolicySnapshot` digests,
+B2a scope note), `prepare.ts` (S18 privileged `["cfc"]` write guard, SC-11
+idempotence skip, `derivePersistedLabel` authoring path,
+`disallowedAuthoredClauseReason`, runtime-mint forgery gate),
+`acl-manager.ts` + `memory/v2/server.ts` (reserved ACL doc, capability
+resolution, owner-gated writes), `cfc/space-membership.ts` (fail-closed point
+query, `HasRole` mint), B6 sanitizer discharge-onto-new-value
+(`schema-sanitization.ts`). Spec: `08-12-store-label-monotonicity.md` §8.12.1
+(`canUpdateStoreLabel`, spec/Lean only), §8.12.5, §8.12.7 (the three routes),
+§8.12.8 (components, replacement-soundness); `03-core-concepts.md` §3.1.8
+(conjunctive join, principal-like alternatives, no-silent-widening) and
+§3.8.4 (robust declassification); `06-events-and-intents.md` §6.2/§6.4/§6.5
+(processed/consumed/attempt cells — spec-only in the runner today);
+`08-10-validation-at-boundaries.md` §8.10.5.2/§8.10.6 (audience expansion is
+a new release judgment); `13-worked-examples.md` §13.4.3–.4 (ShareGrant +
+consuming rule); merged §4.9.3 (HasRole fact generation). Labs-side: Epic B
+decision 1 (`docs/plans/cfc-future-work-implementation.md`), CT-1874
+(home-clause constraint), [`cfc-label-metadata-confidentiality.md`](./cfc-label-metadata-confidentiality.md)
+(grant records as label-adjacent metadata).

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -59,6 +59,7 @@ read, read under `internalVerifierRead` so policy lookups never taint"),
 written only by a trusted policy writer, shaped
 
 ```ts
+// Shown for illustration only.
 type CfcGrant = {
   kind: string;                    // "ShareGrant", …  — matched by policyState guards
   owner: DID;                      // whose release authority this spends

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -95,9 +95,14 @@ Properties inherited for free:
   could consume it (B5's `PreparedDigestInput.policySnapshot`).
 - **Audit**: grants are ordinary docs — enumerable per space at the reserved
   path, with history.
-- **Single-use releases**: a grant consumed at a commit point claims a §6.5
-  consumed cell (`refer({grantConsumed: {grantId}})`) — the attempt-cell
-  contract verbatim, when that substrate ships; standing grants simply never
+- **Single-use releases**: a grant consumed at a commit point claims a
+  create-only receipt document causal to the grant id — the shipped
+  exactly-once discipline (`experimental.commitPreconditions`: the event
+  path already mints the handler result cell from the durable event id via
+  `{resultFor: cause}` + `markCreateOnly`, and a duplicate handling dies as
+  a `receipt-exists` permanent rejection, `runner.ts` /
+  `scheduler/events.ts`). A consuming release claims
+  `{grantConsumed: {grantId}}` the same way; standing grants simply never
   consume.
 
 ### 2.3 Soundness conditions (each red-first-testable)
@@ -150,7 +155,9 @@ rewrite event:
    trusted-builtin writer verifying authority directly → grant → release on
    read; the §13.4.3 verification list minus the intent-evidence rows, which
    strengthen when intents land.
-5. Single-use grants (blocked on §6.5 consumed-cell substrate).
+5. Single-use grants — the receipt discipline exists behind
+   `experimental.commitPreconditions`; blocked only on that flag's
+   maturation, not on new machinery.
 
 Dependency note: (1)+(2) are B2b-adjacent — the same reserved-path,
 content-addressed, verify-on-read machinery. If B2b is built first, grants
@@ -164,11 +171,18 @@ When a widening must survive without evaluation (§2.4), route 2 proper: an
 in-place widening of the **declared** component, executed as a
 declassification event. Contract, if and when built:
 
-1. **Intent-gated**: requires a consumed `IntentOnce` (§6.5) whose parameters
+1. **Intent-gated**: requires a consumed single-use intent whose parameters
    (target doc, clause, added audience) carry integrity per §3.8.4 robust
    declassification — release scope/destination/audience are
-   integrity-sensitive parameters. **Hard dependency: the intent substrate,
-   which does not exist in the runner today.**
+   integrity-sensitive parameters. The **consumption half of this substrate
+   is shipped** (scheduler-v2 §7.6 / decision 13, flag
+   `experimental.commitPreconditions`): a durable event id rides the handler
+   transaction (`tx.dispatchedEventId`), every id minted in the handler
+   frame derives causally from it, and a create-only receipt cell is the
+   exactly-once witness — duplicate handlings collide as `receipt-exists`
+   permanent rejections. What is still missing is the **refinement/evidence
+   half** of §6: the `IntentEvent → IntentOnce` chain, gesture-provenance
+   binding to rendered state, and the bounded-retry attempt-cell ledger.
 2. **Policy-guarded**: the acting principal's authority over the target
    clause verified exactly as a grant writer would (inv-7), plus §8.10.5.2 —
    a broader audience is a new release judgment with its own evidence.
@@ -179,13 +193,16 @@ declassification event. Contract, if and when built:
    event) before the exception, or the "never an ordinary write" clause is
    unenforced prose.
 4. **The event record**, adjacent to but not inside the `["cfc"]` envelope
-   (SC-11 keeps envelopes churn-free and version-neutral; an event wants an
-   ordered, revision-bumping ledger): a content-addressed record at the
-   reserved path, `{doc, path, clauseDigest, priorLabelDigest,
-   newLabelDigest, actingPrincipal, intentId, at}` — clause identity by
-   canonical clause digest (clause *indices* are evaluation-ephemeral; the
-   shipped `RuleFiring.clauseIndex` is explicitly firing-time-only and
-   under-records for this purpose).
+   (SC-11 keeps envelopes churn-free and version-neutral): a **create-only
+   document causal to the consumed intent's id** — the shipped receipt
+   discipline reused, which gives the record ordinary journaling, atomic
+   exactly-once creation (a re-run of the declassification collides as
+   `receipt-exists`), and attribution through the normal write path, with
+   the envelope untouched. Contents: `{doc, path, clauseDigest,
+   priorLabelDigest, newLabelDigest, actingPrincipal, intentId, at}` —
+   clause identity by canonical clause digest (clause *indices* are
+   evaluation-ephemeral; the shipped `RuleFiring.clauseIndex` is explicitly
+   firing-time-only and under-records for this purpose).
 5. **Tighten-back is legal, un-widening is not retroactive**: a later
    monotone tightening (§8.12.5) may re-narrow the label, but reads served
    between event and tightening were released — the event is a real
@@ -205,8 +222,11 @@ Build **grants** when a product surface needs durable sharing (the share UI,
 group-membership beyond space ACLs) — B2b-adjacent, no blockers beyond the
 evaluator extension. Build the **rewrite event** only when all hold: (a) a
 real export/publish/portability requirement that grants demonstrably cannot
-serve; (b) the §6.5 intent substrate exists (IntentOnce + consumed cells);
-(c) the declared-component monotonicity gate (§4.3) has shipped and soaked.
+serve; (b) the §6 refinement/evidence half exists on top of the shipped
+receipt discipline (the `IntentEvent → IntentOnce` chain and
+gesture-provenance binding — the consumption half is already behind
+`experimental.commitPreconditions`); (c) the declared-component monotonicity
+gate (§4.3) has shipped and soaked.
 Until then, "publish" is served by route 3 (copy-forward), which is honest
 about being a new value.
 
@@ -245,7 +265,14 @@ query, `HasRole` mint), B6 sanitizer discharge-onto-new-value
 (processed/consumed/attempt cells — spec-only in the runner today);
 `08-10-validation-at-boundaries.md` §8.10.5.2/§8.10.6 (audience expansion is
 a new release judgment); `13-worked-examples.md` §13.4.3–.4 (ShareGrant +
-consuming rule); merged §4.9.3 (HasRole fact generation). Labs-side: Epic B
-decision 1 (`docs/plans/cfc-future-work-implementation.md`), CT-1874
+consuming rule); merged §4.9.3 (HasRole fact generation). Exactly-once
+substrate (scheduler-v2 §7.6 / decision 13, flag
+`experimental.commitPreconditions`): durable event id on the handler tx
+(`scheduler/events.ts` `tx.dispatchedEventId = queuedEvent.id`), handler
+frame cause derived from it (`runner.ts` — "every id minted in this frame
+derives from the durable event id"), create-only receipt cell
+`{resultFor: cause}` + `markCreateOnly` as the exactly-once witness,
+`receipt-exists` permanent rejection (`scheduler/events.ts`). Labs-side:
+Epic B decision 1 (`docs/plans/cfc-future-work-implementation.md`), CT-1874
 (home-clause constraint), [`cfc-label-metadata-confidentiality.md`](./cfc-label-metadata-confidentiality.md)
 (grant records as label-adjacent metadata).

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -393,8 +393,10 @@ entries and sigil-carried label views, with same-form matching semantics.
 Initial-assignment exception to record: `Space.id` in confidentiality clauses
 stays `public` because §4.9.3's ACL point query must dereference it. Also:
 §4.6.4.2 gains the interim population rule (source-identity confidentiality
-when known, else the entry's own effective confidentiality, else fail closed
-— computable without new persisted metadata), and SC-6's "revisit when
+when known; else, for **derived-component** entries only, the entry's own
+effective confidentiality — sound because the §8.9.2 conservative join
+contains each influencing source's confidentiality; else fail closed —
+computable without new persisted metadata), and SC-6's "revisit when
 invariant 12 is implemented" note is discharged by the introspection-surface
 observation channel. `open`.
 

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -374,10 +374,17 @@ D4 mechanism; (2) a MAY profile for span-attributed provenance: runtime-
 bracketed span tags on the activity record, per-write feeds-closure over
 observed span edges, sound only where the executor structurally enforces span
 non-interference — interpreter-class executors under §18.7-style obligations
-(specs#11), other executors only behind the §8.9.1 `flow-taint-precision`
-gate. States that the egress ceiling / flow join / floor credit MAY upgrade
-from transaction-global where the profile is enforced (upgrades SC-23's
-boundaries (a)/(b) from deliberate to staged). `open`.
+(specs#11); sandboxed executors under the **instance rule** (the span is the
+executor instance: executions sharing a live user-code instance share one
+span; per-run instantiation recovers per-run spans) plus SES-closed
+cross-instance channels and a commit-time observed-vs-attributed consistency
+check — **no trusted static analysis assumed anywhere**; violations surface
+as late errors (prefix fallback / commit rejection), never unsoundness. Bare
+opaque handlers stay at the prefix; the §8.9.1 `flow-taint-precision` gate
+remains only for semantic claims beyond runtime structure. States that the
+egress ceiling / flow join / floor credit MAY upgrade from transaction-global
+where the profile is enforced (upgrades SC-23's boundaries (a)/(b) from
+deliberate to staged). `open`.
 
 **SC-25 [normative] Cross-space label-metadata representation classes —
 §4.6.4.1/§4.6.4.2 (inv-12; supersedes SC-14's posture).** §4.6.4.1's
@@ -412,8 +419,10 @@ content-addressed, fail-closed point-query resolution per §4.9.3, consumed
 via a `policyState` exchange-rule guard kind, revocable, digest-bound into
 the evaluation) and 2b (the rewrite event proper: intent-gated per §6.5 +
 §3.8.4, authority-verified per §8.10.5.2, requires a declared-component
-monotonicity gate to exist first, event record with canonical clause-digest
-identity in a ledger outside the churn-free envelope). Guidance refines to:
+monotonicity gate to exist first, event record = a create-only document
+causal to the consumed intent's id — the shipped `commitPreconditions`
+receipt discipline — with canonical clause-digest identity, outside the
+churn-free envelope). Guidance refines to:
 2a when revocable or policy-derived; 2b only when the widening must survive
 without evaluation (export/publish). Unconflate the §13 table row. `open`.
 

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -362,6 +362,59 @@ break the pinned dial-off/observe byte-compat. If the spec wants the read
 gate itself to reject empty-input floored writes independent of the floor
 dial, that needs its own normative text + rollout dial.
 
+**SC-24 [normative] Journal-order precision blessed; span-attributed
+provenance profiled — §8.9.1.** SC-23's interpretation still has no spec home:
+§8.9.1 names decomposition and trusted claims only, and nothing in the spec
+mentions journal-order bounds. Proposed edit, two parts
+([`cfc-value-level-provenance.md`](./cfc-value-level-provenance.md)): (1) a
+normative paragraph sanctioning per-write gating over the last-overlapping-
+write read prefix as structural precision (both prefix directions, trigger
+reads at −∞, read|write interleaving digest-bound per §8.10.1) — the shipped
+D4 mechanism; (2) a MAY profile for span-attributed provenance: runtime-
+bracketed span tags on the activity record, per-write feeds-closure over
+observed span edges, sound only where the executor structurally enforces span
+non-interference — interpreter-class executors under §18.7-style obligations
+(specs#11), other executors only behind the §8.9.1 `flow-taint-precision`
+gate. States that the egress ceiling / flow join / floor credit MAY upgrade
+from transaction-global where the profile is enforced (upgrades SC-23's
+boundaries (a)/(b) from deliberate to staged). `open`.
+
+**SC-25 [normative] Cross-space label-metadata representation classes —
+§4.6.4.1/§4.6.4.2 (inv-12; supersedes SC-14's posture).** §4.6.4.1's
+known-exposure paragraph is posture ("MUST treat persisted label metadata as
+visible … SHOULD prefer atom forms"); the enforcement design
+([`cfc-label-metadata-confidentiality.md`](./cfc-label-metadata-confidentiality.md))
+needs it normative: cross-space persistence of source-bearing atom fields
+follows a classification-governed representation — `public` / `commitment`
+(canonical digest, equality-preserving, honestly probe-able) / `reference`
+(source-space back-reference; resolution rides the source's read authority;
+failure collapses to `notAvailable`) — applied identically to envelope
+entries and sigil-carried label views, with same-form matching semantics.
+Initial-assignment exception to record: `Space.id` in confidentiality clauses
+stays `public` because §4.9.3's ACL point query must dereference it. Also:
+§4.6.4.2 gains the interim population rule (source-identity confidentiality
+when known, else the entry's own effective confidentiality, else fail closed
+— computable without new persisted metadata), and SC-6's "revisit when
+invariant 12 is implemented" note is discharged by the introspection-surface
+observation channel. `open`.
+
+**SC-26 [reconcile] §8.12.7 route 2 conflates grant records with the rewrite
+event — §8.12.7/§13.4.3.** Route 2's cited shape (§13.4.3) persists a
+ShareGrant consulted at access time — a durable *input* to route-1 evaluation
+— while route 2's text describes an in-place store-label rewrite (durable
+*output*); the §13 summary table says "persistent policy state / label
+rewrite" as if one thing. Proposed edit
+([`cfc-persisted-declassification.md`](./cfc-persisted-declassification.md)):
+split into 2a (grant records: reserved-path, trusted-writer,
+content-addressed, fail-closed point-query resolution per §4.9.3, consumed
+via a `policyState` exchange-rule guard kind, revocable, digest-bound into
+the evaluation) and 2b (the rewrite event proper: intent-gated per §6.5 +
+§3.8.4, authority-verified per §8.10.5.2, requires a declared-component
+monotonicity gate to exist first, event record with canonical clause-digest
+identity in a ledger outside the churn-free envelope). Guidance refines to:
+2a when revocable or policy-derived; 2b only when the widening must survive
+without evaluation (export/publish). Unconflate the §13 table row. `open`.
+
 ## Queue (from the audit; statuses re-checked by the 2026-06-12 sweep where
 ## noted)
 

--- a/docs/specs/cfc-value-level-provenance.md
+++ b/docs/specs/cfc-value-level-provenance.md
@@ -78,6 +78,7 @@ Extend the shipped activity clock (`v2-transaction.ts` — the shared
 optional **span tag**:
 
 ```ts
+// Shown for illustration only.
 // storage/interface.ts additions (sketch)
 interface IReadActivity  { /* … */ journalIndex?: number; span?: SpanId }
 interface IWriteAttempt  { /* … */ journalIndex:  number; span?: SpanId }

--- a/docs/specs/cfc-value-level-provenance.md
+++ b/docs/specs/cfc-value-level-provenance.md
@@ -1,0 +1,292 @@
+# CFC value-level dataflow — the end-state past the D4 prefix
+
+_Companion to [`cfc-write-prefix-provenance.md`](./cfc-write-prefix-provenance.md)
+(Epic D4, shipped). That doc proved the last-overlapping-write **prefix** is the
+tightest per-write bound available from journal order alone. This doc designs
+what lies past it: **span-attributed provenance** — per-write dataflow recorded
+by the runtime where an executor structurally isolates operation spans, composed
+with the shipped prefix everywhere else. Deliberately unscheduled; §8 gives the
+entry criteria. Written 2026-07-09 at owner request._
+
+## 1. What the prefix still over-taints
+
+The shipped gate (`verifyInputRequirements`, `cfc/prepare.ts`) quantifies each
+protected write over the reads before its last overlapping write attempt. That
+is sound and strictly tighter than transaction-global — but within the prefix
+every labeled read still gates the write, fed or not. The residual inventory,
+from code and tests:
+
+- **Within-prefix unrelated reads.** The S7 exemption
+  (`isProvenanceOnlyConsumedLabel`) is still needed for provenance reads
+  *inside* the prefix; a confidential or endorsement-bearing read that merely
+  precedes an unrelated protected write in one handler body still gates it.
+  Multi-concern handlers (read A, decide B) pay this constantly.
+- **Trigger reads at `−∞`** join *every* protected write's prefix
+  (`prepare.ts`, gatedReads assembly) — deliberately conservative; a trigger
+  that provably fed only one write gates them all.
+- **`+Infinity` fallbacks.** No logged overlapping attempt (entry made
+  applicable by an attempted-but-unapplied write), or a backend without the
+  activity clock, degrades that path to transaction-global
+  (`WritePrefixBounds.boundFor`).
+- **Three surfaces are deliberately transaction-global** — recorded as
+  [SC-23](./cfc-spec-changes.md) boundaries (a)/(b):
+  1. the confidentiality **egress ceiling** (`collectConsumedLabel` — "a sink
+     request … does not record its own read provenance");
+  2. the **flow-label join `J(tx)`** — one per-tx join stamped at every written
+     path (`deriveFlowJoin`), which smears unrelated taint across everything a
+     routing transaction shuffles (the in-code shell-stamp comment) and makes
+     the hereditary integrity **meet** "usually empty" — any unlabeled co-read
+     destroys integrity credit for every write;
+  3. the **D3 flow-meet credit** in `verifyWriteFloor`, same join.
+- **Recursive-read descendant union** (`collectConsumedLabel`): a recursive
+  read consumes ancestor *and* descendant entries — read-granularity
+  over-approximation, orthogonal to write-side provenance but part of the same
+  precision budget.
+
+None of these are bugs. Each is the sound over-approximation available from
+what the journal records today. The question is what *new recorded structure*
+buys precision, and under what trust.
+
+## 2. The ceiling argument, and the only two ways past it
+
+The prefix doc's §4 soundness argument is exhaustive for journal order: a read
+before the last overlapping write "could have fed" the value **as far as the
+journal knows**. Excluding any such read is no longer a structural fact *of the
+journal* — so, per §8.9.1's dichotomy (`08-09-runtime-label-propagation.md`),
+anything tighter must be one of:
+
+1. **New structural facts** — the runtime records *more* than order, such that
+   exclusion is again a property of what the record "simply does not contain"
+   (the decomposition rationale). §8.5.4.3 already sanctions the limit case:
+   one transaction per element op. The cost axis is real — the reactive
+   interpreter exists precisely to collapse per-node docs/actions — so the
+   design below records finer structure *within* one transaction instead of
+   splitting transactions.
+2. **Trusted flow-precision claims** — §8.9.1's `flow-taint-precision` concept
+   gate on the executing implementation identity. Claims that cannot be
+   structurally checked live here, and only here.
+
+Everything in this doc is classified against that line. The classification is
+the design.
+
+## 3. Span-attributed provenance
+
+### 3.1 The record
+
+Extend the shipped activity clock (`v2-transaction.ts` — the shared
+`journalIndex` stamp on read activities and the write-attempt log) with an
+optional **span tag**:
+
+```ts
+// storage/interface.ts additions (sketch)
+interface IReadActivity  { /* … */ journalIndex?: number; span?: SpanId }
+interface IWriteAttempt  { /* … */ journalIndex:  number; span?: SpanId }
+// SpanId: opaque per-transaction identifier minted by the runtime bracket
+```
+
+A span is a runtime-bracketed execution interval: "these reads and these write
+attempts were issued while operation S was executing." The bracket already
+exists in the interpreter (`EvalContext.runScoped`, built for per-op scope
+attribution, with the invariant that bracketing must not change the journal);
+span stamping is the same bracket writing one more field. Nothing else in the
+transaction changes; unbracketed activity simply has `span` absent.
+
+Span stamping is **journal-class recording** — the runtime observing *where*
+activity occurred, exactly as `journalIndex` records *when*. It is not a claim
+by the executed code; the executed code cannot set it.
+
+### 3.2 The per-write provenance closure
+
+For a write attempt `w` with span `S`, define `feeds(w)` as the least set
+containing:
+
+- every read in span `S` (its **direct reads** — including lazy in-body derefs,
+  which the interpreter bracket already attributes per-op);
+- for every direct read of address `A`: the reads of `feeds(w')` for the last
+  span-tagged write attempt `w'` overlapping `A` with
+  `journalIndex < read.journalIndex` (intra-transaction producer edges,
+  resolved from **observed** attempts — never from IR edges);
+- if any read in the closure has no resolvable span-tagged producer but a
+  producing write exists in the journal (an **unspanned** producer): the entire
+  prefix of that producer, per the shipped bound — the closure degrades to the
+  prefix exactly where structure runs out;
+- trigger reads: joined into `feeds(w)` for every `w`, as today (`−∞`), unless
+  a future scheduler records which invalidated address scheduled which span —
+  out of scope here.
+
+For an **unspanned** write, `feeds(w)` = the shipped prefix. Mixed granularity
+inside one transaction is therefore well-defined and monotone: spans only ever
+*remove* reads that the prefix would have kept, and only where a bracket
+attests the removal structurally.
+
+The gate change is mechanical: `verifyInputRequirements` and `verifyWriteFloor`
+quantify over `feeds(w)` instead of the prefix set. The S7 exemption shrinks
+again (a provenance read outside `feeds(w)` needs no exemption); the #14
+empty-case delegation to the D3 floor is unchanged (an empty `feeds(w)` is a
+strictly better-grounded "no labeled input" fact than an empty prefix).
+
+### 3.3 What makes the closure sound — and where it stops being structural
+
+The closure embeds one assumption the journal cannot check: **span
+non-interference** — an operation's write depends only on reads in its own
+span plus values it read from other spans' outputs. A JS closure that stashes
+state across spans in lexical scope violates it invisibly.
+
+So the soundness class of `feeds(w)` is decided by the **executor**, not the
+record:
+
+- Where the executor **structurally enforces read isolation** per span — the
+  reactive interpreter's obligations in the proposed §18.7.3
+  (`specs#11`): explicit inputs, no hidden lexical capture, per-op bracketed
+  derefs, fail-closed on unresolved references — non-interference is enforced,
+  and the closure is precision of the same character as decomposition. Per
+  §18.7's own framing, the *package* still rides a flow-precision claim
+  asserted by the **interpreter's implementation identity** (trusted for
+  `flow-taint-precision`), with the structural obligations making the claim
+  auditable. This doc adopts that framing verbatim rather than re-arguing the
+  prefix doc's "no trust gate" conclusion for spans: the prefix needs no gate
+  because journal order alone carries it; spans need the §18.7-class gate
+  because non-interference does not come from the journal.
+- Where the executor is **opaque user JS** (handlers via `events.ts`, legacy
+  per-node actions, RI `leaf` ops beyond their declared structured input),
+  non-interference is unattested. Span tags from such code MUST NOT narrow
+  labels; the gate ignores them (falls back to prefix). If a deployment wants
+  precision there anyway, §8.9.1 already prices it: trust the specific
+  implementation identity for `flow-taint-precision` — per identity, per
+  user, never ambient.
+- A **trusted compiler/transformer** (§14.4.4) that verifies element-locality
+  of code it compiled may stamp spans on that code's behalf; the claim rides
+  the *compiler's* identity. This is the ts-transformers seam, future work.
+
+### 3.4 Tier table
+
+| Tier | Executor | Mechanism | Trust surface |
+|---|---|---|---|
+| T0 (shipped) | any | last-overlapping-write prefix | none — journal order |
+| T1 | reactive interpreter | span closure §3.2 | interpreter identity trusted for `flow-taint-precision`, under §18.7 structural obligations |
+| T2 | opaque JS granted precision | span closure, unverified isolation | per-implementation `flow-taint-precision` grant (§8.9.1), explicit and rare |
+| T2′ | compiled patterns | compiler-asserted spans | compiler identity (§14.4.4) |
+| — | any, when affordable | true per-element transactions | none — §8.5.4.3 decomposition (preferred where the tx tax is acceptable) |
+
+T1 is the payoff tier: the interpreter is where execution is consolidating,
+`runScoped` exists, and the IR's explicit `inputs`/`writeTargets` edges make
+the *predicted* dataflow checkable against the *observed* spans (a divergence
+is a fail-closed diagnostic, never a narrowing).
+
+## 4. Digest binding
+
+Same discipline as the prefix (its §6, "load-bearing for soundness"):
+
+1. Span tags join `PreparedDigestInput` — on both the consumed reads and the
+   write-attempt log. Canonicalization: span ids are per-transaction ordinals
+   rank-normalized over the decision-relevant set, exactly like the shipped
+   activity-clock ranks (raw ids would encode internal bracket count; ranks
+   preserve every containment/producer relation the closure consumes).
+2. The closure itself is **recomputed at commit** from the re-derived digest
+   input, never carried as data (audit S2 shape: bind the verification event,
+   not a caller-supplied summary — §8.10.1).
+3. A post-prepare change to any span boundary, producer order, or read
+   membership flips the digest and invalidates the preparation.
+
+## 5. Consequences for the three transaction-global surfaces
+
+Span provenance changes the premise SC-23's boundaries rest on. Each surface
+upgrades independently, behind its own staging:
+
+1. **Egress ceiling per sink request.** A sink-request document is produced by
+   some span; `feeds(sink-request write)` *is* the request's read provenance —
+   the thing whose absence forced transaction-global. The ceiling check moves
+   to `feeds(w)` for the request-producing write, T1-gated, dialed like
+   `cfcPolicyEvaluation` (off → observe-divergence → enforce).
+2. **Pointwise flow labels.** `J(tx)` becomes `J(feeds(w))` per written path —
+   the §8.9.3 default transition turns pointwise, the shell-stamp smear
+   disappears for spanned producers, and the hereditary integrity meet stops
+   being destroyed by unrelated co-reads (the meet over `feeds(w)` is the
+   per-value meet). This is SC-23(b)'s "needs per-path derived components
+   first" — the derived component exists (S16); it is the join that coarsens,
+   and spans fix exactly that.
+3. **D3 flow-meet credit** follows (2) — credit computed over `feeds(w)`.
+
+Ordering: (2) is the highest-leverage (it compounds into every downstream
+read) but touches persisted labels — ship behind `cfcFlowLabels` staging with
+SC-11 idempotence intact. (1) is self-contained. (3) rides (2).
+
+## 6. Stage 0 — measure before building
+
+There is today **no counter measuring prefix precision** (nothing records
+`boundFor` `+Infinity` rates, reads excluded per write, or would-flip
+decisions). Before any span machinery:
+
+- Extend `CfcInstrumentationHooks` with per-prepare precision counters:
+  gated-read count per protected write (prefix vs transaction-global), bound
+  source (real / `+Infinity` / clock-less), S7-exemption fire count.
+- In the interpreter branch, a shadow mode: compute `feeds(w)` from the
+  existing `runScoped` brackets **without enforcement**, and log
+  `would-flip` — decisions (rejections *and* label joins) that differ between
+  prefix and closure. This is the metric that must be red before T1 is worth
+  building, per the proxy-metric lesson: measure the real mechanism's
+  engagement, not a stand-in.
+
+## 7. Non-goals
+
+- **No IR-derived narrowing.** ROG edges predict; only bracket observations
+  narrow (R-CFC-1/R-CFC-2). A predicted-vs-observed divergence fails closed.
+- **No cross-transaction provenance.** `feeds(w)` is intra-transaction;
+  cross-tx flow stays with persisted labels (§8.12.8 components).
+- **No confidentiality *read*-side change.** The recursive-descendant union
+  (§1) is read-granularity and separately addressable (schema-scoped reads);
+  this design does not touch it.
+- **No new declassification.** §8.9.1's closing line governs: precision only,
+  never release. `feeds(w)` never drops a clause that fed the value — it drops
+  reads that provably did not.
+
+## 8. Entry criteria (deliberately unscheduled)
+
+Build T1 when **all** hold:
+
+1. The reactive interpreter is merged and default-on for the pattern classes
+   whose precision matters (it is branch-only today; its flag-default is
+   gated on the cross-space pull-amplification fix).
+2. Stage-0 diagnostics show material over-taint: would-flip counts on
+   realistic workloads (group-chat, notes, sqlite row flows), not synthetic.
+3. specs#11 (§18.7) or its successor has landed, so T1's trust framing has a
+   normative home to cite.
+
+Until then the shipped prefix is the enforced bound everywhere, and this doc
+is the recorded design intent.
+
+## 9. Spec-change queue
+
+- Give SC-23 its owed spec home: §8.9.1 gains the journal-order structural
+  precision paragraph (the prefix, its last-overlapping-write bound, trigger
+  reads at `−∞`) — the labs-side interpretation becomes normative text.
+- New §8.9.1 subsection (or §18.7 extension once specs#11 lands):
+  span-attributed provenance — the record (§3.1), the closure (§3.2), the
+  non-interference condition and its executor-class trust table (§3.3–3.4),
+  digest binding (§4).
+- §8.10 note: the egress ceiling MAY be evaluated per sink-request provenance
+  where spans are enforced, transaction-global otherwise (upgrades SC-23(a)
+  from "deliberate boundary" to "staged upgrade path").
+
+## Provenance
+
+Runner seams: `WritePrefixBounds`/`buildWritePrefixBounds`/
+`verifyInputRequirements` gating and the S7/#14 comments (`cfc/prepare.ts`),
+the activity clock + write-attempt log (`storage/v2-transaction.ts`,
+`storage/interface.ts`), rank normalization in `buildPreparedDigestInput`
+(`storage/extended-storage-transaction.ts`), order-preserving
+`writeAttemptLog` canonicalization (`cfc/canonical.ts`), transaction-global
+egress/flow-join/floor-credit seams (`collectConsumedLabel`,
+`deriveFlowJoin`, `verifyWriteFloor`, `cfc/prepare.ts`), interpreter bracket
+`EvalContext.runScoped` + `inputsOf`/`writesOf`
+(`reactive-interpreter/{interpret,rog}.ts`, branch
+`claude/priceless-rubin-89ad5e`). Spec: `08-09-runtime-label-propagation.md`
+§8.9.1 (decomposition before claims; the `flow-taint-precision` profile),
+§8.9.2 (transaction-global `O`, trigger reads), `08-05-collection-transitions.md`
+§8.5.4.3 (decomposition preferred), `08-10-validation-at-boundaries.md` §8.10.1
+(digest binds the verification event) and §8.10.2.2 (ordered attempted-write
+views), `14-open-problems-and-proposals.md` §14.4.4 (static analysis),
+§14.1.3.5 (trusted extraction to a supported operation graph), and open PR
+specs#11 (§18.7 non-decomposing reactive interpreter profile, whose trust
+framing §3.3 adopts). Labs-side: [SC-23](./cfc-spec-changes.md) records the
+shipped interpretation this doc extends.

--- a/docs/specs/cfc-value-level-provenance.md
+++ b/docs/specs/cfc-value-level-provenance.md
@@ -146,27 +146,52 @@ record:
   auditable. This doc adopts that framing verbatim rather than re-arguing the
   prefix doc's "no trust gate" conclusion for spans: the prefix needs no gate
   because journal order alone carries it; spans need the §18.7-class gate
-  because non-interference does not come from the journal.
-- Where the executor is **opaque user JS** (handlers via `events.ts`, legacy
-  per-node actions, RI `leaf` ops beyond their declared structured input),
-  non-interference is unattested. Span tags from such code MUST NOT narrow
-  labels; the gate ignores them (falls back to prefix). If a deployment wants
-  precision there anyway, §8.9.1 already prices it: trust the specific
-  implementation identity for `flow-taint-precision` — per identity, per
-  user, never ambient.
-- A **trusted compiler/transformer** (§14.4.4) that verifies element-locality
-  of code it compiled may stamp spans on that code's behalf; the claim rides
-  the *compiler's* identity. This is the ts-transformers seam, future work.
+  because non-interference does not come from the journal. (The interpreter
+  is exempt from the instance rule below — by instance-is-the-span logic
+  every interpreted op shares the interpreter and would merge into one span;
+  the exemption is exactly what trusting the runtime's own executor means,
+  and §18.7's obligations are what make that self-trust auditable.)
+- For **sandboxed user code** (RI `leaf` ops, compiled pattern nodes) no
+  analysis is needed — and none is available: we have no trusted static
+  analysis, so the design must not require one. The workaround is a pure
+  bookkeeping rule: **the span is the executor instance.** State can flow
+  freely inside a live module instance (a closure or module-interior object
+  survives across calls), so all executions sharing an instance share one
+  span — the record says what the heap permits. Per-run spans are recovered
+  by per-run instantiation where the dispatcher chooses to pay for it. The
+  runtime already knows which instance ran; no code property is assumed.
+  Around that rule, the sandbox's existing structure closes the remaining
+  channels: SES lockdown freezes intrinsics and shared globals (no ambient
+  cross-instance heap), and outputs are serializable data through the
+  transaction (function-bearing values are rejected), so cross-**instance**
+  flow is tx-visible — producer edges the closure already follows. A
+  commit-time consistency check completes it: an execution observed touching
+  activity outside its bracket attribution voids its span, and the write
+  falls back to the prefix. The trade is exactly **late errors for static
+  assurance**: without an analyzer, an author learns about a precision
+  violation as a commit-time prefix fallback or gate rejection instead of a
+  compile-time diagnostic — never as unsoundness.
+- **Opaque handlers** (`events.ts`) have no bracket at all: no spans, prefix
+  throughout. Unchanged from shipped behavior.
+- The §8.9.1 `flow-taint-precision` grant remains the spec's mechanism for
+  claims that *exceed* runtime structure (semantic dependency claims of the
+  §8.5.4.1 kind). This design requires none: every narrowing above is either
+  TCB-observed or instance-structural. Static analysis (§14.4.4), if it ever
+  becomes trusted, adds authoring-time diagnostics and per-run-instance
+  elision — an optimization, not a prerequisite.
 
 ### 3.4 Tier table
 
-| Tier | Executor | Mechanism | Trust surface |
+| Tier | Executor | Mechanism | Trust surface / failure mode |
 |---|---|---|---|
 | T0 (shipped) | any | last-overlapping-write prefix | none — journal order |
-| T1 | reactive interpreter | span closure §3.2 | interpreter identity trusted for `flow-taint-precision`, under §18.7 structural obligations |
-| T2 | opaque JS granted precision | span closure, unverified isolation | per-implementation `flow-taint-precision` grant (§8.9.1), explicit and rare |
-| T2′ | compiled patterns | compiler-asserted spans | compiler identity (§14.4.4) |
+| T1 | reactive interpreter | span closure §3.2, per-op brackets | interpreter identity under §18.7 structural obligations (runtime self-trust, auditable) |
+| T2 | sandboxed user code | span = executor instance (merge-on-sharing) + SES-closed channels + commit-time consistency check | none upfront — violations surface as **late errors** (prefix fallback / commit rejection), never unsoundness |
 | — | any, when affordable | true per-element transactions | none — §8.5.4.3 decomposition (preferred where the tx tax is acceptable) |
+
+(A per-implementation `flow-taint-precision` grant, §8.9.1, remains the
+spec's escape for semantic claims beyond runtime structure; no tier here
+needs it, and no trusted static analysis is assumed anywhere.)
 
 T1 is the payoff tier: the interpreter is where execution is consolidating,
 `runScoped` exists, and the IR's explicit `inputs`/`writeTargets` edges make


### PR DESCRIPTION
Design docs for the three accepted-residual CFC items past the implementation plan (owner-requested design session), plus SC-24/25/26 tracking entries. Companion spec PR: commontoolsinc/specs#14 (opened alongside).

## The three designs

**1. `cfc-value-level-provenance.md` — past the D4 prefix.**
The shipped last-overlapping-write prefix is the tightest bound journal *order* carries (its companion doc's §4 argument is a ceiling). Going tighter = new recorded structure: **span-attributed provenance** — the runtime bracket (the RI's existing `runScoped`, built for scope attribution) stamps an op-span tag on reads/write-attempts alongside `journalIndex`; per-write provenance is the transitive closure over *observed* span edges, degrading to the prefix wherever spans run out (opaque handlers). Soundness hinges on span non-interference, which only structurally-isolating executors give — so tiers: T0 prefix (shipped, everything), T1 interpreter spans (identity-trusted claim under specs#11 §18.7 obligations; IR edges predict, only observations narrow), T2 `flow-taint-precision`-gated claims / true §8.5.4.3 decomposition. Consequences: the three deliberately-tx-global surfaces (egress ceiling, flow join J, D3 flow-meet credit — SC-23 boundaries) each get a staged upgrade path. Stage 0 is measurement (no prefix-precision counter exists today). Deliberately unscheduled; entry criteria include RI merged + would-flip diagnostics red.

**2. `cfc-label-metadata-confidentiality.md` — inv-12 / SC-14.**
Key structural fact: the adversary is the destination space's *readers*, not its runtime — envelopes replicate in the doc JSON (plus a second copy inside `value` via sigil `cfcLabelView`), and enforcement is local-first, so no API-seam view transform can work; protection must be the **persisted representation**. Three classes per source-bearing atom field: `public` (product-displayed attribution; `Space.id` — §4.9.3's ACL point query must dereference it), `commitment` (canonical digest; equality-preserving; honestly probe-able), `reference` (back-reference into the source space; label readability rides the source's read authority; failure = `notAvailable` = clause unsatisfiable). Read side: close the open raw `meta:"cfc"` IPC seam (zero callers), `inspectConfLabel` as the only pattern-facing surface, interim population rule (derived-component-only fallback — sound via the conservative join's containment). Corrects the audit sentence: `Origin` URIs and policy names don't actually persist today; the live leak set is DIDs, `Caveat.source`, `LinkReference` addresses, `TransformedBy` code identities.

**3. `cfc-persisted-declassification.md` — §8.12.7 route 2, split.**
Route 2's own cited example (§13.4.3 ShareGrant) doesn't rewrite a label — it persists a **grant record consulted at access time** (durable *input* to route-1 evaluation). The true **in-place rewrite event** (durable *output*) is a different artifact whose every dependency is unbuilt (§6.5 intents, a runtime monotonicity gate, stable clause identity, a ledger outside the SC-11-churn-free envelope). Recommendation: build **grants** (a `policyState` guard kind + reserved-path trusted-writer records, generalizing the merged §4.9.3 ACL doc; B2b-adjacent substrate, CT-1874 home-clause gate applies); keep the **rewrite event** specified-but-unscheduled, entered only for export/publish needs that must survive without evaluation — until then route 3 (copy-forward) is the honest publish primitive.

## Verification
Docs-only. Grounded in three parallel code investigations (all claims carry file:line provenance sections); spec quotes verified against `commontoolsinc/specs` main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three CFC design docs and updates the spec queue (SC‑24/25/26): span‑attributed value‑level provenance past the D4 prefix, cross‑space label‑metadata confidentiality, and persisted declassification via grants.
Clarifies no static analysis is required (instance‑span rule with late‑error fallback), the intent‑consumption/receipt substrate is already shipped, the interim label‑introspection rule applies to derived‑component entries only, Stage 0 re‑derives link‑origin labels at persist before redacting `cfcLabelView` to avoid round‑trip under‑labeling, and marks sketch code blocks as illustration‑only; the rewrite event remains specified but unscheduled.

<sup>Written for commit 3bd3332def33805378cc118967a2f6de366fd69d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

