### PR TITLE
docs: add cfcPrefixProvenanceStats to the experimental-flags registry

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -20,11 +20,12 @@ in the same change.
 > flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
 > record, so the history stays discoverable.
 
-**Last reviewed:** 2026-07-08.
+**Last reviewed:** 2026-07-09. Each flag's section carries the date its status
+was last checked against the code.
 
 ## Summary table
 
-| Flag | Toggle via | Default today | Originally added by | Planned end state | Status (2026-07-08) |
+| Flag | Toggle via | Default today | Originally added by | Planned end state | Status |
 |------|-----------|---------------|---------------------|-------------------|---------------------|
 | [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
@@ -35,6 +36,7 @@ in the same change.
 | [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
 | [`cfcTriggerReadGating`](#cfctriggerreadgating) | `RuntimeOptions.cfcTriggerReadGating` | `false` | Bernhard Seefeld (#4488) | move toward `true` | implemented, staged rollout |
 | [`cfcPolicyEvaluation`](#cfcpolicyevaluation) | `RuntimeOptions.cfcPolicyEvaluation` | `off` | Bernhard Seefeld (#4566) | move toward `enforce` | implemented, staged rollout |
+| [`cfcPrefixProvenanceStats`](#cfcprefixprovenancestats) | `RuntimeOptions.cfcPrefixProvenanceStats` (per-deployment; not env-wired) | `false` | Bernhard Seefeld (#4623) | stays a measurement opt-in; fold in or remove after Stage 0 | implemented, off by default, measurement only |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
@@ -323,6 +325,35 @@ the per-epic implementation notes).
 - **Status on 2026-07-08.** Implemented and in staged rollout.
 - **Path to removal.** Once policy evaluation is the norm, the dial could settle
   on `enforce` and be retired.
+
+### `cfcPrefixProvenanceStats`
+
+- **Toggle via.** `RuntimeOptions.cfcPrefixProvenanceStats` (a plain boolean).
+  Pinned off in the shared `coreOptions`; it is a per-deployment measurement
+  opt-in, not env-wired.
+- **Added by.** Bernhard Seefeld, in "D4 write-prefix precision counters
+  (value-level provenance stage 0, SC-24)" (#4623, 2026-07-09).
+- **Purpose.** Measurement only, and the one dial here that does not affect
+  enforcement. When on, each prepared transaction that has at least one
+  protected write records per-prepare precision counters into `getCfcStats()`:
+  gated-read counts per protected write (prefix versus transaction-global),
+  bound-source classifications, and S7-exemption fires. Enforcement decisions
+  are byte-identical whether it is on or off. It exists to gather the "measure
+  before building" data described in
+  [`docs/specs/cfc-value-level-provenance.md`](../specs/cfc-value-level-provenance.md)
+  §6, which the project needs before deciding whether to build the larger
+  value-level provenance narrowing (its "T1").
+- **Current default and planned end state.** `false` by default; off skips all
+  measurement for a single presence check. There is no plan to graduate it to
+  on across the fleet — it is a diagnostic that a deployment turns on to collect
+  precision data.
+- **Status on 2026-07-09.** Implemented, off by default. Covered by
+  `packages/runner/test/cfc-prefix-provenance-stats.test.ts`.
+- **Path to removal.** Once the Stage 0 measurement has informed the
+  value-level-provenance decision (build the narrowing, or not — the entry
+  criteria are deliberately unscheduled in the spec's §8), the counters either
+  fold into that feature or are removed. Because enforcement is unaffected,
+  retiring it is low-risk.
 
 > The related `RuntimeOptions` fields `cfcSinkMaxConfidentiality`,
 > `cfcPolicyRecords`, and `cfcTrustConfig` are CFC *configuration inputs* (the

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -328,9 +328,11 @@ the per-epic implementation notes).
 
 ### `cfcPrefixProvenanceStats`
 
-- **Toggle via.** `RuntimeOptions.cfcPrefixProvenanceStats` (a plain boolean).
-  Pinned off in the shared `coreOptions`; it is a per-deployment measurement
-  opt-in, not env-wired.
+- **Toggle via.** `RuntimeOptions.cfcPrefixProvenanceStats` (a plain boolean),
+  not env-wired. The presets do not pin it: like every CFC dial except the
+  enforcement mode, it is left out of the shared `coreOptions` and rides the
+  `Runtime` constructor default of `false` until a deployment sets it. The
+  preset classification table marks it `core-default (off)`.
 - **Added by.** Bernhard Seefeld, in "D4 write-prefix precision counters
   (value-level provenance stage 0, SC-24)" (#4623, 2026-07-09).
 - **Purpose.** Measurement only, and the one dial here that does not affect


### PR DESCRIPTION
The experimental-flags registry landed without an entry for cfcPrefixProvenanceStats, because the runtime option was added by a separate change (D4 write-prefix precision counters, value-level provenance stage 0, SC-24) that had not yet merged when the registry did. This documents it.

cfcPrefixProvenanceStats is a boolean, off by default, and is the one dial in the Contextual Flow Control group that does not affect enforcement: when on, each prepared transaction with a protected write records per-prepare precision counters (gated-read counts per write, bound-source classifications, exemption fires) for later inspection, and enforcement decisions are byte-identical either way. It is a "measure before building" diagnostic that the value-level provenance design turns on per deployment to decide whether the larger narrowing work is worth building, so it has no path to fleet-wide graduation and folds in or is removed once that decision is made. Its dedicated test passes.

The change also moves the registry's single review date to a per-section convention: the summary table's status column is no longer stamped with one date, and each flag's section carries the date its status was last checked, so a later flag addition does not force re-dating every section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cfcPrefixProvenanceStats` to the experimental-flags registry and switches the registry to per-flag review dates. The flag is measurement-only and off by default (not env-wired or coreOptions-pinned; it rides the `Runtime` constructor default); it records precision counters for protected writes and does not affect enforcement.

<sup>Written for commit 60c92f650918293f7f42a9a1f6b33ec28eea88e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

