### PR TITLE
docs(cfc): federation resolution — rewrite event superseded, egress records, federation rule

### DIFF
--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -223,7 +223,19 @@ consumes inbound views, redacting the outbound copies is safe.
 - **Stage 3 (strong form):** `reference`-form carried labels + per-reader
   materialization; entry criteria: a concrete deployment whose threat model
   includes targeted DID probing, and cross-space resolution latency measured
-  acceptable on the shared-profile / group-chat flows.
+  acceptable on the shared-profile / group-chat flows. **Federation
+  constraint (owner decision 2026-07-10):** the federation design rule is
+  *evidence replicates with the data; evaluation is local* (attested
+  runtimes enforce locally — reads must never phone the origin to be
+  authorized). The `reference` form is origin-coupled by construction —
+  label readability rides the source's read authority — so in a federated
+  deployment the default stays `commitment`; `reference` is admissible only
+  with per-reader materialization proven on realistic flows, and only for
+  the highest-sensitivity fields. Grants and `commitment`-form labels
+  satisfy the rule as-is; B2a's deployment-config policy source does not
+  (federated instances with different `cfcPolicyRecords` silently fire
+  different rules — B2b's space-hosted, replicating policy docs are the
+  federation-correct source).
 
 Dependencies: none on Epics B/D/E remainder; Stage 2's full population
 profile co-builds with the SC-4/SC-8 envelope design. The D4 value-level

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -221,12 +221,23 @@ declassification event. Contract, if and when built:
 2. **Policy-guarded**: the acting principal's authority over the target
    clause verified exactly as a grant writer would (inv-7), plus §8.10.5.2 —
    a broader audience is a new release judgment with its own evidence.
-3. **A new monotonicity gate**: today no runtime `canUpdateStoreLabel` check
-   exists (declared entries evolve only via the schema-walk re-mint). The
-   event is the *sanctioned exception* to a gate that must first exist —
-   build the gate (reject non-monotone declared-component changes outside an
-   event) before the exception, or the "never an ordinary write" clause is
-   unenforced prose.
+3. **A new monotonicity gate**: the event is the *sanctioned exception* to a
+   gate that must exist first — reject non-monotone declared-component
+   changes outside an event, or the "never an ordinary write" clause is
+   unenforced prose. _Implementation note (2026-07-10): shipped in #4647 —
+   `cfc/declared-monotonicity.ts` hooked at the declared re-mint point,
+   witness = the A2/A3 clause kernel's subsumption (Lean `ClauseLe`) for
+   confidentiality and set-shrink for integrity, behind
+   `cfcDeclaredMonotonicity: off | observe | enforce` with the standard
+   anti-downgrade pin. Characterization found and pinned two pre-existing
+   gaps the gate closes: schema-route `addIntegrity` growth persisted
+   silently, and stored declared entries stronger than their schema were
+   silently weakened under `cfcFlowLabels: "persist"`. The exception seam
+   exists as `setCfcDeclaredWideningExemption` — trusted-builtin only,
+   write-once, exactly one `(doc, path, clauseDigest)` triple per
+   transaction, integrity never exemptable; `cfcCanonicalClauseDigest` is
+   the clause-identity helper §5 anticipated. No consumer of the seam is
+   built (the event itself stays superseded per §5)._
 4. **The event record**, adjacent to but not inside the `["cfc"]` envelope
    (SC-11 keeps envelopes churn-free and version-neutral): a **create-only
    document causal to the consumed intent's id** — the shipped receipt

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -316,16 +316,26 @@ the grant disappear and reasonably believes the disclosure is undone, when
 only the *record that we sent it* changed. The fix is a second artifact
 class with the opposite lifecycle:
 
-- At a send-sink release (the §8.10 boundary that lets a value leave the
-  fabric), the committing transaction mints an **egress record**: a
-  create-only document causal to the consumed intent/event id, shaped
-  `{valueDigest, destination, boundaryContext, releasedAudienceEvidence,
-  at, intentId}` — the destination captured per §8.10.5.2's
-  destination/audience binding (the spec's open destination-binding
-  follow-up is exactly this evidence).
-- **Permanent by construction**: create-only (the receipt discipline),
-  never deleted, no revocation surface. Reserved-path hosted like grants;
-  readable as provenance.
+- The record is minted in two phases, because the transaction commits
+  **before** the outbox flush and the release can still be refused during
+  the flush (`verifySinkRequestRelease` runs post-commit): the committing
+  transaction MAY stage an **attempt** marker, but the permanent **sent**
+  record is created only by the **successful post-commit send path** — a
+  create-only document causal to the outbox idempotency key (itself bound
+  to the consumed intent), shaped `{valueDigest, destination,
+  boundaryContext, releasedAudienceEvidence, at, intentId}`, the
+  destination captured per §8.10.5.2's destination/audience binding (the
+  spec's open destination-binding follow-up is exactly this evidence).
+  Write ordering: **record, then clear the outbox entry** — a crash between
+  send and record leaves a live outbox entry to reconcile from, so the
+  record can understate but never overstate. An attempt marker with no sent
+  record after the retry window means known-not-sent and MUST NOT display
+  as "sent". (This is the same seam as the audit's open "post-commit outbox
+  + sink-release re-verification contract" item — the two should be specced
+  together.)
+- **Permanent by construction**: the sent record is create-only (the
+  receipt discipline), never deleted, no revocation surface. Reserved-path
+  hosted like grants; readable as provenance.
 - **No enforcement role.** The record never feeds a future release
   decision — the label keeps governing what the fabric itself serves (an
   external copy existing is not a reason for our runtime to serve the

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -277,13 +277,64 @@ mechanism level (2026-07-09):
   upgrade a v1, they do not gate it.
 
 So the only *hard* remaining gate is (a): a real export/publish/portability
-requirement that grants demonstrably cannot serve — a product decision, not
-a substrate one. When (a) holds, build order is: monotonicity gate → soak →
-reduced-evidence v1 (§4.1) → §6 evidence upgrades as they land.
-Until then, "publish" is served by route 3 (copy-forward), which is honest
-about being a new value.
+requirement that grants demonstrably cannot serve. **Resolved 2026-07-10
+(owner decision): no such requirement is identified, and the two candidate
+sources dissolve on inspection.** *In-fabric federation* runs on remote
+attestation — every federated instance is a trusted runtime enforcing the
+same rules, so the rewrite event's one technical differentiator ("trust-free
+release": a rewritten label needs no policy/trust config at the destination,
+grants need both) buys nothing where trust is ambient; grants replicate as
+ordinary docs with the owner's space and evaluate locally. *Out-of-fabric
+egress* (an HTTP POST, an email) is irrevocable by nature — and the honest
+artifact for it is the **egress record** (§6), not a label rewrite: folding
+a past external disclosure into the label would loosen *future* fabric
+enforcement as a consequence of a leak, which is the wrong direction. The
+rewrite event therefore stands **superseded on both flanks**; §4's contract
+is retained in case a genuinely new requirement appears, and its
+prerequisite (the monotonicity gate) is being built anyway on its own merits
+as a declared-label integrity guarantee. "Publish" inside the fabric is
+grants (revocable) or route 3 copy-forward (a new value, honestly);
+"publish" outside the fabric is a sink release plus an egress record.
 
-## 6. Spec-change queue
+## 6. Egress records — irrevocability made honest
+
+Revoking the fabric-side record of an external send must never read as
+un-sending. That confusion is structural if external egress is modeled with
+the same revocable artifact as internal sharing: a user who "revokes" sees
+the grant disappear and reasonably believes the disclosure is undone, when
+only the *record that we sent it* changed. The fix is a second artifact
+class with the opposite lifecycle:
+
+- At a send-sink release (the §8.10 boundary that lets a value leave the
+  fabric), the committing transaction mints an **egress record**: a
+  create-only document causal to the consumed intent/event id, shaped
+  `{valueDigest, destination, boundaryContext, releasedAudienceEvidence,
+  at, intentId}` — the destination captured per §8.10.5.2's
+  destination/audience binding (the spec's open destination-binding
+  follow-up is exactly this evidence).
+- **Permanent by construction**: create-only (the receipt discipline),
+  never deleted, no revocation surface. Reserved-path hosted like grants;
+  readable as provenance.
+- **No enforcement role.** The record never feeds a future release
+  decision — the label keeps governing what the fabric itself serves (an
+  external copy existing is not a reason for our runtime to serve the
+  original more widely). It exists for honesty, audit, and UI derivation.
+- **UI vocabulary**: *shared* (a grant — revocable; revoking stops future
+  fabric reads) vs *sent* (an egress record — irrevocable; the only
+  affordance is "left the fabric on T to D"). "Who can see this?" derives
+  from current grants ∪ past egress records.
+- **Composition with single-use grants**: a single-use grant consumed by an
+  external send yields both artifacts atomically — the `grantConsumed`
+  receipt (spends the grant) and the egress record (remembers the send) —
+  in the same commit.
+
+Substrate: create-only receipts (`experimental.commitPreconditions`,
+shipped), the outbox's idempotency keys and sink-release instrumentation
+(`onSinkReleaseReject`/`onSinkDedupHit` seams), and the §8.10.5.2
+destination-binding follow-up for the evidence shape. This is a small
+build, not a design program.
+
+## 7. Spec-change queue
 
 - **§8.12.7 route 2 splits** into 2a (durable grant records consumed by
   access-time rules — the §13.4.3/§13.4.4 shape, generalizing the §4.9.3 ACL
@@ -299,6 +350,11 @@ about being a new value.
 - **`policyState` guard kind** documented next to the exchange-rule grammar
   (§4.3.3 vicinity), with the §4.9.3-style fail-closed resolution rules and
   the CT-1874 home-clause constraint for label-carried discovery.
+- **Egress records** (§6): normative text for the irrevocable release
+  receipt at send sinks, riding the §8.10.5.2 destination/audience-binding
+  follow-up — the record's shape, its create-only permanence, its
+  no-enforcement-role rule, and the shared-vs-sent distinction. Tracked as
+  SC-27 in [`cfc-spec-changes.md`](./cfc-spec-changes.md).
 
 ## Provenance
 

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -444,8 +444,27 @@ without evaluation (export/publish). Unconflate the §13 table row.
 2b contract (including the create-only intent-causal record shape) and the
 §13 summary-table row unconflated. Runner-side: grants build-order items 1–3
 shipped as labs#4627 (`policyState` guards, owner-space `grant:cfc:` records,
-consulted-grant digest binding); the rewrite event stays unscheduled per
-`cfc-persisted-declassification.md` §5.
+consulted-grant digest binding); the rewrite event is **superseded** per
+`cfc-persisted-declassification.md` §5 (owner decision 2026-07-10: in-fabric
+federation trust comes from remote attestation, so trust-free release buys
+nothing; out-of-fabric irrevocability is served by egress records, SC-27).
+
+**SC-27 [normative] Egress records at send sinks — §8.10.5.2 follow-up.**
+Out-of-fabric egress is irrevocable; modeling it with the same revocable
+artifact as internal sharing invites the un-sending confusion (revoking the
+record of a send is not un-sending). Proposed edit
+([`cfc-persisted-declassification.md`](./cfc-persisted-declassification.md)
+§6): at a send-sink release the committing transaction MUST mint a
+create-only **egress record** causal to the consumed intent/event id —
+`{valueDigest, destination, boundaryContext, releasedAudienceEvidence, at,
+intentId}`, the destination captured per the §8.10.5.2 destination/audience
+binding (this discharges the audit's open "destination-binding follow-up").
+The record is permanent (create-only, never deleted, no revocation surface)
+and has **no enforcement role**: it never feeds a future release decision —
+labels keep governing what the fabric serves; the record exists for honesty,
+audit, and deriving "who could have this" (current grants ∪ past egress).
+State the shared-vs-sent vocabulary distinction normatively so UIs cannot
+present an egress as revocable. `open`.
 
 ## Queue (from the audit; statuses re-checked by the 2026-06-12 sweep where
 ## noted)

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -454,11 +454,18 @@ Out-of-fabric egress is irrevocable; modeling it with the same revocable
 artifact as internal sharing invites the un-sending confusion (revoking the
 record of a send is not un-sending). Proposed edit
 ([`cfc-persisted-declassification.md`](./cfc-persisted-declassification.md)
-§6): at a send-sink release the committing transaction MUST mint a
-create-only **egress record** causal to the consumed intent/event id —
-`{valueDigest, destination, boundaryContext, releasedAudienceEvidence, at,
-intentId}`, the destination captured per the §8.10.5.2 destination/audience
-binding (this discharges the audit's open "destination-binding follow-up").
+§6): the permanent **sent** record is minted by the successful post-commit
+send path (the transaction commits before the outbox flush, and the release
+can still be refused during the flush — a commit-time record would assert
+disclosures that never happened): a create-only record causal to the outbox
+idempotency key — `{valueDigest, destination, boundaryContext,
+releasedAudienceEvidence, at, intentId}`, destination per the §8.10.5.2
+destination/audience binding (discharging the audit's open
+"destination-binding follow-up"), written record-then-clear against the
+outbox entry so the record can understate but never overstate; an optional
+commit-time attempt marker MUST NOT display as sent. Spec this together
+with the audit's open "post-commit outbox + sink-release re-verification
+contract" item (§8.10 is entirely pre-commit today).
 The record is permanent (create-only, never deleted, no revocation surface)
 and has **no enforcement role**: it never feeds a future release decision —
 labels keep governing what the fabric serves; the record exists for honesty,


### PR DESCRIPTION
Records the 2026-07-10 owner decisions from the federation discussion, closing the last open product question on the persisted-declassification design.

- **Rewrite event superseded on both flanks** (`cfc-persisted-declassification.md` §5): in-fabric federation runs on remote attestation — every instance is a trusted runtime, grants replicate as ordinary docs and evaluate locally, so "trust-free release" buys nothing; out-of-fabric irrevocability is served by egress records, not label rewrites (folding a past external disclosure into the label would loosen future fabric enforcement because of a leak — wrong direction). §4's contract is retained as a drawer design; its prerequisite (the monotonicity gate, WP5 in flight) is being built on its own merits.
- **New §6 — egress records**: at a send-sink release, mint a create-only record causal to the consumed intent id (`{valueDigest, destination, boundaryContext, releasedAudienceEvidence, at, intentId}`, destination per the §8.10.5.2 binding follow-up). Permanent by construction, no enforcement role, and the shared-vs-sent UI vocabulary so revoking a grant is never confused with un-sending. Substrate is ~shipped (commitPreconditions receipts, outbox idempotency, sink instrumentation seams). Tracked as **SC-27** in `cfc-spec-changes.md`.
- **Federation design rule on SC-14 Stage 3** (`cfc-label-metadata-confidentiality.md`): *evidence replicates with the data; evaluation is local* — reads never phone the origin to be authorized. `reference`-form labels are origin-coupled by construction → federated default stays `commitment`; also names B2a's deployment-config policy source as federation-hostile (B2b's space-hosted policy docs are the federation-correct form).

Docs-only. `deno task check-docs`: all 533 blocks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supersedes the persisted-declassification rewrite, defines post-commit egress records for irrevocable out-of-fabric sends, and codifies the federation rule that evidence replicates and evaluation is local. Stage 3 keeps `commitment` as default; `reference` stays restricted; the declared-label monotonicity gate is documented as shipped.

- **New Features**
  - Egress records at send sinks: minted post-commit on successful send; create-only, causal to the outbox idempotency key and consumed intent; record-then-clear ordering (never overstate); attempt markers never display as sent; shape `{valueDigest, destination, boundaryContext, releasedAudienceEvidence, at, intentId}`; permanent; no enforcement role; clear shared vs sent UI; tracked as SC-27 in `cfc-spec-changes.md`.
  - Federation rule on SC-14 Stage 3: evidence travels with data; reads evaluate locally; `reference` is origin-coupled so default stays `commitment`; `reference` only with per-reader materialization for high-sensitivity fields; B2a deployment-config policy is federation-hostile — prefer space-hosted policy docs (B2b).
  - Rewrite event superseded: in-fabric trust comes from attested runtimes (grants replicate + evaluate locally); out-of-fabric irrevocability is captured by egress records, not label rewrites.
  - Monotonicity gate shipped: declared-label gate landed (`cfc/declared-monotonicity.ts`, `cfcDeclaredMonotonicity` flag, anti-downgrade pin); exception seam `setCfcDeclaredWideningExemption` (write-once; integrity never exemptable); closes two gaps (schema-route `addIntegrity` growth; silent weakening under `cfcFlowLabels: "persist"`).

<sup>Written for commit 1bbfc78ac3ba88e4d4f07e15e6b34c03f366d9d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

