### PR TITLE
docs(cfc): register cfcLabelMetadataProtection in EXPERIMENTAL_OPTIONS (inv-12 Stage 1)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -36,6 +36,7 @@ was last checked against the code.
 | [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
 | [`cfcTriggerReadGating`](#cfctriggerreadgating) | `RuntimeOptions.cfcTriggerReadGating` | `false` | Bernhard Seefeld (#4488) | move toward `true` | implemented, staged rollout |
 | [`cfcPolicyEvaluation`](#cfcpolicyevaluation) | `RuntimeOptions.cfcPolicyEvaluation` | `off` | Bernhard Seefeld (#4566) | move toward `enforce` | implemented, staged rollout |
+| [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` first, then `enforce` | implemented, off by default |
 | [`cfcDeclaredMonotonicity`](#cfcdeclaredmonotonicity) | `RuntimeOptions.cfcDeclaredMonotonicity` | `off` | Bernhard Seefeld (#4647) | `observe` first, then `enforce` (must soak before the §8.12.7 route 2b event ships) | implemented, off by default |
 | [`cfcPrefixProvenanceStats`](#cfcprefixprovenancestats) | `RuntimeOptions.cfcPrefixProvenanceStats` (per-deployment; not env-wired) | `false` | Bernhard Seefeld (#4623) | stays a measurement opt-in; fold in or remove after Stage 0 | implemented, off by default, measurement only |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
@@ -326,6 +327,32 @@ the per-epic implementation notes).
 - **Status on 2026-07-08.** Implemented and in staged rollout.
 - **Path to removal.** Once policy evaluation is the norm, the dial could settle
   on `enforce` and be retired.
+
+### `cfcLabelMetadataProtection`
+
+- **Toggle via.** `RuntimeOptions.cfcLabelMetadataProtection`.
+- **Added by.** Bernhard Seefeld, in "inv-12 stage 1 — cross-space
+  label-metadata representation transform (SC-25, spec §4.6.4.1)" (#4638,
+  2026-07-09).
+- **Purpose.** Controls how a label's metadata is represented when the label
+  crosses a space boundary and is persisted. Values are `off`, `observe`, and
+  `enforce`. `off` persists the label bytes byte-identical to before the dial
+  existed. `observe` computes the classification-governed transformed form for
+  cross-space entries and emits a structured diagnostic when it differs from the
+  verbatim form (the divergence count is the rollout metric), but still persists
+  the verbatim bytes. `enforce` persists the transformed form, with
+  commitment-class atom fields replaced by their canonical digest markers
+  (`{digestOf: <hash>}`). The transform is representation-only — it never rejects
+  a commit.
+- **Current default and planned end state.** `off` by default. The target is
+  `observe`, then `enforce` once the divergence metric confirms the transform is
+  stable across cross-space traffic
+  (`docs/specs/cfc-label-metadata-confidentiality.md` §2/§5).
+- **Status on 2026-07-09.** Implemented, off by default.
+- **Path to removal.** Not planned for removal: the confidential representation
+  of cross-space label metadata is a permanent store property. Once `enforce`
+  has soaked, the dial could settle there and the `off`/`observe` rungs remain
+  for diagnostics, mirroring the enforcement ladder.
 
 ### `cfcDeclaredMonotonicity`
 


### PR DESCRIPTION
## Summary

Registers the `cfcLabelMetadataProtection` CFC dial in the central experimental-options registry (`docs/development/EXPERIMENTAL_OPTIONS.md`). The dial shipped in #4638 (inv-12 Stage 1 / SC-25 — cross-space label-metadata representation transform) but had no summary-table row and no section in the registry, which `AGENTS.md` / `docs/development/EXPERIMENTAL_OPTIONS.md` require for every experimental flag.

Adds, mirroring the neighboring `cfcPolicyEvaluation` / `cfcDeclaredMonotonicity` entries:

- A **summary-table row** (`RuntimeOptions.cfcLabelMetadataProtection`, default `off`, `observe` first then `enforce`, off by default), placed between `cfcPolicyEvaluation` and `cfcDeclaredMonotonicity` to match the preset-classification ordering.
- A **full section** with the six standard fields: Toggle via / Added by / Purpose / Current default and planned end state / Status / Path to removal.

Semantics are taken from the `CfcLabelMetadataProtectionMode` doc comment in `packages/runner/src/cfc/types.ts`: `off` = byte-identical persistence; `observe` = compute the classification-governed transformed form for cross-space entries and emit a divergence diagnostic but persist verbatim; `enforce` = persist the transformed form with commitment-class atom fields replaced by canonical `{digestOf: <hash>}` digest markers. The transform is representation-only and never rejects a commit.

Spec: `docs/specs/cfc-label-metadata-confidentiality.md` §2/§5, spec §4.6.4.1.

## Testing

- `deno task check-docs` — passed (all 533 checked code blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register the `cfcLabelMetadataProtection` experimental dial in `docs/development/EXPERIMENTAL_OPTIONS.md` for inv-12 Stage 1 to document cross-space label metadata persistence. Adds the summary-table row and a full section for `RuntimeOptions.cfcLabelMetadataProtection` (`off` | `observe` | `enforce`, default `off`), including diagnostics in `observe` and digest-marker persistence in `enforce`.

<sup>Written for commit 0395c41ff4e3052bf0716c33efcc7d7290ae8ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

