### PR TITLE
feat(runner): sanitize toLocale* methods under SES instead of amputating them

### DIFF
--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -205,6 +205,22 @@ The current exported helper names are `safeDateNow()` and
 `nonPrivateRandom()`. Older shorthand such as `dateNow` or `insecureRandom`
 does not match the current API.
 
+Locale-sensitive formatting works, with pinned defaults:
+
+- `toLocaleDateString` / `toLocaleTimeString` / `toLocaleString` (and the
+  Number, BigInt, and String locale methods) honor their arguments, but an
+  omitted locale defaults to `"en-US"` and an omitted Date `timeZone` to
+  `"UTC"` — never the host locale or timezone.
+- Pass `timeZone` explicitly (an IANA name) to format in a specific zone. For
+  viewer-local display, compose from the local getters (`getFullYear()`,
+  `getDay()`, `getHours()`, …), which remain host-local; the sandbox exposes
+  no way to obtain the viewer's IANA zone name, so `toLocale*` output is
+  deterministic rather than viewer-local.
+- Watch the mixed-zone trap: a `Date` constructed at *local* midnight (e.g.
+  `new Date("2025-07-11T00:00:00")`) formatted without an explicit `timeZone`
+  renders in UTC and can land on the previous day for zones east of UTC.
+  Construct in UTC (`"…T00:00:00Z"`) or pass the matching `timeZone`.
+
 ```tsx
 // Shown inside a pattern body.
 const createItem = action(() => {

--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -6,7 +6,7 @@
 - AI-assisted specification
 
 ## Last Updated
-2026-03-26
+2026-07-10
 
 This document is the sole authoritative SES sandboxing specification for the
 current reimplementation effort. It supersedes prior divergence notes and
@@ -725,12 +725,24 @@ lockdown({
   stackFiltering: debug ? "verbose" : "concise",
   overrideTaming: "severe",
   consoleTaming: "unsafe",
+  localeTaming: "unsafe", // paired with the pre-lockdown locale sanitizer
 });
 ```
 
 Notes:
 
 - `overrideTaming: "severe"` remains the compatibility default.
+- `localeTaming: "unsafe"` is load-bearing only together with the pre-lockdown
+  vetted shim in `packages/runner/src/sandbox/locale-taming.ts`, which replaces
+  every method SES's `"safe"` mode would amputate with a pinned-default
+  wrapper: omitted locale → `"en-US"`, omitted Date `timeZone` → `"UTC"`, and
+  the ECMA-402 unsupported-tag locale fallback → `"en-US"` (appended to every
+  request so resolution can never reach the host default locale). Explicit
+  arguments pass through; invalid `timeZone` values throw per spec (ECMA-402
+  has no timezone fallback to the host zone). Do not change this option in
+  isolation: `"safe"` would clobber the sanitized methods with
+  argument-ignoring aliases, and bare `"unsafe"` without the shim reintroduces
+  ambient host-locale reads.
 - `mathTaming` and `dateTaming` should not be relied on as policy knobs in the
   reimplementation. In newer SES releases those options are gone; any future
   reintroduction of time/randomness helpers for authored code must be explicit
@@ -2378,6 +2390,24 @@ Potential escape routes and their status:
 | Prototype access | Blocked | SES freezes intrinsics, and the runtime explicitly freezes forwarded host constructors and `.prototype` objects before installation |
 | ambient web-fetch globals | Temporarily allowed | Compatibility shim in authored SES compartments; planned deprecation |
 | `globalThis` | Controlled | Custom minimal Compartment globals; runtime freezes the compartment global object after installing bindings and does not expose internal console-hook globals |
+
+### 11.5 Residual Observability and Fingerprinting Channels
+
+Distinct from escape routes: channels through which sandboxed code can learn
+about the host or the user without leaving the sandbox. Two classes:
+**user-level** (private information about the person — location, language) and
+**environment-level** (fingerprints the software build — engine, ICU/tzdata
+version — roughly user-agent-granularity information). New channels discovered
+in review or incident work should be added here with a class and a status.
+
+| Channel | Reveals | Class | Status |
+|---------|---------|-------|--------|
+| Untamed non-locale `Date` surface: `toString()`/`toTimeString()` (zone name in words), `getTimezoneOffset()`, local getters | Host timezone outright; the exact IANA zone via historical-offset probing (zones differ in DST history) → coarse user location | user-level | Accepted for now — patterns legitimately build local-day logic on the getters. Closure path: introduce viewer timezone as an explicit data input (CT-1881), then pin the ambient surface to UTC |
+| tzdata / ICU version probing: which zone names validate (newer-tzdata-only zones), formatting quirks (e.g. ICU 72's U+202F separators) | Engine / ICU / tzdata version | environment-level | Accepted; inherent to exposing real ICU formatting |
+| Supported-locale-set probing through the sanitized `toLocale*` methods | Full-ICU vs small-ICU build; available locale data | environment-level | Accepted |
+| Ambient web-fetch shim | User IP (→ geolocation, typically more precise than timezone) to any contacted server; general exfiltration and latency probing | user-level | Temporarily allowed; see 11.3 and the escape-hatch table; planned deprecation behind runtime-managed egress |
+| Host default locale via `toLocale*` defaults or the ECMA-402 unsupported-tag fallback | User language/region | user-level | **Closed** by `locale-taming.ts`: omitted locales and the resolution fallback both pin to `"en-US"` |
+| Host timezone via `toLocale*` `timeZone` defaults | User timezone | user-level | **Closed** by `locale-taming.ts`: omitted `timeZone` pins to `"UTC"`; invalid values throw (ECMA-402 has no fallback-to-host-zone path) |
 
 ---
 

--- a/packages/runner/src/sandbox/locale-taming.ts
+++ b/packages/runner/src/sandbox/locale-taming.ts
@@ -65,13 +65,6 @@ export const pinLocales = (locales: Locales): unknown[] | string => {
   return [...Array.from(locales as ArrayLike<unknown>), DEFAULT_LOCALE];
 };
 
-const dataDescriptor = (value: unknown): PropertyDescriptor => ({
-  value,
-  enumerable: true,
-  writable: true,
-  configurable: true,
-});
-
 // Pin the Date `timeZone` so formatting can never fall through to the host
 // zone. Fail closed: only two shapes are accepted — `undefined` (omitted), and
 // a plain object whose `timeZone` is either absent or a plain OWN data
@@ -119,9 +112,12 @@ const pinDateOptions = (
   // resolve through the prototype chain.
   const timeZone = descriptor?.value;
   return Object.create(options, {
-    timeZone: dataDescriptor(
-      timeZone === undefined ? DEFAULT_TIME_ZONE : timeZone,
-    ),
+    timeZone: {
+      value: timeZone === undefined ? DEFAULT_TIME_ZONE : timeZone,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    },
   });
 };
 

--- a/packages/runner/src/sandbox/locale-taming.ts
+++ b/packages/runner/src/sandbox/locale-taming.ts
@@ -58,12 +58,19 @@ export const pinLocales = (locales: Locales): unknown[] | string => {
   return [locales, DEFAULT_LOCALE];
 };
 
-// An omitted `options.timeZone` becomes UTC — never the host timezone.
+// An omitted `options.timeZone` becomes UTC — never the host timezone. That
+// is the ONLY path to the host zone: unlike locale resolution (which silently
+// falls back, see pinLocales), ECMA-402 throws RangeError on any invalid
+// timeZone value rather than falling back. So explicit values — including
+// null, which natively throws — pass through untouched; only `undefined`
+// (omitted) is pinned.
 const pinDateOptions = (
   options: Intl.DateTimeFormatOptions | undefined,
 ): Intl.DateTimeFormatOptions => ({
   ...options,
-  timeZone: options?.timeZone ?? DEFAULT_TIME_ZONE,
+  timeZone: options?.timeZone === undefined
+    ? DEFAULT_TIME_ZONE
+    : options.timeZone,
 });
 
 type AnyLocaleMethod = (

--- a/packages/runner/src/sandbox/locale-taming.ts
+++ b/packages/runner/src/sandbox/locale-taming.ts
@@ -54,8 +54,15 @@ type Locales = string | string[] | undefined;
 // mechanism and ECMA-402 resolution does the rest.
 export const pinLocales = (locales: Locales): unknown[] | string => {
   if (locales === undefined) return DEFAULT_LOCALE;
-  if (Array.isArray(locales)) return [...locales, DEFAULT_LOCALE];
-  return [locales, DEFAULT_LOCALE];
+  // A bare string is a single tag. Everything else — a real array OR an
+  // array-like (`{ 0: "de-DE", length: 1 }`), both of which ECMA-402's
+  // CanonicalizeLocaleList accepts — is materialized to the elements native
+  // would iterate, then the pinned fallback is appended so resolution can
+  // never fall through to the host default locale. `Array.from` also turns a
+  // no-length object into `[]` (→ just the fallback), matching native's
+  // empty-list-uses-default behavior while keeping our default, not the host's.
+  if (typeof locales === "string") return [locales, DEFAULT_LOCALE];
+  return [...Array.from(locales as ArrayLike<unknown>), DEFAULT_LOCALE];
 };
 
 // An omitted `options.timeZone` becomes UTC — never the host timezone. That
@@ -66,12 +73,30 @@ export const pinLocales = (locales: Locales): unknown[] | string => {
 // (omitted) is pinned.
 const pinDateOptions = (
   options: Intl.DateTimeFormatOptions | undefined,
-): Intl.DateTimeFormatOptions => ({
-  ...options,
-  timeZone: options?.timeZone === undefined
-    ? DEFAULT_TIME_ZONE
-    : options.timeZone,
-});
+): unknown => {
+  // Omitted → native leaves timeZone unset and formats in the host zone. Pin.
+  if (options === undefined) return { timeZone: DEFAULT_TIME_ZONE };
+  // Non-object (null, primitives): native's GetOptionsObject throws. Forward
+  // as-is so it still throws rather than being silently coerced to a valid
+  // `{ timeZone: "UTC" }` (which a `{ ...options }` spread of null would do).
+  if (typeof options !== "object" || options === null) return options;
+  // Read the security-sensitive timeZone EXACTLY ONCE (via a normal get, so
+  // an inherited value is honored like native does), then hand native a
+  // stable own data property. Three separate reads (spread + `=== undefined`
+  // check + forward) let a stateful/adversarial getter pass the check with a
+  // real zone yet forward `undefined`, re-opening the host-zone leak. Other
+  // options keep their normal (incl. inherited) lookup through the prototype
+  // chain — only timeZone must be stabilized.
+  const timeZone = options.timeZone;
+  return Object.create(options, {
+    timeZone: {
+      value: timeZone === undefined ? DEFAULT_TIME_ZONE : timeZone,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    },
+  });
+};
 
 type AnyLocaleMethod = (
   this: unknown,

--- a/packages/runner/src/sandbox/locale-taming.ts
+++ b/packages/runner/src/sandbox/locale-taming.ts
@@ -12,11 +12,12 @@
  * ICU/CLDR tables), so amputation throws away a legitimately useful surface.
  *
  * We sanitize instead: each method that `localeTaming: "safe"` would alias is
- * replaced with a wrapper that pins the ambient defaults — locale → "en-US",
- * Date timeZone → "UTC" — and delegates to the original, passing explicit
- * arguments through untouched. Lockdown then runs with
- * `localeTaming: "unsafe"` so SES leaves the sanitized methods in place and
- * hardens them like any other intrinsic.
+ * replaced with a wrapper that pins every ambient default — an omitted locale
+ * → "en-US", an omitted Date timeZone → "UTC", and the unsupported-tag
+ * FALLBACK locale → "en-US" (see pinLocales) — and delegates to the original,
+ * passing explicit arguments through otherwise untouched. Lockdown then runs
+ * with `localeTaming: "unsafe"` so SES leaves the sanitized methods in place
+ * and hardens them like any other intrinsic.
  *
  * Two consequences to be aware of:
  *
@@ -39,14 +40,23 @@ const DEFAULT_TIME_ZONE = "UTC";
 
 type Locales = string | string[] | undefined;
 
-// An omitted `locales` — undefined or an empty array, both meaning "host
-// default" per ECMA-402 — becomes the pinned default. Explicit values pass
-// through, including explicit BCP 47 tags the host may or may not have data
-// for (ECMA-402 fallback semantics apply as usual).
-const pinLocales = (locales: Locales): string | string[] =>
-  locales === undefined || (Array.isArray(locales) && locales.length === 0)
-    ? DEFAULT_LOCALE
-    : locales;
+// Pin every path that ECMA-402 would resolve to the host's default locale:
+// an omitted `locales` (undefined or an empty array) becomes the pinned
+// default, and — the subtle one — the pinned default is APPENDED to every
+// explicit request, because a well-formed-but-unsupported tag ("xx") would
+// otherwise fall back to the host default locale, letting sandboxed code
+// read the user's language/region off the formatted output. With the
+// fallback appended, resolution picks the caller's tag when the host
+// supports it and "en-US" when it doesn't — never the host default.
+// Malformed tags still throw RangeError, unchanged.
+// Exported for tests: the leak closure itself can't be asserted in-process
+// (the realm's default locale is fixed at startup), so the tests pin this
+// mechanism and ECMA-402 resolution does the rest.
+export const pinLocales = (locales: Locales): unknown[] | string => {
+  if (locales === undefined) return DEFAULT_LOCALE;
+  if (Array.isArray(locales)) return [...locales, DEFAULT_LOCALE];
+  return [locales, DEFAULT_LOCALE];
+};
 
 // An omitted `options.timeZone` becomes UTC — never the host timezone.
 const pinDateOptions = (

--- a/packages/runner/src/sandbox/locale-taming.ts
+++ b/packages/runner/src/sandbox/locale-taming.ts
@@ -1,0 +1,160 @@
+/**
+ * Deterministic locale-method sanitization — a vetted pre-lockdown shim.
+ *
+ * SES `localeTaming: "safe"` amputates the `toLocale*` family: each method is
+ * aliased to its non-locale equivalent and its arguments are silently ignored
+ * (`toLocaleDateString("en-US", { month: "short" })` returns `toDateString()`
+ * output). SES does this because the methods' DEFAULT arguments reach ambient
+ * host state — an omitted `locales` resolves to the host locale and an omitted
+ * `options.timeZone` to the host timezone — which is nondeterministic across
+ * runtimes and a fingerprinting channel. But called with explicit arguments
+ * these methods are pure functions of their inputs (modulo the engine's
+ * ICU/CLDR tables), so amputation throws away a legitimately useful surface.
+ *
+ * We sanitize instead: each method that `localeTaming: "safe"` would alias is
+ * replaced with a wrapper that pins the ambient defaults — locale → "en-US",
+ * Date timeZone → "UTC" — and delegates to the original, passing explicit
+ * arguments through untouched. Lockdown then runs with
+ * `localeTaming: "unsafe"` so SES leaves the sanitized methods in place and
+ * hardens them like any other intrinsic.
+ *
+ * Two consequences to be aware of:
+ *
+ * - This must run BEFORE `lockdown()` — the prototypes freeze at lockdown.
+ *   `ensureSESInitialized` sequences it.
+ * - It patches the realm's shared intrinsics, so host (non-pattern) code sees
+ *   the sanitized methods too. That is strictly closer to native behavior
+ *   than the status quo, where post-lockdown host code got the amputated
+ *   aliases.
+ *
+ * Residual nondeterminism, accepted: ICU/CLDR version skew — identical
+ * explicit inputs can format differently across engine versions (e.g. ICU
+ * 72's switch to U+202F time separators). This is the same hazard class as
+ * the untamed local-timezone Date getters (`getFullYear()` etc.), which
+ * remain host-local.
+ */
+
+const DEFAULT_LOCALE = "en-US";
+const DEFAULT_TIME_ZONE = "UTC";
+
+type Locales = string | string[] | undefined;
+
+// An omitted `locales` — undefined or an empty array, both meaning "host
+// default" per ECMA-402 — becomes the pinned default. Explicit values pass
+// through, including explicit BCP 47 tags the host may or may not have data
+// for (ECMA-402 fallback semantics apply as usual).
+const pinLocales = (locales: Locales): string | string[] =>
+  locales === undefined || (Array.isArray(locales) && locales.length === 0)
+    ? DEFAULT_LOCALE
+    : locales;
+
+// An omitted `options.timeZone` becomes UTC — never the host timezone.
+const pinDateOptions = (
+  options: Intl.DateTimeFormatOptions | undefined,
+): Intl.DateTimeFormatOptions => ({
+  ...options,
+  timeZone: options?.timeZone ?? DEFAULT_TIME_ZONE,
+});
+
+type AnyLocaleMethod = (
+  this: unknown,
+  ...args: unknown[]
+) => unknown;
+
+function replaceMethod(
+  proto: object,
+  name: string,
+  wrap: (original: AnyLocaleMethod) => AnyLocaleMethod,
+): void {
+  const original = (proto as Record<string, unknown>)[name];
+  if (typeof original !== "function") return; // absent on this host — nothing to sanitize
+  Object.defineProperty(proto, name, {
+    value: wrap(original as AnyLocaleMethod),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+let applied = false;
+
+/**
+ * Replace every locale-sensitive intrinsic method that
+ * `localeTaming: "safe"` would alias with its pinned-default sanitized
+ * wrapper. Idempotent; must be called before `lockdown()`.
+ */
+export function sanitizeLocaleMethods(): void {
+  if (applied) return;
+  applied = true;
+
+  // Date: pin both the locale and the timezone defaults.
+  for (
+    const name of [
+      "toLocaleDateString",
+      "toLocaleTimeString",
+      "toLocaleString",
+    ] as const
+  ) {
+    replaceMethod(
+      Date.prototype,
+      name,
+      (original) =>
+        function (this: unknown, locales?: unknown, options?: unknown) {
+          return original.call(
+            this,
+            pinLocales(locales as Locales),
+            pinDateOptions(options as Intl.DateTimeFormatOptions | undefined),
+          );
+        },
+    );
+  }
+
+  // Number / BigInt: pin the locale default; options pass through.
+  for (const proto of [Number.prototype, BigInt.prototype]) {
+    replaceMethod(
+      proto,
+      "toLocaleString",
+      (original) =>
+        function (this: unknown, locales?: unknown, options?: unknown) {
+          return original.call(this, pinLocales(locales as Locales), options);
+        },
+    );
+  }
+
+  // String: `localeCompare(that, locales, options)` and the locale-sensitive
+  // case mappings. Left untouched, `localeTaming: "unsafe"` would reintroduce
+  // the ambient host locale for bare calls of all three.
+  replaceMethod(
+    String.prototype,
+    "localeCompare",
+    (original) =>
+      function (
+        this: unknown,
+        that?: unknown,
+        locales?: unknown,
+        options?: unknown,
+      ) {
+        return original.call(
+          this,
+          that,
+          pinLocales(locales as Locales),
+          options,
+        );
+      },
+  );
+  for (const name of ["toLocaleLowerCase", "toLocaleUpperCase"] as const) {
+    replaceMethod(
+      String.prototype,
+      name,
+      (original) =>
+        function (this: unknown, locales?: unknown) {
+          return original.call(this, pinLocales(locales as Locales));
+        },
+    );
+  }
+
+  // Deliberately untouched: Object.prototype.toLocaleString is
+  // locale-independent (`this.toString()` per ES, not amended by ECMA-402),
+  // and Array/%TypedArray%.prototype.toLocaleString delegate to their
+  // elements' toLocaleString — which are sanitized above.
+}

--- a/packages/runner/src/sandbox/locale-taming.ts
+++ b/packages/runner/src/sandbox/locale-taming.ts
@@ -65,36 +65,63 @@ export const pinLocales = (locales: Locales): unknown[] | string => {
   return [...Array.from(locales as ArrayLike<unknown>), DEFAULT_LOCALE];
 };
 
-// An omitted `options.timeZone` becomes UTC — never the host timezone. That
-// is the ONLY path to the host zone: unlike locale resolution (which silently
-// falls back, see pinLocales), ECMA-402 throws RangeError on any invalid
-// timeZone value rather than falling back. So explicit values — including
-// null, which natively throws — pass through untouched; only `undefined`
-// (omitted) is pinned.
+const dataDescriptor = (value: unknown): PropertyDescriptor => ({
+  value,
+  enumerable: true,
+  writable: true,
+  configurable: true,
+});
+
+// Pin the Date `timeZone` so formatting can never fall through to the host
+// zone. Fail closed: only two shapes are accepted — `undefined` (omitted), and
+// a plain object whose `timeZone` is either absent or a plain OWN data
+// property. Everything else throws, because every other shape is a host-zone
+// leak or a read-inconsistency hazard, and no legitimate caller needs it:
+//
+//   - primitives / functions: V8 coerces them to an object with no `timeZone`
+//     (functions are objects; `ToObject` boxes primitives), so native formats
+//     in the host zone. We reject rather than box.
+//   - null: native throws `TypeError`; we reject consistently.
+//   - a `timeZone` accessor (`{ get timeZone() {…} }`): a stateful getter can
+//     return a real zone when we validate and `undefined` (→ host zone) on
+//     native's read.
+//   - an inherited `timeZone`: not a plain own property; treated the same as
+//     an accessor for simplicity.
+//
+// Unlike locale resolution (which silently falls back — see pinLocales),
+// ECMA-402 throws on an invalid *explicit* timeZone string, so a plain own
+// value is safe to forward: `"Not/AZone"` / `null` still throw `RangeError`
+// from native, and `undefined` (== omitted) is pinned to UTC.
 const pinDateOptions = (
   options: Intl.DateTimeFormatOptions | undefined,
 ): unknown => {
-  // Omitted → native leaves timeZone unset and formats in the host zone. Pin.
   if (options === undefined) return { timeZone: DEFAULT_TIME_ZONE };
-  // Non-object (null, primitives): native's GetOptionsObject throws. Forward
-  // as-is so it still throws rather than being silently coerced to a valid
-  // `{ timeZone: "UTC" }` (which a `{ ...options }` spread of null would do).
-  if (typeof options !== "object" || options === null) return options;
-  // Read the security-sensitive timeZone EXACTLY ONCE (via a normal get, so
-  // an inherited value is honored like native does), then hand native a
-  // stable own data property. Three separate reads (spread + `=== undefined`
-  // check + forward) let a stateful/adversarial getter pass the check with a
-  // real zone yet forward `undefined`, re-opening the host-zone leak. Other
-  // options keep their normal (incl. inherited) lookup through the prototype
-  // chain — only timeZone must be stabilized.
-  const timeZone = options.timeZone;
+  if (typeof options !== "object" || options === null) {
+    throw new TypeError(
+      "sanitized Intl: Date options must be a plain object or undefined",
+    );
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(options, "timeZone");
+  if (descriptor !== undefined && !("value" in descriptor)) {
+    throw new TypeError(
+      "sanitized Intl: options.timeZone must be a plain value, not a getter",
+    );
+  }
+  if (descriptor === undefined && "timeZone" in options) {
+    throw new TypeError(
+      "sanitized Intl: options.timeZone must be an own property",
+    );
+  }
+  // `descriptor.value` is the reflected data value — reading it invokes no
+  // getter (accessors were rejected above). Absent or explicit-undefined → UTC;
+  // any other value is forwarded for native to honor or reject. Built on
+  // Object.create so the caller's object is untouched and its other options
+  // resolve through the prototype chain.
+  const timeZone = descriptor?.value;
   return Object.create(options, {
-    timeZone: {
-      value: timeZone === undefined ? DEFAULT_TIME_ZONE : timeZone,
-      enumerable: true,
-      writable: true,
-      configurable: true,
-    },
+    timeZone: dataDescriptor(
+      timeZone === undefined ? DEFAULT_TIME_ZONE : timeZone,
+    ),
   });
 };
 

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -7,6 +7,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import "ses";
 import { createCallbackCompartmentGlobals } from "./compartment-globals.ts";
 import { hardenVerifiedFunction } from "./function-hardening.ts";
+import { sanitizeLocaleMethods } from "./locale-taming.ts";
 
 const logger = getLogger("ses-runtime");
 
@@ -322,6 +323,9 @@ function ensureSESInitialized(lockdownEnabled: boolean): void {
   if (typeof lockdownFn !== "function") {
     throw new Error("SES lockdown() is unavailable");
   }
+  // Vetted shim — must precede lockdown() (the prototypes freeze there).
+  // Pairs with `localeTaming: "unsafe"` below; see locale-taming.ts.
+  sanitizeLocaleMethods();
   lockdownFn(DEFAULT_LOCKDOWN_OPTIONS);
   globalState.lockdownInitialized = true;
   sesInitialized = true;
@@ -350,7 +354,12 @@ const DEFAULT_LOCKDOWN_OPTIONS: SESLockdownOptions = {
   reporting: "none",
   unhandledRejectionTrapping: "report",
   regExpTaming: "safe",
-  localeTaming: "safe",
+  // "unsafe" here does NOT mean ambient locale access: sanitizeLocaleMethods()
+  // (called just before lockdown) replaces every method "safe" would amputate
+  // with a pinned-default wrapper (locale "en-US", Date timeZone "UTC",
+  // explicit arguments honored). "safe" would clobber those wrappers with
+  // argument-ignoring non-locale aliases. See locale-taming.ts.
+  localeTaming: "unsafe",
   consoleTaming: "unsafe",
   overrideTaming: "severe",
   stackFiltering: "concise",

--- a/packages/runner/test/locale-taming.test.ts
+++ b/packages/runner/test/locale-taming.test.ts
@@ -162,7 +162,7 @@ describe("sanitized locale methods under SES lockdown", () => {
     });
   });
 
-  describe("faithful argument handling (no leak, no lost behavior)", () => {
+  describe("locale argument handling (no leak, no lost behavior)", () => {
     it("honors an array-LIKE locale list, not just real arrays", () => {
       // ECMA-402 CanonicalizeLocaleList accepts array-likes; treating one as a
       // single tag would ToString it to "[object Object]" and throw.
@@ -170,33 +170,61 @@ describe("sanitized locale methods under SES lockdown", () => {
         inSES(`(1234.5).toLocaleString({ 0: "de-DE", length: 1 })`),
       ).toBe("1.234,5");
     });
+  });
 
-    it("reads a stateful timeZone getter exactly once (no re-read leak)", () => {
-      // An adversarial getter that returned a real zone on the check-read and
-      // undefined on the forward-read would re-open the host-zone leak. The
-      // wrapper reads once and hands native a stable data property, so the
-      // format matches the explicit-NY result regardless of later reads.
-      const viaGetter = inSES(`(() => {
-        let n = 0;
-        const opts = { get timeZone() { n++; return n === 1 ? "America/New_York" : undefined; } };
-        return new Date(${T}).toLocaleDateString("en-US", opts);
-      })()`);
-      expect(viaGetter).toBe("7/10/2025"); // NY: 2025-07-11T00:00Z is 7/10 local
+  describe("Date options fail closed on non-plain shapes (host-zone leak defense)", () => {
+    // T2 straddles a day boundary: 2025-07-10T23:30:00Z is 7/10 in UTC but
+    // 7/11 in Europe/Berlin — so a host-zone leak (Berlin) would show as a
+    // different DATE than the pinned UTC. Under native semantics every rejected
+    // shape below formats in the host zone (V8 boxes primitives and accepts
+    // functions / objects with an absent timeZone), so the wrapper throws.
+    const T2 = 1752190200000;
+
+    it("throws on a primitive options value (native would box it → host zone)", () => {
+      expect(() => inSES(`new Date(${T2}).toLocaleDateString("en-US", 42)`))
+        .toThrow(TypeError);
+      expect(() => inSES(`new Date(${T2}).toLocaleDateString("en-US", "x")`))
+        .toThrow(TypeError);
     });
 
-    it("honors an inherited timeZone (a spread would have dropped it → UTC)", () => {
+    it("throws on a function options value (a function is an object → host zone)", () => {
+      expect(() =>
+        inSES(`new Date(${T2}).toLocaleDateString("en-US", () => {})`)
+      ).toThrow(TypeError);
+    });
+
+    it("throws on null options (native throws too; kept consistent)", () => {
+      expect(() => inSES(`new Date(${T2}).toLocaleDateString("en-US", null)`))
+        .toThrow(TypeError);
+    });
+
+    it("throws on a timeZone getter rather than reading it", () => {
+      expect(() =>
+        inSES(
+          `new Date(${T2}).toLocaleDateString("en-US", { get timeZone() { return "America/New_York"; } })`,
+        )
+      ).toThrow(TypeError);
+    });
+
+    it("throws on an inherited (non-own) timeZone", () => {
+      expect(() =>
+        inSES(
+          `new Date(${T2}).toLocaleDateString("en-US", Object.create({ timeZone: "America/New_York" }))`,
+        )
+      ).toThrow(TypeError);
+    });
+
+    it("still accepts a plain object with an own data timeZone (or none)", () => {
+      // Regression guard: the fail-closed checks must not reject the ONLY
+      // options shape real patterns use.
       expect(
         inSES(
-          `new Date(${T}).toLocaleDateString("en-US", Object.create({ timeZone: "America/New_York" }))`,
+          `new Date(${T2}).toLocaleDateString("en-US", { timeZone: "America/New_York" })`,
         ),
       ).toBe("7/10/2025");
-    });
-
-    it("lets native reject invalid options instead of coercing them valid", () => {
-      // `{ ...null }` would have become `{ timeZone: "UTC" }` and succeeded;
-      // native throws TypeError on null options, and the wrapper preserves that.
-      expect(() => inSES(`new Date(${T}).toLocaleDateString("en-US", null)`))
-        .toThrow(TypeError);
+      expect(inSES(`new Date(${T2}).toLocaleDateString("en-US", {})`)).toBe(
+        "7/10/2025", // no timeZone → pinned UTC → 7/10
+      );
     });
   });
 

--- a/packages/runner/test/locale-taming.test.ts
+++ b/packages/runner/test/locale-taming.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Sanitized locale methods under SES lockdown (locale-taming.ts).
+ *
+ * `localeTaming: "safe"` used to alias every `toLocale*` method to its
+ * non-locale equivalent, silently ignoring arguments. The sanitized wrappers
+ * keep the methods functional but pin the ambient defaults: omitted locale →
+ * "en-US", omitted Date timeZone → "UTC". Explicit arguments pass through.
+ *
+ * Assertions run INSIDE a lockdown compartment (the pattern-visible surface).
+ * Fixed timestamp: 1752192000000 = 2025-07-11T00:00:00Z, a Friday.
+ *
+ * Expected strings are exact for date-only / number formatting (stable across
+ * ICU versions); time strings match the AM/PM separator loosely because ICU
+ * 72 changed it to U+202F.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { evaluateFunctionSourceInSES } from "../src/sandbox/ses-runtime.ts";
+
+const T = 1752192000000; // 2025-07-11T00:00:00Z (Friday)
+
+const inSES = (expr: string): unknown =>
+  evaluateFunctionSourceInSES(`(() => (${expr}))()`, { lockdown: true });
+
+describe("sanitized locale methods under SES lockdown", () => {
+  describe("Date.prototype.toLocaleDateString", () => {
+    it("honors the options bag (the localeTaming:'safe' alias ignored it)", () => {
+      expect(
+        inSES(
+          `new Date(${T}).toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })`,
+        ),
+      ).toBe("Friday, Jul 11");
+    });
+
+    it("defaults an omitted timeZone to UTC, not the host timezone", () => {
+      // 2025-07-11T00:00:00Z is 7/11 in UTC but 7/10 in every zone west of it;
+      // an ambient-timezone default would make this assertion host-dependent.
+      expect(inSES(`new Date(${T}).toLocaleDateString()`)).toBe("7/11/2025");
+    });
+
+    it("defaults an omitted locale to en-US, including the [] spelling", () => {
+      expect(
+        inSES(`new Date(${T}).toLocaleDateString([], { month: "long" })`),
+      ).toBe("July");
+    });
+
+    it("honors an explicit timeZone", () => {
+      expect(
+        inSES(
+          `new Date(${T}).toLocaleDateString("en-US", { timeZone: "America/New_York" })`,
+        ),
+      ).toBe("7/10/2025");
+    });
+
+    it("honors an explicit locale", () => {
+      expect(inSES(`new Date(${T}).toLocaleDateString("de-DE")`)).toBe(
+        "11.7.2025",
+      );
+    });
+  });
+
+  describe("Date.prototype.toLocaleTimeString / toLocaleString", () => {
+    it("formats UTC midnight, honoring options", () => {
+      const time = inSES(
+        `new Date(${T}).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" })`,
+      ) as string;
+      // ICU ≥72 uses U+202F before AM/PM; older ICU uses a plain space.
+      expect(time).toMatch(/^12:00[\s ]AM$/);
+    });
+
+    it("toLocaleString combines date and time in UTC by default", () => {
+      const s = inSES(`new Date(${T}).toLocaleString()`) as string;
+      expect(s).toMatch(/^7\/11\/2025, 12:00:00[\s ]AM$/);
+    });
+  });
+
+  describe("Number / BigInt toLocaleString", () => {
+    it("defaults to en-US grouping (the alias returned toString output)", () => {
+      expect(inSES(`(1234567.89).toLocaleString()`)).toBe("1,234,567.89");
+    });
+
+    it("honors an explicit locale", () => {
+      expect(inSES(`(1234567.89).toLocaleString("de-DE")`)).toBe(
+        "1.234.567,89",
+      );
+    });
+
+    it("covers BigInt", () => {
+      expect(inSES(`(123456789n).toLocaleString()`)).toBe("123,456,789");
+    });
+  });
+
+  describe("String locale methods", () => {
+    it("localeCompare defaults deterministically and honors explicit locales", () => {
+      // "ä" sorts before "z" in German but after "z" in Swedish — the classic
+      // collation divergence; both being honored proves arguments flow through.
+      expect(inSES(`"ä".localeCompare("z", "de")`)).toBeLessThan(0);
+      expect(inSES(`"ä".localeCompare("z", "sv")`)).toBeGreaterThan(0);
+      expect(inSES(`"a".localeCompare("b")`)).toBeLessThan(0);
+    });
+
+    it("case mappings default to en-US and honor explicit locales", () => {
+      expect(inSES(`"i".toLocaleUpperCase()`)).toBe("I");
+      // Turkish dotted capital İ — only with the explicit locale.
+      expect(inSES(`"i".toLocaleUpperCase("tr")`)).toBe("İ");
+    });
+  });
+
+  describe("delegating methods", () => {
+    it("Array.prototype.toLocaleString reaches the sanitized element methods", () => {
+      expect(inSES(`[1234.5, new Date(${T})].toLocaleString()`)).toMatch(
+        /^1,234\.5,7\/11\/2025, 12:00:00[\s ]AM$/,
+      );
+    });
+  });
+});

--- a/packages/runner/test/locale-taming.test.ts
+++ b/packages/runner/test/locale-taming.test.ts
@@ -17,6 +17,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { evaluateFunctionSourceInSES } from "../src/sandbox/ses-runtime.ts";
+import { pinLocales } from "../src/sandbox/locale-taming.ts";
 
 const T = 1752192000000; // 2025-07-11T00:00:00Z (Friday)
 
@@ -104,6 +105,37 @@ describe("sanitized locale methods under SES lockdown", () => {
       expect(inSES(`"i".toLocaleUpperCase()`)).toBe("I");
       // Turkish dotted capital İ — only with the explicit locale.
       expect(inSES(`"i".toLocaleUpperCase("tr")`)).toBe("İ");
+    });
+  });
+
+  describe("host-locale leak closure (unsupported-tag fallback)", () => {
+    // ECMA-402 resolves a well-formed-but-unsupported requested tag to the
+    // HOST default locale — a read of the user's language/region. pinLocales
+    // closes it by appending "en-US" to every request, so resolution never
+    // reaches the host default. The closure itself can't be asserted
+    // in-process (the realm's default locale is fixed at startup and CI hosts
+    // run en/C); it was verified manually via
+    //   LC_ALL=de_DE.UTF-8 deno eval '...toLocaleString("xx")'
+    // — so these tests pin the mechanism (the appended fallback) and the
+    // resulting in-compartment behavior.
+    it("appends the pinned default to every requested-locales shape", () => {
+      expect(pinLocales(undefined)).toBe("en-US");
+      expect(pinLocales([])).toEqual(["en-US"]);
+      expect(pinLocales("de-DE")).toEqual(["de-DE", "en-US"]);
+      expect(pinLocales(["fr", "de-DE"])).toEqual(["fr", "de-DE", "en-US"]);
+    });
+
+    it("resolves an unsupported tag to en-US output, not the host default", () => {
+      expect(inSES(`(1234567.89).toLocaleString("xx")`)).toBe("1,234,567.89");
+      expect(inSES(`new Date(${T}).toLocaleDateString("xx")`)).toBe(
+        "7/11/2025",
+      );
+    });
+
+    it("still throws RangeError on malformed tags", () => {
+      expect(() => inSES(`(1).toLocaleString("not a tag!")`)).toThrow(
+        RangeError,
+      );
     });
   });
 

--- a/packages/runner/test/locale-taming.test.ts
+++ b/packages/runner/test/locale-taming.test.ts
@@ -137,6 +137,29 @@ describe("sanitized locale methods under SES lockdown", () => {
         RangeError,
       );
     });
+
+    it("timeZone has no analogous fallback hole: invalid values throw, they never resolve to the host zone", () => {
+      // The ECMA-402 asymmetry: locale resolution silently falls back (the
+      // leak pinLocales closes); timeZone validation throws. Only omission
+      // (undefined) reaches a default — and the wrapper pins that to UTC.
+      expect(() =>
+        inSES(
+          `new Date(${T}).toLocaleDateString("en-US", { timeZone: "Not/AZone" })`,
+        )
+      ).toThrow(RangeError);
+      // undefined = omitted → pinned UTC; null is an explicit invalid value
+      // and throws natively — the wrapper preserves that.
+      expect(
+        inSES(
+          `new Date(${T}).toLocaleDateString("en-US", { timeZone: undefined })`,
+        ),
+      ).toBe("7/11/2025");
+      expect(() =>
+        inSES(
+          `new Date(${T}).toLocaleDateString("en-US", { timeZone: null })`,
+        )
+      ).toThrow(RangeError);
+    });
   });
 
   describe("delegating methods", () => {

--- a/packages/runner/test/locale-taming.test.ts
+++ b/packages/runner/test/locale-taming.test.ts
@@ -162,6 +162,57 @@ describe("sanitized locale methods under SES lockdown", () => {
     });
   });
 
+  describe("faithful argument handling (no leak, no lost behavior)", () => {
+    it("honors an array-LIKE locale list, not just real arrays", () => {
+      // ECMA-402 CanonicalizeLocaleList accepts array-likes; treating one as a
+      // single tag would ToString it to "[object Object]" and throw.
+      expect(
+        inSES(`(1234.5).toLocaleString({ 0: "de-DE", length: 1 })`),
+      ).toBe("1.234,5");
+    });
+
+    it("reads a stateful timeZone getter exactly once (no re-read leak)", () => {
+      // An adversarial getter that returned a real zone on the check-read and
+      // undefined on the forward-read would re-open the host-zone leak. The
+      // wrapper reads once and hands native a stable data property, so the
+      // format matches the explicit-NY result regardless of later reads.
+      const viaGetter = inSES(`(() => {
+        let n = 0;
+        const opts = { get timeZone() { n++; return n === 1 ? "America/New_York" : undefined; } };
+        return new Date(${T}).toLocaleDateString("en-US", opts);
+      })()`);
+      expect(viaGetter).toBe("7/10/2025"); // NY: 2025-07-11T00:00Z is 7/10 local
+    });
+
+    it("honors an inherited timeZone (a spread would have dropped it → UTC)", () => {
+      expect(
+        inSES(
+          `new Date(${T}).toLocaleDateString("en-US", Object.create({ timeZone: "America/New_York" }))`,
+        ),
+      ).toBe("7/10/2025");
+    });
+
+    it("lets native reject invalid options instead of coercing them valid", () => {
+      // `{ ...null }` would have become `{ timeZone: "UTC" }` and succeeded;
+      // native throws TypeError on null options, and the wrapper preserves that.
+      expect(() => inSES(`new Date(${T}).toLocaleDateString("en-US", null)`))
+        .toThrow(TypeError);
+    });
+  });
+
+  describe("Intl is absent from the compartment", () => {
+    it("exposes no Intl object — resolvedOptions().timeZone is unreachable", () => {
+      // The toLocale* methods format via the engine's INTERNAL Intl; the
+      // compartment global `Intl` is not installed, so the classic host-zone
+      // read `new Intl.DateTimeFormat().resolvedOptions().timeZone` throws
+      // rather than returning the host zone.
+      expect(inSES(`typeof Intl`)).toBe("undefined");
+      expect(() =>
+        inSES(`new Intl.DateTimeFormat().resolvedOptions().timeZone`)
+      ).toThrow();
+    });
+  });
+
   describe("delegating methods", () => {
     it("Array.prototype.toLocaleString reaches the sanitized element methods", () => {
       expect(inSES(`[1234.5, new Date(${T})].toLocaleString()`)).toMatch(


### PR DESCRIPTION
## Summary

`localeTaming: "safe"` aliased every `toLocale*` method to its non-locale equivalent, silently ignoring arguments — `toLocaleDateString("en-US", { month: "short" })` returned `toDateString()` output inside patterns. But the methods' ambient authority lives entirely in their locale/timeZone *resolution*; called with explicit arguments they are pure functions of their inputs (modulo ICU tables). So this replaces the amputation with a vetted pre-lockdown shim (`locale-taming.ts`) that pins every ambient default and delegates to the originals, then runs lockdown with `localeTaming: "unsafe"` so the sanitized wrappers survive and get hardened as intrinsics.

**Pinned paths** (each is a route ECMA-402 would otherwise resolve to ambient host state):

- omitted locale → `"en-US"`
- the ECMA-402 **unsupported-tag locale fallback** → `"en-US"`, by appending the default to every request — without this, a well-formed-but-unsupported tag (`"xx"`) resolves to the *host default locale*, leaking the user's language/region off the formatted output (verified live under `LC_ALL=de_DE.UTF-8`)
- Date `timeZone` → `"UTC"` when omitted

**Covered methods:** Date `toLocaleDateString`/`toLocaleTimeString`/`toLocaleString`, Number/BigInt `toLocaleString`, String `localeCompare` + locale case mappings. Array/%TypedArray%/Object `toLocaleString` delegate to element methods and need no wrapping. `Intl` itself remains absent from compartments, so the classic `new Intl.DateTimeFormat().resolvedOptions().timeZone` host-zone read is unreachable (asserted).

## Date options: fail closed

Date `timeZone` is the one security-sensitive option, and native's coercion of the `options` argument is a leak surface. The wrapper accepts only two shapes and **throws `TypeError` on everything else**:

- `undefined` (omitted) → pin UTC
- a plain object whose `timeZone` is absent or a plain **own data property** → pin UTC if absent, else forward the value (an invalid explicit zone like `"Not/AZone"`/`null` still throws `RangeError` from native — ECMA-402 has no timezone fallback to the host zone)

Rejected, because each formats in the host zone under native semantics or lets a read diverge from what we validated, and no legitimate pattern uses them (repo grep: every `toLocale*` call passes a plain object literal, a string/`[]` locale, or `undefined`):

- **primitives** (`42`, `"x"`) — V8 boxes them via `ToObject`, leaving `timeZone` absent → host zone
- **functions** — a function is an object, same absent-`timeZone` → host zone
- **`null`** — native throws too; kept consistent
- a **`timeZone` getter** — a stateful accessor could return a real zone on our check and `undefined` (→ host zone) on native's read; the wrapper reads the own-property *descriptor's* reflected value, so there is exactly one side-effect-free read
- an **inherited** `timeZone` — not a plain own property

`pinLocales` likewise materializes array-*like* locale lists (`{ 0: "de-DE", length: 1 }`, which `CanonicalizeLocaleList` accepts) before appending the fallback, rather than treating them as a single tag.

## Security posture

- **Closes** the user-level host-locale and host-timezone channels through `toLocale*` (defaults, the unsupported-tag fallback, and the options-coercion leak).
- **Does not change** the pre-existing untamed `Date` surface (`toString()` includes the zone name; `getTimezoneOffset()` probing recovers the IANA zone) — that channel predates this PR and is tracked, with its closure path, in the new spec §11.5 and CT-1882 (blocked on the CT-1881 viewer-timezone capability).
- **Residual, accepted:** ICU/tzdata version fingerprinting (zone-name validity, formatting quirks like U+202F) — environment-level, inherent to exposing real ICU.
- SES tames realm-wide, so host code also gets the sanitized methods — strictly closer to native than the amputated aliases it had post-lockdown.

## Docs

- `SES_SANDBOXING_SPEC.md` §5.1 documents the `localeTaming: "unsafe"` ⇄ sanitizer pairing (neither side may change in isolation); new §11.5 inventories residual observability/fingerprinting channels with class (user-level vs environment-level) + status.
- Pattern guide: locale formatting semantics + the mixed-zone trap (a local-midnight `Date` formatted without an explicit `timeZone` renders in UTC and can shift a day east of UTC). `calendar.tsx` `formatDate` and lunch-poll `visitLabel` have that shape today — they display *better* than before (options were fully ignored) but deserve a small follow-up pass.

## Test plan

- 34 test steps in `packages/runner/test/locale-taming.test.ts`, all asserting **inside a lockdown compartment**: options honored, bare-call determinism, explicit locale/timeZone honored (German/Swedish collation divergence, Turkish İ), unsupported-tag fallback pinned, array-like locale lists honored, every rejected Date-options shape throws (day-boundary timestamp so a host-zone leak would surface as a different date), and `Intl` absence.
- Suite verified under a hostile host: `TZ=Europe/Berlin LC_ALL=de_DE.UTF-8` — the discriminating assertions pass precisely because neither host default is reachable.
- `security.test.ts` + `stack-trace.test.ts` unchanged and green; end-to-end `cf check` probe confirms through the compile→SES→evaluate stack.

No experimental flag: the change strictly replaces argument-ignoring aliases with argument-honoring (or fail-closed) wrappers at the single lockdown choke point.

## Review

Two adversarial cubic rounds; all threads resolved. Commits, in order: sanitizer → unsupported-tag locale-fallback leak → `timeZone: null` spec fidelity → spec/observability docs → hardening (getter/array-like/coercion) → fail-closed on non-plain Date options → inline a single-use helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
