### PR TITLE
feat(runner,memory,toolshed): pattern-perf telemetry — per-action durations, settle signal, client↔server commit join

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2157,6 +2157,11 @@
           "npm:@opentelemetry/api@^1.9.0"
         ]
       },
+      "packages/patterns": {
+        "dependencies": [
+          "npm:@opentelemetry/api@^1.7.0"
+        ]
+      },
       "packages/runner": {
         "dependencies": [
           "npm:@opentelemetry/api@^1.7.0",

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1918,6 +1918,17 @@ export class Server {
         if (message.commit.branch !== undefined) {
           span.setAttribute("branch", message.commit.branch);
         }
+        // (space.did, session.id, commit.local_seq) is the deterministic join
+        // to the CLIENT half of this commit (the runner's storage.push span).
+        // Unlike request.id — minted per send attempt and re-minted on
+        // reconnect resends — localSeq is stable across retries and known
+        // before the response, so it also identifies rejected commits.
+        if (message.sessionId !== undefined) {
+          span.setAttribute("session.id", message.sessionId);
+        }
+        if (message.commit.localSeq !== undefined) {
+          span.setAttribute("commit.local_seq", message.commit.localSeq);
+        }
         try {
           const engine = await this.openEngine(message.space);
           // The session may be revoked or replaced while openEngine awaits.

--- a/packages/patterns/deno.jsonc
+++ b/packages/patterns/deno.jsonc
@@ -62,5 +62,11 @@
   },
   "exports": {
     ".": "./mod.ts"
+  },
+  // Interface-only (side-effect free); used by the multi-runtime harness
+  // worker to hand the runtime→OTel bridge the ambient tracer/meter when the
+  // process runs under Deno's native OpenTelemetry.
+  "imports": {
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.7.0"
   }
 }

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -172,6 +172,40 @@ function installWsDelay(delayMs: number): void {
   globalThis.WebSocket = Delayed;
 }
 
+// When the harness process runs under Deno's native OpenTelemetry
+// (`OTEL_DENO=true deno run --unstable-otel …` — the harness has no SDK setup
+// of its own), `@opentelemetry/api`'s globals resolve to Deno's providers, so
+// bridging the runtime's existing telemetry bus exports scheduler spans and
+// ct.* metrics with zero configuration. Inert otherwise: without a registered
+// provider the API hands the bridge no-op instruments. Also flips the
+// preflight-telemetry gate, which is what runtime-client's
+// setTelemetryEnabled(true) does for browser sessions — without it the
+// scheduler.event.preflight markers never fire.
+async function maybeAttachOtelBridge(identity: Identity): Promise<void> {
+  const env = (name: string): string | undefined =>
+    typeof Deno !== "undefined" ? Deno.env.get(name) : undefined;
+  const otelActive = env("OTEL_DENO") === "true" || env("OTEL_DENO") === "1" ||
+    env("OTEL_ENABLED") === "true";
+  if (!otelActive) return;
+  const [{ attachRuntimeTelemetryOtelBridge }, { metrics, trace }] =
+    await Promise.all([
+      import("@commonfabric/runner/telemetry-otel-bridge"),
+      import("@opentelemetry/api"),
+    ]);
+  const manager = controller().manager();
+  const runtime = manager.runtime;
+  attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
+    tracer: trace.getTracer("ct-runner-bridge"),
+    meter: metrics.getMeter("ct-runner-bridge"),
+    attributes: {
+      "ct.runtime": "harness",
+      "space.did": manager.getSpace(),
+      "user.did": identity.did(),
+    },
+  });
+  runtime.scheduler.setEventPreflightTelemetryEnabled(true);
+}
+
 const handlers: Record<
   string,
   (args: Record<string, unknown>) => Promise<unknown>
@@ -189,6 +223,7 @@ const handlers: Record<
       scheduler.enableSettleStats();
       scheduler.setActionRunTraceEnabled(true);
     }
+    await maybeAttachOtelBridge(identity);
     return { did: identity.did() };
   },
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -901,6 +901,12 @@ export class Runtime {
     });
 
     this.storageManager = options.storageManager;
+    // Hand the storage layer the telemetry bus so it can emit the
+    // storage.push/pull markers (duck-typed: only the v2 StorageManager
+    // implements it; emulated/test managers simply don't have the method).
+    (this.storageManager as {
+      setTelemetry?: (telemetry: RuntimeTelemetry) => void;
+    }).setTelemetry?.(this.telemetry);
     this.moduleByteCache = options.moduleByteCache;
     // Validated + digested + frozen before the trust-snapshot provider
     // default below, whose `revision` covers the config digest (a trust

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1573,6 +1573,15 @@ export class Scheduler {
       );
     }
 
+    this.runtime.telemetry.submit({
+      type: "scheduler.settle",
+      durationMs: settleResult.settleDurationMs,
+      iterations: settleResult.iterationsRun,
+      settledEarly: settleResult.settledEarly,
+      seedCount: initialSeeds.size,
+      workSetSize: settleResult.lastWorkSet.size,
+    });
+
     this.clearProvisionalDemandAtPassEnd();
     this.activePassId = undefined;
 

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -422,6 +422,15 @@ function finalizeSchedulerAction(
   // Record action execution time for cycle-aware scheduling
   const elapsed = performance.now() - args.actionStartTime;
   recordActionTime(state.actionTimingState, args.action, elapsed);
+  state.runtime.telemetry.submit({
+    type: "scheduler.run.complete",
+    actionId: args.actionId,
+    actionInfo: state.getActionTelemetryInfo(args.action),
+    durationMs: elapsed,
+    ...(args.error !== undefined
+      ? { error: args.error instanceof Error ? args.error.message : "error" }
+      : {}),
+  });
   state.maybeAutoDebounce(args.action);
   state.markActionHasRun(args.action);
   state.markNodeHasRun(args.action);

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -296,6 +296,10 @@ export type SchedulerSettleResult = {
   lastWorkSet: Set<Action>;
   earlyIterationComputations: Set<Action>;
   maxSettleIterations: number;
+  /** Iterations that actually ran work (excludes the final settled check). */
+  iterationsRun: number;
+  /** Wall-clock of the settle loop, measured unconditionally. */
+  settleDurationMs: number;
   settleStats?: SettleStats;
 };
 

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -103,7 +103,10 @@ export async function runPullSchedulerSettleLoop(
   const settleIterStats: SettleIterationStats[] | undefined = collectSettleStats
     ? []
     : undefined;
-  const settleStartTime = collectSettleStats ? performance.now() : 0;
+  // Measured unconditionally (unlike the opt-in per-iteration stats): the
+  // scheduler.settle telemetry marker needs it on every pass.
+  const settleStartTime = performance.now();
+  let iterationsRun = 0;
 
   for (let settleIter = 0; settleIter < maxSettleIterations; settleIter++) {
     const iterStart = settleIterStats ? performance.now() : 0;
@@ -121,6 +124,7 @@ export async function runPullSchedulerSettleLoop(
       settledEarly = true;
       break;
     }
+    iterationsRun++;
 
     lastWorkSet = iteration.workSet;
     const iterationWorkSetSize = iteration.workSet.size;
@@ -154,6 +158,8 @@ export async function runPullSchedulerSettleLoop(
     lastWorkSet,
     earlyIterationComputations,
     maxSettleIterations,
+    iterationsRun,
+    settleDurationMs: performance.now() - settleStartTime,
     ...(settleStats ? { settleStats } : {}),
   };
 }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5,6 +5,7 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { Entity } from "@commonfabric/memory/interface";
+import type { RuntimeTelemetryMarker } from "../telemetry.ts";
 import {
   type ConflictError as IConflictError,
   type ConnectionError as IConnectionError,
@@ -730,6 +731,18 @@ export class StorageManager implements IStorageManager {
   #seedHosts: Record<string, string>;
   /** Late-bound host hints; see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
+  /** Late-bound marker sink (the Runtime's telemetry bus); see setTelemetry. */
+  #telemetry?: TelemetrySink;
+
+  /**
+   * Attach the runtime's telemetry bus so replicas can emit the
+   * `storage.push/pull.*` markers. Late-bound and optional: the manager is
+   * constructed before (and independently of) the Runtime, and providers read
+   * it through a getter so spaces opened earlier still pick it up.
+   */
+  setTelemetry(telemetry: TelemetrySink): void {
+    this.#telemetry = telemetry;
+  }
 
   static open(options: Options) {
     const dynamicHosts = new Map<string, string>();
@@ -825,6 +838,7 @@ export class StorageManager implements IStorageManager {
         createSession: this.#sessionFactory.supportsAclBootstrap === true
           ? () => this.#createInitializedSession(space, signer)
           : () => this.#sessionFactory.create(space, signer),
+        getTelemetry: () => this.#telemetry,
       });
       this.#providers.set(space, provider);
     }
@@ -1246,7 +1260,16 @@ type ProviderOptions = {
     client: MemoryV2Client.Client;
     session: MemoryV2Client.SpaceSession;
   }>;
+  /** Late-bound: resolves to the Runtime's telemetry bus once attached. */
+  getTelemetry?: () => TelemetrySink | undefined;
 };
+
+/**
+ * Minimal marker sink — structurally the Runtime's `RuntimeTelemetry`.
+ * Kept structural (type-only import) so the storage layer takes no runtime
+ * dependency on the telemetry module.
+ */
+type TelemetrySink = { submit(marker: RuntimeTelemetryMarker): void };
 
 class Provider implements IStorageProviderWithReplica {
   readonly replica: SpaceReplica;
@@ -1417,6 +1440,7 @@ class SpaceReplica implements ISpaceReplica {
   #watchedIds = new Set<string>();
   #nextLocalSeq = 1;
   #closed = false;
+  #getTelemetry: () => TelemetrySink | undefined;
   #caughtUpLocalSeq = 0;
   #caughtUpLocalSeqWaiters: {
     localSeq: number;
@@ -1433,6 +1457,7 @@ class SpaceReplica implements ISpaceReplica {
     this.#space = options.space;
     this.#subscription = options.subscription;
     this.#createSession = options.createSession;
+    this.#getTelemetry = options.getTelemetry ?? (() => undefined);
   }
 
   did(): MemorySpace {
@@ -2303,6 +2328,18 @@ class SpaceReplica implements ISpaceReplica {
         }
       }
     }
+    // The push marker window covers observation flush + (re)dial + send +
+    // confirm: the full client-side cost of durably landing this commit.
+    // (space.did, commit.local_seq) joins to the server's memory.transact span.
+    const telemetry = this.#getTelemetry();
+    const pushOpId = `push:${this.#space}:${localSeq}`;
+    telemetry?.submit({
+      type: "storage.push.start",
+      id: pushOpId,
+      operation: "transact",
+      localSeq,
+      spaceDid: this.#space,
+    });
     try {
       if (
         operations.length > 0 &&
@@ -2320,9 +2357,19 @@ class SpaceReplica implements ISpaceReplica {
       const { session } = await this.sessionHandle();
       const applied = await session.transact(commit);
       this.confirmPending(localSeq, operations, applied);
+      telemetry?.submit({
+        type: "storage.push.complete",
+        id: pushOpId,
+        sessionId: session.sessionId,
+      });
       return { ok: {} };
     } catch (error) {
       const rejection = toRejectedError(error, commit, this.#space);
+      telemetry?.submit({
+        type: "storage.push.error",
+        id: pushOpId,
+        error: rejection.name ?? "TransactionError",
+      });
       this.attachProviderReadyToRetry(rejection, localSeq);
       if (admissionMode !== "off" && rejection.name === "ConflictError") {
         this.recordStaleFloor(commit, localSeq);

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -48,6 +48,15 @@ export interface OtelBridgeOptions {
    * bare key ambiguous (resource vs attribute context) in SigNoz queries.
    */
   metricAttributes?: Attributes;
+  /**
+   * Minimum action-run duration that earns a retroactive `scheduler.action.run`
+   * span. Measured on the lunch-poll diagnose workload: ~4.4% of runs exceed
+   * 10ms (the distribution is bimodal — sub-ms computations vs 10–25ms
+   * effects), so the default adds ~5% span volume, not a multiplier. Every run
+   * still lands in the `ct.scheduler.action.duration_ms` histogram.
+   * @default 10
+   */
+  actionRunSpanThresholdMs?: number;
 }
 
 export interface RuntimeTelemetryOtelBridge {
@@ -86,6 +95,7 @@ export function createRuntimeTelemetryOtelBridge(
   options: OtelBridgeOptions,
 ): RuntimeTelemetryOtelBridge {
   const { tracer, meter } = options;
+  const actionRunSpanThresholdMs = options.actionRunSpanThresholdMs ?? 10;
   const base = options.attributes ?? {};
   const attrs = (extra?: Attributes): Attributes =>
     extra ? { ...base, ...extra } : base;
@@ -142,6 +152,22 @@ export function createRuntimeTelemetryOtelBridge(
     "ct.scheduler.preflight.dirty_dependency_count",
     { description: "Dirty dependencies collected per event" },
   );
+  // Per-run action duration — the signal that names a hot derive directly
+  // (group by ct.module). Same measurement ActionStats records.
+  const actionDuration = meter.createHistogram(
+    "ct.scheduler.action.duration_ms",
+    { unit: "ms", description: "Scheduler action run duration" },
+  );
+  // Settle pass duration/iterations — the user-facing "event → stable graph"
+  // numbers, emitted unconditionally per settle pass.
+  const settleDuration = meter.createHistogram(
+    "ct.scheduler.settle.duration_ms",
+    { unit: "ms", description: "Settle loop wall-clock per pass" },
+  );
+  const settleIterations = meter.createHistogram(
+    "ct.scheduler.settle.iterations",
+    { description: "Settle iterations that ran work, per pass" },
+  );
   // busyRatio is the runner-thrash smoking gun: fraction of a window spent busy.
   const busyRatio = meter.createHistogram("ct.scheduler.busy_ratio", {
     description: "Non-settling window busy ratio (0..1)",
@@ -184,20 +210,28 @@ export function createRuntimeTelemetryOtelBridge(
     id: string,
     kind: "push" | "pull",
     operation: string,
+    extra?: Attributes,
   ) => {
     const span = tracer.startSpan(`storage.${kind}`, {
       attributes: attrs({
         "ct.storage.kind": kind,
         "ct.storage.operation": operation,
+        ...extra,
       }),
     });
     openOps.set(id, { span, startMs: nowMs() });
   };
 
-  const endStorageOp = (id: string, kind: "push" | "pull", error?: string) => {
+  const endStorageOp = (
+    id: string,
+    kind: "push" | "pull",
+    error?: string,
+    sessionId?: string,
+  ) => {
     const open = openOps.get(id);
     const durationMs = open ? nowMs() - open.startMs : undefined;
     if (open) {
+      if (sessionId) open.span.setAttribute("session.id", sessionId);
       if (error) {
         open.span.setStatus({ code: SpanStatusCode.ERROR, message: error });
         open.span.setAttribute("error", true);
@@ -224,6 +258,40 @@ export function createRuntimeTelemetryOtelBridge(
             "ct.error": !!marker.error,
           }),
         );
+        break;
+      case "scheduler.run.complete": {
+        actionDuration.record(
+          marker.durationMs,
+          mattrs({
+            ...patternAttrs(marker.actionInfo),
+            "ct.error": !!marker.error,
+          }),
+        );
+        if (marker.durationMs >= actionRunSpanThresholdMs) {
+          // Retroactive span, same technique as scheduler.preflight: the run
+          // already happened; reconstruct its window from the duration.
+          const end = Date.now();
+          const span = tracer.startSpan("scheduler.action.run", {
+            startTime: end - Math.round(marker.durationMs),
+            attributes: attrs({
+              ...patternAttrs(marker.actionInfo),
+              "ct.action_id": marker.actionId,
+              "ct.duration_ms": marker.durationMs,
+            }),
+          });
+          if (marker.error) {
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: marker.error,
+            });
+          }
+          span.end(end);
+        }
+        break;
+      }
+      case "scheduler.settle":
+        settleDuration.record(marker.durationMs, mattrs());
+        settleIterations.record(marker.iterations, mattrs());
         break;
       case "scheduler.invocation":
         invocations.add(1, mattrs(patternAttrs(marker.handlerInfo)));
@@ -286,13 +354,20 @@ export function createRuntimeTelemetryOtelBridge(
         nonSettling.add(1, mattrs());
         break;
       case "storage.push.start":
-        startStorageOp(marker.id, "push", marker.operation);
+        // localSeq/space join to the server's memory.transact span, which
+        // stamps the same pair as commit.local_seq / space.did.
+        startStorageOp(marker.id, "push", marker.operation, {
+          ...(marker.localSeq !== undefined
+            ? { "commit.local_seq": marker.localSeq }
+            : {}),
+          ...(marker.spaceDid ? { "space.did": marker.spaceDid } : {}),
+        });
         break;
       case "storage.push.complete":
-        endStorageOp(marker.id, "push");
+        endStorageOp(marker.id, "push", undefined, marker.sessionId);
         break;
       case "storage.push.error":
-        endStorageOp(marker.id, "push", marker.error);
+        endStorageOp(marker.id, "push", marker.error, marker.sessionId);
         break;
       case "storage.pull.start":
         startStorageOp(marker.id, "pull", marker.operation);

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -152,6 +152,24 @@ export type RuntimeTelemetryMarker = {
   actionInfo?: SchedulerActionInfo;
   error?: string;
 } | {
+  // Emitted when an action run finishes, next to the ActionStats recording —
+  // the same wall-clock measurement, surfaced as a marker so consumers (OTel
+  // bridge, debugger) get per-run durations without polling getActionStats().
+  type: "scheduler.run.complete";
+  actionId: string;
+  actionInfo?: SchedulerActionInfo;
+  durationMs: number;
+  error?: string;
+} | {
+  // Emitted once per settle pass, unconditionally (unlike SettleStats, which
+  // is opt-in): the user-facing "event → stable graph" number.
+  type: "scheduler.settle";
+  durationMs: number;
+  iterations: number;
+  settledEarly: boolean;
+  seedCount: number;
+  workSetSize: number;
+} | {
   type: "cell.update";
   change: IMemoryChange;
   error?: string;
@@ -204,14 +222,22 @@ export type RuntimeTelemetryMarker = {
   type: "storage.push.start";
   id: string;
   operation: string;
+  // Client-side commit sequence + space: the join keys to the memory
+  // server's `memory.transact` span (commit.local_seq / space.did attrs).
+  localSeq?: number;
+  spaceDid?: string;
   error?: string;
 } | {
   type: "storage.push.complete";
   id: string;
+  // Session is only known once the connection is established, so the
+  // session-scoped join key rides the completion rather than the start.
+  sessionId?: string;
   error?: string;
 } | {
   type: "storage.push.error";
   id: string;
+  sessionId?: string;
   error: string;
 } | {
   type: "storage.pull.start";

--- a/packages/runner/test/commit-conflict-reconcile.test.ts
+++ b/packages/runner/test/commit-conflict-reconcile.test.ts
@@ -19,6 +19,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("read-repair-strand");
@@ -129,6 +130,19 @@ describe("read-repair: stale read after cross-replica conflict", () => {
       v: "v0",
     });
 
+    // The rejected commit must also surface through the telemetry markers:
+    // storage.push.error is the client half of the rejected-commit join
+    // (space.did + commit.local_seq — known before the response, unlike a
+    // confirmed seq).
+    const pushMarkers: { type: string; localSeq?: number; error?: string }[] =
+      [];
+    rtB.telemetry.addEventListener("telemetry", (event) => {
+      const marker = (event as RuntimeTelemetryEvent).marker;
+      if (marker.type.startsWith("storage.push.")) {
+        pushMarkers.push(marker as (typeof pushMarkers)[number]);
+      }
+    });
+
     // B commits its v0-based write — the server rejects it (stale read).
     const resB = await txB.commit();
     expect(resB.error, "B's commit should be rejected (conflict)")
@@ -136,6 +150,16 @@ describe("read-repair: stale read after cross-replica conflict", () => {
     expect(
       (resB.error as { name?: string })?.name,
       "cross-replica conflict is a ConflictError",
+    ).toBe("ConflictError");
+
+    const startMarker = pushMarkers.find((m) =>
+      m.type === "storage.push.start"
+    );
+    expect(startMarker?.localSeq, "push.start carries the join key")
+      .toBeDefined();
+    expect(
+      pushMarkers.find((m) => m.type === "storage.push.error")?.error,
+      "rejected commit emits storage.push.error with the rejection name",
     ).toBe("ConflictError");
 
     // INVARIANT under test: after the rejection, B's read must not be staler

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -424,10 +424,32 @@ describe("scheduler.run.complete / scheduler.settle / storage join keys", () => 
     }));
     expect(t.spans[0].attributes["commit.local_seq"]).toBe(7);
     expect(t.spans[0].attributes["space.did"]).toBe("did:key:zX");
-    bridge.handleMarker(
-      marker({ id: "push:did:key:zX:7", type: "storage.push.complete" }),
-    );
+    bridge.handleMarker(marker({
+      id: "push:did:key:zX:7",
+      type: "storage.push.complete",
+      sessionId: "session-a",
+    }));
+    expect(t.spans[0].setAttributes["session.id"]).toBe("session-a");
     expect(t.spans[0].ended).toBe(true);
+
+    // Error half: the rejected-commit span keeps the same join keys and
+    // carries the rejection name.
+    bridge.handleMarker(marker({
+      id: "push:did:key:zX:8",
+      type: "storage.push.start",
+      operation: "transact",
+      localSeq: 8,
+      spaceDid: "did:key:zX",
+    }));
+    bridge.handleMarker(marker({
+      id: "push:did:key:zX:8",
+      type: "storage.push.error",
+      sessionId: "session-a",
+      error: "ConflictError",
+    }));
+    expect(t.spans[1].setAttributes["session.id"]).toBe("session-a");
+    expect(t.spans[1].status?.message).toBe("ConflictError");
+    expect(t.spans[1].ended).toBe(true);
   });
 });
 

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -326,6 +326,111 @@ describe("createRuntimeTelemetryOtelBridge", () => {
   });
 });
 
+describe("scheduler.run.complete / scheduler.settle / storage join keys", () => {
+  it("records action duration and emits a span only at/above the threshold", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const bridge = createRuntimeTelemetryOtelBridge({
+      tracer: t.tracer,
+      meter: m.meter,
+    });
+
+    bridge.handleMarker(marker({
+      type: "scheduler.run.complete",
+      actionId: "hash:1",
+      actionInfo: { patternName: "lunch-poll", moduleName: "tally" },
+      durationMs: 2,
+    }));
+    expect(m.calls).toEqual([{
+      instrument: "ct.scheduler.action.duration_ms",
+      value: 2,
+      attributes: {
+        "ct.pattern": "lunch-poll",
+        "ct.module": "tally",
+        "ct.error": false,
+      },
+    }]);
+    expect(t.spans).toHaveLength(0);
+
+    bridge.handleMarker(marker({
+      type: "scheduler.run.complete",
+      actionId: "hash:2",
+      actionInfo: { patternName: "lunch-poll", moduleName: "tally" },
+      durationMs: 25,
+      error: "boom",
+    }));
+    expect(t.spans).toHaveLength(1);
+    expect(t.spans[0].name).toBe("scheduler.action.run");
+    expect(t.spans[0].attributes["ct.action_id"]).toBe("hash:2");
+    expect(t.spans[0].attributes["ct.duration_ms"]).toBe(25);
+    expect(t.spans[0].status?.message).toBe("boom");
+    expect(t.spans[0].ended).toBe(true);
+    // Retroactive: reconstructed window ≈ durationMs wide.
+    expect(
+      (t.spans[0].endTime ?? 0) - (t.spans[0].startTime ?? 0),
+    ).toBe(25);
+  });
+
+  it("honors a custom action-run span threshold", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const bridge = createRuntimeTelemetryOtelBridge({
+      tracer: t.tracer,
+      meter: m.meter,
+      actionRunSpanThresholdMs: 100,
+    });
+    bridge.handleMarker(marker({
+      type: "scheduler.run.complete",
+      actionId: "hash:3",
+      durationMs: 50,
+    }));
+    expect(t.spans).toHaveLength(0);
+  });
+
+  it("records settle duration and iterations histograms", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const bridge = createRuntimeTelemetryOtelBridge({
+      tracer: t.tracer,
+      meter: m.meter,
+    });
+    bridge.handleMarker(marker({
+      type: "scheduler.settle",
+      durationMs: 120,
+      iterations: 3,
+      settledEarly: false,
+      seedCount: 5,
+      workSetSize: 12,
+    }));
+    expect(m.calls).toEqual([
+      { instrument: "ct.scheduler.settle.duration_ms", value: 120 },
+      { instrument: "ct.scheduler.settle.iterations", value: 3 },
+    ].map((c) => ({ ...c, attributes: {} })));
+  });
+
+  it("stamps commit.local_seq and space.did on storage.push spans", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const bridge = createRuntimeTelemetryOtelBridge({
+      tracer: t.tracer,
+      meter: m.meter,
+    });
+    bridge.handleMarker(marker({
+      id: "push:did:key:zX:7",
+      type: "storage.push.start",
+      operation: "transact",
+      localSeq: 7,
+      spaceDid: "did:key:zX",
+    }));
+    expect(t.spans[0].attributes["commit.local_seq"]).toBe(7);
+    expect(t.spans[0].attributes["space.did"]).toBe("did:key:zX");
+    bridge.handleMarker(
+      marker({ id: "push:did:key:zX:7", type: "storage.push.complete" }),
+    );
+    expect(t.spans[0].ended).toBe(true);
+  });
+});
+
 describe("attachRuntimeTelemetryOtelBridge", () => {
   it("feeds telemetry events through the bridge until detached", () => {
     const m = makeRecordingMeter();

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -18,15 +18,13 @@ const initializeRuntime = () => {
 
     // Options assembly (the MEMORY_URL/API_URL split, EXPERIMENTAL_* wiring)
     // lives in runtime-options.ts, where it is unit-tested (CT-1814).
-    // Construction + the runtime→OTel bridge attach live in
-    // runtime-options.ts (unit-tested there, like the options wiring).
-    ({ runtime } = createToolshedRuntime(
+    runtime = createToolshedRuntime(
       env,
       StorageManager.open({
         memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
-    ));
+    ).runtime;
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);
   } catch (error) {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,9 +1,9 @@
 import app from "@/app.ts";
 import env from "@/env.ts";
 import { identity } from "@/lib/identity.ts";
-import { Runtime } from "@commonfabric/runner";
+import type { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { toolshedRuntimeOptions } from "@/runtime-options.ts";
+import { createToolshedRuntime } from "@/runtime-options.ts";
 import { memory } from "@/routes/storage/memory.ts";
 import { shutdownOpenTelemetry } from "@/lib/otel.ts";
 
@@ -18,37 +18,15 @@ const initializeRuntime = () => {
 
     // Options assembly (the MEMORY_URL/API_URL split, EXPERIMENTAL_* wiring)
     // lives in runtime-options.ts, where it is unit-tested (CT-1814).
-    runtime = new Runtime(toolshedRuntimeOptions(
+    // Construction + the runtime→OTel bridge attach live in
+    // runtime-options.ts (unit-tested there, like the options wiring).
+    ({ runtime } = createToolshedRuntime(
       env,
       StorageManager.open({
         memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
     ));
-    // Second consumer of the runtime's telemetry bus → OTel. Toolshed's own
-    // Runtime only executes patterns for webhook deliveries (interactive
-    // patterns run in browser/bg-piece runtimes), so this is low-volume — but
-    // without it those runs emit markers into the void. Fire-and-forget: the
-    // dynamic import defers OTel module load off the startup path.
-    if (env.OTEL_ENABLED) {
-      Promise.all([
-        import("@commonfabric/runner/telemetry-otel-bridge"),
-        import("@opentelemetry/api"),
-      ]).then(([{ attachRuntimeTelemetryOtelBridge }, { metrics, trace }]) => {
-        attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
-          tracer: trace.getTracer("ct-runner-bridge"),
-          meter: metrics.getMeter("ct-runner-bridge"),
-          attributes: { "ct.runtime": "server" },
-          metricAttributes: {
-            "service.name": env.OTEL_SERVICE_NAME,
-            "deployment.environment": env.ENV,
-          },
-        });
-        runtime.scheduler.setEventPreflightTelemetryEnabled(true);
-      }).catch((error) => {
-        console.warn("Runtime OTel bridge attach failed:", error);
-      });
-    }
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);
   } catch (error) {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -24,7 +24,7 @@ const initializeRuntime = () => {
         memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
-    ).runtime;
+    );
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);
   } catch (error) {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -25,6 +25,30 @@ const initializeRuntime = () => {
         as: identity,
       }),
     ));
+    // Second consumer of the runtime's telemetry bus → OTel. Toolshed's own
+    // Runtime only executes patterns for webhook deliveries (interactive
+    // patterns run in browser/bg-piece runtimes), so this is low-volume — but
+    // without it those runs emit markers into the void. Fire-and-forget: the
+    // dynamic import defers OTel module load off the startup path.
+    if (env.OTEL_ENABLED) {
+      Promise.all([
+        import("@commonfabric/runner/telemetry-otel-bridge"),
+        import("@opentelemetry/api"),
+      ]).then(([{ attachRuntimeTelemetryOtelBridge }, { metrics, trace }]) => {
+        attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
+          tracer: trace.getTracer("ct-runner-bridge"),
+          meter: metrics.getMeter("ct-runner-bridge"),
+          attributes: { "ct.runtime": "server" },
+          metricAttributes: {
+            "service.name": env.OTEL_SERVICE_NAME,
+            "deployment.environment": env.ENV,
+          },
+        });
+        runtime.scheduler.setEventPreflightTelemetryEnabled(true);
+      }).catch((error) => {
+        console.warn("Runtime OTel bridge attach failed:", error);
+      });
+    }
     console.log("Runtime initialized successfully");
     console.log("Configured to remote storage:", env.MEMORY_URL);
   } catch (error) {

--- a/packages/toolshed/lib/otel.ts
+++ b/packages/toolshed/lib/otel.ts
@@ -6,6 +6,7 @@ import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import env from "@/env.ts";
 import { OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-vercel";
 import { samplerFromEnv } from "@/lib/otel-sampler.ts";
+import { detachRuntimeOtelBridgeIfAttached } from "@/runtime-options.ts";
 
 // Ensure we only register once even during hot-reload
 let _providerRegistered = false;
@@ -59,6 +60,9 @@ export function getTracerProvider() {
  * deploy/restart.
  */
 export async function shutdownOpenTelemetry(): Promise<void> {
+  // End any in-flight runtime-bridge spans (e.g. an open storage.push) so
+  // they make the final flush instead of dying with the process.
+  detachRuntimeOtelBridgeIfAttached();
   if (!_provider) return;
   const p = _provider;
   _provider = undefined;

--- a/packages/toolshed/middlewares/opentelemetry.ts
+++ b/packages/toolshed/middlewares/opentelemetry.ts
@@ -67,6 +67,10 @@ export function otelTracing(config: OtelConfig = {}): MiddlewareHandler {
       () =>
         obtainTracer().startActiveSpan(`${method} ${path}`, async (span) => {
           span.setAttribute("http.method", method);
+          // The concrete request path, in addition to any templated route the
+          // span name may carry — without it the target of e.g. a pattern
+          // fetch (`/api/patterns/<file>`) is unrecoverable from the span.
+          span.setAttribute("url.path", path);
           span.setAttribute("http.host", c.req.header("host") || "unknown");
           span.setAttribute(
             "http.user_agent",

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -5,6 +5,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   attachRuntimeOtelBridge,
   createToolshedRuntime,
+  detachRuntimeOtelBridgeIfAttached,
   toolshedRuntimeOptions,
 } from "@/runtime-options.ts";
 
@@ -72,6 +73,11 @@ Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", as
     await runtime.dispose();
     await storageManager.close();
   }
+
+  // A successful attach registers the shutdown detach; detaching is
+  // idempotent and reports whether a bridge was live.
+  assertEquals(detachRuntimeOtelBridgeIfAttached(), true);
+  assertEquals(detachRuntimeOtelBridgeIfAttached(), false);
 
   // Attach failures are logged, never fatal: a runtime whose preflight gate
   // throws must resolve false, not reject.

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -55,12 +55,20 @@ Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", as
 
   for (const enabled of [false, true]) {
     const storageManager = StorageManager.emulate({ as: signer });
-    const { runtime, otelBridgeAttached } = createToolshedRuntime(
+    const runtime = createToolshedRuntime(
       { ...config, OTEL_ENABLED: enabled },
       storageManager,
       () => undefined,
     );
-    assertEquals(await otelBridgeAttached, enabled);
+    // The construction path fire-and-forgets the attach; assert the attach
+    // behavior directly (same runtime, same config).
+    assertEquals(
+      await attachRuntimeOtelBridge(runtime, {
+        ...config,
+        OTEL_ENABLED: enabled,
+      }),
+      enabled,
+    );
     await runtime.dispose();
     await storageManager.close();
   }

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -3,6 +3,7 @@ import { Identity } from "@commonfabric/identity";
 import type { RuntimeOptions } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
+  attachRuntimeOtelBridge,
   createToolshedRuntime,
   toolshedRuntimeOptions,
 } from "@/runtime-options.ts";
@@ -63,4 +64,23 @@ Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", as
     await runtime.dispose();
     await storageManager.close();
   }
+
+  // Attach failures are logged, never fatal: a runtime whose preflight gate
+  // throws must resolve false, not reject.
+  const throwingRuntime = {
+    telemetry: new EventTarget(),
+    scheduler: {
+      setEventPreflightTelemetryEnabled() {
+        throw new Error("gate unavailable");
+      },
+    },
+  } as unknown as Parameters<typeof attachRuntimeOtelBridge>[0];
+  assertEquals(
+    await attachRuntimeOtelBridge(throwingRuntime, {
+      OTEL_ENABLED: true,
+      OTEL_SERVICE_NAME: "toolshed-test",
+      ENV: "test",
+    }),
+    false,
+  );
 });

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals, assertStrictEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
 import type { RuntimeOptions } from "@commonfabric/runner";
-import { toolshedRuntimeOptions } from "@/runtime-options.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  createToolshedRuntime,
+  toolshedRuntimeOptions,
+} from "@/runtime-options.ts";
 
 // Pins toolshed's runtime wiring decisions (CT-1814): the runtime's storage
 // base is MEMORY_URL while patterns fetch against the public API_URL; the
@@ -31,4 +36,31 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
   // Unset flags stay unset (tri-state fidelity), not coerced.
   assertEquals(options.experimental?.persistentSchedulerState, undefined);
   assertEquals(options.cfcEnforcementMode, "enforce-explicit");
+});
+
+// The runtime→OTel bridge attach rides Runtime construction (CT plan: the
+// bridge is a second consumer of the RuntimeTelemetry bus). Off by default;
+// on OTEL_ENABLED it attaches and flips the preflight-telemetry gate. Without
+// a registered OTel provider the API hands the bridge no-op instruments, so
+// the enabled path is safe to exercise in a test.
+Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", async () => {
+  const signer = await Identity.fromPassphrase("runtime-options-otel-test");
+  const config = {
+    MEMORY_URL: "http://memory.test:8000/",
+    API_URL: "http://api.test:9000/",
+    OTEL_SERVICE_NAME: "toolshed-test",
+    ENV: "test",
+  };
+
+  for (const enabled of [false, true]) {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const { runtime, otelBridgeAttached } = createToolshedRuntime(
+      { ...config, OTEL_ENABLED: enabled },
+      storageManager,
+      () => undefined,
+    );
+    assertEquals(await otelBridgeAttached, enabled);
+    await runtime.dispose();
+    await storageManager.close();
+  }
 });

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -1,6 +1,7 @@
 import {
   type EnvReader,
   experimentalOptionsFromEnv,
+  Runtime,
   type RuntimeOptions,
   runtimePresets,
 } from "@commonfabric/runner";
@@ -26,4 +27,59 @@ export function toolshedRuntimeOptions(
     storageManager,
     experimental: experimentalOptionsFromEnv(envGet),
   });
+}
+
+type OtelEnv = Pick<ToolshedEnv, "OTEL_ENABLED" | "OTEL_SERVICE_NAME" | "ENV">;
+
+/**
+ * Construct this toolshed's Runtime and, when OTel is enabled, bridge its
+ * telemetry bus to OpenTelemetry as a second consumer of the same marker
+ * stream the debug tooling uses. Toolshed's Runtime only executes patterns
+ * for webhook deliveries (interactive patterns run in browser/bg-piece
+ * runtimes), so the bridge is low-volume — but without it those runs emit
+ * markers into the void.
+ *
+ * The attach is fire-and-forget off the startup path (dynamic imports defer
+ * OTel module load); the promise is returned so tests can await it. Failures
+ * are logged, never fatal.
+ */
+export function createToolshedRuntime(
+  config: Pick<ToolshedEnv, "MEMORY_URL" | "API_URL"> & OtelEnv,
+  storageManager: RuntimeOptions["storageManager"],
+  envGet: EnvReader = Deno.env.get,
+): { runtime: Runtime; otelBridgeAttached: Promise<boolean> } {
+  const runtime = new Runtime(
+    toolshedRuntimeOptions(config, storageManager, envGet),
+  );
+  return { runtime, otelBridgeAttached: attachOtelBridge(runtime, config) };
+}
+
+async function attachOtelBridge(
+  runtime: Runtime,
+  config: OtelEnv,
+): Promise<boolean> {
+  if (!config.OTEL_ENABLED) return false;
+  try {
+    const [{ attachRuntimeTelemetryOtelBridge }, { metrics, trace }] =
+      await Promise.all([
+        import("@commonfabric/runner/telemetry-otel-bridge"),
+        import("@opentelemetry/api"),
+      ]);
+    attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
+      tracer: trace.getTracer("ct-runner-bridge"),
+      meter: metrics.getMeter("ct-runner-bridge"),
+      attributes: { "ct.runtime": "server" },
+      metricAttributes: {
+        "service.name": config.OTEL_SERVICE_NAME,
+        "deployment.environment": config.ENV,
+      },
+    });
+    // Preflight markers are gated; without the flip the event-admission
+    // spans/histograms never fire.
+    runtime.scheduler.setEventPreflightTelemetryEnabled(true);
+    return true;
+  } catch (error) {
+    console.warn("Runtime OTel bridge attach failed:", error);
+    return false;
+  }
 }

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -47,14 +47,13 @@ export function createToolshedRuntime(
   config: Pick<ToolshedEnv, "MEMORY_URL" | "API_URL"> & OtelEnv,
   storageManager: RuntimeOptions["storageManager"],
   envGet: EnvReader = Deno.env.get,
-): { runtime: Runtime; otelBridgeAttached: Promise<boolean> } {
+): Runtime {
   const runtime = new Runtime(
     toolshedRuntimeOptions(config, storageManager, envGet),
   );
-  return {
-    runtime,
-    otelBridgeAttached: attachRuntimeOtelBridge(runtime, config),
-  };
+  // Fire-and-forget; the attach itself is exported and unit-tested.
+  void attachRuntimeOtelBridge(runtime, config);
+  return runtime;
 }
 
 /**

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -56,22 +56,43 @@ export function createToolshedRuntime(
   return runtime;
 }
 
+// The one live bridge detach (toolshed runs a single Runtime); invoked from
+// shutdownOpenTelemetry so in-flight storage spans are ended before the final
+// flush instead of being dropped with the process.
+let activeOtelBridgeDetach: (() => void) | undefined;
+
+/** Idempotent; returns whether a bridge was attached. */
+export function detachRuntimeOtelBridgeIfAttached(): boolean {
+  const detach = activeOtelBridgeDetach;
+  activeOtelBridgeDetach = undefined;
+  detach?.();
+  return detach !== undefined;
+}
+
 /**
  * Exported for tests; production reaches it through createToolshedRuntime.
  * Structural param so failure paths can be exercised with a stub.
+ *
+ * Metrics caveat: toolshed's own OTel setup (lib/otel.ts) registers a tracer
+ * provider only, so with OTEL_ENABLED alone the bridge's ct.* instruments are
+ * API no-ops. On the VMs the process also runs under Deno native OTel
+ * (OTEL_DENO + --unstable-otel), whose global MeterProvider makes them real —
+ * spans work either way. Deliberate: a second SDK MeterProvider here would
+ * duplicate what Deno native already exports.
  */
 export async function attachRuntimeOtelBridge(
   runtime: Pick<Runtime, "telemetry" | "scheduler">,
   config: OtelEnv,
 ): Promise<boolean> {
   if (!config.OTEL_ENABLED) return false;
+  let detach: (() => void) | undefined;
   try {
     const [{ attachRuntimeTelemetryOtelBridge }, { metrics, trace }] =
       await Promise.all([
         import("@commonfabric/runner/telemetry-otel-bridge"),
         import("@opentelemetry/api"),
       ]);
-    attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
+    detach = attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
       tracer: trace.getTracer("ct-runner-bridge"),
       meter: metrics.getMeter("ct-runner-bridge"),
       attributes: { "ct.runtime": "server" },
@@ -83,8 +104,12 @@ export async function attachRuntimeOtelBridge(
     // Preflight markers are gated; without the flip the event-admission
     // spans/histograms never fire.
     runtime.scheduler.setEventPreflightTelemetryEnabled(true);
+    // Registered only after full success so a failed attach never leaves a
+    // half-wired bridge behind for shutdown to detach.
+    activeOtelBridgeDetach = detach;
     return true;
   } catch (error) {
+    detach?.();
     console.warn("Runtime OTel bridge attach failed:", error);
     return false;
   }

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -51,11 +51,18 @@ export function createToolshedRuntime(
   const runtime = new Runtime(
     toolshedRuntimeOptions(config, storageManager, envGet),
   );
-  return { runtime, otelBridgeAttached: attachOtelBridge(runtime, config) };
+  return {
+    runtime,
+    otelBridgeAttached: attachRuntimeOtelBridge(runtime, config),
+  };
 }
 
-async function attachOtelBridge(
-  runtime: Runtime,
+/**
+ * Exported for tests; production reaches it through createToolshedRuntime.
+ * Structural param so failure paths can be exercised with a stub.
+ */
+export async function attachRuntimeOtelBridge(
+  runtime: Pick<Runtime, "telemetry" | "scheduler">,
   config: OtelEnv,
 ): Promise<boolean> {
   if (!config.OTEL_ENABLED) return false;


### PR DESCRIPTION
Phase 1 of the pattern-performance observability plan (companion to the merged infra work: pivot scripts + runbook annex in commontoolsinc/infra#67). Everything here extends the existing `RuntimeTelemetry` bus — marker enrichments, attach points, and bridge translations; **no parallel instrumentation layer**.

## What it adds

**Per-action duration** (the signal that names a hot action directly): a `scheduler.run.complete` marker emitted at action finalization, next to the existing ActionStats recording — same wall-clock measurement, surfaced as a marker. The bridge records every run into a `ct.scheduler.action.duration_ms` histogram and emits a retroactive `scheduler.action.run` span for runs ≥10ms (configurable). The threshold was measured on the diagnose workload: 4.4% of runs exceed 10ms (bimodal — sub-ms computations vs 10–25ms effects), so spans add ~5% volume, not a multiplier.

**Settle signal** (the user-facing "event → stable graph" number): a `scheduler.settle` marker per settle pass, emitted **unconditionally** — the loop now measures wall-clock and executed-iteration count outside the opt-in SettleStats gate → `ct.scheduler.settle.duration_ms` / `.iterations` histograms.

**Deterministic client↔server commit join**: `memory.transact` spans gain `session.id` + `commit.local_seq`, and the revived client-side `storage.push` span carries `commit.local_seq` + `space.did` (plus `session.id` on completion, once the connection is known). `request.id` was investigated and is unusable as a join key: minted per send attempt, stripped from responses, re-minted on reconnect resends. `localSeq` is stable across retries and known before the response, so it also identifies rejected commits.

**Storage markers actually fire now**: `StorageTelemetry` was dead code (fed only by a zero-caller indirection). The Runtime hands its telemetry bus to the v2 `StorageManager` via a late-bound sink, and the space replica emits `storage.push.start|complete|error` around the commit send (observation flush + dial + send + confirm). The pull side is subscription-driven with no single call site — deliberate follow-up.

**Attach points where patterns actually execute**: multi-runtime harness workers self-attach the bridge when running under Deno native OTel (`OTEL_DENO=true` + `--unstable-otel`) and flip the preflight-telemetry gate — so every diagnose/harness run now exports scheduler signals with zero setup. Toolshed attaches on `OTEL_ENABLED` (low volume by design: toolshed's Runtime only executes patterns for webhook deliveries). Browser shell attach is unchanged (already exists behind the `telemetryEnabled` flag).

**Hygiene**: toolshed HTTP spans gain `url.path` (pattern-fetch targets were unrecoverable from templated route names).

## Verification

- Bridge unit tests extended (threshold behavior incl. custom threshold, settle histograms, join-key attrs on storage spans); full `packages/runner` + `packages/memory` suites pass; `multi-user.test.tsx` runs at parity (4.3s warm, same as main).
- **Live exit test** against stage SigNoz (`perf-lunchpoll-p1-exit-20260710`, 3×5 diagnose run): 886 `storage.push` spans **exactly 1:1** with 886 `memory.transact`; 90 `scheduler.action.run` spans; 22 `scheduler.preflight` spans (first ever exported from a harness run); all new `ct.*` histograms present in ClickHouse with **Delta** temporality (via `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`); the `(space.did, user.did, commit.local_seq)` join returns pairs in ClickHouse.

## Known gaps / follow-ups

- `ct.pattern`/`ct.module` are empty for actions without `TelemetryAnnotations` — which is most lunch-poll actions today. Per-action identity is the content-addressed `ct.action_id` (which embeds the target cell path) until the annotation plumb-through lands. This is pre-existing, not introduced here.
- `storage.pull` markers (subscription-driven; no single call site).
- Infra side: set the delta-temporality env var in the VM envs so toolshed/bg-piece Deno-native metrics match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phase 1 pattern-performance telemetry: per-action durations, settle metrics, and deterministic client↔server commit joins, with zero-config OTel attach in the harness and toolshed and clean shutdown detaches to flush spans.

- **New Features**
  - Action duration: emits `scheduler.run.complete`; records `ct.scheduler.action.duration_ms` and creates retro spans for runs ≥10ms (configurable via `actionRunSpanThresholdMs`).
  - Settle signal: emits `scheduler.settle` per pass; records duration and iterations.
  - Commit join: server `memory.transact` spans add `session.id` and `commit.local_seq`; client `storage.push` spans stamp `commit.local_seq` and `space.did` on start and `session.id` on complete/error; rejected commits emit `storage.push.error`.
  - Storage markers: Runtime hands telemetry to the v2 `StorageManager`; `storage.push` start/complete/error now fire around flush→dial→send→confirm.
  - Auto-attach and shutdown: harness self-attaches the OTel bridge under Deno native OTel or when `OTEL_ENABLED`; toolshed attaches in `createToolshedRuntime` when `OTEL_ENABLED` and detaches on shutdown via `detachRuntimeOtelBridgeIfAttached`; `attachRuntimeOtelBridge` is exported and non-fatal on failure.
  - HTTP tracing: toolshed spans include `url.path` for clearer request targets.

- **Migration**
  - Harness: run with Deno native OTel (`OTEL_DENO=true` and `--unstable-otel`) or set `OTEL_ENABLED=true`.
  - Toolshed: set `OTEL_ENABLED=true` (optional: `OTEL_SERVICE_NAME`, `ENV`). Metrics need a global MeterProvider (e.g., Deno native OTel); spans work with the app tracer provider either way. Optional: `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` for delta temporality.

<sup>Written for commit d3e1db408fcbb00871d3f94a9e361e00d84acfc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

