### PR TITLE
docs(cfc): exchange-rules pattern authoring surface — design + extensions + SC-29..37

### DIFF
--- a/docs/specs/cfc-exchange-rules-authoring-extensions.md
+++ b/docs/specs/cfc-exchange-rules-authoring-extensions.md
@@ -28,11 +28,12 @@ spec-change items: SC-36, SC-37 in [`cfc-spec-changes.md`](./cfc-spec-changes.md
 the dependency classification.
 
 ```ts
+// Shown for illustration only.
 // Strip the gateway token only where it lawfully appears; the sink gate
 // fires this during boundary execution and emits AuthorizedRequest (§5.2.1).
 export const stripGatewayToken = exchangeRule({
-  pre: { confidentiality: [SELF], integrity: [] },
-  post: { confidentiality: [], integrity: [] }, // drop the matched alternative
+  appliesTo: SELF,
+  post: { dropClause: true }, // spec's empty-postcondition removal form
   sink: "fetchData",
   paths: [["options", "headers", "Authorization"]],
 });
@@ -45,13 +46,17 @@ interface GatewayInput {
 }
 ```
 
+- `sink:` / `paths:` are sugar: they lower to `pre.boundary` patterns over
+  the `BoundaryContext` atoms the evaluator mints per boundary evaluation —
+  the shipped generalization of the spec's `allowedSink` / `allowedPaths`
+  metadata (`packages/runner/src/cfc/policy.ts`).
 - `AuthorityOnly<T>` is classification, not magic: the response drops the
   token's taint only because the sink-scoped rule fires at the permitted
   path — "not a global exemption such as 'tokens never taint'" (§5.3.1). A
   token that leaks into the request body has no matching rule and taints.
-- The core doc's lint ("no unguarded rewrites") admits three guard forms: a
-  `pre.integrity` pattern, a `guard.policyState`, or sink+path scoping. A rule
-  with none of the three is rejected.
+- The core doc's lint ("no unguarded rewrites") is satisfied here by the
+  boundary scoping — §5.2.1's structural authorization is one of its
+  admissible guard forms.
 
 Spec owes: nothing — this is §5.2/§5.3 verbatim with a typed carrier.
 
@@ -62,6 +67,7 @@ inherit full input confidentiality unless a rule fires, and §5.4.7 says every
 request-authorizing policy *should* carry error rules.
 
 ```ts
+// Shown for illustration only.
 // A sanitizer is itself an { identity, symbol } artifact (§5.4.4 shape).
 export const gatewayErrorSanitizer = errorSanitizer({
   redact: [
@@ -98,6 +104,7 @@ clause-local rules), §14.1 (prompt-injection caveats; meaning lives in caveat
 `kind` URIs + policy rules), §4.8.9 (concept guards via trust closure).
 
 ```ts
+// Shown for illustration only.
 export const dischargeUnscreenedRisk = caveatDischargeRule({
   kind: CFC_CONCEPT_KIND.PromptInjectionRiskUnscreened,
   evidence: [
@@ -124,16 +131,17 @@ ordinary exchange rules guarded by compatible consent evidence from every
 required participant."
 
 ```ts
+// Shown for illustration only.
 export const participantConsent = exchangeRule({
+  appliesTo: cfcAtom.user(v("P")),                      // each participant clause
   pre: {
-    confidentiality: [cfcAtom.user(v("P"))],            // each participant clause
     integrity: [consentEvidence({
       participant: v("P"),
       scope: "calendar-intersection",
       audience: v("A"),
     })],
   },
-  post: { confidentiality: [cfcAtom.user(v("A"))], integrity: [] },
+  post: { addAlternatives: [cfcAtom.user(v("A"))] },
 });
 ```
 
@@ -155,6 +163,7 @@ under policy P (patterns don't request certification); downstream patterns may
 require it; propagation is hereditary weakest-link (§5.5.3, §15.1.1).
 
 ```ts
+// Shown for illustration only.
 // Require: inputs must have been processed under the named policy.
 type CertifiedAnalysis = RequiresIntegrity<Analysis, [
   PolicyCertifiedBy<typeof approvedModels>,
@@ -180,6 +189,7 @@ a verifier; users delegate to verifiers (§4.8.3). None of that is pattern
 code. The pattern-side piece is the discoverable **claim**:
 
 ```ts
+// Shown for illustration only.
 export const screenInjection = lift(/* ... */);
 
 export const screeningClaim = claimsConcept(
@@ -205,6 +215,7 @@ distinguishing claims from statements would help ecosystem tooling.
 `Expires` at label creation; both are ordinary conjuncts.
 
 ```ts
+// Shown for illustration only.
 type Ephemeral = Confidential<Note, [
   ConceptOf<typeof health>,
   ttl(86_400), // conjunct clause; lowers to TTL → Expires at label creation
@@ -223,6 +234,7 @@ of all contributors, including withheld ones), the disjunctive proposal §6
 declared existence release; aggregates never skip).
 
 ```ts
+// Shown for illustration only.
 const inbox = collectionRead(messages, {
   ceiling: [cfcAtom.user(currentUser())], // result store label, bound at prepare
   onExceed: "skip",                       // declared existence release; default "fail"

--- a/docs/specs/cfc-exchange-rules-authoring-extensions.md
+++ b/docs/specs/cfc-exchange-rules-authoring-extensions.md
@@ -1,0 +1,254 @@
+# CFC Exchange Rules — Authoring Extensions
+
+Syntax sketches for the policy surfaces the core design
+([`cfc-exchange-rules-authoring.md`](./cfc-exchange-rules-authoring.md))
+deliberately left out. Each section: what the spec already defines, the
+authoring sketch, the lowering, and what (if anything) the spec still owes.
+Everything here follows the core design's discipline — module-level exports
+with `{ identity, symbol }` identity, static lowering, no pattern-side
+evaluation, adoption-by-workflow where authority is someone else's to give.
+
+## Status
+
+Design sketches, one notch below the core doc: each is believed lowerable to
+existing spec machinery, but none has been sized against the runtime. New
+spec-change items: SC-36, SC-37 in [`cfc-spec-changes.md`](./cfc-spec-changes.md).
+
+## Last Updated
+
+2026-07-11
+
+---
+
+## 1. Sink-scoped rules and authority-only inputs
+
+**Spec:** §5.2.1 (sink gate), §5.3.1 (authority-only vs data-bearing),
+`PolicyRecord.dependencies` (§4.3.1). Already in the rule language as
+`allowedSink` / `allowedPaths`; what's missing is the authoring ergonomics and
+the dependency classification.
+
+```ts
+// Strip the gateway token only where it lawfully appears; the sink gate
+// fires this during boundary execution and emits AuthorizedRequest (§5.2.1).
+export const stripGatewayToken = exchangeRule({
+  pre: { confidentiality: [SELF], integrity: [] },
+  post: { confidentiality: [], integrity: [] }, // drop the matched alternative
+  sink: "fetchData",
+  paths: [["options", "headers", "Authorization"]],
+});
+
+export const gatewayRules = exchangeRules([stripGatewayToken]);
+
+interface GatewayInput {
+  // AuthorityOnly<T> lowers to dependencies.authorityOnly for this path.
+  accessToken: AuthorityOnly<Confidential<string, [PolicyOf<typeof gatewayRules>]>>;
+}
+```
+
+- `AuthorityOnly<T>` is classification, not magic: the response drops the
+  token's taint only because the sink-scoped rule fires at the permitted
+  path — "not a global exemption such as 'tokens never taint'" (§5.3.1). A
+  token that leaks into the request body has no matching rule and taints.
+- The core doc's lint ("no unguarded rewrites") admits three guard forms: a
+  `pre.integrity` pattern, a `guard.policyState`, or sink+path scoping. A rule
+  with none of the three is rejected.
+
+Spec owes: nothing — this is §5.2/§5.3 verbatim with a typed carrier.
+
+## 2. Error exchange rules
+
+**Spec:** §5.4 (`ErrorExchangeRule`, sanitizers, category table); errors
+inherit full input confidentiality unless a rule fires, and §5.4.7 says every
+request-authorizing policy *should* carry error rules.
+
+```ts
+// A sanitizer is itself an { identity, symbol } artifact (§5.4.4 shape).
+export const gatewayErrorSanitizer = errorSanitizer({
+  redact: [
+    { pattern: /Bearer [A-Za-z0-9._-]+/, replacement: "Bearer [REDACTED]" },
+  ],
+  maxLength: 200,
+});
+
+export const gatewayErrorRules = errorExchangeRules({
+  match: { policy: SELF, errorCode: [400, 401, 404, 429] },
+  release: [
+    { path: "/error/code", to: actingUser() },
+    { path: "/error/message", to: actingUser(), sanitizedBy: gatewayErrorSanitizer },
+  ],
+  retain: ["/error/details", "/headers"],
+  requires: [authorizedRequest(), networkProvenance({ tls: true })],
+});
+```
+
+Lowering: §5.4.2 `ErrorExchangeRule` entries in the same derived policy record
+as the pattern's general rules (one `exchangeRules` array per §5.3.2);
+`$actingUser` binding per §5.4.2. The §5.4.3 observation-model caveat holds:
+descendant-path releases do not make `/error` materializable as a whole.
+Successful sanitization mints `SanitizedError` integrity naming the
+sanitizer's identity pair (§5.4.6).
+
+Spec owes: nothing new; §5.4's `sanitizer: string` id field should be noted as
+subsumable by the identity pair (folds into SC-29's addressing story).
+
+## 3. Caveat-discharge rules
+
+**Spec:** invariant 10 (caveats cleared only by explicit, evidence-bound,
+clause-local rules), §14.1 (prompt-injection caveats; meaning lives in caveat
+`kind` URIs + policy rules), §4.8.9 (concept guards via trust closure).
+
+```ts
+export const dischargeUnscreenedRisk = caveatDischargeRule({
+  kind: CFC_CONCEPT_KIND.PromptInjectionRiskUnscreened,
+  evidence: [
+    screenedBy(concept("https://commonfabric.org/cfc/concepts/prompt-injection-screening")),
+  ],
+});
+```
+
+Lowering: an ordinary rule whose target pattern matches the caveat atom
+(`Caveat{ kind, source }`) and whose integrity pattern is concept-valued —
+satisfied only when the screening implementation's concrete identity reaches
+the concept under the **acting user's** trust closure (§4.8.9). The pattern
+declares the discharge *shape*; authority comes from trust statements it
+cannot mint. A deployed screening lift with no verifier statement discharges
+nothing — fail closed, per invariant 10.
+
+Spec owes: nothing; this is the §14.1 architecture with a helper name.
+
+## 4. Multi-party consent release
+
+**Spec:** §5.3.3–§5.3.4 — the default output of a joint computation keeps
+every participant clause; a profile MAY add shared-result principals "only via
+ordinary exchange rules guarded by compatible consent evidence from every
+required participant."
+
+```ts
+export const participantConsent = exchangeRule({
+  pre: {
+    confidentiality: [cfcAtom.user(v("P"))],            // each participant clause
+    integrity: [consentEvidence({
+      participant: v("P"),
+      scope: "calendar-intersection",
+      audience: v("A"),
+    })],
+  },
+  post: { confidentiality: [cfcAtom.user(v("A"))], integrity: [] },
+});
+```
+
+No quantifier is needed: rules fire per clause, so each participant's clause
+rewrites only on that participant's own consent evidence, and the conjunction
+dissolves exactly when *all* participants' evidence is present — which is
+§5.3.3's requirement stated operationally. Consent evidence itself is minted
+by trusted consent surfaces (the §13.4.3 state-scoped-intent shape per
+participant), never by the computing pattern.
+
+Spec owes: §5.3.4 deliberately doesn't privilege a consent payload, but
+interop wants a *reserved shape* with the binding fields it already demands
+(scope, audience, purpose) — SC-37.
+
+## 5. `PolicyCertified`: requiring it, and running under a policy
+
+**Spec:** §5.5 — the runtime auto-attests `PolicyCertified(P)` for execution
+under policy P (patterns don't request certification); downstream patterns may
+require it; propagation is hereditary weakest-link (§5.5.3, §15.1.1).
+
+```ts
+// Require: inputs must have been processed under the named policy.
+type CertifiedAnalysis = RequiresIntegrity<Analysis, [
+  PolicyCertifiedBy<typeof approvedModels>,
+]>;
+
+// Run-under: ask the runtime to enforce a policy envelope for this pattern's
+// execution, so outputs gain the certification.
+export const analysisEnvelope = executionPolicy(approvedModels);
+```
+
+`approvedModels` is a policy artifact export (an `{ identity, symbol }`
+reference to enforceable constraints — §5.5.7's mechanically-verifiable
+subset). The require side is just `RequiresIntegrity` plus an atom
+constructor (`CFC_ATOM_TYPE.PolicyCertified` already ships). The run-under
+side is new surface: a pattern *requesting* an envelope can only constrain
+its own execution, never widen anything, and the attestation stays
+runtime-minted — SC-36.
+
+## 6. Implements-concept claims
+
+**Spec:** §4.8.2 trust statements bind concrete identity → concept, signed by
+a verifier; users delegate to verifiers (§4.8.3). None of that is pattern
+code. The pattern-side piece is the discoverable **claim**:
+
+```ts
+export const screenInjection = lift(/* ... */);
+
+export const screeningClaim = claimsConcept(
+  screenInjection,
+  "https://commonfabric.org/cfc/concepts/prompt-injection-screening",
+);
+```
+
+A claim is authorable data with zero authority: it says "review me as an
+implementation of C." It becomes effective only when a verifier issues the
+§4.8.2 statement binding the lift's content-addressed identity to the concept
+— the same publish-then-adopt workflow as rule adoption (core doc). Value of
+the in-code form: verifiers can enumerate what wants review, and static
+checking can warn when a declared caveat-discharge rule (§3 above) depends on
+a concept no shipped artifact even claims.
+
+Spec owes: nothing normative (claims are ordinary data); a registry note
+distinguishing claims from statements would help ecosystem tooling.
+
+## 7. Expiry sugar
+
+**Spec:** §4.2.1/§4.2.3 — `TTL` atoms in schemas convert to absolute
+`Expires` at label creation; both are ordinary conjuncts.
+
+```ts
+type Ephemeral = Confidential<Note, [
+  ConceptOf<typeof health>,
+  ttl(86_400), // conjunct clause; lowers to TTL → Expires at label creation
+]>;
+```
+
+Pure sugar; the only rule is inherited from §3.1.8: `Expires`/`TTL` may not
+appear inside `AnyOf` alternatives (it would invert into
+least-restrictive-wins).
+
+## 8. Row-set read modes (existence channel)
+
+**Spec:** §8.17 (row-set reads), invariant 14 (result shape carries the join
+of all contributors, including withheld ones), the disjunctive proposal §6
+(declared output ceiling = result store label; `fail` default; `skip` as a
+declared existence release; aggregates never skip).
+
+```ts
+const inbox = collectionRead(messages, {
+  ceiling: [cfcAtom.user(currentUser())], // result store label, bound at prepare
+  onExceed: "skip",                       // declared existence release; default "fail"
+});
+```
+
+Lowering: the ceiling is the result cell's store label; the per-row check is
+ordinary `canWrite(rowLabel, ceiling)`; `skip` is legitimate only when (a)
+declared here, (b) the container's governing policy permits the existence
+release, (c) skips are audited — all three from §8.17. Interacts with concept
+labels immediately: a feed skipping unreadable `health`-labeled rows is
+releasing one presence bit per row, and the concept kernel is where that
+permission would live.
+
+Spec owes: nothing — §8.17 is the normative home; this is its authoring shape.
+
+---
+
+## Non-proposals
+
+- **`preConfScope: "anywhere"`** — already a field on `exchangeRule()`;
+  needs documentation and a lint nudge (cross-clause side conditions are
+  opt-in per §5.3.2), not new syntax.
+- **Verifier delegation and trust-statement issuance** — user/space-level
+  acts performed through trusted surfaces; deliberately not authorable from
+  pattern code (§4.8.3). Only the claim half (§6 above) lives in code.
+- **Recombination budgets** — §14.3.2 is an open problem no authoring syntax
+  can close; the honest surface-level obligation (enumerate a concept's
+  active grants) is SC-35.

--- a/docs/specs/cfc-exchange-rules-authoring.md
+++ b/docs/specs/cfc-exchange-rules-authoring.md
@@ -11,6 +11,15 @@ are SC-29..SC-37 in [`cfc-spec-changes.md`](./cfc-spec-changes.md); companion
 syntax sketches for the remaining surfaces are in
 [`cfc-exchange-rules-authoring-extensions.md`](./cfc-exchange-rules-authoring-extensions.md).
 
+The evaluator half already shipped: `packages/runner/src/cfc/exchange-eval.ts`
+(fuelled-fixpoint guarded rewrites, clause-local), label-carried `referenced`
+policy records with home-clause locality (CT-1874, #4652), and §4.3.5 grant
+records — `policyState` guards, reserved-path storage, single-use
+commit-precondition receipts (`grants.ts`, #4627 / #4649). But policy records
+enter evaluation only through deployment configuration
+(`RuntimeOptions.cfcPolicyRecords`, `policy.ts`); this design is the missing
+authoring half — pattern modules declaring rules, and labels referencing them.
+
 ## Last Updated
 
 2026-07-11
@@ -77,14 +86,15 @@ evaluates rules; trusted boundaries do.
 ### 1. Declaring rules
 
 ```ts
+// Shown for illustration only.
 import { cfcAtom, exchangeRule, exchangeRules, SELF, v } from "commonfabric";
 
 // "The owner may release a drift flag to an audience they picked in the
 //  trusted share surface." Endorsed intent is the guard (spec §3.8.4);
 //  the audience variable binds from the intent evidence (§4.3.3).
 export const releaseFlagToChosenAudience = exchangeRule({
+  appliesTo: SELF, // target: the clause this rule set governs
   pre: {
-    confidentiality: [SELF], // target: the clause this rule set governs
     integrity: [{
       type: "https://commonfabric.org/cfc/atom/EndorsedIntent",
       action: "share-drift-flag",
@@ -92,10 +102,7 @@ export const releaseFlagToChosenAudience = exchangeRule({
       audience: v("A"),
     }],
   },
-  post: {
-    confidentiality: [cfcAtom.user(v("A"))],
-    integrity: [],
-  },
+  post: { addAlternatives: [cfcAtom.user(v("A"))] },
 });
 
 export const driftFlagRules = exchangeRules([
@@ -113,18 +120,30 @@ export const driftFlagRules = exchangeRules([
   pattern-upgrade story).
 - `SELF` is the placeholder for the policy principal being defined, which
   cannot be named before the module is hashed. It always occupies the
-  target-pattern position; `preConfScope` defaults to `"targetClause"`.
+  `appliesTo` (target-pattern) position.
 - `v("X")` is the `{ var: "X" }` placeholder of spec §4.3.3.
-- The full §4.3.2 surface is available (`preConfScope`, `allowedSink` /
-  `allowedPaths`, `guard.policyState`), all optional. Lowering rejects a rule
-  carrying none of the three guard forms — a `pre.integrity` pattern, a
-  `guard.policyState`, or sink+path scoping (§5.2.1's structural
-  authorization) — since a wholly unguarded rewrite is a standing leak
-  (invariant 3).
+- Field names follow the **shipped evaluator dialect**
+  (`packages/runner/src/cfc/policy.ts`, which documents its mapping to spec
+  §4.3.2): `appliesTo` is the spec's target pattern
+  (`preCondition.confidentiality[0]`); `pre` holds the remaining side
+  conditions — `confidentiality`, `integrity`, `boundary` (patterns over
+  `BoundaryContext` atoms, the shipped generalization of `allowedSink` /
+  `allowedPaths`), and `policyState` (grants); `post` is exactly one of
+  `addAlternatives` / `dropClause`. `preConfScope` defaults to
+  `"targetClause"`.
+- Lowering rejects a rule with no guard at all. Admissible guard forms: a
+  `pre.integrity` pattern, a `pre.policyState` grant guard, `pre.boundary`
+  sink/path scoping (§5.2.1's structural authorization), or the
+  **owner-self binding** — the target's subject constrained to the acting
+  principal with release only to that same principal (the §5.4.2
+  `$actingUser` shape; safe by construction, since it can only ever hand the
+  clause's own subject their own access). A rule with none of these is a
+  standing leak (invariant 3).
 
 ### 2a. Raising, direct
 
 ```ts
+// Shown for illustration only.
 import type { Confidential, PolicyOf } from "commonfabric";
 
 type DriftFlag = Confidential<Flag, [PolicyOf<typeof driftFlagRules>]>;
@@ -136,7 +155,10 @@ space> }`. Because the pair is content-derived, the hash binding that spec
 §4.4.2 requires is inherent in the reference; there is no separate
 name→hash discovery step for pattern-declared rules (SC-29). At deploy the
 runtime registers the derived policy record content-addressed; at label
-creation the principal is bound.
+creation the principal is bound. The record lands as a
+`selection: "referenced"` policy record — the shipped label-carried,
+home-clause-local selection mode (CT-1874) — with the `{ identity, symbol }`
+pair extending the shipped `{ id, digest }` reference form (SC-29).
 
 Semantics, all inherited rather than invented:
 
@@ -156,6 +178,7 @@ concept-kernel rule can rewrite is a compile-time violation.
 ### 2b. Raising, indirect — concept references
 
 ```ts
+// Shown for illustration only.
 import { concept } from "commonfabric";
 import type { ConceptOf, Confidential } from "commonfabric";
 
@@ -189,31 +212,40 @@ rules are generic and grant-guarded, and the user's editable defaults are
 **grant records** (spec §4.3.5) consulted at evaluation time:
 
 ```jsonc
-// 1. Owner access — the concept never locks out its owner.
-{ "pre":  { "confidentiality": [{ "var": "C", "type": ".../atom/Context",
-             "constraints": { "concept": HEALTH, "subject": { "var": "O" } } }],
-            "integrity": [] },
-  "post": { "confidentiality": [{ "type": ".../atom/User",
-             "subject": { "var": "O" } }], "integrity": [] } }
+// 1. Owner access — the concept never locks out its owner. Guarded by the
+//    owner-self binding: the target matches only when the clause's own
+//    subject IS the acting principal (the §5.4.2 $actingUser shape), and
+//    the rule releases only to that same principal — self-scoped by
+//    construction, never a release to anyone else.
+{ "id": "concept-owner-access",
+  "appliesTo": { "type": ".../atom/Context",
+    "concept": HEALTH, "subject": "$actingUser" },
+  "post": { "addAlternatives": [
+    { "type": ".../atom/User", "subject": "$actingUser" }] } }
 
 // 2. Standing default — one rule serves every user-edited default.
-{ "pre":  { "confidentiality": [ /* as above */ ],
-            "integrity": [{ "type": ".../atom/ConsumerIntent",
-              "intent": { "var": "I" }, "surface": { "var": "S" } }] },
-  "guard": { "policyState": [{ "kind": "ConceptGrant", "concept": HEALTH,
-              "owner": { "var": "O" }, "audience": { "var": "A" },
-              "requiredIntent": { "var": "I" } }] },
-  "post": { "confidentiality": [{ "type": ".../atom/User",
-             "subject": { "var": "A" } }], "integrity": [] } }
+{ "id": "concept-standing-grant",
+  "appliesTo": { "type": ".../atom/Context",
+    "concept": HEALTH, "subject": { "var": "O" } },
+  "pre": {
+    "integrity": [{ "type": ".../atom/ConsumerIntent",
+      "intent": { "var": "I" }, "surface": { "var": "S" } }],
+    "policyState": [{ "kind": "ConceptGrant", "concept": HEALTH,
+      "owner": { "var": "O" }, "audience": { "var": "A" },
+      "requiredIntent": { "var": "I" } }] },
+  "post": { "addAlternatives": [
+    { "type": ".../atom/User", "subject": { "var": "A" } }] } }
 
 // 3. One-shot release — same shape, grant marked single-use (§4.3.5),
-//    consumed atomically at the releasing commit.
+//    consumed atomically at the releasing commit (shipped as
+//    commit-precondition receipts, grants.ts / #4649).
 ```
 
 Consequences, inherited from §4.3.5: default edits are grant CRUD — effective
 at next evaluation, no label migration; revocation is grant deletion; one-shot
 declassification rides single-use grants with receipt linearity already proved
-in `formal/Cfc/GrantConsumption.lean`. This resolves the open question the
+in `formal/Cfc/GrantConsumption.lean` and shipped as commit-precondition
+receipts (`packages/runner/src/cfc/grants.ts`). This resolves the open question the
 spec records in `notes/WORKING_GOVERNANCE_EXAMPLES.md` ("How is Alice's
 medical policy at the time represented? What changes automatically for future
 data?").
@@ -237,6 +269,7 @@ Conjunctive by default — two clauses, two independent gates, ordinary CNF
 join:
 
 ```ts
+// Shown for illustration only.
 type CareFlag = Confidential<Flag, [
   ConceptOf<typeof health>,             // owner's defaults govern, AND
   PolicyOf<typeof driftFlagRules>,      // the pattern's own constraint
@@ -248,6 +281,7 @@ narrow what the concept alone would allow. The disjunctive form is an explicit
 opt-in via the authored-OR surface (spec §3.1.8):
 
 ```ts
+// Shown for illustration only.
 type EitherPath = Confidential<Flag, [
   AnyOf<[ConceptOf<typeof health>, PolicyOf<typeof driftFlagRules>]>,
 ]>;

--- a/docs/specs/cfc-exchange-rules-authoring.md
+++ b/docs/specs/cfc-exchange-rules-authoring.md
@@ -1,0 +1,339 @@
+# CFC Exchange Rules — Pattern Authoring Surface
+
+How pattern code declares exchange rules (declassification policies) and
+raises confidentiality by referencing them — directly, or through a **concept
+reference** whose governing rules the data's owner keeps as defaults.
+
+## Status
+
+Design proposal. No runtime or spec edits applied. Companion spec-change items
+are SC-29..SC-37 in [`cfc-spec-changes.md`](./cfc-spec-changes.md); companion
+syntax sketches for the remaining surfaces are in
+[`cfc-exchange-rules-authoring-extensions.md`](./cfc-exchange-rules-authoring-extensions.md).
+
+## Last Updated
+
+2026-07-11
+
+## Motivation
+
+Exchange rules are the spec's only declassification mechanism: integrity-
+guarded rewrites on hash-bound policy records that may rewrite only the
+clause(s) their policy principal appears in (spec §4.3.2, §4.4.5 home-clause
+locality). The shipped authoring surface (`packages/api/cfc.ts`) cannot
+express them: it stops at `Confidential<T, X>` atom lists, and declassification
+exists only as `declassifyConfidentiality={[...]}` attribute lists on trusted
+components — release paths that live in the *component* rather than in a
+policy record that travels with the *data*. Three needs:
+
+1. **Direct use.** A pattern raises confidentiality on data it produces and, in
+   the same declaration, names the exchange rules that are that clause's
+   release paths.
+2. **Indirect use.** A pattern raises confidentiality *to a concept* — an
+   identifier like "health" coordinated across parties — and inherits whatever
+   default rules the data's owner keeps for that concept, as they change.
+3. **Both at once.** Concept defaults and pattern-specific rules governing the
+   same value, composing predictably.
+
+Proposing a rule to someone else's concept is deliberately **not** an API
+(§ Proposing rules is a workflow, below).
+
+## Identity: literal or reference, never bare names
+
+For any policy-bearing thingie — a rule set, a concept, a context — pattern
+code can either define it **literally** (inline, anonymous) or reference it by
+an **id for coordination**. Ids come in exactly the two forms the runtime
+already has; there are no global bare names (no ambient `"health"` string that
+means the same thing everywhere):
+
+- **Well-known URI** — ecosystem-level coordination, the spec §4.8.1 /
+  §5.7.1 form and the existing `CFC_CONCEPT_KIND` convention
+  (`https://commonfabric.org/cfc/concepts/prompt-influence`). Right for
+  concepts whose meaning many independent parties must agree on.
+- **Pattern-relative: `{ identity, symbol }`** — the exported symbol of a
+  pattern module, where `identity` is the content-addressed entry-module
+  identity. This is the same pair the runtime already uses for patterns,
+  lifts, and handlers (`content-addressed-action-identity.md`; owner decision
+  SC-22: implementation identity = content hash of the code artifact +
+  symbol). A pattern-local concept or rule set needs no registration step:
+  deployment gives it a global address, and other patterns reference it by
+  importing from the deployed piece or published pattern
+  (`pattern-imports/README.md` — `import { health } from "cf:/wellness/commons"`
+  pins to the exporting module's identity at compile time).
+
+A "context" in the spec's sense is one kind of concept — the primary one for
+this design — but the identity story is uniform: the same concept id can
+appear in a confidentiality position (as a context/policy principal selecting
+an owner's rules), in an integrity guard (satisfied via trust closure, spec
+§4.8.9), or in a caveat kind. The position determines the machinery; the id is
+just coordination.
+
+## Authoring surface
+
+Two verbs, both declarative, both statically lowerable (same `typeof`-of-a-
+module-level-const discipline as `TrustedActionWrite`). Pattern code never
+evaluates rules; trusted boundaries do.
+
+### 1. Declaring rules
+
+```ts
+import { cfcAtom, exchangeRule, exchangeRules, SELF, v } from "commonfabric";
+
+// "The owner may release a drift flag to an audience they picked in the
+//  trusted share surface." Endorsed intent is the guard (spec §3.8.4);
+//  the audience variable binds from the intent evidence (§4.3.3).
+export const releaseFlagToChosenAudience = exchangeRule({
+  pre: {
+    confidentiality: [SELF], // target: the clause this rule set governs
+    integrity: [{
+      type: "https://commonfabric.org/cfc/atom/EndorsedIntent",
+      action: "share-drift-flag",
+      user: v("O"),
+      audience: v("A"),
+    }],
+  },
+  post: {
+    confidentiality: [cfcAtom.user(v("A"))],
+    integrity: [],
+  },
+});
+
+export const driftFlagRules = exchangeRules([
+  releaseFlagToChosenAudience,
+  releaseFlagToWeeklyDigest,
+]);
+```
+
+- **Identity is free.** A rule set's identity is `{ identity, symbol }` —
+  the module's content-addressed identity plus the exported name, exactly like
+  every other pattern-referenced artifact. No `name` field is needed for
+  identity (an optional `label` stays for diagnostics); no registry; changing
+  a rule changes the module identity and is therefore automatically a new
+  policy version (spec §4.4.4 migration semantics fall out of the ordinary
+  pattern-upgrade story).
+- `SELF` is the placeholder for the policy principal being defined, which
+  cannot be named before the module is hashed. It always occupies the
+  target-pattern position; `preConfScope` defaults to `"targetClause"`.
+- `v("X")` is the `{ var: "X" }` placeholder of spec §4.3.3.
+- The full §4.3.2 surface is available (`preConfScope`, `allowedSink` /
+  `allowedPaths`, `guard.policyState`), all optional. Lowering rejects a rule
+  carrying none of the three guard forms — a `pre.integrity` pattern, a
+  `guard.policyState`, or sink+path scoping (§5.2.1's structural
+  authorization) — since a wholly unguarded rewrite is a standing leak
+  (invariant 3).
+
+### 2a. Raising, direct
+
+```ts
+import type { Confidential, PolicyOf } from "commonfabric";
+
+type DriftFlag = Confidential<Flag, [PolicyOf<typeof driftFlagRules>]>;
+```
+
+Lowering: the schema-time atom is a policy principal addressed by the pair —
+`Policy{ module: <identity>, symbol: "driftFlagRules", subject: <owning
+space> }`. Because the pair is content-derived, the hash binding that spec
+§4.4.2 requires is inherent in the reference; there is no separate
+name→hash discovery step for pattern-declared rules (SC-29). At deploy the
+runtime registers the derived policy record content-addressed; at label
+creation the principal is bound.
+
+Semantics, all inherited rather than invented:
+
+- **Home-clause locality** (spec §4.4.5, `formal/Cfc/HomeClauses.lean`): the
+  referenced rules can rewrite exactly the clause this raise contributes.
+- **Conjunctive join**: labels arriving on the pattern's inputs join as
+  independent clauses the pattern's rules cannot touch. A pattern can make its
+  *own* raise declassifiable; it can never attach release paths to data it
+  merely consumed.
+- Raising is label creation, not rewrite — store monotonicity (§8.12) is
+  unaffected.
+
+This also makes the developer-guide static check (§11.2.4.3) computable from
+the pattern module alone: an egress output whose label no declared or
+concept-kernel rule can rewrite is a compile-time violation.
+
+### 2b. Raising, indirect — concept references
+
+```ts
+import { concept } from "commonfabric";
+import type { ConceptOf, Confidential } from "commonfabric";
+
+// pattern-local concept: id = { identity, symbol } of this export
+export const avoidanceObservation = concept();
+
+// concept bound to a well-known URI for ecosystem coordination
+export const health = concept("https://commonfabric.org/cfc/concepts/health");
+
+// or import someone else's, pinned via cf: resolution
+// import { health } from "cf:/wellness/commons";
+
+type HealthNote = Confidential<Note, [ConceptOf<typeof health>]>;
+// dynamic form: cfcAtom.conceptOf(health)          — subject: owning space
+//               cfcAtom.conceptOf(health, subject) — explicit owner
+```
+
+Lowering: a context principal keyed by the pair (concept id, owner subject) —
+`Context{ concept: <uri | {identity, symbol}>, subject: <owner> }`. The
+governing policy record is the **owner's** record for that concept, discovered
+through the owner-space policy root (spec §4.4.1) and hash-verified at label
+creation. That record is where user default policies live: the pattern raising
+to `health` doesn't know or care what the owner's rules are.
+
+**Stable kernel + grants (recommended record shape).** A concept record that
+directly holds the user's rules has the wrong update semantics for *defaults*:
+every already-labeled value stays pinned to the old hash until migrated
+(§4.4.4), so "I changed my health sharing policy" wouldn't apply to existing
+data. Instead the concept's record is a small hash-stable **kernel** whose
+rules are generic and grant-guarded, and the user's editable defaults are
+**grant records** (spec §4.3.5) consulted at evaluation time:
+
+```jsonc
+// 1. Owner access — the concept never locks out its owner.
+{ "pre":  { "confidentiality": [{ "var": "C", "type": ".../atom/Context",
+             "constraints": { "concept": HEALTH, "subject": { "var": "O" } } }],
+            "integrity": [] },
+  "post": { "confidentiality": [{ "type": ".../atom/User",
+             "subject": { "var": "O" } }], "integrity": [] } }
+
+// 2. Standing default — one rule serves every user-edited default.
+{ "pre":  { "confidentiality": [ /* as above */ ],
+            "integrity": [{ "type": ".../atom/ConsumerIntent",
+              "intent": { "var": "I" }, "surface": { "var": "S" } }] },
+  "guard": { "policyState": [{ "kind": "ConceptGrant", "concept": HEALTH,
+              "owner": { "var": "O" }, "audience": { "var": "A" },
+              "requiredIntent": { "var": "I" } }] },
+  "post": { "confidentiality": [{ "type": ".../atom/User",
+             "subject": { "var": "A" } }], "integrity": [] } }
+
+// 3. One-shot release — same shape, grant marked single-use (§4.3.5),
+//    consumed atomically at the releasing commit.
+```
+
+Consequences, inherited from §4.3.5: default edits are grant CRUD — effective
+at next evaluation, no label migration; revocation is grant deletion; one-shot
+declassification rides single-use grants with receipt linearity already proved
+in `formal/Cfc/GrantConsumption.lean`. This resolves the open question the
+spec records in `notes/WORKING_GOVERNANCE_EXAMPLES.md` ("How is Alice's
+medical policy at the time represented? What changes automatically for future
+data?").
+
+**Bootstrap.** Raising to a concept the owner never configured must not fail:
+the substrate registers the concept's kernel (substrate-shipped, covered by
+attested deployment configuration — spec §5.7.2 / SC-28) with zero grants.
+Result: owner-only data with a standing structure for defaults to grow into —
+strictly private until the owner says otherwise.
+
+**Consumer side.** The `ConsumerIntent` fact in kernel rule 2 is runtime-
+minted evidence for a consuming pattern's *declared* intents (a static
+declaration in the consumer's module, e.g. `intents: ["care-coordination"]`).
+"Health flows to surfaces that declared care-coordination intent, because the
+owner granted that" is then one grant plus one declaration, evaluated by the
+ordinary calculus. Default stays no-access.
+
+### 2c. Both at once
+
+Conjunctive by default — two clauses, two independent gates, ordinary CNF
+join:
+
+```ts
+type CareFlag = Confidential<Flag, [
+  ConceptOf<typeof health>,             // owner's defaults govern, AND
+  PolicyOf<typeof driftFlagRules>,      // the pattern's own constraint
+]>;
+```
+
+Release needs a firing path through *each* clause — the pattern raise can only
+narrow what the concept alone would allow. The disjunctive form is an explicit
+opt-in via the authored-OR surface (spec §3.1.8):
+
+```ts
+type EitherPath = Confidential<Flag, [
+  AnyOf<[ConceptOf<typeof health>, PolicyOf<typeof driftFlagRules>]>,
+]>;
+```
+
+One clause, either path releases — and the clause's admissible rule set is the
+*union* over alternatives, so `AnyOf` raises are a weakening relative to the
+concept alone and should be linted accordingly.
+
+## Proposing rules is a workflow, not an API
+
+A pattern will often know what release *would* be useful ("weekly drift
+summaries may flow to the therapist the owner named") without authority to
+enact it. There is deliberately no `propose()` call. The unit of proposal is
+the **published pattern itself**:
+
+1. The author writes a pattern that declares the rule set (and typically
+   raises to the relevant concept), and publishes it — deployment/publication
+   gives the rule set a global `{ identity, symbol }` address.
+2. Proposing is out-of-band from code: the pattern (piece address) is proposed
+   to the owner's review surface, to a verifier, to a space — whatever the
+   deployment's adoption flow is.
+3. Adoption takes one of the existing evidence-producing forms, none of which
+   pattern code can perform:
+   - **Instantiation** — the owner instantiates the pattern; its declared
+     rules now govern (only) the clauses the pattern itself raises. Same
+     authority bound as authoring.
+   - **Grant** — the owner accepts a standing default for a concept via the
+     trusted review surface: a state-scoped intent executed by the trusted
+     policy writer, which commits a `ConceptGrant` (spec §13.4.3 shape,
+     §4.3.5 write gate: the writer verifies the owner's release authority
+     over the granted scope).
+   - **Trust statement** — a verifier asserts the pattern's implementation
+     satisfies a concept used in integrity guards (spec §4.8.2), extending
+     which concrete code can satisfy concept-guarded rules for users who
+     delegate to that verifier.
+
+This split has a security payoff: the release *parameters* (audience,
+required intent, expiry) originate in the trusted review surface at acceptance
+time, not in pattern-authored data — which structurally removes the main
+§3.8.4 laundering path (a pattern smuggling an injected audience through a
+proposal object). The policy writer's obligation reduces to sourcing grant
+parameters only from endorsed intent evidence.
+
+## Enforcement summary
+
+1. Rules and concepts referenced from `PolicyOf` / `ConceptOf` must be
+   module-level exports (or `cf:` imports); the compiler lowers them
+   statically and rejects runtime-computed rule content (other than `v()`
+   variables and `SELF`).
+2. All rule firing happens in trusted boundaries (render boundary, sink gate,
+   gated writes) via the fuelled fixpoint of spec §4.4.5, fail-closed.
+3. Observing contexts (preview/diagnostics) must not consume single-use
+   grants (§4.3.5) — "would release" chrome renders without spending.
+4. Concept records resolve through owner-space discovery and fail closed on
+   hash mismatch; pattern-declared records are pinned by module identity.
+
+## Companion extensions
+
+Syntax sketches for the remaining policy surfaces live in
+[`cfc-exchange-rules-authoring-extensions.md`](./cfc-exchange-rules-authoring-extensions.md):
+sink-scoped rules and authority-only inputs (spec §5.2.1, §5.3.1), error
+exchange rules (§5.4), caveat-discharge rules (invariant 10 / §14.1),
+multi-party consent release (§5.3.4), `PolicyCertified` require/run-under
+(§5.5), implements-concept claims (§4.8.2), TTL sugar, and row-set read modes
+(invariant 14 / §8.17). Deliberately out of scope everywhere: verifier
+delegation and trust-statement issuance (user/space-level acts, not pattern
+code) and recombination across multiple grants on one concept (§14.3.2 — open
+in the spec; the surface-level obligation is enumerating a concept's active
+grants, SC-35).
+
+## Open questions
+
+1. **Atom shape for concept-scoped principals.** Extend `Context` with a
+   `concept` field (as sketched) vs. a distinct atom type. Leaning extension:
+   all `Context` machinery (discovery, hash binding, home clauses, migration)
+   applies unchanged; SC-30 carries the decision.
+2. **Well-known URI governance.** Who mints `concepts/health` and where the
+   directory lives (spec §5.7.1 names a public concept directory but no
+   process). Pattern-relative ids need no governance, so this only gates the
+   ecosystem-coordination tier.
+3. **Owner-record discovery key.** `{user-space}/.policies/<x>` needs a
+   canonical key for both id forms (URI digest; identity+symbol digest).
+4. **Cross-pattern rule-set reuse.** Sharing rules as importable *values*
+   (each pattern's record hashes its own copy) vs. referencing another
+   pattern's deployed rule set as the *same policy identity*. Values-only
+   reuse is safer (no cross-code-hash coupling of release paths) but loses
+   "we both defer to the same policy"; `cf:` imports make either expressible.
+   Leaning values-only until a concrete need appears.

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -643,3 +643,111 @@ this file is the single tracking place:
   landed** (declared list-coordinator containers), and the generic
   pure-link-write slice **closed in #4674** via the machinery-read marker
   — see the SC-8 note and the design's §6 implementation note.
+
+## From the exchange-rules pattern-authoring design (2026-07-11)
+
+Companion design: [`cfc-exchange-rules-authoring.md`](./cfc-exchange-rules-authoring.md).
+All `open`.
+
+**SC-29 [normative] Module-identity-addressed policy references — §4.4.2 +
+§15.3.** Policy principals today are `{name, subject, hash}` with a
+name→hash discovery step (§4.4.1). For rule sets declared in pattern code,
+the reference should be the SC-22 identity pair — `{module identity, symbol}`
+(content-addressed entry-module identity + exported name), the same reference
+form the runtime uses for patterns/lifts/handlers. The pair is content-derived,
+so §4.4.2's hash-binding requirement is inherent in the reference and no
+separate discovery hop exists to fail; rebinding semantics are SC-22's (any
+code change ⇒ new identity ⇒ new policy version; migration per §4.4.4 rides
+the ordinary pattern-upgrade story). Proposed edit: add the pair-addressed
+`Policy` form to §4.4.2 and the §15.3 table alongside the name-addressed form,
+and state that home-clause locality (§4.4.5) and clause-local authority
+(§5.3.3) apply identically.
+
+**SC-30 [normative] Concept-scoped owner policy records (user defaults) —
+§4.3/§4.4.1 + new §13 worked example.** Define the indirect-raise mechanism:
+a **concept id** (well-known URI per §4.8.1/§5.7.1, or `{identity, symbol}`
+per SC-29) crossed with an **owner subject** selects the owner's policy record
+for that concept — the home of user default policies. Normative content
+needed: (a) atom shape — extend `Context` with a `concept` field (or a
+sibling atom; decide), keyed `(concept, subject)`; (b) the
+**stable-kernel-plus-grants** profile: the record is a hash-stable kernel of
+generic grant-guarded rules; user defaults are §4.3.5 grant records (reserved
+kind `ConceptGrant {concept, owner, audience, requiredIntent, expires?,
+singleUse?}`) so default edits are grant CRUD (no label migration), revocation
+is grant deletion, one-shot release rides single-use grants; (c) bootstrap —
+raising to an unconfigured concept resolves the substrate-shipped kernel
+(covered by attested deployment configuration, SC-28) with zero grants:
+owner-only until granted. This discharges the open questions recorded in
+`notes/WORKING_GOVERNANCE_EXAMPLES.md` (how "Alice's medical policy at the
+time" is represented; what changes automatically for future vs existing data).
+
+**SC-31 [registry] `ConsumerIntent` integrity atom — §15.** Runtime-minted
+evidence that a consuming pattern's module statically declares an intent for
+what flows in (`{intent, surface, pattern}`); matched by concept-kernel grant
+rules' `requiredIntent`. Evidence, not authorable in schemas — same posture
+as `UserSurfaceInput`/`LlmDerived`. Needs a registry row and a minting rule.
+
+**SC-32 [clarify] Concept identity coordination — §4.8.1 + §5.7.1.** State
+that concept ids have exactly two forms — well-known URIs (ecosystem
+coordination) and pattern-relative `{identity, symbol}` (no registration;
+globally referencable once deployed, resolvable via `cf:` imports per the
+labs pattern-imports design) — and that bare string names are not a
+coordination form. Note the same concept id may appear in confidentiality
+position (context principal selecting an owner's record, SC-30), in integrity
+guards (trust-closure satisfaction, §4.8.9), and in caveat kinds; position
+selects the machinery. §5.7.1's "public concept directory" should say who
+mints well-known URIs or point to the process.
+
+**SC-33 [normative] Adoption paths for third-party-authored rules — new §13
+worked example.** Publishing a pattern that declares exchange rules is not
+adoption. Enumerate the three adoption paths and their evidence: (a)
+**instantiation** — owner instantiates the pattern; its rules govern only
+clauses the pattern itself raises (authoring authority bound; conjunctive-join
+rule); (b) **grant** — owner accepts a standing concept default via the
+trusted review surface: state-scoped intent → trusted policy writer → grant
+record (§13.4.3 + §4.3.5 write gate); (c) **verifier trust statement**
+(§4.8.2) for concept-guard satisfaction. Add the parameter-integrity rule:
+the policy writer MUST source grant parameters (audience, requiredIntent,
+expiry) from endorsed intent evidence minted at the review surface, never
+from the proposing pattern's data — this is §3.8.4 applied to adoption, and
+it is what makes "propose" safe as a pure out-of-code workflow.
+
+**SC-34 [normative] Bulk migration for concept kernels — §4.4.4.** §4.4.4
+defines per-label migration only. Grants make kernel changes rare, not never
+(kernel bugs, new guard families). Define the owner-initiated sweep: re-pin
+every value carrying `(concept, owner)` from kernel hash A to B, as an
+intent-gated batch declassification event with an auditable record (the
+§8.12.7 route-2b shape, batched).
+
+**SC-35 [clarify] Grant-set recombination — §14.3.2 pointer from SC-30.**
+Multiple grants on one concept are multiple declassification paths; the
+§14.3.2 recombination attack applies directly to user defaults. No mechanism
+proposed; require that owner-facing surfaces can enumerate a concept's active
+grants (the precondition for any future budget mechanism) and cross-reference
+§14.3.2 from the SC-30 text.
+
+**SC-36 [normative] Pattern-requested execution-policy envelopes — §5.5.2.**
+§5.5.2 says patterns don't request certification — it's a consequence of the
+execution environment — but never says how a pattern comes to execute under
+policy P in the first place. Add the request surface: a pattern MAY declare an
+execution-policy envelope (by policy reference, SC-29 pair form); the runtime
+either enforces P for that pattern's execution (outputs then gain
+`PolicyCertified(P)` exactly as §5.5.2 already specifies) or refuses to run
+the pattern — never runs it unenforced. State the monotonicity: a
+pattern-requested envelope can only constrain its own execution; it adds no
+authority, and the attestation remains runtime-minted (§5.5.7's trust model
+unchanged). Authoring sketch:
+`cfc-exchange-rules-authoring-extensions.md` §5.
+
+**SC-37 [registry] Reserved `ConsentEvidence` integrity family — §5.3.4 +
+§15.** §5.3.4 requires consent evidence to "bind scope, audience, and purpose
+strongly enough that the shared-result rewrite is clause-local and
+reviewable," while deliberately not privileging a payload. Reserve the family
+shape so profiles interoperate: `ConsentEvidence {participant, scope,
+audience, purpose?, expires?}`, minted only by trusted consent surfaces (the
+§13.4.3 state-scoped-intent shape per participant), matched per participant
+clause by ordinary rules (each participant's evidence rewrites only that
+participant's clause; the multi-party conjunction dissolves exactly when all
+are present — §5.3.3 stated operationally). Registry row + a note in §5.3.4
+pointing at the reserved shape. Authoring sketch:
+`cfc-exchange-rules-authoring-extensions.md` §4.

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -680,6 +680,11 @@ raising to an unconfigured concept resolves the substrate-shipped kernel
 owner-only until granted. This discharges the open questions recorded in
 `notes/WORKING_GOVERNANCE_EXAMPLES.md` (how "Alice's medical policy at the
 time" is represented; what changes automatically for future vs existing data).
+Runtime prerequisites already shipped: grant records with `policyState`
+guards, reserved-path storage and single-use commit-precondition receipts
+(`packages/runner/src/cfc/grants.ts`, #4627/#4649), and label-carried
+`referenced` record selection with home-clause locality (CT-1874, #4652) —
+SC-30 is the spec-side profile plus the reserved grant kind.
 
 **SC-31 [registry] `ConsumerIntent` integrity atom — §15.** Runtime-minted
 evidence that a consuming pattern's module statically declares an intent for


### PR DESCRIPTION
## What

Design proposal (docs only) for how pattern code works with **exchange rules** (declassification policies), plus the owed spec-change items.

- **`docs/specs/cfc-exchange-rules-authoring.md`** — the core design:
  - **Identity: literal or reference, never bare names.** Rule sets and concepts are module-level exports whose identity is the content-addressed `{ identity, symbol }` pair (SC-22, `content-addressed-action-identity.md`), or well-known URIs for ecosystem coordination. Pattern-local artifacts become globally referencable by deployment and are importable via `cf:` resolution (`pattern-imports/`). No global bare `"health"`.
  - **Declare**: `exchangeRule()` / `exchangeRules()` module exports, statically lowered; `SELF` placeholder for the not-yet-hashed policy principal; a rule needs one of three guard forms (integrity pattern, `guard.policyState`, sink+path scoping).
  - **Raise, direct**: `Confidential<T, [PolicyOf<typeof rules>]>` — hash binding is inherent in the identity pair; home-clause locality and conjunctive join bound authority.
  - **Raise, indirect**: `ConceptOf<typeof health>` — the `(concept id, owner)` pair selects the owner's default-policy record, recommended shape **stable kernel + grants** (§4.3.5) so default edits are grant CRUD (no label migration), revocation is grant deletion, one-shot releases ride single-use grants.
  - **Both at once**: conjunctive by default; `AnyOf` as the explicit weakening opt-in (§3.1.8 authored-OR).
  - **Proposing is a workflow, not an API**: publish the pattern; adoption = instantiation | grant via trusted review (§13.4.3) | verifier trust statement (§4.8.2). Release parameters originate at the review surface, which structurally removes the §3.8.4 parameter-laundering path.
- **`docs/specs/cfc-exchange-rules-authoring-extensions.md`** — sketches for the remaining surfaces: sink-scoped rules + `AuthorityOnly`, error exchange rules, caveat-discharge rules, multi-party consent (per-clause consent, no quantifier needed), `PolicyCertified` require/run-under, implements-concept claims, TTL sugar, row-set read modes.
- **`docs/specs/cfc-spec-changes.md`** — appends **SC-29..SC-37** (all `open`): module-identity-addressed policy references; concept-scoped owner policy records (kernel + `ConceptGrant`); `ConsumerIntent` registry atom; concept-id coordination text; adoption-paths worked example + parameter-integrity rule; bulk kernel migration; grant-set recombination pointer; pattern-requested execution-policy envelopes; reserved `ConsentEvidence` family.

## Why

Exchange rules are the spec's only declassification mechanism, but the authoring surface (`packages/api/cfc.ts`) stops at `Confidential<T, X>` atom lists — declassification today lives in per-component `declassifyConfidentiality` attribute lists that don't travel with the data. This design gives patterns a declarative way to name release paths at raise time, gives users concept-keyed default policies with sane update semantics, and keeps every authority transfer in existing trusted-workflow shapes.

## Notes for review

- Docs only; no runtime or spec edits. All SC items marked `open`.
- Depends conceptually on the disjunctive-confidentiality proposal (clause-aware labels) and the pattern-imports design; both cited inline.
- The evaluator half is already merged (exchange-eval.ts; grants via #4627/#4649; label-carried referenced-record selection via #4652/CT-1874) — snippets use the shipped rule dialect (`appliesTo` / `post.addAlternatives` / `pre.boundary|policyState`), and the proposal is framed as the missing authoring half.
- Open questions are listed at the end of the core doc (atom shape for `(concept, owner)` principals; well-known URI governance; owner-record discovery key; values-only vs shared-identity rule reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only design for a pattern authoring surface for CFC exchange rules. Adds direct `PolicyOf<typeof rules>` and indirect `ConceptOf<typeof concept>` raises, shows how they compose, and tracks SC-29..SC-37; examples now match the shipped evaluator dialect and clarify guard requirements (including an owner-self binding).

- **New Features**
  - Core doc `docs/specs/cfc-exchange-rules-authoring.md`: identity as `{identity, symbol}` or well-known URIs; `exchangeRule`/`exchangeRules` with `SELF`; direct raises (`PolicyOf`), concept raises (`ConceptOf`) with a stable kernel + grants; conjunctive default with `AnyOf` opt-in; adoption as workflow (instantiate | grant | verifier).
  - Extensions doc `docs/specs/cfc-exchange-rules-authoring-extensions.md`: sink-scoped rules + `AuthorityOnly`, error rules, caveat discharge, multi-party consent, `PolicyCertified` require/run-under, implements-concept claims, TTL sugar, row-set read modes.
  - Spec tracking `docs/specs/cfc-spec-changes.md`: SC-29..SC-37 for module-identity policy refs, concept-scoped owner defaults (kernel + `ConceptGrant`), `ConsumerIntent`, concept-id coordination, adoption paths + parameter integrity, kernel bulk migration, grant-set enumeration pointer, execution-policy envelopes, reserved `ConsentEvidence`.

- **Refactors**
  - Aligned all rule snippets to the shipped evaluator dialect (`appliesTo`, `pre.boundary`/`policyState`, `post.addAlternatives`/`dropClause`) and framed this as the missing authoring half over the shipped machinery (`packages/runner/src/cfc/exchange-eval.ts`, `packages/runner/src/cfc/grants.ts`, `packages/runner/src/cfc/policy.ts`).
  - Fixed concept-kernel owner-access example: now guarded by owner-self binding (`$actingUser` target and release). Listed admissible guard forms explicitly.
  - Marked all TS fences as “Shown for illustration only” to avoid doc tooling compiling proposed APIs.

<sup>Written for commit a76c436d915062c68aeb62268465efc1719f1e32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

