### PR TITLE
cli: replace mounted-callable stat poll with a directory-listing fall…

### DIFF
--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -1,6 +1,6 @@
 import type { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
-import { dirname, join, relative, resolve } from "@std/path";
+import { basename, dirname, join, relative, resolve } from "@std/path";
 import {
   type MountedCallablePath,
   parseMountedCallablePath,
@@ -51,6 +51,7 @@ export interface ExecDependencies {
     manager: CallableManagerLike,
     pieceId: string,
   ) => Promise<CallablePieceLike>;
+  stat?: (path: string) => Promise<Deno.FileInfo>;
   timeoutMs?: number;
   uuid?: () => string;
   waitForResult?: (
@@ -114,32 +115,40 @@ async function readMountedPieceMeta(
   };
 }
 
-async function assertMountedCallableFileExists(absPath: string): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    let stat: Deno.FileInfo;
-    try {
-      stat = await Deno.stat(absPath);
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        if (attempt < 19) {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          continue;
-        }
-        throw new Error(`Mounted callable file not found: ${absPath}`);
-      }
-      throw error;
-    }
-
-    if (stat.isFile) {
+async function assertMountedCallableFileExists(
+  absPath: string,
+  stat: (path: string) => Promise<Deno.FileInfo> = Deno.stat,
+): Promise<void> {
+  try {
+    if ((await stat(absPath)).isFile) {
       return;
     }
-
-    if (attempt < 19) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      continue;
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
     }
-    throw new Error(`Mounted callable file not found: ${absPath}`);
+    // While the fuse bridge rebuilds a piece prop it clears the subtree and
+    // re-hydrates it on demand, and FUSE-T cannot push cache invalidations
+    // to the kernel, so a stat during that window reports NotFound for a
+    // callable file that exists. The parent directory listing is answered
+    // by the bridge after hydration, so it names every callable file that
+    // exists; a file missing from the listing does not exist. The listing
+    // entry's type flags come from the same cached attributes as the stat,
+    // so a name match counts as existence unless the entry is a directory.
+    const name = basename(absPath);
+    try {
+      for await (const entry of Deno.readDir(dirname(absPath))) {
+        if (entry.name === name && !entry.isDirectory) {
+          return;
+        }
+      }
+    } catch (dirError) {
+      if (!(dirError instanceof Deno.errors.NotFound)) {
+        throw dirError;
+      }
+    }
   }
+  throw new Error(`Mounted callable file not found: ${absPath}`);
 }
 
 export async function resolveMountedCallableFile(
@@ -167,7 +176,7 @@ export async function resolveMountedCallableFile(
     throw new Error(`Path is not a mounted callable file: ${absPath}`);
   }
 
-  await assertMountedCallableFileExists(canonicalAbsPath);
+  await assertMountedCallableFileExists(canonicalAbsPath, deps.stat);
   const pieceMeta = await readMountedPieceMeta(canonicalAbsPath, callablePath);
   const manager = deps.loadManager
     ? await deps.loadManager({

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -52,6 +52,8 @@ export interface ExecDependencies {
     pieceId: string,
   ) => Promise<CallablePieceLike>;
   stat?: (path: string) => Promise<Deno.FileInfo>;
+  readDir?: (path: string) => AsyncIterable<Deno.DirEntry>;
+  delay?: (ms: number) => Promise<void>;
   timeoutMs?: number;
   uuid?: () => string;
   waitForResult?: (
@@ -115,10 +117,40 @@ async function readMountedPieceMeta(
   };
 }
 
+// The macOS NFS client serves a cached parent directory listing without a
+// daemon round-trip for up to about three seconds after the directory was
+// last listed. A listing miss is only authoritative once that validity
+// window has passed since the miss was first observed, so this wait must
+// exceed the window; it includes margin over the observed three seconds.
+const DIR_LISTING_RECHECK_DELAY_MS = 3500;
+
+async function parentListingHasFile(
+  absPath: string,
+  readDir: (path: string) => AsyncIterable<Deno.DirEntry>,
+): Promise<boolean> {
+  const name = basename(absPath);
+  try {
+    for await (const entry of readDir(dirname(absPath))) {
+      if (entry.name === name && !entry.isDirectory) {
+        return true;
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+  return false;
+}
+
 async function assertMountedCallableFileExists(
   absPath: string,
-  stat: (path: string) => Promise<Deno.FileInfo> = Deno.stat,
+  deps: ExecDependencies = {},
 ): Promise<void> {
+  const stat = deps.stat ?? Deno.stat;
+  const readDir = deps.readDir ?? Deno.readDir;
+  const delay = deps.delay ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   try {
     if ((await stat(absPath)).isFile) {
       return;
@@ -130,22 +162,21 @@ async function assertMountedCallableFileExists(
     // While the fuse bridge rebuilds a piece prop it clears the subtree and
     // re-hydrates it on demand, and FUSE-T cannot push cache invalidations
     // to the kernel, so a stat during that window reports NotFound for a
-    // callable file that exists. The parent directory listing is answered
-    // by the bridge after hydration, so it names every callable file that
-    // exists; a file missing from the listing does not exist. The listing
-    // entry's type flags come from the same cached attributes as the stat,
-    // so a name match counts as existence unless the entry is a directory.
-    const name = basename(absPath);
-    try {
-      for await (const entry of Deno.readDir(dirname(absPath))) {
-        if (entry.name === name && !entry.isDirectory) {
-          return;
-        }
-      }
-    } catch (dirError) {
-      if (!(dirError instanceof Deno.errors.NotFound)) {
-        throw dirError;
-      }
+    // callable file that exists: the NFS client's negative name cache keeps
+    // answering NotFound long after the bridge has the file again. A parent
+    // directory listing that reaches the bridge is answered after hydration
+    // and names every callable file that exists. The listing entry's type
+    // flags come from the same cached attributes as the stat, so a name
+    // match counts as existence unless the entry is a directory.
+    if (await parentListingHasFile(absPath, readDir)) {
+      return;
+    }
+    // The listing can itself be served from a client cache that predates
+    // the file. Wait out the cache validity window and consult the listing
+    // once more; a second miss means the file does not exist.
+    await delay(DIR_LISTING_RECHECK_DELAY_MS);
+    if (await parentListingHasFile(absPath, readDir)) {
+      return;
     }
   }
   throw new Error(`Mounted callable file not found: ${absPath}`);
@@ -176,7 +207,7 @@ export async function resolveMountedCallableFile(
     throw new Error(`Path is not a mounted callable file: ${absPath}`);
   }
 
-  await assertMountedCallableFileExists(canonicalAbsPath, deps.stat);
+  await assertMountedCallableFileExists(canonicalAbsPath, deps);
   const pieceMeta = await readMountedPieceMeta(canonicalAbsPath, callablePath);
   const manager = deps.loadManager
     ? await deps.loadManager({

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -117,11 +117,16 @@ async function readMountedPieceMeta(
   };
 }
 
-// The macOS NFS client serves a cached parent directory listing without a
+// FUSE-T serves mounts through the macOS NFS client and ignores the entry
+// and attribute cache timeouts the filesystem implementation returns, so
+// the fuse bridge cannot shorten or disable the client's caching from its
+// side. The NFS client answers a negative name lookup from its cache for
+// tens of seconds, and serves a cached parent directory listing without a
 // daemon round-trip for up to about three seconds after the directory was
-// last listed. A listing miss is only authoritative once that validity
-// window has passed since the miss was first observed, so this wait must
-// exceed the window; it includes margin over the observed three seconds.
+// last listed. A listing miss is therefore only authoritative once that
+// validity window has passed since the miss was first observed, so this
+// wait must exceed the window; it includes margin over the observed three
+// seconds.
 const DIR_LISTING_RECHECK_DELAY_MS = 3500;
 
 async function parentListingHasFile(

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -850,6 +850,7 @@ describe("mounted callable resolution and execution", () => {
     const pieceDir = join(mountpoint, "home/pieces/notes-2");
     const filePath = join(pieceDir, "result", "search.tool");
     await Deno.mkdir(join(pieceDir, "result"), { recursive: true });
+    await Deno.writeTextFile(filePath, "");
     await Deno.writeTextFile(
       join(pieceDir, "meta.json"),
       JSON.stringify({
@@ -880,16 +881,25 @@ describe("mounted callable resolution and execution", () => {
     });
     await writeLiveMountState(stateDir, mountpoint);
 
-    setTimeout(() => {
-      void Deno.writeTextFile(filePath, "");
-    }, 50);
-
+    // The file exists, but stat reports NotFound the way a stale FUSE-T
+    // kernel cache does while the bridge rebuilds the prop subtree. The
+    // resolver falls back to the parent directory listing, which names
+    // the file.
+    const statCalls: string[] = [];
     const resolved = await resolveMountedCallableFile(filePath, {
       stateDir,
       loadManager: () => Promise.resolve(harness.manager),
       loadPiece: () => Promise.resolve(harness.piece),
+      stat: (path) => {
+        statCalls.push(path);
+        return Promise.reject(
+          new Deno.errors.NotFound(`stat '${path}': invalidated`),
+        );
+      },
     });
 
+    expect(statCalls.length).toBe(1);
+    expect(statCalls[0].endsWith(join("result", "search.tool"))).toBe(true);
     expect(resolved.absPath).toBe(filePath);
     expect(resolved.pieceId).toBe("of:piece-123");
   });

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -836,13 +836,24 @@ describe("mounted callable resolution and execution", () => {
 
     await writeLiveMountState(stateDir, mountpoint);
 
+    const delays: number[] = [];
     await expect(
       resolveMountedCallableFile(filePath, {
         stateDir,
         loadManager: () => Promise.resolve(harness.manager),
         loadPiece: () => Promise.resolve(harness.piece),
+        delay: (ms) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
       }),
     ).rejects.toThrow(/mounted callable file not found/i);
+
+    // One bounded wait to outlast the directory listing cache, then failure.
+    // The macOS NFS client serves cached listings for up to ~3s, so the
+    // wait must exceed that for the recheck to reach the daemon.
+    expect(delays.length).toBe(1);
+    expect(delays[0]).toBeGreaterThan(3000);
   });
 
   it("tolerates transient mounted callable ENOENT during FUSE invalidation", async () => {
@@ -900,6 +911,71 @@ describe("mounted callable resolution and execution", () => {
 
     expect(statCalls.length).toBe(1);
     expect(statCalls[0].endsWith(join("result", "search.tool"))).toBe(true);
+    expect(resolved.absPath).toBe(filePath);
+    expect(resolved.pieceId).toBe("of:piece-123");
+  });
+
+  it("consults the parent listing again after a stale cached listing", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const pieceDir = join(mountpoint, "home/pieces/notes-2");
+    const filePath = join(pieceDir, "result", "search.tool");
+    await Deno.mkdir(join(pieceDir, "result"), { recursive: true });
+    await Deno.writeTextFile(filePath, "");
+    await Deno.writeTextFile(
+      join(pieceDir, "meta.json"),
+      JSON.stringify({
+        id: "of:piece-123",
+        entityId: "of:piece-123",
+        name: "Fixture Piece",
+      }),
+    );
+    const harness = createExecHarness({
+      callableKind: "tool",
+      cellProp: "result",
+      cellKey: "search",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+        resultSchema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+        },
+      },
+    });
+    await writeLiveMountState(stateDir, mountpoint);
+
+    // stat reports NotFound and the first parent listing is served from a
+    // cache that predates the file; only the listing taken after the cache
+    // validity window names it.
+    const readDirCalls: string[] = [];
+    const delays: number[] = [];
+    const resolved = await resolveMountedCallableFile(filePath, {
+      stateDir,
+      loadManager: () => Promise.resolve(harness.manager),
+      loadPiece: () => Promise.resolve(harness.piece),
+      stat: (path) =>
+        Promise.reject(new Deno.errors.NotFound(`stat '${path}': invalidated`)),
+      readDir: (path) => {
+        readDirCalls.push(path);
+        return readDirCalls.length === 1
+          ? (async function* (): AsyncIterable<Deno.DirEntry> {})()
+          : Deno.readDir(path);
+      },
+      delay: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    expect(readDirCalls.length).toBe(2);
+    expect(delays.length).toBe(1);
     expect(resolved.absPath).toBe(filePath);
     expect(resolved.pieceId).toBe("of:piece-123");
   });


### PR DESCRIPTION
…back

resolveMountedCallableFile guarded against fabricated callable paths by polling Deno.stat up to 20 times with 50ms sleeps, tolerating the transient NotFound that a stale FUSE-T kernel cache reports while the fuse bridge clears and re-hydrates a piece prop subtree. The poll put a one-second upper bound on success: an invalidation window that outlasted the budget failed an invocation that would have succeeded, a genuinely missing file burned a full second before erroring, and each retry re-asked the same cached question that had just returned the stale answer.

Replace the loop with a single stat plus a parent-directory-listing fallback. FUSE-T cannot push kernel cache invalidations, but a readdir goes back to the bridge, which answers after re-hydrating the prop subtree, so the listing names every callable file that exists. A name absent from the listing means the file does not exist, and the check fails immediately with the same diagnostic. The listing entry's type flags come from the same cached attribute channel that produced the stale NotFound, so a name match counts as existence unless the entry is reported as a directory.

A Deno.watchFs-based wait was considered and rejected: FUSE-T mounts are NFS translations where daemon-side rehydration emits no local filesystem events, so a watcher would never fire for the window it is meant to cover, and an event-driven wait cannot terminate for a genuinely absent file without reintroducing a deadline.

The companion test previously created the callable file from a 50ms setTimeout and raced the resolver's poll budget under CPU contention. It now keeps the file on disk throughout and injects a stat through the new optional ExecDependencies.stat hook that reports NotFound, simulating the stale-cache window deterministically, and asserts a single stat call to pin the no-retry behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the mounted callable existence check with a single `Deno.stat` and a parent `Deno.readDir` fallback, with one recheck after the listing cache window. This removes the 1s polling loop, avoids false “not found” on FUSE-T/macOS NFS caches, and only delays genuine misses once before failing.

- **Bug Fixes**
  - On `Deno.errors.NotFound`, read the parent directory; a matching non-directory entry counts as existence.
  - If both `stat` and the first listing miss, wait ~3.5s to outlast macOS NFS cached listings, then list again before erroring.
  - Added optional `ExecDependencies.stat`, `readDir`, and `delay`; tests pin a single `stat` call, both listing consultations, and the one bounded wait.

<sup>Written for commit 520be022c56b6a57d85556afe35eb03989e7acb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

