### PR TITLE
[DO NOT LAND] docs(orientation): add new-engineer architecture orientation

### DIFF
--- a/docs/development/TECHNICAL_DEBT.md
+++ b/docs/development/TECHNICAL_DEBT.md
@@ -1,0 +1,241 @@
+# Technical debt and rough edges
+
+One register of the things in this repository that are broken, half-migrated,
+deliberately conservative, or simply surprising. It exists so that a newcomer can
+find out in one place what will bite them, and so that anyone deciding what to
+pay down can see the whole board at once.
+
+This is **live** documentation: if you fix one of these, delete the entry in the
+same change. If you find a new one, add it. An entry that no longer matches the
+code is a bug.
+
+Scope and tone: this page says what is wrong and why it matters. It does not
+explain how the subsystems work — for that, see the
+[orientation docs](orientation/README.md), which each link back here. Not
+everything below is a defect; some entries are deliberate trade-offs recorded so
+nobody "fixes" them by accident. Those are marked **by design**.
+
+---
+
+## Structural: the import cycles
+
+Four genuine import cycles exist in production code. The
+[dependency graph](orientation/dependency-graph.md) draws them and gives the
+exact seam for each; the short version:
+
+- **`runner ↔ html`** — the runtime's builder (`builder/built-in.ts`,
+  `factory.ts`, `builtins/wish.ts`) imports `h()` to construct view nodes, while
+  `html`'s worker reconciler imports cell helpers back from `runner`. A UI
+  primitive is wired into the foundation.
+- **`runner ↔ memory`** — `memory/v2/query.ts` imports
+  `@commonfabric/runner/traverse` to answer schema-aware graph queries and
+  evaluate per-row CFC labels. The cycle forms on that one package edge, but the
+  same file also reaches runner's CFC, storage-transaction, and builder-type
+  internals through *relative* paths, so the coupling is deeper than the package
+  graph suggests. This is the seam to know if anyone tries to extract `memory` as
+  a standalone library.
+- **`runner ↔ llm`** — one import: `llm/src/prompts/json-import.ts` needs
+  `createJsonSchema`. A prompt helper reaching up into the runtime.
+- **`ui ↔ shell`** — four `cf-*` components import navigation/URL helpers from
+  `@commonfabric/shell/shared`; the shell imports `cf-*` classes and the Lit
+  contexts back. Narrowed to navigation, but real.
+
+Three of the four touch `runner`, which is what you would expect: the cheapest
+place to introduce a cycle is against the package everything already depends on.
+
+## Structural: the layering violation
+
+- **`runner → home-schemas`.** `runner/src/builtins/wish.ts` imports
+  `favoriteListSchema` from `@commonfabric/home-schemas` — a foundation builtin
+  coupled to an end-user-domain schema. A newcomer reasonably expects builtins to
+  be generic; this one is not. (`home-schemas` itself exists to *prevent* a
+  different cycle, by giving `runner` and `piece` somewhere neutral to share
+  schemas.)
+
+## Structural: where the complexity concentrates
+
+- **A handful of files carry a disproportionate share of the system**, each
+  several thousand lines: `runner/src/cfc/prepare.ts`, `memory/v2/engine.ts`,
+  `runner/src/runner.ts`, `runner/src/traverse.ts`,
+  `ts-transformers/src/transformers/schema-injection.ts`,
+  `html/src/worker/reconciler.ts`, `runner/src/builtins/llm-dialog.ts`,
+  `runner/src/storage/v2.ts`, `runner/src/cell.ts`,
+  `ts-transformers/src/policy/capability-analysis.ts`, and
+  `runner/src/scheduler/facade.ts`. Most are in `runner`, and the largest is the
+  CFC write-policy gate — Contextual Flow Control has grown into the biggest
+  single piece of the runtime.
+- **`cli` is a hub, and a growing one.** It imports `runner` most, plus
+  `identity`, `utils`, `js-compiler`, `piece`, `api`, and `state-inspector`. A
+  change in any of those can break the command line.
+
+---
+
+## Security and safety
+
+- **`cf-markdown` renders unsanitized HTML.** It applies `unsafeHTML` to rendered
+  markdown with no sanitizer, and carries an in-code `TODO(CT-1088)` saying so. A
+  cross-site-scripting risk if it is ever fed untrusted markdown. A previous
+  DOMPurify dependency was removed over lockfile issues. Know this before reusing
+  the component.
+- **The iframe sandbox has documented, accepted gaps.** Its README lists them:
+  the hardcoded-CDN allowlist and anchors with `target=_blank` are both
+  exfiltration vectors, and `document.baseURI` leaks the parent URL into the
+  guest.
+- **The shell route's COOP/COEP headers are deliberately non-isolating**
+  (`same-origin-allow-popups` / `unsafe-none`, set after the handler so they
+  override upstream). **By design**: keeping `crossOriginIsolated === false`
+  denies SES-sandboxed patterns `SharedArrayBuffer` and high-resolution timers.
+  Do not "fix" this without understanding why.
+- **The SQL guard is intentionally conservative** (`memory/v2/sqlite/guard.ts`):
+  single statement only, no PRAGMA/ATTACH, no references to core engine tables.
+  **By design** — it rejects some valid statements to keep the attack surface
+  small.
+- **CFC row labels fail closed** (`memory/v2/sqlite/row-label.ts`). Well-formed
+  disjunctive confidentiality clauses are accepted, but unsound shapes are
+  rejected outright: an `any()` alternative that is itself a conjunction or
+  nested disjunction, disjunctive *integrity*, ambiguous multi-op nodes, and
+  ReDoS-shaped regexes. **By design**, but it means legitimate-looking authoring
+  can be refused.
+
+---
+
+## Durability and correctness risks
+
+- **FUSE writes are fire-and-forget.** `write(2)` returns success *before* the
+  cell mutation lands; the buffer is only pushed to the cell on flush (on close)
+  or release. A disconnect between the reply and the flush can silently lose
+  data. `fuse`'s `RELIABILITY_DESIGN.md` and the CFC-writeback state machine are
+  the mitigation, not a fix. Note also that `fsync` is *not* wired as a writeback
+  trigger — the one durability primitive a caller would reach for does nothing
+  here.
+- **The background piece scheduler is approximate.** Its TODOs are the honest
+  record: space managers should watch their own pieces; a terminal worker error
+  cannot always be attributed to a specific piece, so a stray failure can disable
+  a whole space; and sync is assumed never to return partial results.
+- **`background-piece-service` depends on hardcoded constants** — the
+  system-space DID (`BG_SYSTEM_SPACE_ID`) and a dated cause string
+  (`BG_CELL_CAUSE`) in `schema.ts` — and needs a one-time admin grant before any
+  piece is polled at all.
+- **`runtime-client` teardown is intentionally quiet.** After a `Dispose`, the
+  worker silently acknowledges late requests and drops notifications. **By
+  design**, but genuinely confusing while debugging.
+- **CFC silently gates commits.** The default enforcement mode can reject a write
+  or replace blocked content with a placeholder. If a write or a piece of UI
+  "disappears", suspect CFC before the scheduler or the renderer.
+
+---
+
+## Migrations in flight, and legacy that lingers
+
+- **`memory` carries two vocabularies.** An older UCAN-flavored "fact" model —
+  `assert`/`retract`/`unclaimed` in `fact.ts`, its types in `interface.ts`,
+  reached through the `@commonfabric/memory/fact` subpath that runner's storage
+  layer still imports — sits alongside the current v2 document/operation model
+  (`EntityDocument`, `Operation`, `ClientCommit`, `GraphQuery` in `v2.ts`). New
+  work is v2; `lib.ts` is the legacy entry point. The fact model is still
+  exported and still confuses newcomers.
+- **Three link representations coexist**: the serialized `SigilLink`, the
+  in-memory `NormalizedLink`, and a deprecated `LegacyAlias` still present in the
+  `PrimitiveCellLink` union. New readers meet all three.
+- **The modern cell representation is implemented but off.**
+  `data-model/cell-rep.ts` implements both the modern (bare
+  `FabricHash`/`FabricLink`) and legacy (`{ "/": "tag:hash" }` envelope) forms;
+  a module-level `modernCellRepEnabled` flag, default off, selects between them.
+  The flip, when it happens, happens there.
+- **The `TODO(danfuzz)` cluster** across `schema.ts`, `cfc/`, `traverse.ts`, and
+  `cell.ts` marks one incomplete migration, not scattered bugs: several graph
+  walks do not yet admit the newer `FabricValue` special objects on every path.
+- **Two render paths still exist.** The worker-thread reconciler is the live one;
+  the legacy main-thread `renderNode`/`effect` path in `html/src/render.ts`
+  remains and is still selectable by a flag.
+- **`v1` is gone but the `v2/` directory name remains.** `ui/src/index.ts` is
+  just `export * from "./v2/index.ts"`. Everything is v2; the name is flagged for
+  cleanup.
+- **Several shell views are inert pending a worker refactor.** `ACLView` and
+  parts of `QuickJumpView` carry `TODO(runtime-worker-refactor)` and currently do
+  nothing.
+- **The charm→piece rename is complete in source but not on the wire.** So
+  existing spaces keep resolving, the persisted names were deliberately left
+  alone: the `bgUpdater` handler-stream name, the dated `BG_CELL_CAUSE` string,
+  and the derived `BG_SYSTEM_SPACE_ID`. None of them contain the word "charm";
+  they are simply legacy-shaped. (Repo-wide, "charm" now survives only in
+  unrelated test data and git history.)
+
+---
+
+## Hand-maintained couplings
+
+These have no compiler enforcing them; they drift silently.
+
+- **`api` declarations must be kept in sync by hand.** `api/index.ts` is
+  `declare const` / ambient declarations that must match implementations
+  elsewhere: the builder vocabulary against `runner/src/builder`, and (per the
+  sync note at the top of the file) the Fabric value types against `data-model`.
+  Changing a signature means editing it in two places.
+- **Transformer behavior is pinned by golden files.** `ts-transformers` and
+  `schema-generator` are golden-driven (`*.input.tsx`/`*.expected.jsx` and
+  `*.input.ts`/`*.expected.json`). Changing emit shape means regenerating
+  goldens (`UPDATE_GOLDENS=1`) and reviewing a large diff; `FIXTURE=<name>` is
+  the fast path.
+- **The FUSE FFI struct layouts are hand-maintained** and differ per platform
+  (macOS FUSE v2 / FUSE-T, Linux FUSE v3). FUSE-T additionally lacks
+  `notify_inval_entry`, so cache invalidation falls back to per-inode
+  invalidation with short timeouts.
+
+---
+
+## Traps and misleading names
+
+- **`cf-harness` is not a test harness.** It is an experimental agent runtime —
+  an LLM tool-calling loop with a sandbox, tool registry, and CFC awareness.
+  Probably the single most misleading name in the repo.
+- **The runtime-client protocol calls pieces "pages."** `PageCreate`,
+  `PageHandle`, and friends all mean *piece*.
+- **The LLM provider abstraction is not in the `llm` package.** It lives in
+  `toolshed/routes/ai/llm/models.ts`; the `llm` package is only an HTTP client
+  plus prompts. People look in `llm/` first and find nothing.
+- **`runtime.ts` imports from its own package barrel** — it pulls the
+  `RuntimeTelemetry` *value* (a class, not a type) from `@commonfabric/runner`.
+  A load-order trap when reordering exports.
+- **The scheduler is pull-based**, which is counterintuitive if you arrive
+  expecting a push/observer model. Effects are the demand roots; computations are
+  lazy until something demanded needs them. Budget time for this.
+- **The `lift-applied` distinction is subtle.** A single application
+  (`__cfHelpers.lift(cb)(input)`, what `computed` lowers to) is classified
+  `lift-applied`; an unapplied `lift(cb)` or a multi-application chain
+  deliberately is not. This gates whole dispatch branches.
+- **`cf-*` components self-register on import.** Importing the module calls
+  `customElements.define`; there is no separate registration step. If a component
+  is "missing", check that its module was imported.
+- **OAuth providers are skipped silently.** Providers with missing credentials
+  return null and are dropped at startup, and the shared `/api/integrations/bg`
+  route attaches to whichever descriptor has credentials first. Non-obvious when
+  an endpoint "isn't there".
+- **Pattern authority is non-uniform.** Check the Status tiers in
+  `packages/patterns/index.md` before copying anything: only `exemplar`-tier
+  patterns are style references, and the `legacy` tier (the whole `record/`
+  system, the attribute clones, `factory-outputs/`) will teach you deprecated
+  idioms.
+- **Deno is narrowly version-pinned.** A mismatched local Deno fails
+  `deno task check` before any real work runs.
+
+---
+
+## Flagged in the code
+
+Markers worth knowing about, because they name real intent rather than idle
+grumbling:
+
+- `piece/src/manager.ts` — `FIXME(JA): this really really really needs to be
+  revisited`, plus a TODO about temporarily using elevated permissions.
+- `ui/src/v2/components/cf-markdown/cf-markdown.ts` — `TODO(CT-1088): XSS
+  VULNERABILITY`.
+- `shell` — `TODO(runtime-worker-refactor)` in `ACLView` and `QuickJumpView`.
+- `runner` — the `TODO(danfuzz)` `FabricValue` migration cluster.
+- `background-piece-service` — the scheduler-approximation TODOs described above.
+
+By contrast, `ts-transformers` and `js-compiler` are almost free of
+`TODO`/`FIXME`/`HACK` comments. Their open questions live in design documents
+instead (`ts-transformers/docs/`, `docs/specs/ts-transformer/`, and
+`ts-transformers/ISSUES_TO_FOLLOW_UP.md`) — the README tells you to read the
+behavior spec rather than infer from the code, and it means it.

--- a/docs/development/orientation/README.md
+++ b/docs/development/orientation/README.md
@@ -33,11 +33,11 @@ Read the pages in roughly this order:
 A note on vocabulary before anything else: this repository was renamed from
 **"charm"** to **"piece."** That rename is now essentially complete in source —
 `background-charm-service` became `background-piece-service`, and a scan finds
-"charm" only inside a Scrabble word list. What survives is the on-the-wire
-`bgUpdater` stream name and a dated cause string in the background service (kept
-so existing spaces don't break), plus some test file names and git history.
-Treat the two words as the same concept. See the glossary at the bottom of this
-page.
+the word "charm" only in unrelated test data (a Scrabble word list and a
+Frankenstein excerpt used as a hashing fixture). What survives of the old name is
+the on-the-wire `bgUpdater` stream name and a dated cause string in the
+background service (kept so existing spaces don't break), plus git history. Treat
+the two words as the same concept. See the glossary at the bottom of this page.
 
 ---
 
@@ -140,11 +140,11 @@ graph LR
     classDef big fill:#c0392b,stroke:#7b241c,color:#fff
     classDef mid fill:#e67e22,stroke:#a04000,color:#fff
     classDef small fill:#27ae60,stroke:#1e8449,color:#fff
-    R["runner — 100k loc"]:::big
+    R["runner — 106k loc"]:::big
     U["ui — 53k loc"]:::big
-    T["ts-transformers — 40k loc"]:::mid
+    T["ts-transformers — 41k loc"]:::mid
     C["cli — 25k loc"]:::mid
-    M["memory — 16k loc"]:::mid
+    M["memory — 18k loc"]:::mid
     SH["shell — 15k loc"]:::mid
     TS["toolshed — 14k loc"]:::mid
     H["html — 13k loc"]:::mid

--- a/docs/development/orientation/README.md
+++ b/docs/development/orientation/README.md
@@ -30,6 +30,11 @@ Read the pages in roughly this order:
    `patterns`, `utils`, `static`, the test runner, the dev-server scripts, and
    the skills system.
 
+These pages describe how the system works. What is *wrong* with it — the debt,
+the half-finished migrations, and the traps that will cost you an afternoon —
+is collected separately in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md). It is
+worth skimming early; each page here links to it.
+
 A note on vocabulary before anything else: this repository was renamed from
 **"charm"** to **"piece."** That rename is now essentially complete in source —
 `background-charm-service` became `background-piece-service`, and a scan finds

--- a/docs/development/orientation/README.md
+++ b/docs/development/orientation/README.md
@@ -129,10 +129,10 @@ the "foundation."
 
 ## How big each package is
 
-Sizes are non-test TypeScript lines, measured from source. They tell you where
-the weight (and the reading time) actually is. Note that two large numbers are
-not hand-written engineering: `patterns` is example programs, and most of
-`static` is a single generated TypeScript standard-library declaration file.
+Rough sizes (non-test TypeScript lines, order-of-magnitude — they tell you where
+the weight and the reading time are, not an exact measurement). `runner` dwarfs
+everything; `ui` and `ts-transformers` are the next tier; the foundation
+libraries are comparatively small.
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
@@ -140,25 +140,26 @@ graph LR
     classDef big fill:#c0392b,stroke:#7b241c,color:#fff
     classDef mid fill:#e67e22,stroke:#a04000,color:#fff
     classDef small fill:#27ae60,stroke:#1e8449,color:#fff
-    R["runner — 106k loc"]:::big
-    U["ui — 53k loc"]:::big
-    T["ts-transformers — 41k loc"]:::mid
-    C["cli — 25k loc"]:::mid
-    M["memory — 18k loc"]:::mid
-    SH["shell — 15k loc"]:::mid
-    TS["toolshed — 14k loc"]:::mid
-    H["html — 13k loc"]:::mid
-    F["fuse — 12k loc"]:::mid
-    DM["data-model — 8k loc"]:::small
-    SG["schema-generator — 8k loc"]:::small
-    SI["state-inspector — 6k loc"]:::small
-    API["api — 6k loc"]:::small
-    UT["utils — 3.5k loc"]:::small
+    R["runner — ~100k"]:::big
+    U["ui — ~50k"]:::big
+    T["ts-transformers — ~40k"]:::mid
+    C["cli — ~25k"]:::mid
+    M["memory — ~18k"]:::mid
+    SH["shell — ~15k"]:::mid
+    TS["toolshed — ~14k"]:::mid
+    H["html — ~13k"]:::mid
+    F["fuse — ~12k"]:::mid
+    DM["data-model — ~8k"]:::small
+    SG["schema-generator — ~8k"]:::small
+    SI["state-inspector — ~6k"]:::small
+    API["api — ~6k"]:::small
+    UT["utils — ~3.5k"]:::small
 ```
 
-(Excluded from this chart because they are examples, generated, or vendored:
-`patterns` 321k, `generated-patterns` 39k, `vendor-astral` 29k, `cf-harness`
-23k, `static` 13k. See the [tooling page](tooling-and-patterns.md).)
+(Excluded from this chart because they are examples, generated, or vendored, and
+much larger: `patterns` (example programs), `generated-patterns`, `vendor-astral`
+(vendored), `cf-harness`, and `static` (mostly a generated declaration file). See
+the [tooling page](tooling-and-patterns.md).)
 
 ---
 

--- a/docs/development/orientation/README.md
+++ b/docs/development/orientation/README.md
@@ -1,0 +1,280 @@
+# Architecture orientation for new engineers
+
+This folder is a map of the Common Fabric monorepo for someone who has never
+seen it before. It was assembled by reading the actual source in every package
+and by extracting the real import edges between packages, rather than by
+restating intentions. Where the code disagrees with the older prose in
+`AGENTS.md` or a package README, the disagreement is called out instead of
+smoothed over.
+
+Read the pages in roughly this order:
+
+1. **This page** — the big picture: what the system is, the layer model, the
+   deployed runtime topology, and a glossary.
+2. [The dependency graph](dependency-graph.md) — which package imports which,
+   measured from source, including the circular dependencies and the
+   layering violations the layer model would prefer you not to notice.
+3. [The runtime core](runtime-core.md) — `runner`, the reactive engine that
+   everything else is arranged around.
+4. [The storage substrate](storage-substrate.md) — `memory`, `data-model`,
+   `identity`, and the two small leaf libraries underneath them.
+5. [The compile pipeline](compile-pipeline.md) — how an author's `.tsx` file
+   becomes a runnable module with JSON Schemas attached (`api`,
+   `ts-transformers`, `js-compiler`, `schema-generator`).
+6. [The client and rendering stack](client-render.md) — `html`, `ui`,
+   `iframe-sandbox`, `shell`.
+7. [The backend](backend.md) — `toolshed`, `background-piece-service`, `llm`.
+8. [The CLI, pieces, and filesystem](cli-piece-fuse.md) — `cli`, `piece`,
+   `runtime-client`, `fuse`.
+9. [Examples, support libraries, and repo tooling](tooling-and-patterns.md) —
+   `patterns`, `utils`, `static`, the test runner, the dev-server scripts, and
+   the skills system.
+
+A note on vocabulary before anything else: this repository was renamed from
+**"charm"** to **"piece."** That rename is now essentially complete in source —
+`background-charm-service` became `background-piece-service`, and a scan finds
+"charm" only inside a Scrabble word list. What survives is the on-the-wire
+`bgUpdater` stream name and a dated cause string in the background service (kept
+so existing spaces don't break), plus some test file names and git history.
+Treat the two words as the same concept. See the glossary at the bottom of this
+page.
+
+---
+
+## What the system is, in one paragraph
+
+Common Fabric runs small user-written reactive programs called **patterns**.
+A pattern is written in TypeScript with JSX, and it is built out of reactive
+**cells** that live in a durable, content-addressed store. A running instance of
+a pattern is called a **piece**. Pieces live in a **space**, which is a store
+identified by a cryptographic key (a Decentralized Identifier, written "DID").
+When a cell changes, a scheduler re-runs only the computations that read that
+cell, and the results flow out to the user interface, to other pieces, and back
+to durable storage. The whole thing is designed so that every flow of
+information can be observed and gated, which is what the "Contextual Flow
+Control" (CFC) machinery in the runtime is for.
+
+---
+
+## The layer model ("pace layers")
+
+`AGENTS.md` describes the repository as a stack of layers that change at
+different speeds — the foundation changes slowly, the end-user programs change
+constantly. The diagram below mirrors that list. `AGENTS.md` also carves out a
+set of support and test packages that sit outside the layer stack (`utils`,
+`content-hash`, `leb128`, `test-support`, `deno-web-test`, `integration`,
+`generated-patterns`, `felt`, `static`, `vendor-astral`, `fs-sync-example`);
+those are shown in the side box.
+
+```mermaid
+flowchart TB
+    subgraph L7["7 · End-user programs (change constantly)"]
+        patterns["patterns"]
+        homeschemas["home-schemas"]
+    end
+    subgraph L6["6 · User interface"]
+        ui["ui (cf-* web components)"]
+    end
+    subgraph L5["5 · Deployed product"]
+        toolshed["toolshed (backend)"]
+        shell["shell (web SPA)"]
+        libshell["lib-shell"]
+        rtc["runtime-client"]
+    end
+    subgraph L4["4 · Operation"]
+        cli["cli (the cf command)"]
+        bcs["background-piece-service"]
+        fuse["fuse"]
+        sinsp["state-inspector"]
+        cfh["cf-harness"]
+    end
+    subgraph L3["3 · Capabilities"]
+        piece["piece"]
+        html["html (VDOM + JSX)"]
+        llm["llm"]
+    end
+    subgraph L2["2 · System"]
+        schemagen["schema-generator"]
+        iframe["iframe-sandbox"]
+        tstx["ts-transformers"]
+        jsc["js-compiler"]
+    end
+    subgraph L1["1 · Foundation (changes slowly)"]
+        api["api"]
+        datamodel["data-model"]
+        runner["runner"]
+        identity["identity"]
+        memory["memory"]
+    end
+    subgraph SUP["Support & test (outside the stack)"]
+        utils["utils"]
+        contenthash["content-hash"]
+        leb128["leb128"]
+        misc["test-support, deno-web-test, integration,<br/>generated-patterns, felt, static,<br/>vendor-astral, fs-sync-example"]
+    end
+
+    L7 --> L6 --> L5 --> L4 --> L3 --> L2 --> L1
+    L1 -.-> SUP
+```
+
+The layer model is a useful first mental model, but it is aspirational, not
+enforced. The real import graph has edges that point the "wrong way" — for
+example the foundation-layer `runner` imports the capability-layer `html`, and
+imports schemas from the end-user-layer `home-schemas`. Those exceptions are the
+subject of [the dependency graph page](dependency-graph.md), and they matter
+because they are exactly the places where a change in a "leaf" package can break
+the "foundation."
+
+---
+
+## How big each package is
+
+Sizes are non-test TypeScript lines, measured from source. They tell you where
+the weight (and the reading time) actually is. Note that two large numbers are
+not hand-written engineering: `patterns` is example programs, and most of
+`static` is a single generated TypeScript standard-library declaration file.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph LR
+    classDef big fill:#c0392b,stroke:#7b241c,color:#fff
+    classDef mid fill:#e67e22,stroke:#a04000,color:#fff
+    classDef small fill:#27ae60,stroke:#1e8449,color:#fff
+    R["runner — 95k loc"]:::big
+    U["ui — 53k loc"]:::big
+    T["ts-transformers — 40k loc"]:::mid
+    C["cli — 25k loc"]:::mid
+    M["memory — 16k loc"]:::mid
+    SH["shell — 15k loc"]:::mid
+    TS["toolshed — 14k loc"]:::mid
+    H["html — 13k loc"]:::mid
+    F["fuse — 12k loc"]:::mid
+    DM["data-model — 8k loc"]:::small
+    SG["schema-generator — 8k loc"]:::small
+    SI["state-inspector — 6k loc"]:::small
+    API["api — 6k loc"]:::small
+    UT["utils — 3.5k loc"]:::small
+```
+
+(Excluded from this chart because they are examples, generated, or vendored:
+`patterns` 321k, `generated-patterns` 39k, `vendor-astral` 29k, `cf-harness`
+23k, `static` 13k. See the [tooling page](tooling-and-patterns.md).)
+
+---
+
+## The deployed runtime topology
+
+This is what is actually running when the product is up. A browser loads the
+`shell` single-page application (which `toolshed` itself serves). The shell does
+its real work inside a Web Worker that holds a `runner` runtime; that worker
+talks to `toolshed` over a WebSocket. `toolshed` is unusual in that it is *both*
+the durable-storage server *and* a client of its own storage — it holds an
+in-process memory server and also a `runner` runtime that connects back to it.
+A separate `background-piece-service` process runs pieces on a timer when no
+browser is open.
+
+```mermaid
+flowchart LR
+    browser["Browser tab"]
+    subgraph shellbox["shell (single-page app)"]
+        ui2["cf-* components (ui)"]
+        worker["Web Worker: runtime-client → runner Runtime"]
+    end
+    subgraph ts["toolshed process"]
+        hono["Hono HTTP app"]
+        memsrv["in-process memory server (SQLite)"]
+        rt["runner Runtime (a client of its own memory)"]
+        llmgw["LLM gateway"]
+    end
+    bcs["background-piece-service (separate process)"]
+    providers["LLM providers / gateway"]
+    sandbox["external code-exec sandbox"]
+    oauth["OAuth providers"]
+
+    browser --> ui2
+    ui2 --> worker
+    worker -- "WebSocket: memory protocol" --> memsrv
+    browser -- "HTTP: REST, static assets" --> hono
+    hono --> memsrv
+    hono --> rt
+    hono --> llmgw
+    llmgw --> providers
+    hono --> sandbox
+    hono --> oauth
+    bcs -- "WebSocket: memory protocol" --> memsrv
+    bcs -- "HTTP: LLM" --> hono
+```
+
+The detail of each box is on the [backend page](backend.md) and the
+[client page](client-render.md). The single most important thing to internalize
+here: **the WebSocket carrying the memory protocol is the real state channel.**
+The REST endpoints are secondary. Durable cell state, subscriptions, and pushed
+updates all travel over that socket.
+
+---
+
+## The one data-flow picture worth memorizing
+
+Everything in the runtime is a variation on this loop. An author's code becomes
+a graph of reactive computations; a write to a cell wakes the scheduler; the
+scheduler re-runs only the dependent computations; their writes either wake more
+computations or settle; settled state is committed to storage and rendered to
+the screen.
+
+```mermaid
+flowchart LR
+    author[".tsx pattern source"]
+    compile["compile pipeline<br/>(ts-transformers + js-compiler)"]
+    graph["pattern = serializable node graph<br/>(builder)"]
+    instantiate["runner instantiates nodes<br/>into scheduler actions"]
+    cells["Cells in a Space"]
+    scheduler["scheduler<br/>(re-runs readers of changed cells)"]
+    storage["memory<br/>(durable, content-addressed)"]
+    render["html → DOM<br/>(ui web components)"]
+
+    author --> compile --> graph --> instantiate --> scheduler
+    scheduler <--> cells
+    cells <--> storage
+    scheduler --> render
+    render -- "events" --> scheduler
+```
+
+The mechanics of the scheduler loop — why it is "pull-based," what a "settle"
+is, how a write decides which readers to re-run — are on the
+[runtime-core page](runtime-core.md).
+
+---
+
+## Glossary
+
+These words appear everywhere and rarely get defined in one place.
+
+- **Pattern** — a reactive program written in TypeScript/JSX. Older code and
+  some transformers call this a "recipe." Same thing.
+- **Piece** — a running, deployed instance of a pattern, rooted at a result
+  cell. Formerly called a "charm." The rename is now essentially complete in
+  source; see the top of this page.
+- **Space** — a durable store identified by a DID. Pieces and their cells live
+  in a space. A space can be backed by its own derived keypair.
+- **DID** — Decentralized Identifier, here always a `did:key:…` derived from an
+  Ed25519 public key. Produced and verified by the `identity` package.
+- **Cell** — a typed, reactive handle to a path inside a document inside a
+  space. Reads and writes go through a transaction. A `Stream` is the
+  write-only, event-channel sibling of a Cell.
+- **Reactive** — the build-time stand-in for a future Cell, used while a
+  pattern's graph is being constructed. Exported to authors as `cell`. (This was
+  called `OpaqueRef` until that spelling was removed; you may still see the old
+  name in git history.)
+- **Schema** — a JSON Schema. The compile pipeline derives one from your
+  TypeScript types and attaches it at every reactive boundary; subscriptions are
+  driven by schema-plus-path queries.
+- **CFC (Contextual Flow Control)** — the information-flow-control system. It
+  labels data and gates writes and outward flows ("egress"). It lives mostly in
+  `runner/src/cfc` and is enforced at commit and render time.
+- **FabricValue** — the value model used across storage boundaries. It is JSON
+  plus the things JSON cannot carry (bigint, Map, Set, dates, byte arrays,
+  content hashes, links). Defined in `data-model`.
+- **`cf`** — the command-line tool, run with `deno task cf …`. Implemented in
+  the `cli` package.
+- **toolshed** — the backend server process. It has no package name because it
+  is an application, not a library.

--- a/docs/development/orientation/README.md
+++ b/docs/development/orientation/README.md
@@ -140,7 +140,7 @@ graph LR
     classDef big fill:#c0392b,stroke:#7b241c,color:#fff
     classDef mid fill:#e67e22,stroke:#a04000,color:#fff
     classDef small fill:#27ae60,stroke:#1e8449,color:#fff
-    R["runner — 95k loc"]:::big
+    R["runner — 100k loc"]:::big
     U["ui — 53k loc"]:::big
     T["ts-transformers — 40k loc"]:::mid
     C["cli — 25k loc"]:::mid

--- a/docs/development/orientation/README.md
+++ b/docs/development/orientation/README.md
@@ -249,8 +249,8 @@ is, how a write decides which readers to re-run — are on the
 
 These words appear everywhere and rarely get defined in one place.
 
-- **Pattern** — a reactive program written in TypeScript/JSX. Older code and
-  some transformers call this a "recipe." Same thing.
+- **Pattern** — a reactive program written in TypeScript/JSX. Older code called
+  this a "recipe"; the current source has moved off that term.
 - **Piece** — a running, deployed instance of a pattern, rooted at a result
   cell. Formerly called a "charm." The rename is now essentially complete in
   source; see the top of this page.
@@ -263,8 +263,9 @@ These words appear everywhere and rarely get defined in one place.
   write-only, event-channel sibling of a Cell.
 - **Reactive** — the build-time stand-in for a future Cell, used while a
   pattern's graph is being constructed. Exported to authors as `cell`. (This was
-  called `OpaqueRef` until that spelling was removed; you may still see the old
-  name in git history.)
+  called `OpaqueRef` until that spelling was removed from the authoring surface;
+  the name survives only as a backward-compatibility symbol check in
+  `ts-transformers` and in git history.)
 - **Schema** — a JSON Schema. The compile pipeline derives one from your
   TypeScript types and attaches it at every reactive boundary; subscriptions are
   driven by schema-plus-path queries.

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -232,46 +232,8 @@ polled.
 
 ## Technical debt and sharp edges
 
-- **The provider abstraction is in the wrong-feeling place.** It is in
-  `toolshed/routes/ai/llm/models.ts`, not in the `llm` package. Look there.
-- **OAuth providers are auto-wired from descriptors at startup.** The
-  `DESCRIPTORS` array is, in order, Google, Airtable, GitHub, Notion, Linear,
-  Spotify, Discord, Strava (plus Plaid and a webhook-style Discord route that are
-  wired manually because their flows are non-standard). Providers with missing
-  credentials are silently skipped (`Promise.allSettled`, so one failure doesn't
-  block the rest), and the shared `/api/integrations/bg` route — which registers a
-  piece for background updating — attaches to whichever descriptor has credentials
-  first. Non-obvious when an endpoint "isn't there."
-- **The shell route's headers are deliberately non-isolating.** Concretely
-  `Cross-Origin-Opener-Policy: same-origin-allow-popups` and
-  `Cross-Origin-Embedder-Policy: unsafe-none`, set *after* the handler so they
-  override upstream — the goal is to keep `crossOriginIsolated === false` so
-  SES-sandboxed patterns get no `SharedArrayBuffer` or high-resolution timer.
-  The shell route is tri-state: `COMPILED` present → serve the static frontend;
-  else `SHELL_URL` set → proxy the dev server; else 404. Do not "fix" the headers
-  without understanding why.
-- **The new ingest and telemetry routes are gated and fail-safe.**
-  `/api/ingest/:id` requires a `Bearer` token (uniform 401 for any failure),
-  caps the body size, and parses only after the token verifies;
-  `/api/telemetry/*` proxies browser OTLP to the collector and is fail-open (204
-  when disabled, 413 over the size cap, otherwise a fire-and-forget 202 — never a
-  5xx).
-- **`background-piece-service` carries the most TODOs in this group**, several
-  about the scheduler being approximate: space managers should watch their own
-  pieces, a terminal error cannot always be attributed to a specific piece (so a
-  stray failure can disable a whole space), and sync is assumed never to return
-  partial results. Others are about worker/piece lifecycle and cleanup.
-- **`bcs` depends on hardcoded constants** — the system-space DID and a dated
-  cause string `BG_CELL_CAUSE = "bgUpdater-2025-03-18"` in `schema.ts` — and
-  requires a one-time admin grant before any piece is polled.
-- **The rename kept a few backward-compat identifiers.** So existing spaces keep
-  resolving, the charm→piece rename intentionally left the persisted/wire names
-  alone: the `bgUpdater` handler-stream name, the cause string
-  `BG_CELL_CAUSE = "bgUpdater-2025-03-18"`, and the derived system-space DID
-  (`BG_SYSTEM_SPACE_ID`), all in `schema.ts`/`worker.ts`. None of them contain
-  the word "charm"; they are simply legacy-shaped.
-- **A tool-loop cap is hardcoded** (`stepCountIs(...)`) in `generateText.ts` as a
-  runaway guard.
+The debt and rough edges touching these packages are collected, together with
+the rest of the repo's, in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -53,6 +53,42 @@ server-side. New readers find this confusing until they see both wirings in
 
 ---
 
+## Environment and configuration
+
+Everything is driven by a single Zod `EnvSchema` in `env.ts`. The variables a
+newcomer trips on:
+
+- **Storage location is two mutually-exclusive modes.** `MEMORY_DIR` (a directory
+  of one SQLite file per space, the default `./cache/memory/`) versus `DB_PATH`
+  (one absolute-path SQLite file, for clustering; the schema rejects a
+  non-absolute value). `MEMORY_URL` (default `http://localhost:8000`) is the URL
+  toolshed's own runtime connects back through.
+- **A provider is registered by the mere presence of its key.** The LLM keys are
+  all `CFTS_AI_LLM_*` (`ANTHROPIC`, `OPENAI`, `GROQ`, plus AWS/Google-Vertex and a
+  few declared-but-currently-unwired ones like `CEREBRAS`/`PERPLEXITY`/`XAI`).
+  `CFTS_AI_GATEWAY_URL` is a Tailscale-only gateway with clean fallback.
+- **Access control.** `MEMORY_ACL_MODE` is `off` / `observe` / `enforce` (default
+  `enforce`); `MEMORY_SERVICE_DIDS` is a comma-separated list of DIDs granted an
+  implicit OWNER on every space — this is how the background service authorizes
+  itself.
+- `SANDBOX_SERVICE_URL` (external code-exec), `SHELL_URL` (dev-proxy target),
+  and the OTEL block (`OTEL_ENABLED`, endpoint default `http://localhost:4318`,
+  sampler config) round it out. A `boolFlag()` helper treats only `"true"`/`"1"`
+  as true, on purpose — `z.coerce.boolean()` would turn the string `"false"` into
+  `true`.
+
+The server framework glue lives in `lib/`: `create-app.ts` builds the
+`OpenAPIHono` app and serves an OpenAPI spec at `/doc` and a Scalar reference UI
+at `/reference`; `identity.ts` builds the server's signer `Identity` (from the
+`IDENTITY` keyfile, else a passphrase, else `"implicit trust"` in development),
+whose DID signs storage auth and is surfaced at `/api/meta`; `otel.ts` exports
+spans (with an OpenInference processor) to a collector that fans LLM spans to
+Phoenix and all spans to SigNoz. The two middlewares are the pino request logger
+(a per-request `reqId`) and an OpenTelemetry middleware that reads an inbound
+W3C `traceparent` so a request span links to the browser's trace.
+
+---
+
 ## The HTTP and WebSocket request lifecycle
 
 ```mermaid
@@ -130,11 +166,26 @@ flowchart LR
     cache -->|miss| find --> stream --> prov --> ndjson --> client
 ```
 
+Concrete mechanics: `findModel` is a plain `MODELS[name]` lookup (aliases are
+extra keys pointing at the same `ModelConfig`), and the `default` alias resolves
+through `DEFAULT_MODEL_CANDIDATES` (`gateway:claude-sonnet-4-6` →
+`anthropic:claude-sonnet-4-6` → `anthropic:claude-sonnet-4-5`). `loadGatewayModels`
+fetches `${gateway}/v1/models` with a 3-second timeout, forces an HTTP/1.1 client
+(to dodge a Deno HTTP/2 SSE bug), and falls back cleanly off-Tailscale. The disk
+cache keys on the SHA-256 of the request JSON (after stripping the `cache`/
+`metadata` fields), and the two endpoints have *opposite* defaults: `generateText`
+caches only when `cache === true` and there are no live model tools, while
+`generateObject` caches unless `cache === false`. Responses carry an
+`x-cf-llm-trace-id` header, and `/api/ai/llm/feedback` posts human annotations to
+Phoenix.
+
 The `llm` package itself is purely the consumer: `LLMClient.sendRequest`
 POSTs to the endpoint and reassembles the streamed events. It also holds shared
-prompt templates and a mock/fixture system that blocks live calls under test.
-The `llm → runner` import cycle is a single line — `prompts/json-import.ts`
-imports `createJsonSchema` from `runner`.
+prompt templates (`json-gen`, `json-import`, `pattern-fix`, `pattern-guide`,
+`piece-describe`, `piece-suggestions`) and a mock/fixture system that blocks live
+calls when `CI === "true"` or `ENV === "test"` (its mock entries are one-time-use,
+spliced out on match). The `llm → runner` import cycle is a single line —
+`prompts/json-import.ts` imports `createJsonSchema` from `runner`.
 
 ---
 
@@ -159,10 +210,23 @@ flowchart TB
     back -.-> cell
 ```
 
-The registered-pieces list is typed as `BGPieceEntry` (`schema.ts`), fetched via
-`getBGPieces`, and watched with `piecesCell.sink(...)`. Isolation is strict: one
-worker per space, and a terminal worker error disables the whole space and
-recreates the worker. The default rerun interval is 60 seconds.
+The registered-pieces list is typed as `BGPieceEntry` (`schema.ts`, fields
+`space`/`pieceId`/`integration`/`createdAt`/`disabledAt`/`lastRun`/`status`),
+fetched via `getBGPieces` and watched with `piecesCell.sink(...)`. That registry
+cell is synced with a privileged confidentiality label (`ifc: { confidentiality:
+["secret"] }`) at the fixed cause `BG_CELL_CAUSE` in `BG_SYSTEM_SPACE_ID`.
+Concrete scheduler constants: each `SpaceManager` runs at most one piece at a
+time from a timestamp-sorted queue polled every 100 ms (`pollingIntervalMs`),
+reruns a piece every 60 s (`rerunIntervalMs`), applies linear backoff
+(`rerunIntervalMs · (failureCount + 1)`), and disables a piece on its third
+consecutive failure. The `WorkerController` uses `msgId`-keyed IPC with a per-task
+timeout that production sets to 10 minutes. To fire a piece the worker resolves
+the cell by id, loads it with schema `{ bgUpdater: { asCell: ["stream"] } }`, and
+does `updater.withTx(tx).send({}); tx.commit()` then awaits `runtime.idle()`.
+Isolation is strict: one worker per space, and a terminal worker error disables
+the whole space and recreates the worker. A one-time `deno task add-admin-piece`
+(casting `bgAdmin.tsx` into the system space) is required before any piece is
+polled.
 
 ---
 
@@ -170,13 +234,27 @@ recreates the worker. The default rerun interval is 60 seconds.
 
 - **The provider abstraction is in the wrong-feeling place.** It is in
   `toolshed/routes/ai/llm/models.ts`, not in the `llm` package. Look there.
-- **OAuth providers are auto-wired from descriptors at startup.** Providers with
-  missing credentials are silently skipped, and the shared
-  `/api/integrations/bg` route attaches to whichever provider has credentials
+- **OAuth providers are auto-wired from descriptors at startup.** The
+  `DESCRIPTORS` array is, in order, Google, Airtable, GitHub, Notion, Linear,
+  Spotify, Discord, Strava (plus Plaid and a webhook-style Discord route that are
+  wired manually because their flows are non-standard). Providers with missing
+  credentials are silently skipped (`Promise.allSettled`, so one failure doesn't
+  block the rest), and the shared `/api/integrations/bg` route — which registers a
+  piece for background updating — attaches to whichever descriptor has credentials
   first. Non-obvious when an endpoint "isn't there."
-- **The shell route's headers are deliberately non-isolating.** The COOP/COEP
-  headers are set the way they are as defense-in-depth for the SES-sandboxed
-  patterns. Do not "fix" them without understanding why.
+- **The shell route's headers are deliberately non-isolating.** Concretely
+  `Cross-Origin-Opener-Policy: same-origin-allow-popups` and
+  `Cross-Origin-Embedder-Policy: unsafe-none`, set *after* the handler so they
+  override upstream — the goal is to keep `crossOriginIsolated === false` so
+  SES-sandboxed patterns get no `SharedArrayBuffer` or high-resolution timer.
+  The shell route is tri-state: `COMPILED` present → serve the static frontend;
+  else `SHELL_URL` set → proxy the dev server; else 404. Do not "fix" the headers
+  without understanding why.
+- **The new ingest and telemetry routes are gated and fail-safe.**
+  `/api/ingest/:id` requires a `Bearer` token (uniform 401 for any failure),
+  caps the body at 1 MB, and parses only after the token verifies;
+  `/api/telemetry/*` proxies browser OTLP to the collector and is fail-open (204
+  when disabled, 413 over 1 MB, otherwise a fire-and-forget 202 — never 5xx).
 - **`background-piece-service` carries the most TODOs in this group**, several
   about the scheduler being approximate: space managers should watch their own
   pieces, a terminal error cannot always be attributed to a specific piece (so a
@@ -198,9 +276,14 @@ recreates the worker. The default rerun interval is 60 seconds.
 
 ## Entry points and ports
 
-- `toolshed` — entry `index.ts` (`deno task dev` or `production`). Built into a
-  single binary by `Dockerfile.toolshed` at the repo root; a `COMPILED` sentinel
-  file switches the shell route from dev-proxy to static serving.
+- `toolshed` — entry `index.ts` (`deno task dev` or `production`).
+  `tasks/build-binaries.ts` compiles two binaries — `dist/toolshed` and
+  `dist/bg-piece-service` — and writes the `COMPILED` sentinel as JSON
+  (`{commitSha, builtAt}`), `--include`d into the toolshed binary and read at
+  `/api/meta`. `Dockerfile.toolshed` pins Deno 2.8.1 and does a 15-second "warm
+  run" so the `@db/sqlite` FFI library is baked into the image (no GitHub egress
+  on first DB open). The `COMPILED` file's presence also switches the shell route
+  from dev-proxy to static serving.
 - `background-piece-service` (`@commonfabric/background-piece`) — entry
   `src/main.ts` (`deno task start`). It now ships its own tests, so unlike
   `vendor-astral` it is no longer in the test runner's disabled list.

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -1,0 +1,198 @@
+# The backend: `toolshed`, `background-piece-service`, `llm`
+
+`toolshed` is the deployed backend. It is a single Deno process built on the
+Hono HTTP framework, and it does an unusual amount: it is the durable-storage
+server, it runs a runtime of its own, it is an LLM gateway, it does OAuth for a
+handful of third-party providers, and it serves the `shell` frontend.
+`background-piece-service` is a separate process that runs pieces on a timer.
+`llm` is a thin client library that talks to `toolshed`'s LLM endpoints.
+
+`toolshed` has **no package name** in its `deno.jsonc`, because it is an
+application, not an importable library. It is launched from `index.ts`.
+
+`background-piece-service` (package `@commonfabric/background-piece`) was called
+`background-charm-service` until the charm-to-piece rename. The directory and
+package name are now "piece"; only the on-the-wire `bgUpdater` stream name and a
+dated cause string keep the old vocabulary.
+
+---
+
+## The deployed topology
+
+```mermaid
+flowchart LR
+    browser["Browser"]
+    subgraph toolshed["toolshed process"]
+        hono["Hono app (app.ts)"]
+        mem["in-process MemoryServer<br/>(SQLite, one file or a directory)"]
+        rt["a runner Runtime<br/>(connects back to its own MEMORY_URL)"]
+        gw["LLM gateway routes"]
+    end
+    bcs["background-piece-service<br/>(separate process)"]
+    providers["Anthropic / OpenAI / Groq / Vertex / gateway"]
+    extras["OAuth providers, code-exec sandbox,<br/>web search/read, image, voice"]
+
+    browser -- "WebSocket: memory protocol" --> mem
+    browser -- "HTTP: static shell, REST" --> hono
+    hono --> mem
+    hono --> rt
+    hono --> gw --> providers
+    hono --> extras
+    bcs -- "WebSocket: memory protocol" --> mem
+    bcs -- "HTTP: /api/ai/llm" --> hono
+```
+
+The thing to internalize: **`toolshed` is both a memory server and a memory
+client.** It serves the durable store over a WebSocket, and it also holds a
+`runner` runtime that connects back to that same store to run patterns
+server-side. New readers find this confusing until they see both wirings in
+`index.ts`.
+
+---
+
+## The HTTP and WebSocket request lifecycle
+
+```mermaid
+flowchart TB
+    serve["Deno.serve(app.fetch)"]
+    otel["OpenTelemetry span middleware"]
+    pino["pino request logger"]
+    route{"route match"}
+    handler["Zod-validated route handler"]
+    ws["WebSocket upgrade branch<br/>(/api/storage/memory)"]
+    bridge["sniff memory protocol,<br/>hand socket to MemoryServer.connect()"]
+    shellcatch["shell catch-all (/*)<br/>serves the SPA or proxies the dev server"]
+
+    serve --> otel --> pino --> route
+    route -->|"most paths"| handler
+    route -->|"/api/storage/memory"| ws --> bridge
+    route -->|"unmatched"| shellcatch
+```
+
+The memory WebSocket handler is the most intricate file in `toolshed`. It
+upgrades the request, buffers text frames until it can recognize a valid first
+message of the memory protocol, then hands the socket to the in-process memory
+server and bridges frames in both directions. This is the channel `shell`, the
+`cli`, and `background-piece-service` all use for durable state.
+
+### The route groups
+
+Each group follows a `*.routes.ts` (the Zod/OpenAPI schema) plus `*.handlers.ts`
+(the logic) plus `*.index.ts` (the wiring) convention.
+
+| Path | What it does |
+|---|---|
+| `/_health`, `/api/health/*` | liveness, stats, LLM provider health |
+| `/api/storage/memory` | the durable-store WebSocket |
+| `/api/ai/llm`, `/generateObject`, `/models` | the LLM gateway (streaming) |
+| `/api/ai/img`, `/voice/transcribe`, `/webreader/*` | other AI capabilities |
+| `/api/agent-tools/web-search`, `/web-read` | tools patterns and agents can call |
+| `/api/integrations/*` | OAuth2 for ~8 providers, auto-wired from descriptors |
+| `/api/patterns/:filename` | serves pattern source files |
+| `/api/sandbox/exec` | proxies code execution to an external sandbox service |
+| `/api/ingest/:id` | journal-sink ingest channel — posts external data into a space |
+| `/api/webhooks[/:id]` | webhook CRUD and delivery |
+| `/api/telemetry/*` | telemetry ingest |
+| `/api/whoami`, `/api/meta`, `/api/blobs` | identity, build info, blobs |
+| `/*` | the shell SPA (mounted last) |
+
+---
+
+## The LLM gateway
+
+The provider abstraction lives in `toolshed`, not in the `llm` package — which
+surprises people, because they look in `llm/` first and find only an HTTP
+client. Models are keyed `provider:model` (for example
+`anthropic:claude-sonnet-4-6`). The gateway uses the Vercel AI SDK for the
+direct providers and also pulls a dynamic set of "gateway" models from an
+internal endpoint.
+
+```mermaid
+flowchart LR
+    client["LLMClient (the llm package)"]
+    post["POST /api/ai/llm"]
+    cache{"disk cache hit?"}
+    find["findModel(): resolve provider:model,<br/>handle aliases + default candidates"]
+    stream["AI SDK streamText()"]
+    prov["provider (Anthropic / OpenAI / Groq / Vertex / gateway)"]
+    ndjson["NDJSON event stream:<br/>text-delta / tool-call / tool-result / finish"]
+
+    client --> post --> cache
+    cache -->|hit| ndjson
+    cache -->|miss| find --> stream --> prov --> ndjson --> client
+```
+
+The `llm` package itself is purely the consumer: `LLMClient.sendRequest`
+POSTs to the endpoint and reassembles the streamed events. It also holds shared
+prompt templates and a mock/fixture system that blocks live calls under test.
+The `llm → runner` import cycle is a single line — `prompts/json-import.ts`
+imports `createJsonSchema` from `runner`.
+
+---
+
+## The background piece service
+
+This process runs pieces' `bgUpdater` handlers on a schedule, so background work
+happens with no browser open. It watches a system-space cell listing the
+registered pieces, groups them by space, and runs each space's pieces in an
+isolated Web Worker.
+
+```mermaid
+flowchart TB
+    cell["system-space pieces cell (.sink subscription)"]
+    ensure["ensurePieces(): filter enabled, group by space DID"]
+    sm["one SpaceManager per space<br/>(priority queue + polling execLoop)"]
+    wc["WorkerController (IPC, msgId-keyed, timeouts)"]
+    worker["Web Worker: own Runtime + PieceManager"]
+    fire["load piece by id, send({}) to its bgUpdater stream"]
+    back["write success/failure back to the cell<br/>(linear backoff, auto-disable after 3 failures)"]
+
+    cell --> ensure --> sm --> wc --> worker --> fire --> back
+    back -.-> cell
+```
+
+The registered-pieces list is typed as `BGPieceEntry` (`schema.ts`), fetched via
+`getBGPieces`, and watched with `piecesCell.sink(...)`. Isolation is strict: one
+worker per space, and a terminal worker error disables the whole space and
+recreates the worker. The default rerun interval is 60 seconds.
+
+---
+
+## Technical debt and sharp edges
+
+- **The provider abstraction is in the wrong-feeling place.** It is in
+  `toolshed/routes/ai/llm/models.ts`, not in the `llm` package. Look there.
+- **OAuth providers are auto-wired from descriptors at startup.** Providers with
+  missing credentials are silently skipped, and the shared
+  `/api/integrations/bg` route attaches to whichever provider has credentials
+  first. Non-obvious when an endpoint "isn't there."
+- **The shell route's headers are deliberately non-isolating.** The COOP/COEP
+  headers are set the way they are as defense-in-depth for the SES-sandboxed
+  patterns. Do not "fix" them without understanding why.
+- **`background-piece-service` carries the most TODOs in this group**, all about
+  the scheduler being approximate: space managers should watch their own pieces,
+  a terminal error cannot always be attributed to a specific piece (so a stray
+  failure can disable a whole space), and sync is assumed never to return partial
+  results.
+- **`bcs` depends on hardcoded constants** — the system-space DID and a dated
+  cause string `BG_CELL_CAUSE = "bgUpdater-2025-03-18"` in `schema.ts` — and
+  requires a one-time admin grant before any piece is polled.
+- **The wire still says "charm" in one place.** The handler stream is the
+  `bgUpdater` stream and the cause string keeps its original date; the rename to
+  "piece" stopped at the persisted/wire names to avoid breaking existing spaces.
+- **A tool-loop cap is hardcoded** (`stepCountIs(8)`) in `generateText.ts` as a
+  runaway guard.
+
+---
+
+## Entry points and ports
+
+- `toolshed` — entry `index.ts` (`deno task dev` or `production`). Built into a
+  single binary by `Dockerfile.toolshed` at the repo root; a `COMPILED` sentinel
+  file switches the shell route from dev-proxy to static serving.
+- `background-piece-service` (`@commonfabric/background-piece`) — entry
+  `src/main.ts` (`deno task start`). It now ships its own tests, so unlike
+  `vendor-astral` it is no longer in the test runner's disabled list.
+- `llm` — library only; `.`, `./types`, `./client`.
+- `ports.json` (repo root): `toolshed` 8000, `shell` 5173, inspector 9229. The
+  OpenTelemetry collector defaults to 4318.

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -170,7 +170,7 @@ Concrete mechanics: `findModel` is a plain `MODELS[name]` lookup (aliases are
 extra keys pointing at the same `ModelConfig`), and the `default` alias resolves
 through `DEFAULT_MODEL_CANDIDATES` (`gateway:claude-sonnet-4-6` →
 `anthropic:claude-sonnet-4-6` → `anthropic:claude-sonnet-4-5`). `loadGatewayModels`
-fetches `${gateway}/v1/models` with a 3-second timeout, forces an HTTP/1.1 client
+fetches `${gateway}/v1/models` with a short timeout, forces an HTTP/1.1 client
 (to dodge a Deno HTTP/2 SSE bug), and falls back cleanly off-Tailscale. The disk
 cache keys on the SHA-256 of the request JSON (after stripping the `cache`/
 `metadata` fields), and the two endpoints have *opposite* defaults: `generateText`
@@ -215,12 +215,12 @@ The registered-pieces list is typed as `BGPieceEntry` (`schema.ts`, fields
 fetched via `getBGPieces` and watched with `piecesCell.sink(...)`. That registry
 cell is synced with a privileged confidentiality label (`ifc: { confidentiality:
 ["secret"] }`) at the fixed cause `BG_CELL_CAUSE` in `BG_SYSTEM_SPACE_ID`.
-Concrete scheduler constants: each `SpaceManager` runs at most one piece at a
-time from a timestamp-sorted queue polled every 100 ms (`pollingIntervalMs`),
-reruns a piece every 60 s (`rerunIntervalMs`), applies linear backoff
-(`rerunIntervalMs · (failureCount + 1)`), and disables a piece on its third
-consecutive failure. The `WorkerController` uses `msgId`-keyed IPC with a per-task
-timeout that production sets to 10 minutes. To fire a piece the worker resolves
+The scheduling model: each `SpaceManager` runs at most one piece at a time from a
+timestamp-sorted queue (`pollingIntervalMs`), reruns each piece roughly once a
+minute (`rerunIntervalMs`), applies linear backoff on failure, and disables a
+piece after a few consecutive failures. The `WorkerController` uses `msgId`-keyed
+IPC with a per-task timeout (several minutes in production). To fire a piece the
+worker resolves
 the cell by id, loads it with schema `{ bgUpdater: { asCell: ["stream"] } }`, and
 does `updater.withTx(tx).send({}); tx.commit()` then awaits `runtime.idle()`.
 Isolation is strict: one worker per space, and a terminal worker error disables
@@ -252,9 +252,10 @@ polled.
   without understanding why.
 - **The new ingest and telemetry routes are gated and fail-safe.**
   `/api/ingest/:id` requires a `Bearer` token (uniform 401 for any failure),
-  caps the body at 1 MB, and parses only after the token verifies;
+  caps the body size, and parses only after the token verifies;
   `/api/telemetry/*` proxies browser OTLP to the collector and is fail-open (204
-  when disabled, 413 over 1 MB, otherwise a fire-and-forget 202 — never 5xx).
+  when disabled, 413 over the size cap, otherwise a fire-and-forget 202 — never a
+  5xx).
 - **`background-piece-service` carries the most TODOs in this group**, several
   about the scheduler being approximate: space managers should watch their own
   pieces, a terminal error cannot always be attributed to a specific piece (so a
@@ -269,7 +270,7 @@ polled.
   `BG_CELL_CAUSE = "bgUpdater-2025-03-18"`, and the derived system-space DID
   (`BG_SYSTEM_SPACE_ID`), all in `schema.ts`/`worker.ts`. None of them contain
   the word "charm"; they are simply legacy-shaped.
-- **A tool-loop cap is hardcoded** (`stepCountIs(8)`) in `generateText.ts` as a
+- **A tool-loop cap is hardcoded** (`stepCountIs(...)`) in `generateText.ts` as a
   runaway guard.
 
 ---
@@ -280,10 +281,10 @@ polled.
   `tasks/build-binaries.ts` compiles two binaries — `dist/toolshed` and
   `dist/bg-piece-service` — and writes the `COMPILED` sentinel as JSON
   (`{commitSha, builtAt}`), `--include`d into the toolshed binary and read at
-  `/api/meta`. `Dockerfile.toolshed` pins Deno 2.8.1 and does a 15-second "warm
-  run" so the `@db/sqlite` FFI library is baked into the image (no GitHub egress
-  on first DB open). The `COMPILED` file's presence also switches the shell route
-  from dev-proxy to static serving.
+  `/api/meta`. `Dockerfile.toolshed` pins a specific Deno version and does a brief
+  "warm run" so the `@db/sqlite` FFI library is baked into the image (no GitHub
+  egress on first DB open). The `COMPILED` file's presence also switches the shell
+  route from dev-proxy to static serving.
 - `background-piece-service` (`@commonfabric/background-piece`) — entry
   `src/main.ts` (`deno task start`). It now ships its own tests, so unlike
   `vendor-astral` it is no longer in the test runner's disabled list.

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -11,9 +11,12 @@ handful of third-party providers, and it serves the `shell` frontend.
 application, not an importable library. It is launched from `index.ts`.
 
 `background-piece-service` (package `@commonfabric/background-piece`) was called
-`background-charm-service` until the charm-to-piece rename. The directory and
-package name are now "piece"; only the on-the-wire `bgUpdater` stream name and a
-dated cause string keep the old vocabulary.
+`background-charm-service` until the charm-to-piece rename. The directory,
+package, and source all say "piece" now — the word "charm" appears nowhere in
+the package. A couple of persisted identifiers were deliberately left unchanged
+so existing spaces keep resolving (the `bgUpdater` stream name and a dated cause
+string); those are legacy-shaped, not "charm" — see the note under Technical
+debt below.
 
 ---
 

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -70,10 +70,11 @@ flowchart TB
 ```
 
 The memory WebSocket handler is the most intricate file in `toolshed`. It
-upgrades the request, buffers text frames until it can recognize a valid first
-message of the memory protocol, then hands the socket to the in-process memory
-server and bridges frames in both directions. This is the channel `shell`, the
-`cli`, and `background-piece-service` all use for durable state.
+upgrades the request, takes the first text frame as the candidate handshake and
+validates it against the memory protocol (buffering any later frames until the
+handoff so none are lost), then hands the socket to the in-process memory server
+and bridges frames in both directions. This is the channel `shell`, the `cli`,
+and `background-piece-service` all use for durable state.
 
 ### The route groups
 
@@ -118,9 +119,10 @@ flowchart LR
     stream["AI SDK streamText()"]
     prov["provider (Anthropic / OpenAI / Groq / Vertex / gateway)"]
     ndjson["NDJSON event stream:<br/>text-delta / tool-call / tool-result / finish"]
+    cached["return cached final message<br/>as a single JSON body"]
 
     client --> post --> cache
-    cache -->|hit| ndjson
+    cache -->|hit| cached --> client
     cache -->|miss| find --> stream --> prov --> ndjson --> client
 ```
 

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -77,8 +77,10 @@ server and bridges frames in both directions. This is the channel `shell`, the
 
 ### The route groups
 
-Each group follows a `*.routes.ts` (the Zod/OpenAPI schema) plus `*.handlers.ts`
-(the logic) plus `*.index.ts` (the wiring) convention.
+Most groups follow a `*.routes.ts` (the Zod/OpenAPI schema) plus `*.handlers.ts`
+(the logic) plus `*.index.ts` (the wiring) convention. A few (`telemetry`,
+`blobs`) skip the triad and register plain Hono routes inline in their
+`*.index.ts` instead.
 
 | Path | What it does |
 |---|---|
@@ -169,17 +171,20 @@ recreates the worker. The default rerun interval is 60 seconds.
 - **The shell route's headers are deliberately non-isolating.** The COOP/COEP
   headers are set the way they are as defense-in-depth for the SES-sandboxed
   patterns. Do not "fix" them without understanding why.
-- **`background-piece-service` carries the most TODOs in this group**, all about
-  the scheduler being approximate: space managers should watch their own pieces,
-  a terminal error cannot always be attributed to a specific piece (so a stray
-  failure can disable a whole space), and sync is assumed never to return partial
-  results.
+- **`background-piece-service` carries the most TODOs in this group**, several
+  about the scheduler being approximate: space managers should watch their own
+  pieces, a terminal error cannot always be attributed to a specific piece (so a
+  stray failure can disable a whole space), and sync is assumed never to return
+  partial results. Others are about worker/piece lifecycle and cleanup.
 - **`bcs` depends on hardcoded constants** — the system-space DID and a dated
   cause string `BG_CELL_CAUSE = "bgUpdater-2025-03-18"` in `schema.ts` — and
   requires a one-time admin grant before any piece is polled.
-- **The wire still says "charm" in one place.** The handler stream is the
-  `bgUpdater` stream and the cause string keeps its original date; the rename to
-  "piece" stopped at the persisted/wire names to avoid breaking existing spaces.
+- **The rename kept a few backward-compat identifiers.** So existing spaces keep
+  resolving, the charm→piece rename intentionally left the persisted/wire names
+  alone: the `bgUpdater` handler-stream name, the cause string
+  `BG_CELL_CAUSE = "bgUpdater-2025-03-18"`, and the derived system-space DID
+  (`BG_SYSTEM_SPACE_ID`), all in `schema.ts`/`worker.ts`. None of them contain
+  the word "charm"; they are simply legacy-shaped.
 - **A tool-loop cap is hardcoded** (`stepCountIs(8)`) in `generateText.ts` as a
   runaway guard.
 

--- a/docs/development/orientation/backend.md
+++ b/docs/development/orientation/backend.md
@@ -99,7 +99,8 @@ Most groups follow a `*.routes.ts` (the Zod/OpenAPI schema) plus `*.handlers.ts`
 | `/api/ingest/:id` | journal-sink ingest channel — posts external data into a space |
 | `/api/webhooks[/:id]` | webhook CRUD and delivery |
 | `/api/telemetry/*` | telemetry ingest |
-| `/api/whoami`, `/api/meta`, `/api/blobs` | identity, build info, blobs |
+| `/api/whoami`, `/api/meta` | identity, build info |
+| `/:spaceDid/blobs[/:name]` | per-space blob upload/fetch (not under `/api`) |
 | `/*` | the shell SPA (mounted last) |
 
 ---

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -29,7 +29,7 @@ flowchart TB
     tree --- c1["piece (ls, new, step, apply, call,<br/>inspect, view, link, map, rm, set-slug, ...)"]
     tree --- c2["check / dev (compile + run a pattern)"]
     tree --- c3["fuse (mount, unmount, status)"]
-    tree --- c4["id (new, did, from-passphrase, from-mnemonic)"]
+    tree --- c4["id (new, did, derive, from-mnemonic)"]
     tree --- c5["acl (ls, add, remove)"]
     tree --- c6["exec, init, test, deps"]
 ```
@@ -155,24 +155,25 @@ hand-maintained and differ between macOS (FUSE v2 / FUSE-T) and Linux
 - **The "charm" rename is complete in this group.** No `charm` references
   remain in the source of these packages, and the charm-named test files are
   gone too. The former `background-charm-service` package is now
-  `background-piece-service` (`@commonfabric/background-piece`). The only
+  `background-piece-service` (`@commonfabric/background-piece`). The main
   survivors repo-wide are the wire-level `bgUpdater` stream name, a dated cause
-  string in that service, a Scrabble word list, and git history.
+  string in that service, plain-English "charm" occurrences in test-data
+  fixtures (a Scrabble word list, a Frankenstein excerpt), and git history.
 - **`cli` is a hub, and a growing one** (about 25k non-test lines now). It
   imports `runner` (25), `identity` (9), `utils` (9), `js-compiler` (8),
   `piece`/`api` (5 each), and now `state-inspector` (2) — it wires the offline
   space-inspector (see the [storage page](storage-substrate.md)) into the `cf`
   command. A change in any of those can break the command line.
-- **`PieceManager` has a flagged hot spot.** `piece/src/manager.ts:849` carries
+- **`PieceManager` has a flagged hot spot.** `piece/src/manager.ts:856` carries
   `// FIXME(JA): this really really really needs to be revisited`, and there is
-  an elevated-permissions TODO at line 287.
+  an elevated-permissions TODO at line 294.
 - **`runtime-client` teardown is intentionally quiet.** After a `Dispose`, the
   worker silently acknowledges late requests and drops notifications. This is by
   design but surprising while debugging.
 - **The biggest files to budget for:** `fuse/mod.ts` (3389) and
-  `fuse/cell-bridge.ts` (3287); `cli/lib/test-runner.ts` (1895) and
-  `cli/lib/piece.ts` (1412); `runtime-client/backends/runtime-processor.ts`
-  (1676) and `protocol/types.ts` (1128).
+  `fuse/cell-bridge.ts` (3287); `cli/lib/test-runner.ts` (1899) and
+  `cli/lib/piece.ts` (1417); `runtime-client/backends/runtime-processor.ts`
+  (1798) and `protocol/types.ts` (1153).
 
 ---
 
@@ -180,8 +181,9 @@ hand-maintained and differ between macOS (FUSE v2 / FUSE-T) and Linux
 
 - **`cli`** — `.` → `mod.ts`; the real entry is `launcher.ts` (the root `cf`
   task). Subcommands: `help`, `acl`, `piece` (with many verbs), `check`, `dev`
-  (a hidden alias of `check`), `deps`, `exec`, `fuse`, `id`, `init`, `test`, and
-  a hidden deprecated `deploy` that points at `piece new`.
+  (a hidden alias of `check`), `inspect` (the offline state-inspector), `view`,
+  `wish`, `deps`, `exec`, `fuse`, `id`, `init`, `test`, and a hidden `deploy`
+  that just prints guidance to use `piece new`.
 - **`piece`** — `.` (`PieceManager`, `pieceId`, slug helpers), `./ops` (the
   controllers).
 - **`runtime-client`** — `.` → `mod.ts`, `./transports/web-worker`.

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -199,28 +199,8 @@ and differ between macOS (FUSE v2; FUSE-T preferred over macFUSE) and Linux
 
 ## Technical debt and sharp edges
 
-- **The "charm" rename is complete in this group.** No `charm` references
-  remain in the source of these packages, and the charm-named test files are
-  gone too. The former `background-charm-service` package is now
-  `background-piece-service` (`@commonfabric/background-piece`). The main
-  survivors repo-wide are the wire-level `bgUpdater` stream name, a dated cause
-  string in that service, plain-English "charm" occurrences in test-data
-  fixtures (a Scrabble word list, a Frankenstein excerpt), and git history.
-- **`cli` is a hub, and a growing one.** It imports `runner` most, plus
-  `identity`, `utils`, `js-compiler`, `piece`, `api`, and now `state-inspector`
-  — it wires the offline space-inspector (see the
-  [storage page](storage-substrate.md)) into the `cf` command. A change in any of
-  those can break the command line.
-- **`PieceManager` has a flagged hot spot.** `piece/src/manager.ts:856` carries
-  `// FIXME(JA): this really really really needs to be revisited`, and there is
-  an elevated-permissions TODO at line 294.
-- **`runtime-client` teardown is intentionally quiet.** After a `Dispose`, the
-  worker silently acknowledges late requests and drops notifications. This is by
-  design but surprising while debugging.
-- **The biggest files to budget for:** `fuse/mod.ts` and `fuse/cell-bridge.ts`
-  (the two largest, a few thousand lines each); `cli/lib/test-runner.ts` and
-  `cli/lib/piece.ts`; `runtime-client/backends/runtime-processor.ts` and
-  `protocol/types.ts`.
+The debt and rough edges touching these packages are collected, together with
+the rest of the repo's, in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -163,7 +163,7 @@ aliases) are the mitigation. Other concrete details: JSON keys become path
 components via a reversible percent-encoding (`path-codec.ts` escapes `/`, `:`, a
 leading `.`, etc.; empty string → `%_empty`); a callable file is a self-invoking
 shebang script (`#!<cli> exec`, `# schema:` comment lines you can `cat`, then a
-body that re-invokes `cf exec`); virtual files are capped at 64 MB. On a cell
+body that re-invokes `cf exec`); virtual files have a fixed size cap. On a cell
 change the daemon calls `fuse_lowlevel_notify_inval_entry`/`_inode`, but FUSE-T
 returns ENOSYS for `notify_inval_entry`, so it falls back to per-inode
 invalidation with short cache timeouts. The FFI struct layouts are hand-maintained
@@ -184,15 +184,16 @@ and differ between macOS (FUSE v2; FUSE-T preferred over macFUSE) and Linux
   retry loop and single-transaction commit.
 - **`cf-harness`** is the biggest naming trap in the repo. It is **not** a test
   harness for the runtime. It is an experimental, Common-Fabric-native agent
-  runtime: a bounded model-to-tool-call-to-sandbox-execute loop with exactly ten
-  built-in tools (`bash`, `bash-no-sandbox`, `read_file`, `view_image`,
+  runtime: a bounded model-to-tool-call-to-sandbox-execute loop with a small set
+  of built-in tools (`bash`, `bash-no-sandbox`, `read_file`, `view_image`,
   `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
   `write_file`, `delegate_task`), a Docker/gVisor sandbox (`docker-runsc-cfc`,
   default runtime `runsc-cfc`, mounts `/workspace` and `/fabric`), SQLite session
   persistence (WAL mode), an OpenAI-compatible gateway client, and CFC-aware
   deny/recovery shaping. Its design direction is that `runner` owns the
   authoritative CFC meaning and `cf-harness` transports and respects it. Loom is
-  its first target. The `prompt-loop.ts` file (2889 lines) is monolithic.
+  its first target. The `prompt-loop.ts` file is monolithic (several thousand
+  lines).
 
 ---
 
@@ -205,21 +206,21 @@ and differ between macOS (FUSE v2; FUSE-T preferred over macFUSE) and Linux
   survivors repo-wide are the wire-level `bgUpdater` stream name, a dated cause
   string in that service, plain-English "charm" occurrences in test-data
   fixtures (a Scrabble word list, a Frankenstein excerpt), and git history.
-- **`cli` is a hub, and a growing one** (about 25k non-test lines now). It
-  imports `runner` (26), `identity` (9), `utils` (9), `js-compiler` (8),
-  `piece`/`api` (5 each), and now `state-inspector` (2) — it wires the offline
-  space-inspector (see the [storage page](storage-substrate.md)) into the `cf`
-  command. A change in any of those can break the command line.
+- **`cli` is a hub, and a growing one.** It imports `runner` most, plus
+  `identity`, `utils`, `js-compiler`, `piece`, `api`, and now `state-inspector`
+  — it wires the offline space-inspector (see the
+  [storage page](storage-substrate.md)) into the `cf` command. A change in any of
+  those can break the command line.
 - **`PieceManager` has a flagged hot spot.** `piece/src/manager.ts:856` carries
   `// FIXME(JA): this really really really needs to be revisited`, and there is
   an elevated-permissions TODO at line 294.
 - **`runtime-client` teardown is intentionally quiet.** After a `Dispose`, the
   worker silently acknowledges late requests and drops notifications. This is by
   design but surprising while debugging.
-- **The biggest files to budget for:** `fuse/mod.ts` (3389) and
-  `fuse/cell-bridge.ts` (3287); `cli/lib/test-runner.ts` (1951) and
-  `cli/lib/piece.ts` (1417); `runtime-client/backends/runtime-processor.ts`
-  (1794) and `protocol/types.ts` (1177).
+- **The biggest files to budget for:** `fuse/mod.ts` and `fuse/cell-bridge.ts`
+  (the two largest, a few thousand lines each); `cli/lib/test-runner.ts` and
+  `cli/lib/piece.ts`; `runtime-client/backends/runtime-processor.ts` and
+  `protocol/types.ts`.
 
 ---
 

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -38,6 +38,18 @@ A launcher subtlety that bites people: `--config` is the *child Deno* import
 map, not a `cf` or pattern config. Pass same-named flags through to `cf` after a
 `--`.
 
+The `lib/` engines do the real work: `dev.ts` compiles a pattern through the
+runtime's *own* harness (`runtime.harness`, deliberately not a second `Engine`,
+so verified-load registration and source maps stay on one engine) and optionally
+evaluates it; `exec.ts` runs a mounted-callable file and auto-steps
+(`pull()` + `synced()`); `test-runner.ts` is the pattern test runner. That test
+runner recently grew a **multi-user mode**: a test file can
+`export default { setup, participants: { alice, bob } }`, and each participant
+runs in its own worker realm with its own identity against one shared in-process
+storage server, coordinating steps with `{ label }` / `{ await }` markers (the
+orchestrator reports a deadlock if every participant is parked). Assertions retry
+with settling until the step timeout.
+
 ---
 
 ## The piece lifecycle
@@ -61,7 +73,16 @@ flowchart LR
 
 `PieceManager` also tracks the reference graph between pieces
 (`getReadingFrom` / `getReadByPieces`), manages the default (home) pattern, and
-handles ACLs through `PiecesController.acl()`.
+handles ACLs through `PiecesController.acl()` (whose `ACLManager` is actually
+re-exported from `runner`, not defined in `piece`). The persistent lifecycle is a
+small composition: `runPersistent` = `setupPersistent` (create the cell, set the
+pattern, no scheduling) + `startPiece` (start, pull the result cell, wait for
+`synced`); `stopPiece` stops it. The full `cf piece` verb set is `ls`, `new`,
+`set-slug`, `step`, `apply`, `getsrc`, `setsrc`, `inspect`, `view`, `render`,
+`link`, `get`, `set`, `map`, `call`, `rm`, `recreate-root`, and `set-home`
+(`--reset` re-homes). A *slug* is a well-known entity id whose cell stores a
+write-redirect link to the target piece, written inside a compare-and-set
+`editWithRetry`.
 
 ---
 
@@ -95,9 +116,16 @@ sequenceDiagram
     Note over Worker,Main: cell subscriptions push CellUpdateNotifications<br/>back the other way (no msgId), fanned out to CellHandles
 ```
 
-The wire protocol (request types, notification types, response shapes) is in
-`runtime-client/protocol/types.ts`. The worker side that owns the real runtime
-is `runtime-client/backends/runtime-processor.ts`.
+The wire protocol (`runtime-client/protocol/types.ts`) has three enums: a
+`RequestType` (request→response, `msgId`-correlated: `Initialize`/`Dispose`, the
+`Cell*` ops, `GetCell`/`Idle`/`RuntimeSynced`/`UploadBlob`, the `Page*` ops, and
+`VDomMount`/`Unmount`), a `NotificationType` (worker→main, no `msgId`:
+`CellUpdate`, `ConsoleMessage`, `NavigateRequest`, `ErrorReport`, `Telemetry`,
+`VDomBatch`, `PendingWritesChanged`, `VersionSkew`), and a `ClientNotificationType`
+(main→worker, fire-and-forget: `VDomEvent`, `VDomBatchApplied`). A naming gotcha:
+**this protocol calls pieces "pages"** — `PageCreate`, `PageHandle` — so the
+main-thread proxies are `CellHandle<T>` and `PageHandle<T>`. The worker side that
+owns the real runtime is `runtime-client/backends/runtime-processor.ts`.
 
 ---
 
@@ -128,22 +156,40 @@ flowchart TB
 The asymmetry is a real sharp edge: `write(2)` returns success *before* the cell
 mutation lands (fire-and-forget), so a disconnect between the reply and the
 flush can silently lose data. The package's `RELIABILITY_DESIGN.md` and a
-CFC-writeback state machine are the mitigation. The FFI struct layouts are
-hand-maintained and differ between macOS (FUSE v2 / FUSE-T) and Linux
-(FUSE v3 / libfuse3).
+CFC-writeback state machine (`cfc-writeback.ts`, a two-phase `trusted.cfc.*`
+xattr protocol whose per-mutation FSM runs
+`pending-prepare → mutation-applied → …`, with gVisor-compat `user.commonfabric.*`
+aliases) are the mitigation. Other concrete details: JSON keys become path
+components via a reversible percent-encoding (`path-codec.ts` escapes `/`, `:`, a
+leading `.`, etc.; empty string → `%_empty`); a callable file is a self-invoking
+shebang script (`#!<cli> exec`, `# schema:` comment lines you can `cat`, then a
+body that re-invokes `cf exec`); virtual files are capped at 64 MB. On a cell
+change the daemon calls `fuse_lowlevel_notify_inval_entry`/`_inode`, but FUSE-T
+returns ENOSYS for `notify_inval_entry`, so it falls back to per-inode
+invalidation with short cache timeouts. The FFI struct layouts are hand-maintained
+and differ between macOS (FUSE v2; FUSE-T preferred over macFUSE) and Linux
+(FUSE v3 / libfuse3, using `fuse_session_new`/`_mount`).
 
 ---
 
 ## The two passengers
 
 - **`fs-sync-example`** is a worked example, not infrastructure: a daemon that
-  keeps a todo-list pattern's cells in sync with a markdown file, demonstrating
-  the compare-and-set retry loop and single-transaction commits. Its README has
-  a clean diagram of the cell-to-file sync loop.
+  keeps a todo-list pattern's cells in sync with a markdown file. Its `doSync()`
+  loops until `tx.commit()` returns no error; an `editWatermark` records how many
+  edits already reached disk so a retry only applies new ones, and one transaction
+  atomically applies edits, sets the todos cell, writes write-redirect links for
+  optimistic creates, and clears the edit queue. A PID-liveness lockfile enforces
+  single-process operation. It is the cleanest small demo of the compare-and-set
+  retry loop and single-transaction commit.
 - **`cf-harness`** is the biggest naming trap in the repo. It is **not** a test
   harness for the runtime. It is an experimental, Common-Fabric-native agent
-  runtime: a bounded model-to-tool-call-to-sandbox-execute loop, with a tool
-  registry, Docker/gVisor sandboxing, SQLite session persistence, and CFC-aware
+  runtime: a bounded model-to-tool-call-to-sandbox-execute loop with exactly ten
+  built-in tools (`bash`, `bash-no-sandbox`, `read_file`, `view_image`,
+  `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
+  `write_file`, `delegate_task`), a Docker/gVisor sandbox (`docker-runsc-cfc`,
+  default runtime `runsc-cfc`, mounts `/workspace` and `/fabric`), SQLite session
+  persistence (WAL mode), an OpenAI-compatible gateway client, and CFC-aware
   deny/recovery shaping. Its design direction is that `runner` owns the
   authoritative CFC meaning and `cf-harness` transports and respects it. Loom is
   its first target. The `prompt-loop.ts` file (2889 lines) is monolithic.

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -1,0 +1,190 @@
+# The CLI, pieces, and the filesystem: `cli`, `piece`, `runtime-client`, `fuse`
+
+This group is how a human or another process drives the runtime. `cli` is the
+`cf` command. `piece` is the lifecycle layer for deployed pattern instances.
+`runtime-client` is how a client talks to a runtime that lives in another thread.
+`fuse` mounts a space as files. Two more packages ride along: `fs-sync-example`
+is a worked example, and `cf-harness` is an experimental agent runtime that is
+*not* a test harness despite its name.
+
+---
+
+## `cf`: command dispatch
+
+The `cf` command has a two-stage entry. `launcher.ts` is a dependency-free Deno
+script that parses a few launch flags and spawns a child `deno run` of the real
+entry point. This indirection exists so `cf` can start before the import map is
+active, which matters for sibling repositories and vendoring. The real entry
+(`mod.ts`) builds a Cliffy command tree.
+
+```mermaid
+flowchart TB
+    launcher["launcher.ts (no dependencies)<br/>parses --deno/--config/--cwd, spawns child deno run"]
+    mod["mod.ts main(): strip --log-level, parse(args)"]
+    tree["commands/main.ts — the Cliffy command tree"]
+    libs["lib/* engines do the work"]
+
+    launcher --> mod --> tree --> libs
+
+    tree --- c1["piece (ls, new, step, apply, call,<br/>inspect, view, link, map, rm, set-slug, ...)"]
+    tree --- c2["check / dev (compile + run a pattern)"]
+    tree --- c3["fuse (mount, unmount, status)"]
+    tree --- c4["id (new, did, from-passphrase, from-mnemonic)"]
+    tree --- c5["acl (ls, add, remove)"]
+    tree --- c6["exec, init, test, deps"]
+```
+
+A launcher subtlety that bites people: `--config` is the *child Deno* import
+map, not a `cf` or pattern config. Pass same-named flags through to `cf` after a
+`--`.
+
+---
+
+## The piece lifecycle
+
+A "piece" is a deployed instance of a pattern: a runtime cell with input and
+result cells, plus the pattern source. `PieceManager` is the low-level layer
+that talks directly to a `runner` `Runtime`; the `ops/` controllers
+(`PiecesController`, `PieceController`) are the higher-level handles.
+
+```mermaid
+flowchart LR
+    src["pattern.tsx"]
+    prog["js-compiler builds a Program"]
+    setup["PieceManager.setupPersistent<br/>(create piece cell, set pattern)"]
+    start["startPiece → runner schedules it"]
+    io["input cell + result cell become observable"]
+    verbs["cf piece verbs: apply (new input),<br/>call (invoke callable), step, inspect, rm, link"]
+
+    src --> prog --> setup --> start --> io --> verbs
+```
+
+`PieceManager` also tracks the reference graph between pieces
+(`getReadingFrom` / `getReadByPieces`), manages the default (home) pattern, and
+handles ACLs through `PiecesController.acl()`.
+
+---
+
+## The runtime-client worker bridge
+
+Clients (the shell, sometimes the CLI) do not hold a `runner` `Runtime`
+directly. They hold a `RuntimeClient` on the main thread that proxies every
+call across a boundary — currently a Web Worker — to a `RuntimeProcessor` that
+holds the real runtime. This is the clearest "two sides of a boundary" picture
+in the codebase.
+
+```mermaid
+sequenceDiagram
+    participant Main as RuntimeClient (main thread)
+    participant Conn as RuntimeConnection
+    participant Transport as WebWorkerRuntimeTransport
+    participant Worker as worker: RuntimeProcessor
+    participant RT as real Runtime + PieceManager
+
+    Main->>Conn: getCell()
+    Conn->>Conn: assign msgId, create a Deferred
+    Conn->>Transport: postMessage(request)
+    Transport->>Worker: onmessage
+    Worker->>Worker: handleRequest(switch RequestType)
+    Worker->>RT: handleCellGet / Set / Send / PieceCreate
+    RT-->>Worker: result
+    Worker-->>Transport: postMessage({ msgId, data })
+    Transport-->>Conn: resolve the Deferred
+    Conn-->>Main: value
+
+    Note over Worker,Main: cell subscriptions push CellUpdateNotifications<br/>back the other way (no msgId), fanned out to CellHandles
+```
+
+The wire protocol (request types, notification types, response shapes) is in
+`runtime-client/protocol/types.ts`. The worker side that owns the real runtime
+is `runtime-client/backends/runtime-processor.ts`.
+
+---
+
+## The FUSE filesystem mapping
+
+`fuse` mounts a space as a real filesystem. Pieces become directories, cell
+values explode into nested files and directories, handlers and tools become
+executable files, and inter-piece references become symlinks. Reads come from an
+in-memory tree; writes are buffered and written back to cells on flush.
+
+```mermaid
+flowchart TB
+    space["a Space"]
+    pieces["pieces → directories"]
+    cells["input/result cells"]
+    tree["buildJsonTree:<br/>scalar → file, object → dir,<br/>array → numeric-named dir,<br/>handler/stream → executable callable,<br/>link → symlink"]
+    space --> pieces --> cells --> tree
+
+    subgraph io["read vs write are asymmetric"]
+        read["read(): pure memory, slice the in-memory tree (no RPC)"]
+        write["write(): buffer, return success immediately"]
+        flush["flush/fsync: parse buffer → CellBridge.writeValue → cell.set()"]
+        inval["the cell change fires a subscription → rebuild subtree → invalidate kernel cache"]
+        write --> flush --> inval
+    end
+```
+
+The asymmetry is a real sharp edge: `write(2)` returns success *before* the cell
+mutation lands (fire-and-forget), so a disconnect between the reply and the
+flush can silently lose data. The package's `RELIABILITY_DESIGN.md` and a
+CFC-writeback state machine are the mitigation. The FFI struct layouts are
+hand-maintained and differ between macOS (FUSE v2 / FUSE-T) and Linux
+(FUSE v3 / libfuse3).
+
+---
+
+## The two passengers
+
+- **`fs-sync-example`** is a worked example, not infrastructure: a daemon that
+  keeps a todo-list pattern's cells in sync with a markdown file, demonstrating
+  the compare-and-set retry loop and single-transaction commits. Its README has
+  a clean diagram of the cell-to-file sync loop.
+- **`cf-harness`** is the biggest naming trap in the repo. It is **not** a test
+  harness for the runtime. It is an experimental, Common-Fabric-native agent
+  runtime: a bounded model-to-tool-call-to-sandbox-execute loop, with a tool
+  registry, Docker/gVisor sandboxing, SQLite session persistence, and CFC-aware
+  deny/recovery shaping. Its design direction is that `runner` owns the
+  authoritative CFC meaning and `cf-harness` transports and respects it. Loom is
+  its first target. The `prompt-loop.ts` file (2889 lines) is monolithic.
+
+---
+
+## Technical debt and sharp edges
+
+- **The "charm" rename is complete in this group.** No `charm` references
+  remain in the source of these packages, and the charm-named test files are
+  gone too. The former `background-charm-service` package is now
+  `background-piece-service` (`@commonfabric/background-piece`). The only
+  survivors repo-wide are the wire-level `bgUpdater` stream name, a dated cause
+  string in that service, a Scrabble word list, and git history.
+- **`cli` is a hub, and a growing one** (about 25k non-test lines now). It
+  imports `runner` (25), `identity` (9), `utils` (9), `js-compiler` (8),
+  `piece`/`api` (5 each), and now `state-inspector` (2) — it wires the offline
+  space-inspector (see the [storage page](storage-substrate.md)) into the `cf`
+  command. A change in any of those can break the command line.
+- **`PieceManager` has a flagged hot spot.** `piece/src/manager.ts:849` carries
+  `// FIXME(JA): this really really really needs to be revisited`, and there is
+  an elevated-permissions TODO at line 287.
+- **`runtime-client` teardown is intentionally quiet.** After a `Dispose`, the
+  worker silently acknowledges late requests and drops notifications. This is by
+  design but surprising while debugging.
+- **The biggest files to budget for:** `fuse/mod.ts` (3389) and
+  `fuse/cell-bridge.ts` (3287); `cli/lib/test-runner.ts` (1895) and
+  `cli/lib/piece.ts` (1412); `runtime-client/backends/runtime-processor.ts`
+  (1676) and `protocol/types.ts` (1128).
+
+---
+
+## Public surfaces and the `cf` subcommands
+
+- **`cli`** — `.` → `mod.ts`; the real entry is `launcher.ts` (the root `cf`
+  task). Subcommands: `help`, `acl`, `piece` (with many verbs), `check`, `dev`
+  (a hidden alias of `check`), `deps`, `exec`, `fuse`, `id`, `init`, `test`, and
+  a hidden deprecated `deploy` that points at `piece new`.
+- **`piece`** — `.` (`PieceManager`, `pieceId`, slug helpers), `./ops` (the
+  controllers).
+- **`runtime-client`** — `.` → `mod.ts`, `./transports/web-worker`.
+- **`fuse`** — `.` → `mod.ts` (the daemon `main(argv)`).
+- **`cf-harness`** — a large export map: `./engine`, `./prompt-loop`, `./cli`,
+  `./tools`, `./skills/registry`, `./sandbox`, and the `./contracts/*` schemas.

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -119,7 +119,7 @@ flowchart TB
     subgraph io["read vs write are asymmetric"]
         read["read(): pure memory, slice the in-memory tree (no RPC)"]
         write["write(): buffer, return success immediately"]
-        flush["flush/fsync: parse buffer → CellBridge.writeValue → cell.set()"]
+        flush["flush (on close) / release: parse buffer → CellBridge.writeValue → cell.set()"]
         inval["the cell change fires a subscription → rebuild subtree → invalidate kernel cache"]
         write --> flush --> inval
     end

--- a/docs/development/orientation/cli-piece-fuse.md
+++ b/docs/development/orientation/cli-piece-fuse.md
@@ -30,7 +30,7 @@ flowchart TB
     tree --- c2["check / dev (compile + run a pattern)"]
     tree --- c3["fuse (mount, unmount, status)"]
     tree --- c4["id (new, did, derive, from-mnemonic)"]
-    tree --- c5["acl (ls, add, remove)"]
+    tree --- c5["acl (ls, set, remove)"]
     tree --- c6["exec, init, test, deps"]
 ```
 
@@ -86,7 +86,7 @@ sequenceDiagram
     Conn->>Transport: postMessage(request)
     Transport->>Worker: onmessage
     Worker->>Worker: handleRequest(switch RequestType)
-    Worker->>RT: handleCellGet / Set / Send / PieceCreate
+    Worker->>RT: handleCellGet / Set / Send / PageCreate
     RT-->>Worker: result
     Worker-->>Transport: postMessage({ msgId, data })
     Transport-->>Conn: resolve the Deferred
@@ -160,7 +160,7 @@ hand-maintained and differ between macOS (FUSE v2 / FUSE-T) and Linux
   string in that service, plain-English "charm" occurrences in test-data
   fixtures (a Scrabble word list, a Frankenstein excerpt), and git history.
 - **`cli` is a hub, and a growing one** (about 25k non-test lines now). It
-  imports `runner` (25), `identity` (9), `utils` (9), `js-compiler` (8),
+  imports `runner` (26), `identity` (9), `utils` (9), `js-compiler` (8),
   `piece`/`api` (5 each), and now `state-inspector` (2) — it wires the offline
   space-inspector (see the [storage page](storage-substrate.md)) into the `cf`
   command. A change in any of those can break the command line.
@@ -171,9 +171,9 @@ hand-maintained and differ between macOS (FUSE v2 / FUSE-T) and Linux
   worker silently acknowledges late requests and drops notifications. This is by
   design but surprising while debugging.
 - **The biggest files to budget for:** `fuse/mod.ts` (3389) and
-  `fuse/cell-bridge.ts` (3287); `cli/lib/test-runner.ts` (1899) and
+  `fuse/cell-bridge.ts` (3287); `cli/lib/test-runner.ts` (1951) and
   `cli/lib/piece.ts` (1417); `runtime-client/backends/runtime-processor.ts`
-  (1798) and `protocol/types.ts` (1153).
+  (1794) and `protocol/types.ts` (1177).
 
 ---
 

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -68,19 +68,23 @@ flowchart TB
 
 Two facts that catch people out:
 
-- **VNodes are plain serializable JSON.** They contain no functions. Event
-  handlers cross the worker/main boundary as integer `handlerId`s, not closures.
-  This is why the reconciler can live in a worker at all.
+- **Cell-backed VNodes are plain serializable JSON.** Event handlers cross the
+  worker/main boundary as integer `handlerId`s, not closures (the reconciler will
+  accept a raw function prop and register it to a `handlerId`, so a VNode can hold
+  a function transiently, but nothing function-valued crosses the wire). This is
+  why the reconciler can live in a worker at all.
 - **The reconciler enforces CFC render policy.** It can replace blocked content
   with a `cf-cfc-blocked` placeholder. If UI content "disappears," suspect the
   flow-control policy before suspecting a render bug.
 
 On the component side, a `cf-*` element binds to a cell through a
-`CellController` (a Lit reactive controller). The controller subscribes via
-`.sink()` and calls `requestUpdate()` on change; writing back goes through a
-transaction (`runtime.edit()` → `cell.withTx(tx).set(v)` → `tx.commit()`), with
-debounce and blur timing for inputs. The runtime and the current space arrive
-through Lit context (`runtimeContext`, `spaceContext`).
+`CellController` (a Lit reactive controller). The controller subscribes via the
+main-thread `CellHandle.subscribe()` and calls `requestUpdate()` on change;
+writing back calls `cellHandle.set(v)`, which sends a `CellSet` request over IPC
+to the worker, and the worker applies it in a transaction
+(`runtime.edit()` → `withTx(tx).set(v)` → `tx.commit()`). Debounce and blur
+timing for inputs live on the controller. The runtime and the current space
+arrive through Lit context (`runtimeContext`, `spaceContext`).
 
 ---
 

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -74,8 +74,20 @@ Two facts that catch people out:
   a function transiently, but nothing function-valued crosses the wire). This is
   why the reconciler can live in a worker at all.
 - **The reconciler enforces CFC render policy.** It can replace blocked content
-  with a `cf-cfc-blocked` placeholder. If UI content "disappears," suspect the
-  flow-control policy before suspecting a render bug.
+  with a `cf-cfc-blocked` placeholder (`CFC_BLOCKED_PLACEHOLDER_TAG`, carrying
+  `data-cfc-blocked-reason`). If UI content "disappears," suspect the flow-control
+  policy before suspecting a render bug.
+
+The `VDomOp` vocabulary (`vdom-ops.ts`) is a 12-member discriminated union:
+`create-element` (optionally carrying a `space` for cross-space transclusion),
+`create-text`, `update-text`, `set-prop`, `remove-prop`, `set-attrs` (a bulk
+initial-render optimization), `set-event` (carries an integer `handlerId`, not a
+function), `remove-event`, `set-binding` (carries a `cellRef` for a `$`-bound
+prop, not a value), `insert-child`, `move-child`, and `remove-node`. Ops are
+collected into a `VDomBatch { batchId, ops, rootId? }` and applied in order.
+Children are keyed by `generateKey`, which `JSON.stringify`s the VNode with any
+`Cell` replaced by its normalized link so the key is identical on both threads,
+appending an occurrence suffix to disambiguate structurally-identical siblings.
 
 On the component side, a `cf-*` element binds to a cell through a
 `CellController` (a Lit reactive controller). The controller subscribes via the
@@ -83,8 +95,18 @@ main-thread `CellHandle.subscribe()` and calls `requestUpdate()` on change;
 writing back calls `cellHandle.set(v)`, which sends a `CellSet` request over IPC
 to the worker, and the worker applies it in a transaction
 (`runtime.edit()` → `withTx(tx).set(v)` → `tx.commit()`). Debounce and blur
-timing for inputs live on the controller. The runtime and the current space
-arrive through Lit context (`runtimeContext`, `spaceContext`).
+timing for inputs live on the controller (default `debounce` 300 ms). The runtime
+and the current space arrive through Lit context (`runtimeContext`,
+`spaceContext`).
+
+`ui` holds ~110 `cf-*` component directories under `v2/components/`; `v2/core/`
+holds the controllers (`base-element.ts`, `cell-controller.ts` with typed
+subclasses, `input-timing-controller.ts`, `mention-controller.ts`,
+`form-field-controller.ts`, drag/debug/menu helpers), and `v2/styles/variables.ts`
+holds the design tokens (`--cf-colors-*` base palette, `--cf-theme-*` semantic
+contract). The authoritative, type-checked component catalog is not in `ui` — it
+is a Common Fabric pattern at `packages/patterns/catalog/catalog.tsx`, with a
+story file per component under `catalog/stories/`.
 
 ---
 
@@ -112,13 +134,20 @@ sequenceDiagram
     Host->>Guest: Update [key, value] / Effect / LLMResponse
 ```
 
-The outer frame validates the message origin against the known host origin. The
-host side registers a single `IframeContextHandler` whose methods
+The outer frame validates the message origin against the known host origin
+(`e.source === HOST_WINDOW && e.origin === HOST_ORIGIN`). The host side registers
+a single `IframeContextHandler` whose methods
 (`read`/`write`/`subscribe`/`onLLMRequest`/`onPerform`) wire guest requests to
-the real reactive runtime. The README documents the deliberately accepted
-security gaps (for example, a hardcoded-CDN allowlist and anchors with
-`target=_blank` are both exfiltration vectors, and `document.baseURI` leaks the
-parent URL into the iframe).
+the real reactive runtime. Why two frames: the CSP (`default-src 'none'`, then
+per-directive allowances — `script-src` re-enables the host origin plus
+`'unsafe-inline'` and three hardcoded CDNs `unpkg.com`/`cdn.tailwindcss.com`/
+`esm.sh`) is set on the outer `srcdoc` so it propagates into the inner guest
+`srcdoc` across browsers, which the per-element `csp` attribute doesn't do
+reliably. The two iframes carry different `sandbox` attribute sets. Health
+checking is compiled off (`HEALTH_CHECKING_ENABLED = false`). The README
+documents the deliberately accepted security gaps (a hardcoded-CDN allowlist and
+anchors with `target=_blank` are both exfiltration vectors, and `document.baseURI`
+leaks the parent URL into the iframe).
 
 ---
 
@@ -145,9 +174,21 @@ flowchart TB
     appview <--> nav
 ```
 
-The view files are large (`SchedulerGraphView` and `DebuggerView` are each over
-3000 lines) because the shell ships its own debugging and scheduler-visualization
-tools.
+`views/index.ts` registers eight views — `RootView` (`x-root-view`), `AppView`,
+`BodyView`, `HeaderView`, `LoginView`, `QuickJumpView`, `ACLView`, `DebuggerView`
+— and `DebuggerView` pulls in `SchedulerGraphView` and `SchedulerSourceView`.
+Those last two are large (each over 3000 lines) because the shell ships its own
+scheduler-visualization and debugging tools. State changes go through a
+three-variant `Command` union (`set-view` / `set-identity` / `set-config`) applied
+by `applyCommand`, which clones the state and mutates the copy (immutable update);
+`AppState.config` holds four boolean toggles. URL↔view mapping is pure
+(`urlToAppView` / `appViewToUrlPath`, with an `.embed/` prefix for embed mode),
+and navigation is a `globalThis` CustomEvent surface (`cf-navigate`,
+`cf-replace-navigation`, `cf-open-external`, `cf-update-page-title`).
+
+`RuntimeInternals` (in `lib-shell`) bundles one identity's resources: a single
+`RuntimeClient` over one Web Worker serving all of that identity's spaces, with no
+bound "current space" (default worker URL `/scripts/worker-runtime.js`).
 
 ---
 

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -112,8 +112,9 @@ The outer frame validates the message origin against the known host origin. The
 host side registers a single `IframeContextHandler` whose methods
 (`read`/`write`/`subscribe`/`onLLMRequest`/`onPerform`) wire guest requests to
 the real reactive runtime. The README documents the deliberately accepted
-security gaps (for example, a CDN allowlist can still be used to exfiltrate, and
-`target=_blank` can leak a referrer).
+security gaps (for example, a hardcoded-CDN allowlist and anchors with
+`target=_blank` are both exfiltration vectors, and `document.baseURI` leaks the
+parent URL into the iframe).
 
 ---
 
@@ -177,7 +178,8 @@ tools.
 ## Public surfaces
 
 - **`html`** — `.` (`h`, a few UI helpers), plus `./client`, `./jsx-runtime`,
-  `./worker`, `./main`, `./vdom-ops`, `./mock-doc`.
+  `./jsx-dev-runtime`, `./worker`, `./main`, `./vdom-ops`, `./mock-doc`,
+  `./utils`, `./debug`.
 - **`ui`** — `.` → `v2/index.ts` (the `BaseElement`, `CellController`, the Lit
   contexts, the style tokens, and all `cf-*` classes, which self-register).
 - **`iframe-sandbox`** — `.` exports `CommonIframeSandboxElement`, the `IPC`

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -184,8 +184,10 @@ tools.
 - **`html`** — `.` (`h`, a few UI helpers), plus `./client`, `./jsx-runtime`,
   `./jsx-dev-runtime`, `./worker`, `./main`, `./vdom-ops`, `./mock-doc`,
   `./utils`, `./debug`.
-- **`ui`** — `.` → `v2/index.ts` (the `BaseElement`, `CellController`, the Lit
-  contexts, the style tokens, and all `cf-*` classes, which self-register).
+- **`ui`** — `.` → `v2/index.ts` (the `BaseElement`, `DebugController`, the Lit
+  contexts `runtimeContext`/`spaceContext`, the style tokens, and all `cf-*`
+  classes, which self-register). Note `CellController` is *not* re-exported from
+  the barrel — components import it by relative path from `v2/core/`.
 - **`iframe-sandbox`** — `.` exports `CommonIframeSandboxElement`, the `IPC`
   namespace, and `setIframeContextHandler`.
 - **`shell`** — the app entry is `src/index.ts`; the library export is

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -78,7 +78,7 @@ Two facts that catch people out:
   `data-cfc-blocked-reason`). If UI content "disappears," suspect the flow-control
   policy before suspecting a render bug.
 
-The `VDomOp` vocabulary (`vdom-ops.ts`) is a 12-member discriminated union:
+The `VDomOp` vocabulary (`vdom-ops.ts`) is a small discriminated union:
 `create-element` (optionally carrying a `space` for cross-space transclusion),
 `create-text`, `update-text`, `set-prop`, `remove-prop`, `set-attrs` (a bulk
 initial-render optimization), `set-event` (carries an integer `handlerId`, not a
@@ -95,11 +95,11 @@ main-thread `CellHandle.subscribe()` and calls `requestUpdate()` on change;
 writing back calls `cellHandle.set(v)`, which sends a `CellSet` request over IPC
 to the worker, and the worker applies it in a transaction
 (`runtime.edit()` → `withTx(tx).set(v)` → `tx.commit()`). Debounce and blur
-timing for inputs live on the controller (default `debounce` 300 ms). The runtime
+timing for inputs live on the controller (a short debounce by default). The runtime
 and the current space arrive through Lit context (`runtimeContext`,
 `spaceContext`).
 
-`ui` holds ~110 `cf-*` component directories under `v2/components/`; `v2/core/`
+`ui` holds over a hundred `cf-*` component directories under `v2/components/`; `v2/core/`
 holds the controllers (`base-element.ts`, `cell-controller.ts` with typed
 subclasses, `input-timing-controller.ts`, `mention-controller.ts`,
 `form-field-controller.ts`, drag/debug/menu helpers), and `v2/styles/variables.ts`
@@ -177,7 +177,7 @@ flowchart TB
 `views/index.ts` registers eight views — `RootView` (`x-root-view`), `AppView`,
 `BodyView`, `HeaderView`, `LoginView`, `QuickJumpView`, `ACLView`, `DebuggerView`
 — and `DebuggerView` pulls in `SchedulerGraphView` and `SchedulerSourceView`.
-Those last two are large (each over 3000 lines) because the shell ships its own
+Those last two are large (several thousand lines each) because the shell ships its own
 scheduler-visualization and debugging tools. State changes go through a
 three-variant `Command` union (`set-view` / `set-identity` / `set-config`) applied
 by `applyCommand`, which clones the state and mutates the copy (immutable update);
@@ -214,9 +214,9 @@ bound "current space" (default worker URL `/scripts/worker-runtime.js`).
 - **Several shell views are disabled pending a worker refactor.** `ACLView` and
   parts of `QuickJumpView` carry `TODO(runtime-worker-refactor)` and are
   currently inert.
-- **The biggest files to budget for:** `html/src/jsx.d.ts` (5458 lines, but it
-  is generated type declarations), `html/src/worker/reconciler.ts` (3862), and
-  the shell debug views (~3000 each).
+- **The biggest files to budget for:** `html/src/jsx.d.ts` (the largest, but
+  generated type declarations), `html/src/worker/reconciler.ts`, and the shell
+  debug views — each several thousand lines.
 
 ---
 

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -194,29 +194,8 @@ bound "current space" (default worker URL `/scripts/worker-runtime.js`).
 
 ## Technical debt and sharp edges
 
-- **Two of the four repo cycles live here.** `ui ↔ shell` (four `cf-*`
-  components import navigation helpers from `@commonfabric/shell/shared`, and the
-  shell imports `cf-*` classes and Lit contexts back) and `runner ↔ html` (the
-  runtime's builder imports `h()` from `html`, and `html` imports cell helpers
-  back from `runner`). See the [dependency page](dependency-graph.md).
-- **`cf-markdown` renders unsanitized HTML.** It uses `unsafeHTML` without
-  sanitization — a cross-site-scripting risk if it is ever fed untrusted
-  markdown. Worth knowing before you reuse it.
-- **There are two render paths.** The worker-thread reconciler is live; the
-  main-thread `renderNode`/`effect` path in `render.ts` is legacy but still
-  present and still selectable by a flag.
-- **`cf-*` components self-register on import.** Importing the module calls
-  `customElements.define`. There is no separate registration step; if a
-  component is "missing," check that its module was imported.
-- **`v1` is gone but the `v2/` directory name remains.** `ui/src/index.ts` is
-  just `export * from "./v2/index.ts"`. Everything is v2; the directory name is
-  flagged for cleanup.
-- **Several shell views are disabled pending a worker refactor.** `ACLView` and
-  parts of `QuickJumpView` carry `TODO(runtime-worker-refactor)` and are
-  currently inert.
-- **The biggest files to budget for:** `html/src/jsx.d.ts` (the largest, but
-  generated type declarations), `html/src/worker/reconciler.ts`, and the shell
-  debug views — each several thousand lines.
+The debt and rough edges touching these packages are collected, together with
+the rest of the repo's, in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/client-render.md
+++ b/docs/development/orientation/client-render.md
@@ -1,0 +1,188 @@
+# The client and rendering stack: `html`, `ui`, `iframe-sandbox`, `shell`
+
+This is how a reactive cell value becomes pixels. There are four packages in the
+chain, plus two small support packages (`lib-shell`, `felt`). They layer like
+this: `html` is a custom virtual-DOM layer and JSX runtime; `ui` is the
+`cf-*` web-component library built on Lit; `iframe-sandbox` runs untrusted
+pattern UI in an iframe; `shell` is the single-page application that ties it
+together.
+
+---
+
+## How the packages relate
+
+```mermaid
+flowchart TB
+    shell["shell — the single-page app (Lit)"]
+    ui["ui — cf-* web components (Lit)"]
+    iframe["iframe-sandbox — untrusted UI in an iframe"]
+    html["html — VDOM + JSX runtime"]
+    libshell["lib-shell — runtime lifecycle, credentials"]
+    felt["felt — esbuild bundler (build-time only)"]
+    rtc["runtime-client"]
+    runner["runner"]
+
+    shell --> ui
+    shell --> libshell
+    shell --> rtc
+    ui --> html
+    ui --> rtc
+    iframe --> runner
+    html --> runner
+    html --> rtc
+    libshell --> rtc
+    felt -. "bundles" .-> shell
+```
+
+The repository sets `jsxImportSource` to `@commonfabric/html`, so every pattern
+`.tsx` file compiles its JSX into `h()` calls in the `html` package. That is why
+`html` is foundational to the whole client even though it is small.
+
+---
+
+## The render pipeline: cell to DOM, on a worker
+
+There are two render paths in `html`. The live one runs the reconciler **in a
+Web Worker**, where cell values are synchronous, and ships DOM-mutation
+operations to the main thread over a message channel. (A legacy main-thread
+renderer still exists in `render.ts`, selected by a flag.) Understanding the
+worker path is understanding the client.
+
+```mermaid
+flowchart TB
+    uicell["a pattern's [UI] Cell"]
+    render["render(parent, cellHandle)"]
+    vdr["VDomRenderer (main thread)"]
+    mount["session.mount over the runtime connection"]
+    recon["WorkerReconciler (worker thread)"]
+    sink["subscribes via cell.sink(), diffs, keys children"]
+    ops["emits a batch of VDomOps"]
+    applic["DomApplicator (main thread) mutates real DOM"]
+    dom["DOM / cf-* elements"]
+    evt["DOM event → serialized → handlerId → back to worker"]
+
+    uicell --> render --> vdr --> mount --> recon
+    recon --> sink --> ops --> applic --> dom
+    dom --> evt --> recon
+```
+
+Two facts that catch people out:
+
+- **VNodes are plain serializable JSON.** They contain no functions. Event
+  handlers cross the worker/main boundary as integer `handlerId`s, not closures.
+  This is why the reconciler can live in a worker at all.
+- **The reconciler enforces CFC render policy.** It can replace blocked content
+  with a `cf-cfc-blocked` placeholder. If UI content "disappears," suspect the
+  flow-control policy before suspecting a render bug.
+
+On the component side, a `cf-*` element binds to a cell through a
+`CellController` (a Lit reactive controller). The controller subscribes via
+`.sink()` and calls `requestUpdate()` on change; writing back goes through a
+transaction (`runtime.edit()` → `cell.withTx(tx).set(v)` → `tx.commit()`), with
+debounce and blur timing for inputs. The runtime and the current space arrive
+through Lit context (`runtimeContext`, `spaceContext`).
+
+---
+
+## The iframe sandbox protocol
+
+Untrusted pattern UI runs inside a double-nested iframe under a strict
+Content-Security-Policy. The guest never touches the host DOM or the host's
+reactive data directly. Everything goes through a message protocol across three
+frames: the host (the shell), an outer frame, and the inner guest document.
+
+```mermaid
+sequenceDiagram
+    participant Host as Host (shell)
+    participant Outer as Outer frame
+    participant Guest as Inner guest
+
+    Outer->>Host: Ready
+    Host->>Outer: Init { id }
+    Host->>Outer: LoadDocument { html }
+    Outer->>Guest: set srcdoc
+    Outer->>Host: Load
+    Note over Host,Guest: handshake complete, now bidirectional
+
+    Guest->>Host: Subscribe / Read / Write / LLMRequest / Perform
+    Host->>Guest: Update [key, value] / Effect / LLMResponse
+```
+
+The outer frame validates the message origin against the known host origin. The
+host side registers a single `IframeContextHandler` whose methods
+(`read`/`write`/`subscribe`/`onLLMRequest`/`onPerform`) wire guest requests to
+the real reactive runtime. The README documents the deliberately accepted
+security gaps (for example, a CDN allowlist can still be used to exfiltrate, and
+`target=_blank` can leak a referrer).
+
+---
+
+## The shell single-page app
+
+`shell` boots a Lit component tree, authenticates an identity, builds a
+`RuntimeClient` running in a Web Worker, and renders pieces with `cf-render`.
+Navigation is URL-driven with no router library: a small set of pure functions
+maps URLs to an `AppView` and back, and all state changes go through immutable
+`Command` objects.
+
+```mermaid
+flowchart TB
+    html_["public/index.html mounts <x-root-view>"]
+    root["RootView"]
+    identity["restore Identity from KeyStore"]
+    ri["RuntimeInternals (lib-shell) builds RuntimeClient over a Web Worker"]
+    toolshed["toolshed (over the worker's memory WebSocket)"]
+    appview["AppView tree: Header, Body → cf-piece / cf-render"]
+    nav["URL ⟷ AppView mapping, popstate, navigate(AppView)"]
+
+    html_ --> root --> identity --> ri --> toolshed
+    root --> appview
+    appview <--> nav
+```
+
+The view files are large (`SchedulerGraphView` and `DebuggerView` are each over
+3000 lines) because the shell ships its own debugging and scheduler-visualization
+tools.
+
+---
+
+## Technical debt and sharp edges
+
+- **Two of the four repo cycles live here.** `ui ↔ shell` (four `cf-*`
+  components import navigation helpers from `@commonfabric/shell/shared`, and the
+  shell imports `cf-*` classes and Lit contexts back) and `runner ↔ html` (the
+  runtime's builder imports `h()` from `html`, and `html` imports cell helpers
+  back from `runner`). See the [dependency page](dependency-graph.md).
+- **`cf-markdown` renders unsanitized HTML.** It uses `unsafeHTML` without
+  sanitization — a cross-site-scripting risk if it is ever fed untrusted
+  markdown. Worth knowing before you reuse it.
+- **There are two render paths.** The worker-thread reconciler is live; the
+  main-thread `renderNode`/`effect` path in `render.ts` is legacy but still
+  present and still selectable by a flag.
+- **`cf-*` components self-register on import.** Importing the module calls
+  `customElements.define`. There is no separate registration step; if a
+  component is "missing," check that its module was imported.
+- **`v1` is gone but the `v2/` directory name remains.** `ui/src/index.ts` is
+  just `export * from "./v2/index.ts"`. Everything is v2; the directory name is
+  flagged for cleanup.
+- **Several shell views are disabled pending a worker refactor.** `ACLView` and
+  parts of `QuickJumpView` carry `TODO(runtime-worker-refactor)` and are
+  currently inert.
+- **The biggest files to budget for:** `html/src/jsx.d.ts` (5458 lines, but it
+  is generated type declarations), `html/src/worker/reconciler.ts` (3862), and
+  the shell debug views (~3000 each).
+
+---
+
+## Public surfaces
+
+- **`html`** — `.` (`h`, a few UI helpers), plus `./client`, `./jsx-runtime`,
+  `./worker`, `./main`, `./vdom-ops`, `./mock-doc`.
+- **`ui`** — `.` → `v2/index.ts` (the `BaseElement`, `CellController`, the Lit
+  contexts, the style tokens, and all `cf-*` classes, which self-register).
+- **`iframe-sandbox`** — `.` exports `CommonIframeSandboxElement`, the `IPC`
+  namespace, and `setIframeContextHandler`.
+- **`shell`** — the app entry is `src/index.ts`; the library export is
+  `./shared` (app state and navigation).
+- **`lib-shell`** — `.`, `./credentials`, `./runtime`. **`felt`** — `mod.ts`
+  and `./cli`.

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -39,8 +39,9 @@ flowchart LR
 - **`js-compiler`** wraps `npm:typescript` and runs it entirely in memory (no
   disk, no network). It type-checks, runs a caller-supplied list of transformers
   during emit, and produces one CommonJS module body plus a source map per
-  source file. It does not itself know about Common Fabric — the transformers
-  are injected by the caller.
+  source file. It carries none of the Common Fabric transformer logic — that
+  pipeline is injected by the caller (its only Common-Fabric-specific detail is
+  the default JSX factory, `h` / `__cfHelpers.h.fragment`).
 - **`ts-transformers`** is the TypeScript AST transformer pipeline. It rewrites
   natural reactive TypeScript into explicit, schema-annotated runtime form.
 - **`schema-generator`** walks a TypeScript type into a JSON Schema object,
@@ -73,9 +74,11 @@ flowchart TB
 ## The transformer pipeline: 20 stages in three phases
 
 The pipeline is an ordered list (`cf-pipeline.ts`, `CFC_TRANSFORMER_STAGE_SPECS`).
-The ordering matters: validation runs first so illegal code is rejected before
-anything is rewritten; structural lowering runs in the middle; schema work runs
-late, because schema generation reads synthetic type nodes that an earlier stage
+The ordering matters: most validation runs first so illegal code is rejected
+before anything is rewritten (one write-authorization check runs mid-pipeline,
+because it inspects the lowered schema calls); structural lowering runs in the
+middle; schema work runs late, because schema generation reads synthetic type
+nodes that an earlier stage
 injected.
 
 ```mermaid
@@ -194,9 +197,10 @@ generator walks the node instead of the type.
   goldens (`UPDATE_GOLDENS=1`) and reviewing large diffs. The fast-iteration path
   is `FIXTURE=<name>`.
 - **`api` declarations must stay in sync by hand.** `api/index.ts` is
-  `declare const` / ambient declarations that must match the real
-  implementations in `runner`. There is an explicit sync note at the top of the
-  file. Changing a builder signature means editing it in two places.
+  `declare const` / ambient declarations that must match implementations
+  elsewhere — the builder vocabulary against `runner/src/builder`, and (per an
+  explicit sync note at the top of the file) the Fabric value types against
+  `data-model`. Changing a signature means editing it in two places.
 - **The biggest files are the densest part of the system.**
   `schema-injection.ts` (4123 lines) and `type-shrinking.ts` (3285) are the
   least approachable region; budget accordingly.

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -1,0 +1,220 @@
+# The compile pipeline: `api`, `ts-transformers`, `js-compiler`, `schema-generator`
+
+An author writes a pattern as ordinary-looking TypeScript with JSX. The runtime
+cannot run that directly: reactive expressions have to be lowered into explicit
+calls, closures have to be made explicit, and every reactive boundary has to
+carry a JSON Schema derived from the author's TypeScript types. This pipeline
+does that transformation. It is "System"-layer code, and it is large
+(`ts-transformers` alone is 40k lines).
+
+You can see its output for any file with:
+
+```
+deno task cf check <pattern-or-fixture>.tsx --show-transformed --no-run
+```
+
+---
+
+## The four packages and their jobs
+
+```mermaid
+flowchart LR
+    api["api<br/>the authoring surface<br/>(types + declare const)"]
+    jsc["js-compiler<br/>wraps the TypeScript compiler<br/>on a virtual filesystem"]
+    tstx["ts-transformers<br/>AST transformer pipeline<br/>run during emit"]
+    sg["schema-generator<br/>TypeScript type → JSON Schema"]
+
+    api -->|"author code is<br/>type-checked against it"| jsc
+    jsc -->|"injects the pipeline<br/>as beforeTransformers"| tstx
+    tstx -->|"calls it to materialize<br/>schemas"| sg
+    sg -->|"needs JSONSchema types"| api
+```
+
+- **`api`** is what authors import as `commonfabric`, `commonfabric/cfc`, and
+  `commonfabric/schema`. It is almost entirely TypeScript declarations and
+  `declare const` values — the vocabulary (`pattern`, `lift`, `handler`,
+  `computed`, `ifElse`, `Cell`, `Stream`, `Default`, `toSchema`) and the
+  `JSONSchema` type. The real implementations live in `runner`; `api` is the
+  shape author code is compiled against.
+- **`js-compiler`** wraps `npm:typescript` and runs it entirely in memory (no
+  disk, no network). It type-checks, runs a caller-supplied list of transformers
+  during emit, and produces one CommonJS module body plus a source map per
+  source file. It does not itself know about Common Fabric — the transformers
+  are injected by the caller.
+- **`ts-transformers`** is the TypeScript AST transformer pipeline. It rewrites
+  natural reactive TypeScript into explicit, schema-annotated runtime form.
+- **`schema-generator`** walks a TypeScript type into a JSON Schema object,
+  hoisting named types into `$defs`, detecting cycles, and mapping the reactive
+  wrapper types.
+
+---
+
+## The end-to-end flow
+
+The bridge that wires the transformers into the compiler lives in `runner`'s
+harness (`runner/src/harness/engine.ts`): it hands `js-compiler` a
+`beforeTransformers` factory that builds the `CommonFabricTransformerPipeline`.
+
+```mermaid
+flowchart TB
+    src[".tsx source + a Program (entry + in-memory sources)"]
+    compiler["TypeScriptCompiler<br/>(virtual filesystem host, type-check)"]
+    bridge["harness/engine.ts supplies beforeTransformers =<br/>CommonFabricTransformerPipeline.toFactories()"]
+    emit["tsProgram.emit() runs the 19 transformer stages"]
+    out["per-module CommonJS + source map"]
+    records["module records → runner evaluates in the SES sandbox"]
+
+    src --> compiler --> bridge --> emit --> out --> records
+    emit -.->|"--show-transformed taps here<br/>via a SourceCollector"| dump["printed transformed source"]
+```
+
+---
+
+## The transformer pipeline: 19 stages in three phases
+
+The pipeline is an ordered list (`cf-pipeline.ts`, `CFC_TRANSFORMER_STAGE_SPECS`).
+The ordering matters: validation runs first so illegal code is rejected before
+anything is rewritten; structural lowering runs in the middle; schema work runs
+late, because schema generation reads synthetic type nodes that an earlier stage
+injected.
+
+```mermaid
+flowchart TB
+    subgraph p1["Phase 1 · Validate (reject illegal code)"]
+        v1["CastValidation"]
+        v2["EmptyArrayOfValidation"]
+        v3["OpaqueGetValidation"]
+        v4["PatternContextValidation"]
+        v5["WriteAuthorizedByValidation"]
+    end
+    subgraph p2["Phase 2 · Lower (rewrite structure)"]
+        l1["JsxExpressionSiteRouter"]
+        l2["LiftLowering"]
+        l3["Closure (handlers, actions, array methods)"]
+        l4["ExpressionSiteLowering (pattern-owned, helper-owned)"]
+        l5["PatternCallbackLowering"]
+    end
+    subgraph p3["Phase 3 · Schemas + module scope"]
+        s1["SchemaInjection (writes synthetic TypeNodes + registry)"]
+        s2["BuilderCallHoisting"]
+        s3["SchemaGenerator (reads the registry → JSON Schema)"]
+        s4["ReactiveVariableFor"]
+        s5["ModuleScope: shadowing, __cfReg cf-data, function hardening"]
+    end
+    p1 --> p2 --> p3
+    s1 -.->|"hands off via CrossStageState"| s3
+```
+
+The central coupling of the whole pipeline is the hand-off inside Phase 3:
+**`SchemaInjection` writes synthetic type nodes and registry entries into a
+shared `CrossStageState`, and `SchemaGenerator` (a later stage) reads them and
+calls into the `schema-generator` package** to produce the actual schema
+objects. If you only remember one thing about why the stages are ordered the way
+they are, remember that.
+
+---
+
+## Call-kind detection: how the pipeline knows what it is looking at
+
+Before it can lower a call, the pipeline has to classify it. `ast/call-kind.ts`
+(`detectCallKind`) does provenance-first classification: it resolves the callee's
+symbol, verifies it originates from Common Fabric declarations, follows stable
+aliases, and recognizes the synthetic `__cfHelpers.*` calls the pipeline emits
+itself.
+
+```mermaid
+flowchart TB
+    call["a call expression"]
+    resolve["resolve callee symbol"]
+    origin{"originates from<br/>Common Fabric?"}
+    alias["follow const aliases<br/>(const f = lift)"]
+    synth["recognize __cfHelpers.* synthetic calls"]
+    kind["CallKind union:<br/>ifElse / when / unless / builder(lift,handler,pattern,computed) /<br/>array-method / lift-applied / cell-factory / wish /<br/>generate-text / generate-object / runtime-call"]
+
+    call --> resolve --> origin
+    origin -->|yes| alias --> kind
+    origin -->|"alias/synthetic"| synth --> kind
+```
+
+A representative lowering, from the `ts-transformers` README:
+`items.map(item => item.price * discount)` becomes a module-scope
+`__cfPattern_1 = __cfHelpers.pattern(...)` carrying input and result schemas,
+used at the call site as
+`items.mapWithPattern(__cfPattern_1, { params: { discount } })`, and registered
+via `__cfReg({ __cfPattern_1 })`. The closure capture (`discount`) is made
+explicit as a parameter with its own schema.
+
+---
+
+## Type to JSON Schema
+
+`schema-generator` runs a TypeScript type through an ordered chain of
+formatters. The order matters — for example arrays are handled before
+primitives so an array does not get misrouted as `any`.
+
+```mermaid
+flowchart LR
+    type["ts.Type (or a synthetic TypeNode)"]
+    cf["CommonFabricFormatter<br/>(wrapper types: Cell→asCell, etc.)"]
+    nat["NativeTypeFormatter<br/>(Date, URL, typed arrays)"]
+    uni["UnionFormatter"]
+    inter["IntersectionFormatter"]
+    arr["ArrayFormatter"]
+    prim["PrimitiveFormatter"]
+    obj["ObjectFormatter"]
+    schema["JSON Schema<br/>(named types hoisted to $defs, cycles detected)"]
+
+    type --> cf --> nat --> uni --> inter --> arr --> prim --> obj --> schema
+```
+
+The wrapper-type vocabulary — the authored spellings (`Cell`, `Writable`,
+`ReadonlyCell`, `Reactive`, `Stream`, …) and how each normalizes to a resolved
+kind (`Writable` collapses to `Cell`; `Reactive` stays `Reactive`) — is
+canonicalized once in
+`schema-generator/src/typescript/wrapper-names.ts` and consumed by both
+`schema-generator` and `ts-transformers`. There is an auto-detection fork: when
+the resolved type is `any` but a concrete synthetic type node exists, the
+generator walks the node instead of the type.
+
+---
+
+## Technical debt and sharp edges
+
+- **The marker scan is unusually clean.** There are essentially no
+  `TODO`/`FIXME`/`HACK` comments in `ts-transformers` or `js-compiler`. The open
+  work lives in design documents instead: `ts-transformers/docs/`,
+  `docs/specs/ts-transformer/`, and `ts-transformers/ISSUES_TO_FOLLOW_UP.md`.
+  The README explicitly tells you to read the behavior spec rather than infer
+  from the code. Believe it.
+- **Behavior is pinned by golden files.** Both `ts-transformers` and
+  `schema-generator` are driven by hundreds of `*.input` / `*.expected` fixture
+  pairs. Changing emit shape means regenerating goldens (`UPDATE_GOLDENS=1`) and
+  reviewing large diffs. The fast-iteration path is `FIXTURE=<name>`.
+- **`api` declarations must stay in sync by hand.** `api/index.ts` is
+  `declare const` / ambient declarations that must match the real
+  implementations in `runner`. There is an explicit sync note at the top of the
+  file. Changing a builder signature means editing it in two places.
+- **The biggest files are the densest part of the system.**
+  `schema-injection.ts` (4017 lines) and `type-shrinking.ts` (3286) are the
+  least approachable region; budget accordingly.
+- **The `lift-applied` distinction is subtle.** `__cfHelpers.lift(cb)(input)` —
+  a single application — is classified as `lift-applied` and is what `computed`
+  lowers to. An unapplied `lift(cb)` or a multi-application chain is deliberately
+  not. This gates whole dispatch branches.
+
+---
+
+## Public surfaces
+
+- **`api`** — `.` (`index.ts`), `./cfc`, `./cfc-authoring`, `./cfc-atoms`,
+  `./schema`. Authors reach it via the `commonfabric*` import aliases in the root
+  `deno.jsonc`.
+- **`ts-transformers`** — `src/mod.ts` exports
+  `CommonFabricTransformerPipeline`, the base `Pipeline`/`Transformer`/
+  `CrossStageState`, and the individual transformers.
+- **`js-compiler`** — `mod.ts` exports `TypeScriptCompiler`, the three
+  `ProgramResolver` implementations (in-memory, filesystem, HTTP), and
+  source-map helpers.
+- **`schema-generator`** — `src/index.ts` exports `SchemaGenerator` and
+  `createSchemaTransformerV2`, plus the reusable type-classification helpers as
+  subpaths (`./wrapper-names`, `./cell-brand`, `./type-traversal`).

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -61,7 +61,7 @@ flowchart TB
     src[".tsx source + a Program (entry + in-memory sources)"]
     compiler["TypeScriptCompiler<br/>(virtual filesystem host, type-check)"]
     bridge["harness/engine.ts supplies beforeTransformers =<br/>CommonFabricTransformerPipeline.toFactories()"]
-    emit["tsProgram.emit() runs the 20 transformer stages"]
+    emit["tsProgram.emit() runs the 22 transformer stages"]
     out["per-module CommonJS + source map"]
     records["module records → runner evaluates in the SES sandbox"]
 
@@ -71,7 +71,7 @@ flowchart TB
 
 ---
 
-## The transformer pipeline: 20 stages in three phases
+## The transformer pipeline: 22 stages in three phases
 
 The pipeline is an ordered list (`cf-pipeline.ts`, `CFC_TRANSFORMER_STAGE_SPECS`).
 The ordering matters: most validation runs first so illegal code is rejected
@@ -83,12 +83,14 @@ injected.
 
 ```mermaid
 flowchart TB
-    subgraph p1["Phase 1 · Validate (reject illegal code)"]
+    subgraph p1["Phase 1 · Validate + compile CFC policy (stages 1-7)"]
         v1["CastValidation"]
         v2["EmptyArrayOfValidation"]
         v3["OpaqueGetValidation"]
         v4["PatternContextValidation"]
         v5["MergeablePushValidation"]
+        v6["CfcPolicyAuthoring (policy imports → manifests)"]
+        v7["CfcPolicyOfValidation"]
     end
     subgraph p2["Phase 2 · Lower (rewrite structure)"]
         l1["JsxExpressionSiteRouter"]
@@ -100,10 +102,10 @@ flowchart TB
     end
     subgraph p3["Phase 3 · Schemas + module scope"]
         s1["SchemaInjection (writes synthetic TypeNodes + registry)"]
-        s2["BuilderCallHoisting"]
+        s2["BuilderCallHoisting (emits the trailing __cfReg)"]
         s3["SchemaGenerator (reads the registry → JSON Schema)"]
         s4["ReactiveVariableFor"]
-        s5["ModuleScope: shadowing, __cfReg cf-data,<br/>PatternCoverage, function hardening"]
+        s5["ModuleScope: shadowing, __cf_data,<br/>PatternCoverage, function hardening"]
     end
     p1 --> p2 --> p3
     s1 -.->|"hands off via CrossStageState"| s3
@@ -202,7 +204,7 @@ generator walks the node instead of the type.
   explicit sync note at the top of the file) the Fabric value types against
   `data-model`. Changing a signature means editing it in two places.
 - **The biggest files are the densest part of the system.**
-  `schema-injection.ts` (4123 lines) and `type-shrinking.ts` (3285) are the
+  `schema-injection.ts` (4134 lines) and `type-shrinking.ts` (3285) are the
   least approachable region; budget accordingly.
 - **The `lift-applied` distinction is subtle.** `__cfHelpers.lift(cb)(input)` —
   a single application — is classified as `lift-applied` and is what `computed`
@@ -213,9 +215,13 @@ generator walks the node instead of the type.
 
 ## Public surfaces
 
-- **`api`** — `.` (`index.ts`), `./cfc`, `./cfc-authoring`, `./cfc-atoms`,
-  `./schema`. Authors reach it via the `commonfabric*` import aliases in the root
-  `deno.jsonc`.
+- **`api`** — the package exports five subpaths (`.` → `index.ts`, `./cfc` →
+  `cfc.ts` the canonical CFC authoring surface, `./cfc-authoring` and
+  `./cfc-atoms` re-export barrels over it, `./schema` → `schema.ts` the
+  `Schema<>` type-inference machinery). Authors, however, get only three
+  `commonfabric*` aliases (root `deno.jsonc`): `commonfabric` → `index.ts`,
+  `commonfabric/cfc` → `cfc-authoring.ts` (not `cfc.ts`), `commonfabric/schema` →
+  `schema.ts`.
 - **`ts-transformers`** — `src/mod.ts` exports
   `CommonFabricTransformerPipeline`, the base `Pipeline`/`Transformer`/
   `CrossStageState`, and the individual transformers.

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -60,7 +60,7 @@ flowchart TB
     src[".tsx source + a Program (entry + in-memory sources)"]
     compiler["TypeScriptCompiler<br/>(virtual filesystem host, type-check)"]
     bridge["harness/engine.ts supplies beforeTransformers =<br/>CommonFabricTransformerPipeline.toFactories()"]
-    emit["tsProgram.emit() runs the 19 transformer stages"]
+    emit["tsProgram.emit() runs the 20 transformer stages"]
     out["per-module CommonJS + source map"]
     records["module records → runner evaluates in the SES sandbox"]
 
@@ -70,7 +70,7 @@ flowchart TB
 
 ---
 
-## The transformer pipeline: 19 stages in three phases
+## The transformer pipeline: 20 stages in three phases
 
 The pipeline is an ordered list (`cf-pipeline.ts`, `CFC_TRANSFORMER_STAGE_SPECS`).
 The ordering matters: validation runs first so illegal code is rejected before
@@ -85,13 +85,14 @@ flowchart TB
         v2["EmptyArrayOfValidation"]
         v3["OpaqueGetValidation"]
         v4["PatternContextValidation"]
-        v5["WriteAuthorizedByValidation"]
+        v5["MergeablePushValidation"]
     end
     subgraph p2["Phase 2 · Lower (rewrite structure)"]
         l1["JsxExpressionSiteRouter"]
         l2["LiftLowering"]
         l3["Closure (handlers, actions, array methods)"]
         l4["ExpressionSiteLowering (pattern-owned, helper-owned)"]
+        l4b["WriteAuthorizedByValidation"]
         l5["PatternCallbackLowering"]
     end
     subgraph p3["Phase 3 · Schemas + module scope"]
@@ -99,7 +100,7 @@ flowchart TB
         s2["BuilderCallHoisting"]
         s3["SchemaGenerator (reads the registry → JSON Schema)"]
         s4["ReactiveVariableFor"]
-        s5["ModuleScope: shadowing, __cfReg cf-data, function hardening"]
+        s5["ModuleScope: shadowing, __cfReg cf-data,<br/>PatternCoverage, function hardening"]
     end
     p1 --> p2 --> p3
     s1 -.->|"hands off via CrossStageState"| s3
@@ -129,7 +130,7 @@ flowchart TB
     origin{"originates from<br/>Common Fabric?"}
     alias["follow const aliases<br/>(const f = lift)"]
     synth["recognize __cfHelpers.* synthetic calls"]
-    kind["CallKind union:<br/>ifElse / when / unless / builder(lift,handler,pattern,computed) /<br/>array-method / lift-applied / cell-factory / wish /<br/>generate-text / generate-object / runtime-call"]
+    kind["CallKind union:<br/>ifElse / when / unless / builder(lift,handler,pattern,computed) /<br/>array-method / lift-applied / cell-factory / cell-for / wish / pattern-tool /<br/>generate-text / generate-object / runtime-call"]
 
     call --> resolve --> origin
     origin -->|yes| alias --> kind
@@ -187,15 +188,17 @@ generator walks the node instead of the type.
   The README explicitly tells you to read the behavior spec rather than infer
   from the code. Believe it.
 - **Behavior is pinned by golden files.** Both `ts-transformers` and
-  `schema-generator` are driven by hundreds of `*.input` / `*.expected` fixture
-  pairs. Changing emit shape means regenerating goldens (`UPDATE_GOLDENS=1`) and
-  reviewing large diffs. The fast-iteration path is `FIXTURE=<name>`.
+  `schema-generator` are golden-file driven — `ts-transformers` by hundreds of
+  `*.input.tsx` / `*.expected.jsx` pairs, `schema-generator` by dozens of
+  `*.input.ts` / `*.expected.json` pairs. Changing emit shape means regenerating
+  goldens (`UPDATE_GOLDENS=1`) and reviewing large diffs. The fast-iteration path
+  is `FIXTURE=<name>`.
 - **`api` declarations must stay in sync by hand.** `api/index.ts` is
   `declare const` / ambient declarations that must match the real
   implementations in `runner`. There is an explicit sync note at the top of the
   file. Changing a builder signature means editing it in two places.
 - **The biggest files are the densest part of the system.**
-  `schema-injection.ts` (4017 lines) and `type-shrinking.ts` (3286) are the
+  `schema-injection.ts` (4123 lines) and `type-shrinking.ts` (3285) are the
   least approachable region; budget accordingly.
 - **The `lift-applied` distinction is subtle.** `__cfHelpers.lift(cb)(input)` —
   a single application — is classified as `lift-applied` and is what `computed`

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -215,30 +215,8 @@ identity-based depth-first pre-pass detecting cycles.
 
 ## Technical debt and sharp edges
 
-- **The marker scan is unusually clean.** There are essentially no
-  `TODO`/`FIXME`/`HACK` comments in `ts-transformers` or `js-compiler`. The open
-  work lives in design documents instead: `ts-transformers/docs/`,
-  `docs/specs/ts-transformer/`, and `ts-transformers/ISSUES_TO_FOLLOW_UP.md`.
-  The README explicitly tells you to read the behavior spec rather than infer
-  from the code. Believe it.
-- **Behavior is pinned by golden files.** Both `ts-transformers` and
-  `schema-generator` are golden-file driven — `ts-transformers` by hundreds of
-  `*.input.tsx` / `*.expected.jsx` pairs, `schema-generator` by dozens of
-  `*.input.ts` / `*.expected.json` pairs. Changing emit shape means regenerating
-  goldens (`UPDATE_GOLDENS=1`) and reviewing large diffs. The fast-iteration path
-  is `FIXTURE=<name>`.
-- **`api` declarations must stay in sync by hand.** `api/index.ts` is
-  `declare const` / ambient declarations that must match implementations
-  elsewhere — the builder vocabulary against `runner/src/builder`, and (per an
-  explicit sync note at the top of the file) the Fabric value types against
-  `data-model`. Changing a signature means editing it in two places.
-- **The biggest files are the densest part of the system.**
-  `schema-injection.ts` and `type-shrinking.ts` (each several thousand lines) are
-  the least approachable region; budget accordingly.
-- **The `lift-applied` distinction is subtle.** `__cfHelpers.lift(cb)(input)` —
-  a single application — is classified as `lift-applied` and is what `computed`
-  lowers to. An unapplied `lift(cb)` or a multi-application chain is deliberately
-  not. This gates whole dispatch branches.
+The debt and rough edges touching these packages are collected, together with
+the rest of the repo's, in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -5,7 +5,7 @@ cannot run that directly: reactive expressions have to be lowered into explicit
 calls, closures have to be made explicit, and every reactive boundary has to
 carry a JSON Schema derived from the author's TypeScript types. This pipeline
 does that transformation. It is "System"-layer code, and it is large
-(`ts-transformers` alone is 41k lines).
+(`ts-transformers` alone is one of the largest packages in the repo).
 
 You can see its output for any file with:
 
@@ -76,7 +76,7 @@ flowchart TB
     src[".tsx source + a Program (entry + in-memory sources)"]
     compiler["TypeScriptCompiler<br/>(virtual filesystem host, type-check)"]
     bridge["harness/engine.ts supplies beforeTransformers =<br/>CommonFabricTransformerPipeline.toFactories()"]
-    emit["tsProgram.emit() runs the 22 transformer stages"]
+    emit["tsProgram.emit() runs the transformer stages (a couple dozen)"]
     out["per-module CommonJS + source map"]
     records["module records → runner evaluates in the SES sandbox"]
 
@@ -86,7 +86,7 @@ flowchart TB
 
 ---
 
-## The transformer pipeline: 22 stages in three phases
+## The transformer pipeline: a couple dozen stages in three phases
 
 The pipeline is an ordered list (`cf-pipeline.ts`, `CFC_TRANSFORMER_STAGE_SPECS`).
 The ordering matters: most validation runs first so illegal code is rejected
@@ -233,8 +233,8 @@ identity-based depth-first pre-pass detecting cycles.
   explicit sync note at the top of the file) the Fabric value types against
   `data-model`. Changing a signature means editing it in two places.
 - **The biggest files are the densest part of the system.**
-  `schema-injection.ts` (4134 lines) and `type-shrinking.ts` (3285) are the
-  least approachable region; budget accordingly.
+  `schema-injection.ts` and `type-shrinking.ts` (each several thousand lines) are
+  the least approachable region; budget accordingly.
 - **The `lift-applied` distinction is subtle.** `__cfHelpers.lift(cb)(input)` —
   a single application — is classified as `lift-applied` and is what `computed`
   lowers to. An unapplied `lift(cb)` or a multi-application chain is deliberately

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -5,7 +5,7 @@ cannot run that directly: reactive expressions have to be lowered into explicit
 calls, closures have to be made explicit, and every reactive boundary has to
 carry a JSON Schema derived from the author's TypeScript types. This pipeline
 does that transformation. It is "System"-layer code, and it is large
-(`ts-transformers` alone is 40k lines).
+(`ts-transformers` alone is 41k lines).
 
 You can see its output for any file with:
 

--- a/docs/development/orientation/compile-pipeline.md
+++ b/docs/development/orientation/compile-pipeline.md
@@ -13,6 +13,11 @@ You can see its output for any file with:
 deno task cf check <pattern-or-fixture>.tsx --show-transformed --no-run
 ```
 
+The emitted output is dense; pipe it into `deno task cf view` for a less-like,
+syntax-aware pager that colours builders, schemas, closures, and type positions
+and lets you navigate the structure tree. `AGENTS.md` tells you to inspect this
+emitted output directly rather than infer transformer behavior from source.
+
 ---
 
 ## The four packages and their jobs
@@ -41,7 +46,17 @@ flowchart LR
   during emit, and produces one CommonJS module body plus a source map per
   source file. It carries none of the Common Fabric transformer logic — that
   pipeline is injected by the caller (its only Common-Fabric-specific detail is
-  the default JSX factory, `h` / `__cfHelpers.h.fragment`).
+  the default JSX factory, `h` / `__cfHelpers.h.fragment`). Load-bearing compiler
+  options: `module: CommonJS`, `sourceMap: true` with `inlineSources: false`
+  (maps resolve stack frames to `cf:module/<id>`), `declaration: false` (TS's
+  declaration emit chokes on the `CELL_BRAND` unique symbols, so declaration
+  checking runs through the checker instead), `noResolve: true`, and during
+  multi-file compile `skipLibCheck: true` so the trimmed virtual `.d.ts` libs
+  aren't type-checked. A runtime-only specifier with no source (e.g.
+  `commonfabric`) is resolved to `<name>.d.ts`. The three `ProgramResolver`s
+  differ concretely: `InMemoryProgram` is a `Record<string,string>` map;
+  `FileSystemProgramResolver` is Deno-only, requires absolute specifiers, and
+  refuses imports outside its root; `HttpProgramResolver` fetches over HTTP.
 - **`ts-transformers`** is the TypeScript AST transformer pipeline. It rewrites
   natural reactive TypeScript into explicit, schema-annotated runtime form.
 - **`schema-generator`** walks a TypeScript type into a JSON Schema object,
@@ -150,6 +165,14 @@ used at the call site as
 via `__cfReg({ __cfPattern_1 })`. The closure capture (`discount`) is made
 explicit as a parameter with its own schema.
 
+`__cfHelpers` is the single, un-shadowable binding every synthetic call routes
+through. A one-line prelude (`import { __cfHelpers } from "commonfabric";`) is
+injected before the transformers run; at runtime it is literally the whole
+`commonfabric` builder object aliased onto itself
+(`commonfabric.__cfHelpers = commonfabric`), so `__cfHelpers.lift`, `.pattern`,
+`.h.fragment` resolve to the real builder. Most stages extend a
+`HelpersOnlyTransformer` whose filter skips any file without that injected import.
+
 ---
 
 ## Type to JSON Schema
@@ -178,9 +201,15 @@ The wrapper-type vocabulary — the authored spellings (`Cell`, `Writable`,
 kind (`Writable` collapses to `Cell`; `Reactive` stays `Reactive`) — is
 canonicalized once in
 `schema-generator/src/typescript/wrapper-names.ts` and consumed by both
-`schema-generator` and `ts-transformers`. There is an auto-detection fork: when
-the resolved type is `any` but a concrete synthetic type node exists, the
-generator walks the node instead of the type.
+`schema-generator` and `ts-transformers`. Each wrapper is emitted into the
+schema's `asCell` array with a brand from `cell-brand.ts`: `Cell`→`"cell"`,
+`ReadonlyCell`→`"readonly"`, `WriteonlyCell`→`"writeonly"`,
+`ComparableCell`→`"comparable"`, `OpaqueCell`/`Reactive`→`"opaque"`,
+`Stream`→`"stream"`, `SqliteDb`→`"sqlite"` (and `Cell<Stream<T>>` is rejected).
+There is an auto-detection fork: when the resolved type is `any` but a concrete
+synthetic type node exists, the generator walks the node instead of the type; and
+every named type is hoisted into `$defs` and referenced by `$ref`, with an
+identity-based depth-first pre-pass detecting cycles.
 
 ---
 

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -1,0 +1,278 @@
+# The dependency graph (measured, not intended)
+
+This page is the empirical import graph between workspace packages. It was built
+by scanning every package's `.ts` and `.tsx` source for `@commonfabric/*`
+imports and counting them. Two passes were taken: one over all files, and one
+over production files only (excluding anything matching a test, fixture,
+integration, or benchmark path). The production graph is the one that matters
+for runtime layering, so it is the one drawn here. The difference between the
+two passes is itself informative and is noted where it changes the story.
+
+Some apparent edges were discarded after inspection because they were comments
+or strings rather than real imports: `api → runner`, `api → memory`,
+`runner → piece`, `home-schemas → runner`, `html → ui`, and
+`state-inspector → runner` are all mentions in comments, not import statements.
+They are not drawn. (The `runner → piece` "edge" is in fact a comment that reads
+"Avoid importing from `@commonfabric/piece` to prevent circular deps in tests" —
+the absence is deliberate.)
+
+---
+
+## The spine: `runner` is the hub, four leaves are the floor
+
+The graph is not a balanced tree. It is one very large hub (`runner`) sitting on
+a small floor of leaf libraries (`utils`, `data-model`, `api`, `identity`,
+`memory`), with everything else arranged around the hub. Edge labels are the
+number of importing references in production code, so they show where the heavy
+coupling is.
+
+```mermaid
+flowchart TD
+    classDef hub fill:#c0392b,stroke:#7b241c,color:#fff
+    classDef floor fill:#2471a3,stroke:#1a5276,color:#fff
+
+    runner["runner"]:::hub
+    utils["utils"]:::floor
+    datamodel["data-model"]:::floor
+    api["api"]:::floor
+    identity["identity"]:::floor
+    memory["memory"]:::floor
+    contenthash["content-hash"]
+    leb128["leb128"]
+
+    runner -->|149| datamodel
+    runner -->|144| utils
+    runner -->|70| memory
+    runner -->|58| api
+    runner -->|20| jsc["js-compiler"]
+    datamodel -->|35| utils
+    datamodel -->|12| api
+    datamodel -->|1| contenthash
+    datamodel -->|1| leb128
+    memory -->|18| datamodel
+    memory -->|7| api
+    api -->|3| utils
+    identity -->|2| utils
+    contenthash -->|2| utils
+    jsc -->|1| schemagen["schema-generator"]
+    schemagen -->|18| api
+```
+
+Three things to take from this:
+
+- **`utils` is the universal floor.** It is imported by 294 files across the
+  repo. Its own `index.ts` deliberately throws, to force callers to import the
+  specific subpath they need (for example `@commonfabric/utils/defer`).
+- **`runner` is the gravity well.** It pulls in `data-model` 149 times,
+  `utils` 144 times, and `memory` 70 times in production code alone. Any change
+  to `data-model` or `memory` ripples straight into the runtime.
+- **`api` is mostly types.** It sits near the floor because it is the authoring
+  surface — almost entirely TypeScript declarations that author code is compiled
+  against.
+
+---
+
+## The consumers: who sits on the hub
+
+The other half of the graph is the packages that depend on `runner` (and on each
+other). This is where the product, the client, and the tooling live.
+
+```mermaid
+flowchart TD
+    classDef hub fill:#c0392b,stroke:#7b241c,color:#fff
+    runner["runner"]:::hub
+
+    toolshed["toolshed"] -->|21| runner
+    toolshed -->|7| memory["memory"]
+    toolshed -->|6| llm["llm"]
+    toolshed -->|2| bcs["background-piece-service"]
+    cli["cli"] -->|25| runner
+    cli -->|8| jsc["js-compiler"]
+    cli -->|5| piece["piece"]
+    cli -->|2| sinsp["state-inspector"]
+    sinsp -->|7| memory
+    rtc["runtime-client"] -->|22| runner
+    rtc -->|16| memory
+    ui["ui"] -->|50| rtc
+    ui -->|13| runner
+    shell["shell"] -->|16| rtc
+    shell -->|13| identity["identity"]
+    shell -->|3| ui
+    html["html"] -->|10| rtc
+    html -->|8| runner
+    piece -->|11| runner
+    bcs -->|15| runner
+    memory -->|1| runner
+    llm -->|1| runner
+```
+
+`ui` leaning on `runtime-client` 50 times is the strongest single coupling in
+the consumer half. `ui` does not talk to `runner` directly very much; it talks
+to the worker-side runtime through `runtime-client`'s cell handles.
+
+---
+
+## The circular dependencies
+
+There are four genuine import cycles in production code. Each was confirmed by
+reading the actual import statement, not just counting a name. They are drawn in
+red below, with the direction and the evidence.
+
+```mermaid
+flowchart LR
+    classDef cyc fill:#fdebd0,stroke:#c0392b,color:#000
+
+    subgraph c1["Cycle 1"]
+        runner1["runner"]:::cyc
+        html1["html"]:::cyc
+        runner1 -->|"builder/built-in.ts, factory.ts,<br/>builtins/wish.ts import h()"| html1
+        html1 -->|"worker reconciler imports<br/>isCell, getCellOrThrow, schemas"| runner1
+    end
+    subgraph c2["Cycle 2"]
+        runner2["runner"]:::cyc
+        memory2["memory"]:::cyc
+        runner2 -->|"70 refs: stores + queries cells"| memory2
+        memory2 -->|"v2/query.ts imports<br/>runner/traverse"| runner2
+    end
+    subgraph c3["Cycle 3"]
+        runner3["runner"]:::cyc
+        llm3["llm"]:::cyc
+        runner3 -->|"builtins call the LLM"| llm3
+        llm3 -->|"prompts/json-import.ts imports<br/>createJsonSchema"| runner3
+    end
+    subgraph c4["Cycle 4"]
+        ui4["ui"]:::cyc
+        shell4["shell"]:::cyc
+        ui4 -->|"cf-render, cf-cell-link, cf-space-link,<br/>cf-profile-badge import navigation helpers"| shell4
+        shell4 -->|"imports runtimeContext, spaceContext,<br/>DebugController, cf-* classes"| ui4
+    end
+```
+
+| Cycle | Edge into the lower layer | The single seam to know about |
+|---|---|---|
+| `runner ↔ html` | `runner/src/builder` and `builtins/wish.ts` import `h()` to build UI nodes | The builder produces view nodes, so the UI primitive leaks into the foundation |
+| `runner ↔ memory` | `memory/v2/query.ts` imports `@commonfabric/runner/traverse` | One import. Memory needs the runtime's schema traversal to answer graph queries and evaluate per-row CFC labels |
+| `runner ↔ llm` | `llm/src/prompts/json-import.ts` imports `createJsonSchema` | One import. A prompt helper reaches up into the runtime |
+| `ui ↔ shell` | `ui` imports `@commonfabric/shell/shared` in four `cf-*` components | Narrowed to URL/navigation helpers, but real |
+
+The cycles all touch `runner` except the last. That is consistent with `runner`
+being the hub: the cheapest place to introduce a cycle is against the package
+everything already depends on.
+
+---
+
+## The layering violations (downward edges that are not cycles)
+
+A cycle is two arrows. A layering violation is one arrow pointing the wrong way
+through the layer stack — a lower layer reaching up into a higher one. The most
+notable is the foundation runtime reaching into the end-user-program layer:
+
+- **`runner → home-schemas`.** `runner/src/builtins/wish.ts` imports
+  `favoriteListSchema` from `@commonfabric/home-schemas`. The `wish` builtin is
+  specific to the "home" domain, yet it lives in the foundation runtime. A
+  newcomer expects builtins to be generic; this one is not.
+
+Separately, `home-schemas` exists *specifically to prevent* a different
+violation: its module doc says it holds schemas so that both `runner` and
+`piece` can import them without importing each other. It is a deliberate "shared
+leaf to break a cycle" — which is good design, undercut by `runner` then
+reaching into it for a non-generic schema.
+
+---
+
+## God-files: where the line count concentrates
+
+Cycles are one kind of debt; oversized single files are another. These are the
+files a newcomer will be sent to and should expect to lose an afternoon in. All
+counts are lines.
+
+| File | Lines | What it is |
+|---|---|---|
+| `runner/src/cfc/prepare.ts` | 4802 | The Contextual-Flow-Control write-policy gate |
+| `runner/src/runner.ts` | 4471 | Instantiates a pattern's nodes into scheduler actions |
+| `memory/v2/engine.ts` | 4406 | The transactional SQLite core |
+| `runner/src/traverse.ts` | 4350 | Schema-driven traversal of the value/link graph |
+| `ts-transformers/src/transformers/schema-injection.ts` | 4123 | Attaches schemas to reactive boundaries |
+| `html/src/worker/reconciler.ts` | 3862 | The worker-thread VDOM reconciler |
+| `runner/src/builtins/llm-dialog.ts` | 3804 | The LLM dialog builtin |
+| `ts-transformers/src/policy/capability-analysis.ts` | 3446 | CFC capability analysis for the transformer |
+| `runner/src/cell.ts` | 3432 | The Cell and Stream abstractions |
+| `runner/src/storage/v2.ts` | 3017 | The storage manager, provider, and space replica |
+| `runner/src/scheduler.ts` | 2638 | The reactive scheduler |
+
+`runner` alone holds seven of the eleven, and its single largest file is now the
+CFC write-policy gate — Contextual Flow Control has grown into the biggest piece
+of the runtime. The complexity is real and concentrated. (The mechanically
+largest file in the repo, `html/src/jsx.d.ts` at ~5.5k lines, is omitted here
+because it is generated JSX type declarations, not code to read.)
+
+---
+
+## Smaller sharp edges worth knowing on day one
+
+These are individually minor but each will waste someone's time if undocumented.
+
+A batch of stale references that this orientation originally flagged has since
+been cleaned up and is recorded here only so the history is not confusing:
+`AGENTS.md` no longer points at a non-existent top-level `deprecated-patterns`
+folder (it now names the real `packages/patterns/deprecated`); the dangling
+`"./integration"` export in `packages/utils/deno.jsonc` was removed upstream; and
+the root `deno.jsonc` lint config no longer excludes a `patterns-saves-backup`
+directory that never existed. The genuinely still-live ones:
+
+- **Two storage vocabularies.** `memory` has a legacy "fact" model
+  (`assert`/`retract`, in `interface.ts` and `lib.ts`) and the current "v2"
+  document/operation model (in `v2/`). New work is v2. The fact vocabulary is
+  still exported and still confuses people. See the
+  [storage page](storage-substrate.md).
+- **`cf-harness` is misleadingly named.** It is not a test harness for the
+  runtime. It is an experimental agent runtime — an LLM tool-calling loop with
+  sandboxing and CFC awareness. See the [CLI/piece page](cli-piece-fuse.md).
+
+---
+
+## Full production edge list
+
+For completeness, every production import edge with its reference count. "Prod"
+means test, fixture, integration, and benchmark files were excluded.
+
+```
+api               → memory(comment only), runner(comment only), utils(3)
+background-piece  → identity(9), piece(2), runner(15), utils(3)
+cf-harness        → api(18), llm(4), runner(28), utils(2)
+cli               → api(5), data-model(3), fuse(1), html(1), identity(9),
+                    js-compiler(8), llm(2), memory(3), piece(5), runner(25),
+                    runtime-client(1), state-inspector(2), static(1),
+                    test-support(1), ts-transformers(1), utils(9)
+content-hash      → utils(2)
+data-model        → api(12), content-hash(1), leb128(1), utils(35)
+fuse              → api(3), content-hash(2), data-model(1), piece(3), runner(9)
+home-schemas      → api(12), piece(1), runner(comment only)
+html              → api(5), runner(8), runtime-client(10), ui(comment only), utils(6)
+identity          → utils(2)
+iframe-sandbox    → runner(1), utils(4)
+integration       → identity(1), runner(1), shell(1), utils(3)
+js-compiler       → static(1), ts-transformers(1), utils(4)
+lib-shell         → api(1), data-model(1), identity(1), runner(2), runtime-client(2), utils(1)
+llm               → api(1), runner(1), utils(1)
+memory            → api(7), data-model(18), identity(2), runner(1), utils(6)
+piece             → api(3), data-model(2), home-schemas(1), identity(2),
+                    js-compiler(1), runner(11), utils(4)
+runner            → api(58), content-hash(1), data-model(149), home-schemas(1),
+                    html(3), identity(2), js-compiler(20), llm(2), memory(70),
+                    piece(comment only), static(3), ts-transformers(6), utils(144)
+runtime-client    → api(1), data-model(6), home-schemas(2), html(1), identity(6),
+                    js-compiler(4), llm(1), piece(2), runner(22), utils(13)
+schema-generator  → api(18), data-model(1), utils(9)
+shell             → api(1), felt(1), home-schemas(1), html(1), identity(13),
+                    lib-shell(3), memory(1), piece(1), runner(8),
+                    runtime-client(16), ui(3), utils(4)
+state-inspector   → api(2), data-model(5), identity(1), memory(7),
+                    runner(comment only)
+static            → utils(3)
+toolshed          → api(4), background-piece(2), content-hash(2), data-model(8),
+                    identity(2), llm(6), memory(7), runner(21), static(3), utils(11)
+ts-transformers   → api(9), schema-generator(12), utils(5)
+ui                → api(8), content-hash(1), html(2), identity(8),
+                    iframe-sandbox(2), runner(13), runtime-client(50), shell(4)
+```

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -88,7 +88,7 @@ flowchart TD
     toolshed -->|7| memory["memory"]
     toolshed -->|6| llm["llm"]
     toolshed -->|2| bcs["background-piece-service"]
-    cli["cli"] -->|25| runner
+    cli["cli"] -->|26| runner
     cli -->|8| jsc["js-compiler"]
     cli -->|5| piece["piece"]
     cli -->|2| sinsp["state-inspector"]
@@ -246,8 +246,8 @@ means test, fixture, integration, and benchmark files were excluded.
 api               → memory(comment only), runner(comment only), utils(comment only)
 background-piece  → identity(9), piece(2), runner(15), utils(3)
 cf-harness        → api(18), llm(4), runner(28), utils(2)
-cli               → api(5), data-model(3), fuse(1), html(1), identity(9),
-                    js-compiler(8), llm(2), memory(3), piece(5), runner(25),
+cli               → api(5), data-model(3), fuse(1), html(2), identity(9),
+                    js-compiler(8), llm(2), memory(3), piece(5), runner(26),
                     runtime-client(1), state-inspector(2), static(1),
                     test-support(1), ts-transformers(1), utils(9)
 content-hash      → utils(2)

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -40,11 +40,11 @@ flowchart TD
     contenthash["content-hash"]
     leb128["leb128"]
 
-    runner -->|149| datamodel
-    runner -->|144| utils
-    runner -->|70| memory
-    runner -->|58| api
-    runner -->|20| jsc["js-compiler"]
+    runner -->|150| datamodel
+    runner -->|149| utils
+    runner -->|72| memory
+    runner -->|62| api
+    runner -->|22| jsc["js-compiler"]
     datamodel -->|35| utils
     datamodel -->|12| api
     datamodel -->|1| contenthash
@@ -60,11 +60,11 @@ flowchart TD
 
 Three things to take from this:
 
-- **`utils` is the universal floor.** It is imported by 294 files across the
+- **`utils` is the universal floor.** It is imported by 302 files across the
   repo. Its own `index.ts` deliberately throws, to force callers to import the
   specific subpath they need (for example `@commonfabric/utils/defer`).
-- **`runner` is the gravity well.** It pulls in `data-model` 149 times,
-  `utils` 144 times, and `memory` 70 times in production code alone. Any change
+- **`runner` is the gravity well.** It pulls in `data-model` 150 times,
+  `utils` 149 times, and `memory` 72 times in production code alone. Any change
   to `data-model` or `memory` ripples straight into the runtime.
 - **`api` is mostly types.** It sits near the floor because it is the authoring
   surface — almost entirely TypeScript declarations that author code is compiled
@@ -188,7 +188,7 @@ counts are lines.
 
 | File | Lines | What it is |
 |---|---|---|
-| `runner/src/cfc/prepare.ts` | 5078 | The Contextual-Flow-Control write-policy gate |
+| `runner/src/cfc/prepare.ts` | 5366 | The Contextual-Flow-Control write-policy gate |
 | `runner/src/runner.ts` | 4528 | Instantiates a pattern's nodes into scheduler actions |
 | `memory/v2/engine.ts` | 4406 | The transactional SQLite core |
 | `runner/src/traverse.ts` | 4350 | Schema-driven traversal of the value/link graph |
@@ -261,9 +261,9 @@ llm               → api(1), runner(1), utils(1)
 memory            → api(7), data-model(18), identity(2), runner(1), utils(6)
 piece             → api(3), data-model(2), home-schemas(1), identity(2),
                     js-compiler(1), runner(11), utils(4)
-runner            → api(58), content-hash(1), data-model(149), home-schemas(1),
-                    html(3), identity(2), js-compiler(20), llm(2), memory(70),
-                    piece(comment only), static(3), ts-transformers(6), utils(144)
+runner            → api(62), content-hash(1), data-model(150), home-schemas(1),
+                    html(3), identity(1), js-compiler(22), llm(2), memory(72),
+                    piece(comment only), static(2), ts-transformers(6), utils(149)
 runtime-client    → api(1), data-model(6), home-schemas(2), html(1), identity(6),
                     js-compiler(4), llm(1), piece(2), runner(22), utils(13)
 schema-generator  → api(18), data-model(1), utils(9)

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -126,7 +126,7 @@ flowchart LR
         runner1["runner"]:::cyc
         html1["html"]:::cyc
         runner1 -->|"builder/built-in.ts, factory.ts,<br/>builtins/wish.ts import h()"| html1
-        html1 -->|"worker reconciler imports<br/>isCell, getCellOrThrow, schemas"| runner1
+        html1 -->|"worker reconciler imports<br/>isCell, ContextualFlowControl, JSONSchema"| runner1
     end
     subgraph c2["Cycle 2"]
         runner2["runner"]:::cyc
@@ -188,8 +188,8 @@ counts are lines.
 
 | File | Lines | What it is |
 |---|---|---|
-| `runner/src/cfc/prepare.ts` | 4802 | The Contextual-Flow-Control write-policy gate |
-| `runner/src/runner.ts` | 4471 | Instantiates a pattern's nodes into scheduler actions |
+| `runner/src/cfc/prepare.ts` | 5078 | The Contextual-Flow-Control write-policy gate |
+| `runner/src/runner.ts` | 4528 | Instantiates a pattern's nodes into scheduler actions |
 | `memory/v2/engine.ts` | 4406 | The transactional SQLite core |
 | `runner/src/traverse.ts` | 4350 | Schema-driven traversal of the value/link graph |
 | `ts-transformers/src/transformers/schema-injection.ts` | 4123 | Attaches schemas to reactive boundaries |
@@ -197,14 +197,17 @@ counts are lines.
 | `runner/src/builtins/llm-dialog.ts` | 3804 | The LLM dialog builtin |
 | `ts-transformers/src/policy/capability-analysis.ts` | 3446 | CFC capability analysis for the transformer |
 | `runner/src/cell.ts` | 3432 | The Cell and Stream abstractions |
-| `runner/src/storage/v2.ts` | 3017 | The storage manager, provider, and space replica |
+| `runner/src/storage/v2.ts` | 3018 | The storage manager, provider, and space replica |
 | `runner/src/scheduler.ts` | 2638 | The reactive scheduler |
 
 `runner` alone holds seven of the eleven, and its single largest file is now the
 CFC write-policy gate — Contextual Flow Control has grown into the biggest piece
-of the runtime. The complexity is real and concentrated. (The mechanically
-largest file in the repo, `html/src/jsx.d.ts` at ~5.5k lines, is omitted here
-because it is generated JSX type declarations, not code to read.)
+of the runtime. The complexity is real and concentrated. (A large generated JSX
+type-declaration file, `html/src/jsx.d.ts` at ~5.5k lines, is omitted here
+because it is generated declarations, not code to read. Bigger files still —
+`patterns/scrabble/scrabble-words.ts` at ~179k lines and the vendored and
+generated blobs under `vendor-astral/` and `static/assets/` — are data, not
+code.)
 
 ---
 
@@ -221,10 +224,10 @@ the root `deno.jsonc` lint config no longer excludes a `patterns-saves-backup`
 directory that never existed. The genuinely still-live ones:
 
 - **Two storage vocabularies.** `memory` has a legacy "fact" model
-  (`assert`/`retract`, in `interface.ts` and `lib.ts`) and the current "v2"
-  document/operation model (in `v2/`). New work is v2. The fact vocabulary is
-  still exported and still confuses people. See the
-  [storage page](storage-substrate.md).
+  (`assert`/`retract`, defined in `interface.ts` and `fact.ts` and re-exported by
+  the `lib.ts` barrel) and the current "v2" document/operation model (in `v2/`).
+  New work is v2. The fact vocabulary is still exported and still confuses
+  people. See the [storage page](storage-substrate.md).
 - **`cf-harness` is misleadingly named.** It is not a test harness for the
   runtime. It is an experimental agent runtime — an LLM tool-calling loop with
   sandboxing and CFC awareness. See the [CLI/piece page](cli-piece-fuse.md).

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -213,27 +213,11 @@ declarations, not code to read; so are the far larger data blobs —
 
 ---
 
-## Smaller sharp edges worth knowing on day one
+## Smaller sharp edges
 
-These are individually minor but each will waste someone's time if undocumented.
-
-A batch of stale references that this orientation originally flagged has since
-been cleaned up and is recorded here only so the history is not confusing:
-`AGENTS.md` no longer points at a non-existent top-level `deprecated-patterns`
-folder (it now names the real `packages/patterns/deprecated`); the dangling
-`"./integration"` export in `packages/utils/deno.jsonc` was removed upstream; and
-the root `deno.jsonc` lint config no longer excludes a `patterns-saves-backup`
-directory that never existed. The genuinely still-live ones:
-
-- **Two storage vocabularies.** `memory` has a legacy "fact" model — the
-  `assert`/`retract` constructors in `fact.ts` (their types in `interface.ts`),
-  reached through the `@commonfabric/memory/fact` subpath that runner's storage
-  layer still imports — and the current "v2" document/operation model (in `v2/`).
-  New work is v2. The fact vocabulary is still exported and still confuses
-  people. See the [storage page](storage-substrate.md).
-- **`cf-harness` is misleadingly named.** It is not a test harness for the
-  runtime. It is an experimental agent runtime — an LLM tool-calling loop with
-  sandboxing and CFC awareness. See the [CLI/piece page](cli-piece-fuse.md).
+The cycles and the layering violation above are the structural debt. The rest of
+the repo's rough edges — legacy vocabularies, misleading names, hand-maintained
+couplings — are collected in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -1,12 +1,13 @@
 # The dependency graph (measured, not intended)
 
-This page is the empirical import graph between workspace packages. It was built
-by scanning every package's `.ts` and `.tsx` source for `@commonfabric/*`
-imports and counting them. Two passes were taken: one over all files, and one
-over production files only (excluding anything matching a test, fixture,
-integration, or benchmark path). The production graph is the one that matters
-for runtime layering, so it is the one drawn here. The difference between the
-two passes is itself informative and is noted where it changes the story.
+This page is the empirical import graph between workspace packages — which
+package imports which, read from the source rather than from intentions. It is
+built by scanning every package's `.ts` and `.tsx` source for `@commonfabric/*`
+imports, over production files only (test, fixture, integration, and benchmark
+paths excluded, since those don't reflect runtime layering). The shapes that
+matter for orientation are structural: which package is the hub, which are the
+floor, where the cycles are — not the exact reference counts, which drift with
+every commit.
 
 Some apparent edges were discarded after inspection because they were comments
 or strings rather than real imports: `api → runner`, `api → memory`,
@@ -18,15 +19,14 @@ the absence is deliberate.)
 
 ---
 
-## The spine: `runner` is the hub, four leaves are the floor
+## The spine: `runner` is the hub, a few small libraries are the floor
 
 The graph is not a balanced tree. It is one very large hub (`runner`) sitting on
 a small floor of foundation libraries (`utils`, `data-model`, `api`, `identity`,
 `memory`), with everything else arranged around the hub. Of those, `utils`,
 `api`, and `identity` are true leaves (no outgoing package edges); `data-model`
-and `memory` are not — they sit on the leaves below them. Edge labels are the
-number of importing references in production code, so they show where the heavy
-coupling is.
+and `memory` are not — they sit on the leaves below them. The bold edges below
+are `runner`'s heaviest dependencies.
 
 ```mermaid
 flowchart TD
@@ -42,31 +42,31 @@ flowchart TD
     contenthash["content-hash"]
     leb128["leb128"]
 
-    runner -->|152| datamodel
-    runner -->|148| utils
-    runner -->|72| memory
-    runner -->|68| api
-    runner -->|22| jsc["js-compiler"]
-    datamodel -->|35| utils
-    datamodel -->|12| api
-    datamodel -->|1| contenthash
-    datamodel -->|1| leb128
-    memory -->|18| datamodel
-    memory -->|7| api
-    identity -->|2| utils
-    contenthash -->|2| utils
-    jsc -->|1| schemagen["schema-generator"]
-    schemagen -->|18| api
+    runner ==> datamodel
+    runner ==> utils
+    runner ==> memory
+    runner --> api
+    runner --> jsc["js-compiler"]
+    datamodel --> utils
+    datamodel --> api
+    datamodel --> contenthash
+    datamodel --> leb128
+    memory --> datamodel
+    memory --> api
+    identity --> utils
+    contenthash --> utils
+    jsc --> schemagen["schema-generator"]
+    schemagen --> api
 ```
 
 Three things to take from this:
 
-- **`utils` is the universal floor.** It is imported by 303 files across the
+- **`utils` is the universal floor.** It is imported by nearly every file in the
   repo. Its own `index.ts` deliberately throws, to force callers to import the
   specific subpath they need (for example `@commonfabric/utils/defer`).
-- **`runner` is the gravity well.** It pulls in `data-model` 152 times,
-  `utils` 148 times, and `memory` 72 times in production code alone. Any change
-  to `data-model` or `memory` ripples straight into the runtime.
+- **`runner` is the gravity well.** It leans hardest on `data-model`, `utils`,
+  and `memory` — by a wide margin — so any change to `data-model` or `memory`
+  ripples straight into the runtime.
 - **`api` is mostly types, and a pure leaf.** It sits at the very floor because
   it is the authoring surface — almost entirely TypeScript declarations that
   author code is compiled against — and it has no outgoing package imports at all
@@ -84,31 +84,32 @@ flowchart TD
     classDef hub fill:#c0392b,stroke:#7b241c,color:#fff
     runner["runner"]:::hub
 
-    toolshed["toolshed"] -->|21| runner
-    toolshed -->|7| memory["memory"]
-    toolshed -->|6| llm["llm"]
-    toolshed -->|2| bcs["background-piece-service"]
-    cli["cli"] -->|26| runner
-    cli -->|8| jsc["js-compiler"]
-    cli -->|5| piece["piece"]
-    cli -->|2| sinsp["state-inspector"]
-    sinsp -->|7| memory
-    rtc["runtime-client"] -->|22| runner
-    rtc -->|16| memory
-    ui["ui"] -->|50| rtc
-    ui -->|13| runner
-    shell["shell"] -->|16| rtc
-    shell -->|13| identity["identity"]
-    shell -->|3| ui
-    html["html"] -->|10| rtc
-    html -->|8| runner
-    piece -->|11| runner
-    bcs -->|15| runner
-    memory -->|1| runner
-    llm -->|1| runner
+    toolshed["toolshed"] --> runner
+    toolshed --> memory["memory"]
+    toolshed --> llm["llm"]
+    toolshed --> bcs["background-piece-service"]
+    cli["cli"] --> runner
+    cli --> jsc["js-compiler"]
+    cli --> piece["piece"]
+    cli --> sinsp["state-inspector"]
+    sinsp --> memory
+    rtc["runtime-client"] --> runner
+    rtc --> memory
+    ui["ui"] ==> rtc
+    ui --> runner
+    shell["shell"] --> rtc
+    shell --> identity["identity"]
+    shell --> ui
+    html["html"] --> rtc
+    html --> runner
+    piece --> runner
+    bcs --> runner
+    memory --> runner
+    llm --> runner
 ```
 
-`ui` leaning on `runtime-client` 50 times is the strongest single coupling in
+`ui` leans on `runtime-client` far more than on anything else (the bold edge) —
+the strongest single coupling in
 the consumer half. `ui` does not talk to `runner` directly very much; it talks
 to the worker-side runtime through `runtime-client`'s cell handles.
 
@@ -133,7 +134,7 @@ flowchart LR
     subgraph c2["Cycle 2"]
         runner2["runner"]:::cyc
         memory2["memory"]:::cyc
-        runner2 -->|"70 refs: stores + queries cells"| memory2
+        runner2 -->|"heavily: stores + queries cells"| memory2
         memory2 -->|"v2/query.ts imports<br/>runner/traverse"| runner2
     end
     subgraph c3["Cycle 3"]
@@ -182,34 +183,33 @@ reaching into it for a non-generic schema.
 
 ---
 
-## God-files: where the line count concentrates
+## God-files: where the complexity concentrates
 
 Cycles are one kind of debt; oversized single files are another. These are the
-files a newcomer will be sent to and should expect to lose an afternoon in. All
-counts are lines.
+files a newcomer will be sent to and should expect to lose an afternoon in —
+each several thousand lines, listed roughly biggest first:
 
-| File | Lines | What it is |
-|---|---|---|
-| `runner/src/cfc/prepare.ts` | 6407 | The Contextual-Flow-Control write-policy gate |
-| `memory/v2/engine.ts` | 6254 | The transactional SQLite core |
-| `runner/src/runner.ts` | 5218 | Instantiates a pattern's nodes into scheduler actions |
-| `runner/src/traverse.ts` | 4896 | Schema-driven traversal of the value/link graph |
-| `ts-transformers/src/transformers/schema-injection.ts` | 4134 | Attaches schemas to reactive boundaries |
-| `html/src/worker/reconciler.ts` | 3862 | The worker-thread VDOM reconciler |
-| `runner/src/builtins/llm-dialog.ts` | 3804 | The LLM dialog builtin |
-| `runner/src/storage/v2.ts` | 3480 | The storage manager, provider, and space replica |
-| `runner/src/cell.ts` | 3452 | The Cell and Stream abstractions |
-| `ts-transformers/src/policy/capability-analysis.ts` | 3446 | CFC capability analysis for the transformer |
-| `runner/src/scheduler/facade.ts` | 2787 | The scheduler's public facade (after the scheduler-v2 refactor split `scheduler.ts` into `scheduler/`) |
+| File | What it is |
+|---|---|
+| `runner/src/cfc/prepare.ts` | The Contextual-Flow-Control write-policy gate |
+| `memory/v2/engine.ts` | The transactional SQLite core |
+| `runner/src/runner.ts` | Instantiates a pattern's nodes into scheduler actions |
+| `runner/src/traverse.ts` | Schema-driven traversal of the value/link graph |
+| `ts-transformers/src/transformers/schema-injection.ts` | Attaches schemas to reactive boundaries |
+| `html/src/worker/reconciler.ts` | The worker-thread VDOM reconciler |
+| `runner/src/builtins/llm-dialog.ts` | The LLM dialog builtin |
+| `runner/src/storage/v2.ts` | The storage manager, provider, and space replica |
+| `runner/src/cell.ts` | The Cell and Stream abstractions |
+| `ts-transformers/src/policy/capability-analysis.ts` | CFC capability analysis for the transformer |
+| `runner/src/scheduler/facade.ts` | The scheduler's public facade (after scheduler-v2 split `scheduler.ts` into `scheduler/`) |
 
-`runner` alone holds seven of the eleven, and its single largest file is the
-CFC write-policy gate — Contextual Flow Control has grown into the biggest piece
-of the runtime. The complexity is real and concentrated. (A large generated JSX
-type-declaration file, `html/src/jsx.d.ts` at ~5.5k lines, is omitted here
-because it is generated declarations, not code to read. Bigger files still —
-`patterns/scrabble/scrabble-words.ts` at ~179k lines and the vendored and
-generated blobs under `vendor-astral/` and `static/assets/` — are data, not
-code.)
+Most of these are in `runner`, and its single largest file is the CFC
+write-policy gate — Contextual Flow Control has grown into the biggest piece of
+the runtime. The complexity is real and concentrated. (A large *generated* JSX
+type-declaration file, `html/src/jsx.d.ts`, is omitted here because it is
+declarations, not code to read; so are the far larger data blobs —
+`patterns/scrabble/scrabble-words.ts` and the vendored/generated files under
+`vendor-astral/` and `static/assets/`.)
 
 ---
 
@@ -237,48 +237,45 @@ directory that never existed. The genuinely still-live ones:
 
 ---
 
-## Full production edge list
+## Full production dependency list
 
-For completeness, every production import edge with its reference count. "Prod"
-means test, fixture, integration, and benchmark files were excluded.
+For completeness, which packages each package imports in production code (test,
+fixture, integration, and benchmark files excluded). This is the adjacency — the
+structure — without the reference counts, which are noise for orientation and go
+stale immediately.
 
 ```
-api               → memory(comment only), runner(comment only), utils(comment only)
-background-piece  → identity(9), piece(2), runner(15), utils(3)
-cf-harness        → api(18), llm(4), runner(28), utils(2)
-cli               → api(5), data-model(3), fuse(1), html(2), identity(9),
-                    js-compiler(8), llm(2), memory(3), piece(5), runner(26),
-                    runtime-client(1), state-inspector(2), static(1),
-                    test-support(1), ts-transformers(1), utils(9)
-content-hash      → utils(2)
-data-model        → api(12), content-hash(1), leb128(1), utils(35)
-fuse              → api(3), content-hash(2), data-model(1), piece(3), runner(9)
-home-schemas      → api(12), piece(1), runner(comment only)
-html              → api(5), runner(8), runtime-client(10), ui(comment only), utils(6)
-identity          → utils(2)
-iframe-sandbox    → runner(1), utils(4)
-integration       → identity(1), runner(1), shell(1), utils(3)
-js-compiler       → static(1), ts-transformers(1), utils(4)
-lib-shell         → api(1), data-model(1), identity(1), runner(2), runtime-client(2), utils(1)
-llm               → api(1), runner(1), utils(1)
-memory            → api(7), data-model(18), identity(2), runner(1), utils(6)
-piece             → api(3), data-model(2), home-schemas(1), identity(2),
-                    js-compiler(1), runner(11), utils(4)
-runner            → api(68), content-hash(1), data-model(152), home-schemas(1),
-                    html(3), identity(2), js-compiler(22), llm(2), memory(72),
-                    piece(comment only), static(3), ts-transformers(7), utils(148)
-runtime-client    → api(1), data-model(6), home-schemas(2), html(1), identity(6),
-                    js-compiler(4), llm(1), piece(2), runner(22), utils(13)
-schema-generator  → api(18), data-model(1), utils(9)
-shell             → api(1), felt(1), home-schemas(1), html(1), identity(13),
-                    lib-shell(3), memory(1), piece(1), runner(8),
-                    runtime-client(16), ui(3), utils(4)
-state-inspector   → api(2), data-model(5), identity(1), memory(7),
-                    runner(comment only)
-static            → utils(3)
-toolshed          → api(4), background-piece(2), content-hash(2), data-model(8),
-                    identity(2), llm(6), memory(7), runner(21), static(3), utils(11)
-ts-transformers   → api(9), schema-generator(12), utils(5)
-ui                → api(8), content-hash(1), html(2), identity(8),
-                    iframe-sandbox(2), runner(13), runtime-client(50), shell(4)
+api               → utils (all references are comment-only; api is a pure leaf)
+background-piece  → identity, piece, runner, utils
+cf-harness        → api, llm, runner, utils
+cli               → api, data-model, fuse, html, identity, js-compiler, llm,
+                    memory, piece, runner, runtime-client, state-inspector,
+                    static, test-support, ts-transformers, utils
+content-hash      → utils
+data-model        → api, content-hash, leb128, utils
+fuse              → api, content-hash, data-model, piece, runner
+home-schemas      → api, piece
+html              → api, runner, runtime-client, utils
+identity          → utils
+iframe-sandbox    → runner, utils
+integration       → identity, runner, shell, utils
+js-compiler       → static, ts-transformers, utils
+lib-shell         → api, data-model, identity, runner, runtime-client, utils
+llm               → api, runner, utils
+memory            → api, data-model, identity, runner, utils
+piece             → api, data-model, home-schemas, identity, js-compiler, runner, utils
+runner            → api, content-hash, data-model, home-schemas, html, identity,
+                    js-compiler, llm, memory, static, ts-transformers, utils
+runtime-client    → api, data-model, home-schemas, html, identity, js-compiler,
+                    llm, piece, runner, utils
+schema-generator  → api, data-model, utils
+shell             → api, felt, home-schemas, html, identity, lib-shell, memory,
+                    piece, runner, runtime-client, ui, utils
+state-inspector   → api, data-model, identity, memory
+static            → utils
+toolshed          → api, background-piece, content-hash, data-model, identity,
+                    llm, memory, runner, static, utils
+ts-transformers   → api, schema-generator, utils
+ui                → api, content-hash, html, identity, iframe-sandbox, runner,
+                    runtime-client, shell
 ```

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -10,7 +10,7 @@ two passes is itself informative and is noted where it changes the story.
 
 Some apparent edges were discarded after inspection because they were comments
 or strings rather than real imports: `api → runner`, `api → memory`,
-`runner → piece`, `home-schemas → runner`, `html → ui`, and
+`api → utils`, `runner → piece`, `home-schemas → runner`, `html → ui`, and
 `state-inspector → runner` are all mentions in comments, not import statements.
 They are not drawn. (The `runner → piece` "edge" is in fact a comment that reads
 "Avoid importing from `@commonfabric/piece` to prevent circular deps in tests" —
@@ -21,8 +21,10 @@ the absence is deliberate.)
 ## The spine: `runner` is the hub, four leaves are the floor
 
 The graph is not a balanced tree. It is one very large hub (`runner`) sitting on
-a small floor of leaf libraries (`utils`, `data-model`, `api`, `identity`,
-`memory`), with everything else arranged around the hub. Edge labels are the
+a small floor of foundation libraries (`utils`, `data-model`, `api`, `identity`,
+`memory`), with everything else arranged around the hub. Of those, `utils`,
+`api`, and `identity` are true leaves (no outgoing package edges); `data-model`
+and `memory` are not — they sit on the leaves below them. Edge labels are the
 number of importing references in production code, so they show where the heavy
 coupling is.
 
@@ -51,7 +53,6 @@ flowchart TD
     datamodel -->|1| leb128
     memory -->|18| datamodel
     memory -->|7| api
-    api -->|3| utils
     identity -->|2| utils
     contenthash -->|2| utils
     jsc -->|1| schemagen["schema-generator"]
@@ -66,9 +67,10 @@ Three things to take from this:
 - **`runner` is the gravity well.** It pulls in `data-model` 150 times,
   `utils` 149 times, and `memory` 72 times in production code alone. Any change
   to `data-model` or `memory` ripples straight into the runtime.
-- **`api` is mostly types.** It sits near the floor because it is the authoring
-  surface — almost entirely TypeScript declarations that author code is compiled
-  against.
+- **`api` is mostly types, and a pure leaf.** It sits at the very floor because
+  it is the authoring surface — almost entirely TypeScript declarations that
+  author code is compiled against — and it has no outgoing package imports at all
+  (its only `@commonfabric/utils` references are "duplicated from…" comments).
 
 ---
 
@@ -151,7 +153,7 @@ flowchart LR
 | Cycle | Edge into the lower layer | The single seam to know about |
 |---|---|---|
 | `runner ↔ html` | `runner/src/builder` and `builtins/wish.ts` import `h()` to build UI nodes | The builder produces view nodes, so the UI primitive leaks into the foundation |
-| `runner ↔ memory` | `memory/v2/query.ts` imports `@commonfabric/runner/traverse` | One import. Memory needs the runtime's schema traversal to answer graph queries and evaluate per-row CFC labels |
+| `runner ↔ memory` | `memory/v2/query.ts` imports `@commonfabric/runner/traverse` | The one cycle-forming package edge; the same file also pulls runner's CFC, storage-transaction, and builder-type internals through relative paths. Memory needs the runtime's schema traversal and CFC to answer graph queries and evaluate per-row labels |
 | `runner ↔ llm` | `llm/src/prompts/json-import.ts` imports `createJsonSchema` | One import. A prompt helper reaches up into the runtime |
 | `ui ↔ shell` | `ui` imports `@commonfabric/shell/shared` in four `cf-*` components | Narrowed to URL/navigation helpers, but real |
 
@@ -223,9 +225,10 @@ folder (it now names the real `packages/patterns/deprecated`); the dangling
 the root `deno.jsonc` lint config no longer excludes a `patterns-saves-backup`
 directory that never existed. The genuinely still-live ones:
 
-- **Two storage vocabularies.** `memory` has a legacy "fact" model
-  (`assert`/`retract`, defined in `interface.ts` and `fact.ts` and re-exported by
-  the `lib.ts` barrel) and the current "v2" document/operation model (in `v2/`).
+- **Two storage vocabularies.** `memory` has a legacy "fact" model — the
+  `assert`/`retract` constructors in `fact.ts` (their types in `interface.ts`),
+  reached through the `@commonfabric/memory/fact` subpath that runner's storage
+  layer still imports — and the current "v2" document/operation model (in `v2/`).
   New work is v2. The fact vocabulary is still exported and still confuses
   people. See the [storage page](storage-substrate.md).
 - **`cf-harness` is misleadingly named.** It is not a test harness for the
@@ -240,7 +243,7 @@ For completeness, every production import edge with its reference count. "Prod"
 means test, fixture, integration, and benchmark files were excluded.
 
 ```
-api               → memory(comment only), runner(comment only), utils(3)
+api               → memory(comment only), runner(comment only), utils(comment only)
 background-piece  → identity(9), piece(2), runner(15), utils(3)
 cf-harness        → api(18), llm(4), runner(28), utils(2)
 cli               → api(5), data-model(3), fuse(1), html(1), identity(9),

--- a/docs/development/orientation/dependency-graph.md
+++ b/docs/development/orientation/dependency-graph.md
@@ -42,10 +42,10 @@ flowchart TD
     contenthash["content-hash"]
     leb128["leb128"]
 
-    runner -->|150| datamodel
-    runner -->|149| utils
+    runner -->|152| datamodel
+    runner -->|148| utils
     runner -->|72| memory
-    runner -->|62| api
+    runner -->|68| api
     runner -->|22| jsc["js-compiler"]
     datamodel -->|35| utils
     datamodel -->|12| api
@@ -61,11 +61,11 @@ flowchart TD
 
 Three things to take from this:
 
-- **`utils` is the universal floor.** It is imported by 302 files across the
+- **`utils` is the universal floor.** It is imported by 303 files across the
   repo. Its own `index.ts` deliberately throws, to force callers to import the
   specific subpath they need (for example `@commonfabric/utils/defer`).
-- **`runner` is the gravity well.** It pulls in `data-model` 150 times,
-  `utils` 149 times, and `memory` 72 times in production code alone. Any change
+- **`runner` is the gravity well.** It pulls in `data-model` 152 times,
+  `utils` 148 times, and `memory` 72 times in production code alone. Any change
   to `data-model` or `memory` ripples straight into the runtime.
 - **`api` is mostly types, and a pure leaf.** It sits at the very floor because
   it is the authoring surface — almost entirely TypeScript declarations that
@@ -190,19 +190,19 @@ counts are lines.
 
 | File | Lines | What it is |
 |---|---|---|
-| `runner/src/cfc/prepare.ts` | 5366 | The Contextual-Flow-Control write-policy gate |
-| `runner/src/runner.ts` | 4528 | Instantiates a pattern's nodes into scheduler actions |
-| `memory/v2/engine.ts` | 4406 | The transactional SQLite core |
-| `runner/src/traverse.ts` | 4350 | Schema-driven traversal of the value/link graph |
-| `ts-transformers/src/transformers/schema-injection.ts` | 4123 | Attaches schemas to reactive boundaries |
+| `runner/src/cfc/prepare.ts` | 6407 | The Contextual-Flow-Control write-policy gate |
+| `memory/v2/engine.ts` | 6254 | The transactional SQLite core |
+| `runner/src/runner.ts` | 5218 | Instantiates a pattern's nodes into scheduler actions |
+| `runner/src/traverse.ts` | 4896 | Schema-driven traversal of the value/link graph |
+| `ts-transformers/src/transformers/schema-injection.ts` | 4134 | Attaches schemas to reactive boundaries |
 | `html/src/worker/reconciler.ts` | 3862 | The worker-thread VDOM reconciler |
 | `runner/src/builtins/llm-dialog.ts` | 3804 | The LLM dialog builtin |
+| `runner/src/storage/v2.ts` | 3480 | The storage manager, provider, and space replica |
+| `runner/src/cell.ts` | 3452 | The Cell and Stream abstractions |
 | `ts-transformers/src/policy/capability-analysis.ts` | 3446 | CFC capability analysis for the transformer |
-| `runner/src/cell.ts` | 3432 | The Cell and Stream abstractions |
-| `runner/src/storage/v2.ts` | 3018 | The storage manager, provider, and space replica |
-| `runner/src/scheduler.ts` | 2638 | The reactive scheduler |
+| `runner/src/scheduler/facade.ts` | 2787 | The scheduler's public facade (after the scheduler-v2 refactor split `scheduler.ts` into `scheduler/`) |
 
-`runner` alone holds seven of the eleven, and its single largest file is now the
+`runner` alone holds seven of the eleven, and its single largest file is the
 CFC write-policy gate — Contextual Flow Control has grown into the biggest piece
 of the runtime. The complexity is real and concentrated. (A large generated JSX
 type-declaration file, `html/src/jsx.d.ts` at ~5.5k lines, is omitted here
@@ -264,9 +264,9 @@ llm               → api(1), runner(1), utils(1)
 memory            → api(7), data-model(18), identity(2), runner(1), utils(6)
 piece             → api(3), data-model(2), home-schemas(1), identity(2),
                     js-compiler(1), runner(11), utils(4)
-runner            → api(62), content-hash(1), data-model(150), home-schemas(1),
-                    html(3), identity(1), js-compiler(22), llm(2), memory(72),
-                    piece(comment only), static(2), ts-transformers(6), utils(149)
+runner            → api(68), content-hash(1), data-model(152), home-schemas(1),
+                    html(3), identity(2), js-compiler(22), llm(2), memory(72),
+                    piece(comment only), static(3), ts-transformers(7), utils(148)
 runtime-client    → api(1), data-model(6), home-schemas(2), html(1), identity(6),
                     js-compiler(4), llm(1), piece(2), runner(22), utils(13)
 schema-generator  → api(18), data-model(1), utils(9)

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -2,9 +2,9 @@
 
 `runner` is the reactive engine. It is the package everything else is arranged
 around, it is by far the largest hand-written package (roughly 100k non-test
-lines — several times the next-biggest), and it
-holds four of the eleven biggest files in the repo. If you understand `runner`,
-the rest of the system is mostly plumbing around it.
+lines — several times the next-biggest), and it holds most of the repo's largest
+files. If you understand `runner`, the rest of the system is mostly plumbing
+around it.
 
 One terminology note specific to this package: it uses **"piece"**, not "charm".
 
@@ -200,31 +200,8 @@ fires a notification that re-enters the same scheduler loop shown above.
 
 ## Technical debt and sharp edges
 
-- **`runner` is in three of the four import cycles** in the repo
-  (`↔ html`, `↔ memory`, `↔ llm`). See the
-  [dependency page](dependency-graph.md). The `memory` cycle forms on one
-  package edge (`memory/v2/query.ts` imports `runner/traverse`), though that same
-  file also reaches runner's CFC and storage internals through relative paths;
-  the `html` cycle is the builder needing `h()`; the `llm` cycle is a prompt
-  helper needing `createJsonSchema`.
-- **A layering violation lives in the builtins.** `builtins/wish.ts` imports a
-  home-domain schema from `home-schemas`, so a foundation builtin is coupled to
-  an end-user-program schema.
-- **Three link representations coexist.** A serialized `SigilLink`, an in-memory
-  `NormalizedLink`, and a deprecated `LegacyAlias` that is still in the
-  `PrimitiveCellLink` union (`link-types.ts:89`). New readers meet all three.
-- **The scheduler is pull-based**, which is counterintuitive if you expect a
-  push/observer model. Budget time for this.
-- **CFC silently gates commits.** The default enforcement mode can reject a
-  write or replace blocked content. If a write "disappears," check CFC before
-  the scheduler.
-- **The `TODO(danfuzz)` cluster** recurring across `schema.ts`,
-  `cfc/`, `traverse.ts`, and `cell.ts` marks an incomplete migration: several
-  graph walks do not yet admit the newer `FabricValue` special objects on every
-  path. It is a known, in-progress seam, not a set of isolated bugs.
-- **A self-referential import** in `runtime.ts` pulls a value (the
-  `RuntimeTelemetry` class) from the package's own `@commonfabric/runner` barrel
-  — a load-order trap to be aware of when reordering exports.
+The debt and rough edges touching these packages are collected, together with
+the rest of the repo's, in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -1,7 +1,7 @@
 # The runtime core: `runner`
 
 `runner` is the reactive engine. It is the package everything else is arranged
-around, it is the largest hand-written package (100k non-test lines), and it
+around, it is the largest hand-written package (106k non-test lines), and it
 holds four of the eleven biggest files in the repo. If you understand `runner`,
 the rest of the system is mostly plumbing around it.
 
@@ -22,7 +22,7 @@ large hub files at the top level.
 | `traverse.ts` | Schema-driven traversal of the value-and-link graph; resolves a (schema, path) query into concrete reads, following links. One of the largest files in the package. |
 | `schema.ts` | Schema resolution, validate-and-transform, default-value handling. |
 | `link-utils.ts`, `link-types.ts`, `sigil-types.ts` | The link system: the serialized `SigilLink`, the in-memory `NormalizedLink`, and the deprecated `LegacyAlias`. |
-| `scheduler/` + `scheduler.ts` | The reactive engine: dependency graph, trigger index, topological execution, and the pull-based settle loop. |
+| `scheduler/` (31 files) | The reactive engine (post `scheduler-v2` refactor; `scheduler.ts` is a one-line re-export of `scheduler/facade.ts`). `facade.ts` = the `Scheduler` class; `invalidation.ts` marks readers invalid on a commit; `trigger-index.ts` maps entities to the actions that read them; `dependency-graph.ts` holds the `dependents`/`reverseDependencies` edges and demand-reachability (`isLive`); `settle.ts` is the pull settle loop; `run.ts` runs one action (tx → run → commit → resubscribe); `topology.ts` orders the work set; `work-oracle.ts` answers "is there runnable pull work". |
 | `storage/` | Layered persistence and remote sync: the storage manager, per-space replica, journaled transactions, and the WebSocket session to the memory host. |
 | `builder/` | The authoring surface that turns pattern code into a serializable node graph (`pattern`, `lift`, `reactive`/`cell`, `createNodeFactory`). |
 | `builtins/` | Built-in modules patterns can call: `map`/`filter`/`ifElse`/`when`, `llm`/`generateText`/`generateObject`, the fetch builtins (`fetchJson`/`fetchText`/`fetchProgram`/`streamData`), `navigateTo`, `wish`, and SQLite builtins. |
@@ -100,46 +100,64 @@ the time it runs; the `Runner` rebuilds live `Cell` wiring from the node list.
 
 ## The reactive loop: how a write re-runs dependents
 
-This is the diagram to memorize. The scheduler is **pull-based**: effects (such
-as rendering) are the demand roots, and computations are lazy until something
-that is demanded needs them. A write does not eagerly recompute the world; it
-marks readers dirty and lets the next settle pass pull only what is needed.
+This is the diagram to memorize. The scheduler is **pull-based** (its only mode
+is `"pull"`, `scheduler/invalidation.ts`): effects (such as rendering) are the
+demand roots, and computations are lazy until something that is demanded needs
+them. The work splits into two decoupled phases. An **invalidation phase** turns
+a commit's changed addresses into invalid marks on the readers that actually
+observed a changed value; it does no recomputation, it just queues an execute.
+An **execute/settle phase** then drains the invalid-plus-demanded set to
+quiescence.
+
+Since the `scheduler-v2` refactor the engine lives in `runner/src/scheduler/`
+(31 files; `scheduler.ts` is now just a re-export of `scheduler/facade.ts`, which
+holds the `Scheduler` class). The steps below give the current file and function
+for each hop.
 
 ```mermaid
 sequenceDiagram
     participant Code as cell.set(v)
     participant Tx as V2StorageTransaction
     participant Replica as SpaceReplica
-    participant Sched as Scheduler
-    participant Trig as TriggerIndex
-    participant Loop as settle loop
+    participant Inval as invalidation.ts
+    participant Trig as trigger-index.ts
+    participant Loop as settle.ts loop
+    participant Run as run.ts
 
     Code->>Tx: write(address, v)
     Note over Tx: action finishes
     Tx->>Replica: commit()
-    Replica-->>Sched: "commit" notification (changed addresses)
-    Sched->>Trig: which actions read these addresses?
-    Trig-->>Sched: reader actions
-    Note over Sched: effects → pending,<br/>computations → marked dirty
-    Sched->>Loop: execute()
-    Loop->>Loop: collectDirtyDependencies (pull stale upstream in)
+    Replica-->>Inval: "commit" notification (changed addresses)
+    Inval->>Trig: collectTriggeredActionsForChange
+    Note over Trig: determineTriggeredActions (reactive-dependencies.ts)<br/>keeps only readers whose observed value actually changed
+    Trig-->>Inval: reader actions
+    Note over Inval: markInvalid(readers); queueExecution()
+    Inval->>Loop: execute() → runPullSchedulerSettleLoop
+    Loop->>Loop: buildPullIterationWorkSet (seeds + demanded closure)
     Loop->>Loop: topologicalSort (order by read→write edges)
-    Loop->>Loop: runSchedulerAction (new tx, run, commit)
-    Loop->>Loop: only value-changed writes re-dirty their readers
-    Note over Loop: repeat until quiescent<br/>(max 10 iterations, then cycle-break)
+    Loop->>Run: runSchedulerAction (new tx → run → commit → resubscribe)
+    Note over Run: the commit's changed writes re-enter as a new notification
+    Note over Loop: repeat up to MAX_ITERS (10); non-settling subgraphs<br/>get exponential backoff, not a hard cycle-break
     Loop-->>Code: idle / settled
 ```
 
 Three facts that trip people up:
 
-- A write that does not change the value does not re-run readers. The loop
-  compares written values and only propagates real changes
-  (`scheduler/write-propagation.ts`).
-- The loop is bounded. After ten iterations without settling, a cycle-breaker
-  steps in (`scheduler/pull-cycle-break.ts`). If you see that fire, you have a
-  reactive feedback loop.
-- "Idle" and "settled" are observable. `runtime.idle()` is how callers wait for
-  the graph to quiesce; tests and the background service rely on it.
+- **A write that does not change the value does not re-run readers.** The
+  value-equality gate lives at commit-notification time, in
+  `scheduler/reactive-dependencies.ts` (`determineTriggeredActions`, using
+  `valueEqual` for recursive reads and `shallowEqual` for non-recursive ones), so
+  an unchanged write yields no triggered readers and no invalidation. There is no
+  longer a separate "write-propagation" module.
+- **The loop is bounded but has no cycle-breaker.** The settle loop runs at most
+  `MAX_ITERS` (10, in `scheduler/constants.ts`), with a matching per-node
+  `PASS_RUN_BUDGET`. A subgraph that will not settle is not force-broken; it is
+  deferred with exponential backoff (`planBudgetBackoff`, 250 ms → 2 s), and
+  `idle()` is released after `CONVERGENCE_IDLE_HOLD_MAX_BACKOFF_PASSES` (3) so a
+  reactive feedback loop degrades rather than hangs.
+- **"Idle" and "settled" are observable.** `runtime.idle()` waits for reactive
+  quiescence; `runtime.settled()` additionally drains pending commits and
+  storage sync. Tests and the background service rely on both.
 
 ---
 
@@ -183,10 +201,11 @@ fires a notification that re-enters the same scheduler loop shown above.
 
 - **`runner` is in three of the four import cycles** in the repo
   (`↔ html`, `↔ memory`, `↔ llm`). See the
-  [dependency page](dependency-graph.md). The `memory` cycle is one import
-  (`memory/v2/query.ts` needs `runner/traverse`); the `html` cycle is the
-  builder needing `h()`; the `llm` cycle is a prompt helper needing
-  `createJsonSchema`.
+  [dependency page](dependency-graph.md). The `memory` cycle forms on one
+  package edge (`memory/v2/query.ts` imports `runner/traverse`), though that same
+  file also reaches runner's CFC and storage internals through relative paths;
+  the `html` cycle is the builder needing `h()`; the `llm` cycle is a prompt
+  helper needing `createJsonSchema`.
 - **A layering violation lives in the builtins.** `builtins/wish.ts` imports a
   home-domain schema from `home-schemas`, so a foundation builtin is coupled to
   an end-user-program schema.

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -19,13 +19,13 @@ large hub files at the top level.
 | `runtime.ts` | The `Runtime` class — the composition root. One per host. Owns and wires every subsystem by dependency injection. Hands out transactions via `edit()` and `readTx()`. |
 | `runner.ts` | The `Runner` class. Takes a pattern's serialized node graph and instantiates each node into live scheduler actions. |
 | `cell.ts` | The `Cell` and `Stream` abstractions — typed reactive handles over a path in a document in a space. |
-| `traverse.ts` | Schema-driven traversal of the value-and-link graph; resolves a (schema, path) query into concrete reads, following links. Largest file in the repo. |
+| `traverse.ts` | Schema-driven traversal of the value-and-link graph; resolves a (schema, path) query into concrete reads, following links. One of the largest files in the package. |
 | `schema.ts` | Schema resolution, validate-and-transform, default-value handling. |
 | `link-utils.ts`, `link-types.ts`, `sigil-types.ts` | The link system: the serialized `SigilLink`, the in-memory `NormalizedLink`, and the deprecated `LegacyAlias`. |
 | `scheduler/` + `scheduler.ts` | The reactive engine: dependency graph, trigger index, topological execution, and the pull-based settle loop. |
 | `storage/` | Layered persistence and remote sync: the storage manager, per-space replica, journaled transactions, and the WebSocket session to the memory host. |
 | `builder/` | The authoring surface that turns pattern code into a serializable node graph (`pattern`, `lift`, `reactive`/`cell`, `createNodeFactory`). |
-| `builtins/` | Built-in modules patterns can call: `map`/`filter`/`ifElse`/`when`, `llm`/`generateText`/`generateObject`, `fetch-data`, `navigate-to`, `wish`, and SQLite builtins. |
+| `builtins/` | Built-in modules patterns can call: `map`/`filter`/`ifElse`/`when`, `llm`/`generateText`/`generateObject`, the fetch builtins (`fetchJson`/`fetchText`/`fetchProgram`/`streamData`), `navigateTo`, `wish`, and SQLite builtins. |
 | `harness/` | The `Engine` that compiles TypeScript to a verified module-record graph and evaluates it in a secure sandbox. |
 | `sandbox/` | The Secure-EcmaScript (SES) compartment machinery: bundle verification, parsing, module-record compilation, compartment globals, policy. |
 | `cfc/` | Contextual Flow Control: data labeling, the write-policy gate (`prepare.ts`), and the egress gate. |
@@ -190,7 +190,7 @@ fires a notification that re-enters the same scheduler loop shown above.
 - **A layering violation lives in the builtins.** `builtins/wish.ts` imports a
   home-domain schema from `home-schemas`, so a foundation builtin is coupled to
   an end-user-program schema.
-- **Two link representations coexist.** A serialized `SigilLink`, an in-memory
+- **Three link representations coexist.** A serialized `SigilLink`, an in-memory
   `NormalizedLink`, and a deprecated `LegacyAlias` that is still in the
   `PrimitiveCellLink` union (`link-types.ts:89`). New readers meet all three.
 - **The scheduler is pull-based**, which is counterintuitive if you expect a
@@ -202,9 +202,9 @@ fires a notification that re-enters the same scheduler loop shown above.
   `cfc/`, `traverse.ts`, and `cell.ts` marks an incomplete migration: several
   graph walks do not yet admit the newer `FabricValue` special objects on every
   path. It is a known, in-progress seam, not a set of isolated bugs.
-- **A self-referential import** in `runtime.ts` pulls a type from the package's
-  own `@commonfabric/runner` barrel — a load-order trap to be aware of when
-  reordering exports.
+- **A self-referential import** in `runtime.ts` pulls a value (the
+  `RuntimeTelemetry` class) from the package's own `@commonfabric/runner` barrel
+  — a load-order trap to be aware of when reordering exports.
 
 ---
 

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -1,7 +1,8 @@
 # The runtime core: `runner`
 
 `runner` is the reactive engine. It is the package everything else is arranged
-around, it is the largest hand-written package (106k non-test lines), and it
+around, it is by far the largest hand-written package (roughly 100k non-test
+lines — several times the next-biggest), and it
 holds four of the eleven biggest files in the repo. If you understand `runner`,
 the rest of the system is mostly plumbing around it.
 
@@ -22,7 +23,7 @@ large hub files at the top level.
 | `traverse.ts` | Schema-driven traversal of the value-and-link graph; resolves a (schema, path) query into concrete reads, following links. One of the largest files in the package. |
 | `schema.ts` | Schema resolution, validate-and-transform, default-value handling. |
 | `link-utils.ts`, `link-types.ts`, `sigil-types.ts` | The link system: the serialized `SigilLink`, the in-memory `NormalizedLink`, and the deprecated `LegacyAlias`. |
-| `scheduler/` (31 files) | The reactive engine (post `scheduler-v2` refactor; `scheduler.ts` is a one-line re-export of `scheduler/facade.ts`). `facade.ts` = the `Scheduler` class; `invalidation.ts` marks readers invalid on a commit; `trigger-index.ts` maps entities to the actions that read them; `dependency-graph.ts` holds the `dependents`/`reverseDependencies` edges and demand-reachability (`isLive`); `settle.ts` is the pull settle loop; `run.ts` runs one action (tx → run → commit → resubscribe); `topology.ts` orders the work set; `work-oracle.ts` answers "is there runnable pull work". |
+| `scheduler/` (a few dozen files) | The reactive engine (post `scheduler-v2` refactor; `scheduler.ts` is a one-line re-export of `scheduler/facade.ts`). `facade.ts` = the `Scheduler` class; `invalidation.ts` marks readers invalid on a commit; `trigger-index.ts` maps entities to the actions that read them; `dependency-graph.ts` holds the `dependents`/`reverseDependencies` edges and demand-reachability (`isLive`); `settle.ts` is the pull settle loop; `run.ts` runs one action (tx → run → commit → resubscribe); `topology.ts` orders the work set; `work-oracle.ts` answers "is there runnable pull work". |
 | `storage/` | Layered persistence and remote sync: the storage manager, per-space replica, journaled transactions, and the WebSocket session to the memory host. |
 | `builder/` | The authoring surface that turns pattern code into a serializable node graph (`pattern`, `lift`, `reactive`/`cell`, `createNodeFactory`). |
 | `builtins/` | Built-in modules patterns can call: `map`/`filter`/`ifElse`/`when`, `llm`/`generateText`/`generateObject`, the fetch builtins (`fetchJson`/`fetchText`/`fetchProgram`/`streamData`), `navigateTo`, `wish`, and SQLite builtins. |
@@ -110,9 +111,9 @@ An **execute/settle phase** then drains the invalid-plus-demanded set to
 quiescence.
 
 Since the `scheduler-v2` refactor the engine lives in `runner/src/scheduler/`
-(31 files; `scheduler.ts` is now just a re-export of `scheduler/facade.ts`, which
-holds the `Scheduler` class). The steps below give the current file and function
-for each hop.
+(a few dozen files; `scheduler.ts` is now just a re-export of
+`scheduler/facade.ts`, which holds the `Scheduler` class). The steps below give
+the current file and function for each hop.
 
 ```mermaid
 sequenceDiagram
@@ -137,7 +138,7 @@ sequenceDiagram
     Loop->>Loop: topologicalSort (order by read→write edges)
     Loop->>Run: runSchedulerAction (new tx → run → commit → resubscribe)
     Note over Run: the commit's changed writes re-enter as a new notification
-    Note over Loop: repeat up to MAX_ITERS (10); non-settling subgraphs<br/>get exponential backoff, not a hard cycle-break
+    Note over Loop: repeat up to a small fixed cap; non-settling subgraphs<br/>get exponential backoff, not a hard cycle-break
     Loop-->>Code: idle / settled
 ```
 
@@ -150,11 +151,11 @@ Three facts that trip people up:
   an unchanged write yields no triggered readers and no invalidation. There is no
   longer a separate "write-propagation" module.
 - **The loop is bounded but has no cycle-breaker.** The settle loop runs at most
-  `MAX_ITERS` (10, in `scheduler/constants.ts`), with a matching per-node
-  `PASS_RUN_BUDGET`. A subgraph that will not settle is not force-broken; it is
-  deferred with exponential backoff (`planBudgetBackoff`, 250 ms → 2 s), and
-  `idle()` is released after `CONVERGENCE_IDLE_HOLD_MAX_BACKOFF_PASSES` (3) so a
-  reactive feedback loop degrades rather than hangs.
+  a small fixed number of iterations (`MAX_ITERS` in `scheduler/constants.ts`),
+  with a matching per-node run budget. A subgraph that will not settle is not
+  force-broken; it is deferred with exponential backoff (`planBudgetBackoff`), and
+  `idle()` is released after a few backoff passes so a reactive feedback loop
+  degrades rather than hangs.
 - **"Idle" and "settled" are observable.** `runtime.idle()` waits for reactive
   quiescence; `runtime.settled()` additionally drains pending commits and
   storage sync. Tests and the background service rely on both.

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -1,0 +1,222 @@
+# The runtime core: `runner`
+
+`runner` is the reactive engine. It is the package everything else is arranged
+around, it is the largest hand-written package (95k non-test lines), and it
+holds four of the eleven biggest files in the repo. If you understand `runner`,
+the rest of the system is mostly plumbing around it.
+
+One terminology note specific to this package: it uses **"piece"**, not "charm".
+
+---
+
+## What lives in `runner/src`
+
+The package is organized as a set of subsystem directories around a few very
+large hub files at the top level.
+
+| Path | Role |
+|---|---|
+| `runtime.ts` | The `Runtime` class — the composition root. One per host. Owns and wires every subsystem by dependency injection. Hands out transactions via `edit()` and `readTx()`. |
+| `runner.ts` | The `Runner` class. Takes a pattern's serialized node graph and instantiates each node into live scheduler actions. |
+| `cell.ts` | The `Cell` and `Stream` abstractions — typed reactive handles over a path in a document in a space. |
+| `traverse.ts` | Schema-driven traversal of the value-and-link graph; resolves a (schema, path) query into concrete reads, following links. Largest file in the repo. |
+| `schema.ts` | Schema resolution, validate-and-transform, default-value handling. |
+| `link-utils.ts`, `link-types.ts`, `sigil-types.ts` | The link system: the serialized `SigilLink`, the in-memory `NormalizedLink`, and the deprecated `LegacyAlias`. |
+| `scheduler/` + `scheduler.ts` | The reactive engine: dependency graph, trigger index, topological execution, and the pull-based settle loop. |
+| `storage/` | Layered persistence and remote sync: the storage manager, per-space replica, journaled transactions, and the WebSocket session to the memory host. |
+| `builder/` | The authoring surface that turns pattern code into a serializable node graph (`pattern`, `lift`, `reactive`/`cell`, `createNodeFactory`). |
+| `builtins/` | Built-in modules patterns can call: `map`/`filter`/`ifElse`/`when`, `llm`/`generateText`/`generateObject`, `fetch-data`, `navigate-to`, `wish`, and SQLite builtins. |
+| `harness/` | The `Engine` that compiles TypeScript to a verified module-record graph and evaluates it in a secure sandbox. |
+| `sandbox/` | The Secure-EcmaScript (SES) compartment machinery: bundle verification, parsing, module-record compilation, compartment globals, policy. |
+| `cfc/` | Contextual Flow Control: data labeling, the write-policy gate (`prepare.ts`), and the egress gate. |
+
+---
+
+## The composition root: one `Runtime` owns everything
+
+The mental model to start from is that a single `Runtime` object owns one
+instance of every subsystem and injects them into each other. There are no
+globals to hunt for; if you have the `Runtime`, you can reach everything.
+
+```mermaid
+flowchart TB
+    subgraph runtime["Runtime (runtime.ts) — one per host"]
+        scheduler["Scheduler"]
+        runnerc["Runner"]
+        pm["PatternManager"]
+        engine["Engine (harness)"]
+        mods["ModuleRegistry"]
+        cfc["ContextualFlowControl"]
+        sm["StorageManager"]
+    end
+    authorcode[".tsx author code"]
+    cells["Cells in a Space"]
+    host["remote memory host"]
+
+    authorcode --> engine --> pm --> runnerc
+    runnerc --> scheduler
+    scheduler <--> cells
+    cells <--> sm
+    sm <--> host
+    cfc -. "gates writes & egress" .- scheduler
+```
+
+`edit()` and `readTx()` on the `Runtime` are how the outside world gets a
+transaction to read or write cells. Everything funnels through that.
+
+---
+
+## Building a pattern vs. running it (two distinct phases)
+
+The most common source of confusion for newcomers is that "writing a pattern"
+and "running a pattern" are two completely separate phases with two different
+sets of types. At build time you manipulate `Reactive`s — placeholders for
+values that do not exist yet. At run time those become real `Cell`s.
+
+```mermaid
+flowchart TB
+    subgraph build["Build phase (in builder/)"]
+        patfn["pattern(fn) is called"]
+        frame["a Frame is pushed (construction context)"]
+        lift["lift() / reactive() create nodes and Reactives"]
+        collect["the Frame collects all nodes and refs"]
+        serialize["serialize to Pattern { argumentSchema, resultSchema, nodes, result }"]
+        patfn --> frame --> lift --> collect --> serialize
+    end
+    subgraph run["Run phase (in runner.ts)"]
+        startcore["Runner.startCore(resultCell, pattern)"]
+        dispatch["instantiateNode dispatches per node kind:<br/>pattern → recurse, javascript → action/handler,<br/>raw, passthrough"]
+        subscribe["each node registers a Scheduler action<br/>wiring its input cells (reads) to output cells (writes)"]
+        startcore --> dispatch --> subscribe
+    end
+    serialize -.->|"stored, then loaded"| startcore
+```
+
+The key takeaway: a `Pattern` is just serializable data — schemas plus a list of
+nodes. It is not a closure. The `Reactive` you used while writing it is gone by
+the time it runs; the `Runner` rebuilds live `Cell` wiring from the node list.
+
+---
+
+## The reactive loop: how a write re-runs dependents
+
+This is the diagram to memorize. The scheduler is **pull-based**: effects (such
+as rendering) are the demand roots, and computations are lazy until something
+that is demanded needs them. A write does not eagerly recompute the world; it
+marks readers dirty and lets the next settle pass pull only what is needed.
+
+```mermaid
+sequenceDiagram
+    participant Code as cell.set(v)
+    participant Tx as V2StorageTransaction
+    participant Replica as SpaceReplica
+    participant Sched as Scheduler
+    participant Trig as TriggerIndex
+    participant Loop as settle loop
+
+    Code->>Tx: write(address, v)
+    Note over Tx: action finishes
+    Tx->>Replica: commit()
+    Replica-->>Sched: "commit" notification (changed addresses)
+    Sched->>Trig: which actions read these addresses?
+    Trig-->>Sched: reader actions
+    Note over Sched: effects → pending,<br/>computations → marked dirty
+    Sched->>Loop: execute()
+    Loop->>Loop: collectDirtyDependencies (pull stale upstream in)
+    Loop->>Loop: topologicalSort (order by read→write edges)
+    Loop->>Loop: runSchedulerAction (new tx, run, commit)
+    Loop->>Loop: only value-changed writes re-dirty their readers
+    Note over Loop: repeat until quiescent<br/>(max 10 iterations, then cycle-break)
+    Loop-->>Code: idle / settled
+```
+
+Three facts that trip people up:
+
+- A write that does not change the value does not re-run readers. The loop
+  compares written values and only propagates real changes
+  (`scheduler/write-propagation.ts`).
+- The loop is bounded. After ten iterations without settling, a cycle-breaker
+  steps in (`scheduler/pull-cycle-break.ts`). If you see that fire, you have a
+  reactive feedback loop.
+- "Idle" and "settled" are observable. `runtime.idle()` is how callers wait for
+  the graph to quiesce; tests and the background service rely on it.
+
+---
+
+## Where durable state and reactivity meet: the storage layering
+
+Reactivity is in-memory; durability is remote. The `storage/` subsystem is the
+bridge. A `Cell` write goes through a journaled transaction into a per-space
+local replica, which commits to a remote memory host over a WebSocket. Remote
+changes come back the same way and re-enter the scheduler as if they were local
+writes.
+
+```mermaid
+flowchart TB
+    cell["Cell"]
+    tx["V2StorageTransaction (journaled reads/writes)"]
+    replica["SpaceReplica / Provider (local doc cache)"]
+    mgr["StorageManager"]
+    ws["v2-remote-session (WebSocket)"]
+    host["remote memory host"]
+
+    cell --> tx --> replica --> mgr --> ws --> host
+
+    subgraph sub["Query subscription path"]
+        sel["selector-tracker (dedup schema+path selectors)"]
+        watch["watchAddSync over the socket"]
+        consume["consumeUpdates / applySessionSync (merge into local cache)"]
+        notify["pull notification → back into the scheduler"]
+        sel --> watch --> consume --> notify
+    end
+    host -.-> consume
+```
+
+The query side is the subtle part: subscriptions are expressed as
+schema-plus-path **selectors**, deduplicated, and turned into watch requests on
+the socket. When the host pushes an update, it merges into the local cache and
+fires a notification that re-enters the same scheduler loop shown above.
+
+---
+
+## Technical debt and sharp edges
+
+- **`runner` is in three of the four import cycles** in the repo
+  (`↔ html`, `↔ memory`, `↔ llm`). See the
+  [dependency page](dependency-graph.md). The `memory` cycle is one import
+  (`memory/v2/query.ts` needs `runner/traverse`); the `html` cycle is the
+  builder needing `h()`; the `llm` cycle is a prompt helper needing
+  `createJsonSchema`.
+- **A layering violation lives in the builtins.** `builtins/wish.ts` imports a
+  home-domain schema from `home-schemas`, so a foundation builtin is coupled to
+  an end-user-program schema.
+- **Two link representations coexist.** A serialized `SigilLink`, an in-memory
+  `NormalizedLink`, and a deprecated `LegacyAlias` that is still in the
+  `PrimitiveCellLink` union (`link-types.ts:89`). New readers meet all three.
+- **The scheduler is pull-based**, which is counterintuitive if you expect a
+  push/observer model. Budget time for this.
+- **CFC silently gates commits.** The default enforcement mode can reject a
+  write or replace blocked content. If a write "disappears," check CFC before
+  the scheduler.
+- **The `TODO(danfuzz)` cluster** recurring across `schema.ts`,
+  `cfc/`, `traverse.ts`, and `cell.ts` marks an incomplete migration: several
+  graph walks do not yet admit the newer `FabricValue` special objects on every
+  path. It is a known, in-progress seam, not a set of isolated bugs.
+- **A self-referential import** in `runtime.ts` pulls a type from the package's
+  own `@commonfabric/runner` barrel — a load-order trap to be aware of when
+  reordering exports.
+
+---
+
+## Public surface
+
+`src/index.ts` is a large barrel. The high-traffic exports: `Runtime`, `Cell`,
+`Stream`, `effect`, the builder vocabulary (`createBuilder`, `reactive` exported
+as `cell`, `lift`, `schema`, `Pattern`, `Reactive`, the symbols `UI`/`NAME`/
+`TYPE`/`ID`), the link helpers (`parseLink`, `resolveLink`, `isLink`), scheduler
+types (`Action`, `ReactivityLog`), the `Engine`, and `ContextualFlowControl`.
+
+Sub-path exports matter here because other packages import them directly:
+`@commonfabric/runner/traverse` (imported by `memory`),
+`@commonfabric/runner/shared`, `/slugs`, `/schemas`, `/cfc`,
+`/storage/inspector`, `/storage/telemetry`.

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -1,7 +1,7 @@
 # The runtime core: `runner`
 
 `runner` is the reactive engine. It is the package everything else is arranged
-around, it is the largest hand-written package (95k non-test lines), and it
+around, it is the largest hand-written package (100k non-test lines), and it
 holds four of the eleven biggest files in the repo. If you understand `runner`,
 the rest of the system is mostly plumbing around it.
 

--- a/docs/development/orientation/runtime-core.md
+++ b/docs/development/orientation/runtime-core.md
@@ -155,12 +155,12 @@ writes.
 flowchart TB
     cell["Cell"]
     tx["V2StorageTransaction (journaled reads/writes)"]
-    replica["SpaceReplica / Provider (local doc cache)"]
-    mgr["StorageManager"]
+    mgr["StorageManager (owns the per-space providers)"]
+    replica["SpaceReplica / Provider (local doc cache + its own session)"]
     ws["v2-remote-session (WebSocket)"]
     host["remote memory host"]
 
-    cell --> tx --> replica --> mgr --> ws --> host
+    cell --> tx --> mgr --> replica --> ws --> host
 
     subgraph sub["Query subscription path"]
         sel["selector-tracker (dedup schema+path selectors)"]

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -30,7 +30,7 @@ flowchart BT
     runner -.->|"the one upward edge:<br/>v2/query.ts"| memory
 ```
 
-`leb128` (170 lines, one file) and `content-hash` (a SHA-256 backend selector)
+`leb128` (a single small file) and `content-hash` (a SHA-256 backend selector)
 exist only to serve `data-model`'s deterministic hashing. You will rarely touch
 them directly.
 
@@ -216,9 +216,9 @@ across a round trip. Three finer points worth knowing:
   Three kinds: `origin-committed` (a prior commit from this session must be
   durable), `entity-absent` (an id must have no value), and `entity-value-hash`
   (an id pinned to an exact `valueHash`, where `null` pins "absent/deleted").
-- **A snapshot is materialized every `DEFAULT_SNAPSHOT_INTERVAL` (10) patches**
-  for an entity, so a read replays at most ~10 patch rows; setting the interval to
-  `0` disables snapshotting.
+- **A snapshot is materialized every so many patches** for an entity
+  (`DEFAULT_SNAPSHOT_INTERVAL`), so a read replays only a handful of patch rows on
+  top of the nearest snapshot; setting the interval to `0` disables snapshotting.
 - **Branches are first-class.** A `branch` table holds `parent_branch`,
   `fork_seq`, `head_seq`, and `status`; the default root branch is the empty
   string `''`, and every table's key begins with `branch`. A `ClientCommit` can
@@ -238,7 +238,7 @@ holds the per-row CFC label rules; `commit-eval.ts` re-derives row labels
 server-side at commit time and rolls back on a violation; `write-targets.ts` maps
 each positional `?` to its target column for the write-ceiling check (fail-closed
 for shapes it can't attribute). `read-pool.ts` is an LRU of read-only connections
-(default 32) so reads never attach to the engine connection, and `disk-source.ts`
+so reads never attach to the engine connection, and `disk-source.ts`
 lets an external on-disk SQLite file be attached read-only by handle.
 
 Note that space-level ACL (`Record<DID|"*", "READ"|"WRITE"|"OWNER">`, `acl.ts`)
@@ -252,9 +252,8 @@ a complete audit trail. The `state-inspector` package (`@commonfabric/state-insp
 is the lens over it: it opens a space's SQLite file read-only, reconstructs the
 value of any entity at any `(branch, seq)`, and answers who/what/when questions
 — time-travel, conflict inspection, and cross-space queries — with no live
-runtime and no capture step. It depends only on `memory` (7 imports),
-`data-model`, `identity`, and `api`, so it is a clean leaf consumer of the
-storage layer. It is wired into the `cf` CLI as `cf inspect` (the package also
+runtime and no capture step. It depends only on `memory`, `data-model`,
+`identity`, and `api`, so it is a clean leaf consumer of the storage layer. It is wired into the `cf` CLI as `cf inspect` (the package also
 exposes a local `deno task inspect`), and has a matching `state-inspector` agent
 skill. This is the tool to reach for when debugging what
 a space actually recorded.

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -70,10 +70,10 @@ Two pieces of `data-model` are worth knowing by name because they are where
 future migrations will land:
 
 - **Content addressing** (`value-hash.ts`, `schema-hash.ts`). `hashOf` feeds
-  type-tagged bytes into an incremental SHA-256 (from `content-hash`) with
-  length and index prefixes (from `leb128`), so structurally different values
-  cannot collide and structurally equal values hash identically. Schemas are
-  interned and hash-cached.
+  bytes into an incremental SHA-256 (from `content-hash`) using per-value type
+  tags, `leb128` length prefixes, `TAG_END` terminators, and UTF-8-sorted object
+  keys, so structurally different values cannot collide and structurally equal
+  values hash identically. Schemas are interned and hash-cached.
 - **The cell-representation bridge** (`cell-rep.ts`). This is the single file
   that decides how a reference to a cell is serialized — either a bare
   `FabricHash` (the "modern" representation) or a `{ "/": "tag:hash" }` envelope
@@ -169,10 +169,11 @@ sequenceDiagram
     alt a read changed underneath
         Engine-->>Client: ConflictError (client retries)
     else still valid
-        Engine->>DB: append revision rows, update head, write commit row
+        Engine->>DB: write commit row, append revision rows, update head (one atomic tx)
         Engine->>DB: COMMIT
         Engine-->>Server: ok
-        Server-->>Client: pushed SessionEffect to every watcher whose query intersects
+        Server-->>Client: commit accepted
+        Note over Server: separately, a batched timer pushes session/effect to watcher<br/>sessions (usually other connections) whose tracked ids intersect the change
     end
 ```
 
@@ -215,7 +216,7 @@ flowchart LR
     space["space access granted"]
 
     id --> did
-    id --> sign --> verify --> reg --> acl --> space
+    id --> sign --> verify --> acl --> reg --> space
 ```
 
 A subtlety worth flagging: a space's DID can itself be a derived keypair.
@@ -234,11 +235,14 @@ kinds of thing.
   document/operation vocabulary (`EntityDocument`, `Operation`, `ClientCommit`,
   `GraphQuery`). New work is v2; the fact model persists and confuses newcomers.
   `lib.ts` is the legacy entry point.
-- **The `memory ↔ runner` cycle is one import** but architecturally real:
-  `v2/query.ts` imports `@commonfabric/runner/traverse` because answering a
+- **The `memory ↔ runner` cycle is narrow but deeper than the counts suggest.**
+  `v2/query.ts` forms the cycle with one package-alias import
+  (`@commonfabric/runner/traverse`), but the same file also reaches into runner's
+  internals through three relative-path imports (`ContextualFlowControl`, the
+  extended storage transaction, and the builder `JSONSchema` type). Answering a
   schema-aware graph query and evaluating per-row CFC labels needs the runtime's
-  traversal logic. This is the seam to know if you ever try to extract `memory`
-  as a standalone library.
+  traversal and CFC logic. This is the seam to know if you ever try to extract
+  `memory` as a standalone library.
 - **The SQL guard is intentionally conservative** (`v2/sqlite/guard.ts`). It
   rejects some valid statements (single-statement only, no PRAGMA/ATTACH, no
   references to core engine tables) to keep the attack surface small.

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -110,33 +110,45 @@ erDiagram
     revision ||--|| head : "latest pointer per entity"
     revision }o--o| snapshot : "materialized periodically"
 
+    branch ||--o{ commit : "owns"
+
     commit {
         int seq PK
         string branch
         string session_id
+        int local_seq
+        string invocation_ref FK
+        string authorization_ref FK
         json original
         json resolution
     }
     revision {
-        string branch_id_scope PK
-        int seq
-        int op_index
+        string branch_id_scope_seq_opindex PK "compound: (branch,id,scope_key,seq,op_index)"
+        int commit_seq FK
         string op
         json data
     }
     head {
-        string branch_id_scope PK
+        string branch_id_scope PK "compound: (branch,id,scope_key)"
         int seq
         int op_index
     }
     snapshot {
-        string branch_id_scope_seq PK
+        string branch_id_scope_seq PK "compound: (branch,id,scope_key,seq)"
         json value
+    }
+    branch {
+        string name PK
+        string parent_branch
+        int fork_seq
+        int head_seq
+        string status
     }
     blob_store {
         string hash PK
         blob data
         string content_type
+        int size
     }
 ```
 

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -121,7 +121,7 @@ erDiagram
         string branch_id_scope PK
         int seq
         int op_index
-        json op
+        string op
         json data
     }
     head {
@@ -130,7 +130,7 @@ erDiagram
         int op_index
     }
     snapshot {
-        string key PK
+        string branch_id_scope_seq PK
         json value
     }
     blob_store {
@@ -189,8 +189,9 @@ value of any entity at any `(branch, seq)`, and answers who/what/when questions
 — time-travel, conflict inspection, and cross-space queries — with no live
 runtime and no capture step. It depends only on `memory` (7 imports),
 `data-model`, `identity`, and `api`, so it is a clean leaf consumer of the
-storage layer. It ships a `cf-inspect` CLI (`deno task inspect`) and a matching
-`state-inspector` agent skill. This is the tool to reach for when debugging what
+storage layer. It is wired into the `cf` CLI as `cf inspect` (the package also
+exposes a local `deno task inspect`), and has a matching `state-inspector` agent
+skill. This is the tool to reach for when debugging what
 a space actually recorded.
 
 ---
@@ -208,7 +209,7 @@ flowchart LR
     id["Identity (Ed25519 keypair)"]
     did["did:key:… (its DID)"]
     sign["signs a session.open invocation"]
-    verify["v2/session-open-auth.ts verifies<br/>(issuer, optional audience, optional expiry)"]
+    verify["v2/session-open-auth.ts verifies<br/>(issuer, required audience, required expiry + clock-skew grace)"]
     reg["SessionRegistry (principal-bound)"]
     acl["ACL check"]
     space["space access granted"]
@@ -241,13 +242,16 @@ kinds of thing.
 - **The SQL guard is intentionally conservative** (`v2/sqlite/guard.ts`). It
   rejects some valid statements (single-statement only, no PRAGMA/ATTACH, no
   references to core engine tables) to keep the attack surface small.
-- **CFC row labels fail closed.** `v2/sqlite/row-label.ts` rejects `any()` and
-  OR-style clauses and ReDoS-prone regexes rather than risk an unsound read
-  label.
-- **The cell-representation flip is not fully wired.** `data-model/cell-rep.ts`
-  has the modern-mode dispatch to a `FabricLink` deliberately left unwired,
-  pending the migration. There are matching `TODO(danfuzz)` markers in
-  `data-model` about values that `structuredClone` would mangle.
+- **CFC row labels fail closed.** `v2/sqlite/row-label.ts` accepts well-formed
+  disjunctive confidentiality clauses but rejects the unsound cases — an `any()`
+  alternative that is itself a conjunction or nested disjunction, disjunctive
+  *integrity* (which "does not exist"), ambiguous multi-op nodes, and
+  ReDoS-shaped regexes — rather than risk an unsound read label.
+- **The modern cell representation is behind a default-off flag.**
+  `data-model/cell-rep.ts` fully implements both the modern (bare `FabricHash` /
+  `FabricLink`) and the legacy (`{ "/": "tag:hash" }` envelope) forms; which one
+  is used is chosen by the module-level `modernCellRepEnabled` flag, which
+  defaults off. When the representation flips, it flips here.
 
 ---
 
@@ -256,7 +260,7 @@ kinds of thing.
 - **`data-model`** — no root export; import subpaths (`fabric-value`,
   `value-hash`, `cell-rep`, the codecs).
 - **`memory`** — `.` (the legacy interface), `./v2`, `./v2/engine`,
-  `./v2/server`, `./v2/client`, `./v2/query`, `./sqlite` and subpaths,
+  `./v2/server`, `./v2/client`, `./sqlite` and subpaths,
   `./v2/session-open-auth`, `./v2/standalone` (an in-process test server).
 - **`identity`** — `.` exports `Identity`, `VerifierIdentity`, `PassKey`,
   `KeyStore`, `createSession`/`Session`.

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -120,8 +120,6 @@ erDiagram
     revision ||--|| head : "latest pointer per entity"
     revision }o--o| snapshot : "materialized periodically"
 
-    branch ||--o{ commit : "owns"
-
     commit {
         int seq PK
         string branch
@@ -308,33 +306,8 @@ kinds of thing.
 
 ## Technical debt and sharp edges
 
-- **Two vocabularies in one package.** `memory/interface.ts` and `fact.ts`
-  define an older UCAN-flavored "fact" model (`assert`/`retract`/`unclaimed`,
-  content-hash keyed). The current v2 wire protocol in `v2.ts` uses a different
-  document/operation vocabulary (`EntityDocument`, `Operation`, `ClientCommit`,
-  `GraphQuery`). New work is v2; the fact model persists and confuses newcomers.
-  `lib.ts` is the legacy entry point.
-- **The `memory ↔ runner` cycle is narrow but deeper than the counts suggest.**
-  `v2/query.ts` forms the cycle with one package-alias import
-  (`@commonfabric/runner/traverse`), but the same file also reaches into runner's
-  internals through three relative-path imports (`ContextualFlowControl`, the
-  extended storage transaction, and the builder `JSONSchema` type). Answering a
-  schema-aware graph query and evaluating per-row CFC labels needs the runtime's
-  traversal and CFC logic. This is the seam to know if you ever try to extract
-  `memory` as a standalone library.
-- **The SQL guard is intentionally conservative** (`v2/sqlite/guard.ts`). It
-  rejects some valid statements (single-statement only, no PRAGMA/ATTACH, no
-  references to core engine tables) to keep the attack surface small.
-- **CFC row labels fail closed.** `v2/sqlite/row-label.ts` accepts well-formed
-  disjunctive confidentiality clauses but rejects the unsound cases — an `any()`
-  alternative that is itself a conjunction or nested disjunction, disjunctive
-  *integrity* (which "does not exist"), ambiguous multi-op nodes, and
-  ReDoS-shaped regexes — rather than risk an unsound read label.
-- **The modern cell representation is behind a default-off flag.**
-  `data-model/cell-rep.ts` fully implements both the modern (bare `FabricHash` /
-  `FabricLink`) and the legacy (`{ "/": "tag:hash" }` envelope) forms; which one
-  is used is chosen by the module-level `modernCellRepEnabled` flag, which
-  defaults off. When the representation flips, it flips here.
+The debt and rough edges touching these packages are collected, together with
+the rest of the repo's, in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).
 
 ---
 

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -1,0 +1,264 @@
+# The storage substrate: `memory`, `data-model`, `identity`
+
+Underneath the runtime is a small stack of packages that answer three
+questions: how is a value represented so it can be stored and hashed
+(`data-model`, on top of `content-hash` and `leb128`); how is it stored durably
+and queried reactively (`memory`); and who is allowed to touch a space
+(`identity`). This page maps that stack.
+
+---
+
+## The dependency spine of the substrate
+
+These five packages form a clean chain, leaves first. The only edge that points
+"up" is the deliberate cycle where `memory` borrows the runtime's traversal code
+to answer schema-aware queries.
+
+```mermaid
+flowchart BT
+    leb128["leb128<br/>(variable-length integers)"]
+    contenthash["content-hash<br/>(pluggable SHA-256)"]
+    datamodel["data-model<br/>(FabricValue + content addressing)"]
+    memory["memory<br/>(transactional store + sync)"]
+    identity["identity<br/>(DID, keypairs, sessions)"]
+    runner["runner/traverse<br/>(schema traversal)"]
+
+    leb128 --> datamodel
+    contenthash --> datamodel
+    datamodel --> memory
+    identity -.->|"verifies session.open"| memory
+    runner -.->|"the one upward edge:<br/>v2/query.ts"| memory
+```
+
+`leb128` (170 lines, one file) and `content-hash` (a SHA-256 backend selector)
+exist only to serve `data-model`'s deterministic hashing. You will rarely touch
+them directly.
+
+---
+
+## `data-model`: the value model and content addressing
+
+`data-model` defines **FabricValue**, the value model that crosses every storage
+boundary. The reason it exists is that JSON cannot carry everything the runtime
+needs: bigints, symbols, `undefined`, `Map`, `Set`, `Error`, `RegExp`, dates,
+byte arrays, content hashes, and links. FabricValue wraps each of those so it
+round-trips through storage and hashes deterministically.
+
+```mermaid
+flowchart TB
+    fv["FabricValue"]
+    json["JSON primitives + FabricArray + FabricObject"]
+    special["FabricSpecialObject"]
+    inst["FabricInstance (object-like, frozen-when-done)"]
+    prim["FabricPrimitive (immutable at construction)"]
+    link["FabricLink (reference to a cell)"]
+    map["FabricMap / FabricSet"]
+    hash["FabricHash (content address: tag:base64urlHash)"]
+    bytes["FabricBytes / temporal / FabricRegExp"]
+
+    fv --> json
+    fv --> special
+    special --> inst
+    special --> prim
+    inst --> link
+    inst --> map
+    prim --> hash
+    prim --> bytes
+```
+
+Two pieces of `data-model` are worth knowing by name because they are where
+future migrations will land:
+
+- **Content addressing** (`value-hash.ts`, `schema-hash.ts`). `hashOf` feeds
+  type-tagged bytes into an incremental SHA-256 (from `content-hash`) with
+  length and index prefixes (from `leb128`), so structurally different values
+  cannot collide and structurally equal values hash identically. Schemas are
+  interned and hash-cached.
+- **The cell-representation bridge** (`cell-rep.ts`). This is the single file
+  that decides how a reference to a cell is serialized — either a bare
+  `FabricHash` (the "modern" representation) or a `{ "/": "tag:hash" }` envelope
+  (the legacy representation), chosen by a module-level flag that `memory` reads.
+  When the representation flips, it flips here.
+
+`data-model` has **no root export**. You import named subpaths. This is
+intentional, for fine-grained coupling.
+
+---
+
+## `memory`: the durable, reactive, content-addressed store
+
+`memory` keeps one durable replica per space, reached over a WebSocket. It is
+transactional (atomic commits with read-based preconditions, so it detects
+conflicts optimistically), reactive (sessions watch query results and get
+pushed effects when a commit touches them), and access-controlled at row grain
+via CFC labels. On disk, each space is one SQLite file.
+
+### The on-disk model
+
+A document is not stored as a blob. It is stored as an append-only log of
+per-operation patches (`revision`), indexed by a current-pointer table
+(`head`), and periodically materialized into a `snapshot` so reads do not have
+to replay from the beginning. This is the single most important thing to
+understand about `memory`.
+
+```mermaid
+erDiagram
+    commit ||--o{ revision : "groups (commit_seq)"
+    commit }o--|| invocation : "signed by (invocation_ref)"
+    commit }o--|| authorization : "proven by (authorization_ref)"
+    branch ||--o{ commit : "contains"
+    revision ||--|| head : "latest pointer per entity"
+    revision }o--o| snapshot : "materialized periodically"
+
+    commit {
+        int seq PK
+        string branch
+        string session_id
+        json original
+        json resolution
+    }
+    revision {
+        string branch_id_scope PK
+        int seq
+        int op_index
+        json op
+        json data
+    }
+    head {
+        string branch_id_scope PK
+        int seq
+        int op_index
+    }
+    snapshot {
+        string key PK
+        json value
+    }
+    blob_store {
+        string hash PK
+        blob data
+        string content_type
+    }
+```
+
+- A document's current value is the **fold of its `revision` rows**, fast-pathed
+  by the nearest `snapshot`.
+- `blob_store` is content-addressed binary, keyed by hash.
+- `invocation` and `authorization` hold the signed request and its proof
+  (a UCAN-style capability model), referenced from each `commit`.
+- There is also a set of `scheduler_*` tables. These are how the runtime's
+  scheduler durably records what each action read and wrote, so actions can be
+  re-run. They are gated by a protocol flag (`persistentSchedulerState`).
+- `scope_key` (space / user / session) lets one entity id resolve to different
+  rows depending on who is asking — the storage side of a cell's scope.
+
+### The write transaction path
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server as v2/server.ts
+    participant Engine as v2/engine.ts
+    participant DB as SQLite
+
+    Client->>Server: TransactRequest (ClientCommit)
+    Note over Client: operations + recorded reads + preconditions
+    Server->>Server: authenticate session, check ACL WRITE
+    Server->>Engine: transact(commit)
+    Engine->>DB: BEGIN
+    Engine->>Engine: validate preconditions + recorded reads vs head
+    alt a read changed underneath
+        Engine-->>Client: ConflictError (client retries)
+    else still valid
+        Engine->>DB: append revision rows, update head, write commit row
+        Engine->>DB: COMMIT
+        Engine-->>Server: ok
+        Server-->>Client: pushed SessionEffect to every watcher whose query intersects
+    end
+```
+
+Optimistic concurrency is the model: the client sends the reads it depended on,
+and the engine rejects the commit if any of them moved. There are no locks held
+across a round trip.
+
+### Reading the store offline: `state-inspector`
+
+Because the durable store is an append-only log, the on-disk SQLite file is also
+a complete audit trail. The `state-inspector` package (`@commonfabric/state-inspector`)
+is the lens over it: it opens a space's SQLite file read-only, reconstructs the
+value of any entity at any `(branch, seq)`, and answers who/what/when questions
+— time-travel, conflict inspection, and cross-space queries — with no live
+runtime and no capture step. It depends only on `memory` (7 imports),
+`data-model`, `identity`, and `api`, so it is a clean leaf consumer of the
+storage layer. It ships a `cf-inspect` CLI (`deno task inspect`) and a matching
+`state-inspector` agent skill. This is the tool to reach for when debugging what
+a space actually recorded.
+
+---
+
+## `identity`: who can touch a space
+
+An `Identity` is an Ed25519 keypair whose `did()` is a `did:key:` DID. It signs
+payloads and produces a verifier. The package can generate keys, derive them
+deterministically (from a parent identity and a name, from a passphrase, from a
+mnemonic, from a PKCS8 key, or from a WebAuthn passkey), store them in
+IndexedDB, and serialize them.
+
+```mermaid
+flowchart LR
+    id["Identity (Ed25519 keypair)"]
+    did["did:key:… (its DID)"]
+    sign["signs a session.open invocation"]
+    verify["v2/session-open-auth.ts verifies<br/>(issuer, optional audience, optional expiry)"]
+    reg["SessionRegistry (principal-bound)"]
+    acl["ACL check"]
+    space["space access granted"]
+
+    id --> did
+    id --> sign --> verify --> reg --> acl --> space
+```
+
+A subtlety worth flagging: a space's DID can itself be a derived keypair.
+`createSession` can derive the space's own identity reproducibly as
+`Identity.fromPassphrase("common user").derive(spaceName)`, and that derived
+DID *is* the space. So "the space" and "an identity" are not always different
+kinds of thing.
+
+---
+
+## Technical debt and sharp edges
+
+- **Two vocabularies in one package.** `memory/interface.ts` and `fact.ts`
+  define an older UCAN-flavored "fact" model (`assert`/`retract`/`unclaimed`,
+  content-hash keyed). The current v2 wire protocol in `v2.ts` uses a different
+  document/operation vocabulary (`EntityDocument`, `Operation`, `ClientCommit`,
+  `GraphQuery`). New work is v2; the fact model persists and confuses newcomers.
+  `lib.ts` is the legacy entry point.
+- **The `memory ↔ runner` cycle is one import** but architecturally real:
+  `v2/query.ts` imports `@commonfabric/runner/traverse` because answering a
+  schema-aware graph query and evaluating per-row CFC labels needs the runtime's
+  traversal logic. This is the seam to know if you ever try to extract `memory`
+  as a standalone library.
+- **The SQL guard is intentionally conservative** (`v2/sqlite/guard.ts`). It
+  rejects some valid statements (single-statement only, no PRAGMA/ATTACH, no
+  references to core engine tables) to keep the attack surface small.
+- **CFC row labels fail closed.** `v2/sqlite/row-label.ts` rejects `any()` and
+  OR-style clauses and ReDoS-prone regexes rather than risk an unsound read
+  label.
+- **The cell-representation flip is not fully wired.** `data-model/cell-rep.ts`
+  has the modern-mode dispatch to a `FabricLink` deliberately left unwired,
+  pending the migration. There are matching `TODO(danfuzz)` markers in
+  `data-model` about values that `structuredClone` would mangle.
+
+---
+
+## Public surfaces
+
+- **`data-model`** — no root export; import subpaths (`fabric-value`,
+  `value-hash`, `cell-rep`, the codecs).
+- **`memory`** — `.` (the legacy interface), `./v2`, `./v2/engine`,
+  `./v2/server`, `./v2/client`, `./v2/query`, `./sqlite` and subpaths,
+  `./v2/session-open-auth`, `./v2/standalone` (an in-process test server).
+- **`identity`** — `.` exports `Identity`, `VerifierIdentity`, `PassKey`,
+  `KeyStore`, `createSession`/`Session`.
+- **`content-hash`** — `sha256`, `createHasher`. **`leb128`** — the four
+  encode/decode functions.

--- a/docs/development/orientation/storage-substrate.md
+++ b/docs/development/orientation/storage-substrate.md
@@ -80,6 +80,16 @@ future migrations will land:
   (the legacy representation), chosen by a module-level flag that `memory` reads.
   When the representation flips, it flips here.
 
+- **The codec / wire format** (`codec-common/`, `codec-json/`). A non-JSON value
+  serializes as a single-key object `{ "/<Type>@<Version>": <state> }`; the
+  canonical tag set is `BigInt@1`, `Bytes@1`, `Hash@1`, `Link@1`, `Map@1`,
+  `Set@1`, `RegExp@1`, `Error@1`, `Symbol@1`, `Undefined@1`, the temporal tags,
+  and meta-tags for quoting/array-holes. Tags are versioned so a future migration
+  can add `Map@2`. Decoding takes a `ReconstructionContext` (an
+  `EmptyReconstructionContext` at boundaries with no cells); in **lenient mode**
+  (default off) a value that fails to reconstruct comes back as a
+  `ProblematicValue` instead of throwing.
+
 `data-model` has **no root export**. You import named subpaths. This is
 intentional, for fine-grained coupling.
 
@@ -191,7 +201,49 @@ sequenceDiagram
 
 Optimistic concurrency is the model: the client sends the reads it depended on,
 and the engine rejects the commit if any of them moved. There are no locks held
-across a round trip.
+across a round trip. Three finer points worth knowing:
+
+- **Operations come in four kinds** (`v2.ts`): `set`, `patch`, `delete`, and
+  `sqlite`. The `sqlite` op is folded into the same atomic transaction as cell
+  ops but is *not* an entity revision — it never enters the revision/head/snapshot
+  machinery.
+- **Some patch ops are merge-friendly.** Beyond position-based
+  `replace`/`add`/`remove`/`move`/`splice`, the `PatchOp` family includes
+  `append` (tail-relative, carries no index), `add-unique` (idempotent set-add by
+  stored value), `remove-by-value`, and `increment` — these resolve against
+  durable state so concurrent writers merge instead of clobbering.
+- **Preconditions are how a commit pins state it did not read as a full value.**
+  Three kinds: `origin-committed` (a prior commit from this session must be
+  durable), `entity-absent` (an id must have no value), and `entity-value-hash`
+  (an id pinned to an exact `valueHash`, where `null` pins "absent/deleted").
+- **A snapshot is materialized every `DEFAULT_SNAPSHOT_INTERVAL` (10) patches**
+  for an entity, so a read replays at most ~10 patch rows; setting the interval to
+  `0` disables snapshotting.
+- **Branches are first-class.** A `branch` table holds `parent_branch`,
+  `fork_seq`, `head_seq`, and `status`; the default root branch is the empty
+  string `''`, and every table's key begins with `branch`. A `ClientCommit` can
+  carry a `branch` and a `merge { sourceBranch, sourceSeq, baseBranch, baseSeq }`.
+
+### The SQLite and CFC-label layer (`v2/sqlite/`)
+
+Patterns can run SQL against per-space tables, so `memory` wraps SQLite in a set
+of guards. `guard.ts` is a conservative tokenizer (single statement, no
+PRAGMA/ATTACH, and a `CORE_TABLE_NAMES` denylist — `commit`, `revision`, `head`,
+`snapshot`, `branch`, `blob_store`, `invocation`, `authorization`,
+`scheduler_*` — that a pattern statement may never reference). `column-origin.ts`
+uses an FFI build of SQLite with `SQLITE_ENABLE_COLUMN_METADATA` to read each
+result column's *true* `(table, column)` origin, so an `AS`-alias cannot spoof a
+CFC read label (it fails closed to a null origin on expressions). `row-label.ts`
+holds the per-row CFC label rules; `commit-eval.ts` re-derives row labels
+server-side at commit time and rolls back on a violation; `write-targets.ts` maps
+each positional `?` to its target column for the write-ceiling check (fail-closed
+for shapes it can't attribute). `read-pool.ts` is an LRU of read-only connections
+(default 32) so reads never attach to the engine connection, and `disk-source.ts`
+lets an external on-disk SQLite file be attached read-only by handle.
+
+Note that space-level ACL (`Record<DID|"*", "READ"|"WRITE"|"OWNER">`, `acl.ts`)
+and these per-row CFC labels are two distinct layers: the ACL gates who may touch
+a space at all; the CFC labels gate individual rows within it.
 
 ### Reading the store offline: `state-inspector`
 
@@ -207,15 +259,31 @@ exposes a local `deno task inspect`), and has a matching `state-inspector` agent
 skill. This is the tool to reach for when debugging what
 a space actually recorded.
 
+Its modules each answer a distinct question: `reconstruct.ts` replays the
+revision log to the value at any `(branch, seq)` (reusing the server's
+`applyPatch` for fidelity); `timetravel.ts` does structural diffs between two
+seqs and per-entity timelines; `conflicts.ts` finds write-write contention and
+anomalous stale reads (a hit signals corruption, not normal history); `graph.ts`
+builds the entity graph (pieces/modules/streams/schemas/cells with
+`pattern`/`argument`/`owns`/`link` edges); and `multispace.ts` clusters
+cross-space convergence to tell real drift from independent same-pattern
+instances.
+
 ---
 
 ## `identity`: who can touch a space
 
 An `Identity` is an Ed25519 keypair whose `did()` is a `did:key:` DID. It signs
-payloads and produces a verifier. The package can generate keys, derive them
-deterministically (from a parent identity and a name, from a passphrase, from a
-mnemonic, from a PKCS8 key, or from a WebAuthn passkey), store them in
-IndexedDB, and serialize them.
+payloads and produces a verifier. The derivations are concrete: `derive(name)`
+signs the UTF-8 bytes of `name` and SHA-256-hashes the (deterministic) signature
+into the child's raw key; `fromPassphrase(p)` uses `SHA-256(utf8(p))` directly (so
+`"common user"` maps to a fixed keypair — the seed for derived space DIDs);
+mnemonics are BIP-39 (24 words / 256-bit); PKCS8/PEM import works only under the
+noble backend. A `PassKey` uses the WebAuthn `prf` extension with a fixed salt and
+feeds its 32-byte output straight in as key material (PRF is only available from
+`credentials.get()`, not `create()`). WebCrypto native ed25519 is preferred over
+`@noble/ed25519` when the platform supports it. Keys can be stored in IndexedDB
+and serialized.
 
 ```mermaid
 flowchart LR

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -10,7 +10,7 @@ the skills system.
 
 ## `utils` is the universal leaf
 
-Everything depends on `utils`. It is imported by 294 files across the repo. Its
+Everything depends on `utils`. It is imported by 302 files across the repo. Its
 own `src/index.ts` deliberately **throws**, to force callers to import the
 specific subpath they need rather than the whole barrel.
 
@@ -18,7 +18,7 @@ specific subpath they need rather than the whole barrel.
 flowchart TB
     classDef leaf fill:#27ae60,stroke:#1e8449,color:#fff
     utils["utils (subpath-only)<br/>logger, defer, cache, deep-equal,<br/>base64url, bigint, arrays, types,<br/>sandbox-contract, async-local-store"]:::leaf
-    runner["runner (143 files)"]
+    runner["runner (148 files)"]
     datamodel["data-model (27 files)"]
     others["…every other package…"]
 

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -173,19 +173,8 @@ and a few more.
 
 ---
 
-## Sharp edges collected on one page
+## Sharp edges
 
-- Pattern authority is non-uniform; always check `index.md` Status tiers before
-  copying a pattern. Only `exemplar`-tier patterns are style references.
-- Deno is narrowly version-pinned; mismatches fail `deno task check` before any
-  real work runs.
-- The root `deno.jsonc` lint config still excludes one real, quarantined pattern
-  directory (`packages/patterns/record/`); the `fmt` config likewise excludes a
-  handful of `cf-chart`/`cf-toggle`/`cf-checkbox`/`cf-select` component files.
-  Those are intentional, not stale.
-
-A set of genuinely stale references this page used to list has since been
-cleaned up: the dangling `utils` `./integration` export was removed, `AGENTS.md`
-no longer points at a non-existent `deprecated-patterns` folder, and the
-`deno.jsonc` lint config no longer names a `patterns-saves-backup` directory or
-three deleted pattern files that were never present.
+The rough edges in this area — non-uniform pattern authority, the Deno version
+pin, the intentional lint/fmt excludes — are collected with the rest of the
+repo's in [TECHNICAL_DEBT.md](../TECHNICAL_DEBT.md).

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -36,7 +36,7 @@ longer existed; that dangling export has since been removed.)
 
 ## `patterns`: example programs of unequal authority
 
-`patterns` is by far the largest directory (327k lines), but it is example code,
+`patterns` is by far the largest directory (~321k non-test lines), but it is example code,
 not engine code. The most important thing a newcomer must learn here is that
 **the patterns do not carry equal authority.** Copying the wrong one teaches you
 a deprecated idiom. The authority ladder is tracked in
@@ -64,13 +64,15 @@ that never existed; it now names the real one.)
 
 ## The test runner fan-out
 
-`deno task test` runs `tasks/test.ts`, which reads the workspace member list
+`deno task test` runs `tasks/test.ts`, a thin entry point that delegates to
+`tasks/workspace-tests.ts` (kept separate so `deno coverage` does not skip the
+logic for ending in `test.ts`). That module reads the workspace member list
 from the root `deno.jsonc` and spawns `deno task test` in each package
 concurrently, each with its own working directory and coverage directory.
 
 ```mermaid
 flowchart TB
-    runner_["tasks/test.ts"]
+    runner_["tasks/test.ts → tasks/workspace-tests.ts"]
     list["read workspace[] from root deno.jsonc"]
     skip["minus ALL_DISABLED (just vendor-astral)<br/>and TEST_DISABLED_PACKAGES"]
     fan["spawn 'deno task test' per package, concurrently"]
@@ -148,7 +150,7 @@ and a few more.
 | `vendor-astral` | A vendored copy of Astral, a Deno-native browser-automation library over the Chrome DevTools Protocol. Excluded from lint, format, and the test runner. Do not edit it as if it were first-party. |
 | `integration` | The browser-driving test harness: a `Browser`/`Page` wrapper over the Chrome DevTools Protocol, an `env` module of test knobs (target URL, headless toggle, per-run space name), and shell login helpers. Its own `test` task is a stub; the tests that use it live in other packages. |
 | `home-schemas` | Schemas for the "home" space. Exists specifically so that `runner` and `piece` can share schemas without importing each other — a deliberate shared leaf to break a cycle. |
-| `generated-patterns` | 296 machine-generated test patterns plus the harness that generates them (`ralph/`). |
+| `generated-patterns` | 145 machine-generated test patterns (each with a paired test) plus the harness that generates them (`ralph/`). |
 
 ---
 
@@ -161,9 +163,9 @@ and a few more.
 - `tasks/test.ts`, `tasks/integration.ts`, and `tasks/cfcheck.ts` are the test,
   integration, and pattern-check runners, all of which shard in CI.
 - `.github/workflows/deno.yml` is the main CI: format check, lint,
-  `deno task check`, the workspace test fan-out (on a self-hosted runner that
-  installs FUSE and disables AppArmor for browser tests), and a four-way-sharded
-  `cfcheck`. Coverage, benchmarks, perf-regression, and deploy have their own
+  `deno task check`, the workspace test fan-out (on a GitHub-hosted
+  `ubuntu-latest` runner that installs FUSE and disables AppArmor for browser
+  tests), and a four-way-sharded `cfcheck`. Coverage, benchmarks, perf-regression, and deploy have their own
   workflows.
 - `.githooks/pre-commit` runs `deno fmt` and `deno lint`, and refuses to commit
   if there are unstaged tracked changes. Install it with

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -10,7 +10,7 @@ the skills system.
 
 ## `utils` is the universal leaf
 
-Everything depends on `utils`. It is imported by 303 files across the repo. Its
+Everything depends on `utils`. It is imported by nearly every file in the repo. Its
 own `src/index.ts` deliberately **throws**, to force callers to import the
 specific subpath they need rather than the whole barrel.
 
@@ -18,8 +18,8 @@ specific subpath they need rather than the whole barrel.
 flowchart TB
     classDef leaf fill:#27ae60,stroke:#1e8449,color:#fff
     utils["utils (subpath-only)<br/>logger, defer, cache, deep-equal,<br/>base64url, bigint, arrays, types,<br/>sandbox-contract, async-local-store"]:::leaf
-    runner["runner (149 files)"]
-    datamodel["data-model (27 files)"]
+    runner["runner (most files)"]
+    datamodel["data-model"]
     others["…every other package…"]
 
     runner --> utils
@@ -27,7 +27,7 @@ flowchart TB
     others --> utils
 ```
 
-The single largest module inside it is `logger.ts` (1502 lines), a from-scratch
+The single largest module inside it is `logger.ts`, a from-scratch
 logging library that works in both Deno and the browser. (Until recently
 `deno.jsonc` declared a `"./integration"` export pointing at a file that no
 longer existed; that dangling export has since been removed.)
@@ -36,7 +36,7 @@ longer existed; that dangling export has since been removed.)
 
 ## `patterns`: example programs of unequal authority
 
-`patterns` is by far the largest directory (~321k non-test lines), but it is example code,
+`patterns` is by far the largest directory in the repo, but it is example code,
 not engine code. The most important thing a newcomer must learn here is that
 **the patterns do not carry equal authority.** Copying the wrong one teaches you
 a deprecated idiom. The authority ladder is tracked in
@@ -48,7 +48,7 @@ flowchart TB
     exemplar["exemplar — current best practice; copy these<br/>(catalog/, counter/, do-list/, todo-list/, notes/, reading-list/, ...)"]
     demo["demo — real capability use, dated style;<br/>copy the capability call, not the style"]
     fixture["fixture — regression scaffolding; never imitate"]
-    legacy["legacy — superseded; do not copy<br/>(the whole record/ system, ~25 attribute clones, factory-outputs/)"]
+    legacy["legacy — superseded; do not copy<br/>(the whole record/ system, a couple dozen attribute clones, factory-outputs/)"]
 
     primitive --> exemplar --> demo --> fixture --> legacy
 ```
@@ -144,22 +144,22 @@ and a few more.
 
 | Package | Role |
 |---|---|
-| `static` | Lazy-loaded static assets, shared across Deno (read from disk) and browser (served by `toolshed`). Holds the bundled type declarations shipped to the in-browser TypeScript compiler — `es2023.d.ts` (459 KB, generated), `dom.d.ts`, and symlinks to the live `api` and `html` sources. Most of the package's size is that one generated file. |
+| `static` | Lazy-loaded static assets, shared across Deno (read from disk) and browser (served by `toolshed`). Holds the bundled type declarations shipped to the in-browser TypeScript compiler — a large generated `es2023.d.ts`, `dom.d.ts`, and symlinks to the live `api` and `html` sources. Most of the package's size is that one generated file. |
 | `test-support` | Golden-fixture suite runner (`defineFixtureSuite`, unified-diff helpers) and isolated-Deno-subprocess helpers that run `deno check` in a temporary config so tests do not dirty the repo lockfile. |
 | `deno-web-test` | Runs `Deno.test`-style tests inside a real browser, for code that must work in both Deno and the browser. Driven by `vendor-astral`. |
 | `vendor-astral` | A vendored copy of Astral, a Deno-native browser-automation library over the Chrome DevTools Protocol. Excluded from lint, format, and the test runner. Do not edit it as if it were first-party. |
 | `integration` | The browser-driving test harness: a `Browser`/`Page` wrapper over the Chrome DevTools Protocol, an `env` module of test knobs (target URL, headless toggle, per-run space name), and shell login helpers. Its own `test` task is a stub; the tests that use it live in other packages. |
 | `home-schemas` | Schemas for the "home" space. Exists specifically so that `runner` and `piece` can share schemas without importing each other — a deliberate shared leaf to break a cycle. |
-| `generated-patterns` | 145 machine-generated test patterns (each with a paired test) plus the harness that generates them (`ralph/`). |
+| `generated-patterns` | Well over a hundred machine-generated test patterns (each with a paired test) plus the harness that generates them (`ralph/`). |
 
 ---
 
 ## The repository task and CI surface
 
-- `tasks/check.sh` (`deno task check`) is the type-check gate. It pins Deno to
-  `>=2.8.0 <2.9.0` and type-checks an explicit set of directories with an 8 GB
-  V8 heap. `mise.toml` pins Deno to `2.8.1`; a wrong local Deno fails the gate
-  immediately.
+- `tasks/check.sh` (`deno task check`) is the type-check gate. It pins Deno to a
+  narrow version range and type-checks an explicit set of directories with an
+  enlarged V8 heap. `mise.toml` pins the exact Deno version; a wrong local Deno
+  fails the gate immediately.
 - `tasks/test.ts`, `tasks/integration.ts`, and `tasks/cfcheck.ts` are the test,
   integration, and pattern-check runners, all of which shard in CI.
 - `.github/workflows/deno.yml` is the main CI: format check, lint,

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -1,0 +1,189 @@
+# Examples, support libraries, and repo tooling
+
+This page covers the layers that are not the product itself: the example
+programs (`patterns`), the universal leaf library (`utils`), the bundled assets
+(`static`), the test-support packages, the integration browser harness, and the
+repository's own tooling — the dev-server scripts, the test runner, the CI, and
+the skills system.
+
+---
+
+## `utils` is the universal leaf
+
+Everything depends on `utils`. It is imported by 294 files across the repo. Its
+own `src/index.ts` deliberately **throws**, to force callers to import the
+specific subpath they need rather than the whole barrel.
+
+```mermaid
+flowchart TB
+    classDef leaf fill:#27ae60,stroke:#1e8449,color:#fff
+    utils["utils (subpath-only)<br/>logger, defer, cache, deep-equal,<br/>base64url, bigint, arrays, types,<br/>sandbox-contract, async-local-store"]:::leaf
+    runner["runner (143 files)"]
+    datamodel["data-model (27 files)"]
+    others["…every other package…"]
+
+    runner --> utils
+    datamodel --> utils
+    others --> utils
+```
+
+The single largest module inside it is `logger.ts` (1502 lines), a from-scratch
+logging library that works in both Deno and the browser. (Until recently
+`deno.jsonc` declared a `"./integration"` export pointing at a file that no
+longer existed; that dangling export has since been removed.)
+
+---
+
+## `patterns`: example programs of unequal authority
+
+`patterns` is by far the largest directory (327k lines), but it is example code,
+not engine code. The most important thing a newcomer must learn here is that
+**the patterns do not carry equal authority.** Copying the wrong one teaches you
+a deprecated idiom. The authority ladder is tracked in
+`packages/patterns/index.md` under "Status tiers."
+
+```mermaid
+flowchart TB
+    primitive["primitive — composable building blocks<br/>(currently empty)"]
+    exemplar["exemplar — current best practice; copy these<br/>(catalog/, counter/, do-list/, todo-list/, notes/, reading-list/, ...)"]
+    demo["demo — real capability use, dated style;<br/>copy the capability call, not the style"]
+    fixture["fixture — regression scaffolding; never imitate"]
+    legacy["legacy — superseded; do not copy<br/>(the whole record/ system, ~25 attribute clones, factory-outputs/)"]
+
+    primitive --> exemplar --> demo --> fixture --> legacy
+```
+
+The authoritative, type-checked component catalog is
+`packages/patterns/catalog/catalog.tsx`, with a story file per `cf-*` component
+under `catalog/stories/`. The defunct examples are in
+`packages/patterns/deprecated/`, which `AGENTS.md` tells you to ignore. (An
+earlier `AGENTS.md` called this a top-level `deprecated-patterns` folder, a path
+that never existed; it now names the real one.)
+
+---
+
+## The test runner fan-out
+
+`deno task test` runs `tasks/test.ts`, which reads the workspace member list
+from the root `deno.jsonc` and spawns `deno task test` in each package
+concurrently, each with its own working directory and coverage directory.
+
+```mermaid
+flowchart TB
+    runner_["tasks/test.ts"]
+    list["read workspace[] from root deno.jsonc"]
+    skip["minus ALL_DISABLED (just vendor-astral)<br/>and TEST_DISABLED_PACKAGES"]
+    fan["spawn 'deno task test' per package, concurrently"]
+    each["each package's own deno.jsonc defines a test task"]
+
+    runner_ --> list --> skip --> fan --> each
+```
+
+This is why `AGENTS.md` insists every workspace package's `deno.jsonc` define a
+`test` task, even if it is just a stub. If a package has no `test` task, Deno
+falls back to the root workspace task, which re-runs the entire suite — and
+because that happens inside each package, the process count explodes
+exponentially and CI times out.
+
+---
+
+## Local dev startup
+
+`scripts/start-local-dev.sh` brings up the stack. It reads base ports from
+`ports.json`, applies a port offset, and starts the servers in the background,
+waiting for each to report ready before moving on.
+
+```mermaid
+flowchart TB
+    ports["read base ports from ports.json, apply PORT_OFFSET"]
+    shell["start shell dev server (deno task dev-local)<br/>wait for 'Dev server listening' + HTTP 200"]
+    toolshed["start toolshed (index.ts, --unstable-otel)<br/>wait for 'Server running' + /_health 200"]
+    bg["optional --bg-updater:<br/>start background-piece-service (polls every 60s)"]
+
+    ports --> shell --> toolshed --> bg
+```
+
+The critical correctness note (documented in `LOCAL_DEV_SERVERS.md`): the shell
+must run `dev-local`, not `dev`. `dev` points the frontend at the production
+backend; `dev-local` points it at your local `toolshed`.
+
+---
+
+## The skills system and its mirrors
+
+The repository ships its own agent "skills" (procedures and references for AI
+coding assistants). `skills/` is the one canonical source. `.agents/skills/` and
+`.claude/skills/` are directories of **symlinks** back into `skills/`, so that
+both Codex (which reads `.agents/`) and Claude (which reads `.claude/`) discover
+the same single copy. `cubic.yaml`, the AI code-reviewer config, also points
+back at `skills/cf-review/`.
+
+```mermaid
+flowchart TB
+    canonical["skills/<name>/SKILL.md (canonical source)"]
+    agents[".agents/skills/<name> (symlink) → Codex"]
+    claude[".claude/skills/<name> (symlink) → Claude"]
+    cubic["cubic.yaml → references skills/cf-review"]
+
+    canonical --> agents
+    canonical --> claude
+    canonical --> cubic
+```
+
+The skill directories include `pattern-dev`, `pattern-test`, `pattern-deploy`,
+`pattern-debug`, `pattern-critic`, `pattern-ui`, `pattern-schema`,
+`pattern-implement`, `cf`, `cf-review`, `lit-component`, `fuse-workflow`,
+`fuse-agent`, `knowledge-base`, `isolated-test-processes`, `task-management`,
+and a few more.
+
+---
+
+## The remaining support packages
+
+| Package | Role |
+|---|---|
+| `static` | Lazy-loaded static assets, shared across Deno (read from disk) and browser (served by `toolshed`). Holds the bundled type declarations shipped to the in-browser TypeScript compiler — `es2023.d.ts` (459 KB, generated), `dom.d.ts`, and symlinks to the live `api` and `html` sources. Most of the package's size is that one generated file. |
+| `test-support` | Golden-fixture suite runner (`defineFixtureSuite`, unified-diff helpers) and isolated-Deno-subprocess helpers that run `deno check` in a temporary config so tests do not dirty the repo lockfile. |
+| `deno-web-test` | Runs `Deno.test`-style tests inside a real browser, for code that must work in both Deno and the browser. Driven by `vendor-astral`. |
+| `vendor-astral` | A vendored copy of Astral, a Deno-native browser-automation library over the Chrome DevTools Protocol. Excluded from lint, format, and the test runner. Do not edit it as if it were first-party. |
+| `integration` | The browser-driving test harness: a `Browser`/`Page` wrapper over the Chrome DevTools Protocol, an `env` module of test knobs (target URL, headless toggle, per-run space name), and shell login helpers. Its own `test` task is a stub; the tests that use it live in other packages. |
+| `home-schemas` | Schemas for the "home" space. Exists specifically so that `runner` and `piece` can share schemas without importing each other — a deliberate shared leaf to break a cycle. |
+| `generated-patterns` | 296 machine-generated test patterns plus the harness that generates them (`ralph/`). |
+
+---
+
+## The repository task and CI surface
+
+- `tasks/check.sh` (`deno task check`) is the type-check gate. It pins Deno to
+  `>=2.8.0 <2.9.0` and type-checks an explicit set of directories with an 8 GB
+  V8 heap. `mise.toml` pins Deno to `2.8.1`; a wrong local Deno fails the gate
+  immediately.
+- `tasks/test.ts`, `tasks/integration.ts`, and `tasks/cfcheck.ts` are the test,
+  integration, and pattern-check runners, all of which shard in CI.
+- `.github/workflows/deno.yml` is the main CI: format check, lint,
+  `deno task check`, the workspace test fan-out (on a self-hosted runner that
+  installs FUSE and disables AppArmor for browser tests), and a four-way-sharded
+  `cfcheck`. Coverage, benchmarks, perf-regression, and deploy have their own
+  workflows.
+- `.githooks/pre-commit` runs `deno fmt` and `deno lint`, and refuses to commit
+  if there are unstaged tracked changes. Install it with
+  `deno task install-hooks`.
+
+---
+
+## Sharp edges collected on one page
+
+- Pattern authority is non-uniform; always check `index.md` Status tiers before
+  copying a pattern. Only `exemplar`-tier patterns are style references.
+- Deno is narrowly version-pinned; mismatches fail `deno task check` before any
+  real work runs.
+- The root `deno.jsonc` lint config still excludes one real, quarantined pattern
+  directory (`packages/patterns/record/`); the `fmt` config likewise excludes a
+  handful of `cf-chart`/`cf-toggle`/`cf-checkbox`/`cf-select` component files.
+  Those are intentional, not stale.
+
+A set of genuinely stale references this page used to list has since been
+cleaned up: the dangling `utils` `./integration` export was removed, `AGENTS.md`
+no longer points at a non-existent `deprecated-patterns` folder, and the
+`deno.jsonc` lint config no longer names a `patterns-saves-backup` directory or
+three deleted pattern files that were never present.

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -100,7 +100,7 @@ flowchart TB
     ports["read base ports from ports.json, apply PORT_OFFSET"]
     shell["start shell dev server (deno task dev-local)<br/>wait for 'Dev server listening' + HTTP 200"]
     toolshed["start toolshed (index.ts, --unstable-otel)<br/>wait for 'Server running' + /_health 200"]
-    bg["optional --bg-updater:<br/>start background-piece-service (polls every 60s)"]
+    bg["optional --bg-updater:<br/>start background-piece-service (reruns each piece every 60s)"]
 
     ports --> shell --> toolshed --> bg
 ```

--- a/docs/development/orientation/tooling-and-patterns.md
+++ b/docs/development/orientation/tooling-and-patterns.md
@@ -10,7 +10,7 @@ the skills system.
 
 ## `utils` is the universal leaf
 
-Everything depends on `utils`. It is imported by 302 files across the repo. Its
+Everything depends on `utils`. It is imported by 303 files across the repo. Its
 own `src/index.ts` deliberately **throws**, to force callers to import the
 specific subpath they need rather than the whole barrel.
 
@@ -18,7 +18,7 @@ specific subpath they need rather than the whole barrel.
 flowchart TB
     classDef leaf fill:#27ae60,stroke:#1e8449,color:#fff
     utils["utils (subpath-only)<br/>logger, defer, cache, deep-equal,<br/>base64url, bigint, arrays, types,<br/>sandbox-contract, async-local-store"]:::leaf
-    runner["runner (148 files)"]
+    runner["runner (149 files)"]
     datamodel["data-model (27 files)"]
     others["…every other package…"]
 


### PR DESCRIPTION
Adds docs/development/orientation/, a map of the Common Fabric monorepo for engineers who have never seen the codebase. It was assembled by reading the source in every package and by extracting the real cross-package import edges, rather than by restating intent.

Contents:

- README: the hub — the pace-layer model (mirroring AGENTS.md, including the support/test packages carved out of the numbered stack), the deployed runtime topology, the one reactive data-flow loop to memorize, and a glossary.
- dependency-graph: the measured cross-package import graph, the four production import cycles (runner-html, runner-memory, runner-llm, ui-shell), the layering violations, the god-files (the CFC write-policy gate is now the largest runtime file), and the full edge list with reference counts.
- runtime-core, storage-substrate, compile-pipeline, client-render, backend, cli-piece-fuse, tooling-and-patterns: deep-dive pages for each subsystem, each with its internal module map, control/data-flow diagrams, public surface, and technical-debt notes. Storage covers the offline state-inspector; the compile pipeline covers the Reactive authoring placeholder (formerly OpaqueRef).

Diagrams are Mermaid so they render in the repository and on GitHub. Dependency counts, package sizes, and cycles are empirical, extracted from source at the time of writing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new architecture orientation for new engineers with clear subsystem guides and a simplified dependency view, plus a single technical-debt register to track sharp edges. Docs now match current code paths (scheduler‑v2, storage, client/render, backend) without relying on brittle metrics.

- **Highlights**
  - New `docs/development/orientation/` hub with overview and deep‑dives for runtime (`runner`), storage, compile pipeline, client/render, backend, CLI/fs, and repo tooling; Mermaid diagrams render on GitHub.
  - Dependency view favors structure over counts: cycles and layering issues are called out; god‑files listed without line tallies; edges are an adjacency list.
  - Scheduler‑v2 documented in `runner/src/scheduler/` (facade re‑export), with the current invalidate/settle loop and value‑equality gate.
  - Subsystem docs expanded with sourced details: backend env/LLM gateway/OAuth, storage ERD and patch ops, compile pipeline stages and helpers, client VDom ops and iframe CSP/nesting, CLI/fs protocol and FUSE writeback FSM.
  - New `docs/development/TECHNICAL_DEBT.md` consolidates sharp edges and migrations; orientation pages now link here instead of carrying their own lists. Ports kept concrete (toolshed 8000, shell 5173, inspector 9229, OTEL 4318).

- **Bug Fixes**
  - Corrected flow and layering: storage write tx order and identity gate; watcher fan‑out is batched; `StorageManager` sits above `SpaceReplica`; render uses worker IPC; writeback triggers are flush‑on‑close and release; backend WS/LLM behaviors clarified.
  - Clarifications and accuracy fixes across docs: foundation vs leaf packages, cycle depth, fact model location, content‑addressing details, blob routes, CLI verbs/protocol dispatch, `CellController` import path, and background service cadence.

<sup>Written for commit f70dad5253b0c6f09a0de138e7caf565641fff09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

