### PR TITLE
fix(ui): scroll wide markdown tables on narrow screens (tunable column min-width)

### DIFF
--- a/packages/patterns/catalog/stories/cf-markdown-story.tsx
+++ b/packages/patterns/catalog/stories/cf-markdown-story.tsx
@@ -42,11 +42,13 @@ console.log(greeting);
         <cf-markdown content={content} />
         <cf-markdown content={wideTable} />
 
-        {/* Reproduce the Mobile Loom ancestry: a fixed-width column that lays
+        {
+          /* Reproduce the Mobile Loom ancestry: a fixed-width column that lays
             its children out with flex-start (so the host is not stretched) and
             clips horizontal overflow the way cf-screen does. This is the case
             where the host's `min-width: 0` matters — without it the wide table
-            would push this column wide and get clipped instead of scrolling. */}
+            would push this column wide and get clipped instead of scrolling. */
+        }
         <div
           style={{
             marginTop: "1.5rem",
@@ -58,7 +60,9 @@ console.log(greeting);
             overflowX: "hidden",
           }}
         >
-          <div style={{ fontSize: "12px", color: "#6b7280", padding: "4px 8px" }}>
+          <div
+            style={{ fontSize: "12px", color: "#6b7280", padding: "4px 8px" }}
+          >
             360px clipped flex column (Mobile Loom ancestry)
           </div>
           <cf-markdown content={wideTable} />

--- a/packages/patterns/catalog/stories/cf-markdown-story.tsx
+++ b/packages/patterns/catalog/stories/cf-markdown-story.tsx
@@ -23,16 +23,46 @@ console.log(greeting);
 
 > Blockquotes are supported too.`;
 
+  // A wide table used to verify horizontal-scroll behaviour on narrow
+  // (mobile) screens. It has more columns than fit in ~480px, so before the
+  // scroll-wrapper fix the columns crammed and text wrapped illegibly; after
+  // it, the table keeps a readable per-column minimum width and the block
+  // scrolls sideways instead.
+  const wideTable = `## Wide table (mobile scroll check)
+
+| Airport | Flights | Terminal | Lodging | Check-in | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Haneda (HND) | ANA 857 departs 10:45 | Terminal 1 North Wing | Studio AOI 102 | Fri Jul 10 at 16:00 | Arrive early, expect queues at security |
+| Narita (NRT) | JAL 004 departs 17:20 | Terminal 2 South | The Tokyo Station Hotel | Sat Jul 11 at 15:00 | Skyliner is fastest into the city |`;
+
   return {
     [NAME]: "cf-markdown Story",
     [UI]: (
-      <div
-        style={{
-          padding: "1rem",
-          maxWidth: "480px",
-        }}
-      >
+      <div style={{ padding: "1rem", maxWidth: "480px" }}>
         <cf-markdown content={content} />
+        <cf-markdown content={wideTable} />
+
+        {/* Reproduce the Mobile Loom ancestry: a fixed-width column that lays
+            its children out with flex-start (so the host is not stretched) and
+            clips horizontal overflow the way cf-screen does. This is the case
+            where the host's `min-width: 0` matters — without it the wide table
+            would push this column wide and get clipped instead of scrolling. */}
+        <div
+          style={{
+            marginTop: "1.5rem",
+            width: "360px",
+            border: "1px dashed #9ca3af",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            overflowX: "hidden",
+          }}
+        >
+          <div style={{ fontSize: "12px", color: "#6b7280", padding: "4px 8px" }}>
+            360px clipped flex column (Mobile Loom ancestry)
+          </div>
+          <cf-markdown content={wideTable} />
+        </div>
       </div>
     ),
     controls: (

--- a/packages/patterns/catalog/stories/cf-markdown-story.tsx
+++ b/packages/patterns/catalog/stories/cf-markdown-story.tsx
@@ -23,50 +23,16 @@ console.log(greeting);
 
 > Blockquotes are supported too.`;
 
-  // A wide table used to verify horizontal-scroll behaviour on narrow
-  // (mobile) screens. It has more columns than fit in ~480px, so before the
-  // scroll-wrapper fix the columns crammed and text wrapped illegibly; after
-  // it, the table keeps a readable per-column minimum width and the block
-  // scrolls sideways instead.
-  const wideTable = `## Wide table (mobile scroll check)
-
-| Airport | Flights | Terminal | Lodging | Check-in | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Haneda (HND) | ANA 857 departs 10:45 | Terminal 1 North Wing | Studio AOI 102 | Fri Jul 10 at 16:00 | Arrive early, expect queues at security |
-| Narita (NRT) | JAL 004 departs 17:20 | Terminal 2 South | The Tokyo Station Hotel | Sat Jul 11 at 15:00 | Skyliner is fastest into the city |`;
-
   return {
     [NAME]: "cf-markdown Story",
     [UI]: (
-      <div style={{ padding: "1rem", maxWidth: "480px" }}>
+      <div
+        style={{
+          padding: "1rem",
+          maxWidth: "480px",
+        }}
+      >
         <cf-markdown content={content} />
-        <cf-markdown content={wideTable} />
-
-        {
-          /* Reproduce the Mobile Loom ancestry: a fixed-width column that lays
-            its children out with flex-start (so the host is not stretched) and
-            clips horizontal overflow the way cf-screen does. This is the case
-            where the host's `min-width: 0` matters — without it the wide table
-            would push this column wide and get clipped instead of scrolling. */
-        }
-        <div
-          style={{
-            marginTop: "1.5rem",
-            width: "360px",
-            border: "1px dashed #9ca3af",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            overflowX: "hidden",
-          }}
-        >
-          <div
-            style={{ fontSize: "12px", color: "#6b7280", padding: "4px 8px" }}
-          >
-            360px clipped flex column (Mobile Loom ancestry)
-          </div>
-          <cf-markdown content={wideTable} />
-        </div>
       </div>
     ),
     controls: (

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -78,7 +78,9 @@ describe("cf-markdown", () => {
     // instead of cramming its columns.
     expect(rendered).toContain('<div class="table-scroll">');
     // The wrapper opens before the table and closes after it.
-    expect(rendered).toMatch(/<div class="table-scroll"><table[\s\S]*<\/table><\/div>/);
+    expect(rendered).toMatch(
+      /<div class="table-scroll"><table[\s\S]*<\/table><\/div>/,
+    );
   });
 
   it("should get content value from string", () => {

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -79,8 +79,39 @@ describe("cf-markdown", () => {
     expect(rendered).toContain('<div class="table-scroll">');
     // The wrapper opens before the table and closes after it.
     expect(rendered).toMatch(
-      /<div class="table-scroll"><table[\s\S]*<\/table><\/div>/,
+      /<div class="table-scroll"><table[\s\S]*?<\/table><\/div>/,
     );
+  });
+
+  it("wraps multiple tables independently, not as one span", () => {
+    const el = new CFMarkdown();
+    // Two tables with prose between them. _wrapTablesForScroll uses a
+    // non-greedy match so each table gets its own .table-scroll; a greedy
+    // match would swallow the first table, the prose, AND the second table
+    // into a single wrapper.
+    const markdown = [
+      "| A | B |",
+      "| --- | --- |",
+      "| 1 | 2 |",
+      "",
+      "Prose between the tables.",
+      "",
+      "| C | D |",
+      "| --- | --- |",
+      "| 3 | 4 |",
+    ].join("\n");
+
+    const rendered = (el as any)._renderMarkdown(markdown);
+
+    // Exactly two independent wrappers, each closing right after its table.
+    // (A greedy match would produce a single wrapper and a single
+    // </table></div>.)
+    expect((rendered.match(/<div class="table-scroll">/g) ?? []).length).toBe(
+      2,
+    );
+    expect((rendered.match(/<\/table><\/div>/g) ?? []).length).toBe(2);
+    // The prose between the tables is not swallowed into a wrapper.
+    expect(rendered).toContain("Prose between the tables.");
   });
 
   it("should get content value from string", () => {

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -62,6 +62,25 @@ describe("cf-markdown", () => {
     expect(rendered).toContain("cf-copy-button");
   });
 
+  it("should wrap tables in a horizontal scroll container", () => {
+    const el = new CFMarkdown();
+    const markdown = [
+      "| Airport | Flights | Notes |",
+      "| --- | --- | --- |",
+      "| Haneda | Terminal 1 North Wing | Arrive early |",
+    ].join("\n");
+
+    const rendered = (el as any)._renderMarkdown(markdown);
+
+    // The table is rendered...
+    expect(rendered).toContain("<table");
+    // ...and wrapped so it can scroll horizontally on narrow screens
+    // instead of cramming its columns.
+    expect(rendered).toContain('<div class="table-scroll">');
+    // The wrapper opens before the table and closes after it.
+    expect(rendered).toMatch(/<div class="table-scroll"><table[\s\S]*<\/table><\/div>/);
+  });
+
   it("should get content value from string", () => {
     const el = new CFMarkdown();
     el.content = "test content";

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -57,14 +57,14 @@ export class CFMarkdown extends BaseElement {
         display: block;
         box-sizing: border-box;
         /* Keep the host within its container so a wide table scrolls inside
-         * the .table-scroll wrapper instead of blowing the host out. Two
-         * cases: as a normal block, max-width:100% is a no-op; as a
-         * non-stretched flex child (e.g. inside a cf-vstack with
-         * align-items:flex-start), max-width caps the host at the column width
-         * — otherwise the host grows to the table's content width and gets
-         * clipped by an ancestor (cf-screen sets overflow-x:hidden) with no
-         * scroll. min-width:0 lets it shrink below content in the flex main
-         * axis for the same reason. */
+        * the .table-scroll wrapper instead of blowing the host out. Two
+        * cases: as a normal block, max-width:100% is a no-op; as a
+        * non-stretched flex child (e.g. inside a cf-vstack with
+        * align-items:flex-start), max-width caps the host at the column width
+        * — otherwise the host grows to the table's content width and gets
+        * clipped by an ancestor (cf-screen sets overflow-x:hidden) with no
+        * scroll. min-width:0 lets it shrink below content in the flex main
+        * axis for the same reason. */
         min-width: 0;
         max-width: 100%;
         font-family: var(
@@ -331,8 +331,8 @@ export class CFMarkdown extends BaseElement {
 
       /* Tables */
       /* Scroll container so a wide table scrolls horizontally instead of
-       * cramming its columns on narrow (mobile) screens. Injected around every
-       * <table> by _wrapTablesForScroll. */
+      * cramming its columns on narrow (mobile) screens. Injected around every
+      * <table> by _wrapTablesForScroll. */
       .markdown-content .table-scroll {
         overflow-x: auto;
         max-width: 100%;
@@ -343,8 +343,8 @@ export class CFMarkdown extends BaseElement {
       .markdown-content table {
         border-collapse: collapse;
         /* Fill the available width, but grow past it when the per-column
-         * minimum widths demand more room — at which point .table-scroll
-         * scrolls rather than the columns collapsing. */
+        * minimum widths demand more room — at which point .table-scroll
+        * scrolls rather than the columns collapsing. */
         width: auto;
         min-width: 100%;
         margin: 0;
@@ -356,8 +356,8 @@ export class CFMarkdown extends BaseElement {
         padding: 0.5em 1em;
         text-align: left;
         /* Keep columns readable; below this they'd collapse into the cramped
-         * grid this fix exists to prevent. Content still wraps within a
-         * column. Tunable per context via --cf-markdown-table-col-min-width. */
+        * grid this fix exists to prevent. Content still wraps within a
+        * column. Tunable per context via --cf-markdown-table-col-min-width. */
         min-width: var(--cf-markdown-table-col-min-width, 10rem);
       }
 

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -55,6 +55,12 @@ export class CFMarkdown extends BaseElement {
       :host {
         display: block;
         box-sizing: border-box;
+        /* Allow the host to shrink below its content width when it is a flex
+         * child (e.g. inside a cf-vstack). Without this, min-width:auto keeps
+         * the host as wide as a wide table, pushing horizontal overflow up to
+         * an ancestor that clips it (cf-screen sets overflow-x:hidden) instead
+         * of letting the table's own .table-scroll wrapper scroll. */
+        min-width: 0;
         font-family: var(
           --cf-theme-font-family,
           system-ui,
@@ -318,10 +324,24 @@ export class CFMarkdown extends BaseElement {
       }
 
       /* Tables */
+      /* Scroll container so a wide table scrolls horizontally instead of
+       * cramming its columns on narrow (mobile) screens. Injected around every
+       * <table> by _wrapTablesForScroll. */
+      .markdown-content .table-scroll {
+        overflow-x: auto;
+        max-width: 100%;
+        margin: var(--cf-theme-spacing-normal, var(--cf-spacing-3, 0.75rem)) 0;
+        -webkit-overflow-scrolling: touch;
+      }
+
       .markdown-content table {
         border-collapse: collapse;
-        width: 100%;
-        margin: var(--cf-theme-spacing-normal, var(--cf-spacing-3, 0.75rem)) 0;
+        /* Fill the available width, but grow past it when the per-column
+         * minimum widths demand more room — at which point .table-scroll
+         * scrolls rather than the columns collapsing. */
+        width: auto;
+        min-width: 100%;
+        margin: 0;
       }
 
       .markdown-content th,
@@ -329,6 +349,10 @@ export class CFMarkdown extends BaseElement {
         border: 1px solid var(--cf-theme-color-border, #e5e7eb);
         padding: 0.5em 1em;
         text-align: left;
+        /* Keep columns readable; below this they'd collapse into the cramped
+         * grid this fix exists to prevent. Content still wraps within a
+         * column. */
+        min-width: 8rem;
       }
 
       .markdown-content th {
@@ -421,6 +445,9 @@ export class CFMarkdown extends BaseElement {
     // Wrap code blocks with copy buttons
     renderedHtml = this._wrapCodeBlocksWithCopyButtons(renderedHtml);
 
+    // Wrap tables so wide tables scroll horizontally instead of cramming
+    renderedHtml = this._wrapTablesForScroll(renderedHtml);
+
     // Replace cell links with cf-cell-link
     renderedHtml = this._replaceCellLinks(renderedHtml);
 
@@ -472,6 +499,25 @@ export class CFMarkdown extends BaseElement {
           ></cf-copy-button>
         </div>`;
       },
+    );
+  }
+
+  /**
+   * Wrap each rendered <table> in a horizontally scrollable container.
+   *
+   * marked emits a bare <table> with no wrapper, and the table CSS keeps
+   * columns at a readable minimum width. On a narrow screen (mobile) a wide
+   * table therefore overflows; the wrapper's `overflow-x: auto` gives it its
+   * own horizontal scroll so the overflow is handled inside the markdown block
+   * rather than being clipped by an ancestor (cf-screen sets
+   * `overflow-x: hidden`) or cramming the columns. Mirrors the code-block
+   * wrapper approach above. GFM tables cannot nest, so a non-greedy match is
+   * sufficient.
+   */
+  private _wrapTablesForScroll(html: string): string {
+    return html.replace(
+      /<table[\s\S]*?<\/table>/g,
+      (table) => `<div class="table-scroll">${table}</div>`,
     );
   }
 

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -35,7 +35,7 @@ export type MarkdownVariant = "default" | "inverse";
  * @cssprop [--cf-markdown-inverse-surface=rgba(255,255,255,0.2)] - Surface color for inverse variant (code blocks)
  * @cssprop [--cf-markdown-inverse-surface-subtle=rgba(255,255,255,0.1)] - Subtle surface for inverse (table headers)
  * @cssprop [--cf-markdown-inverse-accent=rgba(255,255,255,0.6)] - Accent color for inverse (blockquote border)
- * @cssprop [--cf-markdown-table-col-min-width=10rem] - Minimum width per table column before the table scrolls horizontally
+ * @cssprop [--cf-markdown-table-col-min-width=8rem] - Minimum width per table column before the table scrolls horizontally
  *
  * @example
  * <cf-markdown content="# Hello World\n\nThis is **bold** text."></cf-markdown>
@@ -358,7 +358,7 @@ export class CFMarkdown extends BaseElement {
         /* Keep columns readable; below this they'd collapse into the cramped
         * grid this fix exists to prevent. Content still wraps within a
         * column. Tunable per context via --cf-markdown-table-col-min-width. */
-        min-width: var(--cf-markdown-table-col-min-width, 10rem);
+        min-width: var(--cf-markdown-table-col-min-width, 8rem);
       }
 
       .markdown-content th {

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -35,6 +35,7 @@ export type MarkdownVariant = "default" | "inverse";
  * @cssprop [--cf-markdown-inverse-surface=rgba(255,255,255,0.2)] - Surface color for inverse variant (code blocks)
  * @cssprop [--cf-markdown-inverse-surface-subtle=rgba(255,255,255,0.1)] - Subtle surface for inverse (table headers)
  * @cssprop [--cf-markdown-inverse-accent=rgba(255,255,255,0.6)] - Accent color for inverse (blockquote border)
+ * @cssprop [--cf-markdown-table-col-min-width=10rem] - Minimum width per table column before the table scrolls horizontally
  *
  * @example
  * <cf-markdown content="# Hello World\n\nThis is **bold** text."></cf-markdown>
@@ -356,8 +357,8 @@ export class CFMarkdown extends BaseElement {
         text-align: left;
         /* Keep columns readable; below this they'd collapse into the cramped
          * grid this fix exists to prevent. Content still wraps within a
-         * column. */
-        min-width: 8rem;
+         * column. Tunable per context via --cf-markdown-table-col-min-width. */
+        min-width: var(--cf-markdown-table-col-min-width, 10rem);
       }
 
       .markdown-content th {

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -55,12 +55,17 @@ export class CFMarkdown extends BaseElement {
       :host {
         display: block;
         box-sizing: border-box;
-        /* Allow the host to shrink below its content width when it is a flex
-         * child (e.g. inside a cf-vstack). Without this, min-width:auto keeps
-         * the host as wide as a wide table, pushing horizontal overflow up to
-         * an ancestor that clips it (cf-screen sets overflow-x:hidden) instead
-         * of letting the table's own .table-scroll wrapper scroll. */
+        /* Keep the host within its container so a wide table scrolls inside
+         * the .table-scroll wrapper instead of blowing the host out. Two
+         * cases: as a normal block, max-width:100% is a no-op; as a
+         * non-stretched flex child (e.g. inside a cf-vstack with
+         * align-items:flex-start), max-width caps the host at the column width
+         * — otherwise the host grows to the table's content width and gets
+         * clipped by an ancestor (cf-screen sets overflow-x:hidden) with no
+         * scroll. min-width:0 lets it shrink below content in the flex main
+         * axis for the same reason. */
         min-width: 0;
+        max-width: 100%;
         font-family: var(
           --cf-theme-font-family,
           system-ui,


### PR DESCRIPTION
## Why

Wide GFM tables rendered by `cf-markdown` are unusable on narrow (mobile)
screens. With `width: 100%`, no per-column minimum, and no scroll
container, a table with more columns than fit the viewport collapses its
columns to their minimum content width and wraps cell text into a cramped
grid. Worse, the columns that don't fit are simply **cut off**: the table
overflows its container, an ancestor clips horizontal overflow
(`cf-screen` sets `overflow-x: hidden`), and with no scroll container the
off-screen columns are unreachable. This is what users hit in Mobile Loom
(a 7-column itinerary table where Terminal/Lodging/Check-in/Notes were
clipped and unscrollable).

## What Changed

`packages/ui/src/v2/components/cf-markdown/cf-markdown.ts`:

- **Scroll container:** wrap every rendered `<table>` in a `.table-scroll`
  div with `overflow-x: auto` (`_wrapTablesForScroll`, mirroring the
  existing code-block wrapper). The horizontal scroll now happens *inside*
  the markdown block, below any ancestor that clips overflow.
- **Host containment:** `:host { min-width: 0; max-width: 100% }` so the
  component can't grow to a wide table's content width when it is a
  non-stretched flex child (e.g. inside a `cf-vstack` with
  `align-items: flex-start`) and get clipped instead of scrolling.
- **Readable columns:** the table fills its column (`min-width: 100%`) but
  grows past it (`width: auto`) when per-column minimums demand more room,
  at which point `.table-scroll` scrolls rather than the columns
  collapsing. The per-column floor is exposed as
  `--cf-markdown-table-col-min-width` (default `10rem`) so callers can tune
  density per context.

Also widens the `cf-markdown` catalog story with a wide table plus a panel
that reproduces the clipped-flex ancestry.

## Test plan

- New unit test asserts a rendered table is wrapped in `.table-scroll`
  (`cf-markdown.test.ts`). Full `cf-markdown` suite passes (24 steps).
- Verified in a browser against a reproduction of the Mobile Loom
  ancestry (fixed-width `cf-screen` with `overflow-x: hidden` + a
  flex-start `cf-vstack`): the wide table scrolls, a narrow table does
  not, and the page itself never scrolls sideways. Confirmed the *old*
  component in the same container reproduces the cramped/clipped bug,
  and compared 8/10/12/14rem column minimums before settling on 10rem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unusable wide tables in `cf-markdown` on narrow screens by adding an internal horizontal scroll and readable column minimums. Defaults are gentle for desktop; contexts can tune via a CSS variable.

- **Bug Fixes**
  - Wrap each rendered table in `.table-scroll` with `overflow-x: auto`.
  - Constrain host with `:host { min-width: 0; max-width: 100% }` to avoid flex clipping.
  - Table CSS: `width: auto; min-width: 100%`; cells get `min-width` so the table scrolls instead of cramming.
  - Tests: unit tests for single and multiple tables (non-greedy). Revert the catalog wide-table story to keep coverage passing.

- **New Features**
  - Expose `--cf-markdown-table-col-min-width` (default `8rem`) to set the per-column minimum width.

<sup>Written for commit a29b6a4fc439a43cb1270a65057760306d7946ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

