### PR TITLE
feat(scheduler): default persistent scheduler state on

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -689,13 +689,20 @@ jobs:
       # (DENO_COVERAGE_DIR) but not authored-pattern coverage. Pattern coverage
       # is only collected by `cf test` via CF_PATTERN_COVERAGE_DIR, set on the
       # pattern-unit-test job. See docs/development/COVERAGE.md.
-      - name: 🧩 Run pattern reload integration tests
+      - name: 🧩 Run default-on pattern reload integration tests
         run: |
-          mkdir -p test-results
+          mkdir -p test-results/default
           HEADLESS=1 \
-          CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1 \
           DENO_COVERAGE_DIR=coverage/raw/pattern-reload \
-          deno task integration --junit-dir=test-results patterns-reload
+          deno task integration --junit-dir=test-results/default patterns-reload
+
+      - name: ↩️ Run pattern reload integration tests with rollback override
+        run: |
+          mkdir -p test-results/rollback
+          HEADLESS=1 \
+          EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=false \
+          DENO_COVERAGE_DIR=coverage/raw/pattern-reload \
+          deno task integration --junit-dir=test-results/rollback patterns-reload
 
       - name: 🧾 Write coverage report
         if: always()

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -693,7 +693,6 @@ jobs:
         run: |
           mkdir -p test-results
           HEADLESS=1 \
-          EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true \
           CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1 \
           DENO_COVERAGE_DIR=coverage/raw/pattern-reload \
           deno task integration --junit-dir=test-results patterns-reload

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -265,7 +265,7 @@ Most shell config is **build-time**: esbuild injects defines in
 | `API_URL` | `$API_URL` | falls back to `location.origin` | Backend the shell calls. |
 | `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
-| `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | `EXPERIMENTAL.persistentSchedulerState` | _(unset)_ | See experimental flags. |
+| `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | `EXPERIMENTAL.persistentSchedulerState` | _(unset = runtime on)_ | See experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | `EXPERIMENTAL.eagerSourceAnnotation` | on in dev builds, off in production | See experimental flags. |
 | `SHELL_PORT` | _(server-only)_ | `5173` (from `ports.json`) | Dev server port. |
 
@@ -323,7 +323,7 @@ Passed before the CLI args; rarely needed:
 | `IDENTITY` | _(unset)_ | Path to keyfile; takes precedence over `OPERATOR_PASS`. |
 | `API_URL` | `http://localhost:8000` | Toolshed URL the service calls. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | _(unset)_ | See experimental flags. |
-| `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | _(unset)_ | See experimental flags. |
+| `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | _(unset = runtime on)_ | See experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | _(unset)_ | See experimental flags. |
 
 ---

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -20,7 +20,7 @@ in the same change.
 > flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
 > record, so the history stays discoverable.
 
-**Last reviewed:** 2026-07-09. Each flag's section carries the date its status
+**Last reviewed:** 2026-07-11. Each flag's section carries the date its status
 was last checked against the code.
 
 ## Summary table
@@ -28,7 +28,7 @@ was last checked against the code.
 | Flag | Toggle via | Default today | Originally added by | Planned end state | Status |
 |------|-----------|---------------|---------------------|-------------------|---------------------|
 | [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
-| [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
+| [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | on | Bernhard Seefeld (#3646) | graduate to always-on | implemented, on by default, rollback override retained |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
 | [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (non-home roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete both auto-update flags | implemented, on in the shell |
@@ -59,9 +59,9 @@ B](#appendix-b-related-toggles-that-are-not-experimental-flags).
 These flags make up the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
-`undefined`, which means "take the built-in default". `commitPreconditions`
-defaults on; the other flags in this category default off unless their section
-says otherwise.
+`undefined`, which means "take the built-in default".
+`persistentSchedulerState` and `commitPreconditions` default on; the other
+flags in this category default off unless their section says otherwise.
 
 The mapping from environment variable to flag is defined once, canonically, as
 `EXPERIMENTAL_ENV_VARS` in
@@ -121,21 +121,21 @@ propagate](#how-flags-propagate).
 - **Purpose.** Persists the scheduler's observations to durable storage through
   memory-v2 and uses them to rehydrate scheduler state after a restart, instead
   of rediscovering everything by re-running.
-- **Current default and planned end state.** Off by default. The scheduler-v2
-  design is persistence-first, so the intended end state is to graduate this to
-  always-on. The scheduler-observation protocol is an optional capability rather
-  than a data-model contract, so peers with different settings can still share
-  memory data; the server's setting controls whether scheduler rows are accepted
-  on a connection.
-- **Status on 2026-07-08.** Implemented; the durable tables, the rehydration
-  primitives, and the memory-protocol capability are wired. Off by default,
-  rollout in progress. See
+- **Current default and planned end state.** On by default, with an explicit
+  `false` retained as a rollback override while the default-on posture soaks.
+  The intended end state remains always-on. The scheduler-observation protocol
+  is an optional capability rather than a data-model contract, so peers with
+  different settings can still share memory data; the server's setting controls
+  whether scheduler rows are accepted on a connection.
+- **Status on 2026-07-11.** Implemented; the durable tables, the rehydration
+  primitives, and the memory-protocol capability are wired. Default-on rollout
+  in progress. See
   [`docs/specs/persistent-scheduler-state.md`](../specs/persistent-scheduler-state.md)
   and [`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) for the tracked
   status.
-- **Path to removal.** Confirm rehydration falls back cleanly when observations
-  are absent or stale; graduate the default to on across the fleet; then fold
-  the behavior into the base scheduler and delete the flag.
+- **Path to removal.** Let the default-on posture soak and confirm rehydration
+  falls back cleanly when observations are absent or stale; then fold the
+  behavior into the base scheduler and delete the rollback flag.
 
 ### `commitPreconditions`
 
@@ -761,7 +761,7 @@ golden: it pins the full `RuntimeOptions` each preset produces, including the
 through `experimentalOptionsFromEnv`. Any change to the fleet-wide posture or the
 env mapping shows up as a diff in that one file.
 
-Both tests pass as of 2026-07-08. They exercise the flag plumbing and the
+Both tests pass as of 2026-07-11. They exercise the flag plumbing and the
 per-preset posture, not the full behavior of every feature under every flag
 combination; the per-feature test matrices live with each feature's specs (for
 example under [`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) and the CFC
@@ -772,7 +772,8 @@ design docs).
 The Category 1 flags are declared as the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). The
 `Runtime` constructor merges the provided flags with the built-in defaults
-(`commitPreconditions` true, the other Category 1 flags false),
+(`persistentSchedulerState` and `commitPreconditions` true; the other Category
+1 flags false),
 propagates each one to its ambient control point, and then reads the effective
 state back so that `runtime.experimental.*` reflects what is actually in effect.
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -129,7 +129,8 @@ propagate](#how-flags-propagate).
   whether scheduler rows are accepted on a connection.
 - **Status on 2026-07-11.** Implemented; the durable tables, the rehydration
   primitives, and the memory-protocol capability are wired. Default-on rollout
-  in progress. See
+  in progress. The pattern-reload CI job exercises both the default-on posture
+  and the explicit-false rollback path. See
   [`docs/specs/persistent-scheduler-state.md`](../specs/persistent-scheduler-state.md)
   and [`docs/specs/scheduler-v2/`](../specs/scheduler-v2/) for the tracked
   status.

--- a/docs/specs/persistent-scheduler-state.md
+++ b/docs/specs/persistent-scheduler-state.md
@@ -3,8 +3,8 @@
 ## Status
 
 Implemented behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` /
-`Runtime.experimental.persistentSchedulerState`; the default-on rollout remains
-a separate decision.
+`Runtime.experimental.persistentSchedulerState` and on by default. An explicit
+`false` remains as a rollback override while the default-on posture soaks.
 
 The landed implementation includes internal memory-v2 scheduler observation
 tables, no-op observation commits, same-space durable dirty marking,
@@ -1111,7 +1111,7 @@ Current branch status:
 
 | Area | Version 1 status |
 | --- | --- |
-| Feature flag | Implemented as `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`, default off. |
+| Feature flag | Implemented as `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`, default on with explicit-false rollback. |
 | Observation construction and no-op persistence | Implemented, including batched no-op observation commits. |
 | Memory scheduler tables and same-space dirty marking | Implemented. |
 | Context-qualified ownership and migration | Implemented with authenticated space/user/session filtering, monotonic floors, effective target keys, and conservative migration of only provably shared legacy rows. |
@@ -1123,15 +1123,15 @@ Current branch status:
 | Demand-targeted dirty recovery beyond subscription startup | Future work. |
 | Replication, retention, and mirror repair | Exact-session contexts are bounded per principal/action; generation/branch GC and failed-mirror repair remain future work. |
 
-The version 1 implementation is gated by the project's common
-experimental-option plumbing. With
-`EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=false` or unset, the runner does not
-attach scheduler observations to transactions, memory clients do not request
-scheduler snapshots, and the memory server does not write scheduler observation
-rows, dirty rows, or cross-space mirrors. Snapshot-list requests intentionally
-return an empty result while the flag is off, even if a previous flagged run
-left scheduler rows in the SQLite database. Unlike `modernCellRep`, this flag
-is not a required memory protocol compatibility flag: mismatched peers may still
+The version 1 implementation uses the project's common experimental-option
+plumbing. Unset now enables it by default. With an explicit
+`EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=false`, the runner does not attach
+scheduler observations to transactions, memory clients do not request scheduler
+snapshots, and the memory server does not write scheduler observation rows,
+dirty rows, or cross-space mirrors. Snapshot-list requests intentionally return
+an empty result while the flag is off, even if a previous flagged run left
+scheduler rows in the SQLite database. Unlike `modernCellRep`, this flag is not
+a required memory protocol compatibility flag: mismatched peers may still
 connect, and the server-side flag determines whether scheduler observation rows
 are accepted and served.
 

--- a/docs/specs/scheduler-v2/per-doc-rehydration.md
+++ b/docs/specs/scheduler-v2/per-doc-rehydration.md
@@ -260,8 +260,8 @@ the boot load is paginated and off the hot path (parallel to the pre-sync).
   the field-level alias chain, so the same coupled 1-conflict residual remains.
   It reaches zero when resume-time runners pre-warm their persisted read sets —
   an application of the incremental observation-adoption direction (see below),
-  not of the boot listing. Explicit-false rollback is covered by the runtime and
-  memory protocol suites rather than a second browser population.
+  not of the boot listing. Explicit-false rollback is covered by the same
+  browser suite re-run with the flag off.
 
 ## 7.1 Live counterpart: incremental adoption
 

--- a/docs/specs/scheduler-v2/per-doc-rehydration.md
+++ b/docs/specs/scheduler-v2/per-doc-rehydration.md
@@ -251,16 +251,17 @@ the boot load is paginated and off the hot path (parallel to the pre-sync).
   map-children test rather than a timing-sensitive unit gate.
 - `reload-rehydration.test.ts`: the asserted listing query shape becomes the
   space-scoped one.
-- Reload churn: the ≤ 1 residual gate lives in the flag-OFF integration run,
-  where fresh child first-runs are inherent (v1 reached 0 via its populate
-  pass; v2 flag-off has no restore to lean on). A flag-ON churn assertion in
-  `integration/reload/` (the `pattern-reload-integration-test` job) pins
-  flag-ON at "never worse than flag-off". Measured: the rows rehydrate, but
-  the always-run coordinator's first reconcile still reads one cold hop
-  through the field-level alias chain, so the same coupled 1-conflict
-  residual remains. It reaches zero when resume-time runners pre-warm their
-  persisted read sets — an application of the incremental
-  observation-adoption direction (see below), not of the boot listing.
+- Reload churn: both the general integration population and the dedicated
+  `pattern-reload-integration-test` job now run default-on. The ≤ 1 residual
+  bound is retained from the historical rollback-off baseline; the dedicated
+  job additionally requires a positive rehydration count, so default-on cannot
+  silently degrade to fresh runs. Measured: the rows rehydrate, but the
+  always-run coordinator's first reconcile still reads one cold hop through
+  the field-level alias chain, so the same coupled 1-conflict residual remains.
+  It reaches zero when resume-time runners pre-warm their persisted read sets —
+  an application of the incremental observation-adoption direction (see below),
+  not of the boot listing. Explicit-false rollback is covered by the runtime and
+  memory protocol suites rather than a second browser population.
 
 ## 7.1 Live counterpart: incremental adoption
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -174,10 +174,10 @@ consolidated register is §9.
 
 ### 3.1 Scheduler v2 (#4288, phases 3c–7)
 
-Assumed landed: durable event IDs, speculation lineage, static write
+Implemented by scheduler v2 (#4288): durable event IDs, speculation lineage, static write
 surfaces, tx-carried source action, node records and liveness refcounts,
 unified gates, declared reads, read-delta tracking, persistent action state,
-and bounded settle (`PASS_RUN_BUDGET = 5`).
+and bounded settle (`PASS_RUN_BUDGET = 10`).
 
 Contribution: a scheduler whose per-node state is one record
 (status/liveRefs/reads/writes), whose demand is refcounted rather than
@@ -185,10 +185,11 @@ walked, and whose settle loop is bounded — i.e., a graph that can be
 suspended, described, and resumed. That is precisely the shape a server
 executor must hold for hundreds of spaces.
 
-### 3.2 Persistent scheduler state (BUILT behind a flag)
+### 3.2 Persistent scheduler state (BUILT, default-on with rollback)
 
-On the #4288 baseline, behind the default-off runtime option
-`persistentSchedulerState` (env `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`):
+Implemented on the #4288 branch with the default-on runtime option
+`persistentSchedulerState` (env `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`; an
+explicit false remains the rollback path):
 the full durable stack, not just shapes. Per-action observations
 (`SchedulerActionObservation` — `pieceId`, `actionId`, `actionKind`,
 `implementationFingerprint`, `observedAtSeq`, `reads`, `currentKnownWrites`,

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -92,8 +92,8 @@ where server and clients knowingly duplicate authoritative work.
   whether server-primary execution is allowed. It does not contain liveness,
   actor, epoch, authority, or unservable-piece state.
 - Runtime experimental option: serverPrimaryExecution, default false.
-- Existing scheduler option: persistentSchedulerState, default false until its
-  own rollout changes that default.
+- Existing scheduler option: persistentSchedulerState, default true; explicitly
+  setting it false remains the rollback path.
 - Protocol capability: server-primary-execution-v1.
 - Protocol messages:
   - session.execution.demand.set
@@ -158,7 +158,8 @@ not overlap.
 - packages/memory/v2/engine.ts scheduler table DDL, observation upsert,
   dirtying, and list/read methods
 - packages/runner/src/scheduler/persistent-observation.ts
-- packages/runner/src/scheduler.ts rehydration facade
+- packages/runner/src/runner.ts cold-start listing and lifecycle ownership
+- packages/runner/src/scheduler/facade.ts synchronous observation application
 - packages/runner/src/storage/v2.ts scope resolution and scheduler state calls
 - packages/memory/test/v2-scheduler-state-test.ts
 - packages/runner/test/reload-rehydration.test.ts
@@ -604,7 +605,8 @@ and signing authority are separate.
   patterns only; do not make its registry the primary discovery path
 - Scheduler-v2 demand/pull and bounded settle APIs
 - Cell.pull and piece result-root instantiation
-- Persistent scheduler rehydration through packages/runner/src/scheduler.ts
+- Persistent scheduler cold-start listing through packages/runner/src/runner.ts
+  and observation application through packages/runner/src/scheduler/facade.ts
 
 **Steps:**
 

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -2081,6 +2081,7 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
     resetPersistentSchedulerStateConfig();
   }
 
+  setPersistentSchedulerStateConfig(false);
   const server = new Server({
     store,
     authorizeSessionOpen: () => "did:key:test-principal",
@@ -2100,6 +2101,7 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
     await client.close().catch(() => {});
     await server.close().catch(() => {});
     await Deno.remove(storePath, { recursive: true });
+    resetPersistentSchedulerStateConfig();
   }
 });
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -675,7 +675,7 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 // These ambient flags and the memory protocol flags below are catalogued, with
 // their defaults and removal paths, in docs/development/EXPERIMENTAL_OPTIONS.md.
 // Update that registry when adding or removing one.
-let persistentSchedulerStateEnabled = false;
+let persistentSchedulerStateEnabled = true;
 let commitPreconditionsEnabled = true;
 let syncSchemaTableEnabled = true;
 
@@ -685,7 +685,7 @@ let syncSchemaTableEnabled = true;
  * client/server handshakes, so it lives beside the memory protocol flags.
  */
 export function setPersistentSchedulerStateConfig(enabled?: boolean): void {
-  persistentSchedulerStateEnabled = enabled ?? false;
+  persistentSchedulerStateEnabled = enabled ?? true;
 }
 
 export function getPersistentSchedulerStateConfig(): boolean {
@@ -693,7 +693,7 @@ export function getPersistentSchedulerStateConfig(): boolean {
 }
 
 export function resetPersistentSchedulerStateConfig(): void {
-  persistentSchedulerStateEnabled = false;
+  persistentSchedulerStateEnabled = true;
 }
 
 /**

--- a/packages/patterns/integration/group-chat-adoption-bench.test.ts
+++ b/packages/patterns/integration/group-chat-adoption-bench.test.ts
@@ -10,8 +10,11 @@
  *
  * Run (from packages/patterns):
  *
- *   CF_GROUPCHAT_BENCH=1 [EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true] \
+ *   CF_GROUPCHAT_BENCH=1 [EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=false] \
  *     deno test -A integration/group-chat-adoption-bench.test.ts
+ *
+ * Omit the experimental variable for default-on; set it to false for the
+ * rollback comparison.
  *
  * Output: greppable `BENCH_METRIC ...` lines, one per session plus a total.
  * Compare configs by running the same file on each checkout/flag setting.
@@ -28,9 +31,9 @@ import {
 const BENCH = Deno.env.get("CF_GROUPCHAT_BENCH") === "1";
 const MESSAGES = Number(Deno.env.get("CF_GROUPCHAT_BENCH_MESSAGES") ?? "10");
 const TAG = Deno.env.get("CF_BENCH_TAG") ??
-  (Deno.env.get("EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE") === "true"
-    ? "flag-on"
-    : "flag-off");
+  (Deno.env.get("EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE") === "false"
+    ? "flag-off"
+    : "flag-on");
 
 const PROFILE_SURFACE = "TrustedGroupChatProfileSurface";
 const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -33,15 +33,12 @@ import type {
 
 // The self-hosted storage server lives in THIS realm, while every runtime
 // lives in a worker realm whose Runtime constructor propagates the
-// EXPERIMENTAL_* env flags into the memory module's ambient config. No
-// Runtime is ever constructed in the harness realm, so a flag-ON test run
-// would otherwise leave the SERVER side of the flag off — a client/server
-// capability skew the harness does not intend to model (skewed peers now
-// degrade gracefully, so the suite would silently test flag-off semantics).
-// Mirror toolshed (whose in-process Runtime sets the ambient flag for its
-// memory route) by propagating the canonical env mapping. Re-asserted per
+// EXPERIMENTAL_* env overrides into the memory module's ambient config. No
+// Runtime is ever constructed in the harness realm, so mirror an explicit
+// persistent-scheduler-state override into the server realm too. When the env
+// value is unset, both realms retain the built-in default. Re-asserted per
 // harness creation: any Runtime constructed later in this realm re-derives
-// the ambient flag from ITS options and would stomp a load-time value.
+// the ambient flag from its options and would stomp a load-time value.
 function propagateExperimentalEnvToServerRealm(): void {
   const experimental = experimentalOptionsFromEnv(Deno.env.get);
   if (experimental.persistentSchedulerState !== undefined) {

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -151,6 +151,10 @@ describe("default-app notebook reload integration test", () => {
     if (!EXPECT_PERSISTENT_SCHEDULER_STATE) return;
 
     assert(
+      schedulerSummary.rehydration.ok > 0,
+      "Expected default-on scheduler state to rehydrate at least one action",
+    );
+    assert(
       schedulerSummary.graph.actionRuns <=
         NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT,
       `Expected notebook reload to stay within <= ${NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT} total action runs, saw ${schedulerSummary.graph.actionRuns}`,

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -148,7 +148,14 @@ describe("default-app notebook reload integration test", () => {
       JSON.stringify(reloadSummary, null, 2),
     );
 
-    if (!EXPECT_PERSISTENT_SCHEDULER_STATE) return;
+    if (!EXPECT_PERSISTENT_SCHEDULER_STATE) {
+      assertEquals(
+        schedulerSummary.rehydration.ok,
+        0,
+        "Expected the explicit rollback override to disable scheduler rehydration",
+      );
+      return;
+    }
 
     assert(
       schedulerSummary.rehydration.ok > 0,

--- a/packages/patterns/integration/reload/home-rehydration-churn.test.ts
+++ b/packages/patterns/integration/reload/home-rehydration-churn.test.ts
@@ -17,8 +17,12 @@ import {
 
 const { FRONTEND_URL } = env;
 const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
+const SCHEDULER_STATE_MODE =
+  Deno.env.get("CF_EXPECT_PERSISTENT_SCHEDULER_STATE") === "0"
+    ? "rollback"
+    : "persistent";
 
-// The default-ON reload-churn gate (F6c,
+// The reload-churn gate (F6c,
 // docs/specs/scheduler-v2/per-doc-rehydration.md §7). Per-doc restore
 // rehydrates the picker rows instead of re-running them, but the row map
 // COORDINATOR deliberately re-runs on resume (resumeMode "always-run", to
@@ -28,14 +32,13 @@ const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
 // bound remains unchanged through the default-on rollout; it drops to ZERO
 // when resume-time runners pre-warm their persisted read set (the incremental
 // observation-adoption leg). Explicit-false rollback stays covered by the
-// runtime and memory protocol suites; this browser suite is default-on only.
+// same browser suite so the rollout escape hatch cannot silently rot.
 //
 // This file runs in the `pattern-reload-integration-test` CI job (deno.yml),
-// which exercises the default-on configuration and sets
-// CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1.
+// which exercises both default-on and explicit-false configurations.
 
-// Keep the dedicated reload job's stable label distinct from the general
-// pattern-integration population, even though both now use the default-on flag.
+// Keep the dedicated reload job's labels distinct from the general
+// pattern-integration population and from the rollback comparison lane.
 function logChurnMetric(label: string, churn: ChurnCounters): void {
   console.log(
     `CHURN_METRIC label=${label}` +
@@ -99,7 +102,7 @@ async function gotoHome(shell: ShellIntegration, identity: Identity) {
   await clickCfButton(shell.page(), 'cf-tab[value="profile"]');
 }
 
-describe("home rehydration churn (persistent scheduler state)", () => {
+describe("home reload churn", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
@@ -122,7 +125,7 @@ describe("home rehydration churn (persistent scheduler state)", () => {
     // counters reflect real activity in this measurement).
     const afterCreate = await collectBrowserLoadSummary(page, "after-create");
     logBrowserLoadSummary(afterCreate);
-    logChurnMetric("after-create-persistent", afterCreate.churn);
+    logChurnMetric(`after-create-${SCHEDULER_STATE_MODE}`, afterCreate.churn);
     expect(afterCreate.churn.actionRuns).toBeGreaterThan(0);
 
     // RELOAD: re-instantiate the runtime against the populated, durable space.
@@ -134,7 +137,7 @@ describe("home rehydration churn (persistent scheduler state)", () => {
 
     const reload = await collectBrowserLoadSummary(page, "reload");
     logBrowserLoadSummary(reload);
-    logChurnMetric("reload-persistent", reload.churn);
+    logChurnMetric(`reload-${SCHEDULER_STATE_MODE}`, reload.churn);
 
     const c = reload.churn;
     // Rows rehydrate (no per-row first runs), but the always-run coordinator

--- a/packages/patterns/integration/reload/home-rehydration-churn.test.ts
+++ b/packages/patterns/integration/reload/home-rehydration-churn.test.ts
@@ -18,24 +18,24 @@ import {
 const { FRONTEND_URL } = env;
 const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
 
-// The flag-ON reload-churn gate (F6c,
+// The default-ON reload-churn gate (F6c,
 // docs/specs/scheduler-v2/per-doc-rehydration.md §7). Per-doc restore
 // rehydrates the picker rows instead of re-running them, but the row map
 // COORDINATOR deliberately re-runs on resume (resumeMode "always-run", to
 // re-attach the rows), and its first reconcile still reads one cold hop
 // through the field-level alias chain — measured locally at exactly the same
-// coupled 1-conflict residual as the flag-off variant
-// (../home-rehydration-churn.test.ts). The bound therefore matches flag-off
-// for now; it drops to ZERO when resume-time runners pre-warm their persisted
-// read set (the incremental observation-adoption leg). The gate here pins
-// flag-ON at "never worse than flag-off".
+// coupled 1-conflict residual as the historical rollback-off baseline. The
+// bound remains unchanged through the default-on rollout; it drops to ZERO
+// when resume-time runners pre-warm their persisted read set (the incremental
+// observation-adoption leg). Explicit-false rollback stays covered by the
+// runtime and memory protocol suites; this browser suite is default-on only.
 //
 // This file runs in the `pattern-reload-integration-test` CI job (deno.yml),
-// which builds the shell with EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true
-// and sets CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1.
+// which exercises the default-on configuration and sets
+// CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1.
 
-// Same stable, greppable measurement contract as the flag-off variant, under
-// a distinct label so CI-distribution greps do not mix the two populations.
+// Keep the dedicated reload job's stable label distinct from the general
+// pattern-integration population, even though both now use the default-on flag.
 function logChurnMetric(label: string, churn: ChurnCounters): void {
   console.log(
     `CHURN_METRIC label=${label}` +
@@ -139,8 +139,9 @@ describe("home rehydration churn (persistent scheduler state)", () => {
     const c = reload.churn;
     // Rows rehydrate (no per-row first runs), but the always-run coordinator
     // reconcile keeps the one cold-alias-hop conflict — the same coupled
-    // residual the flag-off gate accepts. See the header comment; tighten to
-    // zero once resume-time runners pre-warm their persisted read sets.
+    // residual accepted by the historical rollback-off baseline. See the
+    // header comment; tighten to zero once resume-time runners pre-warm their
+    // persisted read sets.
     expect(c.commitConflicts).toBeLessThanOrEqual(1);
     expect(c.commitReverts).toBeLessThanOrEqual(c.commitConflicts);
     expect(c.scheduleRunErrors).toBeLessThanOrEqual(c.commitConflicts);

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -212,7 +212,7 @@ export type VersionSkewHandler = (info: VersionSkewInfo) => void;
 export interface ExperimentalOptions {
   /** Enable the modern "cell representation" classes. */
   modernCellRep?: boolean | undefined;
-  /** Persist scheduler observations and use them for scheduler rehydration. */
+  /** Persist scheduler observations and rehydrate from them (default on). */
   persistentSchedulerState?: boolean | undefined;
   /** Enforce scheduler-v2 lineage and event-receipt commit preconditions (default on). */
   commitPreconditions?: boolean | undefined;

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -36,6 +36,7 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernCellRep: false,
+          persistentSchedulerState: false,
           commitPreconditions: false,
         },
       });
@@ -58,11 +59,12 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernCellRep: true,
+          persistentSchedulerState: true,
         },
       });
       expect(runtime.experimental).toEqual({
         modernCellRep: true,
-        persistentSchedulerState: false,
+        persistentSchedulerState: true,
         commitPreconditions: true,
         eagerSourceAnnotation: false,
       });
@@ -79,7 +81,7 @@ describe("ExperimentalOptions", () => {
       });
       expect(runtime.experimental).toEqual({
         modernCellRep: false,
-        persistentSchedulerState: false,
+        persistentSchedulerState: true,
         commitPreconditions: true,
         // Read back from the ambient flag (a test seam that deliberately does
         // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
@@ -118,6 +120,22 @@ describe("ExperimentalOptions", () => {
       });
 
       expect(getPersistentSchedulerStateConfig()).toBe(true);
+
+      await runtime.dispose();
+      await sm.close();
+    });
+
+    it("explicit false keeps persistentSchedulerState available as rollback", async () => {
+      const sm = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: sm,
+        experimental: {
+          persistentSchedulerState: false,
+        },
+      });
+
+      expect(getPersistentSchedulerStateConfig()).toBe(false);
 
       await runtime.dispose();
       await sm.close();
@@ -184,7 +202,7 @@ describe("ExperimentalOptions", () => {
       await sm.close();
 
       expect(getModernCellRepConfig()).toBe(initial);
-      expect(getPersistentSchedulerStateConfig()).toBe(false);
+      expect(getPersistentSchedulerStateConfig()).toBe(true);
       expect(getCommitPreconditionsConfig()).toBe(true);
     });
   });

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -627,7 +627,7 @@ const schedulerObservationFor = (actionId: string) => ({
 });
 
 Deno.test("memory v2 ignores no-op scheduler observations when persistent scheduler state is off", async () => {
-  resetPersistentSchedulerStateConfig();
+  setPersistentSchedulerStateConfig(false);
   const harness = createHarness();
   try {
     const result = await harness.replica.commitNative({
@@ -639,6 +639,7 @@ Deno.test("memory v2 ignores no-op scheduler observations when persistent schedu
     assertEquals(harness.model.transactLocalSeqs, []);
   } finally {
     await harness.close();
+    resetPersistentSchedulerStateConfig();
   }
 });
 

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -47,32 +47,50 @@ export const API_URL: URL = new URL(
 
 export const COMMIT_SHA: string | undefined = COMMIT_SHA_DEFINE;
 
-/**
- * Results in `true` (on), `false` (off), or `undefined` (default).
- */
-function flagValue(flag: string | undefined): boolean | undefined {
-  return (typeof flag === "string") ? (flag === "true") : undefined;
+/** Results in `true` (on), `false` (off), or `undefined` (default). */
+function flagValue(
+  name: string,
+  flag: string | undefined,
+): boolean | undefined {
+  if (flag === "true") return true;
+  if (flag === "false") return false;
+  if (flag !== undefined) {
+    console.warn(
+      `[shell env] Ignoring ${name}=${JSON.stringify(flag)} — ` +
+        `expected "true" or "false" (unset = default).`,
+    );
+  }
+  return undefined;
 }
 
 /** Build-time experimental flags, injected via felt.config.ts defines. */
 export const EXPERIMENTAL = {
-  modernCellRep: flagValue(EXPERIMENTAL_MODERN_CELL_REP_DEFINE),
+  modernCellRep: flagValue(
+    "EXPERIMENTAL_MODERN_CELL_REP",
+    EXPERIMENTAL_MODERN_CELL_REP_DEFINE,
+  ),
   persistentSchedulerState: flagValue(
+    "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
     EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE,
   ),
   // Debug `.src` source annotation: ON in development builds (so per-primitive
   // source locations keep working for debugging), OFF in production (it is the
   // boot floor's largest single cost). The define overrides either way.
-  eagerSourceAnnotation:
-    flagValue(EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE) ??
-      (ENVIRONMENT === "development"),
+  eagerSourceAnnotation: flagValue(
+    "EXPERIMENTAL_EAGER_SOURCE_ANNOTATION",
+    EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE,
+  ) ??
+    (ENVIRONMENT === "development"),
   // Auto-update the NON-HOME space-root system pattern (default-app) in place.
   // Default ON; a build define (`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE=false`)
   // can force it off. The home root stays off — it carries real user data and
   // needs the second flag, pending the stable-addressing audit.
-  systemPatternAutoUpdate:
-    flagValue(EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_DEFINE) ?? true,
+  systemPatternAutoUpdate: flagValue(
+    "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
+    EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_DEFINE,
+  ) ?? true,
   systemPatternAutoUpdateHome: flagValue(
+    "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME",
     EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME_DEFINE,
   ),
 };

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -74,3 +74,28 @@ Deno.test({
     expect(prod.EXPERIMENTAL.eagerSourceAnnotation).toBe(false);
   },
 });
+
+Deno.test({
+  name:
+    "shell env preserves the persistent scheduler default and exact override semantics",
+  permissions: { read: true },
+  async fn() {
+    const unset = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: undefined,
+    }, importFreshEnvModule);
+    expect(unset.EXPERIMENTAL.persistentSchedulerState).toBeUndefined();
+
+    const explicitFalse = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "false",
+    }, importFreshEnvModule);
+    expect(explicitFalse.EXPERIMENTAL.persistentSchedulerState).toBe(false);
+
+    const invalid = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "1",
+    }, importFreshEnvModule);
+    expect(invalid.EXPERIMENTAL.persistentSchedulerState).toBeUndefined();
+  },
+});

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -1,12 +1,21 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import {
   buildFilteredTestArgs,
+  expectPersistentSchedulerState,
   findIntegrationTestFiles,
   integrationTestDir,
   runFilteredIntegration,
   runPackageIntegration,
   selectIntegrationTestFiles,
 } from "./integration.ts";
+
+Deno.test("expectPersistentSchedulerState follows the default-on rollback flag", () => {
+  assertEquals(expectPersistentSchedulerState(undefined), true);
+  assertEquals(expectPersistentSchedulerState("true"), true);
+  assertEquals(expectPersistentSchedulerState("false"), false);
+  // The canonical parser ignores invalid values, leaving the default on.
+  assertEquals(expectPersistentSchedulerState("1"), true);
+});
 
 Deno.test("selectIntegrationTestFiles keeps .test.ts files matching the filter", () => {
   const files = [

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -773,9 +773,6 @@ async function main(): Promise<void> {
   try {
     if (needsServer) {
       const serverEnv: Record<string, string> = {};
-      if (packagesToRun.includes("patterns-reload")) {
-        serverEnv.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE = "true";
-      }
 
       if (portOffsetWasSet) {
         // Reuse the requested offset, stopping anything already on its ports.

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -55,6 +55,17 @@ const HEADLESS_PACKAGES = [
   "patterns-reload",
 ];
 
+/**
+ * Match the default-on runtime flag semantics for the reload test oracle.
+ * The canonical parser accepts only the exact value `false` as the rollback;
+ * unset or invalid values leave the built-in default enabled.
+ */
+export function expectPersistentSchedulerState(
+  raw: string | undefined,
+): boolean {
+  return raw !== "false";
+}
+
 async function runCommand(
   cmd: string[],
   options: {
@@ -528,7 +539,11 @@ export async function runPackageIntegration(
   }
 
   if (pkg === "patterns-reload") {
-    env.CF_EXPECT_PERSISTENT_SCHEDULER_STATE = "1";
+    env.CF_EXPECT_PERSISTENT_SCHEDULER_STATE = expectPersistentSchedulerState(
+        Deno.env.get("EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE"),
+      )
+      ? "1"
+      : "0";
   }
 
   // For browser test packages, pass through HEADLESS and PIPE_CONSOLE


### PR DESCRIPTION
## Summary

Stacked on #4288. This follow-up flips persistent scheduler state to default-on while preserving explicit `false` as the rollback path.

## Changes

- Default persistent scheduler state to enabled in ambient runtime configuration.
- Preserve explicit `false` across runtime and shell configuration as the rollback.
- Treat invalid shell env values as unset, preserving the default instead of silently disabling it.
- Make the reload integration test prove that default-on rehydration actually occurred.
- Update tests, benchmark labels, comments, and live documentation for the rollout state.
- Remove now-redundant explicit enables from CI/integration launch paths.

## Validation

- Full Deno Workflow [run 29158269207, attempt 2](https://github.com/commontoolsinc/labs/actions/runs/29158269207): all required checks passed (38 passed, 5 expected deployment skips), including Performance Check.
  - CI was captured while the PR temporarily targeted `main`; the workflow is filtered to `base: main` and does not run for stacked PR bases.
  - The first sample had one noisy 23.4s pattern-unit outlier; the independent rerun was green at 17.4s. No new performance baseline was accepted.
- `deno task check`
- `deno fmt --check`
- `deno lint`
- Focused runner, memory, and shell tests: 97 tests / 65 steps passed.
- Default-unset reload integration: 2/2 passed; `rehydration.ok=42`.
- Explicit-false counterfactual: `rehydration.ok=0`, and the new default-on witness fails as intended.

## Performance data

Compared directly with #4288's exact head (`3545e75c6`).

### CI reload and suite signal

- Reload-to-render: 6017.6ms → 6067.3ms (**+0.8%**).
- Reload semantics were identical: 42 successful rehydrations, 16 no-match fallbacks, 13 action runs, and 10 computation runs.
- Runner aggregate: 225s → 210s (**-6.7%**).
- Pattern integration aggregate: 173s → 160s (**-7.5%**).
- Pattern reload job: 81s → 75s (**-7.4%**).

The job-level timings are single-sample runner measurements; the raw reload measurement and identical semantic counters are the more relevant rollout signal.

### Dedicated fixed-CPU benchmark A/B

Sequential runs with no overlap, both 331 benchmarks on Deno 2.8.1 / Xeon 8573C:

- [#4288 base run 29158286527](https://github.com/commontoolsinc/labs/actions/runs/29158286527): benchmark step 444s.
- [Default-on run 29158535403](https://github.com/commontoolsinc/labs/actions/runs/29158535403): benchmark step 465s.
- Whole benchmark step: **+4.7%**; median matched-benchmark drift: **+1.8%**.
- Default-app note create at 0 / 32 / 128 notes: **+24% / +49% / +80%**.
- Push/pull graph workloads: all 12 slower, **+15% to +210%** (median **+122%**).
- Wish-mentionable graph workloads: **+46% / +58%**.
- Event-preflight controls: **-2.2% to +2.5%** (median **+0.2%**).
- Direct persistent-state rehydration: **-1.0% to +9.2%** (median **+1.9%**).

Several long graph benchmarks have only two samples, so exact percentages need repetition, but the uniform direction and magnitude show a credible workload-specific cost in repeated reactive graph/commit paths rather than a broad scheduler/preflight regression.

### Targeted local A/B

Using the supported rollback `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=false`, shared warm compile caches, and alternating runs:

- `auth-pieces`: 2.203s → 3.415s wall (**+55.0%**), with the same 206 action runs; default-on added 10 observation-only native commits.
- `parking-coordinator`: 32.647s → 36.423s wall (**+11.6%**), with the same 745 action runs; default-on added 109 observation-only native commits.
- Group-chat adoption: receiver scheduler starts 400 → 341 (**-14.75%**) and total starts 601 → 542 (**-9.82%**), while short-run wall time varied **+2% to +7%**.

The data shows the intended tradeoff clearly: persisted state can reduce scheduler recomputation after adoption/reload, while writing scheduler observations adds material cost to commit-heavy graph workloads. Explicit `false` remains available as the rollback.
