### PR TITLE
docs(pattern-construction): specify first-class serializable factories

### DIFF
--- a/docs/plans/first-class-serializable-factories.md
+++ b/docs/plans/first-class-serializable-factories.md
@@ -1,0 +1,1116 @@
+# First-Class Serializable Factories — Implementation Plan
+
+Status: Not started
+
+This plan implements
+[First-Class Serializable Factories](../specs/pattern-construction/node-factory-shipping.md).
+Read that specification first: it defines the behavior and invariants; this
+document defines the implementation sequence. If the two disagree, update the
+plan or stop for a design decision rather than changing the contract implicitly.
+
+The work is independent of graph snapshots and the reactive-interpreter
+migration. In particular, Stage 0 copies or reimplements only the generic
+`$patternRef` behavior identified from #4514; it does not merge or depend on the
+rest of that branch.
+
+## Status convention
+
+- [ ] Not started
+- [x] Complete and verified
+
+Mark a parent checkbox complete only after all of its child checks and its
+completion gate pass. Keep this live plan updated in the same commits as the
+implementation. When the final removal gate passes, archive it under
+`docs/history/plans/` following `docs/README.md`.
+
+## How to execute this plan
+
+- Work stages in order. Tasks within a work package are dependency ordered
+  unless explicitly marked parallel-safe.
+- Use red/green TDD for every behavioral slice: add the focused failing test,
+  confirm the failure is for the intended missing behavior, implement the
+  smallest coherent change, then refactor.
+- Commit by numbered work package or smaller coherent subtask. Do not combine a
+  data-model protocol change, transformer lowering, and source migration in one
+  commit.
+- Run the affected package's complete test task before completing a work
+  package. Run the cross-package gates at the end of every stage.
+- For transformer changes, inspect emitted code with
+  `deno task cf check <fixture>.tsx --show-transformed --no-run`; do not infer
+  the emitted IR from transformer source alone.
+- Treat `Factory@1` as a wire format. Any field or validation change requires a
+  spec review, encode/decode fixtures, and an explicit compatibility decision.
+- Keep legacy readers until their removal gates pass, but switch each writer to
+  the new representation as soon as its stage lands.
+- Preserve the public rule that authors create another inline pattern to add a
+  binding layer. `.curry(params)` is transformer-only, one-shot, and absent from
+  the public API throughout this plan.
+
+## Fixed design constraints
+
+- [ ] Use one directly branded callable `Factory@1` value for pattern, module,
+  and handler factories; do not introduce `FabricPatternFactory`,
+  `FabricModuleFactory`, or another wrapper object.
+- [ ] Keep the factory artifact ref distinct from `$implRef`; only the complete
+  content-addressed builder artifact can back durable factory state.
+- [ ] Decode to a branded, inert callable shell. Only runner-owned
+  `materializeFactory` may turn a shell into an executable builder factory.
+- [ ] Keep public pattern input in callback argument 0 and closure params in
+  callback argument 1. Never merge the two records.
+- [ ] Carry the compiler-generated params schema with
+  `withPatternParamsSchema(callback, schema)` before `pattern()` eagerly invokes
+  the callback; do not add a fourth `pattern()` argument.
+- [ ] Emit `.curry(params)` only from the transformer, with exactly one
+  argument, no argument index, and a hard error on a second call.
+- [ ] Permit durable encoding only when the root artifact has a cold-resolvable
+  content-addressed `{ identity, symbol }` ref. Reject keyless, action-created,
+  and host-pseudo-module factories.
+- [ ] Keep the dynamic call site's output spot as the stable identity anchor
+  when the selected factory changes.
+- [ ] Preserve `FrameworkProvided` inputs as system-supplied inputs through
+  wrapper chains; reject authored or captured attempts to provide them.
+
+## Dependency map
+
+| Stage | Delivers | Depends on |
+| --- | --- | --- |
+| 0 | Generic `$patternRef` binding and direct setup resolution | Current `main` |
+| 1 | Branded, serializable, materializable factory values | Stage 0 |
+| 2 | `asFactory` schemas and dynamic symbolic invocation | Stage 1 |
+| 3 | Nested-pattern closure conversion and hidden params root | Stages 1–2 |
+| 4 | Boundary/tool migration and `patternTool` writer removal | Stages 1–3 |
+| 5 | Compatibility-reader removal and final documentation | Stored-data and rollout gates |
+
+The API/schema-generator work in Stage 2 may start in parallel with the runner
+dynamic-node work after Stage 1's canonical state is fixed. Stage 3 must not
+invent a second factory representation while waiting for Stage 2.
+
+## Stage 0 — Extract generic `$patternRef` binding
+
+### WP0.1 — Audit and isolate the #4514 prerequisite
+
+Reference commits: `3b028c786`, `39b213e63`, and `ede6c5a7d`.
+
+- [ ] Compare each reference commit against current `main`; record which hunks
+  are already present and which semantic tests still fail.
+- [ ] Copy or reimplement only changes touching generic pattern-value binding,
+  executable lookup, and direct setup/sub-pattern resolution.
+- [ ] Explicitly exclude reactive-interpreter dispatch, strict-interpreter-only
+  rewrites, or unrelated runner refactors from the port.
+- [ ] Keep current runner behavior outside the new `$patternRef` cases byte-for-
+  byte or test-for-test equivalent.
+
+Expected implementation files:
+
+- `packages/runner/src/pattern-binding.ts`
+- `packages/runner/src/runner.ts`
+- `packages/runner/src/builtins/op-pattern-ref.ts`
+- `packages/runner/src/harness/executable-registry.ts` only if the current
+  executable lookup still needs the generic artifact path
+
+### WP0.2 — Bind nested pattern values by reference
+
+- [ ] Add a red test showing an addressable pattern nested in an object/array
+  binding is replaced with a `$patternRef` sentinel rather than copied as an
+  inert graph.
+- [ ] Preserve `argumentSchema` and `resultSchema` on the sentinel.
+- [ ] Preserve derivation provenance so a serialized copy still resolves its
+  root artifact ref after registration.
+- [ ] Cover direct, nested, repeated, and aliased occurrences without changing
+  ordinary object traversal.
+- [ ] Preserve the current legacy graph fallback for a keyless pattern; the new
+  durable `Factory@1` identity rejection belongs to Stage 1, not this
+  prerequisite port.
+
+Tests to port or extend:
+
+- `packages/runner/test/pattern-binding.test.ts`
+- `packages/runner/test/pattern-node-patternref.test.ts` (new if still absent)
+
+### WP0.3 — Resolve a sentinel passed directly to setup/run
+
+- [ ] Add a red test for a `$patternRef` handed directly to sub-pattern setup,
+  not only nested inside another binding.
+- [ ] Resolve synchronously from the artifact index when warm.
+- [ ] Fall back to the existing storage-backed identity loader when cold.
+- [ ] Validate the resolved value is a trusted pattern with matching schemas.
+- [ ] Ensure a missing or wrong-kind ref fails closed and includes identity and
+  symbol in the diagnostic.
+
+Tests to port or extend:
+
+- `packages/runner/test/pattern-tool-invoke-boundary.test.ts`
+- `packages/runner/test/pattern-ref-boundary.test.ts`
+- `packages/runner/test/stored-pattern-rehydration.test.ts`
+
+### Stage 0 completion gate
+
+- [ ] The three reference commits are not ancestors of this work by accident;
+  only reviewed prerequisite behavior has been reproduced.
+- [ ] `deno test` passes for the focused Stage 0 runner tests.
+- [ ] `deno task test` passes in `packages/runner`.
+- [ ] No Stage 0 code depends on reactive-interpreter-only types or flags.
+- [ ] Commit the stage as a standalone, revertible prerequisite.
+
+## Stage 1 — Branded callable Fabric values
+
+### WP1.1 — Define the dependency-light factory protocol
+
+- [ ] Add the `FabricFactory` callable arm to
+  `packages/data-model/src/interface.ts` and mirror it in
+  `packages/api/index.ts`.
+- [ ] Define the `FactoryStateV1` discriminated union with exactly the fields in
+  the specification: shared `ref`; pattern schemas/params/scope/space selector;
+  module schemas/scope; and handler context/event schemas.
+- [ ] Add internal live-state support with a stable root token and an optional,
+  not-yet-sealed ref. Keep live state out of the public wire type.
+- [ ] Add one module-private admission/state table and shared
+  `tryFactoryState()` / `factoryStateOf()` access path. A copied symbol property
+  must not pass admission.
+- [ ] Provide an internal registration API for trusted builder constructors and
+  codec-created shells without granting runner execution trust.
+- [ ] Keep all properties used for branding/state access non-enumerable and do
+  not modify `Function` or `Function.prototype`.
+- [ ] Export only the minimum protocol surface needed by the runner and codec;
+  do not expose `.curry` or state mutation to pattern authors.
+- [ ] Re-export the runner-facing protocol through
+  `packages/data-model/src/fabric-value.ts` without creating a dependency from
+  the data model back into the runner.
+
+Expected implementation files:
+
+- `packages/data-model/src/interface.ts`
+- a new dependency-light module such as
+  `packages/data-model/src/fabric-factory.ts`
+- `packages/data-model/deno.jsonc` export map
+- `packages/api/index.ts`
+
+### WP1.2 — Add `Factory@1` codec dispatch
+
+- [ ] Add the `Factory@1` constant to
+  `packages/data-model/src/codec-common/codec-type-tags.ts`.
+- [ ] Implement a `FactoryCodec` with wire tag `Factory@1`.
+- [ ] Validate discriminant, exact allowed fields, content-addressed ref shape,
+  schemas, modifiers, and pattern-only params fields during decode.
+- [ ] Decode to a frozen branded callable shell whose body throws
+  `factory requires runner materialization` and whose state can be re-encoded.
+- [ ] Add a dedicated callable-factory codec slot to
+  `packages/data-model/src/codec-json/CodecRegistry.ts`; do not classify all
+  functions as primitives or match `Function` by constructor.
+- [ ] Register the codec in
+  `packages/data-model/src/codec-json/createDefaultRegistry.ts`.
+- [ ] Route callable factories through codec lookup before the generic function
+  rejection and before legacy `toJSON()` conversion.
+- [ ] Include callable factories in JSON encoder cycle tracking.
+- [ ] Reject arbitrary functions, copied brand symbols, malformed state,
+  unknown kinds, extra fields, and cyclic state.
+
+Expected implementation and test files:
+
+- `packages/data-model/src/codec-common/` for the codec/state validator
+- `packages/data-model/src/codec-json/CodecRegistry.ts`
+- `packages/data-model/src/codec-json/JsonEncodingContext.ts`
+- `packages/data-model/src/codec-json/createDefaultRegistry.ts`
+- `packages/data-model/src/codec-json/json-encoding.ts`
+- `packages/data-model/test/codec-common/FactoryCodec.test.ts`
+- `packages/data-model/test/codec-json/CodecRegistry.test.ts`
+- `packages/data-model/test/codec-json/JsonEncodingContext.test.ts`
+- `packages/data-model/test/codec-json/json-encoding.test.ts`
+- a focused `packages/data-model/test/fabric-factory.test.ts`
+
+### WP1.3 — Make every Fabric operation see the same factory state
+
+- [ ] Update `packages/data-model/src/native-conversion.ts` so admitted
+  factories are recognized through `tryFactoryState()` before legacy function
+  `toJSON()` and unbranded functions remain invalid. Codec dispatch remains the
+  serialization layer's job.
+- [ ] Update `packages/data-model/src/type-check.ts` and compatibility guards so
+  `FabricFactory` is the only valid function-shaped Fabric value.
+- [ ] Update `packages/data-model/src/deep-freeze.ts` to seal/freeze canonical
+  state and then freeze the callable. Factory handling must precede the current
+  shortcut that treats functions as already frozen.
+- [ ] Update `packages/data-model/src/value-clone.ts` so canonical factories are
+  immutable logical atoms and both mutable/frozen clone requests preserve the
+  same canonical factory.
+- [ ] Update `packages/data-model/src/valueEqual.ts` to compare canonical codec
+  state rather than function identity, before any same-reference shortcut that
+  could accidentally admit an arbitrary function.
+- [ ] Update `packages/data-model/src/value-hash.ts` to hash the `Factory@1` tag
+  and recursively hashed canonical state.
+- [ ] Ensure all of these paths call the shared state/codec visitor rather than
+  independently enumerating hidden fields.
+- [ ] Make encode, hash, equality, and Fabric deep-freeze fail before a live
+  factory's artifact ref can be sealed.
+- [ ] Verify sealing memoizes one immutable state and a stable hash.
+
+Focused tests:
+
+- `packages/data-model/test/native-conversion.test.ts`
+- `packages/data-model/test/type-check.test.ts`
+- `packages/data-model/test/deep-freeze.test.ts`
+- `packages/data-model/test/cloneIfNecessary.test.ts`
+- `packages/data-model/test/cloneForMutation.test.ts`
+- `packages/data-model/test/shallowMutableClone.test.ts`
+- `packages/data-model/test/value-clone.test.ts`
+- `packages/data-model/test/valueEquals.test.ts`
+- `packages/data-model/test/value-hash.test.ts`
+
+Each suite must cover all three factory kinds, nested factory state, independent
+but equal decoded shells, pre-seal failure, and arbitrary-function rejection.
+
+### WP1.4 — Attach canonical state in runner builders
+
+- [ ] Brand the function returned by `pattern()` in
+  `packages/runner/src/builder/pattern.ts` as kind `pattern`.
+- [ ] Brand functions returned by `createNodeFactory()`, including `lift()`,
+  `byRef()`, raw/builtin factories, and equivalent helpers, as kind `module`.
+- [ ] Brand `handler()` results as kind `handler` while retaining separate
+  `contextSchema` and `eventSchema` before the internal `$ctx`/`$event` schema
+  combination.
+- [ ] Populate state from the complete builder descriptor, never from
+  `moduleToJSON(...).$implRef`.
+- [ ] Reuse or generalize the derivation/root tracking in
+  `packages/runner/src/builder/pattern-metadata.ts` so `asScope()`, `inSpace()`,
+  later `.curry()`, and traversal copies share one root token and late ref.
+- [ ] Make `asScope()` and every `inSpace()` selector form create a new branded
+  factory whose canonical state includes the modifier without resolving a raw
+  selector prematurely.
+- [ ] Seal through `getArtifactEntryRef(root)` after `PatternManager` indexes
+  the verified export or `__cfReg` artifact.
+- [ ] Make `setArtifactEntryRef()` feed the root token's late-ref state so a
+  derived factory created before registration seals against the same canonical
+  artifact without introducing a data-model-to-runner dependency.
+- [ ] Reject durable encoding of keyless/manual, action-created, and `host:<n>`
+  pseudo-module factories.
+- [ ] Preserve existing direct live invocation behavior before and after state
+  attachment.
+
+Focused tests:
+
+- `packages/runner/test/factory-input-types.test.ts`
+- `packages/runner/test/pattern-provenance.test.ts`
+- `packages/runner/test/pattern-scope.test.ts`
+- `packages/runner/test/host-pseudo-module.test.ts`
+- new `packages/runner/test/factory-state.test.ts`
+
+### WP1.5 — Traverse hidden factory state during graph construction
+
+- [ ] Adapt the shared visitor/accessor from
+  `packages/data-model/src/fabric-factory.ts` for builder traversal; runner code
+  supplies alias mapping and derived-callable construction but does not define
+  a second state view.
+- [ ] Integrate it into `packages/runner/src/builder/traverse-utils.ts` and
+  `packages/runner/src/builder/json-utils.ts` before generic function handling.
+- [ ] Preserve live, pre-ref factory state during internal graph serialization;
+  sealing belongs at a later durable Fabric boundary, after artifact indexing.
+- [ ] Convert captured Cells/Reactives to aliases inside factory state.
+- [ ] Descend into nested factories without exposing enumerable `curried` or
+  state fields.
+- [ ] Keep CFC inspection and alias traversal on the same logical state view as
+  serialization, hashing, and equality.
+- [ ] Verify two references to the same factory do not cause false cycle errors,
+  while an actual cycle through params is rejected.
+- [ ] Review graph payload fields in `packages/runner/src/builder/types.ts` and
+  static-data walks in `packages/runner/src/cell.ts` so hidden factory state is
+  neither flattened nor skipped.
+- [ ] Verify `packages/runner/src/storage/differential.ts`,
+  `packages/runner/src/storage/v2-transaction.ts`, and
+  `packages/memory/v2/patch.ts` treat factories atomically through the shared
+  equality/clone protocol.
+- [ ] Once canonical factory traversal is available, switch durable
+  factory-valued binding from Stage 0's `$patternRef` sentinel to `Factory@1`.
+  Constrain `$patternRef` emission to explicitly legacy/internal graph fallback
+  paths and add a test that new durable factory writes cannot choose it.
+
+### WP1.6 — Add runner-owned factory materialization and generic resolution
+
+- [ ] Generalize `PatternManager.loadPatternByIdentity()` into, or layer it on,
+  a generic `loadArtifactByIdentity(identity, symbol, space)` path that returns
+  only trusted indexed builder artifacts.
+- [ ] Preserve warm artifact-index lookup, storage-backed cold loading,
+  single-flight behavior, `__cfReg` symbol resolution, and CFC verification.
+- [ ] Keep a pattern-specific wrapper temporarily for existing callers.
+- [ ] Implement the runner chokepoint
+  `materializeFactory(value, runtime)` with warm and async-cold forms as needed.
+- [ ] Return live factories unchanged when their trusted kind/state already
+  match.
+- [ ] For decoded shells, resolve the trusted base artifact, compare kind and
+  normalized schemas, reapply scope/space modifiers, retain canonical codec
+  state, and return a callable builder factory.
+- [ ] Keep schema-light module factories unresolved until a trusted
+  `ModuleRegistry` entry supplies schemas; never promote wire or call-site
+  hints to execution authority.
+- [ ] Until Stage 3 lands, fail materialization closed for decoded pattern state
+  containing `paramsSchema` or `params`; Stage 1 may validate and re-encode that
+  state but cannot yet reconstruct its runtime binding semantics.
+- [ ] Reject missing refs, wrong kinds, schema mismatches, forged metadata, and
+  non-factory values with stable diagnostics.
+
+Expected files and tests:
+
+- `packages/runner/src/pattern-manager.ts`
+- a focused runner module such as
+  `packages/runner/src/factory-materialization.ts`
+- `packages/runner/test/pattern-manager.test.ts`
+- `packages/runner/test/fabric-imports-pattern-manager.test.ts`
+- new `packages/runner/test/factory-materialization.test.ts`
+
+### WP1.7 — Prove context-free and runner-aware round trips
+
+- [ ] Round-trip pattern, module, and handler factories through context-free
+  JSON and confirm decode returns inert callable shells.
+- [ ] Re-encode each shell without a runner and get identical canonical state.
+- [ ] Materialize each shell in a warm runner and invoke it through its existing
+  direct path.
+- [ ] Cold-load each kind in a fresh runtime from the content-addressed module
+  identity.
+- [ ] Round-trip factories nested in plain arrays/objects and synthetic decoded
+  factory state. Typed Cell/piece coverage waits for Stage 2 `asFactory`, and
+  live bound-pattern params wait for Stage 3's internal curry and params root.
+- [ ] Preserve `asScope()` and named, anonymous, and cell-derived `inSpace()`
+  selectors across the round trip.
+- [ ] Verify equal state hashes equally across independent verified module
+  evaluations.
+
+### WP1.8 — Update the live Fabric protocol documentation
+
+- [ ] Update `docs/specs/space-model-formal-spec/1-fabric-values.md` when the
+  callable Fabric arm lands.
+- [ ] Update `docs/specs/space-model-formal-spec/3-json-encoding.md` with the
+  exact `Factory@1` tag, validated state, and inert context-free decode.
+- [ ] Pin `Factory@1` to the existing codec-instance byte arm in
+  `docs/specs/space-model-formal-spec/2-hash-byte-format.md`; do not invent a
+  factory-specific hash encoding.
+- [ ] Keep the proposal's status accurate for the still-unimplemented dynamic
+  invocation and closure stages.
+
+### Stage 1 completion gate
+
+- [ ] `Factory@1` is the only new wire tag and no wrapper factory type exists.
+- [ ] All three trusted factory constructors attach state and direct invocation
+  remains green.
+- [ ] Arbitrary functions and pseudo refs are still rejected.
+- [ ] Context-free decode is inert; runner materialization is the only path to
+  executable behavior.
+- [ ] `deno task test` passes in `packages/data-model` and `packages/runner`.
+- [ ] `deno check packages/api/index.ts` (or the package's standard type-check)
+  passes with `.curry` absent from public `PatternFactory`.
+- [ ] Commit Stage 1 in protocol, builder-state, and materialization slices.
+
+## Stage 2 — Factory schemas and symbolic invocation
+
+### WP2.1 — Add `asFactory` to the public schema vocabulary
+
+- [ ] Extend `JSONSchemaObj` in `packages/api/index.ts` with a discriminated
+  `asFactory` definition for `pattern`, `module`, and `handler`.
+- [ ] Use `argumentSchema`/`resultSchema` for pattern and module kinds and
+  `contextSchema`/`eventSchema` for handler kind.
+- [ ] Define one schema normalization/equality helper for trusted factory
+  comparisons; version 1 requires equality, not variance.
+- [ ] Update schema validation/resolution utilities that copy, merge, sanitize,
+  or format Common Fabric extensions so `asFactory` is preserved.
+- [ ] Teach `Schema<T>` / `SchemaWithoutCell<T>` in
+  `packages/api/schema.ts` to materialize `asFactory` as the matching generic
+  `PatternFactory`, `ModuleFactory`, or `HandlerFactory`.
+- [ ] Ensure `asFactory` composes correctly with refs/definitions and does not
+  silently become `asCell`.
+- [ ] Add public type assertions in `packages/api/test/factory-input-types.test.ts`
+  and `packages/api/index.test.ts` proving factories are Fabric values, schema
+  inference preserves their generics, and `.curry` is unavailable.
+
+### WP2.2 — Generate schemas for all factory kinds
+
+- [ ] Teach `packages/schema-generator/src/formatters/object-formatter.ts` to
+  recognize `PatternFactory`, `ModuleFactory`, and `HandlerFactory` before its
+  generic callable and callable-return-wrapper cases.
+- [ ] Prefer one dedicated factory detector/formatter, registered before union,
+  intersection, and object formatting, so aliases and branded intersections
+  cannot fall through to generic callable handling.
+- [ ] Extract public input/output schemas from the factory type arguments.
+- [ ] Ensure `HandlerFactory` emits `contextSchema`/`eventSchema` and is not
+  mistaken for `{ asCell: ["stream"] }` merely because its call signature
+  returns a stream.
+- [ ] Preserve schemas for aliases, properties, arrays/maps of factories, and
+  factory unions used only as stored/returned values, using `anyOf` or the
+  schema generator's equivalent union representation.
+- [ ] Keep storage representability separate from callability: cross-kind or
+  schema-varying unions are rejected only when WP2.3 tries to invoke them.
+- [ ] Add fixtures covering factory-valued inputs, outputs, captures, nested
+  containers, `byRef()`, and all three kinds.
+
+Expected tests:
+
+- a new `packages/schema-generator/test/schema/factory-types.test.ts`
+- paired fixtures under `packages/schema-generator/test/fixtures/schema/`
+- `packages/schema-generator/test/schema/factory-input-real-api.test.ts`
+- `packages/schema-generator/test/fixtures-runner.test.ts`
+
+### WP2.3 — Lower symbolic factory calls
+
+- [ ] Add a type-directed callee classifier in `packages/ts-transformers` that
+  distinguishes live imported/module-scoped factories from symbolic/reactive
+  factory values.
+- [ ] Follow local aliases, property access, and statically typed element access
+  such as `const f = inputs.operation; f(x)` and
+  `inputs.operations[key](x)`.
+- [ ] Leave calls to live imported or module-scoped factories on the direct
+  builder call path.
+- [ ] Lower symbolic calls to internal `__cfHelpers.invokeFactory(factory,
+  input, expectedSchema)`.
+- [ ] Emit a pattern/module result as `Reactive` and a handler result as
+  `Stream`, preserving handler `$ctx`/`$event` wiring.
+- [ ] Reject a cross-kind union before graph construction and require normalized
+  schema agreement for same-kind unions.
+- [ ] Add a compile-time diagnostic for an untransformed symbolic factory proxy
+  call.
+
+Expected transformer seams:
+
+- `packages/ts-transformers/src/ast/call-kind.ts`
+- a centralized factory-kind/origin classifier under
+  `packages/ts-transformers/src/ast/`
+- the expression-site/type policy modules under
+  `packages/ts-transformers/src/policy/`
+- `packages/ts-transformers/src/transformers/structural-reactive-factory.ts`
+- `packages/ts-transformers/src/transformers/schema-injection.ts`
+- `packages/ts-transformers/src/cf-pipeline.ts`
+- `packages/ts-transformers/src/core/commonfabric-runtime-registry.ts`
+- helper registration/emission alongside existing `__cfHelpers`
+
+Golden coverage must show exact direct-versus-symbolic output for aliases,
+properties, element access, schema-light module refs, handlers, and unions.
+Add dedicated fixtures for direct import, input field, local alias, property,
+static element access, handler stream, compatible same-kind union, cross-kind
+union, and schema mismatch; extend pipeline regression coverage so later
+passes cannot undo the lowering.
+
+### WP2.4 — Build the internal dynamic factory node
+
+- [ ] Implement `invokeFactory` in the runner builder layer so it records a
+  dynamic node whose module input is the symbolic factory value and whose
+  expected kind/public schemas are explicit.
+- [ ] Extend `NodeRef.module`/serialized node typing only as narrowly as needed;
+  do not add another public factory wrapper.
+- [ ] Complete the dynamic-module arm currently marked `TODO` in
+  `packages/runner/src/runner.ts`.
+- [ ] Resolve the factory cell value through `materializeFactory`, validate kind
+  and trusted normalized schemas, then tail-call the existing pattern,
+  JavaScript-module, or handler instantiation path.
+- [ ] Resolve a schema-light `byRef()` through `ModuleRegistry`; fail if no
+  trusted concrete schema is available.
+- [ ] Apply pattern scope and raw space-selector modifiers after base resolution
+  and before child instantiation.
+- [ ] Do not execute implementation code during decode, value resolution, or
+  property inspection.
+
+### WP2.5 — Supervise replacement and teardown
+
+- [ ] Make the factory cell a reactive dependency of one dynamic-node
+  supervisor.
+- [ ] Give each selected child/action/handler generation its own cancellation
+  scope and monotonically increasing generation token.
+- [ ] Add a scheduler/transaction generation guard: cancellation alone does not
+  currently prevent an already-running async action from committing its final
+  writes.
+- [ ] On factory change, cancel the previous generation, fence late async
+  writes/results, tear down result-owned internals and handler subscriptions,
+  and instantiate the replacement.
+- [ ] Preserve the call site's output binding and cause as the stable identity
+  anchor across replacement.
+- [ ] Verify two distinct call sites still receive distinct output identities.
+- [ ] Cover replacement before settle, replacement after settle, same-factory
+  replay, wrong-kind replacement, rejected cold load, and handler unsubscribe.
+- [ ] Cover stale cold load A completing after B is selected, owner/piece
+  teardown while load/action work is pending, invalid-then-valid replacement
+  recovery, replacement-only handler stream routing, and cold resume with the
+  selected factory and stable output identity.
+
+Expected runtime tests:
+
+- new `packages/runner/test/dynamic-factory-node.test.ts`
+- `packages/runner/test/patterns-dynamic.test.ts`
+- `packages/runner/test/patterns-handlers.test.ts`
+- `packages/runner/test/by-identity-handler-exec.test.ts`
+- `packages/runner/test/map-op-by-identity.test.ts`
+
+Likely supervision seams include `packages/runner/src/cancel.ts` and the action,
+subscription, and scheduler modules under `packages/runner/src/scheduler/`.
+
+### WP2.6 — Materialize factories at runner exposure boundaries
+
+- [ ] Route schema-driven `asFactory` Cell reads through the materialization
+  chokepoint.
+- [ ] Materialize recursively in query/result exposure without eagerly walking
+  unrelated opaque data.
+- [ ] Route graph binding and dynamic dispatch through the same helper.
+- [ ] Preserve decoded shells at intentionally context-free data-model
+  boundaries.
+- [ ] Verify memory v1/v2 storage, patch/diff, and sync paths treat a canonical
+  factory as an atomic codec value while still traversing its encoded state.
+- [ ] Cover `packages/memory/v2.ts` `encodeMemoryBoundary` /
+  `decodeMemoryBoundary` with a focused
+  `packages/memory/test/v2-factory-boundary-test.ts` round trip.
+- [ ] Add a fresh-runtime client/server round trip in which one runtime writes a
+  factory, another decodes it, and a runner materializes/invokes it.
+- [ ] Add typed factory round trips through Cells, query-result proxies, pieces,
+  nested arrays, and nested objects now that `asFactory` exists.
+- [ ] Verify cross-space links remain links and CFC labels survive resolution.
+
+Concrete seams and focused tests:
+
+- `packages/runner/src/cell.ts`
+- `packages/runner/src/query-result-proxy.ts`
+- the query/runtime adapters that expose decoded values
+- `packages/runner/test/cell-proxy.test.ts`
+- `packages/runner/test/query-result-proxy-fabric-primitive.test.ts`
+- `packages/runner/test/query.test.ts`
+
+### Stage 2 completion gate
+
+- [ ] Factory-valued inputs, outputs, and stored cells carry `asFactory`.
+- [ ] Symbolic pattern, module, and handler calls all use the same internal
+  dynamic path.
+- [ ] Direct live-factory calls have unchanged emitted code and behavior.
+- [ ] Dynamic replacement cancels/fences the prior generation without changing
+  the stable output spot.
+- [ ] Warm and cold resolution fail closed on kind or schema mismatch.
+- [ ] `deno task test` passes in `packages/api`, `packages/schema-generator`,
+  `packages/ts-transformers`, and `packages/runner` using each package's
+  available task names.
+
+## Stage 3 — Pattern closure conversion
+
+### WP3.1 — Add the compiler-only params-schema carrier
+
+- [ ] Add internal `withPatternParamsSchema(callback, schema)` next to the
+  builder helpers, backed by a private callback WeakMap or equally unforgeable
+  protocol.
+- [ ] Return the original callback so the helper can wrap the first argument of
+  `pattern()` without changing public arity.
+- [ ] Make `pattern()` and `patternFromFrame()` read the schema synchronously
+  before eager callback invocation.
+- [ ] Create a second symbolic root only when compiler metadata declares a
+  params slot, and call the transformed callback as `callback(argument,
+  params)`.
+- [ ] Persist the trusted params schema in the base pattern's internal factory
+  state.
+- [ ] Carry that trusted schema through the internal Pattern/factory metadata
+  used by cold resolution without exposing it as public input schema.
+- [ ] Reject an authored second callback parameter that lacks compiler-created
+  metadata.
+- [ ] Keep the public callback type one-parameter and keep the public
+  `PatternFactory` type free of `.curry`.
+
+Expected files/tests:
+
+- `packages/runner/src/builder/pattern.ts`
+- `packages/runner/src/builder/factory.ts` and builder helper types
+- `packages/runner/test/pattern.test.ts`
+- `packages/runner/test/factory-input-types.test.ts`
+- a compile-time API test proving authored `.curry` is unavailable
+
+### WP3.2 — Implement the internal one-shot curry derivation
+
+- [ ] Attach `.curry(params)` only to the internal transformed-code view of a
+  pattern factory.
+- [ ] Require exactly one argument and always bind callback argument 1.
+- [ ] During graph construction, validate the complete symbolic params record's
+  keys and alias/factory shapes against the trusted schema without prematurely
+  materializing reactive captures. Validate concrete values and links again
+  when WP3.4 populates the hidden params cell.
+- [ ] Return a new branded pattern factory with identical public
+  `argumentSchema`/`resultSchema` and canonical hidden `params`.
+- [ ] Make `materializeFactory()` reapply canonical params from a decoded bound
+  factory, validate them against trusted base metadata, and still reject an
+  unbound closure-bearing base. Reconstruct the one-shot bound derivation for
+  both direct setup and dynamic dispatch.
+- [ ] Preserve the root token/ref and any scope/space derivations regardless of
+  modifier order.
+- [ ] Throw on a second curry, including an equal/empty value.
+- [ ] Throw when the base pattern has no compiler-declared params slot.
+- [ ] Never merge, remove, override, or narrow public input fields.
+- [ ] Test zero- and two-argument internal curry calls, missing/extra keys,
+  wrong concrete values, symbolic Cells/links, second curry, and curry on a
+  capture-free pattern.
+
+### WP3.3 — Generalize nested-pattern hoisting
+
+- [ ] Update transformability validation so an inline `pattern(...)` in a
+  pattern-owned context is a supported value, not only a `patternTool` or
+  `*WithPattern` special case.
+- [ ] Collect every non-module lexical capture, including Cells/Reactives and
+  all three factory kinds; keep verified module-scoped helpers lexical.
+- [ ] Rewrite the hoisted callback to receive public input in argument 0 and a
+  deterministically ordered capture record in argument 1.
+- [ ] Generate public argument/result schemas plus the private params schema.
+- [ ] Wrap the callback with
+  `withPatternParamsSchema(callback, paramsSchema)` before passing it to
+  `pattern()`; assert there is no fourth `pattern()` argument.
+- [ ] Hoist a capture-free base to a deterministic `__cfPattern_N` declaration
+  and register it through `__cfReg`.
+- [ ] Replace a capturing authored site with exactly
+  `__cfPattern_N.curry({ ...captures })`.
+- [ ] Replace a capture-free authored site with the bare hoisted factory and no
+  curry call.
+- [ ] Apply normal cause assignment after the site rewrite.
+- [ ] Reject non-portable captured functions and unrepresentable capture
+  schemas with source-located diagnostics.
+- [ ] Fail closed when an inline wrapper touches a `FrameworkProvided` path
+  until WP3.6's trusted forwarding metadata is available; general closure
+  conversion must never temporarily permit capture or authored supply.
+- [ ] Verify a wrapper around a bound pattern creates a new hoisted wrapper and
+  one curry for that wrapper; it must not curry the original twice.
+
+Primary transformer seams:
+
+- `packages/ts-transformers/src/closures/transformer.ts`
+- `packages/ts-transformers/src/closures/capture-collector.ts`
+- `packages/ts-transformers/src/closures/utils/pattern-builder.ts`
+- `packages/ts-transformers/src/transformers/builder-call-hoisting.ts`
+- `packages/ts-transformers/src/transformers/schema-injection.ts`
+- `packages/ts-transformers/src/transformers/pattern-context-validation.ts`
+- `packages/ts-transformers/src/policy/callback-boundary.ts`
+- `packages/ts-transformers/src/ast/scope-analysis.ts`
+- `packages/ts-transformers/src/core/cross-stage-state.ts`
+- `packages/ts-transformers/src/core/context.ts`
+
+Builder hoisting must recognize the generated `pattern(...).curry(captures)`
+shape, hoist/register the inner base factory, and preserve the curry at the
+authored expression site.
+
+Golden fixtures must cover one/multiple/nested captures, property captures,
+Cells, each factory kind, capture-free patterns, name collisions, invalid
+functions, deterministic ordering, nested wrappers, JSX/conditional positions,
+and an authored second callback argument.
+
+At minimum, add focused `nested-pattern-capture`, capture-free, and
+nested-wrapper fixture pairs; extend
+`packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts`
+and the transformer pipeline regression suite.
+
+### WP3.4 — Add the hidden params root and invocation-owned cell
+
+- [ ] Extend the alias vocabulary with `{ $alias: { cell: "params", ... } }`
+  without treating `params` as piece input.
+- [ ] Give each bound-pattern invocation one immutable hidden params cell with a
+  deterministic result-relative cause and `paramsSchema`.
+- [ ] Link that cell from result metadata under `params` and link it back to its
+  owning result for resume/teardown.
+- [ ] Resolve bound params against the parent binding context before writing or
+  linking them into the hidden cell.
+- [ ] Preserve nested link parents and cross-space links rather than copying
+  values across spaces.
+- [ ] Update `unwrapOneLevelAndBindtoDoc`, `sendValueToBinding`, and direct
+  sub-pattern setup to accept the params pseudo-root only when the invocation
+  owns a params cell.
+- [ ] Populate the same deterministic cell from serialized `Factory@1` state on
+  resume before child nodes start.
+- [ ] Pre-sync the params cell during reload before graph execution and factor
+  the schema-aware projection currently used for argument updates rather than
+  applying public-input defaults to params.
+- [ ] Tear it down with the owning result and never expose it through public
+  argument projection.
+- [ ] Define teardown in terms of cancellation, subscription ownership, and
+  reachability. If durable owned cells are not physically deleted on ordinary
+  stop, prove they cannot be reused or rescheduled by a later generation.
+- [ ] Reject invocation of a closure-bearing base factory with absent params.
+- [ ] Prove a public field and closure param with the same name remain distinct.
+- [ ] Traverse nested factories and preserve CFC labels inside params.
+- [ ] Add an A-with-params → B-with-different-params → A dynamic replacement
+  test proving a stable output spot, generation-fenced captured writes,
+  generation-correct params/CFC labels, and resume of only the active
+  generation.
+
+Expected runtime seams/tests:
+
+- `packages/runner/src/sigil-types.ts`
+- `packages/runner/src/link-utils.ts`
+- `packages/runner/src/pattern-binding.ts`
+- `packages/runner/src/result-utils.ts`
+- `packages/runner/src/runner.ts`
+- result metadata helpers used by `getMetaLink`
+- new `packages/runner/test/pattern-closure-params.test.ts`
+- `packages/runner/test/pattern-node-alias-schema.test.ts`
+- reload/rehydration, `cfc-boundary.test.ts`, and cross-space CFC-focused runner
+  tests
+
+### WP3.5 — Unify list callback lowering
+
+- [ ] Change array callback lowering so `map`/`filter`/`flatMap` capture through
+  a bound `PatternFactory`, with no sibling params object in newly emitted
+  nodes.
+- [ ] Make `mapWithPattern`/`filterWithPattern`/`flatMapWithPattern` accept the
+  bound factory as the new canonical shape.
+- [ ] Make the new canonical node carry only `{ list, op }` and invoke the
+  pattern with public `{ element, index, array }`; hidden captures flow only
+  through the params root.
+- [ ] Keep a dual-read runtime path for stored legacy `{ op, params }` nodes
+  during the compatibility window.
+- [ ] Keep old public overloads only until source migration and stored-data
+  gates pass; mark them deprecated rather than teaching them new semantics.
+- [ ] Keep `packages/runner/src/builtins/op-pattern-ref.ts` and
+  `packages/runner/src/builtins/list-op-argument-usage.ts` only on the named
+  legacy adaptation path; new `Factory@1` nodes go through generic
+  materialization.
+- [ ] Isolate the legacy branch in `Runner.substituteOpPatternRefs()` so it
+  cannot remain an accidental writer dependency.
+- [ ] Update closure-capture diagnostics to recommend inline patterns, not
+  manual sibling params.
+- [ ] Regenerate affected transformer goldens and test nested map/filter/flatMap
+  chains, capture-free callbacks, identity stability, resume, and CFC labels.
+
+Primary files:
+
+- `packages/ts-transformers/src/closures/strategies/array-method-transform.ts`
+- `packages/ts-transformers/src/ast/call-kind.ts`
+- `packages/runner/src/cell.ts`
+- `packages/runner/src/builtins/map.ts`
+- `packages/runner/src/builtins/filter.ts`
+- `packages/runner/src/builtins/flatmap.ts`
+- mirrored overloads in `packages/api/index.ts`
+
+Focused runner coverage includes
+`list-builtin-edge-paths.test.ts`, `list-result-schema.test.ts`,
+`stored-pattern-rehydration.test.ts`, `pattern-scope.test.ts`, and the map,
+filter, and flatMap CFC/identity regression suites. Keep exactly one explicit
+legacy `{ op, params }` fixture per builtin; migrate the remaining fixtures to
+the one-argument form.
+
+### WP3.6 — Preserve `FrameworkProvided` obligations through wrappers
+
+- [ ] Record trusted framework-provided paths in compiler/artifact metadata for
+  each base factory. Do not add them to `FactoryStateV1` or trust paths carried
+  by `Factory@1` wire data.
+- [ ] When an inline wrapper calls such a factory, synthesize the required
+  system fields into the wrapper's argument schema/binding and forward their
+  aliases transitively.
+- [ ] Keep those fields out of the model-facing tool schema.
+- [ ] Inject the value from the wrapper tool instance's stable identity and
+  carry that exact value to the ultimate call.
+- [ ] Reject an authored literal, capture, or closure param that attempts to
+  supply a framework-provided path.
+- [ ] Fail closed when a required system value or stable tool identity is
+  unavailable.
+- [ ] Cover one wrapper, multiple wrappers, a dynamic stored factory, and a
+  cross-space invocation.
+
+Expected tests:
+
+- `packages/api/test/framework-provided.test.ts`
+- `packages/runner/test/cfc-agent-tool-input-integrity.test.ts`
+- `packages/runner/test/sandbox-id-auto-provision.test.ts`
+- transformer fixtures for framework-input synthesis and rejection
+
+Replace the hard-coded framework-field handling in
+`packages/runner/src/builtins/llm-dialog.ts` only after the generic trusted
+metadata path has equivalent fail-closed coverage.
+
+### Stage 3 completion gate
+
+- [ ] Exact emitted IR uses a two-parameter callback,
+  `withPatternParamsSchema`, and at most one transformer-only `.curry(params)`.
+- [ ] No emitted or runtime path merges closure params into public input.
+- [ ] Hidden params cells resume, preserve links/CFC, and tear down with their
+  owner.
+- [ ] List callbacks emit only bound-factory nodes while old stored nodes still
+  read correctly.
+- [ ] Framework-provided values remain system-supplied through wrapper chains.
+- [ ] Transformer, runner, API, schema-generator, and focused CFC tests pass.
+
+## Stage 4 — Boundary and `patternTool` migration
+
+### WP4.1 — Teach tools and external adapters the new factory value
+
+- [ ] Update `BuiltInLLMTool` in `packages/api/index.ts` to accept a direct
+  `PatternFactory` and `{ pattern: PatternFactory, ...metadata }` as canonical
+  authored shapes, while retaining the legacy tool object as a deprecated
+  compatibility input.
+- [ ] Update LLM tool discovery to accept a PatternFactory directly and derive
+  the model-facing input from its public `argumentSchema`.
+- [ ] Keep optional description/presentation data in an ordinary metadata
+  wrapper with a `pattern` field and no `extraParams`.
+- [ ] Invoke through the same `materializeFactory`/dynamic path as ordinary
+  pattern composition.
+- [ ] Update `packages/runner/src/schema-format.ts` and LLM schema formatting to
+  understand `asFactory` without subtracting closure params.
+- [ ] Update `packages/runner/src/builtins/llm-schemas.ts` and
+  `packages/runner/src/builtins/llm-dialog.ts` to write/read the new shape while
+  retaining the legacy reader.
+- [ ] Preserve `description` and `useResultSchemaForObservation` in the metadata
+  wrapper, while sending only reduced `{ description, inputSchema }` data to
+  `packages/llm`; factory state never crosses into a provider request.
+- [ ] Update `packages/cli/lib/callable.ts` to discover/materialize canonical
+  factories and keep legacy `{ pattern, extraParams }` reads.
+- [ ] Update `packages/fuse/callables.ts`, `packages/fuse/callable-path.ts`,
+  `packages/fuse/tree-builder.ts`, and `packages/fuse/cell-bridge.ts` likewise.
+- [ ] Replace FUSE's plain `JSON.stringify`/function-source fallback for factory
+  leaves with Fabric codec projection; otherwise callable values would be
+  dropped or exposed as source text.
+- [ ] Treat callable functions as weak-key-capable discovery values and keep a
+  direct pattern factory's `*.tool` projection as a leaf.
+- [ ] Decode tagged factory JSON on supported FUSE writes to an inert shell and
+  let the runner boundary materialize it.
+- [ ] Verify runtime, CLI, and FUSE discover and invoke the same stored factory
+  and report the same public input schema.
+
+Focused tests:
+
+- `packages/runner/test/generate-object-tools.test.ts`
+- `packages/runner/test/llm-dialog.test.ts`
+- `packages/runner/test/schema-format.test.ts`
+- CLI callable/integration tests
+- `packages/cli/test/exec.test.ts` and the real
+  `packages/cli/integration/fuse-exec.sh` flow
+- `packages/fuse/callable-path.test.ts`
+- `packages/fuse/tree-builder.test.ts`
+- `packages/fuse/cell-bridge.test.ts`
+
+### WP4.2 — Install explicit compatibility readers
+
+- [ ] Accept legacy `{ $patternRef, argumentSchema, resultSchema }` wherever a
+  pattern factory is expected and adapt it to `FactoryStateV1`.
+- [ ] Retain the full surrounding module descriptor when reading legacy
+  `$implRef`; do not reinterpret `$implRef` as a factory artifact ref.
+- [ ] Accept legacy `{ pattern, extraParams, ...metadata }` tool values and
+  preserve their historical merge/precedence rules only in that reader.
+- [ ] Accept stored legacy list nodes carrying sibling `{ op, params }`.
+- [ ] Make canonical transformed/repository writers emit `Factory@1`, inline
+  pattern wrappers, and bound list factories only. Until Stage 5, explicitly
+  deprecated public legacy APIs may still produce old shapes for compatibility.
+- [ ] Add fixtures for every legacy shape before changing writers.
+- [ ] Add diagnostics or counters sufficient to determine whether legacy values
+  remain in supported persistent stores; do not log params or other user data.
+
+### WP4.3 — Migrate repository `patternTool` callers
+
+For every caller, replace
+`patternTool(searchPattern, { entries })` with an inline `pattern` whose public
+input contains only the caller-supplied fields and whose closure invokes the
+original pattern with `entries`.
+
+- [ ] Migrate `packages/patterns/cfc-agent-prompt-injection-demo/main.tsx`.
+- [ ] Migrate `packages/patterns/deep-research.tsx`.
+- [ ] Migrate `packages/patterns/google/core/gmail-importer.tsx`.
+- [ ] Migrate `packages/patterns/google/core/google-calendar-importer.tsx`.
+- [ ] Migrate `packages/patterns/notes/note.tsx`.
+- [ ] Migrate `packages/patterns/shopping-list.tsx`.
+- [ ] Migrate the affected files under `packages/patterns/system/`, including
+  default app, knowledge graph, omnibox, quick capture, space overview,
+  suggestion, suggestion history, and summary index.
+- [ ] Migrate `packages/cli/integration/pattern/fuse-exec.tsx` and any current
+  non-test caller found by the inventory command below.
+- [ ] Replace the old structural `PatternToolResult` type in
+  `packages/patterns/examples/summary-index-tester.tsx`, if still present when
+  this stage begins.
+- [ ] Update `packages/patterns/index.md` only where generated summaries or
+  public examples change.
+- [ ] Update `packages/patterns/test/source-coverage/commonfabric-stub.test.ts`
+  so source coverage models the new public API while retaining an explicitly
+  named legacy fixture if needed.
+- [ ] Verify every wrapper remains readable at the call site and does not expose
+  captured values in the public tool schema.
+- [ ] Run a final source inventory and classify every remaining hit as API,
+  compatibility reader, migration fixture, or historical documentation:
+
+  ```sh
+  rg -n "patternTool|PatternToolResult|extraParams" packages docs/common \
+    --glob '!packages/patterns/deprecated/**'
+  ```
+
+### WP4.4 — Stop canonical production of legacy list and tool shapes
+
+- [ ] Remove canonical transformer, internal tool, and repository-source
+  construction of `PatternToolResult` and `extraParams`; isolate the deprecated
+  public `patternTool` constructor as a named legacy writer until Stage 5.
+- [ ] Remove transformer hoisting/callback-boundary special cases that exist
+  only to produce `patternTool(pattern(...), extraParams)`.
+- [ ] Remove transformer validation messages that recommend `patternTool`.
+- [ ] Ensure newly transformed list callbacks cannot emit sibling `params`.
+- [ ] Keep separately named, well-tested compatibility readers for old stored
+  values; do not leave ambiguous branches in the canonical writer.
+- [ ] Add source/fixture assertions that fail if a new canonical writer emits
+  `extraParams` or legacy list params.
+- [ ] Classify the five transformer `patternTool-*` fixture pairs and the
+  patternTool cases in `validation.test.ts`,
+  `unknown-capture-validation.test.ts`, `transform.test.ts`,
+  `policy/callback-support.test.ts`, and `ast/call-kind-coverage.test.ts`:
+  migrate semantic closure cases to inline-pattern coverage and retain only
+  explicitly named legacy API/reader cases.
+
+### Stage 4 completion gate
+
+- [ ] A PatternFactory works as an LLM tool directly and inside a metadata
+  wrapper.
+- [ ] CLI and FUSE discover/materialize/invoke all three serializable factory
+  kinds where their callable surfaces permit them.
+- [ ] Repository source callers use inline pattern closures, not `patternTool`.
+- [ ] Canonical transformer/repository writers emit no `extraParams`, legacy
+  `$patternRef` factory value, or sibling list params; deprecated public legacy
+  APIs remain isolated and tested until Stage 5.
+- [ ] Legacy tool/list/module fixtures still read with their old semantics.
+- [ ] Pattern, runner, LLM, CLI, FUSE, transformer, and docs checks pass.
+
+## Stage 5 — Compatibility removal and closeout
+
+Stage 5 is a separately scheduled cleanup. Do not infer that source migration
+alone authorizes deleting readers for durable values.
+
+### WP5.1 — Satisfy removal gates
+
+- [ ] Confirm all supported source trees contain no `patternTool` caller.
+- [ ] Add a CI/source-inventory assertion with zero `patternTool`,
+  `PatternToolResult`, or writer-side `extraParams` hits outside an allowlist of
+  compatibility tests and historical docs.
+- [ ] Confirm deployed writers have emitted only `Factory@1` for at least the
+  agreed compatibility window.
+- [ ] Confirm persistent stores have been migrated, expired, or explicitly
+  approved for a wipe; record the evidence and decision in this plan.
+- [ ] Confirm legacy tool and list reader diagnostics show no supported usage
+  for the agreed window.
+- [ ] Confirm every supported client/runtime version can read `Factory@1`.
+- [ ] Obtain an explicit product/runtime owner decision before deleting a
+  durable compatibility reader.
+
+### WP5.2 — Remove legacy APIs and readers
+
+- [ ] Remove `patternTool`, `PatternToolFunction`, and `PatternToolResult` from
+  `packages/api/index.ts`, runner builder exports, and trusted builder factory
+  wiring.
+- [ ] Remove transformer `patternTool` call-kind, boundary, validation, and
+  hoisting special cases.
+- [ ] Remove LLM/schema-format/CLI/FUSE `extraParams` compatibility branches.
+- [ ] Remove legacy list overloads and sibling-params readers.
+- [ ] Remove legacy pattern-factory `$patternRef` adaptation only after its own
+  stored-data gate passes.
+- [ ] Leave module/handler `$implRef` descriptor reconstruction intact unless a
+  separately scoped migration proves all of its non-factory users have moved;
+  first-class factories alone do not authorize its removal.
+- [ ] Remove factory-function `toJSON()` compatibility only after every Fabric
+  boundary uses registered codec dispatch.
+- [ ] Keep negative fixtures that prove deleted writers/readers stay deleted.
+
+### WP5.3 — Update live documentation and archive the plan
+
+- [ ] Update `docs/common/README.md` and the relevant pattern composition,
+  reactivity, types/schema, LLM, CLI, and FUSE docs for first-class factories.
+- [ ] Update live transformer behavior/inventory docs and
+  `packages/ts-transformers/docs/array-method-callback-pipeline.md` so they show
+  bound factories rather than sibling params.
+- [ ] Reconcile `docs/specs/sandboxing/SES_SANDBOXING_SPEC.md`,
+  `docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md`,
+  `docs/specs/ts-transformer/ts_transformers_type_driven_behavior_inventory.md`,
+  `docs/specs/ts-transformer/ts_transformers_design_deltas.md`, and
+  `packages/ts-transformers/docs/derive-to-lift-design.md` with the shipped
+  closure and factory-call behavior.
+- [ ] Update `docs/specs/fuse-filesystem/2-path-scheme.md` and
+  `packages/fuse/README.md` for direct factory `.tool` projection and tagged
+  factory JSON.
+- [ ] Document the author-facing inline-pattern closure model with examples for
+  passing, returning, storing, and invoking all factory kinds.
+- [ ] Document that `.curry` is not public API and that closure params never
+  merge with public input.
+- [ ] Update component/pattern examples whose tool construction changed.
+- [ ] Reconcile the high-level checklist in
+  `docs/specs/pattern-construction/rollout-plan.md`.
+- [ ] Mark the source specification implemented if all completion criteria are
+  met.
+- [ ] Move this completed plan to `docs/history/plans/` with the required
+  historical metadata in the final implementation change.
+
+## Risk register
+
+| Risk | Required mitigation |
+| --- | --- |
+| Internal graph serialization seals before `__cfReg` assigns a ref | Keep live-state traversal separate from durable sealing and test eager construction explicitly. |
+| A copied brand or decoded shell gains execution authority | Keep data admission in data-model private tables and executable trust in runner-owned artifact indexes. |
+| One Fabric operation still treats a function generically | Add shared factory-state dispatch before function shortcuts in conversion, codec lookup, freeze, clone, equality, hash, and traversal. |
+| Factory hashing diverges from codec semantics | Reuse the existing codec-instance byte arm and pin it in the formal hash spec. |
+| A replaced dynamic factory writes after cancellation | Fence every async write/result by supervisor generation and test replacement before and after settle. |
+| Wire/call-site schemas become authority | Resolve the trusted artifact first and require normalized equality; never elevate hints when trusted schemas are absent. |
+| Closure params leak into public input or tool schemas | Maintain separate argument/params roots and assert public-schema snapshots at transformer, runner, LLM, CLI, and FUSE boundaries. |
+| Wrapper patterns launder a `FrameworkProvided` value | Synthesize/forward trusted paths and reject authored literals or captures at compile time and runtime. |
+| Params resume or teardown follows public-argument lifecycle by accident | Pre-sync the hidden root before execution, avoid public defaults, and define durable-cell ownership separately from physical deletion. |
+| FUSE drops callable values or exposes function source | Project factories through the Fabric codec or `.tool` callable view before generic JSON/function handling. |
+| Source migration accidentally deletes durable readers | Separate canonical writer removal from evidenced stored-data removal gates and retain named legacy fixtures. |
+
+## Cross-stage validation matrix
+
+### Fabric protocol
+
+- [ ] Encode/decode/hash/equality/clone/freeze every factory kind.
+- [ ] Round-trip nested factories, params, Cells/links, scope, and space
+  selectors.
+- [ ] Reject arbitrary functions, copied symbols, malformed/cyclic states,
+  pre-seal state, pseudo refs, kind mismatches, and schema mismatches.
+- [ ] Verify independent evaluations of equal factory state hash equally.
+
+### Transformer
+
+- [ ] Golden output shows callback `(argument, params)`, callback-wrapped params
+  schema, deterministic hoist, and exactly one internal curry at capturing
+  sites.
+- [ ] Golden output contains no fourth `pattern()` argument, curry index, input
+  merge, or curry at capture-free sites.
+- [ ] Symbolic calls lower for aliases/properties/elements and direct live calls
+  remain direct.
+- [ ] List callbacks use bound factories with no sibling params writer.
+- [ ] Diagnostics cover invalid captures, authored callback argument 1, second
+  curry, missing params, untransformable symbolic calls, and bad unions.
+
+### Runtime
+
+- [ ] Warm and cold invoke stored pattern, module, and handler factories.
+- [ ] Replacing a factory-valued cell cancels/fences/tears down the prior
+  generation while retaining the output spot.
+- [ ] Hidden params cells preserve same-named public fields, nested aliases,
+  cross-space links, resume, teardown, and CFC labels.
+- [ ] Captured factories can themselves be stored and invoked.
+- [ ] Schema-light `byRef()` resolves only through trusted registry metadata.
+- [ ] Forged refs/metadata fail closed.
+
+### Boundaries and migration
+
+- [ ] JSON, memory client/server, Cell/query, piece, cross-space, CLI, FUSE, and
+  LLM tool paths preserve canonical factory state and callability after runner
+  materialization.
+- [ ] Framework-provided inputs remain hidden from the model and cannot be
+  authored/captured.
+- [ ] Legacy tool and list fixtures read until their explicit removal gates.
+- [ ] No canonical writer emits `extraParams` or sibling list params.
+
+## Final command checklist
+
+Use the package's current task names if they change while this live plan is in
+progress.
+
+- [ ] `deno task test` in `packages/data-model`
+- [ ] `deno task test` in `packages/schema-generator`
+- [ ] `deno task test` in `packages/ts-transformers`
+- [ ] `deno task test` in `packages/runner`
+- [ ] `deno task test` in `packages/llm`
+- [ ] `deno task test` in `packages/cli`
+- [ ] `deno task test` in `packages/fuse`
+- [ ] Root `deno task check`
+- [ ] Focused API type tests, including the negative public `.curry` assertion
+- [ ] A representative `deno task cf check ... --show-transformed --no-run`
+  output inspected for closure and symbolic-call IR
+- [ ] Fresh-runtime cold round-trip integration for all three factory kinds
+- [ ] `deno task check-docs specs/pattern-construction`
+- [ ] `deno task check-docs plans`
+- [ ] `git diff --check`
+
+## Overall completion criteria
+
+- [ ] Every content-addressed pattern/module/handler factory round-trips as a
+  directly callable-after-materialization `Factory@1`; non-resolvable
+  factories fail durable encoding.
+- [ ] Arbitrary JavaScript functions remain invalid Fabric values.
+- [ ] Factory-valued inputs, outputs, stored values, and captures invoke through
+  one dynamic runner path.
+- [ ] Nested patterns preserve lexical semantics through callback argument 1
+  and exactly one transformer-only `.curry(params)` per wrapper layer.
+- [ ] Public pattern input and closure params are never merged.
+- [ ] Refs, schemas, params, scope, space selection, CFC labels, equality, and
+  hashes survive storage and cold reload.
+- [ ] `patternTool` and sibling list params have no writer/source path, and all
+  retained compatibility readers have explicit, evidenced removal gates.

--- a/docs/specs/pattern-construction/node-factory-shipping.md
+++ b/docs/specs/pattern-construction/node-factory-shipping.md
@@ -1,89 +1,1066 @@
-# Serializable Node Factories
+# First-Class Serializable Factories
+
+## Status
+
+Proposed. This document specifies intended behavior, not the current
+implementation.
+
+The content-addressed identity prerequisite is shipped: every verified,
+module-scoped builder factory is addressable by `{ identity, symbol }`.
+Exports use their export name, while transformed and non-exported factories use
+their `__cfReg` name. See
+[Content-Addressed Action Identity](../content-addressed-action-identity.md).
+
+One prerequisite is not yet on `main`: generic `$patternRef` binding and direct
+setup/sub-pattern resolution. The relevant semantic changes currently live in
+the work behind #4514, including commits `3b028c786`, `39b213e63`, and
+`ede6c5a7d`. This feature must copy or reimplement that small behavior and its
+tests as Stage 0. It must not wait for, or import the unrelated reactive-
+interpreter work in that PR.
+
+This is an independent pattern-construction track. It does not depend on graph
+snapshots or the reactive-interpreter migration.
+
+## Summary
+
+Every builder factory gets the same internal factory protocol, and every
+factory with a cold-resolvable content-addressed artifact ref becomes a durable
+first-class Fabric value:
+
+- `PatternFactory` returned by `pattern`;
+- `ModuleFactory` returned by `lift`, `byRef`, and other node-factory builders;
+  and
+- `HandlerFactory` returned by `handler`.
+
+The callable function itself carries an internal Fabric-factory brand and
+codec-state accessor. It serializes as `Factory@1` and decodes to a callable,
+reference-backed factory shell. There is no `FabricPatternFactory` or
+`NodeFactory` wrapper object. Arbitrary JavaScript functions remain invalid
+Fabric values.
+
+Patterns additionally gain lexical closure conversion. A nested authored
+`pattern(...)` is hoisted to module scope. Its callback receives public input as
+argument 0 and its captured environment as compiler-generated argument 1. At
+the authored site, the transformer calls an internal, one-shot
+`.curry(params)` method on the hoisted factory.
+
+That method is not public API. It always binds callback argument 1, takes no
+argument index, and throws if called twice. It never binds, merges, removes, or
+overrides fields in the pattern's public input. Authors express another layer
+of partial application by defining another inline pattern closure, just as
+they would curry a JavaScript function by defining another closure.
+
+This representation replaces `patternTool` and its `{ pattern, extraParams }`
+protocol. An inline pattern closes over the values to bind, and the resulting
+`PatternFactory` is itself the tool value.
+
+## Terminology
+
+- **Factory**: a callable builder value of kind `pattern`, `module`, or
+  `handler`.
+- **Base factory**: the trusted module-scoped artifact identified by a content-
+  addressed factory ref.
+- **Factory state**: the codec-visible, non-public essential state of a factory,
+  including its ref, kind, schemas, modifiers, and optional pattern params.
+- **Public input**: argument 0 of a pattern callback and the value supplied by a
+  pattern caller.
+- **Closure params**: the complete captured environment in compiler-generated
+  pattern callback argument 1.
+- **Bound pattern**: a derived `PatternFactory` whose hidden factory state
+  contains closure params.
+- **Symbolic factory**: a factory-valued pattern input or captured value that is
+  represented by a reactive cell while the enclosing graph is built.
+
+## Current State and Gaps
+
+All three factory kinds are already callable function objects with useful
+descriptor state:
+
+- `PatternFactory.toJSON()` emits `$patternRef`, `argumentSchema`, and
+  `resultSchema` at the storage boundary.
+- `ModuleFactory.toJSON()` and `HandlerFactory.toJSON()` emit module
+  descriptors, using `$implRef` for addressable JavaScript implementations.
+- `asScope()` and `PatternFactory.inSpace()` return derived callable factories.
+- verified exports and `__cfReg` values already enter the generic artifact
+  index, regardless of factory kind.
+
+The existing `toJSON()` path is a one-way conversion. Native conversion calls
+`toJSON()` on a function and replaces the function with inert plain data.
+Generic reads do not recreate a callable factory. Pattern-valued list builtins
+and LLM tools compensate with bespoke `$patternRef` handling.
+
+Serialization alone also does not make a symbolic factory callable. Pattern
+inputs are non-callable reactive proxies. Calling a factory-valued input as
+ordinary JavaScript therefore fails while constructing the outer graph. The
+runner already permits a reactive `NodeRef.module`, but its dynamic-module arm
+is unfinished. This proposal completes that path and adds type-directed call
+lowering.
+
+Pattern construction has two further limitations:
+
+1. `pattern()` currently calls its callback with one symbolic root and only
+   recognizes `argument` and `result` alias roots.
+2. Nested-pattern hoisting is limited to special `*WithPattern` and
+   `patternTool` shapes. There is no general lexical closure conversion for a
+   pattern returned or passed as data.
 
 ## Goals
 
-- Allow lifts (and thus patterns) and handlers to return reusable node factories
-  that can be shipped across spaces or persisted and later instantiated.
-- Support partial application via a `.curry(value, argIndex = 0)` helper that
-  yields another shippable node factory reflecting the bound argument.
-- Use a versioned sigil format (`nodeFactory@1`) that closely mirrors the graph
-  snapshot schema while capturing the additional data required to rehydrate the
-  factory and any curry operations performed on it.
+1. Let every content-addressed factory kind round-trip through cells, pieces,
+   arrays, objects, CLI/FUSE boundaries, and cross-space links without losing
+   its factory kind or callability.
+2. Let patterns accept, return, store, and invoke factory values with ordinary
+   call syntax.
+3. Preserve nested-pattern lexical semantics by making captures explicit,
+   reactive closure params.
+4. Keep pattern public input completely separate from closure params.
+5. Use the existing content-addressed artifact identity and resolution model.
+6. Preserve schemas, CFC labels, scope, and pattern space-selection behavior.
+7. Replace `patternTool` and the separate params-merging rules around it.
+8. Keep transformed output, serialization, hashing, and equality deterministic.
 
-## User Experience
+## Non-goals
 
-- Any node factory created by `lift`, `handler`, or builder helpers returns a
-  callable object that also exposes `.toJSON()` producing the `nodeFactory@1`
-  sigil.
-- Passing a node factory as part of the argument to `Cell.set()` & co, or
-  calling another factory with it, automatically converts it into it's JSON
-  representation.
-- Patterns may return node factories or pass them into other lifts/patterns. When
-  the runtime encounters a `nodeFactory@1` payload (e.g., via `Cell.get()` or as
-  a pattern input), it materializes a callable node factory automatically.
-- `.curry(value, argIndex = 0)` returns a new factory that records the bound
-  argument. Currying is composable; each successive call appends metadata so the
-  runtime can reconstruct the applied arguments before instantiation.
+- Serializing arbitrary JavaScript functions or native lexical closures.
+- Exposing `.curry()` or another partial-application API to authors.
+- General positional currying or repeated currying.
+- Narrowing a factory's public input schema by binding public fields.
+- Executing factory implementation code during decode or property access.
+- Making keyless, action-created, or host-pseudo-module factories durable. A
+  cross-session factory needs a trusted content-addressed module ref; a
+  session-only pseudo-ref has no cold reconstruction path.
+- Putting tool descriptions, observation policy, or other LLM metadata in
+  `Factory@1`.
+- Depending on graph snapshots.
 
-## Sigil Shape
+## Author-Facing Semantics
 
-Serialized form:
+### Factories are values
+
+Factory types are valid fields in pattern inputs and outputs and remain
+invokable after storage or transport.
 
 ```ts
 // Shown for illustration only.
+interface ApplyInput {
+  value: string;
+  operation: PatternFactory<
+    { value: string },
+    { result: string }
+  >;
+}
+
+const apply = pattern<ApplyInput>(({ value, operation }) => {
+  return operation({ value });
+});
+```
+
+The same applies to modules and handlers:
+
+```ts
+// Shown for illustration only.
+interface FactoryInputs {
+  value: string;
+  transform: ModuleFactory<{ value: string }, { length: number }>;
+  select: HandlerFactory<{ source: string }, { id: string }>;
+}
+
+const useFactories = pattern<FactoryInputs>(({
+  value,
+  transform,
+  select,
+}) => ({
+  transformed: transform({ value }),
+  onSelect: select({ source: value }),
+}));
+```
+
+Calling a received factory constructs a normal graph node. It does not execute
+the referenced implementation synchronously and does not fetch source during
+the call.
+
+### Nested patterns close over values
+
+Authors write ordinary lexical closures:
+
+```ts
+// Shown for illustration only.
+const patternOne = pattern(({
+  param2,
+  otherPattern,
+}: {
+  param2: string;
+  otherPattern: PatternFactory<
+    { bar: string },
+    { value: string }
+  >;
+}) => ({
+  callback: pattern(({
+    foo,
+    bar,
+  }: {
+    foo: string;
+    bar: string;
+  }) => {
+    const other = otherPattern({ bar });
+    return { value: something(foo, param2, other.value) };
+  }),
+}));
+```
+
+The inner pattern's public input remains `{ foo, bar }`. `param2` and
+`otherPattern` are closure params; they do not appear in, merge with, or
+override the public input.
+
+Captures may include reactive values, cells, plain Fabric values, and any of
+the three factory kinds. An arbitrary function value is never valid in closure
+params, regardless of where it was declared. A module-scoped helper that the
+hoisted callback references lexically is not a capture; it remains part of the
+verified module.
+
+### Inline patterns are the public partial-application model
+
+Authors do not call `.curry()`. They define a wrapper pattern that closes over
+the desired values:
+
+```ts
+// Shown for illustration only.
+const makeIndex = pattern(({ entries }: { entries: Entry[] }) => ({
+  search: pattern(({ query }: { query: string }) =>
+    searchPattern({ query, entries })
+  ),
+}));
+```
+
+If another layer is useful, define another pattern. Each generated wrapper has
+one environment and the original factory can itself be a closure param:
+
+```ts
+// Shown for illustration only.
+const wrap = pattern(({
+  operation,
+  prefix,
+}: {
+  operation: PatternFactory<{ value: string }, { result: string }>;
+  prefix: string;
+}) => ({
+  prefixed: pattern(({ value }: { value: string }) =>
+    operation({ value: `${prefix}${value}` })
+  ),
+}));
+```
+
+This is the only author-facing currying model in version 1.
+
+### Factory modifiers remain derivations
+
+`asScope()` and `PatternFactory.inSpace()` continue returning new factories.
+Their state is part of `Factory@1`, so modifiers survive storage. The raw
+`inSpace()` selector is retained until graph construction; serializing a named,
+anonymous, or cell-derived selector must not prematurely resolve it in the
+writer's runtime.
+
+For a pattern with closure params, modifiers may be applied before or after the
+transformer-created binding. Every derivation preserves whether params are
+already present, so no route permits a second internal curry.
+
+## Branded Callable Fabric Protocol
+
+### Direct factory branding
+
+The factory function is the Fabric value. Trusted builder constructors attach
+a non-enumerable internal brand and a state accessor. The exact symbol names
+are internal; conceptually the dependency-free protocol is:
+
+```ts
+// Shown for illustration only.
+const FABRIC_FACTORY = Symbol.for("common.fabricFactory");
+const FACTORY_STATE = Symbol.for("common.factoryState");
+
+interface FabricFactory {
+  (...args: unknown[]): unknown;
+  readonly [FABRIC_FACTORY]: true;
+  readonly [FACTORY_STATE]: () => FactoryStateView;
+}
+```
+
+The state accessor resolves through a stable internal root token because an
+artifact ref is assigned after verified module evaluation. Curried, mapped,
+and modifier-derived factories retain that same root token through a
+`noteDerivedCopy`-equivalent side table; they never copy a temporarily missing
+ref by value.
+
+This requires a narrow extension to the current Fabric protocol. Today:
+
+- `FabricValue` has no function arm;
+- `[CODEC]` is class-side and lookup reads `value.constructor[CODEC]`;
+- codec lookup rejects `typeof value === "function"` before class dispatch;
+- native conversion only accepts functions through legacy `toJSON()`; and
+- clone, freeze, equality, and hashing treat functions as invalid or primitive
+  leaves.
+
+Consequently, attaching today's `[CODEC]` property alone is not automatic. The
+implementation adds a narrow `FabricFactory` arm plus one internal
+`factoryStateOf(value)` / `tryFactoryState(value)` resolver. Conversion, JSON
+encoding, deep-freeze, clone, equality, hashing, schema validation, and builder
+traversal consult that resolver before their generic function branches. The
+JSON registry has a dedicated callable-factory codec slot; it does not classify
+`function` as an ordinary primitive type.
+
+`FactoryCodec.canEncode()` accepts only values admitted to the internal
+factory-state table. The brand is checked before legacy `toJSON()` conversion
+and before generic function rejection.
+
+No property on `Function` or `Function.prototype` is changed.
+
+### Canonical state
+
+All factory kinds use one wire tag and a genuinely discriminated essential
+state:
+
+```ts
+// Shown for illustration only.
+interface FactoryStateBaseV1 {
+  ref: {
+    identity: string;
+    symbol: string;
+  };
+}
+
+interface PatternFactoryStateV1 extends FactoryStateBaseV1 {
+  kind: "pattern";
+  argumentSchema: JSONSchema;
+  resultSchema: JSONSchema;
+  paramsSchema?: JSONSchema;
+  params?: FabricPlainObject;
+  defaultScope?: CellScope;
+  spaceSelector?: FabricValue;
+}
+
+interface ModuleFactoryStateV1 extends FactoryStateBaseV1 {
+  kind: "module";
+  argumentSchema?: JSONSchema;
+  resultSchema?: JSONSchema;
+  defaultScope?: CellScope;
+}
+
+interface HandlerFactoryStateV1 extends FactoryStateBaseV1 {
+  kind: "handler";
+  contextSchema?: JSONSchema;
+  eventSchema?: JSONSchema;
+}
+
+type FactoryStateV1 =
+  | PatternFactoryStateV1
+  | ModuleFactoryStateV1
+  | HandlerFactoryStateV1;
+
+// Internal only: refs may be pending and values may still contain
+// Cells/Reactives that builder traversal must rewrite to aliases.
+type LiveFactoryState = {
+  kind: FactoryStateV1["kind"];
+  rootToken: object;
+  ref?: FactoryStateBaseV1["ref"];
+  params?: FactoryInput<Record<string, unknown>>;
+  spaceSelector?: FactoryInput<unknown>;
+  // ...the kind-specific schema and modifier fields above
+};
+
+type FactoryStateView = LiveFactoryState | FactoryStateV1;
+```
+
+`LiveFactoryState` is not yet a hashable or encodable Fabric value. During graph
+construction, shared factory traversal maps Cells/Reactives to aliases while
+preserving `rootToken`. After verified module registration, the first Fabric
+boundary calls `sealFactoryState()`: it resolves the factory artifact ref,
+validates and freezes the mapped state, and memoizes one immutable
+`FactoryStateV1`. Encode, hash, equality, and Fabric deep-freeze fail if sealing
+is attempted before the ref exists. Once sealed, the logical state and its hash
+cannot change.
+
+JavaScript hardening of the callable before registration does not imply Fabric
+deep-frozenness; the side-table state is not canonical until sealing succeeds.
+
+`module` covers `ModuleFactory`, including factories returned by `lift`,
+`byRef`, raw/builtin builders, and equivalent helpers.
+
+`FactoryStateV1.ref` always names the complete builder factory artifact, as
+returned by `getArtifactEntryRef(factory)` through its root token. It is never
+copied from `moduleToJSON(...).$implRef`: that legacy ref names an
+implementation-resolution record and may not recover the factory descriptor or
+methods.
+
+`params` is either absent or the complete value for callback argument 1. It is
+never a map of public input overrides. `paramsSchema` is trusted only after it
+matches compiler metadata on the resolved base artifact; a wire value cannot
+grant its own callback shape.
+
+| Factory state | `paramsSchema` | `params` |
+| --- | --- | --- |
+| Capture-free pattern | absent | absent |
+| Hoisted closure-bearing base pattern | present | absent |
+| Bound closure-bearing pattern | present | present exactly once |
+| Module or handler | forbidden | forbidden |
+
+The public `argumentSchema` and `resultSchema` never change when params are
+bound. Handler construction retains the original public state and event
+schemas as `contextSchema` and `eventSchema` before combining them into the
+existing internal `{ $ctx, $event }` module `argumentSchema`.
+
+The encoded shape is:
+
+```jsonc
 {
-  "/": {
-    "nodeFactory@1":
-      & BoxedNodeFactory
-      & CurriedArguments
-      & (ReactiveNodeNarrowedSchema | HandlerNodeNarrowedSchema)
+  "/Factory@1": {
+    "kind": "pattern",
+    "ref": {
+      "identity": "<module-content-identity>",
+      "symbol": "__cfPattern_1"
+    },
+    "argumentSchema": { "type": "object" },
+    "resultSchema": { "type": "object" },
+    "paramsSchema": { "type": "object" },
+    "params": {
+      "param2": "...",
+      "otherPattern": { "/Factory@1": { "kind": "pattern" } }
+    }
   }
 }
 ```
 
-Notes:
+The nested example is abbreviated; every nested factory carries its complete
+state.
 
-- `BoxedNodeFactory` the descriptors used in `graph-snapshot.md`, including
-  implementation references and descriptor-level `argumentSchema`/`resultSchema`
-  and link to implemention.
-- `CurriedArguments` contains the lists the arguments that are being supplied
-  already, index defaulting to 0 or +1 the previous index.
-  - For event handlers, 0 is the event stream. If it is curried, then the
-    resulting function looks like a reactive node factory that can be called
-    with state to bind. If it isn't curried, the result is a stream factory,
-    just like the original, but bound to state.
-- `ReactiveNodeNarrowedSchema | HandlerNodeNarrowedSchema` are optional
-  constraints due to currying over the original schemas in the module.
+### Encoding and decoding
 
-## Runtime Behavior
+Encoding performs these checks:
 
-- Deserialization: When the runtime reads a value containing the `nodeFactory@1`
-  sigil, it constructs a callable factory that:
-  1. Applies stored currying bindings before invoking the underlying module.
-  2. Exposes `.curry` to append additional entries to `curried` and returns a
-     new serialized-aware wrapper.
-  3. Implements `.toJSON()` to emit the sigil.
-- Invocation: Calling the materialized factory schedules a node instantiation
-  identical to calling the original lift/handler. Inputs are merged with stored
-  curry bindings using positional logic (array inputs) or schema-derived names.
-- Integration with snapshots: When a pattern instantiates a node from a
-  serialized factory, the resulting node appears in the graph snapshot exactly
-  like a regular node (same descriptor, inputs, etc.). The factory sigil itself
-  can also be stored in pattern state for later reuse.
+1. The value is present in the module-private factory state table, having been
+   created by a trusted builder or by `FactoryCodec.decode()`. A copied symbol
+   property is insufficient.
+2. For a live builder factory, the state kind matches its trusted builder kind.
+   A decoded shell may be re-encoded as validated data but gains no executable
+   trust.
+3. The factory has a cold-resolvable, content-addressed artifact ref. A
+   keyless/manual or `host:<n>` pseudo-module factory fails encoding rather
+   than embedding executable source or writing a session-only ref.
+4. Pattern params, modifier state, and schemas are valid Fabric values and
+   contain no cycles.
 
-## Builder Integration
+Decode validates the discriminant, ref, schemas, allowed fields, and
+pattern-only fields, then creates a frozen branded function shell containing
+the unresolved state. Decode never resolves or executes implementation code.
 
-- Builders surface `.curry` on node factories returned from `lift`, `handler`,
-  `.map`, etc. Currying prior to returning from a pattern automatically serializes
-  the bound arguments.
-- Patterns accepting factories receive them as callable objects. Internally the
-  runtime keeps the sigil available so passing the factory back to storage or
-  another pattern preserves currying metadata.
+Generic JSON and memory decode currently run without a runner-aware
+reconstruction context. Therefore generic decode cannot by itself manufacture
+a live runner factory. The decoded shell is function-shaped, branded, and
+round-trippable, but its call body throws "factory requires runner
+materialization" and it does not claim the full behavioral
+`PatternFactory`/`ModuleFactory`/`HandlerFactory` surface.
 
-## Rollout
+The runner owns one chokepoint:
 
-- This is blocked on multi-argument `lift`.
-- However, we can start with curried `pattern` (which later become a variant of
-  `lift`) and instead of treating it as multiple inputs merge the input object
-  instead on call. The first use-case is for actions, so we can even do this
-  just there.
+```ts
+// Shown for illustration only.
+materializeFactory(value: FabricFactory, runtime: Runtime): BuilderFactory;
+```
+
+The hook returns an existing live builder factory or resolves the shell's
+factory artifact ref, reconstructs the correct callable builder factory, and
+reapplies params and modifiers. Sync and async forms may share this contract;
+cold source loading uses the async form.
+
+Every runner exposure path uses this chokepoint: schema-driven `asFactory`
+reads, recursive Cell/query result materialization, graph binding and dynamic
+module dispatch, and CLI/FUSE/tool adapters. Transformed symbolic invocation
+may pass a cell to the same hook after resolving its value. Context-free
+`valueFromJson()` remains the intentional shell-returning boundary.
+
+Materialization returns another function, not a wrapper object, and preserves
+the canonical codec state for reserialization.
+
+### Immutability, cloning, equality, and hashing
+
+Canonical factories are immutable functional values:
+
+- Fabric deep-freeze first seals and recursively freezes codec state, then
+  freezes the callable;
+- `.curry()`, `asScope()`, and `inSpace()` create new factory functions;
+- factory values are always-frozen logical atoms, like `FabricPrimitive`
+  values, so both frozen and mutable clone requests return the same canonical
+  factory rather than exposing mutable hidden state;
+- equality compares canonical `Factory@1` state, not function identity or
+  `Function.prototype.toString()`; and
+- hashing uses the `Factory@1` tag plus the recursively hashed codec state, the
+  same semantic path used for codec-backed Fabric instances.
+
+The JSON encoder must include branded functions in its codec cycle tracking.
+
+### Traversal and binding
+
+Closure params may contain cells and other factories. Keeping params private
+does not make them opaque to the graph builder.
+
+All Fabric-aware walks use the factory state accessor or a shared codec-state
+visitor. Builder traversal, alias conversion, CFC inspection, deep freeze,
+clone, equality, hashing, and serialization must not each invent a different
+view of factory state.
+
+When a parent pattern is built, traversal recursively maps `params` and
+`spaceSelector`. Captured cells become normal aliases, captured factory state
+recurses, and a derived branded factory is returned with the mapped hidden
+state. No public or enumerable `curried` property is required.
+
+## Pattern Closure Transformation
+
+### Pre-construction params-schema carrier
+
+`pattern()` invokes its callback eagerly, before the hoisted factory reaches
+`__cfReg`. The params schema therefore cannot first appear on artifact
+registration. Schema injection decorates the callback before calling
+`pattern()`:
+
+```ts
+// Shown for illustration only.
+__cfHelpers.withPatternParamsSchema(callback, paramsSchema)
+```
+
+This compiler-only helper records the schema in a private callback WeakMap (or
+equivalent symbol protocol) and returns the callback. `pattern()` and
+`patternFromFrame()` read it synchronously on entry, create the second symbolic
+root with that schema, and then invoke `callback(argument, params)`. They copy
+the same trusted schema into the base factory's internal state for registration
+and cold resolution.
+
+The helper is part of the first argument expression. It does not add a fourth
+argument to `pattern()` and is not author-facing API. The public callback type
+still has one parameter; an authored second parameter is rejected unless the
+callback carries this compiler-created metadata.
+
+### Logical transformation
+
+For the nested pattern above, the transformer produces this logical shape:
+
+```ts
+// Shown for illustration only.
+const __cfPattern_1 = pattern(
+  __cfHelpers.withPatternParamsSchema(
+    (
+      { foo, bar },
+      { param2, otherPattern },
+    ) => {
+      const other = otherPattern({ bar });
+      return { value: something(foo, param2, other.value) };
+    },
+    paramsSchema,
+  ),
+  publicArgumentSchema,
+  resultSchema,
+);
+
+const patternOne = pattern(({ param2, otherPattern }) => ({
+  callback: __cfPattern_1.curry({ param2, otherPattern }),
+}));
+```
+
+The shown `.curry()` is emitted JavaScript, not accepted authored API.
+
+There is no fourth argument to `pattern()`. The call remains
+`pattern(callback, argumentSchema, resultSchema)`. The compiler-generated
+closure-param schema enters through the callback wrapper above and is then
+retained on the hoisted artifact. It is not another public positional argument.
+
+### Internal `.curry(params)` contract
+
+The compiler-only method has exactly one argument and these rules:
+
+1. It is available only on the internal factory type used by transformed code;
+   the author-facing `PatternFactory` type does not declare it.
+2. It always binds callback argument 1. There is no argument-index parameter.
+3. The supplied record is the complete closure environment and must satisfy
+   the trusted params schema.
+4. It returns a new branded `PatternFactory` whose hidden state contains
+   `params`.
+5. It does not change the public TypeScript input type or public
+   `argumentSchema`.
+6. It throws if the factory already has params, even if the second value is
+   equal or empty.
+7. It throws if the base pattern has no compiler-declared params slot.
+
+A capture-free nested pattern emits no curry call. It simply references the
+hoisted factory.
+
+### Separate symbolic roots
+
+The internal pattern builder creates up to three roots:
+
+- `argument`: public callback argument 0;
+- `params`: compiler-generated callback argument 1; and
+- `result`: the pattern result.
+
+`params` has its own schema and alias form. It is not nested under the public
+argument and is not persisted as user-editable piece input. At pattern
+invocation, the runner validates public input against `argumentSchema` and
+binds hidden factory params to the separate `params` root.
+
+Each bound pattern invocation creates an immutable hidden params cell owned by
+the invocation's result cell. It has a deterministic result-relative cause,
+uses `paramsSchema`, is linked from result metadata under `params`, and carries
+the normal back-link to `result` for resume and teardown.
+Before child nodes instantiate, setup resolves the bound factory state's params
+against the parent binding context, writes or links them into this cell while
+preserving CFC labels, and supplies the cell to alias resolution.
+
+The alias vocabulary gains `{ $alias: { cell: "params", path, ... } }`.
+`unwrapOneLevelAndBindtoDoc`, `sendValueToBinding`, and direct sub-pattern setup
+accept that pseudo-root only when the invocation has a params cell. Nested
+links resolve relative to their original parent before the hidden cell is
+populated; cross-space links remain links rather than copied values. On resume,
+the serialized bound `Factory@1` state repopulates the same params cell before
+the graph starts. The cell is torn down with its owning result and is never
+exposed as piece input.
+
+An invocation of a closure-bearing base factory without bound params fails.
+Supplying public fields with the same names as closure params has no special
+meaning and creates no collision: the roots are distinct.
+
+### Compiler pipeline
+
+The transformation order is:
+
+1. Validate that the nested builder call occurs in a transformable pattern-
+   owned context.
+2. Collect non-module lexical captures, including captured factory values.
+3. Rewrite the callback to receive captures in argument 1.
+4. Generate the public argument schema, result schema, and private params
+   schema. Wrap the callback with `withPatternParamsSchema(callback, schema)`
+   so `pattern()` receives the metadata before eager construction; do not add a
+   fourth `pattern()` argument.
+5. Hoist the capture-free base `pattern(...)` call to a deterministic
+   `__cfPattern_N` declaration and register it through `__cfReg`.
+6. Replace the authored site with `__cfPattern_N.curry(captures)`, or with the
+   bare hoisted factory when there are no captures.
+7. Apply normal reactive-variable cause assignment after the site rewrite.
+
+Current array-callback lowering must use the same representation. For example,
+`map` lowers to a `mapWithPattern` call receiving a bound PatternFactory; it no
+longer passes closure params as a separate sibling argument. All pattern
+closure values flow through the one internal `.curry(params)` operation.
+
+### Diagnostics
+
+Compilation or runtime fails clearly for:
+
+- a non-portable captured function;
+- a capture the schema generator cannot represent;
+- missing or extra closure params;
+- params that fail their trusted schema;
+- a second internal curry;
+- an internal curry on a capture-free pattern;
+- an unresolved or kind-mismatched factory ref; and
+- an untransformed attempt to invoke a symbolic factory proxy.
+
+Generated names and capture-property order are deterministic.
+
+## Factory Schemas and Symbolic Invocation
+
+### Schema representation
+
+The schema generator recognizes factory types before its generic callable and
+callable-returning-cell logic. A factory-valued field uses a Common Fabric
+extension such as:
+
+```ts
+// Shown for illustration only.
+{
+  asFactory: {
+    kind: "pattern",
+    argumentSchema: { /* ... */ },
+    resultSchema: { /* ... */ },
+  },
+}
+```
+
+The `module` form uses `argumentSchema` / `resultSchema`. The `handler` form
+uses `contextSchema` / `eventSchema`. A `HandlerFactory` must not be mistaken
+for an `asCell: ["stream"]` merely because calling it returns a stream.
+
+Version 1 requires the stored factory's canonical public schemas to equal the
+call site's generated schemas after reference resolution and normalization.
+Schema variance is deferred. The resolved trusted artifact is authoritative;
+wire-carried schema hints never grant execution or CFC authority.
+
+Schema-light factories may still be passed and stored. Before symbolically
+invoking a `type: "ref"` module factory such as `byRef()`, resolution follows
+the ref through `ModuleRegistry` and uses that trusted module's schemas.
+Authored `lift` and `handler` calls retain transformer-injected public schemas
+on their factory metadata. If no trusted concrete schemas are available after
+resolution, symbolic invocation fails; the call site's schema is not promoted
+to authority. Direct invocation of the original live factory keeps its current
+behavior.
+
+### Type-directed call lowering
+
+Calls on imported or module-scoped live factories continue using the existing
+direct builder call path. Calls whose callee is a symbolic/reactive factory are
+lowered to an internal builder helper:
+
+```ts
+// Shown for illustration only.
+operation({ value })
+
+// Logical lowered form:
+__cfHelpers.invokeFactory(
+  operation,
+  { value },
+  {
+    kind: "pattern",
+    argumentSchema,
+    resultSchema,
+  },
+);
+```
+
+The helper records a dynamic node whose module input is the symbolic factory.
+It returns a `Reactive` output for pattern/module factories and a `Stream` for
+handler factories. Handler application retains its existing `$ctx` and
+`$event` node wiring.
+
+The type-directed detector follows local aliases, property access, and
+statically typed element access, so `const f = inputs.factory; f(value)` and
+`inputs.factories[key](value)` use the same lowering. Version 1 rejects a
+callable union spanning factory kinds, because the builder must choose
+`Reactive` versus `Stream` before runtime resolution. Same-kind unions are
+allowed only when their normalized public schemas agree.
+
+At instantiation, the runner reads the Factory value, validates kind and
+schemas, resolves the trusted base artifact, applies modifier and pattern-param
+state, and tail-calls the existing pattern, JavaScript-module, or handler
+instantiation path. It does not call code during value resolution.
+
+The dynamic node is a supervisor for one materialized child/action/handler. It
+owns that instance's cancellation scope, result-owned internal cells, and
+handler subscription. The factory cell is a reactive dependency. On change,
+the supervisor:
+
+1. increments a generation token and cancels the prior instance;
+2. fences late async writes/results from older generations;
+3. tears down the prior child internals and stream subscription while retaining
+   the call site's output binding;
+4. resolves and validates the replacement, including cross-space modifiers;
+   and
+5. instantiates the replacement under the new generation.
+
+The stable output spot remains the cause/identity anchor, matching existing
+sub-pattern and list-builtin invariants. The factory ref is a reactive
+dependency and dispatch fingerprint, not an input to result-cell identity;
+changing a factory must not churn the output cell merely because its program
+changed. Distinct call sites already have distinct output bindings.
+
+## Resolution
+
+Warm resolution uses the existing generic artifact index:
+
+```text
+factory.ref -> trusted builder artifact -> verify kind -> instantiate
+```
+
+Cold resolution generalizes the existing pattern-only loader:
+
+1. Load the source document for `ref.identity`.
+2. Verify and evaluate the content-addressed module.
+3. Resolve `ref.symbol` through exports or `__cfReg`.
+4. Require a trusted builder brand and the expected factory kind.
+5. Cache the artifact in the generic identity index.
+
+This generalized `loadArtifactByIdentity()` path serves pattern, module, and
+handler factories. A legacy `$patternRef` may adapt to a pattern
+`FactoryStateV1` because it names the pattern factory artifact.
+
+A legacy `$implRef` does not feed this resolver as a factory ref. It may name
+only an implementation function and omits module/handler configuration. Its
+compatibility reader retains the surrounding serialized module descriptor,
+resolves the implementation through the legacy path, and reconstructs a
+ModuleFactory or HandlerFactory with the corresponding internal descriptor
+constructor.
+
+For a bound pattern, setup additionally:
+
+1. validates `paramsSchema` against the trusted base metadata;
+2. validates the complete `params` value;
+3. binds it to the pattern's `params` alias root; and
+4. traverses nested factory refs and cell links normally.
+
+Scope and raw pattern space-selector state are applied after base resolution
+and before node instantiation.
+
+## Trust and Security
+
+The Fabric-factory brand is a data-type brand, not executable trust. The
+symbol routes protocol handling; membership in a module-private WeakMap or
+WeakSet is the unforgeable brand.
+
+There are two separate capabilities:
+
+- the data-model factory-state table admits well-formed live factories and
+  decoded shells for conversion and reserialization; and
+- runner-owned provenance tables alone assign/resolve executable artifact refs
+  for verified builder factories.
+
+The data-model registration mechanism is not an execution-trust grant, even if
+an internal materializer must call it to create a derived shell.
+
+- Only trusted builder constructors and `FactoryCodec.decode()` create branded
+  values.
+- `FactoryCodec.canEncode()` additionally checks the internal builder/state
+  brand; a user function with a copied symbol property is rejected.
+- Decoded state resolves only through the trusted artifact index or verified
+  source loading. It cannot supply implementation source.
+- The resolved artifact kind, schemas, and compiler params schema must match
+  the decoded state before invocation.
+- CFC and alias traversal descend into params, so hiding params from the public
+  object shape does not hide their labels or dependencies.
+- A factory's schema, ref, description, or debug preview is never an authority
+  grant.
+
+### Framework-provided inputs
+
+Inline wrappers preserve `FrameworkProvided` obligations transitively. They do
+not turn a framework-provided input such as `sandboxId` into an ordinary
+closure param or let an author bind it indirectly.
+
+The compiler records trusted framework-provided paths for each base factory.
+When a wrapper calls such a factory, it synthesizes those fields into the
+wrapper's argument schema and callback binding, then forwards their aliases to
+the inner factory node. The fields are system-facing inputs, not closure params:
+the tool adapter strips them from the model-facing schema, injects them from
+the wrapper tool instance's identity, and the synthetic forwarding path carries
+that exact value to the ultimate call. Wrapper chains repeat the same
+transitive forwarding.
+
+Authored code may neither supply a literal for such a field nor capture a
+chosen value and forward it. If a required system value or stable tool identity
+is unavailable, invocation fails closed.
+
+Closure conversion rejects a capture that attempts to freeze a
+framework-provided field into `params`. Captured ordinary values remain graph
+bindings from the enclosing pattern, not a second caller-input channel, and
+there is no public curry API that can override framework-supplied fields.
+
+## Replacing `patternTool`
+
+The current shape:
+
+```ts
+// Shown for illustration only.
+const tools = {
+  search: patternTool(searchPattern, { entries }),
+};
+```
+
+becomes an ordinary inline pattern closure:
+
+```ts
+// Shown for illustration only.
+const tools = {
+  search: pattern(({ query }: { query: string }) =>
+    searchPattern({ query, entries })
+  ),
+};
+```
+
+The wrapper's public schema naturally contains only `query`. `entries` is a
+closure param, not a public input that a tool adapter subtracts or merges.
+
+A PatternFactory is directly usable as a tool. Optional description or
+presentation metadata may remain in an ordinary tool metadata wrapper, but
+there is no `extraParams` field:
+
+```ts
+// Shown for illustration only.
+const tools = {
+  search: {
+    pattern: pattern(({ query }: { query: string }) =>
+      searchPattern({ query, entries })
+    ),
+    description: "Search this index",
+  },
+};
+```
+
+Tool discovery reads the factory's public argument schema. Invocation follows
+the same dynamic factory path as ordinary pattern composition.
+
+## Compatibility and Migration
+
+During the migration, readers accept:
+
+- `Factory@1` values;
+- legacy pattern `{ $patternRef, argumentSchema, resultSchema }` values where a
+  PatternFactory is expected;
+- legacy serialized module descriptors carrying `$implRef`; and
+- legacy `{ pattern, extraParams, ...metadata }` tool definitions; and
+- legacy `mapWithPattern` / `filterWithPattern` / `flatMapWithPattern` nodes
+  carrying sibling `{ op, params }` inputs.
+
+New writers emit `Factory@1`. Legacy `extraParams` keep their existing
+tool-boundary merge and precedence rules only in the compatibility reader. They
+are not exposed as `.curry()` and are not redefined as closure params.
+
+During the same dual-read window, list builtins accept either the legacy
+`op + params` shape or a new bound PatternFactory with no sibling params. The
+transformer emits only the new shape, while the old public method overload and
+stored-node reader remain until source usage is gone and stored graphs have
+been migrated or explicitly wiped.
+
+Migration proceeds by changing source callers to inline wrapper patterns. Once
+stored-data and source-usage gates are satisfied, remove:
+
+- `patternTool` and `PatternToolResult`;
+- transformer callback-boundary, validation, and hoisting special cases for
+  `patternTool`;
+- LLM schema-format and invocation special cases for `extraParams`;
+- legacy list-builtin overloads and sibling `params` readers; and
+- factory-function `toJSON()` compatibility once all boundaries use the
+  registered Factory codec.
+
+Current behavior documents remain accurate until the implementation lands;
+they are updated in the same implementation change, not preemptively by this
+proposal.
+
+## Delivery Order
+
+### Stage 0: Extract generic pattern-ref binding
+
+Copy or reimplement the small `$patternRef` binder/setup behavior currently
+coupled to #4514. Cover patterns nested anywhere in bindings and direct
+setup/sub-pattern resolution. Do not take a dependency on the reactive-
+interpreter stack.
+
+### Stage 1: Branded factory Fabric values
+
+Add the narrow callable Fabric protocol, `Factory@1`, canonical factory state,
+codec registration, conversion, clone/freeze/equality/hash behavior, and shared
+factory-state traversal. Brand every trusted pattern/module/handler factory.
+
+### Stage 2: Factory schemas and dynamic invocation
+
+Generate `asFactory` schemas, lower symbolic calls, complete the runner's
+dynamic-module arm, and generalize cold artifact loading across factory kinds.
+
+### Stage 3: Pattern closure conversion
+
+Add the second callback root, pre-construction
+`withPatternParamsSchema(callback, schema)` carrier, deterministic hoisting,
+one-shot internal `.curry(params)`, params binding, and the updated
+`*WithPattern` lowering.
+
+### Stage 4: Remove `patternTool`
+
+Migrate source callers to inline wrapper patterns, dual-read stored legacy tool
+values, then remove the API and transformer/runtime special cases once the
+compatibility gate is met.
+
+Each stage is independently testable and revertible.
+
+## Implementation Areas
+
+- `packages/data-model`: FabricFactory type arm and brand, `FactoryCodec`, codec
+  registry function dispatch, conversion, freeze/clone, equality/hash, JSON
+  cycle tracking, and formal type declarations.
+- `packages/memory` and runner storage/update paths: treat branded factories as
+  atomic codec values at storage boundaries, preserve them through patches and
+  diffs, and reject unbranded functions.
+- `packages/api`: mirrored FabricFactory and `asFactory` schema declarations;
+  keep `.curry` out of the public `PatternFactory` type.
+- `packages/runner/src/builder`: brand/state attachment for every factory,
+  pre-construction callback params-schema metadata, pattern params root,
+  internal curry derivation, symbolic invocation helper, modifier persistence,
+  root-token provenance, and live-to-canonical protocol traversal.
+- `packages/runner`: params pseudo-alias types and binding functions, hidden
+  params-cell metadata/lifecycle, dynamic-module supervision, generic artifact
+  resolution/loading, runner materialization, and compatibility adapters.
+- `packages/schema-generator`: recognize all factory kinds before generic
+  callable handling and emit public factory schemas.
+- `packages/ts-transformers`: capture analysis, nested-pattern closure rewrite,
+  `withPatternParamsSchema` emission, deterministic hoisting, symbolic call
+  lowering, framework-input threading, list callback lowering, and diagnostics.
+- `packages/llm`, CLI, FUSE, and schema formatting: consume Factory values
+  directly and retain legacy reads during migration.
+- pattern sources: replace `patternTool` with inline patterns.
+
+## Validation Plan
+
+### Fabric protocol
+
+- Encode/decode/hash/equality/clone/freeze each factory kind.
+- Round-trip factories nested in objects, arrays, cells, pieces, and other
+  factory params.
+- Round-trip through the memory client/server boundary, where decode has no
+  runner reconstruction context, then materialize in a runner.
+- Reject arbitrary functions, copied symbols, malformed states, cycles,
+  keyless artifacts, kind mismatches, and schema mismatches.
+- Reject encode/hash/deep-freeze before ref sealing and verify that a sealed
+  factory's state and hash never change.
+- Verify equal state hashes equally across independent module evaluations.
+- Verify params and space selectors participate in traversal and hashing.
+
+### Transformer
+
+- Golden-test the exact two-parameter callback and
+  `__cfPattern_N.curry(params)` site.
+- Assert `withPatternParamsSchema(callback, schema)` is present before eager
+  `pattern()` / `patternFromFrame()` construction.
+- Assert there is no fourth `pattern()` argument, argument-index curry, public
+  input merging, or curry call for capture-free patterns.
+- Capture cells, nested properties, and every factory kind.
+- Reject non-portable functions and a second internal curry.
+- Wrap a bound pattern in another authored pattern and verify one curry per
+  wrapper.
+- Lower symbolic factory inputs without changing imported/live-factory calls.
+- Cover aliased, property-selected, element-selected, and same-kind union
+  callees; reject cross-kind callable unions.
+- Lower `map`/`filter`/`flatMap` captures through a bound PatternFactory rather
+  than a sibling params object.
+
+### Runtime
+
+- Invoke stored pattern, module, and handler factories through symbolic inputs.
+- Change a factory-valued cell and verify teardown/re-instantiation.
+- Bind closure params through the separate params root and preserve public
+  argument fields with the same names.
+- Resume and tear down the deterministic hidden params cell, including nested
+  aliases, cross-space links, and CFC labels.
+- Capture and invoke another stored factory from a nested pattern.
+- Verify Factory state uses the builder artifact ref, never an implementation
+  `$implRef`, and exercise schema-light `byRef()` resolution.
+- Preserve `asScope()` and every `inSpace()` selector form across round-trip.
+- Resume all factory kinds cold by content-addressed identity.
+- Preserve CFC labels and fail closed on forged refs or metadata.
+
+### Tool migration
+
+- Use an inline pattern that captures entries as an LLM tool.
+- Wrap a tool with a framework-provided `sandboxId`; verify synthetic forwarding
+  from the wrapper tool identity and reject authored/captured values.
+- Discover and invoke the same tool through runtime, CLI, and FUSE paths.
+- Read legacy `PatternToolResult` values without changing their old precedence.
+- Read legacy list nodes with sibling params and emit only bound-factory nodes.
+- Verify no new source caller or stored writer emits `extraParams`.
+
+## Completion Criteria
+
+This proposal is complete when:
+
+1. Every content-addressed pattern/module/handler factory is directly branded
+   and round-trips through a runner as a callable `Factory@1` value; keyless and
+   session-only factories fail durable encoding.
+2. Arbitrary functions remain rejected.
+3. Factory-valued pattern inputs and captures invoke through one dynamic path.
+4. Nested patterns preserve lexical semantics through callback argument 1 and
+   exactly one transformer-only `.curry(params)` operation.
+5. Public pattern inputs are never merged with closure params.
+6. Factory refs, schemas, params, scopes, space selectors, CFC labels, and
+   hashes survive storage and cold reload.
+7. `patternTool` and sibling list params have no source writer path, and their
+   compatibility readers have explicit stored-data removal gates.

--- a/docs/specs/pattern-construction/node-factory-shipping.md
+++ b/docs/specs/pattern-construction/node-factory-shipping.md
@@ -5,6 +5,9 @@
 Proposed. This document specifies intended behavior, not the current
 implementation.
 
+The ordered execution checklist is
+[First-Class Serializable Factories — Implementation Plan](../../plans/first-class-serializable-factories.md).
+
 The content-addressed identity prerequisite is shipped: every verified,
 module-scoped builder factory is addressable by `{ identity, symbol }`.
 Exports use their export name, while transformed and non-exported factories use

--- a/docs/specs/pattern-construction/overview.md
+++ b/docs/specs/pattern-construction/overview.md
@@ -188,7 +188,8 @@ than a separate V2 system. See `rollout-plan.md` for detailed task breakdown.
 
 This track depends on content-addressed builder-artifact identity, not on graph
 snapshots or the reactive-interpreter rollout. See
-[First-Class Serializable Factories](./node-factory-shipping.md).
+[First-Class Serializable Factories](./node-factory-shipping.md) and its
+[implementation plan](../../plans/first-class-serializable-factories.md).
 
 1. Make pattern, module/lift, and handler factory functions directly branded
    `Factory@1` Fabric values.

--- a/docs/specs/pattern-construction/overview.md
+++ b/docs/specs/pattern-construction/overview.md
@@ -184,6 +184,20 @@ than a separate V2 system. See `rollout-plan.md` for detailed task breakdown.
    - Track created cells and causes in context during execution
    - Wire lift/handler returns to auto-assign causes to returned cells
 
+### Independent Track: First-Class Factory Values (Proposed)
+
+This track depends on content-addressed builder-artifact identity, not on graph
+snapshots or the reactive-interpreter rollout. See
+[First-Class Serializable Factories](./node-factory-shipping.md).
+
+1. Make pattern, module/lift, and handler factory functions directly branded
+   `Factory@1` Fabric values.
+2. Generalize ref binding, cold resolution, and symbolic invocation across
+   factory kinds.
+3. Closure-convert and hoist nested patterns, binding callback argument 1 with
+   one transformer-only `.curry(params)` operation.
+4. Replace `patternTool` with inline wrapper patterns.
+
 ### Phase 2: Graph Snapshot & Metadata (Deferred)
 
 1. **Graph snapshot generation**
@@ -191,10 +205,6 @@ than a separate V2 system. See `rollout-plan.md` for detailed task breakdown.
      cell metadata (implements the graph metadata described in the rollout plan)
    - Update rehydration/teardown logic to consume the snapshot
    - See `graph-snapshot.md` for schema details
-2. **Serializable node factories** (Deferred - see `node-factory-shipping.md`)
-   - Implement `nodeFactory@1` sigil format
-   - Add `.curry()` support for partial application
-   - Enable shipping factories across spaces
 
 ### Phase 3: Cleanup
 

--- a/docs/specs/pattern-construction/rollout-plan.md
+++ b/docs/specs/pattern-construction/rollout-plan.md
@@ -113,8 +113,9 @@
 
 ## Planned Future Work
 
-- [ ] **First-class serializable factories** (see
-  `node-factory-shipping.md`)
+- [ ] **First-class serializable factories** (see the
+  [specification](./node-factory-shipping.md) and
+  [implementation plan](../../plans/first-class-serializable-factories.md))
   - [ ] Extract generic `$patternRef` binding/setup behavior independently of
     graph snapshots and reactive-interpreter work
   - [ ] Make pattern, module/lift, and handler factories directly branded

--- a/docs/specs/pattern-construction/rollout-plan.md
+++ b/docs/specs/pattern-construction/rollout-plan.md
@@ -113,11 +113,17 @@
 
 ## Planned Future Work
 
-- [ ] **Serializable node factories** (see `node-factory-shipping.md`)
-  - [ ] Implement `nodeFactory@1` sigil format for shipping factories
-  - [ ] Add `.curry(value, argIndex)` method for partial application
-  - [ ] Support rehydration of serialized factories from cells/events
-  - [ ] Ensure currying metadata is preserved during serialization
+- [ ] **First-class serializable factories** (see
+  `node-factory-shipping.md`)
+  - [ ] Extract generic `$patternRef` binding/setup behavior independently of
+    graph snapshots and reactive-interpreter work
+  - [ ] Make pattern, module/lift, and handler factories directly branded
+    `Factory@1` Fabric values
+  - [ ] Add factory schemas, symbolic invocation, and generic cold resolution
+  - [ ] Add nested-pattern closure conversion with a separate params root and
+    one transformer-only `.curry(params)` operation
+  - [ ] Replace `patternTool` consumers with inline wrapper patterns and retain
+    compatibility reads
 
 ## Open Questions
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -132,10 +132,23 @@ type FabricValue =
 >   are not functions in this sense — they are class instances whose
 >   serialization is handled by their class's `[CODEC]`.)
 >
+>   A proposed, deliberately narrow exception adds a `FabricFactory` arm for
+>   builder-created factories and codec-decoded factory shells admitted to the
+>   internal data-model brand table. The function itself is the Fabric value
+>   and encodes through `Factory@1`; there is no non-callable wrapper class.
+>   This data-type brand does not grant executable trust, which is established
+>   separately by resolving a content-addressed builder artifact. The exception
+>   is not automatic under the current protocol: it requires branded-function
+>   dispatch before generic function rejection, plus factory-state handling in
+>   conversion, freezing, cloning, equality, hashing, and traversal. Every
+>   unbranded function remains rejected. See
+>   [First-Class Serializable Factories](../pattern-construction/node-factory-shipping.md).
+>
 > Of the two JS primitive types whose `typeof` results (`"symbol"` and
 > `"function"`) describe non-data values, `symbol` has a corresponding
 > `FabricValue` arm (with the runtime interned-vs-unique restriction
-> above) and `"function"` does not. All other `typeof` results
+> above) and `"function"` does not **in the current model**. The proposal above
+> adds only the branded `FabricFactory` function arm. All other `typeof` results
 > (`"undefined"`, `"boolean"`, `"number"`, `"string"`, `"bigint"`,
 > `"object"`) have unconditional `FabricValue` arms.
 


### PR DESCRIPTION
## Summary

- specify one directly branded, serializable `Factory@1` value for pattern, module/lift, and handler factories
- define nested-pattern closure conversion with callback argument 1 plus transformer-only, one-shot `.curry(params)`
- define `asFactory` schemas, symbolic invocation, hidden params binding, generic cold resolution, trust, and compatibility behavior
- replace the `patternTool` authoring model with readable inline wrapper patterns
- add a [detailed implementation plan](https://github.com/commontoolsinc/labs/blob/codex/first-class-factories-spec/docs/plans/first-class-serializable-factories.md) with 330 checkboxes, ordered work packages, tests, risks, and removal gates

## Why

Patterns can already be content-addressed, but factory functions still serialize through a one-way `toJSON()` path and lose callability. Nested patterns also lack a general closure-conversion model. This proposal defines one coherent Fabric representation and invocation path without exposing public currying or introducing wrapper factory classes.

## Implementation plan

1. Extract only the generic `$patternRef` prerequisite from #4514.
2. Add callable Fabric protocol, `Factory@1`, canonical state, and runner materialization.
3. Add factory schemas and dynamically supervised symbolic invocation.
4. Add closure conversion, the hidden params root, list lowering, and `FrameworkProvided` forwarding.
5. Migrate LLM/CLI/FUSE and repository callers, then remove `patternTool` only after explicit stored-data gates.

## Impact

This PR is documentation-only. It defines the target behavior and a staged, red/green implementation contract. Implementation changes will follow separately.

## Checks

- `deno task check-docs plans`
- `deno task check-docs specs/pattern-construction`
- `deno task check-docs specs/space-model-formal-spec`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Specifies first-class, serializable builder factories (`Factory@1`) for `pattern`, `module/lift`, and `handler`, enabling callable round-trips, symbolic invocation, and nested-pattern closure conversion. Documentation-only; adds a detailed implementation plan, clarifies status/prerequisites, updates the Fabric values formal spec, and replaces `patternTool` with inline wrapper patterns.

- **New Features**
  - Branded callable Fabric factories that encode/decode as `Factory@1` (no wrapper class); factories remain callable after storage/transport.
  - Factory schemas (`asFactory`) and type-directed symbolic invocation for pattern/module/handler inputs, with dynamic resolution by content-addressed refs.
  - Nested-pattern closure conversion with a separate params root and a transformer-only `.curry(params)`; no public currying or input merging.
  - Modifier/state persistence for `asScope()` and `inSpace()`, plus cold resolution for all factory kinds; legacy `$patternRef`/`$implRef` compatible reads.

- **Migration**
  - Replace `patternTool` with inline wrapper patterns; list builtins move to bound `PatternFactory` (keep legacy `op + params` read-only during transition).
  - Staged rollout: extract generic `$patternRef` binding → add `Factory@1` branding/codec → add schemas and symbolic invocation → add closure conversion → remove `patternTool`.

<sup>Written for commit fe2f55dcd1a4e396be2baf5b1931dc29f812b28c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

