### PR TITLE
test(runner): pin sync-under-pending rebase in the v2 replica

### DIFF
--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -1,13 +1,11 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { defer } from "@commonfabric/utils/defer";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
   type EntityDocument,
-  getMemoryProtocolFlags,
 } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
@@ -18,11 +16,11 @@ import type {
 } from "../src/storage/interface.ts";
 import {
   NotificationRecorder,
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
   SingleSessionFactory,
-  TEST_HELLO_SESSION_OPEN,
   TEST_MEMORY_SERVER_AUTH,
   testSessionOpenAuthFactory,
-  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
@@ -30,12 +28,6 @@ import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
 const signer = await Identity.fromPassphrase("memory-v2-reconnect-race");
 const space = signer.did();
 const DOCUMENT_MIME = "application/json" as const;
-const HELLO_OK = {
-  type: "hello.ok",
-  protocol: "memory",
-  flags: getMemoryProtocolFlags(),
-  sessionOpen: TEST_HELLO_SESSION_OPEN,
-} as const;
 
 type TestProvider = IStorageProviderWithReplica & {
   get(uri: URI): EntityDocument | undefined;
@@ -129,59 +121,21 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
   }
 }
 
-class RejectThenSucceedTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
-
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+class RejectThenSucceedTransport extends ScriptedSessionTransport {
+  constructor() {
+    super({
+      name: "reject-then-succeed",
+      sessionId: "session:reject-then-succeed",
+      space,
+    });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
-  }
-
-  async send(payload: string): Promise<void> {
-    const message = decodeMemoryBoundary(payload) as {
-      type: string;
-      requestId?: string;
-      commit?: { localSeq?: number };
-      invocation?: { aud?: unknown; challenge?: unknown };
-    };
-
+  protected override async handle(
+    message: ScriptedTransportMessage,
+  ): Promise<void> {
     switch (message.type) {
-      case "hello":
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          "reject-then-succeed-hello",
-        );
-        this.#respond({
-          ...HELLO_OK,
-          sessionOpen: this.#sessionOpen,
-        });
-        return;
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `reject-then-succeed-open-${++this.#sessionOpenCount}`,
-        );
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: "session:reject-then-succeed",
-            serverSeq: 0,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        return;
       case "session.watch.set":
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -196,20 +150,12 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
           },
         });
         return;
-      case "session.ack":
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: 0,
-          },
-        });
-        return;
       case "transact": {
-        const localSeq = message.commit?.localSeq ?? -1;
+        const commit = message.commit as { localSeq?: number } | undefined;
+        const localSeq = commit?.localSeq ?? -1;
         if (localSeq === 1) {
           await new Promise((resolve) => setTimeout(resolve, 5));
-          this.#respond({
+          this.respond({
             type: "response",
             requestId: message.requestId!,
             error: {
@@ -219,7 +165,7 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
           });
           return;
         }
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -240,15 +186,6 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
     }
-  }
-
-  close(): Promise<void> {
-    this.#closeReceiver();
-    return Promise.resolve();
-  }
-
-  #respond(message: FabricValue): void {
-    this.#receiver(encodeMemoryBoundary(message));
   }
 }
 

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -14,9 +14,9 @@ import type { FabricValue } from "@commonfabric/api";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
   type EntityDocument,
-  getMemoryProtocolFlags,
   type PatchOp,
   resetPersistentSchedulerStateConfig,
+  type SessionSync,
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
@@ -41,22 +41,16 @@ import type {
 } from "../src/storage/interface.ts";
 import {
   NotificationRecorder,
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
   SingleSessionFactory,
-  TEST_HELLO_SESSION_OPEN,
   testSessionOpenAuthFactory,
-  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-stacked-commit");
 const space = signer.did();
 const DOCUMENT_MIME = "application/json" as const;
-const helloOk = () => ({
-  type: "hello.ok",
-  protocol: "memory",
-  flags: getMemoryProtocolFlags(),
-  sessionOpen: TEST_HELLO_SESSION_OPEN,
-} as const);
 const testReconstructionContext = new EmptyReconstructionContext(
   true,
   "no cell reconstruction in stacked commit transport",
@@ -359,64 +353,37 @@ class ScriptedServerModel {
   }
 }
 
-class ScriptedModelTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
-
-  constructor(readonly model: ScriptedServerModel) {}
-
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+class ScriptedModelTransport extends ScriptedSessionTransport {
+  constructor(readonly model: ScriptedServerModel) {
+    super({ name: "stacked", sessionId: model.sessionId, space });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
+  protected override openServerSeq(): number {
+    return this.model.serverSeq;
   }
 
-  send(payload: string): Promise<void> {
-    const message = valueFromJson(
+  protected override onHello(): void {
+    this.model.connectionCount += 1;
+  }
+
+  // The commit payloads carry full FabricValues; decode with a context that
+  // FAILS on cell reconstruction rather than the default memory context.
+  protected override decode(payload: string): ScriptedTransportMessage {
+    return valueFromJson(
       payload,
       testReconstructionContext,
-    ) as {
-      type: string;
-      requestId?: string;
-      session?: { sessionId?: string };
-      invocation?: { aud?: unknown; challenge?: unknown };
-      commit?: ClientCommit;
-    };
+    ) as ScriptedTransportMessage;
+  }
+  protected override encode(message: unknown): string {
+    return jsonFromValue(message as FabricValue);
+  }
 
+  // The harness owns teardown; closing the session must not signal a
+  // disconnect (which would trigger client reconnect churn mid-assertion).
+  protected override onClose(): void {}
+
+  protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
-      case "hello":
-        this.model.connectionCount += 1;
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `stacked-hello-${this.model.connectionCount}`,
-        );
-        this.respond({
-          ...helloOk(),
-          sessionOpen: this.#sessionOpen,
-        });
-        break;
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `stacked-open-${++this.#sessionOpenCount}`,
-        );
-        this.respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: message.session?.sessionId ?? this.model.sessionId,
-            serverSeq: this.model.serverSeq,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        break;
       case "session.watch.set":
       case "session.watch.add":
         // Registers the watch but returns an empty sync: the harness NEVER
@@ -438,31 +405,22 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
           },
         });
         break;
-      case "session.ack":
-        this.respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: this.model.serverSeq,
-          },
-        });
-        break;
       case "transact": {
+        const commit = message.commit as ClientCommit;
         // Receipt-time bookkeeping: `transactLocalSeqs` records that a commit
         // reached the server even while its verdict is still gated. The
         // cascade tests (and the stress bookkeeping) use it to distinguish
         // "sent, verdict in flight" from "never sent".
-        this.model.transactLocalSeqs.push(message.commit!.localSeq);
-        const responseGate = message.commit
-          ? this.model.scripted.get(message.commit.localSeq)?.responseGate
-          : undefined;
+        this.model.transactLocalSeqs.push(commit.localSeq);
+        const responseGate = this.model.scripted.get(
+          commit.localSeq,
+        )?.responseGate;
         setTimeout(() => {
           void (async () => {
             await responseGate;
-            const commit = message.commit!;
             const response = this.model.transact(commit);
             if (response.type === "drop") {
-              this.#closeReceiver(new Error("disconnect"));
+              this.disconnect(new Error("disconnect"));
               return;
             }
             this.respond({
@@ -479,11 +437,6 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
     }
-    return Promise.resolve();
-  }
-
-  close(): Promise<void> {
-    return Promise.resolve();
   }
 
   /**
@@ -493,32 +446,23 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
    * when subscription catch-up arrives relative to commit verdicts.
    */
   pushSync(options: PushSyncOptions): void {
-    this.respond({
-      type: "session/effect",
-      space,
-      sessionId: this.model.sessionId,
-      effect: {
-        type: "sync",
-        fromSeq: this.model.serverSeq,
-        toSeq: this.model.serverSeq,
-        ...(options.caughtUpLocalSeq !== undefined
-          ? { caughtUpLocalSeq: options.caughtUpLocalSeq }
-          : {}),
-        upserts: (options.upserts ?? []).map((upsert) => ({
-          branch: "",
-          id: upsert.id,
-          seq: upsert.seq,
-          ...(upsert.deleted === true
-            ? { deleted: true as const }
-            : { doc: { value: upsert.value } }),
-        })),
-        removes: [],
-      },
-    });
-  }
-
-  private respond(message: unknown): void {
-    this.#receiver(jsonFromValue(message as FabricValue));
+    this.emitSync({
+      type: "sync",
+      fromSeq: this.model.serverSeq,
+      toSeq: this.model.serverSeq,
+      ...(options.caughtUpLocalSeq !== undefined
+        ? { caughtUpLocalSeq: options.caughtUpLocalSeq }
+        : {}),
+      upserts: (options.upserts ?? []).map((upsert) => ({
+        branch: "",
+        id: upsert.id,
+        seq: upsert.seq,
+        ...(upsert.deleted === true
+          ? { deleted: true as const }
+          : { doc: { value: upsert.value } }),
+      })),
+      removes: [],
+    } as SessionSync);
   }
 }
 

--- a/packages/runner/test/memory-v2-sync-under-pending.test.ts
+++ b/packages/runner/test/memory-v2-sync-under-pending.test.ts
@@ -1,0 +1,384 @@
+import { assert, assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { URI } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  type EntityDocument,
+  getMemoryProtocolFlags,
+  type SessionSync,
+  type SessionSyncUpsert,
+} from "@commonfabric/memory/v2";
+import type {
+  IStorageProviderWithReplica,
+  StorageNotification,
+} from "../src/storage/interface.ts";
+import {
+  NotificationRecorder,
+  SingleSessionFactory,
+  TEST_HELLO_SESSION_OPEN,
+  testSessionOpenAuthMetadata,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("memory-v2-sync-under-pending");
+const space = signer.did();
+const DOCUMENT_MIME = "application/json" as const;
+const HELLO_OK = {
+  type: "hello.ok",
+  protocol: "memory",
+  flags: getMemoryProtocolFlags(),
+  sessionOpen: TEST_HELLO_SESSION_OPEN,
+} as const;
+
+type TestProvider = IStorageProviderWithReplica & {
+  get(uri: URI): EntityDocument | undefined;
+  sync(
+    uri: URI,
+    selector?: { path: string[]; schema: unknown },
+  ): Promise<unknown>;
+};
+
+const doc = (
+  id: URI,
+  seq: number,
+  doc: SessionSyncUpsert["doc"],
+): SessionSyncUpsert => ({
+  branch: "",
+  id,
+  seq,
+  doc,
+});
+
+const fullSync = (
+  toSeq: number,
+  upserts: SessionSyncUpsert[],
+): SessionSync => ({
+  type: "sync",
+  fromSeq: 0,
+  toSeq,
+  upserts,
+  removes: [],
+});
+
+const getObjectValue = (
+  provider: TestProvider,
+  uri: URI,
+): Record<string, unknown> | undefined => {
+  const value = provider.get(uri)?.value;
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+};
+
+type HeldTransact = {
+  requestId: string;
+  operations: Array<{ op: string; id: string }>;
+};
+
+/**
+ * Scripted transport that serves an initial doc snapshot on watch, HOLDS every
+ * transact response until the test releases it, and can push server syncs
+ * (session/effect) at any point in between. This is what lets a test interleave
+ * "a foreign writer's sync arrives" with "our own commit is still in flight".
+ */
+class HeldTransactTransport implements MemoryV2Client.Transport {
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  readonly #sessionId = "session:sync-under-pending";
+  readonly #space = space;
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
+  #held: HeldTransact | null = null;
+  #transactSent = Promise.withResolvers<void>();
+
+  constructor(
+    private readonly docs: Map<URI, SessionSyncUpsert["doc"]>,
+  ) {}
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  /** Resolves when a transact request has arrived (and is being held). */
+  get transactSent(): Promise<void> {
+    return this.#transactSent.promise;
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+      invocation?: { aud?: unknown; challenge?: unknown };
+      commit?: { operations?: Array<{ op: string; id: string }> };
+      watches?: Array<{
+        query?: { roots?: Array<{ id: string }> };
+      }>;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          "sync-under-pending-hello",
+        );
+        this.#respond({
+          ...HELLO_OK,
+          sessionOpen: this.#sessionOpen,
+        });
+        return Promise.resolve();
+      case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `sync-under-pending-open-${++this.#sessionOpenCount}`,
+        );
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: this.#sessionId,
+            serverSeq: 0,
+            sessionOpen: this.#sessionOpen,
+          },
+        });
+        return Promise.resolve();
+      case "session.ack":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: 10,
+          },
+        });
+        return Promise.resolve();
+      case "session.watch.set":
+      case "session.watch.add": {
+        const roots =
+          message.watches?.flatMap((watch) =>
+            watch.query?.roots?.map((root) => root.id as URI) ?? []
+          ) ?? [];
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: roots.length,
+            sync: fullSync(
+              roots.length,
+              roots.map((id) => doc(id, 1, this.docs.get(id))),
+            ),
+          },
+        });
+        return Promise.resolve();
+      }
+      case "transact": {
+        if (this.#held !== null) {
+          throw new Error("Test transport holds only one transact at a time");
+        }
+        this.#held = {
+          requestId: message.requestId!,
+          operations: message.commit?.operations ?? [],
+        };
+        this.#transactSent.resolve();
+        return Promise.resolve();
+      }
+      default:
+        throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+  }
+
+  /** Acknowledge the held commit as applied at `seq`. */
+  releaseTransact(seq: number): void {
+    const held = this.#held;
+    if (held === null) {
+      throw new Error("No held transact to release");
+    }
+    this.#held = null;
+    this.#transactSent = Promise.withResolvers<void>();
+    this.#respond({
+      type: "response",
+      requestId: held.requestId,
+      ok: {
+        seq,
+        branch: "",
+        revisions: held.operations.map((operation, opIndex) => ({
+          id: operation.id,
+          branch: "",
+          seq,
+          opIndex,
+          commitSeq: seq,
+          op: operation.op,
+        })),
+      },
+    });
+  }
+
+  emitSync(sync: SessionSync): void {
+    this.#respond({
+      type: "session/effect",
+      space: this.#space,
+      sessionId: this.#sessionId,
+      effect: sync,
+    });
+  }
+
+  close(): Promise<void> {
+    this.#closeReceiver();
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+const notificationCarriesField = (
+  notification: StorageNotification,
+  uri: URI,
+  key: string,
+  expected: unknown,
+): boolean =>
+  "changes" in notification &&
+  [...notification.changes].some((change) => {
+    if (change.address.id !== uri) {
+      return false;
+    }
+    const after = change.after as { value?: Record<string, unknown> } | null;
+    return after != null && typeof after === "object" &&
+      after.value != null && typeof after.value === "object" &&
+      after.value[key] === expected;
+  });
+
+// The red/green/blue race: a local leaf write ("green") is committed and in
+// flight (unconfirmed) when a foreign writer's server sync ("blue", which also
+// changes a sibling field) arrives. applySessionSync must only advance the
+// CONFIRMED base — the pending write replays on top, so the visible value keeps
+// the local leaf while integrating the sibling change, exactly matching what
+// the server computes when it later applies the patch on top of blue. The
+// other guards then hold the line: confirming the commit promotes the merged
+// value forward, and a late stale replay of blue can never regress it.
+// (The individual guards are pinned elsewhere — the watch-refresh-race test
+// covers monotonicity, the stacked-commit suite covers pending visibility —
+// but this is the only test that delivers a foreign sync WHILE a commit is
+// pending.)
+Deno.test("memory v2 runner rebases a pending write over a sync arriving before its confirmation", async () => {
+  const docA = `of:sync-under-pending-a-${crypto.randomUUID()}` as URI;
+  const docB = `of:sync-under-pending-b-${crypto.randomUUID()}` as URI;
+  const transport = new HeldTransactTransport(
+    new Map([
+      [docA, { value: { color: "red", note: "seed" } }],
+      [docB, { value: { label: "seed" } }],
+    ]),
+  );
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-sync-under-pending"),
+  }, sessionFactory);
+  const provider = storageManager.open(space) as TestProvider;
+  const notifications = new NotificationRecorder();
+  const firstIntegrate = Promise.withResolvers<void>();
+  const secondIntegrate = Promise.withResolvers<void>();
+  let integrations = 0;
+  notifications.onNotification = (notification) => {
+    if (notification.type === "integrate") {
+      integrations += 1;
+      if (integrations === 1) firstIntegrate.resolve();
+      if (integrations === 2) secondIntegrate.resolve();
+    }
+  };
+  storageManager.subscribe(notifications);
+
+  try {
+    await Promise.all([
+      provider.sync(docA, { path: [], schema: false }),
+      provider.sync(docB, { path: [], schema: false }),
+    ]);
+    assertEquals(getObjectValue(provider, docA), {
+      color: "red",
+      note: "seed",
+    });
+
+    // Local leaf write: color -> "green". The transact is held by the
+    // transport, so the write sits in the pending overlay, unconfirmed.
+    // Transaction paths address the document envelope, so the cell payload
+    // lives under ["value", ...].
+    const tx = storageManager.edit();
+    const read = tx.read({ space, id: docA, type: DOCUMENT_MIME, path: [] });
+    assert(read.ok, "seeded doc should be readable in the tx");
+    const write = tx.write(
+      { space, id: docA, type: DOCUMENT_MIME, path: ["value", "color"] },
+      "green",
+    );
+    assert(write.ok, "leaf write should apply in the tx");
+    const commitPromise = tx.commit();
+    await transport.transactSent;
+    assertEquals(getObjectValue(provider, docA), {
+      color: "green",
+      note: "seed",
+    });
+
+    // Foreign writer's sync lands while green is still pending: blue at a
+    // newer confirmed seq, also rewriting the sibling `note` field. The
+    // confirmed base must advance to blue with the pending green replayed on
+    // top: sibling integrates, leaf stays green.
+    transport.emitSync(fullSync(2, [doc(docA, 2, {
+      value: { color: "blue", note: "remote" },
+    })]));
+    await firstIntegrate.promise;
+    assertEquals(getObjectValue(provider, docA), {
+      color: "green",
+      note: "remote",
+    });
+
+    // The replica must never have surfaced blue at the leaf — not even
+    // transiently in a notification.
+    assert(
+      !notifications.notifications.some((notification) =>
+        notificationCarriesField(notification, docA, "color", "blue")
+      ),
+      "no notification should carry the foreign leaf value under the pending write",
+    );
+
+    // The server (which accepted the blind leaf write on top of blue — the
+    // structural parent precondition does not conflict with a leaf write)
+    // acknowledges the commit at the next seq. confirmPending promotes the
+    // merged value into the confirmed base; the visible value is unchanged.
+    transport.releaseTransact(3);
+    const result = await commitPromise;
+    assert(!result.error, `commit should confirm cleanly: ${result.error}`);
+    assertEquals(getObjectValue(provider, docA), {
+      color: "green",
+      note: "remote",
+    });
+
+    // A stale watch refresh replaying blue (doc seq 2, below the promoted
+    // confirmed seq 3) must be skipped by the monotonic guard. A guard-skipped
+    // sync emits no notification, so a follow-up fresh sync on docB is the
+    // barrier proving the stale one was fully processed (syncs apply in
+    // order).
+    transport.emitSync(fullSync(4, [doc(docA, 2, {
+      value: { color: "blue", note: "remote" },
+    })]));
+    transport.emitSync(fullSync(5, [doc(docB, 6, {
+      value: { label: "barrier" },
+    })]));
+    await secondIntegrate.promise;
+    assertEquals(getObjectValue(provider, docB), { label: "barrier" });
+    assertEquals(getObjectValue(provider, docA), {
+      color: "green",
+      note: "remote",
+    });
+  } finally {
+    storageManager.unsubscribe(notifications);
+    await storageManager.close();
+  }
+});

--- a/packages/runner/test/memory-v2-sync-under-pending.test.ts
+++ b/packages/runner/test/memory-v2-sync-under-pending.test.ts
@@ -11,6 +11,11 @@ import type {
   StorageNotification,
 } from "../src/storage/interface.ts";
 import {
+  markUiInputBlindWriteTx,
+  setBlindStructuralTarget,
+  unmarkUiInputBlindWriteTx,
+} from "../src/storage/reactivity-log.ts";
+import {
   NotificationRecorder,
   ScriptedSessionTransport,
   type ScriptedTransportMessage,
@@ -62,9 +67,17 @@ const getObjectValue = (
     : undefined;
 };
 
+type HeldCommitRead = {
+  id: string;
+  path: string[];
+  seq?: number;
+  nonRecursive?: boolean;
+};
+
 type HeldTransact = {
   requestId: string;
   operations: Array<{ op: string; id: string }>;
+  reads: { confirmed: HeldCommitRead[]; pending: HeldCommitRead[] };
 };
 
 /**
@@ -97,6 +110,11 @@ class HeldTransactTransport extends ScriptedSessionTransport {
     return this.#transactSent.promise;
   }
 
+  /** The commit currently held (for wire-shape assertions). */
+  get heldCommit(): HeldTransact | null {
+    return this.#held;
+  }
+
   protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
       case "session.watch.set":
@@ -123,11 +141,15 @@ class HeldTransactTransport extends ScriptedSessionTransport {
           throw new Error("Test transport holds only one transact at a time");
         }
         const commit = message.commit as
-          | { operations?: Array<{ op: string; id: string }> }
+          | {
+            operations?: Array<{ op: string; id: string }>;
+            reads?: HeldTransact["reads"];
+          }
           | undefined;
         this.#held = {
           requestId: message.requestId!,
           operations: commit?.operations ?? [],
+          reads: commit?.reads ?? { confirmed: [], pending: [] },
         };
         this.#transactSent.resolve();
         return;
@@ -181,19 +203,30 @@ const notificationCarriesField = (
       after.value[key] === expected;
   });
 
-// The red/green/blue race: a local leaf write ("green") is committed and in
-// flight (unconfirmed) when a foreign writer's server sync ("blue", which also
-// changes a sibling field) arrives. applySessionSync must only advance the
-// CONFIRMED base — the pending write replays on top, so the visible value keeps
-// the local leaf while integrating the sibling change, exactly matching what
-// the server computes when it later applies the patch on top of blue. The
-// other guards then hold the line: confirming the commit promotes the merged
-// value forward, and a late stale replay of blue can never regress it.
+// LAYER: this pins the worker-side SpaceReplica against the client↔server
+// WIRE protocol (the scripted transport plays the server). It does NOT touch
+// the main-thread↔worker IPC hop — the CellSet/CellUpdate echo ordering on
+// that hop is pinned separately by
+// packages/runtime-client/backends/cell-set-echo-race.test.ts.
+//
+// The red/green/blue race: a local blind leaf write ("green") is committed and
+// in flight (unconfirmed) when a foreign writer's server sync ("blue", which
+// also changes a sibling field) arrives. The write uses the real blind-UI-input
+// marks (markUiInputBlindWriteTx + setBlindStructuralTarget), so the commit on
+// the wire is shaped exactly like handleCellSet's: no value-equality read at
+// the written leaf, one nonRecursive structural read at the cell's parent —
+// which is why a real server accepts it on top of blue instead of rejecting a
+// stale CAS read. applySessionSync must only advance the CONFIRMED base — the
+// pending write replays on top, so the visible value keeps the local leaf
+// while integrating the sibling change, exactly matching what the server
+// computes when it later applies the patch on top of blue. The other guards
+// then hold the line: confirming the commit promotes the merged value forward,
+// and a late stale replay of blue can never regress it.
 // (The individual guards are pinned elsewhere — the watch-refresh-race test
 // covers monotonicity, the stacked-commit suite covers pending visibility —
 // but this is the only test that delivers a foreign sync WHILE a commit is
 // pending.)
-Deno.test("memory v2 runner rebases a pending write over a sync arriving before its confirmation", async () => {
+Deno.test("memory v2 SpaceReplica rebases a pending blind write over a server sync arriving before its confirmation", async () => {
   const docA = `of:sync-under-pending-a-${crypto.randomUUID()}` as URI;
   const docB = `of:sync-under-pending-b-${crypto.randomUUID()}` as URI;
   const transport = new HeldTransactTransport(
@@ -233,9 +266,12 @@ Deno.test("memory v2 runner rebases a pending write over a sync arriving before 
 
     // Local leaf write: color -> "green". The transact is held by the
     // transport, so the write sits in the pending overlay, unconfirmed.
-    // Transaction paths address the document envelope, so the cell payload
-    // lives under ["value", ...].
+    // Local blind leaf write: color -> "green", using the real blind-UI-input
+    // marks the way handleCellSet does (mark → read/write → structural target
+    // at the leaf's PARENT → unmark → commit). Transaction paths address the
+    // document envelope, so the cell payload lives under ["value", ...].
     const tx = storageManager.edit();
+    markUiInputBlindWriteTx(tx);
     const read = tx.read({ space, id: docA, type: DOCUMENT_MIME, path: [] });
     assert(read.ok, "seeded doc should be readable in the tx");
     const write = tx.write(
@@ -243,12 +279,35 @@ Deno.test("memory v2 runner rebases a pending write over a sync arriving before 
       "green",
     );
     assert(write.ok, "leaf write should apply in the tx");
+    setBlindStructuralTarget(tx, {
+      id: docA,
+      space,
+      scope: "space",
+      path: ["value"],
+    });
+    unmarkUiInputBlindWriteTx(tx);
     const commitPromise = tx.commit();
     await transport.transactSent;
     assertEquals(getObjectValue(provider, docA), {
       color: "green",
       note: "seed",
     });
+
+    // The wire shape must match a blind CellSet's: the tx's own reads carry no
+    // value-equality precondition (they were tagged ignoreReadForCommit and
+    // dropped by buildReads); the ONLY read is the nonRecursive structural
+    // precondition at the leaf's parent. This is what lets a real server accept
+    // the commit on top of a concurrent leaf write instead of rejecting a
+    // stale CAS read.
+    const held = transport.heldCommit;
+    assert(held !== null, "the transact should be held");
+    assertEquals(held.reads.pending, []);
+    assertEquals(held.reads.confirmed.length, 1);
+    const structuralRead = held.reads.confirmed[0]!;
+    assertEquals(structuralRead.id, docA);
+    assertEquals(structuralRead.path, ["value"]);
+    assertEquals(structuralRead.nonRecursive, true);
+    assertEquals(structuralRead.seq, 1);
 
     // Foreign writer's sync lands while green is still pending: blue at a
     // newer confirmed seq, also rewriting the sibling `note` field. The

--- a/packages/runner/test/memory-v2-sync-under-pending.test.ts
+++ b/packages/runner/test/memory-v2-sync-under-pending.test.ts
@@ -1,13 +1,8 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { URI } from "@commonfabric/memory/interface";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
-  decodeMemoryBoundary,
-  encodeMemoryBoundary,
   type EntityDocument,
-  getMemoryProtocolFlags,
   type SessionSync,
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
@@ -17,21 +12,15 @@ import type {
 } from "../src/storage/interface.ts";
 import {
   NotificationRecorder,
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
   SingleSessionFactory,
-  TEST_HELLO_SESSION_OPEN,
-  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-sync-under-pending");
 const space = signer.did();
 const DOCUMENT_MIME = "application/json" as const;
-const HELLO_OK = {
-  type: "hello.ok",
-  protocol: "memory",
-  flags: getMemoryProtocolFlags(),
-  sessionOpen: TEST_HELLO_SESSION_OPEN,
-} as const;
 
 type TestProvider = IStorageProviderWithReplica & {
   get(uri: URI): EntityDocument | undefined;
@@ -81,29 +70,26 @@ type HeldTransact = {
 /**
  * Scripted transport that serves an initial doc snapshot on watch, HOLDS every
  * transact response until the test releases it, and can push server syncs
- * (session/effect) at any point in between. This is what lets a test interleave
- * "a foreign writer's sync arrives" with "our own commit is still in flight".
+ * (session/effect, via the base emitSync) at any point in between. This is
+ * what lets a test interleave "a foreign writer's sync arrives" with "our own
+ * commit is still in flight".
  */
-class HeldTransactTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
-  readonly #sessionId = "session:sync-under-pending";
-  readonly #space = space;
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
+class HeldTransactTransport extends ScriptedSessionTransport {
   #held: HeldTransact | null = null;
   #transactSent = Promise.withResolvers<void>();
 
   constructor(
     private readonly docs: Map<URI, SessionSyncUpsert["doc"]>,
-  ) {}
-
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+  ) {
+    super({
+      name: "sync-under-pending",
+      sessionId: "session:sync-under-pending",
+      space,
+    });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
+  protected override ackServerSeq(): number {
+    return 10;
   }
 
   /** Resolves when a transact request has arrived (and is being held). */
@@ -111,62 +97,15 @@ class HeldTransactTransport implements MemoryV2Client.Transport {
     return this.#transactSent.promise;
   }
 
-  send(payload: string): Promise<void> {
-    const message = decodeMemoryBoundary(payload) as {
-      type: string;
-      requestId?: string;
-      invocation?: { aud?: unknown; challenge?: unknown };
-      commit?: { operations?: Array<{ op: string; id: string }> };
-      watches?: Array<{
-        query?: { roots?: Array<{ id: string }> };
-      }>;
-    };
-
+  protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
-      case "hello":
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          "sync-under-pending-hello",
-        );
-        this.#respond({
-          ...HELLO_OK,
-          sessionOpen: this.#sessionOpen,
-        });
-        return Promise.resolve();
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `sync-under-pending-open-${++this.#sessionOpenCount}`,
-        );
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: this.#sessionId,
-            serverSeq: 0,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        return Promise.resolve();
-      case "session.ack":
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: 10,
-          },
-        });
-        return Promise.resolve();
       case "session.watch.set":
       case "session.watch.add": {
         const roots =
           message.watches?.flatMap((watch) =>
             watch.query?.roots?.map((root) => root.id as URI) ?? []
           ) ?? [];
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -177,18 +116,21 @@ class HeldTransactTransport implements MemoryV2Client.Transport {
             ),
           },
         });
-        return Promise.resolve();
+        return;
       }
       case "transact": {
         if (this.#held !== null) {
           throw new Error("Test transport holds only one transact at a time");
         }
+        const commit = message.commit as
+          | { operations?: Array<{ op: string; id: string }> }
+          | undefined;
         this.#held = {
           requestId: message.requestId!,
-          operations: message.commit?.operations ?? [],
+          operations: commit?.operations ?? [],
         };
         this.#transactSent.resolve();
-        return Promise.resolve();
+        return;
       }
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
@@ -203,7 +145,7 @@ class HeldTransactTransport implements MemoryV2Client.Transport {
     }
     this.#held = null;
     this.#transactSent = Promise.withResolvers<void>();
-    this.#respond({
+    this.respond({
       type: "response",
       requestId: held.requestId,
       ok: {
@@ -219,24 +161,6 @@ class HeldTransactTransport implements MemoryV2Client.Transport {
         })),
       },
     });
-  }
-
-  emitSync(sync: SessionSync): void {
-    this.#respond({
-      type: "session/effect",
-      space: this.#space,
-      sessionId: this.#sessionId,
-      effect: sync,
-    });
-  }
-
-  close(): Promise<void> {
-    this.#closeReceiver();
-    return Promise.resolve();
-  }
-
-  #respond(message: FabricValue): void {
-    this.#receiver(encodeMemoryBoundary(message));
   }
 }
 

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -1,5 +1,13 @@
+import { assertEquals } from "@std/assert";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
-import type { SessionOpenAuthMetadata } from "@commonfabric/memory/v2";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+} from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type {
   IStorageNotification,
@@ -82,6 +90,167 @@ export class NotificationRecorder implements IStorageNotification {
 
   clear(): void {
     this.notifications = [];
+  }
+}
+
+/** The wire-message shape scripted transports care about. `commit` stays
+ * unknown here — transports that script transact verdicts cast it to the
+ * commit shape they need. */
+export type ScriptedTransportMessage = {
+  type: string;
+  requestId?: string;
+  session?: { sessionId?: string };
+  invocation?: { aud?: unknown; challenge?: unknown };
+  watches?: Array<{
+    query?: { roots?: Array<{ id: string }> };
+  }>;
+  commit?: unknown;
+};
+
+/**
+ * Base class for scripted memory-v2 transports: owns the session ceremony
+ * every scripted server answers identically — `hello` (with sessionOpen
+ * challenge rotation), `session.open` (asserting the client echoes the last
+ * issued challenge/audience), and `session.ack` — plus the receiver plumbing
+ * and the `session/effect` server-push frame. Subclasses implement `handle()`
+ * for everything the ceremony doesn't cover (watches, transact, …) and
+ * override the small seams (`openServerSeq`/`ackServerSeq`, codec, `onHello`,
+ * `onClose`) where a harness deviates.
+ */
+export abstract class ScriptedSessionTransport
+  implements MemoryV2Client.Transport {
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #sessionOpen: SessionOpenAuthMetadata = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
+  #helloCount = 0;
+
+  constructor(
+    private readonly script: {
+      /** Challenge-id prefix; keep unique per transport class. */
+      name: string;
+      /** sessionId confirmed on session.open and stamped on effect frames. */
+      sessionId: string;
+      /** The space effect frames (emitSync) are addressed to. */
+      space: MemorySpace;
+    },
+  ) {}
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  /** serverSeq stamped on session.open confirmations. */
+  protected openServerSeq(): number {
+    return 0;
+  }
+
+  /** serverSeq stamped on session.ack confirmations. */
+  protected ackServerSeq(): number {
+    return this.openServerSeq();
+  }
+
+  /** Called for each hello before hello.ok goes out (e.g. count connections). */
+  protected onHello(_helloCount: number): void {}
+
+  /** Wire codec seams — override together when a harness needs a specific
+   * reconstruction context. */
+  protected decode(payload: string): ScriptedTransportMessage {
+    return decodeMemoryBoundary(payload) as unknown as ScriptedTransportMessage;
+  }
+  protected encode(message: unknown): string {
+    return encodeMemoryBoundary(message as FabricValue);
+  }
+
+  /** Handle every message the shared ceremony doesn't (watches, transact, …).
+   * Throw on message types the script does not expect. */
+  protected abstract handle(
+    message: ScriptedTransportMessage,
+  ): void | Promise<void>;
+
+  async send(payload: string): Promise<void> {
+    const message = this.decode(payload);
+    switch (message.type) {
+      case "hello":
+        this.onHello(++this.#helloCount);
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `${this.script.name}-hello-${this.#helloCount}`,
+        );
+        this.respond({
+          type: "hello.ok",
+          protocol: "memory",
+          flags: getMemoryProtocolFlags(),
+          sessionOpen: this.#sessionOpen,
+        });
+        return;
+      case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `${this.script.name}-open-${++this.#sessionOpenCount}`,
+        );
+        this.respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: message.session?.sessionId ?? this.script.sessionId,
+            serverSeq: this.openServerSeq(),
+            sessionOpen: this.#sessionOpen,
+          },
+        });
+        return;
+      case "session.ack":
+        this.respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: this.ackServerSeq(),
+          },
+        });
+        return;
+      default:
+        await this.handle(message);
+        return;
+    }
+  }
+
+  /** Notify the client the connection is closing. Default mirrors most
+   * scripted transports; override to a no-op where teardown must stay
+   * silent. */
+  protected onClose(): void {
+    this.disconnect();
+  }
+
+  close(): Promise<void> {
+    this.onClose();
+    return Promise.resolve();
+  }
+
+  protected respond(message: unknown): void {
+    this.#receiver(this.encode(message));
+  }
+
+  /** Sever the connection from the server side (client sees a close). */
+  protected disconnect(error?: Error): void {
+    this.#closeReceiver(error);
+  }
+
+  /** Deliver an unsolicited server-push sync frame (the real server's
+   * timer-batched `session/effect` fan-out). */
+  emitSync(sync: SessionSync): void {
+    this.respond({
+      type: "session/effect",
+      space: this.script.space,
+      sessionId: this.script.sessionId,
+      effect: sync,
+    });
   }
 }
 

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -1,33 +1,22 @@
 import { assertEquals } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import { Identity } from "@commonfabric/identity";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { URI } from "@commonfabric/memory/interface";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
-  decodeMemoryBoundary,
-  encodeMemoryBoundary,
   type EntityDocument,
-  getMemoryProtocolFlags,
   type SessionSync,
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
 import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
 import {
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
   SingleSessionFactory,
-  TEST_HELLO_SESSION_OPEN,
-  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-watch-refresh-race");
 const space = signer.did();
-const HELLO_OK = {
-  type: "hello.ok",
-  protocol: "memory",
-  flags: getMemoryProtocolFlags(),
-  sessionOpen: TEST_HELLO_SESSION_OPEN,
-} as const;
 
 type TestProvider = IStorageProviderWithReplica & {
   get(uri: URI): EntityDocument | undefined;
@@ -37,71 +26,25 @@ type TestProvider = IStorageProviderWithReplica & {
   ): Promise<unknown>;
 };
 
-class CountingWatchSetTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
+class CountingWatchSetTransport extends ScriptedSessionTransport {
   watchSetCount = 0;
   watchAddCount = 0;
   rootCounts: number[] = [];
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
 
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+  constructor() {
+    super({
+      name: "watch-refresh-batch",
+      sessionId: "session:watch-refresh-batch",
+      space,
+    });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
+  protected override ackServerSeq(): number {
+    return 3;
   }
 
-  send(payload: string): Promise<void> {
-    const message = decodeMemoryBoundary(payload) as {
-      type: string;
-      requestId?: string;
-      invocation?: { aud?: unknown; challenge?: unknown };
-      watches?: Array<{
-        query?: { roots?: Array<{ id: string }> };
-      }>;
-    };
-
+  protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
-      case "hello":
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          "watch-refresh-batch-hello",
-        );
-        this.#respond({
-          ...HELLO_OK,
-          sessionOpen: this.#sessionOpen,
-        });
-        return Promise.resolve();
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `watch-refresh-batch-open-${++this.#sessionOpenCount}`,
-        );
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: "session:watch-refresh-batch",
-            serverSeq: 0,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        return Promise.resolve();
-      case "session.ack":
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: 3,
-          },
-        });
-        return Promise.resolve();
       case "session.watch.set":
       case "session.watch.add": {
         const roots =
@@ -116,7 +59,7 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
         }
         this.rootCounts.push(roots.length);
 
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -129,91 +72,36 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
             ),
           },
         });
-        return Promise.resolve();
+        return;
       }
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
     }
   }
-
-  close(): Promise<void> {
-    this.#closeReceiver();
-    return Promise.resolve();
-  }
-
-  #respond(message: FabricValue): void {
-    this.#receiver(encodeMemoryBoundary(message));
-  }
 }
 
-class DelayedWatchAddTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
+class DelayedWatchAddTransport extends ScriptedSessionTransport {
   readonly firstWatchAddSent = Promise.withResolvers<void>();
   readonly releaseFirstWatchAdd = Promise.withResolvers<
     SessionSyncUpsert["doc"]
   >();
   watchAddCount = 0;
   rootCounts: number[] = [];
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
 
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+  constructor() {
+    super({
+      name: "delayed-watch-add",
+      sessionId: "session:delayed-watch-add",
+      space,
+    });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
+  protected override ackServerSeq(): number {
+    return 10;
   }
 
-  send(payload: string): Promise<void> {
-    const message = decodeMemoryBoundary(payload) as {
-      type: string;
-      requestId?: string;
-      invocation?: { aud?: unknown; challenge?: unknown };
-      watches?: Array<{
-        query?: { roots?: Array<{ id: string }> };
-      }>;
-    };
-
+  protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
-      case "hello":
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          "delayed-watch-add-hello",
-        );
-        this.#respond({
-          ...HELLO_OK,
-          sessionOpen: this.#sessionOpen,
-        });
-        return Promise.resolve();
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `delayed-watch-add-open-${++this.#sessionOpenCount}`,
-        );
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: "session:delayed-watch-add",
-            serverSeq: 0,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        return Promise.resolve();
-      case "session.ack":
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: 10,
-          },
-        });
-        return Promise.resolve();
       case "session.watch.add": {
         this.watchAddCount += 1;
         const roots =
@@ -225,7 +113,7 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
         if (this.watchAddCount === 1) {
           this.firstWatchAddSent.resolve();
           void this.releaseFirstWatchAdd.promise.then((docValue) => {
-            this.#respond({
+            this.respond({
               type: "response",
               requestId: message.requestId!,
               ok: {
@@ -234,10 +122,10 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
               },
             });
           });
-          return Promise.resolve();
+          return;
         }
 
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -250,97 +138,37 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
             ),
           },
         });
-        return Promise.resolve();
+        return;
       }
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
     }
   }
-
-  close(): Promise<void> {
-    this.#closeReceiver();
-    return Promise.resolve();
-  }
-
-  #respond(message: FabricValue): void {
-    this.#receiver(encodeMemoryBoundary(message));
-  }
 }
 
-class IncrementalEffectTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
-  readonly #sessionId = "session:incremental-effect";
-  readonly #space = space;
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
-
+class IncrementalEffectTransport extends ScriptedSessionTransport {
   constructor(
     private readonly docs: Map<URI, SessionSyncUpsert["doc"]>,
-  ) {}
-
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+  ) {
+    super({
+      name: "incremental-effect",
+      sessionId: "session:incremental-effect",
+      space,
+    });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
+  protected override ackServerSeq(): number {
+    return 10;
   }
 
-  send(payload: string): Promise<void> {
-    const message = decodeMemoryBoundary(payload) as {
-      type: string;
-      requestId?: string;
-      invocation?: { aud?: unknown; challenge?: unknown };
-      watches?: Array<{
-        query?: { roots?: Array<{ id: string }> };
-      }>;
-    };
-
+  protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
-      case "hello":
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          "incremental-effect-hello",
-        );
-        this.#respond({
-          ...HELLO_OK,
-          sessionOpen: this.#sessionOpen,
-        });
-        return Promise.resolve();
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `incremental-effect-open-${++this.#sessionOpenCount}`,
-        );
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: this.#sessionId,
-            serverSeq: 0,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        return Promise.resolve();
-      case "session.ack":
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: 10,
-          },
-        });
-        return Promise.resolve();
       case "session.watch.add": {
         const roots =
           message.watches?.flatMap((watch) =>
             watch.query?.roots?.map((root) => root.id as URI) ?? []
           ) ?? [];
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -351,29 +179,11 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
             ),
           },
         });
-        return Promise.resolve();
+        return;
       }
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
     }
-  }
-
-  close(): Promise<void> {
-    this.#closeReceiver();
-    return Promise.resolve();
-  }
-
-  emitSync(sync: SessionSync): void {
-    this.#respond({
-      type: "session/effect",
-      space: this.#space,
-      sessionId: this.#sessionId,
-      effect: sync,
-    });
-  }
-
-  #respond(message: FabricValue): void {
-    this.#receiver(encodeMemoryBoundary(message));
   }
 }
 

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -7,33 +7,22 @@
 
 import { assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { URI } from "@commonfabric/memory/interface";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
-  decodeMemoryBoundary,
-  encodeMemoryBoundary,
   type EntityDocument,
-  getMemoryProtocolFlags,
   type SessionSync,
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
 import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
 import {
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
   SingleSessionFactory,
-  TEST_HELLO_SESSION_OPEN,
-  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-watch-remove-coverage");
 const space = signer.did();
-const HELLO_OK = {
-  type: "hello.ok",
-  protocol: "memory",
-  flags: getMemoryProtocolFlags(),
-  sessionOpen: TEST_HELLO_SESSION_OPEN,
-} as const;
 
 type TestProvider = IStorageProviderWithReplica & {
   get(uri: URI): EntityDocument | undefined;
@@ -67,77 +56,28 @@ const getObjectValue = (
 // Answers the watch.add with a sync that upserts every requested root and then
 // removes `removedId` in the same batch, simulating a watched doc deleted
 // upstream as the watch is established.
-class WatchAddRemoveTransport implements MemoryV2Client.Transport {
-  #receiver: (payload: string) => void = () => {};
-  #closeReceiver: (error?: Error) => void = () => {};
-  #sessionOpen = TEST_HELLO_SESSION_OPEN;
-  #sessionOpenCount = 0;
-
-  constructor(private readonly removedId: URI) {}
-
-  setReceiver(receiver: (payload: string) => void): void {
-    this.#receiver = receiver;
+class WatchAddRemoveTransport extends ScriptedSessionTransport {
+  constructor(private readonly removedId: URI) {
+    super({
+      name: "watch-remove-coverage",
+      sessionId: "session:watch-remove-coverage",
+      space,
+    });
   }
 
-  setCloseReceiver(receiver: (error?: Error) => void): void {
-    this.#closeReceiver = receiver;
+  protected override ackServerSeq(): number {
+    return 5;
   }
 
-  send(payload: string): Promise<void> {
-    const message = decodeMemoryBoundary(payload) as {
-      type: string;
-      requestId?: string;
-      invocation?: { aud?: unknown; challenge?: unknown };
-      watches?: Array<{
-        query?: { roots?: Array<{ id: string }> };
-      }>;
-    };
-
+  protected override handle(message: ScriptedTransportMessage): void {
     switch (message.type) {
-      case "hello":
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          "watch-remove-coverage-hello",
-        );
-        this.#respond({
-          ...HELLO_OK,
-          sessionOpen: this.#sessionOpen,
-        });
-        return Promise.resolve();
-      case "session.open":
-        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
-        assertEquals(
-          message.invocation?.challenge,
-          this.#sessionOpen.challenge.value,
-        );
-        this.#sessionOpen = testSessionOpenAuthMetadata(
-          `watch-remove-coverage-open-${++this.#sessionOpenCount}`,
-        );
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            sessionId: "session:watch-remove-coverage",
-            serverSeq: 0,
-            sessionOpen: this.#sessionOpen,
-          },
-        });
-        return Promise.resolve();
-      case "session.ack":
-        this.#respond({
-          type: "response",
-          requestId: message.requestId!,
-          ok: {
-            serverSeq: 5,
-          },
-        });
-        return Promise.resolve();
       case "session.watch.add": {
         const roots =
           message.watches?.flatMap((watch) =>
             watch.query?.roots?.map((root) => root.id as URI) ?? []
           ) ?? [];
         const toSeq = roots.length + 1;
-        this.#respond({
+        this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -153,20 +93,11 @@ class WatchAddRemoveTransport implements MemoryV2Client.Transport {
             } satisfies SessionSync,
           },
         });
-        return Promise.resolve();
+        return;
       }
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);
     }
-  }
-
-  close(): Promise<void> {
-    this.#closeReceiver();
-    return Promise.resolve();
-  }
-
-  #respond(message: FabricValue): void {
-    this.#receiver(encodeMemoryBoundary(message));
   }
 }
 

--- a/packages/runtime-client/backends/cell-set-echo-race.test.ts
+++ b/packages/runtime-client/backends/cell-set-echo-race.test.ts
@@ -1,0 +1,279 @@
+// Pins the main-thread↔worker IPC hop of the CellSet race: a CellUpdate
+// carrying a concurrent value ("blue") is in flight to the main thread when
+// the client blind-sets "green". The worker↔server hop of the same race (the
+// replica rebasing the pending write under the incoming sync) is pinned by
+// packages/runner/test/memory-v2-sync-under-pending.test.ts; here the worker
+// side runs in-process and the test controls IPC delivery order.
+//
+// What must hold on this hop:
+//  1. `set()` applies optimistically and fires the handle's callbacks before
+//     any IPC round trip.
+//  2. The in-flight stale CellUpdate(blue) is applied blindly when it arrives
+//     (there is deliberately no versioning/suppression on this hop) — the
+//     transient flash is accepted behavior.
+//  3. The worker's own commit of green re-fires the subscription sink — the
+//     "we don't echo back to the sender" suppression exists only on the
+//     server↔worker hop — so a CellUpdate(green) follows blue in channel
+//     order and the handle converges to green.
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { Runtime } from "@commonfabric/runner";
+import * as V2Storage from "../../runner/src/storage/v2.ts";
+import { RuntimeProcessor } from "./runtime-processor.ts";
+import { createCellRef } from "./utils.ts";
+import { $conn, CellHandle, type RuntimeClient } from "../mod.ts";
+import { RuntimeConnection } from "../client/connection.ts";
+import { EventEmitter } from "../client/emitter.ts";
+import type {
+  RuntimeTransport,
+  RuntimeTransportEvents,
+} from "../client/transport.ts";
+import {
+  type InitializationData,
+  type IPCClientMessage,
+  type IPCClientNotification,
+  type IPCRemoteMessage,
+  RequestType,
+} from "../protocol/mod.ts";
+
+const signer = await Identity.fromPassphrase("cell-set-echo-race");
+const space = signer.did();
+const testSessionOpenAudience = "did:key:z6Mk-cell-set-echo-race-audience";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+class SharedV2SessionFactory implements V2Storage.SessionFactory {
+  constructor(private readonly server: MemoryV2Server.Server) {}
+
+  async create(sessionSpace: MemorySpace) {
+    const client = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(this.server),
+    });
+    const session = await client.mount(
+      sessionSpace,
+      {},
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: {
+          principal: signer.did(),
+        },
+      }),
+    );
+    return { client, session };
+  }
+}
+
+const createRuntime = () => {
+  const server = new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: {
+      audience: testSessionOpenAudience,
+    },
+  });
+  const storageManager = new (class extends V2Storage.StorageManager {
+    constructor() {
+      super(
+        { as: signer, memoryHost: new URL("memory://") },
+        new SharedV2SessionFactory(server),
+      );
+    }
+  })();
+  const runtime = new Runtime({
+    apiUrl: new URL("http://localhost/"),
+    storageManager,
+  });
+  return { runtime, storageManager };
+};
+
+/**
+ * The IPC channel, in-process: client requests are handled by the (real)
+ * RuntimeProcessor immediately, but everything the worker sends back —
+ * responses AND notifications, sharing one FIFO like the real postMessage
+ * channel — sits in `outbox` until the test pumps it. Not pumping is the
+ * test's way of holding a message "in flight over IPC".
+ */
+class InProcessWorkerTransport extends EventEmitter<RuntimeTransportEvents>
+  implements RuntimeTransport {
+  readonly outbox: IPCRemoteMessage[] = [];
+
+  constructor(private readonly processor: RuntimeProcessor) {
+    super();
+  }
+
+  send(message: IPCClientMessage | IPCClientNotification): void {
+    if (!("msgId" in message)) {
+      throw new Error("This test sends no one-way client notifications");
+    }
+    const { msgId, data } = message;
+    // Initialize/Dispose are worker-entry concerns (backends/web-worker), not
+    // RuntimeProcessor handlers; the harness acks them directly.
+    if (
+      data.type === RequestType.Initialize || data.type === RequestType.Dispose
+    ) {
+      this.outbox.push({ msgId } as IPCRemoteMessage);
+      return;
+    }
+    void Promise.resolve()
+      .then(() =>
+        RuntimeProcessor.prototype.handleRequest.call(this.processor, data)
+      )
+      .then(
+        (response) =>
+          this.outbox.push(
+            (response !== undefined
+              ? { msgId, data: response }
+              : { msgId }) as IPCRemoteMessage,
+          ),
+        (error) =>
+          this.outbox.push(
+            {
+              msgId,
+              error: error instanceof Error ? error.message : String(error),
+            } as IPCRemoteMessage,
+          ),
+      );
+  }
+
+  /** Deliver everything queued so far to the main thread, in channel order. */
+  pump(): void {
+    while (this.outbox.length > 0) {
+      this.emit("message", this.outbox.shift()!);
+    }
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("CellSet / CellUpdate echo race over IPC", () => {
+  it("echoes the worker commit after a stale in-flight update, converging the handle", async () => {
+    const { runtime, storageManager } = createRuntime();
+
+    // The worker sink posts via self.postMessage; route it into the channel.
+    const hadPostMessage = "postMessage" in globalThis;
+    const originalPostMessage =
+      (globalThis as { postMessage?: unknown }).postMessage;
+
+    const schema = {
+      type: "object",
+      properties: { color: { type: "string" } },
+    } as const;
+
+    try {
+      // Seed the cell with red on the worker-side runtime.
+      const cell = runtime.getCell<{ color: string }>(
+        space,
+        "cell-set-echo-race",
+        schema,
+      );
+      const seed = runtime.edit();
+      cell.withTx(seed).set({ color: "red" });
+      runtime.prepareTxForCommit(seed);
+      await seed.commit();
+      await runtime.idle();
+
+      // A real RuntimeProcessor over that runtime (fields the cell handlers
+      // touch; the private ctor is bypassed the same way the processor's own
+      // test suite does).
+      const processor = Object.assign(
+        Object.create(RuntimeProcessor.prototype) as RuntimeProcessor,
+        { runtime, subscriptions: new Map() },
+      );
+      const transport = new InProcessWorkerTransport(processor);
+      (globalThis as { postMessage?: unknown }).postMessage = (m: unknown) =>
+        transport.outbox.push(m as IPCRemoteMessage);
+
+      const connectionPromise = new RuntimeConnection(transport).initialize(
+        {} as InitializationData,
+      );
+      transport.pump();
+      const connection = await connectionPromise;
+      const client = { [$conn]: () => connection } as unknown as RuntimeClient;
+
+      const handle = new CellHandle<{ color: string }>(
+        client,
+        createCellRef(cell, schema),
+      );
+      const seen: unknown[] = [];
+      const cancel = handle.subscribe((value) => {
+        seen.push(value === undefined ? undefined : { ...value });
+      });
+      await flush();
+      transport.pump();
+      expect(seen).toEqual([undefined, { color: "red" }]);
+
+      // A concurrent write lands worker-side (stands in for a server-pushed
+      // remote update — this hop doesn't care where the worker-local change
+      // came from). Its CellUpdate(blue) is queued but NOT delivered: it is
+      // in flight over IPC.
+      const blueTx = runtime.edit();
+      cell.withTx(blueTx).set({ color: "blue" });
+      runtime.prepareTxForCommit(blueTx);
+      await blueTx.commit();
+      await runtime.idle();
+      await flush();
+      expect(transport.outbox.length).toBeGreaterThan(0);
+
+      // Main thread blind-sets green while blue is in flight. The optimistic
+      // update fires before any IPC round trip.
+      const setPromise = handle.set({ color: "green" });
+      expect(handle.get()).toEqual({ color: "green" });
+      expect(seen).toEqual([
+        undefined,
+        { color: "red" },
+        { color: "green" },
+      ]);
+
+      // Let the worker process the CellSet: the real handleCellSet blind
+      // write commits green over blue, and the subscription sink re-fires for
+      // the worker's OWN commit — the echo — queued after blue.
+      await flush();
+      await runtime.idle();
+      await flush();
+
+      // Deliver the channel. Blue applies blindly (the transient flash — no
+      // suppression on this hop), then the echo converges the handle.
+      transport.pump();
+      expect(seen).toEqual([
+        undefined,
+        { color: "red" },
+        { color: "green" }, // optimistic
+        { color: "blue" }, // stale in-flight update, applied blindly
+        { color: "green" }, // the worker's echo of our own commit
+      ]);
+      expect(handle.get()).toEqual({ color: "green" });
+      await setPromise;
+
+      // Worker-side state agrees.
+      expect(cell.get()).toEqual({ color: "green" });
+
+      cancel();
+      await flush();
+      transport.pump(); // deliver the CellUnsubscribe ack
+      const disposePromise = connection.dispose();
+      transport.pump();
+      await disposePromise;
+    } finally {
+      if (hadPostMessage) {
+        (globalThis as { postMessage?: unknown }).postMessage =
+          originalPostMessage;
+      } else {
+        delete (globalThis as { postMessage?: unknown }).postMessage;
+      }
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> Scope grew across review discussion; the PR now has three parts:
> 1. **Replica-layer test** (`memory-v2-sync-under-pending.test.ts`) — the worker↔server wire hop, now driving a real blind-marked write and asserting the CellSet wire shape.
> 2. **IPC-layer test** (`cell-set-echo-race.test.ts`) — the main-thread↔worker hop this PR was originally motivated by.
> 3. **Test-harness consolidation** — the shared scripted-transport ceremony extracted into `memory-v2-test-utils.ts`.

## Summary

Adds direct coverage for a gap found while investigating a client/worker/server race: what happens when a foreign writer's watch sync arrives **while a local commit is still unconfirmed**.

The scenario (a "red → green vs blue" race): a client blind-writes a leaf (`red → green`) via `CellSet`; before the server acks, a concurrent writer's update (`blue`, also touching a sibling field) is pushed down. The replica's guarantees are:

- `applySessionSync` only advances the **confirmed base** — the pending write replays on top, so the visible value keeps the local leaf while integrating the sibling change (matching what the server computes when it applies the patch after blue).
- Confirmation promotes the merged value forward (`confirmPending`).
- A stale replay of the foreign doc (seq below the promoted confirmed seq) can never regress it (the monotonic guard).

The individual guards were each pinned elsewhere (`memory-v2-watch-refresh-race` pins monotonicity, the `memory-v2-stacked-commit` suite pins pending visibility), but no test delivered a sync with a commit in flight — `emitSync` was never used alongside a held transact.

## Test design

- `HeldTransactTransport` (modeled on the scripted transports in the watch-refresh-race / reconnect-race suites) serves the initial snapshot, **holds** the transact response until released, and can push `session/effect` syncs in between.
- Asserts the visible value at every step: optimistic overlay → rebase under the foreign sync → confirmation → stale replay. Also asserts no notification ever carried the foreign leaf value (no transient "blue" flash), using a second-doc barrier sync to sequence the guard-skipped stale replay.

## Verification

- Mutation-tested against both guards: (1) making `applySessionSync` clobber the pending queue and (2) removing the monotonic-seq skip each make the test fail; the pristine tree passes.
- `deno test packages/runner/test/memory-v2-sync-under-pending.test.ts packages/runner/test/memory-v2-watch-refresh-race.test.ts` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests that pin rebase under a pending commit in the v2 replica and the IPC echo ordering for CellSet, ensuring the local value survives and handles converge correctly. Also consolidate the scripted memory-v2 session ceremony into `ScriptedSessionTransport` and migrate existing suites to it.

- **New Tests**
  - `packages/runner/test/memory-v2-sync-under-pending.test.ts`: Delivers a foreign watch sync while a local commit is unconfirmed using a held-transact scripted transport; verifies rebase (pending leaf survives, sibling integrates), confirmation promotion, and monotonic skip with no transient foreign leaf. The write now uses real blind-UI marks (`markUiInputBlindWriteTx`, `setBlindStructuralTarget`) and asserts the wire shape: no value-equality read and a single nonRecursive structural read at the parent.
  - `packages/runtime-client/backends/cell-set-echo-race.test.ts`: Pins main-thread ↔ worker IPC ordering for CellSet vs a stale in-flight `CellUpdate`; confirms optimistic local set fires before any round trip, the stale update applies blindly, and the worker echoes its own commit to converge back to the local value.

- **Refactors**
  - Extracted `ScriptedSessionTransport` in `packages/runner/test/memory-v2-test-utils.ts` to own the shared `hello`/`session.open`/`session.ack` ceremony, codec plumbing, and `session/effect` push; tests now only script watch responses and transact verdicts. Migrated `memory-v2-stacked-commit`, `memory-v2-reconnect-race`, `memory-v2-watch-refresh-race`, and `memory-v2-watch-remove-coverage`; `SabotagedReconnectTransport` unchanged.

<sup>Written for commit 8a289704cd80007796305b6dff57b87301934c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up: scripted-transport consolidation

The second commit extracts the session ceremony that six scripted transports duplicated near-verbatim (hello + sessionOpen challenge rotation, `session.open` echo assertions, `session.ack`, receiver/codec plumbing, the `session/effect` push frame) into a `ScriptedSessionTransport` base in `memory-v2-test-utils.ts`. Each transport now carries only its scripted behavior (watch responses, transact verdicts) and overrides the seams where it deviates (serverSeq values, codec context, connection counting, silent close). `SabotagedReconnectTransport` is deliberately untouched — it proxies a real `MemoryV2Server` instead of scripting the ceremony. Net −285 lines; all 112 tests across the 29 files importing test-utils pass.



## IPC hop coverage (cell-set-echo-race.test.ts)

The replica test deliberately stops at the worker↔server wire; the main-thread↔worker IPC hop is pinned by a separate test in `packages/runtime-client/backends/`. A real `RuntimeProcessor` runs in-process over an in-memory memory-v2 server, bridged to a real `RuntimeConnection`/`CellHandle` through a transport whose single FIFO channel (responses + notifications, like real `postMessage`) the test pumps manually — not pumping holds a message "in flight over IPC". It asserts, via one strict sequence assertion:

- `set()` applies optimistically before any round trip,
- an in-flight stale `CellUpdate(blue)` is applied blindly on arrival (the accepted transient flash — no versioning/suppression exists on this hop),
- the worker **echoes its own commit** (the sink re-fires for self-originated writes; "don't echo to the sender" exists only server↔worker), ordered after the stale update, converging the handle to green while the worker/server state agrees.

Mutation-checked: silencing the subscription sink's re-fire fails the sequence assertion.

The replica test additionally now uses the real blind-write marks (`markUiInputBlindWriteTx` + `setBlindStructuralTarget`) and asserts the wire shape of the commit — no value-equality read, a single nonRecursive structural read at the leaf's parent — so its scripted server acceptance matches what a real server would do with a blind CellSet.
