### PR TITLE
feat(cfc): B2b label-carried policy selection, clause-local (CT-1874) — space-hosted policy docs descoped per attested-config decision

### DIFF
--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -237,10 +237,19 @@ consumes inbound views, redacting the outbound copies is safe.
   deployment the default stays `commitment`; `reference` is admissible only
   with per-reader materialization proven on realistic flows, and only for
   the highest-sensitivity fields. Grants and `commitment`-form labels
-  satisfy the rule as-is; B2a's deployment-config policy source does not
-  (federated instances with different `cfcPolicyRecords` silently fire
-  different rules — B2b's space-hosted, replicating policy docs are the
-  federation-correct source).
+  satisfy the rule as-is. The deployment-config policy source
+  (`cfcPolicyRecords`) satisfies it through the ATTESTATION channel rather
+  than replication (revised owner decision 2026-07-10, superseding this
+  note's earlier "federation-hostile" conclusion; SC-28 in
+  [`cfc-spec-changes.md`](./cfc-spec-changes.md)): remote attestation
+  covers deployment config for security-sensitive inputs, so attested
+  federated peers provably run the same record set — a config difference is
+  an attestation difference, never a silent rule divergence. The
+  space-hosted policy docs originally scheduled as B2b are descoped; the
+  label-carried `Policy(...)`/`Context(...)` selection half of B2b shipped
+  against the deployment snapshot (its ref fields classified in the §2
+  table: name/hash public so refs stay dereferenceable at the destination,
+  subject commitment).
 
 Dependencies: none on Epics B/D/E remainder; Stage 2's full population
 profile co-builds with the SC-4/SC-8 envelope design. The D4 value-level

--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -26,10 +26,13 @@ persists into a space-B document:
 | `cfc.schemaHash` + replicated schema doc (`ensureSchemaDocument`) | policy structure, field names | schema-driven enforcement |
 
 Two corrections to the audit item's inherited wording: `Origin` URIs have **no
-mint site** in the runner (nothing persists them), and **policy names are never
-persisted** (B2a policy ids reach the prepared digest only; label-carried
-`Policy(...)` is B2b, unbuilt). The live leak set is the DID-bearing rows
-above.
+mint site** in the runner (nothing persists them), and policy names were never
+persisted **until label-carried `Policy(...)`/`Context(...)` refs shipped**
+(B2b label-carried selection, 2026-07-09): a ref atom persists `name` + `hash`
+(public by design — they identify a deployment policy profile and must stay
+dereferenceable against the destination's snapshot) and a DID `subject`
+(commitment, same posture as `User.subject`). The live leak set is the
+DID-bearing rows above.
 
 Three structural facts shape everything below:
 
@@ -91,6 +94,8 @@ Default assignments (initial table, revisable per family):
 | `Caveat.source`, nested caveat sources | commitment | consumed by equality-shaped evidence binding; the audit's named leak |
 | `User.subject` / `PersonalSpace.owner` in confidentiality clauses | commitment | gating is pure equality against the acting reader |
 | `Space.id` in clauses | **public** (initially) | §4.9.3 must dereference it for the ACL point query; a commitment breaks membership-based release. Space DIDs identify a *container*, not a person; revisit under `reference` when cross-space resolution ships |
+| `Policy`/`Context` ref `.name`/`.hash` | **public** | B2b label-carried selection must dereference them against the destination's deployment snapshot (the `Space.id` argument); they identify a policy profile, not a person, and `hash` is already a content digest |
+| `Policy`/`Context` ref `.subject` | commitment | a DID, equality-shaped at selection (well-formedness only — selection keys on name+hash and accepts the commitment marker); rules binding variables from it fail closed at the destination, the narrow direction |
 | `LinkReference.source/target` | commitment (paths), public (space? no — commitment) | display/provenance only; nothing dereferences the persisted copy |
 | `TransformedBy.identity.sourceFile/bindingPath` | commitment | human-readable code layout is the leak; trust statements should bind the content-addressed `moduleIdentity` (public) instead |
 | `authored-by` / `represents-principal` `.subject` | public | product-displayed attribution, minted under the acting principal's own authority |

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -165,12 +165,12 @@ rewrite event:
    `experimental.commitPreconditions`; blocked only on that flag's
    maturation, not on new machinery.
 
-Dependency note (revised 2026-07-09): the B2b space-hosted policy-doc plan
+Dependency note (revised 2026-07-10): the B2b space-hosted policy-doc plan
 this substrate was to be shared with is DESCOPED — the owner decision is
 that remote attestation covers deployment config for security-sensitive
 inputs like `cfcPolicyRecords`, so attested federated peers provably
 evaluate the same record set and space-hosted policy documents are not
-needed for federation soundness (`cfc-spec-changes.md` SC-27). What B2b
+needed for federation soundness (`cfc-spec-changes.md` SC-28). What B2b
 still meant beyond storage shipped against the deployment snapshot:
 label-carried `Policy(...)`/`Context(...)` selection with the CT-1874
 home-clause gate (`referenced` records in `policy.ts` /

--- a/docs/specs/cfc-persisted-declassification.md
+++ b/docs/specs/cfc-persisted-declassification.md
@@ -54,9 +54,11 @@ Two artifacts of exactly this kind already exist or are specced:
   surface concept, share authority).
 
 A grant generalizes both: a content-addressed record at a reserved space-root
-path (the B2b storage discipline: "content-addressed records verified on
-read, read under `internalVerifierRead` so policy lookups never taint"),
-written only by a trusted policy writer, shaped
+path (the storage discipline the archived B2b plan first named:
+"content-addressed records verified on read, read under
+`internalVerifierRead` so policy lookups never taint" — grants are now its
+sole consumer, see the dependency note below), written only by a trusted
+policy writer, shaped
 
 ```ts
 // Shown for illustration only.
@@ -125,9 +127,11 @@ Properties inherited for free:
    invalidation discipline — a grant changed between prepare and commit
    invalidates).
 4. **Clause locality**: a grant releases only the clause(s) its consuming
-   rule matched — inherited from the evaluator, but the B2b home-clause
-   constraint (CT-1874) applies identically when grants are discovered from
-   label-carried atoms: a grant referenced from clause k must not widen
+   rule matched — inherited from the evaluator, where the CT-1874
+   home-clause gate is now SHIPPED for label-carried policy selection
+   (`referenced` records rewrite only the ref atom's home clauses,
+   `exchange-eval.ts`); it applies identically when grants are discovered
+   from label-carried atoms: a grant referenced from clause k must not widen
    clause j ≠ k.
 5. **Cross-space representation**: a grant names DIDs; when its *existence*
    crosses spaces it is label-adjacent metadata and the inv-12 classification
@@ -150,8 +154,8 @@ rewrite event:
 
 1. `policyState` guard kind + grant resolution in `exchange-eval.ts`
    (evaluator change is additive; guards default-absent).
-2. Reserved grant path + trusted-writer gate + §3.1.8 validation (storage
-   discipline shared with B2b's policy docs — build once).
+2. Reserved grant path + trusted-writer gate + §3.1.8 validation (the
+   reserved-path, content-addressed, verify-on-read storage discipline).
 3. Digest binding of consulted grants.
 4. ShareGrant end-to-end: share UI → (until §6 intents ship) a
    trusted-builtin writer verifying authority directly → grant → release on
@@ -161,11 +165,18 @@ rewrite event:
    `experimental.commitPreconditions`; blocked only on that flag's
    maturation, not on new machinery.
 
-Dependency note: (1)+(2) are B2b-adjacent — the same reserved-path,
-content-addressed, verify-on-read machinery. If B2b is built first, grants
-are a second record kind on the same substrate; if grants go first, B2b
-inherits the substrate. Either order, with CT-1874's home-clause gate in the
-shared selection layer.
+Dependency note (revised 2026-07-09): the B2b space-hosted policy-doc plan
+this substrate was to be shared with is DESCOPED — the owner decision is
+that remote attestation covers deployment config for security-sensitive
+inputs like `cfcPolicyRecords`, so attested federated peers provably
+evaluate the same record set and space-hosted policy documents are not
+needed for federation soundness (`cfc-spec-changes.md` SC-27). What B2b
+still meant beyond storage shipped against the deployment snapshot:
+label-carried `Policy(...)`/`Context(...)` selection with the CT-1874
+home-clause gate (`referenced` records in `policy.ts` /
+`exchange-eval.ts`). Grants therefore remain the ONE space-hosted policy
+state, and this section's reserved-path machinery has no second consumer
+planned.
 
 _Implementation note (2026-07-09): items 1–3 shipped in #4627. The
 `policyState` guard resolves through `ExchangeEvalContext.grantResolver`
@@ -254,9 +265,9 @@ already works today with no new machinery.
 ## 5. Entry criteria
 
 Build **grants** when a product surface needs durable sharing (the share UI,
-group-membership beyond space ACLs) — B2b-adjacent, no blockers beyond the
-evaluator extension. For the **rewrite event**, the dependency picture at
-mechanism level (2026-07-09):
+group-membership beyond space ACLs) — no blockers; the evaluator extension
+and storage substrate shipped in #4627. For the **rewrite event**, the
+dependency picture at mechanism level (2026-07-09):
 
 - **Exists**: single-use consumption — `experimental.commitPreconditions`
   receipts (durable event id, event-causal record ids, create-only

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -499,8 +499,8 @@ scope may rewrite ONLY that principal's home clause(s), the mechanical form
 of §5.3.3's clause-local declassification authority (§4.4.5's informative
 pseudocode selects target clauses purely by pattern match and would
 otherwise let a policy referenced in clause k widen sibling clause j: a
-cross-principal implicit release, invariant 11/§3.1.8(3)). Runner-side, in
-the PR introducing this entry: the surviving non-storage half of B2b
+cross-principal implicit release, invariant 11/§3.1.8(3)). Runner-side,
+labs#4652: the surviving non-storage half of B2b
 shipped against the deployment snapshot — `PolicyRecord.selection:
 "ambient" | "referenced"` (`policy.ts`, digest projection v3), hash-bound
 fail-closed ref matching per §4.4.2/§4.4.3, the home-clause gate with

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -473,19 +473,24 @@ audit, and deriving "who could have this" (current grants ∪ past egress).
 State the shared-vs-sent vocabulary distinction normatively so UIs cannot
 present an egress as revocable. `open`.
 
-**SC-27 [normative] Attested deployment config is a federation-sound policy
+**SC-28 [normative] Attested deployment config is a federation-sound policy
 store; space-hosted policy documents descoped — §4.4.1/§4.4.5/§5.7.2.** The
 archived B2b plan (`docs/history/plans/cfc-future-work-implementation.md`
 §3, decision 2) treated `RuntimeOptions.cfcPolicyRecords` as an interim
 source because two federated instances with different deployment config
 would silently fire different exchange rules, and scheduled space-hosted
-policy docs as the federation-correct form. Owner decision (2026-07-09,
-revising this): remote attestation covers deployment config for
-security-sensitive inputs like `cfcPolicyRecords` — the §5.7.2
-runtime-environment claims extend to the enforcement configuration the
-runtime boots with (measured image identity covers it) — so attested
-federated peers provably evaluate the same record set, and space-hosted
-policy documents are not needed for federation soundness. Proposed edit:
+policy docs as the federation-correct form — restated as recently as the
+SC-14 Stage-3 federation constraint ("B2a's deployment-config policy source
+is federation-hostile"). Revised owner decision (2026-07-10, extending the
+same day's federation resolution — SC-26's superseded note, SC-27): remote
+attestation covers deployment config for security-sensitive inputs like
+`cfcPolicyRecords` — the §5.7.2 runtime-environment claims extend to the
+enforcement configuration the runtime boots with (measured image identity
+covers it) — so attested federated peers provably evaluate the same record
+set, and space-hosted policy documents are not needed for federation
+soundness (the Stage-3 note's conclusion is superseded in place; its
+*evidence replicates, evaluation is local* rule stands — config rides the
+attested evaluator, not the data). Proposed edit:
 §4.4.1's storage-location list gains the attested deployment/system policy
 root as a sanctioned primary store (space-hosted discovery stays optional,
 never required for federation); §4.4.5 adds the CT-1874/SP-1 constraint —

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -447,6 +447,36 @@ shipped as labs#4627 (`policyState` guards, owner-space `grant:cfc:` records,
 consulted-grant digest binding); the rewrite event stays unscheduled per
 `cfc-persisted-declassification.md` §5.
 
+**SC-27 [normative] Attested deployment config is a federation-sound policy
+store; space-hosted policy documents descoped — §4.4.1/§4.4.5/§5.7.2.** The
+archived B2b plan (`docs/history/plans/cfc-future-work-implementation.md`
+§3, decision 2) treated `RuntimeOptions.cfcPolicyRecords` as an interim
+source because two federated instances with different deployment config
+would silently fire different exchange rules, and scheduled space-hosted
+policy docs as the federation-correct form. Owner decision (2026-07-09,
+revising this): remote attestation covers deployment config for
+security-sensitive inputs like `cfcPolicyRecords` — the §5.7.2
+runtime-environment claims extend to the enforcement configuration the
+runtime boots with (measured image identity covers it) — so attested
+federated peers provably evaluate the same record set, and space-hosted
+policy documents are not needed for federation soundness. Proposed edit:
+§4.4.1's storage-location list gains the attested deployment/system policy
+root as a sanctioned primary store (space-hosted discovery stays optional,
+never required for federation); §4.4.5 adds the CT-1874/SP-1 constraint —
+rules a label-carried `Policy(...)`/`Context(...)` principal brings into
+scope may rewrite ONLY that principal's home clause(s), the mechanical form
+of §5.3.3's clause-local declassification authority (§4.4.5's informative
+pseudocode selects target clauses purely by pattern match and would
+otherwise let a policy referenced in clause k widen sibling clause j: a
+cross-principal implicit release, invariant 11/§3.1.8(3)). Runner-side, in
+the PR introducing this entry: the surviving non-storage half of B2b
+shipped against the deployment snapshot — `PolicyRecord.selection:
+"ambient" | "referenced"` (`policy.ts`, digest projection v3), hash-bound
+fail-closed ref matching per §4.4.2/§4.4.3, the home-clause gate with
+per-batch recomputation (`exchange-eval.ts`), and inv-12 representation
+rows for the ref atom's fields (name/hash public, subject commitment);
+grants (labs#4627) remain the one space-hosted policy state. `open`.
+
 ## Queue (from the audit; statuses re-checked by the 2026-06-12 sweep where
 ## noted)
 

--- a/packages/api/cfc-atoms.ts
+++ b/packages/api/cfc-atoms.ts
@@ -17,6 +17,7 @@ export type {
   CfcJsonArray,
   CfcJsonValue,
   CfcPersonalSpaceAtom,
+  CfcPolicyRefAtom,
   CfcPromptSlotBoundAtom,
   CfcPromptSlotInfluenceAtom,
   CfcPromptSlotRunManifest,

--- a/packages/api/cfc-authoring.ts
+++ b/packages/api/cfc-authoring.ts
@@ -21,6 +21,7 @@ export type {
   CfcJsonArray,
   CfcJsonValue,
   CfcPersonalSpaceAtom,
+  CfcPolicyRefAtom,
   CfcPromptSlotBoundAtom,
   CfcPromptSlotInfluenceAtom,
   CfcPromptSlotRunManifest,

--- a/packages/api/cfc.ts
+++ b/packages/api/cfc.ts
@@ -43,6 +43,10 @@ export const CFC_ATOM_TYPE = {
   // shape is satisfied via the acting principal's trust closure — never by a
   // literal Concept atom in carried integrity.
   Concept: "https://commonfabric.org/cfc/atom/Concept",
+  // Context principal (confidentiality; spec §4.1.2/§5.1): the CI-context
+  // form of a policy reference — same field shape and selection semantics as
+  // `Policy` (see there).
+  Context: "https://commonfabric.org/cfc/atom/Context",
   // Trusted evidence that a source-linked disclaimer was attached to content
   // emitted through a sink (spec §15.4). Trusted-minted.
   DisclaimerAttached: "https://commonfabric.org/cfc/atom/DisclaimerAttached",
@@ -78,6 +82,13 @@ export const CFC_ATOM_TYPE = {
   // authorable in schemas.
   LlmDerived: "https://commonfabric.org/cfc/atom/LlmDerived",
   Origin: "https://commonfabric.org/cfc/atom/Origin",
+  // Policy principal (confidentiality; spec §4.1.2 PolicyRefAtom, §4.4.2):
+  // references a policy record whose exchange rules may rewrite the clause
+  // the atom sits in — and ONLY that clause (CT-1874 clause-local scoping).
+  // Runtime labels must carry the record's content `hash`; selection fails
+  // closed on mismatch or absence (§4.4.3). Interpreted only by trusted
+  // evaluators at boundary points, never satisfiable as an access principal.
+  Policy: "https://commonfabric.org/cfc/atom/Policy",
   // Hereditary certification (spec §15.1.1 / §3.1.6.1): survives combination
   // via the class-aware meet — present on an output only when present on
   // every input.
@@ -205,6 +216,19 @@ export type CfcExternalIngestAtom = CfcAtomObject & {
 export type CfcUserAtom = CfcAtomObject & {
   readonly type: typeof CFC_ATOM_TYPE.User;
   readonly subject: string;
+};
+
+/**
+ * Hash-bound policy reference (spec §4.1.2 `PolicyRefAtom`): `name` selects
+ * the record, `subject` is the principal the policy speaks for, `hash` binds
+ * the exact record content (required in runtime labels, §4.4.2 — an unbound
+ * name selects nothing). `Policy` and `Context` share the shape.
+ */
+export type CfcPolicyRefAtom = CfcAtomObject & {
+  readonly type: typeof CFC_ATOM_TYPE.Policy | typeof CFC_ATOM_TYPE.Context;
+  readonly name: string;
+  readonly subject: string;
+  readonly hash: string;
 };
 
 export type CfcSpaceAtom = CfcAtomObject & {
@@ -440,6 +464,14 @@ export const cfcAtom = {
 
   user(subject: string): CfcUserAtom {
     return { type: CFC_ATOM_TYPE.User, subject };
+  },
+
+  policyRef(name: string, subject: string, hash: string): CfcPolicyRefAtom {
+    return { type: CFC_ATOM_TYPE.Policy, name, subject, hash };
+  },
+
+  contextRef(name: string, subject: string, hash: string): CfcPolicyRefAtom {
+    return { type: CFC_ATOM_TYPE.Context, name, subject, hash };
   },
 
   space(id: string): CfcSpaceAtom {

--- a/packages/api/test/cfc-atom-mints.test.ts
+++ b/packages/api/test/cfc-atom-mints.test.ts
@@ -30,6 +30,21 @@ Deno.test("cfcAtom mints confidentiality principals and Expires", () => {
   });
 });
 
+Deno.test("cfcAtom mints hash-bound policy references (spec §4.4.2)", () => {
+  assertEquals(cfcAtom.policyRef("share-flow", "did:key:alice", "h1"), {
+    type: CFC_ATOM_TYPE.Policy,
+    name: "share-flow",
+    subject: "did:key:alice",
+    hash: "h1",
+  });
+  assertEquals(cfcAtom.contextRef("primary", "did:key:alice", "h2"), {
+    type: CFC_ATOM_TYPE.Context,
+    name: "primary",
+    subject: "did:key:alice",
+    hash: "h2",
+  });
+});
+
 Deno.test("cfcAtom mints HasRole facts", () => {
   assertEquals(cfcAtom.hasRole("did:key:alice", "space:x", "reader"), {
     type: CFC_ATOM_TYPE.HasRole,

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -9,6 +9,7 @@ import {
   matchAtomPatternAgainstAtoms,
 } from "./atom-pattern.ts";
 import { isRecord } from "@commonfabric/utils/types";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import {
   type CfcConfClause,
   clauseAlternatives,
@@ -16,7 +17,8 @@ import {
   normalizeClause,
 } from "./clause.ts";
 import type { IFCLabel } from "./label-view-core.ts";
-import type { ExchangeRule, PolicySnapshot } from "./policy.ts";
+import { isCfcFieldCommitment } from "./label-representation.ts";
+import type { ExchangeRule, PolicyRecord, PolicySnapshot } from "./policy.ts";
 import type { TrustResolver } from "./trust.ts";
 
 /**
@@ -37,10 +39,20 @@ import type { TrustResolver } from "./trust.ts";
  * (B2a rules carry no integrity postcondition). Evaluation is evaluation-
  * time only — rewritten labels are never persisted (design decision 1).
  *
- * B2a rule scoping: every record in the snapshot is in scope for every label
- * (the degenerate single-policy-root case) — each rule is still gated by its
- * own `appliesTo` + guards. Label-carried `Policy(...)` principals selecting
- * records arrive with B2b.
+ * Rule scoping (B2b, label-carried selection): `ambient` records are in
+ * scope for every label (the B2a posture — operator-vetted standard
+ * profiles; spec §4.4.1's deployment/system policy root), each rule still
+ * gated by its own `appliesTo` + guards. `referenced` records are in scope
+ * only where the CURRENT label carries a matching hash-bound
+ * `Policy(...)`/`Context(...)` ref atom (§4.4.2/§4.4.3, fail-closed on
+ * mismatch or absence), and their rules may rewrite ONLY the ref's home
+ * clause(s) — the CT-1874 constraint; see `matchRule`. Records live in the
+ * deployment snapshot in both modes: the owner decision (2026-07-09,
+ * revising the earlier space-hosted-docs plan) is that remote attestation
+ * covers deployment config for security-sensitive inputs like
+ * `cfcPolicyRecords`, so attested federated peers provably evaluate the
+ * same record set and space-hosted policy documents are not needed for
+ * federation soundness (docs/specs/cfc-spec-changes.md SC-27).
  *
  * Termination (spec §4.4.5): add-only rule sets converge by monotonicity;
  * add+drop sets can cycle, so the evaluator is fuelled and FAILS CLOSED on
@@ -150,6 +162,63 @@ type RuleMatch = {
   readonly bindings: AtomPatternBindings;
 };
 
+/** The two policy-principal families a label may select records by
+ * (spec §4.1.2 `PolicyRefAtom`; §4.4.5 `collectPolicyPrincipals`). */
+const POLICY_REF_ATOM_TYPES: ReadonlySet<string> = new Set([
+  CFC_ATOM_TYPE.Policy,
+  CFC_ATOM_TYPE.Context,
+]);
+
+/**
+ * Clause indices whose alternatives carry a well-formed policy-ref atom
+ * selecting `record`: type `Policy`/`Context`, `name` === record id, `hash`
+ * === record digest (both non-empty strings), and a non-empty string
+ * `subject`. Anything less — an unbound name atom (no hash, §4.4.2 requires
+ * it in runtime labels), a name/hash mismatch or cross-wiring, a malformed
+ * shape — selects NOTHING (the §4.4.3 fail-closed lookup posture; the
+ * intended widening simply does not happen, which is strictly narrower).
+ *
+ * Computed fresh against the CURRENT confidentiality for every rule batch:
+ * drop firings splice clauses and shift indices, so a set computed at pass
+ * start could admit whatever clause shifted into a stale home index; and
+ * rules may ADD policy refs as alternatives, which must be in scope for the
+ * very next batch (spec §4.4.5 recomputes policy principals per pass).
+ */
+const policyRefHomeClauses = (
+  record: PolicyRecord,
+  confidentiality: readonly CfcConfClause[],
+): ReadonlySet<number> => {
+  const homes = new Set<number>();
+  if (record.digest.length === 0) return homes;
+  for (let index = 0; index < confidentiality.length; index++) {
+    for (const alternative of clauseAlternatives(confidentiality[index])) {
+      if (!isRecord(alternative) || Array.isArray(alternative)) continue;
+      const atom = alternative as {
+        type?: unknown;
+        name?: unknown;
+        subject?: unknown;
+        hash?: unknown;
+      };
+      if (
+        typeof atom.type === "string" &&
+        POLICY_REF_ATOM_TYPES.has(atom.type) &&
+        atom.name === record.id && atom.hash === record.digest &&
+        // Selection keys on name+hash; `subject` is only checked
+        // well-formed. It is DID-bearing, so the inv-12 cross-space
+        // transform persists it commitment-form ({digestOf}) — a ref that
+        // crossed spaces must still select (name/hash are classified
+        // public exactly so this dereference keeps working).
+        ((typeof atom.subject === "string" && atom.subject.length > 0) ||
+          isCfcFieldCommitment(atom.subject))
+      ) {
+        homes.add(index);
+        break;
+      }
+    }
+  }
+  return homes;
+};
+
 /**
  * Builds the {@link CfcGrantResolverQuery} for one `policyState` guard
  * pattern under one binding environment, or `undefined` when the pattern is
@@ -239,12 +308,24 @@ const extendThroughGrantGuard = (
  * clause/alternative; remaining guards must all be satisfiable under one
  * shared environment. Every consistent environment is its own match — the
  * §4.3.4 disjunction of all valid bindings.
+ *
+ * `homeClauses` (label-carried selection, CT-1874/SP-1) restricts which
+ * clauses may be the REWRITE TARGET: a rule brought into scope by a policy
+ * ref may only rewrite the clause(s) carrying that ref — the clause whose
+ * author admitted the policy as an alternative. Without the tie, a policy
+ * referenced in clause 0 could add alternatives to an independent sibling
+ * clause 1: a cross-principal implicit release (invariant 11, spec
+ * §3.1.8(3)/§5.3.3). Guards are deliberately NOT restricted: side conditions
+ * under an explicit `preConfScope: "anywhere"` may still READ sibling
+ * clauses — observation feeding a home-clause-local widening stays within
+ * the authority the home clause's author granted.
  */
 const matchRule = (
   rule: ExchangeRule,
   confidentiality: readonly CfcConfClause[],
   availableIntegrity: readonly unknown[],
   ctx: ExchangeEvalContext,
+  homeClauses?: ReadonlySet<number>,
 ): RuleMatch[] => {
   const matches: RuleMatch[] = [];
   const anywhereAlternatives = rule.preConfScope === "anywhere"
@@ -256,6 +337,7 @@ const matchRule = (
     clauseIndex < confidentiality.length;
     clauseIndex++
   ) {
+    if (homeClauses !== undefined && !homeClauses.has(clauseIndex)) continue;
     const alternatives = clauseAlternatives(confidentiality[clauseIndex]);
     for (const alternative of alternatives) {
       const target = matchAtomPattern(rule.appliesTo, alternative);
@@ -434,7 +516,7 @@ export const evaluateExchangeRules = (
   ctx: ExchangeEvalContext = {},
   fuel: number = DEFAULT_EXCHANGE_FUEL,
 ): ExchangeEvalResult => {
-  const rules: Array<{ recordId: string; rule: ExchangeRule }> = [];
+  const rules: Array<{ record: PolicyRecord; rule: ExchangeRule }> = [];
   if (snapshot !== undefined) {
     // Canonical UTF-8 code-point order (not JS `<`, which orders UTF-16 code
     // UNITS and disagrees on astral ids) so evaluation and diagnostic order
@@ -447,7 +529,7 @@ export const evaluateExchangeRules = (
       for (
         const rule of [...record.rules].sort((a, b) => utf8Compare(a.id, b.id))
       ) {
-        rules.push({ recordId: record.id, rule });
+        rules.push({ record, rule });
       }
     }
   }
@@ -472,8 +554,25 @@ export const evaluateExchangeRules = (
 
   while (changed) {
     changed = false;
-    for (const { recordId, rule } of rules) {
-      const matches = matchRule(rule, confidentiality, availableIntegrity, ctx);
+    for (const { record, rule } of rules) {
+      // B2b selection scope: ambient records match every clause; anything
+      // else is label-carried — in scope only where the CURRENT label
+      // references it. The non-"ambient" (rather than === "referenced") arm
+      // keeps a hand-built snapshot with a missing/garbled selection on the
+      // NARROW path — degrading it to ambient would fire rules its author
+      // scoped to references (the guard-degradation posture, cubic P1 on
+      // #4627).
+      const homeClauses = record.selection === "ambient"
+        ? undefined
+        : policyRefHomeClauses(record, confidentiality);
+      if (homeClauses !== undefined && homeClauses.size === 0) continue;
+      const matches = matchRule(
+        rule,
+        confidentiality,
+        availableIntegrity,
+        ctx,
+        homeClauses,
+      );
       // Index discipline (spec §4.4.5): adds never shift clause indices, so
       // add-matches apply in order; drop-matches apply back-to-front. A
       // match whose target was consumed by an earlier application in this
@@ -507,7 +606,11 @@ export const evaluateExchangeRules = (
         }
         remainingFuel -= 1;
         confidentiality = applied.confidentiality;
-        firings.push({ recordId, ruleId: rule.id, ...applied.firing! });
+        firings.push({
+          recordId: record.id,
+          ruleId: rule.id,
+          ...applied.firing!,
+        });
         changed = true;
       }
     }

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -47,12 +47,12 @@ import type { TrustResolver } from "./trust.ts";
  * `Policy(...)`/`Context(...)` ref atom (§4.4.2/§4.4.3, fail-closed on
  * mismatch or absence), and their rules may rewrite ONLY the ref's home
  * clause(s) — the CT-1874 constraint; see `matchRule`. Records live in the
- * deployment snapshot in both modes: the owner decision (2026-07-09,
+ * deployment snapshot in both modes: the owner decision (2026-07-10,
  * revising the earlier space-hosted-docs plan) is that remote attestation
  * covers deployment config for security-sensitive inputs like
  * `cfcPolicyRecords`, so attested federated peers provably evaluate the
  * same record set and space-hosted policy documents are not needed for
- * federation soundness (docs/specs/cfc-spec-changes.md SC-27).
+ * federation soundness (docs/specs/cfc-spec-changes.md SC-28).
  *
  * Termination (spec §4.4.5): add-only rule sets converge by monotonicity;
  * add+drop sets can cycle, so the evaluator is fuelled and FAILS CLOSED on

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -66,7 +66,7 @@ import type {
  * by living in the space it governs. Grants hosted in shared spaces (a team
  * space's policy root) need per-document write-attribution verification —
  * future work on its own track: the B2b space-hosted policy-doc plan this
- * was once coupled to is descoped (SC-27: attestation covers deployment
+ * was once coupled to is descoped (SC-28: attestation covers deployment
  * config; policy records stay in `RuntimeOptions.cfcPolicyRecords`), which
  * leaves grants as the one space-hosted policy state.
  */
@@ -221,7 +221,7 @@ export const prepareCfcGrantWrite = (
     // v1 governing-space posture (module doc): grants live in the owner's
     // identity space. Shared-space grant roots need per-document
     // write-attribution verification (future work; no longer coupled to the
-    // descoped B2b policy-doc storage — SC-27).
+    // descoped B2b policy-doc storage — SC-28).
     throw new Error(
       "cfc-grant: space must equal owner (grants live in the owner's " +
         "identity space; shared-space grant roots are future work)",

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -59,13 +59,16 @@ import type {
  *   does not hash to the address it sits at (a forgery/corruption), before
  *   any lifecycle or audience check. Fail closed throughout.
  *
- * The GOVERNING SPACE for this PR is the owner's identity space
- * (`space === owner`): only the owner (and their runtime) holds write
- * authority there, so a verified document at the derived address carries the
- * owner's release authority implicitly — the same way the space ACL document
- * is owner-gated by living in the space it governs. Grants hosted in shared
- * spaces (a team space's policy root) need per-document write-attribution
- * verification and arrive with the B2b space-hosted policy work.
+ * The GOVERNING SPACE is the owner's identity space (`space === owner`):
+ * only the owner (and their runtime) holds write authority there, so a
+ * verified document at the derived address carries the owner's release
+ * authority implicitly — the same way the space ACL document is owner-gated
+ * by living in the space it governs. Grants hosted in shared spaces (a team
+ * space's policy root) need per-document write-attribution verification —
+ * future work on its own track: the B2b space-hosted policy-doc plan this
+ * was once coupled to is descoped (SC-27: attestation covers deployment
+ * config; policy records stay in `RuntimeOptions.cfcPolicyRecords`), which
+ * leaves grants as the one space-hosted policy state.
  */
 
 /** Reserved id scheme for grant documents. The whole document is policy
@@ -216,10 +219,12 @@ export const prepareCfcGrantWrite = (
   const space = input.space ?? owner;
   if (space !== owner) {
     // v1 governing-space posture (module doc): grants live in the owner's
-    // identity space. Shared-space policy roots arrive with B2b.
+    // identity space. Shared-space grant roots need per-document
+    // write-attribution verification (future work; no longer coupled to the
+    // descoped B2b policy-doc storage — SC-27).
     throw new Error(
       "cfc-grant: space must equal owner (grants live in the owner's " +
-        "identity space until B2b space-hosted policy roots)",
+        "identity space; shared-space grant roots are future work)",
     );
   }
   if (
@@ -291,7 +296,7 @@ export const prepareCfcGrantWrite = (
 };
 
 /**
- * Verify-on-read (B2b storage discipline): a stored value is a grant only if
+ * Verify-on-read (the grants storage discipline): a stored value is a grant only if
  * it is shape-valid AND its identity fields re-derive the exact address it
  * was read from AND its audience passes the §3.1.8 principal-like validation
  * (defense in depth — a document written by a client that skipped the write

--- a/packages/runner/src/cfc/label-field-classification.ts
+++ b/packages/runner/src/cfc/label-field-classification.ts
@@ -81,6 +81,20 @@ export const LABEL_FIELD_CLASSIFICATION:
     // `reference` when cross-space resolution ships." (The SC-25 recorded
     // initial-assignment exception.)
     entry({ type: CFC_ATOM_TYPE.Space }, ["id"], "public"),
+    // Policy/Context refs (B2b label-carried selection): `name`/`hash` →
+    // public — selection must DEREFERENCE them against the deployment
+    // snapshot at the destination (the Space.id argument); both identify a
+    // deployment policy profile, not a person, and `hash` is already a
+    // content digest. `subject` → commitment — a DID, equality-consumed at
+    // selection (same posture as User.subject); rules binding a variable
+    // FROM a commitment-form subject fail closed at the destination, which
+    // is the narrow direction.
+    entry({ type: CFC_ATOM_TYPE.Policy }, ["name"], "public"),
+    entry({ type: CFC_ATOM_TYPE.Policy }, ["hash"], "public"),
+    entry({ type: CFC_ATOM_TYPE.Policy }, ["subject"], "commitment"),
+    entry({ type: CFC_ATOM_TYPE.Context }, ["name"], "public"),
+    entry({ type: CFC_ATOM_TYPE.Context }, ["hash"], "public"),
+    entry({ type: CFC_ATOM_TYPE.Context }, ["subject"], "commitment"),
     // "LinkReference.source/target → commitment — display/provenance only;
     // nothing dereferences the persisted copy."
     entry({ type: CFC_ATOM_TYPE.LinkReference }, ["source"], "commitment"),

--- a/packages/runner/src/cfc/policy.ts
+++ b/packages/runner/src/cfc/policy.ts
@@ -13,7 +13,7 @@ import type { AtomPattern } from "./atom-pattern.ts";
  * for security-sensitive inputs like this one, so attested federated peers
  * provably evaluate the same record set and the originally planned
  * space-hosted policy documents are not needed for federation soundness
- * (owner decision 2026-07-09; docs/specs/cfc-spec-changes.md SC-27). Rule
+ * (owner decision 2026-07-10; docs/specs/cfc-spec-changes.md SC-28). Rule
  * scoping is per record: `ambient` records apply through their rules'
  * `appliesTo` patterns to every label (spec §4.4.1's deployment/system
  * policy root as a discovery source); `referenced` records are selected by

--- a/packages/runner/src/cfc/policy.ts
+++ b/packages/runner/src/cfc/policy.ts
@@ -72,15 +72,31 @@ export type ExchangeRule = {
 };
 
 /**
+ * How a record enters evaluation scope (B2b label-carried selection):
+ *
+ * - `ambient` (default, the B2a posture): in scope for every evaluated label
+ *   — the operator-vetted standard profiles (B6 sanitizer, display), spec
+ *   §4.4.1's deployment/system policy root as a discovery source.
+ * - `referenced`: in scope ONLY where a label clause carries a policy-ref
+ *   atom (`Policy(...)`/`Context(...)`, spec §4.4.2) whose `name` matches the
+ *   record id AND whose `hash` matches the record digest — and its rules may
+ *   rewrite only that atom's home clause(s) (CT-1874 / invariant 11: a policy
+ *   admitted as one clause's alternative must not widen sibling clauses).
+ */
+export type CfcPolicySelection = "ambient" | "referenced";
+
+/**
  * A named, digest-bound set of exchange rules (spec §4.3.1, reduced to the
- * B2a surface: `id` + `rules`). `digest` is COMPUTED content-addressing over
- * the canonical record content — never trusted from input (a supplied digest
- * is verified and mismatch fails closed, §4.4.3 discipline).
+ * B2a surface: `id` + `rules` + `selection`). `digest` is COMPUTED
+ * content-addressing over the canonical record content — never trusted from
+ * input (a supplied digest is verified and mismatch fails closed, §4.4.3
+ * discipline).
  */
 export type PolicyRecord = {
   readonly id: string;
   readonly digest: string;
   readonly rules: readonly ExchangeRule[];
+  readonly selection: CfcPolicySelection;
 };
 
 /**
@@ -102,9 +118,11 @@ export type CfcPolicyRecordInput = {
   readonly id: string;
   readonly rules: readonly ExchangeRule[];
   readonly digest?: string;
+  /** Scope mode (see {@link CfcPolicySelection}); defaults to `ambient`. */
+  readonly selection?: CfcPolicySelection;
 };
 
-const RECORD_INPUT_KEYS = new Set(["id", "rules", "digest"]);
+const RECORD_INPUT_KEYS = new Set(["id", "rules", "digest", "selection"]);
 const RULE_KEYS = new Set([
   "id",
   "appliesTo",
@@ -309,16 +327,22 @@ const validateExchangeRule = (rule: unknown, where: string): ExchangeRule => {
 const policyRecordDigest = (
   id: string,
   rules: readonly ExchangeRule[],
+  selection: CfcPolicySelection,
 ): string =>
   hashStringOf({
-    // Version 2: the digestible projection gained `policyState` (§8.12.7
-    // route 2a guards). The bump changes every record digest — safe today
-    // because policy digests never persist beyond one process (they are
-    // computed at boot and folded into in-memory prepared digests), and it
-    // keeps the projection canonical: absent == [] by construction, with no
-    // conditional key inclusion.
-    version: 2,
+    // Version 3: the digestible projection gained `selection` (B2b
+    // label-carried scope; absent == "ambient" by construction, no
+    // conditional key inclusion). Version 2 added `policyState` (§8.12.7
+    // route 2a guards). Each bump changes every record digest — safe while
+    // digests only feed in-memory prepared digests, and REQUIRED here: a
+    // selection flip re-scopes every rule, so it must invalidate. NOTE:
+    // from B2b on, label-carried policy-ref atoms persist record digests as
+    // their `hash` binding — a future projection change strands those refs
+    // (they stop matching and fail CLOSED, the §4.4.3/§4.4.4 version-
+    // mismatch posture) until labels re-mint against the new digests.
+    version: 3,
     id,
+    selection,
     rules: rules.map((rule) => ({
       id: rule.id,
       appliesTo: rule.appliesTo,
@@ -360,10 +384,11 @@ export const buildCfcPolicySnapshot = (
       throw new Error("cfcPolicyRecords: each record must be an object");
     }
     rejectUnknownKeys(input, RECORD_INPUT_KEYS, "policy record");
-    const { id, rules, digest } = input as {
+    const { id, rules, digest, selection } = input as {
       id?: unknown;
       rules?: unknown;
       digest?: unknown;
+      selection?: unknown;
     };
     if (typeof id !== "string" || id.length === 0) {
       throw new Error(
@@ -374,6 +399,14 @@ export const buildCfcPolicySnapshot = (
       throw new Error(`cfcPolicyRecords: duplicate record id "${id}"`);
     }
     recordIds.add(id);
+    if (
+      selection !== undefined && selection !== "ambient" &&
+      selection !== "referenced"
+    ) {
+      throw new Error(
+        `cfcPolicyRecords: record "${id}" selection must be "ambient" or "referenced"`,
+      );
+    }
     if (!Array.isArray(rules)) {
       throw new Error(`cfcPolicyRecords: record "${id}" needs a rules array`);
     }
@@ -388,13 +421,23 @@ export const buildCfcPolicySnapshot = (
       ruleIds.add(validated.id);
       return validated;
     });
-    const computedDigest = policyRecordDigest(id, validatedRules);
+    const recordSelection: CfcPolicySelection = selection ?? "ambient";
+    const computedDigest = policyRecordDigest(
+      id,
+      validatedRules,
+      recordSelection,
+    );
     if (digest !== undefined && digest !== computedDigest) {
       throw new Error(
         `cfcPolicyRecords: record "${id}" digest mismatch (expected ${computedDigest})`,
       );
     }
-    records.push({ id, digest: computedDigest, rules: validatedRules });
+    records.push({
+      id,
+      digest: computedDigest,
+      rules: validatedRules,
+      selection: recordSelection,
+    });
   }
   const snapshot: PolicySnapshot = {
     records,

--- a/packages/runner/src/cfc/policy.ts
+++ b/packages/runner/src/cfc/policy.ts
@@ -7,12 +7,18 @@ import type { AtomPattern } from "./atom-pattern.ts";
  * Policy records + exchange rules (spec §4.3/§4.4, Epic B2 of
  * docs/history/plans/cfc-future-work-implementation.md §3).
  *
- * This is stage B2a: a deployment-configured, frozen policy set supplied via
- * `RuntimeOptions.cfcPolicyRecords` — the degenerate single-policy-root case
- * of spec §4.4.1's content-addressed policy storage. Rule scoping happens
- * through each rule's explicit `appliesTo` pattern rather than through
- * label-carried `Policy(...)` principals; space-hosted, hash-bound policy
- * docs (B2b) arrive later and reuse these record shapes verbatim.
+ * A deployment-configured, frozen policy set supplied via
+ * `RuntimeOptions.cfcPolicyRecords` — and, per the revised B2b decision,
+ * the ENDURING record store: remote attestation covers deployment config
+ * for security-sensitive inputs like this one, so attested federated peers
+ * provably evaluate the same record set and the originally planned
+ * space-hosted policy documents are not needed for federation soundness
+ * (owner decision 2026-07-09; docs/specs/cfc-spec-changes.md SC-27). Rule
+ * scoping is per record: `ambient` records apply through their rules'
+ * `appliesTo` patterns to every label (spec §4.4.1's deployment/system
+ * policy root as a discovery source); `referenced` records are selected by
+ * label-carried, hash-bound `Policy(...)`/`Context(...)` principals and
+ * rewrite only their home clauses (CT-1874; `exchange-eval.ts`).
  */
 
 /**

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -12,7 +12,7 @@ import { type AtomPattern, matchAtomPattern } from "./atom-pattern.ts";
  * statements an acting principal accepts, and concept edges order concepts.
  *
  * Mirrors the policy-record posture: a deployment-configured, frozen trust
- * set on `RuntimeOptions` — and, per the revised B2b decision (SC-27 in
+ * set on `RuntimeOptions` — and, per the revised B2b decision (SC-28 in
  * docs/specs/cfc-spec-changes.md), the enduring form: remote attestation
  * covers deployment config for security-sensitive inputs, so attested
  * federated peers provably share it and space-hosted stores are not needed

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -11,9 +11,13 @@ import { type AtomPattern, matchAtomPattern } from "./atom-pattern.ts";
  * concrete principals to concepts, verifier delegations decide whose
  * statements an acting principal accepts, and concept edges order concepts.
  *
- * Mirrors B2a's posture: a deployment-configured, frozen trust set on
- * `RuntimeOptions` (signatures and space-hosted trust stores arrive with the
- * B2b-style storage work; deployment config is already operator-trusted).
+ * Mirrors the policy-record posture: a deployment-configured, frozen trust
+ * set on `RuntimeOptions` — and, per the revised B2b decision (SC-27 in
+ * docs/specs/cfc-spec-changes.md), the enduring form: remote attestation
+ * covers deployment config for security-sensitive inputs, so attested
+ * federated peers provably share it and space-hosted stores are not needed
+ * for federation soundness. Deployment config is already operator-trusted;
+ * signed, space-hosted trust statements would need their own motivation.
  *
  * Determinism contract (the folded-in "trust-snapshot determinism" item):
  * `conceptSatisfied` is a pure function of (frozen config, arguments) — no

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -795,4 +795,217 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       }
     });
   });
+
+  describe("label-carried selection (B2b, CT-1874)", () => {
+    const MALLORY = "did:key:mallory";
+    const SECRET = "https://example.com/atoms/Secret";
+    const secretBob = { type: SECRET, subject: BOB };
+
+    // Referenced share policy: the §4.3.3 space-reader rule, in scope only
+    // where a label clause carries its hash-bound ref atom (spec §4.4.2).
+    const shareInput = {
+      id: "share-flow",
+      selection: "referenced" as const,
+      rules: [spaceReaderRule],
+    };
+    const shareSnapshot = buildCfcPolicySnapshot([shareInput])!;
+    const shareDigest = shareSnapshot.records[0].digest;
+    const shareRef = cfcAtom.policyRef("share-flow", ALICE, shareDigest);
+
+    it("keeps a referenced record OUT of scope without a label-carried ref", () => {
+      const result = evaluateExchangeRules(
+        { confidentiality: [spaceX], integrity: [roleAliceX] },
+        shareSnapshot,
+      );
+      expect(result.firings).toEqual([]);
+      expect(result.label.confidentiality).toEqual([spaceX]);
+    });
+
+    it("fires a referenced record's rule on the ref's home clause only", () => {
+      // spaceY sits in an INDEPENDENT sibling clause that appliesTo also
+      // matches — the home-clause gate must keep the rule off it even though
+      // the evidence (roleAliceY) would satisfy the guard.
+      const result = evaluateExchangeRules(
+        {
+          confidentiality: [{ anyOf: [spaceX, shareRef] }, spaceY],
+          integrity: [roleAliceX, roleAliceY],
+        },
+        shareSnapshot,
+      );
+      expect(result.firings).toEqual([{
+        recordId: "share-flow",
+        ruleId: "space-reader-access",
+        clauseIndex: 0,
+        kind: "add",
+        added: [userAlice],
+      }]);
+      expect(clauseSetsEqual(result.label.confidentiality!, [
+        { anyOf: [spaceX, shareRef, userAlice] },
+        spaceY,
+      ])).toBe(true);
+    });
+
+    it("refuses the CT-1874 laundering trace: a policy referenced in clause 0 never rewrites sibling clause 1", () => {
+      // Mallory's policy is admitted as an ALTERNATIVE of clause 0 by that
+      // clause's author. Its rule targets Secret(?x) — present only in
+      // clause 1, Bob's independent requirement. Firing there would be a
+      // cross-principal implicit release (invariant 11 / spec §3.1.8(3)):
+      // Bob never admitted Mallory's policy as a release path.
+      const evil = buildCfcPolicySnapshot([{
+        id: "evil",
+        selection: "referenced" as const,
+        rules: [{
+          id: "launder",
+          appliesTo: { type: SECRET, subject: { var: "$x" } },
+          post: {
+            addAlternatives: [{ type: CFC_ATOM_TYPE.User, subject: MALLORY }],
+          },
+        }],
+      }])!;
+      const evilRef = cfcAtom.policyRef(
+        "evil",
+        MALLORY,
+        evil.records[0].digest,
+      );
+      const label: IFCLabel = {
+        confidentiality: [{ anyOf: [userAlice, evilRef] }, secretBob],
+      };
+      const result = evaluateExchangeRules(label, evil);
+      expect(result.firings).toEqual([]);
+      expect(clauseSetsEqual(result.label.confidentiality!, [
+        { anyOf: [userAlice, evilRef] },
+        secretBob,
+      ])).toBe(true);
+      expect(result.exhausted).toBe(false);
+    });
+
+    it("selects a ref whose subject crossed spaces in commitment form (inv-12)", () => {
+      // The SC-25 transform persists DID-bearing fields as {digestOf}
+      // markers; name/hash stay public so the destination can still
+      // dereference the snapshot. Selection must accept the transformed
+      // subject — it keys on name+hash and only checks subject well-formed.
+      const committedRef = {
+        type: CFC_ATOM_TYPE.Policy,
+        name: "share-flow",
+        subject: { digestOf: "abc123" },
+        hash: shareDigest,
+      };
+      const result = evaluateExchangeRules(
+        {
+          confidentiality: [{ anyOf: [spaceX, committedRef] }],
+          integrity: [roleAliceX],
+        },
+        shareSnapshot,
+      );
+      expect(result.firings.length).toBe(1);
+      expect(result.firings[0].clauseIndex).toBe(0);
+    });
+
+    it("selects by Context refs exactly like Policy refs", () => {
+      const ctxRef = cfcAtom.contextRef("share-flow", ALICE, shareDigest);
+      const result = evaluateExchangeRules(
+        {
+          confidentiality: [{ anyOf: [spaceX, ctxRef] }],
+          integrity: [roleAliceX],
+        },
+        shareSnapshot,
+      );
+      expect(result.firings.length).toBe(1);
+      expect(result.firings[0].clauseIndex).toBe(0);
+    });
+
+    it("fails closed on unbound, mismatched, or cross-wired refs (§4.4.3)", () => {
+      const other = buildCfcPolicySnapshot([
+        shareInput,
+        {
+          id: "other",
+          selection: "referenced" as const,
+          rules: [dropExpiresRule],
+        },
+      ])!;
+      const otherDigest = other.records.find((r) => r.id === "other")!.digest;
+      const cases: unknown[] = [
+        // Unbound name (no hash) — a schema-time PolicyNameAtom must select
+        // nothing at runtime (§4.4.2: hash required).
+        { type: CFC_ATOM_TYPE.Policy, name: "share-flow", subject: ALICE },
+        // Hash mismatch: the name resolves, the content binding does not.
+        cfcAtom.policyRef("share-flow", ALICE, "sha256:bogus"),
+        // Cross-wired: another record's digest under this record's name.
+        cfcAtom.policyRef("share-flow", ALICE, otherDigest),
+        // Absent record: nothing in the snapshot under this name.
+        cfcAtom.policyRef("unknown", ALICE, shareDigest),
+        // Malformed: no subject.
+        { type: CFC_ATOM_TYPE.Policy, name: "share-flow", hash: shareDigest },
+      ];
+      for (const ref of cases) {
+        const result = evaluateExchangeRules(
+          {
+            confidentiality: [{ anyOf: [spaceX, ref] }],
+            integrity: [roleAliceX],
+          },
+          other,
+        );
+        expect(result.firings).toEqual([]);
+      }
+    });
+
+    it("brings a rule-added ref into scope for the next batch (§4.4.5 recompute)", () => {
+      // An ambient rule ADDS the hash-bound ref as an alternative; the
+      // referenced record's rule must then fire on that clause in the SAME
+      // evaluation ("rules can add policy principals as alternatives, so
+      // this is recomputed" — spec §4.4.5).
+      const adder = {
+        id: "adder",
+        rules: [{
+          id: "add-ref",
+          appliesTo: { type: CFC_ATOM_TYPE.Space, id: "space:x" },
+          post: { addAlternatives: [shareRef] },
+        }],
+      };
+      const combined = buildCfcPolicySnapshot([shareInput, adder])!;
+      const result = evaluateExchangeRules(
+        { confidentiality: [spaceX], integrity: [roleAliceX] },
+        combined,
+      );
+      expect(result.firings.map((f) => f.ruleId)).toEqual([
+        "add-ref",
+        "space-reader-access",
+      ]);
+      expect(clauseSetsEqual(result.label.confidentiality!, [
+        { anyOf: [spaceX, shareRef, userAlice] },
+      ])).toBe(true);
+    });
+
+    it("tracks home clauses across a drop-splice (indices shift mid-evaluation)", () => {
+      // Clause 0 is dropped by an ambient rule earlier in the same pass,
+      // shifting the ref's home from index 1 to 0 — and shifting Bob's
+      // independent Space clause INTO the ref's stale index. Home tracking
+      // must follow the clause, not a pass-start index snapshot: User(alice)
+      // lands in the referenced clause, never in Bob's (which the guard
+      // evidence roleAliceY would otherwise satisfy).
+      const combined = buildCfcPolicySnapshot([
+        { id: "a-expiry", rules: [dropExpiresRule] },
+        shareInput,
+      ])!;
+      const result = evaluateExchangeRules(
+        {
+          confidentiality: [
+            cfcAtom.expires(1234),
+            { anyOf: [spaceX, shareRef] },
+            spaceY,
+          ],
+          integrity: [
+            { type: "https://example.com/atoms/DetectedBy" },
+            roleAliceX,
+            roleAliceY,
+          ],
+        },
+        combined,
+      );
+      expect(clauseSetsEqual(result.label.confidentiality!, [
+        { anyOf: [spaceX, shareRef, userAlice] },
+        spaceY,
+      ])).toBe(true);
+    });
+  });
 });

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -949,6 +949,58 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       }
     });
 
+    it("skips non-record alternatives while locating the home clause", () => {
+      // Legacy string atoms are valid clause alternatives; selection walks
+      // past them (they cannot be refs). Clause 0 holds only the string, so
+      // the walk must scan and skip it before finding the ref in clause 1 —
+      // and the firing stays on clause 1 (the string clause is not a home).
+      const result = evaluateExchangeRules(
+        {
+          confidentiality: [
+            "legacy-string-atom",
+            { anyOf: [spaceX, shareRef] },
+          ],
+          integrity: [roleAliceX],
+        },
+        shareSnapshot,
+      );
+      expect(result.firings.length).toBe(1);
+      expect(result.firings[0].clauseIndex).toBe(1);
+      expect(clauseSetsEqual(result.label.confidentiality!, [
+        "legacy-string-atom",
+        { anyOf: [spaceX, shareRef, userAlice] },
+      ])).toBe(true);
+    });
+
+    it("never selects a hand-built record with an empty digest (§4.4.2 belt)", () => {
+      // buildCfcPolicySnapshot always digests, so this only arises through a
+      // hand-built snapshot — an empty digest must not become selectable via
+      // a ref that also carries an empty hash.
+      const handmade = {
+        records: [{
+          id: "handmade",
+          digest: "",
+          rules: [spaceReaderRule],
+          selection: "referenced" as const,
+        }],
+        digest: "",
+      };
+      const emptyHashRef = {
+        type: CFC_ATOM_TYPE.Policy,
+        name: "handmade",
+        subject: ALICE,
+        hash: "",
+      };
+      const result = evaluateExchangeRules(
+        {
+          confidentiality: [{ anyOf: [spaceX, emptyHashRef] }],
+          integrity: [roleAliceX],
+        },
+        handmade,
+      );
+      expect(result.firings).toEqual([]);
+    });
+
     it("brings a rule-added ref into scope for the next batch (§4.4.5 recompute)", () => {
       // An ambient rule ADDS the hash-bound ref as an alternative; the
       // referenced record's rule must then fire on that clause in the SAME

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -289,7 +289,12 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
       const result = evaluateExchangeRules(
         { confidentiality: [userAlice] },
         {
-          records: [{ id: "handmade", digest: "d", rules: [rule] }],
+          records: [{
+            id: "handmade",
+            digest: "d",
+            rules: [rule],
+            selection: "ambient" as const,
+          }],
           digest: "d",
         },
         {
@@ -1242,7 +1247,12 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
 
   describe("evaluator fail-closed arms (hand-built snapshots)", () => {
     const handmade = (rule: ExchangeRule) => ({
-      records: [{ id: "handmade", digest: "d", rules: [rule] }],
+      records: [{
+        id: "handmade",
+        digest: "d",
+        rules: [rule],
+        selection: "ambient" as const,
+      }],
       digest: "d",
     });
 

--- a/packages/runner/test/cfc-policy.test.ts
+++ b/packages/runner/test/cfc-policy.test.ts
@@ -124,6 +124,47 @@ describe("CFC policy records (B2a)", () => {
     });
   });
 
+  describe("selection scope (B2b: label-carried policy selection)", () => {
+    it("defaults to ambient and accepts an explicit selection", () => {
+      const defaulted = buildCfcPolicySnapshot([record()])!;
+      expect(defaulted.records[0].selection).toBe("ambient");
+      const referenced = buildCfcPolicySnapshot([
+        record({ selection: "referenced" }),
+      ])!;
+      expect(referenced.records[0].selection).toBe("referenced");
+    });
+
+    it("digests explicit ambient identically to the default", () => {
+      const a = buildCfcPolicySnapshot([record()])!;
+      const b = buildCfcPolicySnapshot([record({ selection: "ambient" })])!;
+      expect(a.records[0].digest).toBe(b.records[0].digest);
+      expect(a.digest).toBe(b.digest);
+    });
+
+    it("treats the selection mode as record content (digest binding)", () => {
+      // A selection flip re-scopes every rule in the record, so it must
+      // invalidate prepared digests through the snapshot digest the same way
+      // a rule edit does (PreparedDigestInput.policySnapshot, Epic B5).
+      const a = buildCfcPolicySnapshot([record()])!;
+      const b = buildCfcPolicySnapshot([record({ selection: "referenced" })])!;
+      expect(a.records[0].digest).not.toBe(b.records[0].digest);
+      expect(a.digest).not.toBe(b.digest);
+    });
+
+    it("rejects unknown selection values", () => {
+      expect(() =>
+        buildCfcPolicySnapshot([
+          record({ selection: "label" as never }),
+        ])
+      ).toThrow(/selection must be "ambient" or "referenced"/);
+      expect(() =>
+        buildCfcPolicySnapshot([
+          record({ selection: 7 as never }),
+        ])
+      ).toThrow(/selection must be "ambient" or "referenced"/);
+    });
+  });
+
   describe("freeze discipline", () => {
     it("deep-freezes the snapshot, records, rules, and patterns", () => {
       const snapshot = buildCfcPolicySnapshot([record()])!;

--- a/packages/static/assets/types/cfc.ts
+++ b/packages/static/assets/types/cfc.ts
@@ -34,6 +34,7 @@ export declare const CFC_ATOM_TYPE: {
     "https://commonfabric.org/cfc/atom/CaveatAssessment";
   readonly CaveatScreened: "https://commonfabric.org/cfc/atom/CaveatScreened";
   readonly Concept: "https://commonfabric.org/cfc/atom/Concept";
+  readonly Context: "https://commonfabric.org/cfc/atom/Context";
   readonly DisclaimerAttached:
     "https://commonfabric.org/cfc/atom/DisclaimerAttached";
   readonly DisclosureAcknowledged:
@@ -47,6 +48,7 @@ export declare const CFC_ATOM_TYPE: {
   readonly LinkReference: "https://commonfabric.org/cfc/atom/LinkReference";
   readonly LlmDerived: "https://commonfabric.org/cfc/atom/LlmDerived";
   readonly Origin: "https://commonfabric.org/cfc/atom/Origin";
+  readonly Policy: "https://commonfabric.org/cfc/atom/Policy";
   readonly PolicyCertified: "https://commonfabric.org/cfc/atom/PolicyCertified";
   readonly PersonalSpace: "https://commonfabric.org/cfc/atom/PersonalSpace";
   readonly PromptSlotBound: "https://commonfabric.org/cfc/atom/PromptSlotBound";
@@ -115,6 +117,12 @@ export type CfcExternalIngestAtom = CfcAtomObject & {
 export type CfcUserAtom = CfcAtomObject & {
   readonly type: typeof CFC_ATOM_TYPE.User;
   readonly subject: string;
+};
+export type CfcPolicyRefAtom = CfcAtomObject & {
+  readonly type: typeof CFC_ATOM_TYPE.Policy | typeof CFC_ATOM_TYPE.Context;
+  readonly name: string;
+  readonly subject: string;
+  readonly hash: string;
 };
 export type CfcSpaceAtom = CfcAtomObject & {
   readonly type: typeof CFC_ATOM_TYPE.Space;
@@ -265,6 +273,16 @@ export declare const cfcAtom: {
     valueDigest: string,
   ) => CfcPromptSlotBoundAtom<Source, Role>;
   readonly user: (subject: string) => CfcUserAtom;
+  readonly policyRef: (
+    name: string,
+    subject: string,
+    hash: string,
+  ) => CfcPolicyRefAtom;
+  readonly contextRef: (
+    name: string,
+    subject: string,
+    hash: string,
+  ) => CfcPolicyRefAtom;
   readonly space: (id: string) => CfcSpaceAtom;
   readonly personalSpace: (owner: string) => CfcPersonalSpaceAtom;
   readonly expires: (timestamp: number) => CfcExpiresAtom;


### PR DESCRIPTION
## What

The revised B2b, per the owner decision (2026-07-10, extending the #4648 federation resolution): **remote attestation covers deployment config for security-sensitive inputs like `cfcPolicyRecords`**, so attested federated peers provably evaluate the same record set — the space-hosted policy-doc storage originally scheduled as B2b is **descoped** (tracked as **SC-28** in `docs/specs/cfc-spec-changes.md`; supersedes the Stage-3 note's "B2a deployment config is federation-hostile" conclusion in place). What ships is the half of B2b that was never about storage: **label-carried `Policy(...)`/`Context(...)` selection against the deployment snapshot, with the CT-1874 clause-local gate**.

- **`policy.ts`** — `PolicyRecord.selection: "ambient" | "referenced"` (default `ambient` = the B2a every-label posture; the B6/render standard profiles are unchanged). Digest projection bumps to v3 to cover the field: a selection flip re-scopes every rule, so it must invalidate prepared digests through the existing `PreparedDigestInput.policySnapshot` binding — selection is a pure function of (label, snapshot), both already digest-bound, so no new digest input is needed.
- **`api/cfc.ts`** — the spec §4.1.2 `PolicyRefAtom` families: `CFC_ATOM_TYPE.Policy` / `.Context`, `{type, name, subject, hash}` with `hash` required in runtime labels (§4.4.2), plus `cfcAtom.policyRef`/`contextRef` mint helpers.
- **`exchange-eval.ts`** — `referenced` records enter scope only where the **current** label carries a ref with `name === record.id` **and** `hash === record.digest`; unbound names, mismatches, cross-wired digests, absent records, and malformed atoms all select nothing (§4.4.3 fail-closed). Home clauses are recomputed **per rule batch**, not per pass — a drop firing splices clauses, and a pass-start index set would admit whatever clause shifted into the stale home index (pinned by a dedicated test); rule-added refs come into scope for the very next batch (§4.4.5 recompute). A non-`"ambient"` selection value on a hand-built snapshot lands on the narrow (referenced) arm — the guard-degradation posture from #4627.
- **Cross-space representation (inv-12/SC-25)** — classification rows for the new family: `name`/`hash` **public** (selection must dereference them against the destination's snapshot — the `Space.id` argument), `subject` **commitment** (DID-bearing, same posture as `User.subject`); selection accepts a commitment-form subject since it keys on name+hash.

## The CT-1874 hard constraint, red-first

The laundering trace: clause 0 `{anyOf: [User(alice), Policy.Evil(mallory)]}`, clause 1 `[Secret(bob)]`; Mallory's referenced rule has `appliesTo: Secret(?x)`. The scope-only intermediate (selection implemented, no home gate — the label-global default the shipped `matchRule` had) was run to demonstrate the failure before the gate landed:

```
- {added: [{subject: "did:key:mallory", type: ".../atom/User"}],
-  clauseIndex: 1, kind: "add", recordId: "evil", ruleId: "launder"}
+ []
```

Mallory's rule fired on **clause 1** — Bob's independent requirement, a cross-principal implicit release (invariant 11 / spec §3.1.8(3)). The gate ties a referenced record's rewrite targets to the ref's home clause(s): `matchRule` skips any clause outside `homeClauses`. Guards are deliberately not restricted — `preConfScope: "anywhere"` side conditions may still *read* sibling clauses; the widening lands only in the clause whose author admitted the policy alternative.

Test coverage (all red-first where behavior existed to pin): the CT-1874 trace, referenced-out-of-scope-without-ref, home-clause-only firing with satisfiable sibling evidence, §4.4.3 fail-closed matrix (unbound/mismatch/cross-wired/absent/malformed), Context parity, commitment-form subject selection, rule-added-ref recompute, drop-splice home tracking, selection-mode digest binding.

## Docs (live-doc contract, same PR)

- `cfc-spec-changes.md`: **SC-28** records the revised decision (renumbered after #4648 took SC-27 for egress records mid-flight; reconciled in the last commit).
- `cfc-label-metadata-confidentiality.md`: Stage-3 federation-constraint conclusion superseded in place; §2 table rows for the ref fields; the "policy names are never persisted" wording corrected.
- `cfc-persisted-declassification.md`: grants are now the sole consumer of the reserved-path substrate; dependency note rewritten; CT-1874 gate marked shipped.
- `exchange-eval.ts`/`policy.ts`/`trust.ts`/`grants.ts` docstrings: every "arrives with B2b" promise reconciled.

## Verification

- Red→green transitions exercised per slice (`unknown key "selection"` → green; the 5-red selection block → naive intermediate isolating the CT-1874/drop-splice/home-only reds → green with the gate).
- `deno task check` clean at repo root; full `packages/runner` suite green post-merge with origin/main (833 passed / 0 failed, includes #4647's declared-monotonicity suite); `packages/api` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds label‑carried, hash‑bound `Policy(...)`/`Context(...)` selection with clause‑local rule scoping to prevent cross‑principal widening (CT-1874). Space‑hosted policy docs are descoped; attested deployment config is the policy store (SC-28, pinned to labs#4652).

- **New Features**
  - `PolicyRecord.selection: "ambient" | "referenced"` with default `ambient`; digest projection bumped to v3 to include `selection`.
  - New atoms `Policy` and `Context` in `@commonfabric/api/cfc` with `{name, subject, hash}` and mint helpers `cfcAtom.policyRef(...)` / `cfcAtom.contextRef(...)`; `CfcPolicyRefAtom` is re‑exported from `@commonfabric/api/cfc-atoms` and `@commonfabric/api/cfc-authoring`; static types regenerated.
  - Evaluator: `referenced` records are in scope only when the current label carries a matching `name+hash`; rules may rewrite only the ref’s home clause(s) (CT-1874), homes recomputed per batch; selection accepts commitment‑form `subject`; unbound/mismatched/cross‑wired/absent/malformed refs fail closed. Coverage adds two belts: skip non‑record alternatives while locating homes, and never select hand‑built records with empty digests.
  - Cross‑space representation: ref `name`/`hash` are public; `subject` is commitment. Decision (SC‑28): attested deployment config replaces space‑hosted policy docs; grants remain the only space‑hosted policy state. 

- **Migration**
  - To use referenced policies, add `cfcAtom.policyRef(name, subject, digest)` or `.contextRef(...)` in the clause to widen; ensure `hash` equals the record digest.
  - If you hand‑build snapshots (e.g., tests), include `selection: "ambient"`; policy record digests are v3 and will differ from prior builds.

<sup>Written for commit f239bf27735fce01cb6d9300d5d8e1ed3e1a9cec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

