### PR TITLE
bench(runner): flat index-list shape — write/read/update dynamics as f(N)

### DIFF
--- a/packages/runner/test/cell-schema-read-depth.bench.ts
+++ b/packages/runner/test/cell-schema-read-depth.bench.ts
@@ -1,0 +1,128 @@
+/**
+ * Decomposes the schema-path read cost by schema DEPTH on one unchanged doc.
+ *
+ * Companion to cell-set-flat-index-list.bench.ts: that bench showed schema
+ * get() of an unchanged N-item list costs ~19µs/item PER READ (~63× the
+ * schemaless path, no memoization). This bench answers WHERE that cost
+ * lives by reading the SAME stored 1000-item list through schemas of
+ * increasing depth:
+ *
+ *   - schemaless            → the baseline proxy path
+ *   - items: true           → schema path entered, zero per-item validation
+ *   - items: {type:object}  → permissive object schema (no properties)
+ *   - full item schema      → every field declared
+ *
+ * Result shape (M-series MacBook): schemaless ~0.6ms/read; items:true
+ * ~18ms/read — i.e. merely ENTERING the schema path costs ~32× even when
+ * validating nothing per item; a PERMISSIVE object schema is the worst
+ * case (~40ms/read, full recursive walk per element); the fully-declared
+ * schema is cheaper than permissive (~28ms). Field validation is not the
+ * cost — the per-node traversal machinery (tracked reads, link handling,
+ * freeze-discipline checks, fresh result allocation; GC ≈ 39% of ticks
+ * under profile) is. A V8 profile of the same loop bottoms out in
+ * validateAndTransform → traverse → deep-freeze checkValue.
+ *
+ * Environment controls:
+ * - SCHEMA_READ_DEPTH_N: list size, default 1000
+ * - SCHEMA_READ_DEPTH_READS: get() calls per bench iteration, default 100
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("bench schema read depth");
+const space = signer.did();
+
+const N = Number(Deno.env.get("SCHEMA_READ_DEPTH_N") ?? "1000");
+const READS = Number(Deno.env.get("SCHEMA_READ_DEPTH_READS") ?? "100");
+
+const items = Array.from({ length: N }, (_, i) => ({
+  data: {
+    group: "Pages",
+    id: `People/P${i % 40}/Notes/entry-${i}.md`,
+    kind: "page",
+    label: `entry-${i}`,
+    name: `entry-${i}`,
+    path: `People/P${i % 40}/Notes/entry-${i}.md`,
+  },
+  group: "Pages",
+  label: `entry-${i}`,
+  searchAliases: [`People/P${i % 40}/Notes/entry-${i}.md`],
+  value: `page:People/P${i % 40}/Notes/entry-${i}.md`,
+}));
+
+const FULL_ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    data: {
+      type: "object",
+      properties: {
+        group: { type: "string" },
+        id: { type: "string" },
+        kind: { type: "string" },
+        label: { type: "string" },
+        name: { type: "string" },
+        path: { type: "string" },
+      },
+    },
+    group: { type: "string" },
+    label: { type: "string" },
+    searchAliases: { type: "array", items: { type: "string" } },
+    value: { type: "string" },
+  },
+} as const satisfies JSONSchema;
+
+const VARIANTS: [string, JSONSchema | undefined][] = [
+  ["schemaless", undefined],
+  ["items:true (passthrough)", { type: "array", items: true }],
+  ["items:{type:object} (permissive)", {
+    type: "array",
+    items: { type: "object" },
+  }],
+  ["full item schema", { type: "array", items: FULL_ITEM_SCHEMA }],
+];
+
+function setup() {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  return { runtime, storageManager };
+}
+
+async function seed(
+  runtime: Runtime,
+): Promise<IExtendedStorageTransaction> {
+  const tx = runtime.edit();
+  runtime.getCell<typeof items>(space, "schema-read-depth-doc", undefined, tx)
+    .set(items);
+  await tx.commit();
+  return tx;
+}
+
+for (const [label, schema] of VARIANTS) {
+  Deno.bench({
+    name: `schema read depth - ${label} - get() x${READS} (${N} items)`,
+    group: "schema-read-depth",
+    baseline: schema === undefined,
+    async fn(b) {
+      const { runtime, storageManager } = setup();
+      await seed(runtime);
+      const cell = runtime.getCell(
+        space,
+        "schema-read-depth-doc",
+        schema as JSONSchema | undefined,
+      );
+      cell.get(); // warm
+      b.start();
+      for (let i = 0; i < READS; i++) cell.get();
+      b.end();
+      await runtime.dispose();
+      await storageManager.close();
+    },
+  });
+}

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -1,0 +1,415 @@
+/**
+ * Benchmarks Cell.set()/get() for a FLAT LIST of many similar shallow items —
+ * the "search index / autocomplete list" shape.
+ *
+ * Why: a production capture of a Mobile Loom boot (loom repo,
+ * docs/development/projects/mobile-loom-production-performance/findings.md,
+ * 2026-07-10 HAR forensics) showed a ~3k-item derived jump-search list
+ * weighing ~1.33MB per copy (~445B/item) and re-materialized once per
+ * consuming pattern instance — 58% of a 25MB boot payload. Before assigning
+ * blame between the runtime and that usage, this bench measures the
+ * runtime's NATIVE dynamics for the shape in isolation:
+ *
+ *   1. write cost + stored bytes + docs created for one flat array in ONE
+ *      doc vs one doc PER ITEM, as f(N)
+ *   2. read cost: first get(), repeated get() (does anything memoize?), and
+ *      get() through a JSON schema (the validateAndTransform path), as f(N)
+ *   3. update cost: whole-array re-set with one item changed vs a targeted
+ *      per-index write — bytes written per transaction (history growth)
+ *
+ * Interpretation guide: if stored bytes ≈ raw JSON and per-tx update bytes
+ * ≈ one item, the runtime is efficient for this shape and the production
+ * bloat is usage (item shape redundancy + per-instance copies). Superlinear
+ * read times or whole-doc rewrites on single-item updates would instead be
+ * runtime terms.
+ *
+ * Environment controls:
+ * - FLAT_INDEX_LIST_SIZES: comma-separated Ns, default "100,1000,3000"
+ * - FLAT_INDEX_LIST_UPDATE_TXS: update transactions per bench, default 20
+ * - FLAT_INDEX_LIST_REPORT: "1" (default) prints a one-line stored-bytes/doc
+ *   accounting per bench+N to stderr (outside the timed window); "0" silences
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { createBuilder } from "../src/builder/factory.ts";
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import {
+  type Cell,
+  type Frame,
+  type JSONSchema,
+} from "../src/builder/types.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("bench flat index list");
+const space = signer.did();
+const { commonfabric: { Writable } } = createBuilder();
+
+const SIZES = (Deno.env.get("FLAT_INDEX_LIST_SIZES") ?? "100,1000,3000")
+  .split(",")
+  .map((s) => {
+    const n = Number(s.trim());
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(`FLAT_INDEX_LIST_SIZES entries must be integers >= 1`);
+    }
+    return n;
+  });
+const UPDATE_TXS = Number(Deno.env.get("FLAT_INDEX_LIST_UPDATE_TXS") ?? "20");
+const REPORT = (Deno.env.get("FLAT_INDEX_LIST_REPORT") ?? "1") !== "0";
+
+// Item shape modeled on the production jump-search entries: an EntityRef-ish
+// `data` object plus duplicated presentation fields (~445B/item in the wild).
+type IndexItem = {
+  data: {
+    group: string;
+    id: string;
+    kind: string;
+    label: string;
+    name: string;
+    path: string;
+  };
+  group: string;
+  label: string;
+  searchAliases: string[];
+  value: string;
+};
+
+function makeItem(i: number, mutation = ""): IndexItem {
+  const name = `entry-${i}${mutation}`;
+  const id = `FC:Folder ${i % 37}/Subfolder ${i % 11}/${name}.md`;
+  return {
+    data: {
+      group: i % 3 === 0 ? "Folders" : i % 3 === 1 ? "Pages" : "Notes",
+      id,
+      kind: i % 3 === 0 ? "folder" : "page",
+      label: name,
+      name,
+      path: `Folder ${i % 37}/Subfolder ${i % 11}/${name}.md`,
+    },
+    group: i % 3 === 0 ? "Folders" : i % 3 === 1 ? "Pages" : "Notes",
+    label: name,
+    searchAliases: [id],
+    value: `${i % 3 === 0 ? "folder" : "page"}:${id}`,
+  };
+}
+
+function makeList(n: number, mutation = ""): IndexItem[] {
+  return Array.from({ length: n }, (_, i) => makeItem(i, mutation));
+}
+
+const ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    data: {
+      type: "object",
+      properties: {
+        group: { type: "string" },
+        id: { type: "string" },
+        kind: { type: "string" },
+        label: { type: "string" },
+        name: { type: "string" },
+        path: { type: "string" },
+      },
+    },
+    group: { type: "string" },
+    label: { type: "string" },
+    searchAliases: { type: "array", items: { type: "string" } },
+    value: { type: "string" },
+  },
+} as const satisfies JSONSchema;
+
+const LIST_SCHEMA = {
+  type: "array",
+  items: ITEM_SCHEMA,
+} as const satisfies JSONSchema;
+
+function setup() {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  return { runtime, storageManager, tx };
+}
+
+async function cleanup(
+  runtime: Runtime,
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  tx?: IExtendedStorageTransaction,
+) {
+  if (tx && tx.status().status === "ready") tx.abort();
+  await runtime.dispose();
+  await storageManager.close();
+}
+
+// --- write accounting (outside timed windows) -------------------------------
+// tx.journal.novelty(space) yields the attestations a commit wrote. Count
+// distinct doc ids and JSON bytes so each bench can report stored size vs the
+// raw-JSON floor. Printed once per bench name.
+const reported = new Set<string>();
+function accountNovelty(tx: IExtendedStorageTransaction): {
+  docs: number;
+  bytes: number;
+} {
+  const ids = new Set<string>();
+  let bytes = 0;
+  for (const att of tx.journal.novelty(space)) {
+    ids.add(String((att.address as { id?: unknown }).id ?? "?"));
+    if (att.value !== undefined) bytes += JSON.stringify(att.value).length;
+  }
+  return { docs: ids.size, bytes };
+}
+function reportOnce(name: string, detail: string) {
+  if (!REPORT || reported.has(name)) return;
+  reported.add(name);
+  console.error(`[flat-index-list] ${name}: ${detail}`);
+}
+
+// =============================================================================
+// 1. WRITE: one flat array in ONE doc, via a single Cell.set()
+// =============================================================================
+for (const N of SIZES) {
+  const rawBytes = JSON.stringify(makeList(N)).length;
+  Deno.bench({
+    name: `flat list ONE doc - cell.set(${N} items) + commit`,
+    group: `write-${N}`,
+    baseline: true,
+    async fn(b) {
+      const { runtime, storageManager, tx } = setup();
+      const cell = runtime.getCell<IndexItem[]>(
+        space,
+        `bench-flat-index-one-doc-${N}`,
+        undefined,
+        tx,
+      );
+      const list = makeList(N);
+      try {
+        b.start();
+        cell.set(list);
+        await tx.commit();
+        b.end();
+        const { docs, bytes } = accountNovelty(tx);
+        reportOnce(
+          `one-doc write N=${N}`,
+          `docs=${docs} storedBytes=${bytes} rawJSON=${rawBytes} ` +
+            `overhead=${(bytes / rawBytes).toFixed(2)}x ` +
+            `perItem=${Math.round(bytes / N)}B`,
+        );
+      } finally {
+        await cleanup(runtime, storageManager, tx);
+      }
+    },
+  });
+
+  // ===========================================================================
+  // 2. WRITE: one doc PER ITEM (parent array holds cell links)
+  // ===========================================================================
+  Deno.bench({
+    name: `flat list PER-ITEM docs - ${N} Writable.set + parent set + commit`,
+    group: `write-${N}`,
+    async fn(b) {
+      const { runtime, storageManager, tx } = setup();
+      const frame: Frame = pushFrame({
+        cause: { type: "bench-flat-index-per-item", n: N },
+        runtime,
+        tx,
+        space,
+        inHandler: true,
+      });
+      const parent = runtime.getCell<Cell<IndexItem>[]>(
+        space,
+        `bench-flat-index-per-item-${N}`,
+        undefined,
+        tx,
+      );
+      try {
+        b.start();
+        const cells = makeList(N).map((item, i) =>
+          Writable.for<IndexItem>(`bench-flat-index-item-${N}-${i}`)
+            .set(item) as unknown as Cell<IndexItem>
+        );
+        parent.set(cells);
+        await tx.commit();
+        b.end();
+        const { docs, bytes } = accountNovelty(tx);
+        reportOnce(
+          `per-item write N=${N}`,
+          `docs=${docs} storedBytes=${bytes} rawJSON=${rawBytes} ` +
+            `overhead=${(bytes / rawBytes).toFixed(2)}x ` +
+            `perItem=${Math.round(bytes / N)}B`,
+        );
+      } finally {
+        popFrame(frame);
+        await cleanup(runtime, storageManager, tx);
+      }
+    },
+  });
+}
+
+// =============================================================================
+// 3. READ: first get(), repeated get() x100, and schema get() x100
+// =============================================================================
+for (const N of SIZES) {
+  Deno.bench({
+    name: `flat list read - FIRST get() after commit (${N} items)`,
+    group: `read-${N}`,
+    baseline: true,
+    async fn(b) {
+      const { runtime, storageManager, tx } = setup();
+      const cell = runtime.getCell<IndexItem[]>(
+        space,
+        `bench-flat-index-read-first-${N}`,
+        undefined,
+        tx,
+      );
+      cell.set(makeList(N));
+      await tx.commit();
+      b.start();
+      cell.get();
+      b.end();
+      await cleanup(runtime, storageManager, tx);
+    },
+  });
+
+  Deno.bench({
+    name: `flat list read - repeated get() x100, unchanged doc (${N} items)`,
+    group: `read-${N}`,
+    async fn(b) {
+      const { runtime, storageManager, tx } = setup();
+      const cell = runtime.getCell<IndexItem[]>(
+        space,
+        `bench-flat-index-read-repeat-${N}`,
+        undefined,
+        tx,
+      );
+      cell.set(makeList(N));
+      await tx.commit();
+      cell.get(); // warm
+      b.start();
+      for (let i = 0; i < 100; i++) cell.get();
+      b.end();
+      await cleanup(runtime, storageManager, tx);
+    },
+  });
+
+  Deno.bench({
+    name: `flat list read - schema get() x100, unchanged doc (${N} items)`,
+    group: `read-${N}`,
+    async fn(b) {
+      const { runtime, storageManager, tx } = setup();
+      const cell = runtime.getCell(
+        space,
+        `bench-flat-index-read-schema-${N}`,
+        LIST_SCHEMA,
+        tx,
+      );
+      cell.set(makeList(N));
+      await tx.commit();
+      cell.get(); // warm
+      b.start();
+      for (let i = 0; i < 100; i++) cell.get();
+      b.end();
+      await cleanup(runtime, storageManager, tx);
+    },
+  });
+}
+
+// =============================================================================
+// 4. UPDATE: whole-array re-set with ONE item changed vs targeted per-index
+//    write. novelty bytes per tx expose whether the runtime rewrites the
+//    whole doc (history growth ∝ N) or just the delta (∝ 1).
+// =============================================================================
+for (const N of SIZES) {
+  Deno.bench({
+    name: `flat list update - whole cell.set, 1 item changed (${N} items)`,
+    group: `update-${N}`,
+    baseline: true,
+    async fn(b) {
+      const { runtime, storageManager, tx: setupTx } = setup();
+      const cell0 = runtime.getCell<IndexItem[]>(
+        space,
+        `bench-flat-index-update-set-${N}`,
+        undefined,
+        setupTx,
+      );
+      cell0.set(makeList(N));
+      await setupTx.commit();
+
+      let totalBytes = 0;
+      let totalDocs = 0;
+      b.start();
+      for (let t = 0; t < UPDATE_TXS; t++) {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<IndexItem[]>(
+          space,
+          `bench-flat-index-update-set-${N}`,
+          undefined,
+          tx,
+        );
+        const list = makeList(N);
+        list[t % N] = makeItem(t % N, `-mut${t}`);
+        cell.set(list);
+        await tx.commit();
+        const { docs, bytes } = accountNovelty(tx);
+        totalBytes += bytes;
+        totalDocs += docs;
+      }
+      b.end();
+      reportOnce(
+        `update whole-set N=${N}`,
+        `txs=${UPDATE_TXS} avgBytes/tx=${
+          Math.round(totalBytes / UPDATE_TXS)
+        } ` +
+          `avgDocs/tx=${(totalDocs / UPDATE_TXS).toFixed(1)} ` +
+          `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`,
+      );
+      await cleanup(runtime, storageManager);
+    },
+  });
+
+  Deno.bench({
+    name: `flat list update - targeted key(i).set, 1 item changed (${N} items)`,
+    group: `update-${N}`,
+    async fn(b) {
+      const { runtime, storageManager, tx: setupTx } = setup();
+      const cell0 = runtime.getCell<IndexItem[]>(
+        space,
+        `bench-flat-index-update-key-${N}`,
+        undefined,
+        setupTx,
+      );
+      cell0.set(makeList(N));
+      await setupTx.commit();
+
+      let totalBytes = 0;
+      let totalDocs = 0;
+      b.start();
+      for (let t = 0; t < UPDATE_TXS; t++) {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<IndexItem[]>(
+          space,
+          `bench-flat-index-update-key-${N}`,
+          undefined,
+          tx,
+        );
+        cell.key(t % N).set(makeItem(t % N, `-mut${t}`));
+        await tx.commit();
+        const { docs, bytes } = accountNovelty(tx);
+        totalBytes += bytes;
+        totalDocs += docs;
+      }
+      b.end();
+      reportOnce(
+        `update targeted N=${N}`,
+        `txs=${UPDATE_TXS} avgBytes/tx=${
+          Math.round(totalBytes / UPDATE_TXS)
+        } ` +
+          `avgDocs/tx=${(totalDocs / UPDATE_TXS).toFixed(1)} ` +
+          `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`,
+      );
+      await cleanup(runtime, storageManager);
+    },
+  });
+}

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -317,13 +317,42 @@ for (const N of SIZES) {
 }
 
 // =============================================================================
-// 4. UPDATE: whole-array re-set with ONE item changed vs targeted per-index
-//    write. novelty bytes per tx expose whether the runtime rewrites the
-//    whole doc (history growth ∝ N) or just the delta (∝ 1).
+// 4. UPDATE: three writer profiles for "one item changed", distinguished
+//    because they have wildly different write footprints (novelty accounting
+//    runs AFTER b.end(), on the retained per-tx journals):
+//      a. REGENERATE from scratch (what a derivation/lift recompute does):
+//         fresh objects carry no doc identity → every element re-minted.
+//      b. READ-MODIFY-WRITE (the idiomatic handler edit): objects returned
+//         by get() carry their doc identity → only the changed element and
+//         the parent write.
+//      c. TARGETED key(i).set: bypasses the array diff entirely.
 // =============================================================================
+type UpdateAccount = { docs: number; bytes: number };
+
+function accountAll(txs: IExtendedStorageTransaction[]): UpdateAccount {
+  let docs = 0;
+  let bytes = 0;
+  for (const tx of txs) {
+    const a = accountNovelty(tx);
+    docs += a.docs;
+    bytes += a.bytes;
+  }
+  return { docs, bytes };
+}
+
+function reportUpdate(label: string, N: number, acc: UpdateAccount) {
+  reportOnce(
+    `${label} N=${N}`,
+    `txs=${UPDATE_TXS} avgBytes/tx=${Math.round(acc.bytes / UPDATE_TXS)} ` +
+      `avgDocs/tx=${(acc.docs / UPDATE_TXS).toFixed(1)} ` +
+      `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`,
+  );
+}
+
 for (const N of SIZES) {
   Deno.bench({
-    name: `flat list update - whole cell.set, 1 item changed (${N} items)`,
+    name:
+      `flat list update - REGENERATE from scratch, 1 item changed (${N} items)`,
     group: `update-${N}`,
     baseline: true,
     async fn(b) {
@@ -337,8 +366,7 @@ for (const N of SIZES) {
       cell0.set(makeList(N));
       await setupTx.commit();
 
-      let totalBytes = 0;
-      let totalDocs = 0;
+      const txs: IExtendedStorageTransaction[] = [];
       b.start();
       for (let t = 0; t < UPDATE_TXS; t++) {
         const tx = runtime.edit();
@@ -352,19 +380,49 @@ for (const N of SIZES) {
         list[t % N] = makeItem(t % N, `-mut${t}`);
         cell.set(list);
         await tx.commit();
-        const { docs, bytes } = accountNovelty(tx);
-        totalBytes += bytes;
-        totalDocs += docs;
+        txs.push(tx);
       }
       b.end();
-      reportOnce(
-        `update whole-set N=${N}`,
-        `txs=${UPDATE_TXS} avgBytes/tx=${
-          Math.round(totalBytes / UPDATE_TXS)
-        } ` +
-          `avgDocs/tx=${(totalDocs / UPDATE_TXS).toFixed(1)} ` +
-          `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`,
+      reportUpdate("update regenerate", N, accountAll(txs));
+      await cleanup(runtime, storageManager);
+    },
+  });
+
+  Deno.bench({
+    name: `flat list update - READ-MODIFY-WRITE, 1 item changed (${N} items)`,
+    group: `update-${N}`,
+    async fn(b) {
+      const { runtime, storageManager, tx: setupTx } = setup();
+      const cell0 = runtime.getCell<IndexItem[]>(
+        space,
+        `bench-flat-index-update-rmw-${N}`,
+        undefined,
+        setupTx,
       );
+      cell0.set(makeList(N));
+      await setupTx.commit();
+
+      const txs: IExtendedStorageTransaction[] = [];
+      b.start();
+      for (let t = 0; t < UPDATE_TXS; t++) {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<IndexItem[]>(
+          space,
+          `bench-flat-index-update-rmw-${N}`,
+          undefined,
+          tx,
+        );
+        // Idiomatic edit: read the current array (elements carry their doc
+        // identity), replace ONE element, write the array back.
+        const current = cell.get();
+        const list = [...current];
+        list[t % N] = makeItem(t % N, `-mut${t}`);
+        cell.set(list);
+        await tx.commit();
+        txs.push(tx);
+      }
+      b.end();
+      reportUpdate("update read-modify-write", N, accountAll(txs));
       await cleanup(runtime, storageManager);
     },
   });
@@ -383,8 +441,7 @@ for (const N of SIZES) {
       cell0.set(makeList(N));
       await setupTx.commit();
 
-      let totalBytes = 0;
-      let totalDocs = 0;
+      const txs: IExtendedStorageTransaction[] = [];
       b.start();
       for (let t = 0; t < UPDATE_TXS; t++) {
         const tx = runtime.edit();
@@ -396,19 +453,10 @@ for (const N of SIZES) {
         );
         cell.key(t % N).set(makeItem(t % N, `-mut${t}`));
         await tx.commit();
-        const { docs, bytes } = accountNovelty(tx);
-        totalBytes += bytes;
-        totalDocs += docs;
+        txs.push(tx);
       }
       b.end();
-      reportOnce(
-        `update targeted N=${N}`,
-        `txs=${UPDATE_TXS} avgBytes/tx=${
-          Math.round(totalBytes / UPDATE_TXS)
-        } ` +
-          `avgDocs/tx=${(totalDocs / UPDATE_TXS).toFixed(1)} ` +
-          `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`,
-      );
+      reportUpdate("update targeted", N, accountAll(txs));
       await cleanup(runtime, storageManager);
     },
   });

--- a/packages/runner/test/patterns-lift.test.ts
+++ b/packages/runner/test/patterns-lift.test.ts
@@ -500,4 +500,85 @@ describe("Pattern Runner - Lift", () => {
     expect(lift1Runs).toBe(1);
     expect(lift2Runs).toBe(1);
   });
+  it("stores a lifted array-of-objects result inline as a single doc (no per-element entity docs)", async () => {
+    // Pin the write-path contract for DERIVED output: `Cell.set()` of an
+    // array of plain objects decomposes each element into its own entity
+    // doc (editable-array semantics, see cell.ts recursivelyAddIDIfNeeded),
+    // but a lift's RESULT is not editable and is written via the raw path
+    // (runner.ts setRawUntyped) — so an N-element derived list must land as
+    // ONE document with the elements stored INLINE, not as N element docs
+    // referenced by links. A regression here silently multiplies the doc
+    // count and sync cost of every derived list by its length.
+    const N = 50;
+    const makeIndex = lift(
+      ({ count }: { count: number }) =>
+        Array.from({ length: count }, (_, i) => ({
+          name: `entry-${i}`,
+          id: `FC:folder/${i}`,
+        })),
+      {
+        type: "object",
+        properties: { count: { type: "number" } },
+        required: ["count"],
+      } as const satisfies JSONSchema,
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            id: { type: "string" },
+          },
+        },
+      } as const satisfies JSONSchema,
+    );
+
+    const indexPattern = pattern<{ count: number }>((args) => {
+      return { index: makeIndex(args) };
+    });
+
+    const resultCell = runtime.getCell<{ index: unknown }>(
+      space,
+      "lift-array-output-single-doc",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, indexPattern, { count: N }, resultCell);
+    tx.commit();
+    tx = runtime.edit();
+
+    const value = await result.pull() as { index: { name: string }[] };
+    expect(value.index.length).toBe(N);
+    expect(value.index[7]).toMatchObject({
+      name: "entry-7",
+      id: "FC:folder/7",
+    });
+
+    // Follow the result indirection to the doc that actually holds the
+    // array, then assert its RAW stored form: a plain inline array of
+    // records — not element links, and not element `[ID]` markers.
+    const indexCell = result.key("index");
+    const link = resolveLink(
+      runtime,
+      runtime.readTx(),
+      indexCell.getAsNormalizedFullLink(),
+    );
+    const raw = runtime.readTx().readValueOrThrow({
+      ...link,
+      path: link.path,
+    }) as unknown[];
+
+    expect(Array.isArray(raw)).toBe(true);
+    expect(raw.length).toBe(N);
+    for (const element of raw) {
+      // An entity-doc decomposition would store each element as a sigil
+      // link record ({"/": {"link@1": ...}}); inline storage keeps the
+      // record's own fields directly readable.
+      expect(isCell(element)).toBe(false);
+      const record = element as Record<string, unknown>;
+      expect(record["/"]).toBeUndefined();
+      expect(typeof record.name).toBe("string");
+      expect(typeof record.id).toBe("string");
+    }
+  });
 });


### PR DESCRIPTION
## Why

A production capture of a Mobile Loom boot (25MB, 82s, ~180ms RTT; forensics in the loom repo, `docs/development/projects/mobile-loom-production-performance/findings.md`) showed a ~3k-item derived jump-search list weighing **~1.33MB per copy, re-materialized once per consuming pattern instance** — 58% of the boot payload — plus 140s of cumulative slow client-side `get()` warnings (median 65ms) re-reading unchanged docs. Before assigning blame between the runtime and that usage, this bench measures the runtime's **native dynamics for the shape in isolation**: a flat list of many similar shallow `{name, ref}`-ish items, the way any index/autocomplete list looks.

## What it measures

One new bench file, `packages/runner/test/cell-set-flat-index-list.bench.ts`, env-parameterized (`FLAT_INDEX_LIST_SIZES`, default 100/1000/3000), using `tx.journal.novelty()` for stored-bytes/docs accounting printed outside the timed windows:

1. **Write**: one `cell.set(array)` vs one `Writable.for().set()` per item — time, documents created, stored bytes vs raw JSON
2. **Read**: first `get()`, repeated `get()` ×100 on an unchanged doc, `get()` ×100 through a JSON schema (the validateAndTransform path)
3. **Update**: whole-array re-set with ONE item changed vs targeted `key(i).set` — bytes/docs written per transaction (history growth)

## Results (M-series MacBook, emulated loopback storage)

### 1. `cell.set()` of a flat object array creates one document PER ITEM

| N | docs created | stored bytes | raw JSON | overhead | per item |
|---|---|---|---|---|---|
| 100 | **101** | 70.3KB | 31.0KB | 2.27× | 703B |
| 1000 | **1001** | 717KB | 317KB | 2.26× | 717B |
| 3000 | **3001** | 2.18MB | 967KB | 2.26× | 728B |

"One flat array in one doc" does not exist for object arrays — every element becomes its own document (per-item `Writable` docs are the same count at 2.8× overhead). Downstream consequence: any watch/query over the list is N per-doc server materializations, and any client traversal is N doc hops.

### 2. Schema-path reads: linear, but ~19µs/item **per read**, no memoization

| N | first get() | repeated get() ×100 | schema get() ×100 | schema per-read |
|---|---|---|---|---|
| 100 | 164µs | 3.3ms | 165ms | **1.7ms** |
| 1000 | 554µs | 28.1ms | 1.8s | **18ms** |
| 3000 | 2.3ms | 90.1ms | 5.7s | **57ms** |

Good news: not superlinear. Bad news: the constant is brutal and **every read re-pays it in full on an unchanged document** — the schema path is ~63× the schemaless path. 57ms/read at N=3000 matches the production capture's median 65ms slow-`get()` on a ~5.6k-entry space almost exactly; production logged 1,876 re-reads of one unchanged doc = the observed 140s of client CPU.

### 3. Update profiles: regenerate-from-scratch rewrites everything; read-modify-write is cheap

Three writer profiles for "one item changed" (per-tx averages over 20 txs; accounting outside the timed window):

| N | REGENERATE from scratch | READ-MODIFY-WRITE | targeted `key(i).set` |
|---|---|---|---|
| 100 | 27ms · 61.6KB · 101 docs | 6.9ms · **685B · 2 docs** | 1.6ms · 246B · 1 doc |
| 1000 | 445ms · 629KB · 1001 docs | 85ms · **685B · 2 docs** | 16ms · 246B · 1 doc |
| 3000 | **2.15s · 1.92MB · 3001 docs** | 220ms · **685B · 2 docs** | 41ms · 246B · 1 doc |

Per review (@seefeldb): the original "whole-set" finding modeled a **regenerate-from-scratch** writer — fresh objects carry no doc identity, so every element re-mints. The idiomatic **read-modify-write** edit (get → replace one element → set back) reuses doc identity from the `get()` and lands as a flat 2-doc/~685B change at any N; writing back an unchanged array is a perfect no-op (0 docs). The full-rewrite cost applies specifically to derivation-style writers that rebuild lists from scratch — which is what our production index refresh does.

Also pinned in this PR (`patterns-lift.test.ts`): a lifted array-of-objects **result** is stored inline as ONE doc (raw write path) — derived output does not go through the editable-array decomposition.

## Interpretation

- The runtime is **efficient at targeted updates** (246B/tx regardless of N) — the primitives for cheap list maintenance exist.
- The pathological costs come from (a) the **doc-per-element explosion** on plain `cell.set`, (b) the **unmemoized schema-read path**, and (c) **wholesale re-sets** — which is exactly how derived/lifted lists get refreshed in practice.
- Production compounds this by materializing the same derived list **once per consuming pattern instance** (10 copies in the capture). That part is usage/framework layering, not this bench's subject — but it multiplies every number above.

## Test plan

- `deno task bench` filtered to the new file; full matrix run attached above.
- `deno fmt` / `deno lint` clean.
- Env knobs verified (`FLAT_INDEX_LIST_SIZES=50 FLAT_INDEX_LIST_UPDATE_TXS=3` smoke run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds benchmarks for flat index/autocomplete list write/read/update costs and decomposes schema-read overhead by schema depth, plus a test pinning derived array outputs to a single inline document. Helps explain where read costs come from and how update strategies scale.

- **New Features**
  - Added `packages/runner/test/cell-set-flat-index-list.bench.ts` to measure one-doc vs per-item writes, first/repeated/schema reads, and three update profiles at N=100/1000/3000; config via `FLAT_INDEX_LIST_SIZES`, `FLAT_INDEX_LIST_UPDATE_TXS`, `FLAT_INDEX_LIST_REPORT`.
  - Added `packages/runner/test/cell-schema-read-depth.bench.ts` to read the same 1000-item doc through schemaless, `items: true`, permissive `items: {type: "object"}`, and full item schema to locate schema-path costs.
  - Updated `packages/runner/test/patterns-lift.test.ts` to assert a lifted array-of-objects result is stored inline as a single doc (no per-element entity docs).

- **Performance**
  - `cell.set()` of an object array creates N+1 documents.
  - Schema-path reads are ~19µs/item/read (~63× schemaless); depth bench shows merely entering the schema path (`items: true`) is already ~30×, a permissive object schema is worst, and a fully-declared schema is cheaper — field validation isn’t the main cost.
  - Updates with one changed item: regenerate rewrites all N+1 docs; read-modify-write averages ~685B across 2 docs per tx and stays flat with N; targeted `key(i).set` stays ~246B/tx.

<sup>Written for commit eaa71fd994f54a53aa538d0688c9097500c97c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

