### PR TITLE
Fix lunchpoll staging persistence and require registered pieces

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -252,6 +252,11 @@ export const piece = new Command()
     "Root directory for resolving imports. Allows imports from parent directories within this root.",
   )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
+  .option(
+    "--no-register",
+    "Do not add the piece to the home piece list. " +
+      "Requires --slug and the home space.",
+  )
   .action(async (options, main) => {
     setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
@@ -262,7 +267,11 @@ export const piece = new Command()
         mainExport: options.mainExport,
         rootPath: options.root ? absPath(options.root) : undefined,
       },
-      { start: options.start, slug: options.slug },
+      {
+        start: options.start,
+        slug: options.slug,
+        register: options.register,
+      },
     );
     render(pieceId);
     const browserPieceRef = options.slug ?? pieceId;

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -252,11 +252,6 @@ export const piece = new Command()
     "Root directory for resolving imports. Allows imports from parent directories within this root.",
   )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
-  .option(
-    "--no-register",
-    "Do not add the piece to the home piece list. " +
-      "Requires --slug and the home space.",
-  )
   .action(async (options, main) => {
     setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
@@ -270,7 +265,6 @@ export const piece = new Command()
       {
         start: options.start,
         slug: options.slug,
-        register: options.register,
       },
     );
     render(pieceId);

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -404,6 +404,11 @@ export interface NewPieceDependencies {
   assignSlug?: typeof assignSlug;
 }
 
+function shellQuoteCliArgument(value: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./~-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 // Creates a new piece from source code and optional input.
 export async function newPiece(
   config: SpaceConfig,
@@ -502,12 +507,25 @@ export async function newPiece(
       () => manager.add([piece.getCell()]),
     );
   } catch (error) {
+    const inspectCommand = cliCommand([
+      "piece",
+      "ls",
+      "--identity",
+      shellQuoteCliArgument(config.identity),
+      "--api-url",
+      shellQuoteCliArgument(config.apiUrl),
+      "--space",
+      shellQuoteCliArgument(config.space),
+    ]);
     throw new Error(
-      `The piece was created as ${piece.id}, but registration failed: ${
-        error instanceof Error ? error.message : String(error)
-      }\n` +
-        `The piece was not registered in the space's piece list.\n` +
-        `It remains addressable by ID at ${directUrl}`,
+      `The piece was created as ${piece.id}, but registration did not ` +
+        `complete cleanly: ${
+          error instanceof Error ? error.message : String(error)
+        }\n` +
+        `The registration outcome is unknown because the add may have ` +
+        `committed before settling failed.\n` +
+        `The piece remains addressable by ID at ${directUrl}\n` +
+        `Inspect the space's piece list before retrying:\n  ${inspectCommand}`,
       { cause: error },
     );
   }
@@ -523,13 +541,13 @@ export async function newPiece(
         "piece",
         "set-slug",
         "--identity",
-        config.identity,
+        shellQuoteCliArgument(config.identity),
         "--api-url",
-        config.apiUrl,
+        shellQuoteCliArgument(config.apiUrl),
         "--space",
-        config.space,
-        slug,
-        piece.id,
+        shellQuoteCliArgument(config.space),
+        shellQuoteCliArgument(slug),
+        shellQuoteCliArgument(piece.id),
       ]);
       throw new Error(
         `The piece was created and registered as ${piece.id}, but assigning ` +

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -12,6 +12,7 @@ import {
   runtimePresets,
   RuntimeProgram,
   UI,
+  validateSlug,
   VNode,
 } from "@commonfabric/runner";
 import type { CellScope } from "@commonfabric/api";
@@ -388,43 +389,109 @@ export async function resolveLinkEndpointAddress(
   }
 }
 
+export interface NewPieceOptions {
+  start?: boolean;
+  slug?: string;
+  register?: boolean;
+}
+
+export interface NewPieceDependencies {
+  loadManager?: typeof loadManager;
+  createController?: (manager: PieceManager) => PiecesController;
+  getProgram?: (
+    manager: PieceManager,
+    entry: EntryConfig,
+  ) => Promise<RuntimeProgram>;
+  assignSlug?: typeof assignSlug;
+}
+
 // Creates a new piece from source code and optional input.
 export async function newPiece(
   config: SpaceConfig,
   entry: EntryConfig,
-  options?: { start?: boolean; slug?: string },
+  options: NewPieceOptions = {},
+  deps: NewPieceDependencies = {},
 ): Promise<string> {
+  const slug = options.slug === undefined
+    ? undefined
+    : validateSlug(options.slug);
+  const shouldRegister = options.register !== false;
+  if (!shouldRegister && slug === undefined) {
+    throw new Error(
+      `${cliCommand(["piece", "new", "--no-register"])} requires ` +
+        "--slug so the unlisted piece remains addressable.",
+    );
+  }
+
   const manager = await timeCliPhase(
     "newPiece.loadManager",
-    () => loadManager(config),
+    () => (deps.loadManager ?? loadManager)(config),
   );
-  const pieces = new PiecesController(manager);
+  const isHomeSpace = manager.getSpace() === manager.runtime.userIdentityDID;
 
-  // The default pattern is a hard requirement for this command: even when the
-  // user's pattern doesn't use it, registration below (manager.add) sends an
-  // event to the default pattern's addPiece stream. Proceeding past a failure
-  // here can only end in "Cannot add pieces" — fail now, with the real cause.
-  try {
-    await timeCliPhase(
-      "newPiece.ensureDefaultPattern",
-      () => pieces.ensureDefaultPattern(),
-    );
-  } catch (error) {
+  if (!shouldRegister && !isHomeSpace) {
     throw new Error(
-      `Could not initialize the space's default pattern: ${
-        error instanceof Error ? error.message : String(error)
-      }\n` +
-        `The new piece cannot be registered in the space's piece list ` +
-        `without it.\n` +
-        `If this space's root pattern predates a runtime format change, ` +
-        `repair it with: ${cliCommand(["piece", "recreate-root"])}`,
-      { cause: error },
+      `${cliCommand(["piece", "new", "--no-register"])} is only ` +
+        "supported when targeting the identity's home space.",
     );
+  }
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
+
+  if (shouldRegister) {
+    const homeNoRegisterHint =
+      `Create it through the supported home-space workflow instead: ` +
+      cliCommand([
+        "piece",
+        "new",
+        "--no-register",
+        "--slug",
+        "<slug>",
+        "<main>",
+      ]);
+    const nonHomeRepairHint = `Repair the non-home space root with: ` +
+      cliCommand(["piece", "recreate-root"]);
+
+    // Registration is a hard requirement in the default mode. Initialize the
+    // root first, then separately validate its actual addPiece stream before
+    // resolving source or creating the piece. Keeping the errors separate is
+    // important for healthy custom home roots, which need not expose addPiece.
+    try {
+      await timeCliPhase(
+        "newPiece.ensureDefaultPattern",
+        () => pieces.ensureDefaultPattern(),
+      );
+    } catch (error) {
+      throw new Error(
+        `Could not initialize the space's root pattern: ${
+          error instanceof Error ? error.message : String(error)
+        }\n` +
+          `No new piece was created.\n` +
+          (isHomeSpace ? homeNoRegisterHint : nonHomeRepairHint),
+        { cause: error },
+      );
+    }
+
+    try {
+      await timeCliPhase(
+        "newPiece.assertCanAddPieces",
+        () => manager.assertCanAddPieces(),
+      );
+    } catch (error) {
+      throw new Error(
+        `The space's root pattern cannot register a new piece: ${
+          error instanceof Error ? error.message : String(error)
+        }\n` +
+          `No new piece was created.\n` +
+          (isHomeSpace ? homeNoRegisterHint : nonHomeRepairHint),
+        { cause: error },
+      );
+    }
   }
 
   const program = await timeCliPhase(
     "newPiece.getProgramFromFile",
-    () => getPinnedProgramFromFile(manager, entry),
+    () => (deps.getProgram ?? getPinnedProgramFromFile)(manager, entry),
   );
   const PIECE_START_TIMEOUT_MS = 60_000;
   const piece = await timeCliPhase("newPiece.create", () => {
@@ -446,18 +513,46 @@ export async function newPiece(
     );
   });
 
-  if (options?.slug) {
-    await timeCliPhase(
-      "newPiece.assignSlug",
-      () => assignSlug(manager, piece.getCell(), options.slug!),
-    );
+  if (slug !== undefined) {
+    try {
+      await timeCliPhase(
+        "newPiece.assignSlug",
+        () => (deps.assignSlug ?? assignSlug)(manager, piece.getCell(), slug),
+      );
+    } catch (error) {
+      if (!shouldRegister) {
+        const directUrl = `${config.apiUrl.replace(/\/+$/, "")}/` +
+          `${config.space}/${piece.id}`;
+        const recoveryCommand = cliCommand([
+          "piece",
+          "set-slug",
+          "--space",
+          config.space,
+          slug,
+          piece.id,
+        ]);
+        throw new Error(
+          `The unregistered piece was created as ${piece.id}, but assigning ` +
+            `slug "${slug}" failed: ${
+              error instanceof Error ? error.message : String(error)
+            }\n` +
+            `The piece remains addressable by ID at ${directUrl}\n` +
+            `Retry slug assignment with the same API and identity:\n  ` +
+            recoveryCommand,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
   }
 
-  // Explicitly add the piece to the space's allPieces list
-  await timeCliPhase(
-    "newPiece.addToDefaultPattern",
-    () => manager.add([piece.getCell()]),
-  );
+  if (shouldRegister) {
+    // Explicitly add the piece to the space's allPieces list.
+    await timeCliPhase(
+      "newPiece.addToDefaultPattern",
+      () => manager.add([piece.getCell()]),
+    );
+  }
 
   return piece.id;
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -401,6 +401,7 @@ export interface NewPieceDependencies {
     manager: PieceManager,
     entry: EntryConfig,
   ) => Promise<RuntimeProgram>;
+  assignSlug?: typeof assignSlug;
 }
 
 // Creates a new piece from source code and optional input.
@@ -489,18 +490,58 @@ export async function newPiece(
     );
   });
 
-  if (slug !== undefined) {
+  const directUrl = `${config.apiUrl.replace(/\/+$/, "")}/` +
+    `${config.space}/${piece.id}`;
+
+  // Registration is the supported durability/discovery path. Do it before
+  // optional slug assignment so a slug write failure never leaves behind an
+  // otherwise-successful piece that is absent from the space's piece list.
+  try {
     await timeCliPhase(
-      "newPiece.assignSlug",
-      () => assignSlug(manager, piece.getCell(), slug),
+      "newPiece.addToDefaultPattern",
+      () => manager.add([piece.getCell()]),
+    );
+  } catch (error) {
+    throw new Error(
+      `The piece was created as ${piece.id}, but registration failed: ${
+        error instanceof Error ? error.message : String(error)
+      }\n` +
+        `The piece was not registered in the space's piece list.\n` +
+        `It remains addressable by ID at ${directUrl}`,
+      { cause: error },
     );
   }
 
-  // Explicitly add the piece to the space's allPieces list.
-  await timeCliPhase(
-    "newPiece.addToDefaultPattern",
-    () => manager.add([piece.getCell()]),
-  );
+  if (slug !== undefined) {
+    try {
+      await timeCliPhase(
+        "newPiece.assignSlug",
+        () => (deps.assignSlug ?? assignSlug)(manager, piece.getCell(), slug),
+      );
+    } catch (error) {
+      const recoveryCommand = cliCommand([
+        "piece",
+        "set-slug",
+        "--identity",
+        config.identity,
+        "--api-url",
+        config.apiUrl,
+        "--space",
+        config.space,
+        slug,
+        piece.id,
+      ]);
+      throw new Error(
+        `The piece was created and registered as ${piece.id}, but assigning ` +
+          `slug "${slug}" failed: ${
+            error instanceof Error ? error.message : String(error)
+          }\n` +
+          `The piece remains registered and addressable by ID at ${directUrl}\n` +
+          `Retry slug assignment with:\n  ${recoveryCommand}`,
+        { cause: error },
+      );
+    }
+  }
 
   return piece.id;
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -392,7 +392,6 @@ export async function resolveLinkEndpointAddress(
 export interface NewPieceOptions {
   start?: boolean;
   slug?: string;
-  register?: boolean;
 }
 
 export interface NewPieceDependencies {
@@ -402,7 +401,6 @@ export interface NewPieceDependencies {
     manager: PieceManager,
     entry: EntryConfig,
   ) => Promise<RuntimeProgram>;
-  assignSlug?: typeof assignSlug;
 }
 
 // Creates a new piece from source code and optional input.
@@ -415,78 +413,56 @@ export async function newPiece(
   const slug = options.slug === undefined
     ? undefined
     : validateSlug(options.slug);
-  const shouldRegister = options.register !== false;
-  if (!shouldRegister && slug === undefined) {
-    throw new Error(
-      `${cliCommand(["piece", "new", "--no-register"])} requires ` +
-        "--slug so the unlisted piece remains addressable.",
-    );
-  }
 
   const manager = await timeCliPhase(
     "newPiece.loadManager",
     () => (deps.loadManager ?? loadManager)(config),
   );
   const isHomeSpace = manager.getSpace() === manager.runtime.userIdentityDID;
-
-  if (!shouldRegister && !isHomeSpace) {
-    throw new Error(
-      `${cliCommand(["piece", "new", "--no-register"])} is only ` +
-        "supported when targeting the identity's home space.",
-    );
-  }
   const pieces = deps.createController?.(manager) ??
     new PiecesController(manager);
 
-  if (shouldRegister) {
-    const homeNoRegisterHint =
-      `Create it through the supported home-space workflow instead: ` +
-      cliCommand([
-        "piece",
-        "new",
-        "--no-register",
-        "--slug",
-        "<slug>",
-        "<main>",
-      ]);
-    const nonHomeRepairHint = `Repair the non-home space root with: ` +
-      cliCommand(["piece", "recreate-root"]);
+  const homeSpaceHint =
+    `The home space is not a piece registry. Target a named space instead: ` +
+    cliCommand(["piece", "new", "--space", "<space-name>", "<main>"]);
+  const nonHomeRepairHint = `Repair the non-home space root with: ` +
+    cliCommand(["piece", "recreate-root"]);
 
-    // Registration is a hard requirement in the default mode. Initialize the
-    // root first, then separately validate its actual addPiece stream before
-    // resolving source or creating the piece. Keeping the errors separate is
-    // important for healthy custom home roots, which need not expose addPiece.
-    try {
-      await timeCliPhase(
-        "newPiece.ensureDefaultPattern",
-        () => pieces.ensureDefaultPattern(),
-      );
-    } catch (error) {
-      throw new Error(
-        `Could not initialize the space's root pattern: ${
-          error instanceof Error ? error.message : String(error)
-        }\n` +
-          `No new piece was created.\n` +
-          (isHomeSpace ? homeNoRegisterHint : nonHomeRepairHint),
-        { cause: error },
-      );
-    }
+  // Registration is a hard requirement. Initialize the root first, then
+  // separately validate its actual addPiece stream before resolving source or
+  // creating the piece. A healthy system home intentionally has no addPiece;
+  // ordinary pieces belong in a named space whose default-app root registers
+  // them.
+  try {
+    await timeCliPhase(
+      "newPiece.ensureDefaultPattern",
+      () => pieces.ensureDefaultPattern(),
+    );
+  } catch (error) {
+    throw new Error(
+      `Could not initialize the space's root pattern: ${
+        error instanceof Error ? error.message : String(error)
+      }\n` +
+        `No new piece was created.\n` +
+        (isHomeSpace ? homeSpaceHint : nonHomeRepairHint),
+      { cause: error },
+    );
+  }
 
-    try {
-      await timeCliPhase(
-        "newPiece.assertCanAddPieces",
-        () => manager.assertCanAddPieces(),
-      );
-    } catch (error) {
-      throw new Error(
-        `The space's root pattern cannot register a new piece: ${
-          error instanceof Error ? error.message : String(error)
-        }\n` +
-          `No new piece was created.\n` +
-          (isHomeSpace ? homeNoRegisterHint : nonHomeRepairHint),
-        { cause: error },
-      );
-    }
+  try {
+    await timeCliPhase(
+      "newPiece.assertCanAddPieces",
+      () => manager.assertCanAddPieces(),
+    );
+  } catch (error) {
+    throw new Error(
+      `The space's root pattern cannot register a new piece: ${
+        error instanceof Error ? error.message : String(error)
+      }\n` +
+        `No new piece was created.\n` +
+        (isHomeSpace ? homeSpaceHint : nonHomeRepairHint),
+      { cause: error },
+    );
   }
 
   const program = await timeCliPhase(
@@ -514,45 +490,17 @@ export async function newPiece(
   });
 
   if (slug !== undefined) {
-    try {
-      await timeCliPhase(
-        "newPiece.assignSlug",
-        () => (deps.assignSlug ?? assignSlug)(manager, piece.getCell(), slug),
-      );
-    } catch (error) {
-      if (!shouldRegister) {
-        const directUrl = `${config.apiUrl.replace(/\/+$/, "")}/` +
-          `${config.space}/${piece.id}`;
-        const recoveryCommand = cliCommand([
-          "piece",
-          "set-slug",
-          "--space",
-          config.space,
-          slug,
-          piece.id,
-        ]);
-        throw new Error(
-          `The unregistered piece was created as ${piece.id}, but assigning ` +
-            `slug "${slug}" failed: ${
-              error instanceof Error ? error.message : String(error)
-            }\n` +
-            `The piece remains addressable by ID at ${directUrl}\n` +
-            `Retry slug assignment with the same API and identity:\n  ` +
-            recoveryCommand,
-          { cause: error },
-        );
-      }
-      throw error;
-    }
-  }
-
-  if (shouldRegister) {
-    // Explicitly add the piece to the space's allPieces list.
     await timeCliPhase(
-      "newPiece.addToDefaultPattern",
-      () => manager.add([piece.getCell()]),
+      "newPiece.assignSlug",
+      () => assignSlug(manager, piece.getCell(), slug),
     );
   }
+
+  // Explicitly add the piece to the space's allPieces list.
+  await timeCliPhase(
+    "newPiece.addToDefaultPattern",
+    () => manager.add([piece.getCell()]),
+  );
 
   return piece.id;
 }

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -556,7 +556,7 @@ describe("cli piece parsing", () => {
     ]);
   });
 
-  it("reports the durable piece address when registration fails", async () => {
+  it("reports an unknown outcome when registration settling fails", async () => {
     const calls: string[] = [];
     const manager = {
       getSpace: () => "did:key:z6Mktest-space",
@@ -599,9 +599,14 @@ describe("cli piece parsing", () => {
     expect(calls).toEqual(["register"]);
     expect(message).toContain("fid1:created-but-unregistered");
     expect(message).toContain("transaction exhausted");
-    expect(message).toContain("was not registered");
+    expect(message).toContain("registration outcome is unknown");
+    expect(message).toContain("may have committed before settling failed");
     expect(message).toContain(
       `${API_URL}/named-space/fid1:created-but-unregistered`,
+    );
+    expect(message).toContain(
+      `cf piece ls --identity /tmp/test.key --api-url ${API_URL} ` +
+        "--space named-space",
     );
   });
 
@@ -656,6 +661,49 @@ describe("cli piece parsing", () => {
       "cf piece set-slug --identity /tmp/test.key " +
         `--api-url ${API_URL} --space named-space demo ` +
         "fid1:registered-without-slug",
+    );
+  });
+
+  it("shell-quotes dynamic values in recovery commands", async () => {
+    const identity = "/tmp/key with 'quote.key";
+    const apiUrl = "https://cf.dev/root?x=1&y=$(nope)";
+    const space = "named space;echo nope";
+    const manager = {
+      getSpace: () => "did:key:z6Mktest-space",
+      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
+      assertCanAddPieces: () => Promise.resolve(),
+      add: () => Promise.resolve(),
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => Promise.resolve({}),
+      create: () =>
+        Promise.resolve({
+          id: "fid1:shell-safe-recovery",
+          getCell: () => ({}),
+        }),
+    } as unknown as PiecesController;
+
+    let message = "";
+    try {
+      await newPiece(
+        { apiUrl, space, identity },
+        { mainPath: "/tmp/pattern.tsx" },
+        { slug: "demo" },
+        {
+          loadManager: () => Promise.resolve(manager),
+          createController: () => controller,
+          getProgram: () => Promise.resolve({} as RuntimeProgram),
+          assignSlug: () => Promise.reject(new Error("slug write failed")),
+        },
+      );
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain(
+      "cf piece set-slug --identity '/tmp/key with '\\''quote.key' " +
+        "--api-url 'https://cf.dev/root?x=1&y=$(nope)' " +
+        "--space 'named space;echo nope' demo fid1:shell-safe-recovery",
     );
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -2,13 +2,23 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
+  newPiece,
+  type NewPieceDependencies,
   recreateSpaceRootPattern,
   resolveLinkEndpointAddress,
   resolvePieceConfig,
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
-import { SlugResolutionError } from "@commonfabric/piece";
+import {
+  PieceManager,
+  resolvePieceAddress,
+  SlugResolutionError,
+} from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createSession, Identity } from "@commonfabric/identity";
 import {
   normalizeApiUrl,
   parseLink,
@@ -400,8 +410,325 @@ describe("cli piece parsing", () => {
   it("shows slug option for piece new", async () => {
     const { code, stdout, stderr } = await cf("piece new --help");
     checkStderr(stderr);
+    const output = stripAnsi(stdout.join("\n"));
     expect(code).toBe(0);
-    expect(stripAnsi(stdout.join("\n"))).toContain("--slug");
+    expect(output).toContain("--slug");
+    expect(output).toContain("--no-register");
+    expect(output).toContain("Requires --slug and the home space");
+  });
+
+  it("preflights registration before resolving or creating a piece", async () => {
+    const homeSpace = "did:key:z6Mktest-home";
+    const calls: string[] = [];
+    const manager = {
+      getSpace: () => homeSpace,
+      runtime: { userIdentityDID: homeSpace },
+      assertCanAddPieces: () => {
+        calls.push("preflight");
+        return Promise.reject(
+          new Error("addPiece handler not found on default pattern"),
+        );
+      },
+      add: () => {
+        calls.push("add");
+        return Promise.resolve();
+      },
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => {
+        calls.push("ensure-root");
+        return Promise.resolve({});
+      },
+      create: () => {
+        calls.push("create");
+        return Promise.reject(new Error("create must not run"));
+      },
+    } as unknown as PiecesController;
+    const deps: NewPieceDependencies = {
+      loadManager: () => {
+        calls.push("load-manager");
+        return Promise.resolve(manager);
+      },
+      createController: () => controller,
+      getProgram: () => {
+        calls.push("resolve-program");
+        return Promise.reject(new Error("program resolution must not run"));
+      },
+    };
+
+    let message = "";
+    try {
+      await newPiece(
+        { apiUrl: API_URL, space: homeSpace, identity: ID },
+        { mainPath: "/tmp/pattern.tsx" },
+        {},
+        deps,
+      );
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(calls).toEqual(["load-manager", "ensure-root", "preflight"]);
+    expect(message).toContain("No new piece was created");
+    expect(message).toContain("--no-register --slug <slug>");
+    expect(message).not.toContain("recreate-root");
+  });
+
+  it("retains root repair guidance for non-home initialization failure", async () => {
+    const manager = {
+      getSpace: () => "did:key:z6Mktest-other",
+      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => Promise.reject(new Error("broken root")),
+    } as unknown as PiecesController;
+    const deps: NewPieceDependencies = {
+      loadManager: () => Promise.resolve(manager),
+      createController: () => controller,
+    };
+
+    let message = "";
+    try {
+      await newPiece(
+        {
+          apiUrl: API_URL,
+          space: "did:key:z6Mktest-other",
+          identity: ID,
+        },
+        { mainPath: "/tmp/pattern.tsx" },
+        {},
+        deps,
+      );
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain("Could not initialize the space's root pattern");
+    expect(message).toContain("piece recreate-root");
+    expect(message).not.toContain("--no-register");
+  });
+
+  it("creates a slug-addressable home piece without registration", async () => {
+    const homeSpace = "did:key:z6Mktest-home";
+    const calls: string[] = [];
+    const pieceCell = {} as Cell<unknown>;
+    const manager = {
+      getSpace: () => homeSpace,
+      runtime: { userIdentityDID: homeSpace },
+      assertCanAddPieces: () => {
+        calls.push("preflight");
+        return Promise.resolve();
+      },
+      add: () => {
+        calls.push("add");
+        return Promise.resolve();
+      },
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => {
+        calls.push("ensure-root");
+        return Promise.resolve({});
+      },
+      create: () => {
+        calls.push("create");
+        return Promise.resolve({
+          id: "fid1:test-piece",
+          getCell: () => pieceCell,
+        });
+      },
+    } as unknown as PiecesController;
+    const deps: NewPieceDependencies = {
+      loadManager: () => {
+        calls.push("load-manager");
+        return Promise.resolve(manager);
+      },
+      createController: () => controller,
+      getProgram: () => {
+        calls.push("resolve-program");
+        return Promise.resolve({} as RuntimeProgram);
+      },
+      assignSlug: (_manager, cell, slug) => {
+        expect(cell).toBe(pieceCell);
+        expect(slug).toBe("lunchpoll");
+        calls.push("assign-slug");
+        return Promise.resolve();
+      },
+    };
+
+    const id = await newPiece(
+      { apiUrl: API_URL, space: homeSpace, identity: ID },
+      { mainPath: "/tmp/pattern.tsx" },
+      { register: false, slug: "lunchpoll" },
+      deps,
+    );
+
+    expect(id).toBe("fid1:test-piece");
+    expect(calls).toEqual([
+      "load-manager",
+      "resolve-program",
+      "create",
+      "assign-slug",
+    ]);
+  });
+
+  it("reports the created piece ID when unregistered slug assignment fails", async () => {
+    const homeSpace = "did:key:z6Mktest-home";
+    const pieceCell = {} as Cell<unknown>;
+    const manager = {
+      getSpace: () => homeSpace,
+      runtime: { userIdentityDID: homeSpace },
+    } as unknown as PieceManager;
+    const controller = {
+      create: () =>
+        Promise.resolve({
+          id: "fid1:created-but-unlinked",
+          getCell: () => pieceCell,
+        }),
+    } as unknown as PiecesController;
+    const deps: NewPieceDependencies = {
+      loadManager: () => Promise.resolve(manager),
+      createController: () => controller,
+      getProgram: () => Promise.resolve({} as RuntimeProgram),
+      assignSlug: () => Promise.reject(new Error("storage unavailable")),
+    };
+
+    let message = "";
+    try {
+      await newPiece(
+        { apiUrl: API_URL, space: homeSpace, identity: ID },
+        { mainPath: "/tmp/pattern.tsx" },
+        { register: false, slug: "lunchpoll" },
+        deps,
+      );
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain("fid1:created-but-unlinked");
+    expect(message).toContain("storage unavailable");
+    expect(message).toContain(
+      `${API_URL}/${homeSpace}/fid1:created-but-unlinked`,
+    );
+    expect(message).toContain(
+      "piece set-slug --space did:key:z6Mktest-home lunchpoll " +
+        "fid1:created-but-unlinked",
+    );
+  });
+
+  it("cold-loads an unregistered home piece through its persisted slug", async () => {
+    const identity = await Identity.fromPassphrase(
+      "cli unregistered home piece cold persistence",
+    );
+    const storageManager = StorageManager.emulate({ as: identity });
+    const firstRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    let freshRuntime: Runtime | undefined;
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          "/// <cf-disable-transform />",
+          "import { pattern } from 'commonfabric';",
+          "export default pattern(() => ({ marker: 'persisted' }));",
+        ].join("\n"),
+      }],
+    };
+
+    try {
+      const firstSession = await createSession({
+        identity,
+        spaceDid: identity.did(),
+      });
+      const firstManager = new PieceManager(firstSession, firstRuntime);
+      await firstManager.synced();
+
+      const id = await newPiece(
+        {
+          apiUrl: "http://toolshed.test",
+          space: identity.did(),
+          identity: "/unused/test.key",
+        },
+        { mainPath: "/unused/main.tsx" },
+        { register: false, slug: "cold-home-piece" },
+        {
+          loadManager: () => Promise.resolve(firstManager),
+          getProgram: () => Promise.resolve(program),
+        },
+      );
+
+      expect(await firstManager.getDefaultPattern(false)).toBeUndefined();
+      expect(await resolvePieceAddress(firstManager, "cold-home-piece")).toBe(
+        id,
+      );
+      await firstManager.synced();
+      await firstManager.stopPiece(id);
+
+      const freshSession = await createSession({
+        identity,
+        spaceDid: identity.did(),
+      });
+      freshRuntime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      const freshManager = new PieceManager(freshSession, freshRuntime);
+      await freshManager.synced();
+
+      expect(await freshManager.getDefaultPattern(false)).toBeUndefined();
+      expect(await resolvePieceAddress(freshManager, "cold-home-piece")).toBe(
+        id,
+      );
+      const freshPiece = await new PiecesController(freshManager).get(id, true);
+      expect(await freshPiece.result.get()).toEqual({ marker: "persisted" });
+    } finally {
+      await freshRuntime?.dispose();
+      await firstRuntime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects --no-register without a slug before loading a manager", async () => {
+    let managerLoaded = false;
+    const deps: NewPieceDependencies = {
+      loadManager: () => {
+        managerLoaded = true;
+        return Promise.reject(new Error("manager must not load"));
+      },
+    };
+
+    await expect(newPiece(
+      { apiUrl: API_URL, space: "did:key:z6Mktest-home", identity: ID },
+      { mainPath: "/tmp/pattern.tsx" },
+      { register: false },
+      deps,
+    )).rejects.toThrow(/requires --slug/);
+    expect(managerLoaded).toBe(false);
+  });
+
+  it("rejects --no-register outside the home space before creation", async () => {
+    const manager = {
+      getSpace: () => "did:key:z6Mktest-other",
+      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
+    } as unknown as PieceManager;
+    let controllerCreated = false;
+    const deps: NewPieceDependencies = {
+      loadManager: () => Promise.resolve(manager),
+      createController: () => {
+        controllerCreated = true;
+        return {} as PiecesController;
+      },
+    };
+
+    await expect(newPiece(
+      { apiUrl: API_URL, space: "did:key:z6Mktest-other", identity: ID },
+      { mainPath: "/tmp/pattern.tsx" },
+      { register: false, slug: "lunchpoll" },
+      deps,
+    )).rejects.toThrow(/only supported.*home space/);
+    expect(controllerCreated).toBe(false);
   });
 
   it("shows set-slug command options", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -10,15 +10,8 @@ import {
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
-import {
-  PieceManager,
-  resolvePieceAddress,
-  SlugResolutionError,
-} from "@commonfabric/piece";
+import { PieceManager, SlugResolutionError } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
-import { type Cell, Runtime, type RuntimeProgram } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createSession, Identity } from "@commonfabric/identity";
 import {
   normalizeApiUrl,
   parseLink,
@@ -413,8 +406,7 @@ describe("cli piece parsing", () => {
     const output = stripAnsi(stdout.join("\n"));
     expect(code).toBe(0);
     expect(output).toContain("--slug");
-    expect(output).toContain("--no-register");
-    expect(output).toContain("Requires --slug and the home space");
+    expect(output).not.toContain("--no-register");
   });
 
   it("preflights registration before resolving or creating a piece", async () => {
@@ -470,8 +462,27 @@ describe("cli piece parsing", () => {
 
     expect(calls).toEqual(["load-manager", "ensure-root", "preflight"]);
     expect(message).toContain("No new piece was created");
-    expect(message).toContain("--no-register --slug <slug>");
+    expect(message).toContain("home space is not a piece registry");
+    expect(message).toContain("piece new --space <space-name> <main>");
     expect(message).not.toContain("recreate-root");
+  });
+
+  it("validates a slug before loading a manager", async () => {
+    let managerLoaded = false;
+    const deps: NewPieceDependencies = {
+      loadManager: () => {
+        managerLoaded = true;
+        return Promise.reject(new Error("manager must not load"));
+      },
+    };
+
+    await expect(newPiece(
+      { apiUrl: API_URL, space: "named-space", identity: ID },
+      { mainPath: "/tmp/pattern.tsx" },
+      { slug: "Invalid Slug" },
+      deps,
+    )).rejects.toThrow(/lowercase letters, numbers/);
+    expect(managerLoaded).toBe(false);
   });
 
   it("retains root repair guidance for non-home initialization failure", async () => {
@@ -506,229 +517,6 @@ describe("cli piece parsing", () => {
     expect(message).toContain("Could not initialize the space's root pattern");
     expect(message).toContain("piece recreate-root");
     expect(message).not.toContain("--no-register");
-  });
-
-  it("creates a slug-addressable home piece without registration", async () => {
-    const homeSpace = "did:key:z6Mktest-home";
-    const calls: string[] = [];
-    const pieceCell = {} as Cell<unknown>;
-    const manager = {
-      getSpace: () => homeSpace,
-      runtime: { userIdentityDID: homeSpace },
-      assertCanAddPieces: () => {
-        calls.push("preflight");
-        return Promise.resolve();
-      },
-      add: () => {
-        calls.push("add");
-        return Promise.resolve();
-      },
-    } as unknown as PieceManager;
-    const controller = {
-      ensureDefaultPattern: () => {
-        calls.push("ensure-root");
-        return Promise.resolve({});
-      },
-      create: () => {
-        calls.push("create");
-        return Promise.resolve({
-          id: "fid1:test-piece",
-          getCell: () => pieceCell,
-        });
-      },
-    } as unknown as PiecesController;
-    const deps: NewPieceDependencies = {
-      loadManager: () => {
-        calls.push("load-manager");
-        return Promise.resolve(manager);
-      },
-      createController: () => controller,
-      getProgram: () => {
-        calls.push("resolve-program");
-        return Promise.resolve({} as RuntimeProgram);
-      },
-      assignSlug: (_manager, cell, slug) => {
-        expect(cell).toBe(pieceCell);
-        expect(slug).toBe("lunchpoll");
-        calls.push("assign-slug");
-        return Promise.resolve();
-      },
-    };
-
-    const id = await newPiece(
-      { apiUrl: API_URL, space: homeSpace, identity: ID },
-      { mainPath: "/tmp/pattern.tsx" },
-      { register: false, slug: "lunchpoll" },
-      deps,
-    );
-
-    expect(id).toBe("fid1:test-piece");
-    expect(calls).toEqual([
-      "load-manager",
-      "resolve-program",
-      "create",
-      "assign-slug",
-    ]);
-  });
-
-  it("reports the created piece ID when unregistered slug assignment fails", async () => {
-    const homeSpace = "did:key:z6Mktest-home";
-    const pieceCell = {} as Cell<unknown>;
-    const manager = {
-      getSpace: () => homeSpace,
-      runtime: { userIdentityDID: homeSpace },
-    } as unknown as PieceManager;
-    const controller = {
-      create: () =>
-        Promise.resolve({
-          id: "fid1:created-but-unlinked",
-          getCell: () => pieceCell,
-        }),
-    } as unknown as PiecesController;
-    const deps: NewPieceDependencies = {
-      loadManager: () => Promise.resolve(manager),
-      createController: () => controller,
-      getProgram: () => Promise.resolve({} as RuntimeProgram),
-      assignSlug: () => Promise.reject(new Error("storage unavailable")),
-    };
-
-    let message = "";
-    try {
-      await newPiece(
-        { apiUrl: API_URL, space: homeSpace, identity: ID },
-        { mainPath: "/tmp/pattern.tsx" },
-        { register: false, slug: "lunchpoll" },
-        deps,
-      );
-    } catch (error) {
-      message = error instanceof Error ? error.message : String(error);
-    }
-
-    expect(message).toContain("fid1:created-but-unlinked");
-    expect(message).toContain("storage unavailable");
-    expect(message).toContain(
-      `${API_URL}/${homeSpace}/fid1:created-but-unlinked`,
-    );
-    expect(message).toContain(
-      "piece set-slug --space did:key:z6Mktest-home lunchpoll " +
-        "fid1:created-but-unlinked",
-    );
-  });
-
-  it("cold-loads an unregistered home piece through its persisted slug", async () => {
-    const identity = await Identity.fromPassphrase(
-      "cli unregistered home piece cold persistence",
-    );
-    const storageManager = StorageManager.emulate({ as: identity });
-    const firstRuntime = new Runtime({
-      apiUrl: new URL("http://toolshed.test"),
-      storageManager,
-    });
-    let freshRuntime: Runtime | undefined;
-    const program: RuntimeProgram = {
-      main: "/main.tsx",
-      files: [{
-        name: "/main.tsx",
-        contents: [
-          "/// <cf-disable-transform />",
-          "import { pattern } from 'commonfabric';",
-          "export default pattern(() => ({ marker: 'persisted' }));",
-        ].join("\n"),
-      }],
-    };
-
-    try {
-      const firstSession = await createSession({
-        identity,
-        spaceDid: identity.did(),
-      });
-      const firstManager = new PieceManager(firstSession, firstRuntime);
-      await firstManager.synced();
-
-      const id = await newPiece(
-        {
-          apiUrl: "http://toolshed.test",
-          space: identity.did(),
-          identity: "/unused/test.key",
-        },
-        { mainPath: "/unused/main.tsx" },
-        { register: false, slug: "cold-home-piece" },
-        {
-          loadManager: () => Promise.resolve(firstManager),
-          getProgram: () => Promise.resolve(program),
-        },
-      );
-
-      expect(await firstManager.getDefaultPattern(false)).toBeUndefined();
-      expect(await resolvePieceAddress(firstManager, "cold-home-piece")).toBe(
-        id,
-      );
-      await firstManager.synced();
-      await firstManager.stopPiece(id);
-
-      const freshSession = await createSession({
-        identity,
-        spaceDid: identity.did(),
-      });
-      freshRuntime = new Runtime({
-        apiUrl: new URL("http://toolshed.test"),
-        storageManager,
-      });
-      const freshManager = new PieceManager(freshSession, freshRuntime);
-      await freshManager.synced();
-
-      expect(await freshManager.getDefaultPattern(false)).toBeUndefined();
-      expect(await resolvePieceAddress(freshManager, "cold-home-piece")).toBe(
-        id,
-      );
-      const freshPiece = await new PiecesController(freshManager).get(id, true);
-      expect(await freshPiece.result.get()).toEqual({ marker: "persisted" });
-    } finally {
-      await freshRuntime?.dispose();
-      await firstRuntime.dispose();
-      await storageManager.close();
-    }
-  });
-
-  it("rejects --no-register without a slug before loading a manager", async () => {
-    let managerLoaded = false;
-    const deps: NewPieceDependencies = {
-      loadManager: () => {
-        managerLoaded = true;
-        return Promise.reject(new Error("manager must not load"));
-      },
-    };
-
-    await expect(newPiece(
-      { apiUrl: API_URL, space: "did:key:z6Mktest-home", identity: ID },
-      { mainPath: "/tmp/pattern.tsx" },
-      { register: false },
-      deps,
-    )).rejects.toThrow(/requires --slug/);
-    expect(managerLoaded).toBe(false);
-  });
-
-  it("rejects --no-register outside the home space before creation", async () => {
-    const manager = {
-      getSpace: () => "did:key:z6Mktest-other",
-      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
-    } as unknown as PieceManager;
-    let controllerCreated = false;
-    const deps: NewPieceDependencies = {
-      loadManager: () => Promise.resolve(manager),
-      createController: () => {
-        controllerCreated = true;
-        return {} as PiecesController;
-      },
-    };
-
-    await expect(newPiece(
-      { apiUrl: API_URL, space: "did:key:z6Mktest-other", identity: ID },
-      { mainPath: "/tmp/pattern.tsx" },
-      { register: false, slug: "lunchpoll" },
-      deps,
-    )).rejects.toThrow(/only supported.*home space/);
-    expect(controllerCreated).toBe(false);
   });
 
   it("shows set-slug command options", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -10,8 +10,15 @@ import {
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
-import { PieceManager, SlugResolutionError } from "@commonfabric/piece";
+import {
+  PieceManager,
+  resolvePieceAddress,
+  SlugResolutionError,
+} from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   normalizeApiUrl,
   parseLink,
@@ -483,6 +490,277 @@ describe("cli piece parsing", () => {
       deps,
     )).rejects.toThrow(/lowercase letters, numbers/);
     expect(managerLoaded).toBe(false);
+  });
+
+  it("registers a new piece before assigning its optional slug", async () => {
+    const calls: string[] = [];
+    const pieceCell = {};
+    const manager = {
+      getSpace: () => "did:key:z6Mktest-space",
+      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
+      assertCanAddPieces: () => {
+        calls.push("preflight");
+        return Promise.resolve();
+      },
+      add: () => {
+        calls.push("register");
+        return Promise.resolve();
+      },
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => {
+        calls.push("ensure-root");
+        return Promise.resolve({});
+      },
+      create: () => {
+        calls.push("create");
+        return Promise.resolve({
+          id: "fid1:created-piece",
+          getCell: () => pieceCell,
+        });
+      },
+    } as unknown as PiecesController;
+
+    const id = await newPiece(
+      { apiUrl: API_URL, space: "named-space", identity: "/tmp/test.key" },
+      { mainPath: "/tmp/pattern.tsx" },
+      { slug: "demo" },
+      {
+        loadManager: () => {
+          calls.push("load-manager");
+          return Promise.resolve(manager);
+        },
+        createController: () => controller,
+        getProgram: () => {
+          calls.push("resolve-program");
+          return Promise.resolve({} as RuntimeProgram);
+        },
+        assignSlug: (_manager, cell, slug) => {
+          expect(cell).toBe(pieceCell);
+          expect(slug).toBe("demo");
+          calls.push("assign-slug");
+          return Promise.resolve();
+        },
+      },
+    );
+
+    expect(id).toBe("fid1:created-piece");
+    expect(calls).toEqual([
+      "load-manager",
+      "ensure-root",
+      "preflight",
+      "resolve-program",
+      "create",
+      "register",
+      "assign-slug",
+    ]);
+  });
+
+  it("reports the durable piece address when registration fails", async () => {
+    const calls: string[] = [];
+    const manager = {
+      getSpace: () => "did:key:z6Mktest-space",
+      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
+      assertCanAddPieces: () => Promise.resolve(),
+      add: () => {
+        calls.push("register");
+        return Promise.reject(new Error("transaction exhausted"));
+      },
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => Promise.resolve({}),
+      create: () =>
+        Promise.resolve({
+          id: "fid1:created-but-unregistered",
+          getCell: () => ({}),
+        }),
+    } as unknown as PiecesController;
+
+    let message = "";
+    try {
+      await newPiece(
+        { apiUrl: API_URL, space: "named-space", identity: "/tmp/test.key" },
+        { mainPath: "/tmp/pattern.tsx" },
+        { slug: "demo" },
+        {
+          loadManager: () => Promise.resolve(manager),
+          createController: () => controller,
+          getProgram: () => Promise.resolve({} as RuntimeProgram),
+          assignSlug: () => {
+            calls.push("assign-slug");
+            return Promise.resolve();
+          },
+        },
+      );
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(calls).toEqual(["register"]);
+    expect(message).toContain("fid1:created-but-unregistered");
+    expect(message).toContain("transaction exhausted");
+    expect(message).toContain("was not registered");
+    expect(message).toContain(
+      `${API_URL}/named-space/fid1:created-but-unregistered`,
+    );
+  });
+
+  it("reports exact slug recovery after the piece is registered", async () => {
+    const calls: string[] = [];
+    const manager = {
+      getSpace: () => "did:key:z6Mktest-space",
+      runtime: { userIdentityDID: "did:key:z6Mktest-home" },
+      assertCanAddPieces: () => Promise.resolve(),
+      add: () => {
+        calls.push("register");
+        return Promise.resolve();
+      },
+    } as unknown as PieceManager;
+    const controller = {
+      ensureDefaultPattern: () => Promise.resolve({}),
+      create: () =>
+        Promise.resolve({
+          id: "fid1:registered-without-slug",
+          getCell: () => ({}),
+        }),
+    } as unknown as PiecesController;
+
+    let message = "";
+    try {
+      await newPiece(
+        { apiUrl: API_URL, space: "named-space", identity: "/tmp/test.key" },
+        { mainPath: "/tmp/pattern.tsx" },
+        { slug: "demo" },
+        {
+          loadManager: () => Promise.resolve(manager),
+          createController: () => controller,
+          getProgram: () => Promise.resolve({} as RuntimeProgram),
+          assignSlug: () => {
+            calls.push("assign-slug");
+            return Promise.reject(new Error("slug storage unavailable"));
+          },
+        },
+      );
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(calls).toEqual(["register", "assign-slug"]);
+    expect(message).toContain("fid1:registered-without-slug");
+    expect(message).toContain("slug storage unavailable");
+    expect(message).toContain("remains registered");
+    expect(message).toContain(
+      `${API_URL}/named-space/fid1:registered-without-slug`,
+    );
+    expect(message).toContain(
+      "cf piece set-slug --identity /tmp/test.key " +
+        `--api-url ${API_URL} --space named-space demo ` +
+        "fid1:registered-without-slug",
+    );
+  });
+
+  it("registers and cold-loads a slugged piece in a named space", async () => {
+    const identity = await Identity.fromPassphrase(
+      "cli registered named-space piece cold persistence",
+    );
+    const storageManager = StorageManager.emulate({ as: identity });
+    const firstRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    let freshRuntime: Runtime | undefined;
+    const spaceName = `registered-piece-${crypto.randomUUID()}`;
+    const slug = "cold-registered-piece";
+    const defaultPatternProgram: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          "/// <cf-disable-transform />",
+          "import { handler, pattern } from 'commonfabric';",
+          "const addPiece = handler<{ piece: unknown }, { allPieces: unknown[] }>(",
+          "  ({ piece }, { allPieces }) => { allPieces.push(piece); },",
+          "  { proxy: true },",
+          ");",
+          "export default pattern<{ allPieces: unknown[] }>(({ allPieces }) => ({",
+          "  allPieces,",
+          "  addPiece: addPiece({ allPieces }),",
+          "}));",
+        ].join("\n"),
+      }],
+    };
+    const pieceProgram: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          "/// <cf-disable-transform />",
+          "import { pattern } from 'commonfabric';",
+          "export default pattern(() => ({ marker: 'persisted' }));",
+        ].join("\n"),
+      }],
+    };
+
+    try {
+      const firstSession = await createSession({ identity, spaceName });
+      const firstManager = new PieceManager(firstSession, firstRuntime);
+      await firstManager.synced();
+      expect(firstManager.getSpace()).not.toBe(firstRuntime.userIdentityDID);
+
+      const compiledDefaultPattern = await firstRuntime.patternManager
+        .compilePattern(defaultPatternProgram, {
+          space: firstManager.getSpace(),
+        });
+      const defaultPatternPiece = await firstManager.runPersistent(
+        compiledDefaultPattern,
+        { allPieces: [] },
+        "registered-piece-default-pattern",
+      );
+      await firstManager.linkDefaultPattern(defaultPatternPiece);
+      await firstRuntime.idle();
+      await firstManager.synced();
+
+      const id = await newPiece(
+        {
+          apiUrl: "http://toolshed.test",
+          space: firstManager.getSpace(),
+          identity: "/unused/test.key",
+        },
+        { mainPath: "/unused/main.tsx" },
+        { slug },
+        {
+          loadManager: () => Promise.resolve(firstManager),
+          getProgram: () => Promise.resolve(pieceProgram),
+        },
+      );
+
+      const firstPieces = new PiecesController(firstManager);
+      expect((await firstPieces.getAllPieces()).map((piece) => piece.id))
+        .toContain(id);
+      expect(await resolvePieceAddress(firstManager, slug)).toBe(id);
+      await firstManager.synced();
+      await firstManager.stopPiece(id);
+
+      const freshSession = await createSession({ identity, spaceName });
+      freshRuntime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      const freshManager = new PieceManager(freshSession, freshRuntime);
+      await freshManager.synced();
+
+      const freshPieces = new PiecesController(freshManager);
+      expect((await freshPieces.getAllPieces()).map((piece) => piece.id))
+        .toContain(id);
+      const resolvedId = await resolvePieceAddress(freshManager, slug);
+      expect(resolvedId).toBe(id);
+      const freshPiece = await freshPieces.get(resolvedId, true);
+      expect(await freshPiece.result.get()).toEqual({ marker: "persisted" });
+    } finally {
+      await freshRuntime?.dispose();
+      await firstRuntime.dispose();
+      await storageManager.close();
+    }
   });
 
   it("retains root repair guidance for non-home initialization failure", async () => {

--- a/packages/patterns/integration/lunch-poll-history-reload.test.ts
+++ b/packages/patterns/integration/lunch-poll-history-reload.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Cold-runtime persistence regression for lunch-poll visit history.
+ *
+ * A visit used to be appended as an anonymous array element. Its stored link
+ * then lacked the HistoryEntry item schema: the warm writer could still report
+ * historyCount=1, but a fresh runtime traversed `visits`/`recentVisits` as an
+ * empty array and derived an empty mostRecentTitle. This test closes the first
+ * controller entirely before reopening the same piece through a new runtime and
+ * replica, so it exercises persisted link traversal rather than warm cache.
+ */
+
+import { assert, assertEquals, assertMatch } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
+import { type Cell, parseLink } from "@commonfabric/runner";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { MultiRuntimeHarness } from "./multi-runtime-harness.ts";
+import { initializePiecesController } from "./pieces-controller.ts";
+
+const VISIT_TITLE = "Persistence Cafe";
+const VISIT_TIME = 1_703_000_000_000;
+
+type StoredVisit = {
+  id: string;
+  title: string;
+  loggedByName: string;
+  loggedBy: unknown;
+  wentAt: number;
+  votes: unknown[];
+};
+
+const visitsFrom = (value: unknown): StoredVisit[] =>
+  Array.isArray(value) ? value as StoredVisit[] : [];
+
+describe("lunch poll history persistence", () => {
+  it("rehydrates visits and history projections in a cold runtime", async () => {
+    const server = StandaloneMemoryServer.start();
+    const identity = await Identity.fromPassphrase(
+      "lunch-poll history cold reload",
+      { implementation: "noble" },
+    );
+    const spaceName = `lunch-poll-history-${crypto.randomUUID()}`;
+    let pieceId = "";
+    let visitId = "";
+
+    try {
+      const first = await initializePiecesController({
+        apiUrl: server.url,
+        identity,
+        spaceName,
+      });
+      let cancelFirst: (() => void) | undefined;
+      try {
+        const sourcePath = join(
+          import.meta.dirname!,
+          "..",
+          "lunch-poll",
+          "main.tsx",
+        );
+        const rootPath = join(import.meta.dirname!, "..");
+        const program = await first.manager().runtime.harness.resolve(
+          new FileSystemProgramResolver(sourcePath, rootPath),
+        );
+        const piece = await first.create(program, { start: true });
+        pieceId = piece.id;
+        cancelFirst = first.manager().getResult(piece.getCell()).sink(() => {});
+
+        await piece.result.set({ name: "Reload Host" }, ["joinAs"]);
+        await piece.result.set(
+          { title: VISIT_TITLE, wentAt: VISIT_TIME },
+          ["logVisit"],
+        );
+        await first.manager().runtime.idle();
+        await first.manager().synced();
+
+        const warmVisits = visitsFrom(await piece.input.get(["visits"]));
+        assertEquals(warmVisits.length, 1);
+        assertEquals(warmVisits[0].title, VISIT_TITLE);
+        visitId = warmVisits[0].id;
+        assertMatch(visitId, /^h_/);
+      } finally {
+        cancelFirst?.();
+        await first.dispose();
+      }
+
+      // A new controller means a new Runtime and empty replica/cache. Reopen by
+      // durable piece id WITHOUT starting it: both the PerUser leaf and visit
+      // entities must be readable from persisted input links alone.
+      const second = await initializePiecesController({
+        apiUrl: server.url,
+        identity,
+        spaceName,
+      });
+      let cancelSecond: (() => void) | undefined;
+      try {
+        const piece = await second.get(pieceId, false);
+
+        const coldVisits = visitsFrom(await piece.input.get(["visits"]));
+        assertEquals(coldVisits.length, 1);
+        assertEquals(coldVisits[0].id, visitId);
+        assertEquals(coldVisits[0].title, VISIT_TITLE);
+        assertEquals(coldVisits[0].loggedByName, "Reload Host");
+        assertEquals(coldVisits[0].wentAt, VISIT_TIME);
+        assertEquals(coldVisits[0].votes, []);
+        assertEquals(await piece.input.get(["myName"]), "Reload Host");
+
+        await second.start(pieceId);
+        cancelSecond = second.manager().getResult(piece.getCell()).sink(
+          () => {},
+        );
+        await second.manager().runtime.idle();
+
+        const recentVisits = visitsFrom(
+          await piece.result.get(["recentVisits"]),
+        );
+        assertEquals(recentVisits.length, 1);
+        assertEquals(recentVisits[0].id, visitId);
+        assertEquals(recentVisits[0].title, VISIT_TITLE);
+        assertEquals(await piece.result.get(["historyCount"]), 1);
+        assertEquals(
+          await piece.result.get(["mostRecentTitle"]),
+          VISIT_TITLE,
+        );
+      } finally {
+        cancelSecond?.();
+        await second.dispose();
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("merges concurrent visits while enforcing the newest-200 cap", async () => {
+    const identity = await Identity.fromPassphrase(
+      "lunch-poll concurrent history host",
+      { implementation: "noble" },
+    );
+    const seededVisits = Array.from({ length: 199 }, (_, index) => ({
+      id: `h_seed_${index}`,
+      title: `Seed ${index}`,
+      loggedByName: "Concurrent Host",
+      loggedBy: null,
+      wentAt: index,
+      votes: [],
+    }));
+    const harness = await MultiRuntimeHarness.create({
+      programPath: join(
+        import.meta.dirname!,
+        "..",
+        "lunch-poll",
+        "main.tsx",
+      ),
+      rootPath: join(import.meta.dirname!, ".."),
+      input: { visits: seededVisits },
+      sessions: [
+        { label: "host-a", identity },
+        { label: "host-b", identity },
+      ],
+    });
+
+    try {
+      const hostA = harness.session("host-a");
+      const hostB = harness.session("host-b");
+      await hostA.send("joinAs", { name: "Concurrent Host" });
+      await harness.waitFor(
+        "second host session resolves shared PerUser identity",
+        async () => (await hostB.read(["isAdmin"])) === true,
+      );
+
+      await Promise.all([
+        hostA.send(
+          "logVisit",
+          { title: "Concurrent A", wentAt: 10_000 },
+          undefined,
+          { idle: false },
+        ),
+        hostB.send(
+          "logVisit",
+          { title: "Concurrent B", wentAt: 10_001 },
+          undefined,
+          { idle: false },
+        ),
+      ]);
+
+      await harness.waitFor(
+        "both concurrent visits land under the cap",
+        async () => {
+          const rows = visitsFrom(await hostA.read(["recentVisits"]));
+          const titles = rows.map((row) => row.title);
+          return (await hostA.read(["historyCount"])) === 200 &&
+            titles.includes("Concurrent A") &&
+            titles.includes("Concurrent B");
+        },
+      );
+
+      for (const session of [hostA, hostB]) {
+        const rows = visitsFrom(await session.read(["recentVisits"]));
+        const titles = rows.map((row) => row.title);
+        assert(titles.includes("Concurrent A"));
+        assert(titles.includes("Concurrent B"));
+        assertEquals(await session.read(["historyCount"]), 200);
+        assertEquals(
+          await session.read(["mostRecentTitle"]),
+          "Concurrent B",
+        );
+      }
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("preserves a generic opaque schema-less target on log and clears its membership explicitly", async () => {
+    const server = StandaloneMemoryServer.start();
+    const hostIdentity = await Identity.fromPassphrase(
+      "lunch-poll opaque history",
+      { implementation: "noble" },
+    );
+    const opaqueIdentity = await Identity.fromPassphrase(
+      "lunch-poll opaque history other-scope writer",
+      { implementation: "noble" },
+    );
+    const spaceName = `lunch-poll-opaque-${crypto.randomUUID()}`;
+    const opaqueValue: StoredVisit = {
+      id: "h_opaque_schema_less",
+      title: "Legacy Cafe",
+      loggedByName: "Opaque Host",
+      loggedBy: null,
+      wentAt: VISIT_TIME - 1,
+      votes: [],
+    };
+    let pieceId = "";
+    let originalRawLink: unknown;
+    let originalLinkIdentity:
+      | {
+        id: string;
+        path: readonly PropertyKey[];
+        space: string;
+        scope: "space" | "user" | "session";
+      }
+      | undefined;
+
+    try {
+      // Create the real lunchpoll and establish its host identity first.
+      const first = await initializePiecesController({
+        apiUrl: server.url,
+        identity: hostIdentity,
+        spaceName,
+      });
+      let cancelFirst: (() => void) | undefined;
+      try {
+        const sourcePath = join(
+          import.meta.dirname!,
+          "..",
+          "lunch-poll",
+          "main.tsx",
+        );
+        const rootPath = join(import.meta.dirname!, "..");
+        const program = await first.manager().runtime.harness.resolve(
+          new FileSystemProgramResolver(sourcePath, rootPath),
+        );
+        const piece = await first.create(program, { start: true });
+        pieceId = piece.id;
+        cancelFirst = first.manager().getResult(piece.getCell()).sink(() => {});
+        await piece.result.set({ name: "Opaque Host" }, ["joinAs"]);
+      } finally {
+        cancelFirst?.();
+        await first.dispose();
+      }
+
+      // Generic opaque-membership safety fixture (not an exact reconstruction
+      // of the live space-scoped pre-fix link): a second identity writes a
+      // complete HistoryEntry into its PerUser overlay and places that
+      // schema-less link into the shared visits list. The document is real and
+      // durable, while its different user scope makes it deterministically
+      // opaque to the host identity.
+      const opaqueWriter = await initializePiecesController({
+        apiUrl: server.url,
+        identity: opaqueIdentity,
+        spaceName,
+      });
+      try {
+        const piece = await opaqueWriter.get(pieceId, false);
+        const argument = await piece.input.getCell() as Cell<{
+          visits: StoredVisit[];
+        }>;
+        const runtime = opaqueWriter.manager().runtime;
+        const opaque = runtime.getCell<StoredVisit>(
+          opaqueWriter.manager().getSpace(),
+          { test: "schema-less lunch history", id: crypto.randomUUID() },
+          undefined,
+          undefined,
+          "user",
+        );
+        assertEquals(
+          opaque.getAsNormalizedFullLink().schema,
+          undefined,
+          "fixture target must not carry HistoryEntry schema",
+        );
+        const { error } = await runtime.editWithRetry((tx) => {
+          opaque.withTx(tx).set(opaqueValue);
+          argument.withTx(tx).key("visits").set([opaque.withTx(tx)]);
+        });
+        assert(!error, error?.message);
+        await runtime.idle();
+        await opaqueWriter.manager().synced();
+
+        const visitsCell = argument.key("visits");
+        const raw = visitsCell.getRaw();
+        assert(Array.isArray(raw));
+        assertEquals(raw.length, 1);
+        originalRawLink = raw[0];
+        const parsed = parseLink(originalRawLink, visitsCell);
+        assert(parsed, "schema-less membership must still be a link");
+        originalLinkIdentity = {
+          id: parsed.id,
+          path: [...parsed.path],
+          space: parsed.space,
+          scope: parsed.scope,
+        };
+        assertEquals(parsed.scope, "user");
+        assertEquals(parsed.schema, undefined);
+        assertEquals(opaque.getRaw(), opaqueValue);
+      } finally {
+        await opaqueWriter.dispose();
+      }
+
+      // Reopen through an empty replica so the test cannot succeed from the
+      // opaque writer's in-memory entity/schema cache.
+      const second = await initializePiecesController({
+        apiUrl: server.url,
+        identity: hostIdentity,
+        spaceName,
+      });
+      let cancelSecond: (() => void) | undefined;
+      try {
+        const piece = await second.get(pieceId, false);
+        const argument = await piece.input.getCell() as Cell<{
+          visits: StoredVisit[];
+        }>;
+        const visitsCell = argument.key("visits");
+        await visitsCell.sync();
+        const coldRaw = visitsCell.getRaw();
+        assert(Array.isArray(coldRaw));
+        assertEquals(coldRaw.length, 1);
+        assertEquals(coldRaw[0], originalRawLink);
+        assertEquals(visitsFrom(await piece.input.get(["visits"])), []);
+
+        await second.start(pieceId);
+        cancelSecond = second.manager().getResult(piece.getCell()).sink(
+          () => {},
+        );
+        await second.manager().runtime.idle();
+        await piece.result.set(
+          { title: "Readable New Visit", wentAt: VISIT_TIME },
+          ["logVisit"],
+        );
+        await second.manager().runtime.idle();
+        await second.manager().synced();
+
+        const rawAfterLog = visitsCell.getRaw();
+        assert(Array.isArray(rawAfterLog));
+        assertEquals(
+          rawAfterLog.length,
+          2,
+          "logging must retain the opaque membership and append the keyed row",
+        );
+        const survivingOpaqueLink = rawAfterLog.find((candidate) => {
+          const parsed = parseLink(candidate, visitsCell);
+          return parsed?.id === originalLinkIdentity?.id &&
+            parsed?.space === originalLinkIdentity?.space &&
+            parsed?.scope === originalLinkIdentity?.scope &&
+            JSON.stringify(parsed?.path) ===
+              JSON.stringify(originalLinkIdentity?.path);
+        });
+        assertEquals(survivingOpaqueLink, originalRawLink);
+        assertEquals(await piece.result.get(["historyCount"]), 2);
+
+        // Clear-all is deliberately destructive at the membership layer: it
+        // must remove both the readable keyed row and the opaque legacy link.
+        await piece.result.set({}, ["clearHistory"]);
+        await second.manager().runtime.idle();
+        await second.manager().synced();
+        const rawAfterClear = visitsCell.getRaw();
+        assert(Array.isArray(rawAfterClear));
+        assertEquals(rawAfterClear, []);
+        assertEquals(await piece.result.get(["historyCount"]), 0);
+        assertEquals(
+          visitsFrom(await piece.result.get(["recentVisits"])),
+          [],
+        );
+      } finally {
+        cancelSecond?.();
+        await second.dispose();
+      }
+
+      // Reopen as the opaque writer after host log + clear. The original
+      // target document is unchanged even though clear-all removed its shared
+      // membership link.
+      const verifier = await initializePiecesController({
+        apiUrl: server.url,
+        identity: opaqueIdentity,
+        spaceName,
+      });
+      try {
+        assert(originalLinkIdentity);
+        const opaqueTarget = verifier.manager().runtime.getCellFromLink<
+          StoredVisit
+        >(originalLinkIdentity as never);
+        await opaqueTarget.sync();
+        assertEquals(opaqueTarget.getRaw(), opaqueValue);
+      } finally {
+        await verifier.dispose();
+      }
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
@@ -143,12 +143,15 @@ Verification added or run for this work:
 Keep a per-space log of where the group actually ended up eating, with dates, so
 nobody suggests the same place three days running.
 
-- ✅ Stored in a **`PerSpace<HistoryEntry[]>` array** (the `visits` input),
-  capped at the most-recent `MAX_HISTORY` (200) entries by date. Each entry is
+- ✅ Stored in a **`PerSpace<HistoryEntry[]>` array** (the `visits` input). Each
+  new entry is a deterministic keyed entity containing
   `{ id, title, loggedByName (frozen), loggedBy (live Cell<User> link), wentAt,
   votes }`.
-  Appended via the host-only `logVisit` (`visits.push`, then a cap-trim only on
-  overflow). Each option still has a "✓ we went here" button.
+  The host-only `logVisit` migrates readable legacy rows to keyed links and uses
+  a conflict-checked rewrite to keep the most-recent `MAX_HISTORY` (200)
+  entries. Opaque pre-keying memberships are preserved and use best-effort
+  capping rather than being silently deleted. Each option still has a "✓ we went
+  here" button.
   - History was briefly on a **SQLite `visits` table** (#4144/#4145, the team's
     first dogfood of the SQLite builtins, #3776/#3848). It surfaced real builtin
     bugs (below), but SQLite wasn't the right fit for a small in-cell collection
@@ -156,10 +159,13 @@ nobody suggests the same place three days running.
 - ✅ **Backdating:** a host "Log 'we went here' as of:" date field (blank =
   today) backdates the entry; `logVisit` also accepts an explicit `wentAt`. The
   date draft clears after each log so it defaults back to today.
-- ✅ **Editing:** `removeHistoryEntry({ id })` (a `visits.set(filter)`) drops a
-  single mistaken entry via a per-row ✕; `clearHistory` (two-step confirm)
-  empties the log (`visits.set([])`). Both host-only. The embedded vote snapshot
-  goes with the entry — no separate cascade to keep aligned.
+- ✅ **Editing:** `removeHistoryEntry({ id })` drops keyed membership and clears
+  its entity (with a positional fallback for readable legacy rows);
+  `clearHistory` clears every readable keyed entity and then explicitly empties
+  all membership, including opaque legacy links. Both are host-only. The
+  embedded vote snapshot goes with a readable entry — no separate cascade to
+  keep aligned. An opaque target document is not guessed at or destroyed when
+  its membership is cleared.
 - ✅ Shown as a **"Recently eaten" list below the options** (8 most recent,
   newest first), a `computed` over `visits` rendered with the plain-JSX `.map`
   idiom, labelled with each visit's own date ("Tuesday, May 20").

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -26,8 +26,12 @@
  * options (8 most recent); the host can delete a single mistaken entry
  * (`removeHistoryEntry`) or clear the whole log.
  *
- * Storage: visits live in a `PerSpace<HistoryEntry[]>` array, capped at the
- * MAX_HISTORY most recent (by date). Each `logVisit` embeds a snapshot of
+ * Storage: visits live in a `PerSpace<HistoryEntry[]>` array. Fully readable
+ * history is capped at the MAX_HISTORY most recent (by date). Each new visit is
+ * a keyed entity addressed by its generated id, so its full item schema
+ * survives a cold storage traversal. Opaque or pre-keying memberships are
+ * preserved rather than dropped; their cap is best-effort until they can be
+ * read, repaired, or explicitly cleared. Each `logVisit` embeds a snapshot of
  * everyone's current vote in the entry's `votes` list — the option title is
  * denormalized, so the snapshot survives the option being removed. The
  * "📊 Lunch stats" card derives per-place visit + green/yellow/red tallies from
@@ -263,10 +267,28 @@ const parseVisitDate = (draft: string | undefined): number => {
   return Number.isNaN(t) ? safeDateNow() : t;
 };
 
-// Cap the stored visit log at the most-recent MAX_HISTORY entries (by date). A
-// fabric array lives in one cell, so an unbounded log would grow every computed
-// that reads it; 200 is generous for a lunch poll.
+// Cap fully readable visit history at the most-recent MAX_HISTORY entries (by
+// date). A fabric array lives in one cell, so an unbounded log would grow every
+// computed that reads it; 200 is generous for a lunch poll. Opaque legacy
+// memberships are preserved even when that means temporarily exceeding it.
 const MAX_HISTORY = 200;
+
+// Remove one visit by its deterministic entity address. Visits created before
+// keyed history used append-addressed entities, so retain a positional fallback
+// for those rows. The explicit list read in that fallback stays in the conflict
+// set, making a concurrent membership change retry before the index is used.
+const removeVisitEntity = (visits: HistoryCell, id: string): void => {
+  const entry: Writable<HistoryEntry | undefined> = visits.elementById(id);
+  if (entry.get()) {
+    visits.removeByValue(visits.elementById(id));
+    // The entity document outlives its membership link; clear it so capped or
+    // explicitly deleted visits do not leave keyed history documents behind.
+    entry.set(undefined);
+    return;
+  }
+  const legacyIndex = visits.get().findIndex((visit) => visit.id === id);
+  if (legacyIndex >= 0) visits.removeByValue(visits.key(legacyIndex));
+};
 
 // Label for a visit derived purely from its own timestamp — never from the
 // current clock, so it stays idempotent inside reactive computations (timestamps
@@ -384,8 +406,9 @@ const clearMyVote = handler<ClearVoteEvent, {
 
 // Host-only, same gate as the other mutating admin actions. Logs where the
 // group actually ate — by option id (resolved to its title) or a free title —
-// appending an entry to the `visits` array with everyone's current vote
-// snapshotted inline. Capped at the MAX_HISTORY most-recent entries (by date).
+// adding a keyed entry to the `visits` array with everyone's current vote
+// snapshotted inline. Fully readable history is capped at the MAX_HISTORY
+// most-recent entries (by date).
 const logVisit = handler<LogVisitEvent, {
   visits: HistoryCell;
   options: OptionsCell;
@@ -436,22 +459,59 @@ const logVisit = handler<LogVisitEvent, {
       });
     }
 
-    const entry: HistoryEntry = {
-      id: newHistoryId(),
+    const id = newHistoryId();
+    const entryValue: HistoryEntry = {
+      id,
       title: place,
       loggedByName: me,
       loggedBy: cellForName(me),
       wentAt: when,
       votes: voteSnapshot,
     };
-    // Append (push round-trips the live links); cap to the MAX_HISTORY most
-    // recent only on overflow.
-    visits.push(entry);
-    const all = visits.get();
-    if (all.length > MAX_HISTORY) {
-      visits.set(
-        [...all].sort((a, b) => b.wentAt - a.wentAt).slice(0, MAX_HISTORY),
+    const entry = visits.elementById(id);
+    entry.set(entryValue);
+
+    // A legacy or otherwise opaque visit may survive durably as a membership
+    // whose target schema-aware projection cannot return. (`length` still
+    // counts the raw link.) Never CAS-normalize such a list: doing so would
+    // silently delete the opaque member. Add the new keyed row mergeably and
+    // defer exact capping/migration until every membership is readable.
+    const projectedVisits = visits.get() ?? [];
+    const membershipCount = visits.key("length").get();
+    if (projectedVisits.length !== membershipCount) {
+      visits.addUnique(entry);
+      visitDate.set("");
+      return;
+    }
+
+    // A capped newest-N list is content-dependent, not a mergeable set: two
+    // writers can each addUnique from 199 → 200 and converge at 201. Preserve
+    // every item as an entity link, but CAS-rewrite membership/order so a
+    // conflicting writer re-runs against the winner and reapplies the cap.
+    // Re-seed existing rows through the same deterministic address. This
+    // migrates legacy append-addressed memberships whose stored links omitted
+    // the item schema; every retained membership below points at a fully
+    // schema-bearing HistoryEntry entity.
+    const candidates = projectedVisits.map((value) => {
+      const cell = visits.elementById(value.id);
+      cell.set(value);
+      return { value, cell };
+    });
+    candidates.push({ value: entryValue, cell: entry });
+    const ordered = candidates.sort((a, b) => b.value.wentAt - a.value.wentAt);
+    const kept = ordered.slice(0, MAX_HISTORY);
+    const dropped = ordered.slice(MAX_HISTORY);
+    visits.set(kept.map(({ cell }) => cell));
+
+    // A keyed entity document outlives its membership. Clear every dropped
+    // deterministic target (legacy rows were seeded into one just above).
+    // The original anonymous legacy document may remain unreachable, but its
+    // opaque membership is never discarded by this path.
+    for (const oldEntry of dropped) {
+      const oldEntity: Writable<HistoryEntry | undefined> = visits.elementById(
+        oldEntry.value.id,
       );
+      if (oldEntity.get()) oldEntity.set(undefined);
     }
 
     // Reset the date draft so the next log defaults back to today.
@@ -468,7 +528,7 @@ const removeHistoryEntry = handler<RemoveHistoryEntryEvent, {
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
   // The embedded vote snapshot goes with the entry — no separate cascade.
-  visits.set(visits.get().filter((v) => v.id !== id));
+  removeVisitEntity(visits, id);
 });
 
 const clearHistory = handler<ClearHistoryEvent, {
@@ -479,6 +539,15 @@ const clearHistory = handler<ClearHistoryEvent, {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
+  // Explicit host clear-all is authorized destructive semantics. Clear every
+  // readable keyed document first, then overwrite membership so opaque
+  // links (which projection cannot enumerate) cannot leave historyCount /
+  // hasHistory stuck. The projected read remains a commit precondition, so a
+  // concurrent readable log conflicts and retries instead of being silently
+  // lost.
+  for (const entry of visits.get() ?? []) {
+    removeVisitEntity(visits, entry.id);
+  }
   visits.set([]);
 });
 
@@ -551,10 +620,11 @@ export interface CozyPollInput {
   users?: PerSpace<User[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
-  // Durable "we went here" log; each entry embeds its own vote snapshot. Capped
-  // at MAX_HISTORY most-recent entries in `logVisit`. optionDraft etc. are
-  // internal form drafts, declared as local per-session cells in the pattern
-  // body (parking-coordinator idiom).
+  // Durable "we went here" log; each keyed entry embeds its own vote snapshot.
+  // Fully readable history is capped at MAX_HISTORY in `logVisit`; opaque
+  // legacy memberships are retained rather than silently normalized away.
+  // optionDraft etc. are internal form drafts, declared as local per-session
+  // cells in the pattern body (parking-coordinator idiom).
   visits?: PerSpace<HistoryEntry[] | Default<[]>>;
 }
 
@@ -1425,9 +1495,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       // didn't write them, and a computed that RETURNS undefined is
       // indistinguishable from "not yet computed" for cross-runtime readers —
       // so every snapshot yields a real, stable value (the shared EMPTY
-      // constants keep the fallback idempotent across recomputes). The visit
-      // history is no longer a PerSpace input — it lives in SQLite now and is
-      // surfaced via `recentVisits`/`mostRecentTitle` below.
+      // constants keep the fallback idempotent across recomputes). Keyed
+      // PerSpace visit history is surfaced via `recentVisits` and the scalar
+      // projections below.
       options: computed(() => options ?? EMPTY_OPTIONS),
       votes: computed(() => votes ?? EMPTY_VOTES),
       users: computed(() => users ?? EMPTY_USERS),

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -1,5 +1,7 @@
 import { action, computed, Default, pattern, UI, Writable } from "commonfabric";
-import ParticipantIdentityCard from "./participant-identity-card.tsx";
+import ParticipantIdentityCard, {
+  joinAsParticipant,
+} from "./participant-identity-card.tsx";
 import type { User } from "./main.tsx";
 import {
   findNode,
@@ -22,6 +24,45 @@ const findByProp = (
   });
 
 export default pattern(() => {
+  // Bind the handler to deliberately unmaterialized profile values. This is
+  // the runtime shape that exposed the staging failure: an explicit event name
+  // is usable, but unrelated asynchronous wish captures are still undefined.
+  const unresolvedProfileNameSource = new Writable<string>();
+  const unresolvedProfileAvatarSource = new Writable<string>();
+  const unresolvedProfileName = computed(() =>
+    unresolvedProfileNameSource.get()
+  );
+  const unresolvedProfileAvatar = computed(() =>
+    unresolvedProfileAvatarSource.get()
+  );
+  const unresolvedUsers = new Writable<User[] | Default<[]>>([]);
+  const unresolvedMyName = new Writable<string | Default<"">>("");
+  const unresolvedAdminName = new Writable<string | Default<"">>("");
+  const unresolvedJoinName = new Writable<string | Default<"">>("");
+  const joinWithUnresolvedProfile = joinAsParticipant({
+    users: unresolvedUsers,
+    myName: unresolvedMyName,
+    adminName: unresolvedAdminName,
+    joinName: unresolvedJoinName,
+    profileName: unresolvedProfileName,
+    profileAvatar: unresolvedProfileAvatar,
+  });
+
+  // The profile-first path still supplies both resolved values to the same
+  // handler; making those captures optional must not discard the avatar.
+  const profileUsers = new Writable<User[] | Default<[]>>([]);
+  const profileMyName = new Writable<string | Default<"">>("");
+  const profileAdminName = new Writable<string | Default<"">>("");
+  const profileJoinName = new Writable<string | Default<"">>("");
+  const joinWithProfile = joinAsParticipant({
+    users: profileUsers,
+    myName: profileMyName,
+    adminName: profileAdminName,
+    joinName: profileJoinName,
+    profileName: "Profile Pat",
+    profileAvatar: "pat-avatar.png",
+  });
+
   const users = new Writable<User[] | Default<[]>>([]);
   const myName = new Writable<string | Default<"">>("");
   const adminName = new Writable<string | Default<"">>("");
@@ -29,6 +70,32 @@ export default pattern(() => {
     users,
     myName,
     adminName,
+  });
+
+  const action_join_with_unresolved_profile_captures = action(() => {
+    joinWithUnresolvedProfile.send({ name: "Fallback Host" });
+  });
+
+  const assert_joined_despite_unresolved_profile_captures = computed(() => {
+    const currentUsers = unresolvedUsers.get();
+    return currentUsers.length === 1 &&
+      currentUsers[0]?.name === "Fallback Host" &&
+      currentUsers[0]?.avatar === "" &&
+      unresolvedMyName.get() === "Fallback Host" &&
+      unresolvedAdminName.get() === "Fallback Host";
+  });
+
+  const action_join_with_resolved_profile = action(() => {
+    joinWithProfile.send({});
+  });
+
+  const assert_profile_name_and_avatar_preserved = computed(() => {
+    const currentUsers = profileUsers.get();
+    return currentUsers.length === 1 &&
+      currentUsers[0]?.name === "Profile Pat" &&
+      currentUsers[0]?.avatar === "pat-avatar.png" &&
+      profileMyName.get() === "Profile Pat" &&
+      profileAdminName.get() === "Profile Pat";
   });
 
   // Profile-first UI fires `joinAs.send({})` (no name) for the "Join as <name>"
@@ -129,6 +196,10 @@ export default pattern(() => {
 
   return {
     tests: [
+      { action: action_join_with_unresolved_profile_captures },
+      { assertion: assert_joined_despite_unresolved_profile_captures },
+      { action: action_join_with_resolved_profile },
+      { assertion: assert_profile_name_and_avatar_preserved },
       { assertion: assert_initial },
       { assertion: assert_manual_fallback_renders },
       { action: action_join_empty },

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -31,13 +31,13 @@ const PLAYER_COLORS = [
 const trimmedName = (n: string | undefined) => (n ?? "").trim();
 const colorForIndex = (i: number) => PLAYER_COLORS[i % PLAYER_COLORS.length];
 
-const joinAs = handler<JoinEvent, {
+export const joinAsParticipant = handler<JoinEvent, {
   users: ParticipantIdentityUsersCell;
   myName: ParticipantIdentityNameCell;
   adminName: ParticipantIdentityNameCell;
   joinName: ParticipantIdentityNameCell;
-  profileName: string;
-  profileAvatar: string;
+  profileName?: string;
+  profileAvatar?: string;
 }>(
   (
     { name },
@@ -151,7 +151,7 @@ export default pattern<
 
     const profileName = computed(() => profileNameWish.result ?? "");
     const profileAvatar = computed(() => profileAvatarWish.result ?? "");
-    const boundJoin = joinAs({
+    const boundJoin = joinAsParticipant({
       users,
       myName,
       adminName,

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -233,13 +233,26 @@ export class PieceManager {
     return piecesCell;
   }
 
-  async add(newPieces: Cell<unknown>[]): Promise<void> {
+  private async getAddPieceHandler() {
     const defaultPattern = await timePiecePhase(
-      "add.getDefaultPattern",
+      "getAddPieceHandler.getDefaultPattern",
       () => this.getDefaultPattern(true),
     );
     if (!defaultPattern) {
       throw new Error("Cannot add pieces: default pattern not available");
+    }
+
+    // Applying an `asCell: ["stream"]` schema to an absent property still
+    // produces a stream-shaped Cell. Check the stored output first so the
+    // schema view below cannot fabricate a false-positive handler.
+    const defaultPatternOutput = defaultPattern.getRaw();
+    if (
+      !isRecord(defaultPatternOutput) ||
+      Reflect.get(defaultPatternOutput, "addPiece") === undefined
+    ) {
+      throw new Error(
+        "Cannot add pieces: addPiece handler not found on default pattern",
+      );
     }
 
     const cell = defaultPattern.asSchema({
@@ -255,6 +268,22 @@ export class PieceManager {
         "Cannot add pieces: addPiece handler not found on default pattern",
       );
     }
+
+    return addPieceHandler;
+  }
+
+  /**
+   * Verify that this space's root pattern can register pieces.
+   *
+   * This performs the same lookup and stream validation as {@link add}, but
+   * does not send an event or mutate the piece list.
+   */
+  async assertCanAddPieces(): Promise<void> {
+    await this.getAddPieceHandler();
+  }
+
+  async add(newPieces: Cell<unknown>[]): Promise<void> {
+    const addPieceHandler = await this.getAddPieceHandler();
 
     // Send each piece and wait for transaction commit.
     // The onCommit callback fires both on success AND when retries are

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -30,6 +30,24 @@ class PiecePropIo implements PieceCellIo {
   async get(path?: CellPath) {
     const targetCell = await this.#getTargetCell();
     await targetCell.pull();
+
+    // A concrete root schema can contain a narrower-scope write redirect
+    // (PerUser / PerSession). Pulling the root only syncs its declared address;
+    // key() then inherits that "synced" bit even though resolving the redirect
+    // reaches a different scope that a cold replica has not loaded. Explicitly
+    // sync the resolved requested cell before the synchronous path read.
+    if (path?.length) {
+      let requestedCell = targetCell;
+      for (const segment of path) {
+        requestedCell = requestedCell.key(
+          segment as keyof unknown,
+        ) as Cell<unknown>;
+      }
+      const resolvedCell = requestedCell.resolveAsCell();
+      await resolvedCell.sync();
+      await resolvedCell.pull();
+    }
+
     return resolveCellPath(targetCell, path ?? []);
   }
 

--- a/packages/piece/test/default-pattern-persistence.test.ts
+++ b/packages/piece/test/default-pattern-persistence.test.ts
@@ -139,6 +139,11 @@ describe("PieceManager default pattern persistence", () => {
     );
   });
 
+  it("preflight resolves once the default pattern registers pieces", async () => {
+    await createDefaultPatternPieceWithResult(manager);
+    await manager.assertCanAddPieces();
+  });
+
   it("reads persisted allPieces without restarting the default pattern", async () => {
     const { commonfabric } = createBuilder();
     const { handler, pattern } = commonfabric;

--- a/packages/piece/test/default-pattern-persistence.test.ts
+++ b/packages/piece/test/default-pattern-persistence.test.ts
@@ -119,6 +119,26 @@ describe("PieceManager default pattern persistence", () => {
     await storageManager?.close();
   });
 
+  it("preflights the default pattern's actual addPiece stream", async () => {
+    const { commonfabric } = createBuilder();
+    const { pattern } = commonfabric;
+    const rootWithoutRegistration = pattern(() => ({
+      allPieces: [] as Cell<unknown>[],
+    }));
+    const rootPiece = await manager.runPersistent(
+      rootWithoutRegistration,
+      {},
+      "root-without-registration",
+    );
+    await manager.linkDefaultPattern(rootPiece);
+    await manager.runtime.idle();
+    await manager.synced();
+
+    await expect(manager.assertCanAddPieces()).rejects.toThrow(
+      "addPiece handler not found on default pattern",
+    );
+  });
+
   it("reads persisted allPieces without restarting the default pattern", async () => {
     const { commonfabric } = createBuilder();
     const { handler, pattern } = commonfabric;


### PR DESCRIPTION
## What changed

- preflight `cf piece new` against the real root `addPiece` stream before source resolution or durable creation
- require the normal registered-piece path in a named non-home space and remove the experimental home-space `--no-register` bypass
- register a created piece before optional slug assignment; preserve the durable piece ID and give safe inspection/recovery guidance on post-create failures
- hydrate explicitly requested scoped piece paths so one-shot CLI reads fetch the `PerUser` target instead of returning its default
- allow lunchpoll's explicit-name fallback when profile wishes are unresolved
- persist visit history through schema-bearing keyed entities, preserve opaque memberships during ordinary logs, and cap conflict/retry-safe history at 200 entries
- make explicit clear-all remove memberships without guessing or destroying unreadable target documents

## Why

The per-space Toolshed staging POC exposed four application/runtime failures that looked like lost state but were not ZFS failures:

1. home-space piece creation wrote a piece before failing registration
2. unresolved profile captures blocked manual join
3. cold one-shot CLI reads returned the default for a durable `PerUser` value
4. anonymously appended visit links could not be projected in a cold runtime

The POC proved that a slug-only home-space bypass was technically possible, but the selected contract keeps the system home out of the piece-registry role. Ordinary pieces belong to a named space with a registration-capable root.

## Impact

`piece new` aimed at a home space now fails before creation with named-space guidance. A successful named-space create is registered before its optional slug is assigned and remains discoverable if slug assignment fails. Because registration can commit before later settling fails, the CLI reports that outcome as unknown and prints a shell-safe inspection command instead of claiming the piece is absent.

The scoped-read, no-profile join, and keyed-history fixes remain unchanged. The staging canary pinned to `600d728445ab3db6a68ec81e26b2c660495e548a` is historical evidence for the storage/application lifecycle, not the final CLI bootstrap contract.

## Validation

- `deno task check` — 296 paths
- `deno task --cwd packages/cli test`
- focused `packages/cli/test/piece.test.ts` — 36 steps
- `deno fmt --check` and `deno lint` on the changed CLI files
- registered named-space create/list/slug/cold-reload regression
- focused lunchpoll suite and cold/concurrent/opaque history integration from the earlier PR head
- `git diff --check`

## Coverage ratchet

`NEW_PERF_BASELINE: coverage-debt: packages/patterns uncovered lines = 241847 lines`

The six new uncovered `packages/patterns` lines are defensive migration branches in `logVisit`/`removeVisitEntity`. They require storage-level legacy, opaque, or 200-entry states that the pattern-unit idiom cannot fabricate; the end-to-end history integration exercises them, but pattern-runtime coverage is collected only from pattern-unit chunks.
