### PR TITLE
feat(lunch-poll): show the current date and hide votes not cast today

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -11,8 +11,8 @@
  * are covered by multi-user.test.tsx.
  */
 
-import { action, computed, pattern, UI } from "commonfabric";
-import CozyPoll from "./main.tsx";
+import { action, computed, pattern, safeDateNow, UI } from "commonfabric";
+import CozyPoll, { dayKeyOf, type Option, type Vote } from "./main.tsx";
 
 const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
   typeof value === "object" && value !== null;
@@ -63,8 +63,35 @@ const findNodeByProp = (
     .find((child) => child !== undefined);
 };
 
+const SEEDED_OPTION: Option = {
+  id: "opt-seeded",
+  title: "Leftover Café",
+  addedByName: "Stan",
+};
+
 export default pattern(() => {
   const poll = CozyPoll({});
+
+  // One-time clock reads at pattern-body init (module scope must stay plain
+  // data in SES mode): "yesterday" for the seeded stale vote, and the day key
+  // the pattern is expected to filter to.
+  const STALE_CAST_AT = safeDateNow() - 86_400_000;
+  const TODAY_KEY = dayKeyOf(safeDateNow());
+
+  // A vote cast "yesterday" — stored, but hidden by the current-day filter.
+  const STALE_VOTE: Vote = {
+    voterName: "Stan",
+    optionId: "opt-seeded",
+    voteType: "green",
+    castAt: STALE_CAST_AT,
+  };
+
+  // Second instance seeded with a stale vote, for the current-day filter
+  // scenario (castVote always stamps "now", so staleness must be seeded).
+  const stalePoll = CozyPoll({
+    options: [SEEDED_OPTION],
+    votes: [STALE_VOTE],
+  });
 
   // === Actions ===
 
@@ -198,7 +225,11 @@ export default pattern(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "green" &&
-      v?.voterName === "Alex";
+      v?.voterName === "Alex" &&
+      // A handler-cast vote is stamped with today's castAt, so it must also
+      // appear in the current-day view.
+      poll.todaysVotes.length === 1 &&
+      poll.todayVoteCount === 1;
   });
 
   // The "All options" overview renders one swatch per voter, sourced from a
@@ -297,6 +328,55 @@ export default pattern(() => {
     poll.voteHistoryCount === 0
   );
 
+  // === Current-day vote filter ===
+
+  // The header renders the session's date, and `todayDate` exposes the local
+  // day key the votes are filtered to.
+  const assert_today_header_renders = computed(() =>
+    findNodeByProp(poll[UI], "data-poll-today", true) !== undefined &&
+    poll.todayDate === TODAY_KEY
+  );
+
+  // The seeded stale vote is stored but hidden: absent from `todaysVotes`,
+  // the count, and the rendered swatches.
+  const assert_stale_vote_hidden = computed(() =>
+    stalePoll.votes.length === 1 &&
+    stalePoll.todaysVotes.length === 0 &&
+    stalePoll.todayVoteCount === 0 &&
+    findNodeByProp(stalePoll[UI], "data-vote-swatch-name", "Stan") ===
+      undefined
+  );
+
+  const action_stale_join_as_stan = action(() => {
+    stalePoll.joinAs.send({ name: "Stan" });
+  });
+
+  // Same color as the hidden stale vote.
+  const action_stale_vote_green = action(() => {
+    stalePoll.castVote.send({ optionId: "opt-seeded", voteType: "green" });
+  });
+
+  // A same-color click on a stale vote RE-CASTS it for today (fresh castAt)
+  // instead of toggling off a vote the voter cannot see; the vote becomes
+  // visible again (list, count, and swatch).
+  const assert_stale_recast_visible = computed(() => {
+    const v = stalePoll.todaysVotes[0];
+    return stalePoll.todaysVotes.length === 1 &&
+      v?.voterName === "Stan" &&
+      v?.voteType === "green" &&
+      typeof v?.castAt === "number" &&
+      dayKeyOf(v.castAt) === TODAY_KEY &&
+      stalePoll.todayVoteCount === 1 &&
+      findNodeByProp(stalePoll[UI], "data-vote-swatch-name", "Stan") !==
+        undefined;
+  });
+
+  // A second same-color click is the normal today-toggle-off.
+  const assert_stale_recast_cleared = computed(() =>
+    stalePoll.todaysVotes.length === 0 &&
+    stalePoll.todayVoteCount === 0
+  );
+
   return {
     tests: [
       // Admin-gated handlers are no-ops before anyone joins (myName empty).
@@ -388,7 +468,21 @@ export default pattern(() => {
       // Clear all → empty.
       { action: action_clear_history },
       { assertion: assert_history_cleared },
+
+      // === Current-day vote filter ===
+      // Header date + exposed day key.
+      { assertion: assert_today_header_renders },
+      // Seeded stale (yesterday) vote: stored but hidden everywhere.
+      { assertion: assert_stale_vote_hidden },
+      // Same-color click on the stale vote re-casts it for today…
+      { action: action_stale_join_as_stan },
+      { action: action_stale_vote_green },
+      { assertion: assert_stale_recast_visible },
+      // …and a second same-color click toggles today's vote off as usual.
+      { action: action_stale_vote_green },
+      { assertion: assert_stale_recast_cleared },
     ],
     poll,
+    stalePoll,
   };
 });

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -466,10 +466,22 @@ const logVisit = handler<LogVisitEvent, {
   myName: NameCell;
   adminName: NameCell;
   visitDate: NameCell;
+  today: TodayCell;
+  loadedAt: number;
 }>(
   (
     { optionId, title, wentAt },
-    { visits, options, votes, users, myName, adminName, visitDate },
+    {
+      visits,
+      options,
+      votes,
+      users,
+      myName,
+      adminName,
+      visitDate,
+      today,
+      loadedAt,
+    },
   ) => {
     const me = trimmedName(myName.get());
     const admin = trimmedName(adminName.get());
@@ -496,8 +508,12 @@ const logVisit = handler<LogVisitEvent, {
     // Snapshot the current live votes, embedded in the entry. Denormalize the
     // option title (options can be removed later; the title is the record).
     // Only today's votes are "current opinion": stale votes are hidden from
-    // the UI, so they stay out of the snapshot too.
-    const nowDay = dayKeyOf(safeDateNow());
+    // the UI, so they stay out of the snapshot too. Same day source as the
+    // UI's `todaysVotes` (`today` override, else this session's load time) —
+    // the snapshot must capture what the host is looking at, not the wall
+    // clock's day, or a tab crossing midnight logs an empty new-day snapshot
+    // of a board still showing yesterday's votes.
+    const nowDay = dayKeyOf(today.get() || loadedAt);
     const titleById = new Map(options.get().map((o) => [o.id, o.title]));
     const voteSnapshot: VoteSnapshot[] = [];
     for (const v of votes.get()) {
@@ -755,6 +771,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       myName,
       adminName,
       visitDate,
+      today,
+      loadedAt,
     });
     const boundRemoveHistoryEntry = removeHistoryEntry({
       visits,

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -40,6 +40,17 @@
  * but that brought a deployed-piece "invalid database handle" failure plus a
  * stack of workarounds (a write-counter to force query re-runs, TEXT-encoded
  * timestamps, async settle races). It is now back on plain fabric storage.
+ *
+ * Current-day vote filter: every vote is stamped with `castAt` in `castVote`,
+ * and the UI (tallies, swatches, per-option highlights, header count, logVisit
+ * snapshots) only shows votes cast on the current day. Older votes stay stored
+ * but hidden — the (voter, option) vote key means a re-cast overwrites the same
+ * entity, so they don't accumulate. "Today" is the pattern-body clock read
+ * (`loadedAt`, re-evaluated in every viewing runtime; the SES surface has no
+ * timers), overridden by a per-session cell the vote handlers refresh so a tab
+ * left open across midnight snaps forward on the next interaction. The day
+ * boundary is the runtime's local timezone (the viewer's, in the browser); two
+ * viewers in different timezones can see different vote sets around midnight.
  */
 
 import {
@@ -81,6 +92,12 @@ export interface Vote {
   voterName: string;
   optionId: string;
   voteType: VoteColor;
+  /**
+   * When the vote was cast (ms epoch), stamped by `castVote`. Optional for
+   * votes stored before this field existed — those count as not-today, so the
+   * current-day filter hides them.
+   */
+  castAt?: number;
 }
 
 export interface JoinEvent {
@@ -170,6 +187,9 @@ type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
 type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
+// The session's "today" (ms epoch) — see the current-day filter note in the
+// file header.
+type TodayCell = Writable<number>;
 
 const POLL_THEME = {
   fontFamily:
@@ -247,6 +267,43 @@ const DAY_NAMES = [
   "Friday",
   "Saturday",
 ];
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+// Local-calendar day key ("YYYY-MM-DD") for a timestamp — pure given its input
+// (plus the runtime's timezone), so it is safe inside computeds. Local, not
+// UTC, matching parseVisitDate's local-midnight convention. Exported for the
+// tests, which assert against the same day-boundary rule.
+export const dayKeyOf = (ms: number): string => {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${
+    String(d.getDate()).padStart(2, "0")
+  }`;
+};
+
+// Header label for the session's "today" ("Thursday, Jul 10"). Formatted from
+// the name tables, not toLocaleDateString: SES localeTaming ("safe") aliases
+// toLocale* methods to their non-locale forms, so option-driven locale
+// formatting is unreliable under lockdown.
+const dayLabelOf = (ms: number): string => {
+  const d = new Date(ms);
+  return `${DAY_NAMES[d.getDay()]}, ${
+    MONTH_NAMES[d.getMonth()]
+  } ${d.getDate()}`;
+};
 
 const newHistoryId = () =>
   `h_${safeDateNow().toString(36)}_${
@@ -332,21 +389,33 @@ const removeOption = handler<RemoveOptionEvent, {
 const castVote = handler<CastVoteEvent, {
   votes: VotesCell;
   myName: NameCell;
-}>(({ optionId, voteType }, { votes, myName }) => {
+  today: TodayCell;
+}>(({ optionId, voteType }, { votes, myName, today }) => {
   const me = trimmedName(myName.get());
   if (!me) return;
+  // Reading the clock is fine here (handler, not computed). Refresh the
+  // session's "today" so the current-day filter tracks the interaction.
+  const now = safeDateNow();
+  today.set(now);
   // My vote for this option has a deterministic address, so this reads and
   // edits just that one vote — never the whole list. Clicking the current
   // color toggles the vote off; any other color sets it.
   const key = voteKey(me, optionId);
   const myVote = votes.elementById(key);
   const existing = myVote.get();
-  if (existing && existing.voteType === voteType) {
+  // Toggle off only when the same color was cast TODAY. A same-color click on
+  // a stale (hidden) vote re-casts it with a fresh timestamp instead of
+  // removing a vote the voter cannot see.
+  const sameColorToday = existing !== undefined &&
+    existing.voteType === voteType &&
+    typeof existing.castAt === "number" &&
+    dayKeyOf(existing.castAt) === dayKeyOf(now);
+  if (sameColorToday) {
     votes.removeByValue(myVote);
     clearVoteEntity(votes, key);
     return;
   }
-  myVote.set({ voterName: me, optionId, voteType });
+  myVote.set({ voterName: me, optionId, voteType, castAt: now });
   votes.addUnique(myVote);
 });
 
@@ -374,9 +443,12 @@ export interface ClearVoteEvent {
 const clearMyVote = handler<ClearVoteEvent, {
   votes: VotesCell;
   myName: NameCell;
-}>(({ optionId }, { votes, myName }) => {
+  today: TodayCell;
+}>(({ optionId }, { votes, myName, today }) => {
   const me = trimmedName(myName.get());
   if (!me) return;
+  // Vote-affecting interaction → refresh the session's current-day filter.
+  today.set(safeDateNow());
   const key = voteKey(me, optionId);
   votes.removeByValue(votes.elementById(key));
   clearVoteEntity(votes, key);
@@ -423,9 +495,15 @@ const logVisit = handler<LogVisitEvent, {
 
     // Snapshot the current live votes, embedded in the entry. Denormalize the
     // option title (options can be removed later; the title is the record).
+    // Only today's votes are "current opinion": stale votes are hidden from
+    // the UI, so they stay out of the snapshot too.
+    const nowDay = dayKeyOf(safeDateNow());
     const titleById = new Map(options.get().map((o) => [o.id, o.title]));
     const voteSnapshot: VoteSnapshot[] = [];
     for (const v of votes.get()) {
+      if (typeof v.castAt !== "number" || dayKeyOf(v.castAt) !== nowDay) {
+        continue; // stale (previous-day or pre-castAt) vote → not current
+      }
       const optTitle = trimmedName(titleById.get(v.optionId));
       if (!optTitle) continue; // vote for an already-removed option → skip
       voteSnapshot.push({
@@ -563,6 +641,8 @@ export interface CozyPollOutput {
   [UI]: VNode;
   question: string;
   options: readonly Option[];
+  // `votes`/`voteCount` are the RAW stored list (all days); the UI displays
+  // only `todaysVotes` — see the current-day filter note in the file header.
   votes: readonly Vote[];
   users: readonly User[];
   adminName: string;
@@ -570,6 +650,12 @@ export interface CozyPollOutput {
   userCount: number;
   optionCount: number;
   voteCount: number;
+  // The session's current local day ("YYYY-MM-DD") that votes are filtered to.
+  todayDate: string;
+  // Votes cast on the current day — the only votes the UI shows and tallies.
+  todaysVotes: readonly Vote[];
+  // Count of today's votes (what the header shows).
+  todayVoteCount: number;
   historyCount: number;
   // The "Recently eaten" list — the 8 most-recent visits, newest first. Exposed
   // so tests and consumers can read the durable visit log.
@@ -621,6 +707,20 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // Host's backdate field for "we went here" — a "YYYY-MM-DD" draft, blank
     // means today. Per-session like the other form drafts.
     const visitDate = Writable.perSession.of<string>("");
+    // "Now" at pattern evaluation — recomputed in EVERY viewing runtime
+    // (pattern bodies run per session; the calendar idiom). This, not the
+    // cell below, is what makes "today" defined for a session that hasn't
+    // interacted yet: a scoped cell's `.of()` initial is seeded only into the
+    // piece-creating session's partition, and every other session reads
+    // undefined from it (see docs/development/debugging/gotchas/
+    // scoped-cell-pitfalls.md #5).
+    const loadedAt = safeDateNow();
+    // Handler-refreshed override (ms epoch) so a tab left open across
+    // midnight snaps forward on the next vote interaction. 0 = "this session
+    // hasn't interacted"; every read falls back to `loadedAt`. The initial is
+    // a stable literal on purpose — a computed initial would embed a
+    // different schema default per runtime and churn the built graph.
+    const today = Writable.perSession.of<number>(0);
     // Two-step confirmation for destructive actions. Stores the optionId
     // pending remove-confirm (null = nothing pending). Same idiom as
     // parking-coordinator's `removePersonConfirmTarget`.
@@ -644,8 +744,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       myName,
       adminName,
     });
-    const boundCastVote = castVote({ votes, myName });
-    const boundClearMyVote = clearMyVote({ votes, myName });
+    const boundCastVote = castVote({ votes, myName, today });
+    const boundClearMyVote = clearMyVote({ votes, myName, today });
     const boundResetVotes = resetVotes({ votes, myName, adminName });
     const boundLogVisit = logVisit({
       visits,
@@ -669,6 +769,20 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const userCount = users.length;
     const optionCount = options.length;
     const voteCount = votes.length;
+    // Current-day filter: the UI only shows votes cast on this session's
+    // "today" (local calendar day). Derived at top level so every remote
+    // voter's vote entity resolves (same reason `ranked` is computed here,
+    // not per-option — see the swatch comment below).
+    // `|| loadedAt` (not ??) covers both the unwritten cross-session read
+    // (undefined) and the seeded 0.
+    const todayKey = computed(() => dayKeyOf(today.get() || loadedAt));
+    const todaysVotes = computed(() => {
+      const key = dayKeyOf(today.get() || loadedAt);
+      return votes.filter((v) =>
+        typeof v.castAt === "number" && dayKeyOf(v.castAt) === key
+      );
+    });
+    const todayVoteCount = computed(() => todaysVotes.length);
     // The "Recently eaten" card: the 8 most-recent visits (newest first),
     // derived straight from the `visits` array. An array-shaped computed (not a
     // lift-returned VNode) is what lets the card keep its plain-JSX `.map(...)`
@@ -706,9 +820,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const isClearHistoryConfirm = computed(() =>
       clearHistoryConfirmPending.get()
     );
-    const ranked = tallyOptions(options, votes, users);
+    // Rank from today's votes only — the tallies, swatches, and top choice all
+    // reflect the current day.
+    const ranked = tallyOptions(options, todaysVotes, users);
 
-    const topChoice = voteCount > 0 && ranked.length > 0 ? ranked[0] : null;
+    const topChoice = todayVoteCount > 0 && ranked.length > 0
+      ? ranked[0]
+      : null;
 
     return {
       [NAME]: "Cozy lunch poll",
@@ -746,7 +864,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                   {computed(() => {
                     const u = userCount ?? 0;
                     const o = optionCount ?? 0;
-                    const v = voteCount ?? 0;
+                    const v = todayVoteCount ?? 0;
+                    const todayLabel = dayLabelOf(today.get() || loadedAt);
                     const admin = trimmedName(adminName);
                     const viewer = me;
                     const amAdmin = isAdmin;
@@ -763,7 +882,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           color: "#6b7280",
                         }}
                       >
-                        {u} joined · {o} options · {v} votes{hostNote}
+                        <span
+                          data-poll-today
+                          style={{ fontWeight: 600, color: "#374151" }}
+                        >
+                          📅 {todayLabel}
+                        </span>{" "}
+                        · {u} joined · {o} options · {v} votes today{hostNote}
                       </div>
                     );
                   })}
@@ -1079,7 +1204,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                       me={me}
                       isJoined={isJoined}
                       isAdmin={isAdmin}
-                      votes={votes}
+                      votes={todaysVotes}
                       removeConfirmTarget={removeConfirmTarget}
                       castVote={boundCastVote}
                       removeOption={boundRemoveOption}
@@ -1436,6 +1561,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       userCount,
       optionCount,
       voteCount,
+      todayDate: todayKey,
+      todaysVotes,
+      todayVoteCount,
       historyCount,
       recentVisits,
       mostRecentTitle,


### PR DESCRIPTION
## Summary

The lunch poll now shows the current date in the header and only displays votes cast on the current day. Older votes stay stored but hidden — they don't accumulate, since the (voter, option) vote key means a re-cast overwrites the same entity.

- `Vote` gains an optional `castAt` (ms epoch), stamped by `castVote`. Votes without it (anything stored before this change) count as not-today and are hidden.
- Tallies, swatches, rank, top choice, the header count, per-option vote highlights, and `logVisit` snapshots all derive from `todaysVotes`. The raw `votes`/`voteCount` outputs are unchanged; new outputs `todayDate`, `todaysVotes`, `todayVoteCount`.
- Toggle-off only applies to a same-color vote cast **today**; clicking the color of a stale (hidden) vote re-casts it fresh instead of removing a vote the voter can't see.
- `poll-option-card.tsx` is untouched — it now just receives the filtered list.

## Day-boundary mechanics (SES)

- "Today" is the pattern-body clock read (`loadedAt`), re-evaluated in every viewing runtime, with a perSession override cell the vote handlers refresh so a tab crossing midnight snaps forward on the next interaction. The override cell's initial can't carry the value: a scoped cell's `.of()` initial seeds only the piece-creating session's partition; every other session reads `undefined` (verified against the runner's `materializeDerivedInternalCells` manifest gating, and observed live on rapids before the fix).
- Day key is the runtime's **local** calendar day (matching `parseVisitDate`'s local-midnight convention), so the boundary is the viewer's timezone in the browser.
- The header date is formatted from name tables rather than `toLocaleDateString`: SES `localeTaming: "safe"` aliases `toLocale*` methods to their non-locale forms, so option-driven locale formatting is unreliable under lockdown.

## Test plan

- `main.test.tsx` extends the existing scenario and adds a seeded second instance: a stale (yesterday) vote is stored-but-hidden everywhere, a same-color click on it re-casts for today, a second click toggles off, and the header date node + `todayDate` output match the local day key (26 assertions).
- All four suites pass: main 26, poll-option-card 3, lunch-stats 1, multi-user 11.
- Deployed live to `rapids` (fresh `robin-day-filter-test` space) and exercised in the browser: date renders, stale seeded vote hidden, fresh votes stamped and visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the current date in the lunch poll header and filter the UI to votes cast today. Older votes stay stored but hidden; all tallies, swatches, top choice, header count, and visit snapshots now reflect today’s votes.

- **New Features**
  - Votes gain `castAt` (ms epoch), stamped on cast.
  - New outputs: `todayDate`, `todaysVotes`, `todayVoteCount`. Raw `votes`/`voteCount` stay the same.
  - Header shows the local day (e.g., “Thu, Jul 10”) and “votes today”.
  - Same-color click only toggles off if that vote was cast today; same-color on a stale vote re-casts it for today.
  - Day boundary is the viewer’s local timezone; tabs crossing midnight update on next interaction.
  - Older votes without `castAt` are treated as not-today and hidden from the UI.

- **Bug Fixes**
  - `logVisit` snapshots filter by the session’s day (`today.get() || loadedAt`), not the wall clock, so open tabs crossing midnight record exactly what the host sees.

<sup>Written for commit 1f1094a6cc5371f3f61c64fc949fee4685fa3b4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_COVERAGE_BASELINE
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 26s
---END COPY-PASTE---