### PR TITLE
toolshed: decouple dump router from the live memory-server module

### DIFF
--- a/packages/toolshed/routes/storage/memory-store-url.ts
+++ b/packages/toolshed/routes/storage/memory-store-url.ts
@@ -1,0 +1,20 @@
+// The on-disk root URL for the memory engine's SQLite stores, derived purely
+// from the environment. This is deliberately free of the live `MemoryServer`
+// construction and its top-level `await`s (see memory.ts), so a module that
+// only needs the store *location* — such as the dump router resolving a
+// space's file — can import the URL without forcing the whole server, the
+// identity setup, and the filesystem `ensureDir` to initialize first.
+
+import * as Path from "@std/path";
+import env from "@/env.ts";
+import { resolveMemoryEngineStoreRootUrl } from "./memory-path.ts";
+
+// DB_PATH selects single-file mode (an explicit, absolute database file);
+// otherwise MEMORY_DIR selects directory mode. See env.ts for the defaults.
+const storeUrl: URL = env.DB_PATH
+  ? Path.toFileUrl(env.DB_PATH)
+  : new URL(env.MEMORY_DIR);
+
+export const memoryEngineStoreUrl = resolveMemoryEngineStoreRootUrl(storeUrl, {
+  singleFileMode: Boolean(env.DB_PATH),
+});

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -1,9 +1,8 @@
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import { verifySessionOpenAuthorization } from "@commonfabric/memory/v2/session-open-auth";
 import * as FS from "@std/fs";
-import * as Path from "@std/path";
 import env from "@/env.ts";
-import { resolveMemoryEngineStoreRootUrl } from "./memory-path.ts";
+import { memoryEngineStoreUrl } from "./memory-store-url.ts";
 import { identity } from "@/lib/identity.ts";
 
 const memoryAudience = identity.did();
@@ -16,22 +15,15 @@ const authorizeSessionOpen = (
   context: Parameters<typeof verifySessionOpenAuthorization>[1],
 ): Promise<string> => verifySessionOpenAuthorization(message, context);
 
-// Determine store URL: DB_PATH (single-file mode) or MEMORY_DIR (directory mode)
-let storeUrl: URL;
-
+// The store URL is derived in memory-store-url.ts (DB_PATH single-file mode or
+// MEMORY_DIR directory mode). Log which mode is active for this server.
 if (env.DB_PATH) {
-  // Single file mode: use explicit database file (must be absolute path)
-  storeUrl = Path.toFileUrl(env.DB_PATH);
   console.log(`Memory: Using single database file: ${env.DB_PATH}`);
 } else {
-  // Directory mode: use MEMORY_DIR (existing behavior)
-  storeUrl = new URL(env.MEMORY_DIR);
   console.log(`Memory: Using directory mode: ${env.MEMORY_DIR}`);
 }
 
-export const memoryEngineStoreUrl = resolveMemoryEngineStoreRootUrl(storeUrl, {
-  singleFileMode: Boolean(env.DB_PATH),
-});
+export { memoryEngineStoreUrl };
 await FS.ensureDir(memoryEngineStoreUrl);
 
 export const memoryServer = new MemoryServer.Server({

--- a/packages/toolshed/routes/storage/memory/memory-dump.index.ts
+++ b/packages/toolshed/routes/storage/memory/memory-dump.index.ts
@@ -24,7 +24,7 @@ import {
 import { createRouter } from "@/lib/create-app.ts";
 import type { AppBindings } from "@/lib/types.ts";
 import env from "@/env.ts";
-import { memoryEngineStoreUrl } from "@/routes/storage/memory.ts";
+import { memoryEngineStoreUrl } from "@/routes/storage/memory-store-url.ts";
 import { dumpAllowSet, isDumpEnabled } from "./memory-dump-policy.ts";
 
 const DUMP_BASE = "/api/storage/memory/dump";


### PR DESCRIPTION
The memory-dump-disabled test intermittently failed in CI with "Top-level await promise never resolved" at its top-level `await import` of memory-dump.index.ts. The failure was nondeterministic and load-dependent: it passed in adjacent runs with identical code and passes locally under repeated runs, appearing only under CPU contention.

The cause was in the router's import graph, not the test. memory-dump.index.ts imported `memoryEngineStoreUrl` from routes/storage/memory.ts — the module that constructs the live MemoryServer. Reading that one computed URL dragged the entire server-initialization chain into the router's evaluation: memory.ts's top-level `await FS.ensureDir`, the MemoryServer.Server construction (and its engine and SQLite import graph), and transitively lib/identity.ts's top-level `await Identity.fromPassphrase`. Until that whole chain settled, the router module could not finish evaluating, so the test's dynamic import stayed pending. Under CPU contention that chain intermittently failed to settle in time and Deno reported the top-level await as never resolved.

The dump router does not need the server. It needs only the store URL, and only inside the route handler — which never runs in the disabled test, because the gate returns 404 before touching it. The store URL is a pure function of the environment (DB_PATH single-file mode or MEMORY_DIR directory mode).

Extract that derivation into a new dependency-free module, memory-store-url.ts, and have both memory.ts and memory-dump.index.ts import the URL from it. memory.ts keeps its ensureDir, mode logging, and server construction unchanged and re-exports the value for existing consumers. The dump router's import graph now contains no top-level await beyond the test's own, so importing the router no longer forces server, identity, or filesystem initialization, and the structural cause of the hang is removed rather than masked with a timeout.

The test's intent is unchanged: the dump routes still 404 when MEMORY_DUMP_ENABLED is unset, verified against a fresh module graph with a validly signed, allowlisted caller.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled the memory dump router from the live memory server to remove a blocking top-level await chain on import. This fixes the intermittent CI hang in the memory-dump-disabled test without changing behavior.

- **Bug Fixes**
  - Extracted a pure env-derived `memoryEngineStoreUrl` into `routes/storage/memory-store-url.ts` with no server or filesystem side effects.
  - Pointed `memory-dump.index.ts` at the new module so importing the router no longer initializes the server or `identity`.
  - Kept `routes/storage/memory.ts` server setup unchanged; it logs mode, runs `FS.ensureDir`, and re-exports `memoryEngineStoreUrl` for existing consumers.

<sup>Written for commit 319368b7daf883e1165dd3f6f78a9dd482809b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

