### PR TITLE
feat(cfc): declared-component monotonicity gate behind cfcDeclaredMonotonicity (§8.12.1)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -36,6 +36,7 @@ was last checked against the code.
 | [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
 | [`cfcTriggerReadGating`](#cfctriggerreadgating) | `RuntimeOptions.cfcTriggerReadGating` | `false` | Bernhard Seefeld (#4488) | move toward `true` | implemented, staged rollout |
 | [`cfcPolicyEvaluation`](#cfcpolicyevaluation) | `RuntimeOptions.cfcPolicyEvaluation` | `off` | Bernhard Seefeld (#4566) | move toward `enforce` | implemented, staged rollout |
+| [`cfcDeclaredMonotonicity`](#cfcdeclaredmonotonicity) | `RuntimeOptions.cfcDeclaredMonotonicity` | `off` | Bernhard Seefeld (#4647) | `observe` first, then `enforce` (must soak before the §8.12.7 route 2b event ships) | implemented, off by default |
 | [`cfcPrefixProvenanceStats`](#cfcprefixprovenancestats) | `RuntimeOptions.cfcPrefixProvenanceStats` (per-deployment; not env-wired) | `false` | Bernhard Seefeld (#4623) | stays a measurement opt-in; fold in or remove after Stage 0 | implemented, off by default, measurement only |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
@@ -325,6 +326,33 @@ the per-epic implementation notes).
 - **Status on 2026-07-08.** Implemented and in staged rollout.
 - **Path to removal.** Once policy evaluation is the norm, the dial could settle
   on `enforce` and be retired.
+
+### `cfcDeclaredMonotonicity`
+
+- **Toggle via.** `RuntimeOptions.cfcDeclaredMonotonicity`.
+- **Added by.** Bernhard Seefeld, in "declared-component monotonicity gate
+  (WP5, spec §8.12.1/§8.12.8)" (#4647, 2026-07-09).
+- **Purpose.** Guards the one point where a persisted path's declared
+  (store-policy) label component can change — the schema-walk re-mint at the
+  commit boundary — with §8.12.1's `canUpdateStoreLabel` rule: confidentiality
+  may only add clauses or remove alternatives, and the declared integrity
+  claim may only remove atoms. Values are `off`, `observe`, and `enforce`.
+  `observe` emits a structured diagnostic on a non-monotone re-mint while
+  persisting today's bytes; `enforce` records a fail-closed prepare reason
+  (rejecting the commit under the enforcing enforcement modes). The gate
+  governs only the `declared` component; derived/link/structure components
+  keep their §8.12.8 replace disciplines. The per-transaction privileged
+  widening exemption (`setCfcDeclaredWideningExemption`, trusted-builtin
+  only) is the seam for the future §8.12.7 route 2b declassification event.
+- **Current default and planned end state.** `off` by default. The target is
+  `observe`, then `enforce` after soak — the route 2b rewrite event must not
+  ship before this gate is enforced
+  (`docs/specs/cfc-persisted-declassification.md` §4–§5).
+- **Status on 2026-07-09.** Implemented, off by default.
+- **Path to removal.** Not planned for removal: monotonicity is a permanent
+  store invariant. Once `enforce` has soaked, the dial could settle there and
+  the `off`/`observe` rungs remain for diagnostics, mirroring the enforcement
+  ladder.
 
 ### `cfcPrefixProvenanceStats`
 

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -221,12 +221,20 @@ declassification event. Contract, if and when built:
 2. **Policy-guarded**: the acting principal's authority over the target
    clause verified exactly as a grant writer would (inv-7), plus §8.10.5.2 —
    a broader audience is a new release judgment with its own evidence.
-3. **A new monotonicity gate**: today no runtime `canUpdateStoreLabel` check
-   exists (declared entries evolve only via the schema-walk re-mint). The
-   event is the *sanctioned exception* to a gate that must first exist —
-   build the gate (reject non-monotone declared-component changes outside an
-   event) before the exception, or the "never an ordinary write" clause is
-   unenforced prose.
+3. **A new monotonicity gate**: the event is the *sanctioned exception* to a
+   gate that must exist first — without an enforced gate rejecting
+   non-monotone declared-component changes outside an event, the "never an
+   ordinary write" clause is unenforced prose. _Implementation note
+   (2026-07-09): shipped in #4647 behind
+   `RuntimeOptions.cfcDeclaredMonotonicity` (`off | observe | enforce`,
+   default `off`) — the prepare-time re-mint check of §5's gate bullet
+   (`cfc/declared-monotonicity.ts`, hooked at the persist walk), comparing
+   each re-minted declared entry against the per-path join of the stored
+   declared entries via the A2/A3 clause kernel, with
+   `setCfcDeclaredWideningExemption` (trusted-builtin only, one
+   `(doc, path, clauseDigest)` triple per tx, `cfcCanonicalClauseDigest`
+   clause identity) as the event writer's exemption seam. The gate still
+   has to soak at `enforce` before the event ships._
 4. **The event record**, adjacent to but not inside the `["cfc"]` envelope
    (SC-11 keeps envelopes churn-free and version-neutral): a **create-only
    document causal to the consumed intent's id** — the shipped receipt
@@ -265,21 +273,24 @@ mechanism level (2026-07-09):
   clause form (`normalizeClause` + the canonical digest idiom) needs only a
   small `clauseDigest` helper; attribution — verified identities +
   `writeAuthorizedBy` builtin arm.
-- **Missing, buildable now**: the declared-component **monotonicity gate**
-  (§4.3) — a self-contained prepare-time check comparing a re-minted
+- **Shipped 2026-07-09, soaking**: the declared-component **monotonicity
+  gate** (§4.3) — a self-contained prepare-time check comparing a re-minted
   declared entry against the stored one under `canUpdateStoreLabel`
   semantics (confidentiality may only add clauses or drop alternatives;
   integrity may only drop atoms — the A2/A3 clause helpers give
   subsumption), dialed `off | observe | enforce` like every other gate,
-  with the event writer as its sanctioned exception hook. Nothing blocks
-  it; it must ship and soak **before** the exception exists.
+  with the event writer as its sanctioned exception hook. Built in #4647
+  exactly in this shape (including the `cfcCanonicalClauseDigest` helper
+  the "Exists" bullet anticipated); the remaining criterion is soak at
+  `enforce` **before** the exception exists.
 - **Missing, assurance-only**: the four §6 evidence pieces (§4.1) — they
   upgrade a v1, they do not gate it.
 
 So the only *hard* remaining gate is (a): a real export/publish/portability
 requirement that grants demonstrably cannot serve — a product decision, not
-a substrate one. When (a) holds, build order is: monotonicity gate → soak →
-reduced-evidence v1 (§4.1) → §6 evidence upgrades as they land.
+a substrate one. When (a) holds, build order is: soak the shipped
+monotonicity gate → reduced-evidence v1 (§4.1) → §6 evidence upgrades as
+they land.
 Until then, "publish" is served by route 3 (copy-forward), which is honest
 about being a new value.
 

--- a/packages/runner/src/cfc/declared-monotonicity.ts
+++ b/packages/runner/src/cfc/declared-monotonicity.ts
@@ -97,11 +97,35 @@ export const collectDeclaredMonotonicityViolations = (input: {
       input.exemption.id === input.docId
     ? input.exemption
     : undefined;
+  // Both sides are compared as the per-path JOIN of same-path declared
+  // entries, not entry-by-entry (codex/cubic review on this PR). The walk
+  // mints at most one declared entry per path (divergent-branch ifc is
+  // rejected at merge time), but STORED metadata is data — peers/hydration
+  // can present duplicates — and reads join same-component entries at one
+  // path. Joining means: the stored clause set is the union across the
+  // group (all clauses apply — a stored clause survives if ANY proposed
+  // entry witnesses it), and the stored integrity CLAIM is the union of
+  // atoms any same-path declared entry already claimed — keeping such an
+  // atom is a shrink of the claim, not an addition, so proposed [X] against
+  // stored entries [X] and [Y] is monotone.
+  const storedByPath = new Map<
+    string,
+    { path: readonly string[]; entries: LabelMapEntry[] }
+  >();
   for (const stored of input.storedEntries) {
     if (stored.origin !== "declared") {
       continue;
     }
     const storedPath = canonicalizeLogicalPath(stored.path);
+    const key = JSON.stringify(storedPath);
+    const group = storedByPath.get(key);
+    if (group === undefined) {
+      storedByPath.set(key, { path: storedPath, entries: [stored] });
+    } else {
+      group.entries.push(stored);
+    }
+  }
+  for (const { path: storedPath, entries: storedAt } of storedByPath.values()) {
     const proposedAt = proposedDeclared.filter((entry) =>
       samePath(entry.path, storedPath)
     );
@@ -109,45 +133,60 @@ export const collectDeclaredMonotonicityViolations = (input: {
       continue;
     }
     const at = `for ${input.docId} at /${storedPath.join("/")}`;
-    // The walk mints at most one declared entry per path (divergent-branch
-    // ifc is rejected at merge time), but reads join same-component entries
-    // at one path, so quantify over all of them defensively: a stored
-    // clause survives if ANY proposed entry witnesses it; a proposed atom
-    // is an addition only if NO stored atom equals it.
     const proposedClauses = proposedAt.flatMap((entry) =>
       entry.label.confidentiality ?? []
     );
-    for (const storedClause of stored.label.confidentiality ?? []) {
-      const witnessed = proposedClauses.some((proposedClause) =>
-        clauseSubsumes(proposedClause, storedClause)
-      );
-      if (witnessed) {
-        continue;
+    // Duplicate stored clauses across group entries would repeat the same
+    // reason; report each canonical clause once.
+    const reportedClauses = new Set<string>();
+    for (const stored of storedAt) {
+      for (const storedClause of stored.label.confidentiality ?? []) {
+        const witnessed = proposedClauses.some((proposedClause) =>
+          clauseSubsumes(proposedClause, storedClause)
+        );
+        if (witnessed) {
+          continue;
+        }
+        const storedDigest = cfcCanonicalClauseDigest(storedClause);
+        if (
+          exemption !== undefined &&
+          samePath(exemption.path, storedPath) &&
+          exemption.clauseDigest === storedDigest
+        ) {
+          // The sanctioned §8.12.7 route 2b exemption: exactly this stored
+          // clause, at exactly this path of exactly this doc, may be dropped
+          // or widened in this transaction.
+          continue;
+        }
+        if (reportedClauses.has(storedDigest)) {
+          continue;
+        }
+        reportedClauses.add(storedDigest);
+        violations.push(
+          `declared-monotonicity confidentiality violation ${at} ` +
+            `(canUpdateStoreLabel, §8.12.1): stored clause ` +
+            `${JSON.stringify(normalizeClause(storedClause))} dropped or ` +
+            `weakened ` +
+            `(clauses may be added and alternatives removed, never the reverse)`,
+        );
       }
-      const storedCanonical = normalizeClause(storedClause);
-      if (
-        exemption !== undefined &&
-        samePath(exemption.path, storedPath) &&
-        exemption.clauseDigest === cfcCanonicalClauseDigest(storedClause)
-      ) {
-        // The sanctioned §8.12.7 route 2b exemption: exactly this stored
-        // clause, at exactly this path of exactly this doc, may be dropped
-        // or widened in this transaction.
-        continue;
-      }
-      violations.push(
-        `declared-monotonicity confidentiality violation ${at} ` +
-          `(canUpdateStoreLabel, §8.12.1): stored clause ` +
-          `${JSON.stringify(storedCanonical)} dropped or weakened ` +
-          `(clauses may be added and alternatives removed, never the reverse)`,
-      );
     }
-    const storedIntegrity = stored.label.integrity ?? [];
+    const storedIntegrity = storedAt.flatMap((stored) =>
+      stored.label.integrity ?? []
+    );
+    // A proposed atom repeated across proposed entries would repeat the
+    // reason; report each atom once.
+    const reportedAtoms = new Set<string>();
     for (const proposedEntry of proposedAt) {
       for (const atom of proposedEntry.label.integrity ?? []) {
         if (storedIntegrity.some((storedAtom) => deepEqual(storedAtom, atom))) {
           continue;
         }
+        const atomKey = hashStringOf(atom);
+        if (reportedAtoms.has(atomKey)) {
+          continue;
+        }
+        reportedAtoms.add(atomKey);
         violations.push(
           `declared-monotonicity integrity violation ${at} ` +
             `(canUpdateStoreLabel, §8.12.1): integrity atom ` +

--- a/packages/runner/src/cfc/declared-monotonicity.ts
+++ b/packages/runner/src/cfc/declared-monotonicity.ts
@@ -1,0 +1,161 @@
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import {
+  type CfcConfClause,
+  clauseSubsumes,
+  normalizeClause,
+} from "./clause.ts";
+import { canonicalizeLogicalPath } from "./canonical.ts";
+import type { CfcDeclaredWideningExemption, LabelMapEntry } from "./types.ts";
+
+/**
+ * The declared-component monotonicity gate (WP5; spec §8.12.1/§8.12.8;
+ * docs/specs/cfc-persisted-declassification.md §4 item 3).
+ *
+ * A persisted path's DECLARED (store-policy) label component evolves only
+ * through the schema-walk re-mint in `prepare.ts`. §8.12.1's
+ * `canUpdateStoreLabel` — the semantics of record is the Lean mechanization
+ * (`formal/Cfc/Store.lean`: `ConfLe`/`ClauseLe`/`IntegLe`) — requires every
+ * update to be monotone:
+ *
+ * - **Confidentiality (CNF)** may only become more restrictive: every stored
+ *   clause must still be present-or-strengthened in the proposal (the clause
+ *   set may grow; an existing clause's alternative set may only shrink).
+ *   The witness relation is `clauseSubsumes(proposed, stored)` — every
+ *   alternative of the proposed clause entails some alternative of the
+ *   stored clause (`alts(p) ⊆ alts(s)` modulo per-family entailment) —
+ *   exactly the Lean `ClauseLe stored proposed`. `clauseSubsumes` fails
+ *   closed on an empty proposed clause, so an unsatisfiable stored clause
+ *   can never be re-witnessed: fail-closed, and seeded-metadata-only.
+ * - **The declared integrity claim** may only remove atoms (weaker claims
+ *   are safe; the store must not become more trusted "for free"): every
+ *   proposed atom must already be in the stored set, by canonical structural
+ *   equality.
+ *
+ * Scope (§8.12.8): the gate governs ONLY entries with `origin: "declared"`
+ * on BOTH sides. Derived / link-carried / structure components follow
+ * replace-on-overwrite disciplines, and legacy (origin-less) entries keep
+ * the historical combined rules — none of them are ever compared here.
+ *
+ * A consequence worth stating plainly: schema mints that vary per write —
+ * an `addIntegrity` current-principal claim resolving to a different acting
+ * principal, a copied `exactCopyOf` label whose source changed — are
+ * non-monotone declared updates by construction under `enforce`. That is
+ * §8.12.1 semantics, not an accident: per-value evidence belongs in the
+ * derived component, and the dial ships default-`off` while those mints
+ * migrate.
+ *
+ * The one sanctioned exception (§8.12.7 route 2b — the future
+ * declassification-event writer) is the per-transaction privileged
+ * exemption: it names exactly one (doc, path, clauseDigest) triple, where
+ * `clauseDigest` is `cfcCanonicalClauseDigest` of the STORED clause being
+ * dropped or widened. Integrity violations are never exemptable.
+ */
+
+/**
+ * Canonical clause digest — clause identity for the exemption seam and the
+ * future §4 event record (`{doc, path, clauseDigest, …}`). Clause indices
+ * are evaluation-ephemeral; the digest of the canonicalized clause (
+ * alternatives deduped and hash-sorted, singleton unwrapped) is not.
+ */
+export const cfcCanonicalClauseDigest = (clause: CfcConfClause): string =>
+  hashStringOf(normalizeClause(clause));
+
+const samePath = (
+  left: readonly string[],
+  right: readonly string[],
+): boolean =>
+  left.length === right.length &&
+  left.every((segment, index) => segment === right[index]);
+
+/**
+ * Compare the declared entries a prepare walk is about to persist against
+ * the stored declared entries at the same paths; return one stable reason
+ * string per violated §8.12.1 direction (empty = monotone). Stored declared
+ * entries at paths the walk does not re-mint are carried forward verbatim by
+ * the persist loop and need no check; proposed entries at paths with no
+ * stored declared entry are creations, which monotonicity does not
+ * constrain.
+ */
+export const collectDeclaredMonotonicityViolations = (input: {
+  space: MemorySpace;
+  docId: string;
+  storedEntries: readonly LabelMapEntry[];
+  proposedEntries: readonly LabelMapEntry[];
+  exemption?: CfcDeclaredWideningExemption;
+}): string[] => {
+  const violations: string[] = [];
+  const proposedDeclared = input.proposedEntries
+    .filter((entry) => entry.origin === "declared")
+    .map((entry) => ({
+      path: canonicalizeLogicalPath(entry.path),
+      label: entry.label,
+    }));
+  const exemption = input.exemption !== undefined &&
+      input.exemption.space === input.space &&
+      input.exemption.id === input.docId
+    ? input.exemption
+    : undefined;
+  for (const stored of input.storedEntries) {
+    if (stored.origin !== "declared") {
+      continue;
+    }
+    const storedPath = canonicalizeLogicalPath(stored.path);
+    const proposedAt = proposedDeclared.filter((entry) =>
+      samePath(entry.path, storedPath)
+    );
+    if (proposedAt.length === 0) {
+      continue;
+    }
+    const at = `for ${input.docId} at /${storedPath.join("/")}`;
+    // The walk mints at most one declared entry per path (divergent-branch
+    // ifc is rejected at merge time), but reads join same-component entries
+    // at one path, so quantify over all of them defensively: a stored
+    // clause survives if ANY proposed entry witnesses it; a proposed atom
+    // is an addition only if NO stored atom equals it.
+    const proposedClauses = proposedAt.flatMap((entry) =>
+      entry.label.confidentiality ?? []
+    );
+    for (const storedClause of stored.label.confidentiality ?? []) {
+      const witnessed = proposedClauses.some((proposedClause) =>
+        clauseSubsumes(proposedClause, storedClause)
+      );
+      if (witnessed) {
+        continue;
+      }
+      const storedCanonical = normalizeClause(storedClause);
+      if (
+        exemption !== undefined &&
+        samePath(exemption.path, storedPath) &&
+        exemption.clauseDigest === cfcCanonicalClauseDigest(storedClause)
+      ) {
+        // The sanctioned §8.12.7 route 2b exemption: exactly this stored
+        // clause, at exactly this path of exactly this doc, may be dropped
+        // or widened in this transaction.
+        continue;
+      }
+      violations.push(
+        `declared-monotonicity confidentiality violation ${at} ` +
+          `(canUpdateStoreLabel, §8.12.1): stored clause ` +
+          `${JSON.stringify(storedCanonical)} dropped or weakened ` +
+          `(clauses may be added and alternatives removed, never the reverse)`,
+      );
+    }
+    const storedIntegrity = stored.label.integrity ?? [];
+    for (const proposedEntry of proposedAt) {
+      for (const atom of proposedEntry.label.integrity ?? []) {
+        if (storedIntegrity.some((storedAtom) => deepEqual(storedAtom, atom))) {
+          continue;
+        }
+        violations.push(
+          `declared-monotonicity integrity violation ${at} ` +
+            `(canUpdateStoreLabel, §8.12.1): integrity atom ` +
+            `${JSON.stringify(atom)} added ` +
+            `(the declared integrity claim may only remove atoms)`,
+        );
+      }
+    }
+  }
+  return violations;
+};

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -37,6 +37,8 @@ export {
 export type {
   AttemptedWrite,
   CfcAddress,
+  CfcDeclaredMonotonicityMode,
+  CfcDeclaredWideningExemption,
   CfcDereferenceTrace,
   CfcEnforcementMode,
   CfcFlowLabelsMode,
@@ -70,6 +72,7 @@ export {
   CFC_ENFORCEMENT_MODES,
   CFC_ENFORCING_STRICTNESS,
   cfcEnforcementStrictness,
+  DEFAULT_CFC_DECLARED_MONOTONICITY_MODE,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   DEFAULT_CFC_FLOW_LABELS_MODE,
   DEFAULT_CFC_LABEL_METADATA_PROTECTION_MODE,

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -69,6 +69,10 @@ export type {
   WritePolicyInput,
 } from "./types.ts";
 export {
+  cfcCanonicalClauseDigest,
+  collectDeclaredMonotonicityViolations,
+} from "./declared-monotonicity.ts";
+export {
   CFC_ENFORCEMENT_MODES,
   CFC_ENFORCING_STRICTNESS,
   cfcEnforcementStrictness,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4617,7 +4617,9 @@ export const prepareBoundaryCommit = (
           persistedLabelEntries.length = 0;
         } else {
           for (const violation of monotonicityViolations) {
-            tx.noteCfcDiagnostic(`declared-monotonicity(observe): ${violation}`);
+            tx.noteCfcDiagnostic(
+              `declared-monotonicity(observe): ${violation}`,
+            );
           }
         }
       }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -49,6 +49,7 @@ import {
   isOrClause,
   normalizeClause,
 } from "./clause.ts";
+import { collectDeclaredMonotonicityViolations } from "./declared-monotonicity.ts";
 import { externalIngestStamp } from "./external-ingest.ts";
 import {
   atomsOutsideCeiling,
@@ -4585,6 +4586,42 @@ export const prepareBoundaryCommit = (
             }]
             : [];
         });
+    // WP5 (§8.12.1/§8.12.8; docs/specs/cfc-persisted-declassification.md §4
+    // item 3): the declared-component monotonicity gate. Each declared entry
+    // this walk is about to persist replaces the stored declared entry at
+    // the same path (the carry-forward below skips replaced paths), so this
+    // is the ONE point where the store policy can change — compare against
+    // the stored entries per canUpdateStoreLabel before it does. The stored
+    // metadata was read above under the internal-verifier meta
+    // (storedMetadataFor), so the gate consumes no additional reads. Under
+    // `enforce` a violation records fail-closed reasons and skips persisting
+    // this target's labels (mirroring requirementFailure — the stored,
+    // stronger entries stay in place under non-rejecting enforcement modes;
+    // an ingest target keeps only the runtime's mark); under `observe` it
+    // diagnoses and persists today's bytes; `off` runs nothing.
+    if (state.declaredMonotonicityMode !== "off" && existing !== undefined) {
+      const monotonicityViolations = collectDeclaredMonotonicityViolations({
+        space,
+        docId: id,
+        storedEntries: existing.labelMap.entries,
+        proposedEntries: persistedLabelEntries,
+        exemption: state.declaredWideningExemption,
+      });
+      if (monotonicityViolations.length > 0) {
+        if (state.declaredMonotonicityMode === "enforce") {
+          reasons.push(...monotonicityViolations);
+          if (!isIngestTarget) continue;
+          // Mirror ingestVerificationFailed above: the runtime's ingest mark
+          // (appended below) still persists in non-rejecting modes, but the
+          // non-monotone declared claims must not.
+          persistedLabelEntries.length = 0;
+        } else {
+          for (const violation of monotonicityViolations) {
+            tx.noteCfcDiagnostic(`declared-monotonicity(observe): ${violation}`);
+          }
+        }
+      }
+    }
     const persistedLabelEntryKeys = new Set(
       persistedLabelEntries.map((entry) => pathKey(entry.path)),
     );

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -491,6 +491,48 @@ export type CfcLabelMetadataProtectionMode = "off" | "observe" | "enforce";
 export const DEFAULT_CFC_LABEL_METADATA_PROTECTION_MODE:
   CfcLabelMetadataProtectionMode = "off";
 
+/**
+ * Declared-component monotonicity gate dial (WP5; spec §8.12.1/§8.12.8;
+ * docs/specs/cfc-persisted-declassification.md §4 item 3), orthogonal to the
+ * enforcement ladder: the declared (store-policy) component of a persisted
+ * path evolves only through the schema-walk re-mint in prepare, and §8.12.1's
+ * `canUpdateStoreLabel` (confidentiality may only add clauses or remove
+ * alternatives; the declared integrity claim may only remove atoms) had no
+ * runtime check. `off` = nothing runs (bytes identical to before the dial);
+ * `observe` = compare each re-minted declared entry against the stored
+ * declared entry at the same path and emit a structured diagnostic on a
+ * non-monotone re-mint, persisting today's behavior; `enforce` = a
+ * non-monotone re-mint records a fail-closed prepare reason (rejecting the
+ * commit under the enforcing enforcement modes). The gate governs ONLY the
+ * `declared` component — derived/link-carried/structure components follow
+ * their own §8.12.8 disciplines and are never touched. The sanctioned
+ * exception (§8.12.7 route 2b, the future declassification-event writer) is
+ * the per-tx privileged widening exemption below.
+ */
+export type CfcDeclaredMonotonicityMode = "off" | "observe" | "enforce";
+
+export const DEFAULT_CFC_DECLARED_MONOTONICITY_MODE:
+  CfcDeclaredMonotonicityMode = "off";
+
+/**
+ * Per-transaction privileged marker exempting exactly ONE (doc, path,
+ * clauseDigest) triple from the declared-monotonicity gate (the seam for the
+ * §8.12.7 route 2b declassification event; docs/specs/
+ * cfc-persisted-declassification.md §4). `clauseDigest` is the canonical
+ * clause digest (`cfcCanonicalClauseDigest`) of the STORED clause whose
+ * dropping/widening the event sanctions — clause indices are
+ * evaluation-ephemeral, digests are not. Settable only under the same
+ * privileged discipline as `writeCfcGrant` (a trusted-builtin implementation
+ * identity); absent = the gate applies in full; integrity violations are
+ * never exemptable (the event widens a confidentiality clause).
+ */
+export type CfcDeclaredWideningExemption = {
+  readonly space: MemorySpace;
+  readonly id: string;
+  readonly path: readonly string[];
+  readonly clauseDigest: string;
+};
+
 export type CfcTxState = {
   relevant: boolean;
   enforcementMode: CfcEnforcementMode;
@@ -499,6 +541,12 @@ export type CfcTxState = {
   triggerReadGating: CfcTriggerReadGating;
   policyEvaluationMode: CfcPolicyEvaluationMode;
   labelMetadataProtectionMode: CfcLabelMetadataProtectionMode;
+  declaredMonotonicityMode: CfcDeclaredMonotonicityMode;
+  // The one sanctioned per-tx exemption from the declared-monotonicity gate
+  // (§8.12.7 route 2b seam). Absent = gate applies. Set only through the
+  // privileged `setCfcDeclaredWideningExemption` (trusted-builtin identity),
+  // write-once, validated fail-closed — see the type's doc comment.
+  declaredWideningExemption?: CfcDeclaredWideningExemption;
   prepare: CfcPrepareState;
   dereferenceTraces: CfcDereferenceTrace[];
   // Result containers a list coordinator (filter/flatMap) declares each

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -55,6 +55,8 @@
  * | cfcPolicyEvaluation        | core-default (off) — same                        |
  * | cfcLabelMetadataProtection | core-default (off) — same (inv-12 Stage 1        |
  * |                            | rollout: observe first, then enforce)            |
+ * | cfcDeclaredMonotonicity    | core-default (off) — same (WP5 §8.12.1 rollout:  |
+ * |                            | observe first, then enforce)                     |
  * | cfcPolicyRecords           | core-default (none declared) — same              |
  * | cfcPrefixProvenanceStats   | core-default (off) — measurement opt-in, per     |
  * |                            | deployment (value-level provenance Stage 0)      |
@@ -132,6 +134,7 @@ export const RUNTIME_OPTION_KEYS = [
   "cfcTriggerReadGating",
   "cfcPolicyEvaluation",
   "cfcLabelMetadataProtection",
+  "cfcDeclaredMonotonicity",
   "cfcPolicyRecords",
   "cfcPrefixProvenanceStats",
   "cfcTrustConfig",
@@ -249,7 +252,8 @@ function coreOptions(params: CoreParams): RuntimeOptions {
     // lives once. Same value as the constructor default today.
     cfcEnforcementMode: "enforce-explicit",
     // cfcFlowLabels / cfcWriteFloor / cfcTriggerReadGating /
-    // cfcPolicyEvaluation / cfcLabelMetadataProtection / cfcPolicyRecords /
+    // cfcPolicyEvaluation / cfcLabelMetadataProtection /
+    // cfcDeclaredMonotonicity / cfcPolicyRecords /
     // cfcTrustConfig / cfcSinkMaxConfidentiality ride the constructor
     // defaults (off / none) — deliberately absent here until a first-party
     // rollout begins.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -71,9 +71,9 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   buildCfcPolicySnapshot,
   buildCfcTrustConfig,
+  type CfcDeclaredMonotonicityMode,
   type CfcEnforcementMode,
   type CfcFlowLabelsMode,
-  type CfcDeclaredMonotonicityMode,
   type CfcLabelMetadataProtectionMode,
   type CfcLabelView,
   type CfcPolicyEvaluationMode,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -73,6 +73,7 @@ import {
   buildCfcTrustConfig,
   type CfcEnforcementMode,
   type CfcFlowLabelsMode,
+  type CfcDeclaredMonotonicityMode,
   type CfcLabelMetadataProtectionMode,
   type CfcLabelView,
   type CfcPolicyEvaluationMode,
@@ -350,6 +351,18 @@ export interface RuntimeOptions {
    */
   cfcLabelMetadataProtection?: CfcLabelMetadataProtectionMode;
   /**
+   * Declared-component monotonicity gate dial (WP5, spec §8.12.1/§8.12.8;
+   * docs/specs/cfc-persisted-declassification.md §4 item 3). Defaults to
+   * `off` (the declared re-mint persists exactly what it does today).
+   * `observe` compares each re-minted declared labelMap entry against the
+   * stored declared entry at the same path and emits a structured diagnostic
+   * on a non-monotone re-mint while persisting today's bytes; `enforce`
+   * records a fail-closed prepare reason (rejecting the commit under the
+   * enforcing enforcement modes). Governs ONLY the `declared` component —
+   * derived/link/structure components keep their §8.12.8 disciplines.
+   */
+  cfcDeclaredMonotonicity?: CfcDeclaredMonotonicityMode;
+  /**
    * Per-prepare D4 write-prefix precision counters (value-level provenance
    * Stage 0 — docs/specs/cfc-value-level-provenance.md §6, SC-24). Defaults
    * to `false`: the prepare gate then skips all measurement, paying a single
@@ -549,6 +562,7 @@ export class Runtime {
   readonly cfcTriggerReadGating: CfcTriggerReadGating;
   readonly cfcPolicyEvaluation: CfcPolicyEvaluationMode;
   readonly cfcLabelMetadataProtection: CfcLabelMetadataProtectionMode;
+  readonly cfcDeclaredMonotonicity: CfcDeclaredMonotonicityMode;
   readonly cfcPrefixProvenanceStats: boolean;
   readonly cfcSinkMaxConfidentiality: SinkMaxConfidentiality;
   /** Frozen deployment policy snapshot; undefined = no policies configured. */
@@ -702,6 +716,7 @@ export class Runtime {
     this.cfcPolicyEvaluation = options.cfcPolicyEvaluation ?? "off";
     this.cfcLabelMetadataProtection = options.cfcLabelMetadataProtection ??
       "off";
+    this.cfcDeclaredMonotonicity = options.cfcDeclaredMonotonicity ?? "off";
     this.cfcPrefixProvenanceStats = options.cfcPrefixProvenanceStats ?? false;
     // Deep-freeze: the ceiling is CFC enforcement config, so a caller must not
     // be able to mutate it (per-sink array or the map) after construction to
@@ -983,6 +998,7 @@ export class Runtime {
     wrapped.setCfcTriggerReadGating(this.cfcTriggerReadGating);
     wrapped.setCfcPolicyEvaluationMode(this.cfcPolicyEvaluation);
     wrapped.setCfcLabelMetadataProtectionMode(this.cfcLabelMetadataProtection);
+    wrapped.setCfcDeclaredMonotonicityMode(this.cfcDeclaredMonotonicity);
     wrapped.setCfcSinkMaxConfidentiality(this.cfcSinkMaxConfidentiality);
     wrapped.setCfcPolicySnapshot(this.cfcPolicySnapshot);
     wrapped.setCfcTrustConfig(this.cfcTrustConfig);

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -63,6 +63,8 @@ import {
   CFC_ENFORCING_STRICTNESS,
   CFC_GRANT_ID_PREFIX,
   type CfcAddress,
+  type CfcDeclaredMonotonicityMode,
+  type CfcDeclaredWideningExemption,
   type CfcDereferenceTrace,
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
@@ -77,6 +79,7 @@ import {
   type CfcWriteFloorMode,
   type ConsultedGrant,
   type ConsumedRead,
+  DEFAULT_CFC_DECLARED_MONOTONICITY_MODE,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   DEFAULT_CFC_FLOW_LABELS_MODE,
   DEFAULT_CFC_LABEL_METADATA_PROTECTION_MODE,
@@ -262,6 +265,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     triggerReadGating: DEFAULT_CFC_TRIGGER_READ_GATING,
     policyEvaluationMode: DEFAULT_CFC_POLICY_EVALUATION_MODE,
     labelMetadataProtectionMode: DEFAULT_CFC_LABEL_METADATA_PROTECTION_MODE,
+    declaredMonotonicityMode: DEFAULT_CFC_DECLARED_MONOTONICITY_MODE,
     prepare: { status: "unprepared" },
     dereferenceTraces: [],
     structureContainers: [],
@@ -289,6 +293,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   #cfcTriggerReadGatingPinned = false;
   #cfcPolicyEvaluationPinned = false;
   #cfcLabelMetadataProtectionPinned = false;
+  #cfcDeclaredMonotonicityPinned = false;
   // Write-once pin for the deployment policy snapshot. Distinct from the
   // slot's value being defined: the Runtime configures MANY tx with NO
   // policies (`undefined`), and that "no policies" state must be just as
@@ -503,6 +508,35 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcState.labelMetadataProtectionMode = mode;
     if (mode === "enforce") {
       this.#cfcLabelMetadataProtectionPinned = true;
+    }
+  }
+
+  setCfcDeclaredMonotonicityMode(mode: CfcDeclaredMonotonicityMode): void {
+    // Anti-downgrade pin (mirrors the write floor): once `enforce` is set —
+    // by the runtime at tx creation — pattern/handler code that reaches the
+    // tx cannot weaken it to `observe`/`off` and slip a non-monotone
+    // declared re-mint through (WP5, §8.12.1). Strengthening to `enforce`
+    // is always allowed.
+    if (this.#cfcDeclaredMonotonicityPinned && mode !== "enforce") {
+      throw new Error(
+        `CFC declared-monotonicity mode cannot be weakened to "${mode}": ` +
+          `transaction is pinned at "enforce"`,
+      );
+    }
+    // The mode drives which prepare reasons/diagnostics the gate records but
+    // is not part of PreparedDigestInput, so — like the flow-labels /
+    // write-floor / policy-evaluation setters — a real change after prepare
+    // must invalidate the prepared decision; the Runtime's idempotent set at
+    // tx creation (before prepare) does not.
+    if (
+      this.#cfcState.declaredMonotonicityMode !== mode &&
+      this.#cfcState.prepare.status === "prepared"
+    ) {
+      this.invalidateCfc("declared-monotonicity-mode-changed");
+    }
+    this.#cfcState.declaredMonotonicityMode = mode;
+    if (mode === "enforce") {
+      this.#cfcDeclaredMonotonicityPinned = true;
     }
   }
 
@@ -909,6 +943,65 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       }, prepared.value as unknown as FabricValue);
     });
     return { space: prepared.space, id: prepared.id };
+  }
+
+  setCfcDeclaredWideningExemption(
+    exemption: CfcDeclaredWideningExemption,
+  ): void {
+    // The §8.12.7 route 2b seam (docs/specs/cfc-persisted-declassification.md
+    // §4): the future declassification-event writer exempts exactly ONE
+    // (doc, path, clauseDigest) triple from the declared-monotonicity gate
+    // for this transaction. Same privileged discipline as writeCfcGrant —
+    // an in-place widening of the declared component is durable release
+    // state, so authoring the exemption requires a trusted BUILTIN
+    // implementation identity; ordinary pattern/handler code runs under a
+    // `verified` (or no) identity and is refused.
+    const identity = this.#cfcState.implementationIdentity;
+    if (identity?.kind !== "builtin") {
+      throw new Error(
+        "cfc-declared-monotonicity: setCfcDeclaredWideningExemption requires " +
+          "a trusted builtin implementation identity (the §8.12.7 route 2b " +
+          "declassification-event discipline)",
+      );
+    }
+    // Fail closed on any malformed or over-broad marker: every field names
+    // one concrete thing — no wildcards, no empty identifiers, no non-string
+    // path segments. A rejected marker leaves the gate fully in force.
+    if (
+      !isRecord(exemption) ||
+      typeof exemption.space !== "string" || exemption.space.length === 0 ||
+      typeof exemption.id !== "string" || exemption.id.length === 0 ||
+      !Array.isArray(exemption.path) ||
+      !exemption.path.every((segment) => typeof segment === "string") ||
+      typeof exemption.clauseDigest !== "string" ||
+      exemption.clauseDigest.length === 0
+    ) {
+      throw new Error(
+        "cfc-declared-monotonicity: malformed widening exemption (space, id " +
+          "and clauseDigest must be non-empty strings; path must be a string " +
+          "array — no wildcard exemptions)",
+      );
+    }
+    // Write-once: ONE named triple per transaction. A second exemption is a
+    // second declassification event and belongs in its own transaction.
+    if (this.#cfcState.declaredWideningExemption !== undefined) {
+      throw new Error(
+        "cfc-declared-monotonicity: a widening exemption is already set for " +
+          "this transaction (one (doc, path, clauseDigest) triple per tx)",
+      );
+    }
+    this.#cfcState.declaredWideningExemption = deepFreeze({
+      space: exemption.space,
+      id: exemption.id,
+      path: canonicalizeLogicalPath(exemption.path),
+      clauseDigest: exemption.clauseDigest,
+    });
+    // The exemption changes the gate's prepare-time decision but is not part
+    // of PreparedDigestInput — invalidate a prepared decision like the mode
+    // setters above.
+    if (this.#cfcState.prepare.status === "prepared") {
+      this.invalidateCfc("declared-widening-exemption-added");
+    }
   }
 
   enqueuePostCommitEffect(effect: PostCommitSideEffect): void {
@@ -1699,6 +1792,16 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     mode: CfcLabelMetadataProtectionMode,
   ): void {
     this.wrapped.setCfcLabelMetadataProtectionMode(mode);
+  }
+
+  setCfcDeclaredMonotonicityMode(mode: CfcDeclaredMonotonicityMode): void {
+    this.wrapped.setCfcDeclaredMonotonicityMode(mode);
+  }
+
+  setCfcDeclaredWideningExemption(
+    exemption: CfcDeclaredWideningExemption,
+  ): void {
+    this.wrapped.setCfcDeclaredWideningExemption(exemption);
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -41,6 +41,8 @@ import { BaseMemoryAddress } from "@commonfabric/runner/traverse";
 import { Cell } from "../cell.ts";
 import type {
   CfcAddress,
+  CfcDeclaredMonotonicityMode,
+  CfcDeclaredWideningExemption,
   CfcDereferenceTrace,
   CfcEnforcementMode,
   CfcFlowLabelsMode,
@@ -921,6 +923,21 @@ export interface IExtendedStorageTransaction
    */
   setCfcLabelMetadataProtectionMode(
     mode: CfcLabelMetadataProtectionMode,
+  ): void;
+  /**
+   * Set the declared-component monotonicity gate dial (WP5, §8.12.1).
+   * Anti-downgrade pinned: once `enforce`, weakening throws.
+   */
+  setCfcDeclaredMonotonicityMode(mode: CfcDeclaredMonotonicityMode): void;
+  /**
+   * Exempt exactly one (doc, path, clauseDigest) triple from the
+   * declared-monotonicity gate for this transaction — the §8.12.7 route 2b
+   * declassification-event seam. Requires a trusted builtin implementation
+   * identity (the writeCfcGrant discipline); fails closed on malformed or
+   * over-broad markers; write-once per transaction.
+   */
+  setCfcDeclaredWideningExemption(
+    exemption: CfcDeclaredWideningExemption,
   ): void;
   /**
    * Record the addresses whose invalidating writes scheduled this run

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -8,6 +8,7 @@ import type { JSONSchema } from "../src/builder/types.ts";
 import {
   cfcCanonicalClauseDigest,
   type CfcDeclaredMonotonicityMode,
+  collectDeclaredMonotonicityViolations,
 } from "../src/cfc/mod.ts";
 import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
@@ -1548,6 +1549,50 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         await runtime.dispose();
         await storageManager.close();
       }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Reason dedup on degenerate duplicate entries (direct unit call: the
+  // walk mints one declared entry per path and dedups atoms, so the
+  // duplicate arms are reachable only through the exported function).
+  // ------------------------------------------------------------------
+  describe("violation-reason dedup (unit)", () => {
+    it("reports each violated clause and added atom once across duplicate entries", () => {
+      const violations = collectDeclaredMonotonicityViolations({
+        space: signer.did(),
+        docId: "of:dedup-doc",
+        storedEntries: [
+          {
+            path: ["out"],
+            origin: "declared",
+            label: { confidentiality: [CLAUSE_B] },
+          },
+          {
+            path: ["out"],
+            origin: "declared",
+            label: { confidentiality: [CLAUSE_B] },
+          },
+        ],
+        proposedEntries: [
+          {
+            path: ["out"],
+            origin: "declared",
+            label: { confidentiality: [CLAUSE_A], integrity: [ATOM_Y] },
+          },
+          {
+            path: ["out"],
+            origin: "declared",
+            label: { confidentiality: [CLAUSE_A], integrity: [ATOM_Y] },
+          },
+        ],
+      });
+      expect(
+        violations.filter((v) => v.includes("confidentiality violation")),
+      ).toHaveLength(1);
+      expect(
+        violations.filter((v) => v.includes("integrity violation")),
+      ).toHaveLength(1);
     });
   });
 

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -1054,6 +1054,116 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
       expect(entry?.label.integrity).toEqual([ATOM_X]);
     });
 
+    it("multiple stored declared entries at one path are joined before the integrity check", async () => {
+      // Stored duplicates at one path can arrive from peers/hydration. The
+      // stored declared CLAIM at the path is their join — keeping an atom
+      // that ANY same-path declared entry already claimed is a shrink, not
+      // an addition, so proposed [X] against stored entries [X] and [Y]
+      // must pass (codex/cubic review on this PR: the per-entry comparison
+      // reported X as added while iterating the [Y] entry).
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-multi-entry",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) => [
+          ...entries,
+          {
+            path: ["out"],
+            origin: "declared",
+            label: { confidentiality: [CLAUSE_A], integrity: [ATOM_Y] },
+          },
+        ]);
+        const second = await commitWrite(
+          runtime,
+          "dm-multi-entry",
+          SCHEMA_MINT_X,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.integrity).toEqual([ATOM_X]);
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("an atom outside the joined same-path claim still rejects", async () => {
+      // The dual guard on the join fix: aggregating stored entries must not
+      // hollow the check out — an atom no same-path declared entry claimed
+      // is still an addition.
+      const schemaMintXZ = {
+        type: "object",
+        properties: {
+          out: {
+            type: "string",
+            ifc: {
+              confidentiality: [CLAUSE_A],
+              addIntegrity: [ATOM_X, "integrity-z"],
+            },
+          },
+        },
+        required: ["out"],
+      } as const satisfies JSONSchema;
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-multi-entry-z",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) => [
+          ...entries,
+          {
+            path: ["out"],
+            origin: "declared",
+            label: { confidentiality: [CLAUSE_A], integrity: [ATOM_Y] },
+          },
+        ]);
+        const second = await commitWrite(
+          runtime,
+          "dm-multi-entry-z",
+          schemaMintXZ,
+          { out: "v2" },
+        );
+        const message = String((second.error as Error | undefined)?.message);
+        expect(message).toContain("declared-monotonicity integrity");
+        expect(message).toContain(JSON.stringify("integrity-z"));
+        expect(message).not.toContain(`atom ${JSON.stringify(ATOM_X)} added`);
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("an identical re-mint passes (equality is monotone)", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
       const runtime = makeRuntime({

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -1,0 +1,433 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-declared-mono");
+
+// WP5 (docs/specs/cfc-persisted-declassification.md §4 item 3, §5; spec
+// §8.12.1/§8.12.8): the declared-component monotonicity gate. The declared
+// (store-policy) component of a persisted path's label map evolves only
+// through the schema-walk re-mint in prepare.ts; §8.12.1's
+// `canUpdateStoreLabel` (confidentiality may only add clauses or remove
+// alternatives; the integrity claim may only remove atoms) had no runtime
+// check — the "never an ordinary write" clause of §8.12.7 route 2b was
+// unenforced prose. This suite first PINS current behavior (the
+// characterization block — the off/observe byte-compat contract), then
+// specifies the gate behind `cfcDeclaredMonotonicity: off | observe |
+// enforce` (default off).
+
+const CLAUSE_A = "clause-a";
+const CLAUSE_B = "clause-b";
+const ATOM_X = "integrity-x";
+const ATOM_Y = "integrity-y";
+
+const SCHEMA_TWO_CLAUSES = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { confidentiality: [CLAUSE_A, CLAUSE_B] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const SCHEMA_ONE_CLAUSE = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { confidentiality: [CLAUSE_A] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const SCHEMA_OR_CLAUSE = {
+  type: "object",
+  properties: {
+    out: {
+      type: "string",
+      ifc: { confidentiality: [{ anyOf: [CLAUSE_A, CLAUSE_B] }] },
+    },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const SCHEMA_NO_IFC = {
+  type: "object",
+  properties: {
+    out: { type: "string" },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const SCHEMA_MINT_X = {
+  type: "object",
+  properties: {
+    out: {
+      type: "string",
+      ifc: { confidentiality: [CLAUSE_A], addIntegrity: [ATOM_X] },
+    },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const SCHEMA_MINT_XY = {
+  type: "object",
+  properties: {
+    out: {
+      type: "string",
+      ifc: { confidentiality: [CLAUSE_A], addIntegrity: [ATOM_X, ATOM_Y] },
+    },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+type PersistedEntry = {
+  path: string[];
+  origin?: string;
+  observes?: string;
+  label: {
+    confidentiality?: unknown[];
+    integrity?: unknown[];
+  };
+};
+
+const makeRuntime = (opts: {
+  storageManager: ReturnType<typeof StorageManager.emulate>;
+  cfcEnforcementMode?: "disabled" | "observe" | "enforce-explicit";
+  cfcFlowLabels?: "off" | "observe" | "persist";
+}) =>
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager: opts.storageManager,
+    cfcEnforcementMode: opts.cfcEnforcementMode ?? "enforce-explicit",
+    ...(opts.cfcFlowLabels !== undefined
+      ? { cfcFlowLabels: opts.cfcFlowLabels }
+      : {}),
+  });
+
+const persistedEntriesFor = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+): PersistedEntry[] => {
+  const replica = storageManager.open(signer.did()).replica as unknown as {
+    getDocument(id: string): {
+      cfc?: { labelMap?: { entries: PersistedEntry[] } };
+    } | undefined;
+  };
+  return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+};
+
+const declaredEntryAt = (
+  entries: PersistedEntry[],
+  path: string[],
+): PersistedEntry | undefined =>
+  entries.find((entry) =>
+    (entry.origin === "declared" || entry.origin === undefined) &&
+    entry.path.length === path.length &&
+    entry.path.every((segment, index) => segment === path[index])
+  );
+
+/** Commit a value write through a schema-bearing cell; returns the result. */
+const commitWrite = async (
+  runtime: Runtime,
+  name: string,
+  schema: JSONSchema | undefined,
+  value: unknown,
+): Promise<
+  { error?: unknown; docId: string; diagnostics: string[] }
+> => {
+  const tx = runtime.edit();
+  const cell = runtime.getCell(signer.did(), name, schema, tx);
+  const docId = cell.getAsNormalizedFullLink().id;
+  cell.set(value as never);
+  tx.prepareCfc();
+  const result = await tx.commit();
+  return {
+    ...(result.error !== undefined ? { error: result.error } : {}),
+    docId,
+    diagnostics: [...tx.getCfcState().diagnostics],
+  };
+};
+
+/**
+ * Rewrite the stored declared labelMap entries of an existing doc, keeping
+ * the real schemaHash (so the next prepare's stored-schema load succeeds).
+ * Runs on a SEPARATE `disabled`-enforcement runtime over the same storage:
+ * tests seed stored ["cfc"] metadata via an ungated path-[] full-document
+ * write (the shape hydration delivers), and a doc that already carries
+ * metadata trips the missing-schema-input reason on enforcing runtimes.
+ * The caller owns the seeder runtime and must dispose it only AFTER its last
+ * read of the doc — disposing a runtime tears down subscription state shared
+ * through the storage manager, and the doc becomes unreadable from the other
+ * runtime (verified empirically while pinning this suite).
+ */
+const rewriteStoredEntries = async (
+  seeder: Runtime,
+  docId: string,
+  mutate: (entries: PersistedEntry[]) => PersistedEntry[],
+): Promise<void> => {
+  const tx = seeder.edit();
+  const document = tx.readOrThrow({
+    space: signer.did(),
+    id: docId as URI,
+    type: "application/json",
+    path: [],
+  }) as { value?: unknown; cfc?: { labelMap: { entries: PersistedEntry[] } } };
+  const cloned = JSON.parse(JSON.stringify(document)) as {
+    value?: unknown;
+    cfc: {
+      version: 1;
+      schemaHash: string;
+      labelMap: { version: 1; entries: PersistedEntry[] };
+    };
+  };
+  cloned.cfc.labelMap.entries = mutate(cloned.cfc.labelMap.entries);
+  tx.writeOrThrow({
+    space: signer.did(),
+    id: docId as URI,
+    type: "application/json",
+    path: [],
+  }, cloned as never);
+  const result = await tx.commit();
+  expect(result.error).toBeUndefined();
+};
+
+describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
+  // ------------------------------------------------------------------
+  // Characterization: what the re-mint does TODAY, with no gate dial.
+  // These pin the `off`/`observe` byte-compat contract.
+  // ------------------------------------------------------------------
+  describe("current behavior (characterization — the off/observe contract)", () => {
+    it("(a) a schema dropping a confidentiality clause is rejected by the schema merge", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-char-drop",
+          SCHEMA_TWO_CLAUSES,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-char-drop",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v2" },
+        );
+        // Today the SCHEMA-level weakening guard (mergeCfcSchemaEnvelopes)
+        // rejects this route before any entry is re-minted.
+        expect(String((second.error as Error | undefined)?.message)).toContain(
+          "confidentiality cannot be weakened",
+        );
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.confidentiality).toEqual([CLAUSE_A, CLAUSE_B]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("(b) a schema adding an alternative to an existing clause is rejected by the schema merge", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-char-alt",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-char-alt",
+          SCHEMA_OR_CLAUSE,
+          { out: "v2" },
+        );
+        // Replacing clause A with A∨B grows the clause's satisfier set; the
+        // schema merge's clause-set subset check rejects it today.
+        expect(String((second.error as Error | undefined)?.message)).toContain(
+          "confidentiality cannot be weakened",
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("(c) a schema adding an integrity atom silently grows the declared integrity claim", async () => {
+      // THE gap the gate closes: §8.12.1 says the declared integrity claim
+      // may only shrink, but addIntegrity growth is merge-legal and the
+      // re-mint persists the grown claim with no check.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-char-integ",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const before = declaredEntryAt(
+          persistedEntriesFor(storageManager, first.docId),
+          ["out"],
+        );
+        expect(before?.label.integrity).toEqual([ATOM_X]);
+        const second = await commitWrite(
+          runtime,
+          "dm-char-integ",
+          SCHEMA_MINT_XY,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const after = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(after?.label.integrity).toEqual([ATOM_X, ATOM_Y]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("(d) a schema declaring nothing where an entry exists keeps the entry (merge restores stored ifc)", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-char-none",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-char-none",
+          SCHEMA_NO_IFC,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("a stored declared entry stronger than its schema is silently weakened under flow persist", async () => {
+      // The entry-level weakening route the schema merge cannot see: the
+      // stored declared entry carries confidentiality beyond what the
+      // (unchanged) schema declares — an earlier exactCopy mint, an earlier
+      // ratchet fold, a peer's write. Under cfcFlowLabels:"persist" the
+      // re-mint derives from the schema alone and DROPS the extra clause.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager, cfcFlowLabels: "persist" });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-char-entry-drop",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) =>
+          entries.map((entry) =>
+            entry.origin === "declared" && entry.path.join("/") === "out"
+              ? {
+                ...entry,
+                label: {
+                  ...entry.label,
+                  confidentiality: [CLAUSE_A, CLAUSE_B],
+                },
+              }
+              : entry
+          ));
+        const second = await commitWrite(
+          runtime,
+          "dm-char-entry-drop",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        // CLAUSE_B silently dropped: the non-monotone declared re-mint.
+        expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("with flow labels off, the Wave-2 grow-only ratchet folds the stronger stored entry back in", async () => {
+      // The dual pin: under the default cfcFlowLabels:"off" the legacy
+      // ratchet merges prior confidentiality into the fresh entry, so the
+      // confidentiality half of §8.12.1 cannot regress on this path — which
+      // is why the gate's confidentiality tests run under flow persist.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-char-ratchet",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) =>
+          entries.map((entry) =>
+            entry.origin === "declared" && entry.path.join("/") === "out"
+              ? {
+                ...entry,
+                label: {
+                  ...entry.label,
+                  confidentiality: [CLAUSE_A, CLAUSE_B],
+                },
+              }
+              : entry
+          ));
+        const second = await commitWrite(
+          runtime,
+          "dm-char-ratchet",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.confidentiality).toEqual(
+          expect.arrayContaining([CLAUSE_A, CLAUSE_B]),
+        );
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+});

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -5,7 +5,10 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
 import type { JSONSchema } from "../src/builder/types.ts";
-import type { CfcDeclaredMonotonicityMode } from "../src/cfc/mod.ts";
+import {
+  cfcCanonicalClauseDigest,
+  type CfcDeclaredMonotonicityMode,
+} from "../src/cfc/mod.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-declared-mono");
 
@@ -625,6 +628,657 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         await runtime.dispose();
         await storageManager.close();
       }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Shared scenario builders for the gate-behavior blocks below.
+  // ------------------------------------------------------------------
+
+  /**
+   * Seeded-drop scenario: commit v1 under `schema`, then rewrite the stored
+   * declared /out entry via `mutateEntry`, then commit v2 under the SAME
+   * schema on a `cfcFlowLabels:"persist"` runtime (the ratchet-free route
+   * where an entry-level weakening actually reaches the persist walk).
+   * Returns the second commit's outcome plus the doc's persisted entries.
+   */
+  const seededRemintScenario = async (opts: {
+    storageManager: ReturnType<typeof StorageManager.emulate>;
+    name: string;
+    schema: JSONSchema;
+    dial?: CfcDeclaredMonotonicityMode;
+    flowLabels?: "off" | "persist";
+    mutateEntry: (entry: PersistedEntry) => PersistedEntry;
+    beforeSecondCommit?: (
+      tx: ReturnType<Runtime["edit"]>,
+      docId: string,
+    ) => void;
+  }) => {
+    const runtime = makeRuntime({
+      storageManager: opts.storageManager,
+      cfcFlowLabels: opts.flowLabels ?? "persist",
+      ...(opts.dial !== undefined
+        ? { cfcDeclaredMonotonicity: opts.dial }
+        : {}),
+    });
+    const seeder = makeRuntime({
+      storageManager: opts.storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const first = await commitWrite(runtime, opts.name, opts.schema, {
+        out: "v1",
+      });
+      expect(first.error).toBeUndefined();
+      await rewriteStoredEntries(seeder, first.docId, (entries) =>
+        entries.map((entry) =>
+          entry.origin === "declared" && entry.path.join("/") === "out"
+            ? opts.mutateEntry(entry)
+            : entry
+        ));
+      const tx = runtime.edit();
+      const cell = runtime.getCell(signer.did(), opts.name, opts.schema, tx);
+      cell.set({ out: "v2" } as never);
+      opts.beforeSecondCommit?.(tx, first.docId);
+      tx.prepareCfc();
+      const result = await tx.commit();
+      return {
+        docId: first.docId,
+        error: result.error,
+        diagnostics: [...tx.getCfcState().diagnostics],
+        entries: persistedEntriesFor(opts.storageManager, first.docId),
+        prepare: tx.getCfcState().prepare,
+      };
+    } finally {
+      await runtime.dispose();
+      await seeder.dispose();
+      await opts.storageManager.close();
+    }
+  };
+
+  // ------------------------------------------------------------------
+  // The gate under enforce: §8.12.1 weakenings fail closed.
+  // ------------------------------------------------------------------
+  describe("enforce: non-monotone declared re-mints fail closed", () => {
+    it("a dropped confidentiality clause rejects, naming doc, path and direction", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-enf-drop",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+      });
+      const message = String((result.error as Error | undefined)?.message);
+      expect(message).toContain("declared-monotonicity confidentiality");
+      expect(message).toContain(result.docId);
+      expect(message).toContain("at /out");
+      expect(message).toContain("§8.12.1");
+      // The rejected commit persisted nothing: the seeded stored entry is
+      // intact.
+      const entry = declaredEntryAt(result.entries, ["out"]);
+      expect(entry?.label.confidentiality).toEqual([CLAUSE_A, CLAUSE_B]);
+    });
+
+    it("an alternative added to an existing clause rejects", async () => {
+      // Stored clause is the bare CLAUSE_A; the (unchanged) schema declares
+      // the wider A∨B, so the re-mint would grow the clause's satisfier set
+      // — exactly what canUpdateStoreLabel forbids.
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-enf-alt",
+        schema: SCHEMA_OR_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A] },
+        }),
+      });
+      const message = String((result.error as Error | undefined)?.message);
+      expect(message).toContain("declared-monotonicity confidentiality");
+      expect(message).toContain("at /out");
+    });
+
+    it("an added integrity atom rejects (the declared claim may only shrink)", async () => {
+      // The pure schema-evolution route (no seeding, flow labels off): the
+      // schema merge allows addIntegrity growth, so only this gate stands
+      // between the re-mint and a grown declared integrity claim — the
+      // characterization block pins that today this commits silently.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-enf-integ",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-enf-integ",
+          SCHEMA_MINT_XY,
+          { out: "v2" },
+        );
+        const message = String((second.error as Error | undefined)?.message);
+        expect(message).toContain("declared-monotonicity integrity");
+        expect(message).toContain(second.docId);
+        expect(message).toContain("at /out");
+        expect(message).toContain(JSON.stringify(ATOM_Y));
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.integrity).toEqual([ATOM_X]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // The gate under enforce: §8.12.1 tightenings pass.
+  // ------------------------------------------------------------------
+  describe("enforce: monotone tightenings pass", () => {
+    it("an added clause passes and persists", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-tight-add",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-tight-add",
+          SCHEMA_TWO_CLAUSES,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.confidentiality).toEqual(
+          expect.arrayContaining([CLAUSE_A, CLAUSE_B]),
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("a removed alternative passes (stored A∨B tightens to A)", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-tight-alt",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: {
+            ...entry.label,
+            confidentiality: [{ anyOf: [CLAUSE_A, CLAUSE_B] }],
+          },
+        }),
+      });
+      expect(result.error).toBeUndefined();
+      const entry = declaredEntryAt(result.entries, ["out"]);
+      expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+    });
+
+    it("a removed integrity atom passes (stored [X,Y] tightens to [X])", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-tight-integ",
+        schema: SCHEMA_MINT_X,
+        dial: "enforce",
+        flowLabels: "off",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, integrity: [ATOM_X, ATOM_Y] },
+        }),
+      });
+      expect(result.error).toBeUndefined();
+      const entry = declaredEntryAt(result.entries, ["out"]);
+      expect(entry?.label.integrity).toEqual([ATOM_X]);
+    });
+
+    it("an identical re-mint passes (equality is monotone)", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-tight-same",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-tight-same",
+          SCHEMA_MINT_X,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+        expect(entry?.label.integrity).toEqual([ATOM_X]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // §8.12.8 component scoping: only declared↔declared is ever compared.
+  // ------------------------------------------------------------------
+  describe("component scoping (§8.12.8)", () => {
+    it("legacy (origin-less) stored entries are not gated", async () => {
+      // A seeded LEGACY entry whose integrity the fresh declared mint does
+      // not cover: were the gate to compare against it, [X] ⊄ [Y] would
+      // reject — legacy entries keep the historical combined rules instead.
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-scope-legacy",
+        schema: SCHEMA_MINT_X,
+        dial: "enforce",
+        flowLabels: "off",
+        mutateEntry: (entry) => {
+          const { origin: _origin, ...legacy } = entry;
+          return {
+            ...legacy,
+            label: { ...legacy.label, integrity: [ATOM_Y] },
+          };
+        },
+      });
+      expect(result.error).toBeUndefined();
+    });
+
+    it("derived stored entries are not gated (replace-on-overwrite stands)", async () => {
+      // A seeded DERIVED entry at the written path is replaced/cleared by
+      // the flow discipline — a label decrease §8.12.8 explicitly permits
+      // and the gate must not reject.
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-scope-derived",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          origin: "derived",
+          label: { confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+      });
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // off/observe: byte-compat with the characterization block.
+  // ------------------------------------------------------------------
+  describe("off/observe byte-compat", () => {
+    it("off: the seeded weakening persists exactly as characterized, no diagnostic", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-off-drop",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "off",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+      });
+      expect(result.error).toBeUndefined();
+      const entry = declaredEntryAt(result.entries, ["out"]);
+      expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+      expect(
+        result.diagnostics.some((d) => d.includes("declared-monotonicity")),
+      ).toBe(false);
+    });
+
+    it("observe: the weakening persists as characterized AND a structured diagnostic records it", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-obs-drop",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "observe",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+      });
+      expect(result.error).toBeUndefined();
+      const entry = declaredEntryAt(result.entries, ["out"]);
+      expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+      expect(
+        result.diagnostics.some((d) =>
+          d.startsWith("declared-monotonicity(observe):") &&
+          d.includes("at /out") &&
+          d.includes("§8.12.1")
+        ),
+      ).toBe(true);
+    });
+
+    it("observe: the integrity-add characterization outcome is unchanged, with a diagnostic", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "observe",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-obs-integ",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-obs-integ",
+          SCHEMA_MINT_XY,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, second.docId),
+          ["out"],
+        );
+        expect(entry?.label.integrity).toEqual([ATOM_X, ATOM_Y]);
+        expect(
+          second.diagnostics.some((d) =>
+            d.startsWith("declared-monotonicity(observe):") &&
+            d.includes("integrity")
+          ),
+        ).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("the schema-declares-nothing case matches pinned behavior under every dial value", async () => {
+      for (const dial of ["off", "observe", "enforce"] as const) {
+        const storageManager = StorageManager.emulate({ as: signer });
+        const runtime = makeRuntime({
+          storageManager,
+          cfcDeclaredMonotonicity: dial,
+        });
+        try {
+          const first = await commitWrite(
+            runtime,
+            `dm-none-${dial}`,
+            SCHEMA_ONE_CLAUSE,
+            { out: "v1" },
+          );
+          expect(first.error).toBeUndefined();
+          const second = await commitWrite(
+            runtime,
+            `dm-none-${dial}`,
+            SCHEMA_NO_IFC,
+            { out: "v2" },
+          );
+          expect(second.error, `dial=${dial}`).toBeUndefined();
+          const entry = declaredEntryAt(
+            persistedEntriesFor(storageManager, second.docId),
+            ["out"],
+          );
+          expect(entry?.label.confidentiality, `dial=${dial}`).toEqual([
+            CLAUSE_A,
+          ]);
+          expect(
+            second.diagnostics.some((d) =>
+              d.includes("declared-monotonicity")
+            ),
+            `dial=${dial}`,
+          ).toBe(false);
+        } finally {
+          await runtime.dispose();
+          await storageManager.close();
+        }
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // The exemption seam consumed by the gate (§8.12.7 route 2b semantics).
+  // ------------------------------------------------------------------
+  describe("enforce: the widening exemption", () => {
+    const withExemption = (
+      clauseDigest: string,
+      path: string[] = ["out"],
+    ) =>
+    (tx: ReturnType<Runtime["edit"]>, docId: string) => {
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "cfc-declassification-event-writer",
+      });
+      tx.setCfcDeclaredWideningExemption({
+        space: signer.did(),
+        id: docId,
+        path,
+        clauseDigest,
+      });
+      // The event writer's identity must not leak into the ordinary write
+      // attribution of the rest of this test transaction.
+      tx.setCfcImplementationIdentity(undefined);
+    };
+
+    it("a privileged marker exempts exactly its (doc, path, clauseDigest) triple", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-ex-exact",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+        beforeSecondCommit: withExemption(cfcCanonicalClauseDigest(CLAUSE_B)),
+      });
+      expect(result.error).toBeUndefined();
+      const entry = declaredEntryAt(result.entries, ["out"]);
+      // The widening happened — sanctioned, once, for this clause.
+      expect(entry?.label.confidentiality).toEqual([CLAUSE_A]);
+    });
+
+    it("a wrong clause digest exempts nothing", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-ex-wrong-digest",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+        beforeSecondCommit: withExemption(cfcCanonicalClauseDigest(CLAUSE_A)),
+      });
+      expect(
+        String((result.error as Error | undefined)?.message),
+      ).toContain("declared-monotonicity confidentiality");
+    });
+
+    it("an exemption for path A does not exempt path B", async () => {
+      const schema = {
+        type: "object",
+        properties: {
+          out: { type: "string", ifc: { confidentiality: [CLAUSE_A] } },
+          aux: { type: "string", ifc: { confidentiality: [CLAUSE_A] } },
+        },
+        required: ["out", "aux"],
+      } as const satisfies JSONSchema;
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcFlowLabels: "persist",
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(runtime, "dm-ex-paths", schema, {
+          out: "v1",
+          aux: "v1",
+        });
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) =>
+          entries.map((entry) =>
+            entry.origin === "declared"
+              ? {
+                ...entry,
+                label: {
+                  ...entry.label,
+                  confidentiality: [CLAUSE_A, CLAUSE_B],
+                },
+              }
+              : entry
+          ));
+        const tx = runtime.edit();
+        const cell = runtime.getCell(signer.did(), "dm-ex-paths", schema, tx);
+        cell.set({ out: "v2", aux: "v2" });
+        withExemption(cfcCanonicalClauseDigest(CLAUSE_B), ["out"])(
+          tx,
+          first.docId,
+        );
+        tx.prepareCfc();
+        const result = await tx.commit();
+        const message = String((result.error as Error | undefined)?.message);
+        // /out is exempted; /aux still fails closed.
+        expect(message).toContain("at /aux");
+        expect(message).not.toContain("at /out");
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("integrity violations are never exemptable", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-ex-integ",
+          SCHEMA_MINT_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "dm-ex-integ",
+          SCHEMA_MINT_XY,
+          tx,
+        );
+        cell.set({ out: "v2" });
+        withExemption(cfcCanonicalClauseDigest(ATOM_Y))(tx, first.docId);
+        tx.prepareCfc();
+        const result = await tx.commit();
+        expect(
+          String((result.error as Error | undefined)?.message),
+        ).toContain("declared-monotonicity integrity");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Non-taint: the gate's stored-entry reads ride the internal-verifier
+  // meta and must not enter the consumed set.
+  // ------------------------------------------------------------------
+  describe("non-taint", () => {
+    it("the observe-mode gate adds nothing to the prepared consumed set", async () => {
+      const consumedReadsFor = async (
+        dial: CfcDeclaredMonotonicityMode,
+      ): Promise<unknown> => {
+        const storageManager = StorageManager.emulate({ as: signer });
+        const runtime = makeRuntime({
+          storageManager,
+          cfcFlowLabels: "persist",
+          cfcDeclaredMonotonicity: dial,
+        });
+        const seeder = makeRuntime({
+          storageManager,
+          cfcEnforcementMode: "disabled",
+        });
+        try {
+          const first = await commitWrite(
+            runtime,
+            "dm-nontaint",
+            SCHEMA_ONE_CLAUSE,
+            { out: "v1" },
+          );
+          expect(first.error).toBeUndefined();
+          await rewriteStoredEntries(seeder, first.docId, (entries) =>
+            entries.map((entry) =>
+              entry.origin === "declared" && entry.path.join("/") === "out"
+                ? {
+                  ...entry,
+                  label: {
+                    ...entry.label,
+                    confidentiality: [CLAUSE_A, CLAUSE_B],
+                  },
+                }
+                : entry
+            ));
+          const tx = runtime.edit();
+          const cell = runtime.getCell(
+            signer.did(),
+            "dm-nontaint",
+            SCHEMA_ONE_CLAUSE,
+            tx,
+          );
+          cell.set({ out: "v2" });
+          tx.prepareCfc();
+          const prepare = tx.getCfcState().prepare;
+          expect(prepare.status).toBe("prepared");
+          const consumed = prepare.status === "prepared"
+            ? JSON.parse(JSON.stringify(prepare.input.consumedReads))
+            : undefined;
+          tx.abort();
+          return consumed;
+        } finally {
+          await runtime.dispose();
+          await seeder.dispose();
+          await storageManager.close();
+        }
+      };
+      // Identical scenario, gate off vs observing a real violation: the
+      // consumed-read sets must be byte-identical — the gate's stored-
+      // metadata reads never taint.
+      const offReads = await consumedReadsFor("off");
+      const observeReads = await consumedReadsFor("observe");
+      expect(observeReads).toEqual(offReads);
     });
   });
 });

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -355,18 +355,22 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           { out: "v1" },
         );
         expect(first.error).toBeUndefined();
-        await rewriteStoredEntries(seeder, first.docId, (entries) =>
-          entries.map((entry) =>
-            entry.origin === "declared" && entry.path.join("/") === "out"
-              ? {
-                ...entry,
-                label: {
-                  ...entry.label,
-                  confidentiality: [CLAUSE_A, CLAUSE_B],
-                },
-              }
-              : entry
-          ));
+        await rewriteStoredEntries(
+          seeder,
+          first.docId,
+          (entries) =>
+            entries.map((entry) =>
+              entry.origin === "declared" && entry.path.join("/") === "out"
+                ? {
+                  ...entry,
+                  label: {
+                    ...entry.label,
+                    confidentiality: [CLAUSE_A, CLAUSE_B],
+                  },
+                }
+                : entry
+            ),
+        );
         const second = await commitWrite(
           runtime,
           "dm-char-entry-drop",
@@ -406,18 +410,22 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           { out: "v1" },
         );
         expect(first.error).toBeUndefined();
-        await rewriteStoredEntries(seeder, first.docId, (entries) =>
-          entries.map((entry) =>
-            entry.origin === "declared" && entry.path.join("/") === "out"
-              ? {
-                ...entry,
-                label: {
-                  ...entry.label,
-                  confidentiality: [CLAUSE_A, CLAUSE_B],
-                },
-              }
-              : entry
-          ));
+        await rewriteStoredEntries(
+          seeder,
+          first.docId,
+          (entries) =>
+            entries.map((entry) =>
+              entry.origin === "declared" && entry.path.join("/") === "out"
+                ? {
+                  ...entry,
+                  label: {
+                    ...entry.label,
+                    confidentiality: [CLAUSE_A, CLAUSE_B],
+                  },
+                }
+                : entry
+            ),
+        );
         const second = await commitWrite(
           runtime,
           "dm-char-ratchet",
@@ -674,12 +682,16 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         out: "v1",
       });
       expect(first.error).toBeUndefined();
-      await rewriteStoredEntries(seeder, first.docId, (entries) =>
-        entries.map((entry) =>
-          entry.origin === "declared" && entry.path.join("/") === "out"
-            ? opts.mutateEntry(entry)
-            : entry
-        ));
+      await rewriteStoredEntries(
+        seeder,
+        first.docId,
+        (entries) =>
+          entries.map((entry) =>
+            entry.origin === "declared" && entry.path.join("/") === "out"
+              ? opts.mutateEntry(entry)
+              : entry
+          ),
+      );
       const tx = runtime.edit();
       const cell = runtime.getCell(signer.did(), opts.name, opts.schema, tx);
       cell.set({ out: "v2" } as never);
@@ -772,18 +784,22 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           aux: "v1",
         });
         expect(first.error).toBeUndefined();
-        await rewriteStoredEntries(seeder, first.docId, (entries) =>
-          entries.map((entry) =>
-            entry.origin === "declared" && entry.path.join("/") === "aux"
-              ? {
-                ...entry,
-                label: {
-                  ...entry.label,
-                  confidentiality: [CLAUSE_A, CLAUSE_B],
-                },
-              }
-              : entry
-          ));
+        await rewriteStoredEntries(
+          seeder,
+          first.docId,
+          (entries) =>
+            entries.map((entry) =>
+              entry.origin === "declared" && entry.path.join("/") === "aux"
+                ? {
+                  ...entry,
+                  label: {
+                    ...entry.label,
+                    confidentiality: [CLAUSE_A, CLAUSE_B],
+                  },
+                }
+                : entry
+            ),
+        );
         const tx = runtime.edit();
         const cell = runtime.getCell(
           signer.did(),
@@ -832,18 +848,22 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           { out: "v1" },
         );
         expect(first.error).toBeUndefined();
-        await rewriteStoredEntries(seeder, first.docId, (entries) =>
-          entries.map((entry) =>
-            entry.origin === "declared" && entry.path.join("/") === "out"
-              ? {
-                ...entry,
-                label: {
-                  ...entry.label,
-                  confidentiality: [CLAUSE_A, CLAUSE_B],
-                },
-              }
-              : entry
-          ));
+        await rewriteStoredEntries(
+          seeder,
+          first.docId,
+          (entries) =>
+            entries.map((entry) =>
+              entry.origin === "declared" && entry.path.join("/") === "out"
+                ? {
+                  ...entry,
+                  label: {
+                    ...entry.label,
+                    confidentiality: [CLAUSE_A, CLAUSE_B],
+                  },
+                }
+                : entry
+            ),
+        );
         const tx = runtime.edit();
         const cell = runtime.getCell(
           signer.did(),
@@ -1194,9 +1214,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
             CLAUSE_A,
           ]);
           expect(
-            second.diagnostics.some((d) =>
-              d.includes("declared-monotonicity")
-            ),
+            second.diagnostics.some((d) => d.includes("declared-monotonicity")),
             `dial=${dial}`,
           ).toBe(false);
         } finally {
@@ -1320,18 +1338,22 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           aux: "v1",
         });
         expect(first.error).toBeUndefined();
-        await rewriteStoredEntries(seeder, first.docId, (entries) =>
-          entries.map((entry) =>
-            entry.origin === "declared"
-              ? {
-                ...entry,
-                label: {
-                  ...entry.label,
-                  confidentiality: [CLAUSE_A, CLAUSE_B],
-                },
-              }
-              : entry
-          ));
+        await rewriteStoredEntries(
+          seeder,
+          first.docId,
+          (entries) =>
+            entries.map((entry) =>
+              entry.origin === "declared"
+                ? {
+                  ...entry,
+                  label: {
+                    ...entry.label,
+                    confidentiality: [CLAUSE_A, CLAUSE_B],
+                  },
+                }
+                : entry
+            ),
+        );
         const tx = runtime.edit();
         const cell = runtime.getCell(signer.did(), "dm-ex-paths", schema, tx);
         cell.set({ out: "v2", aux: "v2" });
@@ -1414,18 +1436,22 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
             { out: "v1" },
           );
           expect(first.error).toBeUndefined();
-          await rewriteStoredEntries(seeder, first.docId, (entries) =>
-            entries.map((entry) =>
-              entry.origin === "declared" && entry.path.join("/") === "out"
-                ? {
-                  ...entry,
-                  label: {
-                    ...entry.label,
-                    confidentiality: [CLAUSE_A, CLAUSE_B],
-                  },
-                }
-                : entry
-            ));
+          await rewriteStoredEntries(
+            seeder,
+            first.docId,
+            (entries) =>
+              entries.map((entry) =>
+                entry.origin === "declared" && entry.path.join("/") === "out"
+                  ? {
+                    ...entry,
+                    label: {
+                      ...entry.label,
+                      confidentiality: [CLAUSE_A, CLAUSE_B],
+                    },
+                  }
+                  : entry
+              ),
+          );
           const tx = runtime.edit();
           const cell = runtime.getCell(
             signer.did(),

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -10,6 +10,7 @@ import {
   type CfcDeclaredMonotonicityMode,
 } from "../src/cfc/mod.ts";
 import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
+import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-declared-mono");
 
@@ -566,6 +567,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         });
         const attempt = (marker: unknown) => () =>
           tx.setCfcDeclaredWideningExemption(marker as never);
+        expect(attempt(null)).toThrow(/malformed/);
         expect(attempt({ ...EXEMPTION(), space: "" })).toThrow(/malformed/);
         expect(attempt({ ...EXEMPTION(), id: "" })).toThrow(/malformed/);
         expect(attempt({ ...EXEMPTION(), clauseDigest: "" })).toThrow(
@@ -603,6 +605,36 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
             clauseDigest: "another-digest",
           })
         ).toThrow(/already set/);
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("delegates through TransactionWrapper to the wrapped transaction", async () => {
+      // The wrapper forwards every dial setter and the seam; both must
+      // reach the wrapped tx (and its pin/validation) identically.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        const wrapper = new TransactionWrapper(tx);
+        wrapper.setCfcDeclaredMonotonicityMode("enforce");
+        expect(tx.getCfcState().declaredMonotonicityMode).toBe("enforce");
+        expect(() => wrapper.setCfcDeclaredMonotonicityMode("off")).toThrow(
+          /cannot be weakened/,
+        );
+        expect(() => wrapper.setCfcDeclaredWideningExemption(EXEMPTION()))
+          .toThrow(/builtin/);
+        tx.setCfcImplementationIdentity({
+          kind: "builtin",
+          builtinId: "cfc-declassification-event-writer",
+        });
+        wrapper.setCfcDeclaredWideningExemption(EXEMPTION());
+        expect(tx.getCfcState().declaredWideningExemption?.id).toBe(
+          "of:some-doc",
+        );
         tx.abort();
       } finally {
         await runtime.dispose();

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -5,6 +5,7 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcDeclaredMonotonicityMode } from "../src/cfc/mod.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-declared-mono");
 
@@ -96,6 +97,7 @@ const makeRuntime = (opts: {
   storageManager: ReturnType<typeof StorageManager.emulate>;
   cfcEnforcementMode?: "disabled" | "observe" | "enforce-explicit";
   cfcFlowLabels?: "off" | "observe" | "persist";
+  cfcDeclaredMonotonicity?: CfcDeclaredMonotonicityMode;
 }) =>
   new Runtime({
     apiUrl: new URL("https://example.com"),
@@ -103,6 +105,9 @@ const makeRuntime = (opts: {
     cfcEnforcementMode: opts.cfcEnforcementMode ?? "enforce-explicit",
     ...(opts.cfcFlowLabels !== undefined
       ? { cfcFlowLabels: opts.cfcFlowLabels }
+      : {}),
+    ...(opts.cfcDeclaredMonotonicity !== undefined
+      ? { cfcDeclaredMonotonicity: opts.cfcDeclaredMonotonicity }
       : {}),
   });
 
@@ -426,6 +431,198 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
       } finally {
         await runtime.dispose();
         await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // The dial: cfcDeclaredMonotonicity, mirroring cfcWriteFloor exactly.
+  // ------------------------------------------------------------------
+  describe("the cfcDeclaredMonotonicity dial", () => {
+    it("the enforce pin cannot be weakened mid-transaction", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      try {
+        const tx = runtime.edit();
+        expect(() => tx.setCfcDeclaredMonotonicityMode("off")).toThrow(
+          "cannot be weakened",
+        );
+        expect(() => tx.setCfcDeclaredMonotonicityMode("observe")).toThrow(
+          "cannot be weakened",
+        );
+        // Re-asserting enforce is fine.
+        tx.setCfcDeclaredMonotonicityMode("enforce");
+        expect(tx.getCfcState().declaredMonotonicityMode).toBe("enforce");
+        await tx.commit();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("a real mode change after prepare invalidates the prepared decision", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "dm-dial-invalidate",
+          SCHEMA_ONE_CLAUSE,
+          tx,
+        );
+        cell.set({ out: "v1" });
+        tx.prepareCfc();
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
+        tx.setCfcDeclaredMonotonicityMode("enforce");
+        const prepare = tx.getCfcState().prepare;
+        expect(prepare.status).toBe("invalidated");
+        expect(
+          prepare.status === "invalidated" &&
+            prepare.reasons.includes("declared-monotonicity-mode-changed"),
+        ).toBe(true);
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // The exception seam: the per-tx privileged widening exemption
+  // (§8.12.7 route 2b; design doc §4). Setter discipline only here —
+  // the gate-facing semantics are in the enforce block below.
+  // ------------------------------------------------------------------
+  describe("the widening-exemption seam (setter discipline)", () => {
+    const EXEMPTION = () => ({
+      space: signer.did(),
+      id: "of:some-doc",
+      path: ["out"],
+      clauseDigest: "digest-of-clause",
+    });
+
+    it("pattern/handler code cannot set it: no identity fails closed", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        expect(() => tx.setCfcDeclaredWideningExemption(EXEMPTION())).toThrow(
+          /builtin/,
+        );
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("pattern/handler code cannot set it: a verified identity fails closed", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        tx.setCfcImplementationIdentity({
+          kind: "verified",
+          moduleIdentity: "mod:example",
+        });
+        expect(() => tx.setCfcDeclaredWideningExemption(EXEMPTION())).toThrow(
+          /builtin/,
+        );
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("a malformed or over-broad marker fails closed (no wildcard exemptions)", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        tx.setCfcImplementationIdentity({
+          kind: "builtin",
+          builtinId: "cfc-declassification-event-writer",
+        });
+        const attempt = (marker: unknown) => () =>
+          tx.setCfcDeclaredWideningExemption(marker as never);
+        expect(attempt({ ...EXEMPTION(), space: "" })).toThrow(/malformed/);
+        expect(attempt({ ...EXEMPTION(), id: "" })).toThrow(/malformed/);
+        expect(attempt({ ...EXEMPTION(), clauseDigest: "" })).toThrow(
+          /malformed/,
+        );
+        expect(attempt({ ...EXEMPTION(), path: "out" })).toThrow(/malformed/);
+        expect(attempt({ ...EXEMPTION(), path: [42] })).toThrow(/malformed/);
+        expect(attempt({ ...EXEMPTION(), clauseDigest: undefined })).toThrow(
+          /malformed/,
+        );
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("write-once: a second exemption in the same transaction fails closed", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        tx.setCfcImplementationIdentity({
+          kind: "builtin",
+          builtinId: "cfc-declassification-event-writer",
+        });
+        tx.setCfcDeclaredWideningExemption(EXEMPTION());
+        expect(tx.getCfcState().declaredWideningExemption).toMatchObject({
+          id: "of:some-doc",
+          clauseDigest: "digest-of-clause",
+        });
+        expect(() =>
+          tx.setCfcDeclaredWideningExemption({
+            ...EXEMPTION(),
+            clauseDigest: "another-digest",
+          })
+        ).toThrow(/already set/);
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("setting the exemption after prepare invalidates the prepared decision", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager });
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "dm-seam-invalidate",
+          SCHEMA_ONE_CLAUSE,
+          tx,
+        );
+        cell.set({ out: "v1" });
+        tx.setCfcImplementationIdentity({
+          kind: "builtin",
+          builtinId: "cfc-declassification-event-writer",
+        });
+        tx.prepareCfc();
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
+        tx.setCfcDeclaredWideningExemption(EXEMPTION());
+        const prepare = tx.getCfcState().prepare;
+        expect(prepare.status).toBe("invalidated");
+        expect(
+          prepare.status === "invalidated" &&
+            prepare.reasons.includes("declared-widening-exemption-added"),
+        ).toBe(true);
+        tx.abort();
+      } finally {
+        await runtime.dispose();
         await storageManager.close();
       }
     });

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -9,6 +9,7 @@ import {
   cfcCanonicalClauseDigest,
   type CfcDeclaredMonotonicityMode,
 } from "../src/cfc/mod.ts";
+import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-declared-mono");
 
@@ -741,6 +742,148 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
       expect(message).toContain("at /out");
     });
 
+    it("untouched paths are not gated (carry-forward preserves the stored entry)", async () => {
+      // A stored declared entry at a path this write does not touch is never
+      // re-minted — the carry-forward keeps it verbatim, so there is nothing
+      // for the gate to compare (proposedAt empty) and no false positive.
+      const schema = {
+        type: "object",
+        properties: {
+          out: { type: "string", ifc: { confidentiality: [CLAUSE_A] } },
+          aux: { type: "string", ifc: { confidentiality: [CLAUSE_A] } },
+        },
+      } as const satisfies JSONSchema;
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcFlowLabels: "persist",
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(runtime, "dm-enf-untouched", schema, {
+          out: "v1",
+          aux: "v1",
+        });
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) =>
+          entries.map((entry) =>
+            entry.origin === "declared" && entry.path.join("/") === "aux"
+              ? {
+                ...entry,
+                label: {
+                  ...entry.label,
+                  confidentiality: [CLAUSE_A, CLAUSE_B],
+                },
+              }
+              : entry
+          ));
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "dm-enf-untouched",
+          schema,
+          tx,
+        );
+        cell.key("out").set("v2");
+        tx.prepareCfc();
+        const result = await tx.commit();
+        expect(result.error).toBeUndefined();
+        const entry = declaredEntryAt(
+          persistedEntriesFor(storageManager, first.docId),
+          ["aux"],
+        );
+        expect(entry?.label.confidentiality).toEqual([CLAUSE_A, CLAUSE_B]);
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("an ingest target keeps the runtime's mark but not the non-monotone declared claims", async () => {
+      // The ingest carve-out (mirroring ingestVerificationFailed): under a
+      // NON-REJECTING enforcement mode the fail-closed reason cannot abort
+      // the commit, so the gate drops the weakened fresh declared entries —
+      // the stored, stronger ones carry forward — while the runtime's
+      // ExternalIngest mark still persists.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "observe",
+        cfcFlowLabels: "persist",
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      const seeder = makeRuntime({
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-enf-ingest",
+          SCHEMA_ONE_CLAUSE,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        await rewriteStoredEntries(seeder, first.docId, (entries) =>
+          entries.map((entry) =>
+            entry.origin === "declared" && entry.path.join("/") === "out"
+              ? {
+                ...entry,
+                label: {
+                  ...entry.label,
+                  confidentiality: [CLAUSE_A, CLAUSE_B],
+                },
+              }
+              : entry
+          ));
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "dm-enf-ingest",
+          SCHEMA_ONE_CLAUSE,
+          tx,
+        );
+        cell.set({ out: "v2" });
+        stampExternalIngest(tx, {
+          channel: "did:key:channel",
+          audience: "did:key:presenter",
+          receivedAt: "2026-07-09T12:00:00.000Z",
+          valueDigest: "sha256:payload-v2",
+          target: {
+            space: signer.did(),
+            id: first.docId as URI,
+            scope: "space",
+            path: [],
+          },
+        });
+        tx.prepareCfc();
+        const result = await tx.commit();
+        expect(result.error).toBeUndefined();
+        const entries = persistedEntriesFor(storageManager, first.docId);
+        // The stored (stronger) declared entry carried forward; the weakened
+        // fresh mint did not land.
+        const declared = declaredEntryAt(entries, ["out"]);
+        expect(declared?.label.confidentiality).toEqual([CLAUSE_A, CLAUSE_B]);
+        // The runtime's mark persisted regardless.
+        expect(entries.some((e) => e.origin === "external-ingest")).toBe(true);
+        // The violation is on record as a fail-closed reason.
+        expect(
+          tx.getCfcState().diagnostics.some((d) =>
+            d.includes("declared-monotonicity confidentiality")
+          ),
+        ).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await seeder.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("an added integrity atom rejects (the declared claim may only shrink)", async () => {
       // The pure schema-evolution route (no seeding, flow labels off): the
       // schema merge allows addIntegrity growth, so only this gate stands
@@ -1114,6 +1257,35 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
         }),
         beforeSecondCommit: withExemption(cfcCanonicalClauseDigest(CLAUSE_A)),
+      });
+      expect(
+        String((result.error as Error | undefined)?.message),
+      ).toContain("declared-monotonicity confidentiality");
+    });
+
+    it("an exemption naming another doc exempts nothing", async () => {
+      const result = await seededRemintScenario({
+        storageManager: StorageManager.emulate({ as: signer }),
+        name: "dm-ex-other-doc",
+        schema: SCHEMA_ONE_CLAUSE,
+        dial: "enforce",
+        mutateEntry: (entry) => ({
+          ...entry,
+          label: { ...entry.label, confidentiality: [CLAUSE_A, CLAUSE_B] },
+        }),
+        beforeSecondCommit: (tx) => {
+          tx.setCfcImplementationIdentity({
+            kind: "builtin",
+            builtinId: "cfc-declassification-event-writer",
+          });
+          tx.setCfcDeclaredWideningExemption({
+            space: signer.did(),
+            id: "of:some-unrelated-doc",
+            path: ["out"],
+            clauseDigest: cfcCanonicalClauseDigest(CLAUSE_B),
+          });
+          tx.setCfcImplementationIdentity(undefined);
+        },
       });
       expect(
         String((result.error as Error | undefined)?.message),

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -482,6 +482,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         cell.set({ out: "v1" });
         tx.prepareCfc();
         expect(tx.getCfcState().prepare.status).toBe("prepared");
+        // A no-op re-set of the same mode does not invalidate.
+        tx.setCfcDeclaredMonotonicityMode("off");
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
         tx.setCfcDeclaredMonotonicityMode("enforce");
         const prepare = tx.getCfcState().prepare;
         expect(prepare.status).toBe("invalidated");

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -97,6 +97,7 @@ const MINIMAL_TREATMENT: Record<RuntimeOptionKey, MinimalTreatment> = {
   cfcTriggerReadGating: { treat: "absent" },
   cfcPolicyEvaluation: { treat: "absent" },
   cfcLabelMetadataProtection: { treat: "absent" },
+  cfcDeclaredMonotonicity: { treat: "absent" },
   cfcPolicyRecords: { treat: "absent" },
   cfcPrefixProvenanceStats: { treat: "absent" },
   cfcTrustConfig: { treat: "absent" },


### PR DESCRIPTION
Implements WP5: the declared-component monotonicity gate — the `docs/specs/cfc-persisted-declassification.md` §5 "**Missing, buildable now**" bullet, per §4 item 3 ("build the gate before the exception, or the 'never an ordinary write' clause is unenforced prose"). Normative ground: spec §8.12.1 (`canUpdateStoreLabel`: confidentiality may only add clauses or remove alternatives; the declared integrity claim may only remove atoms) and §8.12.8 (the gate governs ONLY the `declared` component). Semantics of record: the Lean mechanization (`formal/Cfc/Store.lean` `ConfLe`/`ClauseLe`/`IntegLe`, `StoreComponents.lean` `declaredUpdateAt`).

## Pinned current behavior (characterization, first commit)

When a write arrives under a schema whose ifc:

- **(a) drops a confidentiality clause** — rejected today by the schema-merge weakening guard (`mergeCfcSchemaEnvelopes`: "confidentiality cannot be weakened"); the stored entry stays intact.
- **(b) adds an alternative to an existing clause** — same schema-merge rejection (the clause-set subset check compares clause values).
- **(c) adds an integrity atom** (`addIntegrity: [X]` → `[X, Y]`) — **silently persisted today**: the merge allows addIntegrity growth, and the re-mint grows the declared integrity claim against §8.12.1. This is the schema-route gap the gate closes.
- **(d) declares nothing where an entry exists** — the entry survives (the schema merge restores the stored ifc; the carry-forward keeps entries the walk does not re-mint).

Plus the entry-level route the schema merge cannot see (a stored declared entry stronger than its unchanged schema — an earlier exactCopy mint, ratchet fold, or peer write):

- under `cfcFlowLabels: "persist"` the re-mint derives from the schema alone and **silently drops the extra clause today** — the confidentiality gap the gate closes;
- under flow-labels `off` the Wave-2 grow-only ratchet folds prior confidentiality back in, so only the integrity direction can regress on that route.

These pins are the `off`/`observe` byte-compat contract: both dial values persist exactly these bytes (dedicated byte-compat tests).

## The gate

`collectDeclaredMonotonicityViolations` (new module `cfc/declared-monotonicity.ts`), called at the one point where the declared store-policy component can change — the schema-walk re-mint in `prepareBoundaryCommit`'s persist loop. Per written doc, per declared labelMap entry, it compares the entry the walk would persist against the stored declared entry at the same path:

- **Confidentiality**: every stored clause must be present-or-strengthened — the witness is `clauseSubsumes(proposed, stored)` from the A2/A3 clause kernel (`cfc/clause.ts`), i.e. `alts(p) ⊆ alts(s)` modulo per-family entailment (Expires ordering included) — exactly the Lean `ClauseLe stored proposed`. No hand-rolled clause comparison.
- **Integrity**: proposed ⊆ stored, atom-level canonical (structural) equality.
- **Scope (§8.12.8)**: declared↔declared only. Derived/link/structure entries keep replace-on-overwrite; legacy (origin-less) entries keep the historical combined rules; untouched paths carry forward unchecked. All pinned by tests.

Stored entries are the already-fetched `storedMetadataFor` read under the internal-verifier meta, so the gate adds nothing to the consumed set (pinned by an off-vs-observe consumed-reads equality test).

Failure contract under `enforce`: stable fail-closed reasons naming the doc, path, and violated direction, e.g. `declared-monotonicity confidentiality violation for <doc> at /out (canUpdateStoreLabel, §8.12.1): stored clause "clause-b" dropped or weakened (…)` — mirroring `requirementFailure` (reasons reject under enforcing enforcement modes; this target's label persist is skipped so the stored, stronger entries stay; an ingest target keeps only the runtime's mark). Under `observe`: structured `declared-monotonicity(observe): …` diagnostics via `tx.noteCfcDiagnostic`, today's bytes persisted. Under `off`: nothing runs.

## The dial

`cfcDeclaredMonotonicity: "off" | "observe" | "enforce"` (default `"off"`), mirroring `cfcWriteFloor`/`cfcLabelMetadataProtection` in full: mode type + default in `cfc/types.ts`, `RuntimeOptions` option, per-tx threading in `Runtime.edit()`, the anti-downgrade mid-tx pin (ECMAScript-private, weakening throws), invalidate-on-real-change-after-prepare, and the `RUNTIME_OPTION_KEYS` presets exhaustiveness registry + conformance-test row.

## The exception seam (hook only, no consumer)

The future §8.12.7 route 2b declassification-event writer is the sanctioned exception. `IExtendedStorageTransaction.setCfcDeclaredWideningExemption` exempts exactly ONE `(doc, path, clauseDigest)` triple per transaction, where `clauseDigest` is `cfcCanonicalClauseDigest` (exported — the "small clauseDigest helper" the §5 bullet names) of the STORED clause being dropped/widened. Discipline matches `writeCfcGrant`: requires a trusted-builtin implementation identity; fails closed on malformed/over-broad markers (no wildcards, empty fields, or non-string paths); write-once per tx. Tests pin: pattern/handler code (no identity or a `verified` identity) cannot set it; an exemption for path A does not exempt path B; a wrong digest or another doc exempts nothing; integrity violations are never exemptable; absent marker = the gate fully applies.

## Verification

Red→green (the same 8 gate-behavior tests before the prepare hook landed):

```
FAILED | 0 passed (29 steps) | 1 failed (11 steps)   # enforce rejections, observe diagnostics, exemption semantics all red
```

Final (`packages/runner/test/cfc-declared-monotonicity.test.ts`, 43 steps):

```
ok | 1 passed (43 steps) | 0 failed
```

Full runner suite on the catch-up merge with origin/main:

```
ok | 833 passed (4469 steps) | 0 failed | 0 ignored (10 steps)
```

`deno task check` clean. Note: `docs/specs/cfc-persisted-declassification.md` §4 item 3's "today no runtime `canUpdateStoreLabel` check exists" becomes stale once this merges; the implementation note is left to a follow-up docs pass to keep this diff off the concurrently-edited doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a monotonicity gate for the declared CFC store-policy component behind `cfcDeclaredMonotonicity`. It enforces §8.12.1 during re-mints: confidentiality can only be strengthened and declared integrity can only shrink, with a one-shot privileged widening exemption.

- New Features
  - Prepare-time check compares proposed declared entries to the per-path join of stored declared entries; confidentiality via `clauseSubsumes`, integrity must not add atoms; violation reasons deduped by canonical clause digest/atom hash. Added unit test pinning the dedup across duplicate entries.
  - Modes: `off` (default), `observe` (emits `declared-monotonicity(observe)` diagnostics), `enforce` (fail-closed reasons; drops weakened declared claims on ingest targets while keeping the runtime’s mark).
  - Scope: declared↔declared only (§8.12.8). Derived/link/structure and legacy entries keep existing rules.
  - APIs/Options: `collectDeclaredMonotonicityViolations`, `cfcCanonicalClauseDigest`; runtime option `cfcDeclaredMonotonicity`; tx setters `setCfcDeclaredMonotonicityMode` (anti-downgrade pin) and `setCfcDeclaredWideningExemption` (trusted builtin; one `(doc, path, clauseDigest)` per tx).
  - Non-taint: observe mode adds no consumed reads. Docs register the experimental option and mark the gate shipped.

- Migration
  - Default behavior is unchanged. To trial: set `cfcDeclaredMonotonicity: "observe"`. To enforce: set `"enforce"`.
  - For sanctioned declassification, call `setCfcDeclaredWideningExemption` with a builtin implementation identity and the `cfcCanonicalClauseDigest` of the stored clause.

<sup>Written for commit f81badb60a9c23d229a37a9fff858d02f9dbd139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

