### PR TITLE
docs(specs): revise server-primary execution design

### DIFF
--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -151,8 +151,11 @@ server-side executor would know natively.
 - `background-piece-service` already runs a runtime per space in a **Deno
   Worker thread** (`packages/background-piece-service/src/worker-controller.ts:78`),
   discovered reactively from a registry cell, under a single service
-  identity. It is the seed of the executor pool (§6), currently limited to
-  a ~60s polling updater and websocket transport back to the same host.
+  identity. It is a lifecycle/isolation precedent for the executor pool (§6),
+  not its registry or discovery substrate: bps-owned spaces are excluded from
+  the client-demand pool until Phase 3 unifies their demand. Today bps remains
+  limited to a ~60s polling updater and websocket transport back to the same
+  host.
 - Server-initiated writes into spaces exist and pass CFC: webhook ingest
   (`POST /api/ingest/:id` with `externalIngestStamp`) and the sqlite
   builtin's server-executed query + result writeback.
@@ -273,8 +276,10 @@ Merkle-verified closure with `loadPatternByIdentity` +
 
 Creation provenance is not producer identity. A computation may redirect its
 output into a pre-existing cell whose creator is unrelated to the action that
-currently recomputes it. `source` remains useful for audit and causality, but
-must not select an executor action.
+currently recomputes it. Existing `source` metadata may remain useful as a
+local or historical diagnostic, but this plan neither adds universal source
+stamping nor promises a per-document causal-audit mechanism. A future audit
+lineage design is separate; creation source must not select an executor action.
 
 The authoritative producer projection is `scheduler_write_index`, joined to
 `scheduler_action_state` and the durable action snapshot. Lookup is by
@@ -298,14 +303,20 @@ than guessing a producer.
 
 Important patterns now go through the transformer. Enforce that every normal
 computation node has exactly one primary output binding, directly to the
-root path of its target cell. The runner must not recursively search an
-arbitrary returned object for a redirect to determine result identity.
-Additional static side writes and materializer envelopes remain explicit
-write surfaces and are indexed separately.
+root path of its target cell. The runner must not recursively search the
+emitted static output binding for a redirect to determine result identity.
+This is the `firstResolvedOutputRedirect` path; plain lift/computed result
+identity from `_resultFor` does not recurse and is not being replaced.
+Additional static side writes and materializer envelopes remain explicit write
+surfaces and are indexed separately.
 
 There is no legacy data migration or corpus audit. Update the small number of
 tests that hand-construct Pattern JSON, reject nonconforming new JSON at the
 runner boundary, and simplify the redirect-resolution code accordingly.
+Hand-built `type: "passthrough"` nodes have no transformer emission path but
+participate in the same output-binding contract: their primary binding must
+also be direct at the root, and nested/multiple aliases are fixed in tests or
+rejected.
 General Cell aliases remain supported; this invariant concerns the primary
 computation result binding, not every Cell redirect in the system.
 
@@ -364,7 +375,8 @@ approach comparison honest.
   explicit input basis and settlement acknowledgement (B) / handlers +
   derived, reconciled by event acks (C).
 - **Q4 — Executor placement and isolation:** none (status quo) / worker
-  thread per space co-located with the memory engine (§6.1) / subprocess
+  thread per active branch/space co-located with the memory engine (§6.1) /
+  subprocess
   tier for untrusted or heavy spaces (§6.6).
 
 ---
@@ -400,7 +412,7 @@ shadow mode has no server data writes or external effects, so it adds no
 writer. The explicit test capability may observe conflicts and exercises
 existing mutex guards without creating a production authority window.
 
-**Perf.** No client-side win. Server cost: one runtime per active space.
+**Perf.** No client-side win. Server cost: one runtime per active branch/space.
 Subscription serving cost unchanged.
 
 **Verdict.** A short shadow-validation milestone, not a product phase. It
@@ -432,8 +444,9 @@ no space-wide `derivedAuthority` bit and no client-maintained exception list.
 At handshake the client must advertise the server-execution protocol version.
 An incompatible client is rejected rather than allowed to participate with
 stale authority rules. A compatible authenticated session exports
-`ExecutionDemand` for the pieces/docs it is pulling. The pool unions demand
-from all sessions; it does not create one worker per client (§6.1).
+branch-qualified `ExecutionDemand` for the pieces/docs it is pulling. The pool
+unions demand from all sessions on that branch; it does not create one worker
+per client (§6.1).
 
 After static eligibility checks and at least one successful shadow run, the
 control plane may publish an ephemeral claim:
@@ -441,6 +454,7 @@ control plane may publish an ephemeral claim:
 ```ts
 // Shown for illustration only.
 interface ExecutionClaim {
+  branch: BranchName;
   space: DID;
   contextKey: SchedulerExecutionContextKey; // `space` in the first phase
   pieceId: string;
@@ -458,8 +472,9 @@ space documents. A durable policy may opt a space into server-primary
 execution, but runtime ownership, liveness, generations, and exceptions do
 not belong in mutable user data.
 
-The fields through `runtimeFingerprint` form the shared `ActionClaimKey` that
-both client and server can derive. `leaseGeneration` fences a Worker;
+The fields from `branch` through `runtimeFingerprint` form the shared
+`ActionClaimKey` that both client and server can derive. `leaseGeneration`
+fences a Worker;
 `claimGeneration` identifies one incarnation of this action's authority and
 changes even when the same Worker revokes and reclaims it. The client runner
 routes by that exact identity:
@@ -476,9 +491,10 @@ routes by that exact identity:
 Connection loss is not proof that a claim ended: another requester may keep the
 shared Worker and claim alive. While disconnected, a client may continue local
 speculation but must not enqueue previously claimed derived writes. Reconnect
-first negotiates the capability and applies a complete claim snapshot at a feed
-sequence barrier; only then may newly unclaimed work flush. Source, handler,
-and direct UI commits keep their existing offline behavior.
+first negotiates the capability and applies a complete claim snapshot for the
+exact branch at a feed-sequence barrier; only then may newly unclaimed work
+flush. Source, handler, and direct UI commits keep their existing offline
+behavior.
 
 Trusted compatible clients cooperate with this split in the first iteration.
 Later server admission and CFC policy can reject commits that conflict with a
@@ -524,6 +540,12 @@ existing conflict/retry machinery
 (`packages/runner/src/scheduler/events.ts`, retry budget + `readyToRetry`)
 *is* the speculation guard.
 
+Phase B does not add persistent scheduler observations for handler runs.
+Handlers remain client-authoritative, their read sets do not drive the
+server-primary wake index, and their existing authenticated event/source
+provenance remains unchanged. Phase 5 defines any handler-observation contract
+needed when events move to the server.
+
 One residual window is accepted knowingly: a handler may read an
 overlay-derived value the server has not computed yet (a prediction), and
 its source write can be admitted before the server's recompute lands —
@@ -552,12 +574,14 @@ claimed run produces an `ActionSettlement` on the control/feed path:
 // Shown for illustration only.
 type ActionSettlement =
   | {
+    branch: BranchName;
     claim: ExecutionClaim;
     inputBasisSeq: number;
     outcome: "committed";
     acceptedCommitSeq: number;
   }
   | {
+    branch: BranchName;
     claim: ExecutionClaim;
     inputBasisSeq: number;
     outcome: "no-op" | "failed" | "unserved";
@@ -581,16 +605,23 @@ sequence. This is an additional data-application gate, not a substitute for
 control ordering. No-op has no data patch and is ordered after its accepted
 observation-only transaction.
 
-Client state per doc is `confirmed(seq)`, speculative `overlay(claim,
-basis)`, and pending local source commits. An overlay based on an unconfirmed
+The settlement's top-level `branch` must equal `claim.branch`, and both must
+match the feed branch before the client considers it. Client state per doc is
+`confirmed(seq)`, speculative `overlay(claim, basis)`, and pending local source
+commits. An overlay based on an unconfirmed
 local commit stays until that commit receives global sequence `S(L)`. Once a
 matching settlement has `inputBasisSeq >= S(L)`, the server has consumed that
-source basis. For `committed` it drops the covered overlay only after applying
+source basis when the claimed action reads that source directly. The scalar is
+not transitive across a claimed-action chain: a downstream action can read a
+stale intermediate while an unrelated newer input pushes its maximum basis past
+`S(L)`. V1 accepts the resulting brief stale-confirmed display after overlay
+drop; the intermediate/downstream re-settle self-heals it and records
+divergence. A later transitive causal-frontier design can remove that window.
+For `committed` the client drops the covered overlay only after applying
 `acceptedCommitSeq`; for `no-op` it drops after the ordered settlement. Exact
 lease + claim generation matching prevents a delayed settlement from an older
 claim incarnation clearing a newer overlay. Rejected source commits invalidate
-dependent overlays; handler retry creates a fresh basis. Divergence resolves
-silently in favor of the server and increments a metric.
+dependent overlays; handler retry creates a fresh basis.
 
 #### B.5 Async builtins and egress parity
 
@@ -801,10 +832,10 @@ the execution model.
 
 ## 6. The server executor (shared architecture for A/B/C/D)
 
-### 6.1 Topology: one unioned, user-sponsored worker per active space
+### 6.1 Topology: one unioned, user-sponsored worker per active branch/space
 
 One **executor pool** service is co-resident with the memory engine (initially
-inside toolshed; separable later). Per active space there is at most one
+inside toolshed; separable later). Per active branch/space there is at most one
 authoritative Deno Worker generation running one Runtime — the bps shape
 (`packages/background-piece-service/src/worker-controller.ts:78`). Realm
 isolation is required, and a worker remains a natural unit of resource
@@ -819,7 +850,8 @@ eligible requesters. Runtime/StorageManager identity is construction-wide, so
 the sponsor does not switch per causal wave. Sponsor loss drains and restarts
 the worker under a replacement rather than mutating its principal in place.
 
-The pool owns a fenced `ExecutionLease(space, leaseGeneration, onBehalfOf)`.
+The pool owns a fenced
+`ExecutionLease(branch, space, leaseGeneration, onBehalfOf)`.
 Only its generation may publish claims or commit through the provider. This
 is the single-owner coordination primitive even if the pool later spans
 multiple processes; a heartbeat document alone is not sufficient.
@@ -875,7 +907,8 @@ A space is *active* when any of:
 1. **Authenticated client-read demand:** the docs a client session reads — which is
    exactly the session's feed set (§6.4), so the server already holds it;
    in the limit no separate declaration protocol is needed. v1 grain is
-   coarser — an authenticated `ExecutionDemand {space, pieces}` message
+   coarser — an authenticated
+   `ExecutionDemand {branch, space, pieces}` message
    replacing `session.watch.set` (G7) — because a standing
    per-doc pulled-set export from clients doesn't exist yet
    (`.pull()` is one-shot, `packages/runner/src/cell.ts:1032`). The
@@ -1164,7 +1197,8 @@ checklists: [implementation-plan.md](./implementation-plan.md).
   state, and indexes (G1); enforce the transformer root binding (G6); add
   writer lookup (G4). Parked-reader wake is Phase 1.
 - **Phase 1 — shadow client-demand executor.** Add authenticated
-  `ExecutionDemand`, one fenced user-sponsored `ExecutionLease` per space,
+  `ExecutionDemand`, one fenced user-sponsored `ExecutionLease` per
+  branch/space,
   the validated provider, and claim eligibility reporting without authority
   transfer plus indexed parked-reader wake (G0/G2/G3/G4). Background-registry
   consolidation is deferred, but legacy-owned spaces are excluded immediately
@@ -1197,12 +1231,12 @@ means a design doc/decision is required before implementation.
 | --- | --- | --- | --- |
 | G0 | Executor-grade provider with canonical ACL/CFC/conflict/apply hooks and commit invalidations | shadow | needs-impl; loopback proves the seam |
 | G1 | `SchedulerExecutionContextKey` and effective scope-qualified snapshots/state/indexes (§3.2.1) | server reliance on durable state | prerequisite; needs-impl |
-| G2 | Authenticated `ExecutionDemand`, sticky sponsor selection, and fenced `ExecutionLease` | shadow | needs-impl |
-| G3 | Ephemeral per-action `ExecutionClaim` with worker lease generation + independent claim generation, revocation, and required client handshake | B | needs-impl |
+| G2 | Branch-qualified authenticated `ExecutionDemand`, sticky sponsor selection, and fenced `ExecutionLease` | shadow | needs-impl |
+| G3 | Branch-qualified ephemeral per-action `ExecutionClaim` with worker lease generation + independent claim generation, revocation, and required client handshake | B | needs-impl |
 | G4 | Named parked-reader wake query plus target/path-overlap `scheduler_write_index` producer lookup | shadow/B | indexes exist; query/consumer needs-impl |
 | G5 | Exact-claim client routing, speculative overlay, read layering, revoke-and-rerun | B | needs-impl |
 | G6 | Transformer/runner enforcement of one direct root result binding; update hand-built tests | producer eligibility | small needs-impl; no migration |
-| G7 | Authenticated demand + reconnect claim snapshots + ordered doc-set delta feed carrying commit/settlement sequence barriers; closure export | B/feed | needs protocol implementation |
+| G7 | Authenticated branch-qualified demand + reconnect claim snapshots + ordered doc-set delta feed carrying commit/settlement sequence barriers; closure export | B/feed | needs protocol implementation |
 | G8 | (retired — reactive interpreter de-scoped from this design, §3.4; its gates are tracked in its own specs) | — | retired |
 | G9 | Cross-space basis vectors, permissions, wake, and dual-space ownership | later expansion | explicitly client-authority in v1 |
 | G10 | Actual-read `inputBasisSeq` plus no-op/failure/unserved `ActionSettlement` and committed `acceptedCommitSeq` gating | B reconciliation | needs-impl; do not reuse `observedAtSeq` |
@@ -1236,3 +1270,8 @@ single authoritative run per event is preserved.
    (co-process, simplest) vs a sibling service with the engine extracted
    behind the in-process channel? Phase 1 forces no commitment; the
    provider seam (G0) is the interface either way.
+4. **What user consent and visibility does sponsorship require:** may any
+   active WRITE-capable requester silently sponsor space-wide derivation caused
+   by other users, should sessions expose an opt-out, or should v1 restrict
+   sponsorship to space owners? Whichever policy is chosen must be visible in
+   sponsor selection and provenance, not inferred from semantic authorship.

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -1,20 +1,21 @@
 # Server-Primary Execution
 
-Status: design exercise — approaches explored, decision pending. Author:
-design session 2026-07-06; revised same day after review (dual handler
-execution as the event end-state, scoped derivation on the executor as the
-end-state, state-residency §6.7); revised 2026-07-07 (doc-centric demand
-§6.3, SQLite-primary state §6.7, transient executor pass §6.5, reactive
-interpreter de-scoped §3.4). No implementation in this spec.
+Status: design approved for phased implementation. Author: design session
+2026-07-06; revised 2026-07-07 (doc-centric demand, SQLite-primary state,
+transient executor passes, reactive interpreter de-scoped); revised
+2026-07-11 after implementation review (scheduler-v2 as the base, user-
+sponsored shared workers, positive per-action authority, writer-index
+producer lookup, scope-safe fallback, causal settlement acknowledgements,
+and server egress parity). No implementation in this spec.
 
 Related specs: `docs/specs/scheduler-v2/`,
-`docs/specs/persistent-scheduler-state.md`, `docs/specs/pull-based-scheduler/`,
+`docs/specs/persistent-scheduler-state.md`,
 `docs/specs/content-addressed-action-identity.md`,
 `docs/history/specs/pattern-id-retirement.md`, `docs/specs/memory-v2/`,
 `docs/specs/toolshed-access-control.md`, `docs/specs/cfc-write-prefix-provenance.md`.
-Related in-flight PRs: #4288 (scheduler-v2 cutover), #4427 (event parking),
-#4495 (conflict catch-up), #4139 (seq-token draft), #4115 (closeSpace),
-#2659 (per-space LLM throttling).
+Related PRs: #4288 (scheduler-v2 cutover, assumed baseline);
+#4495 (conflict catch-up, landed); #4139 (seq-token draft), #4115
+(closeSpace), and #2659 (per-space LLM throttling) remain in flight.
 
 ---
 
@@ -28,25 +29,35 @@ and a per-session subscription machinery whose cost is
 O(commits × sessions × graph-query re-evaluation) on the server.
 
 This document designs the inversion: **the server becomes the primary
-executor**. Clients send only the updates that originate from user intent
-(typically UI events), speculatively execute derived data locally for
-latency, and never push derived results. The server — co-located with the
-SQLite store — keeps every "running" piece current, performs all async work,
-and feeds clients changes. A third motivation joins races and cost: **trust
-asymmetry** — the server is more trustworthy than any client, so
-executor-computed results are the basis for downstream integrity guarantees
-about derived data (§5.B.7), which client-computed results can never
-honestly provide.
+executor for positively claimed actions**. Clients send updates originating
+from user intent, speculatively execute server-claimed derivations locally
+for latency, and keep committing every action the server has not claimed.
+One shared worker per eligible active space unions the demand of every
+connected client, executes on behalf of one eligible requesting user,
+performs async work, and feeds changes back to all clients. Until legacy
+background demand is unified, those owned spaces are excluded rather than
+given a second server runtime. The first iteration treats
+capability-compatible clients as trusted participants; a required handshake
+rejects clients that do not understand the authority protocol. Later server
+admission and CFC work may make the split adversarially enforceable.
+
+A third motivation joins races and cost: **trust asymmetry** — the server is
+more trustworthy than any client, so executor-computed results can eventually
+form the basis for downstream integrity guarantees. In v1, however, the
+important identity fact is narrower and concrete: each server execution is
+attributable as `onBehalfOf` an authenticated user. A future delegated user
+key can strengthen that authorization without changing the execution model.
 
 Four approaches are explored in depth:
 
-- **A — Server catch-up executor**: generalize `background-piece-service`
-  into an always-on space executor; clients unchanged. Low risk, kills async
-  fragility, does *not* kill races.
-- **B — Derived-authority split** (the proposed model): clients commit only
-  event-driven (source) writes; the server is the sole writer of derived
-  data and the sole async executor; clients speculate derived state locally
-  as a never-committed overlay.
+- **A — Server catch-up executor**: run a server participant while clients
+  remain authoritative. Low risk, helps async fragility, does *not* kill
+  races. It remains a useful diagnostic mode, but background-registry cleanup
+  is not on the critical path.
+- **B — Positive derived-authority split** (the proposed model): the server
+  claims eligible actions individually; clients commit event-driven writes
+  and every unclaimed action, while speculative results for claimed actions
+  stay in a never-committed overlay. Authority fails open to the client.
 - **C — Event shipping**: clients ship signed event envelopes; the server
   runs handlers too, authoritatively, while clients keep running them
   speculatively. Total per-space serialization; largest protocol and
@@ -54,30 +65,25 @@ Four approaches are explored in depth:
 - **D — Thin projector**: no client execution at all; the server computes
   everything including VNode docs; clients materialize DOM.
 
-**Recommendation: land A as the enabling milestone, then B as the target
-model, evolving events to dual execution — the handler runs on the server
-authoritatively and on the client speculatively (C's machinery) — as the
-end-state.** B matches the product need (races on derived data disappear structurally;
-async is reliable; clients keep instant local feedback), reuses today's
-commit/conflict machinery for the remaining genuine contention on source
-writes, and can fall back to today's behavior per space via a flag. D is not
-a distinct migration target but where B trends if render output ever
-becomes doc data (§3.4): clients that *choose* not to speculate get a
-working, slightly-laggier UI for free.
+**Recommendation: fix scheduler-state context keys on top of #4288, build
+the shared client-demand executor in shadow mode, then adopt B one eligible
+action at a time.** B matches the product need: races disappear for claimed
+derived data, async survives a tab closing, and clients retain instant local
+feedback. Positive `ExecutionClaim`s make fallback local and structural:
+absence or revocation of a matching claim means today's client-authority
+behavior. Background-only execution remains a lower-priority identity mode;
+event shipping and rigorous delegated authorization follow after the core
+data path works end to end.
 
-The load-bearing enablers are mostly already in the tree behind flags:
-persistent scheduler state (cheap spin-up/down of per-piece graphs —
-BUILT behind `persistentSchedulerState`, §3.2), scheduler v2
-(bounded settle, static write surfaces, read-delta bookkeeping), source
-linking via the `source`/`pattern` doc annotations + content-addressed
-action identity (stale doc → producing piece → runnable action; §3.3.1's
-write-path stamping is what makes the chain universal). Execution density
-on the server is carried by the SQLite-primary state model (§6.7) — idle
-spaces cost no memory, workers can be transient (§6.5) — not by any new
-execution engine (§3.4). §9 is a register of the gaps that remain even
-after all of those land — the two largest are **executor
-authority/identity** (§9 G1–G3) and **the derived/source write split in
-the runner** (§9 G5).
+The load-bearing base is #4288: scheduler v2's demand-driven facade,
+reload-stable action identity, bounded settle, static write surfaces,
+read-delta bookkeeping, and persistent scheduler state. Before the server
+uses those tables as authoritative coordination state, their action keys
+must include the effective space/user/session context (§3.2.1). Producer
+recovery uses `scheduler_write_index` joined to durable action state, not a
+document's creation provenance (§3.3). Execution density comes from the
+SQLite-primary state model (§6.7): idle spaces cost no runtime memory and
+workers can be transient. §9 records the remaining gaps.
 
 ---
 
@@ -159,16 +165,16 @@ server-side executor would know natively.
 
 ## 3. Foundations assumed to land (and what each contributes)
 
-This design assumes the following in-flight work lands. Each subsection
-notes residual gaps *within* that line; the consolidated register is §9.
+This design builds on #4288. It does not preserve compatibility with the
+pre-cutover scheduler. Each subsection notes residual gaps on that base; the
+consolidated register is §9.
 
 ### 3.1 Scheduler v2 (#4288, phases 3c–7)
 
-Already on main: durable event IDs (#4088), speculation lineage (#4090),
-static write surfaces (#4098), tx-carried source action for
-self-suppression (#4099), node records + liveness refcounts (#4101/#4102).
-In flight: gates unification, declared-reads (no dependency-collection
-prefetch), bounded settle (`PASS_RUN_BUDGET = 5`).
+Assumed landed: durable event IDs, speculation lineage, static write
+surfaces, tx-carried source action, node records and liveness refcounts,
+unified gates, declared reads, read-delta tracking, persistent action state,
+and bounded settle (`PASS_RUN_BUDGET = 5`).
 
 Contribution: a scheduler whose per-node state is one record
 (status/liveRefs/reads/writes), whose demand is refcounted rather than
@@ -178,7 +184,7 @@ executor must hold for hundreds of spaces.
 
 ### 3.2 Persistent scheduler state (BUILT behind a flag)
 
-Already on main AND #4288, behind the default-off runtime option
+On the #4288 baseline, behind the default-off runtime option
 `persistentSchedulerState` (env `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`):
 the full durable stack, not just shapes. Per-action observations
 (`SchedulerActionObservation` — `pieceId`, `actionId`, `actionKind`,
@@ -191,32 +197,69 @@ single `applyCommit` SQLite transaction** (`packages/memory/v2/engine.ts:1554`
 (`scheduler_observation`, `scheduler_action_snapshot` LWW,
 `scheduler_read_index`, `scheduler_write_index`, `scheduler_action_state` —
 DDL `engine.ts:206`+). Cold start reads them back
-(`listSchedulerActionSnapshots` `engine.ts:1717` via the provider seam
-`storage/interface.ts:272`) and rehydrates without re-running unchanged
-actions (`rehydrateActionFromStorage` `scheduler.ts:666`, fingerprint-gated,
-fail-open). Restart-skip is proven by `reload-rehydration.test.ts` +
-`v2-scheduler-state-test.ts` (executed, passing). On #4288 the capability
-is identical; only the cold-start orchestration moved from `scheduler.ts`
-into the runner + `scheduler/facade.ts` (see W0.1).
+(`listSchedulerActionSnapshots` through the provider seam) and rehydrates
+without re-running unchanged actions. On #4288, the runner loads the
+snapshots and the facade in `packages/runner/src/scheduler.ts` applies
+fingerprint-gated, fail-open
+rehydration. Restart-skip is proven by `reload-rehydration.test.ts` and
+`v2-scheduler-state-test.ts`.
 
-Still missing (G4), and the real Phase-0 work: durable dirty markers
+Still missing (G4): durable dirty markers
 consumed as a **wake query** — the tree marks readers dirty *inline* during
 commit (`findSchedulerReadersForWrite` `engine.ts:1849`,
 `markSchedulerReadersDirtyForWrites` `:1912`) but exposes no named
 `staleReadersFor(space, changedIds, seq)` batched query for a *parked*
-space (W0.2), and no wake-on-commit consumer of it (W1.3). The reverse
+space, and no wake-on-commit consumer of it (implementation-plan W1.5). The reverse
 *index* itself (`scheduler_read_index`) exists and is populated; what is
-absent is the query + the consumer. The *producer* direction needs no index
-at all: it rides the docs as the `source`/`pattern` annotation chain — the
-shape is in the data model today, universal once §3.3.1's stamping ships
-(G6).
+absent is the query + the consumer. Producer lookup uses the existing
+`scheduler_write_index` (§3.3).
 
 Contribution: spin-up/spin-down becomes cheap. An idle space's graph is a
 set of observation rows; waking it is `rehydrate` + running only actions
-whose inputs moved past their `observedAtSeq`. `observedAtSeq` doubles as
-the **derived-data watermark** the reconciliation protocol needs (§5.B.4).
+whose inputs moved. `observedAtSeq` remains useful scheduler metadata, but is
+not a causal input watermark; reconciliation requires an explicit input
+basis and settlement acknowledgement (§5.B.4).
 
-### 3.3 Source linking (identity landed; `source` stamping partial)
+#### 3.2.1 Prerequisite: context-qualify durable scheduler state
+
+The #4288 schema keys action snapshots and action state by branch, owner
+space, piece, generation, and action identity, but not by the effective
+user/session context. Cell revisions remain correctly partitioned by their
+effective `scope_key`; the bug is in the scheduler projection. Two users or
+sessions running the same scoped action can replace each other's snapshot,
+read/write-index rows, and dirty marker. #4288's fail-open rehydration guard
+prevents adopting another principal's scoped snapshot, but cannot preserve
+the row that was overwritten.
+
+Fix this before server execution relies on these tables for ownership or
+wake decisions:
+
+- derive an action `context_key` on the server using the shareability lattice
+  `space < user < session`, where moving right is narrower;
+- permit a shared `space` or `user` row only when a trusted complete
+  transformer/runner scope summary covers the piece/result plus every possible
+  read, write, materializer envelope, and direct output; incomplete, unknown,
+  or dynamic surfaces start at `session:<principal>:<session-id>`, and observed
+  absence alone can never promote them;
+- include `context_key` in the action snapshot, action-state, read-index,
+  and write-index action keys;
+- persist the resolved `read_scope_key` / `write_scope_key` on indexed
+  addresses and dirty only exact effective-scope matches;
+- never accept principal/session identity from client-provided observation
+  payloads; and
+- retain one shared `space` row for genuinely space-only actions so their
+  scheduler state is reusable across users.
+
+Within one action fingerprint, runtime evidence may only narrow context.
+`space`→scoped invalidates the shared row; `user`→`session` invalidates that
+principal's user row without deleting another principal's independent row.
+Broader classification requires a new implementation/runtime fingerprint.
+
+Regression coverage must run the same action as two users and as two
+sessions, prove their scoped snapshots/index rows/dirty markers coexist, and
+also prove space-only observations continue to coalesce.
+
+### 3.3 Producer lookup: durable writer index, not creation provenance
 
 Result cells carry `patternIdentity = {identity, symbol}`
 (`packages/runner/src/runner.ts:1014`); serialized modules/handlers carry
@@ -228,104 +271,43 @@ Merkle-verified closure with `loadPatternByIdentity` +
 (`cf:module/<hash>:<symbol>:<instanceKey>`,
 `docs/history/specs/action-id-per-instance-decision.md`), reload-stable.
 
-Contribution: **doc → producing piece lives on the docs themselves, not in
-an index.** The document envelope defines the chain
-(`docs/specs/memory-v2/01-data-model.md`): a `source` short-link to the
-doc it derives from, and — on a piece's root docs — the well-known
-`pattern` / `argument` / `result` / `internal` metadata links. The reverse
-lookup is therefore a walk, not an index: **follow `source` until a doc
-carries `pattern`** — that doc is the piece root, and `pattern` +
-`patternIdentity` name the runnable module.
+Creation provenance is not producer identity. A computation may redirect its
+output into a pre-existing cell whose creator is unrelated to the action that
+currently recomputes it. `source` remains useful for audit and causality, but
+must not select an executor action.
 
-Status, honestly: the *shape* is landed, the *coverage* is not.
-`pattern`/`argument`/`internal` stamping is real
-(`packages/runner/src/result-utils.ts:17` writes `pattern`), but `source`
-is an optional/legacy field the runner's write paths do not yet stamp on
-newly created docs, and the query layer's metadata traversal follows
-`cfc`/`result`/`pattern`/`argument`/`internal` but **not** `source`
-(`docs/specs/memory-v2/05-queries.md` §5.10.1). Universal `source`
-coverage is exactly what §3.3.1 builds (G6); the stamping slot already
-exists — the raw `["source"]` surface is runtime metadata excluded from
-CFC flow reads (`packages/runner/src/cfc/prepare.ts:1159`). The full
-catch-up path, once stamping ships:
+The authoritative producer projection is `scheduler_write_index`, joined to
+`scheduler_action_state` and the durable action snapshot. Lookup is by
+effective `(space, scope_key, doc id, path)` with path-overlap semantics and
+returns every candidate writer; it must never choose an arbitrary winner.
+The action snapshot supplies `(pieceId, actionId,
+implementationFingerprint)`, and the piece's `patternIdentity` is the sole
+durable pointer used to load executable code. Implementation-plan W0.3 adds
+target/path lookup over the durable declared, current-known, and materializer
+rows written with scheduler observations. A live worker can also consult its
+registration-time static surface before the first run.
 
-```
-stale doc ──(follow `source` links)──▶ piece root doc carrying `pattern`
-`pattern` / `patternIdentity` ───────▶ {identity, symbol}
-identity  ──(loadPatternByIdentity)──▶ compiled closure (or recompile
-                                        from source docs)
-`argument` meta link ──▶ argument cell ──▶ re-instantiate ──▶ rehydrate
-observations (per-instance actionId) ──▶ pull the stale doc
-```
+If a demanded piece has no usable writer row yet, the client interest already
+identifies the piece. The executor instantiates that piece, validates its
+transformer-emitted root binding and declared surfaces, runs it under client
+authority until an eligible claim can be proven, and persists the resulting
+index. Missing/corrupt rows therefore fail open to ordinary execution rather
+than guessing a producer.
 
-The walk runs directly against the store (state-inspector-style), with
-zero scheduler state; the persisted observations then narrow *which*
-actions inside the piece are stale (`observedAtSeq` vs branch head)
-instead of re-settling the whole piece.
+#### 3.3.1 Transformer invariant: one direct root output binding
 
-Gaps: keyless/hand-built patterns are session-only by design (no durable
-pointer — sanctioned); chain coverage — every doc the executor may be
-asked to catch up must terminate the `source` walk at a `pattern`-bearing
-root — is closable mechanically (§3.3.1) plus a legacy audit (G6); `.src`
-eager annotation is dev-only but debug-only (no identity impact).
+Important patterns now go through the transformer. Enforce that every normal
+computation node has exactly one primary output binding, directly to the
+root path of its target cell. The runner must not recursively search an
+arbitrary returned object for a redirect to determine result identity.
+Additional static side writes and materializer envelopes remain explicit
+write surfaces and are indexed separately.
 
-#### 3.3.1 Closing the chain: source attaching in the write path
-
-Rather than auditing every write site into attaching `source` explicitly,
-source attaching becomes a property of the **cell write mechanism
-itself**. Every transaction is already associated with exactly one
-originating action (`tx.sourceAction` / `debugActionId`, stamped at run
-start — `packages/runner/src/scheduler/action-run.ts:347`, landed with
-#4099 for scheduler self-suppression), and every action belongs to one
-piece. Generalize that stamp into a small **tx provenance envelope**,
-populated at tx open by the runner:
-
-```
-tx.provenance = {
-  source: <short-link to the provenance anchor>,
-      // piece root doc for action txs; ingest-channel doc for ingest txs
-  action: { id, kind },
-      // per-instance action id; computation | effect | event-handler
-  observedAtSeq?: number,
-      // derived-from watermark (§5.B.4), executor txs only
-}
-```
-
-The storage layer **transfers it to documents at apply time**: every
-document the transaction *creates* is stamped with `["source"]` = the
-envelope's anchor link. Later writes by other actions do not re-parent a
-doc — `source` records provenance of existence, and the creator is the
-recomputer. The raw `["source"]` surface is already CFC-excluded from
-flow reads (`packages/runner/src/cfc/prepare.ts:1159`), so automatic
-stamping does not perturb labels. On the wire this is one field on
-`ClientCommit`, mirrored by local apply, so client- and executor-created
-docs are stamped identically.
-
-One mechanism, several consumers:
-
-- **Chain completeness (closes the mechanical part of G6).**
-  Builtin-created result docs, handler-created docs, and schema-less
-  writes all happen inside some tx — they get `source` for free, with no
-  per-site work. External ingest txs anchor to the ingest-channel doc
-  instead of a piece root: the walk then terminates at a registration that
-  names the ingest source — a meaningful root even without `pattern`.
-- **Write-class routing for B (G5).** The envelope's `action.kind` is the
-  classifier the derived/source write split routes on (§5.B.1) — no
-  second channel.
-- **Self-suppression (P5)** keeps reading the same envelope
-  (`tx.sourceAction` becomes `tx.provenance.action`).
-- **Watermark and endorsement (G10, §5.B.7).** The derived-from watermark
-  and, later, the executor-computed endorsement atom are also per-tx facts
-  that transfer onto the committed writes — same envelope, same
-  apply-time transfer.
-
-Open details: **cross-space writes** (the `source` short-link form is
-same-space by definition; a piece writing into another space needs either
-a sigil-link extension of `source` or an accepted walk fallback), and
-**setup txs** (the piece root itself is created by the setup tx — its
-`source` anchors to the creating context, i.e. the parent piece or the
-space root, which is exactly the nesting the walk expects). Docs created
-before stamping ships still need the one-time G6 audit-and-backfill.
+There is no legacy data migration or corpus audit. Update the small number of
+tests that hand-construct Pattern JSON, reject nonconforming new JSON at the
+runner boundary, and simplify the redirect-resolution code accordingly.
+General Cell aliases remain supported; this invariant concerns the primary
+computation result binding, not every Cell redirect in the system.
 
 ### 3.4 Reactive interpreter — de-scoped (delayed; not a dependency)
 
@@ -345,7 +327,7 @@ counts). The de-scope was checked deliberately and invalidates nothing:
 - **D-projector mode** loses its intended mechanism (render output
   stored as VNode docs was prototyped on that line of work); it was
   already a bookend rather than a migration target and is now explicitly
-  deferred (§10.6).
+  deferred until a concrete VNode-document design exists.
 
 If that work later revives, it slots back in as a pure optimizer — no
 interface in this design changes.
@@ -357,8 +339,9 @@ interface in this design changes.
   require it.
 - Verifiable execution / receipts (`docs/specs/verifiable-execution/`) —
   the long-term frame for "who computed this and can we check it", but this
-  design only needs its cheapest primitive (signed request proofs, already
-  precedented by `toolshed-access-control.md`).
+  trusted-client design only needs existing authenticated session-derived
+  authority. Signed delegated request proofs are later hardening, not a v1
+  prerequisite.
 
 ---
 
@@ -368,20 +351,18 @@ Every approach is an answer to these four questions; naming them keeps the
 approach comparison honest.
 
 - **Q1 — Authority: which writes may a client commit?**
-  All writes (today) / source writes only (B) / no writes, events only (C).
-  "Source write" is definable *today* by the originating action kind the
-  scheduler already stamps on transactions (`tx.sourceAction`,
-  `packages/runner/src/scheduler/action-run.ts:348` → node kind:
-  `event-handler` vs `computation`/materializer-effect), plus
-  setup/seed-materialization structural writes, plus direct `.set()` from
-  UI bindings — everything else is derived.
+  All writes (today) / all writes except actions covered by a matching live
+  server claim (B) / no writes, events only (C). B deliberately does not ask
+  the client to predict scope or cross-space behavior: absent a positive
+  action claim, today's commit path remains authoritative.
 - **Q2 — Reads: how do clients learn about remote changes?**
   Per-session graph-query re-evaluation (today) / doc-granular delta feed
   filtered by a server-maintained interest closure (§6.4) / whole-space
   feed for small spaces.
 - **Q3 — Speculation: what does the client compute locally, and how is it
-  reconciled?** Nothing (A, D) / derived overlay reconciled by watermark
-  (B) / handlers + derived, reconciled by event acks (C).
+  reconciled?** Nothing (A, D) / claimed-action overlay reconciled by an
+  explicit input basis and settlement acknowledgement (B) / handlers +
+  derived, reconciled by event acks (C).
 - **Q4 — Executor placement and isolation:** none (status quo) / worker
   thread per space co-located with the memory engine (§6.1) / subprocess
   tier for untrusted or heavy spaces (§6.6).
@@ -392,99 +373,146 @@ approach comparison honest.
 
 ### Approach A — Server catch-up executor (generalized background-piece-service)
 
-**Model.** Keep client behavior exactly as today. Promote
-`background-piece-service` into an executor pool (§6) that keeps *every*
-space with registered interest current — reactively, not on a 60s poll —
-and owns async builtins for spaces it runs. Clients still execute
-everything and still commit derived writes; the server is one more
-(privileged, always-on) participant whose job is to catch up spaces nobody
-has open and to complete async work that clients abandon.
+**Model.** Keep client behavior exactly as today while running the shared
+client-demand executor in observe-only mode. Its private replica may settle
+computations to discover the graph, but the provider rejects all upstream
+derived commits and external builtin effects. An explicit test capability may
+exercise redundant commits/effects; ordinary sessions never see it. This
+validates pool lifecycle, demand unioning, sponsor identity, the provider, and
+scheduler rehydration without transferring authority.
 
 **What changes.**
 
-1. bps's `SpaceManager` workers switch from websocket-to-self to the
-   in-process transport (§6.2) and from polling `bgUpdater` streams to
-   standing demand roots per registered piece.
-2. Async builtins gain an executor-priority rule: the server executor's
-   claim on the existing request-mutex cells
-   (`packages/runner/src/builtins/fetch-utils.ts:90`) always wins; client
-   claims are only taken when no executor is registered for the space.
-   (Cheap: raise the executor's claim precedence and shorten its heartbeat.)
-3. Piece registration generalizes from the BG registry cell to "any piece
-   in a space with executor service enabled" (§6.3 interest sets).
+1. Compatible client sessions export demand; the pool unions it into one
+   worker per eligible active space (§6.3).
+2. The worker uses the full executor-grade provider (§6.2) and reports the
+   actions it could claim without yet changing client authority.
+3. Async builtins can be exercised in test/opt-in spaces, but authority is
+   not transferred until the corresponding action claim is live.
 
-**Identity/CFC.** Unchanged for clients. The executor runs under a service
-identity that space owners grant WRITE (the existing bps model). Derived
-writes it produces carry the same verified implementation identities as
-client-produced ones (it runs the same modules), so `writeAuthorizedBy`
-gates pass identically. No event envelope needed because it never runs
-user-intent handlers — it only reacts to committed state.
+**Identity/CFC.** Unchanged for clients. The worker runs on behalf of an
+eligible requesting user, selected as described in §6.1, rather than an
+anonymous deployment executor. Background-only work keeps its distinct
+service identity and lower-priority lifecycle.
 
-**Failure modes.** Server executor down → exactly today's system. Client
-and executor race on derived writes → conflicts, as today, except the
-executor adds one more writer (slightly *more* contention). The mutex
-priority rule keeps async single-fire in the common case.
+**Failure modes.** Server executor down → exactly today's system. Ordinary
+shadow mode has no server data writes or external effects, so it adds no
+writer. The explicit test capability may observe conflicts and exercises
+existing mutex guards without creating a production authority window.
 
 **Perf.** No client-side win. Server cost: one runtime per active space.
 Subscription serving cost unchanged.
 
-**Verdict.** Not the destination — it does not remove races or client
-execution cost, and adds a writer. But it is the right **first milestone**:
-it builds the executor pool, the in-process transport, the interest
-registry, executor identity/grants, and async ownership — every piece of
-§6 — while being trivially revertible (turn the service off). It also
-immediately fixes the worst user-visible fragility (abandoned async work,
-cold spaces with pending timers/imports).
+**Verdict.** A short shadow-validation milestone, not a product phase. It
+does not remove races or client cost. Move promptly to positive action claims
+once equivalence and provider correctness are proven. Background-registry
+consolidation is later, but the exclusion interlock is immediate.
 
 ---
 
-### Approach B — Derived-authority split (proposed)
+### Approach B — Positive derived-authority split (proposed)
 
-**Model.** Writes are partitioned by origin:
+**Model.** Authority is per action, positive, and ephemeral:
 
-| Write class                                   | Authority        | Sync behavior |
-| --------------------------------------------- | ---------------- | ------------- |
-| Event-handler writes (user intent)            | client commits   | as today: optimistic local apply + commit + conflict retry |
-| Setup / seed-materialization structural writes | client commits   | part of the creating action's tx, as today |
-| Direct UI-binding writes (`$value` etc.)      | client commits   | they are user intent |
-| Computation / materializer (derived) writes   | **server only**  | client computes them into a local, never-committed overlay |
-| Async builtin request/result writes           | **server only**  | client renders `pending` state; server writes results |
-| PerSession / PerUser-scoped derived writes    | client commits (transitional) | executor-computed in a later phase, see B.6 |
+| Write class | Authority | Sync behavior |
+| --- | --- | --- |
+| Event-handler writes (user intent) | client | today's optimistic commit + retry |
+| Setup / seed structural writes | client | part of the creating action's tx |
+| Direct UI-binding writes (`$value`, etc.) | client | user intent |
+| Eligible same-space, space-scoped derivation | server **only while an exact `ExecutionClaim` is live** | client writes go to a local overlay |
+| Unclaimed, scoped, cross-space, render, or unknown actions | client | today's commit path |
+| Eligible async builtin request/result | server while claimed | client renders pending/overlay state |
 
-The server executor (§6) is the sole committer of space-scoped derived
-data. Clients keep running the derived graph *locally* for latency, but
-those writes terminate in an overlay: visible to the local UI and to local
-computations downstream, never shipped, always discardable.
+The fail-open default is therefore unchanged client authority. The server is
+the sole committer only for the actions it has positively claimed; there is
+no space-wide `derivedAuthority` bit and no client-maintained exception list.
 
-#### B.1 Client write path
+#### B.1 Demand, claims, and the client write path
 
-The runner tags every transaction with its originating action
-(`tx.sourceAction`, `packages/runner/src/scheduler/action-run.ts:348`,
-landed with #4099) and the node kind is known at subscribe time. §3.3.1
-generalizes this tag into the tx provenance envelope that also stamps
-`source` onto created docs — one channel, both consumers. The storage
-layer routes on it:
+At handshake the client must advertise the server-execution protocol version.
+An incompatible client is rejected rather than allowed to participate with
+stale authority rules. A compatible authenticated session exports
+`ExecutionDemand` for the pieces/docs it is pulling. The pool unions demand
+from all sessions; it does not create one worker per client (§6.1).
 
-- `event-handler` (and setup/seed) transactions → today's commit pipeline.
-- `computation`/materializer transactions → **overlay apply**: applied to
-  the local `ISpaceReplica` in a speculative layer keyed by
-  `(baseSeq, generation)`, never enqueued for upstream commit.
+After static eligibility checks and at least one successful shadow run, the
+control plane may publish an ephemeral claim:
 
-This is G5, the single biggest runner change in B, and it is smaller than
-it looks: the local-apply half already exists (optimistic apply precedes
-confirmation today); what is new is (a) the routing decision, (b) an
-overlay layer in the replica that can be dropped wholesale, (c) read
-layering (overlay > confirmed) for UI reads.
+```ts
+// Shown for illustration only.
+interface ExecutionClaim {
+  space: DID;
+  contextKey: SchedulerExecutionContextKey; // `space` in the first phase
+  pieceId: string;
+  actionId: string;
+  actionKind: SchedulerActionKind;
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  leaseGeneration: number;
+  claimGeneration: number; // fresh monotonic value for each claim issuance
+}
+```
 
-#### B.2 Server write path
+Claims ride the authenticated session/control feed and are not ordinary
+space documents. A durable policy may opt a space into server-primary
+execution, but runtime ownership, liveness, generations, and exceptions do
+not belong in mutable user data.
 
-The executor runs the same graph with the same scheduler; its
-computation/materializer transactions commit through the in-process engine
-(§6.2) under the executor identity. Every derived commit is stamped with a
-**derived-from watermark**: the max input `seq` consumed by the producing
-action — which is exactly `observedAtSeq` from the persistent-observation
-work, surfaced onto the commit via the §3.3.1 tx provenance envelope
-(G4/G10).
+The fields through `runtimeFingerprint` form the shared `ActionClaimKey` that
+both client and server can derive. `leaseGeneration` fences a Worker;
+`claimGeneration` identifies one incarnation of this action's authority and
+changes even when the same Worker revokes and reclaims it. The client runner
+routes by that exact identity:
+
+- event handlers, setup/seed writes, direct UI writes, and every action with
+  no matching claim use today's commit pipeline;
+- a claimed action applies its result to an `ISpaceReplica` overlay keyed by
+  lease generation, claim generation, and input basis, visible to local
+  downstream computation
+  but never enqueued upstream; and
+- server-confirmed claim removal/fingerprint mismatch restores client
+  authority and dirties the action for a normal rerun/commit.
+
+Connection loss is not proof that a claim ended: another requester may keep the
+shared Worker and claim alive. While disconnected, a client may continue local
+speculation but must not enqueue previously claimed derived writes. Reconnect
+first negotiates the capability and applies a complete claim snapshot at a feed
+sequence barrier; only then may newly unclaimed work flush. Source, handler,
+and direct UI commits keep their existing offline behavior.
+
+Trusted compatible clients cooperate with this split in the first iteration.
+Later server admission and CFC policy can reject commits that conflict with a
+live claim without changing the protocol shape.
+
+#### B.2 Server write path and whole-action servability
+
+The executor runs the scheduler-v2 graph through the executor-grade provider
+(§6.2) under a fenced `ExecutionLease`. It never calls raw engine mutation
+APIs around normal authorization. Its commits traverse the same authenticated
+principal, ACL, CFC preparation/validation, conflict, scheduler-observation,
+and feed-notification path as equivalent client commits, while avoiding wire
+and graph-watch overhead.
+
+Client speculation matches only the shared `ActionClaimKey`. After validating
+the lease, the server appends trusted `ActionExecutionProvenance` —
+`onBehalfOf`, lease/claim generations, causal sources, and `inputBasisSeq`.
+Those server-only fields are not inputs a client must predict to recognize a
+claim.
+
+Initial eligibility is deliberately narrow: the complete action transaction
+must read and write only the same space's space-scoped cells. Static output
+bindings, declared reads/writes, materializer envelopes, and the writer index
+reject known scoped, cross-space, render, or unknown surfaces before a claim.
+The provider additionally stages each claimed transaction behind a scope
+firewall. If any actual read or write crosses a space or effective scope, the
+whole transaction is discarded, the claim is revoked, and clients rerun the
+whole action authoritatively. Never split one action transaction between
+server- and client-authoritative operations.
+
+Async builtins are claimable only when their request and result surfaces pass
+the static check before the external effect starts. This preserves the same
+whole-action fallback rule without attempting to undo an external side
+effect.
 
 #### B.3 Handler reads: today's semantics, then dual execution
 
@@ -512,165 +540,179 @@ client's run is the speculative part, reconciled by the event's durable ID
 target for events rather than an escape hatch; B is the intermediate state
 in which only the handler's *writes* ship, not the event itself.
 
-#### B.4 Reconciliation protocol
+#### B.4 Reconciliation protocol: causal basis and settlement
 
-Client state per doc: `confirmed(seq)` from the feed, `overlay(gen)` from
-local speculation, plus its own pending source commits (localSeq). Rules:
+`observedAtSeq` is the sequence at which an observation commit was accepted;
+it is not proof of which inputs the action consumed. Each server run instead
+tracks `inputBasisSeq`, the maximum confirmed same-space input sequence
+actually read by that action. Derived patches carry that basis, and every
+claimed run produces an `ActionSettlement` on the control/feed path:
 
-1. Client applies its own source write locally → recomputes derived into
-   an overlay generation whose **basis** is the *latest* of the client's
-   own source commits the recompute consumed (with several in-flight
-   source commits, an overlay value reflecting L1 and L2 has basis L2).
-2. Server-derived commits arrive on the feed with watermark `W` = the max
-   input seq the producing action consumed. `W` is per derived commit
-   (per producing tx) and applies to the docs that commit writes. The
-   client's source commit `L` was assigned global seq `S(L)` at
-   confirmation (the confirmation already returns this); an overlay whose
-   basis commit is still unconfirmed cannot be dropped yet — its `S(L)`
-   does not exist until confirmation.
-3. For a derived doc: drop overlay entries whose basis `S(L) ≤ W` — the
-   server has seen everything the speculation was predicting. If `W <
-   S(L)`, keep the overlay (server hasn't caught up to my write yet); the
-   confirmed value updates underneath and the overlay recomputes from it.
-   Feed application is in nondecreasing seq order (a memory-v2 session
-   guarantee the interest feed must preserve — G7/W0.7), so the rule
-   never observes watermarks out of order.
-4. A source commit that is **rejected** (conflict → handler retry)
-   invalidates overlay generations based on it: discard them; the
-   post-retry recompute creates a fresh generation based on the retried
-   commit's newly assigned seq.
-5. Divergence (overlay ≠ confirmed at drop time) is *expected occasionally*
-   (cross-client interleaving, nondeterminism) and resolves in favor of the
-   server silently; it is a metrics counter, not an error.
+```ts
+// Shown for illustration only.
+type ActionSettlement =
+  | {
+    claim: ExecutionClaim;
+    inputBasisSeq: number;
+    outcome: "committed";
+    acceptedCommitSeq: number;
+  }
+  | {
+    claim: ExecutionClaim;
+    inputBasisSeq: number;
+    outcome: "no-op" | "failed" | "unserved";
+    acceptedCommitSeq?: never;
+  };
+```
 
-No new consistency primitive is required: watermark = `observedAtSeq`,
-`S(L)` = the commit-confirmation seq that memory-v2 already assigns. The
-seq-token draft (#4139) is this rule's ancestor and is subsumed by it.
+A no-op must still settle; otherwise a correct local overlay can wait forever
+for a derived patch that will never exist. Failure settles the attempt;
+`session.execution.claim.revoke` separately names and removes the currently
+live claimGeneration and dirties the client action. A later claim issuance
+gets the next generation. Cross-space execution, when admitted later, requires
+an input-basis vector rather than this scalar. A successful
+settlement is published only after the normal confirmed-read validation has
+accepted the data or observation-only transaction; `inputBasisSeq` is not an
+unverified Worker assertion. Commit patches, claim snapshots/revokes, and every
+settlement outcome share an ordered reconnectable feed with sequence barriers.
+A committed settlement always names its `acceptedCommitSeq`; if control arrives
+first, the client buffers it until its confirmed/feed cursor reaches that
+sequence. This is an additional data-application gate, not a substitute for
+control ordering. No-op has no data patch and is ordered after its accepted
+observation-only transaction.
 
-#### B.5 Async builtins
+Client state per doc is `confirmed(seq)`, speculative `overlay(claim,
+basis)`, and pending local source commits. An overlay based on an unconfirmed
+local commit stays until that commit receives global sequence `S(L)`. Once a
+matching settlement has `inputBasisSeq >= S(L)`, the server has consumed that
+source basis. For `committed` it drops the covered overlay only after applying
+`acceptedCommitSeq`; for `no-op` it drops after the ordered settlement. Exact
+lease + claim generation matching prevents a delayed settlement from an older
+claim incarnation clearing a newer overlay. Rejected source commits invalidate
+dependent overlays; handler retry creates a fresh basis. Divergence resolves
+silently in favor of the server and increments a metric.
 
-Builtins run **only** on the executor. Client-side builtin actions register
-in passive mode: they materialize `pending` from the request cells and
-never issue network work (deleting the cross-tab mutex dance). Streaming
-LLM partials are executor writes into the `partial` cell flowing down the
-ordinary feed (66ms batching + 5ms refresh ≈ visually identical). Request
-dedup collapses from "N tabs racing a cell mutex" to "one executor
-consulting its own in-flight table keyed by `(actionId, inputHash)`" —
-the key already exists (`{kind}:{inputHash}` effect idempotency,
-`packages/runner/src/cfc/types.ts:344`). Durable in-flight markers stay in
-the request cells so an executor restart resumes or re-issues
-deterministically (G12: streaming partials need either idempotent re-issue
-or durable chunk append; recommend re-issue for v1).
+#### B.5 Async builtins and egress parity
 
-#### B.6 Scoped state (PerUser / PerSession): transitional carve-out, not the end-state
+Claimed `fetch*` and `generate*` builtins run on the executor. Client-side
+instances remain passive for that claim and render pending/overlay state;
+streaming partials flow down the ordinary feed. Moving execution must not
+widen network reach relative to browser execution:
 
-Reader isolation is a storage-partition + ACL property (`user:<did>`,
-`session:<id>`), not a CFC-label property, so a space executor cannot read
-user partitions without new grants. The **end-state is that the executor
-computes scoped derivations too**: the trust-asymmetry goal (§5.B.7) wants
-*all* derived data — including user-scoped — to be executor-computed so
-its integrity can be endorsed for downstream consumers. Leaving scoped
-derivation on clients permanently would put the integrity hole exactly
-where the most personal data lives. That is more machinery, so it phases:
+- relative request paths resolve against the trusted serving origin for the
+  space and remain allowed, including a localhost serving origin in local
+  development;
+- absolute and authority-bearing inputs (including `//host/path`) are treated
+  as external and reject loopback, link-local, metadata, and private-network
+  destinations; DNS resolution and every redirect hop are revalidated. A
+  request that began relative remains trusted across redirects whose normalized
+  origin equals the canonical serving origin, even if `Location` is absolute;
+  any origin change becomes external and receives the full policy; and
+- the worker receives the canonical serving origin explicitly and must not
+  infer it from an internal memory-server address.
 
-- **Space-scoped only (initial B).** Scoped derivation stays
-  client-executed and client-committed as today; the executor's demand
-  roots exclude scoped subtrees (the scheduler already treats scope as
-  part of the address, so the graph partitions cleanly). Races within one
-  user's own tabs are the only residual derived races. In this phase the
-  executor's identity story is minimal: one principal + one WRITE grant
-  per space (G1/G2) — no impersonation, no delegation chains, no event
-  signatures.
-- **User-scoped on the executor.** Requires delegated read/write grants on
-  `user:<did>` partitions — granted by the *user*, not the space owner
-  (G3) — and per-user demand roots inside the space worker (or per-user
-  sub-sessions of it). This is where G3's delegation machinery enters B's
-  own roadmap rather than being C-only.
-- **Session-scoped on the executor.** Natural once events ship down
-  (§5.B.3 end-state): the event stream carries session identity, so the
-  executor can maintain live per-session subtrees for connected sessions;
-  session state of *disconnected* sessions has no consumers by
-  construction.
+A host egress broker is preferred so workers need no broad network
+permission. Direct builtin execution is acceptable only when it enforces the
+identical policy. Pattern code in SES has no raw-fetch escape from the builtin
+path. Full durable streaming, quotas, cross-engine idempotency, and circuit
+breakers follow after the move; v1 need only preserve current retry and
+deduplication behavior without making it worse.
 
-One consequence elsewhere in the stack:
+Identity-sensitive first-party calls must not silently use whichever sponsor
+currently owns the space. Their broker request carries the server-derived
+`onBehalfOf` from the authenticated request-producing commit. In v1 that actor
+must match the current lease sponsor; a mismatch or ambiguous origin makes the
+builtin unclaimable (or requires a fenced sponsor handoff). Per-action actor
+multiplexing waits for delegated execution contexts.
 
-- Executor-computed scoped writes need the same endorsement treatment as
-  space-scoped ones (§5.B.7): the integrity claim is "computed by the
-  trusted executor from these inputs", regardless of scope.
+#### B.6 Scoped state: explicit first-phase boundary
 
-#### B.7 Identity and CFC
+The first phase claims only provably same-space, space-scoped actions.
+PerUser, PerSession, cross-space, render, and statically unknown actions stay
+client-authoritative. The guarantee does not depend on predicting the whole
+graph: clients run the complete graph by default, and only exact claims
+suppress an action's commits. The static eligibility check plus the staged
+transaction firewall catches dynamic behavior before apply and revokes the
+whole claim.
 
-- The executor's derived writes carry the verified implementation identity
-  of the module that produced them — the same WeakMap-provenance modules
-  the client would have run — so `writeAuthorizedBy` and structural
-  provenance gates behave identically
-  (`packages/runner/src/cfc/prepare.ts:310–481`).
-- Flow labels are data-derived, so a trusted executor reading space-scoped
-  inputs and emitting labeled outputs is CFC-coherent; D4 (per-write
-  prefix provenance) applies unchanged.
-- New: mint a **first-class executor principal** per deployment (precedent:
-  the constant `cf-compiler` atom), granted per space by owners on opt-in;
-  its writes are attributable and revocable (G1, G2).
-- **Integrity endorsement of computations.** Because the executor is more
-  trustworthy than any client, its derived commits can mint an endorsement
-  atom — *executor-computed* — analogous to `LlmDerived` /
-  `ExternalIngest`, carrying the producing action identity and the input
-  watermark. Downstream consumers (other patterns, egress gates, and
-  verifiable-execution receipts later) can then *require*
-  executor-computed integrity for sensitive flows — a claim
-  client-computed derived data could never honestly make. This is a
-  first-class reason for server-primary execution, not a side effect
-  (G1 extends to cover the atom), and it is why scoped derivation must
-  eventually move to the executor too (§5.B.6).
-- Trusted-event gates (`uiContract`) still fire on clients, where the DOM
-  events are — B never needs a serialized event proof.
+Supporting every scope immediately would require principal-aware runtime
+contexts and scheduler lanes: one shared space lane, per-user lanes, and
+per-session lanes, with all replicas, transactions, indexes, dirty matching,
+and CFC context qualified by `SchedulerExecutionContextKey`. The prerequisite
+in §3.2.1 fixes durable metadata collisions but does not by itself make a
+single Runtime switch acting principal per action. Scoped execution therefore
+remains a later phase rather than complicating the first server path.
+
+#### B.7 Identity, provenance, and CFC
+
+Client-demand execution is never signed by an anonymous executor principal.
+The pool derives a short-lived `ExecutionLease` from one authenticated,
+WRITE-capable requesting session. The worker acts as that principal and every
+derived commit records `onBehalfOf: <user DID>`. The host retains the
+credential/provider binding; it does not hand the user's private key to the
+worker. A future user-delegated execution key can replace the session-derived
+lease.
+
+`onBehalfOf` is execution authority, not semantic authorship. Provenance also
+records the producing action and causal source commits/principals. The module's
+verified implementation identity and ordinary CFC labels/gates remain
+unchanged. A future `executor-computed` endorsement must be specified by CFC
+owners; it is not required to move execution in this trusted-client phase.
+
+Background-only execution is the sole use of the existing service identity
+and is separately attributable. It never signs client-pulled work.
 
 #### B.8 Failure modes
 
-- **Executor down / space not served:** flag flips the space back to
-  today's mode (clients commit derived writes again). This must be a
-  per-space runtime switch, not a deploy — it is also the migration lever
-  (§8). Anti-flap: the switch is sticky per epoch so clients and executor
-  don't disagree about who owns derived data (G5b: the ownership bit lives
-  in space config, versioned by seq like everything else). Flips are
-  eventually consistent: clients act when they *observe* the new config
-  through the feed, so a brief dual-writer window exists in either
-  direction; ordinary conflict resolution plus the executor's recompute
-  make it converge, and v1 adds no server-side epoch fencing on commit
-  admission (revisit only if measured flip churn warrants it).
-- **Client offline:** source writes queue (pending commits), overlay keeps
-  the UI coherent; on reconnect the server catches up. True offline
-  (persisted pending queue) remains a separate, orthogonal gap — the
-  replica is in-memory today.
+- **Executor down / space not served:** its lease expires or is revoked and
+  claims disappear. Clients dirty those actions and commit them normally.
+  No mutable config flip or negative exception propagation is required.
+- **Competing/replaced worker:** every claim and commit is fenced by
+  `ExecutionLease.leaseGeneration`; the provider rejects a stale generation.
+  Within one lease, revoke names the action's live `claimGeneration` and the
+  next claim issuance increments it, so delayed settlement cannot target the
+  new incarnation.
+- **Sponsor disconnect:** the worker finishes a bounded in-flight settle,
+  drains, and restarts under another eligible requester. It does not change
+  Runtime principal mid-settle.
+- **Client offline:** source writes queue (pending commits) and local overlays
+  keep the UI coherent, but previously claimed derived writes do not flush
+  merely because the connection disappeared. Reconnect applies the
+  authoritative claim snapshot before derived work resumes. True offline
+  (persisted pending queue) remains a separate, orthogonal gap — the replica
+  is in-memory today.
 - **Executor crash mid-settle:** observations persist per commit;
-  restart rehydrates and re-runs only actions whose inputs moved. Bounded
-  by scheduler-v2's budget + backoff gates.
+  claims are revoked, then a replacement rehydrates and reclaims only after
+  successful catch-up. Bounded by scheduler-v2's budget + backoff gates.
 - **Divergent speculation:** silent server-wins; counted.
 
 #### B.9 Performance model
 
 Per space with C connected clients, piece graph of size G, event rate E:
 
-- Executor compute: 1 × G-scaled settle work (vs C× today), plus event
-  commit validation (unchanged).
-- Client compute: UI-relevant subset of G, discardable; can be *lazily
-  warmed* — first paint can come entirely from server-derived state, then
-  local speculation warms up in the background. The browser compile wedge
-  leaves the critical path (it only gates speculation warm-up and handler
-  execution, and handlers compile per-module on demand).
-- Server subscription serving: from O(commits × sessions × graph re-eval)
-  to O(commits × sessions × set-membership + patch size) — §6.4.
+- Executor compute: one unioned server scheduler's settle work plus today's
+  client schedulers during the initial authority split. The first rollout adds
+  server compute so it can remove duplicate commits and external effects; it
+  does not yet remove N× local speculative computation.
+- Client compute: the complete graph still runs by default so unsupported
+  actions and immediate overlays remain correct. A later, separately gated
+  closure/claim-snapshot optimization may leave remotely owned actions cold
+  until local speculation demands them. First paint therefore retains today's
+  browser compile path; zero-execution first paint requires D/projector output.
+- Server subscription serving: today's graph-query path remains for unclaimed
+  actions. After exact closure parity (§6.4), claimed closures can move toward
+  O(commits × sessions × set-membership + patch size).
 - Store: derived docs written once per change (by the executor) instead of
   once per client + conflict retries.
 - New costs: executor pool memory (∝ active spaces; hibernation via
   persisted state, §6.5), and the feed fan-out (cheap: doc-id filtering).
 
-**Verdict.** B delivers the goal — no derived races, reliable async, cheap
-clients — with the smallest protocol change that gets there: the wire keeps
-exactly today's commit + confirmation + feed shapes, plus one watermark
-field and one interest declaration. Its risk concentrates in the runner
-(the write split + overlay, G5) and the executor pool (§6), both of which A
-de-risks first.
+**Verdict.** B delivers authority transfer incrementally. Every exact claim
+removes redundant wire writes and duplicate external effects; every unsupported
+or failed action remains on the known client path. Removing duplicate local
+compute and browser cold-start work is a later optimization, not a claimed v1
+benefit. B's main additions are authenticated demand, fenced leases, ephemeral
+claims, the overlay, and explicit settlements.
 
 ---
 
@@ -704,7 +746,7 @@ the event's ack (durable event IDs from #4088 give the ack identity).
 - Handler authority semantics: the handler runs server-side but must act
   *as the user* for CFC (`ownerPrincipal` minting, per-user partition
   writes from handlers, trusted-event-gated `uiContract` fields). That
-  means either delegation tokens (G3) or re-deriving "acting-as" from the
+  means either delegation tokens (G16) or re-deriving "acting-as" from the
   envelope — new CFC surface that B avoids entirely.
 - Latency floor: input → authoritative effect now includes a round-trip
   *before* the handler runs; speculation hides it for display, but any
@@ -752,27 +794,46 @@ update is a round-trip unless the pattern splits interactive state into
 PerSession cells — most don't today); PerSession/render entanglement
 (render effects read session state); and it maximizes the identity surface
 (everything C needs). Revisit after B, as "projector mode" for cold start
-(§8 phase 3) rather than as the execution model.
+after render output has a durable document representation, rather than as
+the execution model.
 
 ---
 
 ## 6. The server executor (shared architecture for A/B/C/D)
 
-### 6.1 Topology: worker-thread-per-space, co-located with the engine
+### 6.1 Topology: one unioned, user-sponsored worker per active space
 
-One **executor pool** service co-resident with the memory engine (initially
-inside toolshed; separable later). Per *active* space: one Deno Worker
-running one Runtime — the bps shape
-(`packages/background-piece-service/src/worker-controller.ts:78`), kept for
-three reasons: realm isolation is *required* (two runtimes in one realm
-cross-talk through verified-load registries and break CFC identity — the
-multi-runtime-harness lesson, `packages/patterns/integration/multi-runtime-harness.ts:20`);
-a worker is a natural unit of resource accounting and crash isolation; and
-worker-per-space makes the executor the **single writer of derived data per
-space**, which is what deletes the races. Workers, not subprocesses, by
-default: bps proves the model, spawn is cheap, and structured-clone IPC to
-the engine thread is enough. A subprocess tier stays on the menu (§6.6) for
-hard isolation once pattern code is less trusted than today.
+One **executor pool** service is co-resident with the memory engine (initially
+inside toolshed; separable later). Per active space there is at most one
+authoritative Deno Worker generation running one Runtime — the bps shape
+(`packages/background-piece-service/src/worker-controller.ts:78`). Realm
+isolation is required, and a worker remains a natural unit of resource
+accounting and crash isolation. Most importantly, one scheduler instance
+unions `ExecutionDemand` from every connected client; there is never one
+worker per connection.
+
+The pool chooses one authenticated, WRITE-capable requester as a sticky user
+sponsor. Prefer the principal whose commit wakes a cold worker when that
+principal still has active demand; otherwise choose deterministically from
+eligible requesters. Runtime/StorageManager identity is construction-wide, so
+the sponsor does not switch per causal wave. Sponsor loss drains and restarts
+the worker under a replacement rather than mutating its principal in place.
+
+The pool owns a fenced `ExecutionLease(space, leaseGeneration, onBehalfOf)`.
+Only its generation may publish claims or commit through the provider. This
+is the single-owner coordination primitive even if the pool later spans
+multiple processes; a heartbeat document alone is not sufficient.
+
+Background-only demand is a distinct, lower-priority mode. A background
+generation uses the existing service identity and claims only background work;
+it never signs client-pulled execution. Before the registry is unified, a
+mandatory exclusion interlock makes any branch/space with a legacy background
+registration, controller, or lease ineligible for the new client-demand pool.
+It stays on existing behavior and receives no server-primary claim. Phase 3
+imports that demand into this same slot and removes the exclusion; only then
+may client demand preempt a background generation. Registry cleanup is not a
+prerequisite, but preventing two server runtimes is. A subprocess tier remains
+optional for hard isolation.
 
 Threading note: the engine's SQLite reads are synchronous FFI on the engine
 thread; executor workers do **not** open the database. They talk to the
@@ -781,21 +842,24 @@ engine assumption and keeps WAL discipline in one place.
 
 ### 6.2 Storage transport: in-process, no subscriptions
 
-Stage 1 (zero new code): executor workers connect via the `loopback`
-transport (`packages/memory/v2/client.ts:1299`) to the same `Server` object
-— functionally correct, still pays session/watch machinery.
+An initial prototype may connect through the `loopback` transport
+(`packages/memory/v2/client.ts:1299`) to the same `Server`, but authority
+cannot transfer through a raw `Engine` shortcut.
 
-Stage 2 (the real design): an **executor-grade provider** implementing
+The production design is an **executor-grade provider** implementing
 `IStorageProviderWithReplica` (`packages/runner/src/storage/interface.ts:264`)
 that (a) reads through the engine's read pool directly
 (`packages/memory/v2/server.ts:711`) with MessageChannel batching, (b)
-commits via `applyCommit` directly, and (c) receives invalidations from the
-engine's commit stream as a per-space callback — **not** via
-`session.watch` graph queries. The executor's own scheduler trigger index
-is the subscription; the engine just tells it "space S, commit at seq N,
-docs D₁..Dₖ changed". This is the "replace the cell-get mechanism with
-reading the local sqlite" goal, expressed at the provider seam so the
-runner is unchanged.
+commits through the server's canonical validated apply path, and (c) receives
+invalidations from the engine commit stream as a per-space callback — not via
+`session.watch` graph queries. It preserves authenticated `onBehalfOf`, ACL
+checks, CFC preparation/validation, conflict checks, `ExecutionLease`
+fencing, scheduler-state updates, and feed hooks. In-process means
+transport-efficient, not policy-bypassing.
+
+The executor's scheduler trigger index is its subscription; the engine tells
+it "space S, commit at seq N, docs D1..Dk changed". The provider buffers a
+claimed transaction until whole-action scope validation succeeds (§5.B.2).
 
 ### 6.3 What runs: demand, not pieces
 
@@ -808,16 +872,16 @@ protocol needs; the client just pulls data.
 
 A space is *active* when any of:
 
-1. **Client-read demand:** the docs a client session reads — which is
+1. **Authenticated client-read demand:** the docs a client session reads — which is
    exactly the session's feed set (§6.4), so the server already holds it;
    in the limit no separate declaration protocol is needed. v1 grain is
-   coarser — a `session.interest.set {space, pieces: <ids> | "*"}`
-   message replacing `session.watch.set` (G7) — because a standing
+   coarser — an authenticated `ExecutionDemand {space, pieces}` message
+   replacing `session.watch.set` (G7) — because a standing
    per-doc pulled-set export from clients doesn't exist yet
    (`.pull()` is one-shot, `packages/runner/src/cell.ts:1032`). The
    message is a granularity hint over the doc-centric model, not the
    model.
-2. **Standing registrations:** pieces whose value is their effects rather
+2. **Standing registrations (lower priority):** pieces whose value is their effects rather
    than client-read outputs (importers, BG work, timers, webhook
    targets) — today's bps registry generalized. These are the only place
    a piece-shaped declaration survives, because no pulled doc can imply
@@ -826,68 +890,70 @@ A space is *active* when any of:
    **persisted read index** maps to some demanded-but-parked downstream
    (the §3.2 readers index) — wake, catch up, hibernate.
 
-Serving a demanded doc: if it is stale (readers/write-index watermark),
-the `source`→`pattern` walk on the doc (§3.3) names the producing piece;
-the worker instantiates it — rehydrated, so nothing re-runs except the
-stale subgraph — and pulls **that doc**, not the piece's whole result
-graph. The piece survives only as the code-loading unit
-(`patternIdentity` → module), the observation key (`pieceId`), and the
-CFC identity context — not as a scheduling concept. Per-piece demand
-roots (pull the piece's result cell) are the v1 *implementation* — a
-coarse over-approximation of the demanded doc set — and narrow to
-per-doc pulls as interest granularity improves.
+Serving a demanded doc: `scheduler_write_index` identifies candidate actions
+by effective address/path and joins them to durable action state (§3.3). The
+worker loads the piece through `patternIdentity`, rehydrates scheduler-v2,
+and pulls that doc. Per-piece demand roots are the v1 implementation and a
+safe over-approximation. If no writer row exists, declared piece demand
+supplies the cold-start code-loading unit; the server shadows it without
+claiming until its surfaces are known.
 
-Always excluded from executor demand: scoped subtrees (B.6, until the
-scoped-execution phase) and render effects (unless projector mode is
-on).
+Claims exclude scoped/cross-space subtrees and render effects in the first
+phase. Those actions remain part of the client graph; absence of a claim keeps
+them client-authoritative.
 
 ### 6.4 Client feed (replacing graph-query subscriptions)
 
-Per session: the union of interest closures — maintained **by the
-executor's scheduler** (it already holds every interested piece's read
-closure as node reads; exported per piece, updated on read-delta) — becomes
-a doc-id set in the engine. Commit fan-out is then: for each affected
-session, set-membership filter → push patch ops (+ derived watermark). The
-per-session graph re-evaluation (`refreshTrackedGraph`) disappears for
-executor-served spaces; the session catch-up path (`fromSeq`/`toSeq`,
-`packages/memory/v2/server.ts:2187`) already handles reconnect. Cross-space
-links: the closure naturally names remote docs; the feed for those rides
-the same session against the other space (unchanged semantics, G9 for the
-executor's own cross-space reads).
+During the shadow and first authority-split phases, the existing client
+`session.watch` path remains authoritative for every unclaimed action. The
+server scheduler exports exact read closures only for actions it actually
+serves; those doc ids are unioned with the session's existing interest, and
+matching `ExecutionClaim` / `ActionSettlement` records ride the same ordered
+control/data path. This lets execution move before feed discovery is complete.
+
+Graph-query re-evaluation may be retired only when every demanded action has
+one of two complete closure sources: a server-served scheduler observation or
+an exact client-exported closure. Scoped, cross-space, render, or otherwise
+client-primary actions keep today's watch behavior until that proof exists.
+At that point commit fan-out becomes set-membership filtering plus patch/control
+payload size, while the existing `fromSeq`/`toSeq` catch-up path continues to
+handle reconnect. Cross-space client links continue riding the requesting
+user's ordinary session against the other space.
 
 ### 6.5 Lifecycle: spawn, catch-up, liveness, hibernate
 
 **Spawn triggers** — a space worker starts when any of:
 
-1. **Interest:** a client session opens/declares interest in an
-   executor-enabled space (Phase 1: registry entries; Phase 3:
-   `session.interest.set`), or an administrative warm-up (CLI, deploy
-   pre-seed).
+1. **Demand:** a compatible authenticated client session publishes
+   `ExecutionDemand`, or an administrative warm-up supplies an eligible user
+   sponsor.
 2. **Wake-on-commit:** a commit lands whose written docs have stale
    interested readers per the readers index (§3.2). This subsumes
    webhook/ingest ingress — ingest is itself a commit.
-3. **Async continuation:** executor restart finds request cells still
-   marked in flight (resume/re-issue per G12).
-4. (Future) server-side timers.
+3. **Async continuation:** an existing claimed request remains in flight.
+4. **Background-only demand (Phase 3):** lower-priority standing registration,
+   using the background identity rather than a client sponsor. Until registry
+   import, such a registration triggers the exclusion interlock rather than a
+   second pool Worker.
+5. (Future) server-side timers.
 
 **Spawn sequence** (ordered; the order is load-bearing):
 
 1. Pool capacity check; at cap, evict the idlest live worker (eviction =
    ordinary hibernation, below).
-2. `new Worker(...)` (the bps `worker-controller.ts` shape) + handshake:
-   space DID, executor signer, provider `MessageChannel` port, flags.
+2. Choose a sponsor, acquire/fence the `ExecutionLease`, then create the
+   Worker with space DID, `onBehalfOf`, lease generation, provider
+   `MessageChannel`, and negotiated flags. No raw user key enters the Worker.
 3. The pool registers the engine's `onSpaceCommit(space)` callback and
    starts BUFFERING batches for the worker BEFORE the worker settles
    anything — no notification gap between the rehydration snapshot and
    the live stream.
-4. The worker builds the runtime (in-process provider,
-   `persistentSchedulerState`, executor identity), rehydrates observations
-   for the interested piece set, computes the stale set (`observedAtSeq`
-   vs branch head), and pulls stale pieces; missing/invalid observations
-   degrade to a full pull of that piece (fail-open).
-5. The worker reports "live at seq S"; the pool releases the buffered
-   stream from S. It also registers `onSpaceCommit` for every OTHER
-   space in the pieces' read closures (§6.8).
+4. The worker builds the runtime through the validated provider and rehydrates
+   context-qualified observations for the demanded piece set. Dirty state and
+   confirmed input revisions determine the stale set; missing/invalid rows
+   degrade to a full unclaimed pull (fail-open).
+5. The worker reports "live at seq S"; the pool releases buffered commits
+   from S. Eligible actions shadow-run before claims are published.
 
 Cold-start cost ≈ pattern load (compileCache by identity,
 single-flighted, plus a process-wide disk byte cache; pre-seed system
@@ -908,7 +974,7 @@ below are that policy's defaults, not requirements.
 
 **Liveness — what keeps a worker alive:**
 
-- Live client interest pins the worker (default policy; under memory
+- Live client `ExecutionDemand` and its sponsor lease pin the worker (default policy; under memory
   pressure the pool MAY hibernate pinned-but-quiescent workers anyway —
   wake-on-commit keeps that correct, only latency suffers).
 - In-flight async builtin work pins it past idle, bounded by the builtin
@@ -917,36 +983,30 @@ below are that policy's defaults, not requirements.
 - Otherwise, `idleTimeout` (default 10 min — the existing bps worker
   timeout) of no commits, no dirty work, `settled()` resolved, and no
   interest → hibernate.
-- **Catch-up without spin-up:** if the readers index shows no interested
+- **Catch-up without spin-up:** if the readers index shows no demanded
   piece downstream of a commit, do nothing (the doc is stale but nobody
-  cares — pull semantics, now durable). When a stale doc *is* demanded,
-  the `source`→`pattern` walk on the doc itself names the piece to wake
-  (§3.3), even with no scheduler state at all — contingent on G6 stamping
-  coverage for that doc.
+  cares — pull semantics, now durable). When a stale doc is demanded, the
+  writer index plus declared piece demand names candidates to wake (§3.3).
 - **Hibernate** (the drain protocol): mark the space *draining* in the
   pool and record the worker's last-settled seq (wake decisions treat
   draining spaces as having no worker and compare incoming commit seqs
   against it) → `runtime.settled()` → tear down the space's storage
-  (`StorageManager.closeSpace` — in-flight with PR #4115, not on main) →
-  terminate the worker → the pool re-checks for commits past the
+  through the provider's per-space teardown seam → terminate the worker →
+  the pool re-checks for commits past the
   last-settled seq and respawns immediately if any landed during the
   drain. A parked space holds zero memory; its whole scheduler state is
   the observation rows.
 - **Crash and quarantine:** worker error → restart with exponential
   backoff; after N consecutive failures the space is quarantined (not
-  served) with an operator alert — and, critically, quarantine
-  auto-flips `derivedAuthority` back to `"client"` (W2.1) so a B-mode
-  space degrades to today's client-computed behavior instead of its
-  derived data stalling. Un-quarantine is manual (runbook, W2.6).
+  served) with an operator alert. Revoke its lease and claims first, so
+  clients immediately resume normal commits. Un-quarantine is manual.
 
 ### 6.6 Isolation and resources
 
-- Pattern leaf code still runs in SES inside the worker (same sandbox story
-  as clients). Deno worker permissions
-  pin the executor's net access to the engine channel + toolshed-internal
-  routes (LLM proxy); pattern-level `fetch` egress goes through the fetch
-  builtin, now server-side — apply per-space egress policy + the #2659-style
-  throttles there (G11).
+- Pattern leaf code still runs in SES inside the worker. Pattern network and
+  generation operations are exposed only through `fetch*` / `generate*`
+  builtins. Prefer a host broker and no broad Worker network permission;
+  direct builtin execution is acceptable only with the exact §5.B.5 policy.
 - Budgets per worker: memory cap, settle-pass budget (scheduler-v2), event
   lane depth, async concurrency (`runtime.getOrCreateQueue`). A space that
   exhausts budgets degrades to catch-up-on-demand rather than starving the
@@ -965,18 +1025,17 @@ commits it describes. The design therefore treats **SQLite as the
 primary store of scheduler state, and worker memory as a materialized
 view** rebuilt on demand:
 
-1. **Primary tier — SQLite, transaction-coupled.** The observation rows
-   (reads / writes / `observedAtSeq` / gate options per action,
+1. **Primary tier — SQLite, transaction-coupled.** The context-qualified
+   observation rows (reads / writes / `observedAtSeq` / gate options per action,
    `packages/runner/src/scheduler/persistent-observation.ts:22`), the
    read/write indexes, and `scheduler_action_state` including dirty
    markers — written in the same transaction as the commits they
    describe. Consumers: rehydration on spin-up, wake-on-commit (the
    engine answers "does this commit make any parked piece stale?" with
-   one indexed lookup, no worker running), the derived-from watermark on
-   commits (§5.B.4), and workset reconstruction (below). The *producer*
-   direction is not part of this tier at all: `source`/`pattern`
-   annotations ride the docs themselves (§3.3) — write-side provenance is
-   ground truth, not an index.
+   one indexed lookup, no worker running), producer lookup through
+   `scheduler_write_index`, and workset reconstruction. `inputBasisSeq` is
+   collected from actual confirmed reads during a run; it is not inferred
+   from `observedAtSeq`.
 2. **Cache tier — memory, per live worker.** The RAM residue, enumerated
    — everything here is rebuildable from tier 1, which is what makes the
    transient executor pass (§6.5) legal:
@@ -1009,13 +1068,12 @@ per-commit state updates *are* the flush.
 
 Rules that keep this sound:
 
-- **Disk is an index of ground truth, not ground truth.** Commits and
+- **Disk projections are indexes of ground truth, not ground truth.** Commits and
   revisions remain the durable record; observations are a
   transaction-coupled projection of them. Because observation writes ride
   the same commit, the readers index can never be ahead of or behind the
-  data it indexes — and the producer direction is carried *inside* the
-  data (`source`/`pattern` annotations), so it cannot drift by
-  construction.
+  data it indexes. Context keys and effective scope keys prevent scoped
+  projections from overwriting or dirtying a different user/session.
 - **Fail-open to recompute.** Missing, stale, or corrupt observations
   degrade to re-running actions (the persistent-scheduler-state spec's
   invariant: never incorrect cleanliness, at worst wasted recompute). The
@@ -1030,67 +1088,28 @@ Rules that keep this sound:
   synchronous FFI). SQLite-primary sets the *authority* order, not the
   hot-path data flow.
 - **Growth and compaction.** The action snapshot is last-write-wins per
-  `actionId`; no-op observations are elided (`payloadChanged` gating,
+  `(SchedulerExecutionContextKey, actionId)`; no-op observations are elided (`payloadChanged` gating,
   `schedulerObservationBatch` — shipped); a space's rows drop wholesale
   with the space. The `scheduler_observation` history table is the one
-  unbounded-growth surface — compaction policy is an adopt-phase question
-  (W0.1 records it).
+  unbounded-growth surface; compaction remains a separate storage-maintenance
+  question.
 
 ### 6.8 Cross-space
 
-A piece's graph may read — and occasionally write — docs in other spaces
-(links carry the space; the scheduler's read log and trigger index are
-space-qualified addresses already). v1 scope: spaces hosted by the same
-deployment; federation is noted at the end.
+The scheduler may discover foreign-space reads or writes only at runtime.
+That uncertainty is why v1 authority is positive and whole-action: any known
+cross-space surface prevents a claim, and any dynamically discovered one
+causes the staged transaction to abort and its claim to be revoked. Clients
+then rerun and commit the complete action exactly as today. There is no
+`unservablePieces` document and no stale window waiting for an exception to
+propagate.
 
-- **Read authority (the policy).** The executor principal can read space
-  B iff B is executor-enabled (the per-space grant, G2, implies READ for
-  the deployment's principal), so cross-space reads between
-  executor-enabled spaces just work. A subgraph that reads a NON-enabled
-  space is **unservable**: the executor cannot compute it, and under B
-  nobody else may — so unservable subgraphs stay client-authority. v1
-  granularity is the piece: when the executor hits an ACL-denied
-  cross-space read while serving piece P, it records P in
-  `executorConfig.unservablePieces` (it has WRITE on the config doc;
-  versioned/epoch-bumped like the ownership bit). Clients already
-  subscribe to the config (W2.1) and route P's derived writes as
-  client-authority. There is a bounded first-discovery window (executor
-  denied, clients not yet re-routed → P's derived data is stale until
-  the exception propagates); it self-heals via the config write.
-  Exceptions retry on config epoch bumps (e.g. when B later opts in).
-- **Scoped cross-space state** — the known pathological case
-  (reader-isolated cross-space PerUser docs drove a measured ~270×
-  re-run amplification in earlier experiments) — is already excluded by
-  the scope carve-out (W2.5): the executor never demands scoped
-  subtrees, local or remote.
-- **Derived writes into another space.** Rare — cross-space writes are
-  mostly handler-driven, and handler writes are client-committed source
-  writes, unchanged. When a derived/materializer write targets
-  executor-enabled space B from A's worker, it commits to B under the
-  same principal. A's and B's workers are then occasional co-writers of
-  B — accepted: same trusted principal, ordinary conflict resolution,
-  convergent; the same argument as the authority-flip window (§5.B.8).
-  If B is not enabled, the subgraph is unservable (above).
-- **Invalidations and wake.** A live A-worker registers `onSpaceCommit`
-  for every space in its read closure and lets its trigger index filter.
-  For PARKED pieces, wake-on-commit must find cross-space readers, so
-  the readers index is **deployment-level engine infrastructure**, not
-  per-space data: keyed by target `(space, docId)` →
-  `(readerSpace, pieceId, actionId, observedAtSeq)` (W0.2). Same-space
-  rows ride the observation transaction; cross-space rows either fold
-  into the same transaction via the engine's existing ATTACH mechanism
-  (it already attaches cell-dbs during `applyCommit`) or are written
-  async with fail-open semantics — a missed cross-space wake means
-  "stale until demanded", never wrong data.
-- **Client feed:** unchanged — the interest closure names remote docs,
-  and the feed for those rides the client's own session against the
-  other space (§6.4).
-- **Federation (later).** When spaces live on different hosts (the
-  loom-federation line, #4115), a worker's cross-space providers degrade
-  from in-process to remote sessions — the same provider seam — and the
-  readers index stops being deployment-global: cross-host wake becomes
-  an explicit subscription between deployments. Out of scope here; the
-  unservable-piece mechanism is the fallback in the meantime.
+Client feeds continue following remote links through the requesting user's
+ordinary sessions. Server-side cross-space reads may be added later after
+permission continuity, multi-space input-basis vectors, wake subscriptions,
+and ownership are specified. Cross-space derived writes additionally need
+coordination between both spaces' executor leases; ordinary convergent
+co-writing is not sufficient for server-primary authority.
 
 ---
 
@@ -1098,71 +1117,69 @@ deployment; federation is noted at the end.
 
 | Criterion | A catch-up | B derived split | C event shipping | D projector |
 | --- | --- | --- | --- | --- |
-| Removes derived-data races | no (adds a writer) | **yes, structurally** | yes | yes |
-| Removes redundant N× compute | no | yes (client compute optional) | yes | yes |
-| Async reliability | **yes** | yes | yes | yes |
+| Removes derived-data races | no (shadow only) | **yes, structurally** | yes | yes |
+| Removes redundant N× compute | no | later client-suppression phase | later client-suppression phase | yes |
+| Async reliability | no (shadow only) | yes | yes | yes |
 | Input→display latency | today | today (overlay) | today (speculation) | +RTT |
 | Chained handler reads | today | today's retry semantics | authoritative | authoritative |
-| Client cold start | today | fast (server state first, warm later) | fast | **fastest** |
-| Subscription serving cost | today | set-membership feed | set-membership feed | set-membership feed |
-| New identity machinery | WRITE grant | executor principal + WRITE grant (+ user-partition delegation in the scoped phase) | + signed envelopes | same as C |
+| Client cold start | today | today; zero-exec requires D | today; zero-exec requires D | **fastest** |
+| Subscription serving cost | today | today, then narrower feed | set-membership feed | set-membership feed |
+| New identity machinery | session-derived lease | user-sponsored fenced lease + `onBehalfOf` | + signed envelopes | same as C |
 | CFC surface touched | none | none new (labels data-derived) | trusted-event + acting-as | same as C |
 | Runner changes | small | **write split + overlay (G5)** | + event serialization | + render split |
-| Offline degradation | today | graceful (flag back per space) | needs envelope queue | poor |
-| Incremental deliverability | **high** | high (per-space flag) | medium | low |
-| Revertibility | trivial | per-space flag | protocol migration | protocol migration |
+| Offline degradation | today | source queue + claim-resync barrier | needs envelope queue | poor |
+| Incremental deliverability | **high** | **high (per-action claims)** | medium | low |
+| Revertibility | trivial | revoke claims | protocol migration | protocol migration |
 
-**Recommendation.** A → B → scoped execution → dual handler execution,
-with C's envelope designed (not built) from the start:
+**Recommendation.** Context-key fix → shadow executor → B claims → scoped
+execution → dual handler execution:
 
-1. **A** builds the executor pool, in-process provider, interest registry,
-   executor identity/grants, and async ownership — all §6 — with zero
-   client-protocol risk, and immediately fixes async fragility.
-2. **B** flips derived authority per space behind a flag once the §9
-   runner gaps close. It removes the races the whole exercise is about
-   while keeping today's wire shapes and CFC model essentially intact.
-3. **Scoped execution** extends B to user-scoped derivation via delegated
-   grants (G3), then session-scoped once events ship — closing the
+1. **Correct #4288 scheduler context keys** before durable rows drive server
+   ownership or wake decisions (§3.2.1).
+2. **Shadow A briefly** to validate one unioned user-sponsored worker,
+   provider parity, rehydration, and eligibility without suppressing clients.
+3. **B** publishes claims action by action. Eligible async builtins move with
+   their claims; unsupported actions remain unchanged on clients.
+4. **Scoped execution** extends B to user-scoped derivation via delegated
+   grants (G16), then session-scoped once events ship — closing the
    integrity hole rather than leaving a permanent client-computed
    carve-out (§5.B.6).
-4. **C — dual handler execution** as the end-state for events: envelope
+5. **C — dual handler execution** as the end-state for events: envelope
    designed from day one (durable event IDs and provenance
    serialization-ready), adopted per-handler, then as the default event
    path.
-5. **D-projector** as a boot *mode* riding B (server-computed state first
-   paint), deferred until render output is stored as doc data (§3.4,
-   §10.6).
+6. **D-projector** as the later zero-execution boot mode, deferred until render
+   output is stored as doc data (§3.4).
 
 ---
 
 ## 8. Phased plan
 
-Phases assume #4288 and the persistent-scheduler-state wiring land first.
+Phases build directly on #4288 and its persistent scheduler wiring.
 Executable work orders with per-step success criteria and review
 checklists: [implementation-plan.md](./implementation-plan.md).
 
-- **Phase 0 — foundations (gap closure).** Persistent-state memory tables +
-  commit wiring + doc→readers index (G4); tx-provenance source stamping
-  (G6 mechanism, §3.3.1) so producer walks are total before anything
-  relies on them; executor principal + per-space grant flow (G1/G2);
-  in-process executor provider stage 1→2 (G0); `session.interest.set` +
-  doc-set feed behind a flag (G7).
-- **Phase 1 — Approach A.** Executor pool serves opted-in spaces
-  reactively; async executor-priority rule; bps registry folds into
-  interest sets. Exit criteria: cold space catch-up ≤ seconds; zero
-  double-fired async in multi-tab tests; executor-served spaces' feed
-  latency ≈ today's watch latency.
-- **Phase 2 — Approach B per-space flip.** Runner write split + overlay
-  (G5); derived-from watermark on commits (G10); builtin passive mode;
-  transitional scope carve-out enforcement (executor demand roots exclude
-  scoped subtrees). Flip flagged spaces; measure conflict rate (expect ≈0
-  derived conflicts), multi-client action volume (expect ~1×), divergence
-  counter. Fallback: per-space flag back to legacy mode.
-- **Phase 3 — subscriptions retired + projector boot.** Executor-served
-  spaces drop `session.watch` graph queries entirely; cold clients paint
-  from server state before local warm-up; projector mode where VNode docs
-  exist.
-- **Phase 4 — scoped execution.** User-partition delegation (G3) +
+- **Phase 0 — scheduler correctness.** Add
+  `SchedulerExecutionContextKey` and effective scope keys across snapshots,
+  state, and indexes (G1); enforce the transformer root binding (G6); add
+  writer lookup (G4). Parked-reader wake is Phase 1.
+- **Phase 1 — shadow client-demand executor.** Add authenticated
+  `ExecutionDemand`, one fenced user-sponsored `ExecutionLease` per space,
+  the validated provider, and claim eligibility reporting without authority
+  transfer plus indexed parked-reader wake (G0/G2/G3/G4). Background-registry
+  consolidation is deferred, but legacy-owned spaces are excluded immediately
+  so a second server Worker cannot start.
+- **Phase 2 — positive B claims.** Add client overlay routing, ephemeral
+  `ExecutionClaim`, `ActionSettlement.inputBasisSeq`, whole-action scope
+  firewall, passive claimed builtins, and egress parity (G5/G10/G11). Measure
+  conflict rate, multi-client action volume, divergence, revocations, and
+  fallback latency. Fallback is claim removal.
+- **Phase 3 — background demand + narrower feeds.** Fold existing background
+  registrations into the same lower-priority pool and retire graph-query
+  subscriptions only after the doc-set feed has parity. Separately gate
+  client-compute suppression once claim snapshots and closures are complete;
+  that later optimization, not Phase 2, removes N× local compute.
+- **Phase 4 — scoped execution.** User-partition delegation (G16) +
   per-user demand roots; executor endorsement atom on scoped writes.
 - **Phase 5 — dual handler execution (C).** Signed event envelopes
   (`serialize: "server"` handlers first, then the default event path);
@@ -1178,23 +1195,24 @@ means a design doc/decision is required before implementation.
 
 | # | Gap | Blocks | Status |
 | --- | --- | --- | --- |
-| G0 | Executor-grade in-process storage provider (engine-thread channel; commit-stream invalidations instead of watch) | A | needs-impl; `loopback` + `emulate` prove the seam |
-| G1 | First-class executor principal + executor-computed endorsement atom (`cf-compiler` / `LlmDerived` precedents) | A (principal); atom: Phase 2+ hardening, not a B-flip blocker | principal: needs-spec (small); atom: own CFC-owned mini-spec |
-| G2 | Per-space executor grant flow (owner opt-in → ACL WRITE for executor; revocation) | A | needs-spec; ACL mechanism exists |
-| G3 | Delegation/capability tokens (user → executor, scoped) | scoped-execution phase (user-scoped derivation); C | needs-spec (large); not needed for initial space-scoped B |
-| G4 | Persistent-state memory tables + commit-pipeline wiring + `scheduler_read_index` **already BUILT** behind `persistentSchedulerState` (both refs). Remaining: named `staleReadersFor` batched wake query (W0.2) + a wake-on-commit consumer (W1.3); durable dirty markers exist inline but aren't exposed as a parked-space query. doc→producer needs no *index* once G6 lands (`source`/`pattern` chain: data-model shape landed, §3.3.1 stamping not yet shipped) | A (wake query+consumer), B (watermarks) | substrate shipped; wake query + consumer needs-impl |
-| G5 | Runner write split: route tx by originating action kind (rides the §3.3.1 tx provenance envelope); speculative overlay in `ISpaceReplica`; read layering; per-space ownership bit (sticky flag) | B | needs-spec (this doc §5.B.1) + impl |
-| G6 | Source attaching in the write path (§3.3.1: tx provenance envelope, transferred to created docs at apply) + one-time legacy audit/backfill of pre-stamping docs | catch-up completeness | needs-impl (mechanism); then audit |
-| G7 | `session.interest.set` + doc-set delta feed (+ watermark field); closure export from executor scheduler | A (feed), B | needs-spec (protocol addition) |
+| G0 | Executor-grade provider with canonical ACL/CFC/conflict/apply hooks and commit invalidations | shadow | needs-impl; loopback proves the seam |
+| G1 | `SchedulerExecutionContextKey` and effective scope-qualified snapshots/state/indexes (§3.2.1) | server reliance on durable state | prerequisite; needs-impl |
+| G2 | Authenticated `ExecutionDemand`, sticky sponsor selection, and fenced `ExecutionLease` | shadow | needs-impl |
+| G3 | Ephemeral per-action `ExecutionClaim` with worker lease generation + independent claim generation, revocation, and required client handshake | B | needs-impl |
+| G4 | Named parked-reader wake query plus target/path-overlap `scheduler_write_index` producer lookup | shadow/B | indexes exist; query/consumer needs-impl |
+| G5 | Exact-claim client routing, speculative overlay, read layering, revoke-and-rerun | B | needs-impl |
+| G6 | Transformer/runner enforcement of one direct root result binding; update hand-built tests | producer eligibility | small needs-impl; no migration |
+| G7 | Authenticated demand + reconnect claim snapshots + ordered doc-set delta feed carrying commit/settlement sequence barriers; closure export | B/feed | needs protocol implementation |
 | G8 | (retired — reactive interpreter de-scoped from this design, §3.4; its gates are tracked in its own specs) | — | retired |
-| G9 | Cross-space: v1 policy designed (§6.8 — same-principal reads between enabled spaces; unservable-piece carve-out via `executorConfig.unservablePieces`; deployment-level readers index). Residuals: per-subgraph granularity, federation | B completeness | §6.8 designed; residuals later |
-| G10 | Watermark surfacing: `observedAtSeq` onto derived commits (via the §3.3.1 envelope); confirmation already returns source seq | B reconciliation | small, rides G4 + G6 mechanism |
-| G11 | Server-side async policy: per-space egress/throttle (#2659), retry/circuit-breaker, in-flight registry keyed `(actionId, inputHash)`, heartbeat/reclaim | A | partial (idempotency keys, toolshed LLM cache exist); needs-impl |
-| G12 | Durable LLM streaming (re-issue vs chunk append on executor restart) | A polish | needs-decision (recommend re-issue v1) |
+| G9 | Cross-space basis vectors, permissions, wake, and dual-space ownership | later expansion | explicitly client-authority in v1 |
+| G10 | Actual-read `inputBasisSeq` plus no-op/failure/unserved `ActionSettlement` and committed `acceptedCommitSeq` gating | B reconciliation | needs-impl; do not reuse `observedAtSeq` |
+| G11 | Server builtin egress parity, relative serving-origin resolution, redirect/DNS revalidation | claimed async | needs-impl; full hardening may follow |
+| G12 | Durable streaming, quotas, circuit breakers, and cross-engine effect ledger | async hardening/failover | later; v1 preserves current behavior |
 | G13 | Signed event envelope format (serialize trusted-event provenance; replay protection; verify path) — design now, build in Phase 5 | dual handler execution (C) | needs-spec; request-proof precedent exists |
-| G14 | Multi-executor coordination (space→executor affinity lease) | multi-machine scale | needs-spec later; single-writer-per-space makes it a lease, not consensus |
+| G14 | Durable multi-process `ExecutionLease` acquisition/fencing | shadow executor exclusivity | needs-impl in Phase 1; one host/process may be the first deployment |
 | G15 | Client pending-commit durability (true offline) | orthogonal | out of scope here; noted |
-| G16 | (retired — scoped execution runs on the compiled path; no execution-engine work gates it, §3.4) | — | retired |
+| G16 | Principal-aware scoped runtime lanes and delegated user keys | scoped execution | later; context-key prerequisite is G1 |
+| G17 | Complete-closure client-compute suppression with cold remote-owned actions | remove N× local compute | later; Phase 2 only suppresses writes/effects |
 
 Cross-engine idempotency (the intent/attempt-cell ledger from
 `cfc-runner-future-work.md` Tier 2) is deliberately *not* listed as a B
@@ -1210,22 +1228,11 @@ single authoritative run per event is preserved.
    (§5.B.3)?** Per-handler opt-in is the on-ramp; the trigger for flipping
    the default (contention data, headless-client demand, integrity
    requirements on handler writes) should be named in advance.
-2. **Interest granularity (§6.3):** per-piece is proposed; is per-space
-   ("serve everything running here") acceptable for v1 given typical space
-   sizes, or do large spaces need per-piece from day one?
-3. **Executor identity per deployment vs per space (§9 G1):** one principal
-   simplifies ops; per-space principals improve blast-radius and audit.
-   Proposal: one principal, per-space grants.
-4. **Shape of user-partition delegation (G3):** a standing grant (user →
+2. **Shape of user-partition delegation (G16):** a standing grant (user →
    executor, revocable, per space) vs short-lived tokens minted at session
    time; and does user-scoped execution get its own sub-worker per user or
    per-user demand roots inside the space worker?
-5. **Where does the executor pool live long-term:** inside toolshed
+3. **Where does the executor pool live long-term:** inside toolshed
    (co-process, simplest) vs a sibling service with the engine extracted
    behind the in-process channel? Phase 1 forces no commitment; the
    provider seam (G0) is the interface either way.
-6. **Render effects on the executor (D-mode):** projector boot needs
-   render output stored as doc data, and the work that prototyped that is
-   de-scoped (§3.4). Build a compiled-path VNode materialization, or
-   defer projector mode entirely? Proposal: defer; revisit only with a
-   concrete cold-boot/embed use case.

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -70,13 +70,13 @@ where server and clients knowingly duplicate authoritative work.
 - **SchedulerExecutionContextKey:** server-derived key for durable scheduler
   metadata: space, user:<principal DID>, or
   session:<principal DID>:<session id>.
-- **ExecutionDemand:** authenticated, connection-owned request to keep one or
-  more piece result roots live.
+- **ExecutionDemand:** authenticated, connection-owned, branch-qualified
+  request to keep one or more piece result roots live.
 - **ExecutionLease:** host-side, expiring, fenced authority for exactly one
-  worker generation in a space. It records onBehalfOf.
+  worker generation in a branch/space. It records onBehalfOf.
 - **ActionClaimKey:** action identity available independently to client and
-  server: space, piece/action identity, execution context, action kind, and
-  implementation/runtime fingerprints.
+  server: branch, space, piece/action identity, execution context, action kind,
+  and implementation/runtime fingerprints.
 - **ExecutionClaim:** positive, ephemeral statement that one action is ready
   to be server-primary. It contains an ActionClaimKey, worker lease generation,
   and a monotonic per-action claimGeneration. Every claim issuance gets the
@@ -104,7 +104,8 @@ where server and clients knowingly duplicate authoritative work.
 ExecutionClaim and ActionSettlement are server control-plane messages, not
 ordinary space documents. Client authority is the default whenever no matching
 live claim exists in the authoritative connected claim snapshot. Connection
-loss alone does not prove absence.
+loss alone does not prove absence. Demand, leases, claims, settlements, and
+reconnect snapshots are all branch-qualified.
 
 ---
 
@@ -238,16 +239,19 @@ provenance/echo metadata and is not a substitute for execution_context_key.
 **Unblocks:** deterministic action/output discovery and static servability.
 
 **Decision:** important authored patterns go through the transformer. Do not
-build a legacy Pattern JSON migration or retain recursive result-identity
+build a legacy Pattern JSON migration or retain recursive emitted-output-binding
 guessing for computation nodes.
 
 **Read first:**
 
 - Transformer emission for computation/lift nodes
-- packages/runner/src/runner.ts node instantiation and output redirect
-  resolution
+- packages/runner/src/runner.ts `firstResolvedOutputRedirect` (:403-431), its
+  sub-pattern output (:1988), map/filter container (:3907), and pattern-node
+  (:4248-4271) call sites; contrast plain lift/computed `_resultFor` identity
+  (:3033-3038), which does not recurse
 - Scheduler-v2 action registration and static write diagnostics
-- Hand-built runner fixtures that construct serialized Pattern objects
+- Hand-built runner fixtures that construct serialized Pattern objects,
+  including `type: "passthrough"` nodes
 
 **Steps:**
 
@@ -257,10 +261,14 @@ guessing for computation nodes.
    and fail with an actionable diagnostic if it is violated.
 3. Use that binding as the action's primary output. Keep explicit static side
    writes/materializer envelopes as separate write surfaces; do not pick the
-   first redirect found by recursively walking a structure.
+   first redirect found by recursively walking the emitted output binding.
 4. Simplify computation-specific compatibility code made unreachable by the
    invariant. Do not remove general Cell alias/redirect support.
-5. Fix only the hand-built tests that violate the transformer-produced shape.
+5. Apply the same runner-boundary invariant to hand-built
+   `type: "passthrough"` nodes. They have no transformer emission path: a direct
+   root primary binding is accepted; nested or multiple alias bindings are
+   fixed in tests or rejected.
+6. Fix only the hand-built tests that violate the transformer-produced shape.
 
 **Success criteria:**
 
@@ -268,6 +276,8 @@ guessing for computation nodes.
       stable action/output identity.
 - [ ] A malformed hand-built computation with nested or multiple root bindings
       fails at registration with the new diagnostic.
+- [ ] A compliant passthrough fixture has one direct root binding; nested or
+      multiple passthrough aliases fail with the same actionable diagnostic.
 - [ ] Static side writes still appear as additional write-index entries.
 - [ ] General Cell redirect and alias tests remain green.
 - [ ] No corpus migration, historical JSON compatibility path, or recursive
@@ -371,8 +381,11 @@ that it settled.
    apply a committed settlement only after its confirmed/feed cursor reaches
    acceptedCommitSeq. No-op settlement follows the accepted observation-only
    transaction in that ordered stream.
-8. Keep handler/source commits compatible; handler semantic authorship remains
-   the authenticated event sender.
+8. Do not add persistent scheduler observations for handler runs in this phase.
+   Handlers remain client-authoritative, their read sets do not participate in
+   server-primary wake indexes, and existing event/source commit provenance
+   remains unchanged. Phase 5 owns any handler-observation contract; handler
+   semantic authorship remains the authenticated event sender.
 
 **Success criteria:**
 
@@ -389,6 +402,8 @@ that it settled.
 - [ ] A forged onBehalfOf from worker IPC or a client is rejected/overwritten.
 - [ ] Cross-space input attempts are rejected by W1.3 rather than collapsed
       into this scalar.
+- [ ] Handler execution emits no new scheduler observation in this phase and
+      preserves existing authenticated event/source provenance.
 
 ---
 
@@ -462,20 +477,23 @@ provenance, hook, and notification path as a remote client.
    deployment/space requires server-primary semantics, reject clients that do
    not advertise the capability; do not silently mix stale authority rules.
 2. Add session.execution.demand.set. A demand is bound to the authenticated
-   connection, space, and piece result roots. Replacement and disconnect remove
-   that connection's references automatically.
-3. Add claim set/revoke messages containing ActionClaimKey, leaseGeneration,
-   monotonic per-ActionClaimKey claimGeneration, and server-controlled expiry.
-   Revoke names the live claimGeneration. A later claim set uses the next value
-   even if the worker lease generation is unchanged.
-4. Add settlement messages keyed to the exact leaseGeneration +
+   connection, branch, space, and piece result roots. Replacement and disconnect
+   remove that connection's references automatically.
+3. Add branch-qualified claim set/revoke messages containing ActionClaimKey,
+   leaseGeneration, monotonic per-ActionClaimKey claimGeneration, and
+   server-controlled expiry. Revoke names the live claimGeneration. A later
+   claim set uses the next value even if the worker lease generation is
+   unchanged.
+4. Add settlement messages keyed to the exact branch, leaseGeneration +
    claimGeneration and carrying outcome, inputBasisSeq, diagnostic code, and
-   acceptedCommitSeq for `committed` outcomes. Other outcomes omit it.
+   acceptedCommitSeq for `committed` outcomes. The settlement branch must equal
+   its claim branch. Other outcomes omit acceptedCommitSeq.
 5. Define ordering: claim set is observed before a client may suppress a
-   matching action; revoke is fail-open while connected; settlements cannot
-   apply to a newer claim generation. Carry claim snapshots, claim revokes,
-   commit patches, and every settlement outcome on one ordered reconnectable
-   stream with explicit feed-sequence barriers. For committed outcomes,
+   matching action on that branch; revoke is fail-open while connected;
+   settlements cannot apply to another branch or a newer claim generation.
+   Carry branch-qualified claim snapshots, claim revokes, commit patches, and
+   every settlement outcome on one ordered reconnectable stream with explicit
+   feed-sequence barriers. For committed outcomes,
    acceptedCommitSeq is an additional data-application gate, not a replacement
    for control ordering.
 6. Authorize demand using the session's existing READ access. Sponsor
@@ -494,6 +512,9 @@ provenance, hook, and notification path as a remote client.
       required and works unchanged when it is not.
 - [ ] Two connections demanding the same root produce two references; closing
       one leaves the other live; closing both removes demand.
+- [ ] The same piece/action on two branches retains independent demand, claims,
+      revokes, snapshots, and settlements; neither branch can suppress or clear
+      the other's overlay.
 - [ ] Spoofed connection id, principal, claim, or settlement is rejected.
 - [ ] Revoke/re-claim within one lease gets a new claimGeneration, and a
       reordered old-generation settlement cannot clear the new claim.
@@ -507,8 +528,8 @@ provenance, hook, and notification path as a remote client.
 
 Phase exit:
 
-- Exactly one fenced worker generation runs for an eligible space; a legacy
-  background-owned space is excluded until Phase 3.
+- Exactly one fenced worker generation runs for an eligible branch/space; a
+  legacy background-owned space is excluded until Phase 3.
 - Multiple client demands merge into it without duplicate schedulers.
 - The ordinary rollout remains observation-only: zero authoritative claims,
   derived server commits, or external builtin effects are published.
@@ -569,7 +590,7 @@ generation. Background-only work gets its service identity later.
 
 ---
 
-### W1.2 — Shared demand pool: one Worker per eligible active space
+### W1.2 — Shared demand pool: one Worker per eligible active branch/space
 
 **Depends on:** W0.6, W1.1, W0.1.
 **Unblocks:** W1.3.
@@ -587,7 +608,7 @@ and signing authority are separate.
 
 **Steps:**
 
-1. Add a host pool Map<branch+space, SpaceExecutionSlot>. Union every
+1. Add a host pool `Map<BranchSpaceKey, SpaceExecutionSlot>`. Union every
    connection's ExecutionDemand into the slot; acquire one lease and launch one
    Worker for the union.
 2. Construct one runtime with persistentSchedulerState enabled and the
@@ -805,8 +826,8 @@ Phase exit:
 **Steps:**
 
 1. Subscribe to claims through the negotiated session control stream. Store
-   them ephemerally by ActionClaimKey + leaseGeneration + claimGeneration; do
-   not persist them as space state.
+   them ephemerally by branch-qualified ActionClaimKey + leaseGeneration +
+   claimGeneration; do not persist them as space state.
 2. At transaction enqueue, derive the shared ActionClaimKey from the client
    action/transaction and match it to a live claim. Do not match on
    ActionExecutionProvenance: onBehalfOf and lease/claim generations are
@@ -825,8 +846,9 @@ Phase exit:
 7. Connection loss is not evidence that authority returned: keep claimed
    derived writes local/speculative and do not enqueue them upstream. On
    reconnect, complete capability negotiation and apply an authoritative full
-   claim snapshot at a feed-sequence barrier before flushing any derived work.
-   Source/handler/UI commits retain their existing offline queue behavior.
+   claim snapshot for the exact branch at a feed-sequence barrier before
+   flushing any derived work. Source/handler/UI commits retain their existing
+   offline queue behavior.
 8. Keep clients trusted in v1: protocol tests pin compliance; CFC/server
    enforcement arrives later.
 
@@ -838,6 +860,9 @@ Phase exit:
 - [ ] Mixed-scope claimed action commits whole from client; no partial
       suppression.
 - [ ] Two actions in one piece can independently be server- and client-primary.
+- [ ] Identical action identities on two branches route independently; a claim,
+      revoke, reconnect snapshot, or settlement on branch A never affects
+      branch B.
 - [ ] Revocation/expiry causes deterministic dirty rerun and convergence.
 - [ ] Disconnect while another client keeps the server claim live queues no
       derived wire commit; reconnect claim-snapshot barrier prevents a stale
@@ -870,18 +895,27 @@ Phase exit:
    divergence telemetry; do not surface a pattern exception.
 5. If the client's source commit is rejected/retried, discard overlay
    generations based on the rejected version and recompute.
+6. Treat inputBasisSeq as a direct-read scalar, not transitive lineage. In a
+   chain, a stale intermediate plus an unrelated newer input may let a
+   downstream settlement pass the source sequence and briefly reveal stale
+   confirmed state after overlay drop. V1 accepts, measures, and self-heals
+   that window through the intermediate/downstream re-settle; a later causal
+   frontier closes it.
 
 **Success criteria:**
 
-- [ ] Source at S → local overlay → server settlement basis ≥ S → overlay is
-      physically removed only after acceptedCommitSeq is locally confirmed;
-      the confirmed value remains.
+- [ ] Direct source read at S → local overlay → server settlement basis ≥ S →
+      overlay is physically removed only after acceptedCommitSeq is locally
+      confirmed; the confirmed value remains.
 - [ ] Settlement basis < S retains overlay.
 - [ ] A no-op settlement clears the overlay.
 - [ ] Two rapid source commits require settlement through the later basis.
 - [ ] Old generation cannot clear new overlay.
 - [ ] Delayed/reordered commit data keeps the overlay until the matching data
       frame is applied; settlement-first delivery cannot flash stale state.
+- [ ] A chained-action fixture demonstrates the accepted non-transitive basis
+      window, records divergence, and deterministically converges after the
+      intermediate and downstream actions re-settle.
 - [ ] Rigged divergence records one event and shows server value.
 - [ ] Rejected source basis discards and recomputes correctly.
 

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -1,1224 +1,1050 @@
 # Server-Primary Execution — Implementation Plan
 
-Companion to [README.md](./README.md) (the design). Read the README first;
-this plan does not restate the design rationale. Section references
-(§5.B.3, G4, …) point into the README.
+Companion to [README.md](./README.md). Read the design first; this plan turns
+it into reviewable, red-green work orders.
 
-Status: plan for Phases 0–2 in executable detail; Phases 3–5 outlined with
-entry criteria only (they depend on decisions and landings listed at the
-end). Scope decision from review: direction is A → B → scoped execution →
-dual handler execution.
+Status: executable plan for the scheduler prerequisite and client-driven
+server-primary execution. Later background, feed, scoped, and handler work is
+outlined only.
+
+Baseline assumption: scheduler-v2 from PR #4288 has landed. Build directly on
+its facade, commit-gated starts, cancellation semantics, bounded settle,
+persisted action state, stable action identity, and read/write indexes. Do not
+add compatibility paths for the pre-v2 scheduler.
+
+The first security model trusts protocol-compatible clients to honor server
+claims. The server still authenticates every demand and write, enforces normal
+ACL/CFC validation, and fences duplicate workers. A later phase makes claim
+authority cryptographically enforceable.
+
+Incremental PRs remain dark until both halves of a behavior exist. In
+particular, the server must not publish authoritative claims to ordinary
+sessions until W2.1 claim-aware routing is deployed, and must not claim async
+builtins until W2.3 client passivity is deployed. Earlier WOs exercise those
+paths with explicit test capabilities only; they do not create a rollout window
+where server and clients knowingly duplicate authoritative work.
 
 ---
 
-## 0. How to use this plan (implementing agents)
+## 0. How to use this plan
 
-- **One work order (WO) = one PR.** Do not bundle WOs. If a WO turns out
-  too big for one PR, split at the test boundaries listed in its success
-  criteria and say so in the PR description.
-- **Read-first lists are mandatory.** Every WO names the files/specs that
-  define its seams. Read them before writing code. If the code you find
-  contradicts a step here (line numbers drift, a helper was renamed), the
-  code wins — adapt, and note the delta in the PR description. Do not
-  invent parallel mechanisms when the named seam exists.
-- **Red-green.** For every behavioral criterion, write the failing test
-  first, confirm it fails for the right reason, then implement. PR
-  descriptions must show the red→green transition for the headline test.
-- **Flags default off.** Nothing in Phases 0–2 may change behavior when
-  its flag/option is off. Every WO with a flag has a parity criterion;
-  treat it as the most important one.
-- **Commit style.** Small coherent commits as work completes. Follow
-  existing message conventions (`feat(runner): …`, `test(memory): …`).
-- **When blocked**, stop and surface the blocker with what you learned;
-  do not work around a failed criterion by weakening the test.
+- **One work order (WO) = one PR.** W0.1 may instead be folded into #4288
+  before it lands. Split any other WO only at the test boundaries below and
+  record the resulting dependency.
+- **Red-green is required.** Write the failing behavioral test first, confirm
+  that it fails for the intended reason, then implement. The PR description
+  includes the headline red and green commands/results.
+- **The named seams are mandatory reading.** If symbols move, follow the
+  current code and describe the delta; do not create parallel scheduler,
+  identity, transaction, or serialization machinery.
+- **Flags default off.** Every experimental option is registered in
+  docs/development/EXPERIMENTAL_OPTIONS.md in the same change. Flag-off
+  behavior is proven by test.
+- **Preserve transaction boundaries.** Servability is decided for a whole
+  action transaction. Never commit its space-scoped subset on the server and
+  send scoped or foreign-space operations back to a client.
+- **No anonymous derived writes.** Every server execution lease names the
+  authenticated user on whose behalf it runs. The host, not the Worker,
+  controls that authority.
+- **Use deterministic barriers in timing tests.** Do not use sleeps or polling
+  to force worker, lease, claim, commit, or hibernation races.
+- **Use Deno Workers for multiple runtimes.** Never construct two Engine or
+  runtime realms in one process in a test.
+- **Await runtime.settled()** when async builtin writebacks matter.
+- **Use a port offset** for every test/dev server; never assume port 8000.
+- **Preserve established runtime restrictions.** Raw fetch is unavailable to
+  pattern code in SES. Server execution does not expose it.
 
-### 0.1 Repo practices you must follow (with reasons)
+### 0.1 Definition of done for every WO
 
-- `docs/development/TESTING.md`, `docs/development/DEVELOPMENT.md`,
-  `docs/development/LOCAL_DEV_SERVERS.md` — house rules. Use `dev-local`
-  for shell, not `dev`.
-- **Any test/dev server: always `--port-offset`**, never default `:8000`
-  (a stale toolshed on 8000 produces "No data at cell" wire-skew ghosts).
-- **Never construct a second Engine/runtime realm in one process** in
-  tests — verified identities degrade and CFC gates start failing
-  (`writeAuthorizedBy unsupported`). Multi-runtime tests use Deno Workers:
-  see `packages/patterns/integration/multi-runtime-harness.ts` and
-  `packages/cli/lib/multi-user-test-runner.ts`.
-- **Await `runtime.settled()`** (not `idle()`) when a test depends on
-  async-builtin writebacks (post-commit outbox).
-- **Do not repro flakes by running the same test file ×N in one command**
-  — repeated runs share `$TMPDIR` sqlite state and invalidate the repro.
-- `cf test` fails on console errors/warnings — leave no stray logging.
-- New workspace packages MUST have a `"test"` task in their `deno.jsonc`
-  (root `AGENTS.md` explains why; see `packages/utils/deno.jsonc`).
-- Perf-check: if the Performance Check job flags a change you believe is
-  noise, rerun ONLY that job (up to 3×) before considering
-  `NEW_PERF_BASELINE` with justification.
+1. The touched packages pass their focused tests and deno task check.
+2. Every success criterion is mapped to a named test in the PR description.
+3. Experimental flag-off parity is demonstrated, when applicable.
+4. No new schema-less deep sink, whole-space standing subscription, timer
+   polling loop, identity implementation, or direct database mutation exists.
+5. New protocol fields and storage schemas have compatibility/fail-open tests.
+6. Failure, handoff, and cleanup paths use explicit barriers and are tested.
 
-### 0.2 Definition of done — every PR in this plan
+### 0.2 Terms and reserved names
 
-1. `deno task check` green; the touched packages' `deno task test` green
-   locally.
-2. All success criteria of the WO checked off in the PR description, each
-   with the test file/name that proves it.
-3. Flag-off parity criterion (when the WO has a flag) proven by a test,
-   not by inspection.
-4. CI green on the PR (docs job, runner/memory/pattern shards). Address
-   automated-reviewer comments (fix or rebut with evidence).
-5. No new schema-less deep sinks or whole-state subscriptions anywhere
-   (this family of change caused a ~270× re-run amplification before;
-   reviewers will look for it specifically).
+- **SchedulerExecutionContextKey:** server-derived key for durable scheduler
+  metadata: space, user:<principal DID>, or
+  session:<principal DID>:<session id>.
+- **ExecutionDemand:** authenticated, connection-owned request to keep one or
+  more piece result roots live.
+- **ExecutionLease:** host-side, expiring, fenced authority for exactly one
+  worker generation in a space. It records onBehalfOf.
+- **ActionClaimKey:** action identity available independently to client and
+  server: space, piece/action identity, execution context, action kind, and
+  implementation/runtime fingerprints.
+- **ExecutionClaim:** positive, ephemeral statement that one action is ready
+  to be server-primary. It contains an ActionClaimKey, worker lease generation,
+  and a monotonic per-action claimGeneration. Every claim issuance gets the
+  next value, even within one worker lease; revoke names the currently live
+  value and does not mint another.
+- **CandidateClaim:** host-local shadow diagnostic saying an action passed
+  servability checks. It never transfers client authority.
+- **ActionSettlement:** control event for every claimed action attempt,
+  including committed, no-op, failed, and unserved outcomes.
+- **ActionExecutionProvenance:** transaction metadata containing action
+  identity, onBehalfOf, lease/claim generations, causedBy, and inputBasisSeq.
+- **executionPolicy:** optional owner-managed space policy expressing only
+  whether server-primary execution is allowed. It does not contain liveness,
+  actor, epoch, authority, or unservable-piece state.
+- Runtime experimental option: serverPrimaryExecution, default false.
+- Existing scheduler option: persistentSchedulerState, default false until its
+  own rollout changes that default.
+- Protocol capability: server-primary-execution-v1.
+- Protocol messages:
+  - session.execution.demand.set
+  - session.execution.claim.set
+  - session.execution.claim.revoke
+  - session.execution.settlement
 
-### 0.3 Naming reserved by this plan
-
-- Runtime option (SHIPPED, already in the tree): `persistentSchedulerState:
-  boolean` (default false), env `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`.
-  (An earlier draft reserved `persistSchedulerState`; that name never
-  shipped — the built option is `persistentSchedulerState`. Use the real
-  name everywhere.)
-- Runtime/provider option: `storageConnection: "remote" | "in-process"`.
-- Env flags: `CF_INTEREST_FEED` (client), `EXECUTOR_MODE=reactive` (bps).
-- Protocol messages: `session.interest.set`.
-- Space config doc key: `executorConfig` (fields:
-  `{ enabled, derivedAuthority: "client" | "executor", epoch,
-  unservablePieces?: string[] }`).
-- Tx envelope type: `TxProvenance`
-  (`{ source?, action?: { id, kind }, observedAtSeq? }`).
+ExecutionClaim and ActionSettlement are server control-plane messages, not
+ordinary space documents. Client authority is the default whenever no matching
+live claim exists in the authoritative connected claim snapshot. Connection
+loss alone does not prove absence.
 
 ---
 
 ## 1. Dependency graph
 
-```
-Phase 0:  W0.1 ──▶ W0.2 ─────────────▶ W1.3
-          W0.3 (independent)───────────▶ W2.2, W2.3
-          W0.4 (independent)───────────▶ W1.1, W2.1
-          W0.5 ──▶ W0.6 ──────────────▶ W1.1
-          W0.7 (independent)───────────▶ W1.1 discovery, Phase 3
+    Phase 0:
+      W0.1 context keys ──▶ W0.3 writer lookup ──▶ W1.3 servability
+      W0.2 output invariant ─────────────────────▶ W0.3, W1.3
+      W0.4 input basis/provenance ───────────────▶ W1.3, W2.2
+      W0.5 authenticated provider ───────────────▶ W1.1, W1.2
+      W0.6 handshake/control protocol ───────────▶ W1.2, W2.1
 
-Phase 1:  W1.1 ──▶ W1.2, W1.3, W1.4
-Phase 2:  W2.1 ──▶ W2.2 ──▶ W2.3 ──▶ W2.6
-          W2.4 (after W2.1 + W1.2); W2.5 (after W1.1) — both parallel
-          with W2.2/2.3
-```
+    Phase 1:
+      W1.1 leases/fencing ──▶ W1.2 shared pool
+      W1.2 shared pool ─────▶ W1.3 servability/claim readiness
+      W1.3 claim readiness ─▶ W1.4 async builtins, W1.5 wake/hibernate
 
-Parallelizable start set: W0.1, W0.3, W0.4, W0.5, W0.7.
+    Phase 2:
+      W2.1 client routing/overlay ──▶ W2.2 reconciliation
+      W1.4 + W2.1 + W2.2 ──────────▶ W2.3 client builtin passivity
+      W2.2 + W2.3 + W1.5 ─────────▶ W2.4 measurement/rollout
+
+    Later:
+      Phase 3 background demand and feed narrowing
+      Phase 4 scoped execution with delegated keys
+      Phase 5 server-directed handler events and enforced authority
+
+Parallelizable start set after #4288: W0.1, W0.2, W0.4, W0.5, W0.6.
 
 ---
 
-## 2. Phase 0 — foundations
+## 2. Phase 0 — prerequisites and protocol substrate
 
-### W0.1 — Adopt & verify existing observation persistence (already built)
+### W0.1 — Qualify durable scheduler state by effective execution context
 
-**Already built (do not re-implement).** Observation persistence is
-present and functional on `main` (verified against the current tree) AND
-on #4288 today, behind the default-off flag. A fresh runtime on the same
-store already skips re-running unchanged actions when the flag is on. Do
-not rebuild any of this; these anchors are the seams you verify/extend:
+**Priority:** first standalone prerequisite. It may be folded into #4288.
 
-- **Flag + default (OFF):** `let persistentSchedulerStateEnabled = false;`
-  (`packages/memory/v2.ts:640`; getter `:653`, setter `:649` coerces
-  `undefined`→false); `setPersistentSchedulerStateConfig(this.experimental
-  .persistentSchedulerState)` at runtime construction
-  (`packages/runner/src/runtime.ts:505`). Env
-  `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` plumbed through
-  `packages/toolshed/env.ts`, `packages/shell/src/lib/env.ts`,
-  `packages/background-piece-service/src/{env.ts,main.ts}`.
-- **Durable transactional write:** the runner attaches the observation to
-  the live commit tx — gate
-  `packages/runner/src/scheduler/action-run.ts:646`, build `:666`
-  (`buildSchedulerActionObservation`), attach `:708`
-  (`setSchedulerObservation`). Server strips it when the flag is off
-  (`packages/memory/v2/server.ts:1620`). Persisted INSIDE the single
-  commit transaction:
-  `engine.database.transaction(applyCommitTransaction).immediate`
-  (`packages/memory/v2/engine.ts:1554`) →
-  `upsertSchedulerObservationTransaction` (`:3285`). Five durable tables
-  (DDL `engine.ts:206` `scheduler_observation` history, `:232`
-  `scheduler_action_snapshot` LWW-per-action, `:268`
-  `scheduler_read_index`, `:293` `scheduler_write_index`, `:316`
-  `scheduler_action_state`). No-op elision via `payloadChanged`;
-  observation-only + batched (`schedulerObservationBatch`) commits exist.
-- **Durable read + cold-start skip:** indexed SELECT
-  `listSchedulerActionSnapshots` (`packages/memory/v2/engine.ts:1717`);
-  provider method `packages/runner/src/storage/v2.ts:1108`, optional on
-  `interface.ts:272`. Cold start: flag-gated `schedulerRehydrationOptions`
-  in `packages/runner/src/runner.ts` → subscription `rehydrateFromStorage`
-  → `Scheduler.rehydrateActionFromStorage`
-  (`packages/runner/src/scheduler.ts:666`) → fingerprint check
-  `observationMatchesCurrentAction` (`:716`) →
-  `rehydrateActionFromObservation` (`:593`), which restores reads/writes
-  WITHOUT running (fail-open on miss).
-- **`graph-snapshot.ts` is NOT this.**
-  `packages/runner/src/scheduler/graph-snapshot.ts` is in-memory
-  diagnostics/telemetry only (no storage I/O). The durable snapshot is the
-  `scheduler_action_snapshot` SQLite table — do not conflate them.
-- **`main` vs #4288 (structural only, NO capability delta):** #4288
-  replaces `scheduler.ts` with `export * from ./scheduler/facade.ts` and
-  DROPS `rehydrateActionFromStorage`, moving cold-start orchestration into
-  the runner (`loadSchedulerRehydrationSnapshots` +
-  `schedulerRehydrationOptions` passing `snapshotsByActionId` into the
-  subscription); the skip fires in `facade.ts`
-  (`rehydrateActionFromObservation` → `setStatus(action, "clean")` +
-  `pending.delete`). Flag, tables, provider method, and test names are
-  identical on both refs.
+**Problem:** cell facts are partitioned by effective scope key, but scheduler
+snapshots, action state, and read/write index ownership are currently keyed by
+action without the effective user/session context. Two principals or sessions
+can replace each other's scheduler metadata even though their cell values do
+not overlap.
 
-**Depends on:** nothing (substrate already in the tree).
-**Unblocks:** W0.2, W1.3.
-**Deliverable:** one PR that ADOPTS the shipped persistence rather than
-building it: (1) reconcile this plan + README to the real flag name
-`persistentSchedulerState`; (2) close the one composed-durability test gap
-with a single end-to-end kill→reopen→skip test; (3) record the accepted
-deviations from this plan's original sketch. No new tables, commit-payload
-field, or provider method — they exist.
+**Depends on:** #4288.
+**Unblocks:** authoritative writer lookup and every server-primary phase.
 
 **Read first:**
 
-- The "Already built" anchors above.
-- `docs/specs/persistent-scheduler-state.md` +
-  `docs/specs/persistent-scheduler-state/implementation_notes.md` — the
-  as-shipped design (normalized multi-table, transaction-coupled); it
-  deviates from this plan's original single-`(space,branch,action_id)`
-  sketch.
-- `packages/runner/src/scheduler/persistent-observation.ts` — observation
-  shapes + `buildSchedulerActionObservation`.
-- `packages/runner/test/reload-rehydration.test.ts` and
-  `packages/memory/test/v2-scheduler-state-test.ts` — the two halves of
-  the durability proof you compose into one test.
-- **If #4288 has landed:** cold-start is `runner.ts`
-  `loadSchedulerRehydrationSnapshots` + `scheduler/facade.ts`, NOT
-  `scheduler.ts:666` (that symbol is gone on #4288). Flag, tables,
-  provider method, and test names are unchanged.
+- docs/specs/persistent-scheduler-state.md
+- packages/memory/v2/engine.ts scheduler table DDL, observation upsert,
+  dirtying, and list/read methods
+- packages/runner/src/scheduler/persistent-observation.ts
+- packages/runner/src/scheduler.ts rehydration facade
+- packages/runner/src/storage/v2.ts scope resolution and scheduler state calls
+- packages/memory/test/v2-scheduler-state-test.ts
+- packages/runner/test/reload-rehydration.test.ts
 
 **Steps:**
 
-1. **Naming reconciliation (docs only).** Replace every bare
-   `persistSchedulerState` in this file and in `README.md` with
-   `persistentSchedulerState`; note env
-   `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. No code rename — the shipped
-   name is authoritative.
-2. **Close the durability-composition gap (the only real build).** Add ONE
-   test proving the full stack in a single assertion: commit observations
-   to a FILE-backed store (`Deno.makeTempFile`), fully `close()` server +
-   client, reopen a brand-new runtime whose StorageManager points at the
-   same on-disk path, run the fixture, and assert via a lift-invocation
-   counter that unchanged actions do NOT re-run and that writing one input
-   re-runs exactly the dependent action. The tree lacks this single test
-   (the runtime skip test uses a live `emulate()` server;
-   `v2-scheduler-state-test.ts` reopens the file but stops at the memory
-   layer, not the runner's skip decision).
-3. **Record accepted deviations in the PR description (do not "fix"):**
-   (a) the commit payload carries observations via the bespoke
-   `schedulerObservation`/`schedulerObservationBatch` fields, NOT the
-   patch-operations registry this plan's checklist assumed — accepted
-   as-shipped; a registry migration is a separate follow-up, not this WO.
-   (b) storage is a normalized multi-table shape (history + LWW snapshot +
-   read/write/action-state indexes), not the single LWW-no-history table
-   originally sketched.
-4. **Name the known limitation for W1.1 to inherit:** `processGeneration`
-   is hardcoded `0` on read and write, so cross-generation invalidation is
-   not exercised; per-restart generation bumping is a hibernate/resume
-   identity concern deferred to W1.1.
-5. **Pin handler coverage (persistence only — NOT rehydration).**
-   Persistence should cover event-handler runs, not only
-   computations/effects: the vocabulary already has `"event-handler"` /
-   `"event-preflight"` kinds
-   (`packages/runner/src/scheduler/persistent-observation.ts:9,14`), but
-   `attachSchedulerActionObservation` is wired only at the action-run
-   seam (`packages/runner/src/scheduler/action-run.ts:521`), while
-   handlers dispatch through `dispatchQueuedEvent` with an event payload
-   — a different path. Determine whether that event-commit path attaches
-   observations for handler runs; if it does, pin it with a test; if it
-   does not, wire the attach at the event-commit seam and pin it. Scope
-   note: there is nothing to *rehydrate* for handlers — they run only
-   when an event arrives, and their registration comes from piece
-   instantiation, not from restored scheduler `Action`s. The value of
-   persisting handler observations is (a) their reads populate the
-   readers index (wake/staleness bookkeeping) and (b) run provenance —
-   not skip-on-restart.
-
-**Success criteria (most already pass — this WO proves the DELTA, not the
-substrate):**
-
-- [ ] **Headline delta — single-test cold durability:** the new
-      file-backed kill→reopen→fresh-runtime test (step 2) shows the
-      lift-invocation counter unchanged for stale-free actions (skip) and
-      incremented by exactly one for the dependent action after one input
-      write. Link the red run — it is a genuinely new assertion (no
-      existing test closes the whole stack in one shot), not a re-run of
-      green code.
-- [ ] **Flag-on skip regression guard:** `reload-rehydration.test.ts`
-      ("reload: resumed pattern rehydrates persisted observations") stays
-      green — `reload.ok > 0`, `reload.missNoSnapshot === 0`. On #4288
-      this is the same test name; verify green post-refactor.
-- [ ] **Disk durability guard:** `v2-scheduler-state-test.ts`
-      (close → reopen on-disk `openEngine`) stays green — reader index +
-      `scheduler_action_state` survive reopen.
-- [ ] **Fail-open:** delete all observation rows between the two runtimes
-      → second runtime re-runs everything, byte-identical result docs, no
-      errors (extend the step-2 fixture).
-- [ ] **Parity (flag off, default):** with `persistentSchedulerState`
-      unset, no observation rows are ever written (server strips at
-      `server.ts:1620`); an existing scheduler test file passes
-      unmodified.
-- [ ] **No-op elision guard:** run the fixture twice with no input change
-      → zero new observation writes on the second settle (`payloadChanged`
-      elision; assert via a write-count test hook).
-- [ ] **Naming:** no `persistSchedulerState` used as an option/flag name
-      remains under `docs/specs/server-side-execution/` — only the
-      historical rename note (§0.3, this WO's step 1) may mention the old
-      name.
-- [ ] **Handler coverage (step 5, persistence only):** a fixture
-      event-handler run under the flag persists an observation with
-      `actionKind: "event-handler"` whose reads land in the readers
-      index; red run first if the event-path wire turns out to be
-      missing. Explicitly NOT asserted: any rehydration/registration
-      restore for handlers (no such path exists; see step 5's scope
-      note).
-
-**Review checklist:**
-
-- This is an ADOPT/VERIFY WO: reject any diff that re-adds a
-  `scheduler_observation` table, a second `listSchedulerActionSnapshots`,
-  or a parallel commit-payload field. The seams exist — the diff should be
-  ~one test + docs, not new machinery.
-- The new durability test must actually close the file: assert against a
-  reopened on-disk DB (`Deno.makeTempFile` + `close()` + reopen), not a
-  still-live `emulate()` server — otherwise it does not test the gap.
-- Rehydration must stay fail-open: the fingerprint check
-  (`observationMatchesCurrentAction`, `scheduler.ts:716`; the `facade.ts`
-  equivalent on #4288) gates every clean-restore path — never trust a
-  snapshot without `implementationFingerprint`/`runtimeFingerprint` match.
-- The invocation-counter fixture counts lift executions, not
-  subscriptions.
-- If reviewing on #4288: confirm the skip fires via `facade.ts`
-  `setStatus(action, "clean")` + `pending.delete`, and that `runner.ts`
-  `loadSchedulerRehydrationSnapshots` early-returns when the flag is off.
-
----
-
-### W0.2 — doc→readers wake query (index already built)
-
-**Depends on:** W0.1. **Unblocks:** W1.3.
-**Deliverable:** one PR that EXTENDS the existing reverse index (it is
-already built and populated) with the one missing piece: a named
-engine-side batched query `staleReadersFor(space, changedIds, seq)`
-returning the distinct stale reader list for wake. The index tables,
-population, and inline per-write reader-dirtying already exist — do not
-rebuild them.
-
-**Already built (do not re-implement):** `scheduler_read_index` DDL
-`packages/memory/v2/engine.ts:268` (indexed lookup on the read target),
-populated in the SAME observation transaction from `observation.reads` +
-`shallowReads`; `scheduler_write_index` `:293`;
-`findSchedulerReadersForWrite` `:1849` and
-`markSchedulerReadersDirtyForWrites` `:1912`, consumed INLINE in
-`applyCommit` (`:3276` region) to mark same-space + owner-space readers
-direct-dirty; cross-space MIRROR rows exist as the v1 stand-in (README
-§6.8/G9 flag them as not-yet-deployment-global). Tests already cover it:
-`v2-scheduler-state-test.ts` "marks persisted readers dirty during
-semantic commits". What is GENUINELY MISSING is only the named batched
-wake query — the tree dirties readers inline during commit but exposes no
-distinct wake-list query (`staleReadersFor` does not exist).
-
-**Read first:** W0.1's "Already built" anchors;
-`docs/specs/persistent-scheduler-state.md` §9 (read/write indexes as
-shipped); `packages/memory/v2/engine.ts` `findSchedulerReadersForWrite`
-(~1849) and its `applyCommit` call site (~3276) — you add a *batched
-distinct wake query* beside this per-write finder, not a replacement.
-
-**Steps:**
-
-1. Implement `Engine.staleReadersFor(space, changedIds, commitSeq)`: one
-   indexed SELECT over `scheduler_read_index` returning DISTINCT
-   `(reader_space, piece_id, action_id)` where the read target is in
-   `changedIds` AND `observed_at_seq < commitSeq`. Reuse the existing
-   index; add no new table. (This is the symbol W1.3 calls; only the
-   inline `findSchedulerReadersForWrite` exists today.)
-2. Cross-space: the mirror-row mechanism already lands cross-space reader
-   rows; `staleReadersFor` must read them so a changed doc in space B
-   returns the A-space reader. A missing mirror row is fail-open
-   (stale-until-demanded, never wrong) — state which case ships.
-3. Expose as an engine/server method (no wire protocol yet — Phase 1
-   consumes it in-process via the pool host).
+1. Add execution_context_key to scheduler observation/snapshot/action-state
+   ownership and to every read/write index row's owning-action key. Update
+   primary keys, conflict clauses, deletes, and indexes together.
+2. Add resolved read_scope_key to read-index addresses and write_scope_key to
+   write-index addresses. Dirty matching uses the changed revision's effective
+   scope key, not only its declared scope class.
+3. Derive the key server-side using the shareability lattice `space < user <
+   session`, where moving right is narrower:
+   - `space` is permitted only when a trusted, transformer/runner-produced
+     `CompleteActionScopeSummary` proves the piece/result and every possible
+     read, write, materializer envelope, and direct output are same-space and
+     space-scoped;
+   - `user:<principal>` is permitted only when that complete summary excludes
+     PerSession access but includes PerUser access;
+   - `session:<principal>:<sessionId>` is the initial key for PerSession,
+     incomplete, unknown, or dynamic surfaces.
+   Observed absence is never proof of completeness and never promotes a row.
+   Within one action fingerprint, runtime evidence may only move toward a
+   narrower key; a no-op cannot broaden classification. A newly proven broader
+   classification requires a new implementation/runtime fingerprint. Never
+   accept a client-provided principal. A protocol-compatible trusted client may
+   carry the transformer-produced summary, but it must be bound to the verified
+   implementation/runtime fingerprint rather than inferred from one run.
+4. Return the shared space row plus only the authenticated caller's applicable
+   user/session rows during rehydration. Never return another principal's row.
+5. When runtime evidence violates the complete summary, reject that summary,
+   fail open by running, and transactionally invalidate only rows that are
+   broader than the new floor. A `space`→scoped violation removes the shared
+   space row for that fingerprint. A `user`→`session` violation removes that
+   principal's user row, not another principal's independent user/session row.
+   Never delete an equally narrow unrelated context row.
+6. Preserve one shared space row for actions proven to use only same-space
+   space-scoped addresses.
+7. Migrate the #4288 schema transactionally and idempotently. Preserve active
+   snapshot/state/index rows only when their decoded observation is valid and
+   provably space-only. Rebuild those rows with space context/effective target
+   keys; discard scoped, unknown, malformed, or orphaned active rows so they
+   run fresh. Append-only observation/replay history may remain, but active
+   state must not point at discarded rows.
+8. Update state-inspector output to show execution context and target scope
+   keys so failures are diagnosable.
 
 **Success criteria:**
 
-- [ ] `packages/memory`: after a fixture observation batch, querying a
-      changed doc id returns exactly the reading actions; querying an
-      unread doc id returns empty.
-- [ ] Staleness bound respected: readers whose `observed_at_seq` ≥ commit
-      seq are NOT returned (they already saw it).
-- [ ] Index rows are replaced, not accumulated: re-observing an action
-      with a smaller read set removes the stale rows (assert row count).
-- [ ] Micro-sanity: query over a space with 10k index rows returns in
-      < 5ms in a plain `deno bench`/timed test (reads are sync FFI; this
-      is generous).
-- [ ] Same-transaction guarantee: a conflicted commit leaves the index
-      untouched.
-- [ ] Cross-space rows: an observation for a piece in space A reading a
-      doc in space B yields a row queryable from B's commit path —
-      `staleReadersFor(B, …)` returns the A-space piece.
+- [ ] Red→green headline: Alice and Bob run the same PerUser action; both
+      snapshots, action-state rows, read rows, and write rows remain present
+      and independently rehydrate.
+- [ ] Two sessions for one principal retain distinct PerSession metadata.
+- [ ] Alice's scoped write dirties Alice's matching reader and not Bob's.
+- [ ] Running or clearing Alice's dirty action does not clear Bob's state.
+- [ ] A proven space-only action has one shared row that either principal can
+      rehydrate.
+- [ ] A dynamic `space`→`user` or `user`→`session` violation cannot leave a
+      broadly adoptable snapshot; the incompatible broader row is removed and
+      the next runtime fails open by running.
+- [ ] Observed space-only behavior without a complete static summary remains
+      session-keyed; it cannot promote itself to a shared row.
+- [ ] Narrowing Alice's user row never removes Bob's independent user/session
+      row.
+- [ ] Existing space-only persistent scheduler tests remain green.
+- [ ] Query plans still use indexed target lookup at 10k rows.
 
-**Review checklist:** the query must key on `(space, branch, doc_id)` via
-the index (check the query plan comment or EXPLAIN in a test); deletion on
-re-observation must be per `(space, branch, action_id)`.
+**Review checklist:** inspect every action-key WHERE, DELETE, UPSERT, and JOIN.
+A partial migration is worse than no migration. writerSessionId remains
+provenance/echo metadata and is not a substitute for execution_context_key.
 
 ---
 
-### W0.3 — Tx provenance envelope + `source` stamping (§3.3.1)
+### W0.2 — Enforce one direct root output binding for computations
 
-**Depends on:** nothing (parallel with W0.1). **Unblocks:** W2.2, W2.3.
-**Deliverable:** one PR: `TxProvenance` populated at action-tx open,
-carried on the commit, and transferred by the storage layer onto every
-document the transaction CREATES, as the doc-level `["source"]` field.
+**Depends on:** #4288.
+**Unblocks:** deterministic action/output discovery and static servability.
+
+**Decision:** important authored patterns go through the transformer. Do not
+build a legacy Pattern JSON migration or retain recursive result-identity
+guessing for computation nodes.
 
 **Read first:**
 
-- README §3.3–§3.3.1 (the design, including the two open details:
-  cross-space and setup-tx anchoring — both have decided v1 behaviors
-  below).
-- `packages/runner/src/scheduler/action-run.ts` ~307–348 — the existing
-  stamp: `(tx.tx as …).debugActionId = actionId; tx.tx.sourceAction =
-  action;`.
-- `docs/specs/memory-v2/01-data-model.md` (document envelope: `source` is
-  a same-space short-link `{"/":"<short-id>"}`; `pattern` is a sigil
-  link) and `docs/specs/memory-v2/05-queries.md` §5.10.1 (traversal does
-  NOT follow `source` — fine: our walk is store-direct, not query-layer).
-- `packages/runner/src/cfc/prepare.ts` ~1148–1210 — the raw `["source"]`
-  surface is already excluded from CFC flow reads. Do not change these
-  exclusions; they are what make stamping label-neutral.
-- `packages/runner/src/result-utils.ts:17` — where `pattern` meta is
-  written (the walk's terminator).
-- `packages/state-inspector/db.ts` — offline store reads (for the walk
-  helper + audit).
+- Transformer emission for computation/lift nodes
+- packages/runner/src/runner.ts node instantiation and output redirect
+  resolution
+- Scheduler-v2 action registration and static write diagnostics
+- Hand-built runner fixtures that construct serialized Pattern objects
 
 **Steps:**
 
-1. Define `TxProvenance` in `packages/runner/src/storage/` (new
-   `provenance.ts` or alongside the tx types):
-   `{ source?: <short-link>, action?: { id: string, kind:
-   "computation" | "effect" | "event-handler" }, observedAtSeq?: number }`.
-2. Populate at the two tx-open sites:
-   - action runs (`action-run.ts` — replace/extend the `sourceAction`
-     stamp; keep the old field working until all readers migrate, then
-     remove it in the same PR if the migration is complete);
-   - event-handler dispatch (`packages/runner/src/scheduler/events.ts`).
-   The `source` anchor = the piece root doc id. Resolve it the same way
-   the observation builder resolves `pieceId` (find
-   `buildSchedulerActionObservation`'s call site and reuse its
-   resolution; do NOT invent a second piece-resolution path).
-3. Carry it on the wire: add an optional `provenance` field to the commit
-   payload via the patch-operations registry (same pattern as W0.1 step
-   2; coordinate if both PRs are in flight).
-4. Transfer at apply: in `Engine.applyCommit`, for every entity the
-   commit CREATES (no prior revision row for that id), synthesize the
-   `["source"]` write from `provenance.source` as part of the same
-   commit application (recorded in `revision` like any write). Mirror the
-   identical rule in the runner's local optimistic apply
-   (`packages/runner/src/storage/v2.ts`) so replicas match without
-   waiting for the server echo.
-5. v1 policy decisions (already made in review — implement, don't
-   re-litigate):
-   - **creation-only**: later writes never re-parent (`source` immutable
-     once set);
-   - **same-space only**: if the created doc's space ≠ the anchor's
-     space, skip stamping (walk returns null; counted);
-   - **setup txs**: anchor = the creating context's piece root (parent
-     piece) or, for the space-root pattern itself, unset.
-6. Walk helper + audit: in `packages/state-inspector`, add
-   `followSourceToPatternRoot(space, docId)` returning the pattern-root
-   doc id or null, and a `cf inspect` subcommand (or extend an existing
-   one) that reports, for a space: total docs / docs with terminating
-   chain / orphans grouped by creator hint. This is the G6 audit tool.
-7. Server-side writers: toolshed ingest handlers (`POST /api/ingest/:id`,
-   `packages/toolshed/routes/ingest/`) populate the commit's provenance
-   with `{ source: <ingest-channel doc id> }` so the engine-side transfer
-   stamps ingest-created docs too. Sqlite-builtin result writebacks ride
-   the builtin action's own tx envelope and need no special handling.
+1. Make the transformer emit exactly one direct output binding to the
+   computation's root result cell.
+2. Validate this invariant when registering/instantiating a computation node
+   and fail with an actionable diagnostic if it is violated.
+3. Use that binding as the action's primary output. Keep explicit static side
+   writes/materializer envelopes as separate write surfaces; do not pick the
+   first redirect found by recursively walking a structure.
+4. Simplify computation-specific compatibility code made unreachable by the
+   invariant. Do not remove general Cell alias/redirect support.
+5. Fix only the hand-built tests that violate the transformer-produced shape.
 
 **Success criteria:**
 
-- [ ] Red→green headline: an integration-style runner test runs a fixture
-      pattern that (a) creates docs from a lift, (b) creates docs from a
-      handler, (c) runs a builtin (`fetchJson` against a local stub)
-      whose result cells are created, then asserts via the walk helper
-      that EVERY doc created during the run terminates at a
-      `pattern`-bearing root. This test must exist and fail before the
-      stamping lands (red run linked in the PR).
-- [ ] Creation-only: a second tx (different action) writing an existing
-      doc does not change its `["source"]` (assert byte-equality of the
-      field across the write).
-- [ ] Cross-space: fixture writing into a second space → stamping
-      skipped, walk returns null, and the audit counts it (pin the
-      behavior; do not silently pass).
-- [ ] CFC neutrality: run an existing CFC-heavy test file
-      (reviewer picks; suggestion: one of the S16/observation-class
-      suites) unmodified — green. Plus a targeted test: stamping a doc
-      does not add flow-read/label entries (assert via the CFC policy
-      inputs on a prepared tx).
-- [ ] Wire compatibility: commits WITHOUT the provenance field (old
-      clients) still apply — docs simply get no `source` (test with a
-      hand-built commit payload).
-- [ ] Local/remote parity: after a run against an in-process server, the
-      client replica's doc envelopes equal the server store's (compare
-      `["source"]` for a sample of created docs).
-- [ ] Audit tool: `cf inspect` walk-coverage subcommand runs against a
-      seeded space fixture and prints the coverage report (golden-ish
-      test on its output shape, not exact counts).
-- [ ] Ingest anchoring: a doc created through the ingest route walks to
-      the ingest-channel doc (route-handler test).
-
-**Review checklist:**
-
-- The apply-side stamp must be inside the commit transaction and recorded
-  as a normal revision write (otherwise catch-up/replication would miss
-  it).
-- Check the CFC exclusion list was NOT widened (the diff should not touch
-  `prepare.ts` exclusion predicates at all).
-- Confirm the piece-root resolution is shared with the observation
-  builder, not duplicated.
-- Look for the classic trap: stamping in the runner only (client-side)
-  — server-created docs (ingest, sqlite builtin server writes) must get
-  stamped by the engine-side transfer too. Ask where ingest txs get
-  their anchor (README §3.3.1: the ingest-channel doc).
+- [ ] A transformed lift has one direct root binding and registers the expected
+      stable action/output identity.
+- [ ] A malformed hand-built computation with nested or multiple root bindings
+      fails at registration with the new diagnostic.
+- [ ] Static side writes still appear as additional write-index entries.
+- [ ] General Cell redirect and alias tests remain green.
+- [ ] No corpus migration, historical JSON compatibility path, or recursive
+      first-output heuristic remains for computations.
 
 ---
 
-### W0.4 — Executor principal + per-space grant flow
+### W0.3 — Authoritative writer lookup from scheduler-v2 indexes
 
-**Depends on:** nothing. **Unblocks:** W1.1, W2.1.
-**Deliverable:** one PR: a first-class executor service identity, an
-owner-driven grant that gives it WRITE on a space, revocation, and the
-`executorConfig` space doc that records opt-in.
+**Depends on:** W0.1, W0.2.
+**Unblocks:** demand discovery and cold wake.
 
-**Read first:** `packages/background-piece-service/src/main.ts` ~96
-(service identity from env — the precedent);
-`packages/memory/v2/server.ts` ~813+ (ACL enforcement: OWNER/WRITE/READ
-per DID); `docs/specs/toolshed-access-control.md`;
-README §5.B.7 (executor principal; endorsement atom is NOT this WO — it
-lands with Phase 2 and needs its own small spec, G1's atom half).
+**Decision:** creation provenance is not current producer identity. Do not add
+universal source stamping or walk from a target through its creator.
+
+**Read first:**
+
+- scheduler_write_index DDL and population in packages/memory/v2/engine.ts
+- scheduler_action_state and scheduler snapshots
+- Scheduler-v2 static writes and materializer envelope indexing
+- Current path-overlap logic used for reads/writes
 
 **Steps:**
 
-1. Mint/configure the executor identity exactly like bps does (env
-   `IDENTITY`-derived signer); expose its DID via a small module in the
-   executor service package so tests can reference it.
-2. Grant flow: a `cf` CLI command (e.g. `cf space executor enable
-   <space>`) run by an OWNER session that (a) adds the executor DID with
-   WRITE to the space ACL, (b) writes the `executorConfig` doc
-   `{ enabled: true, derivedAuthority: "client", epoch: <seq> }`.
-   Disable reverses both (ACL removal + `enabled: false`, epoch bump).
-3. Server enforcement already exists (ACL check on transact); add a
-   focused test that the executor DID can transact after enable and is
-   rejected after disable.
+1. Add a named indexed query writersForTargets(branch, space, addresses).
+   Return all candidate writers, not an arbitrary winner.
+2. Match exact documents and the same path-overlap semantics used by scheduler
+   invalidation. Include the effective read/write scope key and action
+   execution_context_key in matches.
+3. Join candidates to scheduler_action_state/snapshot so the pool receives
+   piece id, stable action id, kind, implementation/runtime fingerprints,
+   static/dynamic provenance, and last status.
+   Load executable code only through the piece root's durable patternIdentity;
+   do not synthesize a code identity from a target cell.
+4. Combine durable observation-backed rows with the live scheduler's
+   registration-time static surface when a Worker is already present. Do not
+   manufacture a clean durable observation merely to index a never-run action.
+5. Replace an action's dynamic write rows on re-observation; never accumulate
+   stale targets.
+6. On an index miss, fail open to piece-root instantiation and discovery. Do
+   not infer producer from the target document's creator.
 
 **Success criteria:**
 
-- [ ] `packages/memory` (or toolshed route test): executor DID transact →
-      rejected before grant, accepted after, rejected after revoke; a
-      commit in flight across revocation fails cleanly (no partial
-      apply).
-- [ ] `executorConfig` doc round-trips through a normal cell read (it is
-      an ordinary doc; no new storage surface).
-- [ ] CLI: enable → disable → enable leaves exactly one ACL entry and
-      `epoch` strictly increasing (idempotency).
-- [ ] Non-owner session cannot enable (authorization test).
-
-**Review checklist:** the grant writes must be auditable (they are
-ordinary commits by the owner session — verify no direct-DB mutation
-path was added); revocation must not strand the executor mid-settle in a
-crash loop (its commit failures must be terminal-permanent, not retried
-forever — check the rejection is classified permanent, see the
-permanent-rejection taxonomy from scheduler E0).
+- [ ] A direct result target returns its producing action from the durable row
+      after observation and from the live static surface before first run.
+- [ ] A side-write target and materializer target return the correct action.
+- [ ] A pre-existing target redirected from a computation returns the current
+      writer even though its creator is unrelated.
+- [ ] Multiple candidate writers are all returned deterministically.
+- [ ] PerUser/PerSession target lookups never return another context's writer.
+- [ ] Re-observation with a smaller write set removes obsolete lookup results.
+- [ ] A 10k-row query uses the intended index and meets the existing scheduler
+      index performance budget.
 
 ---
 
-### W0.5 — In-process provider, stage 1 (loopback against a live Server)
+### W0.4 — Exact input basis and execution provenance
 
-**Depends on:** nothing. **Unblocks:** W0.6.
-**Deliverable:** one PR: construct a StorageManager/provider against an
-EXISTING `MemoryV2Server.Server` instance in-process (today `emulate()`
-always builds its own).
+**Depends on:** #4288.
+**Unblocks:** claim settlement and overlay reconciliation.
 
-**Read first:** `packages/runner/src/storage/v2-emulate.ts` (~36:
-`EmulatedStorageManager` holds a `#serverFactory`);
-`packages/memory/v2/client.ts` ~1299 (`loopback(server)` transport);
-`packages/runner/src/storage/cache.deno.ts` ~20 (how emulate is reached).
+**Problem:** the accepting commit/head sequence is not proof of which inputs an
+action consumed. A no-op action also produces no ordinary commit to acknowledge
+that it settled.
+
+**Read first:**
+
+- packages/runner/src/scheduler/action-run.ts read tracking, transaction open,
+  no-op elision, and observation construction
+- Scheduler-v2 commit gates and bounded settle
+- Memory-v2 revision sequence assignment and feed ordering
+- Event dispatch transaction provenance
 
 **Steps:**
 
-1. Add `StorageManager.inProcess(server, options)` (or an
-   `emulate({ server })` overload — pick whichever fits the existing
-   factory shape best) that uses `loopback(existingServer)` instead of a
-   fresh server.
-2. Find the storage conformance tests that currently run under
-   `emulate()` (grep `StorageManager.emulate(` in `packages/runner/test`)
-   and parameterize a representative subset to also run under
-   `inProcess` with a shared server.
+1. Track the revision sequence actually observed for every effective read. For
+   this same-space phase, inputBasisSeq is the maximum consumed same-space
+   revision sequence, or zero for no durable reads. Do not substitute current
+   head or accepting commit seq.
+2. Define ActionExecutionProvenance with:
+   - ActionClaimKey;
+   - onBehalfOf user DID;
+   - execution lease generation;
+   - claimGeneration when the action is claimed;
+   - causedBy source commit sequence(s), when known;
+   - inputBasisSeq.
+3. The host derives onBehalfOf from the authenticated sponsor lease and
+   overwrites/rejects any worker- or client-supplied value. It means
+   server-executed on behalf of this user, not semantic authorship of every
+   input.
+4. Carry provenance through the normal validated transaction path and store it
+   with scheduler observation/commit diagnostics.
+5. Separate acceptedCommitSeq from inputBasisSeq in types and tests.
+6. Add ActionSettlement emission for committed, no-op, failed, and unserved
+   attempts. Settlement names the exact leaseGeneration + claimGeneration and
+   inputBasisSeq. A committed settlement must carry acceptedCommitSeq; no-op
+   has no data commit. Emit either only after the normal confirmed-read
+   validation accepts the corresponding data or observation-only transaction.
+7. Co-order data patches and settlements on the session feed. A client may
+   apply a committed settlement only after its confirmed/feed cursor reaches
+   acceptedCommitSeq. No-op settlement follows the accepted observation-only
+   transaction in that ordered stream.
+8. Keep handler/source commits compatible; handler semantic authorship remains
+   the authenticated event sender.
 
 **Success criteria:**
 
-- [ ] Two runtimes (in Deno Workers — realm rule!) against ONE shared
-      in-process server see each other's committed writes (loopback
-      two-runtime test; the harness recipe exists — see
-      `multi-runtime-harness.ts`).
-- [ ] The parameterized conformance subset passes identically under
-      `emulate` and `inProcess`.
-- [ ] No behavior change for existing `emulate()` callers (test suite
-      untouched and green).
-
-**Review checklist:** the worker-realm rule — reject any test that
-constructs two runtimes in one realm; check the shared server's lifetime
-is owned outside both runtimes (dispose order test).
+- [ ] An action reading an old revision while unrelated newer commits exist
+      records the old consumed basis, not head.
+- [ ] Two consumed inputs at S1 and S2 record max(S1,S2).
+- [ ] A no-op claimed action emits a settlement with its real basis despite
+      producing no data commit.
+- [ ] A committed settlement cannot clear an overlay before the client has
+      applied the acceptedCommitSeq data patch, including forced reordering.
+- [ ] Commit seq and input basis are independently asserted and cannot be
+      accidentally interchanged by type/API.
+- [ ] The store/control event records the sponsor user as onBehalfOf.
+- [ ] A forged onBehalfOf from worker IPC or a client is rejected/overwritten.
+- [ ] Cross-space input attempts are rejected by W1.3 rather than collapsed
+      into this scalar.
 
 ---
 
-### W0.6 — In-process provider, stage 2 (engine-direct, no sessions)
+### W0.5 — Authenticated in-process provider without an Engine bypass
 
-**Depends on:** W0.5. **Unblocks:** W1.1.
-**Deliverable:** one PR: an executor-grade provider that (a) commits via
-the engine directly, (b) reads via the engine read path, (c) receives
-per-space invalidations from a commit-stream callback instead of
-`session.watch` — plus the worker-boundary channel variant.
+**Depends on:** #4288.
+**Unblocks:** leases and executor Workers.
 
-**Read first:** `packages/memory/v2/server.ts`: `Engine.applyCommit` call
-sites (~950, ~1031, ~1628), `markSpaceDirty` (~1051), the read pool
-(`#readPool`, ~711), and the session refresh loop you are bypassing
-(~2155–2466 — understand what you are NOT going through);
-`packages/runner/src/storage/v2.ts` (`Provider`, ~1074) and the
-scheduler's storage-notification entry (search
-`processPullStorageNotification` in `packages/runner/src`).
+**Decision:** low-overhead server execution may be in-process, but every read
+and commit must traverse the same authenticated authorization, conflict, CFC,
+provenance, hook, and notification path as a remote client.
+
+**Read first:**
+
+- packages/memory/v2/server.ts session authentication, ACL/CFC validation,
+  commit apply, and post-commit notifications
+- packages/memory/v2/client.ts loopback transport
+- packages/runner/src/storage/v2.ts provider/replica interfaces
+- Existing multi-runtime Worker harnesses
 
 **Steps:**
 
-1. Server API: `server.onSpaceCommit(space, cb)` — invoked after
-   `applyCommit` success with `{ seq, changedIds }` (the same data
-   `markSpaceDirty` receives). Synchronous registration, idempotent
-   unregister; document that callbacks must not throw (wrap + log).
-2. Provider: implement `IStorageProviderWithReplica` whose replica pulls
-   docs through the engine read path on demand and applies commit-stream
-   notifications into the existing notification entry the scheduler
-   already consumes. Commits go to `applyCommit` with the executor
-   session identity (W0.4) — reuse the commit-validation path, do NOT
-   bypass conflict detection.
-3. Worker variant: the engine lives on the host thread; the executor
-   runtime lives in a Deno Worker. Bridge with a `MessageChannel`:
-   requests (read/commit) as structured-clone messages; invalidations
-   pushed host→worker. Batch reads (the compile-wedge lesson: long
-   MessageChannel chains starve timers — keep the protocol
-   request/response, no polling loops).
-4. Equivalence guard: a differential test running one fixture pattern to
-   settle under (a) the stage-1 loopback provider and (b) the
-   engine-direct provider, then byte-comparing all docs in the space
-   (state-inspector dump) and the observation rows (if W0.1 landed).
+1. Add a host-owned provider adapter against an existing Server. Reuse either
+   authenticated loopback or a dedicated internal Server method that shares
+   all normal validation; do not call Engine.applyCommit directly.
+2. The runtime Worker receives an opaque provider/lease channel over
+   MessageChannel. It receives neither a user private key nor raw Engine
+   access.
+3. Route reads through the authenticated Server read path and commits through
+   normal transact validation. Push post-commit invalidations to the Worker;
+   do not poll.
+4. Allow the host to attach a current ExecutionLease and fence generation to
+   each commit. W1.1 supplies and validates the lease.
+5. Preserve remote and in-process behavioral equivalence with a differential
+   fixture, including scheduler observations and rejected commits. Compare
+   exact user operations/data, then normalize legitimate session ids,
+   sequences, lease generations, and transport metadata before comparing
+   scheduler semantics; assert the expected identity/fence fields separately.
+6. Ensure provider disposal unregisters callbacks and cannot outlive its lease.
 
 **Success criteria:**
 
-- [ ] Differential test green (byte-identical docs under both providers).
-- [ ] Zero sessions: assert the server has no session/watch registered
-      for the executor connection while the fixture runs (inspect server
-      session count — expose a test-only accessor if needed).
-- [ ] Invalidation correctness: an external commit (via a second,
-      ordinary client session) invalidates and re-settles the executor
-      runtime (value observed updated) without any watch.
-- [ ] Worker variant: same fixture green with the runtime in a Worker;
-      no cross-realm construction.
-- [ ] Conflict path: two writers (executor + client) racing one doc →
-      executor sees a normal conflict/retry, not corruption (reuse an
-      existing conflict test shape).
-
-**Review checklist:** confirm commits flow through the SAME
-`applyCommit` validation as remote commits (look for any "trusted"
-shortcut and reject it); callback registration must be per-space and
-cleaned up on provider dispose (leak test); no timer-based polling in the
-worker bridge.
+- [ ] Differential fixture produces identical user operations/data and
+      normalized-equivalent scheduler semantics through remote/loopback and
+      host-provider paths; expected session/provenance/fence differences are
+      asserted explicitly.
+- [ ] ACL denial, CFC denial, conflict, and revoked/fenced lease each produce
+      the same atomic rejection shape; no partial apply.
+- [ ] An ordinary client commit invalidates and re-settles the Worker without a
+      watch/poll loop.
+- [ ] Worker termination releases callbacks and pending requests.
+- [ ] A test guard proves no provider path calls Engine.applyCommit directly.
 
 ---
 
-### W0.7 — `session.interest.set` + doc-set feed (flagged)
+### W0.6 — Trusted-client handshake, demand, claim, and settlement protocol
 
-**Depends on:** nothing. **Unblocks:** W1.1 discovery; Phase 3.
-**Deliverable:** one PR: a flagged alternative to `session.watch` graph
-queries — the session declares interest; the server fans out changed docs
-by set-membership. v0 grain: whole-space (`pieces: "*"`) only;
-piece-granular closures arrive in Phase 1 when the executor can export
-them.
+**Depends on:** #4288.
+**Unblocks:** client-driven pool and client authority split.
 
-**Read first:** `packages/memory/v2/server.ts` — the watch/refresh path
-you are adding an alternative to: `markSpaceDirty` (~2320) → refresh
-loop (~2466) → `refreshDirty` (~649) → `syncSessionForConnection`
-(~2155) → `refreshTrackedGraph` (~2223); catch-up `fromSeq/toSeq`
-(~2187/2269); `docs/specs/memory-v2/04-protocol.md` §4.1.1 (message
-envelope conventions).
+**Read first:**
+
+- docs/specs/memory-v2/04-protocol.md
+- Memory-v2 session handshake/version negotiation
+- Current piece watch/pull registration and session control ordering
+- docs/development/EXPERIMENTAL_OPTIONS.md
 
 **Steps:**
 
-1. Protocol: add `session.interest.set { space, pieces: "*" }` (accept
-   only `"*"` in v0; reject arrays with a clear error so the field can
-   grow). A session in interest mode for a space suppresses graph-query
-   refresh for that space and instead receives `SessionSync` upserts for
-   ALL changed docs in the space (compute from changed ids directly; no
-   graph re-evaluation). Framing: the message is a granularity hint over
-   the doc-centric demand model (README §6.3) — the target grain is the
-   session's read doc-set, with per-piece as the intermediate step.
-2. Catch-up: reuse the existing `seenSeq`→head resume path for interest
-   sessions (it already iterates commits by seq).
-3. Client: behind `CF_INTEREST_FEED`, the shell/runtime sends
-   `interest.set` for each opened space instead of the per-piece watch
-   registration (find where `session.watch.set` is issued in
-   `packages/runner/src/storage/v2.ts` / the shell boot path and branch
-   there). Everything downstream of received upserts is unchanged.
-4. Latency instrumentation: count and time server-side per-commit fan-out
-   work in both modes (a counter the perf test can read; OTel if #4448
-   has landed by then — check).
+1. Add capability negotiation for server-primary-execution-v1. When a
+   deployment/space requires server-primary semantics, reject clients that do
+   not advertise the capability; do not silently mix stale authority rules.
+2. Add session.execution.demand.set. A demand is bound to the authenticated
+   connection, space, and piece result roots. Replacement and disconnect remove
+   that connection's references automatically.
+3. Add claim set/revoke messages containing ActionClaimKey, leaseGeneration,
+   monotonic per-ActionClaimKey claimGeneration, and server-controlled expiry.
+   Revoke names the live claimGeneration. A later claim set uses the next value
+   even if the worker lease generation is unchanged.
+4. Add settlement messages keyed to the exact leaseGeneration +
+   claimGeneration and carrying outcome, inputBasisSeq, diagnostic code, and
+   acceptedCommitSeq for `committed` outcomes. Other outcomes omit it.
+5. Define ordering: claim set is observed before a client may suppress a
+   matching action; revoke is fail-open while connected; settlements cannot
+   apply to a newer claim generation. Carry claim snapshots, claim revokes,
+   commit patches, and every settlement outcome on one ordered reconnectable
+   stream with explicit feed-sequence barriers. For committed outcomes,
+   acceptedCommitSeq is an additional data-application gate, not a replacement
+   for control ordering.
+6. Authorize demand using the session's existing READ access. Sponsor
+   eligibility is a separate WRITE check in W1.1.
+7. Add optional executionPolicy owner doc support. It only opts a space into
+   server-primary execution; absent/disabled policy means client-primary. Do
+   not put claims, actor identity, heartbeat, exception lists, or epochs in it.
+8. Gate all messages behind serverPrimaryExecution, default off.
+   Negotiate routing and builtin-passivity sub-capabilities while the WOs land;
+   a server publishes only the claim classes the client says it can honor.
 
 **Success criteria:**
 
-- [ ] Two-client parity test: clients A (watch mode) and B (interest
-      mode) on one space; a third session commits; A and B converge to
-      identical replicas (compare a sampled doc set), B's delivery
-      latency ≤ A's (coarse assert: within 2× of the 5ms refresh tick).
-- [ ] Reconnect: interest-mode session disconnects, misses N commits,
-      reconnects with `seenSeq` → receives exactly the missed changes
-      (no duplicates: assert upsert count).
-- [ ] Server does NOT run `refreshTrackedGraph` for interest-mode
-      sessions (call counter assert).
-- [ ] Flag off: zero protocol traffic difference (snapshot the message
-      log of a fixture run, compare to main).
-- [ ] Old server + flagged client: client falls back to watch mode
-      gracefully when the server rejects the unknown message (version
-      tolerance test — the stale-server skew trap is real).
-- [ ] Ordering: upserts for a space are delivered and applied in
-      nondecreasing seq order under rapid commits (assert the applied
-      seq sequence is sorted). The overlay drop rule (W2.3, README
-      §5.B.4) depends on this guarantee.
-
-**Review checklist:** interest mode must not leak docs the session's ACL
-would not allow (the watch path had per-session scoping — verify the
-interest path enforces the same reader checks; write the adversarial
-test: user partitions of OTHER users must not appear in the feed).
-This is the WO where reader isolation can silently break — treat that
-last criterion as blocking.
+- [ ] Compatible client negotiates and round-trips demand/claim/settlement.
+- [ ] Incompatible/stale client is explicitly rejected when the feature is
+      required and works unchanged when it is not.
+- [ ] Two connections demanding the same root produce two references; closing
+      one leaves the other live; closing both removes demand.
+- [ ] Spoofed connection id, principal, claim, or settlement is rejected.
+- [ ] Revoke/re-claim within one lease gets a new claimGeneration, and a
+      reordered old-generation settlement cannot clear the new claim.
+- [ ] A committed settlement delivered before its data frame is buffered until
+      the acceptedCommitSeq patch is applied.
+- [ ] Flag off produces no new protocol messages.
 
 ---
 
-## 3. Phase 1 — Approach A: server catch-up executor
+## 3. Phase 1 — one shadow executor per eligible active space
 
-Phase exit criteria (all must hold before Phase 2 starts):
+Phase exit:
 
-- E1.a A cold, opted-in space catches up within 10s of a source commit
-  with no client connected (W1.3 test).
-- E1.b Zero double-fired async requests in the 3-tab multi-runtime test
-  (W1.2 test).
-- E1.c bps regression suite green under the reactive mode (W1.4).
-- E1.d Executor-served space feed latency ≈ watch latency (W0.7 metric
-  within 2×).
+- Exactly one fenced worker generation runs for an eligible space; a legacy
+  background-owned space is excluded until Phase 3.
+- Multiple client demands merge into it without duplicate schedulers.
+- The ordinary rollout remains observation-only: zero authoritative claims,
+  derived server commits, or external builtin effects are published.
+- Test-only negotiated authority proves every derived commit records on behalf
+  of which user it ran.
+- Only statically and dynamically proven same-space, space-scoped actions are
+  reported as CandidateClaim.
+- Async builtins pass broker/egress tests only under an explicit test
+  capability; client passivity and production claim publication wait for
+  Phase 2.
 
-### W1.1 — Executor pool: reactive worker-per-space service
+### W1.1 — User-sponsored execution leases and fencing
 
-**Depends on:** W0.4, W0.5 (W0.6 preferred), W0.1 (for hibernate/resume).
-**Deliverable:** one PR (large; may split into worker-lifecycle +
-demand-loop): `background-piece-service` gains `EXECUTOR_MODE=reactive`
-— per-space Deno Worker running a runtime on the in-process provider,
-kept current by pull-on-invalidation, hibernating when idle.
+**Depends on:** W0.5.
+**Unblocks:** W1.2.
 
-**Read first:** the whole of
-`packages/background-piece-service/src/` — especially `service.ts` (~31:
-BGPieceEntry discovery via `.sink()`; ~107: SpaceManager per space),
-`space-manager.ts` (~40: `rerunIntervalMs ?? 60000` — the polling you are
-replacing), `worker-controller.ts` (~78: `new Worker(...)`),
-`worker-ipc.ts`, `worker.ts`; `packages/runner/src/cell.ts` ~1032
-(`Cell.pull()` — ephemeral demand root, settles to closure);
-README §6.1–§6.5.
+**Decision:** the executor is not an anonymous service principal for
+client-driven work. One authenticated requesting user sponsors a worker
+generation. Background-only work gets its service identity later.
 
 **Steps:**
 
-1. Mode flag `EXECUTOR_MODE=reactive` (env, default absent = today's
-   polling behavior untouched).
-2. Registration: v1 discovery = the existing BG registry cell UNION
-   spaces with `executorConfig.enabled` (W0.4). Per space, the interested
-   piece set = registry entries for that space (client-driven interest
-   arrives in W1.3+/Phase 3).
-3. Space worker: construct runtime with `persistentSchedulerState: true`,
-   `storageConnection: "in-process"` (worker-bridge from W0.6), the
-   executor signer, and `rehydrateFromStorage` subscriptions.
-   Registration order is load-bearing (README §6.5 spawn sequence): the
-   pool registers `onSpaceCommit` and BUFFERS batches before the
-   worker's first settle; the worker reports "live at seq S" and the
-   pool releases the buffer from S — no notification gap. After
-   rehydration, also register `onSpaceCommit` for every OTHER space in
-   the pieces' read closures (README §6.8).
-4. Demand loop (the core): on each `onSpaceCommit` batch → for each
-   interested piece → `resultCell.pull()` → await settle → await
-   `runtime.settled()` (async builtins). Explicitly DO NOT register a
-   standing schema-less sink over piece state (this exact shape caused a
-   ~270× re-run amplification; reviewers will reject it). Per-piece pulls
-   are the v1 implementation of doc-centric demand (README §6.3) — a
-   coarse over-approximation of the demanded doc set. Keep the loop's
-   interface "wake with a stale doc/piece list" so narrowing to per-doc
-   pulls later is a loop change, not an architecture change.
-5. Hibernation: idle timer (no commits, no in-flight async for N min,
-   default 10 to match the existing worker timeout) → `runtime.settled()`
-   → per-space storage teardown (`StorageManager.closeSpace` ships with
-   PR #4115; if unmerged when you get here, implement teardown against
-   the StorageManager seam and say so in the PR) → terminate worker.
-   Drain protocol: record the worker's last-settled seq; mark the space
-   *draining* in the pool until the worker exits; wake decisions treat
-   draining spaces as having no worker and compare incoming commits
-   against last-settled seq (W1.3), so nothing lands unseen between
-   settle and terminate. Wake = W1.3 (until then, workers for registered
-   spaces stay up).
-6. Crash isolation: worker error → report, restart with exponential
-   backoff, other spaces unaffected (worker-controller has error events
-   already — extend). After N consecutive failures, quarantine the space
-   (stop serving, alert, no restart storm). Stub a quarantine hook the
-   ownership machinery will consume (W2.1 auto-flips `derivedAuthority`
-   to `"client"` on quarantine).
+1. Add a Server/control-plane ExecutionLease record per branch/space with
+   monotonic generation, host id, onBehalfOf DID, expiry, and state. Use a
+   database-backed compare-and-swap/transactional seam so multiple server
+   processes cannot both own the space.
+2. Acquire only from an active demand session with WRITE authority. Prefer the
+   active principal whose source commit caused a cold wake; otherwise choose
+   the oldest eligible demand deterministically.
+   If no requester can sponsor, acquire no lease and publish no claim; clients
+   remain authoritative.
+3. Keep the sponsor sticky for the worker generation. Runtime/StorageManager
+   identity is construction-wide; do not switch actor inside a settled graph.
+4. The host retains the authenticated grant and exposes only an opaque lease
+   channel to the Worker. Every executor commit checks current generation,
+   expiry, sponsor authorization, and executionPolicy immediately before apply.
+5. Renew with server time while demand/in-flight work exists. A heartbeat
+   document is not a lease and must not be introduced.
+6. On sponsor disconnect/revocation, allow a bounded drain of already-started
+   work, revoke the lease, and restart under another eligible requester if
+   demand remains. No old/new overlap is allowed.
+7. Provenance records onBehalfOf and worker generation. Future user-delegated
+   keys can replace the session-derived lease without changing that semantic.
 
 **Success criteria:**
 
-- [ ] Integration test (in bps package, in-process server + cf-CLI-style
-      seeding): opted-in space with a fixture pattern whose lift derives
-      `out = f(in)`; commit `in` via an ordinary client session; with NO
-      client-side execution, `out` is correct in the store within 10s.
-- [ ] Async: fixture with a `fetchJson` against a local stub — executor
-      performs the fetch and writes the result; stub sees exactly 1
-      request.
-- [ ] Hibernate/resume: after idle timeout, the worker is gone (assert
-      pool size); a later commit + manual `ensureSpace` call resumes and
-      catches up using rehydration — and the fixture's lift-invocation
-      counter shows only the stale subset re-ran.
-- [ ] Two spaces, two workers; `Worker.terminate()` one mid-settle →
-      other space unaffected; killed space recovers on restart with
-      correct results (no torn state — commits are transactional).
-- [ ] Mode off: bps behaves byte-identically to main (its existing tests
-      unmodified and green).
-- [ ] No standing schema-less sink anywhere in the new demand path
-      (grep-level review criterion; also assert re-run counts stay flat
-      when an unrelated doc in the space changes — the amplification
-      canary).
-- [ ] Drain race: a commit landing between `settled()` and worker
-      terminate triggers a respawn that catches up (force the window
-      with a test hook/delay; assert final derived state correct and
-      exactly one respawn).
-- [ ] No-gap spawn: a commit landing between worker spawn and its first
-      settle is reflected in the catch-up without a second wake (test
-      hook delays the first settle; assert the buffered batch was
-      applied).
-- [ ] Quarantine: N forced crashes → space quarantined, backoff schedule
-      observed (no restart storm), other spaces unaffected.
-
-**Review checklist:** the demand loop must be pull-based
-(`pull()`-per-wake) as specified; check `settled()` (not `idle()`) gates
-hibernation; check the worker bridge does not poll; check executor
-commits carry the executor identity (sample a commit's session in the
-store); verify the amplification canary test is real (unrelated-doc
-write → zero pulls).
+- [ ] One requester yields one valid lease and commits marked onBehalfOf that
+      user.
+- [ ] Two hosts racing acquire produce one winner; loser cannot commit.
+- [ ] A delayed commit from generation N is rejected after generation N+1
+      begins.
+- [ ] Sponsor loses WRITE or disconnects: in-flight boundary is deterministic,
+      old Worker is fenced, and remaining demand restarts under another user.
+- [ ] A READ-only requester can demand data but cannot sponsor writes.
+- [ ] With only READ-only demand, no worker claim appears and current client
+      behavior continues unchanged.
+- [ ] No user private key enters Worker memory or IPC.
 
 ---
 
-### W1.2 — Async executor priority
+### W1.2 — Shared demand pool: one Worker per eligible active space
 
-**Depends on:** W1.1.
-**Deliverable:** one PR: when a space has a live executor, async builtins
-fire only there; clients defer.
+**Depends on:** W0.6, W1.1, W0.1.
+**Unblocks:** W1.3.
 
-**Read first:** `packages/runner/src/builtins/fetch-utils.ts` ~90–151
-(`tryClaimMutex`: claim record + `lastActivity` + timeouts: 5s fetch /
-5min llm-dialog), ~157–180 (`tryWriteResult` guard);
-`packages/runner/src/builtins/fetch.ts` ~473–500 (claim usage);
-README §5.B.5 (the eventual passive mode is Phase 2 — this WO is only
-priority, not prohibition).
+**Decision:** never start one runtime per client. Worker cardinality, demand,
+and signing authority are separate.
+
+**Read first:**
+
+- packages/background-piece-service worker-controller/IPC for lifecycle
+  patterns only; do not make its registry the primary discovery path
+- Scheduler-v2 demand/pull and bounded settle APIs
+- Cell.pull and piece result-root instantiation
+- Persistent scheduler rehydration through packages/runner/src/scheduler.ts
 
 **Steps:**
 
-1. Executor liveness signal: the space worker maintains a heartbeat doc
-   (`executorHeartbeat`, updated every ~5s while awake; ordinary doc, no
-   new surfaces).
-2. Claim precedence: `tryClaimMutex` gains a role — clients, before
-   claiming, read the heartbeat; if fresh (< 3× interval), do not claim
-   (leave pending rendering as-is). The executor claims unconditionally
-   and may take over a stale client claim immediately.
-3. Timeout fallback unchanged: heartbeat stale → clients behave exactly
-   as today.
+1. Add a host pool Map<branch+space, SpaceExecutionSlot>. Union every
+   connection's ExecutionDemand into the slot; acquire one lease and launch one
+   Worker for the union.
+2. Construct one runtime with persistentSchedulerState enabled and the
+   authenticated host provider. Rehydrate the applicable space/user/session
+   scheduler rows for its sponsor context.
+   From the first pull, enforce shadow mode: apply computation results only to
+   the Worker's private replica for graph discovery, reject every upstream
+   derived commit, and deny all external builtin broker calls. Source/handler
+   work is not injected into this runtime.
+3. Register post-commit buffering before initial load. Worker reports live at
+   seq S; release buffered notifications after S so spawn has no gap.
+4. Demand exact piece result roots with pull-per-wake. Do not install a
+   schema-less standing sink. Scheduler-v2 deduplicates overlapping client
+   demand inside this single scheduler.
+5. Demand changes update the union without restarting unless sponsor context
+   must rotate. Empty demand begins bounded drain/hibernate.
+6. Isolate Worker crashes, back off, and discard CandidateClaims before retry.
+7. Add a mandatory legacy-background exclusion interlock without refactoring
+   its registry: if background-piece-service has a registration, active
+   controller, or lease for the branch/space, do not launch the new pool slot
+   and publish no claim. Existing background behavior continues. Phase 3
+   imports that demand into the shared slot and removes the exclusion.
 
 **Success criteria:**
 
-- [ ] Multi-runtime test (3 client workers + executor, shared in-process
-      server, stub fetch endpoint): stub receives exactly 1 request; its
-      auth/identity marker shows the executor session.
-- [ ] Kill the executor mid-request: heartbeat goes stale; a client
-      claims after the existing timeout and completes; result correct
-      (the fixture asserts final value, and total requests ≤ 2).
-- [ ] No executor (heartbeat absent): behavior identical to main (run an
-      existing cross-tab mutex test unmodified).
-- [ ] Clock skew guard: heartbeat freshness uses server seq/time
-      consistently (pin whichever the claim records already use —
-      `lastActivity` convention — do not introduce a second clock).
-
-**Review checklist:** the client defer path must not spin (no tight
-retry loop while heartbeat fresh — it should simply not claim and rely
-on normal invalidation); check llm-dialog's 5-minute timeout is
-respected (don't let executor takeover break a live client streaming
-session — takeover only on stale claims).
+- [ ] Ten clients demanding the same piece produce one Worker, one scheduler
+      action run per invalidation, and ten reference-counted demands.
+- [ ] Disjoint roots from two clients run in the same space Worker and only
+      demanded closures stay live.
+- [ ] Closing one client does not remove another's demand; closing the last
+      drains and terminates.
+- [ ] Commit during spawn buffering is observed without a second wake.
+- [ ] Worker crash discards CandidateClaims (and revokes any test-only claims)
+      before restart and leaves other spaces unaffected.
+- [ ] An unrelated document write causes zero pulls/action runs.
+- [ ] Every ordinary shadow pull produces zero server data operations and zero
+      external builtin calls while still collecting local graph observations.
+- [ ] Concurrent legacy background registration plus client demand starts no
+      second server Worker and publishes no server-primary claim.
 
 ---
 
-### W1.3 — Wake-on-commit
+### W1.3 — Whole-action servability, firewall, and claim readiness
 
-**Depends on:** W0.2, W1.1.
-**Deliverable:** one PR: hibernated spaces wake when a commit makes an
-interested piece stale; irrelevant commits don't wake anything.
+**Depends on:** W0.2, W0.3, W0.4, W1.2.
+**Unblocks:** Phase 2 and async serving.
+
+**Decision:** client authority is the default. The server positively claims
+only an action it can serve. Clients need not predict unsupported actions.
 
 **Steps:**
 
-1. Host-side hook: on `onSpaceCommit` for a space with no live worker
-   (including *draining* ones — W1.1's drain protocol), run
-   `staleReadersFor(space, changedIds, seq)` (W0.2) filtered to the
-   registered piece set; non-empty → `ensureSpace(space)` (W1.1) and
-   hand the worker the stale piece list for targeted pulls. For a
-   draining space, additionally wake when `seq >` the recorded
-   last-settled seq even before the readers query (cheap guard against
-   losing the race).
-2. Debounce: batch wake decisions per space per refresh tick (reuse the
-   5ms dirty-batch cadence; do not add a new timer).
-3. Metrics: counters for wakes, suppressed (no-reader) commits, catch-up
-   duration.
+1. Discover all writer actions for demanded targets with writersForTargets.
+   Instantiate the piece root on a safe index miss.
+2. Static preflight rejects candidates with any known foreign-space,
+   PerUser/PerSession, handler/UI-binding, unknown dynamic effect, or malformed
+   output surface. Pure computations with direct root/static write surfaces may
+   proceed to staged execution.
+3. Stage the entire action transaction. Inspect effective reads and writes
+   before apply. The Server transaction firewall accepts only:
+   - owner/read/write space equals the served space;
+   - every effective scope key is space;
+   - every write belongs to the candidate action transaction;
+   - normal ACL/CFC validation succeeds.
+4. If any operation fails the firewall, discard the entire transaction,
+   record an unserved CandidateClaim diagnostic, and never split it. Under the
+   explicit authority test capability, emit unserved settlement and
+   leave/revoke the claim.
+5. For a first pure run, inspect the staged transaction and record a
+   CandidateClaim. Under the explicit test-only routing capability, install a
+   real claim and commit/retry that same action under the fenced lease. A
+   concurrent identical client write may make it a no-op; settlement still
+   acknowledges it.
+6. Claims are action-granular and ActionClaimKey/leaseGeneration/
+   claimGeneration-specific.
+   A piece may contain both claimed and client-primary actions.
+7. Re-evaluate the firewall every run. A dynamically unservable claimed action
+   atomically aborts, revokes, and tells clients to mark it dirty and resume
+   committing the whole action.
+8. Multiple writer candidates are independently claimed. Suppression requires
+   a matching claim for the action producing that transaction.
+9. Until W2.1 is deployed and negotiated, run this machinery only in
+   validation/shadow mode: inspect eligibility and record CandidateClaim
+   diagnostics, but publish no authoritative claim and perform no
+   server-primary commit. The explicit test capability is never advertised to
+   ordinary sessions.
 
 **Success criteria:**
 
-- [ ] Integration: registered space, worker hibernated; external commit
-      to a doc a piece reads → worker spawns, only stale actions re-run
-      (invocation counter), derived docs correct, worker re-hibernates.
-- [ ] Negative: commit to a doc NO piece reads → no worker spawn
-      (counter asserts suppression), and the readers-index query is the
-      only work done.
-- [ ] Burst: 50 rapid commits → at most a handful of wake evaluations
-      (batching assert), one worker spawn.
-- [ ] Cross-space wake: a piece in space A reads a doc in space B (both
-      enabled); with A parked, a commit to that doc in B wakes A's
-      worker and catches the piece up (rides W0.2's cross-space row).
-
-**Review checklist:** the no-reader suppression is the point of W0.2 —
-reject implementations that spin the worker up to "check". Verify the
-stale piece list actually narrows the pulls (not pull-everything).
+- [ ] Same-space pure computation becomes claim-ready in ordinary shadow mode
+      with zero server data commits.
+- [ ] The explicit test capability claims that computation and commits
+      server-derived output under its sponsor.
+- [ ] Mixed space+user writes abort as one transaction; zero operations apply;
+      claim is absent/revoked; client execution commits the complete result.
+- [ ] Cross-space read or write aborts before apply and remains client-primary.
+- [ ] Dynamic scope change after a claim revokes it and converges via client
+      rerun without data loss.
+- [ ] First-run index miss safely instantiates/discovers the piece.
+- [ ] Pre-existing redirected output is served through writer-index identity,
+      not creation source.
+- [ ] No-op produces settlement and leaves no stuck overlay prerequisite.
+- [ ] CFC/ACL denial is not converted into servability or a trusted shortcut.
 
 ---
 
-### W1.4 — Fold bps registry into interest; deprecation path
+### W1.4 — Server async builtins and egress policy
 
-**Depends on:** W1.1.
-**Deliverable:** one PR: BG piece entries become executor interest
-registrations; the 60s polling updater is off for reactive-mode spaces;
-docs updated.
+**Depends on:** W1.3.
+**Unblocks:** W2.3.
 
-**Success criteria:**
-
-- [ ] Existing bps end-to-end test scenarios pass in reactive mode (port
-      the suite; list any intentionally-changed semantics in the PR).
-- [ ] A space in reactive mode never runs the polling rerun loop
-      (`rerunIntervalMs` timer not scheduled — assert via test hook).
-- [ ] Rollback: flipping `EXECUTOR_MODE` off restores polling behavior
-      without data migration.
-
----
-
-## 4. Phase 2 — Approach B: derived-authority split (per-space flag)
-
-Phase exit criteria:
-
-- E2.a On flagged spaces, client commits contain zero space-scoped
-  derived writes (wire assertion in CI).
-- E2.b Multi-client perf fixtures (lunch-poll, group-chat) on flagged
-  spaces: derived write-write conflicts ≈ 0; per-client action volume ≈
-  single-client baseline (measured, with NEW_PERF_BASELINE process for
-  accepted shifts).
-- E2.c Divergence counter ≈ 0 on deterministic fixtures; nonzero only on
-  the rigged-divergence test.
-- E2.d Flag-off spaces byte-identical to main behavior (differential CI
-  job).
-
-Deliberately NOT a Phase-2 WO: the executor-computed endorsement atom
-(G1's second half). It needs a small CFC-owned spec first
-(`writeAuthorizedBy`/integrity machinery); B's flip does not depend on
-it. Coordinate with CFC owners when Phase 2 starts so the spec is ready
-by Phase 4.
-
-### W2.1 — Ownership bit + client honoring skeleton
-
-**Depends on:** W0.4.
-**Deliverable:** one PR: `executorConfig.derivedAuthority:
-"client" | "executor"` with sticky epoch semantics; client runtime reads
-it at space open, subscribes to changes, and exposes
-`spaceDerivedAuthority(space)` to the storage layer; the pool's
-quarantine hook (W1.1) auto-flips the config to `"client"` (epoch bump,
-written pool-side — the pool holds the signer, so the flip survives the
-worker being gone). No routing yet.
-
-**Success criteria:**
-
-- [ ] Flip test: change `derivedAuthority` → connected clients observe
-      the change (assert the exposed getter flips) within one feed tick;
-      epoch increases monotonically; a stale-epoch write of the config
-      doc is rejected by normal conflict rules.
-- [ ] Default: spaces without the doc report `"client"` (today's mode).
-- [ ] Quarantine auto-flip: simulated quarantine flips the config to
-      client authority; connected clients observe it without reload
-      (getter flips; under W2.2 they resume committing derived writes).
-
-### W2.2 — Write-class routing + speculative overlay
-
-**Depends on:** W2.1, W0.3.
-**Deliverable:** one PR (the core of B; expect it to be the
-most-reviewed): on `derivedAuthority: "executor"` spaces, transactions
-whose `TxProvenance.action.kind` is `computation`/materializer-`effect`
-AND whose writes target space-scoped (unscoped) addresses apply to a
-local overlay and are never enqueued upstream; handler/setup/UI-binding
-txs commit exactly as today.
-
-**Read first:** README §5.B.1 (the routing table — implement it
-literally), §5.B.3 (handler semantics: NO new read restrictions — the
-overlay participates in local reads exactly like today's optimistic
-apply), §5.B.6 (scoped writes are EXEMPT from routing — they stay
-client-committed in this phase);
-`packages/runner/src/storage/v2.ts` (`Provider` commit/apply path) and
-`packages/runner/src/storage/interface.ts` (`ISpaceReplica`, ~1367).
+**Scope:** fetch-family and generate-family builtins. Full quotas, a durable
+async ledger, rigorous idempotency, and delegated execution keys are later
+hardening. This WO must not make network reach or duplicate behavior worse than
+the client runtime.
 
 **Steps:**
 
-1. Overlay structure on the replica: per doc,
-   `{ value, basis, generation }` layered above confirmed state for all
-   local reads; `basis` = the latest of the client's OWN source commits
-   the recompute consumed (its localSeq until confirmation, then the
-   assigned seq — README §5.B.4 rule 1). Dropped en masse per doc on
-   watermark (W2.3), on basis-commit rejection (§5.B.4 rule 4), or on
-   authority flip.
-2. Routing decision at commit-enqueue time, from
-   `tx.provenance.action.kind` + target address scope + the W2.1 getter.
-   Scoped-address writes (user/session) bypass routing (commit as
-   today) even from computation txs. Routing also consults
-   `executorConfig.unservablePieces` (README §6.8): pieces on the list
-   route their derived writes as client-authority even on an
-   executor-owned space.
-3. Instrumentation: per-space counters {overlayWrites, committedSource,
-   committedScoped, droppedOverlay, divergences}.
-4. Safety valve: authority flip back to `"client"` → flush semantics:
-   discard overlay, resume committing derived writes from the next
-   settle (document why discard is safe: server state is authoritative
-   and clients recompute).
+1. Statically classify supported builtin actions and their known same-space
+   output surfaces before claiming. Do not trial-run an external side effect to
+   discover servability.
+2. Route builtin network operations through a host broker where practical.
+   A direct executor implementation is acceptable only if it enforces the same
+   tested policy and exposes no raw capability to pattern code.
+3. Preserve the SES invariant: raw fetch remains unavailable inside authored
+   pattern code.
+4. Give the broker the canonical configured serving origin. Resolve relative
+   paths against that origin, preserving today's behavior. Thus a relative path
+   may intentionally reach the serving host even when local development uses
+   localhost/private addresses.
+5. Treat absolute and authority-bearing URLs as external. Block loopback,
+   link-local, private-network, metadata-service, and disallowed schemes.
+   Re-resolve DNS and reapply policy on every redirect hop. A request that
+   began relative remains in trusted-serving-origin mode across a same-origin
+   redirect even when Location is absolute; any origin change becomes external
+   and receives the full policy.
+6. Route generate-family calls through configured provider policy/credentials;
+   never inherit arbitrary client secrets from the demand payload.
+7. For identity-sensitive first-party requests, derive the request actor from
+   the authenticated commit that produced the request and require it to match
+   the current lease sponsor. Never sign as an unrelated sticky sponsor. A
+   mismatch is unservable in v1 or triggers a fenced sponsor handoff; dynamic
+   per-action actors are later work.
+8. Claim a builtin before clients become passive. Transient failure remains a
+   server-owned pending/retry according to existing builtin semantics;
+   permanent policy/servability failure revokes and settles explicitly.
+9. Preserve existing cross-runtime mutex/result guards as defense in depth.
+10. Keep async claim publication dark until W2.3 builtin passivity is deployed
+   and negotiated by every participating client session.
 
 **Success criteria:**
 
-- [ ] Wire assertion: on a flagged space, run a fixture with handler +
-      lifts; capture all ClientCommits (test transport hook): zero
-      operations target unscoped derived docs from computation txs;
-      handler writes present and unchanged.
-- [ ] Local reactivity: with NO server executor running, the client UI
-      value (read through the normal cell read path) still updates
-      immediately after a source write (overlay serves it) — this pins
-      "speculation works offline".
-- [ ] Scoped exemption: PerUser/PerSession derived fixture → those
-      writes still commit (wire assert), and user-partition contents
-      match main behavior.
-- [ ] Parity: flag off → a differential run of the fixture produces
-      byte-identical commits to main (record/compare op streams).
-- [ ] Authority flip mid-session: no crash, overlay discarded, next
-      settle recommits derived state, store converges (end-state equals
-      a from-scratch run).
-- [ ] Handler-read semantics unchanged: an existing handler
-      conflict/retry test passes unmodified on a flagged space with a
-      live executor (two-runtime test: stale handler read → conflict →
-      retry → success).
-- [ ] Unservable carve-out: with piece P in
-      `executorConfig.unservablePieces`, P's derived writes commit from
-      the client (wire assert) while other pieces' stay overlay-only;
-      removing P from the list flips it back without reload.
-
-**Review checklist:** the routing must key on the W0.3 envelope, not on
-heuristics (doc-id patterns, schema sniffing — reject); the overlay must
-be per-space and fully discardable (no partial-drop states); confirm
-setup/seed txs route as source (structural provenance markers must keep
-passing CFC gates — run a setup-heavy CFC test); confirm no path
-commits an overlay value "for convenience".
-
-### W2.3 — Watermark surfacing + overlay reconciliation
-
-**Depends on:** W2.2, W0.1.
-**Deliverable:** one PR: executor derived commits carry
-`observedAtSeq` (envelope field → persisted on the commit → visible in
-the feed); clients drop overlay per README §5.B.4 rules; divergence
-counter live.
-
-**Success criteria:**
-
-- [ ] End-to-end two-runtime test (client + executor, in-process
-      server): client source write (assigned seq S) → overlay shows
-      predicted derived value → executor recomputes and commits with
-      watermark W ≥ S → client drops overlay, confirmed value shown;
-      assert the overlay is GONE (not just equal).
-- [ ] Laggard: executor commit with W < S → overlay retained (assert),
-      then dropped when a later W ≥ S arrives.
-- [ ] Divergence: rig the executor fixture to compute a different value
-      → server wins silently, divergence counter = 1, no error surfaced
-      to the pattern.
-- [ ] Watermark integrity: W equals the max input seq the producing
-      action consumed (assert against the observation row from W0.1 —
-      they must be the same number, same source).
-- [ ] Multi-commit basis: two rapid source writes with assigned seqs
-      S1 < S2; overlay reflects both (basis S2); an executor derived
-      commit with S1 ≤ W < S2 does NOT drop the overlay, W ≥ S2 does
-      (pins §5.B.4 rules 1–3).
-- [ ] Rejected basis: a source commit that conflicts and retries →
-      overlay generations based on it are discarded, post-retry state
-      converges to the executor's recompute (pins §5.B.4 rule 4).
-
-**Review checklist:** the drop rule must compare against the
-CONFIRMATION-assigned seq of the client's own source commit (not
-localSeq); check overlay retention under out-of-order feed delivery
-(seq-ordered application is a memory-v2 guarantee — verify the client
-applies in order).
-
-### W2.4 — Builtin passive mode on flagged spaces
-
-**Depends on:** W2.1, W1.2.
-**Deliverable:** one PR: on `derivedAuthority: "executor"` spaces,
-client builtin actions never issue network work regardless of heartbeat
-(upgrade of W1.2's priority into prohibition); they materialize
-pending/result purely from cells.
-
-**Success criteria:**
-
-- [ ] Multi-runtime: stub endpoint sees requests only from the executor
-      even when the executor heartbeat is briefly stale (clients wait;
-      assert zero client requests over a 2× timeout window).
-- [ ] UX continuity: client renders `pending` → `result` transitions
-      driven by the feed (existing builtin fixture asserts the cell
-      sequence).
-- [ ] Unflagged spaces keep W1.2 behavior (fallback test unmodified).
-- [ ] Executor absent AND space flagged: requests stay pending; a
-      loud diagnostic is logged once (not per retry); flipping authority
-      back to `"client"` releases the work.
-
-**Review checklist:** the "executor down on a flagged space" state is a
-real operational mode — verify the diagnostic + the flip-back release
-path with a test, and that nothing busy-waits.
-
-### W2.5 — Executor demand-root scope exclusion
-
-**Depends on:** W1.1.
-**Deliverable:** one PR: the executor's demand side gets both
-exclusions — (a) per-piece pulls never demand user/session-scoped
-subtrees (transitional carve-out; lifted in Phase 4), and (b)
-cross-space servability discovery: an ACL-denied cross-space read while
-serving piece P records P in `executorConfig.unservablePieces`
-(epoch-bumped write), stops demanding P, and retries on config epoch
-bumps (README §6.8).
-
-**Read first:** scope brands on links (see
-`packages/runner/test/link-utils.test.ts` and the scope-folding
-history); README §5.B.6.
-
-**Success criteria:**
-
-- [ ] Fixture with space-scoped + PerUser derived state: executor
-      catch-up updates the space-scoped docs and leaves ALL `user:`/
-      `session:` partitions untouched (state-inspector assert: zero
-      writes under any user partition by the executor session, and —
-      critically — zero docs created under the EXECUTOR's own user
-      partition: pulling a scoped cell as the executor identity would
-      materialize an executor-partition copy; that must not happen).
-- [ ] Client-side computation of the scoped values still works (its
-      writes commit per W2.2 exemption).
-- [ ] Unservable discovery: a piece reading a non-enabled space → the
-      executor writes the exception within one settle and stops pulling
-      P (pull counter flat afterwards); enabling the target space (epoch
-      bump) clears the exception and P becomes served (pull counter
-      moves, derived docs update).
-
-**Review checklist:** the exclusion must live in the demand walk (what
-gets pulled), not only in write filtering — the criterion about
-executor-partition copies is the tell.
-
-### W2.6 — Phase-2 measurement + flip runbook
-
-**Depends on:** W2.2–W2.5.
-**Deliverable:** one PR: perf fixtures (lunch-poll, group-chat
-multi-user) runnable on a flagged space with the executor pool; a CI/
-locally-runnable report of E2.a–E2.d; a short runbook section in this
-folder for flagging a space on/off in staging.
-
-**Success criteria:**
-
-- [ ] The report emits: derived-conflict count, per-client action
-      volume vs single-client baseline, divergence count, feed latency —
-      with pass/fail against E2.a–E2.d thresholds.
-- [ ] One staging space flipped on, exercised, flipped off, with store
-      state verified consistent afterwards (runbook executed once;
-      evidence linked).
+- [ ] Relative /api/... reaches the configured serving host in local and
+      deployed fixtures.
+- [ ] A relative request may follow an absolute same-serving-origin redirect;
+      an origin-changing redirect is reclassified and blocked when private.
+- [ ] Absolute localhost/private/metadata URLs are blocked, including DNS and
+      redirect rebinding cases.
+- [ ] Raw fetch remains unavailable in a pattern SES test.
+- [ ] Supported fetch and generate actions execute once on the claimed server
+      path in a multi-client fixture.
+- [ ] A request produced by user B is never signed/executed as sticky sponsor A;
+      it stays unclaimed or performs a fenced handoff.
+- [ ] Unsupported builtin/action stays client-primary without first causing an
+      external request.
+- [ ] Claim loss/crash behavior is no worse than today's client mutex tests.
 
 ---
 
-## 5. Phases 3–5 — outline + entry criteria (do not start)
+### W1.5 — Indexed wake, drain, and hibernation
 
-- **Phase 3 — subscriptions retired + projector boot.** Entry: Phase 1
-  exit + W0.7 piece-granular interest (needs the executor to export
-  per-piece read closures — design a small spec addendum first: closure
-  export format, update cadence, cross-space handling per README §6.4).
-  Projector boot additionally requires render output stored as VNode
-  docs — prototyped only on the de-scoped interpreter branch (README
-  §3.4), currently unscheduled — treat projector boot as deferred.
-- **Phase 4 — scoped execution.** Entry: README §10.4 decided
-  (delegation shape: standing grant vs session-minted tokens; sub-worker
-  vs per-user demand roots) → G3 spec written and reviewed; executor
-  endorsement atom spec (G1's second half) — coordinate with CFC owners,
-  it touches `writeAuthorizedBy`/integrity machinery. (Scoped execution
-  is engine-agnostic — runs on the compiled path; README §3.4.)
-- **Phase 5 — dual handler execution.** Entry: G13 envelope spec written
-  (serialize trusted-event provenance; replay protection; verify path —
-  precedent: `docs/specs/toolshed-access-control.md` request proofs) and
-  README §10.1's default-flip trigger named. First implementation slice:
-  `serialize: "server"` opt-in per handler.
+**Depends on:** W0.3, W1.3.
+**Unblocks:** efficient rollout.
+
+**Steps:**
+
+1. Expose an indexed staleReadersForTargets query qualified by effective target
+   scope and execution context. Return distinct demanded actions/pieces.
+2. While a Worker is live, push changed target batches and pull only stale
+   demanded roots.
+3. When the last demand disappears and no async work remains, await
+   runtime.settled(), record last-settled seq, release claims, release lease,
+   close provider callbacks, and terminate.
+4. During drain, buffer commits. New demand or a relevant commit before final
+   release cancels drain or starts a later generation after fencing.
+5. Demand itself wakes a cold space. A source commit wakes it only while a
+   durable/active demand reference exists; background wake arrives in Phase 3.
+6. Emit counters for worker count, wakes, suppressed unrelated commits,
+   action runs, claim churn, and settle latency.
+
+**Success criteria:**
+
+- [ ] Relevant write wakes/re-runs only its demanded readers.
+- [ ] Unrelated write performs one indexed lookup and no Worker/action work.
+- [ ] Commit in the settle→terminate window is not lost.
+- [ ] Rapid commits and demands coalesce without duplicate Worker generations.
+- [ ] Cold resume rehydrates only context-appropriate scheduler rows.
 
 ---
 
-## 6. Review-agent playbook (applies to every PR above)
+## 4. Phase 2 — trusted-client authority split
 
-1. **Map criteria to tests.** For each success criterion, find the test
-   by name in the diff. If a criterion has no test, the PR is incomplete
-   — regardless of how plausible the code looks. Ask for the red run of
-   the headline test (link or transcript).
-2. **Parity first.** Run/inspect the flag-off differential before
-   reading the feature code. A parity break is an automatic
-   request-changes.
-3. **Known traps to grep for** (each has bitten this codebase):
-   - schema-less/whole-state sinks or deep traversals in new demand or
-     feed paths (re-run amplification);
-   - a second runtime/Engine in one realm in tests (breaks verified
-     identity);
-   - `idle()` where `settled()` is needed around async builtins;
-   - new timers/polling loops where an event/callback seam exists;
-   - direct DB writes bypassing `applyCommit` (breaks transactionality,
-     provenance stamping, and the readers index);
-   - widening the CFC raw-surface exclusions in `cfc/prepare.ts`;
-   - tests sharing `$TMPDIR` sqlite across repetitions;
-   - default `:8000` servers in integration tests.
-4. **Identity checks.** Any new write path: whose session signs it, and
-   does the store show that session? Sample a commit in the test store.
-5. **Reader isolation.** Any new read/feed path: write or demand the
-   adversarial test (other users' `user:` partitions must not leak; the
-   executor must not materialize scoped copies under its own identity).
-6. **Failure modes are features.** Hibernate/crash/flip-back paths need
-   tests, not comments. If a WO lists a rollback criterion, execute it.
-7. **Scope discipline.** The WO's non-goals are binding: e.g. W1.2 must
-   not implement prohibition (that is W2.4); W0.4 must not implement the
-   endorsement atom (Phase 2/CFC spec). Flag scope creep even when the
-   extra code is good.
+Phase exit:
 
-## 7. Decisions this plan intentionally does not make
+- Compatible clients suppress derived commits only for matching live claims.
+- Local UI speculation remains immediate.
+- Server settlements, including no-op, reliably clear or retain overlays.
+- Missing/revoked/mismatched claims fail open to existing client commits.
+- Multiple clients perform approximately one server action run per invalidation.
 
-Tracked in README §10: dual-execution default trigger (§10.1), interest
-granularity beyond `"*"` (§10.2), executor principal per deployment vs
-per space (§10.3 — this plan assumes one principal per deployment, per
-the README proposal), delegation shape (§10.4), executor pool placement
-long-term (§10.5), projector-mode render path (§10.6).
+### W2.1 — Claim-aware whole-action routing and speculative overlay
+
+**Depends on:** W0.6, W1.3.
+
+**Steps:**
+
+1. Subscribe to claims through the negotiated session control stream. Store
+   them ephemerally by ActionClaimKey + leaseGeneration + claimGeneration; do
+   not persist them as space state.
+2. At transaction enqueue, derive the shared ActionClaimKey from the client
+   action/transaction and match it to a live claim. Do not match on
+   ActionExecutionProvenance: onBehalfOf and lease/claim generations are
+   trusted server additions that speculative client work does not yet have.
+   No exact ActionClaimKey match means commit through the existing path.
+3. For a matching computation claim, apply the whole transaction to a local
+   per-document overlay and do not enqueue it upstream only when every actual
+   operation is same-space and space-scoped.
+4. If the client itself observes a scoped/foreign/unknown operation, fail open:
+   bypass suppression for the entire transaction and notify diagnostics. Never
+   split.
+5. Source/setup/UI-binding/handler transactions commit as today.
+6. An explicit revoke/expiry/feature-disable received on the live ordered
+   stream discards affected overlays, marks actions dirty, and resumes
+   committing from the next settle.
+7. Connection loss is not evidence that authority returned: keep claimed
+   derived writes local/speculative and do not enqueue them upstream. On
+   reconnect, complete capability negotiation and apply an authoritative full
+   claim snapshot at a feed-sequence barrier before flushing any derived work.
+   Source/handler/UI commits retain their existing offline queue behavior.
+8. Keep clients trusted in v1: protocol tests pin compliance; CFC/server
+   enforcement arrives later.
+
+**Success criteria:**
+
+- [ ] Claimed pure action produces local UI output but zero derived client wire
+      operations.
+- [ ] Unclaimed action produces byte-identical commits to current behavior.
+- [ ] Mixed-scope claimed action commits whole from client; no partial
+      suppression.
+- [ ] Two actions in one piece can independently be server- and client-primary.
+- [ ] Revocation/expiry causes deterministic dirty rerun and convergence.
+- [ ] Disconnect while another client keeps the server claim live queues no
+      derived wire commit; reconnect claim-snapshot barrier prevents a stale
+      flush and then converges.
+- [ ] Flag off has byte-identical commit and control traffic.
+
+---
+
+### W2.2 — Settlement-driven overlay reconciliation
+
+**Depends on:** W0.4, W2.1.
+
+**Steps:**
+
+1. Overlay generations record the confirmation-assigned sequence of the
+   client's own source commit(s) they consumed. Translate local optimistic
+   sequence to assigned sequence on confirmation.
+2. On matching ActionSettlement:
+   - committed with inputBasisSeq at or beyond overlay basis is buffered until
+     the local confirmed/feed cursor reaches acceptedCommitSeq, then drops it;
+   - no-op with inputBasisSeq at or beyond overlay basis drops it after its
+     ordered observation-only settlement arrives;
+   - an older basis retains it;
+   - failed retains pending only if the claim remains retryable;
+   - unserved discards the attempt; the separately ordered claim.revoke control
+     message restores client authority.
+3. Reject settlements whose leaseGeneration or claimGeneration does not match
+   the exact overlay incarnation.
+4. When confirmed server value differs from overlay, server wins and increment
+   divergence telemetry; do not surface a pattern exception.
+5. If the client's source commit is rejected/retried, discard overlay
+   generations based on the rejected version and recompute.
+
+**Success criteria:**
+
+- [ ] Source at S → local overlay → server settlement basis ≥ S → overlay is
+      physically removed only after acceptedCommitSeq is locally confirmed;
+      the confirmed value remains.
+- [ ] Settlement basis < S retains overlay.
+- [ ] A no-op settlement clears the overlay.
+- [ ] Two rapid source commits require settlement through the later basis.
+- [ ] Old generation cannot clear new overlay.
+- [ ] Delayed/reordered commit data keeps the overlay until the matching data
+      frame is applied; settlement-first delivery cannot flash stale state.
+- [ ] Rigged divergence records one event and shows server value.
+- [ ] Rejected source basis discards and recomputes correctly.
+
+---
+
+### W2.3 — Client builtin passivity per claim
+
+**Depends on:** W1.4, W2.1, W2.2.
+
+**Steps:**
+
+1. A client builtin action becomes passive only for an exact supported live
+   claim. It renders pending/result from local overlay and confirmed feed.
+2. Missing/revoked claims preserve today's client claim/mutex behavior.
+3. Do not use a worker heartbeat as authority. Claim generation and lease-backed
+   settlement are the signal.
+4. Server transient failure keeps clients passive while the claim is valid;
+   permanent failure revokes and releases them.
+
+**Success criteria:**
+
+- [ ] Three clients plus one server claim produce one external request.
+- [ ] Pending→result UI transition arrives through overlay/feed.
+- [ ] No claim behaves identically to current client builtin execution.
+- [ ] Permanent revoke releases client work without busy waiting.
+
+---
+
+### W2.4 — Measurement and opt-in rollout
+
+**Depends on:** W1.5, W2.2, W2.3.
+
+**Deliverable:** perf fixtures, operational metrics, and an enable/disable
+runbook using serverPrimaryExecution plus optional executionPolicy.
+
+**Measure:**
+
+- active demands, workers, sponsor rotations, and fenced rejects;
+- per-action claims/revocations/unserved reasons;
+- client vs server action runs and derived commits;
+- derived conflicts and divergence;
+- feed/settlement latency and overlays retained;
+- async requests by role;
+- hibernation/wake latency.
+
+**Success criteria:**
+
+- [ ] Multi-client lunch-poll/group-chat fixtures approach one server action run
+      per invalidation and zero client derived wire writes for claimed actions.
+- [ ] Unclaimed/scoped/cross-space actions remain behaviorally identical.
+- [ ] Enabling then disabling a staging space converges without data migration.
+- [ ] Kill/restart/sponsor-loss drills demonstrate fail-open authority and no
+      duplicate worker commits.
+- [ ] Browser compute and lazy-client CPU are measured; first rollout is at
+      least no worse, with later suppression optimization tracked explicitly.
+
+---
+
+## 5. Later phases — do not pull into the first implementation
+
+### Phase 3 — background demand and narrower feeds
+
+Client demand is P1. Background registry cleanup is lower priority.
+
+1. Translate existing background registry entries into lower-priority
+   ExecutionDemand references in the same pool. Never create a second worker
+   for a space already serving clients. Remove the Phase-1 legacy exclusion
+   only after a two-source demand test proves one slot/worker.
+2. When only background demand remains, sponsor with the background service
+   identity and record that identity as onBehalfOf. Client-triggered work must
+   never silently switch to it.
+3. Remove the old polling loop only after parity tests pass.
+4. Narrow watch/query refresh toward declared document interest and server
+   control/data events. Preserve ACL isolation and ordered catch-up.
+5. Add a separately gated client-compute suppression mode only after the claim
+   snapshot and closure are complete: a client may leave a remotely owned
+   action cold until local dependency or handler speculation demands it.
+   Measure first-paint and interaction regressions. This later work removes N×
+   client compute; the initial authority split removes duplicate writes and
+   external effects, not local speculative computation.
+
+### Phase 4 — scoped execution and delegated user keys
+
+Entry requires a separate reviewed design for:
+
+- principal/session-qualified runtime and replica contexts;
+- one shared space lane plus per-user and per-session lanes without duplicating
+  unscoped computation;
+- scope-monotonic read/write rules;
+- bounded user-delegated execution keys that survive connection loss;
+- context-qualified claims, indexes, wake, and cross-space permission changes;
+- vector input bases if cross-space actions are admitted.
+
+The W0.1 context-key fix is necessary but not sufficient for this phase.
+
+### Phase 5 — server-directed handler events and enforced authority
+
+Entry requires trusted-event envelope/replay semantics and CFC integration.
+Move handler execution only after events can be sent to the authoritative
+execution location with authenticated sender provenance. Then use CFC and
+server admission to reject unauthorized client-derived writes rather than
+relying on trusted claim compliance.
+
+---
+
+## 6. Review-agent playbook
+
+1. **Start from #4288 surfaces.** Reject pre-v2 scheduler branches, duplicate
+   queues, or compatibility facade code.
+2. **Map every criterion to a named test and red run.**
+3. **Trace identity end to end.** Authenticated demand → sponsor selection →
+   lease → Worker provider → normal Server validation → stored onBehalfOf.
+4. **Trace exclusivity end to end.** Lease CAS → monotonic worker generation →
+   commit fence → distinct monotonic per-action claimGeneration → stale
+   settlement rejection.
+5. **Trace scope end to end.** Effective scope key in scheduler metadata,
+   writer lookup, transaction firewall, client routing, and dirty matching.
+6. **Demand proof, not producer guesses.** Writer index is authoritative;
+   creation source is irrelevant.
+7. **No transaction splitting.** Search specifically for per-operation routing
+   of a claimed action and reject it.
+8. **No implicit authority docs.** executionPolicy is opt-in only. Claims,
+   leases, heartbeats, actors, and unservable lists do not belong in ordinary
+   writable space state.
+9. **No raw Engine shortcut.** In-process commits pass the same ACL, CFC,
+   conflict, provenance, fence, and post-commit hooks as remote commits.
+10. **No ambient network expansion.** Raw SES fetch stays blocked. Builtins
+    enforce relative-serving-origin behavior and external egress restrictions.
+11. **No timing sleeps.** Spawn, drain, commit-gate, cancellation, claim, and
+    lease tests use barriers/signals.
+12. **Fail open deliberately.** Missing index, unsupported scope, live-stream
+    revoke/expiry, or incompatible fingerprint returns authority to existing
+    client behavior. Disconnect instead freezes derived wire writes until the
+    reconnect claim-snapshot barrier; neither path silently drops a transaction.
+
+---
+
+## 7. Decisions fixed by this plan
+
+- #4288 is the scheduler baseline.
+- Compatible clients are trusted in the first iteration; incompatible clients
+  are rejected when server-primary execution is required.
+- One shared worker serves all active client demands in an eligible space;
+  legacy background-owned spaces are excluded until their demand is unified.
+- A sticky authenticated requester sponsors the worker; derived commits record
+  server-executed on behalf of that user.
+- A fenced lease, not a heartbeat, prevents duplicate server workers.
+- executionPolicy is optional opt-in only; positive per-action claims control
+  authority.
+- Every claim has a per-action claimGeneration distinct from its worker lease
+  generation.
+- Client authority is the default for every unclaimed action.
+- Initial servability is same-space and space-scoped, enforced on the complete
+  transaction with deterministic fallback.
+- Scheduler write indexes identify current producers; creation provenance does
+  not.
+- Computation output has one transformer-produced direct root binding; only
+  hand-built tests need adjustment.
+- Overlay reconciliation uses the actual consumed input basis and explicit
+  settlement, including no-op; committed overlays wait for acceptedCommitSeq
+  data before clearing.
+- Raw fetch remains blocked in SES. Supported fetch/generate builtins retain
+  relative serving-host calls while external absolute URLs follow server
+  egress policy.
+- Background registry integration follows the client-driven path, not the
+  reverse.


### PR DESCRIPTION
## Summary

- revise the server-primary execution design around scheduler-v2 PR #4288 and make the execution-context-key collision a first standalone prerequisite
- specify a single user-sponsored worker per eligible active space, positive per-action authority, independent lease/claim generations, ordered settlement reconciliation, and reconnect claim snapshots
- keep compatible clients trusted in the first iteration while preserving the normal ACL/CFC/conflict/provenance path and deferring enforcement hardening
- move supported fetch/generate builtins to server execution through a preferred host broker, keep raw SES fetch blocked, preserve relative serving-origin calls, and constrain external egress
- replace the old plan with dependency-ordered red-green work orders, shadow-only rollout gates, a legacy background-worker exclusion, and explicit later phases for feed narrowing, client-compute suppression, scoped execution, and handler events

## Key decisions captured

- creation provenance is not producer identity; current producers come from the scheduler write index
- transformed computations have one direct root output binding; only hand-built tests need compatibility fixes
- server work always records the authenticated user it ran on behalf of; service identity is background-only
- whole action transactions are either server-servable or client-authoritative; they are never split
- committed overlays clear only after the matching accepted commit is locally applied; connection loss alone never returns client write authority

## Validation

- `deno task check-docs specs/server-side-execution`
- `git diff --check`
- two independent design audits plus a final post-fix consistency pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revises and finalizes the server‑primary execution design on top of `scheduler-v2` (#4288), shifting to per‑action positive claims and one user‑sponsored worker per active space. Incorporates review feedback to clarify invariants, reconciliation, producer lookup, and egress for a safe, incremental rollout.

- **Refactors**
  - Key durable scheduler state and indexes by `SchedulerExecutionContextKey` to prevent user/session scope collisions.
  - Introduce `ExecutionClaim`s backed by a fenced per‑space `ExecutionLease` with lease/claim generations; clients fail open to local authority without a matching claim.
  - Run one unioned, user‑sponsored worker per eligible active space; exclude legacy background‑owned spaces until that registry is imported.
  - Use `scheduler_write_index` for producer lookup and enforce a single direct root output binding in the transformer.
  - Reconcile via `ActionSettlement` using `inputBasisSeq`; drop overlays only after the accepted commit; reconnect applies ordered claim snapshots.
  - Move `fetch*`/`generate*` to server execution with a preferred host egress broker; keep raw SES fetch blocked; preserve serving‑origin parity and constrain external egress.
  - Clarify trust boundaries, reconnect behavior, and rollout gates based on review.

- **Migration**
  - Phase 0: add context keys across snapshots/state/indexes, writer lookup, and the root‑binding invariant.
  - Phase 1: ship a shadow client‑demand executor with authenticated `ExecutionDemand`, fenced leases, and parked‑reader wake (no authority transfer).
  - Phase 2: enable `ExecutionClaim`s and client overlays with compatibility handshake; add `ActionSettlement` and a whole‑action scope firewall; move eligible builtins.
  - Later: fold background demand and narrow feeds; then add user/session‑scoped execution and dual handler execution.

<sup>Written for commit 2d7a09f92e6ff21af5ede3e3141b6a2bd54dd387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

