### PR TITLE
Remove leftover Fly.io deploy artifacts from toolshed

### DIFF
--- a/packages/toolshed/.dockerignore
+++ b/packages/toolshed/.dockerignore
@@ -1,1 +1,0 @@
-fly.toml

--- a/packages/toolshed/README.md
+++ b/packages/toolshed/README.md
@@ -106,25 +106,6 @@ You'll want to install the
 [Deno extension](https://docs.deno.com/runtime/reference/vscode/), and the
 [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode).
 
-## CI/CD
-
-Our CI/CD pipeline is basically: run a linter, run the tests, deploy to fly.
-
-It's built on GitHub Actions, the configuration
-[lives here](https://github.com/commontoolsinc/labs/blob/main/.github/workflows/toolshed.yml).
-
-## Deploying to Production
-
-Toolshed is deployed to fly.io.
-
-To deploy you simply run the following command:
-
-```shell
-fly deploy
-```
-
-If you need access to deploy to fly, ping Jake for access and instructions.
-
 ## Contributing
 
 1. Fork the repository


### PR DESCRIPTION
Removing the stale packages/toolshed/Dockerfile left two more remnants of the same old Fly.io deployment path in the toolshed package:

- packages/toolshed/.dockerignore contained only "fly.toml". It applied to the now-removed Dockerfile's build context, and the fly.toml it named no longer exists anywhere in the repo.
- The README "CI/CD" and "Deploying to Production" sections described deploying with `fly deploy` to fly.io and linked a .github/workflows/toolshed.yml that does not exist. Toolshed is no longer deployed to Fly: CI builds a tarball artifact and staging/production deploy it over SSH via the bastion deploy script, and the cluster image builds from the repo-root Dockerfile.toolshed.

Delete the orphaned .dockerignore and drop the two stale README sections so the package stops documenting a deployment path that no longer exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up leftover Fly.io deploy artifacts in `packages/toolshed`. Deleted the orphaned `.dockerignore` and removed outdated README sections about Fly deploy to align docs with the current SSH-based deploy and repo-root `Dockerfile.toolshed` image build.

<sup>Written for commit 8dd0e0b99c9211e601c882e3e8a8204cadb13f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

