### PR TITLE
feat(patterns): add topics — a multi-user tracker over #topic pieces (CT-1878)

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -189,6 +189,51 @@ addPiece.send({ piece: ann });
 
 ---
 
+## `topics/main.tsx`
+
+**Topics — a multi-user tracker over #topic pieces** (durable units of shared
+attention; CT-1878): title, living body document, flat chronological comment
+thread, typed links out. Deliberately minimal — no statuses, labels, or
+assignees. Demonstrates: reading-list-style piece-in-list composition, `PerUser`
+display-name on a shared piece, mergeable comment appends, session- scoped
+drafts, `multiUserTest` coverage.
+
+**Keywords:** topics, issues, tracker, discussion, thread, comments, multi-user,
+PerUser, mergeable
+
+### Input Schema
+
+```ts
+interface TopicsInput {
+  topics?: Writable<TopicPiece[] | Default<[]>>;
+  myName?: PerUser<Writable<string | Default<"">>>;
+}
+```
+
+### Output Schema
+
+```ts
+interface TopicsOutput {
+  topics: TopicPiece[];
+  mentionable: TopicPiece[];
+  topicCount: number;
+  myName: string;
+  addTopic: Stream<{ title: string }>;
+  setMyName: Stream<{ name: string }>;
+}
+```
+
+## `topics/topic.tsx`
+
+A single #topic piece: the durable object the tracker's list holds. Body edits
+go through an explicit Edit→Save toggle (one whole-value `set` per save keeps
+the concurrent-edit window small); comments and links are mergeable appends. Use
+from `topics/main.tsx` via `navigateTo()`, or standalone.
+
+**Keywords:** topic, detail, thread, comment, links, body, navigateTo
+
+---
+
 ## `agent/agent.tsx`
 
 An agent piece — autonomous worker with directive, learned state, and run

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -195,7 +195,7 @@ addPiece.send({ piece: ann });
 attention; CT-1878): title, living body document, flat chronological comment
 thread, typed links out. Deliberately minimal — no statuses, labels, or
 assignees. Demonstrates: reading-list-style piece-in-list composition, `PerUser`
-display-name on a shared piece, mergeable comment appends, session- scoped
+display-name on a shared piece, mergeable comment appends, session-scoped
 drafts, `multiUserTest` coverage.
 
 **Keywords:** topics, issues, tracker, discussion, thread, comments, multi-user,

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -1,0 +1,42 @@
+# Topics
+
+A multi-user tracker over **#topic** pieces — durable units of shared attention.
+A topic is a title, a **living body document** (durable conclusions get folded
+up into the body; the thread holds the deliberation), a flat chronological
+comment thread, and typed links out to other core objects (PRs, agent sessions,
+other topics — URLs in v0).
+
+Deliberately absent until reached for: statuses (not even open/closed), labels,
+assignees, attachments, nesting. What a topic grows next is part of the
+experiment.
+
+This is the first wedge of Common Fabric's internal dogfooding program — the
+team's own issue-tracker replacement, built on the platform it tracks. The
+project's live design record is the "Build Topics v0" topic itself (bootstrap
+lineage: Linear CT-1878, which this pattern exists to absorb).
+
+## Design commitments
+
+- **Wish-free handlers.** Nothing gates event dispatch on a `wish()` binding
+  (unresolved wish bindings drop events silently — CT-1879). Authorship is a
+  fallback chain: `myName` snapshot at write → identity → profile enrichment
+  later, when the cross-host profile story lands.
+- **Mergeable writes everywhere users collide**: comments, links, and topics are
+  `push` appends; concurrent writers all land. The body is a large string
+  (whole-value conflict semantics), so body edits go through an explicit
+  Edit→Save toggle rather than a live-bound textarea.
+- **`myName` is `PerUser` on the shared piece** — one tracker, one name per
+  authenticated identity, shared with every topic the tracker creates.
+- Verified by `multi-user.test.tsx` (two isolated runtimes, one shared board).
+
+## Headless / agent use
+
+Agents are first-class participants. Against a deployed board piece:
+
+```bash
+cf piece call --piece <board> setMyName '{"name":"Fable"}'
+cf piece call --piece <board> addTopic '{"title":"..."}'
+cf piece get  --piece <board> topics --input      # then address a topic piece
+cf piece call --piece <topic> addComment '{"body":"..."}'
+cf piece step --piece <...>                       # after mutations
+```

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -1,0 +1,179 @@
+import {
+  action,
+  computed,
+  Default,
+  NAME,
+  navigateTo,
+  pattern,
+  type PerUser,
+  safeDateNow,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+import Topic, {
+  asArray,
+  snippet,
+  type TopicPiece,
+  TOPICS_THEME,
+  whenLabel,
+} from "./topic.tsx";
+
+// Re-export the shared types for consumers and tests.
+export type {
+  TopicComment,
+  TopicInput,
+  TopicLink,
+  TopicLinkKind,
+  TopicOutput,
+  TopicPiece,
+} from "./topic.tsx";
+
+export interface TopicsInput {
+  topics?: Writable<TopicPiece[] | Default<[]>>;
+  /** The viewer's display name, set once per user and shared with every topic
+   * this tracker creates ("commenting as"). */
+  myName?: PerUser<Writable<string | Default<"">>>;
+}
+
+/**
+ * Topics — a tracker over #topic pieces: durable units of shared attention
+ * (CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics
+ * sort by last activity. Replaces Linear / GitHub issues / loose process docs
+ * for the team; PR workflows stay in GitHub and arrive here as links.
+ */
+export interface TopicsOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  topics: TopicPiece[];
+  mentionable: TopicPiece[];
+  topicCount: number;
+  /** The viewer's display name (normalized to "" until set). */
+  myName: string;
+  addTopic: Stream<{ title: string }>;
+  setMyName: Stream<{ name: string }>;
+}
+
+export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
+  const newTitle = new Writable.perSession("");
+
+  const addTopic = action(({ title }: { title: string }) => {
+    const trimmed = (title ?? "").trim();
+    if (!trimmed) return;
+    const piece = Topic({
+      title: trimmed,
+      createdAt: safeDateNow(),
+      createdByName: myName.get().trim() || "someone",
+      myName,
+    });
+    // Mergeable append: concurrent creates from different users all land.
+    topics.push(piece);
+    newTitle.set("");
+  });
+
+  const setMyName = action(({ name }: { name: string }) => {
+    myName.set((name ?? "").trim());
+  });
+
+  // Normalized snapshot: a never-written PerUser cell reads as undefined in
+  // other runtimes; assertions need a real, stable value.
+  const myNameView = computed(() => myName.get() ?? "");
+
+  const topicCount = computed(() => asArray(topics.get()).length);
+
+  const sortedTopics = computed(() =>
+    asArray(topics.get())
+      .filter((t) => t)
+      .toSorted((a, b) => (b?.lastActivityAt ?? 0) - (a?.lastActivityAt ?? 0))
+  );
+
+  const hasNoTopics = computed(() => sortedTopics.length === 0);
+
+  return {
+    [NAME]: computed(() => `Topics (${asArray(topics.get()).length})`),
+    [UI]: (
+      <cf-theme theme={TOPICS_THEME}>
+        <cf-screen>
+          <cf-vstack slot="header" gap="2" padding="4">
+            <cf-hstack justify="between" align="center">
+              <cf-vstack gap="0">
+                <cf-heading level={3}>Topics</cf-heading>
+                <cf-text variant="caption" tone="muted">
+                  {topicCount} topics · durable units of shared attention
+                </cf-text>
+              </cf-vstack>
+              <cf-field label="Commenting as" style="width: 180px;">
+                <cf-input $value={myName} placeholder="Your name" />
+              </cf-field>
+            </cf-hstack>
+          </cf-vstack>
+
+          <cf-vstack gap="2" padding="4">
+            {computed(() =>
+              sortedTopics.map((topic) => (
+                <cf-card>
+                  <cf-hstack gap="3" align="center">
+                    <cf-vstack gap="0" style="flex: 1; min-width: 0;">
+                      <cf-text block style="font-weight: 600;">
+                        {topic.title || "(untitled topic)"}
+                      </cf-text>
+                      {topic.body
+                        ? (
+                          <cf-text tone="muted" block truncate>
+                            {snippet(topic.body, 120)}
+                          </cf-text>
+                        )
+                        : null}
+                      <cf-text variant="caption" tone="muted">
+                        {topic.commentCount} comments · by{" "}
+                        {topic.createdByName || "someone"} ·{" "}
+                        {whenLabel(topic.lastActivityAt)}
+                      </cf-text>
+                    </cf-vstack>
+                    <cf-button
+                      variant="secondary"
+                      onClick={() => navigateTo(topic)}
+                    >
+                      Open
+                    </cf-button>
+                  </cf-hstack>
+                </cf-card>
+              ))
+            )}
+
+            {hasNoTopics
+              ? (
+                <cf-empty-state message="No topics yet. Start the first one below." />
+              )
+              : null}
+          </cf-vstack>
+
+          <cf-vstack slot="footer" gap="2" padding="4">
+            <cf-hstack gap="2" align="end">
+              <cf-field label="New topic" style="flex: 1;">
+                <cf-input
+                  $value={newTitle}
+                  placeholder="What deserves shared attention?"
+                />
+              </cf-field>
+              <cf-button
+                variant="primary"
+                onClick={() => addTopic.send({ title: newTitle.get() })}
+              >
+                Start
+              </cf-button>
+            </cf-hstack>
+          </cf-vstack>
+        </cf-screen>
+      </cf-theme>
+    ),
+    topics,
+    mentionable: topics,
+    topicCount,
+    myName: myNameView,
+    addTopic,
+    setMyName,
+  };
+});

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -2,6 +2,7 @@ import {
   action,
   computed,
   Default,
+  handler,
   NAME,
   navigateTo,
   pattern,
@@ -52,9 +53,22 @@ export interface TopicsOutput {
   topicCount: number;
   /** The viewer's display name (normalized to "" until set). */
   myName: string;
+  /** Session-local draft for the footer composer (exposed for embedding and
+   * headless driving, like the chat exemplar's drafts). */
+  newTitle: Writable<string>;
   addTopic: Stream<{ title: string }>;
   setMyName: Stream<{ name: string }>;
+  /** Submit the footer composer: reads newTitle, delegates to addTopic. */
+  submitTopic: Stream<void>;
 }
+
+/** Row navigation, bound per topic card. Module-scope handler (not an inline
+ * closure) so embedders and tests can bind and drive it directly. */
+export const openTopic = handler<void, { topic: TopicPiece }>(
+  (_, { topic }) => {
+    navigateTo(topic);
+  },
+);
 
 export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
   const newTitle = new Writable.perSession("");
@@ -65,7 +79,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     const piece = Topic({
       title: trimmed,
       createdAt: safeDateNow(),
-      createdByName: myName.get().trim() || "someone",
+      createdByName: (myName.get() ?? "").trim() || "someone",
       myName,
     });
     // Mergeable append: concurrent creates from different users all land.
@@ -75,6 +89,10 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
 
   const setMyName = action(({ name }: { name: string }) => {
     myName.set((name ?? "").trim());
+  });
+
+  const submitTopic = action(() => {
+    addTopic.send({ title: newTitle.get() });
   });
 
   // Normalized snapshot: a never-written PerUser cell reads as undefined in
@@ -134,7 +152,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
                     </cf-vstack>
                     <cf-button
                       variant="secondary"
-                      onClick={() => navigateTo(topic)}
+                      onClick={openTopic({ topic })}
                     >
                       Open
                     </cf-button>
@@ -158,10 +176,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
                   placeholder="What deserves shared attention?"
                 />
               </cf-field>
-              <cf-button
-                variant="primary"
-                onClick={() => addTopic.send({ title: newTitle.get() })}
-              >
+              <cf-button variant="primary" onClick={submitTopic}>
                 Start
               </cf-button>
             </cf-hstack>
@@ -173,7 +188,9 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     mentionable: topics,
     topicCount,
     myName: myNameView,
+    newTitle,
     addTopic,
     setMyName,
+    submitTopic,
   };
 });

--- a/packages/patterns/topics/multi-user.test.tsx
+++ b/packages/patterns/topics/multi-user.test.tsx
@@ -1,0 +1,140 @@
+/// <cts-enable />
+/**
+ * Multi-user pattern test for Topics (CT-1878).
+ *
+ * One shared Topics board across two worker-isolated runtimes. Covers the
+ * board's core multi-user promises:
+ * - per-user display-name isolation (`myName` is PerUser: one shared piece,
+ *   two identities, two values),
+ * - concurrent comment appends from different users both land (mergeable
+ *   `push` — no clobbering),
+ * - topics created by either user propagate to the other, with authorship
+ *   snapshots (`createdByName`, `authorName`) taken at write time.
+ *
+ * Cross-runtime reads use INLINE literal accesses (topics[0].comments[0]) —
+ * `.map()`, loop-variable indexing, and helper calls over another runtime's
+ * arrays do not resolve before a local write (see lunch-poll and scrabble
+ * multi-user tests).
+ */
+import { action, computed, multiUserTest, pattern } from "commonfabric";
+import Topics, { type TopicsOutput } from "./main.tsx";
+
+interface Setup {
+  board: TopicsOutput;
+}
+
+export const setup = pattern(() => ({
+  board: Topics({}),
+}));
+
+export const gideon = pattern<{ setup: Setup }>(({ setup }) => {
+  const board = setup.board;
+
+  const action_set_name = action(() => {
+    board.setMyName.send({ name: "Gideon" });
+  });
+  const action_start_topic = action(() => {
+    board.addTopic.send({ title: "First topic" });
+  });
+  const action_comment = action(() => {
+    const topic = board.topics?.[0];
+    if (topic) topic.addComment.send({ body: "opening the thread" });
+  });
+
+  const assert_named = computed(() => board.myName === "Gideon");
+
+  const assert_topic_created = computed(() =>
+    (board.topics ?? []).length === 1 &&
+    board.topics?.[0]?.title === "First topic" &&
+    board.topics?.[0]?.createdByName === "Gideon"
+  );
+
+  const assert_own_comment = computed(() =>
+    board.topics?.[0]?.comments?.[0]?.authorName === "Gideon" &&
+    board.topics?.[0]?.comments?.[0]?.body === "opening the thread" &&
+    board.topics?.[0]?.commentCount === 1
+  );
+
+  // Fable commented on my topic and started a second topic; my identity is
+  // untouched by Fable's name (PerUser isolation).
+  const assert_sees_fable = computed(() =>
+    board.topics?.[0]?.comments?.[1]?.authorName === "Fable" &&
+    board.topics?.[0]?.commentCount === 2 &&
+    (board.topics ?? []).length === 2 &&
+    board.topics?.[1]?.createdByName === "Fable" &&
+    board.myName === "Gideon"
+  );
+
+  return {
+    tests: [
+      { action: action_set_name },
+      { assertion: assert_named },
+      { action: action_start_topic },
+      { assertion: assert_topic_created },
+      { action: action_comment },
+      { assertion: assert_own_comment },
+      { label: "gideon-commented" },
+      { await: "fable-done" },
+      { assertion: assert_sees_fable },
+    ],
+  };
+});
+
+export const fable = pattern<{ setup: Setup }>(({ setup }) => {
+  const board = setup.board;
+
+  const action_set_name = action(() => {
+    board.setMyName.send({ name: "Fable" });
+  });
+  const action_comment = action(() => {
+    const topic = board.topics?.[0];
+    if (topic) topic.addComment.send({ body: "seconding this" });
+  });
+  const action_start_second = action(() => {
+    board.addTopic.send({ title: "Second topic" });
+  });
+
+  // Gideon's topic + comment propagated from his runtime.
+  const assert_sees_gideon_setup = computed(() =>
+    (board.topics ?? []).length === 1 &&
+    board.topics?.[0]?.title === "First topic" &&
+    board.topics?.[0]?.comments?.[0]?.authorName === "Gideon" &&
+    board.topics?.[0]?.commentCount === 1
+  );
+
+  // PerUser isolation: Gideon's name must not leak into this identity.
+  const assert_not_named_yet = computed(() => board.myName === "");
+
+  const assert_named = computed(() => board.myName === "Fable");
+
+  // Both comments landed (mergeable append, no clobber), in thread order.
+  const assert_both_comments = computed(() =>
+    board.topics?.[0]?.commentCount === 2 &&
+    board.topics?.[0]?.comments?.[0]?.authorName === "Gideon" &&
+    board.topics?.[0]?.comments?.[1]?.authorName === "Fable" &&
+    board.topics?.[0]?.comments?.[1]?.body === "seconding this"
+  );
+
+  const assert_second_topic = computed(() =>
+    (board.topics ?? []).length === 2 &&
+    board.topics?.[1]?.title === "Second topic" &&
+    board.topics?.[1]?.createdByName === "Fable"
+  );
+
+  return {
+    tests: [
+      { await: "gideon-commented" },
+      { assertion: assert_sees_gideon_setup },
+      { assertion: assert_not_named_yet },
+      { action: action_set_name },
+      { assertion: assert_named },
+      { action: action_comment },
+      { assertion: assert_both_comments },
+      { action: action_start_second },
+      { assertion: assert_second_topic },
+      { label: "fable-done" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { gideon, fable } });

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -1,0 +1,443 @@
+import {
+  action,
+  computed,
+  Default,
+  NAME,
+  pattern,
+  type PerUser,
+  safeDateNow,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+// ===== Shared types =====
+
+export type TopicLinkKind = "pr" | "topic" | "session" | "web";
+
+export interface TopicComment {
+  /** Snapshot taken at write time (profile enrichment comes later; never gate
+   * authorship on a profile wish — CT-1879). Comments carry no minted id:
+   * array elements have stable entity identity; future editing addresses
+   * elements by reference (`equals()`), not by a synthetic key. */
+  authorName: string | Default<"">;
+  body: string | Default<"">;
+  sentAt: number | Default<0>;
+}
+
+export interface TopicLink {
+  kind: TopicLinkKind | Default<"web">;
+  url: string | Default<"">;
+  label: string | Default<"">;
+}
+
+export interface TopicInput {
+  title?: Writable<string | Default<"">>;
+  /** The topic's living document: durable conclusions get folded up into the
+   * body; the comment thread below holds the deliberation. */
+  body?: Writable<string | Default<"">>;
+  comments?: Writable<TopicComment[] | Default<[]>>;
+  links?: Writable<TopicLink[] | Default<[]>>;
+  createdAt?: number | Default<0>;
+  createdByName?: string | Default<"">;
+  /** The viewer's display name. Per-user: each authenticated identity gets its
+   * own value on the same shared piece. The tracker passes its cell down so one
+   * name covers the whole board. */
+  myName?: PerUser<Writable<string | Default<"">>>;
+}
+
+/**
+ * A #topic — a durable unit of shared attention: a title, a living body
+ * document, a flat chronological comment thread, and typed links out to other
+ * core objects (PRs, agent sessions, other topics). Deliberately has no
+ * status, labels, or assignees; what a topic grows next is part of the
+ * experiment (CT-1878).
+ */
+export interface TopicOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  title: string;
+  body: string;
+  comments: TopicComment[];
+  links: TopicLink[];
+  createdAt: number;
+  createdByName: string;
+  commentCount: number;
+  /** Max of createdAt and the newest comment — the tracker sorts by this. */
+  lastActivityAt: number;
+  addComment: Stream<{ body: string }>;
+  addLink: Stream<{ kind: TopicLinkKind; url: string; label: string }>;
+  setBody: Stream<{ body: string }>;
+}
+
+/** The shape stored in the tracker's list. */
+export type TopicPiece = TopicOutput;
+
+// ===== Shared theme (calm editorial light) =====
+
+export const TOPICS_THEME = {
+  fontFamily: "'Iowan Old Style', 'Palatino', 'Georgia', serif",
+  borderRadius: "0.5rem",
+  density: "comfortable" as const,
+  colorScheme: "light" as const,
+  colors: {
+    primary: "#31572c",
+    primaryForeground: "#fdfcf8",
+    background: "#fdfcf8",
+    surface: "#f6f3ea",
+    text: "#26241f",
+    textMuted: "#7d7767",
+    border: "#e4dfd1",
+    accent: "#a4531f",
+    accentForeground: "#fdfcf8",
+  },
+};
+
+// ===== Pure helpers =====
+
+/** Safely coerce a reactive array read to an array (intermediate updates can
+ * momentarily yield a non-array). Same guard as reading-list. */
+export const asArray = <T,>(v: readonly T[] | T[]): T[] =>
+  Array.isArray(v) ? v as T[] : [];
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/** Label derived purely from the stored timestamp — never from the current
+ * clock — so it stays idempotent inside computeds (lunch-poll idiom). */
+export const whenLabel = (ts: number): string => {
+  if (!ts) return "";
+  const d = new Date(ts);
+  const hh = d.getHours().toString().padStart(2, "0");
+  const mm = d.getMinutes().toString().padStart(2, "0");
+  return `${MONTHS[d.getMonth()]} ${d.getDate()}, ${hh}:${mm}`;
+};
+
+export const snippet = (text: string, max: number): string => {
+  const t = (text ?? "").trim().replace(/\s+/g, " ");
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+};
+
+const LINK_KIND_ITEMS = [
+  { label: "Web", value: "web" },
+  { label: "PR", value: "pr" },
+  { label: "Topic", value: "topic" },
+  { label: "Agent session", value: "session" },
+];
+
+// ===== The pattern =====
+
+export default pattern<TopicInput, TopicOutput>(
+  ({ title, body, comments, links, createdAt, createdByName, myName }) => {
+    // Session-local UI state (new-tab test: none of this should carry over).
+    const commentDraft = new Writable.perSession("");
+    const editingBody = new Writable.perSession(false);
+    const bodyDraft = new Writable.perSession("");
+    const linkUrlDraft = new Writable.perSession("");
+    const linkLabelDraft = new Writable.perSession("");
+    const linkKindDraft = new Writable.perSession<TopicLinkKind>("web");
+
+    // --- Streams (external API; also usable headlessly via CLI) ---
+
+    const addComment = action(({ body: text }: { body: string }) => {
+      const trimmed = (text ?? "").trim();
+      if (!trimmed) return;
+      // Mergeable append: concurrent comments from different users all land.
+      comments.push({
+        authorName: myName.get().trim() || "someone",
+        body: trimmed,
+        sentAt: safeDateNow(),
+      });
+    });
+
+    const addLink = action(
+      ({ kind, url, label }: {
+        kind: TopicLinkKind;
+        url: string;
+        label: string;
+      }) => {
+        const trimmedUrl = (url ?? "").trim();
+        if (!trimmedUrl) return;
+        links.push({
+          kind: kind ?? "web",
+          url: trimmedUrl,
+          label: (label ?? "").trim() || trimmedUrl,
+        });
+      },
+    );
+
+    const setBody = action(({ body: text }: { body: string }) => {
+      body.set(text ?? "");
+    });
+
+    // --- UI-side actions (close over session drafts) ---
+
+    const submitComment = action(() => {
+      const text = commentDraft.get();
+      if (!text.trim()) return;
+      addComment.send({ body: text });
+      commentDraft.set("");
+    });
+
+    const startEditBody = action(() => {
+      bodyDraft.set(body.get());
+      editingBody.set(true);
+    });
+
+    const saveBody = action(() => {
+      // One whole-value set per explicit save keeps the conflict window small;
+      // a live-bound textarea on a shared string would conflict per keystroke.
+      body.set(bodyDraft.get());
+      editingBody.set(false);
+    });
+
+    const cancelEditBody = action(() => {
+      editingBody.set(false);
+    });
+
+    const submitLink = action(() => {
+      const url = linkUrlDraft.get();
+      if (!url.trim()) return;
+      addLink.send({
+        kind: linkKindDraft.get(),
+        url,
+        label: linkLabelDraft.get(),
+      });
+      linkUrlDraft.set("");
+      linkLabelDraft.set("");
+      linkKindDraft.set("web");
+    });
+
+    // --- Derived values ---
+
+    const commentCount = computed(() => asArray(comments.get()).length);
+
+    const lastActivityAt = computed(() => {
+      const newest = asArray(comments.get())
+        .reduce((max, c) => Math.max(max, c?.sentAt ?? 0), 0);
+      return Math.max(createdAt ?? 0, newest);
+    });
+
+    const commentsView = computed(() =>
+      asArray(comments.get())
+        .filter((c) => c)
+        .toSorted((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0))
+    );
+
+    const linksView = computed(() => asArray(links.get()).filter((l) => l));
+
+    const hasLinks = computed(() => linksView.length > 0);
+    const hasComments = computed(() => commentsView.length > 0);
+    const hasBody = computed(() => body.get().trim().length > 0);
+
+    const topicName = computed(() => title.get().trim() || "(untitled topic)");
+
+    return {
+      [NAME]: topicName,
+      [UI]: (
+        <cf-theme theme={TOPICS_THEME}>
+          <cf-screen>
+            <cf-vstack slot="header" gap="1" padding="4">
+              <cf-input
+                $value={title}
+                placeholder="Topic title…"
+                style="font-size: 1.25rem; font-weight: 600;"
+              />
+              <cf-text variant="caption" tone="muted">
+                started by {createdByName || "someone"}
+                {createdAt ? ` · ${whenLabel(createdAt)}` : ""}
+              </cf-text>
+            </cf-vstack>
+
+            <cf-vstack gap="3" padding="4">
+              {/* ── The living body document ── */}
+              <cf-card>
+                <cf-vstack gap="2">
+                  <cf-hstack justify="between" align="center">
+                    <cf-heading level={5}>Body</cf-heading>
+                    {editingBody
+                      ? null
+                      : (
+                        <cf-button variant="secondary" onClick={startEditBody}>
+                          Edit
+                        </cf-button>
+                      )}
+                  </cf-hstack>
+
+                  {editingBody
+                    ? (
+                      <cf-vstack gap="2">
+                        <cf-textarea
+                          $value={bodyDraft}
+                          rows={12}
+                          placeholder="The topic's living document…"
+                        />
+                        <cf-hstack gap="2">
+                          <cf-button variant="primary" onClick={saveBody}>
+                            Save
+                          </cf-button>
+                          <cf-button variant="ghost" onClick={cancelEditBody}>
+                            Cancel
+                          </cf-button>
+                        </cf-hstack>
+                      </cf-vstack>
+                    )
+                    : hasBody
+                    ? (
+                      <cf-text block style="white-space: pre-wrap;">
+                        {body}
+                      </cf-text>
+                    )
+                    : (
+                      <cf-text tone="muted" block>
+                        No body yet. The body is this topic's living document —
+                        durable conclusions get folded up here while the thread
+                        below holds the deliberation.
+                      </cf-text>
+                    )}
+                </cf-vstack>
+              </cf-card>
+
+              {/* ── Links out ── */}
+              <cf-card>
+                <cf-vstack gap="2">
+                  <cf-heading level={5}>Links</cf-heading>
+                  {hasLinks
+                    ? (
+                      <cf-vstack gap="1">
+                        {computed(() =>
+                          linksView.map((link) => (
+                            <cf-hstack gap="2" align="center">
+                              <cf-badge size="xs" color="neutral">
+                                {link.kind}
+                              </cf-badge>
+                              <a
+                                href={link.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                style="color: inherit;"
+                              >
+                                {link.label || link.url}
+                              </a>
+                            </cf-hstack>
+                          ))
+                        )}
+                      </cf-vstack>
+                    )
+                    : (
+                      <cf-text tone="muted" block>
+                        No links yet — PRs, agent sessions, other topics.
+                      </cf-text>
+                    )}
+                  <cf-hstack gap="2" align="end">
+                    <cf-field label="Kind" style="width: 130px;">
+                      <cf-select
+                        $value={linkKindDraft}
+                        items={LINK_KIND_ITEMS}
+                      />
+                    </cf-field>
+                    <cf-field label="URL" style="flex: 1;">
+                      <cf-input $value={linkUrlDraft} placeholder="https://…" />
+                    </cf-field>
+                    <cf-field label="Label" style="width: 180px;">
+                      <cf-input
+                        $value={linkLabelDraft}
+                        placeholder="optional"
+                      />
+                    </cf-field>
+                    <cf-button variant="secondary" onClick={submitLink}>
+                      Add
+                    </cf-button>
+                  </cf-hstack>
+                </cf-vstack>
+              </cf-card>
+
+              {/* ── The thread ── */}
+              <cf-card>
+                <cf-vstack gap="2">
+                  <cf-hstack justify="between" align="center">
+                    <cf-heading level={5}>Thread</cf-heading>
+                    <cf-text variant="caption" tone="muted">
+                      {commentCount} comments
+                    </cf-text>
+                  </cf-hstack>
+
+                  {hasComments
+                    ? (
+                      <cf-vstack gap="2">
+                        {computed(() =>
+                          commentsView.map((comment) => (
+                            <cf-vstack
+                              gap="0"
+                              style="border-left: 2px solid var(--cf-theme-color-border); padding-left: 0.75rem;"
+                            >
+                              <cf-hstack gap="2" align="center">
+                                <cf-text style="font-weight: 600;">
+                                  {comment.authorName || "someone"}
+                                </cf-text>
+                                <cf-text variant="caption" tone="muted">
+                                  {whenLabel(comment.sentAt)}
+                                </cf-text>
+                              </cf-hstack>
+                              <cf-text block style="white-space: pre-wrap;">
+                                {comment.body}
+                              </cf-text>
+                            </cf-vstack>
+                          ))
+                        )}
+                      </cf-vstack>
+                    )
+                    : (
+                      <cf-text tone="muted" block>
+                        No comments yet.
+                      </cf-text>
+                    )}
+
+                  <cf-hstack gap="2" align="end">
+                    <cf-field label="Commenting as" style="width: 160px;">
+                      <cf-input $value={myName} placeholder="Your name" />
+                    </cf-field>
+                    <cf-field label="Comment" style="flex: 1;">
+                      <cf-textarea
+                        $value={commentDraft}
+                        rows={3}
+                        placeholder="Add to the thread…"
+                      />
+                    </cf-field>
+                    <cf-button variant="primary" onClick={submitComment}>
+                      Send
+                    </cf-button>
+                  </cf-hstack>
+                </cf-vstack>
+              </cf-card>
+            </cf-vstack>
+          </cf-screen>
+        </cf-theme>
+      ),
+      title,
+      body,
+      comments,
+      links,
+      createdAt,
+      createdByName,
+      commentCount,
+      lastActivityAt,
+      addComment,
+      addLink,
+      setBody,
+    };
+  },
+);

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -69,6 +69,20 @@ export interface TopicOutput {
   addComment: Stream<{ body: string }>;
   addLink: Stream<{ kind: TopicLinkKind; url: string; label: string }>;
   setBody: Stream<{ body: string }>;
+  /** Session-local composer/edit state, exposed like the chat exemplar's
+   * drafts so embedders and tests can drive the same flows the UI does. */
+  commentDraft: Writable<string>;
+  bodyDraft: Writable<string>;
+  editingBody: boolean;
+  linkUrlDraft: Writable<string>;
+  linkLabelDraft: Writable<string>;
+  linkKindDraft: Writable<TopicLinkKind>;
+  /** UI affordances as streams: composer submit, body edit lifecycle. */
+  submitComment: Stream<void>;
+  startEditBody: Stream<void>;
+  saveBody: Stream<void>;
+  cancelEditBody: Stream<void>;
+  submitLink: Stream<void>;
 }
 
 /** The shape stored in the tracker's list. */
@@ -131,6 +145,13 @@ export const snippet = (text: string, max: number): string => {
   return t.length > max ? `${t.slice(0, max)}…` : t;
 };
 
+/** Only http(s) URLs may become live anchors — a user-supplied `javascript:`
+ * href on a shared surface is script execution in every viewer's session.
+ * Enforced at write (addLink rejects) AND at render (non-http renders as
+ * text), since stored data may predate the write guard. */
+export const isSafeLinkUrl = (url: string): boolean =>
+  /^https?:\/\//i.test((url ?? "").trim());
+
 const LINK_KIND_ITEMS = [
   { label: "Web", value: "web" },
   { label: "PR", value: "pr" },
@@ -157,7 +178,9 @@ export default pattern<TopicInput, TopicOutput>(
       if (!trimmed) return;
       // Mergeable append: concurrent comments from different users all land.
       comments.push({
-        authorName: myName.get().trim() || "someone",
+        // `?? ""`: a never-written PerUser cell can read as undefined (e.g. a
+        // headless caller that never set a name) — same guard as myNameView.
+        authorName: (myName.get() ?? "").trim() || "someone",
         body: trimmed,
         sentAt: safeDateNow(),
       });
@@ -170,7 +193,7 @@ export default pattern<TopicInput, TopicOutput>(
         label: string;
       }) => {
         const trimmedUrl = (url ?? "").trim();
-        if (!trimmedUrl) return;
+        if (!trimmedUrl || !isSafeLinkUrl(trimmedUrl)) return;
         links.push({
           kind: kind ?? "web",
           url: trimmedUrl,
@@ -324,14 +347,22 @@ export default pattern<TopicInput, TopicOutput>(
                               <cf-badge size="xs" color="neutral">
                                 {link.kind}
                               </cf-badge>
-                              <a
-                                href={link.url}
-                                target="_blank"
-                                rel="noreferrer"
-                                style="color: inherit;"
-                              >
-                                {link.label || link.url}
-                              </a>
+                              {isSafeLinkUrl(link.url)
+                                ? (
+                                  <a
+                                    href={link.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    style="color: inherit;"
+                                  >
+                                    {link.label || link.url}
+                                  </a>
+                                )
+                                : (
+                                  <cf-text tone="muted">
+                                    {link.label || link.url}
+                                  </cf-text>
+                                )}
                             </cf-hstack>
                           ))
                         )}
@@ -438,6 +469,17 @@ export default pattern<TopicInput, TopicOutput>(
       addComment,
       addLink,
       setBody,
+      commentDraft,
+      bodyDraft,
+      editingBody,
+      linkUrlDraft,
+      linkLabelDraft,
+      linkKindDraft,
+      submitComment,
+      startEditBody,
+      saveBody,
+      cancelEditBody,
+      submitLink,
     };
   },
 );

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Single-runtime pattern tests for Topics (CT-1878).
+ *
+ * Complements multi-user.test.tsx (which covers cross-runtime isolation and
+ * merge behavior): this file drives every exposed stream and derived value in
+ * one runtime — action guards, authorship fallback ("someone" before a name
+ * is set), the unsafe-scheme link rejection, label defaulting, body Edit→Save
+ * via setBody, activity-based sorting, and the exported pure helpers.
+ */
+import { action, computed, NAME } from "commonfabric";
+import { pattern } from "commonfabric";
+import Topics, { openTopic, type TopicPiece } from "./main.tsx";
+import { isSafeLinkUrl, snippet, whenLabel } from "./topic.tsx";
+
+export default pattern(() => {
+  const board = Topics({});
+
+  // --- actions ---
+
+  const action_add_blank_topic = action(() => {
+    board.addTopic.send({ title: "   " });
+  });
+  const action_add_first_topic = action(() => {
+    board.addTopic.send({ title: "  First topic  " });
+  });
+  const action_set_name = action(() => {
+    board.setMyName.send({ name: "  Tester  " });
+  });
+  const action_add_second_topic = action(() => {
+    board.addTopic.send({ title: "Second topic" });
+  });
+
+  const action_blank_comment = action(() => {
+    board.topics?.[0]?.addComment.send({ body: "   " });
+  });
+  const action_comment_unnamed = action(() => {
+    board.topics?.[0]?.addComment.send({ body: "hello thread" });
+  });
+  const action_set_body = action(() => {
+    board.topics?.[0]?.setBody.send({ body: "line one\nline two" });
+  });
+  const action_link_unsafe = action(() => {
+    board.topics?.[0]?.addLink.send({
+      kind: "web",
+      url: "javascript:alert(1)",
+      label: "evil",
+    });
+  });
+  const action_link_blank = action(() => {
+    board.topics?.[0]?.addLink.send({ kind: "web", url: "   ", label: "x" });
+  });
+  const action_link_valid_unlabeled = action(() => {
+    board.topics?.[0]?.addLink.send({
+      kind: "pr",
+      url: "https://github.com/commontoolsinc/labs/pull/4643",
+      label: "  ",
+    });
+  });
+  const action_comment_first_again = action(() => {
+    board.topics?.[0]?.addComment.send({ body: "bumping the first topic" });
+  });
+
+  // --- UI-affordance flows (the same paths the rendered controls drive) ---
+
+  const action_submit_topic_via_composer = action(() => {
+    board.newTitle.set("Composed topic");
+    board.submitTopic.send();
+  });
+  const action_submit_blank_comment_draft = action(() => {
+    board.topics?.[0]?.commentDraft.set("   ");
+    board.topics?.[0]?.submitComment.send();
+  });
+  const action_submit_comment_draft = action(() => {
+    board.topics?.[0]?.commentDraft.set("via the composer");
+    board.topics?.[0]?.submitComment.send();
+  });
+  // Edit flows are split across test steps: startEditBody's handler runs in
+  // the scheduler AFTER this action body, so a same-action draft-set would be
+  // overwritten by the handler's own body→draft copy.
+  const action_start_edit = action(() => {
+    board.topics?.[0]?.startEditBody.send();
+  });
+  const action_cancel_edit = action(() => {
+    board.topics?.[0]?.bodyDraft.set("abandoned draft");
+    board.topics?.[0]?.cancelEditBody.send();
+  });
+  const action_save_edit = action(() => {
+    board.topics?.[0]?.bodyDraft.set("edited body");
+    board.topics?.[0]?.saveBody.send();
+  });
+  const action_submit_blank_link_draft = action(() => {
+    board.topics?.[0]?.linkUrlDraft.set("   ");
+    board.topics?.[0]?.submitLink.send();
+  });
+  const action_submit_link_draft = action(() => {
+    board.topics?.[0]?.linkUrlDraft.set("https://example.com/design");
+    board.topics?.[0]?.linkLabelDraft.set("design notes");
+    board.topics?.[0]?.linkKindDraft.set("session");
+    board.topics?.[0]?.submitLink.send();
+  });
+  // Bound at pattern-body level (binding inside an action is an illegal
+  // position); the reactive reference resolves at send time, by which point
+  // the first topic exists.
+  const boundOpenFirst = openTopic({
+    topic: board.topics[0] as TopicPiece,
+  });
+  const action_open_topic = action(() => {
+    boundOpenFirst.send();
+  });
+
+  // --- assertions ---
+
+  const assert_initial = computed(() =>
+    board.topicCount === 0 &&
+    board.myName === "" &&
+    (board.topics ?? []).length === 0 &&
+    (board.mentionable ?? []).length === 0
+  );
+
+  // Blank titles are rejected by the addTopic guard.
+  const assert_still_empty = computed(() => board.topicCount === 0);
+
+  // Topic created before any name is set: authorship falls back to "someone"
+  // (the `(myName.get() ?? "").trim()` guard — cubic P1 on PR #4643).
+  const assert_first_topic = computed(() =>
+    board.topicCount === 1 &&
+    board.topics?.[0]?.title === "First topic" &&
+    board.topics?.[0]?.createdByName === "someone" &&
+    (board.topics?.[0]?.createdAt ?? 0) > 0 &&
+    board.topics?.[0]?.commentCount === 0 &&
+    board.topics?.[0]?.lastActivityAt === board.topics?.[0]?.createdAt &&
+    board.topics?.[0]?.[NAME] === "First topic"
+  );
+
+  const assert_named = computed(() => board.myName === "Tester");
+
+  const assert_blank_comment_rejected = computed(() =>
+    board.topics?.[0]?.commentCount === 0
+  );
+
+  const assert_comment_landed = computed(() =>
+    board.topics?.[0]?.commentCount === 1 &&
+    board.topics?.[0]?.comments?.[0]?.authorName === "Tester" &&
+    board.topics?.[0]?.comments?.[0]?.body === "hello thread" &&
+    (board.topics?.[0]?.comments?.[0]?.sentAt ?? 0) > 0 &&
+    (board.topics?.[0]?.lastActivityAt ?? 0) >=
+      (board.topics?.[0]?.createdAt ?? 0)
+  );
+
+  const assert_body_set = computed(() =>
+    board.topics?.[0]?.body === "line one\nline two"
+  );
+
+  // javascript: and blank URLs are rejected; a valid https link with a blank
+  // label defaults its label to the URL.
+  const assert_links_guarded = computed(() =>
+    (board.topics?.[0]?.links ?? []).length === 0
+  );
+  const assert_link_added = computed(() =>
+    (board.topics?.[0]?.links ?? []).length === 1 &&
+    board.topics?.[0]?.links?.[0]?.kind === "pr" &&
+    board.topics?.[0]?.links?.[0]?.label ===
+      "https://github.com/commontoolsinc/labs/pull/4643"
+  );
+
+  // Second topic created after naming: authorship snapshots the name; the
+  // board name computed reflects the count.
+  const assert_second_topic = computed(() =>
+    board.topicCount === 2 &&
+    board.topics?.[1]?.title === "Second topic" &&
+    board.topics?.[1]?.createdByName === "Tester" &&
+    board[NAME] === "Topics (2)"
+  );
+
+  const assert_composed_topic = computed(() =>
+    board.topicCount === 3 &&
+    board.topics?.[2]?.title === "Composed topic" &&
+    board.newTitle.get() === ""
+  );
+
+  const assert_blank_draft_rejected = computed(() =>
+    board.topics?.[0]?.commentCount === 2
+  );
+
+  const assert_composer_comment = computed(() =>
+    board.topics?.[0]?.commentCount === 3 &&
+    board.topics?.[0]?.comments?.[2]?.body === "via the composer" &&
+    board.topics?.[0]?.commentDraft.get() === ""
+  );
+
+  // startEditBody copied the current body into the draft and opened the editor.
+  const assert_editing = computed(() =>
+    board.topics?.[0]?.editingBody === true &&
+    board.topics?.[0]?.bodyDraft.get() === "line one\nline two"
+  );
+
+  const assert_edit_cancelled = computed(() =>
+    board.topics?.[0]?.editingBody === false &&
+    board.topics?.[0]?.body === "line one\nline two"
+  );
+
+  const assert_edit_saved = computed(() =>
+    board.topics?.[0]?.editingBody === false &&
+    board.topics?.[0]?.body === "edited body"
+  );
+
+  const assert_link_draft_flow = computed(() =>
+    (board.topics?.[0]?.links ?? []).length === 2 &&
+    board.topics?.[0]?.links?.[1]?.kind === "session" &&
+    board.topics?.[0]?.links?.[1]?.label === "design notes" &&
+    board.topics?.[0]?.linkUrlDraft.get() === "" &&
+    board.topics?.[0]?.linkKindDraft.get() === "web"
+  );
+
+  // A fresh comment on the FIRST topic makes it the most recently active.
+  const assert_pure_helpers = computed(() =>
+    snippet("a b  c", 3) === "a b…" &&
+    snippet("hi", 10) === "hi" &&
+    whenLabel(0) === "" &&
+    whenLabel(1783560681000).startsWith("Jul ") &&
+    isSafeLinkUrl("https://example.com") === true &&
+    isSafeLinkUrl("HTTP://EXAMPLE.COM") === true &&
+    isSafeLinkUrl("javascript:alert(1)") === false &&
+    isSafeLinkUrl("   ") === false
+  );
+
+  return {
+    tests: [
+      { assertion: assert_initial },
+      { action: action_add_blank_topic },
+      { assertion: assert_still_empty },
+      { action: action_add_first_topic },
+      { assertion: assert_first_topic },
+      { action: action_set_name },
+      { assertion: assert_named },
+      { action: action_blank_comment },
+      { assertion: assert_blank_comment_rejected },
+      { action: action_comment_unnamed },
+      { assertion: assert_comment_landed },
+      { action: action_set_body },
+      { assertion: assert_body_set },
+      { action: action_link_unsafe },
+      { assertion: assert_links_guarded },
+      { action: action_link_blank },
+      { assertion: assert_links_guarded },
+      { action: action_link_valid_unlabeled },
+      { assertion: assert_link_added },
+      { action: action_add_second_topic },
+      { assertion: assert_second_topic },
+      { action: action_comment_first_again },
+      { action: action_submit_topic_via_composer },
+      { assertion: assert_composed_topic },
+      { action: action_submit_blank_comment_draft },
+      { assertion: assert_blank_draft_rejected },
+      { action: action_submit_comment_draft },
+      { assertion: assert_composer_comment },
+      { action: action_start_edit },
+      { assertion: assert_editing },
+      { action: action_cancel_edit },
+      { assertion: assert_edit_cancelled },
+      { action: action_start_edit },
+      { action: action_save_edit },
+      { assertion: assert_edit_saved },
+      { action: action_submit_blank_link_draft },
+      { action: action_submit_link_draft },
+      { assertion: assert_link_draft_flow },
+      { action: action_open_topic },
+      { assertion: assert_pure_helpers },
+    ],
+  };
+});


### PR DESCRIPTION
## Why

First wedge of the team-wide Loom dogfooding program ("Summer 2026: Let's all use Loom"): an in-house primitive to replace Linear / GitHub issues / loose process docs for eng coordination. A **topic** is a durable unit of shared attention — title, living body document, flat chronological comment thread, typed links out — co-inhabited by humans and agents. Deliberately minimal: no statuses, labels, assignees, or deletes; what a topic grows next is part of the experiment (CT-1878).

The primitive is already in real use: verified two-identity (browser + headless agent over the cf CLI) on a shared estuary space, exercised by multiple teammates plus one agent across the estuary shell, Loom share-mounts, and headless CLI — and CT-1878 itself has been ported into the deployed board and closed. The tracker's first tracked item is its own origin story.

## What changed

- `packages/patterns/topics/topic.tsx` — the Topic sub-pattern (shared types, `#topic` wish tag, Edit→Save body flow, mergeable comment/link appends)
- `packages/patterns/topics/main.tsx` — the Topics tracker (reading-list-style piece-in-list composition; PerUser "commenting as" shared with every topic it creates; `navigateTo` detail)
- `packages/patterns/topics/multi-user.test.tsx` — two-runtime `multiUserTest`
- `packages/patterns/topics/README.md` + a `packages/patterns/index.md` entry (new pattern ⇒ demo tier until triaged)

Design commitments, from the substrate spike that preceded the build:

- **Wish-free handlers.** Nothing gates dispatch on a `wish()` binding — unresolved wish bindings drop events silently (CT-1879). Authorship is a snapshot fallback chain: PerUser `myName` at write time → identity → profile enrichment when the cross-host profile story lands (see the "Estuary profiles as canonical identity" topic on the board).
- **Mergeable writes where users collide**: comments, links, and topics are `push` appends, so concurrent writers all land. The body is a large string (whole-value conflict semantics), so body edits go through an explicit Edit→Save toggle rather than a live-bound textarea.
- PerUser scope-lowering of the shared `myName` cell verified via `--show-transformed` (`scope: "user"` in both generated schemas).

## Test plan

- `deno task cf check` green on both patterns (pre- and post-rebase); scoped `deno fmt --check` + `deno lint` clean
- `multi-user.test.tsx` 9/9: per-user name isolation on one shared piece, concurrent comment merge, cross-runtime piece propagation with authorship snapshots
- pattern-critic pass applied (notably: dropped minted comment `id`s per the entity-identity rules; theme-token fix)
- Live: deployed to estuary space `topics-dev-476ea34f`; two-identity read/write verified in both directions; CT-1878 ported in with original comment timestamps preserved

CT-1878 · CT-1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Topics: a multi-user tracker over `#topic` pieces with a title, living body, mergeable comments, and typed links. Implements CT-1878 with CT-1879 wish-free handlers, adds safety guards, and brings test coverage to 100%.

- **New Features**
  - Core tracker in `packages/patterns/topics/topic.tsx` and `packages/patterns/topics/main.tsx`: Edit→Save body, mergeable comment/link appends, `PerUser` `myName`, last-activity sort, and detail navigation; headless streams `addTopic`, `setMyName`, `addComment`, `addLink`, `setBody`.
  - Exposed session-local drafts and lifecycle streams for headless/UI use: `newTitle`/`submitTopic`, `commentDraft`/`submitComment`, body edit (`startEditBody`/`saveBody`/`cancelEditBody`), link drafts/`submitLink`; exported `openTopic` handler for navigation. Added `packages/patterns/topics/topics.test.tsx` single-runtime coverage; docs in `packages/patterns/topics/README.md` and `packages/patterns/index.md`. Two-runtime `multi-user.test.tsx` verifies per-user name isolation, concurrent merges, and propagation.

- **Bug Fixes**
  - Guard authorship reads against never-written `PerUser` cells in `addTopic` and `addComment`; snapshot to "someone" when unset (CT-1879-aligned).
  - Validate link URLs to http(s) at write and render; non-http render as text to prevent `javascript:` injection.

<sup>Written for commit 906284aea1697e4f2c531214a372702679f2422a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/todo-list/todo-list.test.tsx = 5s
