### PR TITLE
feat(cfc): *-path class templates — membership/slot taint closes SC-4/SC-8 residuals (template-population Stage A)

### DIFF
--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -52,7 +52,12 @@ Until the `shape`/`value`/`iterate` observation classes are implemented, one
 label covers all observation kinds at a path; replacing a derived label on
 overwrite then also shrinks the _existence_ label, leaving "this path was once
 written" as a public bit. Document as a known residual of the phase profile,
-fixed by PathLabelTemplate observation classes.
+fixed by PathLabelTemplate observation classes. (Closed in two steps: the C2/C3
+persist split gave existence its own frozen `observes:"shape"` entry, and
+template-population Stage A closed the per-child half — a `*`-path `shape`
+template on declared list-coordinator containers makes a per-child existence
+probe consume the membership `J`; see
+[`cfc-template-population.md`](./cfc-template-population.md) §6.)
 
 **SC-5 [normative] Bless the prepare/digest factoring — §8.10.1.** The runner
 implements the per-attempt verify loop as verify-at-prepare + a canonical-digest
@@ -96,7 +101,10 @@ carry the writing tx's J as exact-path shape labels — joined by reads at the
 container path and by recursive ancestor reads, never by reads strictly below —
 so the §8.5.6.1 membership/length channel is labeled while per-slot pointer
 handling stays clean. Pointer identity at a slot, i.e. WHICH element sits
-there observed without dereferencing, remains an SC-4/SC-8 residual.)
+there observed without dereferencing, was an SC-4/SC-8 residual until
+template-population Stage A: on declared list-coordinator containers a
+standalone slot observation now consumes the assignment `J` through the
+`*`-path `followRef` template — see the SC-8 note below for what remains.)
 
 **SC-8 [normative] Read-API → observation-class mapping — §4.6.3.** The
 primitive read profile defines `shape`/`value`/`enumerate`/`count`/ `followRef`,
@@ -112,10 +120,21 @@ container-anchored structure stamp is an undefined compaction with a known
 under-taint — a static per-child existence probe ("is `/items/3` present?")
 is a `shape` read at the child (§8.10.1.1) and does not consume the
 exact-path container stamp. The spec-conforming fix is per-slot shape
-entries, at the per-row entry-count cost (#3998); recorded here until an
-implementation decides to pay it. Existence-entry update discipline settled
-as freeze-at-creation — spec §8.12.8 amendment on branch
-`cfc/existence-freeze-at-creation`.)
+entries, at the per-row entry-count cost (#3998). **Closed by
+template-population Stage A for declared list-coordinator containers** (the
+actual §8.5.6.1 membership subjects): runtime-minted `*`-path per-class
+entries — O(1) per container where per-slot entries were O(n) — make the
+per-child probe, the raw slot materialization, and the standalone
+slot-pointer observation consume the membership/assignment `J`
+([`cfc-template-population.md`](./cfc-template-population.md) §6 Stage A,
+including the frozen-vs-membership join rule and two machinery boundaries).
+The remaining slice: generic pure-link value writes (non-declared
+containers) keep the container-anchored compaction — extending the mints
+there needs a machinery-read marker first, because the runner's
+op-instantiation scaffolding reads plumbing containers' child paths with no
+distinguishing journal shape (measured re-smear on the phase-B pointwise
+suite). Existence-entry update discipline settled as freeze-at-creation —
+spec §8.12.8 amendment on branch `cfc/existence-freeze-at-creation`.)
 
 (Design settled 2026-07-02, C0 #4476 + follow-up patches:
 `docs/specs/cfc-observation-classes.md` — the §4 read-API → class table, the
@@ -567,4 +586,7 @@ this file is the single tracking place:
   [`cfc-template-population.md`](./cfc-template-population.md)**:
   runtime-minted `*`-path per-class entries (the existing declared-`*`
   entry form; no new wire shape), closing both SC-8 under-taints in Stage
-  A and carrying Stage-2 full metadata population in Stage B.
+  A and carrying Stage-2 full metadata population in Stage B. **Stage A
+  landed** (declared list-coordinator containers; the generic
+  pure-link-write slice stays open pending a machinery-read marker — see
+  the SC-8 note and the design's §6 implementation note).

--- a/docs/specs/cfc-template-population.md
+++ b/docs/specs/cfc-template-population.md
@@ -230,6 +230,43 @@ minted into the same entries, not the mechanism.
   no-op with templates present; Stage-1 transform applies to template
   labels; declared `*` entries byte-identical (regression); coalescing +
   canonicalization property tests with multi-`*` paths.
+
+  **Implementation note (Stage A landed).** Shipped in
+  `packages/runner/src/cfc/prepare.ts` + `types.ts` with the full test
+  list in `packages/runner/test/cfc-template-population.test.ts` (both
+  §1 under-taints red-first on main: the child probe joined nothing, the
+  slot probe joined only the transport label). Two measured refinements
+  against the §2 caution, both found by the phase-B pointwise suite —
+  the same arbiter that forced the C0 §6.1 refinements:
+
+  1. **Template mints ride the DECLARED coordinator route only** (the S16
+     `recordCfcStructureContainer` containers — filter/flatMap results,
+     where the §8.5.6.1 membership decision lives), not the generic
+     pure-link value-write route. Minting on every pure-link write puts
+     templates on the runtime's own builder/coordination plumbing (alias
+     shells, internal arrays), and the op-instantiation machinery reads
+     those docs' child paths (slot scalars, `length`) as scaffolding with
+     no distinguishing journal marker — neither probe-classified nor
+     trace-covered — so each reconcile's `J` smeared into the next
+     (measured: `cfc-flow-pointwise` map). The generic route keeps
+     today's container-anchored stamps; extending mints to it needs a
+     machinery-read marker first (recorded as the remaining slice of the
+     SC-8 residual in `cfc-spec-changes.md`).
+  2. **Two machinery boundaries on template consumption**, both
+     inherited-from-existing disciplines rather than new semantics: a
+     transaction re-deriving a container's membership stamps does not
+     consume the very entries it replaces (`ownRestampContainerPaths` —
+     otherwise an incremental reconciler's readback of its own previous
+     output turns §8.12.8 replace-from-criteria into accumulate-forever,
+     measured on the no-write re-stamp test), and reads covered by a
+     same-tx dereference trace skip templates (the C0 §6.1 row-4
+     machinery rule extended to the plain reads resolution journals at
+     followed slots; standalone observations — the row-3 SC-8 closures —
+     consume in full). Consequence of the second: a full dereference
+     consumes the target's content but not the slot's membership `J`;
+     §2's "probe **or dereference**" overstated what the shipped row-3/
+     row-4 boundary distinguishes, and the probe/standalone-read half is
+     what landed.
 - **Stage B (Stage-2 full population; one PR, after A):** the
   `/cfc/labels/...` template mints per §5 + `inspectConfLabel` consuming
   them (upgrading WP7's computed-in-hand labels to persisted templates),

--- a/docs/specs/cfc-template-population.md
+++ b/docs/specs/cfc-template-population.md
@@ -174,7 +174,9 @@ have none — `walkIfcSchema` does not descend `additionalProperties` at
 all, so "every child of this map" is inexpressible even as a declared
 label. This design extends the schema walk: `additionalProperties`
 (schema-object form) descends as the same `*` segment — **restricted to
-record-only objects (no `properties` present)**. The restriction is
+record-only objects (no named property; an empty `properties: {}` names
+no key, so every key is a properties miss and it stays record-only —
+settled on the Stage-A PR review)**. The restriction is
 load-bearing: `isPrefix`'s `*` matches *any* segment, but
 `additionalProperties` semantically covers only keys *not* listed under
 `properties` (the runner's own `schemaAtPath` traversal consults

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -232,12 +232,14 @@ const effectiveReadLabel = (
     consumes: ReadClassSelection;
     /**
      * Entries excluded from this read's consumption on top of class
-     * selection. Sole current use: the §8.12.8 replace-from-criteria
-     * readback exclusion in `deriveFlowJoin` — a transaction re-deriving a
-     * container's membership stamps must not consume the very entries it
-     * replaces (see `ownRestampContainerPaths`). Absent on every other
-     * call site (notably the `"all"`-selection write gate, which stays
-     * over-inclusive by design).
+     * selection. Sole current user is `deriveFlowJoin`'s pair of template
+     * machinery boundaries: the §8.12.8 replace-from-criteria readback
+     * exclusion (a transaction re-deriving a container's membership stamps
+     * must not consume the very entries it replaces — see
+     * `ownRestampContainerPaths`) and the C0 §6.1 row-4 rule extended to
+     * plain reads (trace-covered resolution machinery skips `*`
+     * templates). Absent on every other call site (notably the
+     * `"all"`-selection write gate, which stays over-inclusive by design).
      */
     excludeEntry?: (entry: LabelMapEntry) => boolean;
   },
@@ -4948,11 +4950,27 @@ export const prepareBoundaryCommit = (
       // under any written path are dropped (fresh ones for this tx are
       // appended below / by the link machinery). Declared and legacy
       // entries are never cleared here.
+      //
+      // `*`-path templates clear only under a write that covers their
+      // CONTAINER (template-population §3.1 "cleared on covering writes"):
+      // `isPrefix`'s bidirectional wildcard would let a bare SLOT write
+      // (["1"]) "cover" the ["*"] template — but a slot write replaces one
+      // child, not the membership, and clearing there (with no re-mint;
+      // slot writes stamp nothing) would open an unlabeled window until
+      // the next declared reconcile. The container-anchored enumerate
+      // stamp survives slot writes for exactly the same reason (exact-path
+      // never matches a deeper write), so the twins match its discipline.
+      const clearProbePath = isRuntimeMintedTemplate({
+          origin: entry.origin,
+          path: entryPath,
+        }) && entryPath[entryPath.length - 1] === "*"
+        ? entryPath.slice(0, -1)
+        : entryPath;
       if (
         flowPersist &&
         (entry.origin === "derived" || entry.origin === "link" ||
           entry.origin === "structure") &&
-        flowWrittenPaths.some((written) => isPrefix(written, entryPath))
+        flowWrittenPaths.some((written) => isPrefix(written, clearProbePath))
       ) {
         flowCleared = true;
         if (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1935,15 +1935,21 @@ const walkIfcSchema = (
     }
     // Record-only `additionalProperties` descends as the same `*` segment
     // arrays get from `items` (template-population §4) — RESTRICTED to
-    // record-only objects (no `properties` key). The restriction is
+    // record-only objects (no NAMED property). The restriction is
     // load-bearing: `isPrefix`'s `*` matches ANY segment, but
     // `additionalProperties` semantically covers only keys NOT listed under
     // `properties` (schemaAtPath consults it only on a properties miss), so
     // an unrestricted `*` entry from a mixed schema would over-taint the
     // named fields. Mixed fixed-plus-record-tail schemas therefore mint no
     // `*` entry (expressing them needs exclusion semantics §3.3 forbids).
+    // An EMPTY `properties` object is still record-only — it names no key,
+    // so every key is a properties miss and `additionalProperties` covers
+    // all of them; schema helpers routinely emit that wrapper shape, and
+    // skipping it would silently drop the declared map label (codex/cubic
+    // review on this PR).
     if (
-      resolved.properties === undefined &&
+      (resolved.properties === undefined ||
+        Object.keys(resolved.properties).length === 0) &&
       typeof resolved.additionalProperties === "object" &&
       resolved.additionalProperties !== null
     ) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -118,6 +118,18 @@ const labelAtPath = (
     ? undefined
     : labelForEntriesAtPath(metadata.labelMap.entries, path);
 
+// A runtime-minted `*`-path class template (template-population §3.1): the
+// membership/slot twins minted beside the container-anchored structure
+// stamps (and any future derived-origin population entries of the same
+// form). Declared `*` entries (items/additionalProperties schemas) are NOT
+// templates in this sense — they keep the declared component's resolution
+// untouched.
+const isRuntimeMintedTemplate = (
+  entry: Pick<LabelMapEntry, "path" | "origin">,
+): boolean =>
+  (entry.origin === "structure" || entry.origin === "derived") &&
+  entry.path.includes("*");
+
 const labelForEntriesAtPath = (
   entries: readonly LabelMapEntry[],
   path: readonly string[],
@@ -136,23 +148,44 @@ const labelForEntriesAtPath = (
     if (!isPrefix(entry.path, path)) {
       continue;
     }
-    // Structure entries label the container's SHAPE: they apply when the
-    // container node itself is observed (read at exactly the entry path),
-    // not to reads strictly below it — slot pointer reads and dereferences
-    // are pointer handling, and tainting them with shape would re-smear
-    // the pointwise split the structure component exists to preserve.
-    if (entry.origin === "structure" && entry.path.length !== path.length) {
+    const template = isRuntimeMintedTemplate(entry);
+    // CONCRETE structure entries label the container's SHAPE: they apply
+    // when the container node itself is observed (read at exactly the
+    // entry path), not to reads strictly below it — slot pointer reads and
+    // dereferences are pointer handling, and tainting them with shape
+    // would re-smear the pointwise split the structure component exists to
+    // preserve. `*`-path templates are the opposite by construction
+    // (template-population §3.2): their whole point is consumption at
+    // matching child paths, so the exact-path rule does not apply to them.
+    if (
+      entry.origin === "structure" && !template &&
+      entry.path.length !== path.length
+    ) {
       continue;
     }
     const component = entry.origin ?? "legacy";
-    const match = matches.get(component);
+    // Frozen-existence vs membership-template join (template-population
+    // §3.2.1): a frozen concrete `shape` entry records departed HISTORY;
+    // the `*` membership template records CURRENT shape. They answer
+    // different questions under one class, so where both cover a read
+    // their labels JOIN rather than compete in replace-down — replacing
+    // would let a stale frozen label mask current membership taint or
+    // vice versa. Scoped to structure/derived-origin shape-class
+    // templates (a separate resolution bucket per component); everything
+    // else keeps replace-down.
+    const bucket = template && entry.observes === "shape"
+      ? `${component}\u0000shape-template`
+      : component;
+    const match = matches.get(bucket);
     if (match === undefined || match.path.length < entry.path.length) {
-      matches.set(component, entry);
+      matches.set(bucket, entry);
     } else if (match.path.length === entry.path.length) {
       // Two equally specific prefixes of one queried path are the same
-      // path; duplicate (path, origin) entries shouldn't survive
-      // coalescing, but join defensively rather than drop one.
-      matches.set(component, {
+      // path — or, with wildcard segments, a concrete entry and a `*`
+      // template covering the same slot; duplicate (path, origin) entries
+      // shouldn't survive coalescing, but join defensively (fail-toward-
+      // taint) rather than drop one.
+      matches.set(bucket, {
         path: match.path,
         label: mergeLabels(match.label, entry.label),
       });
@@ -197,17 +230,32 @@ const effectiveReadLabel = (
   read: {
     nonRecursive: boolean | undefined;
     consumes: ReadClassSelection;
+    /**
+     * Entries excluded from this read's consumption on top of class
+     * selection. Sole current use: the §8.12.8 replace-from-criteria
+     * readback exclusion in `deriveFlowJoin` — a transaction re-deriving a
+     * container's membership stamps must not consume the very entries it
+     * replaces (see `ownRestampContainerPaths`). Absent on every other
+     * call site (notably the `"all"`-selection write gate, which stays
+     * over-inclusive by design).
+     */
+    excludeEntry?: (entry: LabelMapEntry) => boolean;
   },
 ): IFCLabel | undefined => {
-  const view = read.consumes === "all" || metadata === undefined ? metadata : {
-    ...metadata,
-    labelMap: {
-      ...metadata.labelMap,
-      entries: metadata.labelMap.entries.filter((entry) =>
-        readConsumesEntry(read.consumes, entry)
-      ),
-    },
-  };
+  const view = (read.consumes === "all" && read.excludeEntry === undefined) ||
+      metadata === undefined
+    ? metadata
+    : {
+      ...metadata,
+      labelMap: {
+        ...metadata.labelMap,
+        entries: metadata.labelMap.entries.filter((entry) =>
+          (read.consumes === "all" ||
+            readConsumesEntry(read.consumes, entry)) &&
+          read.excludeEntry?.(entry) !== true
+        ),
+      },
+    };
   const base = labelAtPath(view, path);
   if (read.nonRecursive === true || view === undefined) {
     return base;
@@ -1316,6 +1364,13 @@ const forEachFlowObservation = (
     observation: {
       shape: ReadObservationShape;
       nonRecursive: boolean | undefined;
+      // True when a same-tx dereference-trace source covers this read
+      // at-or-above (the C0 §6.1 row-4 machinery predicate). Probe reads
+      // never arrive covered (they are skipped outright); a covered PLAIN
+      // read is the resolution machinery's ordinary journal shape at a
+      // followed slot, and is excluded from `*`-template consumption in
+      // `deriveFlowJoin`.
+      coveredByTrace: boolean;
     },
   ) => boolean,
 ): boolean => {
@@ -1382,9 +1437,15 @@ const forEachFlowObservation = (
     const space = read.space;
     const id = read.id as URI;
     const scope = normalizeCellScope(read.scope);
+    const coveredByTrace = probeBelongsToDereference(
+      space,
+      id,
+      scope,
+      logicalPath,
+    );
     let shape: ReadObservationShape;
     if (isLinkResolutionProbe(read.meta)) {
-      if (probeBelongsToDereference(space, id, scope, logicalPath)) {
+      if (coveredByTrace) {
         continue;
       }
       shape = "followRef";
@@ -1398,7 +1459,14 @@ const forEachFlowObservation = (
         scope,
         (read.type ?? "application/json") as MediaType,
         logicalPath,
-        { shape, nonRecursive: read.nonRecursive },
+        // `coveredByTrace` extends the C0 §6.1 row-3/row-4 boundary to
+        // PLAIN reads for the one entry kind whose consumption at slot
+        // paths is new (the `*`-path class templates): resolution
+        // machinery journals ordinary reads at followed slots and inside
+        // their link sigils, and those must stay pointer HANDLING, not
+        // pointer observation — see the template exclusion in
+        // `deriveFlowJoin`.
+        { shape, nonRecursive: read.nonRecursive, coveredByTrace },
       )
     ) {
       return true;
@@ -1437,13 +1505,85 @@ const forEachFlowObservation = (
         normalizeCellScope(trigger.scope),
         "application/json",
         trigger.path,
-        { shape: "value", nonRecursive: false },
+        { shape: "value", nonRecursive: false, coveredByTrace: false },
       )
     ) {
       return true;
     }
   }
   return false;
+};
+
+// The containers whose membership stamps THIS transaction re-derives this
+// attempt — the §8.12.8 replace-from-criteria readback exclusion set
+// (template-population §3.1). Two re-stamp routes, mirroring the persist
+// region: containers a list coordinator DECLARED this reconcile
+// (`recordCfcStructureContainer`), and container nodes of pure-link-structure
+// value writes. A reconciling coordinator reads its own previous output as
+// diff/identity scaffolding; with the `*`-child class templates persisted,
+// those readback reads would resolve the very entries this attempt drops and
+// re-mints — joining J_prev into J on every reconcile and turning the
+// normative replace-from-criteria into the accumulate-forever §8.12.8
+// rejects. So the writer's own flow join skips exactly the REPLACED entries
+// (the enumerate stamp and the `*`-child templates of its own re-stamped
+// containers); the frozen existence entry is not replaced and not excluded.
+// Foreign readers — and this transaction's reads of every OTHER container —
+// consume templates in full, which is what closes the SC-4/SC-8 residuals.
+const ownRestampContainerPaths = (
+  tx: IExtendedStorageTransaction,
+): Map<string, Set<string>> => {
+  const result = new Map<string, Set<string>>();
+  const add = (key: string, containerPath: readonly string[]) => {
+    let paths = result.get(key);
+    if (paths === undefined) {
+      paths = new Set();
+      result.set(key, paths);
+    }
+    paths.add(pathKey(containerPath));
+  };
+  for (const addr of tx.getCfcState().structureContainers) {
+    add(
+      targetKey({
+        space: addr.space,
+        id: addr.id as URI,
+        scope: normalizeCellScope(addr.scope),
+      }),
+      canonicalizeLogicalPath(addr.path),
+    );
+  }
+  for (const [key, target] of valueWriteTargets(tx)) {
+    for (const path of target.paths) {
+      const written = target.valuesByPath.get(pathKey(path));
+      if (written === undefined || !isPureLinkStructure(written)) {
+        continue;
+      }
+      const containers: (readonly string[])[] = [];
+      pureLinkContainerPaths(written, path, containers);
+      for (const container of containers) {
+        add(key, container);
+      }
+    }
+  }
+  return result;
+};
+
+// Whether `entry` is one of the membership entries a re-stamp of the given
+// container paths replaces: the container-anchored enumerate stamp, or a
+// `*`-child class template of one of the containers.
+const isReplacedMembershipEntry = (
+  entry: LabelMapEntry,
+  containers: ReadonlySet<string>,
+): boolean => {
+  if (entry.origin !== "structure") {
+    return false;
+  }
+  const entryPath = canonicalizeLogicalPath(entry.path);
+  if (entry.observes === "enumerate") {
+    return containers.has(pathKey(entryPath));
+  }
+  return entryPath.length > 0 &&
+    entryPath[entryPath.length - 1] === "*" &&
+    containers.has(pathKey(entryPath.slice(0, -1)));
 };
 
 // Exported for tests: the trigger-read cid: guard above defends
@@ -1483,6 +1623,8 @@ export const deriveFlowJoin = (
     ? new Set<MemorySpace>()
     : undefined;
   const metadataByDoc = new Map<string, CfcMetadata | undefined>();
+  // §8.12.8 readback exclusion: see `ownRestampContainerPaths`.
+  const ownRestamps = ownRestampContainerPaths(tx);
   forEachFlowObservation(
     tx,
     (space, id, scope, type, logicalPath, observation) => {
@@ -1490,12 +1632,38 @@ export const deriveFlowJoin = (
       if (!metadataByDoc.has(key)) {
         metadataByDoc.set(key, storedMetadataFor(tx, space, id, scope, type));
       }
+      const ownedContainers = ownRestamps.get(key);
+      // `*`-template consumption keeps the C0 §6.1 row-3/row-4 boundary the
+      // probe channel already has, extended to PLAIN reads: resolution
+      // machinery journals ordinary reads at followed slots (the slot
+      // scalar, the sigil interior) on its way to the target, and those
+      // must not consume the slot templates — the follow's taint arrives
+      // via the target's own reads (row 4), while STANDALONE slot
+      // observations (no covering trace) consume in full (row 3, the SC-8
+      // closures). Without this, every traversal hop through a stamped
+      // container smears the container's J onto whatever the transaction
+      // writes — re-importing the pointwise smear the S16 substrate
+      // removed (measured: the phase-B pointwise map suite).
+      const excludesTemplates = observation.coveredByTrace ||
+        ownedContainers !== undefined;
       const label = effectiveReadLabel(
         metadataByDoc.get(key),
         logicalPath,
         {
           nonRecursive: observation.nonRecursive,
           consumes: observation.shape,
+          ...(excludesTemplates
+            ? {
+              excludeEntry: (entry: LabelMapEntry) =>
+                (observation.coveredByTrace &&
+                  isRuntimeMintedTemplate({
+                    origin: entry.origin,
+                    path: canonicalizeLogicalPath(entry.path),
+                  })) ||
+                (ownedContainers !== undefined &&
+                  isReplacedMembershipEntry(entry, ownedContainers)),
+            }
+            : {}),
         },
       );
       // Any observation with label CONTENT marks its space as a label
@@ -1748,6 +1916,28 @@ const walkIfcSchema = (
     }
     if (typeof resolved.items === "object" && resolved.items !== null) {
       walkIfcSchema(resolved.items, [...path, "*"], entries, childRoot, active);
+    }
+    // Record-only `additionalProperties` descends as the same `*` segment
+    // arrays get from `items` (template-population §4) — RESTRICTED to
+    // record-only objects (no `properties` key). The restriction is
+    // load-bearing: `isPrefix`'s `*` matches ANY segment, but
+    // `additionalProperties` semantically covers only keys NOT listed under
+    // `properties` (schemaAtPath consults it only on a properties miss), so
+    // an unrestricted `*` entry from a mixed schema would over-taint the
+    // named fields. Mixed fixed-plus-record-tail schemas therefore mint no
+    // `*` entry (expressing them needs exclusion semantics §3.3 forbids).
+    if (
+      resolved.properties === undefined &&
+      typeof resolved.additionalProperties === "object" &&
+      resolved.additionalProperties !== null
+    ) {
+      walkIfcSchema(
+        resolved.additionalProperties,
+        [...path, "*"],
+        entries,
+        childRoot,
+        active,
+      );
     }
     return entries;
   } finally {
@@ -3756,11 +3946,16 @@ const collectConsumedLabel = (
     // false-reject valid commits (review round 2 on #3993).
     for (const entry of metadata.labelMap.entries) {
       const entryPath = canonicalizeLogicalPath(entry.path);
-      // Structure entries label only the container node's shape: an
-      // ancestor structure entry does not apply to a read strictly below
-      // it (same exact-path rule as `labelAtPath`); as a descendant of a
-      // recursive read it does apply (the read materializes the shape).
-      const overlapsRead = entry.origin === "structure"
+      // CONCRETE structure entries label only the container node's shape:
+      // an ancestor structure entry does not apply to a read strictly
+      // below it (same exact-path rule as `labelAtPath`); as a descendant
+      // of a recursive read it does apply (the read materializes the
+      // shape). `*`-path templates (template-population §3.2) exist to be
+      // consumed at matching child paths, so they take the generic
+      // ancestor-or-equal arm — this collector stays additive; templates
+      // just participate.
+      const overlapsRead = entry.origin === "structure" &&
+          !isRuntimeMintedTemplate({ origin: entry.origin, path: entryPath })
         ? (entryPath.length === path.length
           ? isPrefix(entryPath, path)
           : read.nonRecursive !== true && isPrefix(path, entryPath))
@@ -4700,13 +4895,19 @@ export const prepareBoundaryCommit = (
       // observes:"shape" entry is policy, not measurement — it keeps the
       // declared component's own discipline (grow-only re-mint through
       // the schema walk) and must not be captured by the freeze carry
-      // (review on this PR). Known residual: deletion leaves the frozen
-      // entry in place (over-taint) and re-creation keeps it instead of
-      // re-minting at the re-creating join — re-mint-on-recreation needs
-      // per-path previousValue plumbing.
+      // (review on this PR). `*`-path TEMPLATES are excluded too: the
+      // shape-class membership template records CURRENT shape under
+      // replace-from-criteria (template-population §3.1/§3.2.1), so
+      // freezing it here would both unhinge it from the criteria and
+      // accumulate stale J forever through the coalesce join. Known
+      // residual: deletion leaves the frozen entry in place (over-taint)
+      // and re-creation keeps it instead of re-minting at the re-creating
+      // join — re-mint-on-recreation needs per-path previousValue
+      // plumbing.
       if (
         (entry.origin === "derived" || entry.origin === "structure") &&
-        entry.observes === "shape"
+        entry.observes === "shape" &&
+        !isRuntimeMintedTemplate({ origin: entry.origin, path: entryPath })
       ) {
         persistedLabelEntries.push({
           path: entryPath,
@@ -5018,20 +5219,29 @@ export const prepareBoundaryCommit = (
       // stamp (origin structure, observes enumerate — replace-from-criteria,
       // §8.12.8-normative per #4546) from J this reconcile even with no value
       // write: drop the carried-forward enumerate entry at the exact container
-      // path and re-stamp it below with the current J. The frozen existence
-      // entry (observes shape) and legacy covering entries are left in place —
-      // deleting the frozen entry would make the stamp loop re-mint it from
-      // the CURRENT join, silently unfreezing it; legacy entries await the
-      // write-path migration absorb.
+      // path and re-stamp it below with the current J. The `*`-child class
+      // templates minted beside it (template-population §3.1) follow the same
+      // replace-from-criteria discipline, so the carried template twins at
+      // [...container, "*"] are dropped and re-minted too — leaving them would
+      // coalesce-JOIN with the fresh mints and accumulate stale J forever.
+      // The frozen existence entry (observes shape, concrete path) and legacy
+      // covering entries are left in place — deleting the frozen entry would
+      // make the stamp loop re-mint it from the CURRENT join, silently
+      // unfreezing it; legacy entries await the write-path migration absorb.
       const structureContainerPath = structureContainerPaths.get(key);
       if (structureContainerPath !== undefined) {
         const containerPathKey = pathKey(structureContainerPath);
+        const containerTemplateKey = pathKey([
+          ...structureContainerPath,
+          "*",
+        ]);
         for (let i = persistedLabelEntries.length - 1; i >= 0; i--) {
           const candidateEntry = persistedLabelEntries[i];
           if (
             candidateEntry.origin === "structure" &&
-            candidateEntry.observes === "enumerate" &&
-            pathKey(candidateEntry.path) === containerPathKey
+            ((candidateEntry.observes === "enumerate" &&
+              pathKey(candidateEntry.path) === containerPathKey) ||
+              pathKey(candidateEntry.path) === containerTemplateKey)
           ) {
             persistedLabelEntries.splice(i, 1);
           }
@@ -5154,8 +5364,7 @@ export const prepareBoundaryCommit = (
         // normative for it, so it carries the current J only, never the
         // pool. Labs-axis mapping note: the `observes` axis is read-op
         // shaped, so "enumerate" here approximates the spec's container-
-        // level `iterate.{order,count}` classes; the spec's per-child
-        // shape encoding of membership remains a recorded residual.
+        // level `iterate.{order,count}` classes.
         if (flowHasLabels && flowConfidentiality.length > 0) {
           persistedLabelEntries.push(markFlowStampEntry({
             path,
@@ -5163,6 +5372,55 @@ export const prepareBoundaryCommit = (
             origin: "structure",
             observes: "enumerate",
           }));
+        }
+        // `*`-child CLASS TEMPLATES (template-population §3.1, closing the
+        // SC-4/SC-8 residuals): the same J, minted once per class at
+        // [...container, "*"] — O(1) in the container's size where the
+        // spec's per-child `shape` encoding (§8.5.6.1) needed O(n).
+        //  - `shape`: a per-child existence probe ("is /items/3
+        //    present?", §8.10.1.1) consumes the membership decision;
+        //  - `value`: materializing the reference scalar at a slot
+        //    (§4.6.3 ref-container rule) consumes it too;
+        //  - `followRef`: a slot-pointer probe/deref consumes the
+        //    assignment J — WHICH element the reader resolves through
+        //    was decided by it (inv-9) — while `shape`/`value` templates
+        //    stay out of probes (readConsumesEntry), keeping blind
+        //    pass-through clean of content taint. All three carry ONLY
+        //    the membership J (confidentiality-only, like every
+        //    structure stamp), never the container's content label.
+        // Same replace-from-criteria discipline as the enumerate stamp:
+        // dropped + re-minted from the current J each reconcile, cleared
+        // (never pooled — `poolsExistence` requires a class-less entry)
+        // on covering writes.
+        //
+        // DECLARED-CONTAINER ROUTE ONLY — a measured deviation from the
+        // design's §3.1 "both routes" (documented in
+        // cfc-template-population.md §6 Stage A). Minting templates on
+        // EVERY pure-link-structure value write puts them on the runtime's
+        // own builder/coordination plumbing (alias shells, internal
+        // arrays), and the op-instantiation machinery reads those docs'
+        // child paths (slot scalars, length) as scaffolding with NO
+        // distinguishing journal marker — neither probe-classified nor
+        // trace-covered — so each reconcile's J smears into the next
+        // (measured: the phase-B pointwise map suite). The declared
+        // list-coordinator containers (filter/flatMap results — the actual
+        // §8.5.6.1/SC-7 membership subjects) are where the membership
+        // decision lives; their templates close the SC-4/SC-8 residuals,
+        // and the generic value-write route keeps today's
+        // container-anchored stamps until machinery reads carry a marker.
+        if (
+          flowHasLabels && flowConfidentiality.length > 0 &&
+          structureContainerPath !== undefined &&
+          pathKey(structureContainerPath) === pathKey(path)
+        ) {
+          for (const observes of ["shape", "value", "followRef"] as const) {
+            persistedLabelEntries.push(markFlowStampEntry({
+              path: [...path, "*"],
+              label: { confidentiality: [...flowConfidentiality] },
+              origin: "structure",
+              observes,
+            }));
+          }
         }
         // FROZEN existence entry (freeze-at-creation, spec branch
         // cfc/existence-freeze-at-creation): minted once — at the first

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -161,13 +161,31 @@ export type CfcSandboxResult = {
  * - `structure`: flow label on a container's SHAPE (membership, key set,
  *   order, length — §8.5.6.1/SC-7) for written values made purely of
  *   references, where per-slot link entries already label each reference.
- *   Applies only to reads at exactly the entry's path (observing the
- *   container is observing its shape); reads strictly below it (slot
- *   pointer reads, dereferences) are pointer handling and stay clean —
- *   that asymmetry is what lets membership taint persist without smearing
- *   the pointwise per-element split. Update discipline matches `derived`.
- *   Readers that predate this component treat it as covering (over-taint,
- *   fail-safe).
+ *   A CONCRETE-path structure entry applies only to reads at exactly its
+ *   path (observing the container is observing its shape); reads strictly
+ *   below it are pointer handling and stay clean. On DECLARED
+ *   list-coordinator containers (the S16 `recordCfcStructureContainer`
+ *   hook — filter/flatMap results, where the membership decision lives)
+ *   the runtime additionally mints three `*`-child CLASS TEMPLATES at
+ *   `[...container, "*"]` beside the container-anchored
+ *   `observes:"enumerate"` stamp — `shape`, `value`, `followRef` —
+ *   carrying the same per-tx J (docs/specs/cfc-template-population.md §3):
+ *   templates ARE consumed at matching child paths, so a per-child
+ *   existence probe or a slot-pointer observation consumes the
+ *   membership/assignment decision (the SC-4/SC-8 residual fixes) while
+ *   `readConsumesEntry`'s class table keeps probes clean of content taint
+ *   — the pointer/content split moves onto the class axis instead of
+ *   hanging on path anchoring alone. Two machinery boundaries keep
+ *   scaffolding out (measured on the phase-B pointwise suite): reads
+ *   covered by a same-tx dereference trace are resolution machinery and
+ *   skip templates (the C0 §6.1 row-4 rule extended to plain reads), and
+ *   a transaction re-deriving a container's membership stamps does not
+ *   consume the entries it replaces (§8.12.8 replace-from-criteria
+ *   readback exclusion). Update discipline matches `derived` (templates
+ *   replace-from-criteria with the enumerate stamp they accompany;
+ *   concrete `observes:"shape"` existence entries freeze at creation).
+ *   Readers that predate this component treat its entries as covering
+ *   (over-taint, fail-safe).
  * - `external-ingest`: the `ExternalIngest` provenance mark a vouched ingest
  *   channel mints onto the value it durably appends. Builtin-authored from
  *   verified channel metadata only (the split-mint), so it bypasses the

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -385,6 +385,43 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     expect(frozen[0].label.confidentiality).toEqual(["creation-atom"]);
   });
 
+  // A bare SLOT write does not clear the container's templates: it
+  // replaces one child, not the membership, and slot writes mint nothing —
+  // clearing would open an unlabeled window until the next declared
+  // reconcile. The container-anchored enumerate stamp already survives
+  // slot writes (exact-path never matches a deeper write); the twins
+  // follow the same discipline. Only a write covering the CONTAINER
+  // clears.
+  it("slot writes leave the container's templates in place", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-sw", { n: 1 }, []);
+    const otherId = await seedDoc(rt, "tp-el-sw-2", { n: 2 }, []);
+    const criteriaId = await seedDoc(rt, "tp-criteria-sw", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-sw", criteriaId, ["tp-el-sw"]);
+
+    // Clean tx replaces slot 0 with a link to another doc — no declaration,
+    // no covering write.
+    const slotWrite = rt.edit();
+    slotWrite.writeOrThrow(
+      { space, scope: "space", id: uri(listId), path: ["value", "0"] },
+      { "/": { "link@1": { id: otherId, path: [] } } },
+    );
+    slotWrite.prepareCfc();
+    expect((await slotWrite.commit()).ok).toBeDefined();
+
+    const templates = entriesOf(listId).filter(
+      (e) => e.origin === "structure" && e.path.length === 1,
+    );
+    expect(templates.map((e) => e.observes).sort()).toEqual(
+      ["followRef", "shape", "value"],
+    );
+    for (const entry of templates) {
+      expect(entry.label.confidentiality).toEqual(["memb-secret"]);
+    }
+  });
+
   // SC-11 with templates present: an identical re-declaration (same
   // criteria, same members, no value write) re-derives byte-identical
   // metadata and must not write the ["cfc"] envelope at all.

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -1,13 +1,25 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
+import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
+import {
+  commitCfcFieldValue,
+  containsCfcFieldCommitment,
+} from "../src/cfc/label-representation.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 import type { LabelMapEntry } from "../src/cfc/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-template-population");
+const foreignSigner = await Identity.fromPassphrase(
+  "runner-cfc-template-population-foreign",
+);
 const space = signer.did();
+const foreignSpace = foreignSigner.did();
 
 type StoredEntry = {
   path: string[];
@@ -216,5 +228,775 @@ describe("CFC template population (Stage A): the two under-taints", () => {
       tx.readOrThrow(readAddress(listId, ["0"]));
     });
     expect(join).toContainEqual("memb-secret");
+  });
+
+  // The template mint itself, pinned: a declared coordinator container gets
+  // the container-anchored enumerate stamp, the frozen existence entry, and
+  // exactly three `*`-child templates — shape/value/followRef — all
+  // carrying the membership J, confidentiality-only.
+  it("declared containers mint the three `*`-child class templates beside the enumerate stamp", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-m", { n: 1 }, []);
+    const criteriaId = await seedDoc(rt, "tp-criteria-m", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-m", criteriaId, ["tp-el-m"]);
+
+    const structure = entriesOf(listId).filter((e) => e.origin === "structure");
+    const container = structure.filter((e) => e.path.length === 0);
+    expect([...new Set(container.map((e) => e.observes))].sort()).toEqual(
+      ["enumerate", "shape"],
+    );
+    const templates = structure.filter((e) => e.path.length === 1);
+    expect(templates.map((e) => e.path)).toEqual([["*"], ["*"], ["*"]]);
+    expect(templates.map((e) => e.observes).sort()).toEqual(
+      ["followRef", "shape", "value"],
+    );
+    for (const entry of structure) {
+      expect(entry.label.confidentiality).toEqual(["memb-secret"]);
+      expect(entry.label.integrity).toBeUndefined();
+    }
+  });
+
+  // Replace-from-criteria (§8.12.8, the discipline the templates share with
+  // the enumerate stamp): when the criteria change across reconciles, the
+  // templates follow — the departed criteria's atom leaves — while the
+  // FROZEN existence entry keeps the creation join. A transient empty-J
+  // reconcile (declare with nothing labeled read — resume/loading) does NOT
+  // clear a correct prior label.
+  it("templates re-stamp from current J each reconcile; transient empty-J reconciles leave them alone", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-r", { n: 1 }, []);
+    const criteriaA = await seedDoc(rt, "tp-criteria-r-a", { keep: true }, [
+      { path: [], label: { confidentiality: ["alice-criteria"] } },
+    ]);
+    const criteriaB = await seedDoc(rt, "tp-criteria-r-b", { keep: false }, [
+      { path: [], label: { confidentiality: ["bob-criteria"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-r", criteriaA, ["tp-el-r"]);
+
+    const templateConf = () =>
+      entriesOf(listId)
+        .filter((e) => e.origin === "structure" && e.path.length === 1)
+        .flatMap((e) => e.label.confidentiality ?? []);
+    const frozenConf = () =>
+      entriesOf(listId)
+        .filter((e) =>
+          e.origin === "structure" && e.path.length === 0 &&
+          e.observes === "shape"
+        )
+        .flatMap((e) => e.label.confidentiality ?? []);
+    expect(templateConf()).toEqual([
+      "alice-criteria",
+      "alice-criteria",
+      "alice-criteria",
+    ]);
+
+    // Re-declare with NO value write under the new criteria: the templates
+    // (and the enumerate stamp) are dropped and re-minted from the new J —
+    // alice's atom leaves with her criteria (no accumulate-forever).
+    const restamp = rt.edit();
+    restamp.readOrThrow(readAddress(criteriaB, []));
+    restamp.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    restamp.prepareCfc();
+    expect((await restamp.commit()).ok).toBeDefined();
+    expect(templateConf()).toEqual([
+      "bob-criteria",
+      "bob-criteria",
+      "bob-criteria",
+    ]);
+    // The frozen existence entry keeps the CREATION join, untouched.
+    expect(frozenConf()).toEqual(["alice-criteria"]);
+
+    // Transient empty-J reconcile: the container is declared but nothing
+    // labeled was read (J empty) — the prior templates must survive
+    // (fail-safe: keep the existing label, mirroring the enumerate stamp).
+    const transient = rt.edit();
+    transient.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    transient.prepareCfc();
+    expect((await transient.commit()).ok).toBeDefined();
+    expect(templateConf()).toEqual([
+      "bob-criteria",
+      "bob-criteria",
+      "bob-criteria",
+    ]);
+  });
+
+  // Covering writes clear templates and NEVER pool them into the existence
+  // channel: after a criteria change re-stamped the templates to a new atom,
+  // a covering overwrite of the container removes every `*` entry, and the
+  // re-stamped atom must not surface anywhere else (pooling it into the
+  // frozen shape entry would ratchet §8.12.8's replace into a grow).
+  it("covering write clears templates without pooling them", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-cw", { n: 1 }, []);
+    const criteriaA = await seedDoc(rt, "tp-criteria-cw-a", { keep: true }, [
+      { path: [], label: { confidentiality: ["creation-atom"] } },
+    ]);
+    const criteriaB = await seedDoc(rt, "tp-criteria-cw-b", { keep: true }, [
+      { path: [], label: { confidentiality: ["tmpl-only-atom"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-cw", criteriaA, ["tp-el-cw"]);
+    const restamp = rt.edit();
+    restamp.readOrThrow(readAddress(criteriaB, []));
+    restamp.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    restamp.prepareCfc();
+    expect((await restamp.commit()).ok).toBeDefined();
+    expect(
+      entriesOf(listId)
+        .filter((e) => e.path.length === 1)
+        .flatMap((e) => e.label.confidentiality ?? []),
+    ).toContainEqual("tmpl-only-atom");
+
+    // Covering overwrite (clean tx, plain content): every structure entry
+    // under the written path is cleared; templates are class-carrying and
+    // never pool, so tmpl-only-atom vanishes entirely — while the frozen
+    // existence entry (creation-atom) survives the overwrite in place.
+    const cover = rt.edit();
+    cover.writeOrThrow(
+      { space, scope: "space", id: uri(listId), path: ["value"] },
+      { replaced: true },
+    );
+    cover.prepareCfc();
+    expect((await cover.commit()).ok).toBeDefined();
+
+    const after = entriesOf(listId);
+    expect(after.some((e) => e.path.includes("*"))).toBe(false);
+    expect(JSON.stringify(after)).not.toContain("tmpl-only-atom");
+    const frozen = after.filter((e) =>
+      e.origin === "structure" && e.observes === "shape"
+    );
+    expect(frozen.length).toBe(1);
+    expect(frozen[0].label.confidentiality).toEqual(["creation-atom"]);
+  });
+
+  // SC-11 with templates present: an identical re-declaration (same
+  // criteria, same members, no value write) re-derives byte-identical
+  // metadata and must not write the ["cfc"] envelope at all.
+  it("recompute with templates present is a no-op (SC-11: zero cfc writes)", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-i", { n: 1 }, []);
+    const criteriaId = await seedDoc(rt, "tp-criteria-i", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-i", criteriaId, ["tp-el-i"]);
+    const before = JSON.stringify(entriesOf(listId));
+
+    const again = rt.edit();
+    again.readOrThrow(readAddress(criteriaId, []));
+    again.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    again.prepareCfc();
+    const wroteCfc = [...(again.getWriteDetails?.(space) ?? [])].some(
+      (w) => w.address.id === listId && w.address.path[0] === "cfc",
+    );
+    expect(wroteCfc).toBe(false);
+    expect((await again.commit()).ok).toBeDefined();
+    expect(JSON.stringify(entriesOf(listId))).toEqual(before);
+  });
+
+  // The §8.12.8 replace-from-criteria READBACK EXCLUSION, pinned at the
+  // unit level: the re-deriving transaction's own reads of the container's
+  // slots (an incremental reconciler diffing its previous output) must not
+  // feed the replaced templates back into the J it re-mints them from —
+  // otherwise replace degenerates into accumulate-forever. The end-to-end
+  // pin is cfc-flow-pointwise's "membership replaces from criteria".
+  it("the re-deriving tx's own slot readback does not ratchet J (readback exclusion)", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-rb", { n: 1 }, []);
+    const criteriaA = await seedDoc(rt, "tp-criteria-rb-a", { keep: true }, [
+      { path: [], label: { confidentiality: ["old-criteria"] } },
+    ]);
+    const criteriaB = await seedDoc(rt, "tp-criteria-rb-b", { keep: true }, [
+      { path: [], label: { confidentiality: ["new-criteria"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-rb", criteriaA, ["tp-el-rb"]);
+
+    // The reconcile: reads the new criteria AND its own container's slot
+    // (the diff readback — a standalone probe at the slot plus a raw slot
+    // read), then re-declares. Without the exclusion the readback would
+    // resolve the old templates and mint old ∪ new.
+    const reconcile = rt.edit();
+    reconcile.readOrThrow(readAddress(criteriaB, []));
+    reconcile.read(readAddress(listId, ["0"]), { meta: linkResolutionProbe });
+    reconcile.readOrThrow(readAddress(listId, ["0"]));
+    reconcile.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    reconcile.prepareCfc();
+    expect((await reconcile.commit()).ok).toBeDefined();
+
+    const templateConf = entriesOf(listId)
+      .filter((e) => e.origin === "structure" && e.path.length === 1)
+      .flatMap((e) => e.label.confidentiality ?? []);
+    expect(templateConf).toContainEqual("new-criteria");
+    expect(templateConf).not.toContainEqual("old-criteria");
+  });
+
+  // The C0 §6.1 row-4 boundary extended to plain reads: a read at a slot
+  // that is COVERED by a same-tx dereference trace is resolution machinery
+  // passing through — it must not consume the slot templates (the follow's
+  // taint arrives via the target's own reads). A standalone read of the
+  // same slot (the row-3 case) consumes them — that asymmetry is pinned by
+  // this test together with the red tests above.
+  it("trace-covered slot reads are machinery: no template consumption", async () => {
+    const rt = makeRuntime();
+    const elId = await seedDoc(rt, "tp-el-tc", { n: 1 }, []);
+    const criteriaId = await seedDoc(rt, "tp-criteria-tc", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-tc", criteriaId, ["tp-el-tc"]);
+
+    const join = await flowJoinOf(rt, "tp-probe-tc-out", (tx) => {
+      tx.readOrThrow(readAddress(listId, ["0"]));
+      tx.recordCfcDereferenceTrace({
+        source: { space, id: listId, scope: "space", path: ["0"] },
+        target: { space, id: elId, scope: "space", path: [] },
+        kind: "value",
+      });
+    });
+    expect(join).not.toContainEqual("memb-secret");
+  });
+});
+
+// Resolution semantics over hand-seeded template entries with DISTINCT
+// per-class atoms — the runtime mints identical labels per class, so the
+// class split is only observable with seeded metadata.
+describe("CFC template population (Stage A): class-split resolution", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const seedDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    entries: LabelMapEntry[],
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: { version: 1, entries },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const derivedConfidentiality = (id: string): unknown[] =>
+    entriesOf(id)
+      .filter((e) => e.origin === "derived")
+      .flatMap((e) => e.label.confidentiality ?? []);
+
+  const readAddress = (id: string, path: string[]) => ({
+    space,
+    scope: "space" as const,
+    id: id as `${string}:${string}`,
+    type: "application/json" as const,
+    path: ["value", ...path],
+  });
+
+  const flowJoinOf = async (
+    rt: Runtime,
+    outCause: string,
+    observe: (tx: ReturnType<Runtime["edit"]>) => void,
+  ): Promise<unknown[]> => {
+    const tx = rt.edit();
+    observe(tx);
+    const out = rt.getCell(space, outCause, undefined, tx);
+    out.set({ observed: true });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+  };
+
+  // One doc, every class distinct: a covering root entry, the three
+  // templates with per-class atoms, and a link-origin pointer label on
+  // slot 0.
+  const seedSplitDoc = (rt: Runtime, cause: string) =>
+    seedDoc(rt, cause, {
+      items: [{ "/": { "link@1": { id: "of:tp-target", path: [] } } }],
+    }, [
+      { path: [], label: { confidentiality: ["root-covering"] } },
+      {
+        path: ["items", "*"],
+        label: { confidentiality: ["memb-shape"] },
+        origin: "structure",
+        observes: "shape",
+      },
+      {
+        path: ["items", "*"],
+        label: { confidentiality: ["memb-value"] },
+        origin: "structure",
+        observes: "value",
+      },
+      {
+        path: ["items", "*"],
+        label: { confidentiality: ["memb-ref"] },
+        origin: "structure",
+        observes: "followRef",
+      },
+      {
+        path: ["items", "0"],
+        label: { confidentiality: ["ptr-label"] },
+        origin: "link",
+      },
+    ]);
+
+  // The refined split, pinned (design §2): a slot followRef consumes the
+  // followRef template and the slot's own link entry — NO content-class
+  // template (shape/value), NO covering entry (the types.ts:194-199 blind
+  // pass-through property, preserved by class), and nothing of the target
+  // beyond its own link entry.
+  it("slot followRef consumes followRef template + link entry only", async () => {
+    const rt = makeRuntime();
+    const id = await seedSplitDoc(rt, "tp-split-ref");
+    const join = await flowJoinOf(rt, "tp-split-ref-out", (tx) => {
+      tx.read(readAddress(id, ["items", "0"]), { meta: linkResolutionProbe });
+    });
+    expect(join).toContainEqual("memb-ref");
+    expect(join).toContainEqual("ptr-label");
+    expect(join).not.toContainEqual("memb-shape");
+    expect(join).not.toContainEqual("memb-value");
+    expect(join).not.toContainEqual("root-covering");
+  });
+
+  // A per-child shape probe consumes the shape template (and covering
+  // ancestors — content channel), never the value/followRef twins.
+  it("per-child shape probe consumes the shape template only", async () => {
+    const rt = makeRuntime();
+    const id = await seedSplitDoc(rt, "tp-split-shape");
+    const join = await flowJoinOf(rt, "tp-split-shape-out", (tx) => {
+      tx.readOrThrow(readAddress(id, ["items", "0"]), { nonRecursive: true });
+    });
+    expect(join).toContainEqual("memb-shape");
+    expect(join).not.toContainEqual("memb-value");
+    expect(join).not.toContainEqual("memb-ref");
+    expect(join).not.toContainEqual("ptr-label");
+  });
+
+  // A raw sigil value read at the slot consumes the value twin and the
+  // shape twin (value reads consume the shape class, C0 §4) — never the
+  // followRef twin or the pointer's transport label.
+  it("raw value read at the slot consumes value + shape twins, not followRef", async () => {
+    const rt = makeRuntime();
+    const id = await seedSplitDoc(rt, "tp-split-value");
+    const join = await flowJoinOf(rt, "tp-split-value-out", (tx) => {
+      tx.readOrThrow(readAddress(id, ["items", "0"]));
+    });
+    expect(join).toContainEqual("memb-value");
+    expect(join).toContainEqual("memb-shape");
+    expect(join).not.toContainEqual("memb-ref");
+    expect(join).not.toContainEqual("ptr-label");
+  });
+
+  // Templates apply below the direct child too (§4.6.3 recursive descent):
+  // a value read strictly inside a slot's subtree still consumes the
+  // value/shape twins — the exact-path structure rule does not apply to
+  // `*`-path templates.
+  it("templates apply to reads strictly below the slot", async () => {
+    const rt = makeRuntime();
+    const id = await seedDoc(rt, "tp-split-deep", {
+      items: [{ name: "x" }],
+    }, [
+      {
+        path: ["items", "*"],
+        label: { confidentiality: ["memb-value"] },
+        origin: "structure",
+        observes: "value",
+      },
+    ]);
+    const join = await flowJoinOf(rt, "tp-split-deep-out", (tx) => {
+      tx.readOrThrow(readAddress(id, ["items", "0", "name"]));
+    });
+    expect(join).toContainEqual("memb-value");
+  });
+
+  // The frozen-vs-membership JOIN exception (design §3.2.1): a frozen
+  // concrete shape entry (departed history) and the `*` membership template
+  // (current shape) answer different questions under one class — where both
+  // cover a read their labels JOIN rather than replace-down, in the
+  // same-origin case (structure) and the cross-origin case (derived).
+  it("frozen concrete shape entry and `*` membership template JOIN", async () => {
+    const rt = makeRuntime();
+    const id = await seedDoc(rt, "tp-join", {
+      items: [[], []],
+    }, [
+      {
+        path: ["items", "*"],
+        label: { confidentiality: ["memb-current"] },
+        origin: "structure",
+        observes: "shape",
+      },
+      // Same origin, concrete path, same class: a nested container's frozen
+      // existence entry.
+      {
+        path: ["items", "0"],
+        label: { confidentiality: ["frozen-structure"] },
+        origin: "structure",
+        observes: "shape",
+      },
+      // Cross-origin concrete shape at another slot (a departed derived
+      // write's frozen existence).
+      {
+        path: ["items", "1"],
+        label: { confidentiality: ["frozen-derived"] },
+        origin: "derived",
+        observes: "shape",
+      },
+    ]);
+    const joinSame = await flowJoinOf(rt, "tp-join-same-out", (tx) => {
+      tx.readOrThrow(readAddress(id, ["items", "0"]), { nonRecursive: true });
+    });
+    expect(joinSame).toContainEqual("memb-current");
+    expect(joinSame).toContainEqual("frozen-structure");
+    const joinCross = await flowJoinOf(rt, "tp-join-cross-out", (tx) => {
+      tx.readOrThrow(readAddress(id, ["items", "1"]), { nonRecursive: true });
+    });
+    expect(joinCross).toContainEqual("memb-current");
+    expect(joinCross).toContainEqual("frozen-derived");
+  });
+
+  // Declared `*` entries (items schemas) keep their behavior byte-for-byte:
+  // the persisted declared entry form is unchanged and a value read at a
+  // child consumes it exactly as before this design (regression pin).
+  it("declared items-`*` entries persist and resolve unchanged (regression)", async () => {
+    const rt = makeRuntime();
+    const guarded = internSchema(
+      {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              ifc: { confidentiality: ["declared-member"] },
+            },
+          },
+        },
+      } as JSONSchema,
+      true,
+    );
+    const tx = rt.edit();
+    const cell = rt.getCell(space, "tp-declared-star", guarded.schema, tx);
+    cell.set({ items: [{ n: 1 }] });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    const id = cell.getAsNormalizedFullLink().id;
+
+    const declared = entriesOf(id).filter((e) => e.origin === "declared");
+    expect(declared).toEqual([{
+      path: ["items", "*"],
+      label: { confidentiality: ["declared-member"] },
+      origin: "declared",
+    }]);
+
+    const join = await flowJoinOf(rt, "tp-declared-star-out", (tx2) => {
+      tx2.readOrThrow(readAddress(id, ["items", "0"]));
+    });
+    expect(join).toContainEqual("declared-member");
+  });
+});
+
+// The §4 schema-walk extension: record-only `additionalProperties` descends
+// as a `*` segment; mixed properties+additionalProperties schemas mint NO
+// `*` entry (pinned — the restriction is load-bearing, `*` matches any
+// segment and would over-taint the named fields).
+describe("CFC template population (Stage A): record-only additionalProperties walk", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const persistThroughSchema = async (
+    rt: Runtime,
+    cause: string,
+    schema: JSONSchema,
+    value: unknown,
+  ): Promise<string> => {
+    const interned = internSchema(schema, true);
+    const tx = rt.edit();
+    const cell = rt.getCell(space, cause, interned.schema, tx);
+    cell.set(value as never);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    return cell.getAsNormalizedFullLink().id;
+  };
+
+  it("record-only additionalProperties mints a declared `*` entry", async () => {
+    const rt = makeRuntime();
+    const id = await persistThroughSchema(rt, "tp-ap-record", {
+      type: "object",
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["map-member"] },
+      },
+    } as JSONSchema, { anyKey: "v" });
+
+    const declared = entriesOf(id).filter((e) => e.origin === "declared");
+    expect(declared).toEqual([{
+      path: ["*"],
+      label: { confidentiality: ["map-member"] },
+      origin: "declared",
+    }]);
+  });
+
+  it("mixed properties + additionalProperties mints NO `*` entry (§4 restriction)", async () => {
+    const rt = makeRuntime();
+    const id = await persistThroughSchema(rt, "tp-ap-mixed", {
+      type: "object",
+      properties: {
+        named: { type: "string", ifc: { confidentiality: ["named-field"] } },
+      },
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["map-member"] },
+      },
+    } as JSONSchema, { named: "v", extra: "w" });
+
+    const stored = entriesOf(id);
+    expect(stored.some((e) => e.path.includes("*"))).toBe(false);
+    expect(JSON.stringify(stored)).not.toContain("map-member");
+    // The named field's declared entry still lands.
+    expect(
+      stored.some((e) =>
+        e.origin === "declared" && e.path.join("/") === "named"
+      ),
+    ).toBe(true);
+  });
+
+  it("boolean additionalProperties never descends", async () => {
+    const rt = makeRuntime();
+    const id = await persistThroughSchema(rt, "tp-ap-bool", {
+      type: "object",
+      additionalProperties: true,
+      ifc: { confidentiality: ["root-label"] },
+    } as JSONSchema, { k: 1 });
+    const stored = entriesOf(id);
+    expect(stored.some((e) => e.path.includes("*"))).toBe(false);
+  });
+});
+
+// Inv-12 Stage 1 rides along (design §3.3): template entries opt into the
+// cross-space representation transform at mint exactly like the container
+// stamps they accompany — a membership J fed by a foreign labeled read
+// persists in commitment form under `enforce`.
+describe("CFC template population (Stage A): cross-space label protection", () => {
+  const userAtom = { type: CFC_ATOM_TYPE.User, subject: "did:key:alice" };
+
+  it("templates with cross-space J persist commitment forms under enforce", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+      cfcLabelMetadataProtection: "enforce",
+    });
+    try {
+      // Foreign labeled criteria doc in spaceA.
+      const seed = runtime.edit();
+      const criteria = runtime.getCell(
+        foreignSpace,
+        "tp-xs-criteria",
+        undefined,
+        seed,
+      );
+      const criteriaId = criteria.getAsNormalizedFullLink().id;
+      seed.writeOrThrow(
+        { space: foreignSpace, scope: "space", id: criteriaId, path: [] },
+        {
+          value: { keep: true },
+          cfc: {
+            version: 1,
+            schemaHash: "seed-schema",
+            labelMap: {
+              version: 1,
+              entries: [{ path: [], label: { confidentiality: [userAtom] } }],
+            },
+          },
+        },
+      );
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // Declared container in the local space whose membership J consumed
+      // the foreign read.
+      const tx = runtime.edit();
+      tx.readOrThrow({
+        space: foreignSpace,
+        scope: "space",
+        id: criteriaId,
+        type: "application/json",
+        path: ["value"],
+      });
+      const el = runtime.getCell(space, "tp-xs-el", undefined, tx);
+      const list = runtime.getCell(space, "tp-xs-list", {
+        type: "array",
+        items: { asCell: ["cell"] },
+      }, tx);
+      list.set([el]);
+      const listId = list.getAsNormalizedFullLink().id;
+      tx.recordCfcStructureContainer({
+        space,
+        id: listId,
+        scope: "space",
+        path: [],
+      });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const replica = storageManager.open(space).replica as unknown as {
+        getDocument(id: string): {
+          cfc?: { labelMap?: { entries: StoredEntry[] } };
+        } | undefined;
+      };
+      const entries = replica.getDocument(listId)?.cfc?.labelMap?.entries ??
+        [];
+      const templates = entries.filter((e) =>
+        e.origin === "structure" && e.path.length === 1 && e.path[0] === "*"
+      );
+      expect(templates.length).toBe(3);
+      for (const entry of templates) {
+        expect(entry.label.confidentiality).toContainEqual({
+          type: CFC_ATOM_TYPE.User,
+          subject: commitCfcFieldValue("did:key:alice"),
+        });
+      }
+      expect(JSON.stringify(entries)).not.toContain("did:key:alice");
+      expect(containsCfcFieldCommitment(entries)).toBe(true);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});
+
+// Canonicalization and coalescing over multi-`*` paths (design §3.3 "no
+// changes required" — verified, not assumed).
+describe("CFC template population (Stage A): canonical form with `*` paths", () => {
+  const entry = (
+    path: string[],
+    atom: string,
+    observes?: string,
+  ): LabelMapEntry => ({
+    path,
+    label: { confidentiality: [atom] },
+    origin: "structure",
+    ...(observes !== undefined
+      ? { observes: observes as LabelMapEntry["observes"] }
+      : {}),
+  });
+
+  it("sorts multi-`*` template entries deterministically and keeps classes separate", () => {
+    const entries: LabelMapEntry[] = [
+      entry(["items", "*"], "a", "value"),
+      entry(["items", "*", "*"], "b", "shape"),
+      entry(["items", "*"], "c", "shape"),
+      entry(["items", "*"], "d", "followRef"),
+      entry(["items", "0"], "e", "shape"),
+    ];
+    const canonical = canonicalizeCfcMetadata({
+      version: 1,
+      schemaHash: "h",
+      labelMap: { version: 1, entries },
+    });
+    // Deterministic: same set in any input order canonicalizes identically.
+    const permuted = canonicalizeCfcMetadata({
+      version: 1,
+      schemaHash: "h",
+      labelMap: { version: 1, entries: [...entries].reverse() },
+    });
+    expect(permuted).toEqual(canonical);
+    // Idempotent.
+    expect(canonicalizeCfcMetadata(canonical)).toEqual(canonical);
+    // No cross-class merge: all five entries survive distinct, ordered by
+    // (path pointer, origin, observes).
+    expect(
+      canonical.labelMap.entries.map((e) => [e.path.join("/"), e.observes]),
+    ).toEqual([
+      ["items/*", "followRef"],
+      ["items/*", "shape"],
+      ["items/*", "value"],
+      ["items/*/*", "shape"],
+      ["items/0", "shape"],
+    ]);
   });
 });

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
+import type { LabelMapEntry } from "../src/cfc/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-template-population");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+// Stage A of docs/specs/cfc-template-population.md: runtime-minted `*`-path
+// per-class `structure` entries (the membership/slot templates) close the two
+// SC-4/SC-8 residual under-taints:
+//   §1.1 a per-child existence probe ("is /items/3 present?" — a nonRecursive
+//        shape read AT the child) never consumed the membership J, because
+//        the runner's membership stamp is container-anchored and structure
+//        entries applied only at exactly their own path;
+//   §1.2 a slot-pointer observation (followRef probe at a computed slot)
+//        consumed only the per-slot link entry (the target's transport
+//        label), never the assignment J that decided WHICH element sits
+//        there.
+// The fix mints three `*`-child entries beside the container-anchored
+// enumerate stamp — {path:[...container,"*"], origin:"structure", observes}
+// for observes ∈ {shape, value, followRef} — all carrying the same per-tx J,
+// under the same replace-from-criteria discipline.
+describe("CFC template population (Stage A): the two under-taints", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const seedDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    entries: LabelMapEntry[],
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: { version: 1, entries },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const derivedConfidentiality = (id: string): unknown[] =>
+    entriesOf(id)
+      .filter((e) => e.origin === "derived")
+      .flatMap((e) => e.label.confidentiality ?? []);
+
+  const readAddress = (id: string, path: string[]) => ({
+    space,
+    scope: "space" as const,
+    id: id as `${string}:${string}`,
+    type: "application/json" as const,
+    path: ["value", ...path],
+  });
+
+  const uri = (id: string) => id as `${string}:${string}`;
+
+  // Builds a pure-link list at `listCause` whose membership was decided
+  // under the label of `criteriaId` (the predicate-output stand-in the
+  // writing tx reads), DECLARED as a list-coordinator result container
+  // (`recordCfcStructureContainer`, the S16 hook the filter/flatMap
+  // coordinators call each reconcile): the declared container gets the
+  // container-anchored `enumerate` stamp AND the `*`-child class templates,
+  // all carrying that tx's J — the membership taint. The criteria doc is
+  // DISTINCT from the elements so the membership J is distinguishable from
+  // the per-slot transport labels.
+  const buildList = async (
+    rt: Runtime,
+    listCause: string,
+    criteriaId: string,
+    memberCauses: string[],
+  ): Promise<string> => {
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(criteriaId, []));
+    const members = memberCauses.map((cause) =>
+      rt.getCell(space, cause, undefined, tx)
+    );
+    const list = rt.getCell(space, listCause, {
+      type: "array",
+      items: { asCell: ["cell"] },
+    }, tx);
+    list.set(members);
+    const listId = list.getAsNormalizedFullLink().id;
+    tx.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    return listId;
+  };
+
+  // Runs `observe` in a fresh tx that also writes an out doc, commits, and
+  // returns the out doc's derived flow confidentiality.
+  const flowJoinOf = async (
+    rt: Runtime,
+    outCause: string,
+    observe: (tx: ReturnType<Runtime["edit"]>) => void,
+  ): Promise<unknown[]> => {
+    const tx = rt.edit();
+    observe(tx);
+    const out = rt.getCell(space, outCause, undefined, tx);
+    out.set({ observed: true });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+  };
+
+  // §1.1 — the per-child existence probe. "Is /0 present?" is a shape read
+  // AT THE CHILD (spec §8.10.1.1); the membership decision (which slots
+  // survived) was computed under `memb-secret`, so the probe must consume
+  // it. RED on main: the only membership carrier is the container-anchored
+  // enumerate stamp, which a child-path read never consumes.
+  it("per-child existence probe consumes the membership J (SC-8 residual №1)", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-a", { n: 1 }, [
+      { path: [], label: { confidentiality: ["el-label"] } },
+    ]);
+    const criteriaId = await seedDoc(rt, "tp-criteria-a", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-a", criteriaId, ["tp-el-a"]);
+
+    const join = await flowJoinOf(rt, "tp-probe-a-out", (tx) => {
+      tx.readOrThrow(readAddress(listId, ["0"]), { nonRecursive: true });
+    });
+    expect(join).toContainEqual("memb-secret");
+    // The probe observed presence, not content or pointer identity: the
+    // element's transport label rides the slot's link entry (followRef
+    // class) and must NOT taint a shape probe.
+    expect(join).not.toContainEqual("el-label");
+  });
+
+  // §1.2 — the slot-pointer observation. A followRef probe at a computed
+  // slot observes WHICH reference sits there; the assignment J decided
+  // exactly that (inv-9 flow-path confidentiality), so the probe must
+  // consume it — while still consuming nothing of the container's content
+  // classes and nothing of the target beyond its own link entry. RED on
+  // main: the probe consumes only the per-slot link entry.
+  it("slot followRef probe consumes the assignment J (SC-8 residual №2)", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-b", { n: 2 }, [
+      { path: [], label: { confidentiality: ["el-label"] } },
+    ]);
+    const criteriaId = await seedDoc(rt, "tp-criteria-b", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-b", criteriaId, ["tp-el-b"]);
+
+    const join = await flowJoinOf(rt, "tp-probe-b-out", (tx) => {
+      tx.read(readAddress(listId, ["0"]), { meta: linkResolutionProbe });
+    });
+    expect(join).toContainEqual("memb-secret");
+  });
+
+  // §1.2's value half — materializing the reference scalar at the slot
+  // without dereferencing (a raw sigil value read) is a `value` observation
+  // of the slot and consumes the value twin. RED on main: value reads skip
+  // link-origin entries and no structure entry applies at the slot.
+  it("raw sigil value read at the slot consumes the value twin", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "tp-el-c", { n: 3 }, [
+      { path: [], label: { confidentiality: ["el-label"] } },
+    ]);
+    const criteriaId = await seedDoc(rt, "tp-criteria-c", { keep: true }, [
+      { path: [], label: { confidentiality: ["memb-secret"] } },
+    ]);
+    const listId = await buildList(rt, "tp-list-c", criteriaId, ["tp-el-c"]);
+
+    const join = await flowJoinOf(rt, "tp-probe-c-out", (tx) => {
+      tx.readOrThrow(readAddress(listId, ["0"]));
+    });
+    expect(join).toContainEqual("memb-secret");
+  });
+});

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -880,6 +880,31 @@ describe("CFC template population (Stage A): record-only additionalProperties wa
     ).toBe(true);
   });
 
+  // `properties: {}` is still record-only: no key is named, so EVERY key is
+  // a properties miss and schemaAtPath consults additionalProperties for
+  // all of them — and existing schema helpers produce exactly this
+  // empty-properties wrapper shape, which must not silently lose the
+  // declared map label. The §4 restriction excludes only schemas with ≥1
+  // NAMED property (codex/cubic review on this PR).
+  it("empty-object properties + additionalProperties still mints the `*` entry", async () => {
+    const rt = makeRuntime();
+    const id = await persistThroughSchema(rt, "tp-ap-empty-props", {
+      type: "object",
+      properties: {},
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["map-member"] },
+      },
+    } as JSONSchema, { anyKey: "v" });
+
+    const declared = entriesOf(id).filter((e) => e.origin === "declared");
+    expect(declared).toEqual([{
+      path: ["*"],
+      label: { confidentiality: ["map-member"] },
+      origin: "declared",
+    }]);
+  });
+
   it("boolean additionalProperties never descends", async () => {
     const rt = makeRuntime();
     const id = await persistThroughSchema(rt, "tp-ap-bool", {


### PR DESCRIPTION
Stage A of `docs/specs/cfc-template-population.md` (#4656): the `*`-path class-entry substrate plus the SC-4/SC-8 residual fixes. Stage B (`/cfc/labels/...` population) is out of scope.

## What lands (design §1–§4, §6 Stage A)

**The three template mints (§3.1).** Declared list-coordinator containers (the S16 `recordCfcStructureContainer` route — filter/flatMap results, where the §8.5.6.1 membership decision lives) now mint, beside the container-anchored `{origin:"structure", observes:"enumerate"}` stamp, three `*`-child entries from the same per-tx J:

```
{ path: [...container, "*"], label: {confidentiality: J}, origin: "structure", observes }
```

for `observes ∈ {shape, value, followRef}` — O(1) per container where the spec's per-child `shape` encoding (§8.5.6.1) needed O(n). Same replace-from-criteria discipline as the enumerate stamp: dropped + re-minted from current J each reconcile, cleared (never pooled — `poolsExistence` requires a class-less entry) on container-covering writes, transient-empty-J protected, cross-space-marked via `markFlowStampEntry` like the sibling stamps. The container-anchored enumerate entry is unchanged.

**Resolution (§3.2, surgical).**
- `labelForEntriesAtPath` / `collectConsumedLabel`: the structure exact-path rule is retained for concrete structure entries and does not apply to `*`-path templates (their whole point is child-path consumption). Wildcard matching itself was already in `isPrefix` — verified, not rebuilt.
- The frozen-vs-membership JOIN exception (§3.2.1): shape-class structure/derived `*`-templates resolve in their own per-component bucket, so a frozen concrete `shape` entry (departed history) and the membership template (current shape) JOIN where both cover a read; everything else keeps replace-down.
- `readConsumesEntry` unchanged — the class table already gives the pointer/content split (probes consume `followRef` only; the types.ts:194-199 blind-pass-through property is preserved by class).

**Record-only `additionalProperties` walk (§4).** `walkIfcSchema` descends schema-object `additionalProperties` as a `"*"` segment only when the object has no `properties`. A mixed properties+additionalProperties schema mints NO `*` entry — pinned by test (the restriction is load-bearing: `*` matches any segment and would over-taint the named fields).

**Live-doc contract.** Design §6 Stage-A implementation note; SC-4/SC-7/SC-8 residual paragraphs updated in `cfc-spec-changes.md` (the owed §4.6.3 spec-table sentence left intact); `types.ts` structure-origin doc updated for the twins.

## Red → green (both under-taints, red-first on main)

`packages/runner/test/cfc-template-population.test.ts`, run against main's behavior before the fix:

```
per-child existence probe consumes the membership J (SC-8 residual №1)
  AssertionError: Value: []                    Expected: memb-secret
slot followRef probe consumes the assignment J (SC-8 residual №2)
  AssertionError: Value: [el-label,el-label]   Expected: memb-secret
raw sigil value read at the slot consumes the value twin
  AssertionError: Value: []                    Expected: memb-secret
```

Exactly the design's §1 analysis: the child probe consumed nothing (the container-anchored stamp is wrong-path), and the slot probe consumed only the per-slot transport label — never the assignment J. All three green with the templates; the refined split is pinned with distinct per-class atoms (a slot followRef consumes followRef template + link entry only — no content-class template, no covering entry, nothing of the target beyond its link entry).

## Two measured deviations (documented in the design's §6 note)

Both found by the phase-B pointwise suite (`cfc-flow-pointwise.test.ts`) — the same arbiter that forced the C0 §6.1 refinements — and both are the failure class the design's §2 over-taint caution predicted:

1. **Template mints ride the declared coordinator route only**, not the generic pure-link value-write route. Minting on every pure-link write puts templates on the runtime's own builder plumbing (alias shells, internal arrays), and the op-instantiation machinery reads those docs' child paths (slot scalars, `length`) as scaffolding with no distinguishing journal marker — measured: one instantiation tx (J=[alice], writing `length`/`internal`/`patternIdentity`/el1's result doc) picked alice up purely through el0-era plumbing templates, smearing element 1's reader with element 0's taint. The generic route keeps today's container-anchored stamps; the remaining slice is recorded in the SC-8 note (needs a machinery-read marker first).
2. **Two machinery boundaries on template consumption**, both extensions of existing disciplines rather than new semantics:
   - *§8.12.8 readback exclusion*: a tx re-deriving a container's membership stamps does not consume the very entries it replaces (`ownRestampContainerPaths`). Without it, the coordinator's diff readback of its own previous output joins J_prev into every reconcile — measured as `[dave,erin]` where replace-from-criteria requires `[erin]` on the no-write re-stamp test; replace degenerates into the accumulate-forever §8.12.8 normatively rejects.
   - *C0 §6.1 row-4 extended to plain reads*: reads covered by a same-tx dereference-trace source skip templates (resolution machinery journals ordinary reads at followed slots and inside their sigils); standalone observations — the row-3 SC-8 closures — consume in full. Consequence, noted in the design doc: a full dereference consumes the target's content but not the slot's membership J; §2's "probe **or dereference**" overstated what the shipped row-3/row-4 boundary distinguishes.

One repair in the same family: the flow-clear's bidirectional-wildcard prefix let a bare slot write (`["1"]`) count as "covering" the `["*"]` template; templates now clear only under a write covering their container path (matching the enumerate stamp's exact-path survival of slot writes). Pinned.

## Integration guard (design §2 caution / §6)

`PORT_OFFSET=47 deno task integration patterns cfc` — the S16 CFC pattern flows (group-chat demo, group-chat multi-runtime, two-browsers, authorship-chat, staged publish, render-policy, spec gallery, authorized save):

```
ok | 8 passed (15 steps) | 0 failed
```

run twice — before and after the catch-up merge of #4657. No unexpected rejections, no label growth from the followRef template.

## Tests

Stage-A battery in `cfc-template-population.test.ts` (21 steps): the two red-first under-taints + the value twin; declared-container mint pin (enumerate + frozen shape + exactly three `*` twins, confidentiality-only); refined class split with distinct atoms; templates-apply-below-the-slot; frozen-vs-membership JOIN (same-origin and cross-origin); replace-from-criteria restamp + transient-empty-J protection; covering-write clear without pooling; slot writes leave templates in place; SC-11 zero-cfc-write recompute; readback-exclusion and trace-covered machinery pins; record-only/mixed/boolean `additionalProperties`; declared items-`*` byte-identical regression; inv-12 Stage-1 commitment forms on cross-space template J; multi-`*` canonicalization determinism/idempotence/no-cross-class-merge.

Full `packages/runner` suite green; `deno task check` + `deno task check-docs` clean. Catch-up merged `origin/main` (#4657's label-metadata observation channel is additive beside this — separate consumption loop; `readConsumesEntry` untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime `*`-path class templates to declared list containers so per-child existence and slot-pointer reads consume the correct membership/assignment labels, closing SC-4/SC-8 residuals. Also refines resolution, clearing, and the schema walk (including an empty-`properties` fix).

- **New Features**
  - Mint three templates per container at `[...container, "*"]` for `shape`, `value`, and `followRef` (confidentiality-only J). Restamped each reconcile; cleared on container-covering writes; slot writes do not clear.
  - Scoped to declared list-coordinator containers; generic pure-link writes keep container-anchored stamps for now.
  - Cross-space commitment forms are preserved on templates.

- **Bug Fixes**
  - Per-child shape probe, raw slot value read, and slot `followRef` probe now consume the membership/assignment J.
  - Resolution: exact-path rule doesn’t block `*` templates; frozen concrete `shape` entries join with membership templates; same-tx restamp readback is excluded; trace-covered slot reads skip templates.
  - Schema: record-only `additionalProperties` mints a declared `*`; “record-only” includes empty `properties: {}`; mixed `properties` + `additionalProperties` mints no `*`.

<sup>Written for commit 5abd783c8bfbcff006b4556bf41ccfcd0f1d2f3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

