### PR TITLE
docs(cfc): reorg catch-up — archive the executed future-work plan, implementation notes, SC statuses

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -101,6 +101,10 @@ One line per archived document; each document's header carries the fuller
 - [2026-03-17-ct-exec-fuse-callables.md](plans/2026-03-17-ct-exec-fuse-callables.md)
   and [its test plan](plans/2026-03-17-ct-exec-fuse-callables-test-plan.md) —
   `cf exec` and mounted callable files.
+- [cfc-future-work-implementation.md](plans/cfc-future-work-implementation.md)
+  — the CFC future-work epics (clause core, exchange rules/policy,
+  observation classes, integrity floors, sqlite row-set, deployment flips),
+  executed 2026-07.
 - [STANDARD_DECORATORS_MIGRATION_PLAN.md](development/STANDARD_DECORATORS_MIGRATION_PLAN.md)
   — the cutover to standard decorators.
 - [content-addressed-action-identity-implementation-plan.md](specs/content-addressed-action-identity-implementation-plan.md)

--- a/docs/history/plans/cfc-future-work-implementation.md
+++ b/docs/history/plans/cfc-future-work-implementation.md
@@ -501,7 +501,7 @@ entries per written path — bench before/after (canonicalize + label-sync).
 
 **Goal.** Close the three composing holes that let an injected `sendMail`
 recipient send under `enforce` (scoping doc:
-[docs/history/specs/cfc-trusted-agent-tool-integrity.md](../../specs/cfc-trusted-agent-tool-integrity.md)),
+[docs/history/specs/cfc-trusted-agent-tool-integrity.md](../specs/cfc-trusted-agent-tool-integrity.md)),
 and build the write-side `requiredIntegrity` floor (§8.12.4.1 / SC-18). Track
 runs independently of A/B (D5 excepted) — **start immediately; this is the
 security-urgent track.**

--- a/docs/history/plans/cfc-future-work-implementation.md
+++ b/docs/history/plans/cfc-future-work-implementation.md
@@ -1,9 +1,16 @@
+---
+status: historical
+created: 2026-07-02
+archived: 2026-07-09
+reason: "Executed plan; all scheduled stages (Epics A–E, H, F-doc) merged by 2026-07-07. Residual designs live in docs/specs/cfc-{value-level-provenance,label-metadata-confidentiality,persisted-declassification}.md; the deferred tail (B2b, E5, SC-18b, rewrite event) is tracked in docs/specs/cfc-spec-changes.md."
+---
+
 # CFC future-work implementation plan
 
 _Started 2026-07-02. The detailed "how" companion to
-[`docs/specs/cfc-runner-future-work.md`](../specs/cfc-runner-future-work.md)
+[`docs/specs/cfc-runner-future-work.md`](../../specs/cfc-runner-future-work.md)
 (the prioritized "what/why" gap inventory). Sibling to
-[`runner_cfc_implementation.md`](./runner_cfc_implementation.md), the phase-1
+[`runner_cfc_implementation.md`](../../plans/runner_cfc_implementation.md), the phase-1
 commit-boundary plan this builds on. Spec references (`§…`, `04-…md`,
 `proposals/…`) are paths in the
 [`commontoolsinc/specs`](https://github.com/commontoolsinc/specs) repo under
@@ -25,7 +32,7 @@ coding; `prepare.ts` line numbers in particular will drift.
 - **Dials, not flag-days.** New behavior lands behind a mode dial defaulting to
   today's behavior; rollout = flip the dial in hosts, not merge the PR. Existing
   dials: `cfcEnforcementMode` (Runtime default `enforce-explicit`,
-  [runtime.ts:495](../../packages/runner/src/runtime.ts)), `cfcFlowLabels`
+  [runtime.ts:495](../../../packages/runner/src/runtime.ts)), `cfcFlowLabels`
   (default `off`), `cfcSinkMaxConfidentiality` (default none). New dials this
   plan adds: `cfcPolicyEvaluation` (B5), `cfcWriteFloor` (D3).
 - **Fail-closed on the new path, byte-identical on the old.** Every
@@ -37,7 +44,7 @@ coding; `prepare.ts` line numbers in particular will drift.
   the new form as **more** restrictive, never less (the `{anyOf:…}` wrapper and
   additive-entry designs below are chosen precisely for this).
 - **Digest coverage.** Anything that can change a boundary decision must be in
-  `PreparedDigestInput` ([types.ts:299](../../packages/runner/src/cfc/types.ts))
+  `PreparedDigestInput` ([types.ts:299](../../../packages/runner/src/cfc/types.ts))
   so post-prepare changes invalidate: this plan adds `policySnapshot` (B5) and
   the write-attempt log (D4).
 - **Perf gates.** Label-path changes run
@@ -93,11 +100,11 @@ outline).
 
 **Current state.** Flat sets everywhere:
 `IFCLabel = { confidentiality?: unknown[]; integrity?: unknown[] }`
-([label-view-core.ts:5](../../packages/runner/src/cfc/label-view-core.ts));
+([label-view-core.ts:5](../../../packages/runner/src/cfc/label-view-core.ts));
 join = concat + structural dedup (`mergeLabel`,
-[label-view-core.ts:123](../../packages/runner/src/cfc/label-view-core.ts));
+[label-view-core.ts:123](../../../packages/runner/src/cfc/label-view-core.ts));
 fit = flat membership (`atomsOutsideCeiling` / `cfcObservationFitsCeiling`,
-[observation.ts:81-138](../../packages/runner/src/cfc/observation.ts)).
+[observation.ts:81-138](../../../packages/runner/src/cfc/observation.ts)).
 Integrity stays flat forever (no OR-integrity — spec §3.1.6; mixed integrity is
 `IntegritySummary`, out of scope here).
 
@@ -128,7 +135,7 @@ Integrity stays flat forever (no OR-integrity — spec §3.1.6; mixed integrity 
    (spec §3.1.8 rationale: OR-Expires inverts most-restrictive-wins; OR-Caveat
    makes risk dischargeable by identity).
 6. **Ceiling meet.** `meetCfcObservationCeilings`
-   ([observation.ts:188](../../packages/runner/src/cfc/observation.ts)).
+   ([observation.ts:188](../../../packages/runner/src/cfc/observation.ts)).
    _Corrected 2026-07-02 — the original decision here ("pairwise
    alternative-set intersection, sound: the intersection clause subsumes via
    both parents") was **unsound**._ Ceiling clauses sit on the demanding side
@@ -195,7 +202,7 @@ union, join of `[[A∨B]]` and `[C]` = both clauses) and a
 Accept `{anyOf:[…]}` entries in schema `ifc.confidentiality`: validation at the
 schema write-policy path (reject non-principal-like alternatives with an
 `unsupportedTrustSensitiveReason`-style fail-closed reason,
-[prepare.ts:1623](../../packages/runner/src/cfc/prepare.ts)); schema-merge
+[prepare.ts:1623](../../../packages/runner/src/cfc/prepare.ts)); schema-merge
 direction rule (growing = adding clauses; merging alternative sets is never a
 merge result — extend `schema-merge.ts` conflict table + tests). Persistence:
 clause objects ride `LabelMapEntry.label` unchanged (shape already `unknown[]`);
@@ -238,16 +245,16 @@ prompt-caveat strip; enables declassification/discharge for the first time.
 
 **Current state (verified absent).** Zero exchange/policy machinery repo-wide.
 What exists to build on: `trustSnapshotProvider` (Runtime option,
-[runtime.ts:248,485,748](../../packages/runner/src/runtime.ts) — injected
+[runtime.ts:248,485,748](../../../packages/runner/src/runtime.ts) — injected
 per-tx via `setCfcTrustSnapshot`); `WritePolicyInput` recording
-([extended-storage-transaction.ts:464](../../packages/runner/src/storage/extended-storage-transaction.ts));
+([extended-storage-transaction.ts:464](../../../packages/runner/src/storage/extended-storage-transaction.ts));
 the runtime-minted-integrity gate (`gateRuntimeMintedIntegrity`,
-[prepare.ts:2680](../../packages/runner/src/cfc/prepare.ts), builtins bypass);
+[prepare.ts:2680](../../../packages/runner/src/cfc/prepare.ts), builtins bypass);
 the per-space system-doc pattern (`ACLManager`,
-[acl-manager.ts:10-61](../../packages/runner/src/acl-manager.ts)); the
+[acl-manager.ts:10-61](../../../packages/runner/src/acl-manager.ts)); the
 content-addressed + identity-memoized resolution pattern
 (`resolveCfcSchemaRefs`,
-[schema-refs.ts:213](../../packages/runner/src/cfc/schema-refs.ts)); the
+[schema-refs.ts:213](../../../packages/runner/src/cfc/schema-refs.ts)); the
 evidence-matching precedent (`ui-contract.ts` trusted-event verification).
 The only "discharge" today is `schema-sanitization.ts`'s bulk strip of the four
 prompt-risk kind strings — exactly the "prompt-specific runtime branch" spec
@@ -291,14 +298,14 @@ bindings) → bindings | null`, multi-binding enumeration over a label
 valid bindings), post-match equality constraints between variables, and the
 `atomEntails(a, b)` hook (deepEqual default; `Expires`: timestamp ordering;
 everything else fails closed). Register the missing atom families in
-[packages/api/cfc.ts](../../packages/api/cfc.ts) `CFC_ATOM_TYPE` with mint
+[packages/api/cfc.ts](../../../packages/api/cfc.ts) `CFC_ATOM_TYPE` with mint
 helpers + `atom-classes.ts` propagation classes (SC-10 parity): `Expires`,
 `BoundaryContext`, `CaveatScreened`, `DisclosureRendered`,
 `DisclosureAcknowledged`, `DisclaimerAttached`, `CaveatAssessment`, `User`,
 `Space`, `HasRole`. Add the missing `CFC_CONCEPT_KIND` tier kinds
 (`…-ingress-screened`, `…-value-screened`). Extend
 `RUNTIME_MINTED_INTEGRITY_ATOM_TYPES`
-([prepare.ts:2644](../../packages/runner/src/cfc/prepare.ts)) for the new
+([prepare.ts:2644](../../../packages/runner/src/cfc/prepare.ts)) for the new
 evidence families so pattern code cannot self-mint them.
 Tests: `cfc-atom-pattern.test.ts` — binding, multi-binding disjunction,
 constraint correlation, entailment, fail-closed unknown families.
@@ -311,14 +318,14 @@ integrity?: AtomPattern[]; boundary?: AtomPattern[] }`, `preConfScope:
 AtomPattern[]; dropClause?: boolean }`), `PolicyRecord` (id, digest, rules),
 `PolicySnapshot` (frozen record set + digest). `RuntimeOptions.cfcPolicyRecords`
 → frozen snapshot at construction (deep-freeze like the sink ceilings,
-[runtime.ts:499-507](../../packages/runner/src/runtime.ts)); snapshot injected
+[runtime.ts:499-507](../../../packages/runner/src/runtime.ts)); snapshot injected
 into tx CFC state alongside the trust snapshot. Tests: canonicalization/digest
 stability, freeze, malformed-record fail-closed.
 
 **B3 — trust closure.**
 `packages/runner/src/cfc/trust.ts`: a `TrustResolver` built from frozen
 deployment config + the tx `TrustSnapshot`
-([types.ts:246](../../packages/runner/src/cfc/types.ts)) — `conceptSatisfied
+([types.ts:246](../../../packages/runner/src/cfc/types.ts)) — `conceptSatisfied
 (concept, integrityAtoms, actingPrincipal) → boolean` via declared
 concept-delegate edges (transitive, bounded depth). Determinism contract: the
 resolver is a pure function of snapshot + config; `TrustSnapshot.revision`
@@ -344,14 +351,14 @@ clause locality).
 
 **B5 — boundary integration (dial: `cfcPolicyEvaluation: "off" | "observe" |
 "enforce"`, default `off`).**
-In `prepareBoundaryCommit` ([prepare.ts:3095](../../packages/runner/src/cfc/prepare.ts)):
+In `prepareBoundaryCommit` ([prepare.ts:3095](../../../packages/runner/src/cfc/prepare.ts)):
 - Mint `BoundaryContext` atoms per sink-request input (sink name; `sinkClass`
   starts with `"network"` for fetch/LLM — the display class arrives with H3b)
   — this is the Tier-2 "`sinkClass`/`BoundaryContext` substrate" item, landed
   here.
 - For each gated label (sink-request payloads in `verifySinkRequestCeilings`,
-  [prepare.ts:3058](../../packages/runner/src/cfc/prepare.ts); consumed-read
-  labels in `verifyInputRequirements`, [prepare.ts:2386](../../packages/runner/src/cfc/prepare.ts)):
+  [prepare.ts:3058](../../../packages/runner/src/cfc/prepare.ts); consumed-read
+  labels in `verifyInputRequirements`, [prepare.ts:2386](../../../packages/runner/src/cfc/prepare.ts)):
   evaluate to fixpoint, then subsumption-fit the **rewritten** label.
   `observe` = evaluate + diagnostics, decide on the un-rewritten label;
   `enforce` = decide on the rewritten label; exhaustion/lookup failure =
@@ -407,18 +414,18 @@ dereferencing, is unlabeled).
 **Current substrate (better than the audit implied).** The persisted entry
 already has a provenance axis (`LabelMapEntry.origin`:
 declared/link/derived/structure/external-ingest,
-[types.ts:171-182](../../packages/runner/src/cfc/types.ts)); reads already
+[types.ts:171-182](../../../packages/runner/src/cfc/types.ts)); reads already
 distinguish shape-only observations (`nonRecursive` on `IReadActivity`,
-[storage/interface.ts:1469](../../packages/runner/src/storage/interface.ts))
+[storage/interface.ts:1469](../../../packages/runner/src/storage/interface.ts))
 and link-topology probes (`linkResolutionProbe` marker,
-[reactivity-log.ts:58](../../packages/runner/src/storage/reactivity-log.ts) —
+[reactivity-log.ts:58](../../../packages/runner/src/storage/reactivity-log.ts) —
 currently **excluded** from flow taint, which *is* the SC-8 residual);
 read-side resolution already threads `nonRecursive`
 (`effectiveReadLabel(metadata, logicalPath, nonRecursive, { excludeLinkOrigin:
 true })` inside `deriveFlowJoin`,
-[prepare.ts:1321](../../packages/runner/src/cfc/prepare.ts)); and the
+[prepare.ts:1321](../../../packages/runner/src/cfc/prepare.ts)); and the
 `structure` origin already labels container shape at exact paths
-([prepare.ts:3517-3583](../../packages/runner/src/cfc/prepare.ts)).
+([prepare.ts:3517-3583](../../../packages/runner/src/cfc/prepare.ts)).
 
 **C0 — design doc first (`docs/specs/cfc-observation-classes.md`).** This epic
 has real open semantics; write them down before code:
@@ -445,7 +452,7 @@ has real open semantics; write them down before code:
 
 **C1 — read-shape plumbing.** Classify each flow observation (value /
 shape-only via `nonRecursive` / followRef via `linkResolutionProbe`) in
-`forEachFlowObservation` ([prepare.ts:1215](../../packages/runner/src/cfc/prepare.ts));
+`forEachFlowObservation` ([prepare.ts:1215](../../../packages/runner/src/cfc/prepare.ts));
 `effectiveReadLabel` selects entries by class-compatibility instead of the
 boolean; `excludeLinkOrigin` becomes class selection (link-origin entries
 consumed by `followRef` reads). Flow-taint parity test, scoped per C0 §6:
@@ -463,7 +470,7 @@ class.
 **C3 — the two channel fixes (red first).**
 SC-4: test — write secret → derived label present; overwrite with public value
 → **existence/shape entry still carries the old J** (today it vanishes; the
-in-code acknowledgment sits near [prepare.ts:1150](../../packages/runner/src/cfc/prepare.ts)).
+in-code acknowledgment sits near [prepare.ts:1150](../../../packages/runner/src/cfc/prepare.ts)).
 SC-8: test — read WHICH link sits at a slot (no dereference) → flow join now
 carries the link entry's `followRef` label (today: clean).
 
@@ -474,7 +481,7 @@ the epic).
 
 **C5 — sqlite precision.** Null-origin/computed-column conservative merge
 (`deriveNullOriginIfc`,
-[sqlite-builtins.ts:205](../../packages/runner/src/builtins/sqlite-builtins.ts))
+[sqlite-builtins.ts:205](../../../packages/runner/src/builtins/sqlite-builtins.ts))
 narrows to the classes actually consumed.
 
 **Rollout.** _Corrected by C0 (#4476) — two regimes, not one._
@@ -494,7 +501,7 @@ entries per written path — bench before/after (canonicalize + label-sync).
 
 **Goal.** Close the three composing holes that let an injected `sendMail`
 recipient send under `enforce` (scoping doc:
-[docs/history/specs/cfc-trusted-agent-tool-integrity.md](../history/specs/cfc-trusted-agent-tool-integrity.md)),
+[docs/history/specs/cfc-trusted-agent-tool-integrity.md](../../specs/cfc-trusted-agent-tool-integrity.md)),
 and build the write-side `requiredIntegrity` floor (§8.12.4.1 / SC-18). Track
 runs independently of A/B (D5 excepted) — **start immediately; this is the
 security-urgent track.**
@@ -502,10 +509,10 @@ security-urgent track.**
 **Current state.** (1) tool-invoke never consults `inputSchema.ifc.
 requiredIntegrity` (`llm-dialog.ts` `handleInvoke`/`executeToolCalls`); (2) the
 enforced gate is write-target-scoped (`verifyInputRequirements`,
-[prepare.ts:2386](../../packages/runner/src/cfc/prepare.ts)) and the demo's
+[prepare.ts:2386](../../../packages/runner/src/cfc/prepare.ts)) and the demo's
 targets carry no floor; (3) vacuous pass — empty consumed set satisfies the
 gate, acknowledged in-code with the coupling warning
-([prepare.ts:2372-2380](../../packages/runner/src/cfc/prepare.ts): tightening
+([prepare.ts:2372-2380](../../../packages/runner/src/cfc/prepare.ts): tightening
 without per-write provenance would over-reject); model output carries no label
 at all. The red test already exists and is `it.ignore`'d:
 `packages/runner/test/cfc-agent-tool-input-integrity.test.ts`.
@@ -561,7 +568,7 @@ floor-declaring schema + integrity-less write commits today under
 **D4 — per-write read-prefix provenance (the deferred end-state of
 `runner_cfc_implementation.md` "Potential and Final Write Sets").**
 _Design superseded by the soundness review
-[`docs/specs/cfc-write-prefix-provenance.md`](../specs/cfc-write-prefix-provenance.md):
+[`docs/specs/cfc-write-prefix-provenance.md`](../../specs/cfc-write-prefix-provenance.md):
 the bound below ("first attempt") is unsound under write re-attempts — the
 sound bound is the **last write overlapping the protected path** (both prefix
 directions), and consumed-read journal positions must join the digest
@@ -576,7 +583,7 @@ honestly). Two payoffs, both tested red-first: (i) the general audit-#14
 tightening — a floor-declaring write with an **empty read prefix** fails
 instead of vacuously passing; (ii) the S7-style false-reject scaffolding
 (`isProvenanceOnlyConsumedLabel`,
-[prepare.ts:2381](../../packages/runner/src/cfc/prepare.ts)) can narrow — the
+[prepare.ts:2381](../../../packages/runner/src/cfc/prepare.ts)) can narrow — the
 admin-grant lookup no longer gates an unrelated later write (port the
 group-chat regression scenario from the comment into a test). Digest: the
 write-attempt log joins `PreparedDigestInput` + `canonical.ts`.
@@ -596,14 +603,14 @@ aggregates work via the common-alternative property, land read-time clearance
 (Phase 3.b) and server-side commit-time re-derivation (Phase 3.c).
 
 **Current state.** Phase 3.a is done and well-factored: rule AST + shared
-evaluator in [packages/memory/v2/sqlite/row-label.ts](../../packages/memory/v2/sqlite/row-label.ts)
+evaluator in [packages/memory/v2/sqlite/row-label.ts](../../../packages/memory/v2/sqlite/row-label.ts)
 (memory-side — conveniently already where 3.c needs it); `any()` serializes but
 is rejected at `table()` time with the clause-profile error
 (row-label.ts:246-249, enforced at 311/343/582); read side
-([row-label-read.ts](../../packages/runner/src/builtins/sqlite/row-label-read.ts)):
+([row-label-read.ts](../../../packages/runner/src/builtins/sqlite/row-label-read.ts)):
 true-origin attribution, `onExceed: fail|skip` with the aggregate-skip
 refusal, ceiling placeholder resolution (`__ctCurrentPrincipal`/`__ctDbOwner`);
-write side ([row-label-write.ts](../../packages/runner/src/builtins/sqlite/row-label-write.ts)):
+write side ([row-label-write.ts](../../../packages/runner/src/builtins/sqlite/row-label-write.ts)):
 no-laundering fit + fail-closed rejects for every non-attributable shape, each
 error naming 3.c as the lift; `authoredBy`/`endorsedBy` already mint
 self-describing `claimed-*` atoms (the forgeability mitigation is **already
@@ -697,11 +704,11 @@ needs it.
 
 **Goal.** Turn on what is built. Corrected picture from the seam mapping: the
 Runtime constructor **already defaults `enforce-explicit`**
-([runtime.ts:495](../../packages/runner/src/runtime.ts)), as does lib-shell
-([lib-shell/src/runtime.ts:113-149](../../packages/lib-shell/src/runtime.ts));
+([runtime.ts:495](../../../packages/runner/src/runtime.ts)), as does lib-shell
+([lib-shell/src/runtime.ts:113-149](../../../packages/lib-shell/src/runtime.ts));
 `InitializationData` already carries `renderDeclassificationPolicy` and
 `renderConfidentialityCeiling` across the worker IPC
-([runtime-client/protocol/types.ts:130-187](../../packages/runtime-client/protocol/types.ts)).
+([runtime-client/protocol/types.ts:130-187](../../../packages/runtime-client/protocol/types.ts)).
 The dormant pieces are: the flow dial (`off` everywhere), the render ceiling
 (plumbed, never populated), `enforce-strict` (rankable, no distinct behavior),
 and trigger-read labels on the enforcement side.
@@ -732,7 +739,7 @@ profile per §8.10.6 owner direction: `atoms: [<acting-user DID string>, …]`
 (exact-match forms the reconciler can check today) +
 `caveatKinds: [<influence-class kinds>]` allow-list. Dogfood behind a shell
 flag; the reconciler's fail-closed narrowing
-([reconciler.ts childRenderPolicyForNode](../../packages/html/src/worker/reconciler.ts))
+([reconciler.ts childRenderPolicyForNode](../../../packages/html/src/worker/reconciler.ts))
 does the rest. Expect over-blocking (no exchange resolution yet) — that is the
 point of the dogfood stage; H3b fixes precision.
 
@@ -748,7 +755,7 @@ here (completing B5's substrate).
 Define the mode matrix in a short doc section first (which combinations of
 enforcement × flow dial are conforming deployment states; rollout ordering:
 propagation-observe → persist → strict). Implement strict-only rejects at the
-ladder ([extended-storage-transaction.ts:1016-1033](../../packages/runner/src/storage/extended-storage-transaction.ts)).
+ladder ([extended-storage-transaction.ts:1016-1033](../../../packages/runner/src/storage/extended-storage-transaction.ts)).
 Missing-policy is **not** part of the strict delta: `enforce-explicit` already
 fail-closes it (prepare records `missing schema write-policy input`, the
 ladder rejects any reasoned tx under both enforcing modes, asserted in
@@ -760,7 +767,7 @@ an explicit-mode grace, each with its error contract (SC-18c: stable reason
 strings naming rule id + path).
 
 **H5 — trigger reads on the enforcement side (SC-3 completion).**
-`CfcTxState.triggerReads` ([types.ts:339-345](../../packages/runner/src/cfc/types.ts))
+`CfcTxState.triggerReads` ([types.ts:339-345](../../../packages/runner/src/cfc/types.ts))
 currently joins only the flow derivation. Add their `effectiveReadLabel`s to
 the consumed set for the sink-request ceiling and input-requirement gates,
 behind a flag folded into the H4 matrix (cost: extra metadata reads per

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -1,7 +1,7 @@
 # CFC enforcement × propagation × write-floor × trigger gating — the deployment mode matrix
 
 _Epic H, stage H4 (first sub-step), of
-[`docs/plans/cfc-future-work-implementation.md`](../plans/cfc-future-work-implementation.md).
+[`docs/history/plans/cfc-future-work-implementation.md`](../history/plans/cfc-future-work-implementation.md).
 Spec residual: SC-13 in [`cfc-spec-changes.md`](./cfc-spec-changes.md) (§18) and
 the `enforce-strict` differentiation (SC-13 / §18.6.3). This section settles
 **which combinations of the five CFC dials are conforming deployment states and

--- a/docs/specs/cfc-observation-classes.md
+++ b/docs/specs/cfc-observation-classes.md
@@ -1,7 +1,7 @@
 # CFC observation classes (`PathLabelTemplate`) — design
 
 _Epic C, stage C0, of
-[`docs/plans/cfc-future-work-implementation.md`](../plans/cfc-future-work-implementation.md).
+[`docs/history/plans/cfc-future-work-implementation.md`](../history/plans/cfc-future-work-implementation.md).
 Spec: `commontoolsinc/specs` `cfc/04-label-representation.md` §4.6.3 (the
 primitive read profile) and §4.5.2; the residuals are SC-4 / SC-8 in
 [`cfc-spec-changes.md`](./cfc-spec-changes.md). This doc settles the semantics

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -74,9 +74,10 @@ type CfcGrant = {
 
 ### 2.2 Consumption: the `policyState` guard kind
 
-Shipped `ExchangeRule.preCondition` admits `confidentiality | integrity |
-boundary` guards only — §13.4.4's `policyState` guard kind is unimplementable
-in B2a. The extension: a `policyState` guard names a grant `kind` plus field
+Before #4627, `ExchangeRule.preCondition` admitted `confidentiality |
+integrity | boundary` guards only — §13.4.4's `policyState` guard kind was
+unimplementable in B2a. The extension: a `policyState` guard names a grant
+`kind` plus field
 patterns; at evaluation the runtime resolves matching, unexpired, unrevoked
 grants from the governing space's grant path (point query per candidate, the
 §4.9.3 discipline: fail-closed on absent/malformed/unsynced; discovered from
@@ -165,6 +166,26 @@ content-addressed, verify-on-read machinery. If B2b is built first, grants
 are a second record kind on the same substrate; if grants go first, B2b
 inherits the substrate. Either order, with CT-1874's home-clause gate in the
 shared selection layer.
+
+_Implementation note (2026-07-09): items 1–3 shipped in #4627. The
+`policyState` guard resolves through `ExchangeEvalContext.grantResolver`
+(evaluator stays pure; variables bind from grant fields; unresolvable or
+throwing resolution fails closed). `CfcGrant` records live in the **owner's
+identity space** at `grant:cfc:` + a digest of the release scope
+`{version, space, kind, owner, resource}` — identity is the scope only, so
+the audience and lifecycle live in the value and revocation keeps the
+address (a full-record hash would give revocations a fresh address while
+the stale one kept resolving). Writes go through
+`IExtendedStorageTransaction.writeCfcGrant()` and require a trusted
+**builtin** implementation identity (pattern/handler code cannot author
+durable release state); audience entries pass the §3.1.8 principal-like
+validation shared with authored clauses (`clause.ts`); `owner` must equal
+the acting principal — the fuller §13.4.3 intent-evidence chain lands with
+item 4. Lookups ride `internalVerifierRead`;
+`PreparedDigestInput.consultedGrants` binds each consulted grant's content
+address (absent candidates carry an `"absent"` marker so a grant appearing
+also invalidates), with a live prepare→revoke→commit-reject test. Items 4–5
+remain open._
 
 ## 4. The rewrite event (specify now, build later)
 
@@ -274,6 +295,6 @@ frame cause derived from it (`runner.ts` — "every id minted in this frame
 derives from the durable event id"), create-only receipt cell
 `{resultFor: cause}` + `markCreateOnly` as the exactly-once witness,
 `receipt-exists` permanent rejection (`scheduler/events.ts`). Labs-side:
-Epic B decision 1 (`docs/plans/cfc-future-work-implementation.md`), CT-1874
+Epic B decision 1 (`docs/history/plans/cfc-future-work-implementation.md`), CT-1874
 (home-clause constraint), [`cfc-label-metadata-confidentiality.md`](./cfc-label-metadata-confidentiality.md)
 (grant records as label-adjacent metadata).

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -203,8 +203,21 @@ declassification event. Contract, if and when built:
    frame derives causally from it, and a create-only receipt cell is the
    exactly-once witness — duplicate handlings collide as `receipt-exists`
    permanent rejections. What is still missing is the **refinement/evidence
-   half** of §6: the `IntentEvent → IntentOnce` chain, gesture-provenance
-   binding to rendered state, and the bounded-retry attempt-cell ledger.
+   half** of §6, four named pieces: the `IntentEvent → IntentOnce`
+   refinement chain, gesture-provenance binding to rendered state
+   (§6.3/§6.7.3), the `exp`/`maxAttempts` attempt-cell ledger (§6.5.3), and
+   long-intent display/cancellation. **None of the four gates the
+   mechanism** — they raise assurance from "owner-authenticated call" to
+   "provably user-gestured". A **reduced-evidence v1 is buildable on the
+   receipt substrate alone**: the declassification event is an ordinary
+   stream event `{doc, path, clauseDigest, audience}`; its handler is a
+   trusted builtin that verifies release authority directly (`owner` ===
+   acting principal from the trust snapshot — the shipped `writeCfcGrant`
+   discipline) and consumes the event's receipt as the single-use gate. For
+   the owner-decided case §3.8.4's conjunctive gate is satisfied in this
+   form: the release condition *is* the authenticated owner's event, and
+   the parameters' integrity is the verified session identity. The four
+   §6 pieces slot in later without changing the event record or the gate.
 2. **Policy-guarded**: the acting principal's authority over the target
    clause verified exactly as a grant writer would (inv-7), plus §8.10.5.2 —
    a broader audience is a new release judgment with its own evidence.
@@ -242,13 +255,31 @@ already works today with no new machinery.
 
 Build **grants** when a product surface needs durable sharing (the share UI,
 group-membership beyond space ACLs) — B2b-adjacent, no blockers beyond the
-evaluator extension. Build the **rewrite event** only when all hold: (a) a
-real export/publish/portability requirement that grants demonstrably cannot
-serve; (b) the §6 refinement/evidence half exists on top of the shipped
-receipt discipline (the `IntentEvent → IntentOnce` chain and
-gesture-provenance binding — the consumption half is already behind
-`experimental.commitPreconditions`); (c) the declared-component monotonicity
-gate (§4.3) has shipped and soaked.
+evaluator extension. For the **rewrite event**, the dependency picture at
+mechanism level (2026-07-09):
+
+- **Exists**: single-use consumption — `experimental.commitPreconditions`
+  receipts (durable event id, event-causal record ids, create-only
+  exactly-once witness); authority verification — the `writeCfcGrant`
+  owner === acting-principal discipline; clause identity — the canonical
+  clause form (`normalizeClause` + the canonical digest idiom) needs only a
+  small `clauseDigest` helper; attribution — verified identities +
+  `writeAuthorizedBy` builtin arm.
+- **Missing, buildable now**: the declared-component **monotonicity gate**
+  (§4.3) — a self-contained prepare-time check comparing a re-minted
+  declared entry against the stored one under `canUpdateStoreLabel`
+  semantics (confidentiality may only add clauses or drop alternatives;
+  integrity may only drop atoms — the A2/A3 clause helpers give
+  subsumption), dialed `off | observe | enforce` like every other gate,
+  with the event writer as its sanctioned exception hook. Nothing blocks
+  it; it must ship and soak **before** the exception exists.
+- **Missing, assurance-only**: the four §6 evidence pieces (§4.1) — they
+  upgrade a v1, they do not gate it.
+
+So the only *hard* remaining gate is (a): a real export/publish/portability
+requirement that grants demonstrably cannot serve — a product decision, not
+a substrate one. When (a) holds, build order is: monotonicity gate → soak →
+reduced-evidence v1 (§4.1) → §6 evidence upgrades as they land.
 Until then, "publish" is served by route 3 (copy-forward), which is honest
 about being a new value.
 

--- a/docs/specs/cfc-range-scoped-integrity.md
+++ b/docs/specs/cfc-range-scoped-integrity.md
@@ -1,7 +1,7 @@
 # CFC range-scoped integrity for collaborative fields (Epic F) — design
 
 _Epic F of
-[`docs/plans/cfc-future-work-implementation.md`](../plans/cfc-future-work-implementation.md)
+[`docs/history/plans/cfc-future-work-implementation.md`](../history/plans/cfc-future-work-implementation.md)
 (§8). Spec: `commontoolsinc/specs` `cfc/14-open-problems-and-proposals.md`
 §14.4.8 (collaborative documents, OT materialization, range-scoped integrity)
 plus the `views` storage hook the spec already reserves in

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -360,7 +360,10 @@ the D3 write floor's check (§8.12.4.1) under its staged dial — an
 unconditional read-side rejection would duplicate it under `enforce` and
 break the pinned dial-off/observe byte-compat. If the spec wants the read
 gate itself to reject empty-input floored writes independent of the floor
-dial, that needs its own normative text + rollout dial.
+dial, that needs its own normative text + rollout dial. _Spec home landed:
+specs#14 added §8.9.1.1 (journal-order structural precision — the prefix,
+its bounds, trigger reads, digest binding), discharging the owed home; the
+interpretation recorded here is now normative text._
 
 **SC-24 [normative] Journal-order precision blessed; span-attributed
 provenance profiled — §8.9.1.** SC-23's interpretation still has no spec home:
@@ -384,7 +387,12 @@ opaque handlers stay at the prefix; the §8.9.1 `flow-taint-precision` gate
 remains only for semantic claims beyond runtime structure. States that the
 egress ceiling / flow join / floor credit MAY upgrade from transaction-global
 where the profile is enforced (upgrades SC-23's boundaries (a)/(b) from
-deliberate to staged). `open`.
+deliberate to staged). `applied` — specs#14 (2026-07-09): part (1) as
+§8.9.1.1, part (2) as the §8.9.1.2 span-attributed provenance profile
+(executor classes incl. the instance rule, late-error framing, digest
+discipline, predictions-never-narrow). Runner-side stage 0 (precision
+counters) shipped as labs#4623; span machinery remains behind the
+entry criteria in `cfc-value-level-provenance.md`.
 
 **SC-25 [normative] Cross-space label-metadata representation classes —
 §4.6.4.1/§4.6.4.2 (inv-12; supersedes SC-14's posture).** §4.6.4.1's
@@ -405,7 +413,14 @@ effective confidentiality — sound because the §8.9.2 conservative join
 contains each influencing source's confidentiality; else fail closed —
 computable without new persisted metadata), and SC-6's "revisit when
 invariant 12 is implemented" note is discharged by the introspection-surface
-observation channel. `open`.
+observation channel. `applied` — specs#14 (2026-07-09): the §4.6.4.1
+known-exposure paragraph upgraded to the normative representation rule
+(public/commitment/reference, same-form matching, `notAvailable` collapse)
+and §4.6.4.2 gained the derived-component interim fallback. Runner-side:
+stage 0 shipped as labs#4624 (seam close, persist re-derivation, sigil
+redaction, classification table), stage 1 as labs#4638
+(`cfcLabelMetadataProtection` dial, `{digestOf}` commitment transform,
+commitment-aware matching); stages 2–3 remain per the design doc.
 
 **SC-26 [reconcile] §8.12.7 route 2 conflates grant records with the rewrite
 event — §8.12.7/§13.4.3.** Route 2's cited shape (§13.4.3) persists a
@@ -424,7 +439,13 @@ causal to the consumed intent's id — the shipped `commitPreconditions`
 receipt discipline — with canonical clause-digest identity, outside the
 churn-free envelope). Guidance refines to:
 2a when revocable or policy-derived; 2b only when the widening must survive
-without evaluation (export/publish). Unconflate the §13 table row. `open`.
+without evaluation (export/publish). Unconflate the §13 table row.
+`applied` — specs#14 (2026-07-09): §8.12.7 route 2 split into 2a/2b with the
+2b contract (including the create-only intent-causal record shape) and the
+§13 summary-table row unconflated. Runner-side: grants build-order items 1–3
+shipped as labs#4627 (`policyState` guards, owner-space `grant:cfc:` records,
+consulted-grant digest binding); the rewrite event stays unscheduled per
+`cfc-persisted-declassification.md` §5.
 
 ## Queue (from the audit; statuses re-checked by the 2026-06-12 sweep where
 ## noted)

--- a/docs/specs/cfc-value-level-provenance.md
+++ b/docs/specs/cfc-value-level-provenance.md
@@ -239,13 +239,21 @@ SC-11 idempotence intact. (1) is self-contained. (3) rides (2).
 
 ## 6. Stage 0 — measure before building
 
-There is today **no counter measuring prefix precision** (nothing records
-`boundFor` `+Infinity` rates, reads excluded per write, or would-flip
-decisions). Before any span machinery:
+Stage 0 gives the prefix its missing precision counters (before it, nothing
+recorded `boundFor` `+Infinity` rates, reads excluded per write, or
+would-flip decisions). Before any span machinery:
 
 - Extend `CfcInstrumentationHooks` with per-prepare precision counters:
   gated-read count per protected write (prefix vs transaction-global), bound
   source (real / `+Infinity` / clock-less), S7-exemption fire count.
+  _Implementation note (2026-07-09): shipped in #4623 —
+  `CfcInstrumentationHooks.onPrefixProvenance` emits a per-prepare
+  `CfcPrefixProvenanceSummary` (per-write prefix vs pre-D4 transaction-global
+  gated counts, bound classification `real`/`infinityFallback`/`clockLess`,
+  within-prefix S7 fires, clock-less read count; per-write paths in RFC 6901
+  via `encodePointer`), opt-in via `RuntimeOptions.cfcPrefixProvenanceStats`
+  with nine `prefix*` totals aggregated into `getCfcStats()`. Zero
+  allocation when the hook is absent; enforcement decisions byte-identical._
 - In the interpreter branch, a shadow mode: compute `feeds(w)` from the
   existing `runScoped` brackets **without enforcement**, and log
   `would-flip` — decisions (rejections *and* label joins) that differ between

--- a/docs/specs/cfc-write-prefix-provenance.md
+++ b/docs/specs/cfc-write-prefix-provenance.md
@@ -1,7 +1,7 @@
 # CFC per-write read-prefix provenance (Epic D4) — soundness review
 
 _Epic D, stage D4, of
-[`docs/plans/cfc-future-work-implementation.md`](../plans/cfc-future-work-implementation.md).
+[`docs/history/plans/cfc-future-work-implementation.md`](../history/plans/cfc-future-work-implementation.md).
 This doc is a **soundness review** of the plan's proposed prefix approximation,
 grounded in the CFC spec (`commontoolsinc/specs` `cfc/08-09-runtime-label-propagation.md`
 §8.9, §8.9.1, §8.9.2). It found a real unsoundness in the plan text and fixes the

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -53,7 +53,7 @@ export type RuntimeRenderConfidentialityCeiling = NonNullable<
 
 /**
  * The §8.10.6 initial display-sink release ceiling (Epic H3a/H3b,
- * docs/plans/cfc-future-work-implementation.md): what a display surface
+ * docs/history/plans/cfc-future-work-implementation.md): what a display surface
  * admits when no authored policy covers it. The audience of a display sink
  * is the acting user, so the identity/personal-space principal forms naming
  * exactly that audience are admissible by construction. Shared `Space(...)`
@@ -215,7 +215,7 @@ export function createRuntimeClientOptions({
   spaceHostMap,
   experimental,
   cfcEnforcementMode = "enforce-explicit",
-  // Epic H2 (docs/plans/cfc-future-work-implementation.md): shell hosts run the
+  // Epic H2 (docs/history/plans/cfc-future-work-implementation.md): shell hosts run the
   // flow-label dial at "persist" — the per-tx conservative join is derived AND
   // written as a `derived` label component on every value write. This
   // activates inv-9 (flow-path confidentiality) in real shell deployments:

--- a/packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts
+++ b/packages/patterns/integration/sqlite-read-clearance-multi-runtime.test.ts
@@ -200,7 +200,7 @@ describe("sqlite read-time clearance across runtimes", () => {
   });
 
   it("releases nothing about withheld rows beyond the declared surface", async () => {
-    // §6 E3 (docs/plans/cfc-future-work-implementation.md): "the
+    // §6 E3 (docs/history/plans/cfc-future-work-implementation.md): "the
     // withheld-count is not observable in the result shape beyond the
     // declared release". The raw stored doc — read with NO result-schema
     // shaping, so it is the query's ENTIRE observable surface — must carry

--- a/packages/runner/src/builtins/llm-schemas.ts
+++ b/packages/runner/src/builtins/llm-schemas.ts
@@ -2,7 +2,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { cfcAtom } from "@commonfabric/api/cfc";
 
-// Epic D1b (docs/plans/cfc-future-work-implementation.md): model output written
+// Epic D1b (docs/history/plans/cfc-future-work-implementation.md): model output written
 // by the `llm`, `generateText`, and `generateObject` builtins carries an
 // explicit `LlmDerived` provenance stamp — the same mark D1 attaches to dialog
 // messages, so "model-derived" is explicit provenance rather than mere absence

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -66,7 +66,7 @@ const client = new LLMClient();
 /** Batch interval for partial streaming updates (~15fps). */
 const PARTIAL_BATCH_MS = 66;
 
-// Epic D1b (docs/plans/cfc-future-work-implementation.md): the llm builtins
+// Epic D1b (docs/history/plans/cfc-future-work-implementation.md): the llm builtins
 // stamp their model-output writebacks with an explicit `LlmDerived` provenance
 // atom — the same mark D1 attaches to dialog messages. `llm`/`generateText`
 // write `result`/`partial` through {@link LLM_DERIVED_RESULT_STAMP_SCHEMA};

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -9,7 +9,7 @@ import {
 
 /**
  * Atom pattern matching for the exchange-rule calculus (spec §4.3.3/§4.4.5,
- * Epic B1 of docs/plans/cfc-future-work-implementation.md).
+ * Epic B1 of docs/history/plans/cfc-future-work-implementation.md).
  *
  * An `AtomPattern` is one of:
  * - a **concrete scalar/array** — matches by structural equality;

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -7,7 +7,7 @@ import { uniqueCfcAtoms } from "./observation.ts";
 
 /**
  * CNF confidentiality clauses (spec §3.1.8 / §4.2.1; Epic A of
- * docs/plans/cfc-future-work-implementation.md).
+ * docs/history/plans/cfc-future-work-implementation.md).
  *
  * A confidentiality label is a conjunction of clauses. Each clause is either
  * a bare atom (a singleton clause — every entry in today's flat labels) or an

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -21,7 +21,7 @@ import type { TrustResolver } from "./trust.ts";
 
 /**
  * The guarded-rewrite evaluator (spec §4.4.5, Epic B4 of
- * docs/plans/cfc-future-work-implementation.md §3): runs a policy snapshot's
+ * docs/history/plans/cfc-future-work-implementation.md §3): runs a policy snapshot's
  * exchange rules over one label to a fuelled fixpoint. The ONLY things a
  * firing may do:
  *

--- a/packages/runner/src/cfc/policy.ts
+++ b/packages/runner/src/cfc/policy.ts
@@ -5,7 +5,7 @@ import type { AtomPattern } from "./atom-pattern.ts";
 
 /**
  * Policy records + exchange rules (spec §4.3/§4.4, Epic B2 of
- * docs/plans/cfc-future-work-implementation.md §3).
+ * docs/history/plans/cfc-future-work-implementation.md §3).
  *
  * This is stage B2a: a deployment-configured, frozen policy set supplied via
  * `RuntimeOptions.cfcPolicyRecords` — the degenerate single-policy-root case

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -15,7 +15,7 @@ import type { SpaceMembershipProvider } from "./space-membership.ts";
 
 /**
  * Display-sink render ceiling resolution (Epic H3b of
- * docs/plans/cfc-future-work-implementation.md §7; spec §8.10.6).
+ * docs/history/plans/cfc-future-work-implementation.md §7; spec §8.10.6).
  *
  * The render path is a display-sink egress boundary. Spec §8.10.6: "Ordinary
  * exchange-rule evaluation runs before the fit check, as at any boundary.

--- a/packages/runner/src/cfc/standard-profile.ts
+++ b/packages/runner/src/cfc/standard-profile.ts
@@ -3,7 +3,7 @@ import type { CfcPolicyRecordInput, ExchangeRule } from "./policy.ts";
 
 /**
  * The §10.1 standard prompt-caveat profile, expressed entirely as ordinary
- * exchange rules (Epic B6 of docs/plans/cfc-future-work-implementation.md §3;
+ * exchange rules (Epic B6 of docs/history/plans/cfc-future-work-implementation.md §3;
  * spec §10.1 / §8.10.5). There is NO prompt-specific runtime branch: the
  * runtime surfaces atoms (caveats in confidentiality, evidence in integrity,
  * `BoundaryContext` at release sites) and these rules decide discharge.

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -5,7 +5,7 @@ import { type AtomPattern, matchAtomPattern } from "./atom-pattern.ts";
 
 /**
  * User-scoped trust closure (spec §4.8, Epic B3 of
- * docs/plans/cfc-future-work-implementation.md §3): concept guards in
+ * docs/history/plans/cfc-future-work-implementation.md §3): concept guards in
  * exchange rules and integrity floors are satisfied from CONCRETE carried
  * integrity via the acting principal's trust closure — trust statements bind
  * concrete principals to concepts, verifier delegations decide whose

--- a/packages/runner/test/cfc-atom-pattern.test.ts
+++ b/packages/runner/test/cfc-atom-pattern.test.ts
@@ -14,7 +14,7 @@ import {
 import { atomPropagationClass } from "../src/cfc/atom-classes.ts";
 import { clauseSubsumes } from "../src/cfc/clause.ts";
 
-// Epic B1 (docs/plans/cfc-future-work-implementation.md §3): the atom
+// Epic B1 (docs/history/plans/cfc-future-work-implementation.md §3): the atom
 // pattern-matching kernel of the exchange-rule calculus (spec §4.3.3/§4.3.4)
 // plus the per-family entailment hook and the new atom families' registry
 // entries. Pure helpers — B4 wires them into the fuelled evaluator.

--- a/packages/runner/test/cfc-clause-authoring.test.ts
+++ b/packages/runner/test/cfc-clause-authoring.test.ts
@@ -15,7 +15,7 @@ import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-clause-authoring");
 
-// Epic A4 (docs/plans/cfc-future-work-implementation.md): authors may write
+// Epic A4 (docs/history/plans/cfc-future-work-implementation.md): authors may write
 // disjunctive confidentiality clauses (`{anyOf:[…]}`) in schema
 // `ifc.confidentiality`. Principal-like alternatives persist intact; Expires /
 // Caveat alternatives are rejected fail-closed (spec §3.1.8).
@@ -79,7 +79,7 @@ describe("CFC authored disjunctive confidentiality", () => {
 
   it("persisted clause read by a clause-UNAWARE flat reader is outside every ceiling (mixed-version fail-closed, design decision 1)", async () => {
     // The mixed-version story of design decision 1
-    // (docs/plans/cfc-future-work-implementation.md, Epic A): a reader that
+    // (docs/history/plans/cfc-future-work-implementation.md, Epic A): a reader that
     // predates clause subsumption (#4470) deepEquals the WHOLE `{anyOf:[…]}`
     // object against each ceiling entry, so an authored clause can only ever
     // over-restrict on old readers — never leak. Confirmed end-to-end: schema

--- a/packages/runner/test/cfc-clause-ceiling-fit.test.ts
+++ b/packages/runner/test/cfc-clause-ceiling-fit.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/cfc/observation.ts";
 import { normalizeClause } from "../src/cfc/clause.ts";
 
-// Epic A2 (docs/plans/cfc-future-work-implementation.md): the ceiling-fit
+// Epic A2 (docs/history/plans/cfc-future-work-implementation.md): the ceiling-fit
 // check becomes CNF clause subsumption (spec §8.10.3). The load-bearing case
 // is the reader-enumeration quantifier fix — a multi-party label must NOT fit
 // an "A or B may observe" ceiling.

--- a/packages/runner/test/cfc-clause-consumers.test.ts
+++ b/packages/runner/test/cfc-clause-consumers.test.ts
@@ -8,7 +8,7 @@ import {
 import { isOrClause } from "../src/cfc/clause.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 
-// Epic A5 (docs/plans/cfc-future-work-implementation.md): the flat-assumption
+// Epic A5 (docs/history/plans/cfc-future-work-implementation.md): the flat-assumption
 // consumer sweep. Every remaining site that iterates `.confidentiality` as a
 // bare atom list must treat an OR-clause CORRECTLY — opaque where that is
 // fail-safe (over-restrict), and clause-aware where opacity would under-

--- a/packages/runner/test/cfc-clause-join.test.ts
+++ b/packages/runner/test/cfc-clause-join.test.ts
@@ -3,7 +3,7 @@ import { expect } from "@std/expect";
 import { mergeCfcLabelViews, mergeLabel } from "../src/cfc/label-view-core.ts";
 import { clauseAlternatives, isOrClause } from "../src/cfc/clause.ts";
 
-// Epic A3 (docs/plans/cfc-future-work-implementation.md): the confidentiality
+// Epic A3 (docs/history/plans/cfc-future-work-implementation.md): the confidentiality
 // join is clause CONCATENATION with normalize-on-ingest. It upholds the
 // §3.1.8 prohibitions: never merge distinct clauses, never union alternative
 // sets, never dedup an atom across a singleton and an OR-clause containing it.

--- a/packages/runner/test/cfc-clause-meet.test.ts
+++ b/packages/runner/test/cfc-clause-meet.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/cfc/observation.ts";
 import { clausesEqual, normalizeClause } from "../src/cfc/clause.ts";
 
-// Decision 6 of docs/plans/cfc-future-work-implementation.md (corrected
+// Decision 6 of docs/history/plans/cfc-future-work-implementation.md (corrected
 // 2026-07-02, #4482): the general clause meet is the pairwise
 // alternative-set UNION. This file carries the targeted algebra cases and
 // the both-direction property test the plan requires before clause ceilings

--- a/packages/runner/test/cfc-clause.test.ts
+++ b/packages/runner/test/cfc-clause.test.ts
@@ -18,7 +18,7 @@ import type {
   WritePolicyInput,
 } from "../src/cfc/types.ts";
 
-// Epic A1 (docs/plans/cfc-future-work-implementation.md): the CNF clause
+// Epic A1 (docs/history/plans/cfc-future-work-implementation.md): the CNF clause
 // kernel. Pure helpers — no runtime behavior change; A2 wires subsumption
 // into the ceiling checks.
 

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -26,7 +26,7 @@ import type { JSONSchema } from "../src/builder/types.ts";
 const signer = await Identity.fromPassphrase("runner-cfc-concept-floor");
 enableMockMode();
 
-// Epic D5 (docs/plans/cfc-future-work-implementation.md §5; spec §4.8.9 /
+// Epic D5 (docs/history/plans/cfc-future-work-implementation.md §5; spec §4.8.9 /
 // §8.10.3 / §8.12.4.1): integrity-floor membership matches a CONCEPT-valued
 // requirement against carried CONCRETE integrity through the acting
 // principal's trust closure. A floor like "minted by a valid GPS measurement"

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -18,7 +18,7 @@ import {
 import type { IFCLabel } from "../src/cfc/label-view-core.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
-// Epic B4 (docs/plans/cfc-future-work-implementation.md §3): the guarded
+// Epic B4 (docs/history/plans/cfc-future-work-implementation.md §3): the guarded
 // rewrite + fuelled fixpoint (spec §4.4.5). Property tests (i)-(vi) from the
 // plan, plus the worked examples the calculus exists for.
 

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -19,7 +19,7 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { LLM_DERIVED_RESULT_STAMP_SCHEMA } from "../src/builtins/llm-schemas.ts";
 
-// Epic D1b (docs/plans/cfc-future-work-implementation.md): the `llm`,
+// Epic D1b (docs/history/plans/cfc-future-work-implementation.md): the `llm`,
 // `generateText`, and `generateObject` builtins stamp their MODEL-OUTPUT
 // writebacks with an explicit `LlmDerived` provenance atom — the same mark D1
 // (cfc-llm-derived-stamp.test.ts) attaches to dialog messages. These tests are

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -19,7 +19,7 @@ import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-llm-derived-stamp");
 
-// Epic D1 (docs/plans/cfc-future-work-implementation.md): model output must
+// Epic D1 (docs/history/plans/cfc-future-work-implementation.md): model output must
 // carry an explicit LlmDerived provenance stamp instead of representing
 // untrust as mere absence of integrity. This file starts with the stamping
 // MECHANISM kernel: a builtin-identity write through an item schema carrying

--- a/packages/runner/test/cfc-policy-boundary.test.ts
+++ b/packages/runner/test/cfc-policy-boundary.test.ts
@@ -18,7 +18,7 @@ import type { JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-policy-boundary");
 
-// Epic B5 (docs/plans/cfc-future-work-implementation.md §3): exchange-rule
+// Epic B5 (docs/history/plans/cfc-future-work-implementation.md §3): exchange-rule
 // evaluation wired into the boundary gates behind the cfcPolicyEvaluation
 // dial. `off` is byte-identical to the pre-dial gates; `observe` evaluates
 // and diagnoses but decides on the raw label; `enforce` decides on the

--- a/packages/runner/test/cfc-policy.test.ts
+++ b/packages/runner/test/cfc-policy.test.ts
@@ -12,7 +12,7 @@ import {
 
 const signer = await Identity.fromPassphrase("runner-cfc-policy");
 
-// Epic B2a (docs/plans/cfc-future-work-implementation.md §3): deployment
+// Epic B2a (docs/history/plans/cfc-future-work-implementation.md §3): deployment
 // policy records — validation, content digests, freeze discipline, and the
 // Runtime → tx snapshot injection. The evaluator that consumes these lands
 // in B4/B5.

--- a/packages/runner/test/cfc-render-ceiling.test.ts
+++ b/packages/runner/test/cfc-render-ceiling.test.ts
@@ -8,7 +8,7 @@ import {
 import type { SpaceMembershipProvider } from "../src/cfc/space-membership.ts";
 import { atomsOutsideCeiling } from "../src/cfc/observation.ts";
 
-// Epic H3b (docs/plans/cfc-future-work-implementation.md §7): the display-sink
+// Epic H3b (docs/history/plans/cfc-future-work-implementation.md §7): the display-sink
 // render ceiling resolves §15.2 principal shapes via exchange rules
 // (spec §8.10.6 — "ordinary exchange-rule evaluation runs before the fit
 // check"; §4.3.3 SpaceReaderAccess; §4.9.3 HasRole membership facts). The

--- a/packages/runner/test/cfc-standard-profile.test.ts
+++ b/packages/runner/test/cfc-standard-profile.test.ts
@@ -20,7 +20,7 @@ import { clauseAlternatives, clausesEqual } from "../src/cfc/clause.ts";
 import { uniqueCfcAtoms } from "../src/cfc/observation.ts";
 import { normalizeClause } from "../src/cfc/clause.ts";
 
-// Epic B6 (docs/plans/cfc-future-work-implementation.md §3): the §10.1
+// Epic B6 (docs/history/plans/cfc-future-work-implementation.md §3): the §10.1
 // standard prompt-caveat profile as PolicyRecords. The goldens prove the
 // material-risk discharge rule reproduces the retired `filterMaterialRiskAtoms`
 // strip byte-for-byte; the remaining tests exercise the tier upgrades,

--- a/packages/runner/test/cfc-trust.test.ts
+++ b/packages/runner/test/cfc-trust.test.ts
@@ -13,7 +13,7 @@ import {
 
 const signer = await Identity.fromPassphrase("runner-cfc-trust");
 
-// Epic B3 (docs/plans/cfc-future-work-implementation.md §3): the user-scoped
+// Epic B3 (docs/history/plans/cfc-future-work-implementation.md §3): the user-scoped
 // trust closure (spec §4.8.9). Concept guards resolve from CONCRETE carried
 // integrity via the acting principal's delegations; concrete integrity stays
 // portable across users while concept satisfaction is acting-principal

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -172,7 +172,7 @@ export interface InitializationData {
     | "enforce-explicit"
     | "enforce-strict";
   // Flow-label propagation dial for the worker runtime (S16 default
-  // transition; docs/plans/cfc-future-work-implementation.md Epic H1):
+  // transition; docs/history/plans/cfc-future-work-implementation.md Epic H1):
   // "off" = no derivation; "observe" = compute the per-tx conservative
   // join and emit diagnostics, persist nothing; "persist" = write derived
   // label components. Propagation never rejects by itself. Absent =

--- a/packages/shell/src/lib/render-ceiling.ts
+++ b/packages/shell/src/lib/render-ceiling.ts
@@ -1,6 +1,6 @@
 /**
  * Dogfood toggle for the CFC render confidentiality ceiling (Epic H3a,
- * docs/plans/cfc-future-work-implementation.md §7). When enabled, the shell
+ * docs/history/plans/cfc-future-work-implementation.md §7). When enabled, the shell
  * creates its runtime with the §8.10.6 default display ceiling populated:
  * display sinks admit only the acting user's own identity atom plus
  * allow-listed influence-class caveat kinds, everything else fails closed,


### PR DESCRIPTION
Catch-up to the #4610 documentation-lifecycle reorg for the CFC docs this week's merged PRs (#4622, #4623, #4624, #4627, #4638) created or touched.

## Archive
- `docs/plans/cfc-future-work-implementation.md` → `docs/history/plans/` — an executed plan per the docs/plans graduation rule: every scheduled stage (Epics A–E, H, F-doc) is merged; the reorg's audit predated the completion verification, so it received only mechanical link fixes there. Header records creation/archival/reason; the deferred tail (B2b, E5, SC-18b, rewrite event) is tracked live in `cfc-spec-changes.md` and the three residual design docs. All 34 inbound references (spec docs, runner/test file headers, lib-shell/shell comments) repointed; internal relative links rewritten for the new depth; index line added to `docs/history/README.md`.

## Live-doc obligations discharged (the contract's "update in the same change" — owed by #4623/#4627, which shipped behavior without notes)
- `cfc-value-level-provenance.md` §6: stage-0 wording updated + implementation note for the shipped precision counters (#4623).
- `cfc-persisted-declassification.md` §2.2/§3: "unimplementable in B2a" corrected to pre-#4627 phrasing + implementation note covering the shipped grants (addressing decision, builtin-only writer, consulted-grant digest binding; items 4–5 open).
- `cfc-spec-changes.md`: SC-24/25/26 flipped `open` → `applied` (specs#14) with runner-side shipped-state pointers; SC-23 notes its owed spec home landed as §8.9.1.1.

## Deliberately NOT moved
The three residual design docs stay live per `docs/specs/README.md`'s keep clauses: each is the best description of a shipped subsystem (stage-0/1 inv-12 machinery, grants) *and* a governing decision record for its unbuilt remainder (span tiers, reference form, rewrite event).

## Verification
`deno task check-docs` — all 533 blocks pass (the archived plan's blocks correctly excluded); `deno task check` clean (source changes are comment-string repoints only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archive the executed CFC future‑work plan to `docs/history/plans/` (with header metadata and an index entry), add implementation notes for Stage 0 prefix‑precision counters and persisted declassification grants, clarify the rewrite event’s mechanism‑level dependencies and build order, and fix a double‑rewritten link in the archived plan. Flip SC‑24/25/26 to applied in `docs/specs/cfc-spec-changes.md`, record SC‑23’s spec home, and repoint references across docs, code, and tests; no runtime behavior changes.

<sup>Written for commit a08871098214442534d6070d7ffad19a63283e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

