### PR TITLE
fix(memory): make reconnect backoff cancellable without polling a flag

### DIFF
--- a/docs/development/waitfor-migration.md
+++ b/docs/development/waitfor-migration.md
@@ -289,3 +289,47 @@ already-listening server, and on reconnect the subscriber re-issues its watch
 against the fresh server, which reads current committed state — so the update is
 delivered whether the write lands before or after the reconnect completes. The
 sleeps were removed with no replacement wait.
+
+## Production reconnect backoff (evaluated separately)
+
+Removing those post-restart test sleeps drew attention to a retry loop in
+production code that sits right next to them: `MemoryClient.reconnect()` in
+`packages/memory/v2/client.ts`. When the websocket to the memory server drops,
+the client loops. It re-runs the `hello` handshake and re-opens every mounted
+space's session, and when an attempt fails it waits a short, growing delay
+before trying again. A retry loop with a sleep is exactly the shape the rest of
+this note works to remove, so it was evaluated on its own terms rather than
+changed in passing. The conclusion is that the delay is a legitimate exception,
+and it is recorded here.
+
+The connection attempt itself is already event-driven. `hello()` calls
+`transport.send()`, which opens the websocket. The websocket transport
+(`WebSocketTransport` in `packages/runner/src/storage/v2-remote-session.ts`)
+resolves the open on the real `open` event and rejects it on the real `error`
+or `close` event. The client never polls to discover whether a connection
+attempt has succeeded; it awaits the transport event. So on the success path
+there is no timer standing in for a missing event.
+
+The delay is only the pause between one failed attempt and the next, and that
+pause cannot be replaced by awaiting an event, because there is no event to
+await. A server that is down or restarting is, from the client's point of view,
+just a host that refuses the connection. When the host refuses, the websocket
+`error` event fires almost immediately. Nothing tells the client when the server
+has come back. The only way to find out is to try to connect again. Without a
+delay between attempts the loop would open a socket, receive an instant error,
+and open another socket as fast as the event loop allows, which is a busy loop
+hammering the host. The growing backoff — 25 milliseconds doubling to a
+30-second cap, with up to 20 percent jitter — is the honest way to keep checking
+whether the server is back without flooding it. It is the same shape as the
+committed-write backoff described in `committed-write-backpressure.md`, where a
+capped exponential backoff also stands in for a retry that has no event to wait
+on.
+
+One part of the old code was a genuine poll, and it has been removed. The wait
+between attempts used to run in a loop that slept in 25-millisecond chunks and
+re-checked a `closed` flag between chunks, so that closing the client during a
+backoff would end the wait within 25 milliseconds instead of after the full
+delay. That chunked re-check was a poll on the flag. It is now a single timer
+that `close()` cancels directly, so a client closed mid-backoff settles at once
+and nothing wakes on an interval. The backoff delay between attempts stays; only
+the polling that implemented its cancellation is gone.

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -2753,6 +2753,60 @@ Deno.test("memory v2 client close interrupts long reconnect backoff", async () =
   }
 });
 
+// Answers the first `hello` and leaves every later one hanging: no reply and no
+// close event. A reconnect triggered by `disconnect()` then parks the loop
+// inside the handshake rather than in a backoff wait.
+class HandshakeHangReconnectTransport implements Transport {
+  helloCount = 0;
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  disconnect(): void {
+    this.#closeReceiver(new Error("disconnect"));
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as { type: string };
+    if (message.type === "hello") {
+      this.helloCount += 1;
+      if (this.helloCount === 1) {
+        this.#receiver(encodeMemoryBoundary(HELLO_OK));
+      }
+      return Promise.resolve();
+    }
+    throw new Error(`Unhandled handshake-hang message: ${message.type}`);
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+Deno.test("memory v2 client close ends a reconnect parked in the handshake", async () => {
+  const transport = new HandshakeHangReconnectTransport();
+  const client = await connect({ transport });
+
+  // Drop the connection. The reconnect loop sends a fresh `hello` that gets no
+  // reply, so it is parked awaiting the handshake, with no backoff timer armed.
+  transport.disconnect();
+  await Promise.resolve();
+  assertEquals(transport.helloCount, 2);
+
+  // Closing rejects the in-flight handshake. The loop then reaches the backoff
+  // step with the client already closed, which returns without arming a timer,
+  // so the close settles through microtasks.
+  await client.close();
+  assertEquals(client.isConnected(), false);
+});
+
 Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
   let receiver = (_payload: string) => {};
   const transport: Transport = {

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -2741,20 +2741,12 @@ Deno.test("memory v2 client close interrupts long reconnect backoff", async () =
     await time.runMicrotasks();
     assertEquals(transport.helloCount, 3);
 
-    let closed = false;
-    const closePromise = client.close().then(() => {
-      closed = true;
-    });
-    await time.runMicrotasks();
-
-    await time.tickAsync(24);
-    assertEquals(closed, false);
-
-    await time.tickAsync(1);
-    await time.runMicrotasks();
-    assertEquals(closed, true);
-
-    await closePromise;
+    // The client is now parked in a 50ms reconnect backoff. Closing cancels
+    // that wait at once, so the close settles through microtasks with the
+    // clock held still. Were the backoff required to elapse, awaiting the
+    // close under fake time would hang, since nothing ticks its timer.
+    await client.close();
+    assertEquals(transport.helloCount, 3);
   } finally {
     Math.random = originalRandom;
     time.restore();

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -74,8 +74,6 @@ export interface WatchMutationResult {
 const RECONNECT_BASE_DELAY_MS = 25;
 const RECONNECT_MAX_DELAY_MS = 30_000;
 const RECONNECT_JITTER_RATIO = 0.2;
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 const reconnectDelayMs = (attempt: number): number => {
   const baseDelay = Math.min(
@@ -110,6 +108,7 @@ export class Client {
   #sessionOpenAuthContext: SessionOpenAuthContext | null = null;
   #serverFlags: MemoryProtocolFlags | null = null;
   #reconnecting: Promise<void> | null = null;
+  #cancelReconnectDelay: (() => void) | null = null;
   #connected = false;
   #closed = false;
 
@@ -136,6 +135,7 @@ export class Client {
   async close(): Promise<void> {
     this.#closed = true;
     this.#connected = false;
+    this.#cancelReconnectDelay?.();
     this.rejectPending(new Error("memory client closed"));
     await Promise.all([...this.#spaces].map((space) => space.close()));
     this.#spaces.clear();
@@ -409,14 +409,26 @@ export class Client {
     }
   }
 
-  private async waitForReconnectDelay(delayMs: number): Promise<void> {
-    for (
-      let remaining = delayMs;
-      remaining > 0 && !this.#closed;
-      remaining -= RECONNECT_BASE_DELAY_MS
-    ) {
-      await sleep(Math.min(RECONNECT_BASE_DELAY_MS, remaining));
+  // The reconnect attempt is event-driven: `hello()` awaits the transport's
+  // real open/error/close. The pause between a failed attempt and the next
+  // runs on a timer, since a returning server raises no event to await. The
+  // delay bounds the retry rate, and `close()` ends it through the stored
+  // canceller.
+  private waitForReconnectDelay(delayMs: number): Promise<void> {
+    if (this.#closed) {
+      return Promise.resolve();
     }
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.#cancelReconnectDelay = null;
+        resolve();
+      }, delayMs);
+      this.#cancelReconnectDelay = () => {
+        clearTimeout(timer);
+        this.#cancelReconnectDelay = null;
+        resolve();
+      };
+    });
   }
 
   private rejectPending(error: Error): void {


### PR DESCRIPTION
The memory v2 client reconnects to the server by looping: it re-runs the `hello` handshake, re-opens every mounted space's session, and on failure waits a growing delay before the next attempt. The wait between attempts used to run as a loop that slept in 25-millisecond chunks and re-checked the client's `closed` flag between chunks. The only reason for the chunking was to notice a close mid-wait, so that closing the client during a backoff would end the wait within 25 milliseconds rather than after the full delay, which grows to a 30-second cap. That chunked re-check was a poll on the flag: it woke every 25 milliseconds during every backoff purely to test a boolean.

Replace it with a single timer that `close()` cancels directly. The client now holds a canceller for the in-flight backoff wait. `close()` invokes it, which clears the timer and resolves the wait, so a client closed mid-backoff settles at once with no repeated wake-up.

The backoff delay between attempts is unchanged. That delay is the honest mechanism for retrying against a server that is down or restarting, which raises no event when it returns, so the loop discovers the server is back by attempting a fresh connection and the delay bounds how often it retries. The connection attempt itself was already event-driven and stays so: `hello()` sends over the transport, whose websocket implementation resolves on the real `open` event and rejects on `error` or `close`. No timer stands in for a missing event on the success path; only the polling that cancelled the delay is gone.

Update the "close interrupts long reconnect backoff" test, which asserted the old 25-millisecond close latency, to assert the stronger guarantee: a close mid-backoff settles through microtasks with the fake clock held still.

Also record this finding in the waitfor-migration note, whose "Also noticed" section first flagged this production loop while removing the bare post-restart test sleeps. The note explains why the backoff is a legitimate exception to the project's avoid-timeouts-retries-sleeps policy: the connection attempt is already event-driven, and the only sleep is the inter-attempt backoff, which cannot be made event-driven because a returning server raises no event to await. The capped exponential backoff is the honest mechanism, in the same spirit as the committed-write backoff already documented in the repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the reconnect backoff poll in the memory v2 client with a single cancellable timer. Closing the client during backoff now settles immediately, while backoff timing and retry behavior stay the same.

- **Bug Fixes**
  - Removed 25ms chunked sleep/flag polling; added a stored canceller and a closed fast path so `waitForReconnectDelay()` returns immediately; `close()` cancels the timer in `packages/memory/v2/client.ts`.
  - Expanded tests to assert microtask-only close both during backoff and when reconnect is parked in the handshake (no timer), without advancing fake time.
  - Documented the rationale and exception to the no-sleeps policy in `docs/development/waitfor-migration.md`.

<sup>Written for commit 45f9f0814c460ada6742e61c472a74089098877c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

