### PR TITLE
feat(cfc): D4 write-prefix precision counters (value-level provenance stage 0, SC-24)

### DIFF
--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -137,10 +137,17 @@ export {
   spaceReaderRole,
 } from "./space-membership.ts";
 export {
+  CFC_PREFIX_PROVENANCE_MAX_WRITES,
   flowLabelWorkExists,
   flowReadExcluded,
   gatedSinkRequestExists,
   prepareBoundaryCommit,
+} from "./prepare.ts";
+export type {
+  CfcPrefixBoundSource,
+  CfcPrefixProvenanceSummary,
+  CfcPrefixProvenanceWrite,
+  CfcPrepareInstrumentation,
 } from "./prepare.ts";
 export {
   createSinkRequestPolicyInput,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2655,7 +2655,11 @@ export type CfcPrefixBoundSource =
 export type CfcPrefixProvenanceWrite = {
   /** Document id of the protected write's target. */
   id: string;
-  /** Protected schema-entry path, pointer-style (e.g. "/out"). */
+  /**
+   * Protected schema-entry path as an RFC 6901 JSON pointer (e.g. "/out";
+   * "" is the root; "~"/"/" in property names escape as "~0"/"~1"), so
+   * consumers can recover the exact segments via parsePointer.
+   */
   path: string;
   boundSource: CfcPrefixBoundSource;
   /** Gated reads within this write's D4 prefix (post-S7-exemption). */
@@ -2979,7 +2983,13 @@ const verifyInputRequirements = (
       if (provenance.writes.length < CFC_PREFIX_PROVENANCE_MAX_WRITES) {
         provenance.writes.push({
           id: target.id,
-          path: `/${entry.path.join("/")}`,
+          // RFC 6901 escaping, so a consumer can round-trip the pointer to
+          // the exact schema-entry segments even when a property name
+          // contains "/" or "~" (parsePointer is the inverse). Deliberately
+          // NOT logicalPathToPointer: entry.path is already value-relative,
+          // and its canonicalization would strip a root property literally
+          // named "value".
+          path: encodePointer(entry.path),
           boundSource,
           prefixGatedReads: gating.length,
           txGlobalGatedReads,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2549,6 +2549,14 @@ type WritePrefixBounds = {
     },
     path: readonly string[],
   ): number;
+  /**
+   * Stage-0 instrumentation only (docs/specs/cfc-value-level-provenance.md
+   * §6): whether the transaction logged ANY value-surface write attempt.
+   * False means the order source was absent or empty — every +Infinity
+   * bound then degrades for lack of a clock, not for lack of an
+   * overlapping attempt. Never consulted by enforcement.
+   */
+  sawLoggedAttempts(): boolean;
 };
 
 const buildWritePrefixBounds = (
@@ -2610,8 +2618,103 @@ const buildWritePrefixBounds = (
       }
       return bound === -Infinity ? Infinity : bound;
     },
+    sawLoggedAttempts() {
+      return load().size > 0;
+    },
   };
 };
+
+// ---------------------------------------------------------------------------
+// Stage 0 of the value-level-provenance design
+// (docs/specs/cfc-value-level-provenance.md §6, SC-24): per-prepare
+// precision counters measuring how much the shipped D4 prefix narrows the
+// gated-read set versus the pre-D4 transaction-global gate, before any span
+// machinery exists. Measurement only: nothing here feeds an enforcement
+// decision, the summary is collected exclusively when a hook consumes it,
+// and the hook-absent path pays one presence check.
+
+/** How a protected write's activity-clock bound was obtained. */
+export type CfcPrefixBoundSource =
+  /** A logged overlapping write attempt — the prefix engaged. */
+  | "real"
+  /**
+   * +Infinity fallback: the transaction logged write attempts, but none
+   * overlapped this path (e.g. the entry was made applicable by an
+   * attempted-but-unapplied write). Transaction-global gating for this
+   * write.
+   */
+  | "infinityFallback"
+  /**
+   * The transaction logged no ordered write attempt at all — a backend
+   * without the activity clock, or a transaction whose only overlapping
+   * writes were never applied. Every bound degrades to +Infinity.
+   */
+  | "clockLess";
+
+/** Per-protected-write detail row of a CfcPrefixProvenanceSummary. */
+export type CfcPrefixProvenanceWrite = {
+  /** Document id of the protected write's target. */
+  id: string;
+  /** Protected schema-entry path, pointer-style (e.g. "/out"). */
+  path: string;
+  boundSource: CfcPrefixBoundSource;
+  /** Gated reads within this write's D4 prefix (post-S7-exemption). */
+  prefixGatedReads: number;
+  /** What the pre-D4 transaction-global gate would have counted. */
+  txGlobalGatedReads: number;
+  /** Provenance-only reads within the prefix the S7 exemption excluded. */
+  s7ExemptionFires: number;
+};
+
+/**
+ * Per-prepare D4 precision summary, emitted at most once per
+ * prepareBoundaryCommit — and only when at least one protected write
+ * (a schema entry with requiredIntegrity or maxConfidentiality applying to
+ * an attempted write) was measured.
+ */
+export type CfcPrefixProvenanceSummary = {
+  /** Protected writes measured (may exceed writes.length — see the cap). */
+  protectedWrites: number;
+  /** Sum of per-write prefix-gated read counts. */
+  prefixGatedReads: number;
+  /** Sum of per-write pre-D4 transaction-global gated-read counts. */
+  txGlobalGatedReads: number;
+  /** Bound-source classification counts across protected writes. */
+  boundSources: {
+    real: number;
+    infinityFallback: number;
+    clockLess: number;
+  };
+  /** Total S7 provenance-only exemption fires within prefixes. */
+  s7ExemptionFires: number;
+  /**
+   * Non-internal read activities without an activity-clock position,
+   * treated at -Infinity (joining every prefix). Deliberate -Infinity
+   * trigger reads are not counted. Same read set for every protected
+   * write, so this is per-prepare, not per-write.
+   */
+  clockLessReads: number;
+  /** Per-write detail, capped at CFC_PREFIX_PROVENANCE_MAX_WRITES. */
+  writes: CfcPrefixProvenanceWrite[];
+};
+
+/** Cap on the per-write detail list in a CfcPrefixProvenanceSummary. */
+export const CFC_PREFIX_PROVENANCE_MAX_WRITES = 16;
+
+/** Optional measurement hooks threaded into prepareBoundaryCommit. */
+export type CfcPrepareInstrumentation = {
+  onPrefixProvenance?: (summary: CfcPrefixProvenanceSummary) => void;
+};
+
+const createPrefixProvenanceSummary = (): CfcPrefixProvenanceSummary => ({
+  protectedWrites: 0,
+  prefixGatedReads: 0,
+  txGlobalGatedReads: 0,
+  boundSources: { real: 0, infinityFallback: 0, clockLess: 0 },
+  s7ExemptionFires: 0,
+  clockLessReads: 0,
+  writes: [],
+});
 
 // Structural-link provenance atoms the runtime mints when a value is
 // dereferenced / fetched. They describe HOW a value was obtained, never an
@@ -2694,6 +2797,10 @@ const verifyInputRequirements = (
   // the per-path last-overlapping-write bounds each entry's input checks
   // quantify under.
   prefixBounds: WritePrefixBounds,
+  // Stage-0 precision counters (docs/specs/cfc-value-level-provenance.md §6),
+  // accumulated across the boundary pass. undefined — the default, whenever
+  // no onPrefixProvenance hook is installed — skips all measurement.
+  provenance?: CfcPrefixProvenanceSummary,
 ): string | undefined => {
   // The labeled reads the per-entry checks below quantify over, each carrying
   // its activity-clock position. Distinct from the egress side's consumed set
@@ -2706,15 +2813,24 @@ const verifyInputRequirements = (
   //
   // Provenance-only reads are NOT filtered here (unlike before D4): the S7
   // exemption is applied per entry, inside that entry's prefix.
+  // Stage-0 measurement: read activities lacking a clock position (counted
+  // below only while a hook collects; the enforcement path pays a
+  // short-circuited presence check per read, nothing else).
+  let clockLessReads = 0;
   const gatedReads = [
     ...[...(tx.getReadActivities?.() ?? [])].filter((read) =>
       !isInternalVerifierRead(read.meta)
-    ).map((read) => ({
-      ...read,
-      // A read without a clock position (journal-less backend) is treated as
-      // preceding every write: it joins every prefix — conservative.
-      journalIndex: read.journalIndex ?? -Infinity,
-    })),
+    ).map((read) => {
+      if (provenance !== undefined && read.journalIndex === undefined) {
+        clockLessReads += 1;
+      }
+      return {
+        ...read,
+        // A read without a clock position (journal-less backend) is treated
+        // as preceding every write: it joins every prefix — conservative.
+        journalIndex: read.journalIndex ?? -Infinity,
+      };
+    }),
     // §8.9.2 / SC-3 (H5): the trigger reads join the gate when enabled — a
     // handler scheduled by a labeled write must satisfy requiredIntegrity even
     // if its branch never re-reads that write. Empty when the flag is off.
@@ -2749,6 +2865,19 @@ const verifyInputRequirements = (
     // membership.
     hasLabelValues(read.label)
   );
+
+  // Stage-0 measurement: the pre-D4 comparison baseline. Before D4 the gate
+  // quantified over every labeled read with the S7 provenance-only exemption
+  // applied transaction-globally — so the baseline is the label filter
+  // without the prefix condition. The gate-visible read set is the same on
+  // every call within one prepare, hence assignment (not accumulation) for
+  // the per-prepare clock-less count.
+  const txGlobalGatedReads = provenance === undefined ? 0 : gatedReads
+    .filter((read) => !isProvenanceOnlyConsumedLabel(read.label!))
+    .length;
+  if (provenance !== undefined) {
+    provenance.clockLessReads = clockLessReads;
+  }
 
   for (const entry of walkIfcSchema(schema)) {
     if (
@@ -2802,6 +2931,8 @@ const verifyInputRequirements = (
     }
     const requiredIntegrity = ifc?.requiredIntegrity ?? [];
     const maxConfidentiality = ifc?.maxConfidentiality;
+    const protectedEntry = requiredIntegrity.length > 0 ||
+      maxConfidentiality !== undefined;
     // D4: quantify this entry's input checks over its own read prefix —
     // labeled reads whose clock position precedes the last write attempt
     // overlapping this path. A read at-or-after that write provably did not
@@ -2809,8 +2940,7 @@ const verifyInputRequirements = (
     // longer gates this entry. A +Infinity bound (order unknown for this
     // path) keeps every read: transaction-global, the pre-D4 conservative
     // behavior.
-    const bound = requiredIntegrity.length > 0 ||
-        maxConfidentiality !== undefined
+    const bound = protectedEntry
       ? prefixBounds.boundFor(target, entry.path)
       : -Infinity;
     // Provenance-only reads (link/origin/current-principal, no
@@ -2823,6 +2953,40 @@ const verifyInputRequirements = (
       read.journalIndex < bound &&
       !isProvenanceOnlyConsumedLabel(read.label!)
     );
+    // Stage-0 precision counters (cfc-value-level-provenance.md §6): what
+    // the shipped prefix did for THIS protected write versus the pre-D4
+    // transaction-global quantification. Recorded before the entry's own
+    // checks so a rejecting write is still measured; nothing below reads
+    // these values.
+    if (provenance !== undefined && protectedEntry) {
+      let inPrefix = 0;
+      for (const read of gatedReads) {
+        if (read.journalIndex < bound) inPrefix += 1;
+      }
+      // Within-prefix reads excluded as provenance-only structural plumbing
+      // — exactly where the S7 exemption still fires under D4.
+      const s7ExemptionFires = inPrefix - gating.length;
+      const boundSource: CfcPrefixBoundSource = bound !== Infinity
+        ? "real"
+        : prefixBounds.sawLoggedAttempts()
+        ? "infinityFallback"
+        : "clockLess";
+      provenance.protectedWrites += 1;
+      provenance.prefixGatedReads += gating.length;
+      provenance.txGlobalGatedReads += txGlobalGatedReads;
+      provenance.boundSources[boundSource] += 1;
+      provenance.s7ExemptionFires += s7ExemptionFires;
+      if (provenance.writes.length < CFC_PREFIX_PROVENANCE_MAX_WRITES) {
+        provenance.writes.push({
+          id: target.id,
+          path: `/${entry.path.join("/")}`,
+          boundSource,
+          prefixGatedReads: gating.length,
+          txGlobalGatedReads,
+          s7ExemptionFires,
+        });
+      }
+    }
     // An empty gating set passes here — but it is NOT the pre-D4 vacuous
     // pass (audit #14, "a requiredIntegrity gate whose consumed set is empty
     // passes"). The prefix makes the empty case a sound DELEGATION: with no
@@ -3897,6 +4061,7 @@ const verifyWriteFloor = (
 
 export const prepareBoundaryCommit = (
   tx: IExtendedStorageTransaction,
+  instrumentation?: CfcPrepareInstrumentation,
 ): string[] => {
   const reasons: string[] = [];
   const state = tx.getCfcState();
@@ -3906,6 +4071,12 @@ export const prepareBoundaryCommit = (
   // verifyInputRequirements); the egress ceiling deliberately does not
   // (collectConsumedLabel stays transaction-global).
   const prefixBounds = buildWritePrefixBounds(tx);
+  // Stage-0 precision counters (cfc-value-level-provenance.md §6): the
+  // summary is allocated only when a hook will consume it — the default
+  // path pays this one presence check.
+  const prefixProvenance = instrumentation?.onPrefixProvenance !== undefined
+    ? createPrefixProvenanceSummary()
+    : undefined;
   // A write to a document's ["cfc"] label-map path made outside the runtime's
   // privileged persistence scope forges the metadata that drives CFC derivation
   // for other writes (audit S18). Each was recorded at the extended-tx write
@@ -4125,6 +4296,7 @@ export const prepareBoundaryCommit = (
       target,
       (path) => identityForSchemaPath(writeAuthorIdentities.get(key), path),
       prefixBounds,
+      prefixProvenance,
     );
     // A verification failure records a reason (which rejects the whole commit
     // in enforcing modes) and skips persisting this target's declared label.
@@ -4846,5 +5018,11 @@ export const prepareBoundaryCommit = (
     }, metadata as unknown as FabricValue);
   }
   reasons.push(...verifySinkRequestCeilings(tx));
+  // Stage-0 summary: at most once per prepare, and only when a protected
+  // write was measured — a prepare that gated nothing has no precision to
+  // report.
+  if (prefixProvenance !== undefined && prefixProvenance.protectedWrites > 0) {
+    instrumentation!.onPrefixProvenance!(prefixProvenance);
+  }
   return reasons;
 };

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -54,6 +54,8 @@
  * | cfcTriggerReadGating       | core-default (off) — same                        |
  * | cfcPolicyEvaluation        | core-default (off) — same                        |
  * | cfcPolicyRecords           | core-default (none declared) — same              |
+ * | cfcPrefixProvenanceStats   | core-default (off) — measurement opt-in, per     |
+ * |                            | deployment (value-level provenance Stage 0)      |
  * | cfcTrustConfig             | core-default (none declared) — same              |
  * | cfcSinkMaxConfidentiality  | core-default (none declared) — same              |
  * | patternEnvironment         | pinned from apiUrl in productionServer /         |
@@ -128,6 +130,7 @@ export const RUNTIME_OPTION_KEYS = [
   "cfcTriggerReadGating",
   "cfcPolicyEvaluation",
   "cfcPolicyRecords",
+  "cfcPrefixProvenanceStats",
   "cfcTrustConfig",
   "cfcSinkMaxConfidentiality",
   "trustSnapshotProvider",

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -76,6 +76,7 @@ import {
   type CfcLabelView,
   type CfcPolicyEvaluationMode,
   type CfcPolicyRecordInput,
+  type CfcPrefixProvenanceSummary,
   type CfcTriggerReadGating,
   type CfcTrustConfig,
   type CfcTrustConfigInput,
@@ -331,6 +332,17 @@ export interface RuntimeOptions {
    * rewritten label and fails closed on fuel exhaustion.
    */
   cfcPolicyEvaluation?: CfcPolicyEvaluationMode;
+  /**
+   * Per-prepare D4 write-prefix precision counters (value-level provenance
+   * Stage 0 — docs/specs/cfc-value-level-provenance.md §6, SC-24). Defaults
+   * to `false`: the prepare gate then skips all measurement, paying a single
+   * presence check. When `true`, each prepared transaction with at least one
+   * protected write aggregates prefix-vs-transaction-global gated-read
+   * counts, bound-source classifications and S7-exemption fires into
+   * `getCfcStats()`. Measurement only — enforcement decisions are
+   * byte-identical either way.
+   */
+  cfcPrefixProvenanceStats?: boolean;
   /** Per-sink confidentiality ceilings for the sink-request egress gate. A sink
    *  absent from the map is ungated; a declared ceiling rejects (or, in observe
    *  mode, flags) a request carrying confidentiality outside it. Defaults to
@@ -392,6 +404,28 @@ export interface CfcRuntimeStats {
   cfcOutboxFlushes: number;
   sinkDedupHits: number;
   sinkReleaseRejects: number;
+  // Stage-0 D4 write-prefix precision counters
+  // (docs/specs/cfc-value-level-provenance.md §6, SC-24). All zero unless
+  // `cfcPrefixProvenanceStats` is enabled. Aggregated over the per-prepare
+  // summaries; the per-write detail lists are not retained here.
+  /** Prepares that measured at least one protected write. */
+  prefixProvenanceSummaries: number;
+  /** Protected writes measured (requiredIntegrity / maxConfidentiality). */
+  prefixProtectedWrites: number;
+  /** Gated reads under the shipped D4 per-write prefix. */
+  prefixGatedReads: number;
+  /** What the pre-D4 transaction-global gate would have counted. */
+  prefixTxGlobalGatedReads: number;
+  /** Writes bounded by a logged overlapping attempt (prefix engaged). */
+  prefixBoundReal: number;
+  /** Writes on the +Infinity fallback (no logged overlapping attempt). */
+  prefixBoundInfinityFallback: number;
+  /** Writes with no ordered write-attempt evidence at all (clock-less). */
+  prefixBoundClockLess: number;
+  /** S7 provenance-only exemption fires within prefixes. */
+  prefixS7ExemptionFires: number;
+  /** Read activities without a clock position (treated at -Infinity). */
+  prefixClockLessReads: number;
 }
 
 const initialCfcRuntimeStats = (): CfcRuntimeStats => ({
@@ -402,6 +436,15 @@ const initialCfcRuntimeStats = (): CfcRuntimeStats => ({
   cfcOutboxFlushes: 0,
   sinkDedupHits: 0,
   sinkReleaseRejects: 0,
+  prefixProvenanceSummaries: 0,
+  prefixProtectedWrites: 0,
+  prefixGatedReads: 0,
+  prefixTxGlobalGatedReads: 0,
+  prefixBoundReal: 0,
+  prefixBoundInfinityFallback: 0,
+  prefixBoundClockLess: 0,
+  prefixS7ExemptionFires: 0,
+  prefixClockLessReads: 0,
 });
 
 /**
@@ -488,6 +531,7 @@ export class Runtime {
   readonly cfcWriteFloor: CfcWriteFloorMode;
   readonly cfcTriggerReadGating: CfcTriggerReadGating;
   readonly cfcPolicyEvaluation: CfcPolicyEvaluationMode;
+  readonly cfcPrefixProvenanceStats: boolean;
   readonly cfcSinkMaxConfidentiality: SinkMaxConfidentiality;
   /** Frozen deployment policy snapshot; undefined = no policies configured. */
   readonly cfcPolicySnapshot: PolicySnapshot | undefined;
@@ -638,6 +682,7 @@ export class Runtime {
     this.cfcWriteFloor = options.cfcWriteFloor ?? "off";
     this.cfcTriggerReadGating = options.cfcTriggerReadGating ?? false;
     this.cfcPolicyEvaluation = options.cfcPolicyEvaluation ?? "off";
+    this.cfcPrefixProvenanceStats = options.cfcPrefixProvenanceStats ?? false;
     // Deep-freeze: the ceiling is CFC enforcement config, so a caller must not
     // be able to mutate it (per-sink array or the map) after construction to
     // change what egresses are allowed (review on #3993).
@@ -891,6 +936,26 @@ export class Runtime {
       onSinkReleaseReject: () => {
         this.cfcStats.sinkReleaseRejects += 1;
       },
+      // Stage-0 D4 precision counters: installed only when the deployment
+      // opted in, so the default prepare path skips all measurement.
+      ...(this.cfcPrefixProvenanceStats
+        ? {
+          onPrefixProvenance: (summary: CfcPrefixProvenanceSummary) => {
+            this.cfcStats.prefixProvenanceSummaries += 1;
+            this.cfcStats.prefixProtectedWrites += summary.protectedWrites;
+            this.cfcStats.prefixGatedReads += summary.prefixGatedReads;
+            this.cfcStats.prefixTxGlobalGatedReads +=
+              summary.txGlobalGatedReads;
+            this.cfcStats.prefixBoundReal += summary.boundSources.real;
+            this.cfcStats.prefixBoundInfinityFallback +=
+              summary.boundSources.infinityFallback;
+            this.cfcStats.prefixBoundClockLess +=
+              summary.boundSources.clockLess;
+            this.cfcStats.prefixS7ExemptionFires += summary.s7ExemptionFires;
+            this.cfcStats.prefixClockLessReads += summary.clockLessReads;
+          },
+        }
+        : {}),
     });
     wrapped.setCfcEnforcementMode(this.cfcEnforcementMode);
     wrapped.setCfcFlowLabelsMode(this.cfcFlowLabels);

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -913,10 +913,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         this,
         // Stage-0 precision counters: threaded through only when the hook is
         // installed, so the gate skips all measurement (and the summary
-        // allocation) otherwise.
+        // allocation) otherwise. The non-null assertion restates the
+        // presence check above — the hooks object is fixed at construction.
         this.cfcInstrumentation.onPrefixProvenance === undefined ? undefined : {
           onPrefixProvenance: (summary) =>
-            this.cfcInstrumentation.onPrefixProvenance?.(summary),
+            this.cfcInstrumentation.onPrefixProvenance!(summary),
         },
       )
     );

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -67,6 +67,7 @@ import {
   cfcEnforcementStrictness,
   type CfcFlowLabelsMode,
   type CfcPolicyEvaluationMode,
+  type CfcPrefixProvenanceSummary,
   type CfcTriggerReadGating,
   type CfcTrustConfig,
   type CfcTxState,
@@ -112,6 +113,10 @@ type CfcInstrumentationHooks = {
   onSinkReleaseReject?(
     info: { sink: string; effectId: string; detail: string },
   ): void;
+  // Stage-0 D4 precision counters (cfc-value-level-provenance.md §6, SC-24):
+  // one summary per prepared transaction that measured a protected write.
+  // When absent — the default — the prepare gate skips all measurement.
+  onPrefixProvenance?(summary: CfcPrefixProvenanceSummary): void;
 };
 
 // Read-only view of the transaction's CFC state, returned by getCfcState().
@@ -904,7 +909,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // code (audit S18). The runtime's own persistence is the one legitimate
     // writer, so it alone is exempt.
     const reasons = this.#runPrivilegedSystemWrite(() =>
-      prepareBoundaryCommit(this)
+      prepareBoundaryCommit(
+        this,
+        // Stage-0 precision counters: threaded through only when the hook is
+        // installed, so the gate skips all measurement (and the summary
+        // allocation) otherwise.
+        this.cfcInstrumentation.onPrefixProvenance === undefined ? undefined : {
+          onPrefixProvenance: (summary) =>
+            this.cfcInstrumentation.onPrefixProvenance?.(summary),
+        },
+      )
     );
     if (reasons.length > 0) {
       this.cfcInstrumentation.onPrepareReject?.(reasons);

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -1,0 +1,493 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type {
+  IExtendedStorageTransaction,
+  IReadActivity,
+} from "../src/storage/interface.ts";
+import {
+  CFC_PREFIX_PROVENANCE_MAX_WRITES,
+  type CfcPrefixProvenanceSummary,
+  prepareBoundaryCommit,
+} from "../src/cfc/mod.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-prefix-provenance");
+
+// Stage 0 of the value-level-provenance design
+// (docs/specs/cfc-value-level-provenance.md §6, SC-24): per-prepare precision
+// counters measuring how much the shipped D4 write prefix
+// (docs/specs/cfc-write-prefix-provenance.md) narrows the gated-read set
+// versus the pre-D4 transaction-global gate. Measurement only — every
+// scenario here pairs its counter assertions with the UNCHANGED enforcement
+// outcome, and the hook-absent default is pinned byte-identical (all-zero
+// stats, same decision).
+
+const FLOOR_ATOM = "prefix-endorsed";
+const OTHER_ATOM = "prefix-unrelated";
+
+const SINK_SCHEMA = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { requiredIntegrity: [FLOOR_ATOM] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const makeRuntime = (options: {
+  storageManager: ReturnType<typeof StorageManager.emulate>;
+  cfcPrefixProvenanceStats?: boolean;
+}): Runtime =>
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager: options.storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    ...(options.cfcPrefixProvenanceStats !== undefined
+      ? { cfcPrefixProvenanceStats: options.cfcPrefixProvenanceStats }
+      : {}),
+  });
+
+// Seed a doc's stored CFC metadata directly via an ungated path-[]
+// full-document write (how the runtime persists it), so a later read picks
+// up the given label.
+const seedLabeledDoc = async (
+  runtime: Runtime,
+  id: string,
+  value: unknown,
+  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+): Promise<void> => {
+  const seed = runtime.edit();
+  const cell = runtime.getCell(signer.did(), id, undefined, seed);
+  const docId = cell.getAsNormalizedFullLink().id as URI;
+  seed.writeOrThrow({
+    space: signer.did(),
+    id: docId,
+    type: "application/json",
+    path: [],
+  }, {
+    value,
+    cfc: {
+      version: 1,
+      schemaHash: `seed-${id}`,
+      labelMap: { version: 1, entries: [{ path: [], label }] },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+const seedPlainDoc = async (
+  runtime: Runtime,
+  id: string,
+  value: unknown,
+): Promise<void> => {
+  const seed = runtime.edit();
+  const cell = runtime.getCell(signer.did(), id, undefined, seed);
+  const docId = cell.getAsNormalizedFullLink().id as URI;
+  seed.writeOrThrow({
+    space: signer.did(),
+    id: docId,
+    type: "application/json",
+    path: [],
+  }, { value });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+describe("CFC prefix-provenance precision counters (Stage 0, doc §6)", () => {
+  it("a labeled read past the last overlapping write reports prefix-gated < transaction-global", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcPrefixProvenanceStats: true,
+    });
+    try {
+      await seedLabeledDoc(runtime, "d4-stats-endorsed", "endorsed", {
+        integrity: [FLOOR_ATOM],
+      });
+      await seedLabeledDoc(runtime, "d4-stats-low", "tainted", {
+        integrity: [OTHER_ATOM],
+      });
+      await seedPlainDoc(runtime, "d4-stats-sink", { out: "seed" });
+
+      const tx = runtime.edit();
+      // journal: read E (endorsed) | write out = "a" | read R (low). R sits
+      // past the last write overlapping /out, so the D4 prefix excludes it —
+      // the transaction-global gate would have counted it. The commit
+      // outcome is the shipped one (accepted); the counters just measure
+      // the narrowing.
+      runtime.getCell(signer.did(), "d4-stats-endorsed", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "d4-stats-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "a" });
+      runtime.getCell(signer.did(), "d4-stats-low", undefined, tx).get();
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      const stats = runtime.getCfcStats();
+      expect(stats.prefixProvenanceSummaries).toBe(1);
+      expect(stats.prefixProtectedWrites).toBe(1);
+      // Counts are per gate-visible read ACTIVITY (a doc .get() can record
+      // several), so pin the relation, not traverse's read granularity: the
+      // prefix kept the endorsed doc's reads and dropped the low doc's.
+      expect(stats.prefixGatedReads).toBeGreaterThan(0);
+      expect(stats.prefixGatedReads).toBeLessThan(
+        stats.prefixTxGlobalGatedReads,
+      );
+      expect(stats.prefixBoundReal).toBe(1);
+      expect(stats.prefixBoundInfinityFallback).toBe(0);
+      expect(stats.prefixBoundClockLess).toBe(0);
+      expect(stats.prefixS7ExemptionFires).toBe(0);
+      expect(stats.prefixClockLessReads).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a protected path with no logged overlapping attempt reports the +Infinity fallback", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcPrefixProvenanceStats: true,
+    });
+    try {
+      await seedLabeledDoc(runtime, "d4-inf-endorsed", "endorsed", {
+        integrity: [FLOOR_ATOM],
+      });
+      await seedPlainDoc(runtime, "d4-inf-sink", { out: "same" });
+      await seedPlainDoc(runtime, "d4-inf-other", { n: 0 });
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "d4-inf-endorsed", undefined, tx).get();
+      // Value-equal write: the diff applies nothing, so no write attempt is
+      // logged for the sink — but the attempted-write-marked read makes the
+      // protected entry applicable (the doc §1 "attempted-but-unapplied"
+      // shape). boundFor degrades to +Infinity for /out while the log stays
+      // non-empty (the other doc's applied write), so the bound source is
+      // the +Infinity fallback, not clock-less.
+      const sink = runtime.getCell(
+        signer.did(),
+        "d4-inf-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "same" });
+      runtime.getCell(signer.did(), "d4-inf-other", undefined, tx).set({
+        n: 1,
+      });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      const stats = runtime.getCfcStats();
+      expect(stats.prefixProvenanceSummaries).toBe(1);
+      expect(stats.prefixProtectedWrites).toBe(1);
+      expect(stats.prefixBoundReal).toBe(0);
+      expect(stats.prefixBoundInfinityFallback).toBe(1);
+      expect(stats.prefixBoundClockLess).toBe(0);
+      // +Infinity means transaction-global for this write: no narrowing.
+      expect(stats.prefixGatedReads).toBe(stats.prefixTxGlobalGatedReads);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a provenance-only read within the prefix increments the S7 exemption counter", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcPrefixProvenanceStats: true,
+    });
+    try {
+      // The ported group-chat shape: a structural provenance lookup (link
+      // reference + current-principal claim) in the protected write's
+      // prefix. Only the S7 exemption keeps it out of the gate — exactly
+      // the event the counter measures.
+      await seedLabeledDoc(runtime, "d4-s7-lookup", "lookup", {
+        integrity: [
+          { kind: "represents-principal", subject: signer.did() },
+          { type: "https://commonfabric.org/cfc/atom/LinkReference" },
+        ],
+      });
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "d4-s7-lookup", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "d4-s7-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "granted" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      const stats = runtime.getCfcStats();
+      expect(stats.prefixProvenanceSummaries).toBe(1);
+      expect(stats.prefixProtectedWrites).toBe(1);
+      // At least one per gate-visible read activity of the lookup (a .get()
+      // can record several — the exact count is traverse granularity).
+      expect(stats.prefixS7ExemptionFires).toBeGreaterThanOrEqual(1);
+      // The provenance-only reads are exempt on BOTH sides of the comparison
+      // (the pre-D4 gate filtered them transaction-globally) — exact zeros,
+      // independent of read granularity.
+      expect(stats.prefixGatedReads).toBe(0);
+      expect(stats.prefixTxGlobalGatedReads).toBe(0);
+      expect(stats.prefixBoundReal).toBe(1);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("hook absent: no summary, and the enforcement outcome is identical to hook present", async () => {
+    // The §3 re-attempt rejection from the D4 suite, run twice: counters off
+    // (the default) and on. Same reason either way — measurement must be
+    // byte-identical on decisions — and the disabled run reports no summary.
+    const runScenario = async (
+      cfcPrefixProvenanceStats: boolean,
+    ): Promise<
+      { message: string; stats: ReturnType<Runtime["getCfcStats"]> }
+    > => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        ...(cfcPrefixProvenanceStats ? { cfcPrefixProvenanceStats: true } : {}),
+      });
+      try {
+        await seedLabeledDoc(runtime, "d4-pair-endorsed", "endorsed", {
+          integrity: [FLOOR_ATOM],
+        });
+        await seedLabeledDoc(runtime, "d4-pair-low", "tainted", {
+          integrity: [OTHER_ATOM],
+        });
+        await seedPlainDoc(runtime, "d4-pair-sink", { out: "seed" });
+
+        const tx = runtime.edit();
+        runtime.getCell(signer.did(), "d4-pair-endorsed", undefined, tx)
+          .get();
+        const sink = runtime.getCell(
+          signer.did(),
+          "d4-pair-sink",
+          SINK_SCHEMA,
+          tx,
+        );
+        sink.set({ out: "a" });
+        runtime.getCell(signer.did(), "d4-pair-low", undefined, tx).get();
+        sink.set({ out: "b" });
+
+        tx.prepareCfc();
+        const result = await tx.commit();
+        return {
+          message: String((result.error as Error | undefined)?.message),
+          stats: runtime.getCfcStats(),
+        };
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    const off = await runScenario(false);
+    const on = await runScenario(true);
+
+    expect(off.message).toContain("requiredIntegrity failed");
+    expect(on.message).toBe(off.message);
+
+    // Hook absent: nothing collected, nothing emitted.
+    expect(off.stats.prefixProvenanceSummaries).toBe(0);
+    expect(off.stats.prefixProtectedWrites).toBe(0);
+    expect(off.stats.prefixGatedReads).toBe(0);
+    expect(off.stats.prefixTxGlobalGatedReads).toBe(0);
+    expect(off.stats.prefixBoundReal).toBe(0);
+    expect(off.stats.prefixS7ExemptionFires).toBe(0);
+
+    // Hook present: the rejecting write was still measured (both labeled
+    // docs' reads precede the re-attempt, so the prefix equals
+    // transaction-global here).
+    expect(on.stats.prefixProvenanceSummaries).toBe(1);
+    expect(on.stats.prefixProtectedWrites).toBe(1);
+    expect(on.stats.prefixGatedReads).toBeGreaterThan(0);
+    expect(on.stats.prefixGatedReads).toBe(on.stats.prefixTxGlobalGatedReads);
+    expect(on.stats.prefixBoundReal).toBe(1);
+  });
+
+  it("hook present but no protected writes: no summary is emitted", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({
+      storageManager,
+      cfcPrefixProvenanceStats: true,
+    });
+    try {
+      await seedLabeledDoc(runtime, "d4-none-labeled", "data", {
+        integrity: [OTHER_ATOM],
+      });
+
+      const tx = runtime.edit();
+      // A labeled read plus an UNPROTECTED write: the gate walks no entry
+      // with requiredIntegrity/maxConfidentiality, so nothing is measured
+      // and the per-prepare summary must not fire.
+      runtime.getCell(signer.did(), "d4-none-labeled", undefined, tx).get();
+      runtime.getCell(signer.did(), "d4-none-sink", undefined, tx).set({
+        out: "plain",
+      });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      const stats = runtime.getCfcStats();
+      expect(stats.prefixProvenanceSummaries).toBe(0);
+      expect(stats.prefixProtectedWrites).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});
+
+describe("CFC prefix-provenance summary (direct gate probes)", () => {
+  // Delegating view that erases every order source the D4 bound consumes:
+  // read activities lose their activity-clock stamp (they degrade to
+  // -Infinity, joining every prefix) and the ordered write-attempt log is
+  // empty. This is the clock-less backend of WritePrefixBounds.boundFor's
+  // doc comment, which the V2 harness cannot otherwise produce.
+  const clockLessView = (
+    tx: IExtendedStorageTransaction,
+  ): IExtendedStorageTransaction =>
+    new Proxy(tx, {
+      get(target, prop) {
+        if (prop === "getReadActivities") {
+          return (): IReadActivity[] =>
+            [...target.getReadActivities?.() ?? []].map((activity) => {
+              const { journalIndex: _journalIndex, ...rest } = activity;
+              return rest as IReadActivity;
+            });
+        }
+        if (prop === "getWriteAttemptLog") {
+          return () => [];
+        }
+        const member = Reflect.get(target, prop, target);
+        return typeof member === "function" ? member.bind(target) : member;
+      },
+    });
+
+  it("clock-less order sources classify as clockLess and count the -Infinity reads", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager });
+    try {
+      await seedLabeledDoc(runtime, "d4-clockless-endorsed", "endorsed", {
+        integrity: [FLOOR_ATOM],
+      });
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "d4-clockless-endorsed", undefined, tx)
+        .get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "d4-clockless-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "a" });
+
+      const summaries: CfcPrefixProvenanceSummary[] = [];
+      const reasons = prepareBoundaryCommit(clockLessView(tx), {
+        onPrefixProvenance: (summary) => summaries.push(summary),
+      });
+      expect(reasons).toEqual([]);
+      expect(summaries.length).toBe(1);
+      const summary = summaries[0];
+      expect(summary.protectedWrites).toBe(1);
+      expect(summary.boundSources).toEqual({
+        real: 0,
+        infinityFallback: 0,
+        clockLess: 1,
+      });
+      // Every gate-visible read activity lost its clock position, so the
+      // clock-less count covers at least the gated (labeled) ones.
+      expect(summary.clockLessReads).toBeGreaterThanOrEqual(
+        summary.prefixGatedReads,
+      );
+      expect(summary.clockLessReads).toBeGreaterThanOrEqual(1);
+      // Order unknown = transaction-global gating: no narrowing to report.
+      expect(summary.prefixGatedReads).toBeGreaterThan(0);
+      expect(summary.prefixGatedReads).toBe(summary.txGlobalGatedReads);
+      expect(summary.writes.length).toBe(1);
+      expect(summary.writes[0].path).toBe("/out");
+      expect(summary.writes[0].boundSource).toBe("clockLess");
+
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("the per-write list is capped while the totals keep counting", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager });
+    try {
+      await seedLabeledDoc(runtime, "d4-cap-endorsed", "endorsed", {
+        integrity: [FLOOR_ATOM],
+      });
+      const width = CFC_PREFIX_PROVENANCE_MAX_WRITES + 1;
+      const wideSchema = {
+        type: "object",
+        properties: Object.fromEntries(
+          Array.from({ length: width }, (_, i) => [
+            `f${i}`,
+            { type: "string", ifc: { requiredIntegrity: [FLOOR_ATOM] } },
+          ]),
+        ),
+      } as JSONSchema;
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "d4-cap-endorsed", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "d4-cap-sink",
+        wideSchema,
+        tx,
+      );
+      sink.set(Object.fromEntries(
+        Array.from({ length: width }, (_, i) => [`f${i}`, `v${i}`]),
+      ));
+
+      const summaries: CfcPrefixProvenanceSummary[] = [];
+      const reasons = prepareBoundaryCommit(tx, {
+        onPrefixProvenance: (summary) => summaries.push(summary),
+      });
+      expect(reasons).toEqual([]);
+      expect(summaries.length).toBe(1);
+      const summary = summaries[0];
+      expect(summary.protectedWrites).toBe(width);
+      expect(summary.writes.length).toBe(CFC_PREFIX_PROVENANCE_MAX_WRITES);
+      expect(summary.boundSources.real).toBe(width);
+      // Totals aggregate past the cap: every protected write gates the same
+      // endorsed read activities, so the total is width times the per-write
+      // count (whatever traverse's read granularity makes that).
+      expect(summary.writes[0].prefixGatedReads).toBeGreaterThan(0);
+      expect(summary.prefixGatedReads).toBe(
+        width * summary.writes[0].prefixGatedReads,
+      );
+
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -14,6 +14,7 @@ import {
   type CfcPrefixProvenanceSummary,
   prepareBoundaryCommit,
 } from "../src/cfc/mod.ts";
+import { parsePointer } from "../../memory/v2/path.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-prefix-provenance");
 
@@ -483,6 +484,57 @@ describe("CFC prefix-provenance summary (direct gate probes)", () => {
       expect(summary.prefixGatedReads).toBe(
         width * summary.writes[0].prefixGatedReads,
       );
+
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("per-write paths RFC-6901-escape property names containing '/' and '~'", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeRuntime({ storageManager });
+    try {
+      await seedLabeledDoc(runtime, "d4-esc-endorsed", "endorsed", {
+        integrity: [FLOOR_ATOM],
+      });
+      // A raw join would emit "/a/b~c" — indistinguishable from the nested
+      // path ["a", "b~c"]. The summary must escape per RFC 6901 so a
+      // consumer can map writes[].path back to the exact schema entry.
+      const trickyField = "a/b~c";
+      const trickySchema = {
+        type: "object",
+        properties: {
+          [trickyField]: {
+            type: "string",
+            ifc: { requiredIntegrity: [FLOOR_ATOM] },
+          },
+        },
+      } as JSONSchema;
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "d4-esc-endorsed", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "d4-esc-sink",
+        trickySchema,
+        tx,
+      );
+      sink.set({ [trickyField]: "x" });
+
+      const summaries: CfcPrefixProvenanceSummary[] = [];
+      const reasons = prepareBoundaryCommit(tx, {
+        onPrefixProvenance: (summary) => summaries.push(summary),
+      });
+      expect(reasons).toEqual([]);
+      expect(summaries.length).toBe(1);
+      const summary = summaries[0];
+      expect(summary.protectedWrites).toBe(1);
+      expect(summary.writes.length).toBe(1);
+      expect(summary.writes[0].path).toBe("/a~1b~0c");
+      // Round-trip: the pointer decodes to the exact schema-entry segments.
+      expect(parsePointer(summary.writes[0].path)).toEqual([trickyField]);
 
       tx.abort();
     } finally {

--- a/packages/runner/test/cfc-runtime-stats.test.ts
+++ b/packages/runner/test/cfc-runtime-stats.test.ts
@@ -38,6 +38,15 @@ describe("CFC runtime stats", () => {
       cfcOutboxFlushes: 0,
       sinkDedupHits: 0,
       sinkReleaseRejects: 0,
+      prefixProvenanceSummaries: 0,
+      prefixProtectedWrites: 0,
+      prefixGatedReads: 0,
+      prefixTxGlobalGatedReads: 0,
+      prefixBoundReal: 0,
+      prefixBoundInfinityFallback: 0,
+      prefixBoundClockLess: 0,
+      prefixS7ExemptionFires: 0,
+      prefixClockLessReads: 0,
     });
 
     const preparedTx = runtime.edit();
@@ -163,6 +172,18 @@ describe("CFC runtime stats", () => {
       cfcOutboxFlushes: 2,
       sinkDedupHits: 1,
       sinkReleaseRejects: 0,
+      // Stage-0 prefix-provenance counters stay untouched without the
+      // cfcPrefixProvenanceStats opt-in — the hook-absent default collects
+      // nothing even across relevant, rejected, and invalidated prepares.
+      prefixProvenanceSummaries: 0,
+      prefixProtectedWrites: 0,
+      prefixGatedReads: 0,
+      prefixTxGlobalGatedReads: 0,
+      prefixBoundReal: 0,
+      prefixBoundInfinityFallback: 0,
+      prefixBoundClockLess: 0,
+      prefixS7ExemptionFires: 0,
+      prefixClockLessReads: 0,
     });
   });
 });

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -97,6 +97,7 @@ const MINIMAL_TREATMENT: Record<RuntimeOptionKey, MinimalTreatment> = {
   cfcTriggerReadGating: { treat: "absent" },
   cfcPolicyEvaluation: { treat: "absent" },
   cfcPolicyRecords: { treat: "absent" },
+  cfcPrefixProvenanceStats: { treat: "absent" },
   cfcTrustConfig: { treat: "absent" },
   cfcSinkMaxConfidentiality: { treat: "absent" },
   trustSnapshotProvider: { treat: "absent" },


### PR DESCRIPTION
Stage 0 of [`docs/specs/cfc-value-level-provenance.md`](../blob/main/docs/specs/cfc-value-level-provenance.md) §6 ("measure before building"), first bullet: per-prepare precision counters for the shipped D4 write-prefix gate ([`docs/specs/cfc-write-prefix-provenance.md`](../blob/main/docs/specs/cfc-write-prefix-provenance.md)), so a deployment can measure how much the prefix actually narrows versus transaction-global before any span machinery is built. The §6 second bullet (interpreter shadow mode / would-flip logging) is deliberately not here — the reactive interpreter is branch-only.

## What is measured

Per prepared transaction, per **protected write** (a schema entry with `requiredIntegrity` or `maxConfidentiality` that applies to an attempted write), collected inside `verifyInputRequirements`:

- **gated-read counts, prefix vs transaction-global** — the reads that gate the write under the D4 last-overlapping-write prefix, next to what the pre-D4 transaction-global gate would have counted (same S7 provenance-only filter on both sides, so the delta is purely the prefix);
- **bound-source classification** — `real` (a logged overlapping attempt bounded the prefix), `infinityFallback` (`WritePrefixBounds.boundFor` returned `+Infinity` with a non-empty attempt log: no overlapping logged attempt, e.g. an attempted-but-unapplied write made the entry applicable), `clockLess` (no ordered write-attempt evidence in the transaction at all);
- **S7 exemption fires** — provenance-only reads excluded *within* the prefix (a provenance read past the prefix needs no exemption, so this counts exactly the residual §1 case);
- **clock-less reads** — non-internal read activities without a `journalIndex`, treated at `−∞` (joining every prefix); deliberate `−∞` trigger reads are not counted.

The summary (`CfcPrefixProvenanceSummary`) carries totals plus a per-write detail list capped at `CFC_PREFIX_PROVENANCE_MAX_WRITES` (16).

## Wiring

Follows the existing CFC instrumentation pattern end to end:

- `CfcInstrumentationHooks` (`extended-storage-transaction.ts`) gains optional `onPrefixProvenance(summary)`; `prepareCfc()` threads it into `prepareBoundaryCommit(tx, instrumentation?)`, which emits **at most once per prepare**, and only when at least one protected write was measured.
- `RuntimeOptions.cfcPrefixProvenanceStats` (default `false`) installs the hook in `Runtime.edit()` and aggregates totals into `getCfcStats()` (new flat `prefix*` counters). Registered in `runtime-presets.ts` (rides the constructor default; the presets conformance table/test gained the row).

## Zero cost when off, byte-identical decisions always

- Hook absent (the default everywhere): `prepareBoundaryCommit` allocates no summary; the gate's only added work is `provenance !== undefined` presence checks (no allocation, no string building). Enforcement decisions and reason strings are untouched in both modes — the collection block sits after the gating set is computed and nothing downstream reads it.
- The one enforcement-adjacent touch is hoisting the existing `requiredIntegrity.length > 0 || maxConfidentiality !== undefined` expression into a `protectedEntry` const (used by the existing `bound` ternary and the new measurement guard) and adding instrumentation-only `WritePrefixBounds.sawLoggedAttempts()`.

## Verification

- `deno task check` — green (full repo typecheck).
- `cd packages/runner && deno task test` — full runner unit suite green (output below).
- New tests (`packages/runner/test/cfc-prefix-provenance-stats.test.ts`, red-first — they fail to typecheck/assert without the feature):
  - labeled read **after** the last overlapping write → `prefixGatedReads < prefixTxGlobalGatedReads` (commit still accepted, the shipped outcome);
  - value-equal (attempted-but-unapplied) protected write + an applied write elsewhere → `infinityFallback` classification, prefix == transaction-global;
  - provenance-only read within the prefix → S7 exemption counter fires while both gated-read counts stay 0;
  - hook absent vs present on the §3 re-attempt **rejection**: identical error message, all-zero stats when absent, measured when present (plus the existing `cfc-runtime-stats` golden now pins the all-zero prefix fields across relevant/rejected/invalidated prepares without the opt-in);
  - hook present with no protected writes → no summary emitted;
  - direct `prepareBoundaryCommit` probes: a clock-stripped transaction view classifies `clockLess` and counts the `−∞` reads; a 17-protected-entry write caps the per-write list at 16 while totals keep counting.
- The existing D4 suite (`cfc-write-prefix-provenance.test.ts`) passes unchanged.

Full runner unit suite (`cd packages/runner && deno task test`):

```
ok | 817 passed (4256 steps) | 0 failed | 0 ignored (10 steps) (3m23s)
```

New suite at HEAD:

```
CFC prefix-provenance precision counters (Stage 0, doc §6) ...
  a labeled read past the last overlapping write reports prefix-gated < transaction-global ... ok
  a protected path with no logged overlapping attempt reports the +Infinity fallback ... ok
  a provenance-only read within the prefix increments the S7 exemption counter ... ok
  hook absent: no summary, and the enforcement outcome is identical to hook present ... ok
  hook present but no protected writes: no summary is emitted ... ok
CFC prefix-provenance summary (direct gate probes) ...
  clock-less order sources classify as clockLess and count the -Infinity reads ... ok
  the per-write list is capped while the totals keep counting ... ok
(with cfc-write-prefix-provenance.test.ts, cfc-runtime-stats.test.ts and
runtime-presets.test.ts: ok | 6 passed (30 steps) | 0 failed)
```

## Deviations from the design doc (with reasons)

1. **`clockLess` is observed per transaction, not per backend.** The doc's classification names "a backend without the activity clock"; at the gate, `ExtendedStorageTransaction.getWriteAttemptLog()` coalesces "no order source" to an empty log, so backend support is not observable there. The implemented split is: `+Infinity` bound with a non-empty attempt log → `infinityFallback`; with an empty log → `clockLess`. A transaction whose only writes were never applied therefore also lands in `clockLess` — documented on the type; read-side degradation is covered by the separate `clockLessReads` counter either way.
2. **Emission is suppressed when no protected write was measured** ("at most once per prepare" is preserved). Counters compare prefix vs transaction-global gating; a prepare that gated nothing has no precision to report, and unconditional emission would fire on every prepared transaction. Pinned by a test.
3. **`clockLessReads` counts non-internal read activities pre-label-filter** — the literal "reads without `journalIndex` treated at `−∞`" population — rather than only label-bearing ones.
4. **Counters count gate-visible read *activities***, the exact set the gate quantifies over (a single `.get()` can record several); tests pin relations rather than traverse's read granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stage‑0 value‑level provenance (SC‑24): opt‑in precision counters that measure how much the shipped D4 write‑prefix narrows gated reads vs the pre‑D4 transaction‑global gate. Enforcement behavior and messages are unchanged; overhead is near zero when disabled.

- **New Features**
  - Optional per‑prepare `CfcPrefixProvenanceSummary` via `onPrefixProvenance` hook in `prepareBoundaryCommit`; emitted once only when a protected write is measured.
  - Stats: prefix vs tx‑global gated reads, bound source (`real`, `infinityFallback`, `clockLess`), S7 exemptions, per‑prepare `clockLessReads`; per‑write details capped at `CFC_PREFIX_PROVENANCE_MAX_WRITES`.
  - Runtime opt‑in `cfcPrefixProvenanceStats` aggregates into `getCfcStats()` as `prefix*` counters.
  - `WritePrefixBounds.sawLoggedAttempts()` splits `infinityFallback` from `clockLess`.
  - Exported: `CfcPrefixProvenanceSummary`, `CfcPrefixProvenanceWrite`, `CfcPrefixBoundSource`, `CfcPrepareInstrumentation`, `CFC_PREFIX_PROVENANCE_MAX_WRITES`.

- **Bug Fixes**
  - Per‑write `writes[].path` now RFC‑6901‑escaped (root encodes as `""`) to avoid ambiguous pointers; diagnostics remain unchanged.

<sup>Written for commit 5b782e0a14f7e4010d5d7c736c4fb11b1e2f52cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

