### PR TITLE
fix(shell/piece): unknown-build version skew must not raise the reload banner (local default-app red)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -180,8 +180,8 @@ propagate](#how-flags-propagate).
   `RuntimeOptions.experimental.eagerSourceAnnotation`. The ambient control point
   is `setEagerSourceAnnotation` in
   [`packages/runner/src/builder/module.ts`](../../packages/runner/src/builder/module.ts).
-  Unlike the other three, the runtime propagates this one only when it is set
-  explicitly, because the ambient flag is also a test seam.
+  Unlike the other env-backed flags, the runtime propagates this one only when
+  it is set explicitly, because the ambient flag is also a test seam.
 - **Added by.** gideon, in "make fn.src lazy/debug-only — re-root identity off
   .src" (#4458, 2026-07-06).
 - **Purpose.** Resolves the per-primitive debug source annotation (`fn.src`)

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -31,6 +31,8 @@ was last checked against the code.
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic-only — in the canonical env registry) | off | Bernhard Seefeld (#4090) | graduate with scheduler-v2 speculation lineage | implemented, off by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
+| [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (non-home roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete both auto-update flags | implemented, on in the shell |
+| [`systemPatternAutoUpdateHome`](#systempatternautoupdatehome) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME` env / shell build define, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#4611) | on after the home.tsx stable-addressing audit | implemented, off by default |
 | [`cfcEnforcementMode`](#cfcenforcementmode) | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse) | `enforce-explicit` | Bernhard Seefeld (#3263) | tighten default toward `enforce-strict` | active; ladder is permanent |
 | [`cfcFlowLabels`](#cfcflowlabels) | `RuntimeOptions.cfcFlowLabels` | `off` | Bernhard Seefeld (#4011) | move toward `persist` | implemented, staged rollout |
 | [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
@@ -66,9 +68,11 @@ The mapping from environment variable to flag is defined once, canonically, as
 and read by `experimentalOptionsFromEnv(envReader)`. The toolshed, the CLI, and
 the background piece service all go through that one mapping, so their wirings
 cannot drift; the shell reads the same variables from its build-time defines.
-Three flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
-`eagerSourceAnnotation`); `commitPreconditions` is deliberately mapped to `null`
-there, which records "not env-reachable" as a decision rather than an omission.
+Five flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
+`eagerSourceAnnotation`, `systemPatternAutoUpdate`,
+`systemPatternAutoUpdateHome`); `commitPreconditions` is deliberately mapped to
+`null` there, which records "not env-reachable" as a decision rather than an
+omission.
 The mapping accepts exactly `"true"` and `"false"`; any other value is ignored
 with a warning rather than coerced. See [How flags
 propagate](#how-flags-propagate).
@@ -201,6 +205,57 @@ propagate](#how-flags-propagate).
 - **Path to removal.** There is no planned removal. It would only be deleted if
   the debug source-annotation mechanism itself were removed, which is unlikely
   because `.src` is a public debugging surface.
+
+### `systemPatternAutoUpdate`
+
+- **Toggle via.** `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` environment variable
+  (through the canonical mapping) server-side, the shell build define of the
+  same name (injected by
+  [`packages/shell/felt.config.ts`](../../packages/shell/felt.config.ts) via
+  [`packages/shell/src/lib/env.ts`](../../packages/shell/src/lib/env.ts))
+  browser-side, or `RuntimeOptions.experimental.systemPatternAutoUpdate`.
+- **Added by.** Bernhard Seefeld, in "system-pattern auto-update (in-place
+  rollforward, flag-gated)" (#4611, 2026-07-08); defaulted on for the shell in
+  #4619 (2026-07-09).
+- **Purpose.** At space open, rolls a space's **non-home** root system pattern
+  (default-app) forward in place when its toolshed serves a newer content
+  identity: version gate (client vs toolshed build sha) → cached `?identity`
+  compare → in-place `patternIdentity` swap, re-instantiated by the existing
+  pattern watcher onto the same result cell. Best-effort and non-blocking: no
+  failure of the check may break space open. When either build sha is unknown
+  (dev/source servers carry none) the check skips silently; the `versionSkew`
+  IPC signal — which raises the shell's reload banner — fires only on a proven
+  mismatch (both shas known and different). See
+  [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).
+- **Current default and planned end state.** The runner built-in default is off
+  like every flag in this category; the shell build injects `true` unless the
+  define is set to `"false"`, so the deployed product (and local shell dev
+  builds) run it on for non-home roots. Server-side processes (toolshed, CLI,
+  background piece service) leave it off unless the env var is set. End state:
+  graduate to always-on for system roots once golden-replay coverage has soaked
+  and the home audit lands, then delete both auto-update flags.
+- **Status on 2026-07-09.** Implemented; on in the shell for non-home roots,
+  off elsewhere.
+- **Path to removal.** Graduate the home root (below), make the check
+  unconditional, and remove both flags together.
+
+### `systemPatternAutoUpdateHome`
+
+- **Toggle via.** `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME` environment
+  variable, the shell build define of the same name, or
+  `RuntimeOptions.experimental.systemPatternAutoUpdateHome`.
+- **Added by.** Bernhard Seefeld, in #4611 (2026-07-08).
+- **Purpose.** Second gate holding the **home** root (home.tsx) out of
+  [`systemPatternAutoUpdate`](#systempatternautoupdate): the home root carries
+  real user data (favorites, journal, the spaces list) and stays pinned until
+  the stable-addressing audit verifies an in-place swap preserves that state.
+  Both flags must be on for a home root to auto-update.
+- **Current default and planned end state.** Off everywhere (no shell-side
+  default-on). End state: flip on after the home.tsx stable-addressing audit,
+  then remove together with `systemPatternAutoUpdate`.
+- **Status on 2026-07-09.** Implemented, off by default.
+- **Path to removal.** Complete the audit, default the home root on, and delete
+  both flags when the check becomes unconditional.
 
 ---
 
@@ -563,10 +618,12 @@ the per-epic implementation notes).
 ## How flags propagate
 
 The environment-backed flags (`EXPERIMENTAL_MODERN_CELL_REP`,
-`EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`, `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`)
-reach the runtime through the deployed processes. The runtime-only flags
-(`commitPreconditions`, the CFC dials) reach it only through the `RuntimeOptions`
-passed to `new Runtime(...)`.
+`EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`,
+`EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`,
+`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE`,
+`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME`) reach the runtime through the
+deployed processes. The runtime-only flags (`commitPreconditions`, the CFC
+dials) reach it only through the `RuntimeOptions` passed to `new Runtime(...)`.
 
 All first-party processes build their `RuntimeOptions` through a construction
 preset in

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -191,7 +191,8 @@ and `home.tsx`:
    `pieces-controller.ts:274` — it must resolve against the space's host, which
    also fixes a latent cross-host bug where a foreign-homed space fetches the
    wrong toolshed's default-app.)*
-2. **Version gate** (§ below). Skew → skip, signal the shell, done.
+2. **Version gate** (§ below). Not the same known build → skip; signal the
+   shell only on a proven mismatch (both shas known).
 3. `currentId` = **cached** `GET {host}{url}?identity` (cache keyed by
    `(host, url)`; cleared on socket reset — the identity is fixed for the
    toolshed's lifetime, and a socket reset is the proxy for "maybe a restarted
@@ -211,11 +212,16 @@ literally the same function). So gate on it:
   cached per host).
 - **Match** → direct compare against the running `patternIdentity` is valid;
   **no sidecar id is stored.**
-- **Mismatch** → touch nothing; emit an IPC signal to the shell
+- **Proven mismatch** (both shas known, different) → touch nothing; emit an
+  IPC signal to the shell
   (`versionSkew: { space, clientVersion, toolshedVersion }`). The shell
   visualizes it and may restart/reload the worker to pick up a matching client
   build (a page reload / cache-bust is what actually swaps the client bundle;
   the shell owns that UX).
+- **Unknown build on either side** (dev/source servers carry no sha) → touch
+  nothing and skip **silently** (`skipped-unknown-build`). Nothing is provably
+  newer, so there is nothing to tell the user — signalling here would raise
+  the reload banner on every space open in local dev, where no reload helps.
 
 **The gate is exactly what makes the light `?identity` sound** — the only
 failure mode of the light computation is cross-build drift, and we now never

--- a/docs/specs/pattern-imports/system-pattern-updates-implementation-plan.md
+++ b/docs/specs/pattern-imports/system-pattern-updates-implementation-plan.md
@@ -251,7 +251,10 @@ New `packages/lib-shell/src/version-gate.ts` (or nearest worker-side util):
 
 ```ts
 // Shown for illustration only.
-/** undefined = unknown (missing gitSha either side) → treated as "skew". */
+/** undefined = unknown (missing gitSha either side) → gate fails, but skip
+ * SILENTLY ("skipped-unknown-build"): the versionSkew signal is reserved for a
+ * PROVEN mismatch (both shas known and different). Signalling on unknown would
+ * raise the shell's reload banner on every space open in local dev (#4653). */
 export async function toolshedGitSha(runtime, host): Promise<string | undefined>;
 export function clientGitSha(): string | undefined;
 /** True only when both are known AND equal. Unknown → false (fail-safe: do not update). */
@@ -343,7 +346,8 @@ New method on `PiecesController` (`pieces-controller.ts`):
 
 ```ts
 // Shown for illustration only.
-/** Returns "updated" | "current" | "skipped-skew" | "skipped-disabled". */
+/** Returns "updated" | "current" | "skipped-skew" | "skipped-unknown-build"
+ *  | "skipped-disabled". */
 async checkAndUpdateDefaultPattern(space): Promise<UpdateOutcome>;
 ```
 
@@ -357,8 +361,10 @@ Steps (exactly):
    *(This per-space host is a change from `ensureDefaultPattern`'s global
    `runtime.apiUrl` at `pieces-controller.ts:274/375`; use the space host
    here.)*
-4. **Version gate** (M1.2): `if (!(await buildsMatch(runtime, host)))` → emit
-   `versionSkew` IPC, return `"skipped-skew"`.
+4. **Version gate** (M1.2): `if (!(await buildsMatch(runtime, host)))` → if
+   both shas are known (a proven mismatch) emit the `versionSkew` IPC and
+   return `"skipped-skew"`; if either sha is unknown (dev/source servers)
+   return `"skipped-unknown-build"` with no signal (#4653).
 5. `currentId = await cachedPatternIdentity(host, url)` (M3.2).
 6. `running = getPatternIdentityRef(root)?.identity`. If `currentId ===
    running` → `"current"`.
@@ -410,8 +416,9 @@ pattern source; you may need a fake `?identity`/source responder):
 - **State preserved**: seed a durable cell the root reads by stable key; after
   update, it is still readable (guards the in-place property — use
   `default-app.tsx`-shaped state).
-- **Skew**: force `buildsMatch` false → `"skipped-skew"`, no write, one
-  `versionSkew` IPC.
+- **Skew**: force a proven mismatch (both shas known, different) →
+  `"skipped-skew"`, no write, one `versionSkew` IPC. An unknown sha on either
+  side → `"skipped-unknown-build"`, no write, NO IPC (#4653).
 - **Cache**: two checks in a row do one `?identity` fetch; after a simulated
   socket reset, the next check re-fetches.
 - **Failure isolation**: a throwing `?identity` fetch → the check logs and

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -69,6 +69,7 @@ export type UpdateOutcome =
   | "updated"
   | "current"
   | "skipped-skew"
+  | "skipped-unknown-build"
   | "skipped-disabled";
 
 // This module can load outside Deno (browser-safe storage import above), so
@@ -580,6 +581,16 @@ export class PiecesController<T = unknown> {
       // 4. Version gate: the light ?identity is only comparable within a build.
       const toolshedVersion = await runtime.toolshedGitSha(host);
       if (!buildsMatch(runtime.clientVersion, toolshedVersion)) {
+        // An unknown sha on either side (dev/source servers carry none)
+        // proves nothing — skip silently. The skew signal raises the shell's
+        // "reload to update" banner, which must only claim what is proven:
+        // both builds known and different. Signalling on unknown would show
+        // the banner on every space open in local dev, where no reload helps.
+        if (
+          runtime.clientVersion === undefined || toolshedVersion === undefined
+        ) {
+          return "skipped-unknown-build";
+        }
         runtime.reportVersionSkew({
           space,
           clientVersion: runtime.clientVersion,

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -102,13 +102,16 @@ describe("checkAndUpdateDefaultPattern", () => {
   let controller: PiecesController;
   let versionSkews: VersionSkewInfo[];
 
-  async function setup(experimental: Record<string, boolean>) {
+  async function setup(
+    experimental: Record<string, boolean>,
+    clientVersion: string | undefined = BUILD_SHA,
+  ) {
     versionSkews = [];
     storageManager = StorageManager.emulate({ as: signer });
     runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
-      clientVersion: BUILD_SHA,
+      clientVersion,
       experimental,
       onVersionSkew: (info) => versionSkews.push(info),
     });
@@ -191,6 +194,43 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(versionSkews.length).toBe(1);
     expect(versionSkews[0].clientVersion).toBe(BUILD_SHA);
     expect(versionSkews[0].toolshedVersion).toBe("a-different-build");
+  });
+
+  it("skips silently when both builds are unknown (dev servers)", async () => {
+    // Local dev: a source-run toolshed serves gitSha null and a dev shell
+    // build carries no COMMIT_SHA. Nothing is provably newer, so the check
+    // must skip WITHOUT the versionSkew signal — the signal raises the
+    // shell's "reload to update" banner, which would appear on every space
+    // open in local dev where no reload can help.
+    await setup({ systemPatternAutoUpdate: true }, undefined);
+    const piece = await controller.ensureDefaultPattern();
+    const before = getPatternIdentityRef(piece.getCell())?.identity;
+
+    stub.setSource(SOURCE_V2);
+    stub.setGitSha(null);
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+      "skipped-unknown-build",
+    );
+    // No write, no signal, and the gate failed before any ?identity fetch.
+    expect(getPatternIdentityRef(piece.getCell())?.identity).toBe(before);
+    expect(versionSkews.length).toBe(0);
+    expect(stub.identityFetches()).toBe(0);
+  });
+
+  it("skips silently when only the toolshed build is unknown", async () => {
+    // A known client build against a sha-less toolshed proves nothing either
+    // — only a KNOWN, DIFFERENT pair is a skew worth surfacing.
+    await setup({ systemPatternAutoUpdate: true });
+    await controller.ensureDefaultPattern();
+
+    stub.setGitSha(null);
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+      "skipped-unknown-build",
+    );
+    expect(versionSkews.length).toBe(0);
+    expect(stub.identityFetches()).toBe(0);
   });
 
   it("caches ?identity and re-fetches after the caches are cleared", async () => {

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -59,9 +59,13 @@ export class XRootView extends BaseView {
       width: 100%;
     }
 
+    /* Anchored to the BOTTOM edge: an overlay pinned to the top covers the
+      header breadcrumbs and steals their (hit-tested) clicks, breaking
+      space navigation until dismissed. Nothing interactive is shell-owned
+      at the bottom edge. */
     #version-skew-banner {
       position: fixed;
-      inset-block-start: 0;
+      inset-block-end: 0;
       inset-inline: 0;
       z-index: 2000;
       display: flex;
@@ -72,7 +76,7 @@ export class XRootView extends BaseView {
       font: 500 14px/1.4 system-ui, sans-serif;
       color: #1a1a1a;
       background: #ffe8a3;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+      box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.2);
     }
 
     #version-skew-banner button {


### PR DESCRIPTION
Fixes the deterministic local-only failure of `deno task integration patterns default-app` ("should create a note via default app and see it in the space list", 60s `waitForState` timeout at `default-app.test.ts:486`) introduced by the #4619 flag flip, while CI stayed green.

## Mechanism

With `systemPatternAutoUpdate` on, space open runs `checkAndUpdateDefaultPattern`. On local **source-run servers neither side has a build sha** (a source toolshed serves `/api/meta` `gitSha: null`; a dev/`felt` shell build has no `COMMIT_SHA` define), so the version gate fails — correctly, fail-safe, no update — but the failure path unconditionally fired `reportVersionSkew`. That IPC raises the shell's "A newer version is available" banner: `position: fixed` at the **top**, `z-index: 2000` — directly over the header breadcrumbs.

The integration test's click helpers dispatch **trusted, hit-tested CDP clicks**. Body buttons ("Notes", "New Note") sit below the banner band and work; the header space link does not — the click back to the space landed on the banner, the view never changed, and the one-shot `waitForState({ view: { spaceName } })` timed out at its 60s ceiling. Note creation itself was fine (the same run's second test passes; post-fix the full create-and-return flow takes ~400ms).

## Why CI never saw it

The `pattern-integration-test` job runs the **compiled toolshed binary** from `build-binaries`, built with `COMMIT_SHA: ${{ github.sha }}`: the sha is baked into the binary's `COMPILED` file (served by `/api/meta`) **and** into the shell bundle the binary serves. Both sides match, the gate passes, identities compare equal, no signal, no banner. Locally the harness starts source servers (`start-local-dev.sh`) with no shas on either side — an environment split, not a race: red every local run, green every CI run. The same false banner also appeared in every `dev-local` shell session since the flip (covering the header there too).

## Fix — close the class, not the symptom

1. **piece:** skew is only reported when it is **proven** — both shas known and different. An unknown sha on either side returns the new `skipped-unknown-build` outcome silently (still no update; the light `?identity` is never trusted across unvalidated builds). "Nothing is provably newer" must not tell the user a newer version is available — in dev there is nothing to reload into.
2. **shell:** the banner is anchored to the **bottom** edge. Even a proven skew (e.g. every production deploy until clients reload) must not overlay header navigation; nothing interactive is shell-owned at the bottom edge.
3. **docs:** `pattern-updates.md` §version-skew-gate now distinguishes proven-mismatch (signal) from unknown-build (silent skip); `systemPatternAutoUpdate` / `systemPatternAutoUpdateHome` registered in `EXPERIMENTAL_OPTIONS.md` (missing since the registry landed — owed by #4611/#4619).

No timeout was touched.

## Verification (all on the same macOS machine)

| Run | Result |
|---|---|
| origin/main tip (`ddf495d9d`), pre-fix | **FAILED 1m3s**, hung at "Navigate back to space page (note 1)", `default-app.test.ts:486` — exact reported signature |
| green anchor `f1604f027` (parent of #4619) | ok, 2 passed (11s) — bisect anchors reproduced |
| unit red→green | new cases `skipped-unknown-build` + no signal: red before the fix (got `skipped-skew` + report), green after; existing proven-skew test unchanged |
| fixed branch | **ok, 2 passed (11s)**; note create-and-return 397ms. The `/api/meta` fetch still runs post-fix, so the fetch is exonerated — the banner chain was the blocker |
| post catch-up-merge (#4652) | integration oracle re-run green; piece/shell/runtime-client suites green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the false “newer version available” banner in local dev and unblocks the default-app integration test. We only signal version skew on a proven mismatch, and the banner is now anchored to the bottom.

- **Bug Fixes**
  - `packages/piece`: signal `versionSkew` only when both shas are known and different; otherwise return `skipped-unknown-build` without signaling.
  - `packages/shell`: move the version-skew banner to the bottom to avoid covering header navigation.
  - Tests: add coverage for `skipped-unknown-build` and ensure no `?identity` fetch or signal on unknown builds.

- **Docs**
  - Document `systemPatternAutoUpdate` and `systemPatternAutoUpdateHome` in `EXPERIMENTAL_OPTIONS.md`.
  - Clarify the version gate: proven mismatch signals; unknown build skips silently in `pattern-updates.md`.
  - Align the implementation plan with the unknown-build skip and proven-mismatch-only signal in `system-pattern-updates-implementation-plan.md`.

<sup>Written for commit dba706c73988f12597549397b36c3c52f0bc897d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

