### PR TITLE
test(lunch-poll): recover participant-identity-card coverage lost to …

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -174,6 +174,18 @@ positives and a less faithful, more gameable gate.
   the same line set whether or not it has a record) would make the numbers
   easier to trust.
 
+- Event-handler bodies are never covered by the pattern-unit gate. A JSX handler
+  such as `onClick={() => stream.send({})}` compiles to a handler that the
+  runtime materializes as an opaque reference, not a callable function. A pattern
+  unit test can walk the rendered tree to pull reactive computeds, but it cannot
+  fire that handler, because firing needs the runtime's event dispatch and
+  `cf test` has no DOM. So the statements inside every event handler count as
+  uncovered. A change that adds UI buttons therefore raises the group's
+  uncovered-line count by an amount no unit test can bring back down. Accept that
+  rise with a `NEW_PERF_BASELINE` marker (see
+  [CI_PERFORMANCE.md](CI_PERFORMANCE.md)); do not restructure the handler to move
+  the counter, because that changes wiring no test exercises.
+
 ## Related documentation
 
 - [TESTING.md](TESTING.md) — how to run the test suites whose execution this

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -1,6 +1,25 @@
-import { action, computed, Default, pattern, Writable } from "commonfabric";
+import { action, computed, Default, pattern, UI, Writable } from "commonfabric";
 import ParticipantIdentityCard from "./participant-identity-card.tsx";
 import type { User } from "./main.tsx";
+import {
+  findNode,
+  hasText,
+  propsOf,
+  readValue,
+} from "../test/vnode-helpers.ts";
+
+// Find a rendered node by a prop value. Walking the tree pulls the join
+// surface's UI-only computeds (showManualEntry, hasProfile, joinHint), which no
+// direct handler/output read reaches otherwise.
+const findByProp = (
+  root: unknown,
+  prop: string,
+  expected: unknown,
+): unknown | undefined =>
+  findNode(root, (node) => {
+    const props = propsOf(node);
+    return props !== undefined && readValue(props[prop]) === expected;
+  });
 
 export default pattern(() => {
   const users = new Writable<User[] | Default<[]>>([]);
@@ -48,6 +67,28 @@ export default pattern(() => {
     participantIdentity.isAdmin === false
   );
 
+  // With no profile resolved and nobody joined, the join surface shows the
+  // manual-name fallback: the text input and Join button render, the "First to
+  // join becomes the host." hint shows, and neither profile-first control (the
+  // "Use a different name" toggle nor the "Cancel" escape hatch) is present.
+  // Walking the tree materializes showManualEntry, hasProfile, and joinHint.
+  const assert_manual_fallback_renders = computed(() => {
+    const ui = participantIdentity[UI];
+    const input = findByProp(ui, "id", "lp-join-name");
+    const joinButton = findByProp(ui, "id", "lp-join-button");
+    const useDifferentName = findByProp(
+      ui,
+      "aria-label",
+      "Use a different name",
+    );
+    const cancel = findByProp(ui, "aria-label", "Use my profile name instead");
+    return input !== undefined &&
+      joinButton !== undefined &&
+      useDifferentName === undefined &&
+      cancel === undefined &&
+      hasText(ui, "First to join becomes the host.");
+  });
+
   const assert_empty_send_noop = computed(() =>
     users.get().length === 0 &&
     participantIdentity.me === "" &&
@@ -89,6 +130,7 @@ export default pattern(() => {
   return {
     tests: [
       { assertion: assert_initial },
+      { assertion: assert_manual_fallback_renders },
       { action: action_join_empty },
       { assertion: assert_empty_send_noop },
       { action: action_join_as_alex },

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -169,11 +169,9 @@ export default pattern<
     const profileDisplayName = computed(() =>
       trimmedName(profileNameWish.result ?? "")
     );
-    const hasProfile = computed(() =>
-      trimmedName(profileNameWish.result ?? "") !== ""
-    );
+    const hasProfile = computed(() => profileDisplayName !== "");
     const showManualEntry = computed(() =>
-      trimmedName(profileNameWish.result ?? "") === "" || useCustomName.get()
+      profileDisplayName === "" || useCustomName.get()
     );
 
     const me = computed(() => trimmedName(myName.get()));


### PR DESCRIPTION
…profile-first join

PR #4597 made the participant identity card's join surface profile-first: when a shared profile resolves it offers a one-click "Join as <name>", and the manual name input became a fallback. That added several reactive computeds and four button handlers, and it raised the "coverage-debt: packages/patterns" metric by seven uncovered lines. The pull request carried no baseline marker, so the ratchet absorbed the increase silently and the new code went untested.

The seven new uncovered lines were three reactive computeds (profileDisplayName, hasProfile, showManualEntry) and four onClick handler bodies. The computeds are only read by the join-surface UI, which the card's own test never rendered, so they were never pulled. The handler bodies are unreachable a different way: the pattern-unit test runner materializes an onClick as an opaque handler reference, not a callable, and it has no DOM to dispatch a click, so no unit test can execute them.

This recovers everything a pattern unit test can reach:

- Add an assertion that walks the card's rendered [UI] tree in the unjoined, no-profile state. Reading the reactive nodes pulls showManualEntry, hasProfile, and the pre-existing joinHint. The assertion also checks the behavior directly: the manual input and Join button render, the "First to join becomes the host." hint shows, and the profile-first controls stay hidden. It imports the shared test/vnode-helpers module instead of copying the tree walkers.

- Derive hasProfile and showManualEntry from the existing profileDisplayName computed instead of each re-running trimmedName(profileNameWish.result ?? ""). This removes the triplicated expression and routes a covered read through profileDisplayName, so the "Join as <name>" display computed is now exercised too. The comparison operates on the same trimmed string, so behavior is unchanged.

- Document in COVERAGE.md that event-handler bodies are structurally uncoverable by the pattern-unit gate, and that the way to accept the debt they add is a NEW_PERF_BASELINE marker rather than restructuring the handler to move the counter.

This brings the metric from 241847 back to 241841. The six lines that remain uncovered are all onClick handler bodies. The net one-line rise over the 241840 baseline is the four new button handlers minus the three joinHint lines this now covers; it is the irreducible portion, which a NEW_PERF_BASELINE marker on the merging pull request should accept.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores test coverage for the lunch-poll participant identity card after the profile-first join update. Adds a UI-walking test, simplifies computeds, and documents why click handlers stay uncovered; coverage returns to 241841.

- **Refactors**
  - Test: render and walk the card UI in the unjoined/no-profile state to pull `showManualEntry`, `hasProfile`, and `joinHint`; assert manual input and Join button show, profile-first controls stay hidden; use `../test/vnode-helpers.ts`.
  - Computeds: derive `hasProfile` and `showManualEntry` from `profileDisplayName` to remove duplicate `trimmedName(...)` calls and route a covered read.
  - Docs: note in `COVERAGE.md` that event-handler bodies aren’t coverable by pattern-unit tests; accept added debt via `NEW_PERF_BASELINE`.
  - Coverage: metric drops from 241847 to 241841; six lines remain uncovered (onClick handlers). Net +1 over the 241840 baseline to accept with a new baseline.

<sup>Written for commit b894744c021d1982f9c35328090a5af99fdc9697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

