### PR TITLE
feat(cfc): single-use grants via commit-precondition receipts (declass item 5)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -144,17 +144,29 @@ propagate](#how-flags-propagate).
   work (scheduler-v2 E1)" (#4090, 2026-06-12).
 - **Purpose.** Attaches origin-committed preconditions to scheduler-v2 lineage
   commits, so that event-launched follow-up work commits only against the state
-  it was speculated from.
+  it was speculated from. Since #4649 it is also the exactly-once substrate for
+  **single-use CFC grant consumption**
+  (`docs/specs/cfc-persisted-declassification.md` §2.2): the releasing
+  transaction claims a create-only consumption receipt, and the storage commit
+  emits that entity-absent precondition only under this flag.
 - **Current default and planned end state.** Off by default. It is meant to
   graduate together with the rest of scheduler-v2 speculation lineage.
 - **Status on 2026-07-08.** Implemented and plumbed through the runner and the
   memory protocol, behind the flag. Off by default and reachable only
   programmatically.
-- **Path to removal.** This exists to serve scheduler-v2 speculation lineage; it
-  can be deleted only when lineage tracking becomes part of the base scheduler
-  semantics. At that point remove the flag, the precondition attach and check in
-  the storage transaction path, and the server-side precondition check in the
-  memory engine.
+- **Status on 2026-07-10.** Single-use CFC grants (#4649) depend on it: with
+  the flag OFF (the default), a `singleUse` grant is unsatisfiable at every
+  evaluation site — fail closed, never silently multi-use — with a diagnostic
+  naming this flag. Standing grants are unaffected. Operators enabling CFC
+  grant-based sharing that needs single-use releases must turn this flag on.
+- **Path to removal.** This exists to serve scheduler-v2 speculation lineage
+  and (since #4649) single-use CFC grant consumption; it can be deleted only
+  when lineage tracking becomes part of the base scheduler semantics AND the
+  create-only receipt discipline is unconditionally on. At that point remove
+  the flag, the precondition attach and check in the storage transaction path,
+  and the server-side precondition check in the memory engine — the single-use
+  grant path then drops its availability check (`cfcGrantReceiptsAvailable` in
+  `packages/runner/src/cfc/grants.ts`) rather than the receipts themselves.
 
 ### `eagerSourceAnnotation`
 

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -157,9 +157,23 @@ rewrite event:
    trusted-builtin writer verifying authority directly → grant → release on
    read; the §13.4.3 verification list minus the intent-evidence rows, which
    strengthen when intents land.
-5. Single-use grants — the receipt discipline exists behind
-   `experimental.commitPreconditions`; blocked only on that flag's
-   maturation, not on new machinery.
+5. Single-use grants — **shipped (#4649)**: `CfcGrant.singleUse: true`
+   satisfies a `policyState` guard only in a CONSUMING evaluation context
+   (the sink-request egress ceiling and the input-requirement gate on gated
+   writes, under the `enforce` policy-evaluation dial — never the render
+   ceiling or observe-dial diagnostics, where a grant would be spent by
+   looking at it) and only while its consumption receipt is absent. The
+   receipt is `grant:cfc:` + a digest of `{grantConsumed: {grantId}}` — the
+   §6.5.1 `consumedCellId` shape on the item-2 address idiom, so the
+   S18-class reserved-namespace write gate covers forging AND the
+   re-arming delete. The releasing transaction stages the receipt write +
+   create-only mark inside `prepareBoundaryCommit`, so consumption commits
+   atomically with the release (no-consume-on-failure, §6.5.2) and a
+   racing second release dies as a permanent `receipt-exists` rejection.
+   **Requires `experimental.commitPreconditions`** (the storage commit
+   emits entity-absent preconditions only under it): with the flag off —
+   the default — single-use grants are unsatisfiable everywhere, fail
+   closed, never silently multi-use. Standing grants are flag-independent.
 
 Dependency note: (1)+(2) are B2b-adjacent — the same reserved-path,
 content-addressed, verify-on-read machinery. If B2b is built first, grants
@@ -184,8 +198,10 @@ the acting principal — the fuller §13.4.3 intent-evidence chain lands with
 item 4. Lookups ride `internalVerifierRead`;
 `PreparedDigestInput.consultedGrants` binds each consulted grant's content
 address (absent candidates carry an `"absent"` marker so a grant appearing
-also invalidates), with a live prepare→revoke→commit-reject test. Items 4–5
-remain open._
+also invalidates), with a live prepare→revoke→commit-reject test. Item 5
+shipped in #4649 (single-use consumption receipts — see the build-order
+entry above; receipt consulted-state rides the same `consultedGrants`
+binding). Item 4 remains open._
 
 ## 4. The rewrite event (specify now, build later)
 

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -66,6 +66,21 @@ export type RuleFiring = {
 };
 
 /**
+ * Whether a `policyState` evaluation site is a CONSUMING context (design
+ * §2.2 single-use releases). Consuming sites are exactly the boundary gates
+ * whose evaluation outcome changes a persisted or egress decision inside a
+ * writing transaction's prepare — the sink-request egress ceiling and the
+ * input-requirement gate on gated writes, and only under the `enforce`
+ * policy-evaluation dial (under `observe` the decision is made on the raw
+ * label, so the evaluation is diagnostics-only). Everything else — the
+ * render ceiling, observe-dial evaluation, any read-path resolution — is
+ * OBSERVING: a single-use grant is unsatisfiable there, fail closed, because
+ * a grant consumed by looking at it would be spent by rendering. Standing
+ * grants ignore this axis entirely.
+ */
+export type CfcGrantConsumptionContext = "consuming" | "observing";
+
+/**
  * The point-query a `policyState` guard sends to the grant resolver: the
  * guard's concrete `kind` plus every guard field that is concrete under the
  * current binding environment (a literal value, or a pattern whose variables
@@ -75,6 +90,13 @@ export type RuleFiring = {
 export type CfcGrantResolverQuery = {
   readonly kind: string;
   readonly fields: Readonly<Record<string, unknown>>;
+  /**
+   * The evaluation site's consumption context, stamped from
+   * {@link ExchangeEvalContext.grantConsumption}. ABSENT means observing
+   * (fail closed): a hand-built query that never states its context cannot
+   * resolve a single-use grant.
+   */
+  readonly consumption?: CfcGrantConsumptionContext;
 };
 
 /**
@@ -112,6 +134,14 @@ export type ExchangeEvalContext = {
    * policyState guard is unsatisfied and its rule never fires (fail closed).
    */
   readonly grantResolver?: CfcGrantResolver;
+  /**
+   * Consuming vs observing evaluation site (single-use releases, design
+   * §2.2) — stamped onto every resolver query. Absent = observing (fail
+   * closed): only the writing-transaction boundary gates in prepare.ts pass
+   * `"consuming"`, coupled to the claim staging that flushes at the end of
+   * the same prepare pass. See {@link CfcGrantConsumptionContext}.
+   */
+  readonly grantConsumption?: CfcGrantConsumptionContext;
 };
 
 export type ExchangeEvalResult = {
@@ -166,6 +196,7 @@ type RuleMatch = {
 const grantGuardQuery = (
   pattern: unknown,
   bindings: AtomPatternBindings,
+  consumption: CfcGrantConsumptionContext,
 ): CfcGrantResolverQuery | undefined => {
   if (
     !isRecord(pattern) || Array.isArray(pattern) ||
@@ -185,7 +216,7 @@ const grantGuardQuery = (
       fields[key] = instantiated.value;
     }
   }
-  return { kind, fields };
+  return { kind, fields, consumption };
 };
 
 /**
@@ -201,11 +232,12 @@ const extendThroughGrantGuard = (
   environments: readonly AtomPatternBindings[],
   pattern: unknown,
   resolver: CfcGrantResolver | undefined,
+  consumption: CfcGrantConsumptionContext,
 ): AtomPatternBindings[] => {
   if (resolver === undefined) return [];
   const next: AtomPatternBindings[] = [];
   for (const environment of environments) {
-    const query = grantGuardQuery(pattern, environment);
+    const query = grantGuardQuery(pattern, environment, consumption);
     if (query === undefined) continue;
     let facts: readonly unknown[];
     try {
@@ -333,6 +365,9 @@ const matchRule = (
             environments,
             pattern,
             ctx.grantResolver,
+            // Absent = observing, fail closed: a context that never states
+            // it is a consuming site cannot resolve single-use grants.
+            ctx.grantConsumption ?? "observing",
           );
           if (environments.length === 0) break;
         }

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -654,20 +654,29 @@ const resolveSingleUseGrant = (
   const claims = claimsFor(tx);
   const own = claims.get(receiptId);
   if (own === undefined) {
-    const receiptValue = tx.readOrThrow({
+    // Read the document ROOT, not the ["value"] subpath: presence of the
+    // receipt DOCUMENT is the consumption signal, and a Memory v2 document
+    // can exist with no value (a metadata-only write). A value-subpath read
+    // would report `undefined` for such a document and re-arm the grant at
+    // evaluation time (cubic P1 on #4649) — the create-only backstop would
+    // still kill the release at commit (any prior set on the entity fails
+    // the entity-absent precondition), but resolution must already fail
+    // closed. Grant documents keep their ["value"] reads: there ABSENCE is
+    // the fail-closed direction (a value-less grant doc must not resolve).
+    const receiptDoc = tx.readOrThrow({
       space: grant.space as MemorySpace,
       id: receiptId,
       type: "application/json",
-      path: ["value"],
+      path: [],
     }, { meta: INTERNAL_VERIFIER_META });
     tx.recordCfcConsultedGrant({
       space: grant.space as MemorySpace,
       id: receiptId,
-      digest: receiptValue === undefined
+      digest: receiptDoc === undefined
         ? CFC_GRANT_ABSENT_DIGEST
-        : hashStringOf(receiptValue),
+        : hashStringOf(receiptDoc),
     });
-    if (receiptValue !== undefined) {
+    if (receiptDoc !== undefined) {
       // Consumed (or unreadable garbage at the receipt address — same
       // outcome): the durable decision was already spent.
       return [];

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -290,6 +290,19 @@ export const flushCfcGrantConsumptionClaims = (
   const reasons: string[] = [];
   for (const claim of claims.values()) {
     try {
+      // The exactly-once witness FIRST: without the mark two racing releases
+      // would both commit (last write wins on the receipt document), so the
+      // optional method is a hard requirement — fail closed if absent — and
+      // marking before writing means a refused mark (unsupported storage,
+      // cross-space write isolation, read-only) never leaves an unguarded
+      // receipt value in the journal.
+      if (typeof tx.markCreateOnly !== "function") {
+        throw new Error("storage transaction does not support markCreateOnly");
+      }
+      tx.markCreateOnly({
+        space: claim.space as MemorySpace,
+        id: claim.receiptId,
+      });
       const receipt: CfcGrantConsumptionReceipt = {
         version: CFC_GRANT_VERSION,
         grantConsumed: { grantId: claim.grantId },
@@ -302,16 +315,6 @@ export const flushCfcGrantConsumptionClaims = (
         type: "application/json",
         path: ["value"],
       }, receipt as unknown as FabricValue);
-      // The exactly-once witness: without the mark two racing releases would
-      // both commit (last write wins on the receipt document). The optional
-      // method is a hard requirement here — fail closed if absent.
-      if (typeof tx.markCreateOnly !== "function") {
-        throw new Error("storage transaction does not support markCreateOnly");
-      }
-      tx.markCreateOnly({
-        space: claim.space as MemorySpace,
-        id: claim.receiptId,
-      });
     } catch (error) {
       reasons.push(
         `cfc-grant: staging consumption receipt for single-use grant ` +

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -1,6 +1,8 @@
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isRecord } from "@commonfabric/utils/types";
+import type { FabricValue } from "@commonfabric/api";
 import type { URI } from "@commonfabric/memory/interface";
+import { getCommitPreconditionsConfig } from "@commonfabric/memory/v2";
 import type {
   IExtendedStorageTransaction,
   MemorySpace,
@@ -104,6 +106,19 @@ export type CfcGrant = CfcGrantIdentity & {
   /** §6 intent attribution once the intent substrate exists. */
   readonly sourceIntentId?: string;
   readonly revoked?: { readonly at: number; readonly by: string };
+  /**
+   * Single-use release (design §2.2 "Single-use releases", spec §6.5.1-.2):
+   * the grant satisfies a `policyState` guard only while its consumption
+   * receipt (`cfcGrantConsumedReceiptId`) does not exist, and only in a
+   * CONSUMING evaluation context — the releasing transaction claims the
+   * receipt atomically with the release. Exactly boolean-true or absent:
+   * "standing" has one spelling (absent), validated at write AND on read, so
+   * a present-but-false marker can never be read as a third state. Lives in
+   * the document VALUE like audience/lifecycle — the address (identity =
+   * release scope) is unchanged, so converting a standing grant to
+   * single-use is an in-place update of the same durable decision.
+   */
+  readonly singleUse?: true;
 };
 
 /** Authoring input for the trusted policy-writer path. */
@@ -119,6 +134,8 @@ export type CfcGrantWriteInput = {
   readonly expiresAt?: number;
   readonly sourceIntentId?: string;
   readonly revoked?: { readonly at: number; readonly by: string };
+  /** See {@link CfcGrant.singleUse}: boolean-true or absent, else refused. */
+  readonly singleUse?: true;
 };
 
 /** The derived grant-document id for a release scope (module doc). */
@@ -134,6 +151,178 @@ export const cfcGrantDocId = (identity: CfcGrantIdentity): URI =>
       },
     })
   }` as URI;
+
+/**
+ * The consumption-receipt document id for a single-use grant (design §2.2;
+ * spec §6.5.1 `consumedCellId`).
+ *
+ * ## Derivation decision
+ *
+ * Spec §6.5.1 derives an intent's consumption cell as
+ * `refer({ intentConsumed: { intentOnceId } })`; the runner's shipped event
+ * receipts derive theirs as `runtime.getCell(space, { resultFor: cause })` —
+ * `createRef` over the cause record, minting an ordinary `of:` entity id.
+ * This receipt instead follows the §6.5.1 SHAPE (`{ grantConsumed:
+ * { grantId } }`, one receipt per grant id) realized with the #4627 ADDRESS
+ * IDIOM (the reserved `grant:cfc:` URI scheme + a versioned `hashStringOf`
+ * wrapper, exactly like `cfcGrantDocId`) rather than `createRef`, because:
+ *
+ * - **The receipt is policy state and must live in the reserved namespace.**
+ *   `noteSystemWrite` records ANY unprivileged write at ANY path under a
+ *   `grant:cfc:` id as an S18-class violation. An `of:` receipt would sit
+ *   outside that gate: forging one is merely fail-closed (a denied live
+ *   grant), but unprivileged DELETION/overwrite of a spent receipt would
+ *   RE-ARM a consumed single-use grant — fail open. The reserved scheme
+ *   covers both directions with the gate that already exists.
+ * - **Point-derivable from the grant id alone** (the §4.9.3 discipline): the
+ *   resolver computes the one candidate receipt address from the grant it
+ *   just verified — no enumeration, no cell machinery, readable under
+ *   `internalVerifierRead` like every other policy lookup.
+ * - **Same space as the grant**: the receipt is part of the grant's
+ *   lifecycle state and rides the owner-space write authority the v1
+ *   governing-space posture already establishes (module doc).
+ *
+ * Enforcement reads PRESENCE only: any document at this address — even a
+ * malformed one — means the grant is consumed (a receipt cannot be forged
+ * into absence; fail closed). The stored {@link CfcGrantConsumptionReceipt}
+ * value is audit content, not the enforcement signal.
+ */
+export const cfcGrantConsumedReceiptId = (grantId: string): URI =>
+  `${CFC_GRANT_ID_PREFIX}${
+    hashStringOf({
+      cfcGrantConsumed: {
+        version: CFC_GRANT_VERSION,
+        grantConsumed: { grantId },
+      },
+    })
+  }` as URI;
+
+/** The audit value a consuming release writes at the receipt address. */
+export type CfcGrantConsumptionReceipt = {
+  readonly version: typeof CFC_GRANT_VERSION;
+  readonly grantConsumed: { readonly grantId: string };
+  /** Governing space (== the grant's space; the receipt lives beside it). */
+  readonly space: string;
+  /** Runner clock at claim time — captured once per transaction so repeated
+   * prepares of the same tx stage a byte-identical receipt. */
+  readonly consumedAt: number;
+};
+
+/** One consumption claim staged by boundary evaluation in a transaction. */
+type PendingGrantConsumptionClaim = {
+  readonly space: string;
+  readonly receiptId: URI;
+  readonly grantId: string;
+  readonly consumedAt: number;
+};
+
+/**
+ * Pending single-use consumption claims, keyed by transaction and receipt id.
+ *
+ * Deliberately a module-private WeakMap rather than a field on `CfcTxState`
+ * or a method on the transaction interface: a claim staged here is written
+ * into the reserved `grant:cfc:` namespace INSIDE the privileged scope by
+ * `flushCfcGrantConsumptionClaims` (called from `prepareBoundaryCommit`), so
+ * a registration surface reachable from handler code via `(cell.tx as any)`
+ * would launder unprivileged receipt forgeries — spending any grant the
+ * caller can name — through the runtime's own privileged flush, bypassing
+ * the S18 gate that blocks direct writes. Module privacy keeps the ONLY
+ * writers the resolver below (which registers a claim exclusively for a
+ * verified, live, receipt-absent grant it just resolved in a consuming
+ * context) and the flush (which stages exactly what was registered).
+ *
+ * The registry is PER-TRANSACTION and survives re-prepares on purpose: it is
+ * how a re-evaluation recognizes the receipt now sitting in its own journal
+ * as "claimed by this transaction" (the same consumption, not a competing
+ * one) — see the own-claim arm in the resolver.
+ */
+const pendingGrantConsumptionClaims = new WeakMap<
+  IExtendedStorageTransaction,
+  Map<string, PendingGrantConsumptionClaim>
+>();
+
+const claimsFor = (
+  tx: IExtendedStorageTransaction,
+): Map<string, PendingGrantConsumptionClaim> => {
+  let claims = pendingGrantConsumptionClaims.get(tx);
+  if (claims === undefined) {
+    claims = new Map();
+    pendingGrantConsumptionClaims.set(tx, claims);
+  }
+  return claims;
+};
+
+/**
+ * Receipts are available only when the exactly-once substrate is on: the
+ * ambient `experimental.commitPreconditions` flag (set by the Runtime at
+ * construction) gates whether the storage commit EMITS entity-absent
+ * preconditions at all — without it a `markCreateOnly` mark is silently
+ * dropped at commit and the create-only race protection vanishes, so a
+ * single-use grant MUST be unsatisfiable everywhere (never silently
+ * multi-use, design §2.2 / spec §6.5.2 fail-closed posture).
+ */
+const cfcGrantReceiptsAvailable = (): boolean =>
+  getCommitPreconditionsConfig() === true;
+
+/**
+ * Stages every consumption claim this transaction's boundary evaluation
+ * registered: writes the receipt document and marks it create-only, so
+ * consumption commits ATOMICALLY with the release it justifies —
+ * no-consume-on-failure (spec §6.5.2) holds because the receipt write rides
+ * the same transaction as the released write/egress decision, and a racing
+ * second release loses the create-only race (`receipt-exists`, a permanent
+ * rejection the scheduler never retries).
+ *
+ * Called at the END of `prepareBoundaryCommit` — inside the privileged
+ * system-write scope `prepareCfc` wraps it in, after every gate has run (so
+ * all resolutions are registered) — and idempotent across re-prepares (the
+ * re-write is byte-identical; the create-only mark is a set). Returns
+ * fail-closed reasons for claims that could not be staged (a read-only
+ * transaction, a receipt space outside this transaction's write space —
+ * cross-space consumption arrives with B2b): an unstageable claim means the
+ * release's exactly-once witness cannot commit, so the release must not.
+ */
+export const flushCfcGrantConsumptionClaims = (
+  tx: IExtendedStorageTransaction,
+): string[] => {
+  const claims = pendingGrantConsumptionClaims.get(tx);
+  if (claims === undefined || claims.size === 0) return [];
+  const reasons: string[] = [];
+  for (const claim of claims.values()) {
+    try {
+      const receipt: CfcGrantConsumptionReceipt = {
+        version: CFC_GRANT_VERSION,
+        grantConsumed: { grantId: claim.grantId },
+        space: claim.space,
+        consumedAt: claim.consumedAt,
+      };
+      tx.writeOrThrow({
+        space: claim.space as MemorySpace,
+        id: claim.receiptId,
+        type: "application/json",
+        path: ["value"],
+      }, receipt as unknown as FabricValue);
+      // The exactly-once witness: without the mark two racing releases would
+      // both commit (last write wins on the receipt document). The optional
+      // method is a hard requirement here — fail closed if absent.
+      if (typeof tx.markCreateOnly !== "function") {
+        throw new Error("storage transaction does not support markCreateOnly");
+      }
+      tx.markCreateOnly({
+        space: claim.space as MemorySpace,
+        id: claim.receiptId,
+      });
+    } catch (error) {
+      reasons.push(
+        `cfc-grant: staging consumption receipt for single-use grant ` +
+          `${claim.grantId} failed (${
+            error instanceof Error ? error.message : String(error)
+          })`,
+      );
+    }
+  }
+  return reasons;
+};
 
 const isDid = (value: unknown): value is string =>
   typeof value === "string" && value.startsWith("did:");
@@ -267,6 +456,14 @@ export const prepareCfcGrantWrite = (
       );
     }
   }
+  if (input.singleUse !== undefined && input.singleUse !== true) {
+    // Exactly boolean-true or absent (CfcGrant.singleUse): a `false`/truthy
+    // spelling is refused so "standing" keeps its single spelling and no
+    // consumer can ever read a present-but-non-true marker as a third state.
+    throw new Error(
+      "cfc-grant: singleUse must be boolean true or absent",
+    );
+  }
   const value: CfcGrant = {
     version: CFC_GRANT_VERSION,
     space,
@@ -282,6 +479,7 @@ export const prepareCfcGrantWrite = (
     ...(input.revoked !== undefined
       ? { revoked: { at: input.revoked.at, by: input.revoked.by } }
       : {}),
+    ...(input.singleUse === true ? { singleUse: true as const } : {}),
   };
   return {
     space: space as MemorySpace,
@@ -342,6 +540,12 @@ export const verifyCfcGrantDocument = (
       return undefined;
     }
   }
+  // Boolean-true or absent (CfcGrant.singleUse) — defense in depth against a
+  // document written past the writer gate: a malformed marker must fail the
+  // WHOLE grant closed, never degrade to standing (silently multi-use).
+  if (candidate.singleUse !== undefined && candidate.singleUse !== true) {
+    return undefined;
+  }
   // The content-address check: identity fields must re-derive the address.
   if (
     cfcGrantDocId({
@@ -384,9 +588,105 @@ export const expandCfcGrantFacts = (grant: CfcGrant): readonly unknown[] =>
     ...(grant.sourceIntentId !== undefined
       ? { sourceIntentId: grant.sourceIntentId }
       : {}),
+    // Conditional spread keeps standing-grant facts byte-identical to #4627;
+    // a guard pattern MAY bind on `singleUse: true` if a rule wants to scope
+    // itself to single-use releases.
+    ...(grant.singleUse === true ? { singleUse: true as const } : {}),
   }));
 
 const INTERNAL_VERIFIER_META = { ...internalVerifierRead };
+
+/**
+ * Resolves a verified, live, SINGLE-USE grant (design §2.2; spec §6.5.1-.2):
+ * facts only in a consuming context, with receipts available, while the
+ * consumption receipt does not exist — and registers the atomic claim.
+ *
+ * - **Observing context → unsatisfiable.** A single-use grant consumed by a
+ *   read-path evaluation (render ceiling, observe-dial diagnostics) would be
+ *   spent by looking at it; and resolving WITHOUT consuming there would make
+ *   "single use" advisory. So it resolves ONLY where resolution is
+ *   atomically coupled to the receipt claim — the consuming boundary gates.
+ *   (Consequence, stated for the observe dial: its diagnostics never show a
+ *   would-be single-use release, because observe decides on the raw label
+ *   and must not spend the grant.)
+ * - **Receipts unavailable → unsatisfiable everywhere** (never silently
+ *   multi-use): see `cfcGrantReceiptsAvailable`.
+ * - **Receipt present → does not resolve** (guard unsatisfied, fail closed,
+ *   exactly like revoked/expired). PRESENCE is the signal — malformed
+ *   content still counts as consumed. The receipt's resolution-time state
+ *   joins `consultedGrants` (present → content digest, absent →
+ *   `CFC_GRANT_ABSENT_DIGEST`), so it binds into the prepared digest with
+ *   the same invalidation discipline as the grant itself.
+ * - **Own claim → resolves.** The registry remembers receipts THIS
+ *   transaction claimed, so a re-prepare that finds its own staged receipt
+ *   in the journal recognizes the same consumption instead of failing
+ *   itself. If another release committed a receipt in between, this
+ *   transaction's create-only mark still dies at commit (`receipt-exists`)
+ *   — the race backstop makes the shortcut safe.
+ *
+ * Consumption attaches at RESOLUTION: the grant's facts entered the
+ * decision basis of a consuming gate. Whether a specific rule firing then
+ * used them — or changed the final decision — is not reconstructable at
+ * staging time, and erring toward consumption is the fail-closed direction
+ * (a spent grant releases nothing; an unspent-but-used grant would be a
+ * replay). A resolved-but-rejected commit still consumes nothing: the
+ * receipt rides the rejected transaction.
+ */
+const resolveSingleUseGrant = (
+  tx: IExtendedStorageTransaction,
+  grant: CfcGrant,
+  grantId: URI,
+  consumption: CfcGrantResolverQuery["consumption"],
+  now: () => number,
+): readonly unknown[] => {
+  if (consumption !== "consuming") return [];
+  if (!cfcGrantReceiptsAvailable()) {
+    tx.noteCfcDiagnostic(
+      `cfc-grant: single-use grant ${grantId} requires ` +
+        `experimental.commitPreconditions (receipts unavailable; fail closed)`,
+    );
+    return [];
+  }
+  const receiptId = cfcGrantConsumedReceiptId(grantId);
+  const claims = claimsFor(tx);
+  const own = claims.get(receiptId);
+  if (own === undefined) {
+    const receiptValue = tx.readOrThrow({
+      space: grant.space as MemorySpace,
+      id: receiptId,
+      type: "application/json",
+      path: ["value"],
+    }, { meta: INTERNAL_VERIFIER_META });
+    tx.recordCfcConsultedGrant({
+      space: grant.space as MemorySpace,
+      id: receiptId,
+      digest: receiptValue === undefined
+        ? CFC_GRANT_ABSENT_DIGEST
+        : hashStringOf(receiptValue),
+    });
+    if (receiptValue !== undefined) {
+      // Consumed (or unreadable garbage at the receipt address — same
+      // outcome): the durable decision was already spent.
+      return [];
+    }
+    claims.set(receiptId, {
+      space: grant.space,
+      receiptId,
+      grantId,
+      consumedAt: now(),
+    });
+  } else {
+    // Re-evaluation within the claiming transaction: the durable state the
+    // decision consumes is still "receipt absent" (our own staged write is
+    // not durable), so re-record exactly that — the recorder dedups it.
+    tx.recordCfcConsultedGrant({
+      space: grant.space as MemorySpace,
+      id: receiptId,
+      digest: CFC_GRANT_ABSENT_DIGEST,
+    });
+  }
+  return expandCfcGrantFacts(grant);
+};
 
 /**
  * The runner-side grant resolver for boundary evaluation sites that hold a
@@ -440,7 +740,13 @@ export const createTxCfcGrantResolver = (
       // evaluator's own catch is the backstop, but the resolver stays
       // self-contained — cubic P2 on #4627).
       const id = cfcGrantDocId({ space, kind: query.kind, owner, resource });
-      const memoKey = `${space}\0${id}`;
+      // Consumption context in the key: a single-use grant resolves in a
+      // consuming query but not an observing one, so a mixed-context resolver
+      // (hand-built; the prepare gates are single-context per instance) must
+      // never serve a consuming resolution to an observing query.
+      const memoKey = `${space}\0${id}\0${
+        query.consumption === "consuming" ? "consuming" : "observing"
+      }`;
       const memoized = memo.get(memoKey);
       if (memoized !== undefined) return memoized;
       const value = tx.readOrThrow({
@@ -463,7 +769,9 @@ export const createTxCfcGrantResolver = (
             `cfc-grant: malformed grant document at ${id} (fail closed)`,
           );
         } else if (cfcGrantIsLive(grant, now())) {
-          facts = expandCfcGrantFacts(grant);
+          facts = grant.singleUse === true
+            ? resolveSingleUseGrant(tx, grant, id, query.consumption, now)
+            : expandCfcGrantFacts(grant);
         }
       }
       memo.set(memoKey, facts);

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -133,6 +133,7 @@ export {
   MAX_TRUST_CLOSURE_DEPTH,
 } from "./trust.ts";
 export type {
+  CfcGrantConsumptionContext,
   CfcGrantResolver,
   CfcGrantResolverQuery,
   ExchangeEvalContext,
@@ -145,17 +146,20 @@ export {
 } from "./exchange-eval.ts";
 export type {
   CfcGrant,
+  CfcGrantConsumptionReceipt,
   CfcGrantIdentity,
   CfcGrantWriteInput,
 } from "./grants.ts";
 export {
   CFC_GRANT_ABSENT_DIGEST,
   CFC_GRANT_ID_PREFIX,
+  cfcGrantConsumedReceiptId,
   cfcGrantDocId,
   cfcGrantIsLive,
   createTxCfcGrantResolver,
   disallowedGrantAudienceEntryReason,
   expandCfcGrantFacts,
+  flushCfcGrantConsumptionClaims,
   prepareCfcGrantWrite,
   verifyCfcGrantDocument,
 } from "./grants.ts";

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -57,8 +57,14 @@ import {
   cfcIntegritySatisfiesFloorCoherently,
   uniqueCfcAtoms,
 } from "./observation.ts";
-import { evaluateExchangeRules } from "./exchange-eval.ts";
-import { createTxCfcGrantResolver } from "./grants.ts";
+import {
+  type CfcGrantConsumptionContext,
+  evaluateExchangeRules,
+} from "./exchange-eval.ts";
+import {
+  createTxCfcGrantResolver,
+  flushCfcGrantConsumptionClaims,
+} from "./grants.ts";
 import { cfcLabelViewFromMetadata } from "./label-view-state.ts";
 import {
   commitmentAwareEquals,
@@ -3110,12 +3116,16 @@ const verifyInputRequirements = (
         const confidentiality = read.label?.confidentiality ?? [];
         if (mode === "off") return fitsLegacy(confidentiality);
         // Evaluate the consumed label to fixpoint (Epic B5). No boundary
-        // atoms: this is a write-target input gate, not a sink.
+        // atoms: this is a write-target input gate, not a sink. A gated
+        // WRITE is a consuming site for single-use grants — the ceiling
+        // decision persists with the written value — but only under the
+        // enforce dial, where this evaluation's outcome IS the decision.
         const outcome = evaluateGatedConfidentiality(
           tx,
           confidentiality,
           read.label?.integrity ?? [],
           [],
+          mode === "enforce" ? "consuming" : "observing",
         );
         if (mode === "enforce") {
           // Exhaustion fails closed; otherwise subsumption-fit the REWRITTEN
@@ -3775,12 +3785,27 @@ const collectConsumedLabel = (
  * `exhausted` flag with the ORIGINAL confidentiality (never a partial
  * rewrite) — the caller decides whether that fails closed (enforce) or is a
  * diagnostic (observe).
+ *
+ * `consumption` is the single-use-grant seam (design §2.2): the two callers
+ * — the sink-request egress ceiling and the input-requirement gate on gated
+ * writes — are exactly the sites where an evaluation outcome changes a
+ * persisted/egress decision inside a writing transaction's prepare, so they
+ * pass `"consuming"` when (and only when) the policy-evaluation dial is
+ * `enforce` (the rewritten label IS the decision there; under `observe` the
+ * decision is the raw label and the evaluation is diagnostics-only, which
+ * must never spend a grant). Every other evaluation site (the render
+ * ceiling's display boundary, hand-built contexts) never states a consuming
+ * context, so single-use grants are unsatisfiable there — fail closed.
+ * Claims registered by a consuming resolution are staged into receipt
+ * writes at the end of `prepareBoundaryCommit` (the same pass), so
+ * consumption commits atomically with the release.
  */
 const evaluateGatedConfidentiality = (
   tx: IExtendedStorageTransaction,
   confidentiality: readonly unknown[],
   integrity: readonly unknown[],
   boundary: readonly unknown[],
+  consumption: CfcGrantConsumptionContext,
 ): {
   confidentiality: readonly unknown[];
   exhausted: boolean;
@@ -3802,6 +3827,7 @@ const evaluateGatedConfidentiality = (
       // digest binding. Rides the same cfcPolicyEvaluation dial as the rest
       // of this evaluation — this function only runs when the dial is on.
       grantResolver: createTxCfcGrantResolver(tx),
+      grantConsumption: consumption,
     },
   );
   return {
@@ -3850,11 +3876,16 @@ const verifySinkRequestCeilings = (
         cfcAtom.boundaryContext("sink", sink),
         cfcAtom.boundaryContext("sinkClass", "network"),
       ];
+      // The sink egress gate is a consuming site for single-use grants
+      // (design §2.2) under the enforce dial — the rewritten label decides
+      // whether the request flushes past the ceiling. Observe evaluates for
+      // diagnostics only and must never spend a grant.
       const outcome = evaluateGatedConfidentiality(
         tx,
         consumed.confidentiality,
         consumed.integrity,
         boundary,
+        mode === "enforce" ? "consuming" : "observing",
       );
       if (mode === "enforce") {
         if (outcome.exhausted) {
@@ -5275,6 +5306,17 @@ export const prepareBoundaryCommit = (
     }, metadata as unknown as FabricValue);
   }
   reasons.push(...verifySinkRequestCeilings(tx));
+  // Single-use grant consumption (design §2.2): stage every claim the
+  // consuming gates above registered — the receipt write plus its
+  // create-only mark — into THIS transaction, inside the privileged scope
+  // prepareCfc wraps this whole pass in (the receipt is reserved-namespace
+  // policy state; the unprivileged arm is the S18 gate). After every gate so
+  // all resolutions are registered; before the return so a claim that cannot
+  // stage fails closed as a prepare reason. The staged write rides the
+  // releasing commit: consumption is atomic with the release, a failed
+  // commit consumes nothing (spec §6.5.2 no-consume-on-failure), and the
+  // create-only race loser dies as a permanent `receipt-exists` rejection.
+  reasons.push(...flushCfcGrantConsumptionClaims(tx));
   // Stage-0 summary: at most once per prepare, and only when a protected
   // write was measured — a prepare that gated nothing has no precision to
   // report.

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -369,6 +369,12 @@ export type WritePolicyInput =
  * "looked, found nothing" so a grant APPEARING between prepare and commit
  * invalidates too). Recorded by the runner-side grant resolver
  * (`createTxCfcGrantResolver`), folded into `PreparedDigestInput` below.
+ *
+ * Single-use CONSUMPTION RECEIPTS (design §2.2) ride the same entries: a
+ * consuming resolution of a `singleUse` grant records the receipt address
+ * with its present/absent state, so a receipt appearing between evaluations
+ * invalidates the prepared digest exactly like a changed grant — the
+ * digest-level complement to the create-only commit race.
  */
 export type ConsultedGrant = {
   readonly space: MemorySpace;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1268,13 +1268,25 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     link: { space: MemorySpace; id: string; scope?: unknown },
   ): void {
     this.assertWritable("markCreateOnly");
+    // Fail closed, same posture as addCommitPrecondition above: a
+    // create-only mark is a commit gate — the exactly-once witness for
+    // event receipts and single-use grant consumption — so silently
+    // swallowing it over an inner transaction that cannot enforce it would
+    // let a duplicate commit through unguarded (cubic P1 on #4649). Every
+    // production transaction (v2) implements it; this arm exists for
+    // hand-built/legacy inner transactions.
+    if (!this.tx.markCreateOnly) {
+      throw new Error(
+        "storage transaction does not support markCreateOnly()",
+      );
+    }
     let marks = this.createOnlyMarks.get(link.space);
     if (!marks) {
       marks = new Set();
       this.createOnlyMarks.set(link.space, marks);
     }
     marks.add(createOnlyMarkKey(link));
-    this.tx.markCreateOnly?.(link);
+    this.tx.markCreateOnly(link);
   }
 
   recordMergeableOp(link: NormalizedFullLink, delta: MergeableOpDelta): void {

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -3,7 +3,15 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  EmulatedStorageManager,
+  type Options as StorageManagerOptions,
+  StorageManager,
+} from "../src/storage/cache.deno.ts";
+import { StorageManager as V2StorageManager } from "../src/storage/v2.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { isPermanentRejection } from "../src/storage/rejection.ts";
 import { Runtime } from "../src/runtime.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
 import type { CfcGrantResolverQuery } from "../src/cfc/exchange-eval.ts";
@@ -168,6 +176,1006 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       expect(receipt).not.toBe(grantId);
       const other = cfcGrantDocId({ ...identity, resource: "of:other" });
       expect(cfcGrantConsumedReceiptId(other)).not.toBe(receipt);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Shared harness (cfc-grant-records.test.ts style): a labeled cell, a
+  // policyState-guarded sink rule, and a Runtime whose experimental
+  // commitPreconditions flag is the receipts dial.
+  // ---------------------------------------------------------------------------
+  const SECRET_SCHEMA = internSchema(
+    {
+      type: "object",
+      properties: {
+        secret: { type: "string", ifc: { confidentiality: ["never-fits"] } },
+      },
+      required: ["secret"],
+    } satisfies JSONSchema,
+    true,
+  );
+
+  const seedLabeledCell = async (
+    runtime: Runtime,
+    id: string,
+    label: { confidentiality: unknown[]; integrity?: unknown[] },
+  ): Promise<void> => {
+    const seed = runtime.edit();
+    const target = runtime.getCell(signer.did(), id, undefined, seed);
+    const targetId = target.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({
+      space: signer.did(),
+      scope: "space",
+      id: targetId,
+      path: [],
+    }, {
+      value: { secret: "rosebud" },
+      cfc: {
+        version: 1,
+        schemaHash: SECRET_SCHEMA.taggedHashString,
+        labelMap: { version: 1, entries: [{ path: ["secret"], label }] },
+      },
+    });
+    seed.writeOrThrow({
+      space: signer.did(),
+      scope: "space",
+      id: `cid:${SECRET_SCHEMA.taggedHashString}`,
+      path: [],
+    }, { value: SECRET_SCHEMA.schema });
+    expect((await seed.commit()).ok).toBeDefined();
+  };
+
+  // The §13.4.4 rule at the network egress boundary (grant-records shape).
+  const sinkShareRule: ExchangeRule = {
+    id: "user-to-user-share",
+    appliesTo: { type: CFC_ATOM_TYPE.User, subject: { var: "$owner" } },
+    preCondition: {
+      policyState: [{
+        kind: "ShareGrant",
+        owner: { var: "$owner" },
+        resource: PHOTO_REF,
+        audience: { type: CFC_ATOM_TYPE.User, subject: { var: "$recipient" } },
+      }],
+      boundary: [{
+        type: CFC_ATOM_TYPE.BoundaryContext,
+        key: "sinkClass",
+        value: "network",
+      }],
+    },
+    post: {
+      addAlternatives: [{
+        type: CFC_ATOM_TYPE.User,
+        subject: { var: "$recipient" },
+      }],
+    },
+  };
+
+  const withRuntime = async (
+    opts: {
+      receipts?: boolean;
+      policyEvaluation?: "off" | "observe" | "enforce";
+      enforcement?: "enforce-explicit" | "observe" | "disabled";
+    },
+    body: (runtime: Runtime) => void | Promise<void>,
+  ): Promise<void> => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      // The receipts dial: the Runtime constructor propagates it to the
+      // ambient commit-preconditions config the storage commit consults.
+      experimental: { commitPreconditions: opts.receipts ?? true },
+      cfcEnforcementMode: opts.enforcement ?? "enforce-explicit",
+      cfcSinkMaxConfidentiality: { fetchJson: [userBob] },
+      cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
+      cfcPolicyEvaluation: opts.policyEvaluation ?? "enforce",
+    });
+    try {
+      await body(runtime);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  };
+
+  const writeGrant = async (
+    runtime: Runtime,
+    overrides: Record<string, unknown> = {},
+  ): Promise<{ space: string; id: string }> => {
+    const tx = runtime.edit();
+    tx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: "cfc-grant-writer",
+    });
+    const written = tx.writeCfcGrant({
+      kind: "ShareGrant",
+      owner: signer.did(),
+      resource: PHOTO_REF,
+      audience: [userBob],
+      grantedAt: 1000,
+      singleUse: true,
+      ...overrides,
+    });
+    const result = await tx.commit();
+    expect(result.ok).toBeDefined();
+    return written;
+  };
+
+  const grantIdFor = (runtime: Runtime): URI =>
+    cfcGrantDocId({
+      space: signer.did(),
+      kind: "ShareGrant",
+      owner: signer.did(),
+      resource: PHOTO_REF,
+    });
+
+  // Read the labeled cell, enqueue the gated egress, prepare. Returns the
+  // OPEN transaction plus its prepare outcome; callers commit or abort.
+  const buildRelease = (
+    runtime: Runtime,
+    id: string,
+    effectSuffix = "",
+  ) => {
+    const tx = runtime.edit();
+    const cell = runtime.getCell(signer.did(), id, SECRET_SCHEMA.schema, tx);
+    expect(cell.key("secret").get()).toBe("rosebud");
+    enqueueSinkRequestPostCommitEffect(
+      tx,
+      "fetchJson",
+      `fetchJson:single-use-${id}${effectSuffix}`,
+      createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+      "fetchJson-start",
+      () => {},
+    );
+    tx.prepareCfc();
+    const state = tx.getCfcState();
+    return {
+      tx,
+      reasons: state.prepare.status === "invalidated"
+        ? [...state.prepare.reasons]
+        : [],
+      diagnostics: [...state.diagnostics],
+      prepare: state.prepare,
+    };
+  };
+
+  const readReceipt = (runtime: Runtime, receiptId: URI): unknown => {
+    const tx = runtime.edit();
+    const value = tx.readOrThrow({
+      space: signer.did(),
+      id: receiptId,
+      type: "application/json",
+      path: ["value"],
+    });
+    tx.abort();
+    return value;
+  };
+
+  const stagedReceiptWrite = (
+    tx: ReturnType<Runtime["edit"]>,
+    receiptId: URI,
+  ): boolean =>
+    [...(tx.getWriteDetails?.(signer.did() as MemorySpace) ?? [])].some(
+      (write) => write.address.id === receiptId,
+    );
+
+  // ---------------------------------------------------------------------------
+  // Consuming vs observing context (the seam decision): single-use grants
+  // resolve ONLY in consuming contexts; everywhere else they are
+  // unsatisfiable, fail closed.
+  // ---------------------------------------------------------------------------
+  describe("consumption context (resolver + evaluator threading)", () => {
+    const singleUseRule: ExchangeRule = {
+      id: "single-use-share",
+      appliesTo: { type: CFC_ATOM_TYPE.User, subject: { var: "$owner" } },
+      preCondition: {
+        policyState: [{
+          kind: "ShareGrant",
+          owner: { var: "$owner" },
+          resource: PHOTO_REF,
+          audience: {
+            type: CFC_ATOM_TYPE.User,
+            subject: { var: "$recipient" },
+          },
+        }],
+      },
+      post: {
+        addAlternatives: [{
+          type: CFC_ATOM_TYPE.User,
+          subject: { var: "$recipient" },
+        }],
+      },
+    };
+    const ruleSnapshot = buildCfcPolicySnapshot([{
+      id: "p",
+      rules: [singleUseRule],
+    }])!;
+
+    it("stamps the context onto resolver queries (absent = observing)", () => {
+      const queries: CfcGrantResolverQuery[] = [];
+      const resolver = (query: CfcGrantResolverQuery) => {
+        queries.push(query);
+        return [];
+      };
+      evaluateExchangeRules(
+        { confidentiality: [cfcAtom.user(ALICE)] },
+        ruleSnapshot,
+        { grantResolver: resolver },
+      );
+      evaluateExchangeRules(
+        { confidentiality: [cfcAtom.user(ALICE)] },
+        ruleSnapshot,
+        { grantResolver: resolver, grantConsumption: "consuming" },
+      );
+      expect(queries.length).toBe(2);
+      expect(queries[0].consumption).toBe("observing");
+      expect(queries[1].consumption).toBe("consuming");
+    });
+
+    it("a single-use grant is unsatisfiable in observing queries; a standing grant resolves", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime); // singleUse: true
+        const tx = runtime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        const fields = { owner: signer.did(), resource: PHOTO_REF };
+        // Absent consumption → observing → unsatisfiable.
+        expect(resolver({ kind: "ShareGrant", fields })).toEqual([]);
+        // Explicit observing → unsatisfiable.
+        expect(
+          resolver({ kind: "ShareGrant", fields, consumption: "observing" }),
+        ).toEqual([]);
+        // No receipt was consulted for the observing evaluations — the grant
+        // is unsatisfiable there regardless of receipt state, so the decision
+        // never depended on it.
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        expect(
+          tx.getCfcState().consultedGrants.some((g) => g.id === receiptId),
+        ).toBe(false);
+        tx.abort();
+
+        // The SAME release scope as a standing grant resolves in an
+        // observing query (regression pin: the context axis is single-use
+        // only).
+        await writeGrant(runtime, { singleUse: undefined });
+        const tx2 = runtime.edit();
+        const standingResolver = createTxCfcGrantResolver(tx2);
+        expect(
+          standingResolver({ kind: "ShareGrant", fields }).length,
+        ).toBe(1);
+        tx2.abort();
+      });
+    });
+
+    it("resolves in a consuming query, records the receipt consulted-absent, and stages the claim", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const grantId = grantIdFor(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        const tx = runtime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        const facts = resolver({
+          kind: "ShareGrant",
+          fields: { owner: signer.did(), resource: PHOTO_REF },
+          consumption: "consuming",
+        });
+        expect(facts.length).toBe(1);
+        expect(facts[0]).toMatchObject({ singleUse: true });
+        // Both the grant AND the receipt joined the consulted set — the
+        // receipt as ABSENT (digest binding, same discipline as the grant).
+        const consulted = tx.getCfcState().consultedGrants;
+        expect(consulted.some((g) => g.id === grantId)).toBe(true);
+        expect(
+          consulted.some((g) =>
+            g.id === receiptId && g.digest === CFC_GRANT_ABSENT_DIGEST
+          ),
+        ).toBe(true);
+        // The claim flushes into a receipt write + create-only mark.
+        expect(stagedReceiptWrite(tx, receiptId)).toBe(false);
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        expect(stagedReceiptWrite(tx, receiptId)).toBe(true);
+        tx.abort();
+      });
+    });
+
+    it("a durably consumed receipt makes the grant unsatisfiable in consuming queries", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const grantId = grantIdFor(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        // Seed a receipt as another release would have committed it.
+        const seed = runtime.edit();
+        seed.setCfcImplementationIdentity({
+          kind: "builtin",
+          builtinId: "cfc-grant-writer",
+        });
+        // Receipts live in the reserved namespace: use an OBSERVE-mode
+        // runtime? No — write privileged is not reachable here, so seed
+        // through a fresh observe-enforcement runtime sharing storage is
+        // overkill; instead exercise the real path: a full release commit.
+        seed.abort();
+        await seedLabeledCell(runtime, "consumed-check", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        const release = buildRelease(runtime, "consumed-check");
+        expect(release.reasons).toEqual([]);
+        expect((await release.tx.commit()).ok).toBeDefined();
+        expect(readReceipt(runtime, receiptId)).toBeDefined();
+
+        // Now the consuming query fails closed and records the receipt as
+        // PRESENT (content digest, not the absent marker).
+        const tx = runtime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        expect(
+          resolver({
+            kind: "ShareGrant",
+            fields: { owner: signer.did(), resource: PHOTO_REF },
+            consumption: "consuming",
+          }),
+        ).toEqual([]);
+        expect(
+          tx.getCfcState().consultedGrants.some((g) =>
+            g.id === receiptId && g.digest !== CFC_GRANT_ABSENT_DIGEST
+          ),
+        ).toBe(true);
+        // No claim staged for a consumed grant.
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        expect(stagedReceiptWrite(tx, receiptId)).toBe(false);
+        tx.abort();
+      });
+    });
+
+    it("garbage at the receipt address still counts as consumed (presence is the signal)", async () => {
+      // Seed garbage at the receipt address through an observe-enforcement
+      // runtime (the forged-write diagnosis path — same discipline as the
+      // malformed-grant test in cfc-grant-records).
+      const storageManager = StorageManager.emulate({ as: signer });
+      const observeRuntime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        experimental: { commitPreconditions: true },
+        cfcEnforcementMode: "observe",
+        cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
+        cfcPolicyEvaluation: "enforce",
+      });
+      try {
+        const grantId = cfcGrantDocId({
+          space: signer.did(),
+          kind: "ShareGrant",
+          owner: signer.did(),
+          resource: PHOTO_REF,
+        });
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        await writeGrant(observeRuntime);
+        const seed = observeRuntime.edit();
+        seed.writeOrThrow({
+          space: signer.did(),
+          id: receiptId,
+          type: "application/json",
+          path: ["value"],
+        }, { forged: "garbage" });
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const tx = observeRuntime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        expect(
+          resolver({
+            kind: "ShareGrant",
+            fields: { owner: signer.did(), resource: PHOTO_REF },
+            consumption: "consuming",
+          }),
+        ).toEqual([]);
+        tx.abort();
+      } finally {
+        await observeRuntime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("flag off: unsatisfiable even in consuming queries, with a diagnostic", async () => {
+      await withRuntime({ receipts: false }, async (runtime) => {
+        await writeGrant(runtime);
+        const tx = runtime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        expect(
+          resolver({
+            kind: "ShareGrant",
+            fields: { owner: signer.did(), resource: PHOTO_REF },
+            consumption: "consuming",
+          }),
+        ).toEqual([]);
+        expect(
+          tx.getCfcState().diagnostics.some((note) =>
+            note.includes("commitPreconditions")
+          ),
+        ).toBe(true);
+        // Nothing claimed, nothing staged.
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        tx.abort();
+      });
+    });
+
+    it("evaluator: a consuming context fires the rule; an observing one does not", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const label = { confidentiality: [cfcAtom.user(signer.did())] };
+        const observing = runtime.edit();
+        const observed = evaluateExchangeRules(
+          label,
+          ruleSnapshot,
+          { grantResolver: createTxCfcGrantResolver(observing) },
+        );
+        expect(observed.firings).toEqual([]);
+        observing.abort();
+
+        const consuming = runtime.edit();
+        const consumed = evaluateExchangeRules(
+          label,
+          ruleSnapshot,
+          {
+            grantResolver: createTxCfcGrantResolver(consuming),
+            grantConsumption: "consuming",
+          },
+        );
+        expect(consumed.firings.length).toBe(1);
+        consuming.abort();
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Claim staging arms.
+  // ---------------------------------------------------------------------------
+  describe("claim staging (flushCfcGrantConsumptionClaims)", () => {
+    it("no claims → no writes, no reasons", async () => {
+      await withRuntime({}, (runtime) => {
+        const tx = runtime.edit();
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        tx.abort();
+      });
+    });
+
+    it("is idempotent across repeated flushes (re-prepare shape)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        const tx = runtime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        resolver({
+          kind: "ShareGrant",
+          fields: { owner: signer.did(), resource: PHOTO_REF },
+          consumption: "consuming",
+        });
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        expect(stagedReceiptWrite(tx, receiptId)).toBe(true);
+        tx.abort();
+      });
+    });
+
+    it("own claim: a second resolution in the same tx still resolves (re-prepare)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const tx = runtime.edit();
+        const query = {
+          kind: "ShareGrant",
+          fields: { owner: signer.did(), resource: PHOTO_REF },
+          consumption: "consuming" as const,
+        };
+        expect(createTxCfcGrantResolver(tx)(query).length).toBe(1);
+        expect(flushCfcGrantConsumptionClaims(tx)).toEqual([]);
+        // Fresh resolver instance (a re-prepare builds one per evaluation):
+        // the receipt now sits in this tx's journal, but it is OUR claim —
+        // the same consumption, so the grant still resolves.
+        expect(createTxCfcGrantResolver(tx)(query).length).toBe(1);
+        tx.abort();
+      });
+    });
+
+    it("fails closed when a claim cannot be staged (cross-space write isolation)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const tx = runtime.edit();
+        // Claim another space as the write target first: the receipt write
+        // (owner's space) then violates single-space write isolation.
+        tx.writeOrThrow({
+          space: BOB as MemorySpace,
+          id: "of:elsewhere" as URI,
+          type: "application/json",
+          path: ["value"],
+        }, { probe: true });
+        const resolver = createTxCfcGrantResolver(tx);
+        expect(
+          resolver({
+            kind: "ShareGrant",
+            fields: { owner: signer.did(), resource: PHOTO_REF },
+            consumption: "consuming",
+          }).length,
+        ).toBe(1);
+        const failures = flushCfcGrantConsumptionClaims(tx);
+        expect(failures.length).toBe(1);
+        expect(failures[0]).toContain("staging consumption receipt");
+        tx.abort();
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The core: consumption semantics at the sink egress gate, end to end.
+  // ---------------------------------------------------------------------------
+  describe("single-use release at the sink egress gate", () => {
+    it("releases once, committing the receipt atomically; the second evaluation fails closed", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "single-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+
+        const first = buildRelease(runtime, "single-release", "-1");
+        expect(first.reasons).toEqual([]);
+        // The receipt write is staged in the SAME transaction (atomic).
+        expect(stagedReceiptWrite(first.tx, receiptId)).toBe(true);
+        expect((await first.tx.commit()).ok).toBeDefined();
+        // The receipt committed with the release.
+        expect(readReceipt(runtime, receiptId)).toMatchObject({
+          grantConsumed: { grantId: grantIdFor(runtime) },
+        });
+
+        // Second evaluation: the receipt exists → the rule no longer fires →
+        // fail closed, exactly like revoked/expired.
+        const second = buildRelease(runtime, "single-release", "-2");
+        expect(
+          second.reasons.some((reason) =>
+            reason.includes("sink-request confidentiality exceeds ceiling")
+          ),
+        ).toBe(true);
+        second.tx.abort();
+      });
+    });
+
+    it("standing grants (singleUse absent) release repeatedly with no receipt (regression pin)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime, { singleUse: undefined });
+        const grantId = grantIdFor(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        await seedLabeledCell(runtime, "standing-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        for (const suffix of ["-1", "-2"]) {
+          const release = buildRelease(runtime, "standing-release", suffix);
+          expect(release.reasons).toEqual([]);
+          // No receipt machinery for standing grants: no staged write, no
+          // receipt consulted — byte-identical decision inputs to #4627.
+          expect(stagedReceiptWrite(release.tx, receiptId)).toBe(false);
+          const prepared = release.prepare;
+          expect(prepared.status).toBe("prepared");
+          if (prepared.status === "prepared") {
+            // The grant itself was consulted (plus any absent candidate
+            // addresses the fixpoint's label-carried discovery probed — the
+            // added User(bob) alternative re-matches the rule and probes
+            // Bob's own would-be grant scope, #4627 behavior), but never
+            // the consumption receipt.
+            const consulted = prepared.input.consultedGrants!;
+            expect(consulted.some((g) => g.id === grantId)).toBe(true);
+            expect(consulted.some((g) => g.id === receiptId)).toBe(false);
+          }
+          expect((await release.tx.commit()).ok).toBeDefined();
+        }
+        expect(readReceipt(runtime, receiptId)).toBeUndefined();
+      });
+    });
+
+    it("two racing releases in one runtime: exactly one commits; the re-run does not fire", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "racing-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+
+        // Both transactions resolve the grant before either commits: both
+        // see the receipt durably absent, both stage the claim.
+        const first = buildRelease(runtime, "racing-release", "-1");
+        const second = buildRelease(runtime, "racing-release", "-2");
+        expect(first.reasons).toEqual([]);
+        expect(second.reasons).toEqual([]);
+
+        expect((await first.tx.commit()).ok).toBeDefined();
+        // SAME-replica loser: the local replica already applied the winner,
+        // so the loser dies on the client-side consistency guard
+        // (StorageTransactionInconsistent — retryable class) before its
+        // commit ever reaches the server precondition. Either rejection
+        // surface converges identically: the re-run re-evaluates, the
+        // receipt exists, the rule does not fire. The server-side
+        // receipt-exists classification proper (a REMOTE second replica
+        // that could not know) is pinned by the next test.
+        const lost = await second.tx.commit();
+        expect(lost.error).toBeDefined();
+
+        // Exactly one release: the winner's receipt.
+        expect(readReceipt(runtime, receiptId)).toMatchObject({
+          grantConsumed: { grantId: grantIdFor(runtime) },
+        });
+
+        // Re-evaluation after the lost race: the receipt exists → the rule
+        // no longer fires.
+        const rerun = buildRelease(runtime, "racing-release", "-3");
+        expect(
+          rerun.reasons.some((reason) =>
+            reason.includes("sink-request confidentiality exceeds ceiling")
+          ),
+        ).toBe(true);
+        rerun.tx.abort();
+      });
+    });
+
+    it("a remote racing claim loses as a permanent receipt-exists rejection (create-only race)", async () => {
+      // The create-only race proper needs a second REPLICA on the same
+      // server: a same-replica loser is caught by the local consistency
+      // guard first (previous test). A second storage manager sharing the
+      // base manager's in-process server plays the remote releaser whose
+      // replica never observed the winner's receipt.
+      class SharedServerStorageManager extends EmulatedStorageManager {
+        static shareServerOf(
+          base: EmulatedStorageManager,
+        ): SharedServerStorageManager {
+          return new SharedServerStorageManager(
+            {
+              as: signer,
+              memoryHost: new URL("memory://"),
+            } satisfies StorageManagerOptions,
+            () =>
+              (base as unknown as { server(): MemoryV2Server.Server })
+                .server(),
+          );
+        }
+        // The server belongs to the base manager; EmulatedStorageManager's
+        // close would close the shared instance's cached reference to it.
+        // Close only the storage-manager half (the grandparent close).
+        override close(): Promise<void> {
+          return V2StorageManager.prototype.close.call(this);
+        }
+      }
+
+      const base = StorageManager.emulate({ as: signer });
+      const remote = SharedServerStorageManager.shareServerOf(base);
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager: base,
+        experimental: { commitPreconditions: true },
+        cfcEnforcementMode: "enforce-explicit",
+        cfcSinkMaxConfidentiality: { fetchJson: [userBob] },
+        cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
+        cfcPolicyEvaluation: "enforce",
+      });
+      try {
+        await writeGrant(runtime);
+        const grantId = grantIdFor(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        await seedLabeledCell(runtime, "remote-racing-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+
+        // The remote releaser stages its claim — the receipt write plus the
+        // create-only mark, exactly the shape flushCfcGrantConsumptionClaims
+        // stages — against a replica that has not observed any receipt.
+        const remoteTx = new ExtendedStorageTransaction(remote.edit());
+        remoteTx.writeOrThrow({
+          space: signer.did(),
+          id: receiptId,
+          type: "application/json",
+          path: ["value"],
+        }, {
+          version: 1,
+          grantConsumed: { grantId },
+          space: signer.did(),
+          consumedAt: 1000,
+        });
+        remoteTx.markCreateOnly({ space: signer.did(), id: receiptId });
+
+        // The local release wins.
+        const local = buildRelease(runtime, "remote-racing-release");
+        expect(local.reasons).toEqual([]);
+        expect((await local.tx.commit()).ok).toBeDefined();
+
+        // The remote claim reaches the server unaware — and dies on the
+        // entity-absent precondition as the PERMANENT receipt-exists
+        // rejection the scheduler never retries.
+        const lost = await remoteTx.commit();
+        expect(lost.error).toBeDefined();
+        expect(lost.error!.name).toBe("PreconditionFailedError");
+        expect(
+          (lost.error as { precondition?: string }).precondition,
+        ).toBe("receipt-exists");
+        expect(isPermanentRejection(lost.error!)).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await remote.close();
+        await base.close();
+      }
+    });
+
+    it("a failed commit consumes nothing; a retry can still consume (no-consume-on-failure)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "failed-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        // A doc the release reads (confirmed) and an interloper then bumps,
+        // making the release's commit fail on a stale confirmed read.
+        const seedY = runtime.edit();
+        seedY.writeOrThrow({
+          space: signer.did(),
+          id: "of:conflict-anchor" as URI,
+          type: "application/json",
+          path: ["value"],
+        }, { rev: 1 });
+        expect((await seedY.commit()).ok).toBeDefined();
+
+        const tx = runtime.edit();
+        expect(
+          tx.readOrThrow({
+            space: signer.did(),
+            id: "of:conflict-anchor" as URI,
+            type: "application/json",
+            path: ["value"],
+          }),
+        ).toMatchObject({ rev: 1 });
+        const cell = runtime.getCell(
+          signer.did(),
+          "failed-release",
+          SECRET_SCHEMA.schema,
+          tx,
+        );
+        expect(cell.key("secret").get()).toBe("rosebud");
+        enqueueSinkRequestPostCommitEffect(
+          tx,
+          "fetchJson",
+          "fetchJson:single-use-failed-release",
+          createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+          "fetchJson-start",
+          () => {},
+        );
+        tx.prepareCfc();
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
+        expect(stagedReceiptWrite(tx, receiptId)).toBe(true);
+
+        // Interloper bumps the anchor; the prepared release's basis is stale.
+        const interloper = runtime.edit();
+        interloper.writeOrThrow({
+          space: signer.did(),
+          id: "of:conflict-anchor" as URI,
+          type: "application/json",
+          path: ["value"],
+        }, { rev: 2 });
+        expect((await interloper.commit()).ok).toBeDefined();
+
+        const failed = await tx.commit();
+        expect(failed.error).toBeDefined();
+        // The staged receipt rode the failed transaction: nothing landed.
+        expect(readReceipt(runtime, receiptId)).toBeUndefined();
+
+        // The retry (a fresh transaction, as the scheduler would run it)
+        // re-resolves the grant — the receipt is still absent — and lands.
+        const retry = buildRelease(runtime, "failed-release", "-retry");
+        expect(retry.reasons).toEqual([]);
+        expect((await retry.tx.commit()).ok).toBeDefined();
+        expect(readReceipt(runtime, receiptId)).toBeDefined();
+      });
+    });
+
+    it("re-prepare in one transaction: still releases, one receipt, commit ok", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "reprepare-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        const release = buildRelease(runtime, "reprepare-release");
+        expect(release.reasons).toEqual([]);
+        // Invalidate and re-prepare: the resolver finds its own staged
+        // receipt in the journal and recognizes the claim as this
+        // transaction's own consumption.
+        release.tx.invalidateCfc("test-reprepare");
+        release.tx.prepareCfc();
+        expect(release.tx.getCfcState().prepare.status).toBe("prepared");
+        expect((await release.tx.commit()).ok).toBeDefined();
+        expect(readReceipt(runtime, receiptId)).toBeDefined();
+
+        // Spent: the next evaluation fails closed.
+        const next = buildRelease(runtime, "reprepare-release", "-next");
+        expect(next.reasons.length).toBeGreaterThan(0);
+        next.tx.abort();
+      });
+    });
+
+    it("flag off: a single-use grant is unsatisfiable at the gate (never silently multi-use)", async () => {
+      await withRuntime({ receipts: false }, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "flag-off-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        const release = buildRelease(runtime, "flag-off-release");
+        expect(
+          release.reasons.some((reason) =>
+            reason.includes("sink-request confidentiality exceeds ceiling")
+          ),
+        ).toBe(true);
+        expect(
+          release.diagnostics.some((note) =>
+            note.includes("commitPreconditions")
+          ),
+        ).toBe(true);
+        expect(stagedReceiptWrite(release.tx, receiptId)).toBe(false);
+        release.tx.abort();
+
+        // A standing grant under the SAME flag-off runtime keeps releasing
+        // (the flag gates single-use consumption, nothing else).
+        await writeGrant(runtime, { singleUse: undefined });
+        const standing = buildRelease(runtime, "flag-off-release", "-standing");
+        expect(standing.reasons).toEqual([]);
+        standing.tx.abort();
+      });
+    });
+
+    it("observe dial: decides on the raw label and never stages a claim", async () => {
+      await withRuntime({ policyEvaluation: "observe" }, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "observe-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        const release = buildRelease(runtime, "observe-release");
+        // Observe decides on the raw label: the egress still rejects.
+        expect(
+          release.reasons.some((reason) =>
+            reason.includes("sink-request confidentiality exceeds ceiling")
+          ),
+        ).toBe(true);
+        // And the observing evaluation must not spend the grant: no claim.
+        expect(stagedReceiptWrite(release.tx, receiptId)).toBe(false);
+        release.tx.abort();
+      });
+    });
+
+    it("receipt lookups never taint (internalVerifierRead discipline)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        await seedLabeledCell(runtime, "no-taint-release", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+        const release = buildRelease(runtime, "no-taint-release");
+        expect(release.prepare.status).toBe("prepared");
+        if (release.prepare.status !== "prepared") return;
+        // Grant + receipt were consulted…
+        const grantId = grantIdFor(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        const consulted = release.prepare.input.consultedGrants!;
+        expect(consulted.some((g) => g.id === grantId)).toBe(true);
+        expect(
+          consulted.some((g) =>
+            g.id === receiptId && g.digest === CFC_GRANT_ABSENT_DIGEST
+          ),
+        ).toBe(true);
+        // …but neither entered the consumed read set.
+        expect(
+          release.prepare.input.consumedReads.some((read) =>
+            read.id.startsWith(CFC_GRANT_ID_PREFIX)
+          ),
+        ).toBe(false);
+        release.tx.abort();
+      });
+    });
+
+    it("rejects an unprivileged write at the receipt address (S18 gate)", async () => {
+      await withRuntime({}, async (runtime) => {
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        const tx = runtime.edit();
+        tx.writeOrThrow({
+          space: signer.did(),
+          id: receiptId,
+          type: "application/json",
+          path: ["value"],
+        }, { forged: true });
+        const result = await tx.commit();
+        expect(result.error).toBeDefined();
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Digest binding (item 3): receipt consulted-state rides consultedGrants
+  // with the grants' own canonicalization + invalidation discipline.
+  // ---------------------------------------------------------------------------
+  describe("digest binding of the receipt state", () => {
+    it("a receipt appearing between evaluations invalidates the prepared digest", async () => {
+      await withRuntime({}, async (runtime) => {
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        const tx = runtime.edit();
+        // Prepare with the receipt consulted ABSENT (as a consuming
+        // resolution records it)…
+        tx.recordCfcConsultedGrant({
+          space: signer.did(),
+          id: receiptId,
+          digest: CFC_GRANT_ABSENT_DIGEST,
+        });
+        tx.markCfcRelevant("test");
+        tx.prepareCfc();
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
+        // …then the receipt APPEARS (a re-evaluation records it present):
+        // the prepared decision consumed "absent", so it must invalidate —
+        // the cfc-prepared-digest-mismatch class, independent of the
+        // create-only race.
+        tx.recordCfcConsultedGrant({
+          space: signer.did(),
+          id: receiptId,
+          digest: "receipt-present-digest",
+        });
+        const state = tx.getCfcState().prepare;
+        expect(state.status).toBe("invalidated");
+        if (state.status === "invalidated") {
+          expect(state.reasons).toContain("consulted-grant-changed");
+        }
+        tx.abort();
+      });
+    });
+
+    it("present vs absent receipt state digests differently (pure)", async () => {
+      const { preparedDigestFor } = await import("../src/cfc/canonical.ts");
+      const base = {
+        consumedReads: [],
+        attemptedWrites: [],
+        writes: [],
+        writeAttemptLog: [],
+        dereferenceTraces: [],
+        triggerReads: [],
+        writePolicyInputs: [],
+      };
+      const receiptId = cfcGrantConsumedReceiptId(
+        cfcGrantDocId(identity),
+      );
+      const absent = preparedDigestFor({
+        ...base,
+        consultedGrants: [{
+          space: ALICE as MemorySpace,
+          id: receiptId,
+          digest: CFC_GRANT_ABSENT_DIGEST,
+        }],
+      });
+      const present = preparedDigestFor({
+        ...base,
+        consultedGrants: [{
+          space: ALICE as MemorySpace,
+          id: receiptId,
+          digest: "receipt-present-digest",
+        }],
+      });
+      expect(absent).not.toBe(present);
+      expect(preparedDigestFor(base)).not.toBe(absent);
+      // Order-insensitive alongside the grant's own entry.
+      const grantEntry = {
+        space: ALICE as MemorySpace,
+        id: cfcGrantDocId(identity),
+        digest: "grant-digest",
+      };
+      const receiptEntry = {
+        space: ALICE as MemorySpace,
+        id: receiptId,
+        digest: CFC_GRANT_ABSENT_DIGEST,
+      };
+      expect(
+        preparedDigestFor({
+          ...base,
+          consultedGrants: [grantEntry, receiptEntry],
+        }),
+      ).toBe(
+        preparedDigestFor({
+          ...base,
+          consultedGrants: [receiptEntry, grantEntry],
+        }),
+      );
     });
   });
 });

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -1,0 +1,173 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
+import type { CfcGrantResolverQuery } from "../src/cfc/exchange-eval.ts";
+import {
+  buildCfcPolicySnapshot,
+  type ExchangeRule,
+} from "../src/cfc/policy.ts";
+import {
+  CFC_GRANT_ABSENT_DIGEST,
+  CFC_GRANT_ID_PREFIX,
+  cfcGrantConsumedReceiptId,
+  cfcGrantDocId,
+  createTxCfcGrantResolver,
+  expandCfcGrantFacts,
+  flushCfcGrantConsumptionClaims,
+  prepareCfcGrantWrite,
+  verifyCfcGrantDocument,
+} from "../src/cfc/grants.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-single-use-grants");
+
+// Single-use CFC grants (declass build-order item 5;
+// docs/specs/cfc-persisted-declassification.md §2.2 "Single-use releases",
+// spec §6.5.1-.2 claim semantics): a grant with `singleUse: true` satisfies
+// its policyState guard only while its consumption receipt does not exist,
+// and the releasing transaction claims the receipt atomically with the
+// release via the shipped `experimental.commitPreconditions` exactly-once
+// discipline (create-only receipt document, `receipt-exists` permanent
+// rejection for the create-only race loser).
+
+const ALICE = "did:key:alice";
+const BOB = "did:key:bob";
+const MALLORY = "did:key:mallory";
+const userBob = cfcAtom.user(BOB);
+const userMallory = cfcAtom.user(MALLORY);
+const PHOTO_REF = "of:photo42";
+
+const identity = {
+  space: ALICE,
+  kind: "ShareGrant",
+  owner: ALICE,
+  resource: PHOTO_REF,
+};
+
+const baseInput = {
+  kind: "ShareGrant",
+  owner: ALICE,
+  resource: PHOTO_REF,
+  audience: [userBob],
+  grantedAt: 1000,
+};
+
+describe("CFC single-use grants (§2.2 single-use releases)", () => {
+  // ---------------------------------------------------------------------------
+  // Item 1: the `singleUse` field.
+  // ---------------------------------------------------------------------------
+  describe("singleUse field (writer validation)", () => {
+    it("accepts singleUse: true and stores it in the value", () => {
+      const prepared = prepareCfcGrantWrite(
+        { ...baseInput, singleUse: true },
+        ALICE,
+      );
+      expect(prepared.value.singleUse).toBe(true);
+    });
+
+    it("omits the field for a standing grant (absent, not false)", () => {
+      const prepared = prepareCfcGrantWrite(baseInput, ALICE);
+      expect("singleUse" in prepared.value).toBe(false);
+    });
+
+    it("refuses anything but boolean-true or absent (malformed)", () => {
+      // `false` is refused too: "standing" has exactly one spelling (absent),
+      // so no consumer can ever treat a present-but-false marker as a third
+      // state.
+      const attempt = (singleUse: unknown) => () =>
+        prepareCfcGrantWrite(
+          { ...baseInput, singleUse } as Parameters<
+            typeof prepareCfcGrantWrite
+          >[0],
+          ALICE,
+        );
+      expect(attempt(false)).toThrow(/singleUse/);
+      expect(attempt(1)).toThrow(/singleUse/);
+      expect(attempt("yes")).toThrow(/singleUse/);
+      expect(attempt(null)).toThrow(/singleUse/);
+    });
+
+    it("does not participate in the address (identity = release scope)", () => {
+      // Same release scope, same document: converting a standing grant to
+      // single-use (or back) is an in-place update of the SAME durable
+      // decision, exactly like audience/lifecycle changes.
+      const standing = prepareCfcGrantWrite(baseInput, ALICE);
+      const single = prepareCfcGrantWrite(
+        { ...baseInput, singleUse: true },
+        ALICE,
+      );
+      expect(single.id).toBe(standing.id);
+      expect(single.id).toBe(cfcGrantDocId(identity));
+    });
+  });
+
+  describe("singleUse field (verify-on-read)", () => {
+    const id = cfcGrantDocId(identity);
+    const value = {
+      version: 1,
+      ...identity,
+      audience: [userBob],
+      grantedAt: 1000,
+    };
+
+    it("admits singleUse: true and absent", () => {
+      expect(verifyCfcGrantDocument(ALICE, id, value)).toBeDefined();
+      expect(
+        verifyCfcGrantDocument(ALICE, id, { ...value, singleUse: true })
+          ?.singleUse,
+      ).toBe(true);
+    });
+
+    it("rejects a malformed singleUse (defense in depth)", () => {
+      expect(verifyCfcGrantDocument(ALICE, id, { ...value, singleUse: false }))
+        .toBeUndefined();
+      expect(verifyCfcGrantDocument(ALICE, id, { ...value, singleUse: 1 }))
+        .toBeUndefined();
+      expect(
+        verifyCfcGrantDocument(ALICE, id, { ...value, singleUse: "true" }),
+      ).toBeUndefined();
+    });
+
+    it("carries singleUse through fact expansion (absent stays absent)", () => {
+      const single = verifyCfcGrantDocument(ALICE, id, {
+        ...value,
+        singleUse: true,
+      })!;
+      expect(expandCfcGrantFacts(single)[0]).toMatchObject({
+        singleUse: true,
+      });
+      const standing = verifyCfcGrantDocument(ALICE, id, value)!;
+      const fact = expandCfcGrantFacts(standing)[0] as Record<string, unknown>;
+      // Standing facts stay byte-identical to #4627 — no new key.
+      expect("singleUse" in fact).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Item 2: the consumption receipt identity.
+  // ---------------------------------------------------------------------------
+  describe("consumption receipt derivation", () => {
+    const grantId = cfcGrantDocId(identity);
+
+    it("derives a deterministic receipt id in the reserved namespace", () => {
+      const receipt = cfcGrantConsumedReceiptId(grantId);
+      expect(receipt.startsWith(CFC_GRANT_ID_PREFIX)).toBe(true);
+      expect(cfcGrantConsumedReceiptId(grantId)).toBe(receipt);
+    });
+
+    it("is distinct from the grant id and varies with it", () => {
+      const receipt = cfcGrantConsumedReceiptId(grantId);
+      expect(receipt).not.toBe(grantId);
+      const other = cfcGrantDocId({ ...identity, resource: "of:other" });
+      expect(cfcGrantConsumedReceiptId(other)).not.toBe(receipt);
+    });
+  });
+});

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -48,9 +48,7 @@ const signer = await Identity.fromPassphrase("runner-cfc-single-use-grants");
 
 const ALICE = "did:key:alice";
 const BOB = "did:key:bob";
-const MALLORY = "did:key:mallory";
 const userBob = cfcAtom.user(BOB);
-const userMallory = cfcAtom.user(MALLORY);
 const PHOTO_REF = "of:photo42";
 
 const identity = {
@@ -301,7 +299,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     return written;
   };
 
-  const grantIdFor = (runtime: Runtime): URI =>
+  const grantIdFor = (_runtime: Runtime): URI =>
     cfcGrantDocId({
       space: signer.did(),
       kind: "ShareGrant",
@@ -1091,7 +1089,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
   // ---------------------------------------------------------------------------
   describe("digest binding of the receipt state", () => {
     it("a receipt appearing between evaluations invalidates the prepared digest", async () => {
-      await withRuntime({}, async (runtime) => {
+      await withRuntime({}, (runtime) => {
         const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
         const tx = runtime.edit();
         // Prepare with the receipt consulted ABSENT (as a consuming

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -253,6 +253,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       receipts?: boolean;
       policyEvaluation?: "off" | "observe" | "enforce";
       enforcement?: "enforce-explicit" | "observe" | "disabled";
+      rules?: readonly ExchangeRule[];
     },
     body: (runtime: Runtime) => void | Promise<void>,
   ): Promise<void> => {
@@ -265,7 +266,10 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       experimental: { commitPreconditions: opts.receipts ?? true },
       cfcEnforcementMode: opts.enforcement ?? "enforce-explicit",
       cfcSinkMaxConfidentiality: { fetchJson: [userBob] },
-      cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
+      cfcPolicyRecords: [{
+        id: "share-policy",
+        rules: [...(opts.rules ?? [sinkShareRule])],
+      }],
       cfcPolicyEvaluation: opts.policyEvaluation ?? "enforce",
     });
     try {
@@ -1064,6 +1068,76 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
           ),
         ).toBe(false);
         release.tx.abort();
+      });
+    });
+
+    it("the input-requirement gate (gated write) consumes too: releases once, then fails closed", async () => {
+      // The OTHER consuming site (design §2.2 seam decision): a write whose
+      // maxConfidentiality ceiling is satisfied through the grant persists a
+      // released value — the ceiling decision is durable, so it consumes
+      // exactly like the sink gate. The rule carries no boundary guard
+      // (write gates mint no BoundaryContext atoms).
+      const writeGateRule: ExchangeRule = {
+        ...sinkShareRule,
+        preCondition: {
+          policyState: sinkShareRule.preCondition!.policyState,
+        },
+      };
+      const gatedSchema = {
+        type: "object",
+        properties: {
+          out: {
+            type: "string",
+            ifc: { maxConfidentiality: [userBob] },
+          },
+        },
+        required: ["out"],
+      } as const satisfies JSONSchema;
+      const readThenGatedWrite = (runtime: Runtime, suffix: string) => {
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "gated-write",
+          SECRET_SCHEMA.schema,
+          tx,
+        );
+        expect(cell.key("secret").get()).toBe("rosebud");
+        runtime.getCell(
+          signer.did(),
+          `gated-write-out${suffix}`,
+          gatedSchema,
+          tx,
+        ).set({ out: "derived" });
+        tx.prepareCfc();
+        const state = tx.getCfcState();
+        return {
+          tx,
+          reasons: state.prepare.status === "invalidated"
+            ? [...state.prepare.reasons]
+            : [],
+        };
+      };
+      await withRuntime({ rules: [writeGateRule] }, async (runtime) => {
+        await writeGrant(runtime);
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await seedLabeledCell(runtime, "gated-write", {
+          confidentiality: [cfcAtom.user(signer.did())],
+        });
+
+        const first = readThenGatedWrite(runtime, "-1");
+        expect(first.reasons).toEqual([]);
+        expect(stagedReceiptWrite(first.tx, receiptId)).toBe(true);
+        expect((await first.tx.commit()).ok).toBeDefined();
+        expect(readReceipt(runtime, receiptId)).toBeDefined();
+
+        // Spent: the same gated write no longer releases.
+        const second = readThenGatedWrite(runtime, "-2");
+        expect(
+          second.reasons.some((reason) =>
+            reason.includes("maxConfidentiality failed")
+          ),
+        ).toBe(true);
+        second.tx.abort();
       });
     });
 

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -573,6 +573,66 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       }
     });
 
+    it("a metadata-only (value-less) receipt document still counts as consumed", async () => {
+      // Memory v2 documents can exist with no `value` subpath (a
+      // metadata-only write). Presence of the receipt DOCUMENT is the
+      // consumption signal, so the resolver must read the document root: a
+      // value-subpath read would report `undefined` for such a document and
+      // re-arm the grant at evaluation time (cubic P1 on #4649). The
+      // create-only backstop would still kill the release at commit — any
+      // prior set on the entity fails the entity-absent precondition — but
+      // resolution itself must already fail closed as consumed.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const observeRuntime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        experimental: { commitPreconditions: true },
+        cfcEnforcementMode: "observe",
+        cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
+        cfcPolicyEvaluation: "enforce",
+      });
+      try {
+        const grantId = cfcGrantDocId({
+          space: signer.did(),
+          kind: "ShareGrant",
+          owner: signer.did(),
+          resource: PHOTO_REF,
+        });
+        const receiptId = cfcGrantConsumedReceiptId(grantId);
+        await writeGrant(observeRuntime);
+        // A full-document write with NO value key: the document exists, its
+        // ["value"] subpath does not (the `source`-only sibling-field shape).
+        const seed = observeRuntime.edit();
+        seed.writeOrThrow({
+          space: signer.did(),
+          id: receiptId,
+          type: "application/json",
+          path: [],
+        }, { source: { note: "metadata-only" } } as never);
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const tx = observeRuntime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        expect(
+          resolver({
+            kind: "ShareGrant",
+            fields: { owner: signer.did(), resource: PHOTO_REF },
+            consumption: "consuming",
+          }),
+        ).toEqual([]);
+        // The receipt joined the consulted set as PRESENT, not absent.
+        expect(
+          tx.getCfcState().consultedGrants.some((g) =>
+            g.id === receiptId && g.digest !== CFC_GRANT_ABSENT_DIGEST
+          ),
+        ).toBe(true);
+        tx.abort();
+      } finally {
+        await observeRuntime.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("flag off: unsatisfiable even in consuming queries, with a diagnostic", async () => {
       await withRuntime({ receipts: false }, async (runtime) => {
         await writeGrant(runtime);

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -673,6 +673,69 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       });
     });
 
+    it("one resolver never serves a consuming resolution to an observing query (memo isolation)", async () => {
+      await withRuntime({}, async (runtime) => {
+        await writeGrant(runtime);
+        const tx = runtime.edit();
+        const resolver = createTxCfcGrantResolver(tx);
+        const fields = { owner: signer.did(), resource: PHOTO_REF };
+        // Consuming first (facts memoized under the consuming key)…
+        expect(
+          resolver({ kind: "ShareGrant", fields, consumption: "consuming" })
+            .length,
+        ).toBe(1);
+        // …must not leak to an observing query on the SAME instance.
+        expect(resolver({ kind: "ShareGrant", fields })).toEqual([]);
+        expect(
+          resolver({ kind: "ShareGrant", fields, consumption: "observing" }),
+        ).toEqual([]);
+        tx.abort();
+      });
+    });
+
+    it("fails closed when the storage cannot enforce create-only (no markCreateOnly)", async () => {
+      // A hand-built transaction without markCreateOnly (the optional
+      // interface member): the claim's exactly-once witness cannot be
+      // enforced, so staging must fail closed with a reason — never a
+      // silently unguarded receipt write. The ambient flag is forced on so
+      // the resolver reaches the claim path at all.
+      const { setCommitPreconditionsConfig, resetCommitPreconditionsConfig } =
+        await import("@commonfabric/memory/v2");
+      setCommitPreconditionsConfig(true);
+      try {
+        const writes: unknown[] = [];
+        const grantValue = prepareCfcGrantWrite(
+          { ...baseInput, singleUse: true },
+          ALICE,
+        );
+        const stubTx = {
+          readOrThrow: (address: { id: string }) =>
+            address.id === grantValue.id ? grantValue.value : undefined,
+          recordCfcConsultedGrant: () => {},
+          noteCfcDiagnostic: () => {},
+          writeOrThrow: (address: unknown, value: unknown) =>
+            writes.push([address, value]),
+          // no markCreateOnly
+        } as unknown as Parameters<typeof createTxCfcGrantResolver>[0];
+        const resolver = createTxCfcGrantResolver(stubTx);
+        expect(
+          resolver({
+            kind: "ShareGrant",
+            fields: { owner: ALICE, resource: PHOTO_REF },
+            consumption: "consuming",
+          }).length,
+        ).toBe(1);
+        const failures = flushCfcGrantConsumptionClaims(stubTx);
+        expect(failures.length).toBe(1);
+        expect(failures[0]).toContain("markCreateOnly");
+        // Mark-first discipline: the refused mark left no unguarded receipt
+        // value in the journal.
+        expect(writes).toEqual([]);
+      } finally {
+        resetCommitPreconditionsConfig();
+      }
+    });
+
     it("fails closed when a claim cannot be staged (cross-space write isolation)", async () => {
       await withRuntime({}, async (runtime) => {
         await writeGrant(runtime);

--- a/packages/runner/test/storage-commit-preconditions.test.ts
+++ b/packages/runner/test/storage-commit-preconditions.test.ts
@@ -85,3 +85,18 @@ Deno.test("extended transaction refuses preconditions the storage cannot enforce
     "does not support",
   );
 });
+
+Deno.test("extended transaction refuses create-only marks the storage cannot enforce", () => {
+  // Same fail-closed posture as addCommitPrecondition above: a create-only
+  // mark is a commit gate — the exactly-once witness for event receipts and
+  // single-use grant consumption — so a wrapper that swallowed it over an
+  // inner transaction without markCreateOnly would let a duplicate commit
+  // through unguarded (cubic P1 on #4649).
+  const innerWithoutSupport = {} as IStorageTransaction;
+  const tx = new ExtendedStorageTransaction(innerWithoutSupport);
+  assertThrows(
+    () => tx.markCreateOnly({ space, id: "of:receipt-probe" }),
+    Error,
+    "does not support",
+  );
+});


### PR DESCRIPTION
Implements single-use CFC grants — build-order item 5 of `docs/specs/cfc-persisted-declassification.md` §2.2 ("Single-use releases") — on the grant machinery #4627 shipped and the `experimental.commitPreconditions` exactly-once substrate (spec `06-events-and-intents.md` §6.5.1–.2: consume only on successful commit, no-consume-on-failure, atomic claim).

## What ships

**1. The field.** `CfcGrant.singleUse?: true` — validated in the trusted writer (`prepareCfcGrantWrite`) AND on verify-on-read: boolean-true or absent; anything else (including `false`) refuses the whole grant, so a malformed marker can never degrade to a standing (silently multi-use) grant. Address derivation is unchanged — identity = release scope; `singleUse` lives in the value like audience/lifecycle, so converting a standing grant to single-use is an in-place update of the same durable decision. Fact expansion carries `singleUse: true` via conditional spread — standing facts stay byte-identical to #4627.

**2. The receipt (derivation decision).** `cfcGrantConsumedReceiptId(grantId)` follows spec §6.5.1's `consumedCellId` SHAPE (`{grantConsumed: {grantId}}`, one receipt per grant id) realized with the #4627 ADDRESS IDIOM (reserved `grant:cfc:` URI scheme + versioned `hashStringOf` wrapper, exactly like `cfcGrantDocId`) rather than the `{resultFor: cause}`/`createRef` idiom (which mints ordinary `of:` entity ids), because the receipt is policy state and must live inside the reserved namespace: `noteSystemWrite` already records ANY unprivileged write at ANY path under `grant:cfc:` as an S18-class violation — covering both receipt forging (fail closed: a denied live grant) and unprivileged receipt deletion/overwrite (which would RE-ARM a spent grant — fail open) with the gate that already exists. Point-derivable from the grant id alone (§4.9.3 discipline, no enumeration), hosted in the grant's space. Presence is the enforcement signal — garbage at the address still counts as consumed; the stored value (`{version, grantConsumed, space, consumedAt}`) is audit content.

**3. Consumption semantics.** A single-use grant satisfies its `policyState` guard only in a **consuming** evaluation context, with receipts available, while its receipt does not exist:

- **Consuming vs observing (the seam decision).** Consuming contexts are exactly the boundary gates whose evaluation outcome changes a persisted/egress decision inside a writing transaction's prepare — the **sink-request egress ceiling** and the **input-requirement gate on gated writes** — and only under the `enforce` policy-evaluation dial (under `observe` the decision is made on the raw label; that evaluation is diagnostics-only and must never spend a grant). Everything else — the render ceiling's display boundary, hand-built contexts — never states a consuming context, so single-use grants are **unsatisfiable there, fail closed**: a grant consumed by rendering would be spent by looking at it, and resolving without consuming would make "single use" advisory. Mechanically: `ExchangeEvalContext.grantConsumption` is stamped onto every resolver query (`CfcGrantResolverQuery.consumption`); absent = observing.
- **Resolution (prepare).** The resolver point-reads the receipt under `internalVerifierRead` (no taint — pinned), records its present/absent state into `consultedGrants` (digest binding, below), fails closed on any present value, and registers the claim in a **module-private per-tx registry** — deliberately not a transaction-surface method, which would let handler code reaching `cell.tx` launder receipt forgeries through the privileged flush; the WeakMap keeps the only writers the resolver and the flush. Consumption attaches at resolution: the grant's facts entered a consuming gate's decision basis; firing-level attribution is not reconstructable at staging time, and erring toward consumption is the fail-closed direction (a spent grant releases nothing; an unspent-but-used grant would be a replay). A resolved-but-rejected commit still consumes nothing (atomicity).
- **Release (commit).** `prepareBoundaryCommit` flushes the claims at the end of the pass, inside the privileged scope `prepareCfc` wraps it in: `markCreateOnly` first (a refused mark never leaves an unguarded receipt value in the journal), then the receipt write — both riding the releasing transaction. Consumption commits atomically with the release; a commit that fails for any reason leaves no receipt, and a retry (fresh transaction) re-resolves and can still consume. A same-replica race loser dies on the client-side consistency guard; a remote race loser reaches the server and dies on the entity-absent precondition as the **permanent `receipt-exists` rejection** (`isPermanentRejection` pinned — never retried), and its re-evaluation finds the receipt so the rule no longer fires. Unstageable claims (read-only tx; receipt space outside the transaction's write space — cross-space consumption arrives with B2b's shared policy roots) fail closed as prepare reasons.
- **Re-prepare stability.** The per-tx registry recognizes the receipt in the transaction's own journal as its own consumption (the same claim, not a competing one); a receipt that landed durably in between still loses at commit via the create-only backstop.
- **Flag gating.** Without `experimental.commitPreconditions` the storage commit never emits entity-absent preconditions — a `markCreateOnly` mark would be silently dropped — so single-use grants are **unsatisfiable everywhere** when the flag is off (never silently multi-use), with a diagnostic naming the flag. Standing grants are unaffected by the flag.

**4. Digest binding.** The receipt's resolution-time state rides `consultedGrants` — the same entries #4627 binds grants with (present → content digest, absent → `CFC_GRANT_ABSENT_DIGEST`), so a receipt appearing between evaluations invalidates the prepared digest (`consulted-grant-changed`, the `cfc-prepared-digest-mismatch` class) independently of the create-only race; address-sorted, order-insensitive canonicalization is inherited and pinned.

## Tests (`packages/runner/test/cfc-single-use-grants.test.ts`, red-first)

- `singleUse` writer/verify arms (true ok; `false`/`1`/`"yes"`/`null` refused at write and on read), address invariance, fact expansion (standing facts unchanged).
- Receipt derivation: deterministic, reserved prefix, distinct from and varying with the grant id.
- Context threading: the evaluator stamps consuming/observing onto queries (absent = observing); observing queries cannot satisfy a single-use grant and never consult the receipt, while standing grants still resolve; consuming resolution records grant + receipt-absent and stages the claim; evaluator-level consuming-fires / observing-does-not pin; a durably consumed receipt (and garbage at the receipt address) fails consuming queries closed.
- Claim staging: no-claims no-op; idempotence across flushes; own-claim re-resolution (fresh resolver, same tx); cross-space staging failure → fail-closed reason.
- End-to-end at the sink gate: releases once with the receipt committed atomically, second evaluation fails closed; same-runtime race → exactly one release, loser errors, re-run does not fire; remote race (second replica on the same in-process server) → permanent `receipt-exists`; commit failure leaves no receipt and a retry consumes; re-prepare in one tx still releases with one receipt; flag-off unsatisfiable while a standing grant on the same runtime keeps releasing; observe-dial never stages a claim; receipt lookups never taint; forged receipt write rejected (S18); standing-grant regression pin (no receipt machinery in the decision inputs).
- Digest binding: pure present-vs-absent digest difference + order-insensitivity beside the grant's entry, and prepared-digest invalidation on a receipt appearing between evaluations.

## Verification

```
cd packages/runner && deno task test        (on the catch-up-merged final tree,
                                             incl. the review-fix commits)
→ 835 passed (4520 steps) | 0 failed (exit 0)

deno test test/cfc-single-use-grants.test.ts   → 43 steps, 0 failed
deno test test/cfc-grant-records.test.ts       → 80 steps, 0 failed (regression)
deno test test/cfc-exchange-eval.test.ts test/cfc-policy.test.ts
  test/cfc-policy-boundary.test.ts test/cfc-render-ceiling.test.ts
  test/cfc-sink-ceiling.test.ts test/cfc-sink-request-policy.test.ts
  test/scheduler-event-receipts.test.ts test/storage-commit-preconditions.test.ts
→ all green

deno task integration --port-offset=317 patterns cfc   (commit paths touched)
→ 8 passed (15 steps) | 0 failed — cfc-authorized-save, cfc-authorship-chat,
  cfc-group-chat-demo (single, multi-runtime, two-browsers),
  cfc-render-policy-demo, cfc-spec-gallery, cfc-staged-publish
```

## Review follow-ups (post-CI round 1)

- **cubic P1 (receipt read)**: resolver now reads the receipt at the document ROOT — a value-less/metadata-only document at the receipt address counts as consumed at resolution (previously only the create-only commit backstop caught it); grant docs keep `["value"]` reads where absence is the fail-closed direction. 516922ffe.
- **cubic P1 (markCreateOnly presence)**: `ExtendedStorageTransaction.markCreateOnly()` now fails closed (throws) over an inner transaction that cannot enforce it — same posture as `addCommitPrecondition`; the flush turns that into a prepare reason. 02ced7961.
- **codex P2 (docs)**: `EXPERIMENTAL_OPTIONS.md` records the single-use-grant dependency on `commitPreconditions` (fail-closed when off) and the declass doc's build-order item 5 is marked shipped. de3af4091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds single-use CFC grants enforced by atomic consumption receipts to guarantee exactly-once releases in consuming contexts. Requires `experimental.commitPreconditions`; standing grants are unchanged.

- **New Features**
  - `CfcGrant.singleUse?: true` with strict validation at write and verify-on-read.
  - `cfcGrantConsumedReceiptId(grantId)` in `grant:cfc:`; presence enforces consumption (value is audit-only).
  - Threads consumption context through resolver/evaluator; only sink egress and gated writes under `enforce` consume; `observe` never consumes.
  - `flushCfcGrantConsumptionClaims` in `prepareBoundaryCommit` writes the receipt and `markCreateOnly` for atomicity; races reject as permanent `receipt-exists`; receipt state joins `consultedGrants` to bind the prepared digest.

- **Bug Fixes**
  - Read receipts at the document root so value-less receipts still count as consumed.
  - `markCreateOnly` now fails closed if the inner transaction can’t enforce it, preventing unguarded duplicates.
  - Docs record the `commitPreconditions` dependency and flag-off fail-closed behavior.

<sup>Written for commit f97f55f757cae6a710b828beb0b609e78ff90219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


