### PR TITLE
fix(scripts): make get_pids_on_port fail safe under minimal PATH

### DIFF
--- a/scripts/common/port-utils.sh
+++ b/scripts/common/port-utils.sh
@@ -3,18 +3,38 @@
 
 # Get PIDs listening on a port (cross-platform)
 # Usage: get_pids_on_port <port>
+#
+# Output contract: newline-separated numeric PIDs, or empty if none found.
+# Callers pipe this straight into kill, so no branch may ever leak
+# non-numeric text (e.g. tool error messages) to stdout.
 get_pids_on_port() {
     local port=$1
 
+    # lsof is the primary detector on macOS, but it lives in /usr/sbin,
+    # which minimal PATHs (e.g. launchd-spawned processes) often omit.
+    # Probe absolute locations before giving up on it.
+    local lsof_bin=""
     if command -v lsof &>/dev/null; then
-        lsof -ti :"$port" -sTCP:LISTEN 2>/dev/null
-    elif command -v ss &>/dev/null; then
-        # Use awk instead of grep -P for portability
-        ss -tlnp "sport = :$port" 2>/dev/null | awk -F'pid=' 'NF>1{split($2,a,","); print a[1]}' | sort -u
-    elif command -v fuser &>/dev/null; then
-        # fuser outputs to stderr, and prefixes with port info
-        fuser "$port/tcp" 2>&1 | awk '{for(i=2;i<=NF;i++) print $i}'
+        lsof_bin=lsof
+    elif [[ -x /usr/sbin/lsof ]]; then
+        lsof_bin=/usr/sbin/lsof
+    elif [[ -x /usr/bin/lsof ]]; then
+        lsof_bin=/usr/bin/lsof
     fi
+
+    {
+        if [[ -n "$lsof_bin" ]]; then
+            "$lsof_bin" -ti :"$port" -sTCP:LISTEN 2>/dev/null
+        elif command -v ss &>/dev/null; then
+            # Use awk instead of grep -P for portability
+            ss -tlnp "sport = :$port" 2>/dev/null | awk -F'pid=' 'NF>1{split($2,a,","); print a[1]}' | sort -u
+        elif [[ "$(uname)" == "Linux" ]] && command -v fuser &>/dev/null; then
+            # Linux only: macOS fuser has no port/tcp form and would print
+            # an error instead of PIDs. fuser outputs to stderr, and
+            # prefixes with port info.
+            fuser "$port/tcp" 2>&1 | awk '{for(i=2;i<=NF;i++) print $i}'
+        fi
+    } | grep -E '^[0-9]+$' || true
 }
 
 # Read base ports from ports.json at repo root

--- a/scripts/common/port-utils.sh
+++ b/scripts/common/port-utils.sh
@@ -27,7 +27,7 @@ get_pids_on_port() {
             "$lsof_bin" -ti :"$port" -sTCP:LISTEN 2>/dev/null
         elif command -v ss &>/dev/null; then
             # Use awk instead of grep -P for portability
-            ss -tlnp "sport = :$port" 2>/dev/null | awk -F'pid=' 'NF>1{split($2,a,","); print a[1]}' | sort -u
+            ss -tlnp "sport = :$port" 2>/dev/null | awk -F'pid=' '{for(i=2;i<=NF;i++){split($i,a,","); print a[1]}}' | sort -u
         elif [[ "$(uname)" == "Linux" ]] && command -v fuser &>/dev/null; then
             # Linux only: macOS fuser has no port/tcp form and would print
             # an error instead of PIDs. fuser outputs to stderr, and


### PR DESCRIPTION
## Why

Loom recently hit a wedged local-dev restart traced to this helper: its launchd-spawned services ran with a minimal PATH that omits `/usr/sbin`, so `command -v lsof` failed on macOS and `get_pids_on_port` fell through to `fuser`. macOS `fuser` doesn't support the Linux-style `port/tcp` argument — it errors, and the awk post-processing shredded that error text into garbage tokens. `free_port_if_forced()` in `scripts/start-local-dev.sh` pipes the result straight into `xargs kill`, so the garbage killed nothing, the real port holder survived, and `--force` restarts of the local toolshed failed with "Port in use" (`restart-local-dev.sh` hits the same path).

Loom has since shipped its own PATH fix so its services carry `/usr/sbin`; this change is upstream defense-in-depth so the helper can't silently misbehave under a hostile PATH regardless of caller.

Reproduce on macOS (something listening on 5173, PATH stripped of `/usr/sbin`):

```bash
PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
  bash -c 'source scripts/common/port-utils.sh; get_pids_on_port 5173'
# BEFORE: '5173/tcp'  does  not  exist   (garbage tokens, fed to kill)
# AFTER:  the real numeric PID
```

## What Changed

`scripts/common/port-utils.sh` → `get_pids_on_port()`, belt and suspenders:

- **lsof resolves off PATH**: probe `/usr/sbin/lsof` and `/usr/bin/lsof` before giving up — macOS always ships it at `/usr/sbin/lsof`, and it's the primary reliable detector there.
- **fuser branch guarded to Linux**: the `port/tcp` form is a Linux-fuser feature; on macOS it's actively harmful. The `ss`/`fuser` fallbacks keep working for Linux CI/containers where lsof may be absent.
- **Numeric-only output filter**: every branch is piped through `grep -E '^[0-9]+$'`, so callers piping into `kill` can only ever receive real PIDs — an unresolvable port yields empty (the safe "nothing to kill" outcome), never garbage. The function now always exits 0, so it's also safe under `set -e` callers.
- **ss branch returns every PID on multi-process listeners** (found in review): the parser only extracted the first `pid=` per line, so a port held by multiple processes (SO_REUSEPORT, pre-forked workers) was never fully freed — `kill` missed the other holders. It now iterates all `pid=` fields.

All existing callers (`start-local-dev.sh`, `stop-local-dev.sh`, `check-local-dev.sh`) already treat empty as "nothing on the port", so the contract is unchanged for them.

## Test plan

Verified on macOS with a real listener on a test port:

- Stripped PATH (no `/usr/sbin`): returns the real numeric PID (was garbage before the fix).
- Normal PATH: returns the same PID.
- Free port under stripped PATH: returns empty, exit 0 (including under `bash -e`).
- Simulated Linux via stub `ss`/`fuser`/`uname` binaries and neutralized lsof probes: `ss` branch parses `pid=` correctly; `fuser` branch emits PIDs; macOS `uname` with a `fuser`-only PATH skips the fuser branch and returns empty.
- Real Linux (debian container, docker): end-to-end `get_pids_on_port` detects a live listener via the `ss` branch; `fuser` branch output survives the numeric filter intact.
- Multi-PID `ss` lines (canned input): both PIDs extracted; single-PID and header lines unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `get_pids_on_port` fail-safe under minimal PATHs on macOS, so only real PIDs reach `kill` and forced restarts no longer wedge with “Port in use.” The function now outputs only numeric PIDs or empty across platforms.

- **Bug Fixes**
  - Resolve `lsof` via `/usr/sbin/lsof` or `/usr/bin/lsof` before relying on PATH.
  - Restrict `fuser "$port/tcp"` to Linux; keep `ss`/`fuser` fallbacks for Linux environments.
  - Filter all outputs to numeric-only and always exit 0, making it safe for `set -e` and preventing garbage from reaching `xargs kill`.

<sup>Written for commit 6817adc3e20073bc0d97a83b8589597562f956b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


