### PR TITLE
test(patterns): drop cross-space-sync workaround from profile-embed c…

### DIFF
--- a/packages/patterns/integration/profile-embed.test.ts
+++ b/packages/patterns/integration/profile-embed.test.ts
@@ -13,7 +13,6 @@ import {
   clickTrustedAction,
   fillCfInput,
   waitForRuntimeIdle,
-  waitForRuntimeSynced,
   waitForText,
   waitForTextAbsent,
 } from "./cfc-browser-helpers.ts";
@@ -154,7 +153,11 @@ describe("profile-embed integration test", () => {
       { timeout: PROFILE_EMBED_TIMEOUT },
     );
     await clickSaveByLabel(page, "Save name");
-    await waitForRuntimeSynced(page);
+    // The save dispatches into the resolved profile's owner-protected setName
+    // stream — a cross-space write into the profile space this session created
+    // and still holds open. `waitForRuntimeIdle` awaits the pending-commit
+    // barrier, so the write is server-confirmed before the next edit.
+    await waitForRuntimeIdle(page);
 
     // Amend the bio too (bio is clearable; the embed sends the trimmed draft).
     // cf-textarea wraps a native <textarea> (not an <input>), so fillCfInput —
@@ -165,7 +168,10 @@ describe("profile-embed integration test", () => {
       "Countess of computing.",
     );
     await clickSaveByLabel(page, "Save bio");
-    await waitForRuntimeSynced(page);
+    // As with the name save, the bio dispatches into the resolved profile's
+    // owner-protected setBio stream; `waitForRuntimeIdle` confirms the write
+    // through the pending-commit barrier before edit mode is left.
+    await waitForRuntimeIdle(page);
 
     // Leave edit mode and assert the RESOLVED presentation reflects the amends:
     // the hero badge shows the new name and the bio paragraph renders.
@@ -201,12 +207,18 @@ async function waitForSelector(page: Page, selector: string) {
 // shared-profile.test.ts: fill the create input like a user, then fire the
 // trusted CreateProfile click carrying the typed name.
 async function createProfileFromFallback(page: Page, name: string) {
-  await waitForRuntimeSynced(page);
   await fillCfInput(page, CREATE_INPUT, name, {
     timeout: PROFILE_EMBED_TIMEOUT,
   });
   await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
-  await waitForRuntimeSynced(page);
+  // Creating a profile satisfies `#profile` by committing into a new cross-space
+  // child space, issued fire-and-forget by the trusted action's handler.
+  // `waitForRuntimeIdle` awaits the storage manager's pending-commit barrier
+  // alongside scheduler quiescence, so the create is server-confirmed before the
+  // caller reads the resolved profile back. The read renders in this same
+  // session, so the child space stays open and subscribed and the reactive read
+  // resolves from already-open state without a separate cross-space sync.
+  await waitForRuntimeIdle(page);
 }
 
 // Fill a cf-textarea's inner native <textarea> and durably commit the edit.


### PR DESCRIPTION
…reate and amend

The profile-embed integration test bracketed its profile create and its two edit-mode saves with `waitForRuntimeSynced` (rt.allSynced) calls. Those were added when the client-facing idle guaranteed only reactive quiescence, not commit durability. Creating a profile, and saving an amended name or bio, each issue a fire-and-forget cross-space commit from an event handler, and `waitForRuntimeIdle` used to return while that commit was still travelling to the server. `waitForRuntimeSynced` papered over that by additionally awaiting every opened space to reconcile.

The idle-durability fix (#4453) folded the storage manager's pending-commit barrier into the client-facing idle. `waitForRuntimeIdle` now awaits `idleWithPendingCommits`, which re-checks the pending-commit set in the same convergence loop as reactive quiescence, and each commit is registered synchronously as it is issued. So the durability half of the workaround is now redundant for all three sites.

The `createProfileFromFallback` helper also had a second `waitForRuntimeSynced` before it filled the create input. That pre-submit reconciliation is covered too: the shell's login navigation ends with its own `rt.idle()`, so the rehydration commits from loading the piece are already awaited to durability before the helper runs, and the create lands against reconciled state without a separate `allSynced`.

The remaining question was the rendering half. `allSynced` additionally awaits every opened space's cross-space reads to converge, which idle deliberately excludes: the pending-commit barrier is kept distinct from the cross-space read set. The profile's name and bio live in the profile's own child space, and the resolved presentation reads them back across that space boundary through the `#profile` wish. Dropping `allSynced` could therefore have left the badge or the bio paragraph rendering blank. It does not here, because every assertion reads in the same session that created or wrote the data. The test holds the result cell subscribed for the whole run, so the child space stays open and subscribed, the reactive read resolves from already-open state, and the rendered value reaches the DOM. The `waitForText` assertions poll for exactly that value over a thirty-second budget, so any lag between idle returning and the cross-space read converging is bridged by the poll rather than by a separate sync.

This matches the idle-only cross-space-read shape already shipped and passing in the sibling profile tests. The home-profile create-then-read and the shared-profile create-then-read both read a name back through the same cross-space path using only `waitForRuntimeIdle`. The tests that still need `allSynced` are the ones that read after a full reload, where the worker is torn down and the child space is no longer subscribed; those are left untouched.

Each dropped `waitForRuntimeSynced` becomes a single trailing `waitForRuntimeIdle`, and the now-unused import is removed. Verified by running the test file five times with a fresh identity each run; the create-then-read and both amend-then-read assertions stayed green with no timeouts. Five local runs do not exercise the cross-browser contention that would most stress the cross-space read, so the durable safety margin is the thirty-second `waitForText` window together with the sibling tests' track record on the same idle-only shape, not the local runs alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop cross-space sync workaround in the profile-embed integration test to rely on durable idle. Replaced `waitForRuntimeSynced` with `waitForRuntimeIdle` to keep commits durable while reducing unnecessary cross-space sync waits.

- **Refactors**
  - Replaced post-create and post-save `waitForRuntimeSynced` with `waitForRuntimeIdle`.
  - Removed pre-fill `waitForRuntimeSynced` in `createProfileFromFallback`; login flow `rt.idle()` already covers rehydration.
  - Removed unused import and added brief comments on durability and cross-space reads.

<sup>Written for commit faf01b436a25b8a8ef9a0f3c9f116d7c9baf2705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

