### PR TITLE
test(toolshed): close the memory-server singleton the storage tests open

### DIFF
--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { afterAll, afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import createApp from "@/lib/create-app.ts";
 import router from "./blobs.index.ts";
@@ -30,6 +30,14 @@ const blobUploadEncoding = new JsonEncodingContext();
 describe("Blob Routes", () => {
   afterEach(async () => {
     await memoryServer.flushSessions();
+  });
+
+  afterAll(async () => {
+    // The toolshed `memoryServer` is a module-level singleton constructed when
+    // memory.ts is imported. Deno isolates each test file's module graph, so
+    // this instance is owned by this file alone. Closing it releases its SQLite
+    // handles, engine map, and refresh timer.
+    await memoryServer.close();
   });
 
   it("stores and serves a FabricBytes blob by content id", async () => {

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1333,3 +1333,12 @@ serialTest(
     }
   },
 );
+
+// Registered last so it runs after every case above. Per-test `idle()` only
+// drains the singleton's refresh timer; its SQLite engine handles and read-pool
+// connections stay open until `close()`. Deno isolates each test file's module
+// graph, so this instance is owned by this file alone. Closing it here releases
+// those handles.
+serialTest("memory websocket server releases its resources", async () => {
+  await memoryServer.close();
+});


### PR DESCRIPTION
`packages/toolshed/routes/storage/memory.ts` constructs a live memory server at module load and exports it as the `memoryServer` singleton. Any test that imports this module, directly or transitively, gets that server. Deno gives each test file its own module graph, so the instance belongs to whichever file imported it. Two test files actually drive traffic through the server and so open real resources against it: the blob-route tests write documents (opening the per-space SQLite engines), and the memory-websocket tests exercise the full request path. Neither closed the server, leaving its SQLite engine handles, read-pool connections, and engine map open until the test process exited.

Close the server once each of these files has finished with it. The blob-route tests are BDD-style, so this is an `afterAll` that awaits `memoryServer.close()`. The memory-websocket tests use `Deno.test` through a serial-queue wrapper rather than BDD hooks, so the close is a final test registered last in the file; the serial queue and Deno's in-file source ordering both guarantee it runs after every prior case. `Server.close()` cancels the refresh timer, drains any in-flight refresh, closes every engine and the read pool, and clears the engine and connection maps, so this releases everything the server can hold. Calling the per-test `idle()` drain after close is a no-op, because close has already cleared the timer and settled the refresh promise.

The other importers are left alone because their server never opens anything: the `Server` constructor only stores its options (engines, the read pool, and the timer are all created lazily on first use), so a constructed-but-unused singleton holds no operating-system resources. That covers the memory-dump route test, which imports the module only to read the store URL, and the ingest and webhook route tests, which pull the module in through the app entry point but never touch memory storage.

Verified by running the two affected suites under Deno's leak detector (`deno test --trace-leaks`): both pass with no resource- or op-leak warnings and unchanged behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close the in-memory storage server in tests that use it to prevent leaked SQLite handles and timers. This stabilizes the blob and memory websocket suites and removes leak warnings.

- **Bug Fixes**
  - In `packages/toolshed/routes/blobs/blobs.test.ts`, add `afterAll` to call `memoryServer.close()` once the suite finishes.
  - In `packages/toolshed/routes/storage/memory/memory.test.ts`, add a final `serialTest` that calls `memoryServer.close()` to release engines and the read pool.
  - Verified with `deno test --trace-leaks`: no resource/op leaks and no behavior changes.

<sup>Written for commit e51023510646ce8e86172b3c21f77a003cad9814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

