### PR TITLE
docs: dedup cfcLabelMetadataProtection registry entry (#4650/#4651 race)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -36,7 +36,6 @@ was last checked against the code.
 | [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
 | [`cfcTriggerReadGating`](#cfctriggerreadgating) | `RuntimeOptions.cfcTriggerReadGating` | `false` | Bernhard Seefeld (#4488) | move toward `true` | implemented, staged rollout |
 | [`cfcPolicyEvaluation`](#cfcpolicyevaluation) | `RuntimeOptions.cfcPolicyEvaluation` | `off` | Bernhard Seefeld (#4566) | move toward `enforce` | implemented, staged rollout |
-| [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` first, then `enforce` | implemented, off by default |
 | [`cfcDeclaredMonotonicity`](#cfcdeclaredmonotonicity) | `RuntimeOptions.cfcDeclaredMonotonicity` | `off` | Bernhard Seefeld (#4647) | `observe` first, then `enforce` (must soak before the §8.12.7 route 2b event ships) | implemented, off by default |
 | [`cfcPrefixProvenanceStats`](#cfcprefixprovenancestats) | `RuntimeOptions.cfcPrefixProvenanceStats` (per-deployment; not env-wired) | `false` | Bernhard Seefeld (#4623) | stays a measurement opt-in; fold in or remove after Stage 0 | implemented, off by default, measurement only |
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
@@ -340,32 +339,6 @@ the per-epic implementation notes).
 - **Status on 2026-07-08.** Implemented and in staged rollout.
 - **Path to removal.** Once policy evaluation is the norm, the dial could settle
   on `enforce` and be retired.
-
-### `cfcLabelMetadataProtection`
-
-- **Toggle via.** `RuntimeOptions.cfcLabelMetadataProtection`.
-- **Added by.** Bernhard Seefeld, in "inv-12 stage 1 — cross-space
-  label-metadata representation transform (SC-25, spec §4.6.4.1)" (#4638,
-  2026-07-09).
-- **Purpose.** Controls how a label's metadata is represented when the label
-  crosses a space boundary and is persisted. Values are `off`, `observe`, and
-  `enforce`. `off` persists the label bytes byte-identical to before the dial
-  existed. `observe` computes the classification-governed transformed form for
-  cross-space entries and emits a structured diagnostic when it differs from the
-  verbatim form (the divergence count is the rollout metric), but still persists
-  the verbatim bytes. `enforce` persists the transformed form, with
-  commitment-class atom fields replaced by their canonical digest markers
-  (`{digestOf: <hash>}`). The transform is representation-only — it never rejects
-  a commit.
-- **Current default and planned end state.** `off` by default. The target is
-  `observe`, then `enforce` once the divergence metric confirms the transform is
-  stable across cross-space traffic
-  (`docs/specs/cfc-label-metadata-confidentiality.md` §2/§5).
-- **Status on 2026-07-09.** Implemented, off by default.
-- **Path to removal.** Not planned for removal: the confidential representation
-  of cross-space label metadata is a permanent store property. Once `enforce`
-  has soaked, the dial could settle there and the `off`/`observe` rungs remain
-  for diagnostics, mirroring the enforcement ladder.
 
 ### `cfcDeclaredMonotonicity`
 


### PR DESCRIPTION
Two sessions registered the same dial concurrently (#4650 from the spawned chip, #4651 from the main session) and both merged; the registry carried two summary rows and two sections. Keep one of each — the fuller section text. Docs-only; check-docs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the `cfcLabelMetadataProtection` entry in `EXPERIMENTAL_OPTIONS.md` after a concurrent double-add. Kept a single table row with staged-rollout wording and the fuller section; docs-only with no functional changes.

<sup>Written for commit 53fae0140b03365a38e0cf8062f77716b06ec92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

