### PR TITLE
fix(runner): verify source-doc closures per reachable view; name the element that voids an array read

### DIFF
--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -352,12 +352,28 @@ export interface SourceDocVerification {
  * checking it equals the identity the document is keyed by. This is the
  * content-addressed analog of the structural graph verifier: because the
  * identity is a one-way Merkle hash over `(source, import identities)`, a
- * single document's content does not determine its key — the whole closure
- * must recompute consistently. Tampering with any source, or rewiring an
- * import link, makes the recomputed identity diverge from the key.
+ * single document's content does not determine its key — the reachable
+ * closure must recompute consistently. Tampering with any source, or rewiring
+ * an import link, makes the recomputed identity diverge from the key.
  *
- * Extra unrelated documents in the set are harmless: a module's identity
- * depends only on its own reachable closure, so siblings do not perturb it.
+ * Each document is verified against **its own view**: the documents reachable
+ * from it over authored-import edges (root links excluded — a
+ * {@link ROOT_LINK_SPECIFIER} edge is never part of any module's Merkle
+ * preimage). One closure may legally hold several generations of the same
+ * ambient filename (e.g. two seals' injected `cfc.ts`, each root-linked by a
+ * different entry): identities are entry-point independent, so a shared
+ * dependency document keeps whichever seal's root links wrote it last, and a
+ * link walk then reaches sibling generations. Hashing the whole closure as
+ * one program would collide those filenames and permanently fail one
+ * generation; per-view recomputation verifies each against the emission
+ * that produced it. Within a single view, filenames are unique by
+ * construction (one program emission cannot contain two files at one path) —
+ * a view that violates this cannot be attributed to any emission, and its
+ * root document is rejected.
+ *
+ * Extra unrelated documents in the set are harmless to their siblings: a
+ * module's identity depends only on its own reachable view. Every document in
+ * the set is still verified (in its own view).
  */
 export function verifySourceDocs(
   entryIdentity: string,
@@ -369,25 +385,66 @@ export function verifySourceDocs(
     return { ok: false, mismatches: [], missing: [entryIdentity] };
   }
 
-  const files = [...docsByIdentity.values()].map((doc) => ({
-    name: doc.filename,
-    contents: doc.code,
-  }));
-  const recomputed = computeModuleHashes(
-    { main: entry.filename, files },
-    { runtimeFingerprint },
-  );
-
-  const mismatches: string[] = [];
   const missing: string[] = [];
-  for (const [identity, doc] of docsByIdentity) {
-    if (recomputed.get(doc.filename) !== identity) {
-      mismatches.push(identity);
-    }
+  for (const doc of docsByIdentity.values()) {
     for (const imp of doc.imports) {
       if (!docsByIdentity.has(imp.identity)) missing.push(imp.identity);
     }
   }
+
+  // identity → whether its recomputed hash matches its key. A verdict reached
+  // inside one view holds in every view (entry-point independence), so each
+  // document is hashed at most once.
+  const verdicts = new Map<string, boolean>();
+  for (const [rootIdentity, rootDoc] of docsByIdentity) {
+    if (verdicts.has(rootIdentity)) continue;
+
+    // The root's view: BFS over authored-import edges only.
+    const viewIds: string[] = [];
+    const seen = new Set<string>();
+    const queue = [rootIdentity];
+    while (queue.length > 0) {
+      const id = queue.shift()!;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const doc = docsByIdentity.get(id);
+      if (doc === undefined) continue; // dangling edge — recorded in `missing`
+      viewIds.push(id);
+      for (const imp of doc.imports) {
+        if (imp.specifier.startsWith(ROOT_LINK_SPECIFIER)) continue;
+        queue.push(imp.identity);
+      }
+    }
+
+    const files = viewIds.map((id) => {
+      const doc = docsByIdentity.get(id)!;
+      return { name: doc.filename, contents: doc.code };
+    });
+    if (new Set(files.map((f) => f.name)).size !== files.length) {
+      // Duplicate filename within one view: not attributable to any emission.
+      // Only the root is condemned — an intact member still verifies in its
+      // own (necessarily smaller) view when the loop reaches it.
+      verdicts.set(rootIdentity, false);
+      continue;
+    }
+
+    const recomputed = computeModuleHashes(
+      { main: rootDoc.filename, files },
+      { runtimeFingerprint },
+    );
+    for (const id of viewIds) {
+      if (!verdicts.has(id)) {
+        verdicts.set(
+          id,
+          recomputed.get(docsByIdentity.get(id)!.filename) === id,
+        );
+      }
+    }
+  }
+
+  const mismatches = [...verdicts.entries()]
+    .filter(([, ok]) => !ok)
+    .map(([identity]) => identity);
 
   return {
     ok: mismatches.length === 0 && missing.length === 0,
@@ -619,10 +676,22 @@ export async function loadVerifiedSourceClosure(
     runtimeFingerprint,
   );
   if (!verification.ok) {
+    // Name the offenders (bounded): a bare count forces whoever hits this
+    // into probe archaeology to find which doc failed and why.
+    const describe = (identities: readonly string[]) =>
+      identities.slice(0, 4)
+        .map((id) => `${id}(${closure.get(id)?.filename ?? "absent"})`)
+        .join(",") + (identities.length > 4 ? ",…" : "");
     logger.warn("source-closure-verify-failed", () => [
       `entry=${entryIdentity}`,
-      `mismatches=${verification.mismatches.length}`,
-      `missing=${verification.missing.length}`,
+      `mismatches=${verification.mismatches.length}` +
+      (verification.mismatches.length > 0
+        ? ` [${describe(verification.mismatches)}]`
+        : ""),
+      `missing=${verification.missing.length}` +
+      (verification.missing.length > 0
+        ? ` [${describe(verification.missing)}]`
+        : ""),
     ]);
     return undefined;
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3487,10 +3487,18 @@ export class SchemaObjectTraverser<V extends FabricValue>
           } else if (this.isValidType(curSelector.schema!, "null")) {
             arrayObj[index] = null;
           } else {
-            // this array is invalid; one or more items do not match the schema
+            // This array is invalid; one or more items do not match the
+            // schema — the ENTIRE array reads as invalid for this caller.
+            // Name the failing index + doc so the mismatch is diagnosable
+            // without probe archaeology (2026-07-10 board outage: a blanked
+            // array with a bare mismatch log hid WHICH element was at fault).
             logger.info(
               "traverse",
-              () => ["Item doesn't match array schema", curDoc, curSelector],
+              () => [
+                "Array element does not match the item schema — voiding the whole array read",
+                `index=${index}`,
+                curDoc.address,
+              ],
             );
             valid = false;
           }

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -22,6 +22,7 @@ import {
   loadSourceClosure,
   loadVerifiedSourceClosure,
   ROOT_LINK_SPECIFIER,
+  type SourceDoc,
   sourceDocKey,
   verifySourceDocs,
   writeCompiledDocs,
@@ -275,6 +276,136 @@ describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
     const utilEntry = { ...PROGRAM, main: "/util.ts" };
     const viaUtil = computeModuleHashes(utilEntry).get("/util.ts")!;
     expect(viaUtil).toBe(viaMain);
+  });
+
+  it("accepts a closure holding two generations of one ambient filename (2026-07-10 board outage)", () => {
+    // Seal 1 (older runtime): a leaf pattern plus that runtime's injected
+    // ambient helper. The ambient has no import edge, so buildSourceDocs
+    // root-links it from the seal's entry — the leaf document.
+    const ambientModule = (source: string): CacheableModule => ({
+      identity: computeModuleHashes({
+        main: "/cfc.ts",
+        files: [{ name: "/cfc.ts", contents: source }],
+      }).get("/cfc.ts")!,
+      filename: "/cfc.ts",
+      source,
+      js: "/* ambient */",
+      imports: [],
+    });
+    const oldAmbient = ambientModule("export const gen = 'old';");
+    const leafProgram = {
+      main: "/leaf.tsx",
+      files: [{ name: "/leaf.tsx", contents: "export const leaf = 1;" }],
+    };
+    const { modules: leafModules, entryIdentity: leafIdentity } = toModules(
+      leafProgram,
+    );
+    const sealOne = buildSourceDocs(
+      [...leafModules, oldAmbient],
+      leafIdentity,
+    );
+    expect(
+      sealOne.get(leafIdentity)!.imports.map((i) => i.specifier),
+    ).toContain(`${ROOT_LINK_SPECIFIER}${oldAmbient.identity}`);
+
+    // Seal 2 (newer runtime): an entry importing the same leaf module, plus the
+    // newer helper generation at the SAME ambient path. The leaf's identity is
+    // entry-point independent, so both seals share the `pattern:<leaf>` doc.
+    const newAmbient = ambientModule("export const gen = 'new';");
+    const boardProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents:
+            `import { leaf } from "./leaf.tsx";\nexport const n = leaf;`,
+        },
+        ...leafProgram.files,
+      ],
+    };
+    const { modules: boardModules, entryIdentity: boardIdentity } = toModules(
+      boardProgram,
+    );
+    expect(computeModuleHashes(boardProgram).get("/leaf.tsx")).toBe(
+      leafIdentity,
+    );
+    const sealTwo = buildSourceDocs(
+      [...boardModules, newAmbient],
+      boardIdentity,
+    );
+
+    // The stored state after both seals: the shared leaf doc carries seal 1's
+    // root link (last write of that cell), so the board's link walk reaches
+    // BOTH helper generations — two byte-intact docs at /cfc.ts.
+    const merged = new Map(sealTwo);
+    merged.set(leafIdentity, sealOne.get(leafIdentity)!);
+    merged.set(oldAmbient.identity, sealOne.get(oldAmbient.identity)!);
+    expect(
+      [...merged.values()].filter((d) => d.filename === "/cfc.ts").length,
+    ).toBe(2);
+
+    // Regression: filename-keyed recomputation could never verify both
+    // generations (one always shadowed → mismatch → pattern bricked on every
+    // cold recompile). Per-view verification accepts the closure.
+    const v = verifySourceDocs(boardIdentity, merged);
+    expect(v.mismatches).toEqual([]);
+    expect(v.missing).toEqual([]);
+    expect(v.ok).toBe(true);
+  });
+
+  it("still rejects a view whose authored imports reach two files at one path", () => {
+    // Rewired/corrupt closure: the entry's authored edges point at two
+    // documents that both claim /dup.ts. No single emission can produce that
+    // view, so the entry must not verify — but each intact dependency still
+    // verifies standalone in its own view.
+    const depA: CacheableModule = {
+      identity: "",
+      filename: "/dup.ts",
+      source: "export const a = 1;",
+      js: "",
+      imports: [],
+    };
+    const depB: CacheableModule = {
+      identity: "",
+      filename: "/dup.ts",
+      source: "export const b = 2;",
+      js: "",
+      imports: [],
+    };
+    const idOfSingle = (m: CacheableModule) =>
+      computeModuleHashes({
+        main: m.filename,
+        files: [{ name: m.filename, contents: m.source }],
+      }).get(m.filename)!;
+    const a = { ...depA, identity: idOfSingle(depA) };
+    const b = { ...depB, identity: idOfSingle(depB) };
+    const entrySource = `import { a } from "./dup.ts";\nexport const n = a;`;
+    const entryIdentity = "corrupt-entry";
+    const docs = new Map<string, SourceDoc>(
+      [a, b].map((m) => [m.identity, {
+        kind: "source",
+        code: m.source,
+        filename: m.filename,
+        imports: [],
+      }]),
+    );
+    docs.set(entryIdentity, {
+      kind: "source",
+      code: entrySource,
+      filename: "/main.tsx",
+      imports: [
+        { specifier: "./dup.ts", identity: a.identity },
+        { specifier: "./also-dup.ts", identity: b.identity },
+      ],
+    });
+
+    const v = verifySourceDocs(entryIdentity, docs);
+    expect(v.ok).toBe(false);
+    expect(v.mismatches).toContain(entryIdentity);
+    // The intact same-filename dependencies are not condemned by the corrupt
+    // root's view.
+    expect(v.mismatches).not.toContain(a.identity);
+    expect(v.mismatches).not.toContain(b.identity);
   });
 
   it("ignores non-normative annotations (W4): annotated and unannotated docs verify identically", () => {

--- a/packages/runner/test/traverse-element-grace.test.ts
+++ b/packages/runner/test/traverse-element-grace.test.ts
@@ -20,6 +20,10 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import type { SchemaPathSelector } from "@commonfabric/api";
 import type {
@@ -198,5 +202,49 @@ describe("element-level required grace for unresolvable links (B2)", () => {
 
     expect(result).toBeUndefined();
     expect(error).toBeDefined();
+  });
+});
+
+describe("array-void diagnosability", () => {
+  // The 2026-07-10 board outage presented as a blanked array with a bare
+  // "Item doesn't match" log — nothing named WHICH element was at fault. Pin
+  // that the (unchanged) strict void now leaves an info breadcrumb carrying
+  // the failing index + doc address (the message body is a lazy lambda: it
+  // only runs when the level admits it).
+  it("still voids on a mismatched element, and names the failing index + doc at info", () => {
+    const traverseLogger = getLogger("traverse");
+    const priorLevel = traverseLogger.level;
+    traverseLogger.level = "info";
+    try {
+      const infoCount = () => {
+        const breakdown = getLoggerCountsBreakdown()["traverse"] as
+          | Record<string, { info?: number }>
+          | undefined;
+        return breakdown?.["traverse"]?.info ?? 0;
+      };
+      const store = new Map<string, Revision<State>>();
+      const rootUri = "of:void-diag-root" as URI;
+      const badUri = "of:void-diag-bad" as URI;
+      putDoc(store, badUri, "not-an-object");
+      const rootValue = {
+        messages: [{ author: "alice", profile: linkTo(badUri) }],
+      };
+      putDoc(store, rootUri, rootValue, 2);
+
+      const before = infoCount();
+      const { ok: result, error } = traverseRoot(
+        store,
+        rootUri,
+        rootValue,
+        listSchema,
+      );
+      // Strict semantics unchanged: the mismatched element voids the read.
+      expect(result).toBeUndefined();
+      expect(error).toBeDefined();
+      // And the void is attributable: at least one info breadcrumb fired.
+      expect(infoCount() - before).toBeGreaterThanOrEqual(1);
+    } finally {
+      traverseLogger.level = priorLevel;
+    }
   });
 });


### PR DESCRIPTION
Fixes the platform bug behind the 2026-07-10 topics-dev board outage's first phase ("Could not load pattern" on estuary's overnight redeploy), plus a diagnosability fix for its second phase. Full forensic record on the board: topic ["Board outage 2026-07-10"](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:ea3aFbIW7yT5pyTcZ8i5WoryiKh3kcs5y-_rtKjL_O0).

## Commit 1 — verify source-doc closures per reachable view

A stored source closure may legally hold several generations of the same ambient filename (`cfc.ts`): identities are entry-point independent, so a dependency doc is shared across seals and keeps whichever seal's `cf:cache-root` links wrote it last; a later entry's link walk then reaches sibling ambient generations. `verifySourceDocs` hashed the whole closure as one filename-keyed program, so one generation always shadowed the other → permanent mismatch → every runtime-version bump bricks such pieces on cold recompile (estuary's redeploy was the detector, not the cause). No data fix applies: the stored bytes are correct; the verifier was wrong.

Now each document verifies against its own authored-import-reachable view (root links excluded — never part of a Merkle preimage). Within a view, filenames stay unique by construction; a view violating that cannot be attributed to any emission and its root is rejected, while intact same-filename siblings still verify in their own views. The verify-failed warn names the offending identities/filenames instead of bare counts.

**Live-repro verified**: the original bricked board entry `ZOdGfc…` still in the topics-dev space (closure of 4 docs incl. two byte-intact `cfc.ts` generations) verifies `ok=true` under the fix; the pre-fix verifier reproduces `mismatches=1` side-by-side.

## Commit 2 — name the failing index and doc when an array element voids the read

Logging precision only; no semantics change. A schema-mismatched array element voids the ENTIRE array read for the caller, and the log line said only that "an item" mismatched — the outage's second phase (a blanked board) presented as silent data loss, and finding WHICH element and doc was at fault took probe archaeology. The log now carries the failing index + doc address; a test pins both the (unchanged) strict void and the breadcrumb.

## Deferred: the element-level generation-skew grace

An earlier revision of this PR also degraded generation-skew `required` failures on array elements (fields absent from older-generation docs read as omitted — never invented — instead of voiding the whole array). Per review discussion (thread + Discord), that contract change is **deferred**: loosening `required` on element reads risks becoming a foot-gun for contracts that rely on it, and the class is better addressed upstream. The full grace (both signatures + red/green tests) is parked whole on [`gideon/element-grace-parked`](https://github.com/commontoolsinc/labs/tree/gideon/element-grace-parked) if the upstream work wants it back.

Where the class is being addressed instead:
- [combineSchema manufactures closed-world additionalProperties — intended semantics or upstream bug?](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:XVmEOgkcYE8UlIVYTtlx6scxGLpl9zv-G5ocLiWl1Xc) (board topic, for @ubik2 / @seefeldb)
- [Result-schema evolution: session affordances shouldn't brick old data — optionality and an authoring-time gate](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:AdxT1VowiEELWrb8OPrnEM9bHDwGGoA0uCMgonEeE_8) (board topic; a hard gate on default-less required additions means declared defaults exist, and the read path already fills declared defaults before the `required` check)
- Agent-driven data repair via cf get/set for existing skewed data — already proven on the topics board (authorless-topic fixup, setsrc restore runbook).

## Verification

- Closure-verifier regression tests red-without/green-with in `cell-cache.test.ts` (the outage shape: two same-filename ambient generations across seals; plus corrupt dup-view rejection), and the live repro above.
- Array-void diagnosability pin in `traverse-element-grace.test.ts` (strict void unchanged + breadcrumb carries index/doc).
- Full runner suite green locally on the rebased tree (918 tests / 4867 steps, scheduler-v2 underneath); traverse-replay goldens unchanged.
- CI fully green on this shape (39 checks incl. all pattern shards, workspace typecheck, and the coverage-debt ratchet).

## Deploy note

An estuary redeploy bumps the runtime version → cold recompile → that is commit 1's trigger condition. Merging before the next redeploy closes the recurring brick threat for multi-generation closures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
