### PR TITLE
feat(cfc): metadata templates — §4.6.4.2 field-precise population on *-path entries (template-population Stage B)

### DIFF
--- a/docs/specs/cfc-label-metadata-confidentiality.md
+++ b/docs/specs/cfc-label-metadata-confidentiality.md
@@ -145,7 +145,15 @@ revisited when invariant 12 is implemented." This is that revisit:
    confidentiality; declared/authored entries carry no such containment
    guarantee and stay fail-closed), else fail closed. Computable from the
    entry in hand, no cross-space resolution. `type`/`kind`/presence stay
-   public per the default profile.
+   public per the default profile. _Note (2026-07-10): the full profile now
+   ships — template-population Stage B persists it as multi-`*` templates
+   under `/cfc/labels/...` at the same seam that writes the payload entries
+   (`cfc-template-population.md` §5/§6). The interim rule remains the label
+   SOURCE; the templates are its CARRIER (the labels minted into them), the
+   introspection surface resolves them at concrete metadata paths and falls
+   back to computing the rule in hand on template-less envelopes, and the
+   fail-closed arm is unchanged — declared/authored fields mint nothing and
+   a sibling template never re-opens them._
 4. **Runtime enforcement reads stay outside the consumed set** (verifier
    reads are not observations — §8.10.1), unchanged. What changes is that
    *application-visible* projections of label metadata always pass through
@@ -225,10 +233,12 @@ consumes inbound views, redacting the outbound copies is safe.
   mark._
 - **Stage 2 (observation):** `inspectConfLabel` + interim population rule +
   the label-metadata observation channel (SC-6 revisit). _Implementation note
-  (2026-07-09): shipped (reduced form — §3 items 2–4; the full per-field
-  `PathLabelTemplate` profile stays with the SC-4/SC-8 co-build, designed in
+  (2026-07-09): shipped (initially in reduced form — §3 items 2–4; the full
+  per-field `PathLabelTemplate` profile co-built with SC-4/SC-8, designed in
   [`cfc-template-population.md`](./cfc-template-population.md) — its Stage B
-  upgrades this stage's computed-in-hand labels to persisted templates). The
+  landed 2026-07-10, upgrading this stage's computed-in-hand labels to
+  persisted `/cfc/labels/...` templates resolved at concrete metadata paths,
+  with the in-hand rule as fallback on template-less envelopes). The
   §4.6.4.1 evaluator + §4.6.4.2 interim population rule live in
   `runner/src/cfc/label-introspection.ts`: equality predicates over the six
   query fields; first-layer only (a `/cfc/...` target path refuses — payload

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -452,7 +452,7 @@ redaction, classification table), stage 1 as labs#4638
 commitment-aware matching), stage 2 as labs#4657
 (`inspectConfLabel` builtin + §4.6.4.2 interim population rule +
 `labelMetadata` observation channel — the SC-6 revisit discharged)
-completed by template-population Stage B (2026-07-10): the full per-field
+completed by template-population Stage B (labs#4660): the full per-field
 §4.6.4.2 profile persists as multi-`*` templates under `/cfc/labels/...`
 (`origin:"label-metadata"`, `observes:"labelMetadata"` — no payload read
 class consumes them), minted at the persist seam from each source-bearing

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -449,12 +449,18 @@ and §4.6.4.2 gained the derived-component interim fallback. Runner-side:
 stage 0 shipped as labs#4624 (seam close, persist re-derivation, sigil
 redaction, classification table), stage 1 as labs#4638
 (`cfcLabelMetadataProtection` dial, `{digestOf}` commitment transform,
-commitment-aware matching), stage 2 in reduced form as labs#4657
+commitment-aware matching), stage 2 as labs#4657
 (`inspectConfLabel` builtin + §4.6.4.2 interim population rule +
-`labelMetadata` observation channel — the SC-6 revisit discharged; the full
-per-field `PathLabelTemplate` population profile co-builds with SC-4/SC-8,
-[`cfc-template-population.md`](./cfc-template-population.md) Stage B);
-stage 3 remains per the design doc.
+`labelMetadata` observation channel — the SC-6 revisit discharged)
+completed by template-population Stage B (2026-07-10): the full per-field
+§4.6.4.2 profile persists as multi-`*` templates under `/cfc/labels/...`
+(`origin:"label-metadata"`, `observes:"labelMetadata"` — no payload read
+class consumes them), minted at the persist seam from each source-bearing
+derived-containment payload entry, resolved by `inspectConfLabel` at
+concrete clause/alternative metadata paths with the interim rule staying
+the label source and the in-hand computation the fallback on template-less
+envelopes ([`cfc-template-population.md`](./cfc-template-population.md)
+§5/§6 Stage B note); stage 3 remains per the design doc.
 
 **SC-26 [reconcile] §8.12.7 route 2 conflates grant records with the rewrite
 event — §8.12.7/§13.4.3.** Route 2's cited shape (§13.4.3) persists a

--- a/docs/specs/cfc-template-population.md
+++ b/docs/specs/cfc-template-population.md
@@ -274,7 +274,7 @@ minted into the same entries, not the mechanism.
   them (upgrading WP7's computed-in-hand labels to persisted templates),
   per-field tests from the §4.6.4.2 example, SC-25 tail updated.
 
-  **Implementation note (Stage B landed, 2026-07-10).** Shipped in
+  **Implementation note (Stage B landed, 2026-07-10, #4660).** Shipped in
   `packages/runner/src/cfc/label-metadata-population.ts` (mint derivation +
   wildcard resolver) wired into the `prepare.ts` persist seam and the
   `label-introspection.ts` consumption, tests in

--- a/docs/specs/cfc-template-population.md
+++ b/docs/specs/cfc-template-population.md
@@ -273,6 +273,45 @@ minted into the same entries, not the mechanism.
   `/cfc/labels/...` template mints per §5 + `inspectConfLabel` consuming
   them (upgrading WP7's computed-in-hand labels to persisted templates),
   per-field tests from the §4.6.4.2 example, SC-25 tail updated.
+
+  **Implementation note (Stage B landed, 2026-07-10).** Shipped in
+  `packages/runner/src/cfc/label-metadata-population.ts` (mint derivation +
+  wildcard resolver) wired into the `prepare.ts` persist seam and the
+  `label-introspection.ts` consumption, tests in
+  `packages/runner/test/cfc-template-metadata-population.test.ts`. Entry
+  form: `origin:"label-metadata"` with `observes:"labelMetadata"`, plain
+  `IFCLabel` under `label` per §3.3. The dedicated ORIGIN because the origin
+  axis is the update-discipline axis and these entries' discipline — a pure
+  function of the payload entries in the SAME envelope, re-derived from the
+  final entry set at every persist (never carried forward) — is none of the
+  existing ones; it buys replace-on-overwrite / cleared-with-the-described-
+  entry / SC-11-no-op by construction and keeps every derived/structure-
+  keyed persist rule (freeze-carry, SC-4 pooling, writer-fit selection,
+  restamp drops) ignoring them without carve-outs. The Stage-2 observation
+  CLASS on the `observes` axis because `readConsumesEntry` then already
+  yields the needed consumption table: no payload read class consumes them —
+  the introspection surface is the only consumer (the deliberately
+  over-inclusive `"all"` write-gate selection may, harmlessly: template
+  content duplicates the payload entries it derives from). Per labeled
+  target path: the whole-atom template plus one per-field template per
+  DISTINCT protected top-level field name (deeper protected content —
+  nested atoms behind public wrapper fields, array elements, bare
+  commitment markers — rides the whole-atom template only); templates
+  derive AFTER the Stage-1 representation transform, so committed forms
+  carry through identically. Two measured semantics notes: (1) the §4.6.4.1
+  metadata addressing concatenates clause indices across the entries stored
+  at one path, so coalescing JOINS same-path payload entries' population
+  labels (the C2 value/shape split) into one per-path template —
+  fail-toward-taint vs the per-entry in-hand rule, exact on the
+  single-source-bearing-entry common case (agreement pinned by test); (2)
+  consumption keeps the containment gate FIRST — a persisted template never
+  re-opens a declared/authored sibling's fields — and falls back to the
+  computed-in-hand rule on template-less (pre-Stage-B) envelopes, which
+  also heals the mixed-version residual (an older runtime rewriting payload
+  entries carries stale templates forward; the next Stage-B-runtime persist
+  re-derives them). Recorded `labelMetadata` observations now reference the
+  CONCRETE consulted clause/alternative metadata paths rather than the
+  subtree root.
 - **No new dial.** Template mints ride the existing dials of the stamps
   they accompany (`cfcFlowLabels` for flow-derived structure stamps); the
   new entries are additive taint (fail-safe direction). If review finds a

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -132,8 +132,10 @@ export type ConfLabelQueryEvaluation = {
    */
   consumedConfidentiality: readonly unknown[];
   /**
-   * The same consumption, per concrete metadata path (deduped per path,
-   * labels joined). Empty exactly when `consumedConfidentiality` is.
+   * The same consumption, one record per consulted concrete metadata path
+   * (paths are unique by construction — clause/alternative indices plus
+   * distinct predicate fields), each record's label deduped. Empty exactly
+   * when `consumedConfidentiality` is.
    */
   consumedObservations: readonly ConfLabelConsumedObservation[];
 };
@@ -433,10 +435,13 @@ export const evaluateConfLabelQuery = (
   // and template resolution reads at those concrete paths.
   const metaBase = ["cfc", "labels", "value", ...targetPath];
   const consumed: unknown[] = [];
-  const consumedByPath = new Map<
-    string,
-    { path: readonly string[]; atoms: unknown[] }
-  >();
+  // One record per labeled consultation. Paths are UNIQUE by construction —
+  // per-field consultations key on (clauseIndex, alternativeIndex, predicate
+  // field) with the six predicate fields distinct, whole-atom projections
+  // key on (clauseIndex, alternativeIndex), and a field path can never equal
+  // an alternative path (field paths extend an alternative path by one
+  // segment) — so no per-path merge step exists to reach.
+  const consumedObservations: ConfLabelConsumedObservation[] = [];
   const consumeAt = (
     path: readonly string[],
     atoms: readonly unknown[],
@@ -445,13 +450,10 @@ export const evaluateConfLabelQuery = (
       return;
     }
     consumed.push(...atoms);
-    const key = encodePointer(path);
-    const bucket = consumedByPath.get(key);
-    if (bucket === undefined) {
-      consumedByPath.set(key, { path, atoms: [...atoms] });
-    } else {
-      bucket.atoms.push(...atoms);
-    }
+    consumedObservations.push({
+      path,
+      confidentiality: uniqueCfcAtoms([...atoms]),
+    });
   };
   const atoms: LabelAtomProjection[] = [];
   let clauseIndex = 0;
@@ -592,10 +594,7 @@ export const evaluateConfLabelQuery = (
   return {
     result: { status: "ok", atoms },
     consumedConfidentiality: uniqueCfcAtoms(consumed),
-    consumedObservations: [...consumedByPath.values()].map((bucket) => ({
-      path: bucket.path,
-      confidentiality: uniqueCfcAtoms(bucket.atoms),
-    })),
+    consumedObservations,
   };
 };
 

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -6,7 +6,12 @@ import { normalizeCellScope } from "../scope.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
 import { clauseAlternatives } from "./clause.ts";
-import { classifyAtomField } from "./label-field-classification.ts";
+import {
+  cfcEntryHasDerivedContainment,
+  isLabelMetadataTemplateEntry,
+  labelMetadataFieldIsProtected,
+  resolveLabelMetadataTemplateConfidentiality,
+} from "./label-metadata-population.ts";
 import {
   commitmentAwareEquals,
   isCfcFieldCommitment,
@@ -17,7 +22,7 @@ import type { CfcMetadata, LabelMapEntry } from "./types.ts";
 
 // Inv-12 Stage 2 (SC-25/SC-6; docs/specs/cfc-label-metadata-confidentiality.md
 // §3/§5; spec §4.6.4.1-.2): the bounded first-layer label-introspection
-// evaluator behind the `inspectConfLabel` builtin, plus the §4.6.4.2 interim
+// evaluator behind the `inspectConfLabel` builtin, plus the §4.6.4.2
 // population rule that labels each metadata observation it consumes.
 //
 // Scope discipline:
@@ -34,11 +39,21 @@ import type { CfcMetadata, LabelMapEntry } from "./types.ts";
 //   every per-atom field observation consulted to establish the miss was
 //   observable (its population label exists), so the caller cannot
 //   distinguish the hidden arms.
+// - LABEL SOURCE (template-population Stage B). Protected field/projection
+//   observation labels RESOLVE from the persisted `/cfc/labels/...`
+//   population templates when the envelope carries them (the §4.6.4.2
+//   field-precise profile, minted at the persist seam —
+//   `label-metadata-population.ts`), falling back to the computed-in-hand
+//   interim rule when absent (pre-Stage-B envelopes). On envelopes the
+//   current runtime persisted the two agree exactly: the interim rule is the
+//   label SOURCE, the templates its CARRIER.
 // - CONSUMPTION. Every `ok` outcome reports the joined population-rule
 //   confidentiality of the field observations it consumed
-//   (`consumedConfidentiality`); the transaction channel
-//   (`recordCfcLabelMetadataObservation`) is wired by the builtin, not here —
-//   this module stays pure over stored metadata.
+//   (`consumedConfidentiality`) plus the per-consulted-path records
+//   (`consumedObservations`, at the CONCRETE clause/alternative metadata
+//   paths); the transaction channel (`recordCfcLabelMetadataObservation`) is
+//   wired by `inspectStoredConfLabel`, not the evaluator — the evaluator
+//   stays pure over stored metadata.
 
 /**
  * The §4.6.4.1 query: equality tests only, family-qualified where the spec
@@ -91,6 +106,21 @@ export const CONF_LABEL_NOT_AVAILABLE: InspectConfLabelResult = Object.freeze({
   status: "notAvailable" as const,
 });
 
+/**
+ * One labeled metadata observation the evaluation consumed, at its CONCRETE
+ * metadata path (`["cfc","labels","value",...,"clauses","1","alternatives",
+ * "0","source"]` — clause/alternative indices per the stored addressing, the
+ * §4.6.4.2 example's shape). Per-field query consultations record at the
+ * field segment; whole-atom projections record at the alternative node.
+ * These are what `inspectStoredConfLabel` records on the transaction — reads
+ * of the metadata subtree that resolved the `*`-path population templates
+ * through the wildcard machinery like any read.
+ */
+export type ConfLabelConsumedObservation = {
+  path: readonly string[];
+  confidentiality: readonly unknown[];
+};
+
 export type ConfLabelQueryEvaluation = {
   result: InspectConfLabelResult;
   /**
@@ -101,6 +131,11 @@ export type ConfLabelQueryEvaluation = {
    * the shared constant), so nothing protected flowed to the caller.
    */
   consumedConfidentiality: readonly unknown[];
+  /**
+   * The same consumption, per concrete metadata path (deduped per path,
+   * labels joined). Empty exactly when `consumedConfidentiality` is.
+   */
+  consumedObservations: readonly ConfLabelConsumedObservation[];
 };
 
 /**
@@ -134,7 +169,8 @@ export const parseConfLabelTargetPath = (
 };
 
 // ---------------------------------------------------------------------------
-// The §4.6.4.2 interim population rule, computed from the entry in hand.
+// The §4.6.4.2 population rule: persisted templates as the carrier, the
+// interim rule computed from the entry in hand as source and fallback.
 
 /**
  * Observation label of one atom field, or `undefined` when the field is
@@ -144,34 +180,58 @@ export const parseConfLabelTargetPath = (
 type FieldObservation = readonly unknown[] | undefined;
 
 /**
- * Whether the entry's own effective confidentiality is a sound population
- * label for its source-bearing fields: true exactly for the components
- * produced by the §8.9.2 conservative join — `derived` (the per-tx flow
- * stamp) and `structure` (the same join stamped on container shape,
- * §8.5.6.1) — whose label contains each influencing source's confidentiality
- * by construction. Declared/authored entries, link-carried pointer labels,
- * the external-ingest mark and legacy (component-less) entries carry no such
- * containment guarantee and stay fail-closed (spec §4.6.4.2, merged via
- * specs#14).
+ * The protected-chain arm of the population rule for one consultation at one
+ * CONCRETE metadata path:
+ *
+ * 1. Containment gate first (spec §4.6.4.2, merged via specs#14): only
+ *    derived-containment entries (`derived`/`structure` — the §8.9.2
+ *    conservative join) have observable source-bearing fields at all.
+ *    Declared/authored, link, external-ingest and legacy entries stay
+ *    fail-closed UNOBSERVABLE — and a persisted template at the same path
+ *    never re-opens them: the per-path metadata addressing conflates the
+ *    entries stored at one payload path, so a template minted for a derived
+ *    sibling must not leak an observation label onto a declared entry's
+ *    fields.
+ * 2. The persisted `/cfc/labels/...` population template covering the
+ *    concrete path, when the envelope carries one (template-population
+ *    Stage B) — resolved with §4.6.3 replace-down through the wildcard
+ *    machinery like any read. This is the carrier arm the future per-source
+ *    precision upgrade changes labels in.
+ * 3. Else the computed-in-hand interim rule: the entry's own effective
+ *    confidentiality (sound per the §8.9.2 containment argument) —
+ *    pre-Stage-B envelopes carry no templates and land here.
  */
-const entryHasDerivedContainment = (entry: LabelMapEntry): boolean =>
-  entry.origin === "derived" || entry.origin === "structure";
+const protectedFieldObservationLabel = (
+  entry: LabelMapEntry,
+  entries: readonly LabelMapEntry[],
+  concretePath: readonly string[],
+): FieldObservation => {
+  if (!cfcEntryHasDerivedContainment(entry)) {
+    return undefined;
+  }
+  const template = resolveLabelMetadataTemplateConfidentiality(
+    entries,
+    concretePath,
+  );
+  if (template !== undefined) {
+    return template;
+  }
+  return entry.label.confidentiality ?? [];
+};
 
 /**
- * The interim population rule for one field of one atom in one entry:
+ * The population rule for one field of one atom in one entry:
  *
  * 1. `type`/`kind` at an atom root — and atom presence itself — are public
  *    (the normative §4.6.4.2 default).
  * 2. A field the Stage-0 classification table marks `public` (disclosure is
  *    the feature: authored attribution subjects, Policy/Context ref
  *    name/hash, `TransformedBy.identity.moduleIdentity`) is public.
- * 3. Every other present field is source-protected: its observation label is
- *    the source identity's confidentiality when known — no carrier exists
- *    for that today (the full per-field PathLabelTemplate profile under
- *    `/cfc/labels/...` is the SC-4/SC-8 co-build) — else, for
- *    derived-component entries only, the entry's own effective
- *    confidentiality (sound per the §8.9.2 containment argument); else
- *    UNOBSERVABLE (fail closed).
+ *    (Arms 1-2 are `labelMetadataFieldIsProtected`, shared with the persist
+ *    seam's mint so the two cannot drift.)
+ * 3. Every other present field is source-protected:
+ *    {@link protectedFieldObservationLabel} — persisted template when
+ *    present, derived-containment fallback, else UNOBSERVABLE (fail closed).
  *
  * A committed `{digestOf}` field keeps the same population label as its
  * plaintext form: the commitment hides the identity from casual observation
@@ -181,21 +241,12 @@ const fieldObservationLabel = (
   entry: LabelMapEntry,
   atom: unknown,
   field: string,
-): FieldObservation => {
-  if (field === "type" || field === "kind") {
-    return [];
-  }
-  if (classifyAtomField(atom, [field]) === "public") {
-    return [];
-  }
-  // Source-protected chain. Arm 1 (source identity confidentiality) has no
-  // in-entry carrier today; arm 2 is the derived-component fallback; arm 3
-  // fails closed.
-  if (entryHasDerivedContainment(entry)) {
-    return entry.label.confidentiality ?? [];
-  }
-  return undefined;
-};
+  entries: readonly LabelMapEntry[],
+  concretePath: readonly string[],
+): FieldObservation =>
+  labelMetadataFieldIsProtected(atom, field)
+    ? protectedFieldObservationLabel(entry, entries, concretePath)
+    : [];
 
 /**
  * Observation label of a WHOLE-ATOM projection: the join of the labels of
@@ -207,6 +258,15 @@ const fieldObservationLabel = (
  * a protected nested field out. Bare non-record atoms (string atoms) are
  * type-only tags — their entire content is the public type observation.
  *
+ * Protected consultations resolve per-field templates at their concrete
+ * paths (direct alternative fields land where the mint addresses them;
+ * nested/array-indexed positions miss and use the fallback — the mint
+ * deliberately materializes no nested per-field templates). When the walk
+ * consumed anything protected, the persisted whole-atom template covering
+ * the alternative node joins in: it IS the minted join of the revealed-field
+ * labels, so on runtime-minted envelopes this is a dedup no-op, and a
+ * foreign wider template fails toward taint.
+ *
  * Returns `undefined` when any revealed field is unobservable: the projection
  * — and with it the whole query (a matching-but-unreadable atom) — fails
  * closed.
@@ -214,11 +274,19 @@ const fieldObservationLabel = (
 const atomProjectionLabel = (
   entry: LabelMapEntry,
   atom: unknown,
+  entries: readonly LabelMapEntry[],
+  alternativePath: readonly string[],
 ): FieldObservation => {
   const consumed: unknown[] = [];
-  const walk = (value: unknown, contextAtom: unknown): boolean => {
+  const walk = (
+    value: unknown,
+    contextAtom: unknown,
+    valuePath: readonly string[],
+  ): boolean => {
     if (Array.isArray(value)) {
-      return value.every((element) => walk(element, contextAtom));
+      return value.every((element, index) =>
+        walk(element, contextAtom, [...valuePath, String(index)])
+      );
     }
     if (!isRecord(value)) {
       return true;
@@ -226,9 +294,7 @@ const atomProjectionLabel = (
     if (isCfcFieldCommitment(value)) {
       // A bare commitment marker outside a classified field position (it
       // would have been consumed AS the field value below): protected.
-      const label = entryHasDerivedContainment(entry)
-        ? entry.label.confidentiality ?? []
-        : undefined;
+      const label = protectedFieldObservationLabel(entry, entries, valuePath);
       if (label === undefined) return false;
       consumed.push(...label);
       return true;
@@ -245,7 +311,14 @@ const atomProjectionLabel = (
       typeof (value as { kind?: unknown }).kind === "string";
     const context = isAtom ? value : contextAtom;
     for (const [key, field] of Object.entries(value)) {
-      const observation = fieldObservationLabel(entry, context, key);
+      const fieldPath = [...valuePath, key];
+      const observation = fieldObservationLabel(
+        entry,
+        context,
+        key,
+        entries,
+        fieldPath,
+      );
       if (observation === undefined) {
         return false;
       }
@@ -257,14 +330,26 @@ const atomProjectionLabel = (
       // User atom) is still classified on its own terms — a public wrapper
       // field must not smuggle a protected nested field out. Scalar public
       // fields end the walk trivially.
-      const nestedObservable = walk(field, context);
+      const nestedObservable = walk(field, context, fieldPath);
       if (!nestedObservable) {
         return false;
       }
     }
     return true;
   };
-  return walk(atom, undefined) ? consumed : undefined;
+  if (!walk(atom, undefined, alternativePath)) {
+    return undefined;
+  }
+  if (consumed.length > 0) {
+    const template = resolveLabelMetadataTemplateConfidentiality(
+      entries,
+      alternativePath,
+    );
+    if (template !== undefined) {
+      consumed.push(...template);
+    }
+  }
+  return consumed;
 };
 
 // ---------------------------------------------------------------------------
@@ -335,16 +420,49 @@ export const evaluateConfLabelQuery = (
     return {
       result: CONF_LABEL_NOT_AVAILABLE,
       consumedConfidentiality: [],
+      consumedObservations: [],
     };
   }
   const predicates = (Object.keys(QUERY_PREDICATES) as (keyof ConfLabelQuery)[])
     .filter((key) => query[key] !== undefined)
     .map((key) => ({ ...QUERY_PREDICATES[key], expected: query[key] }));
   const pointer = encodePointer(targetPath);
+  const entries = metadata.labelMap.entries;
+  // The concrete metadata subtree of this target (§4.6.4.1 addressing):
+  // consultation paths extend it with the stored clause/alternative indices,
+  // and template resolution reads at those concrete paths.
+  const metaBase = ["cfc", "labels", "value", ...targetPath];
   const consumed: unknown[] = [];
+  const consumedByPath = new Map<
+    string,
+    { path: readonly string[]; atoms: unknown[] }
+  >();
+  const consumeAt = (
+    path: readonly string[],
+    atoms: readonly unknown[],
+  ): void => {
+    if (atoms.length === 0) {
+      return;
+    }
+    consumed.push(...atoms);
+    const key = encodePointer(path);
+    const bucket = consumedByPath.get(key);
+    if (bucket === undefined) {
+      consumedByPath.set(key, { path, atoms: [...atoms] });
+    } else {
+      bucket.atoms.push(...atoms);
+    }
+  };
   const atoms: LabelAtomProjection[] = [];
   let clauseIndex = 0;
-  for (const entry of metadata.labelMap.entries) {
+  for (const entry of entries) {
+    // Label-metadata population templates are the OBSERVATION-LABEL carrier
+    // for the payload label, not payload clauses: they never enumerate as
+    // atoms (a `*`-bearing target path could otherwise wildcard-match their
+    // `cfc`-prefixed entry paths).
+    if (isLabelMetadataTemplateEntry(entry)) {
+      continue;
+    }
     if (!entryPathMatchesTarget(entry, targetPath)) {
       continue;
     }
@@ -356,6 +474,14 @@ export const evaluateConfLabelQuery = (
         alternativeIndex++
       ) {
         const atom = alternatives[alternativeIndex];
+        const alternativePath = [
+          ...metaBase,
+          "confidentiality",
+          "clauses",
+          String(clauseIndex),
+          "alternatives",
+          String(alternativeIndex),
+        ];
         let matched = true;
         for (const { field, familyTypes, expected } of predicates) {
           if (!isRecord(atom)) {
@@ -389,7 +515,14 @@ export const evaluateConfLabelQuery = (
             matched = false;
             break;
           }
-          const observation = fieldObservationLabel(entry, atom, field);
+          const fieldPath = [...alternativePath, field];
+          const observation = fieldObservationLabel(
+            entry,
+            atom,
+            field,
+            entries,
+            fieldPath,
+          );
           if (observation === undefined) {
             // The query needs a field observation the population rule cannot
             // label: the WHOLE evaluation is unevaluable for this caller.
@@ -399,6 +532,7 @@ export const evaluateConfLabelQuery = (
             return {
               result: CONF_LABEL_NOT_AVAILABLE,
               consumedConfidentiality: [],
+              consumedObservations: [],
             };
           }
           // Testing equality observes the field whether it matches or not:
@@ -406,7 +540,7 @@ export const evaluateConfLabelQuery = (
           // same per-field label (§4.6.4.2). Commitment-aware so a committed
           // `{digestOf}` field digest-matches its plaintext query form
           // (Stage 1 same-form matching).
-          consumed.push(...observation);
+          consumeAt(fieldPath, observation);
           if (
             !commitmentAwareEquals(
               (atom as Record<string, unknown>)[field],
@@ -420,7 +554,12 @@ export const evaluateConfLabelQuery = (
         if (!matched) {
           continue;
         }
-        const projection = atomProjectionLabel(entry, atom);
+        const projection = atomProjectionLabel(
+          entry,
+          atom,
+          entries,
+          alternativePath,
+        );
         if (projection === undefined) {
           // Matching but unreadable: the projection would reveal a field the
           // population rule cannot label. Returning the other matches would
@@ -429,9 +568,11 @@ export const evaluateConfLabelQuery = (
           return {
             result: CONF_LABEL_NOT_AVAILABLE,
             consumedConfidentiality: [],
+            consumedObservations: [],
           };
         }
-        consumed.push(...projection);
+        // The whole-atom projection is a read AT the alternative node.
+        consumeAt(alternativePath, projection);
         atoms.push({
           targetPath: pointer,
           clauseIndex,
@@ -451,6 +592,10 @@ export const evaluateConfLabelQuery = (
   return {
     result: { status: "ok", atoms },
     consumedConfidentiality: uniqueCfcAtoms(consumed),
+    consumedObservations: [...consumedByPath.values()].map((bucket) => ({
+      path: bucket.path,
+      confidentiality: uniqueCfcAtoms(bucket.atoms),
+    })),
   };
 };
 
@@ -479,10 +624,12 @@ export const evaluateConfLabelQuery = (
  *    degrades to the same notAvailable as every hidden arm (indistinguishable
  *    by construction). Purely public results (empty consumed join) flow under
  *    every dial.
- * 5. Record the consumed observation (`recordCfcLabelMetadataObservation`):
- *    it joins the flow derivation (labeling the result through the normal
- *    per-tx J), the egress consumed set, the per-write input gate, and the
- *    prepared digest.
+ * 5. Record the consumed observations (`recordCfcLabelMetadataObservation`),
+ *    one per consulted CONCRETE metadata path (field consultations at the
+ *    field segment, whole-atom projections at the alternative node — the
+ *    evaluator's `consumedObservations`): they join the flow derivation
+ *    (labeling the result through the normal per-tx J), the egress consumed
+ *    set, the per-write input gate, and the prepared digest.
  */
 export const inspectStoredConfLabel = (
   tx: IExtendedStorageTransaction,
@@ -509,11 +656,19 @@ export const inspectStoredConfLabel = (
     ...canonicalizeLogicalPath(target.path),
     ...parsed,
   ];
-  const { result, consumedConfidentiality } = evaluateConfLabelQuery(
-    metadata,
-    payloadPath,
-    query,
-  );
+  if (payloadPath[0] === "cfc") {
+    // The RESOLVED target path lands in the envelope metadata subtree: the
+    // §4.6.4.1 first-layer rule refuses labels-of-labels however addressed —
+    // `parseConfLabelTargetPath` catches the query pointer; this catches a
+    // target cell whose own path collides with the metadata sibling.
+    return CONF_LABEL_NOT_AVAILABLE;
+  }
+  const { result, consumedConfidentiality, consumedObservations } =
+    evaluateConfLabelQuery(
+      metadata,
+      payloadPath,
+      query,
+    );
   if (result.status !== "ok" || consumedConfidentiality.length === 0) {
     return result;
   }
@@ -528,17 +683,21 @@ export const inspectStoredConfLabel = (
     );
     return CONF_LABEL_NOT_AVAILABLE;
   }
-  tx.recordCfcLabelMetadataObservation({
-    target: {
-      space: target.space,
-      id: target.id,
-      scope: normalizeCellScope(target.scope),
-      // The first-layer metadata subtree the observation is about
-      // (§4.6.4.1): /cfc/labels/value/<payload path>.
-      path: ["cfc", "labels", "value", ...payloadPath],
-    },
-    observes: "labelMetadata",
-    confidentiality: [...consumedConfidentiality],
-  });
+  const scope = normalizeCellScope(target.scope);
+  for (const observation of consumedObservations) {
+    tx.recordCfcLabelMetadataObservation({
+      target: {
+        space: target.space,
+        id: target.id,
+        scope,
+        // The CONCRETE first-layer metadata path the consultation resolved
+        // (§4.6.4.1 addressing, the §4.6.4.2 example's shape):
+        // /cfc/labels/value/<payload path>/confidentiality/clauses/<i>/...
+        path: [...observation.path],
+      },
+      observes: "labelMetadata",
+      confidentiality: [...observation.confidentiality],
+    });
+  }
   return result;
 };

--- a/packages/runner/src/cfc/label-metadata-population.ts
+++ b/packages/runner/src/cfc/label-metadata-population.ts
@@ -1,0 +1,322 @@
+import { isRecord } from "@commonfabric/utils/types";
+import { canonicalizeLogicalPath } from "./canonical.ts";
+import { clauseAlternatives } from "./clause.ts";
+import { classifyAtomField } from "./label-field-classification.ts";
+import { isCfcFieldCommitment } from "./label-representation.ts";
+import { uniqueCfcAtoms } from "./observation.ts";
+import type { IFCLabel, LabelEntryOrigin, LabelMapEntry } from "./types.ts";
+
+// Template-population Stage B (docs/specs/cfc-template-population.md §5/§6;
+// spec §4.6.4.2): the §4.6.4.2 field-precise label-metadata population
+// profile, carried as multi-`*` labelMap entries under the
+// `/cfc/labels/<target-envelope-path>/...` metadata subtree.
+//
+// For every persisted payload label entry that carries source-bearing fields,
+// the persist seam mints (via {@link deriveLabelMetadataTemplateEntries}):
+//
+//   ["cfc","labels","value",...target,"confidentiality","clauses","*",
+//    "alternatives","*"]            → whole-atom projection label
+//   [...same, <field>]              → per-field observation label, one entry
+//                                     per DISTINCT protected top-level field
+//                                     name present in the entry's atoms
+//
+// Entry count is O(#source-bearing-field-kinds) per labeled path — the
+// clause/alternative axes ride the `*` wildcards, so counts are independent
+// of how many clauses or alternatives the label has (the same one-level-up
+// entry-count wall §5 dissolves). Presence/`type`/`kind` and table-`public`
+// fields mint NOTHING: absence of a metadata entry is PUBLIC under the
+// §4.6.4.2 default profile, and public entries are never materialized.
+//
+// The labels minted are the SAME §4.6.4.2 interim population rule the
+// introspection surface computes in hand (source-identity confidentiality
+// when known — no carrier feeds that arm yet; else, for derived-containment
+// entries only, the entry's own effective confidentiality; else fail closed —
+// mint nothing, `inspectConfLabel` keeps those fields unobservable). The
+// interim rule stays the label SOURCE; these entries are the CARRIER —
+// upgrading precision later (true per-source labels) changes the labels
+// minted into the same entries, not the mechanism.
+//
+// `origin`/`observes` decision (documented for the design's §3.3 rule —
+// plain `IFCLabel` under `label`, no new entry fields):
+//
+// - `origin: "label-metadata"` — a DEDICATED origin, because the origin axis
+//   is the update-discipline axis and these entries have a discipline no
+//   existing origin has: they are a pure function of the payload entries in
+//   the SAME envelope, re-derived at every persist of that envelope (so
+//   replace-on-overwrite / cleared-with-the-entry-they-describe / SC-11
+//   zero-write all hold by construction). Reusing `derived` would put them
+//   through every derived/structure-keyed rule in the persist loop (the
+//   freeze-carry, the SC-4 existence pool, writer-fit policy selection,
+//   `isRuntimeMintedTemplate` machinery boundaries), each needing a carve-out;
+//   a dedicated origin makes every existing origin-keyed rule ignore them by
+//   construction.
+// - `observes: "labelMetadata"` — the #4657 observation class, now allowed on
+//   persisted entries: `readConsumesEntry`'s class table already gives the
+//   needed consumption for free (no payload read class — value/shape/
+//   enumerate/followRef — consumes it; the introspection surface is the only
+//   consumer, resolving explicitly via
+//   {@link resolveLabelMetadataTemplateConfidentiality}).
+// - Canonicalization/coalescing need nothing new: both key on
+//   (path, origin, observes), so templates coalesce only with themselves —
+//   two payload entries at one path (the C2 value/shape split) coalesce-JOIN
+//   their per-entry population labels into the per-path template, the
+//   fail-toward-taint direction the per-path §4.6.4.1 addressing (clause
+//   indices run across the concatenated per-entry clause lists) requires.
+
+/**
+ * The dedicated origin of label-metadata population templates. See the module
+ * doc for the decision rationale.
+ */
+export const LABEL_METADATA_TEMPLATE_ORIGIN: LabelEntryOrigin =
+  "label-metadata";
+
+/** Whether a persisted entry is a label-metadata population template. */
+export const isLabelMetadataTemplateEntry = (
+  entry: Pick<LabelMapEntry, "origin">,
+): boolean => entry.origin === LABEL_METADATA_TEMPLATE_ORIGIN;
+
+/**
+ * Whether the entry's own effective confidentiality is a sound population
+ * label for its source-bearing fields: true exactly for the components
+ * produced by the §8.9.2 conservative join — `derived` (the per-tx flow
+ * stamp) and `structure` (the same join stamped on container shape,
+ * §8.5.6.1) — whose label contains each influencing source's confidentiality
+ * by construction. Declared/authored entries, link-carried pointer labels,
+ * the external-ingest mark, label-metadata templates themselves and legacy
+ * (component-less) entries carry no such containment guarantee and stay
+ * fail-closed (spec §4.6.4.2, merged via specs#14). Shared by the mint
+ * (which entries GET templates) and the introspection surface (which entries'
+ * fields are observable at all) so the two cannot drift.
+ */
+export const cfcEntryHasDerivedContainment = (
+  entry: Pick<LabelMapEntry, "origin">,
+): boolean => entry.origin === "derived" || entry.origin === "structure";
+
+/**
+ * The §4.6.4.2 public/protected split for one atom field, shared by the mint
+ * and the introspection surface's in-hand rule: `type`/`kind` (and atom
+ * presence itself) are public per the normative default; a field the Stage-0
+ * classification table marks `public` (disclosure is the feature) is public;
+ * every OTHER present field is source-protected. Commitment-classified
+ * fields are protected too: the commitment hides the identity from casual
+ * observation but stays probe-able, so observing it is still a protected
+ * observation.
+ */
+export const labelMetadataFieldIsProtected = (
+  atom: unknown,
+  field: string,
+): boolean =>
+  field !== "type" && field !== "kind" &&
+  classifyAtomField(atom, [field]) !== "public";
+
+const TEMPLATE_TAIL = [
+  "confidentiality",
+  "clauses",
+  "*",
+  "alternatives",
+  "*",
+] as const;
+
+/**
+ * Protected-content scan of one clause alternative, mirroring the
+ * introspection surface's projection walk (`atomProjectionLabel`): direct
+ * fields of a record alternative register their FIELD NAME (they are
+ * addressable at the `<field>` segment under `.../alternatives/*`, where the
+ * evaluator's query predicates and depth-0 projection consultations land);
+ * protected content found deeper — nested atoms smuggled inside public
+ * wrapper fields, array elements, bare commitment markers — sets the
+ * whole-atom flag only (its consultations land at nested concrete paths no
+ * per-field template addresses; the whole-atom template carries the
+ * projection label for it).
+ */
+const scanAlternative = (
+  alternative: unknown,
+  fields: Set<string>,
+): boolean => {
+  const scanNested = (value: unknown, contextAtom: unknown): boolean => {
+    if (Array.isArray(value)) {
+      return value.some((element) => scanNested(element, contextAtom));
+    }
+    if (!isRecord(value)) {
+      return false;
+    }
+    if (isCfcFieldCommitment(value)) {
+      // A bare commitment marker outside a classified field position:
+      // protected (the introspection walk's marker arm).
+      return true;
+    }
+    // Same atom-context rule as the projection walk: a record carrying a
+    // string `type` or `kind` is an atom for classification purposes; plain
+    // nested records keep the enclosing atom's context.
+    const isAtom = typeof (value as { type?: unknown }).type === "string" ||
+      typeof (value as { kind?: unknown }).kind === "string";
+    const context = isAtom ? value : contextAtom;
+    let found = false;
+    for (const [key, field] of Object.entries(value)) {
+      if (labelMetadataFieldIsProtected(context, key)) {
+        found = true;
+        continue;
+      }
+      if (scanNested(field, context)) {
+        found = true;
+      }
+    }
+    return found;
+  };
+
+  if (Array.isArray(alternative)) {
+    return alternative.some((element) => scanNested(element, undefined));
+  }
+  if (!isRecord(alternative)) {
+    // Bare string atoms are type-only tags: their entire content is the
+    // public type observation.
+    return false;
+  }
+  if (isCfcFieldCommitment(alternative)) {
+    return true;
+  }
+  const isAtom =
+    typeof (alternative as { type?: unknown }).type === "string" ||
+    typeof (alternative as { kind?: unknown }).kind === "string";
+  const context = isAtom ? alternative : undefined;
+  let found = false;
+  for (const [key, field] of Object.entries(alternative)) {
+    if (labelMetadataFieldIsProtected(context, key)) {
+      fields.add(key);
+      found = true;
+      continue;
+    }
+    if (scanNested(field, context)) {
+      found = true;
+    }
+  }
+  return found;
+};
+
+/**
+ * Derive the label-metadata population template entries for one envelope's
+ * FINAL payload entry set (post-clear, post-carry-forward, post-Stage-1
+ * representation transform — so template label content is byte-identical to
+ * the payload labels it describes, and the Stage-1 transform applies to it
+ * by construction). Pure and deterministic: same payload entries in, same
+ * templates out — the SC-11 canonical comparison then skips unchanged
+ * envelopes exactly as before.
+ *
+ * Only derived-containment entries mint (the interim rule's observable
+ * family); declared/authored source-bearing entries mint NOTHING — their
+ * fields stay fail-closed-unobservable at the introspection surface, and a
+ * sibling template at the same path never re-opens them (consumption is
+ * containment-scoped, see `label-introspection.ts`).
+ */
+export const deriveLabelMetadataTemplateEntries = (
+  entries: readonly LabelMapEntry[],
+): LabelMapEntry[] => {
+  const out: LabelMapEntry[] = [];
+  for (const entry of entries) {
+    if (
+      isLabelMetadataTemplateEntry(entry) ||
+      !cfcEntryHasDerivedContainment(entry)
+    ) {
+      continue;
+    }
+    const confidentiality = entry.label.confidentiality ?? [];
+    if (confidentiality.length === 0) {
+      continue;
+    }
+    const fields = new Set<string>();
+    let anyProtected = false;
+    for (const clause of confidentiality) {
+      for (const alternative of clauseAlternatives(clause)) {
+        if (scanAlternative(alternative, fields)) {
+          anyProtected = true;
+        }
+      }
+    }
+    if (!anyProtected) {
+      continue;
+    }
+    const base = [
+      "cfc",
+      "labels",
+      "value",
+      ...canonicalizeLogicalPath(entry.path),
+      ...TEMPLATE_TAIL,
+    ];
+    const label = (): IFCLabel => ({ confidentiality: [...confidentiality] });
+    out.push({
+      path: base,
+      label: label(),
+      origin: LABEL_METADATA_TEMPLATE_ORIGIN,
+      observes: "labelMetadata",
+    });
+    for (const field of [...fields].sort()) {
+      out.push({
+        path: [...base, field],
+        label: label(),
+        origin: LABEL_METADATA_TEMPLATE_ORIGIN,
+        observes: "labelMetadata",
+      });
+    }
+  }
+  return out;
+};
+
+// Bidirectional wildcard prefix — the same rule `labelAtPath` /
+// `collectConsumedLabel` resolve payload entries with (`isPrefix` in
+// prepare.ts): `*` in either the entry path or the queried path matches any
+// segment, so a concrete consultation path resolves multi-`*` templates and
+// a template minted for a `*`-path payload target (a Stage-A membership
+// template) resolves for concrete slot consultations.
+const wildcardIsPrefix = (
+  prefix: readonly string[],
+  path: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((segment, index) =>
+    segment === path[index] || segment === "*" || path[index] === "*"
+  );
+
+/**
+ * Resolve the persisted population label at one CONCRETE metadata path
+ * (`["cfc","labels","value",...,"clauses","1","alternatives","0","source"]`)
+ * — the introspection surface's read of the metadata subtree, resolved
+ * through the wildcard machinery like any read: within the label-metadata
+ * component, the most specific covering template wins (§4.6.3 replace-down —
+ * a per-field template shadows the whole-atom template for field reads),
+ * equally specific covers JOIN (two payload entries' per-path templates
+ * coalesce at persist, but foreign/stale siblings fail toward taint).
+ *
+ * `undefined` = no template (the caller falls back to the computed-in-hand
+ * interim rule — pre-Stage-B envelopes have no templates). An EMPTY template
+ * is treated as absent too: mints never produce one, and honoring a crafted
+ * empty entry would turn protected fields public — absence must fail toward
+ * the fallback, never toward disclosure.
+ */
+export const resolveLabelMetadataTemplateConfidentiality = (
+  entries: readonly LabelMapEntry[],
+  path: readonly string[],
+): readonly unknown[] | undefined => {
+  let best: { pathLength: number; atoms: unknown[] } | undefined;
+  for (const entry of entries) {
+    if (
+      !isLabelMetadataTemplateEntry(entry) ||
+      entry.observes !== "labelMetadata"
+    ) {
+      continue;
+    }
+    const entryPath = canonicalizeLogicalPath(entry.path);
+    if (!wildcardIsPrefix(entryPath, path)) {
+      continue;
+    }
+    const confidentiality = entry.label.confidentiality ?? [];
+    if (confidentiality.length === 0) {
+      continue;
+    }
+    if (best === undefined || best.pathLength < entryPath.length) {
+      best = { pathLength: entryPath.length, atoms: [...confidentiality] };
+    } else if (best.pathLength === entryPath.length) {
+      best.atoms.push(...confidentiality);
+    }
+  }
+  return best === undefined ? undefined : uniqueCfcAtoms(best.atoms);
+};

--- a/packages/runner/src/cfc/label-metadata-population.ts
+++ b/packages/runner/src/cfc/label-metadata-population.ts
@@ -175,8 +175,7 @@ const scanAlternative = (
   if (isCfcFieldCommitment(alternative)) {
     return true;
   }
-  const isAtom =
-    typeof (alternative as { type?: unknown }).type === "string" ||
+  const isAtom = typeof (alternative as { type?: unknown }).type === "string" ||
     typeof (alternative as { kind?: unknown }).kind === "string";
   const context = isAtom ? alternative : undefined;
   let found = false;

--- a/packages/runner/src/cfc/label-metadata-population.ts
+++ b/packages/runner/src/cfc/label-metadata-population.ts
@@ -3,6 +3,7 @@ import { canonicalizeLogicalPath } from "./canonical.ts";
 import { clauseAlternatives } from "./clause.ts";
 import { classifyAtomField } from "./label-field-classification.ts";
 import { isCfcFieldCommitment } from "./label-representation.ts";
+import { cfcLabelPathPrefixMatches } from "./label-view-core.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
 import type { IFCLabel, LabelEntryOrigin, LabelMapEntry } from "./types.ts";
 
@@ -260,21 +261,6 @@ export const deriveLabelMetadataTemplateEntries = (
   return out;
 };
 
-// Bidirectional wildcard prefix — the same rule `labelAtPath` /
-// `collectConsumedLabel` resolve payload entries with (`isPrefix` in
-// prepare.ts): `*` in either the entry path or the queried path matches any
-// segment, so a concrete consultation path resolves multi-`*` templates and
-// a template minted for a `*`-path payload target (a Stage-A membership
-// template) resolves for concrete slot consultations.
-const wildcardIsPrefix = (
-  prefix: readonly string[],
-  path: readonly string[],
-): boolean =>
-  prefix.length <= path.length &&
-  prefix.every((segment, index) =>
-    segment === path[index] || segment === "*" || path[index] === "*"
-  );
-
 /**
  * Resolve the persisted population label at one CONCRETE metadata path
  * (`["cfc","labels","value",...,"clauses","1","alternatives","0","source"]`)
@@ -303,8 +289,14 @@ export const resolveLabelMetadataTemplateConfidentiality = (
     ) {
       continue;
     }
+    // Bidirectional wildcard prefix — the canonical matcher label views and
+    // the payload resolution share (`*` in either the entry path or the
+    // queried path matches any segment), so a concrete consultation path
+    // resolves multi-`*` templates and a template minted for a `*`-path
+    // payload target (a Stage-A membership template) resolves for concrete
+    // slot consultations.
     const entryPath = canonicalizeLogicalPath(entry.path);
-    if (!wildcardIsPrefix(entryPath, path)) {
+    if (!cfcLabelPathPrefixMatches(entryPath, path)) {
       continue;
     }
     const confidentiality = entry.label.confidentiality ?? [];

--- a/packages/runner/src/cfc/label-view-state.ts
+++ b/packages/runner/src/cfc/label-view-state.ts
@@ -43,17 +43,26 @@ export const cfcLabelViewFromMetadata = (
   return rebaseCfcLabelView(
     {
       version: 1,
-      entries: metadata.labelMap.entries.map((entry) => {
+      entries: metadata.labelMap.entries.flatMap((entry) => {
         // The view carries the EFFECTIVE class: the persisted
         // `origin:"link"` ⇒ implicit `followRef` carve-out (C0 §3) is
         // resolved here, so view consumers classify without knowing about
         // origins.
         const observes = entryObservationClass(entry);
-        return {
+        // Label-metadata population templates (template-population Stage B)
+        // are envelope-LOCAL: they describe this envelope's own payload
+        // entries and are re-derived per envelope at persist, so they never
+        // ride label views — a link transports the source's payload labels,
+        // and the target's envelope mints its own templates from whatever
+        // entries land there.
+        if (observes === "labelMetadata") {
+          return [];
+        }
+        return [{
           path: entry.path,
           label: entry.label,
           ...(observes !== undefined ? { observes } : {}),
-        };
+        }];
       }),
     },
     path,

--- a/packages/runner/src/cfc/observation-classes.ts
+++ b/packages/runner/src/cfc/observation-classes.ts
@@ -71,7 +71,7 @@ const CONSUMED_CLASSES: Record<
  */
 export const entryObservationClass = (
   entry: Pick<LabelMapEntry, "origin" | "observes">,
-): LabelObservationClass | undefined =>
+): LabelObservationClass | LabelMetadataObservationClass | undefined =>
   entry.observes ?? (entry.origin === "link" ? "followRef" : undefined);
 
 /** Whether a read of the given shape consumes the given entry's label. */
@@ -93,6 +93,17 @@ export const readConsumesEntry = (
     // consumption is still strictly wider than pre-C1 behavior, which
     // consumed nothing for probes.
     return selection !== "followRef";
+  }
+  if (entryClass === LABEL_METADATA_OBSERVATION) {
+    // Persisted label-metadata population templates (template-population
+    // Stage B): NO payload read class consumes them — the introspection
+    // surface is their only consumer, resolving them explicitly
+    // (`resolveLabelMetadataTemplateConfidentiality`). The classified arms
+    // above already returned for `"all"`, which deliberately stays
+    // over-inclusive (a screen; the templates' content duplicates the
+    // payload entries they were derived from, so the write gate sees no
+    // new atoms through them).
+    return false;
   }
   return CONSUMED_CLASSES[selection].includes(entryClass);
 };

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -68,6 +68,10 @@ import {
 } from "./grants.ts";
 import { cfcLabelViewFromMetadata } from "./label-view-state.ts";
 import {
+  deriveLabelMetadataTemplateEntries,
+  isLabelMetadataTemplateEntry,
+} from "./label-metadata-population.ts";
+import {
   commitmentAwareEquals,
   containsCfcFieldCommitment,
   transformCfcLabelForCrossSpacePersist,
@@ -4939,6 +4943,16 @@ export const prepareBoundaryCommit = (
     for (const entry of existing?.labelMap.entries ?? []) {
       const entryPath = canonicalizeLogicalPath(entry.path);
       const key = pathKey(entryPath);
+      // Label-metadata population templates (template-population Stage B,
+      // spec §4.6.4.2) are a pure function of the payload entries in this
+      // same envelope: never carried forward — re-derived below from the
+      // FINAL payload entry set, so they replace on overwrite and clear
+      // with the entries they describe by construction (and a stale
+      // template left by a mixed-version writer heals on the next persist
+      // here).
+      if (isLabelMetadataTemplateEntry(entry)) {
+        continue;
+      }
       // RUNTIME-MINTED shape-class (existence) entries survive every
       // overwrite of a still-existing path (freeze-at-creation): not the
       // flow-clear, not a link write replacing the slot, not a declared
@@ -5607,6 +5621,23 @@ export const prepareBoundaryCommit = (
         );
       }
     }
+
+    // Stage B (template-population §5/§6; spec §4.6.4.2): derive the
+    // label-metadata population templates from the FINAL payload entries —
+    // after every clear/carry/mint AND after the Stage-1 representation
+    // transform above, so template label content is byte-identical to the
+    // payload labels it describes (the transform applies to templates by
+    // construction: they copy post-transform bytes — one transform, both
+    // sinks). Deterministic per payload-entry set, so the SC-11 canonical
+    // comparison below still skips unchanged recomputes; coalescing next
+    // joins the per-entry population labels of same-path payload entries
+    // (the C2 value/shape split) into one per-path template, which is what
+    // the per-path §4.6.4.1 metadata addressing requires. No new dial: the
+    // templates describe whatever payload entries the existing dials
+    // persisted.
+    persistedLabelEntries.push(
+      ...deriveLabelMetadataTemplateEntries(persistedLabelEntries),
+    );
 
     const coalescedLabelEntries = coalesceLabelEntries(persistedLabelEntries);
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4602,12 +4602,23 @@ export const prepareBoundaryCommit = (
         target.scope,
         target.type,
       );
+      const existingEntries = existingMeta?.labelMap.entries ?? [];
       if (
-        existingMeta?.labelMap.entries.some((entry) =>
+        existingEntries.some((entry) =>
           (entry.origin === "derived" || entry.origin === "link" ||
             entry.origin === "structure") &&
           target.paths.some((written) => isPrefix(written, entry.path))
-        )
+        ) ||
+        // Stage B healing, the template-ONLY arm (cubic P2 on the Stage B
+        // PR): an envelope whose entries are ALL label-metadata templates
+        // has no payload entry a written path could cover, so it would
+        // never re-enter this loop — and its templates describe entries
+        // that no longer exist. Admit it so the re-derivation writes the
+        // healed (empty) label map. Envelopes with any payload entry heal
+        // through the ordinary covering-write arm above (the re-derivation
+        // rebuilds templates whenever payload entries are re-persisted).
+        (existingEntries.length > 0 &&
+          existingEntries.every((entry) => isLabelMetadataTemplateEntry(entry)))
       ) {
         targetKeys.add(key);
       }
@@ -4912,6 +4923,15 @@ export const prepareBoundaryCommit = (
       linkWriteInputs.map((input) => pathKey(input.target.path)),
     );
     let flowCleared = false;
+    // Stage B: stored label-metadata templates this persist drops (they are
+    // re-derived from the FINAL payload entry set below). Tracked so a
+    // TEMPLATE-ONLY stale envelope — a mixed-version writer cleared the
+    // payload entries while carrying the unknown-origin templates forward —
+    // heals: dropping them counts as a clear, so an empty final label map
+    // is WRITTEN rather than short-circuited into keeping the stale bytes
+    // (cubic P2 on the Stage B PR). When the final entries are non-empty
+    // the flag is inert — the SC-11 canonical comparison decides as usual.
+    let droppedLabelMetadataTemplates = false;
     // SC-4 (C3, disciplines settled with the spec 2026-07-06 — freeze-at-
     // creation, specs branch cfc/existence-freeze-at-creation): existence
     // never shrinks, but it does not grow either. When a clear drops a
@@ -4949,8 +4969,10 @@ export const prepareBoundaryCommit = (
       // FINAL payload entry set, so they replace on overwrite and clear
       // with the entries they describe by construction (and a stale
       // template left by a mixed-version writer heals on the next persist
-      // here).
+      // here — see `droppedLabelMetadataTemplates` for the template-only
+      // arm).
       if (isLabelMetadataTemplateEntry(entry)) {
+        droppedLabelMetadataTemplates = true;
         continue;
       }
       // RUNTIME-MINTED shape-class (existence) entries survive every
@@ -5641,7 +5663,10 @@ export const prepareBoundaryCommit = (
 
     const coalescedLabelEntries = coalesceLabelEntries(persistedLabelEntries);
 
-    if (coalescedLabelEntries.length === 0 && !flowCleared) {
+    if (
+      coalescedLabelEntries.length === 0 && !flowCleared &&
+      !droppedLabelMetadataTemplates
+    ) {
       continue;
     }
 

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -194,6 +194,17 @@ export type CfcSandboxResult = {
  *   runtime-minted gate; anchored at the ingest target cell and re-minted
  *   (replacing the prior mark for that doc) on each ingest. Its update
  *   discipline is replace-per-doc, driven by the ingest stamp.
+ * - `label-metadata`: the §4.6.4.2 field-precise population profile
+ *   (template-population Stage B) — multi-`*` templates under the
+ *   `/cfc/labels/<target-envelope-path>/...` metadata subtree carrying the
+ *   observation labels of the payload label's source-bearing fields. Update
+ *   discipline: a pure function of the payload entries in the same envelope,
+ *   re-derived from the FINAL payload entry set at every persist (so they
+ *   replace on overwrite, clear with the entries they describe, and stay
+ *   SC-11 no-op on unchanged recomputes by construction; never carried
+ *   forward). Always paired with `observes:"labelMetadata"`: no payload read
+ *   class consumes them — the introspection surface (`inspectConfLabel`) is
+ *   their only consumer. See `label-metadata-population.ts`.
  * Entries without an origin are legacy (pre-component) entries and are
  * treated as one combined component with the historical update rules.
  * The effective label at a path is the join of all components.
@@ -203,7 +214,8 @@ export type LabelEntryOrigin =
   | "link"
   | "derived"
   | "structure"
-  | "external-ingest";
+  | "external-ingest"
+  | "label-metadata";
 
 /**
  * Consumption class of a persisted labelMap entry (Epic C,
@@ -234,7 +246,13 @@ export type LabelMapEntry = {
   path: readonly string[];
   label: IFCLabel;
   origin?: LabelEntryOrigin;
-  observes?: LabelObservationClass;
+  /**
+   * Payload consumption classes, or — on `origin:"label-metadata"`
+   * population templates only (Stage B) — the `labelMetadata` class, which
+   * no payload read consumes (`readConsumesEntry`): those entries are
+   * resolved exclusively by the introspection surface.
+   */
+  observes?: LabelObservationClass | LabelMetadataObservationClass;
 };
 
 export type CfcMetadata = {

--- a/packages/runner/test/cfc-label-introspection-channel.test.ts
+++ b/packages/runner/test/cfc-label-introspection-channel.test.ts
@@ -416,7 +416,7 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
     }
   });
 
-  it("inspectStoredConfLabel records the observation at the metadata subtree address", async () => {
+  it("inspectStoredConfLabel records the observation at the concrete metadata path", async () => {
     const { storageManager, runtime } = makeRuntime({
       cfcFlowLabels: "persist",
     });
@@ -432,15 +432,25 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
       );
       expect(outcome.status).toBe("ok");
       const observations = tx.getCfcState().labelMetadataObservations;
+      // The seeded label holds two clauses ("secret" — a public type-only
+      // string atom, nothing recorded — and the source-bearing caveat): one
+      // protected whole-atom projection.
       expect(observations).toHaveLength(1);
       expect(observations[0].observes).toBe("labelMetadata");
-      // The record addresses the FIRST-LAYER metadata subtree, never a
-      // payload path (§4.6.4.1 addressing).
+      // The record addresses the CONCRETE first-layer metadata path the
+      // projection consulted (§4.6.4.1 addressing; template-population
+      // Stage B upgraded the record from the subtree root to the
+      // clause/alternative-indexed path) — never a payload path.
       expect([...observations[0].target.path]).toEqual([
         "cfc",
         "labels",
         "value",
         "body",
+        "confidentiality",
+        "clauses",
+        "1",
+        "alternatives",
+        "0",
       ]);
       expect(observations[0].target.id).toBe(id);
       expect([...observations[0].confidentiality]).toContainEqual("secret");

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -853,24 +853,26 @@ describe("CFC template metadata population (Stage B): derivation unit properties
       ]),
     ).toEqual(["atom-label"]);
     // Equally specific covers JOIN (fail-toward-taint).
-    expect(
-      resolveLabelMetadataTemplateConfidentiality([
-        ...entries,
-        templateEntry(["items", "3"], ["source"], ["concrete-label"]),
-      ], [
-        "cfc",
-        "labels",
-        "value",
-        "items",
-        "3",
-        "confidentiality",
-        "clauses",
-        "0",
-        "alternatives",
-        "0",
-        "source",
-      ])?.sort(),
-    ).toEqual(["concrete-label", "source-label"]);
+    const joined = resolveLabelMetadataTemplateConfidentiality([
+      ...entries,
+      templateEntry(["items", "3"], ["source"], ["concrete-label"]),
+    ], [
+      "cfc",
+      "labels",
+      "value",
+      "items",
+      "3",
+      "confidentiality",
+      "clauses",
+      "0",
+      "alternatives",
+      "0",
+      "source",
+    ]);
+    expect([...(joined ?? [])].sort()).toEqual([
+      "concrete-label",
+      "source-label",
+    ]);
     // No cover → undefined (the caller falls back to the in-hand rule).
     expect(
       resolveLabelMetadataTemplateConfidentiality(entries, [

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -15,6 +15,7 @@ import {
   inspectStoredConfLabel,
 } from "../src/cfc/label-introspection.ts";
 import { containsCfcFieldCommitment } from "../src/cfc/label-representation.ts";
+import { cfcLabelViewFromMetadata } from "../src/cfc/label-view-state.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { CfcMetadata, LabelMapEntry } from "../src/cfc/types.ts";
@@ -757,6 +758,56 @@ describe("CFC template metadata population (Stage B): evaluator resolution", () 
     );
     expect(result.status).toBe("ok");
     expect(consumedConfidentiality).toContainEqual("secret");
+  });
+
+  it("refuses a target whose resolved CELL path lands in the metadata subtree", async () => {
+    // parseConfLabelTargetPath catches a `/cfc/...` query pointer; the
+    // resolved-path guard catches a target cell whose OWN path collides with
+    // the metadata sibling — labels-of-labels stays refused however
+    // addressed.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    try {
+      const tx = runtime.edit();
+      const cell = runtime.getCell(space, "mp-cfc-path-target", undefined, tx);
+      const link = cell.getAsNormalizedFullLink();
+      const outcome = inspectStoredConfLabel(
+        tx,
+        { ...link, path: ["cfc", "labels"] },
+        "/x",
+        {},
+      );
+      expect(outcome).toEqual({ status: "notAvailable" });
+      expect(tx.getCfcState().labelMetadataObservations).toHaveLength(0);
+      await tx.commit();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("label views exclude the envelope-local templates", () => {
+    // Link transport / display / LLM-observation views ride
+    // cfcLabelViewFromMetadata: templates describe THIS envelope's payload
+    // entries and never travel (the link target's own envelope mints its
+    // own).
+    const view = cfcLabelViewFromMetadata(
+      metadataWith([
+        derivedBodyEntry(),
+        templateEntry(["body"], [], ["tmpl-atom-label"]),
+        templateEntry(["body"], ["source"], ["tmpl-source-label"]),
+      ]),
+      [],
+    );
+    expect(view?.entries.map((entry) => entry.path.join("/"))).toEqual([
+      "body",
+    ]);
+    expect(JSON.stringify(view)).not.toContain("tmpl-");
   });
 
   it("never enumerates template entries as payload label atoms", () => {

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -843,7 +843,33 @@ describe("CFC template metadata population (Stage B): derivation unit properties
       },
       { path: ["body"], label: { confidentiality: [caveatAtom()] } },
       templateEntry(["body"], ["source"], [caveatAtom()]),
+      // A template entry stays skipped by origin even without its class.
+      {
+        path: ["cfc", "labels", "value", "body"],
+        label: { confidentiality: [caveatAtom()] },
+        origin: "label-metadata",
+      },
+      // Integrity-only derived entries have no confidentiality clauses to
+      // describe.
+      {
+        path: ["body"],
+        label: { integrity: [caveatAtom()] },
+        origin: "derived",
+      },
     ])).toEqual([]);
+  });
+
+  it("array and bare-marker alternatives mint the whole-atom template only", () => {
+    // An array alternative smuggling a protected record and a bare
+    // commitment-marker alternative are protected CONTENT with no direct
+    // field addressing: whole-atom template, no per-field entries.
+    const derived = deriveLabelMetadataTemplateEntries([
+      derivedEntry([
+        ["tag", { custom: "protected-field-in-array" }],
+        { digestOf: "abc" },
+      ]),
+    ]);
+    expect(derived.map((e) => e.path.at(-1))).toEqual(["*"]);
   });
 
   it("resolves the most specific template with wildcard segments (replace-down)", () => {
@@ -915,6 +941,30 @@ describe("CFC template metadata population (Stage B): derivation unit properties
         "0",
         "alternatives",
         "0",
+      ]),
+    ).toBeUndefined();
+    // Only well-formed templates resolve: a label-metadata entry missing
+    // its class, and payload entries of other origins, never cover.
+    expect(
+      resolveLabelMetadataTemplateConfidentiality([
+        {
+          path: ["cfc", "labels", "value", "items", "*"],
+          label: { confidentiality: ["classless"] },
+          origin: "label-metadata",
+        },
+        {
+          path: ["cfc", "labels", "value", "items", "*", "confidentiality"],
+          label: { confidentiality: ["wrong-origin"] },
+          origin: "derived",
+          observes: "value",
+        },
+      ], [
+        "cfc",
+        "labels",
+        "value",
+        "items",
+        "*",
+        "confidentiality",
       ]),
     ).toBeUndefined();
   });

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -604,6 +604,58 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     );
   });
 
+  // Mixed-version healing, the template-ONLY arm (cubic P2 on this PR): an
+  // envelope whose only surviving entries are stale templates (an older
+  // runtime cleared the payload entries while carrying the unknown-origin
+  // templates forward) must heal to an EMPTY label map on the next Stage-B
+  // persist — dropping the templates counts as a clear, so the empty final
+  // map is written rather than short-circuited into keeping the stale bytes.
+  it("heals a stale template-only envelope to an empty label map", async () => {
+    const rt = makeRuntime();
+    // Seed the stale state with a RESOLVABLE schema document (a real
+    // mixed-version envelope always references a stored cid: schema).
+    const interned = internSchema({ type: "object" } as JSONSchema, true);
+    const seed = rt.edit();
+    const seedCell = rt.getCell(space, "mp-heal", undefined, seed);
+    const seededId = seedCell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow(
+      {
+        space,
+        scope: "space",
+        id: `cid:${interned.taggedHashString}` as `${string}:${string}`,
+        path: [],
+      },
+      { value: interned.schema },
+    );
+    seed.writeOrThrow({ space, scope: "space", id: seededId, path: [] }, {
+      value: { x: 1 },
+      cfc: {
+        version: 1,
+        schemaHash: interned.taggedHashString,
+        labelMap: {
+          version: 1,
+          entries: [
+            templateEntry([], [], ["stale-tmpl-atom"]),
+            templateEntry([], ["source"], ["stale-tmpl-atom"]),
+          ],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    expect(entriesOf(seededId).length).toBe(2);
+
+    // A clean (unlabeled) value write: no payload entries survive the
+    // re-derivation, so no templates re-derive either — the heal writes the
+    // empty label map instead of keeping the stale bytes.
+    const tx = rt.edit();
+    const cell = rt.getCell(space, "mp-heal", undefined, tx);
+    cell.set({ fresh: true } as never);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(entriesOf(seededId)).toEqual([]);
+  });
+
   // The recorded labelMetadata observations reference the CONCRETE metadata
   // paths the evaluation consulted (clause/alternative indices), not the
   // subtree root.
@@ -878,6 +930,40 @@ describe("CFC template metadata population (Stage B): derivation unit properties
       derivedEntry([{ kind: "authored-by", subject: caveatAtom() }]),
     ]);
     expect(smuggling.map((e) => e.path.at(-1))).toEqual(["*"]);
+
+    // Deeper smuggling shapes stay whole-atom-only through the nested scan:
+    // an ARRAY under a public wrapper field whose element is itself a
+    // public-fielded claim atom wrapping the protected caveat (the scan
+    // recurses array elements and unprotected record fields), ...
+    const nestedArray = deriveLabelMetadataTemplateEntries([
+      derivedEntry([{
+        kind: "authored-by",
+        subject: [{ kind: "authored-by", subject: caveatAtom() }],
+      }]),
+    ]);
+    expect(nestedArray.map((e) => e.path.at(-1))).toEqual(["*"]);
+
+    // ...and a bare commitment marker nested under a public wrapper field
+    // (protected content wherever it sits, mirroring the projection walk's
+    // marker arm).
+    const nestedMarker = deriveLabelMetadataTemplateEntries([
+      derivedEntry([{
+        kind: "authored-by",
+        subject: { digestOf: "committed-nested" },
+      }]),
+    ]);
+    expect(nestedMarker.map((e) => e.path.at(-1))).toEqual(["*"]);
+
+    // An all-public nested shape mints nothing through the same scan.
+    expect(deriveLabelMetadataTemplateEntries([
+      derivedEntry([{
+        kind: "authored-by",
+        subject: ["did:key:alice", {
+          kind: "authored-by",
+          subject: "did:key:bob",
+        }],
+      }]),
+    ])).toEqual([]);
   });
 
   it("derives nothing from non-containment or template entries", () => {

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -270,9 +270,14 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const txB = rt.edit();
     txB.readOrThrow(readAddress(criteriaB, []));
     txB.writeOrThrow(
-      { space, scope: "space", id: outId as `${string}:${string}`, path: [
-        "value",
-      ] },
+      {
+        space,
+        scope: "space",
+        id: outId as `${string}:${string}`,
+        path: [
+          "value",
+        ],
+      },
       { observed: "second" },
     );
     txB.prepareCfc();
@@ -289,9 +294,14 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const txC = rt.edit();
     txC.readOrThrow(readAddress(criteriaC, []));
     txC.writeOrThrow(
-      { space, scope: "space", id: outId as `${string}:${string}`, path: [
-        "value",
-      ] },
+      {
+        space,
+        scope: "space",
+        id: outId as `${string}:${string}`,
+        path: [
+          "value",
+        ],
+      },
       { observed: "third" },
     );
     txC.prepareCfc();
@@ -326,9 +336,14 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const again = rt.edit();
     again.readOrThrow(readAddress(criteriaId, []));
     again.writeOrThrow(
-      { space, scope: "space", id: outId as `${string}:${string}`, path: [
-        "value",
-      ] },
+      {
+        space,
+        scope: "space",
+        id: outId as `${string}:${string}`,
+        path: [
+          "value",
+        ],
+      },
       { observed: "same" },
     );
     again.prepareCfc();
@@ -424,7 +439,12 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const rt = runtime;
     // Foreign labeled doc whose label carries a Caveat with plaintext source.
     const seed = rt.edit();
-    const criteria = rt.getCell(foreignSpace, "mp-xs-criteria", undefined, seed);
+    const criteria = rt.getCell(
+      foreignSpace,
+      "mp-xs-criteria",
+      undefined,
+      seed,
+    );
     const criteriaId = criteria.getAsNormalizedFullLink().id;
     seed.writeOrThrow(
       { space: foreignSpace, scope: "space", id: criteriaId, path: [] },
@@ -518,7 +538,12 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     // Recursive value read at the root.
     const txValue = rt.edit();
     txValue.readOrThrow(readAddress(seededId, []));
-    const outValue = rt.getCell(space, "mp-guard-out-value", undefined, txValue);
+    const outValue = rt.getCell(
+      space,
+      "mp-guard-out-value",
+      undefined,
+      txValue,
+    );
     outValue.set({ observed: true });
     txValue.prepareCfc();
     expect((await txValue.commit()).ok).toBeDefined();
@@ -531,7 +556,12 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     // Shape probe (nonRecursive) at the root.
     const txShape = rt.edit();
     txShape.readOrThrow(readAddress(seededId, []), { nonRecursive: true });
-    const outShape = rt.getCell(space, "mp-guard-out-shape", undefined, txShape);
+    const outShape = rt.getCell(
+      space,
+      "mp-guard-out-shape",
+      undefined,
+      txShape,
+    );
     outShape.set({ observed: true });
     txShape.prepareCfc();
     expect((await txShape.commit()).ok).toBeDefined();

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,0 +1,941 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
+import {
+  deriveLabelMetadataTemplateEntries,
+  resolveLabelMetadataTemplateConfidentiality,
+} from "../src/cfc/label-metadata-population.ts";
+import {
+  evaluateConfLabelQuery,
+  inspectStoredConfLabel,
+} from "../src/cfc/label-introspection.ts";
+import { containsCfcFieldCommitment } from "../src/cfc/label-representation.ts";
+import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcMetadata, LabelMapEntry } from "../src/cfc/types.ts";
+
+const signer = await Identity.fromPassphrase(
+  "runner-cfc-template-metadata-population",
+);
+const foreignSigner = await Identity.fromPassphrase(
+  "runner-cfc-template-metadata-population-foreign",
+);
+const space = signer.did();
+const foreignSpace = foreignSigner.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  origin?: string;
+  observes?: string;
+};
+
+const SOURCE_A = { space: "did:key:remote-a", id: "of:origin-a", path: [] };
+const SOURCE_B = { space: "did:key:remote-b", id: "of:origin-b", path: [] };
+
+const caveatAtom = (source: unknown = SOURCE_A) => ({
+  type: CFC_ATOM_TYPE.Caveat,
+  kind: "prompt-influence",
+  source,
+});
+
+const metadataWith = (
+  entries: CfcMetadata["labelMap"]["entries"],
+): CfcMetadata => ({
+  version: 1,
+  schemaHash: "test-schema",
+  labelMap: { version: 1, entries },
+});
+
+/** A persisted label-metadata population template, as the mint produces it. */
+const templateEntry = (
+  targetPath: string[],
+  tail: string[],
+  confidentiality: unknown[],
+): LabelMapEntry => ({
+  path: [
+    "cfc",
+    "labels",
+    "value",
+    ...targetPath,
+    "confidentiality",
+    "clauses",
+    "*",
+    "alternatives",
+    "*",
+    ...tail,
+  ],
+  label: { confidentiality },
+  origin: "label-metadata",
+  observes: "labelMetadata",
+});
+
+// Stage B of docs/specs/cfc-template-population.md (§5/§6; spec §4.6.4.1-.2):
+// the §4.6.4.2 field-precise label-metadata population profile, carried as
+// multi-`*` templates under /cfc/labels/<target-envelope-path>/... — minted at
+// the envelope persist seam from each source-bearing derived-containment
+// payload entry, consumed ONLY by the introspection surface (which resolves
+// them at concrete clause/alternative paths through the wildcard machinery,
+// falling back to the computed-in-hand interim rule for pre-Stage-B
+// envelopes).
+
+describe("CFC template metadata population (Stage B): persist-seam mints", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const makeRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  const seedDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: unknown,
+    entries: LabelMapEntry[],
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: { version: 1, entries },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const readAddress = (id: string, path: string[]) => ({
+    space,
+    scope: "space" as const,
+    id: id as `${string}:${string}`,
+    type: "application/json" as const,
+    path: ["value", ...path],
+  });
+
+  // One transaction that reads the labeled criteria doc and writes an out
+  // doc: the out doc's derived value/shape entries carry the criteria's J.
+  const deriveOutDoc = async (
+    rt: Runtime,
+    outCause: string,
+    criteriaId: string,
+    value: unknown = { observed: true },
+  ): Promise<string> => {
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(criteriaId, []));
+    const out = rt.getCell(space, outCause, undefined, tx);
+    out.set(value as never);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    return out.getAsNormalizedFullLink().id;
+  };
+
+  // The spec's example shape (§4.6.4.2): a derived entry whose clause list
+  // carries Caveat(kind, source=S). The persist seam mints the whole-atom
+  // projection template and the per-field `source` template at the multi-`*`
+  // metadata paths, both carrying the interim-rule label (the entry's own
+  // effective confidentiality), confidentiality-only.
+  it("mints the multi-`*` templates for a derived entry with Caveat.source", async () => {
+    const rt = makeRuntime();
+    const criteriaId = await seedDoc(rt, "mp-criteria", { keep: true }, [
+      { path: [], label: { confidentiality: [caveatAtom()] } },
+    ]);
+    const outId = await deriveOutDoc(rt, "mp-out", criteriaId);
+
+    const templates = entriesOf(outId).filter(
+      (e) => e.origin === "label-metadata",
+    );
+    expect(templates.map((e) => [e.path.join("/"), e.observes])).toEqual([
+      [
+        "cfc/labels/value/confidentiality/clauses/*/alternatives/*",
+        "labelMetadata",
+      ],
+      [
+        "cfc/labels/value/confidentiality/clauses/*/alternatives/*/source",
+        "labelMetadata",
+      ],
+    ]);
+    for (const entry of templates) {
+      expect(entry.label.confidentiality).toEqual([caveatAtom()]);
+      expect(entry.label.integrity).toBeUndefined();
+    }
+    // Presence/type/kind stay public: NO template materializes for them
+    // (absence = public under the §4.6.4.2 default profile).
+    expect(templates.some((e) => e.path.at(-1) === "type")).toBe(false);
+    expect(templates.some((e) => e.path.at(-1) === "kind")).toBe(false);
+  });
+
+  // Declared/authored entries carry no containment guarantee: their
+  // source-bearing fields are fail-closed UNOBSERVABLE under the interim
+  // rule, so the mint materializes nothing for them (a template would imply
+  // an observation label exists).
+  it("mints nothing for declared source-bearing entries", async () => {
+    const rt = makeRuntime();
+    const guarded = internSchema(
+      {
+        type: "object",
+        ifc: { confidentiality: [caveatAtom()] },
+      } as JSONSchema,
+      true,
+    );
+    const tx = rt.edit();
+    const cell = rt.getCell(space, "mp-declared", guarded.schema, tx);
+    cell.set({ n: 1 } as never);
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    const id = cell.getAsNormalizedFullLink().id;
+
+    const stored = entriesOf(id);
+    expect(stored.some((e) => e.origin === "declared")).toBe(true);
+    expect(stored.some((e) => e.origin === "label-metadata")).toBe(false);
+  });
+
+  // All-public atoms (string tags; authored-attribution claims whose every
+  // field is table-public) have nothing source-protected to label: no
+  // templates.
+  it("mints nothing when the derived label has no protected fields", async () => {
+    const rt = makeRuntime();
+    const criteriaId = await seedDoc(rt, "mp-criteria-pub", { keep: true }, [
+      {
+        path: [],
+        label: {
+          confidentiality: [
+            "public-tag",
+            { kind: "authored-by", subject: "did:key:alice" },
+          ],
+        },
+      },
+    ]);
+    const outId = await deriveOutDoc(rt, "mp-out-pub", criteriaId);
+
+    const stored = entriesOf(outId);
+    expect(stored.some((e) => e.origin === "derived")).toBe(true);
+    expect(stored.some((e) => e.origin === "label-metadata")).toBe(false);
+  });
+
+  // Replace-on-overwrite alongside the payload entry they describe: a
+  // re-derivation under a new J replaces the derived value entry AND its
+  // templates — the departed J's atoms leave the templates entirely.
+  it("overwrite replaces the templates with the payload entry they describe", async () => {
+    const rt = makeRuntime();
+    // Creation under a NON-source-bearing J so the frozen shape entry never
+    // contributes template atoms of its own.
+    const plainId = await seedDoc(rt, "mp-criteria-plain", { keep: true }, [
+      { path: [], label: { confidentiality: ["plain-tag"] } },
+    ]);
+    const criteriaB = await seedDoc(rt, "mp-criteria-b", { keep: true }, [
+      { path: [], label: { confidentiality: [caveatAtom(SOURCE_A)] } },
+    ]);
+    const criteriaC = await seedDoc(rt, "mp-criteria-c", { keep: true }, [
+      { path: [], label: { confidentiality: [caveatAtom(SOURCE_B)] } },
+    ]);
+
+    const outId = await deriveOutDoc(rt, "mp-out-replace", plainId);
+    expect(entriesOf(outId).some((e) => e.origin === "label-metadata")).toBe(
+      false,
+    );
+
+    // Overwrite under J = caveat(SOURCE_A): templates appear with it.
+    const txB = rt.edit();
+    txB.readOrThrow(readAddress(criteriaB, []));
+    txB.writeOrThrow(
+      { space, scope: "space", id: outId as `${string}:${string}`, path: [
+        "value",
+      ] },
+      { observed: "second" },
+    );
+    txB.prepareCfc();
+    expect((await txB.commit()).ok).toBeDefined();
+    const afterB = entriesOf(outId).filter(
+      (e) => e.origin === "label-metadata",
+    );
+    expect(afterB.length).toBe(2);
+    for (const entry of afterB) {
+      expect(entry.label.confidentiality).toContainEqual(caveatAtom(SOURCE_A));
+    }
+
+    // Overwrite under J = caveat(SOURCE_B): SOURCE_A leaves with its entry.
+    const txC = rt.edit();
+    txC.readOrThrow(readAddress(criteriaC, []));
+    txC.writeOrThrow(
+      { space, scope: "space", id: outId as `${string}:${string}`, path: [
+        "value",
+      ] },
+      { observed: "third" },
+    );
+    txC.prepareCfc();
+    expect((await txC.commit()).ok).toBeDefined();
+    const afterC = entriesOf(outId).filter(
+      (e) => e.origin === "label-metadata",
+    );
+    expect(afterC.length).toBe(2);
+    for (const entry of afterC) {
+      expect(entry.label.confidentiality).toContainEqual(caveatAtom(SOURCE_B));
+      expect(entry.label.confidentiality).not.toContainEqual(
+        caveatAtom(SOURCE_A),
+      );
+    }
+  });
+
+  // SC-11 with metadata templates present: an identical re-derivation is
+  // canonically equal to the stored envelope and must not write ["cfc"].
+  it("recompute with metadata templates present is a no-op (SC-11)", async () => {
+    const rt = makeRuntime();
+    const criteriaId = await seedDoc(rt, "mp-criteria-i", { keep: true }, [
+      { path: [], label: { confidentiality: [caveatAtom()] } },
+    ]);
+    const outId = await deriveOutDoc(rt, "mp-out-i", criteriaId, {
+      observed: "same",
+    });
+    expect(
+      entriesOf(outId).some((e) => e.origin === "label-metadata"),
+    ).toBe(true);
+    const before = JSON.stringify(entriesOf(outId));
+
+    const again = rt.edit();
+    again.readOrThrow(readAddress(criteriaId, []));
+    again.writeOrThrow(
+      { space, scope: "space", id: outId as `${string}:${string}`, path: [
+        "value",
+      ] },
+      { observed: "same" },
+    );
+    again.prepareCfc();
+    const wroteCfc = [...(again.getWriteDetails?.(space) ?? [])].some(
+      (w) => w.address.id === outId && w.address.path[0] === "cfc",
+    );
+    expect(wroteCfc).toBe(false);
+    expect((await again.commit()).ok).toBeDefined();
+    expect(JSON.stringify(entriesOf(outId))).toEqual(before);
+  });
+
+  // Stage-A composition: the membership templates a declared list
+  // coordinator mints at [...container,"*"] are derived-containment payload
+  // entries with `*` in their TARGET path — their metadata templates nest
+  // wildcards three deep and still resolve for concrete slot queries.
+  it("mints metadata templates for `*`-path membership entries and resolves them at slots", async () => {
+    const rt = makeRuntime();
+    await seedDoc(rt, "mp-el", { n: 1 }, []);
+    const criteriaId = await seedDoc(rt, "mp-criteria-list", { keep: true }, [
+      { path: [], label: { confidentiality: [caveatAtom()] } },
+    ]);
+    const tx = rt.edit();
+    tx.readOrThrow(readAddress(criteriaId, []));
+    const member = rt.getCell(space, "mp-el", undefined, tx);
+    const list = rt.getCell(space, "mp-list", {
+      type: "array",
+      items: { asCell: ["cell"] },
+    }, tx);
+    list.set([member]);
+    const listId = list.getAsNormalizedFullLink().id;
+    tx.recordCfcStructureContainer({
+      space,
+      id: listId,
+      scope: "space",
+      path: [],
+    });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const templates = entriesOf(listId).filter(
+      (e) => e.origin === "label-metadata",
+    );
+    // Container-anchored entries (enumerate + frozen shape at []) and the
+    // three `*`-child twins each carry the caveat J: one whole-atom + one
+    // `source` template per target path — 4 total, the slot pair with the
+    // `*` target segment.
+    expect(templates.map((e) => e.path.join("/")).sort()).toEqual([
+      "cfc/labels/value/*/confidentiality/clauses/*/alternatives/*",
+      "cfc/labels/value/*/confidentiality/clauses/*/alternatives/*/source",
+      "cfc/labels/value/confidentiality/clauses/*/alternatives/*",
+      "cfc/labels/value/confidentiality/clauses/*/alternatives/*/source",
+    ]);
+
+    // A slot-addressed introspection ("/0") resolves the `*`-target
+    // templates at its concrete consultation paths.
+    const inspect = rt.edit();
+    const outcome = inspectStoredConfLabel(
+      inspect,
+      list.getAsNormalizedFullLink(),
+      "/0",
+      { source: SOURCE_A },
+    );
+    expect(outcome.status).toBe("ok");
+    if (outcome.status !== "ok") throw new Error("unreachable");
+    expect(outcome.atoms.length).toBeGreaterThan(0);
+    const observations = inspect.getCfcState().labelMetadataObservations;
+    expect(observations.length).toBeGreaterThan(0);
+    for (const observation of observations) {
+      expect([...observation.target.path].slice(0, 4)).toEqual([
+        "cfc",
+        "labels",
+        "value",
+        "0",
+      ]);
+      expect([...observation.confidentiality]).toContainEqual(caveatAtom());
+    }
+    await inspect.commit();
+  });
+
+  // Inv-12 Stage 1 rides along: templates derive from the FINAL (post
+  // representation transform) payload labels, so a cross-space J persists in
+  // commitment form in the templates too — and digest-matching still
+  // consumes the right template.
+  it("commitment-form templates: digest-matched source queries consume the committed template", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+      cfcLabelMetadataProtection: "enforce",
+    });
+    const rt = runtime;
+    // Foreign labeled doc whose label carries a Caveat with plaintext source.
+    const seed = rt.edit();
+    const criteria = rt.getCell(foreignSpace, "mp-xs-criteria", undefined, seed);
+    const criteriaId = criteria.getAsNormalizedFullLink().id;
+    seed.writeOrThrow(
+      { space: foreignSpace, scope: "space", id: criteriaId, path: [] },
+      {
+        value: { keep: true },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [
+              { path: [], label: { confidentiality: [caveatAtom()] } },
+            ],
+          },
+        },
+      },
+    );
+    expect((await seed.commit()).ok).toBeDefined();
+
+    const tx = rt.edit();
+    tx.readOrThrow({
+      space: foreignSpace,
+      scope: "space",
+      id: criteriaId,
+      type: "application/json",
+      path: ["value"],
+    });
+    const out = rt.getCell(space, "mp-xs-out", undefined, tx);
+    out.set({ observed: true });
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
+    const outId = out.getAsNormalizedFullLink().id;
+
+    const templates = entriesOf(outId).filter(
+      (e) => e.origin === "label-metadata",
+    );
+    expect(templates.length).toBe(2);
+    // The templates carry the committed form — no plaintext source anywhere.
+    expect(containsCfcFieldCommitment(templates)).toBe(true);
+    expect(JSON.stringify(templates)).not.toContain("did:key:remote-a");
+
+    // Digest-matching: the plaintext query still matches the committed
+    // stored field, and the consumed observation carries the committed
+    // template label.
+    const inspect = rt.edit();
+    const outcome = inspectStoredConfLabel(
+      inspect,
+      out.getAsNormalizedFullLink(),
+      "",
+      { source: SOURCE_A },
+    );
+    expect(outcome.status).toBe("ok");
+    if (outcome.status !== "ok") throw new Error("unreachable");
+    expect(outcome.atoms.length).toBeGreaterThan(0);
+    expect(containsCfcFieldCommitment(outcome.atoms[0].atom)).toBe(true);
+    const observations = inspect.getCfcState().labelMetadataObservations;
+    expect(observations.length).toBeGreaterThan(0);
+    expect(
+      containsCfcFieldCommitment(
+        observations.map((o) => [...o.confidentiality]),
+      ),
+    ).toBe(true);
+    expect(
+      JSON.stringify(observations.map((o) => [...o.confidentiality])),
+    ).not.toContain("did:key:remote-a");
+    await inspect.commit();
+  });
+
+  // Guardrail: metadata templates are NOT payload labels. Payload reads —
+  // recursive value reads, shape probes — never consume them (pinned with a
+  // template carrying a DISTINCT atom, which runtime mints never produce),
+  // and raw ["cfc"] envelope reads stay flow-excluded entirely.
+  it("payload reads never consume metadata templates; raw cfc reads stay excluded", async () => {
+    const rt = makeRuntime();
+    const seededId = await seedDoc(rt, "mp-guard", { x: 1 }, [
+      {
+        path: [],
+        label: { confidentiality: ["payload-label", caveatAtom()] },
+        origin: "derived",
+        observes: "value",
+      },
+      templateEntry([], [], ["tmpl-only-atom"]),
+      templateEntry([], ["source"], ["tmpl-only-atom"]),
+    ]);
+
+    const derivedConfidentiality = (id: string): unknown[] =>
+      entriesOf(id)
+        .filter((e) => e.origin === "derived")
+        .flatMap((e) => e.label.confidentiality ?? []);
+
+    // Recursive value read at the root.
+    const txValue = rt.edit();
+    txValue.readOrThrow(readAddress(seededId, []));
+    const outValue = rt.getCell(space, "mp-guard-out-value", undefined, txValue);
+    outValue.set({ observed: true });
+    txValue.prepareCfc();
+    expect((await txValue.commit()).ok).toBeDefined();
+    const joinValue = derivedConfidentiality(
+      outValue.getAsNormalizedFullLink().id,
+    );
+    expect(joinValue).toContainEqual("payload-label");
+    expect(joinValue).not.toContainEqual("tmpl-only-atom");
+
+    // Shape probe (nonRecursive) at the root.
+    const txShape = rt.edit();
+    txShape.readOrThrow(readAddress(seededId, []), { nonRecursive: true });
+    const outShape = rt.getCell(space, "mp-guard-out-shape", undefined, txShape);
+    outShape.set({ observed: true });
+    txShape.prepareCfc();
+    expect((await txShape.commit()).ok).toBeDefined();
+    expect(
+      derivedConfidentiality(outShape.getAsNormalizedFullLink().id),
+    ).not.toContainEqual("tmpl-only-atom");
+
+    // Raw ["cfc"] envelope read: flow-excluded (flowReadExcluded), so not
+    // even the payload label taints through it.
+    const txRaw = rt.edit();
+    txRaw.readOrThrow({
+      space,
+      scope: "space",
+      id: seededId as `${string}:${string}`,
+      type: "application/json",
+      path: ["cfc"],
+    });
+    const outRaw = rt.getCell(space, "mp-guard-out-raw", undefined, txRaw);
+    outRaw.set({ observed: true });
+    txRaw.prepareCfc();
+    expect((await txRaw.commit()).ok).toBeDefined();
+    const rawId = outRaw.getAsNormalizedFullLink().id;
+    expect(derivedConfidentiality(rawId)).toEqual([]);
+
+    // The introspection surface is their one consumer: the SAME distinct
+    // atom the payload reads never saw is exactly what a query consumes.
+    const inspect = rt.edit();
+    const evaluation = evaluateConfLabelQuery(
+      readStoredCfcMetadata(inspect, { space, id: seededId }),
+      [],
+      { source: SOURCE_A },
+    );
+    await inspect.commit();
+    expect(evaluation.consumedConfidentiality).toContainEqual(
+      "tmpl-only-atom",
+    );
+    expect(evaluation.consumedConfidentiality).not.toContainEqual(
+      "payload-label",
+    );
+  });
+
+  // The recorded labelMetadata observations reference the CONCRETE metadata
+  // paths the evaluation consulted (clause/alternative indices), not the
+  // subtree root.
+  it("records observations at concrete clause/alternative metadata paths", async () => {
+    const rt = makeRuntime();
+    const criteriaId = await seedDoc(rt, "mp-criteria-obs", { keep: true }, [
+      { path: [], label: { confidentiality: [caveatAtom()] } },
+    ]);
+    await deriveOutDoc(rt, "mp-out-obs", criteriaId);
+
+    const inspect = rt.edit();
+    const out = rt.getCell(space, "mp-out-obs", undefined, inspect);
+    const outcome = inspectStoredConfLabel(
+      inspect,
+      out.getAsNormalizedFullLink(),
+      "",
+      { source: SOURCE_A },
+    );
+    expect(outcome.status).toBe("ok");
+    const paths = inspect.getCfcState().labelMetadataObservations.map(
+      (observation) => [...observation.target.path].join("/"),
+    ).sort();
+    // The out doc carries the derived shape + value entries at [] (stored in
+    // that canonical order), each with the caveat clause: per matching atom,
+    // one field consultation and one whole-atom projection, at concrete
+    // clause indices across the concatenated per-entry clause lists.
+    expect(paths).toEqual([
+      "cfc/labels/value/confidentiality/clauses/0/alternatives/0",
+      "cfc/labels/value/confidentiality/clauses/0/alternatives/0/source",
+      "cfc/labels/value/confidentiality/clauses/1/alternatives/0",
+      "cfc/labels/value/confidentiality/clauses/1/alternatives/0/source",
+    ]);
+    await inspect.commit();
+  });
+});
+
+describe("CFC template metadata population (Stage B): evaluator resolution", () => {
+  // A derived-component entry guarding /value/body with a source-bearing
+  // caveat clause — the interim-rule shape.
+  const derivedBodyEntry = (atom: unknown = caveatAtom()): LabelMapEntry => ({
+    path: ["body"],
+    label: { confidentiality: ["secret", atom] },
+    origin: "derived",
+  });
+
+  it("resolves per-field observation labels from the persisted template", () => {
+    const metadata = metadataWith([
+      derivedBodyEntry(),
+      templateEntry(["body"], [], ["tmpl-atom-label"]),
+      templateEntry(["body"], ["source"], ["tmpl-source-label"]),
+    ]);
+    const { result, consumedConfidentiality, consumedObservations } =
+      evaluateConfLabelQuery(metadata, ["body"], { source: SOURCE_A });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") throw new Error("unreachable");
+    expect(result.atoms).toHaveLength(1);
+    // The templates are the label CARRIER now: the consumed labels come from
+    // them, not from the in-hand fallback (the entry's own confidentiality).
+    expect(consumedConfidentiality).toContainEqual("tmpl-source-label");
+    expect(consumedConfidentiality).toContainEqual("tmpl-atom-label");
+    expect(consumedConfidentiality).not.toContainEqual("secret");
+    // Per-consultation records at concrete paths: the source-field consult
+    // resolved the field template; the whole-atom projection consumed the
+    // atom template.
+    const byPath = new Map(
+      consumedObservations.map(
+        (o) => [o.path.join("/"), o.confidentiality] as const,
+      ),
+    );
+    expect(
+      byPath.get(
+        "cfc/labels/value/body/confidentiality/clauses/1/alternatives/0/source",
+      ),
+    ).toEqual(["tmpl-source-label"]);
+    expect(
+      byPath.get(
+        "cfc/labels/value/body/confidentiality/clauses/1/alternatives/0",
+      ),
+    ).toContainEqual("tmpl-atom-label");
+  });
+
+  it("falls back to the in-hand interim rule when no template exists (old envelopes)", () => {
+    const metadata = metadataWith([derivedBodyEntry()]);
+    const { result, consumedConfidentiality } = evaluateConfLabelQuery(
+      metadata,
+      ["body"],
+      { source: SOURCE_A },
+    );
+    expect(result.status).toBe("ok");
+    expect(consumedConfidentiality).toContainEqual("secret");
+  });
+
+  it("template resolution and the in-hand fallback agree on runtime-shaped data", () => {
+    // The mint copies the entry's own confidentiality into the templates
+    // (the interim rule is the label SOURCE; templates are the CARRIER), so
+    // on an envelope the current runtime persisted the two arms agree
+    // exactly.
+    const entry = derivedBodyEntry();
+    const withTemplates = metadataWith([
+      entry,
+      ...deriveLabelMetadataTemplateEntries([entry]),
+    ]);
+    const stripped = metadataWith([entry]);
+    for (
+      const query of [
+        { source: SOURCE_A },
+        { atomType: CFC_ATOM_TYPE.Caveat },
+        {},
+        { source: SOURCE_B },
+      ]
+    ) {
+      const resolved = evaluateConfLabelQuery(withTemplates, ["body"], query);
+      const fallback = evaluateConfLabelQuery(stripped, ["body"], query);
+      expect(resolved.result).toEqual(fallback.result);
+      expect([...resolved.consumedConfidentiality].sort()).toEqual(
+        [...fallback.consumedConfidentiality].sort(),
+      );
+    }
+  });
+
+  it("keeps declared entries fail-closed even when a sibling template exists", () => {
+    // A declared source-bearing entry at the same path as a template (the
+    // per-path addressing conflates entries): the containment gate keeps the
+    // declared fields unobservable — a template never re-opens them.
+    const metadata = metadataWith([
+      {
+        path: ["body"],
+        label: { confidentiality: [caveatAtom()] },
+        origin: "declared",
+      },
+      templateEntry(["body"], [], ["tmpl-atom-label"]),
+      templateEntry(["body"], ["source"], ["tmpl-source-label"]),
+    ]);
+    const { result, consumedConfidentiality } = evaluateConfLabelQuery(
+      metadata,
+      ["body"],
+      { source: SOURCE_A },
+    );
+    expect(result).toEqual({ status: "notAvailable" });
+    expect(consumedConfidentiality).toEqual([]);
+  });
+
+  it("treats a crafted EMPTY template as absent (fallback, never public)", () => {
+    const metadata = metadataWith([
+      derivedBodyEntry(),
+      templateEntry(["body"], ["source"], []),
+    ]);
+    const { result, consumedConfidentiality } = evaluateConfLabelQuery(
+      metadata,
+      ["body"],
+      { source: SOURCE_A },
+    );
+    expect(result.status).toBe("ok");
+    expect(consumedConfidentiality).toContainEqual("secret");
+  });
+
+  it("never enumerates template entries as payload label atoms", () => {
+    // Template entries live under the ["cfc"] namespace: no payload target
+    // path addresses them, so a query's atom projection never includes the
+    // template's own label atoms as if they were payload clauses.
+    const metadata = metadataWith([
+      derivedBodyEntry(),
+      templateEntry(["body"], [], ["tmpl-atom-label"]),
+    ]);
+    const { result } = evaluateConfLabelQuery(metadata, ["body"], {});
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") throw new Error("unreachable");
+    // Exactly the payload entry's two clauses — nothing from the template.
+    expect(result.atoms).toHaveLength(2);
+    expect(JSON.stringify(result.atoms)).not.toContain("tmpl-atom-label");
+  });
+});
+
+describe("CFC template metadata population (Stage B): derivation unit properties", () => {
+  const derivedEntry = (confidentiality: unknown[]): LabelMapEntry => ({
+    path: ["body"],
+    label: { confidentiality },
+    origin: "derived",
+  });
+
+  it("entry count is O(#field-kinds), independent of clause/alternative counts", () => {
+    const single = deriveLabelMetadataTemplateEntries([
+      derivedEntry([caveatAtom(SOURCE_A)]),
+    ]);
+    // Whole-atom template + one `source` field template.
+    expect(single.map((e) => e.path.at(-1))).toEqual(["*", "source"]);
+
+    // Many clauses, an anyOf with several alternatives, extra public atoms:
+    // same field kinds → same entry count.
+    const manyClauses = deriveLabelMetadataTemplateEntries([
+      derivedEntry([
+        caveatAtom(SOURCE_A),
+        { anyOf: [caveatAtom(SOURCE_B), caveatAtom({ id: "of:origin-c" })] },
+        caveatAtom({ id: "of:origin-d" }),
+        "public-tag",
+        { kind: "authored-by", subject: "did:key:alice" },
+      ]),
+    ]);
+    expect(manyClauses.length).toBe(single.length);
+    expect(manyClauses.map((e) => e.path.at(-1))).toEqual(["*", "source"]);
+
+    // A second protected field KIND (User.subject is commitment-classified,
+    // i.e. protected) adds exactly one per-field template.
+    const twoKinds = deriveLabelMetadataTemplateEntries([
+      derivedEntry([
+        caveatAtom(SOURCE_A),
+        { type: CFC_ATOM_TYPE.User, subject: "did:key:alice" },
+      ]),
+    ]);
+    expect(twoKinds.map((e) => e.path.at(-1))).toEqual([
+      "*",
+      "source",
+      "subject",
+    ]);
+  });
+
+  it("nested-only protected content mints the whole-atom template only", () => {
+    // A protected atom smuggled inside a table-public wrapper field: its
+    // consultations land at nested concrete paths no per-field template
+    // addresses, so only the whole-atom projection template is minted.
+    const smuggling = deriveLabelMetadataTemplateEntries([
+      derivedEntry([{ kind: "authored-by", subject: caveatAtom() }]),
+    ]);
+    expect(smuggling.map((e) => e.path.at(-1))).toEqual(["*"]);
+  });
+
+  it("derives nothing from non-containment or template entries", () => {
+    expect(deriveLabelMetadataTemplateEntries([
+      {
+        path: ["body"],
+        label: { confidentiality: [caveatAtom()] },
+        origin: "declared",
+      },
+      {
+        path: ["body"],
+        label: { confidentiality: [caveatAtom()] },
+        origin: "link",
+      },
+      { path: ["body"], label: { confidentiality: [caveatAtom()] } },
+      templateEntry(["body"], ["source"], [caveatAtom()]),
+    ])).toEqual([]);
+  });
+
+  it("resolves the most specific template with wildcard segments (replace-down)", () => {
+    const entries = [
+      templateEntry(["items", "*"], [], ["atom-label"]),
+      templateEntry(["items", "*"], ["source"], ["source-label"]),
+    ];
+    // Field consultation: the per-field template shadows the whole-atom one.
+    expect(
+      resolveLabelMetadataTemplateConfidentiality(entries, [
+        "cfc",
+        "labels",
+        "value",
+        "items",
+        "3",
+        "confidentiality",
+        "clauses",
+        "2",
+        "alternatives",
+        "1",
+        "source",
+      ]),
+    ).toEqual(["source-label"]);
+    // Whole-atom consultation: only the atom template covers.
+    expect(
+      resolveLabelMetadataTemplateConfidentiality(entries, [
+        "cfc",
+        "labels",
+        "value",
+        "items",
+        "3",
+        "confidentiality",
+        "clauses",
+        "2",
+        "alternatives",
+        "1",
+      ]),
+    ).toEqual(["atom-label"]);
+    // Equally specific covers JOIN (fail-toward-taint).
+    expect(
+      resolveLabelMetadataTemplateConfidentiality([
+        ...entries,
+        templateEntry(["items", "3"], ["source"], ["concrete-label"]),
+      ], [
+        "cfc",
+        "labels",
+        "value",
+        "items",
+        "3",
+        "confidentiality",
+        "clauses",
+        "0",
+        "alternatives",
+        "0",
+        "source",
+      ])?.sort(),
+    ).toEqual(["concrete-label", "source-label"]);
+    // No cover → undefined (the caller falls back to the in-hand rule).
+    expect(
+      resolveLabelMetadataTemplateConfidentiality(entries, [
+        "cfc",
+        "labels",
+        "value",
+        "other",
+        "confidentiality",
+        "clauses",
+        "0",
+        "alternatives",
+        "0",
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+describe("CFC template metadata population (Stage B): canonical form", () => {
+  it("canonicalizes deep multi-`*` template paths deterministically", () => {
+    const entries: LabelMapEntry[] = [
+      templateEntry(["items", "*"], ["source"], ["a"]),
+      templateEntry(["items", "*"], [], ["b"]),
+      templateEntry([], ["source"], ["c"]),
+      {
+        path: ["items", "*"],
+        label: { confidentiality: ["memb"] },
+        origin: "structure",
+        observes: "shape",
+      },
+    ];
+    const canonical = canonicalizeCfcMetadata({
+      version: 1,
+      schemaHash: "h",
+      labelMap: { version: 1, entries },
+    });
+    const permuted = canonicalizeCfcMetadata({
+      version: 1,
+      schemaHash: "h",
+      labelMap: { version: 1, entries: [...entries].reverse() },
+    });
+    expect(permuted).toEqual(canonical);
+    expect(canonicalizeCfcMetadata(canonical)).toEqual(canonical);
+    expect(
+      canonical.labelMap.entries.map((e) => [
+        e.path.join("/"),
+        e.origin,
+        e.observes,
+      ]),
+    ).toEqual([
+      [
+        "cfc/labels/value/confidentiality/clauses/*/alternatives/*/source",
+        "label-metadata",
+        "labelMetadata",
+      ],
+      [
+        "cfc/labels/value/items/*/confidentiality/clauses/*/alternatives/*",
+        "label-metadata",
+        "labelMetadata",
+      ],
+      [
+        "cfc/labels/value/items/*/confidentiality/clauses/*/alternatives/*/source",
+        "label-metadata",
+        "labelMetadata",
+      ],
+      ["items/*", "structure", "shape"],
+    ]);
+  });
+});


### PR DESCRIPTION
Stage B of the CFC template-population design ([`docs/specs/cfc-template-population.md`](../blob/main/docs/specs/cfc-template-population.md) §5 "Stage-2 full population on the same form" / §6 "Stage B"; spec `04-label-representation.md` §4.6.4.1 metadata-subtree addressing and §4.6.4.2 population profile): the field-precise label-metadata population profile, persisted as multi-`*` templates under `/cfc/labels/<target-envelope-path>/...` and consumed by the Stage-2 introspection surface. Builds on the shipped substrates #4657 (introspection channel + interim rule) and #4658 (Stage-A `*`-path template machinery).

## What ships

**1. Metadata template mints at the envelope persist seam.** For every persisted source-bearing derived-containment payload entry, `prepareBoundaryCommit` now mints (via the new `cfc/label-metadata-population.ts`):

- `["cfc","labels","value",...target,"confidentiality","clauses","*","alternatives","*"]` — the whole-atom projection template (join of revealed-field labels), and
- `[...same, <field>]` — one per-field template per **distinct protected top-level field name** present in the entry's atoms (`source`, `subject`, `by`, `identity`, … — every field the interim rule protects; deeper protected content such as nested atoms behind public wrapper fields rides the whole-atom template only, matching the in-hand walk's consumption structure),

all carrying the **same §4.6.4.2 interim-rule label** the introspection surface computes in hand today (the interim rule stays the label *source*; templates are the *carrier* — a later precision upgrade changes the labels minted into the same entries). Presence/`type`/`kind` and table-`public` fields mint **nothing** (absence = public; public entries are never materialized). Declared/authored source-bearing entries mint **nothing** (fail-closed unobservable, as today).

Same disciplines as Stage A: templates are re-derived from the **final** payload entry set at every persist (after clears/carries/mints **and after the Stage-1 representation transform**, so committed forms carry through and one transform serves both sinks) and are never carried forward — replace-on-overwrite / cleared-with-the-described-entry / SC-11 zero-write hold by construction. Multi-`*` composition works end-to-end: Stage-A membership templates (payload entries at `[...container,"*"]`) get metadata templates with a wildcard *target* segment, resolved for concrete slot queries.

**2. `origin`/`observes` decision** (design §3.3 rule kept: plain `IFCLabel` under `label`, no new entry fields):

- `origin: "label-metadata"` — a **dedicated origin**, because the origin axis is the update-discipline axis and these entries' discipline (pure function of the payload entries in the same envelope, re-derived per persist) is none of the existing ones. Reusing `derived` would drag them through every derived/structure-keyed persist rule (freeze-carry, SC-4 existence pooling, writer-fit policy selection, `isRuntimeMintedTemplate` machinery boundaries), each needing a carve-out; the dedicated origin makes every existing origin-keyed rule ignore them by construction.
- `observes: "labelMetadata"` — the #4657 observation class, now admitted on persisted entries (`LabelMapEntry.observes` widened): `readConsumesEntry`'s table then gives the needed consumption for free — **no payload read class** (value/shape/enumerate/followRef) consumes them; the deliberately over-inclusive `"all"` write-gate selection may, harmlessly (template content duplicates the payload entries it derives from).
- Canonicalization/coalescing need nothing new (both key on path/origin/observes). Coalescing **joins** same-path payload entries' population labels (the C2 value/shape split) into one per-path template — required by the per-path §4.6.4.1 addressing (clause indices concatenate across the entries at one path), fail-toward-taint vs the per-entry in-hand rule, and exact on the single-source-bearing-entry common case (agreement pinned by test).

**3. Consumption upgrade.** `inspectConfLabel`'s protected consultations now **resolve from the persisted templates** at concrete clause/alternative metadata paths (§4.6.3 replace-down through the wildcard machinery: the per-field template shadows the whole-atom one for field reads; equal-specificity covers join), **falling back to the computed-in-hand interim rule when absent** (pre-Stage-B envelopes; agreement pinned). The containment gate stays first: a persisted template never re-opens a declared entry's fields, and a crafted *empty* template is treated as absent (fallback, never public). Recorded `labelMetadata` observations now reference the **concrete** consulted metadata paths (e.g. `/cfc/labels/value/body/confidentiality/clauses/1/alternatives/0/source` — the §4.6.4.2 worked example's shape), one record per consulted path.

**4. Guardrails.** Payload reads never consume metadata templates (class table + pinned end-to-end with a distinct-atom seeded template across value/shape reads; raw `["cfc"]` reads stay `flowReadExcluded`, pinned); label views (`cfcLabelViewFromMetadata` — link transport, display, LLM-observation paths) exclude them (envelope-local; the target envelope mints its own); the evaluator never enumerates them as payload clauses. **No new dial** — templates describe whatever payload entries the existing dials persisted. Entry count is O(#source-bearing-field-kinds) per labeled path, independent of clause/alternative counts (pinned with a multi-clause multi-alternative label).

**5. Live-doc contract.** Design §6 Stage B implementation note; `cfc-label-metadata-confidentiality.md` §3 item 3 + Stage-2 note upgraded (full profile carried by templates; interim rule remains the label source); SC-25 tail updated. SC-4/SC-8 untouched (their remaining residual — the generic pure-link route — is payload-side and unaffected).

**Documented residual:** a mixed-version writer (pre-Stage-B runtime rewriting payload entries) carries stale templates forward; the next Stage-B-runtime persist of that envelope re-derives them, and the fallback arm keeps template-less envelopes correct. Same staleness class Stage A accepted for its twins.

## Verification

Red-first (commit `8599381a5`, seams intentionally unwired): **8 steps red** — persist-seam mints (spec-example shape, overwrite-replace, SC-11-with-templates, `*`-path composition, commitment forms, payload-read guardrail, concrete observation paths) and evaluator template resolution — with the leaf-module unit tests green. Implementation commit `14c122cea` turned all red steps green.

- `packages/runner/test/cfc-template-metadata-population.test.ts`: **4 suites / 23 steps green** (mints, evaluator resolution incl. template-vs-fallback agreement + declared-stays-closed + empty-template defense, derivation unit properties incl. entry-count independence, canonicalization determinism over deep multi-`*` paths).
- Adjacent CFC suites (introspection, channel, builtin, Stage-A template population, label-metadata persist/protection/dial): **15 suites / 128 steps green**; one channel test re-pinned from the subtree-root observation address to the concrete clause/alternative path (the upgrade this PR makes).
- Full runner suite: **847 passed (4637 steps), 0 failed** (2m56s).
- `deno task check` (repo-wide type check): clean. `deno task check-docs`: 534 code blocks pass.
- CFC pattern integration flows (`PORT_OFFSET=41 deno task integration patterns cfc`): **8 passed (15 steps), 0 failed** — the S16 regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Stage B of CFC template population: persist field-precise label-metadata templates under `/cfc/labels/...` and have `inspectConfLabel` resolve them at concrete clause/alternative paths, with a safe fallback to the interim rule. Templates are envelope-local, excluded from label views, and never consumed by payload reads.

- New Features
  - Persist multi-`*` templates for each derived-containment payload entry: whole-atom and per protected top-level field; none for public fields or declared/authored entries; derived from the final post-transform payload set; entry count is O(#field-kinds).
  - Dedicated `origin:"label-metadata"` with `observes:"labelMetadata"`; no payload read class consumes these; templates are envelope-local and excluded from label views.
  - `inspectConfLabel` resolves labels from templates at concrete metadata paths and records observations per consulted concrete path; falls back to in-hand interim rule when templates are absent; containment gate stays first; crafted empty templates are treated as absent; refuses labels-of-labels when the resolved target path lands under `/cfc/...`.
  - Supports Stage-A `*`-path entries via wildcard replace-down; recomputes remain SC-11 no-ops; commitment-form labels are preserved through the transform.

- Bug Fixes
  - Heal template-only stale envelopes (mixed-version) by admitting them to the persist loop and counting dropped templates as a clear, so an empty label map is written.
  - Use the canonical wildcard matcher for template resolution to align replace-down behavior with label views.

<sup>Written for commit 4835a453ade76b88be0e1f98dd10b7d7e759a100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

