### PR TITLE
Split CI Gantt bars by step phase using emoji markers

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -17,6 +17,10 @@ concurrency:
 env:
   BINARIES: "toolshed bg-piece-service cf"
 
+# Every step name must begin with a phase-marker emoji (setup / work / shutdown).
+# scripts/ci-gantt.ts reads that emoji to split each job bar by phase. See the
+# "Step phase markers" table in docs/development/CI_PERFORMANCE.md for the
+# vocabulary and which emoji belongs to which phase.
 jobs:
   # ---------------------------------------------------------------------------
   # Tier 0 – These jobs all start immediately with no dependencies
@@ -348,7 +352,7 @@ jobs:
           name: common-binaries
           path: common-binaries
 
-      - name: 🚀 Start Toolshed server for testing
+      - name: 🔌 Start Toolshed server for testing
         env:
           TOOLSHED_PORT: 8000
         run: |
@@ -449,7 +453,7 @@ jobs:
           name: common-binaries
           path: common-binaries
 
-      - name: 🚀 Start Toolshed server for testing
+      - name: 🔌 Start Toolshed server for testing
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
           TOOLSHED_URL: http://localhost:${{ matrix.toolshed_port }}
@@ -583,7 +587,7 @@ jobs:
           name: common-binaries
           path: common-binaries
 
-      - name: 🚀 Start Toolshed server for testing
+      - name: 🔌 Start Toolshed server for testing
         run: |
           chmod +x ./common-binaries/toolshed
           CFTS_AI_GATEWAY_URL="" \
@@ -991,7 +995,7 @@ jobs:
             ${{ steps.attest_cf.outputs.bundle-path }}
             ${{ steps.attest_tarball.outputs.bundle-path }}
 
-      - name: 🔍 Verify binary attestations
+      - name: 🔎 Verify binary attestations
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -1047,7 +1051,7 @@ jobs:
       - name: ⚙️ Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
 
-      - name: 🚀 Upload artifacts to Google Cloud Storage
+      - name: 📤 Upload artifacts to Google Cloud Storage
         run: |
           gsutil cp release/labs-${{ github.sha }}.tar.gz gs://commontools-build-artifacts/workspace-artifacts/
           gsutil cp release/labs-${{ github.sha }}.hash.txt gs://commontools-build-artifacts/workspace-artifacts/

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -62,6 +62,88 @@ Jobs and steps for a run:
 `GET /repos/commontoolsinc/labs/actions/runs/<run-id>/jobs?per_page=100` — each
 job and step carries `started_at` and `completed_at`.
 
+## Step Phase Markers
+
+`scripts/ci-gantt.ts` draws each job as a bar and splits that bar into three
+segments — setup, work, and shutdown — so the shared scaffolding around a job is
+visually separated from the job's own work. For a matrix job this shows, per
+shard, how much wall time is setup that every shard repeats versus the unique
+work that one shard does.
+
+The chart decides a step's phase from the emoji its name starts with. The emoji
+is the marker: the script never reads step wording, only the leading emoji. Every
+step we control — in `.github/workflows/*` and in the composite actions under
+`.github/actions/*` — must begin with a marker emoji from the table below, and
+each emoji belongs to exactly one phase. When you add a step, pick an emoji whose
+phase matches what the step does. When you add a genuinely new kind of step,
+choose a new emoji, then add it to both this table and the `PHASE_MARKERS` array
+in `scripts/ci-gantt.ts`, keeping the one-emoji-one-phase rule.
+
+**setup** — fetch code, install tools and dependencies, restore caches,
+authenticate, and bring test servers and devices up before the real work:
+
+| Emoji | Used for |
+| --- | --- |
+| 📥 | checkout, download inputs |
+| 🦕 | set up Deno |
+| 🔍 | verify the lock file and install, resolve refs |
+| 📦 | install packages, cache dependencies |
+| ♻️ | restore or save a build cache |
+| 🛡️ | relax the sandbox for browser tests |
+| 🔧 | enable a device |
+| ⚙️ | set up an external SDK |
+| 🔑 | authenticate to a cloud |
+| 🔌 | start a local server for tests |
+| ⏳ | wait for a service to be ready |
+| 💾 | restore or save a cache |
+| 🧮 | compute a cache identity |
+
+**work** — the job's actual purpose:
+
+| Emoji | Used for |
+| --- | --- |
+| 🔎 | checks (format, type, patterns, attestations) |
+| 🚧 | guard that fails the build on a banned pattern |
+| 🧪 | run tests |
+| 🧩 | run integration tests |
+| 🧹 | lint |
+| 🧭 | check skill facts |
+| 📄 | type-check docs |
+| 🏗️ | build binaries or assets |
+| 🏋️ | run benchmarks |
+| 📊 | produce performance metrics or status reports |
+| 🧬 | combine coverage |
+| 📝 | generate attestations |
+| 🔐 | sign binaries |
+| 🚀 | deploy |
+| 💬 | post a pull-request comment |
+
+**shutdown** — post-work reports, artifact uploads, log capture, teardown:
+
+| Emoji | Used for |
+| --- | --- |
+| 🧾 | write a coverage report |
+| 📤 | upload artifacts |
+| 📋 | capture logs on failure |
+
+A few markers were chosen so the phase stays unambiguous, which is worth knowing
+before you "correct" a step name back to a more obvious emoji:
+
+- 🚀 means deploy, which is work. A step that starts a local server for tests is
+  setup, so it uses 🔌 instead of 🚀. A step that uploads artifacts to cloud
+  storage is shutdown, so it uses 📤.
+- 🔍 means verify-then-install, which is setup. Verifying binary attestations is
+  work, so that step uses 🔎.
+- Downloading logs after a failure is shutdown, so those steps use 📋 rather than
+  the 📥 or 📦 download markers.
+
+The steps GitHub injects into every job — `Set up job`, `Post …`, and
+`Complete job` — carry no marker, so the script classifies them by name (setup
+for `Set up job`, shutdown for the other two). Any other step that reaches the
+chart without a recognized marker is counted as "other", drawn in gray, and
+listed on standard error when the script runs, so a missing marker is easy to
+find and fix.
+
 ## Root Test Job Shape
 
 The `Test (n/6)` jobs in `.github/workflows/deno.yml` run the root

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -9,19 +9,30 @@
 // The output is a PNG whose width scales with run length and whose height scales
 // with the number of jobs.
 //
+// Each median bar is split into "setup", "work" and "shutdown" segments so the
+// shared scaffolding around a job (checkout, tool install, cache restore,
+// coverage upload) is visually separated from the job's own work. For matrix
+// shards this shows how much of a shard's wall time is setup duplicated across
+// every shard versus the unique work that shard does. A step is placed into a
+// phase by the marker emoji its name starts with; the segment widths are the
+// median time spent in each phase, scaled to fill the median bar. The marker
+// vocabulary lives in docs/development/CI_PERFORMANCE.md ("Step phase markers")
+// and is mirrored in PHASE_MARKERS below.
+//
 // Usage:
 //   scripts/ci-gantt.ts [options]
 //     --repo OWNER/REPO     default commontoolsinc/labs
 //     --workflow FILE       default deno.yml
 //     --limit N             runs to fetch, default 100
-//     --out PATH            output PNG, default ci-gantt.png
+//     --out PATH            output file, default ci-gantt.png; a .svg path
+//                           writes the raw SVG instead of a rasterized PNG
 //     --scale N             raster scale factor, default 2
 //     --concurrency N       parallel job fetches, default 8
 //     --min-runs N          drop jobs seen in fewer than N runs (default: 10% of runs)
 //     --main-only           only fetch pushes to main, skipping pre-land PR runs
 //     --run-id ID           chart this workflow run ID, repeatable
 //     --theme NAME          color palette: "default" (light) or "dark"
-//     --colors JSON         override palette keys, e.g. '{"bar":"#6ea8fe"}'
+//     --colors JSON         override palette keys, e.g. '{"work":"#6ea8fe"}'
 
 const args = Deno.args;
 function opt(name: string, def: string): string {
@@ -176,12 +187,21 @@ interface Run {
   workflowName?: string;
 }
 
+interface Step {
+  name: string;
+  number: number;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
 interface Job {
   name: string;
   status: string;
   conclusion: string | null;
   started_at: string | null;
   completed_at: string | null;
+  steps?: Step[];
 }
 
 function hasTiming(job: Job): boolean {
@@ -189,6 +209,86 @@ function hasTiming(job: Job): boolean {
   const st = Date.parse(job.started_at);
   const en = Date.parse(job.completed_at);
   return Number.isFinite(st) && Number.isFinite(en) && en > st;
+}
+
+// ---------------------------------------------------------------------------
+// Step phases
+//
+// Every step is placed into a phase from the marker emoji its name begins with.
+// The emoji is load-bearing: workflow and composite-action authors pick one from
+// the vocabulary below, and the chart splits each job bar into these phases
+// without having to recognise step wording. The authoritative table is
+// docs/development/CI_PERFORMANCE.md ("Step phase markers"); keep them in sync.
+// A step whose name carries no known marker lands in "other" and is reported to
+// stderr so a missing marker is easy to spot. In a normal run the only unmarked
+// steps are the ones GitHub injects ("Set up job", "Post …", "Complete job"),
+// which are classified below by name because their wording is not ours to set.
+// ---------------------------------------------------------------------------
+
+type Phase = "setup" | "work" | "shutdown" | "other";
+
+// Chart order, left to right (matches the order steps run in). "other" trails so
+// an unmarked step stands out at the end of the bar.
+const PHASE_ORDER: Phase[] = ["setup", "work", "shutdown", "other"];
+
+// Marker emoji -> phase. Each emoji maps to exactly one phase; when a step's
+// natural emoji would land it in the wrong phase, the step name is changed to a
+// marker that fits (see docs/development/CI_PERFORMANCE.md). Matching ignores a
+// trailing variation selector, so the base emoji covers both the plain and the
+// selector-suffixed form of a glyph.
+const PHASE_MARKERS: [string, Phase][] = [
+  // setup: fetch code, install tools and dependencies, restore caches,
+  // authenticate, and bring test servers and devices up before the real work.
+  ["📥", "setup"], // checkout / download inputs
+  ["🦕", "setup"], // set up Deno
+  ["🔍", "setup"], // verify lock file & install, resolve refs
+  ["📦", "setup"], // install packages, cache dependencies
+  ["♻️", "setup"], // restore/save build caches
+  ["🛡️", "setup"], // relax sandbox for browser tests
+  ["🔧", "setup"], // enable devices
+  ["⚙️", "setup"], // set up external SDKs
+  ["🔑", "setup"], // authenticate to a cloud
+  ["🔌", "setup"], // start a local server for tests
+  ["⏳", "setup"], // wait for a service to be ready
+  ["💾", "setup"], // restore/save caches
+  ["🧮", "setup"], // compute a cache identity
+  // work: the job's actual purpose.
+  ["🔎", "work"], // checks (format, type, patterns, attestations)
+  ["🚧", "work"], // guard that fails the build on a banned pattern
+  ["🧪", "work"], // run tests
+  ["🧩", "work"], // run integration tests
+  ["🧹", "work"], // lint
+  ["🧭", "work"], // check skill facts
+  ["📄", "work"], // type-check docs
+  ["🏗️", "work"], // build binaries/assets
+  ["🏋️", "work"], // run benchmarks
+  ["📊", "work"], // produce performance metrics / status reports
+  ["🧬", "work"], // combine coverage
+  ["📝", "work"], // generate attestations
+  ["🔐", "work"], // sign binaries
+  ["🚀", "work"], // deploy
+  ["💬", "work"], // post a PR comment
+  // shutdown: post-work reports, artifact uploads, log capture, teardown.
+  ["🧾", "shutdown"], // write coverage report
+  ["📤", "shutdown"], // upload artifacts
+  ["📋", "shutdown"], // capture logs on failure
+];
+
+const stripVS = (s: string) => s.replace(/\uFE0F/g, "");
+
+function phaseOf(stepName: string): Phase {
+  const name = stepName.trim();
+  // A leading marker wins, so a step named "💬 Post …" is classified by its
+  // marker rather than the "Post " rule below.
+  const norm = stripVS(name);
+  for (const [emoji, phase] of PHASE_MARKERS) {
+    if (norm.startsWith(stripVS(emoji))) return phase;
+  }
+  // Steps GitHub injects carry no marker; their wording is not ours to set.
+  if (name.startsWith("Post ")) return "shutdown";
+  if (name === "Set up job") return "setup";
+  if (name === "Complete job") return "shutdown";
+  return "other";
 }
 
 const JOBS_PER_PAGE = 100;
@@ -232,6 +332,7 @@ interface JobAgg {
   dur: Stat; // seconds
   count: number;
   mainOnly: boolean; // never observed on a pull_request
+  phase: Record<Phase, number>; // median seconds spent in each phase
 }
 
 function shardKeyOf(name: string): string {
@@ -307,8 +408,17 @@ const jobsPerRun = await pool(completed, CONCURRENCY, async (run, i) => {
 // Accumulate timings keyed by exact job name (each shard is its own key).
 const acc = new Map<
   string,
-  { start: number[]; end: number[]; dur: number[]; events: Set<string> }
+  {
+    start: number[];
+    end: number[];
+    dur: number[];
+    events: Set<string>;
+    phase: Record<Phase, number[]>; // per-run seconds in each phase
+  }
 >();
+// Step names that carried no known marker, surfaced at the end so a missing
+// marker can be fixed.
+const unmarkedSteps = new Set<string>();
 
 for (const { run, jobs } of jobsPerRun) {
   const startCandidates = [
@@ -335,12 +445,42 @@ for (const { run, jobs } of jobsPerRun) {
     if (startOff < -5) continue;
     let e = acc.get(j.name);
     if (!e) {
-      acc.set(j.name, e = { start: [], end: [], dur: [], events: new Set() });
+      acc.set(
+        j.name,
+        e = {
+          start: [],
+          end: [],
+          dur: [],
+          events: new Set(),
+          phase: { setup: [], work: [], shutdown: [], other: [] },
+        },
+      );
     }
     e.start.push(startOff);
     e.end.push(endOff);
     e.dur.push(dur);
     e.events.add(run.event);
+    // Sum this run's step durations by phase, keyed off each step's marker.
+    const perPhase: Record<Phase, number> = {
+      setup: 0,
+      work: 0,
+      shutdown: 0,
+      other: 0,
+    };
+    for (const step of j.steps ?? []) {
+      if (!step.started_at || !step.completed_at) continue;
+      const ss = Date.parse(step.started_at);
+      const se = Date.parse(step.completed_at);
+      if (!(se > ss)) continue;
+      const p = phaseOf(step.name);
+      perPhase[p] += (se - ss) / 1000;
+      if (p === "other") unmarkedSteps.add(step.name);
+    }
+    // Only record a phase row when this run had step timing, so a run whose job
+    // came back without steps doesn't drag the medians toward zero.
+    if (PHASE_ORDER.some((p) => perPhase[p] > 0)) {
+      for (const p of PHASE_ORDER) e.phase[p].push(perPhase[p]);
+    }
   }
 }
 
@@ -350,6 +490,13 @@ const minRuns = MIN_RUNS_OVERRIDE ??
 const aggregates: JobAgg[] = [];
 for (const [name, e] of acc) {
   if (e.start.length < minRuns) continue;
+  const phase = { setup: 0, work: 0, shutdown: 0, other: 0 } as Record<
+    Phase,
+    number
+  >;
+  for (const p of PHASE_ORDER) {
+    phase[p] = e.phase[p].length ? stat(e.phase[p]).med : 0;
+  }
   aggregates.push({
     name,
     base: name.replace(/\s*\([^)]*\)\s*$/, ""),
@@ -363,7 +510,15 @@ for (const [name, e] of acc) {
     mainOnly: RUN_IDS.length || MAIN_ONLY
       ? false
       : !e.events.has("pull_request"),
+    phase,
   });
+}
+if (unmarkedSteps.size) {
+  console.error(
+    `${unmarkedSteps.size} step name(s) had no phase marker and were counted ` +
+      `as "other" (see docs/development/CI_PERFORMANCE.md "Step phase markers"):`,
+  );
+  for (const n of unmarkedSteps) console.error(`  - ${n}`);
 }
 if (aggregates.length === 0) {
   console.error("No jobs met the minimum run threshold; nothing to draw.");
@@ -441,9 +596,17 @@ interface Palette {
   sub: string;
   grid: string;
   axis: string;
-  bar: string;
-  main: string;
+  main: string; // main-branch-only bars
   whisker: string;
+  envelope: string; // neutral fill for the min-start..max-end range
+  // Phase segment colors. Work is the deep, saturated blue so the job's own work
+  // reads as the focus; the shared scaffolding around it — setup and shutdown
+  // — share one subtle teal so they recede together, leaving the work standing
+  // out between them. "other" marks a step whose name carried no phase marker.
+  setup: string;
+  work: string;
+  shutdown: string;
+  other: string;
 }
 const THEMES: Record<string, Palette> = {
   default: {
@@ -452,9 +615,13 @@ const THEMES: Record<string, Palette> = {
     sub: "#57606a",
     grid: "#e7e7e7",
     axis: "#8a8a8a",
-    bar: "#3f7fb8",
     main: "#8a897f",
     whisker: "#2a2a2a",
+    envelope: "#aab2bd",
+    setup: "#6ba7bd",
+    work: "#2f6fa8",
+    shutdown: "#6ba7bd",
+    other: "#c2c8cf",
   },
   dark: {
     bg: "#0d0e11",
@@ -462,18 +629,26 @@ const THEMES: Record<string, Palette> = {
     sub: "#9aa0ab",
     grid: "#23262d",
     axis: "#6a7079",
-    bar: "#5f9ae6",
     main: "#7c828c",
     whisker: "#8a93a5",
+    envelope: "#454b54",
+    setup: "#345f92",
+    work: "#5f9ae6",
+    shutdown: "#345f92",
+    other: "#5a616b",
   },
 };
 // --theme picks a base palette; --colors '<json>' then overrides individual keys.
 const C: Palette = { ...(THEMES[opt("theme", "default")] ?? THEMES.default) };
 const colorsArg = opt("colors", "");
 if (colorsArg) {
-  // Accept only hex/rgb values for known palette keys, so an override can't
-  // inject markup into the SVG or set a nonsense fill.
-  const COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$|^rgba?\([\d.,\s%]+\)$/;
+  // Accept only well-formed hex, rgb() and rgba() values for known palette keys,
+  // so an override can't inject markup into the SVG or set a nonsense fill. The
+  // rgb/rgba branches require three numeric components (plus an alpha for rgba)
+  // so a malformed body like "rgb(,,,)" is rejected and reported, not written
+  // into a fill as a color the renderer silently falls back from.
+  const COLOR_RE =
+    /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$|^rgb\(\s*\d{1,3}%?(?:\s*,\s*\d{1,3}%?){2}\s*\)$|^rgba\(\s*\d{1,3}%?(?:\s*,\s*\d{1,3}%?){2}\s*,\s*\d*\.?\d+%?\s*\)$/;
   try {
     const overrides = JSON.parse(colorsArg) as Record<string, unknown>;
     for (const k of Object.keys(C) as (keyof Palette)[]) {
@@ -510,26 +685,47 @@ function drawSection(title: string, jobs: JobAgg[]) {
   for (const j of jobs) {
     const top = y;
     const cy = top + BAR_H / 2;
-    const fill = j.mainOnly ? C.main : C.bar;
     const xs = x(j.start.min), xe = x(j.end.max);
 
     // envelope: full min-start to max-end extent
     body.push(
       `<rect x="${xs.toFixed(1)}" y="${top}" width="${
         Math.max(1, xe - xs).toFixed(1)
-      }" height="${BAR_H}" rx="2" fill="${fill}" fill-opacity="0.18"/>`,
+      }" height="${BAR_H}" rx="2" fill="${C.envelope}" fill-opacity="0.25"/>`,
     );
-    // median bar
+    // median bar, split into phase segments. Segment widths are the median time
+    // in each phase, scaled so they fill the median start-to-finish span.
     const mb = x(j.start.med), me = x(j.end.med);
-    body.push(
-      `<rect x="${mb.toFixed(1)}" y="${top}" width="${
-        Math.max(2, me - mb).toFixed(1)
-      }" height="${BAR_H}" rx="2" fill="${fill}"/>`,
-    );
+    const barW = Math.max(2, me - mb);
+    const segs = PHASE_ORDER
+      .map((p) => ({ p, sec: j.phase[p] }))
+      .filter((s) => s.sec > 0);
+    const phaseTotal = segs.reduce((sum, s) => sum + s.sec, 0);
+    if (phaseTotal > 0) {
+      let cum = 0;
+      let prevX = mb;
+      for (const s of segs) {
+        cum += s.sec;
+        const nextX = mb + (cum / phaseTotal) * barW;
+        body.push(
+          `<rect x="${prevX.toFixed(1)}" y="${top}" width="${
+            Math.max(0.5, nextX - prevX).toFixed(1)
+          }" height="${BAR_H}" fill="${C[s.p]}"/>`,
+        );
+        prevX = nextX;
+      }
+    } else {
+      // No step timing for this job: fall back to a plain work-colored bar.
+      body.push(
+        `<rect x="${mb.toFixed(1)}" y="${top}" width="${
+          barW.toFixed(1)
+        }" height="${BAR_H}" rx="2" fill="${C.work}"/>`,
+      );
+    }
     if (j.mainOnly) {
       body.push(
-        `<rect x="${xs.toFixed(1)}" y="${top}" width="${
-          Math.max(1, xe - xs).toFixed(1)
+        `<rect x="${mb.toFixed(1)}" y="${top}" width="${
+          barW.toFixed(1)
         }" height="${BAR_H}" rx="2" fill="url(#hatch)"/>`,
       );
     }
@@ -640,7 +836,11 @@ function legendBox(color: string, hatch: boolean, label: string) {
   );
   lx += 30 + label.length * 6.2;
 }
-legendBox(C.bar, false, "median bar");
+legendBox(C.setup, false, "setup / shutdown");
+legendBox(C.work, false, "work");
+if (aggregates.some((j) => j.phase.other > 0)) {
+  legendBox(C.other, false, "other (unmarked)");
+}
 if (mainJobs.length) legendBox(C.main, true, "main branch only");
 {
   const cyl = legendY - 4, a = lx, b = lx + 22;
@@ -688,7 +888,8 @@ const titleCount = RUN_IDS.length
   }`;
 const title = `${REPO} · ${workflowLabel} — ${titleScope} (${titleCount})`;
 const subtitle =
-  `Bars = median start to finish; whiskers = min/max; text = median (min–max) duration; ` +
+  `Bars = median start to finish, split into setup/work/shutdown by step; ` +
+  `whiskers = min/max; text = median (min–max) duration; ` +
   `${
     SUCCESS_ONLY ? "successful jobs only" : "all conclusions"
   }; ${runKind} finishes ~${clock(prFinish)} · generated ${date}`;
@@ -710,21 +911,28 @@ const svg = [
 ].join("\n");
 
 // ---------------------------------------------------------------------------
-// Rasterize to PNG
+// Write output: the raw SVG when --out ends in .svg, otherwise a rasterized PNG.
 // ---------------------------------------------------------------------------
 
-const { Resvg } = await import("npm:@resvg/resvg-js@2.6.2");
-const resvg = new Resvg(svg, {
-  fitTo: { mode: "zoom", value: SCALE },
-  font: { loadSystemFonts: true, defaultFontFamily: "Helvetica" },
-  background: "white",
-});
-const png = resvg.render().asPng();
-await Deno.writeFile(OUT, png);
-console.error(
-  `Wrote ${OUT} (${totalW}×${totalH} @ ${SCALE}x = ${
-    Math.round(totalW * SCALE)
-  }×${
-    Math.round(totalH * SCALE)
-  } px, ${png.length} bytes, ${aggregates.length} jobs)`,
-);
+if (OUT.toLowerCase().endsWith(".svg")) {
+  await Deno.writeTextFile(OUT, svg);
+  console.error(
+    `Wrote ${OUT} (${totalW}×${totalH} SVG, ${aggregates.length} jobs)`,
+  );
+} else {
+  const { Resvg } = await import("npm:@resvg/resvg-js@2.6.2");
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: "zoom", value: SCALE },
+    font: { loadSystemFonts: true, defaultFontFamily: "Helvetica" },
+    background: "white",
+  });
+  const png = resvg.render().asPng();
+  await Deno.writeFile(OUT, png);
+  console.error(
+    `Wrote ${OUT} (${totalW}×${totalH} @ ${SCALE}x = ${
+      Math.round(totalW * SCALE)
+    }×${
+      Math.round(totalH * SCALE)
+    } px, ${png.length} bytes, ${aggregates.length} jobs)`,
+  );
+}


### PR DESCRIPTION
scripts/ci-gantt.ts drew one solid bar per job, so there was no way to see how much of a matrix shard's wall time is the setup every shard repeats (checkout, tool install, cache restore) versus the work that is unique to that shard. The data was already available: the GitHub jobs API returns per-step start and finish times in the same response the script fetches, and the script simply dropped the steps array.

Each step is now bucketed into a phase and the median bar is drawn as stacked segments. Setup and shutdown, the shared scaffolding around a job, share one recessive color, and the job's own work uses the brighter main blue, so the work stands out between them. The exact shades come from the selected theme. Segment widths are the median time spent in each phase, normalized to fill the median start-to-finish span.

A step's phase comes only from the emoji its name starts with. The classifier never reads step wording, so adding a step needs no change to the script: the author picks a marker emoji whose phase fits. Each emoji maps to exactly one phase. To make that rule hold across the charted workflow, a few step names in deno.yml were changed so their emoji matches their phase: the deploy steps keep the rocket as work, while starting a test server uses a plug, uploading artifacts to cloud storage uses the upload marker, verifying attestations uses the check marker, and capturing logs on failure uses the clipboard marker. Renaming a step's name is display-only, because GitHub Actions references steps by id.

The convention is documented in docs/development/CI_PERFORMANCE.md under "Step phase markers", with the full emoji-to-phase table and the reason for the deliberate reassignments so the names are not changed back. The same table is mirrored in the PHASE_MARKERS array, and a comment above the jobs block in deno.yml points authors at the doc. Any step that reaches the chart without a recognized marker is drawn in gray as "other" and listed on standard error, so a missing marker is easy to find.

The phase and envelope colors are folded into the themeable palette that landed upstream, so they follow --theme and can be overridden with --colors like every other color. That override validation is also tightened here: its rgb/rgba branch only checked the parenthesized body's character set, so a malformed value such as "rgb(,,,)" was accepted and written into a fill where the renderer silently falls back to a default; it now requires three numeric rgb components plus an alpha for rgba and reports anything malformed.

Also: an --out path ending in .svg now writes the raw SVG instead of a rasterized PNG, which gives a compact, scalable output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits CI Gantt bars into setup, work, and shutdown segments based on leading emoji markers in step names, making setup overhead vs unique work easy to see per shard. Also adds SVG output, theme-aware phase colors with stricter `--colors` validation, and updates docs and workflow step markers.

- **New Features**
  - `scripts/ci-gantt.ts`: Buckets steps by phase from the leading emoji and draws stacked median segments; unmarked steps render as “other” and are listed on stderr.
  - Theme: Adds envelope and per-phase colors; tightens `--colors` hex/rgb/rgba validation; legend reflects phases.
  - Output: `--out` ending in `.svg` writes raw SVG; otherwise PNG.
  - Docs: Adds “Step phase markers” table and guidance in `docs/development/CI_PERFORMANCE.md`.

- **Migration**
  - Step names should start with a phase-marker emoji; unmarked steps appear gray and are logged. See the doc for the emoji-to-phase table.
  - Workflow updates: 🔌 to start test servers (was 🚀), 📤 to upload artifacts (was 🚀), 🔎 to verify attestations (was 🔍). Deploy keeps 🚀.
  - For new step types, add the emoji to the doc and to `PHASE_MARKERS` in `scripts/ci-gantt.ts`.

<sup>Written for commit 4ebeba774cee54ba4e92237e1ef54a22f0c0e80d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

