### PR TITLE
docs(specs): attention system — canonical design for notices, the steward, and seen-state

### DIFF
--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -1,7 +1,7 @@
 # Attention System
 
 A canonical runtime substrate for managing user attention: a per-user
-**attention ledger** written by a single trusted **ranker** under the user's
+ledger of **notices** written by a single trusted **usher** under the user's
 own **policies**, **seen-state over artifacts** derived from the version
 history the runtime already keeps, and **surface adapters** that project the
 ledger onto shell lanes, digests, and (eventually) OS notifications. An OS
@@ -14,14 +14,16 @@ Draft — seeking framework author review. None of this is implemented in labs
 today (§3 inventories what exists), and §10 names the net-new runtime surface
 this design requires — most importantly the **changes projection** (§10.1), a
 small read-only query primitive over shipped memory-v2 machinery, and a
-cross-principal append gate for candidate intake (§10.2). The Loom product's
+cross-principal append gate for the notice inbox (§10.2). The Loom product's
 in-flight attention framework and Pond's spatial shell are the first intended
 consumers; this spec defines the runtime primitives their product surfaces
 should compile onto, so each stops hand-rolling its own attention state
-(Appendix A maps Loom's candidate shape onto the envelope). Derived from the
-2026-05-21 multi-user/notifications design sessions and the 2026-07 attention
-reframe; revised 2026-07-12 after two adversarial review rounds (runtime +
-product, then Android-as-gold-standard + primitive-shape + parsimony).
+(Appendix A maps Loom's candidate shape onto the envelope; Appendix B walks
+four stress-case user stories). Derived from the 2026-05-21
+multi-user/notifications design sessions and the 2026-07 attention reframe;
+revised 2026-07-12 across three adversarial review rounds (runtime + product;
+Android-as-gold-standard + primitive-shape + parsimony; user-story grading +
+naming ergonomics).
 
 ## Last Updated
 
@@ -31,40 +33,42 @@ product, then Android-as-gold-standard + primitive-shape + parsimony).
 
 Every existing notification system is biased toward interruption because the
 *emitter* chooses how loudly to surface, and emitters' incentives favor
-loudness. This design inverts that: **sources only request a posture; the
-user's ranker — running with the user's policies, structurally on the user's
-side — decides**. The runtime's job is to make that inversion enforceable
-(CFC write-gating on the canonical ledger), cheap (derived queries over
-stores the user already holds, no second event journal), and portable across
-surfaces (one envelope, per-platform adapters).
+loudness. This design inverts that: **sources only post notices with a
+posture hint; the user's usher — running with the user's policies,
+structurally on the user's side — decides**. The runtime's job is to make
+that inversion enforceable (CFC write-gating on the canonical ledger), cheap
+(derived queries over stores the user already holds, no second event
+journal), and portable across surfaces (one envelope, per-platform
+adapters).
 
 Five load-bearing moves:
 
-1. **One ledger, one posture scale.** Attention items land on exactly one
-   rung of an ordered scale — `silent` → `review` → `heads-up` →
-   `interrupt` — and the rung is the promise made to the user (§4.2). The
-   system is biased downward: a source earns its way up through **learned
-   policies** the user can read and edit (§7), and every
-   dismiss-without-open pushes its future items back down.
-2. **The ranker is the only writer.** The canonical ledger carries a
-   `writeAuthorizedBy` claim; untrusted patterns can emit candidates and
+1. **One ledger, one posture scale.** Notices land on exactly one rung of an
+   ordered scale — `silent` → `review` → `heads-up` → `interrupt` — and the
+   rung is the promise made to the user (§4.2). The system is biased
+   downward: a source earns its way up through **learned policies** the user
+   can read and edit (§7), and every dismiss-without-open pushes its future
+   notices back down.
+2. **The usher is the only writer.** The canonical ledger carries a
+   `writeAuthorizedBy` claim; untrusted patterns can post candidates and
    render their own local views, but cannot spam the ledger (§6).
-3. **Attention over artifacts is derived, not emitted.** The runtime already
+3. **Attention over artifacts is derived, not posted.** The runtime already
    versions every entity (memory-v2 `seq`), and the version already crosses
    the wire on every query result; exposing it is one small read-only
    primitive, the changes projection (§10.1). Seen-state is one small
    relation — last observed version per (user, entity) — and "unseen
-   change", "while you were away", item currency, and the artifact
-   lifecycle all fall out as joins against it (§5). For in-fabric sources,
-   an attention item is a *view over* "an artifact you care about changed",
-   which dissolves the "every pattern must remember to emit notifications"
+   change", "while you were away", notice currency, and the artifact
+   lifecycle all fall out as joins against it (§5). For in-fabric sources, a
+   notice is a *view over* "an artifact you care about changed", which
+   dissolves the "every pattern must remember to send notifications"
    problem.
-4. **Policies are user-owned cells**, not ranker code. The core ships a
+4. **Policies are user-owned cells**, not usher code. The core ships a
    good-enough default fold; the bespoke last 20% ("library book due"
-   escalations, quiet hours, per-thread mutes) is data the user — or a
-   pattern, on proposal, or the ranker itself, legibly (§7) — writes.
-5. **Multi-user needs almost nothing new.** Attention is a per-(user, item)
-   relation: a shared space emits one candidate and each member's ranker
+   escalations, quiet hours, per-thread mutes, nag-until-done) is data the
+   user — or a pattern, on proposal, or the usher itself, legibly (§7) —
+   writes.
+5. **Multi-user needs almost nothing new.** A notice is a per-(user, notice)
+   relation: a shared space posts one candidate and each member's usher
    lanes it independently. "Who has seen this" — and, per disclosure policy,
    "who has handled this" — is the same state contributed into shared space,
    read the other direction (§8).
@@ -72,29 +76,35 @@ Five load-bearing moves:
 ### Division of labor
 
 This spec owns **routing, terminal state, seen-state, and delivery**.
-Everything upstream of a candidate — deciding whether an agent may *start*
-work, preparing material, continuity ownership, receipts, onboarding
+Everything upstream of a posted notice — deciding whether an agent may
+*start* work, preparing material, continuity ownership, receipts, onboarding
 interviews that seed policy — is product-side and stays there. A product
 framework (e.g. Loom's attention framework) enters this pipeline as a
-*trusted source* emitting well-prepared candidates with a requested posture;
-the runtime ranker's job for such a source is cross-source arbitration and
+*trusted source* posting well-prepared candidates with a posture hint; the
+runtime usher's job for such a source is cross-source arbitration and
 enforcement of the user's posture clamps, not re-litigating the product's
 preparation decisions.
 
 ### Vocabulary
 
-*Item* — a materialized record in the ledger (*claim* when speaking of what
-it means to the user). *Candidate* — the same envelope before the ranker
-assigns `id`, `posture`, and `weight`; not a separate type. *Ledger* — the
-items store specifically. *Attention state* — the triple of stores (items,
-actions, seen — §4.5). *Lane* — a shell projection over attention state
-(most lanes correspond to a posture rung; some, like the snoozed lane, are
-lifecycle views).
+*Notice* — the unit: a posted announcement with a destination, that waits to
+be noticed. A **candidate** is a notice as posted, before the usher admits
+it (assigning `id`, `posture`, `weight`) — the same envelope at an earlier
+stage, exactly as `wish()` resolves `candidates` into a `result`.
+*Disposition* — what the user (or the usher on their behalf) did with a
+notice; the append-only log. *Usher* — the per-user trusted fold that admits
+candidates, assigns postures, and keeps the room quiet; called an usher, not
+a "ranker", because ranking is its most minor duty and it works for the
+user, not the feed. *Ledger* — the notices store specifically. *Attention
+state* — the triple of stores (notices, dispositions, seen — §4.5). *Lane* —
+a shell projection over attention state (most lanes correspond to a posture
+rung; some, like the snoozed lane, are lifecycle views). *Watch set* — the
+entity set whose changes the user's attention system observes (§5).
 
 ## Goals
 
-- A single canonical attention envelope and ledger that shell, product
-  surfaces (Loom, Pond), patterns, and OS adapters all read.
+- A single canonical notice envelope and ledger that shell, product surfaces
+  (Loom, Pond), patterns, and OS adapters all read.
 - Make autonomous/agent work *visible* without interruption — the user can
   always see that something was done on their behalf, at zero notification
   cost ("quiet disposition" must not mean "invisible disposition").
@@ -109,7 +119,7 @@ lifecycle views).
 - Per-viewer lanes over shared state: the same event can interrupt one member
   of a space and be texture for another.
 - OS delivery (Web Push, APNs/FCM) as replaceable adapters over the same
-  ledger, honoring per-platform replace/retract semantics and the item's
+  ledger, honoring per-platform replace/retract semantics and the notice's
   confidentiality labels (§9.3).
 
 ## Non-goals
@@ -125,20 +135,24 @@ lifecycle views).
 - **Policy seeding / onboarding flows.** How a product interviews the user
   and proposes an initial policy set is product-scope; the runtime primitive
   is only "patterns propose, the user disposes" (§7) — adoption *is* the
-  write, and proposed-but-unadopted policies never enter the ranker's fold.
+  write, and proposed-but-unadopted policies never enter the usher's fold.
+  (One product obligation this spec *names* because safety depends on it:
+  ship an emergency-sources policy pack through this same propose/adopt
+  flow — §7, Appendix B.1.)
 - **Coverage/miss measurement** ("earn the right to say all caught up") —
   product-layer analytics over the ledger; the ledger just has to be
   complete enough to measure.
 - **V1 delivery breadth.** No SMS/email channels, no iOS Live Activities, no
-  `time-sensitive`/`critical` interruption levels (both need platform
-  entitlements), no wearables. The envelope reserves room; adapters come
-  later (§9.3).
+  wearables. `time-sensitive`/`critical` OS interruption levels are not
+  *implemented* in V1 (both need platform entitlements) but their adapter
+  mapping is **reserved** (§9.3) so user-adopted break-glass policies have
+  somewhere to compile when entitlements land.
 - **A "list all members of a space" primitive.** The runtime deliberately
   lacks one (see `docs/specs/shared-profile-rosters.md`); multi-user features
   here are designed within that constraint, not around it.
-- **Replacing source UIs.** An attention item opens its focused destination
-  (the artifact, the draft, the conversation); within a thread, the newest
-  live claim displaces older ones (§6.4) rather than piling on.
+- **Replacing source UIs.** A notice opens its focused destination (the
+  artifact, the draft, the conversation); within a thread, the newest live
+  notice displaces older ones (§6.4) rather than piling on.
 
 ## 3. Background — what exists today
 
@@ -174,18 +188,19 @@ judgment policies stay product-side (§Division of labor).
 
 ## 4. Model
 
-### 4.1 The unit: a claim on attention
+### 4.1 The unit: a notice
 
-An attention item is a **claim on the user's attention with a focused
-destination**. Borrowing the product framing: a raw source occurrence, or the
-bare fact that an agent ran, is not by itself a claim on attention. The
-envelope therefore always carries *where to go* (`target`, a stored cell
-link) and *what is ready there* (title/body describing the prepared result or
-the change), never just "something happened".
+A notice is a **posted announcement with a focused destination** — it waits
+to be noticed; it does not get to decide how loudly. Borrowing the product
+framing: a raw source occurrence, or the bare fact that an agent ran, does
+not deserve a notice. The envelope therefore always carries *where to go*
+(`subject`, and optionally a distinct `target`) and *what is ready there*
+(title/body describing the prepared result or the change), never just
+"something happened".
 
-The runtime does not — cannot — enforce that items are well-prepared; it
+The runtime does not — cannot — enforce that notices are well-prepared; it
 enforces the things preparation depends on: who may write the ledger, which
-posture a claim actually gets, and that handled claims retract everywhere.
+posture a notice actually gets, and that handled notices retract everywhere.
 
 ### 4.2 The posture scale
 
@@ -196,8 +211,8 @@ suppress < silent < review < heads-up < interrupt
 ```
 
 `suppress` is rank zero: never materialized for this user (distinct from
-`silent`, which is recorded and findable). Every materialized item occupies
-exactly one rung, and the rung is a promise:
+`silent`, which is recorded and findable). Every materialized notice
+occupies exactly one rung, and the rung is a promise:
 
 | Posture | Promise to the user | Typical projection |
 |---|---|---|
@@ -208,41 +223,46 @@ exactly one rung, and the rung is a promise:
 
 Two invariants:
 
-- **Downward bias.** Defaults sit low (`silent`/`review`). Sources *request*
-  a posture; the ranker assigns the real one via the policy clamp (§7), and
+- **Downward bias.** Defaults sit low (`silent`/`review`). Sources post a
+  *hint*; the usher assigns the real posture via the policy clamp (§7), and
   repeated dismiss-without-open feeds back as learned clamps. Crucially,
   **no emitter-controlled field may raise posture**: reaching `interrupt`
   (or `heads-up` above a source's learned baseline) requires a user-adopted
   policy floor — never urgency claims, expiry times, or any other field the
-  emitter writes. An emitter cannot buy `interrupt` with enthusiasm.
-- **Attention ≠ confidence.** How sure the system is about an item and how
+  emitter writes. An emitter cannot buy `interrupt` with enthusiasm. The
+  same discipline binds the *shipped defaults*: any default above `review`
+  must match on **usher-verified facts** (e.g. `actor` is a human DID with
+  an established relationship to the user), never on self-declared fields
+  like `kind` — otherwise declaring a kind *is* choosing a baseline, which
+  re-opens the loophole this invariant closes.
+- **Attention ≠ confidence.** How sure the system is about a notice and how
   loudly it surfaces are separate axes. Uncertain-but-urgent goes to
-  `heads-up` with its uncertainty stated (product copy; `ext` if structured);
-  certain-but-routine stays in `review`.
+  `heads-up` with its uncertainty stated (product copy; `ext` if
+  structured); certain-but-routine stays in `review`.
 
 The rung names deliberately match the posture vocabulary the Loom product
 already uses (silent memory → daily review → timely heads-up → interrupt), so
 product surfaces map 1:1 onto runtime postures. Within a rung, ordering is
-the ranker-assigned `weight` (§4.4) — an opaque scalar that never crosses
+the usher-assigned `weight` (§4.4) — an opaque scalar that never crosses
 rungs and never gates delivery; it exists so continuous surfaces (Pond's
-radial layout, "ordered by the ranker" lists) don't have to invent one.
+radial layout, "ordered by the usher" lists) don't have to invent one.
 
 ### 4.3 The pipeline
 
 ```text
-Sources                         emit candidates (requested posture = advisory)
-  agents/pieces running as me     │
-  pieces I joined, running        │  per-source prefilter: "important within
-    as others (group chat)        │   my world?" — cannot judge cross-source
-  sharing directed at me          │
-  artifact changes (derived, §5)  │
-  external ingress (webhooks)     ▼
-Candidate intake (durable; quota-gated append)   §6.1, §10.2
+Sources                          post candidates (postureHint = advisory)
+  agents/pieces running as me      │
+  pieces I joined, running         │  per-source prefilter: "important within
+    as others (group chat)         │   my world?" — cannot judge cross-source
+  sharing directed at me           │
+  artifact changes (derived, §5)   │
+  external ingress (webhooks)      ▼
+Notice inbox (durable; quota-gated append)       §6.1, §10.2
   ▼
-Ranker (per-user, trusted single writer)         §6
+Usher (per-user, trusted single writer)          §6
   folds candidates × policy cells (§7)
   assigns posture + weight; coalesces; writes the ledger
-  ── writeAuthorizedBy gate: only the ranker's verified
+  ── writeAuthorizedBy gate: only the usher's verified
      module identity may write the canonical ledger ──
 Ledger (per-user, durable, queryable)            §4.5
   ▼
@@ -257,171 +277,194 @@ cannot do is write the canonical ledger the shell and OS adapters trust.
 
 ### 4.4 The envelope
 
-A **candidate** is this envelope minus the ranker-assigned fields (`id`,
-`posture`, `weight`); the ranker *promotes* candidates to items. One type,
-two stages.
+A source **posts a candidate**; the usher **admits it as a notice**. Same
+envelope, two stages — and the stage split is structural: a candidate
+*cannot carry* an assigned posture, because `posture`, `weight`, and `id`
+exist only on the admitted type.
 
 ```ts
 // Shown for illustration only.
-// A source-entity version: memory-v2 seq is per-space (a space-global
+// A subject-entity version: memory-v2 seq is per-space (a space-global
 // Lamport clock, monotone per entity), so versions are only comparable
 // within the same space. Read via the changes projection (§10.1).
 type EntityVersion = { space: string; seq: number };
 
-type AttentionItem = {
-  // Identity — THE load-bearing field. Every surface adapter targets it for
-  // replace/retract (iOS UNNotificationRequest.identifier + apns-collapse-id,
-  // Android notify(id), Web Push options.tag). Deterministic, and derived by
-  // the RANKER from verified provenance (source space DID + entity id
-  // [+ event key]) — never from candidate-supplied strings, so a hostile
-  // source cannot collide another source's id to hijack coalescing or
-  // OS replace/retract.
-  id: string;
-
-  // Pointer to the source of truth (a stored cell link, not a query string).
-  // The item is the invitation; the source is the truth.
-  source: unknown;            // asCell: ["cell"]
-  // Source classification ("group-chat", "importer", "agent-run", ...).
-  // First-class because policy matching (§7) and digest grouping (§9.2) key
-  // on it. BOUND BY THE RANKER to the source's verified identity: the
-  // first-seen kind for a given source sticks; a source changing its
-  // declared kind is itself a reputation signal (and does not escape
-  // kind-matched clamps, which follow the source identity).
-  sourceKind: string;
-  // The source entity's version at emission. Drives coalescing (same id,
+// What a source posts (into the notice inbox, §6.1). Everything on the
+// candidate is descriptive or advisory — no field a source writes can
+// raise loudness (§4.2).
+type NoticeCandidate = {
+  // THE entity this notice is about (a stored cell link, not a query
+  // string). The notice is the invitation; the subject is the truth.
+  // Satisfaction, coalescing, and re-emergence all key on it: once your
+  // seen mark on subject reaches subjectVersion, the notice retracts
+  // everywhere (alreadySeen, below).
+  subject: unknown;           // asCell: ["cell"]
+  // The subject's version at posting. Drives coalescing (same id,
   // advancing version) and re-emergence tombstones (§4.7).
-  sourceVersion: EntityVersion;
+  subjectVersion: EntityVersion;
+  // Source classification ("group-chat", "importer", "agent-run", ...).
+  // BOUND BY THE USHER to the source's verified identity: the first-seen
+  // kind for a given source sticks; a source changing its declared kind
+  // is itself a reputation signal (and does not escape kind-matched
+  // clamps, which follow the source identity). Policy matching (§7) and
+  // digest grouping (§9.2) key on it. Self-declared, therefore never a
+  // basis for above-review shipped defaults (§4.2).
+  kind: string;
   // Grouping key for presentation AND displacement: within a threadKey,
-  // only the newest live claim is visible (§6.4). One conversation, one
+  // only the newest live notice is visible (§6.4). One conversation, one
   // task, one agent run (threadKey = run id).
   threadKey?: string;
-  // Who this claim is about/from (a DID when known): "Ana: running late"
+  // Who this notice is from/about (a DID when known): "Ana: running late"
   // vs "New message". Serves OS payloads, digest grouping, and §5's
   // "by whom" in one field.
   actor?: string;
 
-  // Content. Snapshot at emission (title/body) plus the live destination.
+  // Content. Snapshot at posting (title/body) plus the live destinations.
   title: string;
   body: string;
-  // Redacted variant for untrusted displays: lockscreens and push relays
-  // (§9.3). When absent and labels forbid egress, adapters send a generic
+  // Variant for untrusted displays: lockscreens and push relays (§9.3).
+  // When absent and labels forbid egress, adapters send a generic
   // envelope and fetch full content on unlock/open.
   redacted?: { title: string; body: string };
-  // Focused destination: a stored cell link navigated with navigateTo().
-  target: unknown;            // asCell: ["cell"]
-  // Optional link to prepared material (draft, diff, packet) when it is a
-  // different artifact than target.
-  prepared?: unknown;         // asCell: ["cell"]
+  // Where opening the notice goes, when that differs from subject
+  // (default: subject). Navigated with navigateTo().
+  target?: unknown;           // asCell: ["cell"]
+  // Prepared material (draft, diff, packet) when it is a different
+  // artifact than the destination.
+  attachment?: unknown;       // asCell: ["cell"]
   // Close-the-loop affordances rendered on the surface itself (§4.6):
   // approve/deny, done/later, inline reply — act without opening the app.
-  actions?: Array<{
-    key: string;              // semantic key, recorded in the acted action
-    label: string;
-    input?: "text";           // direct reply / free-text input
-    // Durable endpoint in the source space; acting appends
-    // {key, input?, itemId, at} under the user's ordinary session
-    // authority — the same authority the user would have acting in-app.
-    // No new trust surface.
-    handler?: unknown;        // asCell: ["cell"]
-  }>;
-  // Live progress for ongoing work ("agent is 60% through your refactor").
-  // Progress updates are same-rung coalesces and therefore silent (§9.3).
-  // Absent total = indeterminate. Rich live chrome (Live Activities) is a
-  // later adapter track; the field is the floor every surface can render.
+  actions?: NoticeAction[];
+  // Live progress for ongoing work ("agent is 60% through your
+  // refactor"). Progress updates are same-rung coalesces and therefore
+  // silent (§9.3). Absent total = indeterminate. Rich live chrome (Live
+  // Activities) is a later adapter track; this field is the floor every
+  // surface can render.
   progress?: { done: number; total?: number };
 
-  // Routing. requestedPosture is advisory input from the source; posture is
-  // assigned by the ranker and is the only one surfaces read.
-  requestedPosture: "silent" | "review" | "heads-up" | "interrupt";
-  posture: "silent" | "review" | "heads-up" | "interrupt";
-  // Intra-rung ordering, ranker-assigned. Opaque; never crosses rungs;
-  // never gates delivery (§4.2).
-  weight?: number;
+  // Advisory only — the "requested" loudness. The usher assigns the real
+  // posture; surfaces never read the hint.
+  postureHint: "silent" | "review" | "heads-up" | "interrupt";
 
-  emittedAt: number;
+  postedAt: number;
   notBefore?: number;         // embargo: hold materialization until then
   expiresAt?: number;         // evaluate-on-read; swept terminally by the
-                              // ranker (§4.7, §9.3)
+                              // usher (§4.7, §9.3)
 
-  // Opaque product extension. Disciplined by invariant: NO runtime-derived
-  // predicate, NO ranker fold step, and NO policy match may read ext — it
-  // is a round-trip channel for product fields (Loom's why_now, channel,
-  // authorization_state — Appendix A), not a side door into routing. An
-  // ext key consumed by two independent products is a candidate for
-  // promotion to the envelope (or a sign the envelope is wrong).
+  // Opaque product round-trip channel. Disciplined by invariant: NO
+  // runtime-derived predicate, NO usher fold step, and NO policy match
+  // may read ext — it carries product fields (Loom's why_now, channel,
+  // authorization_state — Appendix A), not routing inputs. An ext key
+  // consumed by two independent products is a candidate for promotion to
+  // the envelope (or a sign the envelope is wrong).
   ext?: Record<string, unknown>;
 };
 
-// Append-only per-item action log — the state-bearing user dispositions.
-// Deliberately small: "seen" is NOT an action (it lives in the seen store,
-// §4.5/§5, and item-seen is a join); "muted" is NOT an action (mute IS a
-// policy write, §7). Cause-preservation across the three terminal types is
-// the point: undo, history, and calibration all key on it.
-type AttentionAction = {
-  itemId: string;
-  type: "dismissed" | "snoozed" | "archived" | "acted";
+// An admitted notice IS a candidate plus the three fields only the usher
+// may write. Two stages, one envelope, enforced by the type.
+type Notice = NoticeCandidate & {
+  // Identity — THE load-bearing field. Every surface adapter targets it
+  // for replace/retract (iOS UNNotificationRequest.identifier +
+  // apns-collapse-id, Android notify(id), Web Push options.tag). Derived
+  // by the USHER from verified provenance (source space DID + entity id
+  // [+ event key]) — never from candidate-supplied strings, so a hostile
+  // source cannot collide another source's id to hijack coalescing or OS
+  // replace/retract.
+  id: string;
+  // The promise made to the user (§4.2) — the only loudness surfaces read.
+  posture: "silent" | "review" | "heads-up" | "interrupt";
+  // Intra-rung ordering. Opaque; never crosses rungs; never gates
+  // delivery (§4.2).
+  weight?: number;
+};
+
+// One button on a notice: approve/deny, done/later, inline reply (§4.6).
+type NoticeAction = {
+  key: string;                // semantic key, recorded in the disposition
+  label: string;
+  input?: "text";             // direct reply / free-text input
+  // Durable endpoint in the source space — a durable array cell, NEVER a
+  // Stream (stream payloads don't persist, §4.5). Acting appends
+  // {key, input?, noticeId, at} under the user's ordinary session
+  // authority — the same authority the user would have acting in-app.
+  // No new trust surface.
+  replyTo?: unknown;          // asCell: ["cell"]
+};
+
+// Append-only per-notice disposition log — what the user (or the usher,
+// on the user's behalf) did with the notice. Deliberately small: "seen"
+// is NOT a disposition (it lives in the seen store, §4.5/§5, and
+// notice-seen is a join); "muted" is NOT a disposition (mute IS a policy
+// write, §7). Cause-preservation across the three terminal types is the
+// point: undo, history, and calibration all key on it.
+type NoticeDisposition = {
+  noticeId: string;
   at: number;
-  // Which surface the action came from (shell, os-tray, digest, ...). Lets
-  // policy decide e.g. "os-tray dismiss clears that device only".
+  // Which surface the disposition came from (shell, os-tray, digest,
+  // ...). Lets policy decide e.g. "os-tray dismiss clears that device
+  // only" (§9.3).
   surface: string;
-  by: string;                 // DID; or the ranker's module identity for
-                              // system-on-behalf actions (expiry sweep,
-                              // thread displacement — §4.7)
-  // The sourceVersion the action was taken against. A dismissal tombstones
-  // that version; if the source advances past it, the item re-emerges (the
-  // ranker's coalesce advances sourceVersion past the tombstone — one
-  // operation, not a separate mechanism) and the old dismissal no longer
-  // applies. Comparable only within sourceVersion.space.
+  // Who did it: the user's DID, or the usher's module identity for
+  // system dispositions (expiry sweep, thread displacement — §4.7).
+  actor: string;
+  // The subjectVersion this disposition was taken against. A dismissal
+  // tombstones that version; if the subject advances past it, the notice
+  // re-emerges (the usher's coalesce advances subjectVersion past the
+  // tombstone — one operation, not a separate mechanism) and the old
+  // dismissal no longer applies. Comparable only within
+  // subjectVersion.space.
   againstVersion: EntityVersion;
-  payload?: unknown;          // snoozeUntil, acted {key, input?}, ...
   ext?: Record<string, unknown>; // product extension (e.g. calibration
                               // feedback like "not-useful"); same
-                              // discipline as item.ext
-};
+                              // discipline as NoticeCandidate.ext
+} & (
+  | { type: "dismissed" }
+  | { type: "archived" }
+  | { type: "snoozed"; until: number }
+  | { type: "acted"; key: string; input?: string }
+);
 ```
 
 Nothing stores `active`, `dismissed`, or `unread` flags — dispositions are
 derived. And critically, **currency is a local join, not a cross-space
-read**: an item is *observed-satisfied* once the user's own seen mark on its
-target reaches the item's version. This is the Android behavioral gold
-standard — view the source anywhere, the notification retracts everywhere —
-computed entirely from the user's own stores:
+read**: a notice is satisfied once the user's own seen mark on its *subject*
+reaches the notice's version. This is the Android behavioral gold standard —
+view the source anywhere, the notification retracts everywhere — computed
+entirely from the user's own stores:
 
 ```ts
 // Shown for illustration only.
 const sameSpaceGte = (a: EntityVersion, b: EntityVersion) =>
   a.space === b.space && a.seq >= b.seq;
-const terminal = (n: AttentionItem, log: AttentionAction[]) =>
-  log.some((a) =>
-    (a.type === "dismissed" || a.type === "archived" || a.type === "acted") &&
-    sameSpaceGte(a.againstVersion, n.sourceVersion)
+const terminal = (n: Notice, log: NoticeDisposition[]) =>
+  log.some((d) =>
+    (d.type === "dismissed" || d.type === "archived" || d.type === "acted") &&
+    sameSpaceGte(d.againstVersion, n.subjectVersion)
   );
-const observedSatisfied = (n: AttentionItem, seen: SeenStore) =>
-  sameSpaceGte(seen.versionOf(n.target), n.sourceVersion);
+const alreadySeen = (n: Notice, seen: SeenStore) =>
+  sameSpaceGte(seen.versionOf(n.subject), n.subjectVersion);
 const visible = (
-  n: AttentionItem, log: AttentionAction[], seen: SeenStore, now: number,
+  n: Notice, log: NoticeDisposition[], seen: SeenStore, now: number,
 ) =>
-  !terminal(n, log) && !observedSatisfied(n, seen) &&
-  !snoozedUntil(log, now) &&
+  !terminal(n, log) && !alreadySeen(n, seen) && !snoozed(log, now) &&
   (n.notBefore === undefined || now >= n.notBefore) &&
   (n.expiresAt === undefined || now < n.expiresAt);
 ```
 
-Claims that should outlive observation (a todo is not done because you
-looked at it) are *re-emitted deliberately* — a deadline policy or the
-source's own artifact change produces a fresh claim at a newer version —
-rather than the runtime guessing which glances "count". Source-side
-satisfaction that doesn't involve the user looking (someone else handled it;
-the trip ended) is the ranker's job: its fold observes the source change and
-terminally retracts the item (system `acted`/`dismissed` by module
-identity).
+Notices that should outlive observation (a todo is not done because you
+looked at it; a medication reminder must nag) are handled deliberately, not
+by the runtime guessing which glances "count": the source re-posts at a
+newer version when it is meaningfully newsworthy again, and a user-adopted
+`realert` policy (§7) governs whether re-emergence may make sound.
+Satisfaction that doesn't involve the user looking (someone else handled it;
+the trip ended) is the usher's job: its fold observes the subject change and
+terminally retracts the notice (system disposition by module identity).
 
 A caveat on "cheap": pull-based scheduling makes *unobserved* queries free
 (`docs/specs/pull-based-scheduler/README.md`), not observed ones. A mounted
-lane is a live subscription over the user's own three stores — no per-item
-cross-space reads (that was a design bug this revision fixed; cross-space
-reading happens once, in the ranker's fold) — and §4.5's write discipline
-bounds how often those stores change.
+lane is a live subscription over the user's own three stores — no per-notice
+cross-space reads (cross-space reading happens once, in the usher's fold) —
+and §4.5's write discipline bounds how often those stores change.
 
 ### 4.5 Storage
 
@@ -433,35 +476,35 @@ three stores, and the three backings are not ad-hoc — they derive from a
 
 | | wakes lane queries | must never wake lane queries |
 |---|---|---|
-| **ranker-only writes** | `items` | *(learned policies live with §7 policies, not here — they are user-visible data)* |
-| **any-surface writes** | `actions` | `seen` |
+| **usher-only writes** | `notices` | *(learned policies live with §7 policies, not here — they are user-visible data)* |
+| **any-surface writes** | `dispositions` | `seen` |
 
-1. **`items`** — written *only* by the ranker. Backing for phase 1:
-   a **durable array cell carrying the `writeAuthorizedBy` claim**, the
-   mechanism already protecting profile links in production
+1. **`notices`** (the ledger) — written *only* by the usher. Backing for
+   phase 1: a **durable array cell carrying the `writeAuthorizedBy`
+   claim**, the mechanism already protecting profile links in production
    (`docs/common/conventions/HOME_SPACE.md`,
-   `packages/runner/src/cfc/prepare.ts`). Coalescing (same `id`, source
-   advanced) is an in-place element update by the single leased ranker
+   `packages/runner/src/cfc/prepare.ts`). Coalescing (same `id`, subject
+   advanced) is an in-place element update by the single leased usher
    instance (§6.2); coalescing **refreshes** content, `expiresAt`, and
-   `progress` — a re-emerged claim carries the new emission's lifetime, not
+   `progress` — a re-emerged notice carries the new posting's lifetime, not
    a stale one. This is deliberately *not* sqlite yet: `writeAuthorizedBy`
    is enforced on the cell-write prepare path and **does not gate
    `db.exec`** today — sqlite's implemented CFC covers confidentiality
    ceilings and row-label rules, not write authorization
-   (`docs/specs/sqlite-builtin/06-cfc.md`). Migrating `items` to a sqlite
+   (`docs/specs/sqlite-builtin/06-cfc.md`). Migrating `notices` to a sqlite
    table (better ranking/pagination/retention at volume) is gated on the
-   net-new work item in §10.3, and on giving `items` **its own database**:
-   every `db.exec` serializes on the database handle cell's `rev`, so one
-   shared db cannot hold both a ranker-only table and an
-   everyone-writes table without gating both or neither.
-2. **`actions`** — written by every surface on every device. Backing: a
+   net-new work item in §10.3, and on giving it **its own database**: every
+   `db.exec` serializes on the database handle cell's `rev`, so one shared
+   db cannot hold both an usher-only table and an everyone-writes table
+   without gating both or neither.
+2. **`dispositions`** — written by every surface on every device. Backing: a
    durable array cell appended with **mergeable ops only** (`push`,
-   `addUnique`), so concurrent user actions from two devices merge against
+   `addUnique`), so concurrent dispositions from two devices merge against
    durable state instead of clobbering (memory is optimistic-concurrency
    with path-aware validation, not CRDT — and this design needs no CRDT:
-   the canonical writer is singular per store, and user actions are
-   mergeable appends). The ranker periodically compacts actions for
-   terminal, swept items.
+   the canonical writer is singular per store, and dispositions are
+   mergeable appends). The usher periodically compacts dispositions for
+   terminal, swept notices.
 3. **`seen`** — the seen store (§5), highest write rate in the system,
    ships in phase 0 and gets its own store so its writes never wake lane
    queries eagerly (lanes sample it; the join is evaluated on lane
@@ -474,11 +517,8 @@ three stores, and the three backings are not ad-hoc — they derive from a
    when it advances** (`newSeq > seenSeq` — re-renders and repeat views are
    no-ops, which is also what breaks any render→write→render cycle) and
    **debounced per focus session** (at most one write per entity per
-   focused open). A focused open writes *only* the seen mark — item-seen
-   is a join (`observedSatisfied`, §4.4), not a second record; the earlier
-   draft's duplicate "seen" action defeated this store's whole reason to
-   exist. Retention is trivial — one row per cared-about entity, reaped
-   when the care-relation drops the entity.
+   focused open). A focused open writes *only* the seen mark — notice-seen
+   is a join (`alreadySeen`, §4.4), not a second record.
 
 Two rules regardless of backing:
 
@@ -487,20 +527,21 @@ Two rules regardless of backing:
   `docs/specs/space-model/4-cells.md`). Streams are append *endpoints*, not
   logs. This matters doubly for ingress: webhook payloads ride an ephemeral
   stream, so a **receiving handler must persist candidates durably at
-  ingress** — otherwise external candidates arriving while no ranker is
-  live are lost permanently, not delayed (§6.1).
+  ingress** — otherwise external candidates arriving while no usher is
+  live are lost permanently, not delayed (§6.1). The same rule is why
+  `NoticeAction.replyTo` must be a durable cell, never a stream.
 - **Never `set()` a whole array** that has more than one writer.
 
-Retention: the ranker's sweep terminally retracts expired items (system
-action, `by` = module identity — this is the *one* expiry mechanism;
-`visible()`'s expiry check is the read-side shadow of it, so an expired item
-is hidden immediately and reaped eventually) and reaps items that are
-terminal with `sourceVersion` below a watermark, plus their actions.
-Sweeping is a ranker duty (it owns `items`), bounded and boring by design.
-Because sweeping only reaps terminal rows, per-source intake quotas (§6.1)
-are what bound a flooding source, not retention.
+Retention: the usher's sweep terminally retracts expired notices (system
+disposition — this is the *one* expiry mechanism; `visible()`'s expiry check
+is the read-side shadow of it, so an expired notice is hidden immediately
+and reaped eventually) and reaps notices that are terminal with
+`subjectVersion` below a watermark, plus their dispositions. Sweeping is an
+usher duty (it owns the ledger), bounded and boring by design. Because
+sweeping only reaps terminal rows, per-source intake quotas (§6.1) are what
+bound a flooding source, not retention.
 
-### 4.6 Actions on the claim
+### 4.6 Actions on the notice
 
 The most attention-respecting affordance in existing systems (Android
 actions + direct reply) is closing the loop *without opening the app* —
@@ -512,44 +553,46 @@ approve/deny, done/later, reply, from the shade or the bell. The envelope's
   `Notification.Action`/`RemoteInput`; Web Push to `showNotification`
   actions (buttons; inline text where supported); the shell renders
   natively. The PWA floor holds — Web Push supports action buttons.
-- Acting: writes the ordinary `acted` action (`payload: {key, input?}`),
-  which is terminal; and, when `handler` is present, appends
-  `{key, input?, itemId, at}` to the handler cell in the source space
+- Acting: writes the ordinary `acted` disposition (`{key, input?}`), which
+  is terminal; and, when `replyTo` is present, appends
+  `{key, input?, noticeId, at}` to the reply cell in the source space
   **under the user's ordinary session authority** — exactly the authority
   the user would exercise replying in-app. No new trust surface: the
   source granted itself read on its own cell, and the user could always
   write there through the source's own UI.
 - The "needs your approval" genre (Loom's `authorization_state:
   proposal-required`) compiles to `actions: [approve, deny]` — the approval
-  affordance travels with the claim instead of forcing navigation.
+  affordance travels with the notice instead of forcing navigation.
 
 ### 4.7 Lifecycle
 
-For review clarity, the full per-(user, item) state machine, every
+For review clarity, the full per-(user, notice) state machine, every
 transition named once:
 
 ```text
-(candidate) --ranker fold: clamp > suppress--> MATERIALIZED
-MATERIALIZED --now < notBefore--> EMBARGOED --time--> VISIBLE
+(candidate) --usher fold: clamp > suppress--> ADMITTED
+ADMITTED --now < notBefore--> EMBARGOED --time--> VISIBLE
+EMBARGOED --usher: subject satisfied / superseded--> TERMINAL
+         (a pre-scheduled reminder is retracted when its reason ends)
 VISIBLE --user: dismissed|archived|acted--> TERMINAL
-VISIBLE --ranker: source satisfied / thread displaced / expiry sweep
-         (system action)--> TERMINAL
-VISIBLE --user: snoozed--> SNOOZED --snoozeUntil--> VISIBLE
-VISIBLE --seen mark on target reaches sourceVersion--> OBSERVED-SATISFIED
-         (hidden; no action row — pure join)
+VISIBLE --usher: subject satisfied / thread displaced / expiry sweep
+         (system disposition)--> TERMINAL
+VISIBLE --user: snoozed--> SNOOZED --until--> VISIBLE
+VISIBLE --seen mark on subject reaches subjectVersion--> SATISFIED
+         (hidden; no disposition row — pure join)
 VISIBLE --now ≥ expiresAt--> hidden immediately (read-side),
          TERMINAL at next sweep (write-side)
-TERMINAL --ranker coalesce advances sourceVersion past tombstone-->
+TERMINAL --usher coalesce advances subjectVersion past tombstone-->
          VISIBLE (re-emergence: a consequence of coalescing, not a
-         separate mechanism)
+         separate mechanism; silent unless a realert policy applies, §9.3)
 TERMINAL + below watermark --sweep--> reaped
 ```
 
-Posture may change after materialization (escalation raises it, collective
+Posture may change after admission (escalation raises it, collective
 handling demotes it — §8); §9.3 defines alerting and retraction in terms of
 these posture transitions. **Policy changes re-fold**: policy cells are fold
-inputs, so a policy commit wakes the ranker and materialized items re-lane —
-muting a thread demotes its existing items, not just future ones.
+inputs, so a policy commit wakes the usher and admitted notices re-lane —
+muting a thread demotes its existing notices, not just future ones.
 
 ## 5. Seen-state and attention over artifacts
 
@@ -560,12 +603,12 @@ seen-state.
 
 **The seen store** is one small relation per user: the last version of an
 entity the user actually observed. "Observed" is defined strictly:
-**seen = focused open** — the user navigated to the entity (or an item whose
-`target` is the entity) and it was the focus of their attention. Scrolling
-past a row in a list is *not* seen; rendering a lane is *not* seen. This
-single definition is load-bearing three ways: it keeps unseen dots honest,
-it keeps disclosed read-receipts meaningful (§8), and it keeps seen writes
-rare (§4.5.3).
+**seen = focused open** — the user navigated to the entity (or a notice
+whose subject is the entity) and it was the focus of their attention.
+Scrolling past a row in a list is *not* seen; rendering a lane is *not*
+seen. This single definition is load-bearing three ways: it keeps unseen
+dots honest, it keeps disclosed read-receipts meaningful (§8), and it keeps
+seen writes rare (§4.5.3).
 
 ```ts
 // Shown for illustration only.
@@ -581,9 +624,9 @@ Everything else is the **changes projection** (§10.1) joined against marks:
 - `unseen(entity)` = `changes([entity], sinceSeq: seenVersion.seq)` is
   non-empty → change dots on artifacts and their containers (space lists,
   home).
-- **"While you were away"** = one `changes(careSet, basis: seenWatermark,
+- **"While you were away"** = one `changes(watchSet, basis: seenWatermark,
   attribution: true)` call, grouped by run/thread then space, ordered by
-  the ranker. Renders as a pattern on the home context. This is the
+  the usher. Renders as a pattern on the home context. This is the
   first-run view and the every-return view — the same query. The affordance
   must answer *what changed, by whom, since you looked* — the projection's
   `author` field gives session-grain attribution from day one (§10.1) — and
@@ -594,59 +637,59 @@ Everything else is the **changes projection** (§10.1) joined against marks:
   *fresh* (unseen changes) → *seen* → *stale* (untouched for N) →
   *archived*. No new subsystem.
 
-**Derivation beats emission.** For in-fabric sources, an attention candidate
-is *derived from* artifact-change + care-relation — the attention system
-watches; patterns just write their artifacts. Explicit candidate emission
-remains for sources with no artifact (external ingress, transient events),
-but it is the minority path. This is the platform's grain: derived state over
-stored state, and no parallel event journal duplicating what memory-v2's
-commit log already records.
+**Derivation beats posting.** For in-fabric sources, a candidate is *derived
+from* artifact-change + watch set — the attention system watches; patterns
+just write their artifacts. Explicit posting remains for sources with no
+artifact (external ingress, transient events), but it is the minority path.
+This is the platform's grain: derived state over stored state, and no
+parallel event journal duplicating what memory-v2's commit log already
+records.
 
 **Run-level grouping.** One agent run touching twelve artifacts must not be
-twelve scattered dots. From phase 1, agent-shaped sources emit one
-receipt-shaped claim per run (`threadKey` = run id), and the
+twelve scattered dots. From phase 1, agent-shaped sources post one
+receipt-shaped notice per run (`threadKey` = run id), and the
 while-you-were-away view folds entity changes under the run's receipt by
 **attribution**: changes whose `author` is the run's session group beneath
-the receipt rather than appearing as free-floating dots. (Attribution-based
-folding, not an envelope field — the changes projection already carries the
-join key.) Phase 0 — dots only — does not have this, which is a stated
-limitation, not an oversight: phase 0 makes agent work *visible*; run-level
-legibility is phase 1's tracked follow-through (§11).
+the receipt rather than appearing as free-floating dots.
+(Attribution-based folding, not an envelope field — the changes projection
+already carries the join key.) Phase 0 — dots only — does not have this,
+which is a stated limitation, not an oversight: phase 0 makes agent work
+*visible*; run-level legibility is phase 1's tracked follow-through (§11).
 
-**The care-relation** is not a fourth kind of policy — it is **the ranker's
-watch set**: the entity set handed to the changes projection, seeded by
-derived defaults (*touched-recently ∪ agent-did-it-for-you*) and extended by
-explicit watch/unwatch policies (§7). Getting the defaults right is an open
-question (§12.2); getting them wrong in the "too broad" direction is the
-failure mode to avoid (dots everywhere = dots nowhere).
+**The watch set** is not a fourth kind of policy — it is the entity set
+handed to the changes projection, seeded by derived defaults
+(*touched-recently ∪ agent-did-it-for-you*) and extended by explicit
+watch/unwatch policies (§7). Getting the defaults right is an open question
+(§12.2); getting them wrong in the "too broad" direction is the failure
+mode to avoid (dots everywhere = dots nowhere).
 
-## 6. The ranker
+## 6. The usher
 
-**One logical ranker per user.** It folds candidates and policies into the
-ledger, assigns postures and weights, coalesces (same `id` when the same
-source object advances — re-emergence is this same operation crossing a
-tombstone), applies thread displacement (§6.4), retracts source-satisfied
-claims, and sweeps retention (§4.5).
+**One logical usher per user.** It admits candidates, folds policies,
+assigns postures and weights, coalesces (same `id` when the same subject
+advances — re-emergence is this same operation crossing a tombstone),
+applies thread displacement (§6.4), retracts satisfied notices, and sweeps
+retention (§4.5).
 
-### 6.1 Candidate intake
+### 6.1 The notice inbox
 
-Candidates must be **durable before ranking**: the ranker may be asleep or
+Candidates must be **durable before admission**: the usher may be asleep or
 absent (interim mode, closed clients), and ephemeral candidates would be
 silently lost, not delayed. Intake shape:
 
-- In-fabric artifact changes need no *emission* — they are derived (§5).
+- In-fabric artifact changes need no *posting* — they are derived (§5).
   (They do need *reach*: until server-side cross-space wake exists, changes
-  in other spaces reach a server-side ranker via the same forwarding path as
-  explicit candidates below; a client-side ranker reads them directly
-  through the user's ordinary sessions.)
-- Pattern-emitted candidates land in the **candidate inbox in the user's
-  home space** — a cross-principal, quota-gated append surface, named
-  net-new work (§10.2), because it is the one place untrusted-ish writers
-  meet the user's home space: the write gate enforces per-source quotas
-  against the *verified writer identity*, not against self-reported fields.
-  Until §10.2 lands, candidates rest in a durable per-source cell in the
-  space where they arise and the ranker reads them there (client-side
-  interim), with quotas enforced at fold time — weaker (a flood bloats the
+  in other spaces reach a server-side usher via the same forwarding path as
+  posted candidates below; a client-side usher reads them directly through
+  the user's ordinary sessions.)
+- Posted candidates land in the **notice inbox in the user's home space** —
+  a cross-principal, quota-gated append surface, named net-new work
+  (§10.2), because it is the one place untrusted-ish writers meet the
+  user's home space: the write gate enforces per-source quotas against the
+  *verified writer identity*, not against self-reported fields. Until
+  §10.2 lands, candidates rest in a durable per-source cell in the space
+  where they arise and the usher reads them there (client-side interim),
+  with quotas enforced at fold time — weaker (a flood bloats the
   source-space cell, not the home space) but sound.
 - Webhook ingress: the receiving handler persists the payload durably at
   ingress (§4.5); the ephemeral stream is transport, not storage.
@@ -655,12 +698,11 @@ silently lost, not delayed. Intake shape:
 
 ### 6.2 Trust and instance discipline
 
-The `items` store carries a CFC `writeAuthorizedBy` claim. Two viable
-bindings:
+The ledger carries a CFC `writeAuthorizedBy` claim. Two viable bindings:
 
-1. **Verified module identity** (recommended): the ranker ships as a pattern
+1. **Verified module identity** (recommended): the usher ships as a pattern
    with a content-addressed module identity; `writeAuthorizedBy` binds to it.
-   The ranker stays in pattern-space — inspectable, forkable in principle,
+   The usher stays in pattern-space — inspectable, forkable in principle,
    updated like any pattern — and "trusted" means *this exact code*, not
    "runs on a server".
 2. **Trusted builtin**: a runtime builtin id in the claim. Stronger, but
@@ -671,16 +713,16 @@ Recommendation: (1), with the fold's *inputs* (policies) as data so the code
 rarely needs to change. Note the identity subtlety: *acting as the user*
 (session `as` / `actingPrincipal` = the user's DID) and *being authorized to
 write the ledger* (module identity matching the claim) are two separate
-checks, and the design uses both — every ranker write is attributable
-`onBehalfOf` the user and provably from the ranker's code.
+checks, and the design uses both — every usher write is attributable
+`onBehalfOf` the user and provably from the usher's code.
 
 `writeAuthorizedBy` authorizes *code*, not an *instance*: two devices running
-the ranker both pass the claim. The single-writer premise therefore needs
-instance discipline, not just CFC: **the interim client-side ranker takes a
+the usher both pass the claim. The single-writer premise therefore needs
+instance discipline, not just CFC: **the interim client-side usher takes a
 lease** (a mutex cell claimed with an expiry; the sqlite spec's
 `tryClaimMutex` shape) and only the leaseholder folds. Independent of the
-lease, the fold is specified **idempotent and commutative over the candidate
-inbox** (deterministic ids; coalescing recomputes from source state rather
+lease, the fold is specified **idempotent and commutative over the notice
+inbox** (deterministic ids; coalescing recomputes from subject state rather
 than incrementally mutating), so a lease handoff or a brief double-writer
 window degrades to wasted work, not divergence.
 
@@ -688,63 +730,62 @@ window degrades to wasted work, not divergence.
 
 - **Target: the server-primary execution model**
   (`docs/specs/server-side-execution/`). With intake home-space-local
-  (§6.1), the ranker is a *standing registration on the user's home space* —
+  (§6.1), the usher is a *standing registration on the user's home space* —
   work whose value is its effects rather than client-read output — woken by
-  commits to the candidate inbox, the policy cells, or forwarded
-  care-events. Execution is attributed `onBehalfOf` the user. Named
+  commits to the notice inbox, the policy cells, or forwarded watch-set
+  events. Execution is attributed `onBehalfOf` the user. Named
   dependencies, since that spec's workers, registrations, and wake-on-commit
   are all **per-space**: standing registrations are its own later phase;
   scoped (`PerUser`) state claims are gated (its G16); server-side
   *cross-space* reads/wake are explicitly deferred there — which is exactly
-  why intake forwards into the home space instead of the ranker reading N
+  why intake forwards into the home space instead of the usher reading N
   spaces.
 - **Interim: client-side, under lease** (§6.2). Until standing registrations
-  land, the leaseholder client runs the ranker as an ordinary piece. This
+  land, the leaseholder client runs the usher as an ordinary piece. This
   degrades gracefully for in-fabric state (candidates are durable; folding
   happens on next lease) — what's lost is only *timeliness* while no client
   is open, which matters from phase 2 (OS delivery) onward and not before.
-- **Not: `background-piece-service` as-is.** It is per-space (the ranker is
-  per-user), ~60s polling (the ranker is wake-on-commit shaped), and its own
+- **Not: `background-piece-service` as-is.** It is per-space (the usher is
+  per-user), ~60s polling (the usher is wake-on-commit shaped), and its own
   README documents async-completion unreliability. If bps is pressed into
   interim service, treat that as scaffolding, not the design.
 
-**Laziness.** The ranker materializes *rows*; it does not keep derived
+**Laziness.** The usher materializes *rows*; it does not keep derived
 predicates hot. `visible()` evaluates on surface demand over the user's own
 stores (§4.4). The one push-shaped duty is OS delivery (§9.3), which is
 explicitly an edge adapter fed by wake-on-commit, not a hot loop.
 
 ### 6.4 Coalescing and thread displacement
 
-Three mechanisms in the earlier draft (`id`-coalescing, `threadKey`
-grouping, an emitter-declared `displaces` list) are two in this one, at
-distinct altitudes:
+Two mechanisms at two altitudes:
 
-- **`id` is identity**: the same claim at a newer source version. Coalescing
-  updates the item in place (refreshing content, expiry, progress);
-  crossing a dismissal tombstone is re-emergence. Identity is
-  ranker-derived from verified provenance (§4.4), so it cannot be forged.
+- **`id` is identity**: the same notice at a newer subject version.
+  Coalescing updates the notice in place (refreshing content, expiry,
+  progress); crossing a dismissal tombstone is re-emergence. Identity is
+  usher-derived from verified provenance (§4.4), so it cannot be forged.
 - **`threadKey` is the thread**, and displacement is a *derived rule over
-  it*: **within a threadKey, only the newest live claim is visible**; older
-  live claims in the thread are terminally retracted by the ranker (system
-  action) when a newer one materializes. A prepared result therefore
-  displaces the raw occurrence by *sharing its thread*, not by naming item
-  ids — no displacement chains, no tombstone bookkeeping for the emitter,
-  and "the displaced item's source advances again" needs no special case
-  (it is simply the thread's newest claim again). Cross-thread or
-  multi-target displacement is deliberately not expressible; a consumer
-  who needs it should make the case with a concrete scenario (§12.7).
+  it*: **within a threadKey, only the newest live notice is visible**;
+  older live notices in the thread are terminally retracted by the usher
+  (system disposition) when a newer one is admitted. A prepared result
+  therefore displaces the raw occurrence by *sharing its thread*, not by
+  naming notice ids — no displacement chains, no tombstone bookkeeping for
+  the emitter, and "the displaced notice's subject advances again" needs no
+  special case (it is simply the thread's newest notice again).
+  Cross-thread or multi-target displacement is deliberately not
+  expressible; a consumer who needs it should make the case with a concrete
+  scenario (§12.7).
 
 ## 7. Policies
 
-A policy is a small declarative record the ranker folds over — **data, not
-ranker code**:
+A policy is a small declarative record the usher folds over — **data, not
+usher code**:
 
 ```ts
 // Shown for illustration only.
 type AttentionPolicy = {
   match: {
-    source?: unknown;         // asCell: ["cell"] — a specific source/thread
-    sourceKind?: string;      // as bound by the ranker, §4.4
+    subject?: unknown;        // asCell: ["cell"] — a specific source/thread
+    kind?: string;            // as bound by the usher, §4.4
     spaceDid?: string;
     threadKey?: string;
   };
@@ -754,54 +795,72 @@ type AttentionPolicy = {
     clamp?: { min?: "review" | "heads-up" | "interrupt";
               max?: "suppress" | "silent" | "review" | "heads-up" };
     // Exempts this policy's min from quiet-hours clamping (the babysitter
-    // thread breaks through). User-set only.
+    // thread breaks through). User-authored only.
     bypassQuietHours?: boolean;
+    // Nag-until-done: while a matching notice is visible and unhandled,
+    // re-alert on this cadence — the SINGLE sanctioned exception to
+    // §9.3's alert-once rule. User-authored only; needs timer wake
+    // (§10.5) to fire between commits.
+    realert?: { everyMs: number };
     coalesceWindowMs?: number;
     // Time-conditional clamp sugar: during these hours, max = "review".
     quietHours?: { start: string; end: string };
-    watch?: boolean;          // extend/prune the care-relation (§5)
+    watch?: boolean;          // extend/prune the watch set (§5)
   };
   reason?: string;            // human-legible: why this policy exists
-  createdBy: string;          // user DID; a pattern's module identity for
-                              // proposals; the RANKER's module identity for
+  author: string;             // user DID; a pattern's module identity for
+                              // proposals; the USHER's module identity for
                               // learned policies (see below)
 };
 ```
 
 **Composition is one formula.** Effective posture =
 `clampScale(baseline, max(matching mins), min(matching maxes))` where
-`baseline` is the requested posture bounded by the source's learned
-baseline; **maxes dominate mins** on conflict, with one exception —
-a user-created min marked `bypassQuietHours` survives the quiet-hours max.
-`quietHours` is defined as nothing more than a time-conditional
-`max: "review"`. The canonical case — "quiet hours 22:00–07:00, but the
-babysitter thread always breaks through" — is two records and zero
-ambiguity.
+`baseline` is the posture hint bounded by the source's learned baseline;
+**maxes dominate mins** on conflict, with one exception — a user-authored
+min marked `bypassQuietHours` survives the quiet-hours max. `quietHours` is
+defined as nothing more than a time-conditional `max: "review"`. The
+canonical case — "quiet hours 22:00–07:00, but the babysitter thread always
+breaks through" — is two records and zero ambiguity.
 
 - Policies live in the user's home space (`PerUser` scope). The core ships a
-  handful of defaults: messages-from-humans → `heads-up`;
-  agent-completions → `silent` (visible as seen-state, never buzzing).
-  There is deliberately **no default that maps any emitter-supplied field to
-  `interrupt`** — deadline-driven interruption ("library book due
-  tomorrow") exists only as a user-adopted policy min on a named source.
-- **Mute is a policy, not a special relation** (and not an action type).
+  handful of defaults: messages from **verified human actors with an
+  established relationship** (rosters, prior threads) → `heads-up`;
+  agent-completions → `silent` (visible as seen-state, never buzzing). Per
+  §4.2, shipped defaults above `review` key on usher-verified facts only —
+  never on self-declared `kind` (declaring `kind: "group-chat"` must not
+  buy the human-messages baseline). There is deliberately **no default
+  that maps any emitter-supplied field to `interrupt`**.
+- **Mute is a policy, not a special relation** (and not a disposition).
   "Mute this thread" writes `{match: {threadKey}, effect: {clamp: {max:
-  "suppress"}}}`; the re-fold rule (§4.7) demotes existing items too.
+  "suppress"}}}`; the re-fold rule (§4.7) demotes existing notices too.
 - **Patterns propose, the user disposes.** A pattern can ship a suggested
   policy with its artifacts ("library book due → heads-up 3 days before");
   adoption goes through a trusted surface, exactly like other user-consented
   writes — adoption *is* the write, and unadopted proposals never enter the
-  fold. (Onboarding flows that propose an initial policy set are this same
-  primitive N times, batch-confirmed by a product surface — out of scope,
-  §Non-goals.)
+  fold. Two idioms this primitive must carry, because users won't write
+  these policies unaided:
+  - **The emergency pack.** Nobody writes an interrupt floor for their
+    kid's school until the day it's too late. Products should propose a
+    small break-glass set at onboarding (school/daycare numbers, smoke/CO
+    alerts, bank-fraud kinds) — `{clamp: {min: "interrupt"},
+    bypassQuietHours: true}` per source — through this same adopt flow.
+    The runtime's part: those adopted policies compile to the OS's
+    highest available interruption level (§9.3's reserved mapping).
+  - **The deadline ladder.** Long-lived obligations post their whole
+    escalation ladder ahead of time: three candidates with `notBefore` =
+    T-90/T-30/T-7, same `threadKey` (each new admission displaces the
+    prior rung), ascending posture hints, plus a proposed min the user
+    adopts once. Obligation met → subject advances → the usher retracts
+    the pending rungs (§4.7's EMBARGOED retraction).
 - **Learned policies: the reputation loop, made legible.** The downward
   feedback the spec promises (dismiss-without-open, quota pressure ⇒ the
-  source's items sink) has to live *somewhere*, and hidden ranker state
-  would break the inspectability goal. It lives here: the ranker — which is
+  source's notices sink) has to live *somewhere*, and hidden usher state
+  would break the inspectability goal. It lives here: the usher — which is
   already the trusted fold, not a third party petitioning for adoption —
-  writes ordinary policy records (`createdBy` = its module identity,
-  `reason` = the evidence, e.g. "7 of 8 items dismissed without open over
-  30d") into a designated **learned** section of the policy store. They are
+  writes ordinary policy records (`author` = its module identity, `reason`
+  = the evidence, e.g. "7 of 8 notices dismissed without open over 30d")
+  into a designated **learned** section of the policy store. They are
   visible, editable, and deletable exactly like hand-written policies; a
   user deleting one is itself a signal. Learned policies may only *lower*
   (set maxes / lower the baseline) — raising posture remains exclusively
@@ -809,52 +868,56 @@ ambiguity.
   system-inferred-but-user-owned data (`packages/home-schemas/learned.ts`).
 - **Product policy dimensions compile down.** Stance-like vocabularies
   (Loom's `attention-policy-v1`) do not ride an opaque field on runtime
-  policies — there is deliberately no `policy.ext`, because an opaque blob
-  on the user's routing rules would imply a second, shadow interpreter of
-  the same cells. Product policy systems keep their own records and
-  *compile* to plain runtime clamps/watches, exactly as a trusted source
-  compiles its channel semantics to requested postures.
+  policies — there is deliberately no `AttentionPolicy.ext`, because an
+  opaque blob on the user's routing rules would imply a second, shadow
+  interpreter of the same cells. Product policy systems keep their own
+  records and *compile* to plain runtime clamps/watches, exactly as a
+  trusted source compiles its channel semantics to posture hints.
 - **Policy privacy, honestly stated.** Policy cells are never directly
   readable by other principals — they are ordinary confidential home-space
   data. But *behavioral* inference cannot be fully prevented: in a space
   that discloses read receipts, a muted member's persistent silence is
   statistically visible to a patient observer. The runtime's guarantee is
   scoped: no direct exposure, and inference surface bounded by the space's
-  own disclosure policy (§8, §12.5). Ranker *output* ordering/timing is not
+  own disclosure policy (§8, §12.5). Usher *output* ordering/timing is not
   considered a protected channel in v1.
 
 ## 8. Multi-user
 
-Three properties, all falling out of "attention is a per-(user, item)
+Three properties, all falling out of "a notice is a per-(user, notice)
 relation" plus existing constraints:
 
-- **One candidate, N ledgers.** A shared space emits one candidate per event;
-  each member's own ranker lanes it under their own policies. A new message
-  can be `interrupt` for the on-call member and `silent` for the member who
-  muted the thread. The emitter cannot know or decide this — correctly so.
+- **One candidate, N ledgers.** A shared space posts one candidate per
+  event; each member's own usher lanes it under their own policies. A new
+  message can be `interrupt` for the on-call member and `silent` for the
+  member who muted the thread. The emitter cannot know or decide this —
+  correctly so.
 - **"Who has seen this" — and "who handled this" — is contributed, not
   enumerated.** There is no runtime primitive for listing a space's members
   or reaching into their home spaces
   (`docs/specs/shared-profile-rosters.md`), and this design does not add
   one. Shared attention state follows the roster idiom: members' runtimes
   write their own **seen marks and, per disclosure policy, terminal
-  actions** into `PerSpace` state in the shared space — *if* the space's
-  disclosure policy says to. Read receipts, "3 people haven't seen the new
-  plan", and *"Bea already handled this"* are queries over that contributed
-  state. Disclosing terminal actions matters because handling often doesn't
-  touch the source artifact (triaged verbally, replied off-fabric): when the
-  source *is* mutated, everyone's claims coalesce or satisfy for free; when
-  it isn't, a disclosed `acted` is the only retraction signal others can
-  get. A per-space opt-in policy — *"acted-by-any-member demotes to
-  `silent` for all"* — turns that signal into collective quiet.
-  Disclosure is a per-space policy cell (some spaces want receipts, some
-  don't); a member who discloses nothing simply doesn't appear.
+  dispositions** into `PerSpace` state in the shared space — *if* the
+  space's disclosure policy says to. Read receipts, "3 people haven't seen
+  the new plan", and *"Bea already handled this"* are queries over that
+  contributed state. Disclosing terminal dispositions matters because
+  handling often doesn't touch the source artifact (triaged verbally,
+  replied off-fabric): when the subject *is* mutated, everyone's notices
+  coalesce or satisfy for free; when it isn't, a disclosed `acted` is the
+  only retraction signal others can get. A per-space opt-in policy —
+  *"acted-by-any-member demotes to `silent` for all"* — turns that signal
+  into collective quiet. Disclosure is a per-space policy cell (some spaces
+  want receipts, some don't); a member who discloses nothing simply doesn't
+  appear — and, corollary, silently opts out of collective quiet, which the
+  space's members should understand when choosing the policy.
 - **Escalation across people is a policy.** "If nobody attends to this
   within 2h, raise it to `heads-up` for the space owner" is a policy cell on
-  the shared space, evaluated by the owner's ranker against contributed
+  the shared space, evaluated by the owner's usher against contributed
   state. No siloed notification system can express this; here it is one
-  record. (Escalation is a posture *raise* after materialization; §9.3's
-  transition rule makes it alert exactly once.)
+  record. (Escalation is a posture *raise* after admission; §9.3's
+  transition rule makes it alert exactly once. Deadline-shaped escalation —
+  "nobody acted" produces no commits — needs timer wake, §10.5.)
 
 ## 9. Surfaces
 
@@ -868,8 +931,8 @@ experience. Concretely:
 - lanes: `interrupt` (modal-adjacent), `heads-up` (bell + badge count),
   `review` (digest entry point), `silent` (dots via seen-state, §5);
 - unseen-change dots on artifacts and containers;
-- a snoozed lane (snoozed items must stay discoverable);
-- item `actions` rendered in place (§4.6);
+- a snoozed lane (snoozed notices must stay discoverable);
+- notice `actions` rendered in place (§4.6);
 - **focused opens** — never renders — write the seen mark, under §4.5's
   advance-only + debounced discipline. Rendering a lane writes nothing.
 
@@ -877,7 +940,7 @@ Presentation components exist (`cf-toast`/`cf-toast-provider`, `cf-alert`,
 badge conventions); the net-new work is mounting them against ledger
 queries. One CFC note for badge counts: aggregates over a rule-bearing
 store refuse unless every row is readable by the counting principal —
-for a home-space ledger this holds as long as item rows' clauses always
+for a home-space ledger this holds as long as notice rows' clauses always
 include the owner; state that invariant in the schema rather than
 discovering it when someone adds a per-row rule.
 
@@ -885,11 +948,11 @@ discovering it when someone adds a per-row rule.
 
 A digest is **bounded history, not a feed**: a periodic artifact-shaped
 summary over the ledger and seen-state — quiet dispositions, artifact
-updates, prepared material, grouped by `sourceKind` — rendered by a pattern.
-The runtime contribution is only that the queries behind it (terminal items
-since T, unseen changes since T, actions by surface) are cheap and complete.
-Whether a digest's *summary* may itself claim `heads-up` is a policy
-decision, default no.
+updates, prepared material, grouped by `kind` — rendered by a pattern. The
+runtime contribution is only that the queries behind it (terminal notices
+since T, unseen changes since T, dispositions by surface) are cheap and
+complete. Whether a digest's *summary* may itself claim `heads-up` is a
+policy decision, default no.
 
 ### 9.3 OS delivery
 
@@ -898,34 +961,49 @@ Adapters compile the envelope down; the ledger stays canonical and
 "Android-shaped" (live update + auto-retract), and platforms degrade from
 there:
 
-- **Alerting rides posture transitions, not writes.** A delivered item
+- **Alerting rides posture transitions, not writes.** A delivered notice
   alerts when it first materializes at an alert-bearing rung and again only
-  when the ranker *raises* its posture (escalation, §8); every same-rung
+  when the usher *raises* its posture (escalation, §8); every same-rung
   coalesce — new message in the thread, progress tick, content refresh —
   **replaces silently** on every surface (Android `setOnlyAlertOnce`
   semantics, made unconditional: the emitter cannot choose to re-buzz).
-  Posture *demotion* and visibility flips are retraction triggers: the
-  dispatcher retracts or downgrades the delivered surface when either
-  occurs. Without this rule a coalescing thread would legally buzz on
-  every advance — louder than Android, inverting the spec's promise.
+  The **single sanctioned exception** is a user-authored `realert` policy
+  (§7): while a matching notice is visible and unhandled, it re-alerts on
+  the policy's cadence — nag-until-done for medication-grade obligations,
+  grantable only by the user, so the alert-once invariant bends only where
+  its owner says so. Posture *demotion* and visibility flips are
+  retraction triggers: the dispatcher retracts or downgrades the delivered
+  surface when either occurs. Without the base rule a coalescing thread
+  would legally buzz on every advance — louder than Android, inverting the
+  spec's promise.
+- **Break-glass compiles to the platform's ceiling.** A user-adopted
+  `{clamp: {min: "interrupt"}, bypassQuietHours: true}` policy (the
+  emergency pack, §7) maps to the highest interruption level the platform
+  grants us: today a maximally-prominent standard alert; when
+  `time-sensitive` / `critical` (iOS) and DND-bypass channels (Android)
+  entitlements land, *this same policy* compiles to them with no policy
+  migration — the mapping is reserved now precisely so the novel emergency
+  isn't re-designed later. (Implementing those entitlements stays a
+  non-goal for V1; reserving their compile target is not.)
 - **Replace/retract rides `id`** everywhere: iOS
   `UNNotificationRequest.identifier` / `apns-collapse-id`, Android
   `notify(id)`, Web Push `options.tag`. Two honesty notes. First,
   transitions are evaluated on commit-driven wakes and on read — **nothing
   wakes anything at `expiresAt`**: server-side timers don't exist yet (they
   are "(Future)" in `docs/specs/server-side-execution/`), so an expired
-  item may linger on an OS tray until the next wake re-evaluates it. Timer
-  registrations that feed the dispatcher are named net-new work (§10.5);
-  until they land, expiry is evaluate-on-read with explicitly stale OS
-  surfaces (the ranker's sweep is the terminal write-side, §4.5). Second,
-  iOS replaces but does not tick (text refreshes when the shade reopens);
-  genuinely-live claims (`progress`) render best-effort per platform, and
-  rich live chrome (Live Activities) is a separate later track.
+  notice may linger on an OS tray until the next wake re-evaluates it.
+  Timer registrations that feed the dispatcher are named net-new work
+  (§10.5); until they land, expiry is evaluate-on-read with explicitly
+  stale OS surfaces (the usher's sweep is the terminal write-side, §4.5).
+  Second, iOS replaces but does not tick (text refreshes when the shade
+  reopens); genuinely-live notices (`progress`) render best-effort per
+  platform, and rich live chrome (Live Activities) is a separate later
+  track.
 - **Confidentiality crosses the push boundary explicitly.** Push payloads
   and lockscreens are untrusted displays: they carry `redacted` when
-  present, otherwise a generic envelope ("Update from <sourceKind>"), with
-  full content fetched on unlock/app-open (the conventional
-  mutable-content/fetch-on-receive shape). Items whose confidentiality
+  present, otherwise a generic envelope ("Update from <kind>"), with full
+  content fetched on unlock/app-open (the conventional
+  mutable-content/fetch-on-receive shape). Notices whose confidentiality
   labels forbid egress to the push relay get the generic envelope
   unconditionally — the same CFC labels that govern every other flow govern
   this one; a system that gates reading a version number (§10.1) does not
@@ -934,16 +1012,17 @@ there:
   worker). Wrapped mobile apps: native APNs/FCM via the wrapper's plugin —
   embedded webviews do not get Web Push. The server side (toolshed) needs a
   device-registration table `{userDid, deviceId, transport, token}` and a
-  delivery ledger `{itemId, deviceId, platformIdentifier, deliveredAt,
+  delivery log `{noticeId, deviceId, platformIdentifier, deliveredAt,
   retractedAt}` so retraction can target what was actually delivered.
   Ship Web Push first; the envelope is transport-agnostic.
 - **The PWA is the floor.** The canonical shape includes nothing that cannot
   be expressed on the most-constrained surface (action buttons included —
   Web Push has them); richer platforms are adapter opt-ins, not envelope
   fields.
-- **Tray-dismiss is per-device by default.** An OS-tray dismissal writes an
-  action with `surface: "os-tray"`; whether it terminates the item globally
-  is policy (default: clears that device only; the shell is canonical).
+- **Tray-dismiss is per-device by default.** An OS-tray dismissal writes a
+  disposition with `surface: "os-tray"`; whether it terminates the notice
+  globally is policy (default: clears that device only; the shell is
+  canonical).
 
 ## 10. Net-new runtime surface
 
@@ -964,7 +1043,7 @@ that first needs it (§11), and each needs its own (small) design pass.
 
    (a) With a single root and no basis it is the **non-reactive head read**
    — a one-shot query, not a watch, so re-renders never re-fire. (b) With
-   the care-relation as roots and the seen watermark as basis it is the
+   the watch set as roots and the seen watermark as basis it is the
    **"while you were away" enumeration** — one indexed scan of the `head`
    table (add a `(branch, seq)` index). (c) With `attribution: true` it
    joins the commit log's already-persisted `sessionId` — **session-grain,
@@ -980,7 +1059,7 @@ that first needs it (§11), and each needs its own (small) design pass.
    range-anchored collaborative-field machinery, self-declared future work;
    the one annotation prototype's review (PR #4132) documents why
    side-table indexes invisible to the reactive graph are the wrong shape.
-2. **Candidate inbox append gate** *(phase 1; hardened by phase 2)*. A
+2. **Notice inbox append gate** *(phase 1; hardened by phase 2)*. A
    home-space inbox cell with **restricted cross-principal append**: other
    principals' patterns may append candidates (the rosters
    contribute-your-own idiom, reversed) but the write gate enforces
@@ -988,26 +1067,31 @@ that first needs it (§11), and each needs its own (small) design pass.
    makes dead-device delivery an authority question with an answer instead
    of an open question — the full chain "someone messages me while all my
    devices are closed → my phone buzzes" is inbox append → home-space
-   wake → ranker fold → dispatcher push.
-3. **Write-authorization for sqlite** *(pre-migration of `items` to sqlite;
-   not needed for phase 1's array-cell backing)*. `writeAuthorizedBy` is
-   enforced on the cell-write prepare path only; `db.exec` today checks
-   confidentiality ceilings and row-label rules but not write authorization.
-   Gating `db.exec` per database handle (the `rev` bump is a cell write, so
-   the prepare path sees it) needs specification and a security review of
-   its own, including whether any sqlite write path bypasses the rev write.
-4. **Ranker lease** *(phase 1)*. A small mutex-cell convention (claim with
+   wake → usher fold → dispatcher push.
+3. **Write-authorization for sqlite** *(pre-migration of the ledger to
+   sqlite; not needed for phase 1's array-cell backing)*.
+   `writeAuthorizedBy` is enforced on the cell-write prepare path only;
+   `db.exec` today checks confidentiality ceilings and row-label rules but
+   not write authorization. Gating `db.exec` per database handle (the `rev`
+   bump is a cell write, so the prepare path sees it) needs specification
+   and a security review of its own, including whether any sqlite write
+   path bypasses the rev write.
+4. **Usher lease** *(phase 1)*. A small mutex-cell convention (claim with
    expiry, renew, steal-on-expiry) for single-instance election of the
-   interim client-side ranker (§6.2). Generalizes beyond attention.
+   interim client-side usher (§6.2). Generalizes beyond attention.
 5. **Timer wake** *(phase 2+)*. Executor-pool timer registrations
-   (`notBefore`, `expiresAt`, snooze expiry, digest cadence) feeding
-   wake-on-commit's machinery, so time-driven transitions don't depend on
-   coincidental commits. Until then: evaluate-on-read, stale OS surfaces
-   acknowledged (§9.3). Note this also bounds the "library book due"
-   genre: alarm-shaped interruption is only as timely as the wake source.
+   (`notBefore`, `expiresAt`, snooze expiry, `realert` cadences, escalation
+   deadlines, digest cadence) feeding wake-on-commit's machinery, so
+   time-driven transitions don't depend on coincidental commits. Until
+   then: evaluate-on-read, stale OS surfaces acknowledged (§9.3). Note this
+   is the single load-bearing dependency for every deadline-shaped story
+   (2FA expiry, medication, on-call escalation, visa ladder — Appendix B);
+   it is small, but it is not optional for phase 2.
 6. **Push transports** *(phase 2/3)*. Web Push then APNs/FCM: device
-   registration, delivery ledger, retraction dispatch (§9.3). Net-new but
-   conventional.
+   registration, delivery log, retraction dispatch (§9.3). Net-new but
+   conventional. The break-glass entitlements (`time-sensitive`/`critical`,
+   DND-bypass channels) are a named later extension with their compile
+   target reserved now (§9.3).
 
 ## 11. Phasing
 
@@ -1015,57 +1099,62 @@ Each phase is independently shippable and none re-shapes the data model.
 
 - **Phase 0 — seen-state.** The changes projection (§10.1), the seen store
   with its write discipline (§4.5.3), unseen dots in the shell, and a
-  "while you were away" home pattern. No ranker, no candidates, no push.
+  "while you were away" home pattern. No usher, no candidates, no push.
   Acceptance bar: the user can see *what changed, by whom (session-grain),
   and since when*, and jump in with the changed region emphasized — not
   merely that a dot exists. This makes agent work **visible** — the single
-  most-requested product gap — while run-level *legibility* (one claim per
+  most-requested product gap — while run-level *legibility* (one notice per
   agent run, not twelve dots) is explicitly phase 1's follow-through.
-- **Phase 1 — ledger + lanes.** Envelope, home-space `items` (array cell +
-  `writeAuthorizedBy`) and `actions` stores, candidate intake (inbox gate
-  §10.2, or interim source-space cells), a minimal client-executed ranker
-  under lease (defaults + clamp composition + learned policies + thread
-  displacement), shell bell/lanes with item actions (§4.6), receipt-shaped
-  claims for agent runs with attribution folding (§5). Policies v0.
-- **Phase 2 — server ranker + first transport.** Ranker as a standing
+- **Phase 1 — ledger + lanes.** Envelope, home-space `notices` (array cell
+  + `writeAuthorizedBy`) and `dispositions` stores, notice intake (inbox
+  gate §10.2, or interim source-space cells), a minimal client-executed
+  usher under lease (verified-fact defaults + clamp composition + learned
+  policies + thread displacement), shell bell/lanes with notice actions
+  (§4.6), receipt-shaped notices for agent runs with attribution folding
+  (§5). Policies v0 (including the emergency-pack and deadline-ladder
+  propose/adopt idioms, §7).
+- **Phase 2 — server usher + first transport.** Usher as a standing
   registration on the home space under server-primary execution
   (dependencies named in §6.3); Web Push with device registration,
-  redaction rules, and retraction; digest queries; timer wake (§10.5).
+  redaction rules, and retraction; digest queries; timer wake (§10.5),
+  which activates `realert`, escalation deadlines, and timely `notBefore`
+  materialization.
 - **Phase 3 — breadth.** Wrapped-app APNs/FCM; shared seen-state +
-  disclosed terminal actions + escalation policies (§8); `items` on sqlite
-  once §10.3 lands; snooze/archive surfaced fully; `progress` rich chrome
-  (Live Activities) as its own track.
+  disclosed terminal dispositions + escalation policies (§8); the ledger
+  on sqlite once §10.3 lands; snooze/archive surfaced fully; `progress`
+  rich chrome (Live Activities) and the break-glass OS entitlements as
+  their own tracks.
 
 ## 12. Open questions
 
-1. **Ranker trust binding.** Verified module identity is recommended (§6.2),
+1. **Usher trust binding.** Verified module identity is recommended (§6.2),
    but the "wholly-system service" alternative keeps resurfacing; if the
    server executor itself writes the ledger, is that a builtin identity, and
-   does that preempt user-forkable rankers? Resolve before phase 1.
-2. **Care-relation defaults.** Touched ∪ agent-authored ∪ watched is the
-   working answer for the watch set (§5); validate against real spaces
-   before hardening, and decide whether "touched" decays.
-3. **Forwarder contract.** Cross-space reach for a server-side ranker
+   does that preempt user-forkable ushers? Resolve before phase 1.
+2. **Watch-set defaults.** Touched ∪ agent-authored ∪ watched is the
+   working answer (§5); validate against real spaces before hardening, and
+   decide whether "touched" decays.
+3. **Forwarder contract.** Cross-space reach for a server-side usher
    (§6.1, §6.3): who runs the forwarding (the emitting pattern? the user's
    runtime on visit?), and what happens for spaces the user hasn't opened
    in weeks? Partially subsumed by §10.2's inbox gate; the residue is
-   *derived* care-events from spaces with no cooperating emitter.
+   *derived* watch-set events from spaces with no cooperating emitter.
 4. **Seen-mark granularity.** Per-entity marks are the floor. Do container
    views (a space list showing N dots) warrant container-level marks, and
    does "seen the container" imply anything about members?
-5. **Disclosure defaults** for shared seen-state and terminal actions (§8):
-   receipts on or off by default, what the non-disclosing member's absence
-   reveals, and how much of §7's policy-privacy bound this sets.
+5. **Disclosure defaults** for shared seen-state and terminal dispositions
+   (§8): receipts on or off by default, what the non-disclosing member's
+   absence reveals, and how much of §7's policy-privacy bound this sets.
 6. **Policy expressiveness boundary.** V1 is plain predicates. Content
    regexes and LLM-judged predicates ("only interrupt if actually urgent")
-   are clearly coming — as ranker inputs they inherit the ranker's authority,
+   are clearly coming — as usher inputs they inherit the usher's authority,
    so they need their own integrity story before admission.
 7. **Displacement scope.** Thread displacement (§6.4) deliberately cannot
    express cross-thread or multi-target displacement. If a real consumer
    produces a scenario that needs it, revisit with that scenario on the
    table; until then the simpler rule stands.
 8. **Learned-policy dynamics.** Decay (does a learned clamp relax after N
-   weeks of the user opening that source's items?), evidence thresholds,
+   weeks of the user opening that source's notices?), evidence thresholds,
    and whether a user deleting a learned policy suppresses re-learning for
    a period.
 9. **Digest self-promotion.** May a digest claim `heads-up` on a schedule
@@ -1075,35 +1164,204 @@ Each phase is independently shippable and none re-shapes the data model.
     seen-timestamps. Appendix A is the field mapping; the remaining
     question is sequencing — which loom surface adopts the runtime ledger
     first, and whether loom's materializer becomes the trusted source or a
-    second ranker (§Division of labor says: trusted source).
+    second usher (§Division of labor says: trusted source).
+11. **`realert` bounds.** Minimum cadence, maximum duration, and whether a
+    realert policy requires re-confirmation after N fires — the exception
+    to alert-once must not become a resharpened nag machine (§7, §9.3).
 
 ## Appendix A — mapping Loom's `attention-candidate-v1`
 
-For the first consumer's adoption review. Loom fields → envelope:
+For the first consumer's adoption review. Loom fields → envelope. (Naming
+flag: Loom's `claim_kind` vocabulary includes a value `notice`; product-side
+that value should be renamed — e.g. `fyi` — before the runtime noun lands.)
 
 | Loom candidate field | Envelope home |
 |---|---|
-| `id` / source identity | `id` (re-derived by ranker from verified provenance) |
-| subject / focused target | `target` (cell link); `focused_view_fallback` → `ext` |
-| prepared material | `prepared` |
+| `id` / source identity | `id` (re-derived by usher from verified provenance) |
+| subject / focused target | `subject` (cell link); distinct destination → `target`; `focused_view_fallback` → `ext` |
+| prepared material | `attachment` |
 | `title`, body copy | `title`, `body` (+ `redacted` where the product wants lockscreen-safe copy) |
 | `why_now` | `ext.why_now` (product copy, runtime-opaque) |
-| `claim_kind` (act-now / review / notice / …) | `sourceKind` + `requestedPosture` (kind is classification; posture is the loudness request derived from it) |
+| `claim_kind` (act-now / review / notice→fyi / …) | `kind` + `postureHint` (kind is classification; the hint is the loudness request derived from it) |
 | `channel` (important-and-urgent / yours-in-progress / might-interest-you) | `ext.channel` — audience/genre, orthogonal to posture; product lanes render it |
 | `relation_to_trigger` (augments / supersedes / resolves / …) | `ext.relation_to_trigger`, whole; *supersedes* additionally = share the trigger's `threadKey` (thread displacement, §6.4, does the retraction) |
-| `authorization_state: proposal-required` | `actions: [{key:"approve"…},{key:"deny"…}]` (§4.6) + `ext.authorization_state` — the approval affordance travels with the claim |
+| `authorization_state: proposal-required` | `actions: [{key:"approve"…},{key:"deny"…}]` (§4.6) + `ext.authorization_state` — the approval affordance travels with the notice |
 | `authority_class` | `ext` (work-start domain, product-side per §Division of labor) |
 | `not_before` | `notBefore` |
 | sender / subject person | `actor` |
-| delivery/interrupt eligibility | `requestedPosture`, clamped by user policy (§7) |
-| feedback: done / later | actions `acted` / `snoozed` |
+| delivery/interrupt eligibility | `postureHint`, clamped by user policy (§7) |
+| feedback: done / later | dispositions `acted` / `snoozed` |
 | feedback: never-for-this-class | a policy write (`clamp.max`) via the trusted surface |
-| feedback: not-useful | action `dismissed` + `ext.feedback: "not-useful"` (calibration signal round-trips to the product) |
+| feedback: not-useful | disposition `dismissed` + `ext.feedback: "not-useful"` (calibration signal round-trips to the product) |
 
 Not mapped, deliberately: Work-start Policies, continuity owners, typed
 receipts' internals, stance vocabularies — upstream product machinery
 (§Division of labor); stance policies compile down to plain clamps/watches
 (§7). A receipt *summary* enters as an ordinary candidate.
+
+## Appendix B — ten worked stories
+
+Ten deliberately diverse stress cases from the user-story review, each
+walking the mechanism end to end, with honest grades: **fully built**
+(phase 3) and **phase 1 reality**. The pattern in the grades is itself a
+finding: stories whose essence is *time* or *other people* are phase-gated
+on timer wake (§10.5) and push (§10.6); stories derivable from state the
+user already holds are strong almost immediately.
+
+| # | Story | Axis | Fully built | Phase 1 |
+|---|---|---|---|---|
+| B.1 | School emergency | must-interrupt, novel source | B− (with §7 pack + §9.3 reserved mapping) | F (no push) |
+| B.2 | Medication | seeing must not satisfy | B+ (with `realert`) | D (no timer wake) |
+| B.3 | On-call triage | multi-user coordination | A− | D (shared state is phase 3) |
+| B.4 | Overnight agent run | quiet agent work | A | A− |
+| B.5 | 2FA code | time-critical, brief | B | B− |
+| B.6 | Social stream | high-volume, low-value | A | A |
+| B.7 | Medical privacy | lockscreen leakage | A | A− (trivially — no push yet) |
+| B.8 | Approve rebooking | act from the surface | A− | B (shell only) |
+| B.9 | Visa renewal | long-lived deadline ladder | B | C+ (evaluate-on-read only) |
+| B.10 | Adversarial source | spam defense | A− | A− |
+
+### B.1 The school emergency (must-interrupt, novel source)
+
+Priya's kid has an allergic reaction at school; the office texts "come now."
+Quiet is the failure mode — and the *novel* emergency is downward bias's
+structural blind spot, because interrupt requires a pre-adopted floor that
+by definition doesn't exist for a first-time source. The design's answer is
+two-part, and honest about its limits: (1) the **emergency pack** (§7) —
+onboarding proposes break-glass floors for school/daycare/alarm/fraud
+sources at the moment the user is thinking about setup, via the ordinary
+propose/adopt flow; (2) the **reserved break-glass mapping** (§9.3) — that
+adopted policy compiles to the OS's highest granted interruption level,
+upgrading to `time-sensitive`/`critical` when entitlements land, with no
+policy migration. What the design will *not* do is let the message's own
+urgency raise its posture — that lever, once granted to emergencies, is
+granted to everyone claiming to be one. Residual risk: an emergency from a
+source the user never adopted lands at the verified-human-messages
+`heads-up` default — loud enough to be present, not loud enough to break
+Focus. That residual is the honest price of the inversion, and the
+emergency pack exists to shrink it.
+
+### B.2 The medication reminder (seeing must not satisfy)
+
+Elena must take tacrolimus by 9pm; a glance must not silence the reminder.
+Three mechanisms compose: the med pattern re-posts as the deadline nears
+(fresh event key, same `threadKey` — each rung displaces the last); her
+one-time adopted policy carries `{clamp: {min: "interrupt"},
+bypassQuietHours: true, realert: {everyMs: 600_000}}` — `realert` being the
+single user-grantable exception to alert-once (§9.3); logging the dose
+advances the subject artifact, and the usher terminally retracts every
+pending rung, including embargoed ones (§4.7). Phase gating is real: cadence
+firing between commits needs timer wake (§10.5) — before phase 2 this story
+is not safely servable and products should not pretend otherwise.
+
+### B.3 On-call triage (exactly one person must act)
+
+A pager event lands in a three-person ops space at 11pm. Each on-call
+member's rotation adopted `{match: {kind: "pager"}, clamp: {min:
+"interrupt"}, bypassQuietHours: true}`. Bea acks from her lockscreen via
+`actions` (§4.6): terminal `acted`, appended to the pattern's `replyTo`
+cell under her session authority. Her runtime discloses the disposition
+into `PerSpace` state; the space's opt-in policy "acted-by-any demotes to
+silent for all" re-lanes Dana's and Sam's notices; posture demotion
+retracts their banners (§9.3). If nobody acts in 15 minutes, the space's
+escalation policy raises the owner's notice — a deadline evaluation that
+needs timer wake (§10.5). One pager event, three independent ledgers,
+collective quiet from one policy record — the part no siloed platform can
+express.
+
+### B.4 The overnight agent run (quiet work, visible)
+
+Tomás's filing agent renames 200 documents at 3am. It posts *one*
+receipt-shaped notice (`threadKey` = run id, `progress` ticking silently),
+laned `silent` by the agent-completions default. The 200 changes are never
+posted at all — they are derived: the while-you-were-away view runs one
+`changes(watchSet, basis, attribution: true)` call and folds every entity
+whose change `author` is the run's session under the receipt. Tomás sees
+one line, expands it, jumps into anything suspicious with the changed
+region emphasized. Zero buzz, full visibility, and the trust that makes
+overnight agents acceptable — the design's home turf, strong from phase 1
+(phase 0 gives the dots without the run grouping).
+
+### B.5 The 2FA code (time-critical, worthless in minutes)
+
+Marcus is mid-login on his laptop; the code arrives via his SMS forwarder.
+Webhook ingress persists durably at the handler (§6.1); the candidate
+carries `expiresAt: +5min` and a `postureHint: "heads-up"` (or `interrupt`
+via a one-time adopted policy the OTP pattern proposed at setup — a
+realistic single config). A second code coalesces silently over the first
+(`id`-keyed replace, §9.3). Expiry hides the notice immediately on read;
+the OS tray copy goes stale until timer wake lands — the spec's own §9.3
+honesty note, and tolerable here because the user is at a client by
+construction (they're logging in). One friction worth product attention: a
+cautious confidentiality label pushes the code behind the generic envelope
+— the rare notice whose whole value is lockscreen visibility; the OTP
+pattern should set `redacted` to carry the code deliberately.
+
+### B.6 The social stream (high-volume, low-value; downward bias earns its keep)
+
+Nina's social importer posts ~80 like/follow events daily; she never opens
+them. Intake quotas bound the flood at the write gate against verified
+writer identity (§10.2). Her dismiss-without-open pattern becomes a
+**learned policy** she can read — `{match: {kind: "social"}, clamp: {max:
+"silent"}, author: usher, reason: "37 of 40 dismissed without open over
+30d"}` — and the source can never buy its way back up (learned policies
+only lower; §7). The review lane stays bounded; the weekly digest groups
+the residue by `kind`. This is the reputation loop as a legible artifact
+rather than a black-box feed model — strong from phase 1.
+
+### B.7 Medical results on a shared-visibility lockscreen (privacy)
+
+Ray's clinic portal posts test results; his partner sometimes sees his
+lockscreen. The notice's confidentiality labels forbid egress to the push
+relay, so the adapter sends the generic envelope unconditionally — full
+content fetched on unlock/app-open (§9.3) — and `redacted` lets the product
+choose neutral copy. Tray-dismiss on the shared-visibility device is
+per-device (§9.3), so dismissing there doesn't clear his laptop. Muting the
+thread is a policy write in his home space — never readable by the clinic
+or anyone else, with the behavioral-inference bound §7 states honestly.
+
+### B.8 Approving the agent's rebooking (act from the surface)
+
+Grace's travel agent drafted a rebooking; the fare hold expires soon. The
+notice carries `attachment` (the itinerary diff), `expiresAt` (the hold),
+and `actions: [approve, deny]` with a `replyTo` cell (§4.6). Approve from
+the lockscreen: terminal `acted` disposition + `{key: "approve", noticeId,
+at}` appended to the pattern's reply cell under her ordinary session
+authority; the acted terminal retracts the notice on every device. Two
+honest caveats: acting from a locked device presumes an authenticated
+session on-device, and a stale tray (§9.3) means she could approve a
+just-expired fare between wakes — the reply cell's consumer must treat
+replies as requests, not facts.
+
+### B.9 The visa renewal (long-lived deadline ladder)
+
+Hana's visa expires in October; she wants `review` at T−90, `heads-up` at
+T−30, `interrupt` at T−7. The **deadline ladder** idiom (§7): the pattern
+posts all three candidates ahead of time with ascending `notBefore` dates,
+the same `threadKey` (each admission displaces the prior rung), ascending
+hints, plus a proposed min she adopts once — at setup, when she's thinking
+about it. Renewal filed → subject advances → the usher retracts every
+pending rung including embargoed ones (§4.7). The gate is timeliness:
+`notBefore` materialization is evaluate-on-read until timer wake (§10.5) —
+nearly harmless at 90-day horizons for a daily shell user, unacceptable for
+B.2's same-day cadence, which is why both stories hang on the same §10.5
+line item.
+
+### B.10 The adversarial source (spam defense)
+
+"DealBlaster," installed for price tracking, turns hostile: floods
+candidates, hints `interrupt` with `ext.urgency: "CRITICAL"`, tries to
+collide the banking source's notification id, re-declares its kind as
+"group-chat" to catch the human-messages default. Every defense is
+structural, not heuristic: hints can't raise (§4.2); `ext` is quarantined
+from routing (§4.4); `id` is usher-derived from verified provenance, so the
+collision is impossible by construction; quotas bind to verified writer
+identity (§10.2); dismiss-without-open writes a legible learned max (§7);
+unconditional alert-once means even fresh-event-key spam can't re-buzz past
+its clamped rung; and the kind-lie fails because above-`review` defaults
+key on verified facts, never self-declared `kind` (§4.2) — declaring
+yourself "group-chat" buys nothing without a verified human `actor` the
+user actually knows.
 
 ## References
 
@@ -1111,7 +1369,7 @@ receipts' internals, stance vocabularies — upstream product machinery
   `docs/common/conventions/HOME_SPACE.md` — multi-user substrate; the
   contribute-your-own idiom; `writeAuthorizedBy` in production.
 - `docs/specs/server-side-execution/README.md` — standing registrations,
-  wake-on-commit, `onBehalfOf` attribution (ranker execution home; §6.3
+  wake-on-commit, `onBehalfOf` attribution (usher execution home; §6.3
   names this spec's dependencies on it).
 - `docs/specs/memory-v2/` — `01-data-model.md` (seq, heads),
   `03-commit-model.md` (optimistic concurrency; commit-log `sessionId` /
@@ -1131,16 +1389,16 @@ receipts' internals, stance vocabularies — upstream product machinery
   (durable persistence at the handler required, §6.1).
 - `packages/home-schemas/` (`journal.ts`, `favorites.ts`, `learned.ts`,
   `home.ts`) — the durable-array + stream-append precedent; stable-key
-  discipline; the system-inferred-but-user-owned precedent for learned
-  policies (§7).
+  discipline; the `subject` field-naming precedent; the
+  system-inferred-but-user-owned precedent for learned policies (§7).
 - `packages/runner/src/cfc/prepare.ts`, `packages/runner/src/cfc/ui-contract.ts`
   — `writeAuthorizedBy` enforcement (cell-write path); trusted surfaces.
 - `packages/runner/src/builtins/navigate-to.ts`,
   `docs/common/conventions/wish.md` — navigation from stored cell links;
-  well-known targets.
+  the `candidates` → `result` lifecycle precedent for candidate → notice.
 - `packages/ui/src/v2/components/cf-toast/`, `cf-alert`, `cf-badge` —
   existing presentation components.
-- `packages/background-piece-service/README.md` — why the ranker does not
+- `packages/background-piece-service/README.md` — why the usher does not
   run there.
 - PR #4132 (annotation-primitive prototype, draft) — the documented
   anti-precedent for storage-side reverse indexes invisible to the reactive

--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -1,0 +1,624 @@
+# Attention System
+
+A canonical runtime substrate for managing user attention: a per-user
+**attention ledger** written by a single trusted **ranker** under the user's
+own **policies**, **seen-state over artifacts** derived from the version
+history the runtime already keeps, and **surface adapters** that project the
+ledger onto shell lanes, digests, and (eventually) OS notifications. An OS
+push notification is the *most degraded projection* of this system, not its
+model.
+
+## Status
+
+Draft — seeking framework author review. None of this is implemented in labs
+today (§3 inventories what exists). The Loom product's in-flight attention
+framework and Pond's spatial shell are the first intended consumers; this
+spec defines the runtime primitives their product surfaces should compile
+onto, so each stops hand-rolling its own attention state. Derived from the
+2026-05-21 multi-user/notifications design sessions and the 2026-07 attention
+reframe.
+
+## Last Updated
+
+2026-07-12
+
+## Summary
+
+Every existing notification system is biased toward interruption because the
+*emitter* chooses how loudly to surface, and emitters' incentives favor
+loudness. This design inverts that: **sources only request a posture; the
+user's ranker — running with the user's policies, structurally on the user's
+side — decides**. The runtime's job is to make that inversion enforceable
+(CFC write-gating on the canonical ledger), cheap (pull-based derived
+queries, no second event journal), and portable across surfaces (one
+envelope, per-platform adapters).
+
+Five load-bearing moves:
+
+1. **One ledger, four postures.** Attention items land in exactly one rung of
+   a posture ladder — `silent` → `review` → `heads-up` → `interrupt` — and
+   the rung is the promise made to the user (§4.2). The system is biased
+   downward: a source earns its way up, and every ignore/dismiss/mute pushes
+   its future items back down.
+2. **The ranker is the only writer.** The canonical ledger carries a
+   `writeAuthorizedBy` claim; untrusted patterns can emit candidates and
+   render their own local views, but cannot spam the ledger (§6).
+3. **Attention over artifacts is derived, not emitted.** The runtime already
+   versions every entity (memory-v2 `seq`). Seen-state is one small relation
+   — last observed `seq` per (user, entity) — and "unseen change", "while you
+   were away", and the artifact lifecycle all fall out as queries (§5). For
+   in-fabric sources, an attention item is a *view over* "an artifact you
+   care about changed", which dissolves the "every pattern must remember to
+   emit notifications" problem.
+4. **Policies are user-owned cells**, not ranker code. The core ships a
+   good-enough default fold; the bespoke last 20% ("library book due"
+   escalations, quiet hours, per-thread mutes) is data the user — or a
+   pattern, on proposal — writes (§7).
+5. **Multi-user needs almost nothing new.** Attention is a per-(user, item)
+   relation: a shared space emits one candidate and each member's ranker
+   lanes it independently. "Who has seen this" is the same seen-state
+   contributed into shared space, read the other direction (§8).
+
+## Goals
+
+- A single canonical attention envelope and ledger that shell, product
+  surfaces (Loom, Pond), patterns, and OS adapters all read.
+- Make autonomous/agent work *legible* without interruption — the user can
+  always see that something was done on their behalf, at zero notification
+  cost ("quiet disposition" must not mean "invisible disposition").
+- Structural downward bias: interruption is the exception and must be earned;
+  the emitter cannot force it.
+- User-owned, inspectable, editable routing policy — when the system
+  mis-lanes something, the fix is a one-line policy edit, not a black box.
+- Per-viewer lanes over shared state: the same event can interrupt one member
+  of a space and be texture for another.
+- OS delivery (Web Push, APNs/FCM) as replaceable adapters over the same
+  ledger, honoring per-platform replace/retract semantics.
+
+## Non-goals
+
+- **Product surface design.** Which views exist (Today block, attention
+  center, donut zones), their copy, and their capacity budgets are product
+  decisions; this spec only guarantees the queries they need are cheap and
+  the data they render is trustworthy.
+- **Coverage/miss measurement** ("earn the right to say all caught up") —
+  product-layer analytics over the ledger; the ledger just has to be
+  complete enough to measure.
+- **V1 delivery breadth.** No SMS/email channels, no iOS Live Activities, no
+  `time-sensitive`/`critical` interruption levels (both need platform
+  entitlements), no wearables. The envelope reserves room; adapters come
+  later (§9.3).
+- **A "list all members of a space" primitive.** The runtime deliberately
+  lacks one (see `docs/specs/shared-profile-rosters.md`); multi-user features
+  here are designed within that constraint, not around it.
+- **Replacing source UIs.** An attention item opens its focused destination
+  (the artifact, the draft, the conversation); it displaces the source
+  occurrence rather than duplicating it.
+
+## 3. Background — what exists today
+
+In labs, effectively nothing:
+
+- `packages/ui/src/v2/components/cf-toast/` and `cf-alert` are polished
+  presentation components, but no toast provider is mounted anywhere in
+  `packages/shell` — the only real usage is a demo pattern
+  (`packages/patterns/mobile-app-demo.tsx`).
+- The shell header (`packages/shell/src/views/HeaderView.ts`) has no bell, no
+  badge, no activity surface.
+- No read/seen tracking exists anywhere — `packages/patterns/group-chat-room.tsx`
+  has no read receipts or unread counts.
+- No push transport of any kind: no service-worker push, no APNs/FCM, no
+  device registration in `packages/toolshed` or `packages/identity`.
+- The two adjacent primitives are ingress- or scheduling-shaped, not
+  attention-shaped: webhook ingress delivers external POSTs into a reactive
+  stream (`docs/specs/webhook-ingress/`, `packages/toolshed/routes/webhooks/`),
+  and `packages/background-piece-service` polls registered pieces every ~60s
+  with documented reliability caveats.
+
+Meanwhile the products above the runtime are already building attention
+systems without runtime support: Loom's attention framework (in flight, on a
+feature branch as of 2026-07-12) defines *prepared claims*, an
+attention-posture ladder, stance-bearing attention policies, a
+capacity-bounded Today block, and a default-weekly digest — materialized in
+product-local storage; its current "unseen" affordance is a localStorage
+last-seen timestamp per browser. Pond's donut prototype ranks pieces
+spatially by an attention score. Both need the same substrate: durable
+per-user seen-state, a trustworthy canonical ledger, and per-user policy.
+This spec is that substrate.
+
+## 4. Model
+
+### 4.1 The unit: a claim on attention
+
+An attention item is a **claim on the user's attention with a focused
+destination**. Borrowing the product framing: a raw source occurrence, or the
+bare fact that an agent ran, is not by itself a claim on attention. The
+envelope therefore always carries *where to go* (`target`, a stored cell
+link) and *what is ready there* (title/body describing the prepared result or
+the change), never just "something happened".
+
+The runtime does not — cannot — enforce that items are well-prepared; it
+enforces the things preparation depends on: who may write the ledger, which
+posture a claim actually gets, and that handled claims retract everywhere.
+
+### 4.2 The posture ladder
+
+Every visible item occupies exactly one rung. The rung is a promise:
+
+| Posture | Promise to the user | Typical projection |
+|---|---|---|
+| `silent` | "Recorded; you'll find it if you look." | seen-state dots on artifacts, history views |
+| `review` | "Batched for your next review; no urgency." | digest, review queue — bounded history, not a feed |
+| `heads-up` | "Look when you next check in; we'll hold it." | shell bell/badge count, quiet OS delivery |
+| `interrupt` | "Worth breaking your flow for." | OS banner/sound, in-shell takeover |
+
+Plus one policy *effect* that is not a rung: `suppress` (never materialize
+for this user; distinct from `silent`, which is findable).
+
+Two invariants:
+
+- **Downward bias.** Defaults sit low (`silent`/`review`). Sources *request*
+  a posture; the ranker assigns the real one, capped by policy, and repeated
+  dismiss-without-open or mute feeds back as posture caps. An emitter cannot
+  buy `interrupt` with enthusiasm.
+- **Attention ≠ confidence.** How sure the system is about an item and how
+  loudly it surfaces are separate axes. Uncertain-but-urgent goes to
+  `heads-up` with its uncertainty stated; certain-but-routine stays in
+  `review`. The envelope carries them separately.
+
+The ladder deliberately matches the posture vocabulary the Loom product
+already uses (silent memory → daily review → timely heads-up → interrupt), so
+product surfaces map 1:1 onto runtime postures.
+
+### 4.3 The pipeline
+
+```text
+Sources                         emit candidates (requested posture = advisory)
+  agents/pieces running as me     │
+  pieces I joined, running        │  per-source prefilter: "important within
+    as others (group chat)        │   my world?" — cannot judge cross-source
+  sharing directed at me          │
+  artifact changes (derived, §5)  │
+  external ingress (webhooks)     ▼
+Ranker (per-user, trusted single writer)         §6
+  folds candidates × policy cells (§7)
+  assigns posture; coalesces; writes the ledger
+  ── writeAuthorizedBy gate: only the ranker's verified
+     module identity may write the canonical ledger ──
+Ledger (per-user, durable, queryable)            §4.4
+  ▼
+Surfaces (pull-based readers)                    §9
+  shell lanes / bell · product views (Today, donut, digest)
+  · patterns rendering their own slices · OS adapters (push)
+```
+
+Untrusted patterns are not locked out of *rendering* — any pattern may show
+its own local, clearly-attributed view of its own events. What untrusted code
+cannot do is write the canonical ledger the shell and OS adapters trust.
+
+### 4.4 The envelope
+
+```ts
+// Shown for illustration only.
+type AttentionItem = {
+  // Identity — THE load-bearing field. Every surface adapter targets it for
+  // replace/retract (iOS UNNotificationRequest.identifier + apns-collapse-id,
+  // Android notify(id), Web Push options.tag). Deterministic:
+  // "<source-system>:<source-key>[:<event-key>]", set by the ranker on first
+  // emission and reused for every replacement.
+  id: string;
+
+  // Pointer to the source of truth (a stored cell link, not a query string).
+  // The item is the invitation; the source is the truth. Used to evaluate
+  // active(), to navigate, and as the key for source-scoped policies.
+  source: unknown;            // asCell: ["cell"]
+  // The source entity's memory-v2 seq at emission. Monotone per entity
+  // (space-global Lamport clock — an opaque, comparable token, not a dense
+  // counter). Drives replace, retract, and re-emerge semantics.
+  sourceSeq: number;
+  // Optional grouping key for presentation (one conversation, one task).
+  threadKey?: string;
+
+  // Content. Snapshot at emission (title/body) plus the live destination.
+  title: string;
+  body: string;
+  // Focused destination: a stored cell link navigated with navigateTo().
+  target: unknown;            // asCell: ["cell"]
+  // Optional link to prepared material (draft, diff, packet) when it is a
+  // different artifact than target.
+  prepared?: unknown;         // asCell: ["cell"]
+
+  // Routing. requestedPosture is advisory input from the source; posture is
+  // assigned by the ranker and is the only one surfaces read.
+  requestedPosture: "silent" | "review" | "heads-up" | "interrupt";
+  posture: "silent" | "review" | "heads-up" | "interrupt";
+  // Confidence is orthogonal to posture (§4.2); surfaces may render it.
+  confidence?: number;        // 0..1
+
+  emittedAt: number;
+  expiresAt?: number;         // time-bound claims retract themselves
+};
+
+// Append-only per-item action log. Replaces {active, dismissed} booleans:
+// cause is preserved, multi-device writes merge, re-emerge is well-defined.
+type AttentionAction = {
+  itemId: string;
+  type: "seen" | "dismissed" | "snoozed" | "archived" | "acted" | "muted";
+  at: number;
+  // Which surface the action came from (shell, os-tray, digest, ...). Lets
+  // policy decide e.g. "os-tray dismiss clears that device only".
+  surface: string;
+  by: string;                 // DID; may be a module identity for
+                              // system-on-behalf actions (auto-expiry)
+  // The sourceSeq the action was taken against. A dismissal tombstones that
+  // seq; if the source advances past it, the item re-emerges and the old
+  // dismissal no longer applies.
+  againstSeq: number;
+  payload?: unknown;          // snoozeUntil, acted result, mute scope, ...
+};
+```
+
+Nothing stores `active`, `dismissed`, or `unread` flags. They are **derived,
+pull-evaluated queries** — computed when a surface demands them, per the
+pull-based scheduler's grain (a claim nobody is looking at costs nothing):
+
+```ts
+// Shown for illustration only.
+const active = (n: AttentionItem) =>
+  currentSeq(n.source) <= n.sourceSeq || stillCurrent(n); // source's call
+const terminal = (n: AttentionItem, log: AttentionAction[]) =>
+  log.some((a) =>
+    (a.type === "dismissed" || a.type === "archived" || a.type === "acted") &&
+    a.againstSeq >= n.sourceSeq
+  );
+const visible = (n: AttentionItem, log: AttentionAction[], now: number) =>
+  !terminal(n, log) && active(n) && !snoozedUntil(log, now) &&
+  (n.expiresAt === undefined || now < n.expiresAt);
+```
+
+### 4.5 Storage
+
+The ledger lives in the **user's home space** (home space DID = user identity
+DID; the established home for durable per-user state, alongside favorites and
+journal — see `docs/common/conventions/HOME_SPACE.md`).
+
+Recommended storage is a **`sqlite-builtin` database with two tables**
+(`items`, `actions`) declared by the attention pattern
+(`docs/specs/sqlite-builtin/`):
+
+- The ledger is append-heavy, queryable, and long-lived — SQL gives
+  filtering, ranking, pagination, and retention sweeps that an array cell
+  makes awkward at volume; `.query<Row>()` reads are reactive.
+- `db.exec` commits atomically with surrounding cell writes, and concurrent
+  writers serialize on the handle cell's `rev` — which *matches* the
+  single-trusted-writer model instead of fighting it.
+- Cell links in rows (`cfLink<T>()` columns) keep `source`/`target`/`prepared`
+  live and navigable.
+- Per-column CFC labels extend the same `ifc` gating to the table.
+- Deterministic ids (already required by §4.4) fit `exec`'s
+  no-`lastInsertRowid` constraint.
+
+A phase-0 implementation may instead start with a **durable array cell plus
+stream append handlers**, exactly following the favorites/journal precedent
+in `packages/home-schemas/` (`journal.ts`: durable array; `home.ts`:
+`addJournalEntry: { asCell: ["stream"] }` as the append endpoint). Two rules
+carry over regardless of backing:
+
+- **Never model the ledger itself as `asCell: ["stream"]`** — stream cells
+  are ephemeral (only the marker persists; payloads do not — see
+  `docs/specs/space-model/4-cells.md`). Streams are append *endpoints*, not
+  logs.
+- **Never `set()` the whole array.** Concurrent device writes must use the
+  mergeable ops (`push`, `addUnique`, `removeByValue`) so user actions from
+  two devices merge against durable state instead of clobbering. Memory is
+  optimistic-concurrency with path-aware validation, not CRDT — this design
+  needs no CRDT because the ranker is a single canonical writer and user
+  actions are mergeable appends.
+
+Retention: `expiresAt` handles time-bound claims; a periodic sweep reaps
+rows that are terminal with `sourceSeq` below a watermark. Sweeping is a
+ranker duty (it owns the ledger), bounded and boring by design.
+
+## 5. Seen-state and attention over artifacts
+
+The most common attention event in practice is not "interrupt me" — it is
+"an agent (or another member) did work while I wasn't looking, and I need to
+be able to *see that it happened*". That is not a notification; it is
+seen-state, and the runtime already has almost everything needed.
+
+**The seen ledger** is one small relation per user: the last `seq` the user
+actually observed, per entity.
+
+```ts
+// Shown for illustration only.
+type SeenMark = {
+  entity: unknown;            // asCell: ["cell"] — the artifact/piece
+  seenSeq: number;            // last observed memory-v2 seq
+  at: number;
+};
+```
+
+Everything else is a query over marks joined against current heads:
+
+- `unseen(entity) = head(entity).seq > seenSeq` → change dots on artifacts
+  and their containers (space lists, home). The shell writes a `seen` mark
+  when the artifact is actually viewed.
+- **"While you were away"** = all cared-about entities with unseen changes,
+  grouped by space, agent-authored changes flagged (commit attribution says
+  who wrote), ordered by the ranker. Renders as a pattern on the home
+  context. This is the first-run view and the every-return view — the same
+  query.
+- **Artifact lifecycle** falls out of the same two numbers plus a timestamp:
+  *fresh* (unseen changes) → *seen* → *stale* (untouched for N) →
+  *archived*. No new subsystem.
+
+**Derivation beats emission.** For in-fabric sources, an attention candidate
+is *derived from* artifact-change + care-relation — the attention system
+watches; patterns just write their artifacts. Explicit candidate emission
+remains for sources with no artifact (external ingress, transient events),
+but it is the minority path. This is the platform's grain: derived state over
+stored state, and no parallel event journal duplicating what memory-v2's
+commit log already records.
+
+**The care-relation** answers "which entities produce dots at all":
+approximately *touched-recently ∪ agent-did-it-for-you ∪ explicitly-watched*,
+itself tunable by policy. Getting this right is an open question (§11.2);
+getting it wrong in the "too broad" direction is the failure mode to avoid
+(dots everywhere = dots nowhere).
+
+## 6. The ranker
+
+**One logical ranker per user.** It folds candidates and policies into the
+ledger, assigns postures, coalesces (same `id` when the same source object
+advances; same `threadKey` when distinct events share a conversation),
+computes re-emergence, and sweeps retention.
+
+**Trust.** The ledger's `items` schema carries a CFC `writeAuthorizedBy`
+claim (the same mechanism that already protects profile links in production —
+see `docs/common/conventions/HOME_SPACE.md` and
+`packages/runner/src/cfc/prepare.ts`). Two viable bindings:
+
+1. **Verified module identity** (recommended): the ranker ships as a pattern
+   with a content-addressed module identity; `writeAuthorizedBy` binds to it.
+   The ranker stays in pattern-space — inspectable, forkable in principle,
+   updated like any pattern — and "trusted" means *this exact code*, not
+   "runs on a server".
+2. **Trusted builtin**: a runtime builtin id in the claim. Stronger, but
+   moves the fold out of pattern-space and makes policy-fold evolution a
+   runtime release.
+
+Recommendation: (1), with the fold's *inputs* (policies) as data so the code
+rarely needs to change. Note the identity subtlety: *acting as the user*
+(session `as` / `actingPrincipal` = the user's DID) and *being authorized to
+write the ledger* (module identity matching the claim) are two separate
+checks, and the design uses both — every ranker write is attributable
+`onBehalfOf` the user and provably from the ranker's code.
+
+**Execution.** Where does the ranker run?
+
+- **Target: the server-primary execution model**
+  (`docs/specs/server-side-execution/`). The ranker is exactly the shape that
+  model's *standing registrations* exist for — work whose value is its
+  effects rather than client-read output — and *wake-on-commit* is its
+  trigger: a commit touching a cared-about entity or candidate stream wakes
+  the worker, the ranker folds, the ledger updates, connected clients see it
+  through the ordinary feed. Execution is attributed `onBehalfOf` the user.
+- **Interim: client-side.** Until standing registrations land, the ranker
+  runs as an ordinary piece while the user has a client open. This degrades
+  gracefully: seen-state and lanes still work (computed on arrival);
+  what's lost is delivery to a *closed* client — which is only needed from
+  phase 2 (§10) anyway.
+- **Not: `background-piece-service` as-is.** It is per-space (the ranker is
+  per-user), ~60s polling (the ranker is wake-on-commit shaped), and its own
+  README documents async-completion unreliability. If bps is pressed into
+  interim service, treat that as scaffolding, not the design.
+
+**Laziness.** The ranker materializes *rows*; it does not keep derived
+predicates hot. `active()`/`visible()` evaluate on surface demand
+(pull-based). The one push-shaped duty is OS delivery (§9.3), which is
+explicitly an edge adapter fed by wake-on-commit, not a hot loop.
+
+## 7. Policies
+
+A policy is a small declarative record the ranker folds over — **data, not
+ranker code**:
+
+```ts
+// Shown for illustration only.
+type AttentionPolicy = {
+  match: {
+    source?: unknown;         // asCell: ["cell"] — a specific source/thread
+    sourceKind?: string;      // "group-chat", "importer", "agent-run", ...
+    spaceDid?: string;
+    threadKey?: string;
+  };
+  effect: {
+    postureCap?: "suppress" | "silent" | "review" | "heads-up";
+    postureFloor?: "review" | "heads-up" | "interrupt";
+    coalesceWindowMs?: number;
+    quietHours?: { start: string; end: string };
+  };
+  reason?: string;            // human-legible: why this policy exists
+  createdBy: string;          // user DID, or module identity for proposals
+};
+```
+
+- Policies live in the user's home space (`PerUser` scope). The core ships a
+  handful of defaults: messages-from-humans → `heads-up`;
+  agent-completions → `silent` (visible as seen-state, never buzzing);
+  anything with `expiresAt` sooner than ~1h → eligible for `interrupt`.
+- **Mute is a policy, not a special relation.** "Mute this thread" writes
+  `{match: {threadKey}, effect: {postureCap: "suppress"}}`. The ledger item
+  that carried the mute action just records that it happened.
+- **Patterns propose, the user disposes.** A pattern can ship a suggested
+  policy with its artifacts ("library book due → heads-up 3 days before");
+  adoption goes through a trusted surface, exactly like other user-consented
+  writes. This is where the bespoke 20% lives, and why the ranker doesn't
+  have to be perfect: when it mis-lanes something, the fix is a legible
+  one-line policy, written by the user or by their agent on request.
+- **Policies are confidential.** "Mute everything from person X" is itself
+  sensitive. Policy cells carry confidentiality labels like any other data;
+  ranker output must not let an observer reconstruct another user's policies
+  (a shared-space member must not be able to detect they've been muted).
+  Rich product-level policy dimensions (e.g. stance vocabularies) layer on
+  top as additional fields the runtime treats as opaque.
+
+## 8. Multi-user
+
+Three properties, all falling out of "attention is a per-(user, item)
+relation" plus existing constraints:
+
+- **One candidate, N ledgers.** A shared space emits one candidate per event;
+  each member's own ranker lanes it under their own policies. A new message
+  can be `interrupt` for the on-call member and `silent` for the member who
+  muted the thread. The emitter cannot know or decide this — correctly so.
+- **"Who has seen this" is contributed, not enumerated.** There is no
+  runtime primitive for listing a space's members or reaching into their
+  home spaces (`docs/specs/shared-profile-rosters.md`), and this design does
+  not add one. Shared seen-state follows the roster idiom: members'
+  runtimes write their own seen marks into `PerSpace` state in the shared
+  space — *if* the space's disclosure policy says to. Read receipts,
+  "3 people haven't seen the new plan", presence-of-attention are queries
+  over that contributed state. Disclosure is a per-space policy cell
+  (some spaces want receipts, some don't); a member who discloses nothing
+  simply doesn't appear.
+- **Escalation across people is a policy.** "If nobody attends to this
+  within 2h, raise it to `heads-up` for the space owner" is a policy cell on
+  the shared space, evaluated by the owner's ranker against contributed
+  seen-state. No siloed notification system can express this; here it is
+  one record.
+
+## 9. Surfaces
+
+### 9.1 Shell
+
+The shell renders the ledger; it does not own attention logic. Per the
+"pattern on the context" resolution: the home/shell context declares how the
+attention surface renders, so it is replaceable like the rest of the home
+experience. Concretely:
+
+- lanes: `interrupt` (modal-adjacent), `heads-up` (bell + badge count),
+  `review` (digest entry point), `silent` (dots via seen-state, §5);
+- unseen-change dots on artifacts and containers;
+- a snoozed lane (snoozed items must stay discoverable);
+- every render of an item is also the write-path for `seen` actions.
+
+Presentation components exist (`cf-toast`/`cf-toast-provider`, `cf-alert`,
+badge conventions); the net-new work is mounting them against ledger
+queries.
+
+### 9.2 Digests
+
+A digest is **bounded history, not a feed**: a periodic artifact-shaped
+summary over the ledger and seen-state — quiet dispositions, artifact
+updates, prepared material, grouped by class — rendered by a pattern. The
+runtime contribution is only that the queries behind it (terminal items
+since T, unseen changes since T, actions by surface) are cheap and complete.
+Whether a digest's *summary* may itself claim `heads-up` is a policy
+decision, default no.
+
+### 9.3 OS delivery
+
+Only `interrupt` (and optionally `heads-up`, quietly) ever reaches the OS.
+Adapters compile the envelope down; the ledger stays canonical and
+"Android-shaped" (live update + auto-retract), and platforms degrade from
+there:
+
+- **Replace/retract rides `id`** everywhere: iOS
+  `UNNotificationRequest.identifier` / `apns-collapse-id`, Android
+  `notify(id)`, Web Push `options.tag`. When `visible()` flips false, the
+  dispatcher retracts on every delivered surface. iOS replaces but does not
+  tick (text refreshes when the shade reopens); genuinely-live claims are a
+  Live Activities track, explicitly out of V1.
+- **Two transports, not one.** Browser/PWA: Web Push (VAPID + service
+  worker). Wrapped mobile apps: native APNs/FCM via the wrapper's plugin —
+  embedded webviews do not get Web Push. The server side (toolshed) needs a
+  device-registration table `{userDid, deviceId, transport, token}` and a
+  delivery ledger `{itemId, deviceId, platformIdentifier, deliveredAt,
+  retractedAt}` so retraction can target what was actually delivered.
+  Ship Web Push first; the envelope is transport-agnostic.
+- **The PWA is the floor.** The canonical shape includes nothing that cannot
+  be expressed on the most-constrained surface; richer platforms are adapter
+  opt-ins, not envelope fields.
+- **Tray-dismiss is per-device by default.** An OS-tray dismissal writes an
+  action with `surface: "os-tray"`; whether it terminates the item globally
+  is policy (default: clears that device only; the shell is canonical).
+
+## 10. Phasing
+
+Each phase is independently shippable and none re-shapes the data model.
+
+- **Phase 0 — seen-state.** The seen ledger (§5), unseen dots in the shell,
+  and a "while you were away" home pattern. No ranker, no candidates, no
+  push. This alone makes agent work legible — the single most-requested
+  product gap — and exercises the exact relation everything else builds on.
+- **Phase 1 — ledger + lanes.** Envelope, home-space ledger, a minimal
+  client-executed ranker (defaults + mute + posture caps), shell bell/lanes,
+  candidate emission for non-artifact sources. Policies v0.
+- **Phase 2 — server ranker + first transport.** Ranker as a standing
+  registration under server-primary execution (wake-on-commit); Web Push
+  with device registration and retraction; digest queries.
+- **Phase 3 — breadth.** Wrapped-app APNs/FCM; full action vocabulary
+  (snooze/archive surfaced); shared seen-state + escalation policies;
+  coalescing refinements. Live Activities remain a separate track.
+
+## 11. Open questions
+
+1. **Ranker trust binding.** Verified module identity is recommended (§6),
+   but the "wholly-system service" alternative keeps resurfacing; if the
+   server executor itself writes the ledger, is that a builtin identity, and
+   does that preempt user-forkable rankers? Resolve before phase 1.
+2. **The care-relation.** Which entities produce seen-state dots (§5)?
+   Touched ∪ agent-authored ∪ watched is the working answer; validate
+   against real spaces before hardening, and decide whether "touched" decays.
+3. **Ledger backing for phase 1.** sqlite tables (recommended) vs array
+   cells (journal precedent). If array cells ship first, define the
+   migration to sqlite before volume forces it.
+4. **Seen-mark write amplification.** Naive per-view marks write on every
+   artifact open, from every device. Batch/debounce policy, and whether
+   marks for low-value views are worth persisting at all.
+5. **Disclosure defaults** for shared seen-state (§8): receipts on or off by
+   default, and what the non-disclosing member's absence reveals.
+6. **Policy expressiveness boundary.** V1 is plain predicates. Content
+   regexes and LLM-judged predicates ("only interrupt if actually urgent")
+   are clearly coming — as ranker inputs they inherit the ranker's authority,
+   so they need their own integrity story before admission.
+7. **Coalescing.** Same `id` vs same `threadKey` heuristics; sub-object
+   edge cases (a thread whose items have their own lifecycles).
+8. **`seq` across spaces.** `sourceSeq` is per-space; items whose source
+   lives in a different space than the ledger need the pair (space, seq).
+   Confirm the envelope treats `sourceSeq` as opaque-with-provenance rather
+   than globally comparable.
+9. **Digest self-promotion.** May a digest claim `heads-up` on a schedule
+   (§9.2)? Leaning policy-gated, default off.
+10. **Convergence with product stores.** Loom currently materializes
+    attention candidates in product-local storage with localStorage
+    seen-timestamps. Define the migration: product candidates become
+    candidates into this pipeline; localStorage dots become seen-ledger
+    reads.
+
+## References
+
+- `docs/specs/shared-profile-rosters.md`, `docs/specs/shared-profile-space.md`,
+  `docs/common/conventions/HOME_SPACE.md` — multi-user substrate; the
+  contribute-your-own idiom; `writeAuthorizedBy` in production.
+- `docs/specs/server-side-execution/README.md` — standing registrations,
+  wake-on-commit, `onBehalfOf` attribution (ranker execution home).
+- `docs/specs/memory-v2/` (esp. `01-data-model.md`, `03-commit-model.md`,
+  `08-conflict-granularity.md`) — `seq`, optimistic concurrency, mergeable
+  ops.
+- `docs/specs/sqlite-builtin/` — recommended ledger backing.
+- `docs/specs/space-model/4-cells.md` — stream-cell ephemerality.
+- `docs/specs/pull-based-scheduler/README.md` — demand-driven evaluation.
+- `docs/specs/webhook-ingress/README.md` — external candidate ingress.
+- `packages/home-schemas/` (`journal.ts`, `favorites.ts`, `home.ts`) — the
+  durable-array + stream-append precedent and stable-key discipline.
+- `packages/runner/src/cfc/prepare.ts`, `packages/runner/src/cfc/ui-contract.ts`
+  — `writeAuthorizedBy` enforcement; trusted surfaces.
+- `packages/runner/src/builtins/navigate-to.ts`,
+  `docs/common/conventions/wish.md` — navigation from stored cell links;
+  well-known targets.
+- `packages/ui/src/v2/components/cf-toast/`, `cf-alert`, `cf-badge` —
+  existing presentation components.
+- `packages/background-piece-service/README.md` — why the ranker does not
+  run there.

--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -12,14 +12,16 @@ model.
 
 Draft — seeking framework author review. None of this is implemented in labs
 today (§3 inventories what exists), and §10 names the net-new runtime surface
-this design requires — most importantly a version-exposure API (§10.1) and
-write-authorization gating for sqlite (§10.2). The Loom product's in-flight
-attention framework and Pond's spatial shell are the first intended
+this design requires — most importantly the **changes projection** (§10.1), a
+small read-only query primitive over shipped memory-v2 machinery, and a
+cross-principal append gate for candidate intake (§10.2). The Loom product's
+in-flight attention framework and Pond's spatial shell are the first intended
 consumers; this spec defines the runtime primitives their product surfaces
 should compile onto, so each stops hand-rolling its own attention state
 (Appendix A maps Loom's candidate shape onto the envelope). Derived from the
 2026-05-21 multi-user/notifications design sessions and the 2026-07 attention
-reframe; revised 2026-07-12 after adversarial runtime and product review.
+reframe; revised 2026-07-12 after two adversarial review rounds (runtime +
+product, then Android-as-gold-standard + primitive-shape + parsimony).
 
 ## Last Updated
 
@@ -32,32 +34,35 @@ Every existing notification system is biased toward interruption because the
 loudness. This design inverts that: **sources only request a posture; the
 user's ranker — running with the user's policies, structurally on the user's
 side — decides**. The runtime's job is to make that inversion enforceable
-(CFC write-gating on the canonical ledger), cheap (pull-based derived
-queries, no second event journal), and portable across surfaces (one
-envelope, per-platform adapters).
+(CFC write-gating on the canonical ledger), cheap (derived queries over
+stores the user already holds, no second event journal), and portable across
+surfaces (one envelope, per-platform adapters).
 
 Five load-bearing moves:
 
-1. **One ledger, four postures.** Attention items land in exactly one rung of
-   a posture ladder — `silent` → `review` → `heads-up` → `interrupt` — and
-   the rung is the promise made to the user (§4.2). The system is biased
-   downward: a source earns its way up, and every ignore/dismiss/mute pushes
-   its future items back down.
+1. **One ledger, one posture scale.** Attention items land on exactly one
+   rung of an ordered scale — `silent` → `review` → `heads-up` →
+   `interrupt` — and the rung is the promise made to the user (§4.2). The
+   system is biased downward: a source earns its way up through **learned
+   policies** the user can read and edit (§7), and every
+   dismiss-without-open pushes its future items back down.
 2. **The ranker is the only writer.** The canonical ledger carries a
    `writeAuthorizedBy` claim; untrusted patterns can emit candidates and
    render their own local views, but cannot spam the ledger (§6).
 3. **Attention over artifacts is derived, not emitted.** The runtime already
-   versions every entity (memory-v2 `seq`) — though exposing that version to
-   patterns is net-new API work (§10.1). Seen-state is one small relation —
-   last observed version per (user, entity) — and "unseen change", "while
-   you were away", and the artifact lifecycle all fall out as queries (§5).
-   For in-fabric sources, an attention item is a *view over* "an artifact
-   you care about changed", which dissolves the "every pattern must remember
-   to emit notifications" problem.
+   versions every entity (memory-v2 `seq`), and the version already crosses
+   the wire on every query result; exposing it is one small read-only
+   primitive, the changes projection (§10.1). Seen-state is one small
+   relation — last observed version per (user, entity) — and "unseen
+   change", "while you were away", item currency, and the artifact
+   lifecycle all fall out as joins against it (§5). For in-fabric sources,
+   an attention item is a *view over* "an artifact you care about changed",
+   which dissolves the "every pattern must remember to emit notifications"
+   problem.
 4. **Policies are user-owned cells**, not ranker code. The core ships a
    good-enough default fold; the bespoke last 20% ("library book due"
    escalations, quiet hours, per-thread mutes) is data the user — or a
-   pattern, on proposal — writes (§7).
+   pattern, on proposal, or the ranker itself, legibly (§7) — writes.
 5. **Multi-user needs almost nothing new.** Attention is a per-(user, item)
    relation: a shared space emits one candidate and each member's ranker
    lanes it independently. "Who has seen this" — and, per disclosure policy,
@@ -73,8 +78,18 @@ interviews that seed policy — is product-side and stays there. A product
 framework (e.g. Loom's attention framework) enters this pipeline as a
 *trusted source* emitting well-prepared candidates with a requested posture;
 the runtime ranker's job for such a source is cross-source arbitration and
-enforcement of the user's posture caps, not re-litigating the product's
+enforcement of the user's posture clamps, not re-litigating the product's
 preparation decisions.
+
+### Vocabulary
+
+*Item* — a materialized record in the ledger (*claim* when speaking of what
+it means to the user). *Candidate* — the same envelope before the ranker
+assigns `id`, `posture`, and `weight`; not a separate type. *Ledger* — the
+items store specifically. *Attention state* — the triple of stores (items,
+actions, seen — §4.5). *Lane* — a shell projection over attention state
+(most lanes correspond to a posture rung; some, like the snoozed lane, are
+lifecycle views).
 
 ## Goals
 
@@ -87,10 +102,15 @@ preparation decisions.
   the emitter cannot force it.
 - User-owned, inspectable, editable routing policy — when the system
   mis-lanes something, the fix is a one-line policy edit, not a black box.
+  This includes what the system learns on its own: learned policies are
+  visible and editable, never hidden state.
+- Close the loop without a context switch where the platform allows it:
+  one-tap approve/deny/done and direct reply from the surface (§4.6).
 - Per-viewer lanes over shared state: the same event can interrupt one member
   of a space and be texture for another.
 - OS delivery (Web Push, APNs/FCM) as replaceable adapters over the same
-  ledger, honoring per-platform replace/retract semantics.
+  ledger, honoring per-platform replace/retract semantics and the item's
+  confidentiality labels (§9.3).
 
 ## Non-goals
 
@@ -117,8 +137,8 @@ preparation decisions.
   lacks one (see `docs/specs/shared-profile-rosters.md`); multi-user features
   here are designed within that constraint, not around it.
 - **Replacing source UIs.** An attention item opens its focused destination
-  (the artifact, the draft, the conversation); it displaces the source
-  occurrence rather than duplicating it (`displaces`, §4.4).
+  (the artifact, the draft, the conversation); within a thread, the newest
+  live claim displaces older ones (§6.4) rather than piling on.
 
 ## 3. Background — what exists today
 
@@ -167,9 +187,17 @@ The runtime does not — cannot — enforce that items are well-prepared; it
 enforces the things preparation depends on: who may write the ledger, which
 posture a claim actually gets, and that handled claims retract everywhere.
 
-### 4.2 The posture ladder
+### 4.2 The posture scale
 
-Every visible item occupies exactly one rung. The rung is a promise:
+One ordered scale:
+
+```text
+suppress < silent < review < heads-up < interrupt
+```
+
+`suppress` is rank zero: never materialized for this user (distinct from
+`silent`, which is recorded and findable). Every materialized item occupies
+exactly one rung, and the rung is a promise:
 
 | Posture | Promise to the user | Typical projection |
 |---|---|---|
@@ -178,25 +206,21 @@ Every visible item occupies exactly one rung. The rung is a promise:
 | `heads-up` | "Look when you next check in; we'll hold it." | shell bell/badge count, quiet OS delivery |
 | `interrupt` | "Worth breaking your flow for." | OS banner/sound, in-shell takeover |
 
-Plus one policy *effect* that is not a rung: `suppress` (never materialize
-for this user; distinct from `silent`, which is findable).
-
 Two invariants:
 
 - **Downward bias.** Defaults sit low (`silent`/`review`). Sources *request*
-  a posture; the ranker assigns the real one, capped by policy, and repeated
-  dismiss-without-open or mute feeds back as posture caps. Crucially,
-  **no emitter-controlled field may raise posture**: eligibility for
-  `interrupt` (and `heads-up` above a source's baseline) comes only from a
-  user-granted posture floor in policy (§7) — never from urgency claims,
-  expiry times, or any other field the emitter writes. An emitter cannot buy
-  `interrupt` with enthusiasm.
+  a posture; the ranker assigns the real one via the policy clamp (§7), and
+  repeated dismiss-without-open feeds back as learned clamps. Crucially,
+  **no emitter-controlled field may raise posture**: reaching `interrupt`
+  (or `heads-up` above a source's learned baseline) requires a user-adopted
+  policy floor — never urgency claims, expiry times, or any other field the
+  emitter writes. An emitter cannot buy `interrupt` with enthusiasm.
 - **Attention ≠ confidence.** How sure the system is about an item and how
   loudly it surfaces are separate axes. Uncertain-but-urgent goes to
-  `heads-up` with its uncertainty stated; certain-but-routine stays in
-  `review`. The envelope carries them separately.
+  `heads-up` with its uncertainty stated (product copy; `ext` if structured);
+  certain-but-routine stays in `review`.
 
-The ladder deliberately matches the posture vocabulary the Loom product
+The rung names deliberately match the posture vocabulary the Loom product
 already uses (silent memory → daily review → timely heads-up → interrupt), so
 product surfaces map 1:1 onto runtime postures. Within a rung, ordering is
 the ranker-assigned `weight` (§4.4) — an opaque scalar that never crosses
@@ -213,11 +237,11 @@ Sources                         emit candidates (requested posture = advisory)
   sharing directed at me          │
   artifact changes (derived, §5)  │
   external ingress (webhooks)     ▼
-Candidate intake (durable, per-source quotas)    §6.1
+Candidate intake (durable; quota-gated append)   §6.1, §10.2
   ▼
 Ranker (per-user, trusted single writer)         §6
   folds candidates × policy cells (§7)
-  assigns posture; coalesces; writes the ledger
+  assigns posture + weight; coalesces; writes the ledger
   ── writeAuthorizedBy gate: only the ranker's verified
      module identity may write the canonical ledger ──
 Ledger (per-user, durable, queryable)            §4.5
@@ -233,11 +257,15 @@ cannot do is write the canonical ledger the shell and OS adapters trust.
 
 ### 4.4 The envelope
 
+A **candidate** is this envelope minus the ranker-assigned fields (`id`,
+`posture`, `weight`); the ranker *promotes* candidates to items. One type,
+two stages.
+
 ```ts
 // Shown for illustration only.
 // A source-entity version: memory-v2 seq is per-space (a space-global
 // Lamport clock, monotone per entity), so versions are only comparable
-// within the same space. Exposing this to patterns is net-new API (§10.1).
+// within the same space. Read via the changes projection (§10.1).
 type EntityVersion = { space: string; seq: number };
 
 type AttentionItem = {
@@ -251,33 +279,56 @@ type AttentionItem = {
   id: string;
 
   // Pointer to the source of truth (a stored cell link, not a query string).
-  // The item is the invitation; the source is the truth. Used to evaluate
-  // active(), to navigate, and as the key for source-scoped policies.
+  // The item is the invitation; the source is the truth.
   source: unknown;            // asCell: ["cell"]
   // Source classification ("group-chat", "importer", "agent-run", ...).
-  // First-class because policy matching (§7) and digest grouping (§9.2)
-  // both key on it.
+  // First-class because policy matching (§7) and digest grouping (§9.2) key
+  // on it. BOUND BY THE RANKER to the source's verified identity: the
+  // first-seen kind for a given source sticks; a source changing its
+  // declared kind is itself a reputation signal (and does not escape
+  // kind-matched clamps, which follow the source identity).
   sourceKind: string;
-  // The source entity's version at emission. Drives replace, retract, and
-  // re-emerge semantics.
+  // The source entity's version at emission. Drives coalescing (same id,
+  // advancing version) and re-emergence tombstones (§4.7).
   sourceVersion: EntityVersion;
-  // Optional grouping key for presentation (one conversation, one task,
-  // one agent run — see §5 on run-level grouping).
+  // Grouping key for presentation AND displacement: within a threadKey,
+  // only the newest live claim is visible (§6.4). One conversation, one
+  // task, one agent run (threadKey = run id).
   threadKey?: string;
+  // Who this claim is about/from (a DID when known): "Ana: running late"
+  // vs "New message". Serves OS payloads, digest grouping, and §5's
+  // "by whom" in one field.
+  actor?: string;
 
   // Content. Snapshot at emission (title/body) plus the live destination.
   title: string;
   body: string;
+  // Redacted variant for untrusted displays: lockscreens and push relays
+  // (§9.3). When absent and labels forbid egress, adapters send a generic
+  // envelope and fetch full content on unlock/open.
+  redacted?: { title: string; body: string };
   // Focused destination: a stored cell link navigated with navigateTo().
   target: unknown;            // asCell: ["cell"]
   // Optional link to prepared material (draft, diff, packet) when it is a
   // different artifact than target.
   prepared?: unknown;         // asCell: ["cell"]
-  // Cross-item displacement: item ids this claim supersedes. A prepared
-  // result displaces the raw occurrence's claim — the ranker terminates the
-  // displaced items (system-on-behalf action) so source and result never
-  // both surface unless each has an independent live claim.
-  displaces?: string[];
+  // Close-the-loop affordances rendered on the surface itself (§4.6):
+  // approve/deny, done/later, inline reply — act without opening the app.
+  actions?: Array<{
+    key: string;              // semantic key, recorded in the acted action
+    label: string;
+    input?: "text";           // direct reply / free-text input
+    // Durable endpoint in the source space; acting appends
+    // {key, input?, itemId, at} under the user's ordinary session
+    // authority — the same authority the user would have acting in-app.
+    // No new trust surface.
+    handler?: unknown;        // asCell: ["cell"]
+  }>;
+  // Live progress for ongoing work ("agent is 60% through your refactor").
+  // Progress updates are same-rung coalesces and therefore silent (§9.3).
+  // Absent total = indeterminate. Rich live chrome (Live Activities) is a
+  // later adapter track; the field is the floor every surface can render.
+  progress?: { done: number; total?: number };
 
   // Routing. requestedPosture is advisory input from the source; posture is
   // assigned by the ranker and is the only one surfaces read.
@@ -286,78 +337,104 @@ type AttentionItem = {
   // Intra-rung ordering, ranker-assigned. Opaque; never crosses rungs;
   // never gates delivery (§4.2).
   weight?: number;
-  // Confidence is orthogonal to posture (§4.2); surfaces may render it.
-  confidence?: number;        // 0..1
 
   emittedAt: number;
   notBefore?: number;         // embargo: hold materialization until then
-  expiresAt?: number;         // time-bound claims retract themselves —
-                              // evaluate-on-read semantics, see §9.3
+  expiresAt?: number;         // evaluate-on-read; swept terminally by the
+                              // ranker (§4.7, §9.3)
 
-  // Opaque product extension. The runtime never interprets it; products
-  // round-trip their own fields (e.g. Loom's why_now, channel,
-  // authorization_state — Appendix A) here instead of smuggling them
-  // into body.
+  // Opaque product extension. Disciplined by invariant: NO runtime-derived
+  // predicate, NO ranker fold step, and NO policy match may read ext — it
+  // is a round-trip channel for product fields (Loom's why_now, channel,
+  // authorization_state — Appendix A), not a side door into routing. An
+  // ext key consumed by two independent products is a candidate for
+  // promotion to the envelope (or a sign the envelope is wrong).
   ext?: Record<string, unknown>;
 };
 
-// Append-only per-item action log. Replaces {active, dismissed} booleans:
-// cause is preserved, multi-device writes merge, re-emerge is well-defined.
+// Append-only per-item action log — the state-bearing user dispositions.
+// Deliberately small: "seen" is NOT an action (it lives in the seen store,
+// §4.5/§5, and item-seen is a join); "muted" is NOT an action (mute IS a
+// policy write, §7). Cause-preservation across the three terminal types is
+// the point: undo, history, and calibration all key on it.
 type AttentionAction = {
   itemId: string;
-  type: "seen" | "dismissed" | "snoozed" | "archived" | "acted" | "muted";
+  type: "dismissed" | "snoozed" | "archived" | "acted";
   at: number;
   // Which surface the action came from (shell, os-tray, digest, ...). Lets
   // policy decide e.g. "os-tray dismiss clears that device only".
   surface: string;
-  by: string;                 // DID; may be a module identity for
-                              // system-on-behalf actions (auto-expiry,
-                              // displacement)
+  by: string;                 // DID; or the ranker's module identity for
+                              // system-on-behalf actions (expiry sweep,
+                              // thread displacement — §4.7)
   // The sourceVersion the action was taken against. A dismissal tombstones
-  // that version; if the source advances past it, the item re-emerges and
-  // the old dismissal no longer applies. Comparable only within
-  // sourceVersion.space.
+  // that version; if the source advances past it, the item re-emerges (the
+  // ranker's coalesce advances sourceVersion past the tombstone — one
+  // operation, not a separate mechanism) and the old dismissal no longer
+  // applies. Comparable only within sourceVersion.space.
   againstVersion: EntityVersion;
-  payload?: unknown;          // snoozeUntil, acted result, mute scope, ...
+  payload?: unknown;          // snoozeUntil, acted {key, input?}, ...
   ext?: Record<string, unknown>; // product extension (e.g. calibration
-                              // feedback like "not-useful")
+                              // feedback like "not-useful"); same
+                              // discipline as item.ext
 };
 ```
 
-Nothing stores `active`, `dismissed`, or `unread` flags. They are **derived,
-pull-evaluated queries** — computed when a surface demands them:
+Nothing stores `active`, `dismissed`, or `unread` flags — dispositions are
+derived. And critically, **currency is a local join, not a cross-space
+read**: an item is *observed-satisfied* once the user's own seen mark on its
+target reaches the item's version. This is the Android behavioral gold
+standard — view the source anywhere, the notification retracts everywhere —
+computed entirely from the user's own stores:
 
 ```ts
 // Shown for illustration only.
 const sameSpaceGte = (a: EntityVersion, b: EntityVersion) =>
   a.space === b.space && a.seq >= b.seq;
-const active = (n: AttentionItem) =>
-  // pull-read of the source's current head version (§10.1); a claim's
-  // currency is the source's call
-  !sameSpaceGte(currentVersion(n.source), advancedPast(n));
 const terminal = (n: AttentionItem, log: AttentionAction[]) =>
   log.some((a) =>
     (a.type === "dismissed" || a.type === "archived" || a.type === "acted") &&
     sameSpaceGte(a.againstVersion, n.sourceVersion)
   );
-const visible = (n: AttentionItem, log: AttentionAction[], now: number) =>
-  !terminal(n, log) && active(n) && !snoozedUntil(log, now) &&
+const observedSatisfied = (n: AttentionItem, seen: SeenStore) =>
+  sameSpaceGte(seen.versionOf(n.target), n.sourceVersion);
+const visible = (
+  n: AttentionItem, log: AttentionAction[], seen: SeenStore, now: number,
+) =>
+  !terminal(n, log) && !observedSatisfied(n, seen) &&
+  !snoozedUntil(log, now) &&
   (n.notBefore === undefined || now >= n.notBefore) &&
   (n.expiresAt === undefined || now < n.expiresAt);
 ```
 
+Claims that should outlive observation (a todo is not done because you
+looked at it) are *re-emitted deliberately* — a deadline policy or the
+source's own artifact change produces a fresh claim at a newer version —
+rather than the runtime guessing which glances "count". Source-side
+satisfaction that doesn't involve the user looking (someone else handled it;
+the trip ended) is the ranker's job: its fold observes the source change and
+terminally retracts the item (system `acted`/`dismissed` by module
+identity).
+
 A caveat on "cheap": pull-based scheduling makes *unobserved* queries free
 (`docs/specs/pull-based-scheduler/README.md`), not observed ones. A mounted
-lane is a live subscription and re-evaluates when its inputs change; §4.5 and
-§10.1 bound how often that happens (conditional seen writes, non-reactive
-version reads by default, seen-state segregated from lane queries).
+lane is a live subscription over the user's own three stores — no per-item
+cross-space reads (that was a design bug this revision fixed; cross-space
+reading happens once, in the ranker's fold) — and §4.5's write discipline
+bounds how often those stores change.
 
 ### 4.5 Storage
 
-The ledger lives in the **user's home space** (home space DID = user identity
-DID; the established home for durable per-user state, alongside favorites and
-journal — see `docs/common/conventions/HOME_SPACE.md`). It is **three
-stores with three writer models**, not one:
+Attention state lives in the **user's home space** (home space DID = user
+identity DID; the established home for durable per-user state, alongside
+favorites and journal — see `docs/common/conventions/HOME_SPACE.md`). It is
+three stores, and the three backings are not ad-hoc — they derive from a
+2×2 of **writer authority × reactivity coupling**:
+
+| | wakes lane queries | must never wake lane queries |
+|---|---|---|
+| **ranker-only writes** | `items` | *(learned policies live with §7 policies, not here — they are user-visible data)* |
+| **any-surface writes** | `actions` | `seen` |
 
 1. **`items`** — written *only* by the ranker. Backing for phase 1:
    a **durable array cell carrying the `writeAuthorizedBy` claim**, the
@@ -365,13 +442,15 @@ stores with three writer models**, not one:
    (`docs/common/conventions/HOME_SPACE.md`,
    `packages/runner/src/cfc/prepare.ts`). Coalescing (same `id`, source
    advanced) is an in-place element update by the single leased ranker
-   instance (§6.2). This is deliberately *not* sqlite yet: `writeAuthorizedBy`
+   instance (§6.2); coalescing **refreshes** content, `expiresAt`, and
+   `progress` — a re-emerged claim carries the new emission's lifetime, not
+   a stale one. This is deliberately *not* sqlite yet: `writeAuthorizedBy`
    is enforced on the cell-write prepare path and **does not gate
    `db.exec`** today — sqlite's implemented CFC covers confidentiality
    ceilings and row-label rules, not write authorization
    (`docs/specs/sqlite-builtin/06-cfc.md`). Migrating `items` to a sqlite
    table (better ranking/pagination/retention at volume) is gated on the
-   net-new work item in §10.2, and on giving `items` **its own database**:
+   net-new work item in §10.3, and on giving `items` **its own database**:
    every `db.exec` serializes on the database handle cell's `rev`, so one
    shared db cannot hold both a ranker-only table and an
    everyone-writes table without gating both or neither.
@@ -383,23 +462,28 @@ stores with three writer models**, not one:
    the canonical writer is singular per store, and user actions are
    mergeable appends). The ranker periodically compacts actions for
    terminal, swept items.
-3. **`seen`** — the seen ledger (§5), highest write rate in the system,
+3. **`seen`** — the seen store (§5), highest write rate in the system,
    ships in phase 0 and gets its own store so its writes never wake lane
-   queries. One mark per (entity), upserted: recommended backing is a small
-   **sqlite database private to seen-state** (upsert-by-key is what SQL is
-   for; no trust gating needed — every surface of the *user's own runtime*
-   may write the user's own marks), with an array-cell fallback. Write
-   discipline is part of the spec, not an optimization: a mark is written
-   **only when it advances** (`newSeq > seenSeq`, so re-renders and repeat
-   views are no-ops — this is also what breaks any render→write→render
-   cycle) and **debounced per focus session** (at most one write per entity
-   per focused open). Retention is trivial — one row per cared-about
-   entity, reaped when the care-relation drops the entity.
+   queries eagerly (lanes sample it; the join is evaluated on lane
+   re-render, not per seen-write). One mark per entity, upserted:
+   recommended backing is a small **sqlite database private to seen-state**
+   (upsert-by-key is what SQL is for; no trust gating needed — every
+   surface of the *user's own runtime* may write the user's own marks),
+   with an array-cell fallback. Write discipline is part of the spec, not
+   an optimization: **seen = focused open** (§5), a mark is written **only
+   when it advances** (`newSeq > seenSeq` — re-renders and repeat views are
+   no-ops, which is also what breaks any render→write→render cycle) and
+   **debounced per focus session** (at most one write per entity per
+   focused open). A focused open writes *only* the seen mark — item-seen
+   is a join (`observedSatisfied`, §4.4), not a second record; the earlier
+   draft's duplicate "seen" action defeated this store's whole reason to
+   exist. Retention is trivial — one row per cared-about entity, reaped
+   when the care-relation drops the entity.
 
 Two rules regardless of backing:
 
-- **Never model a ledger itself as `asCell: ["stream"]`** — stream cells
-  are ephemeral (only the marker persists; payloads do not — see
+- **Never model a store as `asCell: ["stream"]`** — stream cells are
+  ephemeral (only the marker persists; payloads do not — see
   `docs/specs/space-model/4-cells.md`). Streams are append *endpoints*, not
   logs. This matters doubly for ingress: webhook payloads ride an ephemeral
   stream, so a **receiving handler must persist candidates durably at
@@ -407,11 +491,65 @@ Two rules regardless of backing:
   live are lost permanently, not delayed (§6.1).
 - **Never `set()` a whole array** that has more than one writer.
 
-Retention: `expiresAt` handles time-bound claims (evaluate-on-read, §9.3); a
-sweep reaps items that are terminal with `sourceVersion` below a watermark,
-plus their actions. Sweeping is a ranker duty (it owns `items`), bounded and
-boring by design. Because sweeping only reaps *terminal* rows, per-source
-intake quotas (§6.1) are what bound a flooding source, not retention.
+Retention: the ranker's sweep terminally retracts expired items (system
+action, `by` = module identity — this is the *one* expiry mechanism;
+`visible()`'s expiry check is the read-side shadow of it, so an expired item
+is hidden immediately and reaped eventually) and reaps items that are
+terminal with `sourceVersion` below a watermark, plus their actions.
+Sweeping is a ranker duty (it owns `items`), bounded and boring by design.
+Because sweeping only reaps terminal rows, per-source intake quotas (§6.1)
+are what bound a flooding source, not retention.
+
+### 4.6 Actions on the claim
+
+The most attention-respecting affordance in existing systems (Android
+actions + direct reply) is closing the loop *without opening the app* —
+approve/deny, done/later, reply, from the shade or the bell. The envelope's
+`actions` field carries it:
+
+- Rendering: shell lanes and OS adapters render `actions` as buttons (plus
+  an inline input when `input: "text"`). Android compiles to
+  `Notification.Action`/`RemoteInput`; Web Push to `showNotification`
+  actions (buttons; inline text where supported); the shell renders
+  natively. The PWA floor holds — Web Push supports action buttons.
+- Acting: writes the ordinary `acted` action (`payload: {key, input?}`),
+  which is terminal; and, when `handler` is present, appends
+  `{key, input?, itemId, at}` to the handler cell in the source space
+  **under the user's ordinary session authority** — exactly the authority
+  the user would exercise replying in-app. No new trust surface: the
+  source granted itself read on its own cell, and the user could always
+  write there through the source's own UI.
+- The "needs your approval" genre (Loom's `authorization_state:
+  proposal-required`) compiles to `actions: [approve, deny]` — the approval
+  affordance travels with the claim instead of forcing navigation.
+
+### 4.7 Lifecycle
+
+For review clarity, the full per-(user, item) state machine, every
+transition named once:
+
+```text
+(candidate) --ranker fold: clamp > suppress--> MATERIALIZED
+MATERIALIZED --now < notBefore--> EMBARGOED --time--> VISIBLE
+VISIBLE --user: dismissed|archived|acted--> TERMINAL
+VISIBLE --ranker: source satisfied / thread displaced / expiry sweep
+         (system action)--> TERMINAL
+VISIBLE --user: snoozed--> SNOOZED --snoozeUntil--> VISIBLE
+VISIBLE --seen mark on target reaches sourceVersion--> OBSERVED-SATISFIED
+         (hidden; no action row — pure join)
+VISIBLE --now ≥ expiresAt--> hidden immediately (read-side),
+         TERMINAL at next sweep (write-side)
+TERMINAL --ranker coalesce advances sourceVersion past tombstone-->
+         VISIBLE (re-emergence: a consequence of coalescing, not a
+         separate mechanism)
+TERMINAL + below watermark --sweep--> reaped
+```
+
+Posture may change after materialization (escalation raises it, collective
+handling demotes it — §8); §9.3 defines alerting and retraction in terms of
+these posture transitions. **Policy changes re-fold**: policy cells are fold
+inputs, so a policy commit wakes the ranker and materialized items re-lane —
+muting a thread demotes its existing items, not just future ones.
 
 ## 5. Seen-state and attention over artifacts
 
@@ -420,8 +558,8 @@ The most common attention event in practice is not "interrupt me" — it is
 be able to *see that it happened*". That is not a notification; it is
 seen-state.
 
-**The seen ledger** is one small relation per user: the last version the
-user actually observed, per entity. "Observed" is defined strictly:
+**The seen store** is one small relation per user: the last version of an
+entity the user actually observed. "Observed" is defined strictly:
 **seen = focused open** — the user navigated to the entity (or an item whose
 `target` is the entity) and it was the focus of their attention. Scrolling
 past a row in a list is *not* seen; rendering a lane is *not* seen. This
@@ -438,22 +576,20 @@ type SeenMark = {
 };
 ```
 
-Everything else is a query over marks joined against current heads (which
-requires the version-exposure API, §10.1 — the versions exist in memory-v2;
-reading them from pattern/shell code is net-new):
+Everything else is the **changes projection** (§10.1) joined against marks:
 
-- `unseen(entity) = head(entity).seq > seenVersion.seq` (same space) →
-  change dots on artifacts and their containers (space lists, home).
-- **"While you were away"** = all cared-about entities with unseen changes,
-  grouped by space, ordered by the ranker. Renders as a pattern on the home
-  context. This is the first-run view and the every-return view — the same
-  query. The affordance must answer *what changed, by whom, since you
-  looked* — author and time of the unseen changes, and a jump-in that
-  emphasizes the changed region (memory-v2 holds both versions; the diff is
-  derivable). A bare dot that says "something happened" does not meet the
-  bar (§4.1). Note the *by whom* half is gated on commit attribution
-  exposure (§10.1); until it lands, the view can say what changed but only
-  approximate who.
+- `unseen(entity)` = `changes([entity], sinceSeq: seenVersion.seq)` is
+  non-empty → change dots on artifacts and their containers (space lists,
+  home).
+- **"While you were away"** = one `changes(careSet, basis: seenWatermark,
+  attribution: true)` call, grouped by run/thread then space, ordered by
+  the ranker. Renders as a pattern on the home context. This is the
+  first-run view and the every-return view — the same query. The affordance
+  must answer *what changed, by whom, since you looked* — the projection's
+  `author` field gives session-grain attribution from day one (§10.1) — and
+  a jump-in that emphasizes the changed region (memory-v2 holds both
+  versions; the diff is derivable). A bare dot that says "something
+  happened" does not meet the bar (§4.1).
 - **Artifact lifecycle** falls out of the same two numbers plus a timestamp:
   *fresh* (unseen changes) → *seen* → *stale* (untouched for N) →
   *archived*. No new subsystem.
@@ -468,25 +604,29 @@ commit log already records.
 
 **Run-level grouping.** One agent run touching twelve artifacts must not be
 twelve scattered dots. From phase 1, agent-shaped sources emit one
-receipt-shaped candidate per run (`threadKey` = run id, `displaces` covering
-the per-artifact noise), and "while you were away" groups by `threadKey`
-before space. Phase 0 — dots only — does not have this, which is a stated
+receipt-shaped claim per run (`threadKey` = run id), and the
+while-you-were-away view folds entity changes under the run's receipt by
+**attribution**: changes whose `author` is the run's session group beneath
+the receipt rather than appearing as free-floating dots. (Attribution-based
+folding, not an envelope field — the changes projection already carries the
+join key.) Phase 0 — dots only — does not have this, which is a stated
 limitation, not an oversight: phase 0 makes agent work *visible*; run-level
 legibility is phase 1's tracked follow-through (§11).
 
-**The care-relation** answers "which entities produce dots at all":
-approximately *touched-recently ∪ agent-did-it-for-you ∪ explicitly-watched*,
-itself tunable by policy. Getting this right is an open question (§12.2);
-getting it wrong in the "too broad" direction is the failure mode to avoid
-(dots everywhere = dots nowhere).
+**The care-relation** is not a fourth kind of policy — it is **the ranker's
+watch set**: the entity set handed to the changes projection, seeded by
+derived defaults (*touched-recently ∪ agent-did-it-for-you*) and extended by
+explicit watch/unwatch policies (§7). Getting the defaults right is an open
+question (§12.2); getting them wrong in the "too broad" direction is the
+failure mode to avoid (dots everywhere = dots nowhere).
 
 ## 6. The ranker
 
 **One logical ranker per user.** It folds candidates and policies into the
 ledger, assigns postures and weights, coalesces (same `id` when the same
-source object advances; same `threadKey` when distinct events share a
-conversation or run), applies displacement, computes re-emergence, and
-sweeps retention.
+source object advances — re-emergence is this same operation crossing a
+tombstone), applies thread displacement (§6.4), retracts source-satisfied
+claims, and sweeps retention (§4.5).
 
 ### 6.1 Candidate intake
 
@@ -494,19 +634,24 @@ Candidates must be **durable before ranking**: the ranker may be asleep or
 absent (interim mode, closed clients), and ephemeral candidates would be
 silently lost, not delayed. Intake shape:
 
-- In-fabric artifact changes need no intake at all — they are derived (§5).
-- Pattern-emitted candidates land in a durable per-source candidate cell in
-  the space where they arise; a small forwarder (part of the emitting
-  pattern's contract) or the user's runtime copies them into a **candidate
-  inbox in the user's home space**, making the ranker's whole world
-  home-space-local (this is also what makes server-side execution viable
-  before cross-space wake exists — §6.3).
+- In-fabric artifact changes need no *emission* — they are derived (§5).
+  (They do need *reach*: until server-side cross-space wake exists, changes
+  in other spaces reach a server-side ranker via the same forwarding path as
+  explicit candidates below; a client-side ranker reads them directly
+  through the user's ordinary sessions.)
+- Pattern-emitted candidates land in the **candidate inbox in the user's
+  home space** — a cross-principal, quota-gated append surface, named
+  net-new work (§10.2), because it is the one place untrusted-ish writers
+  meet the user's home space: the write gate enforces per-source quotas
+  against the *verified writer identity*, not against self-reported fields.
+  Until §10.2 lands, candidates rest in a durable per-source cell in the
+  space where they arise and the ranker reads them there (client-side
+  interim), with quotas enforced at fold time — weaker (a flood bloats the
+  source-space cell, not the home space) but sound.
 - Webhook ingress: the receiving handler persists the payload durably at
   ingress (§4.5); the ephemeral stream is transport, not storage.
-- **Per-source quotas** apply at intake (candidates per source per window).
-  Retention only reaps terminal items, so quotas — not retention — are the
-  bound on a flooding source. Quota state feeds the same source-reputation
-  signal as dismiss-without-open.
+- Quota pressure and dismiss-without-open feed the same **learned-policy**
+  signal (§7): the source's baseline clamps down, legibly.
 
 ### 6.2 Trust and instance discipline
 
@@ -545,13 +690,14 @@ window degrades to wasted work, not divergence.
   (`docs/specs/server-side-execution/`). With intake home-space-local
   (§6.1), the ranker is a *standing registration on the user's home space* —
   work whose value is its effects rather than client-read output — woken by
-  commits to the candidate inbox or cared-about entities' forwarded events.
-  Execution is attributed `onBehalfOf` the user. Named dependencies, since
-  that spec's workers, registrations, and wake-on-commit are all
-  **per-space**: standing registrations are its own later phase; scoped
-  (`PerUser`) state claims are gated (its G16); server-side *cross-space*
-  reads/wake are explicitly deferred there — which is exactly why intake
-  forwards into the home space instead of the ranker reading N spaces.
+  commits to the candidate inbox, the policy cells, or forwarded
+  care-events. Execution is attributed `onBehalfOf` the user. Named
+  dependencies, since that spec's workers, registrations, and wake-on-commit
+  are all **per-space**: standing registrations are its own later phase;
+  scoped (`PerUser`) state claims are gated (its G16); server-side
+  *cross-space* reads/wake are explicitly deferred there — which is exactly
+  why intake forwards into the home space instead of the ranker reading N
+  spaces.
 - **Interim: client-side, under lease** (§6.2). Until standing registrations
   land, the leaseholder client runs the ranker as an ordinary piece. This
   degrades gracefully for in-fabric state (candidates are durable; folding
@@ -563,9 +709,30 @@ window degrades to wasted work, not divergence.
   interim service, treat that as scaffolding, not the design.
 
 **Laziness.** The ranker materializes *rows*; it does not keep derived
-predicates hot. `active()`/`visible()` evaluate on surface demand. The one
-push-shaped duty is OS delivery (§9.3), which is explicitly an edge adapter
-fed by wake-on-commit, not a hot loop.
+predicates hot. `visible()` evaluates on surface demand over the user's own
+stores (§4.4). The one push-shaped duty is OS delivery (§9.3), which is
+explicitly an edge adapter fed by wake-on-commit, not a hot loop.
+
+### 6.4 Coalescing and thread displacement
+
+Three mechanisms in the earlier draft (`id`-coalescing, `threadKey`
+grouping, an emitter-declared `displaces` list) are two in this one, at
+distinct altitudes:
+
+- **`id` is identity**: the same claim at a newer source version. Coalescing
+  updates the item in place (refreshing content, expiry, progress);
+  crossing a dismissal tombstone is re-emergence. Identity is
+  ranker-derived from verified provenance (§4.4), so it cannot be forged.
+- **`threadKey` is the thread**, and displacement is a *derived rule over
+  it*: **within a threadKey, only the newest live claim is visible**; older
+  live claims in the thread are terminally retracted by the ranker (system
+  action) when a newer one materializes. A prepared result therefore
+  displaces the raw occurrence by *sharing its thread*, not by naming item
+  ids — no displacement chains, no tombstone bookkeeping for the emitter,
+  and "the displaced item's source advances again" needs no special case
+  (it is simply the thread's newest claim again). Cross-thread or
+  multi-target displacement is deliberately not expressible; a consumer
+  who needs it should make the case with a concrete scenario (§12.7).
 
 ## 7. Policies
 
@@ -577,43 +744,76 @@ ranker code**:
 type AttentionPolicy = {
   match: {
     source?: unknown;         // asCell: ["cell"] — a specific source/thread
-    sourceKind?: string;      // "group-chat", "importer", "agent-run", ...
+    sourceKind?: string;      // as bound by the ranker, §4.4
     spaceDid?: string;
     threadKey?: string;
   };
   effect: {
-    postureCap?: "suppress" | "silent" | "review" | "heads-up";
-    // The ONLY path to interrupt: a user-granted floor (§4.2).
-    postureFloor?: "review" | "heads-up" | "interrupt";
+    // One clamp on the one ordered scale (§4.2):
+    // suppress < silent < review < heads-up < interrupt.
+    clamp?: { min?: "review" | "heads-up" | "interrupt";
+              max?: "suppress" | "silent" | "review" | "heads-up" };
+    // Exempts this policy's min from quiet-hours clamping (the babysitter
+    // thread breaks through). User-set only.
+    bypassQuietHours?: boolean;
     coalesceWindowMs?: number;
+    // Time-conditional clamp sugar: during these hours, max = "review".
     quietHours?: { start: string; end: string };
+    watch?: boolean;          // extend/prune the care-relation (§5)
   };
   reason?: string;            // human-legible: why this policy exists
-  createdBy: string;          // user DID, or module identity for proposals
-  ext?: Record<string, unknown>; // product dimensions (e.g. stances),
-                              // opaque to the runtime fold
+  createdBy: string;          // user DID; a pattern's module identity for
+                              // proposals; the RANKER's module identity for
+                              // learned policies (see below)
 };
 ```
+
+**Composition is one formula.** Effective posture =
+`clampScale(baseline, max(matching mins), min(matching maxes))` where
+`baseline` is the requested posture bounded by the source's learned
+baseline; **maxes dominate mins** on conflict, with one exception —
+a user-created min marked `bypassQuietHours` survives the quiet-hours max.
+`quietHours` is defined as nothing more than a time-conditional
+`max: "review"`. The canonical case — "quiet hours 22:00–07:00, but the
+babysitter thread always breaks through" — is two records and zero
+ambiguity.
 
 - Policies live in the user's home space (`PerUser` scope). The core ships a
   handful of defaults: messages-from-humans → `heads-up`;
   agent-completions → `silent` (visible as seen-state, never buzzing).
   There is deliberately **no default that maps any emitter-supplied field to
   `interrupt`** — deadline-driven interruption ("library book due
-  tomorrow") exists only as a user-adopted policy floor on a named source.
-- **Mute is a policy, not a special relation.** "Mute this thread" writes
-  `{match: {threadKey}, effect: {postureCap: "suppress"}}`. The ledger item
-  that carried the mute action just records that it happened.
+  tomorrow") exists only as a user-adopted policy min on a named source.
+- **Mute is a policy, not a special relation** (and not an action type).
+  "Mute this thread" writes `{match: {threadKey}, effect: {clamp: {max:
+  "suppress"}}}`; the re-fold rule (§4.7) demotes existing items too.
 - **Patterns propose, the user disposes.** A pattern can ship a suggested
   policy with its artifacts ("library book due → heads-up 3 days before");
   adoption goes through a trusted surface, exactly like other user-consented
   writes — adoption *is* the write, and unadopted proposals never enter the
-  fold. This is where the bespoke 20% lives, and why the ranker doesn't
-  have to be perfect: when it mis-lanes something, the fix is a legible
-  one-line policy, written by the user or by their agent on request.
-  (Onboarding flows that propose an initial policy set are this same
-  primitive N times, batch-confirmed by a product surface — out of scope
-  here, §Non-goals.)
+  fold. (Onboarding flows that propose an initial policy set are this same
+  primitive N times, batch-confirmed by a product surface — out of scope,
+  §Non-goals.)
+- **Learned policies: the reputation loop, made legible.** The downward
+  feedback the spec promises (dismiss-without-open, quota pressure ⇒ the
+  source's items sink) has to live *somewhere*, and hidden ranker state
+  would break the inspectability goal. It lives here: the ranker — which is
+  already the trusted fold, not a third party petitioning for adoption —
+  writes ordinary policy records (`createdBy` = its module identity,
+  `reason` = the evidence, e.g. "7 of 8 items dismissed without open over
+  30d") into a designated **learned** section of the policy store. They are
+  visible, editable, and deletable exactly like hand-written policies; a
+  user deleting one is itself a signal. Learned policies may only *lower*
+  (set maxes / lower the baseline) — raising posture remains exclusively
+  user-authored (§4.2). This follows the platform's existing precedent for
+  system-inferred-but-user-owned data (`packages/home-schemas/learned.ts`).
+- **Product policy dimensions compile down.** Stance-like vocabularies
+  (Loom's `attention-policy-v1`) do not ride an opaque field on runtime
+  policies — there is deliberately no `policy.ext`, because an opaque blob
+  on the user's routing rules would imply a second, shadow interpreter of
+  the same cells. Product policy systems keep their own records and
+  *compile* to plain runtime clamps/watches, exactly as a trusted source
+  compiles its channel semantics to requested postures.
 - **Policy privacy, honestly stated.** Policy cells are never directly
   readable by other principals — they are ordinary confidential home-space
   data. But *behavioral* inference cannot be fully prevented: in a space
@@ -643,23 +843,24 @@ relation" plus existing constraints:
   plan", and *"Bea already handled this"* are queries over that contributed
   state. Disclosing terminal actions matters because handling often doesn't
   touch the source artifact (triaged verbally, replied off-fabric): when the
-  source *is* mutated, everyone's `active()` flips false for free; when it
-  isn't, a disclosed `acted` is the only retraction signal others can get.
-  A per-space opt-in policy — *"acted-by-any-member demotes to `silent` for
-  all"* — turns that signal into collective quiet. Disclosure is a per-space
-  policy cell (some spaces want receipts, some don't); a member who
-  discloses nothing simply doesn't appear.
+  source *is* mutated, everyone's claims coalesce or satisfy for free; when
+  it isn't, a disclosed `acted` is the only retraction signal others can
+  get. A per-space opt-in policy — *"acted-by-any-member demotes to
+  `silent` for all"* — turns that signal into collective quiet.
+  Disclosure is a per-space policy cell (some spaces want receipts, some
+  don't); a member who discloses nothing simply doesn't appear.
 - **Escalation across people is a policy.** "If nobody attends to this
   within 2h, raise it to `heads-up` for the space owner" is a policy cell on
   the shared space, evaluated by the owner's ranker against contributed
   state. No siloed notification system can express this; here it is one
-  record.
+  record. (Escalation is a posture *raise* after materialization; §9.3's
+  transition rule makes it alert exactly once.)
 
 ## 9. Surfaces
 
 ### 9.1 Shell
 
-The shell renders the ledger; it does not own attention logic. Per the
+The shell renders attention state; it does not own attention logic. Per the
 "pattern on the context" resolution: the home/shell context declares how the
 attention surface renders, so it is replaceable like the rest of the home
 experience. Concretely:
@@ -668,9 +869,9 @@ experience. Concretely:
   `review` (digest entry point), `silent` (dots via seen-state, §5);
 - unseen-change dots on artifacts and containers;
 - a snoozed lane (snoozed items must stay discoverable);
-- **focused opens** — not renders — write `seen` (an `AttentionAction` for
-  the item, a `SeenMark` for its target entity), under §4.5's
-  advance-only + debounced discipline. Rendering a lane never writes.
+- item `actions` rendered in place (§4.6);
+- **focused opens** — never renders — write the seen mark, under §4.5's
+  advance-only + debounced discipline. Rendering a lane writes nothing.
 
 Presentation components exist (`cf-toast`/`cf-toast-provider`, `cf-alert`,
 badge conventions); the net-new work is mounting them against ledger
@@ -697,20 +898,38 @@ Adapters compile the envelope down; the ledger stays canonical and
 "Android-shaped" (live update + auto-retract), and platforms degrade from
 there:
 
+- **Alerting rides posture transitions, not writes.** A delivered item
+  alerts when it first materializes at an alert-bearing rung and again only
+  when the ranker *raises* its posture (escalation, §8); every same-rung
+  coalesce — new message in the thread, progress tick, content refresh —
+  **replaces silently** on every surface (Android `setOnlyAlertOnce`
+  semantics, made unconditional: the emitter cannot choose to re-buzz).
+  Posture *demotion* and visibility flips are retraction triggers: the
+  dispatcher retracts or downgrades the delivered surface when either
+  occurs. Without this rule a coalescing thread would legally buzz on
+  every advance — louder than Android, inverting the spec's promise.
 - **Replace/retract rides `id`** everywhere: iOS
   `UNNotificationRequest.identifier` / `apns-collapse-id`, Android
-  `notify(id)`, Web Push `options.tag`. When `visible()` flips false *on
-  evaluation*, the dispatcher retracts on every delivered surface. Two
-  honesty notes. First, `visible()` is evaluated on commit-driven wakes and
-  on read — **nothing wakes anything at `expiresAt`**: server-side timers
-  don't exist yet (they are "(Future)" in
-  `docs/specs/server-side-execution/`), so an expired item may linger on an
-  OS tray until the next wake or app-open re-evaluates it. Timer
-  registrations that feed the dispatcher are named net-new work (§10.4);
-  until they land, `expiresAt` is evaluate-on-read with explicitly stale OS
-  surfaces. Second, iOS replaces but does not tick (text refreshes when the
-  shade reopens); genuinely-live claims are a Live Activities track,
-  explicitly out of V1.
+  `notify(id)`, Web Push `options.tag`. Two honesty notes. First,
+  transitions are evaluated on commit-driven wakes and on read — **nothing
+  wakes anything at `expiresAt`**: server-side timers don't exist yet (they
+  are "(Future)" in `docs/specs/server-side-execution/`), so an expired
+  item may linger on an OS tray until the next wake re-evaluates it. Timer
+  registrations that feed the dispatcher are named net-new work (§10.5);
+  until they land, expiry is evaluate-on-read with explicitly stale OS
+  surfaces (the ranker's sweep is the terminal write-side, §4.5). Second,
+  iOS replaces but does not tick (text refreshes when the shade reopens);
+  genuinely-live claims (`progress`) render best-effort per platform, and
+  rich live chrome (Live Activities) is a separate later track.
+- **Confidentiality crosses the push boundary explicitly.** Push payloads
+  and lockscreens are untrusted displays: they carry `redacted` when
+  present, otherwise a generic envelope ("Update from <sourceKind>"), with
+  full content fetched on unlock/app-open (the conventional
+  mutable-content/fetch-on-receive shape). Items whose confidentiality
+  labels forbid egress to the push relay get the generic envelope
+  unconditionally — the same CFC labels that govern every other flow govern
+  this one; a system that gates reading a version number (§10.1) does not
+  get to mail full message bodies through third-party relays unexamined.
 - **Two transports, not one.** Browser/PWA: Web Push (VAPID + service
   worker). Wrapped mobile apps: native APNs/FCM via the wrapper's plugin —
   embedded webviews do not get Web Push. The server side (toolshed) needs a
@@ -719,8 +938,9 @@ there:
   retractedAt}` so retraction can target what was actually delivered.
   Ship Web Push first; the envelope is transport-agnostic.
 - **The PWA is the floor.** The canonical shape includes nothing that cannot
-  be expressed on the most-constrained surface; richer platforms are adapter
-  opt-ins, not envelope fields.
+  be expressed on the most-constrained surface (action buttons included —
+  Web Push has them); richer platforms are adapter opt-ins, not envelope
+  fields.
 - **Tray-dismiss is per-device by default.** An OS-tray dismissal writes an
   action with `surface: "os-tray"`; whether it terminates the item globally
   is policy (default: clears that device only; the shell is canonical).
@@ -731,34 +951,61 @@ This design mostly composes existing primitives, but not entirely. Naming
 the gaps is the point of this section — each is a prerequisite of the phase
 that first needs it (§11), and each needs its own (small) design pass.
 
-1. **Version exposure** *(phase 0)*. Patterns and the shell currently cannot
-   read an entity's memory-v2 head `seq` — the `Cell` interface exposes no
-   version, deliberately. Seen-state needs: (a) a **non-reactive** per-entity
-   head-version read (non-reactive by default is essential — a reactive seq
-   read re-fires on every change, exactly what seen writes must not do);
-   (b) a *changed-since(version)* enumeration over a set of cared-about
-   entities for "while you were away"; (c) eventually, commit-attribution
-   exposure (who wrote) — memory-v2 reserves `invocationRef` /
-   `authorizationRef` for a later signed-write pass, so phase 0's "by whom"
-   is approximate until that lands. CFC story required: observing a head
-   version reveals *that* activity occurred; version reads must be gated by
-   the same read authority as the entity itself.
-2. **Write-authorization for sqlite** *(pre-migration of `items` to sqlite;
+1. **Changes projection** *(phase 0)*. Patterns and the shell cannot read an
+   entity's memory-v2 head `seq` — `Cell` exposes no version, deliberately —
+   yet `seq` already crosses the wire in every query result
+   (`FactEntry.seq`, memory-v2 §5.7.1), and changed-since-a-basis is
+   precisely the session catch-up computation (memory-v2 §5.4.2,
+   `SessionSync.fromSeq/toSeq`). Rather than a Cell method, seen-state
+   needs one small **read-only, one-shot, session-independent query**:
+
+   `graph.changes(roots, branch, sinceSeq?, attribution?) →
+   { toSeq, entries: [{id, seq, deleted?, author?}] }`
+
+   (a) With a single root and no basis it is the **non-reactive head read**
+   — a one-shot query, not a watch, so re-renders never re-fire. (b) With
+   the care-relation as roots and the seen watermark as basis it is the
+   **"while you were away" enumeration** — one indexed scan of the `head`
+   table (add a `(branch, seq)` index). (c) With `attribution: true` it
+   joins the commit log's already-persisted `sessionId` — **session-grain,
+   server-asserted "by whom" from day one**, upgrading in place to
+   `invocationRef`-backed proof when the signed-write pass lands (a join,
+   not a cryptography project). CFC: an entity may appear in a changes
+   result iff the caller may read the entity on that branch — strictly less
+   than a materialized read reveals. Not attention-specific: offline
+   catch-up UIs, activity/audit views, incremental derived indexes, and
+   retention watermarks consume the same query. It is the entity-grain,
+   payload-free member of the projection family memory-v2 §07 sketches —
+   and deliberately *not* built on §07's annotations plane, which is
+   range-anchored collaborative-field machinery, self-declared future work;
+   the one annotation prototype's review (PR #4132) documents why
+   side-table indexes invisible to the reactive graph are the wrong shape.
+2. **Candidate inbox append gate** *(phase 1; hardened by phase 2)*. A
+   home-space inbox cell with **restricted cross-principal append**: other
+   principals' patterns may append candidates (the rosters
+   contribute-your-own idiom, reversed) but the write gate enforces
+   per-source quotas against the verified writer identity. This is what
+   makes dead-device delivery an authority question with an answer instead
+   of an open question — the full chain "someone messages me while all my
+   devices are closed → my phone buzzes" is inbox append → home-space
+   wake → ranker fold → dispatcher push.
+3. **Write-authorization for sqlite** *(pre-migration of `items` to sqlite;
    not needed for phase 1's array-cell backing)*. `writeAuthorizedBy` is
    enforced on the cell-write prepare path only; `db.exec` today checks
    confidentiality ceilings and row-label rules but not write authorization.
    Gating `db.exec` per database handle (the `rev` bump is a cell write, so
    the prepare path sees it) needs specification and a security review of
    its own, including whether any sqlite write path bypasses the rev write.
-3. **Ranker lease** *(phase 1)*. A small mutex-cell convention (claim with
+4. **Ranker lease** *(phase 1)*. A small mutex-cell convention (claim with
    expiry, renew, steal-on-expiry) for single-instance election of the
    interim client-side ranker (§6.2). Generalizes beyond attention.
-4. **Timer wake** *(phase 2+)*. Executor-pool timer registrations
+5. **Timer wake** *(phase 2+)*. Executor-pool timer registrations
    (`notBefore`, `expiresAt`, snooze expiry, digest cadence) feeding
    wake-on-commit's machinery, so time-driven transitions don't depend on
    coincidental commits. Until then: evaluate-on-read, stale OS surfaces
-   acknowledged (§9.3).
-5. **Push transports** *(phase 2/3)*. Web Push then APNs/FCM: device
+   acknowledged (§9.3). Note this also bounds the "library book due"
+   genre: alarm-shaped interruption is only as timely as the wake source.
+6. **Push transports** *(phase 2/3)*. Web Push then APNs/FCM: device
    registration, delivery ledger, retraction dispatch (§9.3). Net-new but
    conventional.
 
@@ -766,28 +1013,28 @@ that first needs it (§11), and each needs its own (small) design pass.
 
 Each phase is independently shippable and none re-shapes the data model.
 
-- **Phase 0 — seen-state.** The seen ledger (§5) with its write discipline
-  (§4.5.3), unseen dots in the shell, and a "while you were away" home
-  pattern. Requires version exposure (§10.1). No ranker, no candidates, no
-  push. Acceptance bar: the user can see *what changed and since when* (by
-  whom, to the extent §10.1c allows), and jump in with the changed region
-  emphasized — not merely that a dot exists. This makes agent work
-  **visible** — the single most-requested product gap — while run-level
-  *legibility* (one claim per agent run, not twelve dots) is explicitly
-  phase 1's follow-through.
+- **Phase 0 — seen-state.** The changes projection (§10.1), the seen store
+  with its write discipline (§4.5.3), unseen dots in the shell, and a
+  "while you were away" home pattern. No ranker, no candidates, no push.
+  Acceptance bar: the user can see *what changed, by whom (session-grain),
+  and since when*, and jump in with the changed region emphasized — not
+  merely that a dot exists. This makes agent work **visible** — the single
+  most-requested product gap — while run-level *legibility* (one claim per
+  agent run, not twelve dots) is explicitly phase 1's follow-through.
 - **Phase 1 — ledger + lanes.** Envelope, home-space `items` (array cell +
-  `writeAuthorizedBy`) and `actions` stores, candidate inbox with quotas
-  (§6.1), a minimal client-executed ranker under lease (defaults + mute +
-  posture caps/floors + displacement), shell bell/lanes, receipt-shaped
-  candidates for agent runs. Policies v0.
+  `writeAuthorizedBy`) and `actions` stores, candidate intake (inbox gate
+  §10.2, or interim source-space cells), a minimal client-executed ranker
+  under lease (defaults + clamp composition + learned policies + thread
+  displacement), shell bell/lanes with item actions (§4.6), receipt-shaped
+  claims for agent runs with attribution folding (§5). Policies v0.
 - **Phase 2 — server ranker + first transport.** Ranker as a standing
   registration on the home space under server-primary execution
-  (dependencies named in §6.3); Web Push with device registration and
-  retraction; digest queries; timer wake (§10.4).
-- **Phase 3 — breadth.** Wrapped-app APNs/FCM; full action vocabulary
-  (snooze/archive surfaced); shared seen-state + disclosed terminal actions
-  + escalation policies (§8); `items` on sqlite once §10.2 lands;
-  coalescing refinements. Live Activities remain a separate track.
+  (dependencies named in §6.3); Web Push with device registration,
+  redaction rules, and retraction; digest queries; timer wake (§10.5).
+- **Phase 3 — breadth.** Wrapped-app APNs/FCM; shared seen-state +
+  disclosed terminal actions + escalation policies (§8); `items` on sqlite
+  once §10.3 lands; snooze/archive surfaced fully; `progress` rich chrome
+  (Live Activities) as its own track.
 
 ## 12. Open questions
 
@@ -795,12 +1042,14 @@ Each phase is independently shippable and none re-shapes the data model.
    but the "wholly-system service" alternative keeps resurfacing; if the
    server executor itself writes the ledger, is that a builtin identity, and
    does that preempt user-forkable rankers? Resolve before phase 1.
-2. **The care-relation.** Which entities produce seen-state dots (§5)?
-   Touched ∪ agent-authored ∪ watched is the working answer; validate
-   against real spaces before hardening, and decide whether "touched" decays.
-3. **Forwarder contract.** §6.1 makes intake home-space-local via
-   forwarders. Who runs them (the emitting pattern? the user's runtime on
-   visit?), and what happens for spaces the user hasn't opened in weeks?
+2. **Care-relation defaults.** Touched ∪ agent-authored ∪ watched is the
+   working answer for the watch set (§5); validate against real spaces
+   before hardening, and decide whether "touched" decays.
+3. **Forwarder contract.** Cross-space reach for a server-side ranker
+   (§6.1, §6.3): who runs the forwarding (the emitting pattern? the user's
+   runtime on visit?), and what happens for spaces the user hasn't opened
+   in weeks? Partially subsumed by §10.2's inbox gate; the residue is
+   *derived* care-events from spaces with no cooperating emitter.
 4. **Seen-mark granularity.** Per-entity marks are the floor. Do container
    views (a space list showing N dots) warrant container-level marks, and
    does "seen the container" imply anything about members?
@@ -811,13 +1060,14 @@ Each phase is independently shippable and none re-shapes the data model.
    regexes and LLM-judged predicates ("only interrupt if actually urgent")
    are clearly coming — as ranker inputs they inherit the ranker's authority,
    so they need their own integrity story before admission.
-7. **Coalescing.** Same `id` vs same `threadKey` heuristics; displacement
-   chains (a prepared result displacing an item that itself displaced);
-   sub-object edge cases (a thread whose items have their own lifecycles).
-8. **Cross-space lane cost.** A rendered lane is a ledger query plus N
-   cross-space source reads (per-item `active()`), each through the user's
-   ordinary session against the source space. Fine at dozens; model the
-   cost before hundreds, and decide how stale a lane's `active()` may be.
+7. **Displacement scope.** Thread displacement (§6.4) deliberately cannot
+   express cross-thread or multi-target displacement. If a real consumer
+   produces a scenario that needs it, revisit with that scenario on the
+   table; until then the simpler rule stands.
+8. **Learned-policy dynamics.** Decay (does a learned clamp relax after N
+   weeks of the user opening that source's items?), evidence thresholds,
+   and whether a user deleting a learned policy suppresses re-learning for
+   a period.
 9. **Digest self-promotion.** May a digest claim `heads-up` on a schedule
    (§9.2)? Leaning policy-gated, default off.
 10. **Convergence with product stores.** Loom currently materializes
@@ -836,23 +1086,24 @@ For the first consumer's adoption review. Loom fields → envelope:
 | `id` / source identity | `id` (re-derived by ranker from verified provenance) |
 | subject / focused target | `target` (cell link); `focused_view_fallback` → `ext` |
 | prepared material | `prepared` |
-| `title`, body copy | `title`, `body` |
+| `title`, body copy | `title`, `body` (+ `redacted` where the product wants lockscreen-safe copy) |
 | `why_now` | `ext.why_now` (product copy, runtime-opaque) |
 | `claim_kind` (act-now / review / notice / …) | `sourceKind` + `requestedPosture` (kind is classification; posture is the loudness request derived from it) |
 | `channel` (important-and-urgent / yours-in-progress / might-interest-you) | `ext.channel` — audience/genre, orthogonal to posture; product lanes render it |
-| `relation_to_trigger: supersedes` | `displaces` |
-| other `relation_to_trigger` values | `ext.relation_to_trigger` |
-| `authorization_state` (proposal-required / …) | `ext.authorization_state` — the "needs your approval" affordance is product chrome; posture only governs loudness |
+| `relation_to_trigger` (augments / supersedes / resolves / …) | `ext.relation_to_trigger`, whole; *supersedes* additionally = share the trigger's `threadKey` (thread displacement, §6.4, does the retraction) |
+| `authorization_state: proposal-required` | `actions: [{key:"approve"…},{key:"deny"…}]` (§4.6) + `ext.authorization_state` — the approval affordance travels with the claim |
 | `authority_class` | `ext` (work-start domain, product-side per §Division of labor) |
 | `not_before` | `notBefore` |
-| delivery/interrupt eligibility | `requestedPosture`, capped/floored by user policy (§7) |
+| sender / subject person | `actor` |
+| delivery/interrupt eligibility | `requestedPosture`, clamped by user policy (§7) |
 | feedback: done / later | actions `acted` / `snoozed` |
-| feedback: never-for-this-class | a policy write (`postureCap`) via the trusted surface |
+| feedback: never-for-this-class | a policy write (`clamp.max`) via the trusted surface |
 | feedback: not-useful | action `dismissed` + `ext.feedback: "not-useful"` (calibration signal round-trips to the product) |
 
 Not mapped, deliberately: Work-start Policies, continuity owners, typed
 receipts' internals, stance vocabularies — upstream product machinery
-(§Division of labor). A receipt *summary* enters as an ordinary candidate.
+(§Division of labor); stance policies compile down to plain clamps/watches
+(§7). A receipt *summary* enters as an ordinary candidate.
 
 ## References
 
@@ -862,19 +1113,26 @@ receipts' internals, stance vocabularies — upstream product machinery
 - `docs/specs/server-side-execution/README.md` — standing registrations,
   wake-on-commit, `onBehalfOf` attribution (ranker execution home; §6.3
   names this spec's dependencies on it).
-- `docs/specs/memory-v2/` (esp. `01-data-model.md`, `03-commit-model.md`,
-  `08-conflict-granularity.md`) — `seq`, optimistic concurrency, mergeable
-  ops, reserved commit-attribution fields.
+- `docs/specs/memory-v2/` — `01-data-model.md` (seq, heads),
+  `03-commit-model.md` (optimistic concurrency; commit-log `sessionId` /
+  reserved `invocationRef`), `04-protocol.md` + `05-queries.md`
+  (`SessionSync` catch-up, `FactEntry.seq` — the shipped machinery behind
+  §10.1), `07-op-views-and-annotations.md` (the projection-family framing
+  §10.1 borrows; the annotations plane it deliberately does not build on),
+  `08-conflict-granularity.md` (mergeable ops).
 - `docs/specs/sqlite-builtin/` (esp. `05-reactivity.md`, `06-cfc.md`) —
-  seen-ledger backing; why trust-bearing tables wait on §10.2; `reactOn`
-  coarseness; the rev-serialized write path.
+  seen-store backing; why trust-bearing tables wait on §10.3; `reactOn`
+  coarseness; the rev-serialized write path; the `tryClaimMutex` shape §10.4
+  borrows.
 - `docs/specs/space-model/4-cells.md` — stream-cell ephemerality.
 - `docs/specs/pull-based-scheduler/README.md` — demand-driven evaluation
   (and its limits for observed queries, §4.4).
 - `docs/specs/webhook-ingress/README.md` — external candidate ingress
   (durable persistence at the handler required, §6.1).
-- `packages/home-schemas/` (`journal.ts`, `favorites.ts`, `home.ts`) — the
-  durable-array + stream-append precedent and stable-key discipline.
+- `packages/home-schemas/` (`journal.ts`, `favorites.ts`, `learned.ts`,
+  `home.ts`) — the durable-array + stream-append precedent; stable-key
+  discipline; the system-inferred-but-user-owned precedent for learned
+  policies (§7).
 - `packages/runner/src/cfc/prepare.ts`, `packages/runner/src/cfc/ui-contract.ts`
   — `writeAuthorizedBy` enforcement (cell-write path); trusted surfaces.
 - `packages/runner/src/builtins/navigate-to.ts`,
@@ -884,3 +1142,6 @@ receipts' internals, stance vocabularies — upstream product machinery
   existing presentation components.
 - `packages/background-piece-service/README.md` — why the ranker does not
   run there.
+- PR #4132 (annotation-primitive prototype, draft) — the documented
+  anti-precedent for storage-side reverse indexes invisible to the reactive
+  graph; §10.1's design constraint.

--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -11,12 +11,15 @@ model.
 ## Status
 
 Draft — seeking framework author review. None of this is implemented in labs
-today (§3 inventories what exists). The Loom product's in-flight attention
-framework and Pond's spatial shell are the first intended consumers; this
-spec defines the runtime primitives their product surfaces should compile
-onto, so each stops hand-rolling its own attention state. Derived from the
+today (§3 inventories what exists), and §10 names the net-new runtime surface
+this design requires — most importantly a version-exposure API (§10.1) and
+write-authorization gating for sqlite (§10.2). The Loom product's in-flight
+attention framework and Pond's spatial shell are the first intended
+consumers; this spec defines the runtime primitives their product surfaces
+should compile onto, so each stops hand-rolling its own attention state
+(Appendix A maps Loom's candidate shape onto the envelope). Derived from the
 2026-05-21 multi-user/notifications design sessions and the 2026-07 attention
-reframe.
+reframe; revised 2026-07-12 after adversarial runtime and product review.
 
 ## Last Updated
 
@@ -44,26 +47,40 @@ Five load-bearing moves:
    `writeAuthorizedBy` claim; untrusted patterns can emit candidates and
    render their own local views, but cannot spam the ledger (§6).
 3. **Attention over artifacts is derived, not emitted.** The runtime already
-   versions every entity (memory-v2 `seq`). Seen-state is one small relation
-   — last observed `seq` per (user, entity) — and "unseen change", "while you
-   were away", and the artifact lifecycle all fall out as queries (§5). For
-   in-fabric sources, an attention item is a *view over* "an artifact you
-   care about changed", which dissolves the "every pattern must remember to
-   emit notifications" problem.
+   versions every entity (memory-v2 `seq`) — though exposing that version to
+   patterns is net-new API work (§10.1). Seen-state is one small relation —
+   last observed version per (user, entity) — and "unseen change", "while
+   you were away", and the artifact lifecycle all fall out as queries (§5).
+   For in-fabric sources, an attention item is a *view over* "an artifact
+   you care about changed", which dissolves the "every pattern must remember
+   to emit notifications" problem.
 4. **Policies are user-owned cells**, not ranker code. The core ships a
    good-enough default fold; the bespoke last 20% ("library book due"
    escalations, quiet hours, per-thread mutes) is data the user — or a
    pattern, on proposal — writes (§7).
 5. **Multi-user needs almost nothing new.** Attention is a per-(user, item)
    relation: a shared space emits one candidate and each member's ranker
-   lanes it independently. "Who has seen this" is the same seen-state
-   contributed into shared space, read the other direction (§8).
+   lanes it independently. "Who has seen this" — and, per disclosure policy,
+   "who has handled this" — is the same state contributed into shared space,
+   read the other direction (§8).
+
+### Division of labor
+
+This spec owns **routing, terminal state, seen-state, and delivery**.
+Everything upstream of a candidate — deciding whether an agent may *start*
+work, preparing material, continuity ownership, receipts, onboarding
+interviews that seed policy — is product-side and stays there. A product
+framework (e.g. Loom's attention framework) enters this pipeline as a
+*trusted source* emitting well-prepared candidates with a requested posture;
+the runtime ranker's job for such a source is cross-source arbitration and
+enforcement of the user's posture caps, not re-litigating the product's
+preparation decisions.
 
 ## Goals
 
 - A single canonical attention envelope and ledger that shell, product
   surfaces (Loom, Pond), patterns, and OS adapters all read.
-- Make autonomous/agent work *legible* without interruption — the user can
+- Make autonomous/agent work *visible* without interruption — the user can
   always see that something was done on their behalf, at zero notification
   cost ("quiet disposition" must not mean "invisible disposition").
 - Structural downward bias: interruption is the exception and must be earned;
@@ -81,6 +98,14 @@ Five load-bearing moves:
   center, donut zones), their copy, and their capacity budgets are product
   decisions; this spec only guarantees the queries they need are cheap and
   the data they render is trustworthy.
+- **Work-start authorization and preparation.** Policies governing whether
+  an agent may autonomously begin work, budgets, authority ceilings, and
+  continuity ownership are product-side (§Division of labor). The runtime
+  never decides what work happens — only how its results claim attention.
+- **Policy seeding / onboarding flows.** How a product interviews the user
+  and proposes an initial policy set is product-scope; the runtime primitive
+  is only "patterns propose, the user disposes" (§7) — adoption *is* the
+  write, and proposed-but-unadopted policies never enter the ranker's fold.
 - **Coverage/miss measurement** ("earn the right to say all caught up") —
   product-layer analytics over the ledger; the ledger just has to be
   complete enough to measure.
@@ -93,7 +118,7 @@ Five load-bearing moves:
   here are designed within that constraint, not around it.
 - **Replacing source UIs.** An attention item opens its focused destination
   (the artifact, the draft, the conversation); it displaces the source
-  occurrence rather than duplicating it.
+  occurrence rather than duplicating it (`displaces`, §4.4).
 
 ## 3. Background — what exists today
 
@@ -118,13 +143,14 @@ In labs, effectively nothing:
 Meanwhile the products above the runtime are already building attention
 systems without runtime support: Loom's attention framework (in flight, on a
 feature branch as of 2026-07-12) defines *prepared claims*, an
-attention-posture ladder, stance-bearing attention policies, a
-capacity-bounded Today block, and a default-weekly digest — materialized in
-product-local storage; its current "unseen" affordance is a localStorage
-last-seen timestamp per browser. Pond's donut prototype ranks pieces
-spatially by an attention score. Both need the same substrate: durable
-per-user seen-state, a trustworthy canonical ledger, and per-user policy.
-This spec is that substrate.
+attention-posture ladder, a capacity-bounded Today block, and a
+default-weekly digest — materialized in product-local storage; its current
+"unseen" affordance is a localStorage last-seen timestamp per browser.
+Pond's donut prototype ranks pieces spatially by an attention score. Both
+need the same substrate: durable per-user seen-state, a trustworthy
+canonical ledger, and per-user routing policy. This spec is that substrate —
+and only that substrate; Loom's work-start machinery and stance-bearing
+judgment policies stay product-side (§Division of labor).
 
 ## 4. Model
 
@@ -159,8 +185,12 @@ Two invariants:
 
 - **Downward bias.** Defaults sit low (`silent`/`review`). Sources *request*
   a posture; the ranker assigns the real one, capped by policy, and repeated
-  dismiss-without-open or mute feeds back as posture caps. An emitter cannot
-  buy `interrupt` with enthusiasm.
+  dismiss-without-open or mute feeds back as posture caps. Crucially,
+  **no emitter-controlled field may raise posture**: eligibility for
+  `interrupt` (and `heads-up` above a source's baseline) comes only from a
+  user-granted posture floor in policy (§7) — never from urgency claims,
+  expiry times, or any other field the emitter writes. An emitter cannot buy
+  `interrupt` with enthusiasm.
 - **Attention ≠ confidence.** How sure the system is about an item and how
   loudly it surfaces are separate axes. Uncertain-but-urgent goes to
   `heads-up` with its uncertainty stated; certain-but-routine stays in
@@ -168,7 +198,10 @@ Two invariants:
 
 The ladder deliberately matches the posture vocabulary the Loom product
 already uses (silent memory → daily review → timely heads-up → interrupt), so
-product surfaces map 1:1 onto runtime postures.
+product surfaces map 1:1 onto runtime postures. Within a rung, ordering is
+the ranker-assigned `weight` (§4.4) — an opaque scalar that never crosses
+rungs and never gates delivery; it exists so continuous surfaces (Pond's
+radial layout, "ordered by the ranker" lists) don't have to invent one.
 
 ### 4.3 The pipeline
 
@@ -180,12 +213,14 @@ Sources                         emit candidates (requested posture = advisory)
   sharing directed at me          │
   artifact changes (derived, §5)  │
   external ingress (webhooks)     ▼
+Candidate intake (durable, per-source quotas)    §6.1
+  ▼
 Ranker (per-user, trusted single writer)         §6
   folds candidates × policy cells (§7)
   assigns posture; coalesces; writes the ledger
   ── writeAuthorizedBy gate: only the ranker's verified
      module identity may write the canonical ledger ──
-Ledger (per-user, durable, queryable)            §4.4
+Ledger (per-user, durable, queryable)            §4.5
   ▼
 Surfaces (pull-based readers)                    §9
   shell lanes / bell · product views (Today, donut, digest)
@@ -200,23 +235,34 @@ cannot do is write the canonical ledger the shell and OS adapters trust.
 
 ```ts
 // Shown for illustration only.
+// A source-entity version: memory-v2 seq is per-space (a space-global
+// Lamport clock, monotone per entity), so versions are only comparable
+// within the same space. Exposing this to patterns is net-new API (§10.1).
+type EntityVersion = { space: string; seq: number };
+
 type AttentionItem = {
   // Identity — THE load-bearing field. Every surface adapter targets it for
   // replace/retract (iOS UNNotificationRequest.identifier + apns-collapse-id,
-  // Android notify(id), Web Push options.tag). Deterministic:
-  // "<source-system>:<source-key>[:<event-key>]", set by the ranker on first
-  // emission and reused for every replacement.
+  // Android notify(id), Web Push options.tag). Deterministic, and derived by
+  // the RANKER from verified provenance (source space DID + entity id
+  // [+ event key]) — never from candidate-supplied strings, so a hostile
+  // source cannot collide another source's id to hijack coalescing or
+  // OS replace/retract.
   id: string;
 
   // Pointer to the source of truth (a stored cell link, not a query string).
   // The item is the invitation; the source is the truth. Used to evaluate
   // active(), to navigate, and as the key for source-scoped policies.
   source: unknown;            // asCell: ["cell"]
-  // The source entity's memory-v2 seq at emission. Monotone per entity
-  // (space-global Lamport clock — an opaque, comparable token, not a dense
-  // counter). Drives replace, retract, and re-emerge semantics.
-  sourceSeq: number;
-  // Optional grouping key for presentation (one conversation, one task).
+  // Source classification ("group-chat", "importer", "agent-run", ...).
+  // First-class because policy matching (§7) and digest grouping (§9.2)
+  // both key on it.
+  sourceKind: string;
+  // The source entity's version at emission. Drives replace, retract, and
+  // re-emerge semantics.
+  sourceVersion: EntityVersion;
+  // Optional grouping key for presentation (one conversation, one task,
+  // one agent run — see §5 on run-level grouping).
   threadKey?: string;
 
   // Content. Snapshot at emission (title/body) plus the live destination.
@@ -227,16 +273,32 @@ type AttentionItem = {
   // Optional link to prepared material (draft, diff, packet) when it is a
   // different artifact than target.
   prepared?: unknown;         // asCell: ["cell"]
+  // Cross-item displacement: item ids this claim supersedes. A prepared
+  // result displaces the raw occurrence's claim — the ranker terminates the
+  // displaced items (system-on-behalf action) so source and result never
+  // both surface unless each has an independent live claim.
+  displaces?: string[];
 
   // Routing. requestedPosture is advisory input from the source; posture is
   // assigned by the ranker and is the only one surfaces read.
   requestedPosture: "silent" | "review" | "heads-up" | "interrupt";
   posture: "silent" | "review" | "heads-up" | "interrupt";
+  // Intra-rung ordering, ranker-assigned. Opaque; never crosses rungs;
+  // never gates delivery (§4.2).
+  weight?: number;
   // Confidence is orthogonal to posture (§4.2); surfaces may render it.
   confidence?: number;        // 0..1
 
   emittedAt: number;
-  expiresAt?: number;         // time-bound claims retract themselves
+  notBefore?: number;         // embargo: hold materialization until then
+  expiresAt?: number;         // time-bound claims retract themselves —
+                              // evaluate-on-read semantics, see §9.3
+
+  // Opaque product extension. The runtime never interprets it; products
+  // round-trip their own fields (e.g. Loom's why_now, channel,
+  // authorization_state — Appendix A) here instead of smuggling them
+  // into body.
+  ext?: Record<string, unknown>;
 };
 
 // Append-only per-item action log. Replaces {active, dismissed} booleans:
@@ -249,105 +311,149 @@ type AttentionAction = {
   // policy decide e.g. "os-tray dismiss clears that device only".
   surface: string;
   by: string;                 // DID; may be a module identity for
-                              // system-on-behalf actions (auto-expiry)
-  // The sourceSeq the action was taken against. A dismissal tombstones that
-  // seq; if the source advances past it, the item re-emerges and the old
-  // dismissal no longer applies.
-  againstSeq: number;
+                              // system-on-behalf actions (auto-expiry,
+                              // displacement)
+  // The sourceVersion the action was taken against. A dismissal tombstones
+  // that version; if the source advances past it, the item re-emerges and
+  // the old dismissal no longer applies. Comparable only within
+  // sourceVersion.space.
+  againstVersion: EntityVersion;
   payload?: unknown;          // snoozeUntil, acted result, mute scope, ...
+  ext?: Record<string, unknown>; // product extension (e.g. calibration
+                              // feedback like "not-useful")
 };
 ```
 
 Nothing stores `active`, `dismissed`, or `unread` flags. They are **derived,
-pull-evaluated queries** — computed when a surface demands them, per the
-pull-based scheduler's grain (a claim nobody is looking at costs nothing):
+pull-evaluated queries** — computed when a surface demands them:
 
 ```ts
 // Shown for illustration only.
+const sameSpaceGte = (a: EntityVersion, b: EntityVersion) =>
+  a.space === b.space && a.seq >= b.seq;
 const active = (n: AttentionItem) =>
-  currentSeq(n.source) <= n.sourceSeq || stillCurrent(n); // source's call
+  // pull-read of the source's current head version (§10.1); a claim's
+  // currency is the source's call
+  !sameSpaceGte(currentVersion(n.source), advancedPast(n));
 const terminal = (n: AttentionItem, log: AttentionAction[]) =>
   log.some((a) =>
     (a.type === "dismissed" || a.type === "archived" || a.type === "acted") &&
-    a.againstSeq >= n.sourceSeq
+    sameSpaceGte(a.againstVersion, n.sourceVersion)
   );
 const visible = (n: AttentionItem, log: AttentionAction[], now: number) =>
   !terminal(n, log) && active(n) && !snoozedUntil(log, now) &&
+  (n.notBefore === undefined || now >= n.notBefore) &&
   (n.expiresAt === undefined || now < n.expiresAt);
 ```
+
+A caveat on "cheap": pull-based scheduling makes *unobserved* queries free
+(`docs/specs/pull-based-scheduler/README.md`), not observed ones. A mounted
+lane is a live subscription and re-evaluates when its inputs change; §4.5 and
+§10.1 bound how often that happens (conditional seen writes, non-reactive
+version reads by default, seen-state segregated from lane queries).
 
 ### 4.5 Storage
 
 The ledger lives in the **user's home space** (home space DID = user identity
 DID; the established home for durable per-user state, alongside favorites and
-journal — see `docs/common/conventions/HOME_SPACE.md`).
+journal — see `docs/common/conventions/HOME_SPACE.md`). It is **three
+stores with three writer models**, not one:
 
-Recommended storage is a **`sqlite-builtin` database with two tables**
-(`items`, `actions`) declared by the attention pattern
-(`docs/specs/sqlite-builtin/`):
+1. **`items`** — written *only* by the ranker. Backing for phase 1:
+   a **durable array cell carrying the `writeAuthorizedBy` claim**, the
+   mechanism already protecting profile links in production
+   (`docs/common/conventions/HOME_SPACE.md`,
+   `packages/runner/src/cfc/prepare.ts`). Coalescing (same `id`, source
+   advanced) is an in-place element update by the single leased ranker
+   instance (§6.2). This is deliberately *not* sqlite yet: `writeAuthorizedBy`
+   is enforced on the cell-write prepare path and **does not gate
+   `db.exec`** today — sqlite's implemented CFC covers confidentiality
+   ceilings and row-label rules, not write authorization
+   (`docs/specs/sqlite-builtin/06-cfc.md`). Migrating `items` to a sqlite
+   table (better ranking/pagination/retention at volume) is gated on the
+   net-new work item in §10.2, and on giving `items` **its own database**:
+   every `db.exec` serializes on the database handle cell's `rev`, so one
+   shared db cannot hold both a ranker-only table and an
+   everyone-writes table without gating both or neither.
+2. **`actions`** — written by every surface on every device. Backing: a
+   durable array cell appended with **mergeable ops only** (`push`,
+   `addUnique`), so concurrent user actions from two devices merge against
+   durable state instead of clobbering (memory is optimistic-concurrency
+   with path-aware validation, not CRDT — and this design needs no CRDT:
+   the canonical writer is singular per store, and user actions are
+   mergeable appends). The ranker periodically compacts actions for
+   terminal, swept items.
+3. **`seen`** — the seen ledger (§5), highest write rate in the system,
+   ships in phase 0 and gets its own store so its writes never wake lane
+   queries. One mark per (entity), upserted: recommended backing is a small
+   **sqlite database private to seen-state** (upsert-by-key is what SQL is
+   for; no trust gating needed — every surface of the *user's own runtime*
+   may write the user's own marks), with an array-cell fallback. Write
+   discipline is part of the spec, not an optimization: a mark is written
+   **only when it advances** (`newSeq > seenSeq`, so re-renders and repeat
+   views are no-ops — this is also what breaks any render→write→render
+   cycle) and **debounced per focus session** (at most one write per entity
+   per focused open). Retention is trivial — one row per cared-about
+   entity, reaped when the care-relation drops the entity.
 
-- The ledger is append-heavy, queryable, and long-lived — SQL gives
-  filtering, ranking, pagination, and retention sweeps that an array cell
-  makes awkward at volume; `.query<Row>()` reads are reactive.
-- `db.exec` commits atomically with surrounding cell writes, and concurrent
-  writers serialize on the handle cell's `rev` — which *matches* the
-  single-trusted-writer model instead of fighting it.
-- Cell links in rows (`cfLink<T>()` columns) keep `source`/`target`/`prepared`
-  live and navigable.
-- Per-column CFC labels extend the same `ifc` gating to the table.
-- Deterministic ids (already required by §4.4) fit `exec`'s
-  no-`lastInsertRowid` constraint.
+Two rules regardless of backing:
 
-A phase-0 implementation may instead start with a **durable array cell plus
-stream append handlers**, exactly following the favorites/journal precedent
-in `packages/home-schemas/` (`journal.ts`: durable array; `home.ts`:
-`addJournalEntry: { asCell: ["stream"] }` as the append endpoint). Two rules
-carry over regardless of backing:
-
-- **Never model the ledger itself as `asCell: ["stream"]`** — stream cells
+- **Never model a ledger itself as `asCell: ["stream"]`** — stream cells
   are ephemeral (only the marker persists; payloads do not — see
   `docs/specs/space-model/4-cells.md`). Streams are append *endpoints*, not
-  logs.
-- **Never `set()` the whole array.** Concurrent device writes must use the
-  mergeable ops (`push`, `addUnique`, `removeByValue`) so user actions from
-  two devices merge against durable state instead of clobbering. Memory is
-  optimistic-concurrency with path-aware validation, not CRDT — this design
-  needs no CRDT because the ranker is a single canonical writer and user
-  actions are mergeable appends.
+  logs. This matters doubly for ingress: webhook payloads ride an ephemeral
+  stream, so a **receiving handler must persist candidates durably at
+  ingress** — otherwise external candidates arriving while no ranker is
+  live are lost permanently, not delayed (§6.1).
+- **Never `set()` a whole array** that has more than one writer.
 
-Retention: `expiresAt` handles time-bound claims; a periodic sweep reaps
-rows that are terminal with `sourceSeq` below a watermark. Sweeping is a
-ranker duty (it owns the ledger), bounded and boring by design.
+Retention: `expiresAt` handles time-bound claims (evaluate-on-read, §9.3); a
+sweep reaps items that are terminal with `sourceVersion` below a watermark,
+plus their actions. Sweeping is a ranker duty (it owns `items`), bounded and
+boring by design. Because sweeping only reaps *terminal* rows, per-source
+intake quotas (§6.1) are what bound a flooding source, not retention.
 
 ## 5. Seen-state and attention over artifacts
 
 The most common attention event in practice is not "interrupt me" — it is
 "an agent (or another member) did work while I wasn't looking, and I need to
 be able to *see that it happened*". That is not a notification; it is
-seen-state, and the runtime already has almost everything needed.
+seen-state.
 
-**The seen ledger** is one small relation per user: the last `seq` the user
-actually observed, per entity.
+**The seen ledger** is one small relation per user: the last version the
+user actually observed, per entity. "Observed" is defined strictly:
+**seen = focused open** — the user navigated to the entity (or an item whose
+`target` is the entity) and it was the focus of their attention. Scrolling
+past a row in a list is *not* seen; rendering a lane is *not* seen. This
+single definition is load-bearing three ways: it keeps unseen dots honest,
+it keeps disclosed read-receipts meaningful (§8), and it keeps seen writes
+rare (§4.5.3).
 
 ```ts
 // Shown for illustration only.
 type SeenMark = {
   entity: unknown;            // asCell: ["cell"] — the artifact/piece
-  seenSeq: number;            // last observed memory-v2 seq
+  seenVersion: EntityVersion; // last observed version
   at: number;
 };
 ```
 
-Everything else is a query over marks joined against current heads:
+Everything else is a query over marks joined against current heads (which
+requires the version-exposure API, §10.1 — the versions exist in memory-v2;
+reading them from pattern/shell code is net-new):
 
-- `unseen(entity) = head(entity).seq > seenSeq` → change dots on artifacts
-  and their containers (space lists, home). The shell writes a `seen` mark
-  when the artifact is actually viewed.
+- `unseen(entity) = head(entity).seq > seenVersion.seq` (same space) →
+  change dots on artifacts and their containers (space lists, home).
 - **"While you were away"** = all cared-about entities with unseen changes,
-  grouped by space, agent-authored changes flagged (commit attribution says
-  who wrote), ordered by the ranker. Renders as a pattern on the home
+  grouped by space, ordered by the ranker. Renders as a pattern on the home
   context. This is the first-run view and the every-return view — the same
-  query.
+  query. The affordance must answer *what changed, by whom, since you
+  looked* — author and time of the unseen changes, and a jump-in that
+  emphasizes the changed region (memory-v2 holds both versions; the diff is
+  derivable). A bare dot that says "something happened" does not meet the
+  bar (§4.1). Note the *by whom* half is gated on commit attribution
+  exposure (§10.1); until it lands, the view can say what changed but only
+  approximate who.
 - **Artifact lifecycle** falls out of the same two numbers plus a timestamp:
   *fresh* (unseen changes) → *seen* → *stale* (untouched for N) →
   *archived*. No new subsystem.
@@ -360,23 +466,52 @@ but it is the minority path. This is the platform's grain: derived state over
 stored state, and no parallel event journal duplicating what memory-v2's
 commit log already records.
 
+**Run-level grouping.** One agent run touching twelve artifacts must not be
+twelve scattered dots. From phase 1, agent-shaped sources emit one
+receipt-shaped candidate per run (`threadKey` = run id, `displaces` covering
+the per-artifact noise), and "while you were away" groups by `threadKey`
+before space. Phase 0 — dots only — does not have this, which is a stated
+limitation, not an oversight: phase 0 makes agent work *visible*; run-level
+legibility is phase 1's tracked follow-through (§11).
+
 **The care-relation** answers "which entities produce dots at all":
 approximately *touched-recently ∪ agent-did-it-for-you ∪ explicitly-watched*,
-itself tunable by policy. Getting this right is an open question (§11.2);
+itself tunable by policy. Getting this right is an open question (§12.2);
 getting it wrong in the "too broad" direction is the failure mode to avoid
 (dots everywhere = dots nowhere).
 
 ## 6. The ranker
 
 **One logical ranker per user.** It folds candidates and policies into the
-ledger, assigns postures, coalesces (same `id` when the same source object
-advances; same `threadKey` when distinct events share a conversation),
-computes re-emergence, and sweeps retention.
+ledger, assigns postures and weights, coalesces (same `id` when the same
+source object advances; same `threadKey` when distinct events share a
+conversation or run), applies displacement, computes re-emergence, and
+sweeps retention.
 
-**Trust.** The ledger's `items` schema carries a CFC `writeAuthorizedBy`
-claim (the same mechanism that already protects profile links in production —
-see `docs/common/conventions/HOME_SPACE.md` and
-`packages/runner/src/cfc/prepare.ts`). Two viable bindings:
+### 6.1 Candidate intake
+
+Candidates must be **durable before ranking**: the ranker may be asleep or
+absent (interim mode, closed clients), and ephemeral candidates would be
+silently lost, not delayed. Intake shape:
+
+- In-fabric artifact changes need no intake at all — they are derived (§5).
+- Pattern-emitted candidates land in a durable per-source candidate cell in
+  the space where they arise; a small forwarder (part of the emitting
+  pattern's contract) or the user's runtime copies them into a **candidate
+  inbox in the user's home space**, making the ranker's whole world
+  home-space-local (this is also what makes server-side execution viable
+  before cross-space wake exists — §6.3).
+- Webhook ingress: the receiving handler persists the payload durably at
+  ingress (§4.5); the ephemeral stream is transport, not storage.
+- **Per-source quotas** apply at intake (candidates per source per window).
+  Retention only reaps terminal items, so quotas — not retention — are the
+  bound on a flooding source. Quota state feeds the same source-reputation
+  signal as dismiss-without-open.
+
+### 6.2 Trust and instance discipline
+
+The `items` store carries a CFC `writeAuthorizedBy` claim. Two viable
+bindings:
 
 1. **Verified module identity** (recommended): the ranker ships as a pattern
    with a content-addressed module identity; `writeAuthorizedBy` binds to it.
@@ -394,29 +529,43 @@ write the ledger* (module identity matching the claim) are two separate
 checks, and the design uses both — every ranker write is attributable
 `onBehalfOf` the user and provably from the ranker's code.
 
-**Execution.** Where does the ranker run?
+`writeAuthorizedBy` authorizes *code*, not an *instance*: two devices running
+the ranker both pass the claim. The single-writer premise therefore needs
+instance discipline, not just CFC: **the interim client-side ranker takes a
+lease** (a mutex cell claimed with an expiry; the sqlite spec's
+`tryClaimMutex` shape) and only the leaseholder folds. Independent of the
+lease, the fold is specified **idempotent and commutative over the candidate
+inbox** (deterministic ids; coalescing recomputes from source state rather
+than incrementally mutating), so a lease handoff or a brief double-writer
+window degrades to wasted work, not divergence.
+
+### 6.3 Execution
 
 - **Target: the server-primary execution model**
-  (`docs/specs/server-side-execution/`). The ranker is exactly the shape that
-  model's *standing registrations* exist for — work whose value is its
-  effects rather than client-read output — and *wake-on-commit* is its
-  trigger: a commit touching a cared-about entity or candidate stream wakes
-  the worker, the ranker folds, the ledger updates, connected clients see it
-  through the ordinary feed. Execution is attributed `onBehalfOf` the user.
-- **Interim: client-side.** Until standing registrations land, the ranker
-  runs as an ordinary piece while the user has a client open. This degrades
-  gracefully: seen-state and lanes still work (computed on arrival);
-  what's lost is delivery to a *closed* client — which is only needed from
-  phase 2 (§10) anyway.
+  (`docs/specs/server-side-execution/`). With intake home-space-local
+  (§6.1), the ranker is a *standing registration on the user's home space* —
+  work whose value is its effects rather than client-read output — woken by
+  commits to the candidate inbox or cared-about entities' forwarded events.
+  Execution is attributed `onBehalfOf` the user. Named dependencies, since
+  that spec's workers, registrations, and wake-on-commit are all
+  **per-space**: standing registrations are its own later phase; scoped
+  (`PerUser`) state claims are gated (its G16); server-side *cross-space*
+  reads/wake are explicitly deferred there — which is exactly why intake
+  forwards into the home space instead of the ranker reading N spaces.
+- **Interim: client-side, under lease** (§6.2). Until standing registrations
+  land, the leaseholder client runs the ranker as an ordinary piece. This
+  degrades gracefully for in-fabric state (candidates are durable; folding
+  happens on next lease) — what's lost is only *timeliness* while no client
+  is open, which matters from phase 2 (OS delivery) onward and not before.
 - **Not: `background-piece-service` as-is.** It is per-space (the ranker is
   per-user), ~60s polling (the ranker is wake-on-commit shaped), and its own
   README documents async-completion unreliability. If bps is pressed into
   interim service, treat that as scaffolding, not the design.
 
 **Laziness.** The ranker materializes *rows*; it does not keep derived
-predicates hot. `active()`/`visible()` evaluate on surface demand
-(pull-based). The one push-shaped duty is OS delivery (§9.3), which is
-explicitly an edge adapter fed by wake-on-commit, not a hot loop.
+predicates hot. `active()`/`visible()` evaluate on surface demand. The one
+push-shaped duty is OS delivery (§9.3), which is explicitly an edge adapter
+fed by wake-on-commit, not a hot loop.
 
 ## 7. Policies
 
@@ -434,34 +583,45 @@ type AttentionPolicy = {
   };
   effect: {
     postureCap?: "suppress" | "silent" | "review" | "heads-up";
+    // The ONLY path to interrupt: a user-granted floor (§4.2).
     postureFloor?: "review" | "heads-up" | "interrupt";
     coalesceWindowMs?: number;
     quietHours?: { start: string; end: string };
   };
   reason?: string;            // human-legible: why this policy exists
   createdBy: string;          // user DID, or module identity for proposals
+  ext?: Record<string, unknown>; // product dimensions (e.g. stances),
+                              // opaque to the runtime fold
 };
 ```
 
 - Policies live in the user's home space (`PerUser` scope). The core ships a
   handful of defaults: messages-from-humans → `heads-up`;
-  agent-completions → `silent` (visible as seen-state, never buzzing);
-  anything with `expiresAt` sooner than ~1h → eligible for `interrupt`.
+  agent-completions → `silent` (visible as seen-state, never buzzing).
+  There is deliberately **no default that maps any emitter-supplied field to
+  `interrupt`** — deadline-driven interruption ("library book due
+  tomorrow") exists only as a user-adopted policy floor on a named source.
 - **Mute is a policy, not a special relation.** "Mute this thread" writes
   `{match: {threadKey}, effect: {postureCap: "suppress"}}`. The ledger item
   that carried the mute action just records that it happened.
 - **Patterns propose, the user disposes.** A pattern can ship a suggested
   policy with its artifacts ("library book due → heads-up 3 days before");
   adoption goes through a trusted surface, exactly like other user-consented
-  writes. This is where the bespoke 20% lives, and why the ranker doesn't
+  writes — adoption *is* the write, and unadopted proposals never enter the
+  fold. This is where the bespoke 20% lives, and why the ranker doesn't
   have to be perfect: when it mis-lanes something, the fix is a legible
   one-line policy, written by the user or by their agent on request.
-- **Policies are confidential.** "Mute everything from person X" is itself
-  sensitive. Policy cells carry confidentiality labels like any other data;
-  ranker output must not let an observer reconstruct another user's policies
-  (a shared-space member must not be able to detect they've been muted).
-  Rich product-level policy dimensions (e.g. stance vocabularies) layer on
-  top as additional fields the runtime treats as opaque.
+  (Onboarding flows that propose an initial policy set are this same
+  primitive N times, batch-confirmed by a product surface — out of scope
+  here, §Non-goals.)
+- **Policy privacy, honestly stated.** Policy cells are never directly
+  readable by other principals — they are ordinary confidential home-space
+  data. But *behavioral* inference cannot be fully prevented: in a space
+  that discloses read receipts, a muted member's persistent silence is
+  statistically visible to a patient observer. The runtime's guarantee is
+  scoped: no direct exposure, and inference surface bounded by the space's
+  own disclosure policy (§8, §12.5). Ranker *output* ordering/timing is not
+  considered a protected channel in v1.
 
 ## 8. Multi-user
 
@@ -472,21 +632,28 @@ relation" plus existing constraints:
   each member's own ranker lanes it under their own policies. A new message
   can be `interrupt` for the on-call member and `silent` for the member who
   muted the thread. The emitter cannot know or decide this — correctly so.
-- **"Who has seen this" is contributed, not enumerated.** There is no
-  runtime primitive for listing a space's members or reaching into their
-  home spaces (`docs/specs/shared-profile-rosters.md`), and this design does
-  not add one. Shared seen-state follows the roster idiom: members'
-  runtimes write their own seen marks into `PerSpace` state in the shared
-  space — *if* the space's disclosure policy says to. Read receipts,
-  "3 people haven't seen the new plan", presence-of-attention are queries
-  over that contributed state. Disclosure is a per-space policy cell
-  (some spaces want receipts, some don't); a member who discloses nothing
-  simply doesn't appear.
+- **"Who has seen this" — and "who handled this" — is contributed, not
+  enumerated.** There is no runtime primitive for listing a space's members
+  or reaching into their home spaces
+  (`docs/specs/shared-profile-rosters.md`), and this design does not add
+  one. Shared attention state follows the roster idiom: members' runtimes
+  write their own **seen marks and, per disclosure policy, terminal
+  actions** into `PerSpace` state in the shared space — *if* the space's
+  disclosure policy says to. Read receipts, "3 people haven't seen the new
+  plan", and *"Bea already handled this"* are queries over that contributed
+  state. Disclosing terminal actions matters because handling often doesn't
+  touch the source artifact (triaged verbally, replied off-fabric): when the
+  source *is* mutated, everyone's `active()` flips false for free; when it
+  isn't, a disclosed `acted` is the only retraction signal others can get.
+  A per-space opt-in policy — *"acted-by-any-member demotes to `silent` for
+  all"* — turns that signal into collective quiet. Disclosure is a per-space
+  policy cell (some spaces want receipts, some don't); a member who
+  discloses nothing simply doesn't appear.
 - **Escalation across people is a policy.** "If nobody attends to this
   within 2h, raise it to `heads-up` for the space owner" is a policy cell on
   the shared space, evaluated by the owner's ranker against contributed
-  seen-state. No siloed notification system can express this; here it is
-  one record.
+  state. No siloed notification system can express this; here it is one
+  record.
 
 ## 9. Surfaces
 
@@ -501,18 +668,24 @@ experience. Concretely:
   `review` (digest entry point), `silent` (dots via seen-state, §5);
 - unseen-change dots on artifacts and containers;
 - a snoozed lane (snoozed items must stay discoverable);
-- every render of an item is also the write-path for `seen` actions.
+- **focused opens** — not renders — write `seen` (an `AttentionAction` for
+  the item, a `SeenMark` for its target entity), under §4.5's
+  advance-only + debounced discipline. Rendering a lane never writes.
 
 Presentation components exist (`cf-toast`/`cf-toast-provider`, `cf-alert`,
 badge conventions); the net-new work is mounting them against ledger
-queries.
+queries. One CFC note for badge counts: aggregates over a rule-bearing
+store refuse unless every row is readable by the counting principal —
+for a home-space ledger this holds as long as item rows' clauses always
+include the owner; state that invariant in the schema rather than
+discovering it when someone adds a per-row rule.
 
 ### 9.2 Digests
 
 A digest is **bounded history, not a feed**: a periodic artifact-shaped
 summary over the ledger and seen-state — quiet dispositions, artifact
-updates, prepared material, grouped by class — rendered by a pattern. The
-runtime contribution is only that the queries behind it (terminal items
+updates, prepared material, grouped by `sourceKind` — rendered by a pattern.
+The runtime contribution is only that the queries behind it (terminal items
 since T, unseen changes since T, actions by surface) are cheap and complete.
 Whether a digest's *summary* may itself claim `heads-up` is a policy
 decision, default no.
@@ -526,10 +699,18 @@ there:
 
 - **Replace/retract rides `id`** everywhere: iOS
   `UNNotificationRequest.identifier` / `apns-collapse-id`, Android
-  `notify(id)`, Web Push `options.tag`. When `visible()` flips false, the
-  dispatcher retracts on every delivered surface. iOS replaces but does not
-  tick (text refreshes when the shade reopens); genuinely-live claims are a
-  Live Activities track, explicitly out of V1.
+  `notify(id)`, Web Push `options.tag`. When `visible()` flips false *on
+  evaluation*, the dispatcher retracts on every delivered surface. Two
+  honesty notes. First, `visible()` is evaluated on commit-driven wakes and
+  on read — **nothing wakes anything at `expiresAt`**: server-side timers
+  don't exist yet (they are "(Future)" in
+  `docs/specs/server-side-execution/`), so an expired item may linger on an
+  OS tray until the next wake or app-open re-evaluates it. Timer
+  registrations that feed the dispatcher are named net-new work (§10.4);
+  until they land, `expiresAt` is evaluate-on-read with explicitly stale OS
+  surfaces. Second, iOS replaces but does not tick (text refreshes when the
+  shade reopens); genuinely-live claims are a Live Activities track,
+  explicitly out of V1.
 - **Two transports, not one.** Browser/PWA: Web Push (VAPID + service
   worker). Wrapped mobile apps: native APNs/FCM via the wrapper's plugin —
   embedded webviews do not get Web Push. The server side (toolshed) needs a
@@ -544,58 +725,134 @@ there:
   action with `surface: "os-tray"`; whether it terminates the item globally
   is policy (default: clears that device only; the shell is canonical).
 
-## 10. Phasing
+## 10. Net-new runtime surface
+
+This design mostly composes existing primitives, but not entirely. Naming
+the gaps is the point of this section — each is a prerequisite of the phase
+that first needs it (§11), and each needs its own (small) design pass.
+
+1. **Version exposure** *(phase 0)*. Patterns and the shell currently cannot
+   read an entity's memory-v2 head `seq` — the `Cell` interface exposes no
+   version, deliberately. Seen-state needs: (a) a **non-reactive** per-entity
+   head-version read (non-reactive by default is essential — a reactive seq
+   read re-fires on every change, exactly what seen writes must not do);
+   (b) a *changed-since(version)* enumeration over a set of cared-about
+   entities for "while you were away"; (c) eventually, commit-attribution
+   exposure (who wrote) — memory-v2 reserves `invocationRef` /
+   `authorizationRef` for a later signed-write pass, so phase 0's "by whom"
+   is approximate until that lands. CFC story required: observing a head
+   version reveals *that* activity occurred; version reads must be gated by
+   the same read authority as the entity itself.
+2. **Write-authorization for sqlite** *(pre-migration of `items` to sqlite;
+   not needed for phase 1's array-cell backing)*. `writeAuthorizedBy` is
+   enforced on the cell-write prepare path only; `db.exec` today checks
+   confidentiality ceilings and row-label rules but not write authorization.
+   Gating `db.exec` per database handle (the `rev` bump is a cell write, so
+   the prepare path sees it) needs specification and a security review of
+   its own, including whether any sqlite write path bypasses the rev write.
+3. **Ranker lease** *(phase 1)*. A small mutex-cell convention (claim with
+   expiry, renew, steal-on-expiry) for single-instance election of the
+   interim client-side ranker (§6.2). Generalizes beyond attention.
+4. **Timer wake** *(phase 2+)*. Executor-pool timer registrations
+   (`notBefore`, `expiresAt`, snooze expiry, digest cadence) feeding
+   wake-on-commit's machinery, so time-driven transitions don't depend on
+   coincidental commits. Until then: evaluate-on-read, stale OS surfaces
+   acknowledged (§9.3).
+5. **Push transports** *(phase 2/3)*. Web Push then APNs/FCM: device
+   registration, delivery ledger, retraction dispatch (§9.3). Net-new but
+   conventional.
+
+## 11. Phasing
 
 Each phase is independently shippable and none re-shapes the data model.
 
-- **Phase 0 — seen-state.** The seen ledger (§5), unseen dots in the shell,
-  and a "while you were away" home pattern. No ranker, no candidates, no
-  push. This alone makes agent work legible — the single most-requested
-  product gap — and exercises the exact relation everything else builds on.
-- **Phase 1 — ledger + lanes.** Envelope, home-space ledger, a minimal
-  client-executed ranker (defaults + mute + posture caps), shell bell/lanes,
-  candidate emission for non-artifact sources. Policies v0.
+- **Phase 0 — seen-state.** The seen ledger (§5) with its write discipline
+  (§4.5.3), unseen dots in the shell, and a "while you were away" home
+  pattern. Requires version exposure (§10.1). No ranker, no candidates, no
+  push. Acceptance bar: the user can see *what changed and since when* (by
+  whom, to the extent §10.1c allows), and jump in with the changed region
+  emphasized — not merely that a dot exists. This makes agent work
+  **visible** — the single most-requested product gap — while run-level
+  *legibility* (one claim per agent run, not twelve dots) is explicitly
+  phase 1's follow-through.
+- **Phase 1 — ledger + lanes.** Envelope, home-space `items` (array cell +
+  `writeAuthorizedBy`) and `actions` stores, candidate inbox with quotas
+  (§6.1), a minimal client-executed ranker under lease (defaults + mute +
+  posture caps/floors + displacement), shell bell/lanes, receipt-shaped
+  candidates for agent runs. Policies v0.
 - **Phase 2 — server ranker + first transport.** Ranker as a standing
-  registration under server-primary execution (wake-on-commit); Web Push
-  with device registration and retraction; digest queries.
+  registration on the home space under server-primary execution
+  (dependencies named in §6.3); Web Push with device registration and
+  retraction; digest queries; timer wake (§10.4).
 - **Phase 3 — breadth.** Wrapped-app APNs/FCM; full action vocabulary
-  (snooze/archive surfaced); shared seen-state + escalation policies;
+  (snooze/archive surfaced); shared seen-state + disclosed terminal actions
+  + escalation policies (§8); `items` on sqlite once §10.2 lands;
   coalescing refinements. Live Activities remain a separate track.
 
-## 11. Open questions
+## 12. Open questions
 
-1. **Ranker trust binding.** Verified module identity is recommended (§6),
+1. **Ranker trust binding.** Verified module identity is recommended (§6.2),
    but the "wholly-system service" alternative keeps resurfacing; if the
    server executor itself writes the ledger, is that a builtin identity, and
    does that preempt user-forkable rankers? Resolve before phase 1.
 2. **The care-relation.** Which entities produce seen-state dots (§5)?
    Touched ∪ agent-authored ∪ watched is the working answer; validate
    against real spaces before hardening, and decide whether "touched" decays.
-3. **Ledger backing for phase 1.** sqlite tables (recommended) vs array
-   cells (journal precedent). If array cells ship first, define the
-   migration to sqlite before volume forces it.
-4. **Seen-mark write amplification.** Naive per-view marks write on every
-   artifact open, from every device. Batch/debounce policy, and whether
-   marks for low-value views are worth persisting at all.
-5. **Disclosure defaults** for shared seen-state (§8): receipts on or off by
-   default, and what the non-disclosing member's absence reveals.
+3. **Forwarder contract.** §6.1 makes intake home-space-local via
+   forwarders. Who runs them (the emitting pattern? the user's runtime on
+   visit?), and what happens for spaces the user hasn't opened in weeks?
+4. **Seen-mark granularity.** Per-entity marks are the floor. Do container
+   views (a space list showing N dots) warrant container-level marks, and
+   does "seen the container" imply anything about members?
+5. **Disclosure defaults** for shared seen-state and terminal actions (§8):
+   receipts on or off by default, what the non-disclosing member's absence
+   reveals, and how much of §7's policy-privacy bound this sets.
 6. **Policy expressiveness boundary.** V1 is plain predicates. Content
    regexes and LLM-judged predicates ("only interrupt if actually urgent")
    are clearly coming — as ranker inputs they inherit the ranker's authority,
    so they need their own integrity story before admission.
-7. **Coalescing.** Same `id` vs same `threadKey` heuristics; sub-object
-   edge cases (a thread whose items have their own lifecycles).
-8. **`seq` across spaces.** `sourceSeq` is per-space; items whose source
-   lives in a different space than the ledger need the pair (space, seq).
-   Confirm the envelope treats `sourceSeq` as opaque-with-provenance rather
-   than globally comparable.
+7. **Coalescing.** Same `id` vs same `threadKey` heuristics; displacement
+   chains (a prepared result displacing an item that itself displaced);
+   sub-object edge cases (a thread whose items have their own lifecycles).
+8. **Cross-space lane cost.** A rendered lane is a ledger query plus N
+   cross-space source reads (per-item `active()`), each through the user's
+   ordinary session against the source space. Fine at dozens; model the
+   cost before hundreds, and decide how stale a lane's `active()` may be.
 9. **Digest self-promotion.** May a digest claim `heads-up` on a schedule
    (§9.2)? Leaning policy-gated, default off.
 10. **Convergence with product stores.** Loom currently materializes
     attention candidates in product-local storage with localStorage
-    seen-timestamps. Define the migration: product candidates become
-    candidates into this pipeline; localStorage dots become seen-ledger
-    reads.
+    seen-timestamps. Appendix A is the field mapping; the remaining
+    question is sequencing — which loom surface adopts the runtime ledger
+    first, and whether loom's materializer becomes the trusted source or a
+    second ranker (§Division of labor says: trusted source).
+
+## Appendix A — mapping Loom's `attention-candidate-v1`
+
+For the first consumer's adoption review. Loom fields → envelope:
+
+| Loom candidate field | Envelope home |
+|---|---|
+| `id` / source identity | `id` (re-derived by ranker from verified provenance) |
+| subject / focused target | `target` (cell link); `focused_view_fallback` → `ext` |
+| prepared material | `prepared` |
+| `title`, body copy | `title`, `body` |
+| `why_now` | `ext.why_now` (product copy, runtime-opaque) |
+| `claim_kind` (act-now / review / notice / …) | `sourceKind` + `requestedPosture` (kind is classification; posture is the loudness request derived from it) |
+| `channel` (important-and-urgent / yours-in-progress / might-interest-you) | `ext.channel` — audience/genre, orthogonal to posture; product lanes render it |
+| `relation_to_trigger: supersedes` | `displaces` |
+| other `relation_to_trigger` values | `ext.relation_to_trigger` |
+| `authorization_state` (proposal-required / …) | `ext.authorization_state` — the "needs your approval" affordance is product chrome; posture only governs loudness |
+| `authority_class` | `ext` (work-start domain, product-side per §Division of labor) |
+| `not_before` | `notBefore` |
+| delivery/interrupt eligibility | `requestedPosture`, capped/floored by user policy (§7) |
+| feedback: done / later | actions `acted` / `snoozed` |
+| feedback: never-for-this-class | a policy write (`postureCap`) via the trusted surface |
+| feedback: not-useful | action `dismissed` + `ext.feedback: "not-useful"` (calibration signal round-trips to the product) |
+
+Not mapped, deliberately: Work-start Policies, continuity owners, typed
+receipts' internals, stance vocabularies — upstream product machinery
+(§Division of labor). A receipt *summary* enters as an ordinary candidate.
 
 ## References
 
@@ -603,18 +860,23 @@ Each phase is independently shippable and none re-shapes the data model.
   `docs/common/conventions/HOME_SPACE.md` — multi-user substrate; the
   contribute-your-own idiom; `writeAuthorizedBy` in production.
 - `docs/specs/server-side-execution/README.md` — standing registrations,
-  wake-on-commit, `onBehalfOf` attribution (ranker execution home).
+  wake-on-commit, `onBehalfOf` attribution (ranker execution home; §6.3
+  names this spec's dependencies on it).
 - `docs/specs/memory-v2/` (esp. `01-data-model.md`, `03-commit-model.md`,
   `08-conflict-granularity.md`) — `seq`, optimistic concurrency, mergeable
-  ops.
-- `docs/specs/sqlite-builtin/` — recommended ledger backing.
+  ops, reserved commit-attribution fields.
+- `docs/specs/sqlite-builtin/` (esp. `05-reactivity.md`, `06-cfc.md`) —
+  seen-ledger backing; why trust-bearing tables wait on §10.2; `reactOn`
+  coarseness; the rev-serialized write path.
 - `docs/specs/space-model/4-cells.md` — stream-cell ephemerality.
-- `docs/specs/pull-based-scheduler/README.md` — demand-driven evaluation.
-- `docs/specs/webhook-ingress/README.md` — external candidate ingress.
+- `docs/specs/pull-based-scheduler/README.md` — demand-driven evaluation
+  (and its limits for observed queries, §4.4).
+- `docs/specs/webhook-ingress/README.md` — external candidate ingress
+  (durable persistence at the handler required, §6.1).
 - `packages/home-schemas/` (`journal.ts`, `favorites.ts`, `home.ts`) — the
   durable-array + stream-append precedent and stable-key discipline.
 - `packages/runner/src/cfc/prepare.ts`, `packages/runner/src/cfc/ui-contract.ts`
-  — `writeAuthorizedBy` enforcement; trusted surfaces.
+  — `writeAuthorizedBy` enforcement (cell-write path); trusted surfaces.
 - `packages/runner/src/builtins/navigate-to.ts`,
   `docs/common/conventions/wish.md` — navigation from stored cell links;
   well-known targets.

--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -19,11 +19,12 @@ in-flight attention framework and Pond's spatial shell are the first intended
 consumers; this spec defines the runtime primitives their product surfaces
 should compile onto, so each stops hand-rolling its own attention state
 (Appendix A maps Loom's candidate shape onto the envelope; Appendix B walks
-four stress-case user stories). Derived from the 2026-05-21
+fourteen stress-case user stories). Derived from the 2026-05-21
 multi-user/notifications design sessions and the 2026-07 attention reframe;
-revised 2026-07-12 across three adversarial review rounds (runtime + product;
+revised 2026-07-12 across four adversarial review rounds (runtime + product;
 Android-as-gold-standard + primitive-shape + parsimony; user-story grading +
-naming ergonomics).
+naming ergonomics; a second story round that re-verified fixes and added
+first-contact, catch-up, profile, and cold-start coverage).
 
 ## Last Updated
 
@@ -614,9 +615,11 @@ const visible = (
 
 Notices that should outlive observation (a todo is not done because you
 looked at it; a medication reminder must nag) are handled deliberately, not
-by the runtime guessing which glances "count": the source re-posts at a
-newer version when it is meaningfully newsworthy again, and a user-adopted
-`realert` policy (§7) governs whether re-emergence may make sound.
+by the runtime guessing which glances "count": a user-adopted `realert`
+policy (§7) **exempts matched notices from seen-satisfaction entirely** —
+they clear only on a terminal disposition, never because the user glanced
+at the subject — and the source re-posts at a newer version when it is
+meaningfully newsworthy again (content escalation, not liveness).
 Satisfaction that doesn't involve the user looking (someone else handled it;
 the trip ended) is the steward's job: its fold observes the subject change and
 terminally retracts the notice (system disposition by module identity).
@@ -696,7 +699,10 @@ Two rules regardless of backing:
 Retention: the steward's sweep terminally retracts expired notices (system
 disposition — this is the *one* expiry mechanism; `visible()`'s expiry check
 is the read-side shadow of it, so an expired notice is hidden immediately
-and reaped eventually) and reaps notices that are terminal with
+and reaped eventually), **ages the bell** — unhandled `heads-up` notices
+older than N days (default 7; realert-matched notices exempt) demote to
+`review` as a posture transition, so a long absence returns to a digest,
+not a wall of stale urgency — and reaps notices that are terminal with
 `subjectVersion` below a watermark, plus their dispositions. Sweeping is an
 steward duty (it owns the ledger), bounded and boring by design. Because
 sweeping only reaps terminal rows, per-source intake quotas (§6.1) are what
@@ -740,7 +746,8 @@ VISIBLE --steward: subject satisfied / thread displaced / expiry sweep
          (system disposition)--> TERMINAL
 VISIBLE --user: snoozed--> SNOOZED --until--> VISIBLE
 VISIBLE --seen mark on subject reaches subjectVersion--> SATISFIED
-         (hidden; no disposition row — pure join)
+         (hidden; no disposition row — pure join; does NOT apply to
+         realert-matched notices, which clear only terminally, §7)
 VISIBLE --now ≥ expiresAt--> hidden immediately (read-side),
          TERMINAL at next sweep (write-side)
 TERMINAL --steward coalesce advances subjectVersion past tombstone-->
@@ -946,7 +953,16 @@ steward code**:
 type AttentionPolicy = {
   match: {
     subject?: unknown;        // asCell: ["cell"] — a specific source/thread
-    kind?: string;            // as bound by the steward, §4.4
+    // Verified actor identity (DID). THE dimension for interrupt-bearing
+    // floors: "messages from this person/number → heads-up". Steward-
+    // verified, unlike kind.
+    actor?: string;
+    kind?: string;            // as bound by the steward, §4.4 — but note:
+                              // self-declared at first posting, so an
+                              // interrupt-bearing min matched on kind is
+                              // first-declaration-spoofable by a NEW
+                              // source; bind alert floors to actor,
+                              // subject, or spaceDid instead
     spaceDid?: string;
     threadKey?: string;
   };
@@ -958,14 +974,18 @@ type AttentionPolicy = {
     // Exempts this policy's min from quiet-hours clamping (the babysitter
     // thread breaks through). User-authored only.
     bypassQuietHours?: boolean;
-    // Nag-until-done: while a matching notice is visible and unhandled,
-    // re-alert on this cadence — the SINGLE sanctioned exception to
-    // §9.3's alert-once rule. User-authored only; needs timer wake
-    // (§10.5) to fire between commits.
+    // Nag-until-done: a matched notice is EXEMPT from seen-satisfaction —
+    // it clears only on a terminal disposition (acted/dismissed/archived),
+    // never because the user glanced at the subject — and re-alerts on
+    // this cadence while live. One of the two consented exceptions to
+    // §9.3's alert-once rule. User-authored only; the cadence needs timer
+    // wake (§10.5) to fire between commits.
     realert?: { everyMs: number };
     coalesceWindowMs?: number;
-    // Time-conditional clamp sugar: during these hours, max = "review".
-    quietHours?: { start: string; end: string };
+    // Time-conditional clamp sugar: during these hours/days, apply
+    // `max` (default "review"). days omitted = every day.
+    quietHours?: { start: string; end: string; days?: string[];
+                   max?: "suppress" | "silent" | "review" };
     watch?: boolean;          // extend/prune the watch set (§5)
   };
   reason?: string;            // human-legible: why this policy exists
@@ -975,23 +995,42 @@ type AttentionPolicy = {
 };
 ```
 
-**Composition is one formula.** Effective posture =
+**Composition is one formula, with a hard ceiling.** Effective posture =
 `clampScale(baseline, max(matching mins), min(matching maxes))` where
-`baseline` is the posture hint bounded by the source's learned baseline;
-**maxes dominate mins** on conflict, with one exception — a user-authored
-min marked `bypassQuietHours` survives the quiet-hours max. `quietHours` is
-defined as nothing more than a time-conditional `max: "review"`. The
-canonical case — "quiet hours 22:00–07:00, but the babysitter thread always
-breaks through" — is two records and zero ambiguity.
+**`baseline = min(postureHint, "review")`**, further bounded by the
+source's learned baseline. The ceiling is load-bearing: absent it, a
+brand-new source with no learned history and no matching max would get
+whatever it hinted — the exact cold-start hole §4.2 forbids. As written,
+no notice exceeds `review` unless a *policy min* raises it, and mins above
+`review` are user-authored only (shipped defaults and learned policies
+never set them). **Maxes dominate mins** on conflict, with one exception —
+a user-authored min marked `bypassQuietHours` survives the quiet-hours
+max. `quietHours` is defined as nothing more than a time-conditional max
+(default `"review"`; `days` scopes it — "work sources suppressed on
+weekends" is `{quietHours: {start: "00:00", end: "24:00", days:
+["sat","sun"], max: "suppress"}}`). The canonical case — "quiet hours
+22:00–07:00, but the babysitter thread always breaks through" — is two
+records and zero ambiguity.
 
 - Policies live in the user's home space (`PerUser` scope). The core ships a
   handful of defaults: messages from **verified human actors with an
-  established relationship** (rosters, prior threads) → `heads-up`;
+  established relationship** (rosters, prior threads — and rosters are
+  seeded by contact import at onboarding, so this default works on day
+  one, not after weeks of thread history) → `heads-up`; **first contact
+  from a verified human actor with no established relationship** →
+  `review`, grouped in a distinguished **requests** shelf (the
+  message-requests idiom), quota-bounded per source, where the notice
+  carries a one-tap promote affordance that writes `{match: {actor},
+  clamp: {min: "heads-up"}}` through the trusted surface — legitimate
+  strangers (the marketplace buyer, the new-school-year parent) are
+  distinguishable from importer noise without being handed loudness;
   agent-completions → `silent` (visible as seen-state, never buzzing). Per
-  §4.2, shipped defaults above `review` key on steward-verified facts only —
-  never on self-declared `kind` (declaring `kind: "group-chat"` must not
-  buy the human-messages baseline). There is deliberately **no default
-  that maps any emitter-supplied field to `interrupt`**.
+  §4.2, shipped defaults above `silent` key on steward-verified facts only
+  — never on self-declared `kind` (declaring `kind: "group-chat"` must not
+  buy the human-messages baseline; "first contact from a verified human"
+  is verifiable — DID checked, roster/thread absence checked). There is
+  deliberately **no default that maps any emitter-supplied field to
+  `interrupt`**.
 - **Mute is a policy, not a special relation** (and not a disposition).
   "Mute this thread" writes `{match: {threadKey}, effect: {clamp: {max:
   "suppress"}}}`; the re-fold rule (§4.7) demotes existing notices too.
@@ -1003,11 +1042,18 @@ breaks through" — is two records and zero ambiguity.
   these policies unaided:
   - **The emergency pack.** Nobody writes an interrupt floor for their
     kid's school until the day it's too late. Products should propose a
-    small break-glass set at onboarding (school/daycare numbers, smoke/CO
-    alerts, bank-fraud kinds) — `{clamp: {min: "interrupt"},
-    bypassQuietHours: true}` per source — through this same adopt flow.
-    The runtime's part: those adopted policies compile to the OS's
-    highest available interruption level (§9.3's reserved mapping).
+    small break-glass set at onboarding — school/daycare numbers and
+    alarm/fraud *sources* — as `{match: {actor | subject | spaceDid},
+    clamp: {min: "interrupt"}, bypassQuietHours: true}` through this same
+    adopt flow. Bind these floors to **verified identities** (`actor`,
+    `subject`, `spaceDid`), never to `kind`: a kind-matched interrupt
+    floor is first-declaration-spoofable by any new source that declares
+    the magic kind. The runtime's part: those adopted policies compile to
+    the OS's highest available interruption level (§9.3's reserved
+    mapping). Honest residual: an emergency from a source the user never
+    adopted and doesn't know lands at `review` (first-contact shelf at
+    best) — the price of the inversion, which the pack exists to shrink,
+    not erase.
   - **The deadline ladder.** Long-lived obligations post their whole
     escalation ladder ahead of time: three candidates with `notBefore` =
     T-90/T-30/T-7, same `threadKey` (each new admission displaces the
@@ -1080,6 +1126,18 @@ relation" plus existing constraints:
   transition rule makes it alert exactly once. Deadline-shaped escalation —
   "nobody acted" produces no commits — needs timer wake, §10.5.)
 
+**Profiles.** A user with multiple profiles (work, personal) has one
+attention system *per profile*: profile ≡ its own space graph ≡ its own
+home space, so attention state, policies, steward, and learned baselines
+are independent per profile by construction — nothing new to build, and no
+cross-profile leakage to prevent (a work source cannot learn it's quiet on
+the personal profile because it never met the personal profile). Merging
+the two into one device's shell — one bell over N profiles' lanes — is a
+shell/product presentation concern over N independent ledgers, not a
+runtime concept. Context separation *within* one profile ("work spaces
+quiet on weekends") is ordinary policy: `spaceDid`-matched `quietHours`
+with `days` and a `max` of choice (§7).
+
 ## 9. Surfaces
 
 ### 9.1 Shell
@@ -1128,15 +1186,25 @@ there:
   coalesce — new message in the thread, progress tick, content refresh —
   **replaces silently** on every surface (Android `setOnlyAlertOnce`
   semantics, made unconditional: the emitter cannot choose to re-buzz).
-  The **single sanctioned exception** is a user-authored `realert` policy
-  (§7): while a matching notice is visible and unhandled, it re-alerts on
-  the policy's cadence — nag-until-done for medication-grade obligations,
-  grantable only by the user, so the alert-once invariant bends only where
-  its owner says so. Posture *demotion* and visibility flips are
-  retraction triggers: the dispatcher retracts or downgrades the delivered
-  surface when either occurs. Without the base rule a coalescing thread
-  would legally buzz on every advance — louder than Android, inverting the
-  spec's promise.
+  The invariant bends in exactly **two consented ways**, both bounded by
+  user grants: a user-authored `realert` policy (§7) re-alerts a live
+  matched notice on its cadence and exempts it from seen-satisfaction —
+  nag-until-done for medication-grade obligations, grantable only by the
+  user; and a *fresh* notice (new event key, new `id`) first materializing
+  at an alert-bearing rung alerts — which means a source holding a
+  user-granted floor can alert once per genuinely new event, bounded by
+  intake quotas (§6.1) and revocable by editing the floor. Name that
+  honestly: alert-once is per-*notice*; per-*source* alert frequency is
+  governed by quotas plus the user's grant, not by the coalesce rule.
+  Posture *demotion* and visibility flips are retraction triggers: the
+  dispatcher retracts or downgrades the delivered surface when either
+  occurs. And on device (re)registration after an offline gap, the
+  dispatcher **damps the backlog**: it alerts only for notices newer than
+  the gap start (newest per thread); older live notices land silently in
+  lanes — the delivery log already records what was never delivered, so
+  "returning from vacation" is a quiet catch-up, not a buzz storm.
+  Without the base rule a coalescing thread would legally buzz on every
+  advance — louder than Android, inverting the spec's promise.
 - **Break-glass compiles to the platform's ceiling.** A user-adopted
   `{clamp: {min: "interrupt"}, bypassQuietHours: true}` policy (the
   emergency pack, §7) maps to the highest interruption level the platform
@@ -1329,6 +1397,12 @@ Each phase is independently shippable and none re-shapes the data model.
 11. **`realert` bounds.** Minimum cadence, maximum duration, and whether a
     realert policy requires re-confirmation after N fires — the exception
     to alert-once must not become a resharpened nag machine (§7, §9.3).
+12. **Ingress-actor verification.** The first-contact default and the
+    emergency pack both bind to verified `actor` identities — but an actor
+    arriving via external ingress (an SMS number, an email address) is not
+    a fabric DID. What vouches an ingress identity into "verified human"
+    (importer attestation? user confirmation on first sight?) decides how
+    much of B.1 and B.11 external sources can actually reach.
 
 ## Appendix A — mapping Loom's `attention-candidate-v1`
 
@@ -1360,19 +1434,22 @@ receipts' internals, stance vocabularies — upstream product machinery
 (§Division of labor); stance policies compile down to plain clamps/watches
 (§7). A receipt *summary* enters as an ordinary candidate.
 
-## Appendix B — ten worked stories
+## Appendix B — fourteen worked stories
 
-Ten deliberately diverse stress cases from the user-story review, each
-walking the mechanism end to end, with honest grades: **fully built**
-(phase 3) and **phase 1 reality**. The pattern in the grades is itself a
-finding: stories whose essence is *time* or *other people* are phase-gated
-on timer wake (§10.5) and push (§10.6); stories derivable from state the
-user already holds are strong almost immediately.
+Fourteen deliberately diverse stress cases from two rounds of user-story
+review, each walking the mechanism end to end, with honest grades: **fully
+built** (phase 3) and **phase 1 reality**. Grades were adversarially
+re-verified against the spec *as revised* — where a fix earned a grade, the
+fix is in the spec, and where a story still fails, the failure is stated.
+The pattern in the grades is itself a finding: stories whose essence is
+*time* or *other people* are phase-gated on timer wake (§10.5) and push
+(§10.6); stories derivable from state the user already holds are strong
+almost immediately.
 
 | # | Story | Axis | Fully built | Phase 1 |
 |---|---|---|---|---|
-| B.1 | School emergency | must-interrupt, novel source | B− (with §7 pack + §9.3 reserved mapping) | F (no push) |
-| B.2 | Medication | seeing must not satisfy | B+ (with `realert`) | D (no timer wake) |
+| B.1 | School emergency | must-interrupt, novel source | B− (actor-bound pack + reserved mapping; honest residual = `review`) | F (no push) |
+| B.2 | Medication | seeing must not satisfy | A− (`realert` = terminal-only satisfaction) | D (no timer wake) |
 | B.3 | On-call triage | multi-user coordination | A− | D (shared state is phase 3) |
 | B.4 | Overnight agent run | quiet agent work | A | A− |
 | B.5 | 2FA code | time-critical, brief | B | B− |
@@ -1381,6 +1458,10 @@ user already holds are strong almost immediately.
 | B.8 | Approve rebooking | act from the surface | A− | B (shell only) |
 | B.9 | Visa renewal | long-lived deadline ladder | B | C+ (evaluate-on-read only) |
 | B.10 | Adversarial source | spam defense | A− | A− |
+| B.11 | Marketplace stranger | first contact, unknown human | B+ (requests shelf + promote) | B− (shell only) |
+| B.12 | Return from vacation | bulk catch-up boundedness | B (aging + reconnect damping) | B− |
+| B.13 | Work/personal split | context separation | B (per-profile state + day-scoped quietHours) | B− |
+| B.14 | Day-one cold start | defaults before any learning | B− (ceiling + roster seeding) | C+ |
 
 ### B.1 The school emergency (must-interrupt, novel source)
 
@@ -1391,35 +1472,46 @@ by definition doesn't exist for a first-time source. The design's answer is
 two-part, and honest about its limits: (1) the **emergency pack** (§7) —
 onboarding proposes break-glass floors for school/daycare/alarm/fraud
 sources at the moment the user is thinking about setup, via the ordinary
-propose/adopt flow; (2) the **reserved break-glass mapping** (§9.3) — that
-adopted policy compiles to the OS's highest granted interruption level,
-upgrading to `time-sensitive`/`critical` when entitlements land, with no
-policy migration. What the design will *not* do is let the message's own
-urgency raise its posture — that lever, once granted to emergencies, is
-granted to everyone claiming to be one. Residual risk: an emergency from a
-source the user never adopted lands at the verified-human-messages
-`heads-up` default — loud enough to be present, not loud enough to break
-Focus. That residual is the honest price of the inversion, and the
-emergency pack exists to shrink it.
+propose/adopt flow, **bound to verified identities** (`match.actor` /
+`subject` / `spaceDid` — never spoofable `kind`); (2) the **reserved
+break-glass mapping** (§9.3) — that adopted policy compiles to the OS's
+highest granted interruption level, upgrading to
+`time-sensitive`/`critical` when entitlements land, with no policy
+migration. What the design will *not* do is let the message's own urgency
+raise its posture — that lever, once granted to emergencies, is granted to
+everyone claiming to be one. The residual, stated without varnish: an
+emergency from a source the user never adopted and has no relationship
+with lands at **`review`** (the first-contact requests shelf if it's a
+verified human; §7) — a full miss until the next check-in. That is the
+price of the inversion; the pack exists to shrink it, and how an
+SMS-ingress phone number gets verified as a known actor at all is open
+question §12.12.
 
 ### B.2 The medication reminder (seeing must not satisfy)
 
 Elena must take tacrolimus by 9pm; a glance must not silence the reminder.
-Three mechanisms compose: the med pattern re-posts as the deadline nears
-(fresh event key, same `threadKey` — each rung displaces the last); her
-one-time adopted policy carries `{clamp: {min: "interrupt"},
-bypassQuietHours: true, realert: {everyMs: 600_000}}` — `realert` being the
-single user-grantable exception to alert-once (§9.3); logging the dose
-advances the subject artifact, and the steward terminally retracts every
-pending rung, including embargoed ones (§4.7). Phase gating is real: cadence
-firing between commits needs timer wake (§10.5) — before phase 2 this story
-is not safely servable and products should not pretend otherwise.
+Her one-time adopted policy carries `{clamp: {min: "interrupt"},
+bypassQuietHours: true, realert: {everyMs: 600_000}}`, and `realert` does
+the whole job on its own: a matched notice is **exempt from
+seen-satisfaction** — glancing at the reminder does not clear it; only a
+terminal disposition (logging the dose → `acted`, or an explicit dismiss)
+does — and it re-alerts on the cadence while live (§7, §9.3). The med
+pattern may still re-post as the deadline nears (fresh event key, same
+`threadKey`, each rung displacing the last), but that is *content
+escalation* ("30 minutes left"), not liveness — the nag no longer depends
+on the source's own timer discipline. Logging the dose advances the
+subject artifact and the steward terminally retracts every pending rung,
+including embargoed ones (§4.7). Phase gating is real: the cadence firing
+between commits needs timer wake (§10.5) — before phase 2 this story is
+not safely servable and products should not pretend otherwise.
 
 ### B.3 On-call triage (exactly one person must act)
 
 A pager event lands in a three-person ops space at 11pm. Each on-call
-member's rotation adopted `{match: {kind: "pager"}, clamp: {min:
-"interrupt"}, bypassQuietHours: true}`. Bea acks from her lockscreen via
+member's rotation adopted `{match: {spaceDid: ops-space, kind: "pager"},
+clamp: {min: "interrupt"}, bypassQuietHours: true}` — the `spaceDid` bound
+matters: a bare kind-matched interrupt floor would be claimable by any new
+source declaring `kind: "pager"` (§7). Bea acks from her lockscreen via
 `actions` (§4.6): terminal `acted`, appended to the pattern's `replyTo`
 cell under her session authority. Her runtime discloses the disposition
 into `PerSpace` state; the space's opt-in policy "acted-by-any demotes to
@@ -1523,6 +1615,72 @@ its clamped rung; and the kind-lie fails because above-`review` defaults
 key on verified facts, never self-declared `kind` (§4.2) — declaring
 yourself "group-chat" buys nothing without a verified human `actor` the
 user actually knows.
+
+### B.11 The marketplace stranger (first contact from an unknown human)
+
+Maya lists a couch; a legitimate buyer — verified human DID, zero prior
+relationship — messages her, and the first responder wins the sale. Before
+the first-contact default existed, this story graded C: the buyer failed
+the established-relationship test and sank indistinguishably into `review`
+alongside importer noise, and Maya couldn't even hand-write a fix because
+`match` had no `actor` dimension. As specced now: the message lands in the
+**requests shelf** (`review`, distinguished grouping, quota-bounded — §7),
+where it reads as a person, not noise; one tap on the promote affordance
+writes `{match: {actor}, clamp: {min: "heads-up"}}` and the conversation is
+loud thereafter. For time-critical listings, the sanctioned louder path is
+the pattern proposing a listing-scoped min at listing time (the
+moment-of-intent idiom). Downward bias holds: minting DIDs buys a stranger
+nothing above the requests shelf. Note `threadKey` must be per-buyer, not
+per-listing — thread displacement (§6.4) would otherwise let buyer #2's
+inquiry retract buyer #1's.
+
+### B.12 Return from vacation (bulk catch-up must be bounded)
+
+Jonas is offline 16 days: ~300 notices, ~80 unseen artifact changes across
+12 spaces. The joins do most of the collapsing for free — 16 days of one
+chat is *one* notice (coalescing + thread displacement), everything he
+handled from his phone abroad is already satisfied everywhere (seen-join),
+expired 2FA/fare-holds are hidden and swept, matured ladder rungs displaced
+each other. Two rules close the rest: the sweep's **aging** demotes
+unhandled `heads-up` older than 7 days to `review` (§4.5), so the bell
+shows this week, not a 16-day wall; and the dispatcher's **reconnect
+damping** (§9.3) alerts only for notices newer than the gap — the return is
+a quiet shelf plus one "while you were away" view (which is *specified* as
+the every-return view, §5), not a buzz storm. Residual: whether
+"touched-recently" survives 16 days in the watch set is open question
+§12.2 — the vacation is the case that forces that answer.
+
+### B.13 Work and personal (context separation)
+
+Sofia keeps work and personal profiles and wants work quiet on evenings
+and weekends, family always through, one device. Profiles are the coarse
+cut: profile ≡ own home space ≡ own attention state (§8) — her work
+steward and personal steward are independent by construction, and one
+shell merging two ledgers is presentation, not runtime. Within the work
+profile, context is ordinary policy: `{match: {spaceDid: work-space},
+effect: {quietHours: {start: "18:00", end: "09:00"}}}` for evenings plus
+`{quietHours: {start: "00:00", end: "24:00", days: ["sat","sun"], max:
+"suppress"}}` for weekends (§7's day-scoped, max-bearing quietHours), and
+`{match: {threadKey: family}, clamp: {min: "heads-up"}, bypassQuietHours:
+true}` for the always-through exception. Every piece is a legible record
+she can read back.
+
+### B.14 Day one (defaults before any learning)
+
+Riley is brand new: no learned policies, no adopted packs, defaults only.
+The load-bearing line is §7's composition ceiling — `baseline =
+min(postureHint, "review")` — without which a day-one source hinting
+`interrupt` would simply get it (no learned history, no matching max: the
+formula's original cold-start hole, now closed). The week then looks like:
+messages from imported contacts → `heads-up` from day one (rosters are
+seeded by contact import, §7 — without that, the established-relationship
+default fires for nobody and the app reads as broken silence exactly when
+it's being judged); strangers → the requests shelf; importers and agents →
+`review`/`silent`, bounded by intake quotas until learned clamps
+accumulate evidence. Honest weakness: the review lane is at its noisiest
+in week one, before any learning — the propose/adopt idiom (patterns
+proposing their own sensible clamps at install) is the mitigation, and
+§12.8's evidence thresholds decide how fast learning kicks in.
 
 ## References
 

--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -1,7 +1,7 @@
 # Attention System
 
 A canonical runtime substrate for managing user attention: a per-user
-ledger of **notices** written by a single trusted **usher** under the user's
+ledger of **notices** written by a single trusted **steward** under the user's
 own **policies**, **seen-state over artifacts** derived from the version
 history the runtime already keeps, and **surface adapters** that project the
 ledger onto shell lanes, digests, and (eventually) OS notifications. An OS
@@ -34,7 +34,7 @@ naming ergonomics).
 Every existing notification system is biased toward interruption because the
 *emitter* chooses how loudly to surface, and emitters' incentives favor
 loudness. This design inverts that: **sources only post notices with a
-posture hint; the user's usher — running with the user's policies,
+posture hint; the user's steward — running with the user's policies,
 structurally on the user's side — decides**. The runtime's job is to make
 that inversion enforceable (CFC write-gating on the canonical ledger), cheap
 (derived queries over stores the user already holds, no second event
@@ -49,7 +49,7 @@ Five load-bearing moves:
    downward: a source earns its way up through **learned policies** the user
    can read and edit (§7), and every dismiss-without-open pushes its future
    notices back down.
-2. **The usher is the only writer.** The canonical ledger carries a
+2. **The steward is the only writer.** The canonical ledger carries a
    `writeAuthorizedBy` claim; untrusted patterns can post candidates and
    render their own local views, but cannot spam the ledger (§6).
 3. **Attention over artifacts is derived, not posted.** The runtime already
@@ -62,13 +62,13 @@ Five load-bearing moves:
    notice is a *view over* "an artifact you care about changed", which
    dissolves the "every pattern must remember to send notifications"
    problem.
-4. **Policies are user-owned cells**, not usher code. The core ships a
+4. **Policies are user-owned cells**, not steward code. The core ships a
    good-enough default fold; the bespoke last 20% ("library book due"
    escalations, quiet hours, per-thread mutes, nag-until-done) is data the
-   user — or a pattern, on proposal, or the usher itself, legibly (§7) —
+   user — or a pattern, on proposal, or the steward itself, legibly (§7) —
    writes.
 5. **Multi-user needs almost nothing new.** A notice is a per-(user, notice)
-   relation: a shared space posts one candidate and each member's usher
+   relation: a shared space posts one candidate and each member's steward
    lanes it independently. "Who has seen this" — and, per disclosure policy,
    "who has handled this" — is the same state contributed into shared space,
    read the other direction (§8).
@@ -81,21 +81,22 @@ Everything upstream of a posted notice — deciding whether an agent may
 interviews that seed policy — is product-side and stays there. A product
 framework (e.g. Loom's attention framework) enters this pipeline as a
 *trusted source* posting well-prepared candidates with a posture hint; the
-runtime usher's job for such a source is cross-source arbitration and
+runtime steward's job for such a source is cross-source arbitration and
 enforcement of the user's posture clamps, not re-litigating the product's
 preparation decisions.
 
 ### Vocabulary
 
 *Notice* — the unit: a posted announcement with a destination, that waits to
-be noticed. A **candidate** is a notice as posted, before the usher admits
+be noticed. A **candidate** is a notice as posted, before the steward admits
 it (assigning `id`, `posture`, `weight`) — the same envelope at an earlier
 stage, exactly as `wish()` resolves `candidates` into a `result`.
-*Disposition* — what the user (or the usher on their behalf) did with a
-notice; the append-only log. *Usher* — the per-user trusted fold that admits
-candidates, assigns postures, and keeps the room quiet; called an usher, not
-a "ranker", because ranking is its most minor duty and it works for the
-user, not the feed. *Ledger* — the notices store specifically. *Attention
+*Disposition* — what the user (or the steward on their behalf) did with a
+notice; the append-only log. *Steward* — the per-user trusted fold that admits
+candidates, assigns postures, and guards the user's quiet; called a steward,
+not a "ranker", because ranking is its most minor duty and it works for the
+user, not the feed. (No relation to Loom's retired "Attention Steward"
+auto-surfacing system — this is a routing fold, not a suggestion engine.) *Ledger* — the notices store specifically. *Attention
 state* — the triple of stores (notices, dispositions, seen — §4.5). *Lane* —
 a shell projection over attention state (most lanes correspond to a posture
 rung; some, like the snoozed lane, are lifecycle views). *Watch set* — the
@@ -135,7 +136,7 @@ entity set whose changes the user's attention system observes (§5).
 - **Policy seeding / onboarding flows.** How a product interviews the user
   and proposes an initial policy set is product-scope; the runtime primitive
   is only "patterns propose, the user disposes" (§7) — adoption *is* the
-  write, and proposed-but-unadopted policies never enter the usher's fold.
+  write, and proposed-but-unadopted policies never enter the steward's fold.
   (One product obligation this spec *names* because safety depends on it:
   ship an emergency-sources policy pack through this same propose/adopt
   flow — §7, Appendix B.1.)
@@ -224,14 +225,14 @@ occupies exactly one rung, and the rung is a promise:
 Two invariants:
 
 - **Downward bias.** Defaults sit low (`silent`/`review`). Sources post a
-  *hint*; the usher assigns the real posture via the policy clamp (§7), and
+  *hint*; the steward assigns the real posture via the policy clamp (§7), and
   repeated dismiss-without-open feeds back as learned clamps. Crucially,
   **no emitter-controlled field may raise posture**: reaching `interrupt`
   (or `heads-up` above a source's learned baseline) requires a user-adopted
   policy floor — never urgency claims, expiry times, or any other field the
   emitter writes. An emitter cannot buy `interrupt` with enthusiasm. The
   same discipline binds the *shipped defaults*: any default above `review`
-  must match on **usher-verified facts** (e.g. `actor` is a human DID with
+  must match on **steward-verified facts** (e.g. `actor` is a human DID with
   an established relationship to the user), never on self-declared fields
   like `kind` — otherwise declaring a kind *is* choosing a baseline, which
   re-opens the loophole this invariant closes.
@@ -243,9 +244,9 @@ Two invariants:
 The rung names deliberately match the posture vocabulary the Loom product
 already uses (silent memory → daily review → timely heads-up → interrupt), so
 product surfaces map 1:1 onto runtime postures. Within a rung, ordering is
-the usher-assigned `weight` (§4.4) — an opaque scalar that never crosses
+the steward-assigned `weight` (§4.4) — an opaque scalar that never crosses
 rungs and never gates delivery; it exists so continuous surfaces (Pond's
-radial layout, "ordered by the usher" lists) don't have to invent one.
+radial layout, "ordered by the steward" lists) don't have to invent one.
 
 ### 4.3 The pipeline
 
@@ -259,10 +260,10 @@ Sources                          post candidates (postureHint = advisory)
   external ingress (webhooks)      ▼
 Notice inbox (durable; quota-gated append)       §6.1, §10.2
   ▼
-Usher (per-user, trusted single writer)          §6
+Steward (per-user, trusted single writer)          §6
   folds candidates × policy cells (§7)
   assigns posture + weight; coalesces; writes the ledger
-  ── writeAuthorizedBy gate: only the usher's verified
+  ── writeAuthorizedBy gate: only the steward's verified
      module identity may write the canonical ledger ──
 Ledger (per-user, durable, queryable)            §4.5
   ▼
@@ -277,7 +278,7 @@ cannot do is write the canonical ledger the shell and OS adapters trust.
 
 ### 4.4 The envelope
 
-A source **posts a candidate**; the usher **admits it as a notice**. Same
+A source **posts a candidate**; the steward **admits it as a notice**. Same
 envelope, two stages — and the stage split is structural: a candidate
 *cannot carry* an assigned posture, because `posture`, `weight`, and `id`
 exist only on the admitted type.
@@ -303,7 +304,7 @@ type NoticeCandidate = {
   // advancing version) and re-emergence tombstones (§4.7).
   subjectVersion: EntityVersion;
   // Source classification ("group-chat", "importer", "agent-run", ...).
-  // BOUND BY THE USHER to the source's verified identity: the first-seen
+  // BOUND BY THE STEWARD to the source's verified identity: the first-seen
   // kind for a given source sticks; a source changing its declared kind
   // is itself a reputation signal (and does not escape kind-matched
   // clamps, which follow the source identity). Policy matching (§7) and
@@ -342,17 +343,17 @@ type NoticeCandidate = {
   // surface can render.
   progress?: { done: number; total?: number };
 
-  // Advisory only — the "requested" loudness. The usher assigns the real
+  // Advisory only — the "requested" loudness. The steward assigns the real
   // posture; surfaces never read the hint.
   postureHint: "silent" | "review" | "heads-up" | "interrupt";
 
   postedAt: number;
   notBefore?: number;         // embargo: hold materialization until then
   expiresAt?: number;         // evaluate-on-read; swept terminally by the
-                              // usher (§4.7, §9.3)
+                              // steward (§4.7, §9.3)
 
   // Opaque product round-trip channel. Disciplined by invariant: NO
-  // runtime-derived predicate, NO usher fold step, and NO policy match
+  // runtime-derived predicate, NO steward fold step, and NO policy match
   // may read ext — it carries product fields (Loom's why_now, channel,
   // authorization_state — Appendix A), not routing inputs. An ext key
   // consumed by two independent products is a candidate for promotion to
@@ -360,13 +361,13 @@ type NoticeCandidate = {
   ext?: Record<string, unknown>;
 };
 
-// An admitted notice IS a candidate plus the three fields only the usher
+// An admitted notice IS a candidate plus the three fields only the steward
 // may write. Two stages, one envelope, enforced by the type.
 type Notice = NoticeCandidate & {
   // Identity — THE load-bearing field. Every surface adapter targets it
   // for replace/retract (iOS UNNotificationRequest.identifier +
   // apns-collapse-id, Android notify(id), Web Push options.tag). Derived
-  // by the USHER from verified provenance (source space DID + entity id
+  // by the STEWARD from verified provenance (source space DID + entity id
   // [+ event key]) — never from candidate-supplied strings, so a hostile
   // source cannot collide another source's id to hijack coalescing or OS
   // replace/retract.
@@ -391,7 +392,7 @@ type NoticeAction = {
   replyTo?: unknown;          // asCell: ["cell"]
 };
 
-// Append-only per-notice disposition log — what the user (or the usher,
+// Append-only per-notice disposition log — what the user (or the steward,
 // on the user's behalf) did with the notice. Deliberately small: "seen"
 // is NOT a disposition (it lives in the seen store, §4.5/§5, and
 // notice-seen is a join); "muted" is NOT a disposition (mute IS a policy
@@ -404,12 +405,12 @@ type NoticeDisposition = {
   // ...). Lets policy decide e.g. "os-tray dismiss clears that device
   // only" (§9.3).
   surface: string;
-  // Who did it: the user's DID, or the usher's module identity for
+  // Who did it: the user's DID, or the steward's module identity for
   // system dispositions (expiry sweep, thread displacement — §4.7).
   actor: string;
   // The subjectVersion this disposition was taken against. A dismissal
   // tombstones that version; if the subject advances past it, the notice
-  // re-emerges (the usher's coalesce advances subjectVersion past the
+  // re-emerges (the steward's coalesce advances subjectVersion past the
   // tombstone — one operation, not a separate mechanism) and the old
   // dismissal no longer applies. Comparable only within
   // subjectVersion.space.
@@ -457,13 +458,13 @@ by the runtime guessing which glances "count": the source re-posts at a
 newer version when it is meaningfully newsworthy again, and a user-adopted
 `realert` policy (§7) governs whether re-emergence may make sound.
 Satisfaction that doesn't involve the user looking (someone else handled it;
-the trip ended) is the usher's job: its fold observes the subject change and
+the trip ended) is the steward's job: its fold observes the subject change and
 terminally retracts the notice (system disposition by module identity).
 
 A caveat on "cheap": pull-based scheduling makes *unobserved* queries free
 (`docs/specs/pull-based-scheduler/README.md`), not observed ones. A mounted
 lane is a live subscription over the user's own three stores — no per-notice
-cross-space reads (cross-space reading happens once, in the usher's fold) —
+cross-space reads (cross-space reading happens once, in the steward's fold) —
 and §4.5's write discipline bounds how often those stores change.
 
 ### 4.5 Storage
@@ -476,15 +477,15 @@ three stores, and the three backings are not ad-hoc — they derive from a
 
 | | wakes lane queries | must never wake lane queries |
 |---|---|---|
-| **usher-only writes** | `notices` | *(learned policies live with §7 policies, not here — they are user-visible data)* |
+| **steward-only writes** | `notices` | *(learned policies live with §7 policies, not here — they are user-visible data)* |
 | **any-surface writes** | `dispositions` | `seen` |
 
-1. **`notices`** (the ledger) — written *only* by the usher. Backing for
+1. **`notices`** (the ledger) — written *only* by the steward. Backing for
    phase 1: a **durable array cell carrying the `writeAuthorizedBy`
    claim**, the mechanism already protecting profile links in production
    (`docs/common/conventions/HOME_SPACE.md`,
    `packages/runner/src/cfc/prepare.ts`). Coalescing (same `id`, subject
-   advanced) is an in-place element update by the single leased usher
+   advanced) is an in-place element update by the single leased steward
    instance (§6.2); coalescing **refreshes** content, `expiresAt`, and
    `progress` — a re-emerged notice carries the new posting's lifetime, not
    a stale one. This is deliberately *not* sqlite yet: `writeAuthorizedBy`
@@ -495,7 +496,7 @@ three stores, and the three backings are not ad-hoc — they derive from a
    table (better ranking/pagination/retention at volume) is gated on the
    net-new work item in §10.3, and on giving it **its own database**: every
    `db.exec` serializes on the database handle cell's `rev`, so one shared
-   db cannot hold both an usher-only table and an everyone-writes table
+   db cannot hold both a steward-only table and an everyone-writes table
    without gating both or neither.
 2. **`dispositions`** — written by every surface on every device. Backing: a
    durable array cell appended with **mergeable ops only** (`push`,
@@ -503,7 +504,7 @@ three stores, and the three backings are not ad-hoc — they derive from a
    durable state instead of clobbering (memory is optimistic-concurrency
    with path-aware validation, not CRDT — and this design needs no CRDT:
    the canonical writer is singular per store, and dispositions are
-   mergeable appends). The usher periodically compacts dispositions for
+   mergeable appends). The steward periodically compacts dispositions for
    terminal, swept notices.
 3. **`seen`** — the seen store (§5), highest write rate in the system,
    ships in phase 0 and gets its own store so its writes never wake lane
@@ -527,17 +528,17 @@ Two rules regardless of backing:
   `docs/specs/space-model/4-cells.md`). Streams are append *endpoints*, not
   logs. This matters doubly for ingress: webhook payloads ride an ephemeral
   stream, so a **receiving handler must persist candidates durably at
-  ingress** — otherwise external candidates arriving while no usher is
+  ingress** — otherwise external candidates arriving while no steward is
   live are lost permanently, not delayed (§6.1). The same rule is why
   `NoticeAction.replyTo` must be a durable cell, never a stream.
 - **Never `set()` a whole array** that has more than one writer.
 
-Retention: the usher's sweep terminally retracts expired notices (system
+Retention: the steward's sweep terminally retracts expired notices (system
 disposition — this is the *one* expiry mechanism; `visible()`'s expiry check
 is the read-side shadow of it, so an expired notice is hidden immediately
 and reaped eventually) and reaps notices that are terminal with
 `subjectVersion` below a watermark, plus their dispositions. Sweeping is an
-usher duty (it owns the ledger), bounded and boring by design. Because
+steward duty (it owns the ledger), bounded and boring by design. Because
 sweeping only reaps terminal rows, per-source intake quotas (§6.1) are what
 bound a flooding source, not retention.
 
@@ -570,19 +571,19 @@ For review clarity, the full per-(user, notice) state machine, every
 transition named once:
 
 ```text
-(candidate) --usher fold: clamp > suppress--> ADMITTED
+(candidate) --steward fold: clamp > suppress--> ADMITTED
 ADMITTED --now < notBefore--> EMBARGOED --time--> VISIBLE
-EMBARGOED --usher: subject satisfied / superseded--> TERMINAL
+EMBARGOED --steward: subject satisfied / superseded--> TERMINAL
          (a pre-scheduled reminder is retracted when its reason ends)
 VISIBLE --user: dismissed|archived|acted--> TERMINAL
-VISIBLE --usher: subject satisfied / thread displaced / expiry sweep
+VISIBLE --steward: subject satisfied / thread displaced / expiry sweep
          (system disposition)--> TERMINAL
 VISIBLE --user: snoozed--> SNOOZED --until--> VISIBLE
 VISIBLE --seen mark on subject reaches subjectVersion--> SATISFIED
          (hidden; no disposition row — pure join)
 VISIBLE --now ≥ expiresAt--> hidden immediately (read-side),
          TERMINAL at next sweep (write-side)
-TERMINAL --usher coalesce advances subjectVersion past tombstone-->
+TERMINAL --steward coalesce advances subjectVersion past tombstone-->
          VISIBLE (re-emergence: a consequence of coalescing, not a
          separate mechanism; silent unless a realert policy applies, §9.3)
 TERMINAL + below watermark --sweep--> reaped
@@ -591,7 +592,7 @@ TERMINAL + below watermark --sweep--> reaped
 Posture may change after admission (escalation raises it, collective
 handling demotes it — §8); §9.3 defines alerting and retraction in terms of
 these posture transitions. **Policy changes re-fold**: policy cells are fold
-inputs, so a policy commit wakes the usher and admitted notices re-lane —
+inputs, so a policy commit wakes the steward and admitted notices re-lane —
 muting a thread demotes its existing notices, not just future ones.
 
 ## 5. Seen-state and attention over artifacts
@@ -626,7 +627,7 @@ Everything else is the **changes projection** (§10.1) joined against marks:
   home).
 - **"While you were away"** = one `changes(watchSet, basis: seenWatermark,
   attribution: true)` call, grouped by run/thread then space, ordered by
-  the usher. Renders as a pattern on the home context. This is the
+  the steward. Renders as a pattern on the home context. This is the
   first-run view and the every-return view — the same query. The affordance
   must answer *what changed, by whom, since you looked* — the projection's
   `author` field gives session-grain attribution from day one (§10.1) — and
@@ -663,9 +664,9 @@ watch/unwatch policies (§7). Getting the defaults right is an open question
 (§12.2); getting them wrong in the "too broad" direction is the failure
 mode to avoid (dots everywhere = dots nowhere).
 
-## 6. The usher
+## 6. The steward
 
-**One logical usher per user.** It admits candidates, folds policies,
+**One logical steward per user.** It admits candidates, folds policies,
 assigns postures and weights, coalesces (same `id` when the same subject
 advances — re-emergence is this same operation crossing a tombstone),
 applies thread displacement (§6.4), retracts satisfied notices, and sweeps
@@ -673,14 +674,14 @@ retention (§4.5).
 
 ### 6.1 The notice inbox
 
-Candidates must be **durable before admission**: the usher may be asleep or
+Candidates must be **durable before admission**: the steward may be asleep or
 absent (interim mode, closed clients), and ephemeral candidates would be
 silently lost, not delayed. Intake shape:
 
 - In-fabric artifact changes need no *posting* — they are derived (§5).
   (They do need *reach*: until server-side cross-space wake exists, changes
-  in other spaces reach a server-side usher via the same forwarding path as
-  posted candidates below; a client-side usher reads them directly through
+  in other spaces reach a server-side steward via the same forwarding path as
+  posted candidates below; a client-side steward reads them directly through
   the user's ordinary sessions.)
 - Posted candidates land in the **notice inbox in the user's home space** —
   a cross-principal, quota-gated append surface, named net-new work
@@ -688,7 +689,7 @@ silently lost, not delayed. Intake shape:
   user's home space: the write gate enforces per-source quotas against the
   *verified writer identity*, not against self-reported fields. Until
   §10.2 lands, candidates rest in a durable per-source cell in the space
-  where they arise and the usher reads them there (client-side interim),
+  where they arise and the steward reads them there (client-side interim),
   with quotas enforced at fold time — weaker (a flood bloats the
   source-space cell, not the home space) but sound.
 - Webhook ingress: the receiving handler persists the payload durably at
@@ -700,9 +701,9 @@ silently lost, not delayed. Intake shape:
 
 The ledger carries a CFC `writeAuthorizedBy` claim. Two viable bindings:
 
-1. **Verified module identity** (recommended): the usher ships as a pattern
+1. **Verified module identity** (recommended): the steward ships as a pattern
    with a content-addressed module identity; `writeAuthorizedBy` binds to it.
-   The usher stays in pattern-space — inspectable, forkable in principle,
+   The steward stays in pattern-space — inspectable, forkable in principle,
    updated like any pattern — and "trusted" means *this exact code*, not
    "runs on a server".
 2. **Trusted builtin**: a runtime builtin id in the claim. Stronger, but
@@ -713,12 +714,12 @@ Recommendation: (1), with the fold's *inputs* (policies) as data so the code
 rarely needs to change. Note the identity subtlety: *acting as the user*
 (session `as` / `actingPrincipal` = the user's DID) and *being authorized to
 write the ledger* (module identity matching the claim) are two separate
-checks, and the design uses both — every usher write is attributable
-`onBehalfOf` the user and provably from the usher's code.
+checks, and the design uses both — every steward write is attributable
+`onBehalfOf` the user and provably from the steward's code.
 
 `writeAuthorizedBy` authorizes *code*, not an *instance*: two devices running
-the usher both pass the claim. The single-writer premise therefore needs
-instance discipline, not just CFC: **the interim client-side usher takes a
+the steward both pass the claim. The single-writer premise therefore needs
+instance discipline, not just CFC: **the interim client-side steward takes a
 lease** (a mutex cell claimed with an expiry; the sqlite spec's
 `tryClaimMutex` shape) and only the leaseholder folds. Independent of the
 lease, the fold is specified **idempotent and commutative over the notice
@@ -730,7 +731,7 @@ window degrades to wasted work, not divergence.
 
 - **Target: the server-primary execution model**
   (`docs/specs/server-side-execution/`). With intake home-space-local
-  (§6.1), the usher is a *standing registration on the user's home space* —
+  (§6.1), the steward is a *standing registration on the user's home space* —
   work whose value is its effects rather than client-read output — woken by
   commits to the notice inbox, the policy cells, or forwarded watch-set
   events. Execution is attributed `onBehalfOf` the user. Named
@@ -738,19 +739,19 @@ window degrades to wasted work, not divergence.
   are all **per-space**: standing registrations are its own later phase;
   scoped (`PerUser`) state claims are gated (its G16); server-side
   *cross-space* reads/wake are explicitly deferred there — which is exactly
-  why intake forwards into the home space instead of the usher reading N
+  why intake forwards into the home space instead of the steward reading N
   spaces.
 - **Interim: client-side, under lease** (§6.2). Until standing registrations
-  land, the leaseholder client runs the usher as an ordinary piece. This
+  land, the leaseholder client runs the steward as an ordinary piece. This
   degrades gracefully for in-fabric state (candidates are durable; folding
   happens on next lease) — what's lost is only *timeliness* while no client
   is open, which matters from phase 2 (OS delivery) onward and not before.
-- **Not: `background-piece-service` as-is.** It is per-space (the usher is
-  per-user), ~60s polling (the usher is wake-on-commit shaped), and its own
+- **Not: `background-piece-service` as-is.** It is per-space (the steward is
+  per-user), ~60s polling (the steward is wake-on-commit shaped), and its own
   README documents async-completion unreliability. If bps is pressed into
   interim service, treat that as scaffolding, not the design.
 
-**Laziness.** The usher materializes *rows*; it does not keep derived
+**Laziness.** The steward materializes *rows*; it does not keep derived
 predicates hot. `visible()` evaluates on surface demand over the user's own
 stores (§4.4). The one push-shaped duty is OS delivery (§9.3), which is
 explicitly an edge adapter fed by wake-on-commit, not a hot loop.
@@ -762,10 +763,10 @@ Two mechanisms at two altitudes:
 - **`id` is identity**: the same notice at a newer subject version.
   Coalescing updates the notice in place (refreshing content, expiry,
   progress); crossing a dismissal tombstone is re-emergence. Identity is
-  usher-derived from verified provenance (§4.4), so it cannot be forged.
+  steward-derived from verified provenance (§4.4), so it cannot be forged.
 - **`threadKey` is the thread**, and displacement is a *derived rule over
   it*: **within a threadKey, only the newest live notice is visible**;
-  older live notices in the thread are terminally retracted by the usher
+  older live notices in the thread are terminally retracted by the steward
   (system disposition) when a newer one is admitted. A prepared result
   therefore displaces the raw occurrence by *sharing its thread*, not by
   naming notice ids — no displacement chains, no tombstone bookkeeping for
@@ -777,15 +778,15 @@ Two mechanisms at two altitudes:
 
 ## 7. Policies
 
-A policy is a small declarative record the usher folds over — **data, not
-usher code**:
+A policy is a small declarative record the steward folds over — **data, not
+steward code**:
 
 ```ts
 // Shown for illustration only.
 type AttentionPolicy = {
   match: {
     subject?: unknown;        // asCell: ["cell"] — a specific source/thread
-    kind?: string;            // as bound by the usher, §4.4
+    kind?: string;            // as bound by the steward, §4.4
     spaceDid?: string;
     threadKey?: string;
   };
@@ -809,7 +810,7 @@ type AttentionPolicy = {
   };
   reason?: string;            // human-legible: why this policy exists
   author: string;             // user DID; a pattern's module identity for
-                              // proposals; the USHER's module identity for
+                              // proposals; the STEWARD's module identity for
                               // learned policies (see below)
 };
 ```
@@ -827,7 +828,7 @@ breaks through" — is two records and zero ambiguity.
   handful of defaults: messages from **verified human actors with an
   established relationship** (rosters, prior threads) → `heads-up`;
   agent-completions → `silent` (visible as seen-state, never buzzing). Per
-  §4.2, shipped defaults above `review` key on usher-verified facts only —
+  §4.2, shipped defaults above `review` key on steward-verified facts only —
   never on self-declared `kind` (declaring `kind: "group-chat"` must not
   buy the human-messages baseline). There is deliberately **no default
   that maps any emitter-supplied field to `interrupt`**.
@@ -851,12 +852,12 @@ breaks through" — is two records and zero ambiguity.
     escalation ladder ahead of time: three candidates with `notBefore` =
     T-90/T-30/T-7, same `threadKey` (each new admission displaces the
     prior rung), ascending posture hints, plus a proposed min the user
-    adopts once. Obligation met → subject advances → the usher retracts
+    adopts once. Obligation met → subject advances → the steward retracts
     the pending rungs (§4.7's EMBARGOED retraction).
 - **Learned policies: the reputation loop, made legible.** The downward
   feedback the spec promises (dismiss-without-open, quota pressure ⇒ the
-  source's notices sink) has to live *somewhere*, and hidden usher state
-  would break the inspectability goal. It lives here: the usher — which is
+  source's notices sink) has to live *somewhere*, and hidden steward state
+  would break the inspectability goal. It lives here: the steward — which is
   already the trusted fold, not a third party petitioning for adoption —
   writes ordinary policy records (`author` = its module identity, `reason`
   = the evidence, e.g. "7 of 8 notices dismissed without open over 30d")
@@ -879,7 +880,7 @@ breaks through" — is two records and zero ambiguity.
   that discloses read receipts, a muted member's persistent silence is
   statistically visible to a patient observer. The runtime's guarantee is
   scoped: no direct exposure, and inference surface bounded by the space's
-  own disclosure policy (§8, §12.5). Usher *output* ordering/timing is not
+  own disclosure policy (§8, §12.5). Steward *output* ordering/timing is not
   considered a protected channel in v1.
 
 ## 8. Multi-user
@@ -888,7 +889,7 @@ Three properties, all falling out of "a notice is a per-(user, notice)
 relation" plus existing constraints:
 
 - **One candidate, N ledgers.** A shared space posts one candidate per
-  event; each member's own usher lanes it under their own policies. A new
+  event; each member's own steward lanes it under their own policies. A new
   message can be `interrupt` for the on-call member and `silent` for the
   member who muted the thread. The emitter cannot know or decide this —
   correctly so.
@@ -913,7 +914,7 @@ relation" plus existing constraints:
   space's members should understand when choosing the policy.
 - **Escalation across people is a policy.** "If nobody attends to this
   within 2h, raise it to `heads-up` for the space owner" is a policy cell on
-  the shared space, evaluated by the owner's usher against contributed
+  the shared space, evaluated by the owner's steward against contributed
   state. No siloed notification system can express this; here it is one
   record. (Escalation is a posture *raise* after admission; §9.3's
   transition rule makes it alert exactly once. Deadline-shaped escalation —
@@ -963,7 +964,7 @@ there:
 
 - **Alerting rides posture transitions, not writes.** A delivered notice
   alerts when it first materializes at an alert-bearing rung and again only
-  when the usher *raises* its posture (escalation, §8); every same-rung
+  when the steward *raises* its posture (escalation, §8); every same-rung
   coalesce — new message in the thread, progress tick, content refresh —
   **replaces silently** on every surface (Android `setOnlyAlertOnce`
   semantics, made unconditional: the emitter cannot choose to re-buzz).
@@ -994,7 +995,7 @@ there:
   notice may linger on an OS tray until the next wake re-evaluates it.
   Timer registrations that feed the dispatcher are named net-new work
   (§10.5); until they land, expiry is evaluate-on-read with explicitly
-  stale OS surfaces (the usher's sweep is the terminal write-side, §4.5).
+  stale OS surfaces (the steward's sweep is the terminal write-side, §4.5).
   Second, iOS replaces but does not tick (text refreshes when the shade
   reopens); genuinely-live notices (`progress`) render best-effort per
   platform, and rich live chrome (Live Activities) is a separate later
@@ -1067,7 +1068,7 @@ that first needs it (§11), and each needs its own (small) design pass.
    makes dead-device delivery an authority question with an answer instead
    of an open question — the full chain "someone messages me while all my
    devices are closed → my phone buzzes" is inbox append → home-space
-   wake → usher fold → dispatcher push.
+   wake → steward fold → dispatcher push.
 3. **Write-authorization for sqlite** *(pre-migration of the ledger to
    sqlite; not needed for phase 1's array-cell backing)*.
    `writeAuthorizedBy` is enforced on the cell-write prepare path only;
@@ -1076,9 +1077,9 @@ that first needs it (§11), and each needs its own (small) design pass.
    bump is a cell write, so the prepare path sees it) needs specification
    and a security review of its own, including whether any sqlite write
    path bypasses the rev write.
-4. **Usher lease** *(phase 1)*. A small mutex-cell convention (claim with
+4. **Steward lease** *(phase 1)*. A small mutex-cell convention (claim with
    expiry, renew, steal-on-expiry) for single-instance election of the
-   interim client-side usher (§6.2). Generalizes beyond attention.
+   interim client-side steward (§6.2). Generalizes beyond attention.
 5. **Timer wake** *(phase 2+)*. Executor-pool timer registrations
    (`notBefore`, `expiresAt`, snooze expiry, `realert` cadences, escalation
    deadlines, digest cadence) feeding wake-on-commit's machinery, so
@@ -1099,7 +1100,7 @@ Each phase is independently shippable and none re-shapes the data model.
 
 - **Phase 0 — seen-state.** The changes projection (§10.1), the seen store
   with its write discipline (§4.5.3), unseen dots in the shell, and a
-  "while you were away" home pattern. No usher, no candidates, no push.
+  "while you were away" home pattern. No steward, no candidates, no push.
   Acceptance bar: the user can see *what changed, by whom (session-grain),
   and since when*, and jump in with the changed region emphasized — not
   merely that a dot exists. This makes agent work **visible** — the single
@@ -1108,12 +1109,12 @@ Each phase is independently shippable and none re-shapes the data model.
 - **Phase 1 — ledger + lanes.** Envelope, home-space `notices` (array cell
   + `writeAuthorizedBy`) and `dispositions` stores, notice intake (inbox
   gate §10.2, or interim source-space cells), a minimal client-executed
-  usher under lease (verified-fact defaults + clamp composition + learned
+  steward under lease (verified-fact defaults + clamp composition + learned
   policies + thread displacement), shell bell/lanes with notice actions
   (§4.6), receipt-shaped notices for agent runs with attribution folding
   (§5). Policies v0 (including the emergency-pack and deadline-ladder
   propose/adopt idioms, §7).
-- **Phase 2 — server usher + first transport.** Usher as a standing
+- **Phase 2 — server steward + first transport.** Steward as a standing
   registration on the home space under server-primary execution
   (dependencies named in §6.3); Web Push with device registration,
   redaction rules, and retraction; digest queries; timer wake (§10.5),
@@ -1127,14 +1128,14 @@ Each phase is independently shippable and none re-shapes the data model.
 
 ## 12. Open questions
 
-1. **Usher trust binding.** Verified module identity is recommended (§6.2),
+1. **Steward trust binding.** Verified module identity is recommended (§6.2),
    but the "wholly-system service" alternative keeps resurfacing; if the
    server executor itself writes the ledger, is that a builtin identity, and
-   does that preempt user-forkable ushers? Resolve before phase 1.
+   does that preempt user-forkable stewards? Resolve before phase 1.
 2. **Watch-set defaults.** Touched ∪ agent-authored ∪ watched is the
    working answer (§5); validate against real spaces before hardening, and
    decide whether "touched" decays.
-3. **Forwarder contract.** Cross-space reach for a server-side usher
+3. **Forwarder contract.** Cross-space reach for a server-side steward
    (§6.1, §6.3): who runs the forwarding (the emitting pattern? the user's
    runtime on visit?), and what happens for spaces the user hasn't opened
    in weeks? Partially subsumed by §10.2's inbox gate; the residue is
@@ -1147,7 +1148,7 @@ Each phase is independently shippable and none re-shapes the data model.
    absence reveals, and how much of §7's policy-privacy bound this sets.
 6. **Policy expressiveness boundary.** V1 is plain predicates. Content
    regexes and LLM-judged predicates ("only interrupt if actually urgent")
-   are clearly coming — as usher inputs they inherit the usher's authority,
+   are clearly coming — as steward inputs they inherit the steward's authority,
    so they need their own integrity story before admission.
 7. **Displacement scope.** Thread displacement (§6.4) deliberately cannot
    express cross-thread or multi-target displacement. If a real consumer
@@ -1164,7 +1165,7 @@ Each phase is independently shippable and none re-shapes the data model.
     seen-timestamps. Appendix A is the field mapping; the remaining
     question is sequencing — which loom surface adopts the runtime ledger
     first, and whether loom's materializer becomes the trusted source or a
-    second usher (§Division of labor says: trusted source).
+    second steward (§Division of labor says: trusted source).
 11. **`realert` bounds.** Minimum cadence, maximum duration, and whether a
     realert policy requires re-confirmation after N fires — the exception
     to alert-once must not become a resharpened nag machine (§7, §9.3).
@@ -1177,7 +1178,7 @@ that value should be renamed — e.g. `fyi` — before the runtime noun lands.)
 
 | Loom candidate field | Envelope home |
 |---|---|
-| `id` / source identity | `id` (re-derived by usher from verified provenance) |
+| `id` / source identity | `id` (re-derived by steward from verified provenance) |
 | subject / focused target | `subject` (cell link); distinct destination → `target`; `focused_view_fallback` → `ext` |
 | prepared material | `attachment` |
 | `title`, body copy | `title`, `body` (+ `redacted` where the product wants lockscreen-safe copy) |
@@ -1249,7 +1250,7 @@ Three mechanisms compose: the med pattern re-posts as the deadline nears
 one-time adopted policy carries `{clamp: {min: "interrupt"},
 bypassQuietHours: true, realert: {everyMs: 600_000}}` — `realert` being the
 single user-grantable exception to alert-once (§9.3); logging the dose
-advances the subject artifact, and the usher terminally retracts every
+advances the subject artifact, and the steward terminally retracts every
 pending rung, including embargoed ones (§4.7). Phase gating is real: cadence
 firing between commits needs timer wake (§10.5) — before phase 2 this story
 is not safely servable and products should not pretend otherwise.
@@ -1303,7 +1304,7 @@ Nina's social importer posts ~80 like/follow events daily; she never opens
 them. Intake quotas bound the flood at the write gate against verified
 writer identity (§10.2). Her dismiss-without-open pattern becomes a
 **learned policy** she can read — `{match: {kind: "social"}, clamp: {max:
-"silent"}, author: usher, reason: "37 of 40 dismissed without open over
+"silent"}, author: steward, reason: "37 of 40 dismissed without open over
 30d"}` — and the source can never buy its way back up (learned policies
 only lower; §7). The review lane stays bounded; the weekly digest groups
 the residue by `kind`. This is the reputation loop as a legible artifact
@@ -1340,7 +1341,7 @@ T−30, `interrupt` at T−7. The **deadline ladder** idiom (§7): the pattern
 posts all three candidates ahead of time with ascending `notBefore` dates,
 the same `threadKey` (each admission displaces the prior rung), ascending
 hints, plus a proposed min she adopts once — at setup, when she's thinking
-about it. Renewal filed → subject advances → the usher retracts every
+about it. Renewal filed → subject advances → the steward retracts every
 pending rung including embargoed ones (§4.7). The gate is timeliness:
 `notBefore` materialization is evaluate-on-read until timer wake (§10.5) —
 nearly harmless at 90-day horizons for a daily shell user, unacceptable for
@@ -1354,7 +1355,7 @@ candidates, hints `interrupt` with `ext.urgency: "CRITICAL"`, tries to
 collide the banking source's notification id, re-declares its kind as
 "group-chat" to catch the human-messages default. Every defense is
 structural, not heuristic: hints can't raise (§4.2); `ext` is quarantined
-from routing (§4.4); `id` is usher-derived from verified provenance, so the
+from routing (§4.4); `id` is steward-derived from verified provenance, so the
 collision is impossible by construction; quotas bind to verified writer
 identity (§10.2); dismiss-without-open writes a legible learned max (§7);
 unconditional alert-once means even fresh-event-key spam can't re-buzz past
@@ -1369,7 +1370,7 @@ user actually knows.
   `docs/common/conventions/HOME_SPACE.md` — multi-user substrate; the
   contribute-your-own idiom; `writeAuthorizedBy` in production.
 - `docs/specs/server-side-execution/README.md` — standing registrations,
-  wake-on-commit, `onBehalfOf` attribution (usher execution home; §6.3
+  wake-on-commit, `onBehalfOf` attribution (steward execution home; §6.3
   names this spec's dependencies on it).
 - `docs/specs/memory-v2/` — `01-data-model.md` (seq, heads),
   `03-commit-model.md` (optimistic concurrency; commit-log `sessionId` /
@@ -1398,7 +1399,7 @@ user actually knows.
   the `candidates` → `result` lifecycle precedent for candidate → notice.
 - `packages/ui/src/v2/components/cf-toast/`, `cf-alert`, `cf-badge` —
   existing presentation components.
-- `packages/background-piece-service/README.md` — why the usher does not
+- `packages/background-piece-service/README.md` — why the steward does not
   run there.
 - PR #4132 (annotation-primitive prototype, draft) — the documented
   anti-precedent for storage-side reverse indexes invisible to the reactive

--- a/docs/specs/attention-system.md
+++ b/docs/specs/attention-system.md
@@ -155,9 +155,11 @@ entity set whose changes the user's attention system observes (§5).
   artifact, the draft, the conversation); within a thread, the newest live
   notice displaces older ones (§6.4) rather than piling on.
 
-## 3. Background — what exists today
+## 3. Background
 
-In labs, effectively nothing:
+### 3.1 What exists in labs today
+
+Effectively nothing:
 
 - `packages/ui/src/v2/components/cf-toast/` and `cf-alert` are polished
   presentation components, but no toast provider is mounted anywhere in
@@ -186,6 +188,164 @@ need the same substrate: durable per-user seen-state, a trustworthy
 canonical ledger, and per-user routing policy. This spec is that substrate —
 and only that substrate; Loom's work-start machinery and stance-bearing
 judgment policies stay product-side (§Division of labor).
+
+### 3.2 Prior art: how the OS notification stacks work
+
+This design borrows deliberately from the OS notification systems — and its
+strongest claims are about what their architecture *cannot* express — so
+reviewers need the minimum shape of those APIs to judge the comparison.
+(Deeper per-field mappings live in the adapter sections, §9.3.)
+
+**The shared architecture.** On every platform, an app granted a one-time
+binary permission constructs a notification payload — title, body, media,
+optional buttons — hands it to the OS, and **chooses its own loudness**.
+Delivery to a device where the app isn't running rides a vendor relay
+(Apple's APNs, Google's FCM, a browser's push service) to an OS daemon. The
+notification is a **snapshot copy**: once posted, it has no live tie to the
+data it describes beyond an app-chosen identifier the app can use to replace
+or cancel it. Seen/dismissed state is **per-device tray state** — dismissing
+on the phone does nothing on the laptop unless the app hand-builds
+push-to-cancel sync. The only cross-app arbitration the user gets is a
+chronological pile in a tray.
+
+**Android — the most capable, and this spec's behavioral reference:**
+
+- **Channels**: an app declares named notification categories; after
+  creation, the *user* controls each channel's importance, sound, and
+  lockscreen visibility, and the app can never raise them — only lower.
+  This is the germ of this spec's inversion, but only the germ: the app
+  still picks every channel's *initial* importance, can mint fresh channels
+  freely (resetting defaults), and the user discovers channels reactively,
+  buried in settings, usually after being annoyed.
+- **Replace/retract**: `notify(id, …)` with the same id replaces the
+  delivered notification in place; `cancel(id)` retracts it.
+  `setOnlyAlertOnce(true)` — *optionally* — makes re-posts update silently.
+  `setTimeoutAfter(ms)` auto-cancels. Groups get a summary notification.
+- **Actions + RemoteInput**: buttons and inline text reply on the
+  notification itself — act without opening the app; the input is delivered
+  back to the app via a broadcast.
+- **Lockscreen visibility tiers**: per notification, public / private /
+  secret, with an app-supplied redacted `publicVersion` for untrusted
+  displays.
+- **Ongoing + progress** notifications; full-screen intents for calls and
+  alarms; per-channel do-not-disturb bypass flags.
+- **Delivery**: FCM wakes the app process; notifications post with the app
+  dead and survive reboot.
+
+**iOS:**
+
+- **Interruption levels** — `passive` (no wake), `active` (default),
+  `time-sensitive` (breaks through Focus; requires an entitlement),
+  `critical` (breaks mute; Apple-granted entitlement, effectively
+  medical/safety only). An OS-enforced ceiling on loudness classes — but
+  the *app* picks the level per notification, subject only to those gates.
+- **Replace** via `UNNotificationRequest.identifier` (local) and
+  `apns-collapse-id` (push). Content freezes at delivery — it refreshes
+  when the user reopens the shade but never ticks live; genuinely live UI
+  is a separate API surface (Live Activities).
+- **Notification Service Extension**: a slice of app code runs on receipt
+  and may mutate content before display — the platform's hook for
+  decrypt-on-device and fetch-on-receive (the shape §9.3's redaction rule
+  compiles to).
+- **Focus modes**: user-side routing — which apps and which *people* may
+  break through — but coarse: app-grain and contact-grain, with no
+  conditions, and each app self-reports what a "person" is.
+
+**Web Push**: VAPID-authenticated push to a service worker;
+`showNotification` with `tag` for replace and `actions` for buttons;
+payloads are encrypted to the subscription, so the browser vendor's relay
+cannot read content (alone among the three). The most constrained surface —
+which is exactly why it is this spec's envelope floor (§9.3).
+
+**What the architecture structurally cannot do.** These are not missing
+features; they are consequences of "emitter-priced snapshot copies delivered
+to per-device trays," and they are the holes this design exists to fill:
+
+1. **The emitter prices its own loudness.** Android's channel initial
+   importance and iOS's interruption level are chosen by the party with the
+   incentive to interrupt. The user's recourse is reactive and blunt:
+   per-app or per-channel toggles, discovered after the annoyance.
+2. **Permission is binary and app-grain.** Allow-or-deny at first run.
+   There is no "this thread, quietly", no "this source, only until I've
+   handled one", no conditional grant — unless the app builds its own
+   settings screen, which the OS cannot verify it honors.
+3. **The notification is a dead copy.** Nothing retracts it when the
+   underlying thing is handled elsewhere; read-state doesn't cross devices;
+   the email you answered on your laptop still sits on your phone's
+   lockscreen. Well-engineered apps simulate liveness with push-to-cancel;
+   most don't.
+4. **No cross-source arbitration.** The tray is a chronological pile.
+   Nothing sees "forty things are competing for this person right now" —
+   notification fatigue is unaddressable at the system level because no
+   system-level party holds the queue.
+5. **No cross-person semantics.** "Someone on the team handled it" and
+   "escalate if nobody does" are unexpressible; every paging product is a
+   SaaS control plane bolted on top to compensate.
+6. **The relay reads the payload** (APNs and FCM; Web Push excepted).
+   Confidentiality requires per-app heroics — end-to-end encryption plus
+   on-device decrypt in an extension — rather than being a property of the
+   flow.
+7. **User policy is not data.** The user cannot write, inspect, or port a
+   routing rule. What the OS learned about their preferences (if anything)
+   is invisible and vendor-locked.
+
+### 3.3 What this design adopts, inverts, and adds
+
+**Adopted — the mechanics that earned their keep** (this spec's ledger stays
+"Android-shaped" so adapters compile 1:1):
+
+- Stable-identity replace/retract → `id`, steward-derived (§4.4).
+- Only-alert-once → made *unconditional*: alerting rides posture
+  transitions, and the emitter cannot opt back into re-buzzing (§9.3).
+- Lockscreen visibility tiers → `redacted`, generalized from an app choice
+  to CFC label enforcement at the push boundary (§9.3).
+- Actions + inline reply → `actions`/`replyTo`, with the broadcast-back
+  replaced by an append to a source-space cell under the user's ordinary
+  session authority (§4.6) — same UX, radically simpler trust story.
+- iOS's interruption-level vocabulary → the posture scale's rungs map onto
+  it (and Android channel importance) so OS compilation is a table lookup,
+  and the reserved break-glass mapping (§9.3) targets `time-sensitive` /
+  `critical` when entitlements land.
+- Channels-as-classification → `kind`, but bound to verified source
+  identity instead of self-declared (§4.4).
+
+**Inverted — the same levers, moved to the user's side:**
+
+- Android lets the user *lower* a channel after the app priced it; here the
+  emitter never prices at all — `postureHint` is advisory, the steward
+  assigns, and raising is exclusively user-authored (§4.2). The one lever
+  Android proved users understand (per-channel importance) becomes the
+  *whole* model rather than the escape hatch.
+- Binary app permission becomes per-source, condition-bearing policy data:
+  clamps, quiet hours with named exceptions, watches — proposable by
+  patterns at the moment of intent, adopted by the user, editable forever
+  (§7). Focus modes' "which people break through" becomes a verified-actor
+  policy rather than app-self-reported metadata.
+- The OS's invisible ML ranking (Android's notification assistant) becomes
+  **learned policies**: the same adaptive demotion, materialized as
+  records the user can read, edit, and delete (§7).
+
+**Added — expressible here, structurally impossible there:**
+
+- A notice is live-tied to its `subject`: handle the thing *anywhere* and
+  the notice retracts *everywhere* — the seen-join (§4.4) gives every
+  source the auto-retract behavior only the best-engineered apps simulate,
+  cross-device, for free.
+- Derived notices: in-fabric changes need no posting at all (§5) — there is
+  no "the app forgot to notify" failure mode, and quiet agent work is
+  visible at zero notification cost.
+- Cross-person semantics as single policy records: collective quiet
+  ("acted-by-any demotes for all") and escalation ("nobody in 2h → raise
+  for the owner") (§8).
+- One canonical, queryable ledger with the OS trays as degraded
+  projections — digests, audit, and coverage measurement read the ledger,
+  not N device states.
+
+**Inherited, honestly:** dead-device delivery still rides APNs/FCM/Web Push
+and their gates — the break-glass ceilings (`time-sensitive`, `critical`,
+DND-bypass) are the platforms' to grant, not ours to declare (§9.3), and
+push timing is theirs. This design compiles down to the OS stacks; it does
+not pretend to replace them.
 
 ## 4. Model
 

--- a/docs/specs/attention-system/README.md
+++ b/docs/specs/attention-system/README.md
@@ -21,10 +21,15 @@ should compile onto, so each stops hand-rolling its own attention state
 (Appendix A maps Loom's candidate shape onto the envelope; Appendix B walks
 fourteen stress-case user stories). Derived from the 2026-05-21
 multi-user/notifications design sessions and the 2026-07 attention reframe;
-revised 2026-07-12 across four adversarial review rounds (runtime + product;
+revised 2026-07-12 across five adversarial review rounds (runtime + product;
 Android-as-gold-standard + primitive-shape + parsimony; user-story grading +
 naming ergonomics; a second story round that re-verified fixes and added
-first-contact, catch-up, profile, and cold-start coverage).
+first-contact, catch-up, profile, and cold-start coverage; a coherence +
+idiomaticness + pragmatism round that consolidated the raise-authority rule,
+merged phantom concepts, and split this spec into its current directory
+form: [`changes-projection.md`](./changes-projection.md) — independently
+approvable — plus [`prior-art.md`](./prior-art.md),
+[`stories.md`](./stories.md), and [`loom-mapping.md`](./loom-mapping.md)).
 
 ## Last Updated
 
@@ -97,11 +102,14 @@ notice; the append-only log. *Steward* — the per-user trusted fold that admits
 candidates, assigns postures, and guards the user's quiet; called a steward,
 not a "ranker", because ranking is its most minor duty and it works for the
 user, not the feed. (No relation to Loom's retired "Attention Steward"
-auto-surfacing system — this is a routing fold, not a suggestion engine.) *Ledger* — the notices store specifically. *Attention
-state* — the triple of stores (notices, dispositions, seen — §4.5). *Lane* —
-a shell projection over attention state (most lanes correspond to a posture
-rung; some, like the snoozed lane, are lifecycle views). *Watch set* — the
-entity set whose changes the user's attention system observes (§5).
+auto-surfacing system — this is a routing fold, not a suggestion engine.)
+*Ledger* — the notices store specifically. *Attention state* — the triple
+of stores (notices, dispositions, seen — §4.5). *Lane* — a shell projection
+over attention state (most lanes correspond to a posture rung; some, like
+the snoozed lane, are lifecycle views). *Watch set* — the entity set whose
+changes the user's attention system observes (§5). *Artifact* — a
+user-meaningful entity, typically a piece's result cell; the spec says
+"entity" where the memory-v2 identity (versioning, `seq`) is what matters.
 
 ## Goals
 
@@ -132,7 +140,7 @@ entity set whose changes the user's attention system observes (§5).
   the data they render is trustworthy.
 - **Work-start authorization and preparation.** Policies governing whether
   an agent may autonomously begin work, budgets, authority ceilings, and
-  continuity ownership are product-side (§Division of labor). The runtime
+  continuity ownership are product-side (Division of labor, in the Summary). The runtime
   never decides what work happens — only how its results claim attention.
 - **Policy seeding / onboarding flows.** How a product interviews the user
   and proposes an initial policy set is product-scope; the runtime primitive
@@ -188,165 +196,31 @@ Pond's donut prototype ranks pieces spatially by an attention score. Both
 need the same substrate: durable per-user seen-state, a trustworthy
 canonical ledger, and per-user routing policy. This spec is that substrate —
 and only that substrate; Loom's work-start machinery and stance-bearing
-judgment policies stay product-side (§Division of labor).
+judgment policies stay product-side (Division of labor, in the Summary).
 
-### 3.2 Prior art: how the OS notification stacks work
+### 3.2 Prior art, compressed
 
-This design borrows deliberately from the OS notification systems — and its
-strongest claims are about what their architecture *cannot* express — so
-reviewers need the minimum shape of those APIs to judge the comparison.
-(Deeper per-field mappings live in the adapter sections, §9.3.)
+Full reviewer background on the OS notification stacks — Android's channels
+and `notify(id)` model, iOS's interruption levels and Notification Service
+Extension, Web Push, and the seven things the shared
+emitter-priced-snapshot-to-device-tray architecture structurally cannot do —
+lives in [`prior-art.md`](./prior-art.md). The relationship in three lines:
 
-**The shared architecture.** On every platform, an app granted a one-time
-binary permission constructs a notification payload — title, body, media,
-optional buttons — hands it to the OS, and **chooses its own loudness**.
-Delivery to a device where the app isn't running rides a vendor relay
-(Apple's APNs, Google's FCM, a browser's push service) to an OS daemon. The
-notification is a **snapshot copy**: once posted, it has no live tie to the
-data it describes beyond an app-chosen identifier the app can use to replace
-or cancel it. Seen/dismissed state is **per-device tray state** — dismissing
-on the phone does nothing on the laptop unless the app hand-builds
-push-to-cancel sync. The only cross-app arbitration the user gets is a
-chronological pile in a tray.
+- **Adopted**: stable-id replace/retract; only-alert-once (made unconditional
+  for the emitter); lockscreen visibility tiers (generalized to CFC labels);
+  actions + inline reply (re-based on session authority); the
+  interruption-level vocabulary as the posture scale's OS compile target.
+- **Inverted**: the emitter never prices loudness (`postureHint` is
+  advisory; the steward assigns; raising is policy, §4.2/§7); binary app
+  permission becomes condition-bearing policy data; invisible adaptive
+  ranking becomes legible learned policies.
+- **Added** (structurally impossible there): notices live-tied to their
+  subject (handle anywhere → retract everywhere); derived notices (no
+  forgot-to-notify failure mode); cross-person quiet and escalation as
+  single policy records; one queryable ledger with OS trays as degraded
+  projections. Inherited honestly: delivery still rides APNs/FCM/Web Push
+  and their entitlement gates — we compile down, we don't replace.
 
-**Android — the most capable, and this spec's behavioral reference:**
-
-- **Channels**: an app declares named notification categories; after
-  creation, the *user* controls each channel's importance, sound, and
-  lockscreen visibility, and the app can never raise them — only lower.
-  This is the germ of this spec's inversion, but only the germ: the app
-  still picks every channel's *initial* importance, can mint fresh channels
-  freely (resetting defaults), and the user discovers channels reactively,
-  buried in settings, usually after being annoyed.
-- **Replace/retract**: `notify(id, …)` with the same id replaces the
-  delivered notification in place; `cancel(id)` retracts it.
-  `setOnlyAlertOnce(true)` — *optionally* — makes re-posts update silently.
-  `setTimeoutAfter(ms)` auto-cancels. Groups get a summary notification.
-- **Actions + RemoteInput**: buttons and inline text reply on the
-  notification itself — act without opening the app; the input is delivered
-  back to the app via a broadcast.
-- **Lockscreen visibility tiers**: per notification, public / private /
-  secret, with an app-supplied redacted `publicVersion` for untrusted
-  displays.
-- **Ongoing + progress** notifications; full-screen intents for calls and
-  alarms; per-channel do-not-disturb bypass flags.
-- **Delivery**: FCM wakes the app process; notifications post with the app
-  dead and survive reboot.
-
-**iOS:**
-
-- **Interruption levels** — `passive` (no wake), `active` (default),
-  `time-sensitive` (breaks through Focus; requires an entitlement),
-  `critical` (breaks mute; Apple-granted entitlement, effectively
-  medical/safety only). An OS-enforced ceiling on loudness classes — but
-  the *app* picks the level per notification, subject only to those gates.
-- **Replace** via `UNNotificationRequest.identifier` (local) and
-  `apns-collapse-id` (push). Content freezes at delivery — it refreshes
-  when the user reopens the shade but never ticks live; genuinely live UI
-  is a separate API surface (Live Activities).
-- **Notification Service Extension**: a slice of app code runs on receipt
-  and may mutate content before display — the platform's hook for
-  decrypt-on-device and fetch-on-receive (the shape §9.3's redaction rule
-  compiles to).
-- **Focus modes**: user-side routing — which apps and which *people* may
-  break through — but coarse: app-grain and contact-grain, with no
-  conditions, and each app self-reports what a "person" is.
-
-**Web Push**: VAPID-authenticated push to a service worker;
-`showNotification` with `tag` for replace and `actions` for buttons;
-payloads are encrypted to the subscription, so the browser vendor's relay
-cannot read content (alone among the three). The most constrained surface —
-which is exactly why it is this spec's envelope floor (§9.3).
-
-**What the architecture structurally cannot do.** These are not missing
-features; they are consequences of "emitter-priced snapshot copies delivered
-to per-device trays," and they are the holes this design exists to fill:
-
-1. **The emitter prices its own loudness.** Android's channel initial
-   importance and iOS's interruption level are chosen by the party with the
-   incentive to interrupt. The user's recourse is reactive and blunt:
-   per-app or per-channel toggles, discovered after the annoyance.
-2. **Permission is binary and app-grain.** Allow-or-deny at first run.
-   There is no "this thread, quietly", no "this source, only until I've
-   handled one", no conditional grant — unless the app builds its own
-   settings screen, which the OS cannot verify it honors.
-3. **The notification is a dead copy.** Nothing retracts it when the
-   underlying thing is handled elsewhere; read-state doesn't cross devices;
-   the email you answered on your laptop still sits on your phone's
-   lockscreen. Well-engineered apps simulate liveness with push-to-cancel;
-   most don't.
-4. **No cross-source arbitration.** The tray is a chronological pile.
-   Nothing sees "forty things are competing for this person right now" —
-   notification fatigue is unaddressable at the system level because no
-   system-level party holds the queue.
-5. **No cross-person semantics.** "Someone on the team handled it" and
-   "escalate if nobody does" are unexpressible; every paging product is a
-   SaaS control plane bolted on top to compensate.
-6. **The relay reads the payload** (APNs and FCM; Web Push excepted).
-   Confidentiality requires per-app heroics — end-to-end encryption plus
-   on-device decrypt in an extension — rather than being a property of the
-   flow.
-7. **User policy is not data.** The user cannot write, inspect, or port a
-   routing rule. What the OS learned about their preferences (if anything)
-   is invisible and vendor-locked.
-
-### 3.3 What this design adopts, inverts, and adds
-
-**Adopted — the mechanics that earned their keep** (this spec's ledger stays
-"Android-shaped" so adapters compile 1:1):
-
-- Stable-identity replace/retract → `id`, steward-derived (§4.4).
-- Only-alert-once → made *unconditional*: alerting rides posture
-  transitions, and the emitter cannot opt back into re-buzzing (§9.3).
-- Lockscreen visibility tiers → `redacted`, generalized from an app choice
-  to CFC label enforcement at the push boundary (§9.3).
-- Actions + inline reply → `actions`/`replyTo`, with the broadcast-back
-  replaced by an append to a source-space cell under the user's ordinary
-  session authority (§4.6) — same UX, radically simpler trust story.
-- iOS's interruption-level vocabulary → the posture scale's rungs map onto
-  it (and Android channel importance) so OS compilation is a table lookup,
-  and the reserved break-glass mapping (§9.3) targets `time-sensitive` /
-  `critical` when entitlements land.
-- Channels-as-classification → `kind`, but bound to verified source
-  identity instead of self-declared (§4.4).
-
-**Inverted — the same levers, moved to the user's side:**
-
-- Android lets the user *lower* a channel after the app priced it; here the
-  emitter never prices at all — `postureHint` is advisory, the steward
-  assigns, and raising is exclusively user-authored (§4.2). The one lever
-  Android proved users understand (per-channel importance) becomes the
-  *whole* model rather than the escape hatch.
-- Binary app permission becomes per-source, condition-bearing policy data:
-  clamps, quiet hours with named exceptions, watches — proposable by
-  patterns at the moment of intent, adopted by the user, editable forever
-  (§7). Focus modes' "which people break through" becomes a verified-actor
-  policy rather than app-self-reported metadata.
-- The OS's invisible ML ranking (Android's notification assistant) becomes
-  **learned policies**: the same adaptive demotion, materialized as
-  records the user can read, edit, and delete (§7).
-
-**Added — expressible here, structurally impossible there:**
-
-- A notice is live-tied to its `subject`: handle the thing *anywhere* and
-  the notice retracts *everywhere* — the seen-join (§4.4) gives every
-  source the auto-retract behavior only the best-engineered apps simulate,
-  cross-device, for free.
-- Derived notices: in-fabric changes need no posting at all (§5) — there is
-  no "the app forgot to notify" failure mode, and quiet agent work is
-  visible at zero notification cost.
-- Cross-person semantics as single policy records: collective quiet
-  ("acted-by-any demotes for all") and escalation ("nobody in 2h → raise
-  for the owner") (§8).
-- One canonical, queryable ledger with the OS trays as degraded
-  projections — digests, audit, and coverage measurement read the ledger,
-  not N device states.
-
-**Inherited, honestly:** dead-device delivery still rides APNs/FCM/Web Push
-and their gates — the break-glass ceilings (`time-sensitive`, `critical`,
-DND-bypass) are the platforms' to grant, not ours to declare (§9.3), and
-push timing is theirs. This design compiles down to the OS stacks; it does
-not pretend to replace them.
 
 ## 4. Model
 
@@ -385,18 +259,21 @@ occupies exactly one rung, and the rung is a promise:
 
 Two invariants:
 
-- **Downward bias.** Defaults sit low (`silent`/`review`). Sources post a
-  *hint*; the steward assigns the real posture via the policy clamp (§7), and
-  repeated dismiss-without-open feeds back as learned clamps. Crucially,
-  **no emitter-controlled field may raise posture**: reaching `interrupt`
-  (or `heads-up` above a source's learned baseline) requires a user-adopted
-  policy floor — never urgency claims, expiry times, or any other field the
-  emitter writes. An emitter cannot buy `interrupt` with enthusiasm. The
-  same discipline binds the *shipped defaults*: any default above `review`
-  must match on **steward-verified facts** (e.g. `actor` is a human DID with
-  an established relationship to the user), never on self-declared fields
-  like `kind` — otherwise declaring a kind *is* choosing a baseline, which
-  re-opens the loophole this invariant closes.
+- **Downward bias — the raise-authority rule.** This is the spec's central
+  invariant; it has exactly four tiers, and this bullet is its one canonical
+  home (other sections reference it, never restate it):
+  1. **Emitter fields never raise.** No field a source writes — hints,
+     urgency copy, expiry times, self-declared `kind` — can raise posture.
+     An emitter cannot buy `interrupt` with enthusiasm.
+  2. **Shipped defaults may set floors up to `heads-up`**, and only when
+     matching on **steward-verified facts** (e.g. `actor` is a verified
+     human DID with an established relationship) — never on self-declared
+     fields like `kind`, since declaring a kind would *be* choosing a
+     baseline.
+  3. **`interrupt` floors are user-adopted only** — hand-written or
+     accepted through the propose/adopt flow (§7).
+  4. **Learned policies only lower** (§7) — the system's own adaptation can
+     quiet a source, never amplify one.
 - **Attention ≠ confidence.** How sure the system is about a notice and how
   loudly it surfaces are separate axes. Uncertain-but-urgent goes to
   `heads-up` with its uncertainty stated (product copy; `ext` if
@@ -469,8 +346,9 @@ type NoticeCandidate = {
   // kind for a given source sticks; a source changing its declared kind
   // is itself a reputation signal (and does not escape kind-matched
   // clamps, which follow the source identity). Policy matching (§7) and
-  // digest grouping (§9.2) key on it. Self-declared, therefore never a
-  // basis for above-review shipped defaults (§4.2).
+  // digest grouping (§9.2) key on it. Self-declared — see §4.2's
+  // raise-authority tiers and the match-schema comment (§7) for what may
+  // therefore never key on it.
   kind: string;
   // Grouping key for presentation AND displacement: within a threadKey,
   // only the newest live notice is visible (§6.4). One conversation, one
@@ -489,7 +367,11 @@ type NoticeCandidate = {
   // envelope and fetch full content on unlock/open.
   redacted?: { title: string; body: string };
   // Where opening the notice goes, when that differs from subject
-  // (default: subject). Navigated with navigateTo().
+  // (default: subject). Navigation grain: navigateTo() navigates to a
+  // PIECE — when the subject is finer-grain (one message, one entity of
+  // twelve), target must resolve to the containing piece, with the
+  // specific entity carried as a focus hint the destination renders
+  // (changed-region emphasis rides the same hint).
   target?: unknown;           // asCell: ["cell"]
   // Prepared material (draft, diff, packet) when it is a different
   // artifact than the destination.
@@ -536,7 +418,10 @@ type Notice = NoticeCandidate & {
   // The promise made to the user (§4.2) — the only loudness surfaces read.
   posture: "silent" | "review" | "heads-up" | "interrupt";
   // Intra-rung ordering. Opaque; never crosses rungs; never gates
-  // delivery (§4.2).
+  // delivery (§4.2). Write discipline: assigned at admission and updated
+  // only during coalesce — never by standalone re-ranking writes (ledger
+  // writes wake lanes, §4.5); surfaces wanting continuous re-ordering
+  // derive it at read.
   weight?: number;
 };
 
@@ -608,18 +493,18 @@ const alreadySeen = (n: Notice, seen: SeenStore) =>
 const visible = (
   n: Notice, log: NoticeDisposition[], seen: SeenStore, now: number,
 ) =>
+  // realert-matched notices skip the alreadySeen term (§7): they clear
+  // only on a terminal disposition.
   !terminal(n, log) && !alreadySeen(n, seen) && !snoozed(log, now) &&
   (n.notBefore === undefined || now >= n.notBefore) &&
   (n.expiresAt === undefined || now < n.expiresAt);
 ```
 
 Notices that should outlive observation (a todo is not done because you
-looked at it; a medication reminder must nag) are handled deliberately, not
-by the runtime guessing which glances "count": a user-adopted `realert`
-policy (§7) **exempts matched notices from seen-satisfaction entirely** —
-they clear only on a terminal disposition, never because the user glanced
-at the subject — and the source re-posts at a newer version when it is
-meaningfully newsworthy again (content escalation, not liveness).
+looked at it; a medication reminder must nag) are handled by a user-adopted
+`realert` policy — semantics in §7: matched notices are exempt from
+seen-satisfaction and clear only terminally. Sources re-post at newer
+versions for *content* escalation, not liveness.
 Satisfaction that doesn't involve the user looking (someone else handled it;
 the trip ended) is the steward's job: its fold observes the subject change and
 terminally retracts the notice (system disposition by module identity).
@@ -676,8 +561,11 @@ three stores, and the three backings are not ad-hoc — they derive from a
    recommended backing is a small **sqlite database private to seen-state**
    (upsert-by-key is what SQL is for; no trust gating needed — every
    surface of the *user's own runtime* may write the user's own marks),
-   with an array-cell fallback. Write discipline is part of the spec, not
-   an optimization: **seen = focused open** (§5), a mark is written **only
+   with an array-cell fallback. The handle is instantiated and owned by
+   the shell's home-context attention pattern (a trusted surface); other
+   surfaces write marks through it, not via their own handles. Write
+   discipline is part of the spec, not
+   an optimization: seen = focused open (defined in §5), a mark is written **only
    when it advances** (`newSeq > seenSeq` — re-renders and repeat views are
    no-ops, which is also what breaks any render→write→render cycle) and
    **debounced per focus session** (at most one write per entity per
@@ -776,7 +664,7 @@ whose subject is the entity) and it was the focus of their attention.
 Scrolling past a row in a list is *not* seen; rendering a lane is *not*
 seen. This single definition is load-bearing three ways: it keeps unseen
 dots honest, it keeps disclosed read-receipts meaningful (§8), and it keeps
-seen writes rare (§4.5.3).
+seen writes rare (§4.5, seen store).
 
 ```ts
 // Shown for illustration only.
@@ -797,10 +685,11 @@ Everything else is the **changes projection** (§10.1) joined against marks:
   the steward. Renders as a pattern on the home context. This is the
   first-run view and the every-return view — the same query. The affordance
   must answer *what changed, by whom, since you looked* — the projection's
-  `author` field gives session-grain attribution from day one (§10.1) — and
-  a jump-in that emphasizes the changed region (memory-v2 holds both
-  versions; the diff is derivable). A bare dot that says "something
-  happened" does not meet the bar (§4.1).
+  `author` field gives session-grain attribution from day one (§10.1) —
+  with a jump-in to the destination. Emphasizing the changed region at the
+  destination (memory-v2 holds both versions; the diff is derivable) is
+  the phase-1 stretch of this bar, not its phase-0 gate — but a bare dot
+  that says "something happened" does not meet it at any phase (§4.1).
 - **Artifact lifecycle** falls out of the same two numbers plus a timestamp:
   *fresh* (unseen changes) → *seen* → *stale* (untouched for N) →
   *archived*. No new subsystem.
@@ -887,8 +776,8 @@ checks, and the design uses both — every steward write is attributable
 `writeAuthorizedBy` authorizes *code*, not an *instance*: two devices running
 the steward both pass the claim. The single-writer premise therefore needs
 instance discipline, not just CFC: **the interim client-side steward takes a
-lease** (a mutex cell claimed with an expiry; the sqlite spec's
-`tryClaimMutex` shape) and only the leaseholder folds. Independent of the
+lease** (a mutex cell claimed with an expiry — the `tryClaimMutex` shape from the
+fetch builtin's utilities, `packages/runner/src/builtins/fetch-utils.ts`) and only the leaseholder folds. Independent of the
 lease, the fold is specified **idempotent and commutative over the notice
 inbox** (deterministic ids; coalescing recomputes from subject state rather
 than incrementally mutating), so a lease handoff or a brief double-writer
@@ -977,8 +866,8 @@ type AttentionPolicy = {
     // Nag-until-done: a matched notice is EXEMPT from seen-satisfaction —
     // it clears only on a terminal disposition (acted/dismissed/archived),
     // never because the user glanced at the subject — and re-alerts on
-    // this cadence while live. One of the two consented exceptions to
-    // §9.3's alert-once rule. User-authored only; the cadence needs timer
+    // this cadence while live. The one consented exception to §9.3's
+    // alert-once rule. User-authored only; the cadence needs timer
     // wake (§10.5) to fire between commits.
     realert?: { everyMs: number };
     coalesceWindowMs?: number;
@@ -997,40 +886,39 @@ type AttentionPolicy = {
 
 **Composition is one formula, with a hard ceiling.** Effective posture =
 `clampScale(baseline, max(matching mins), min(matching maxes))` where
-**`baseline = min(postureHint, "review")`**, further bounded by the
-source's learned baseline. The ceiling is load-bearing: absent it, a
-brand-new source with no learned history and no matching max would get
-whatever it hinted — the exact cold-start hole §4.2 forbids. As written,
-no notice exceeds `review` unless a *policy min* raises it, and mins above
-`review` are user-authored only (shipped defaults and learned policies
-never set them). **Maxes dominate mins** on conflict, with one exception —
-a user-authored min marked `bypassQuietHours` survives the quiet-hours
-max. `quietHours` is defined as nothing more than a time-conditional max
-(default `"review"`; `days` scopes it — "work sources suppressed on
-weekends" is `{quietHours: {start: "00:00", end: "24:00", days:
-["sat","sun"], max: "suppress"}}`). The canonical case — "quiet hours
-22:00–07:00, but the babysitter thread always breaks through" — is two
-records and zero ambiguity.
+**`baseline = min(postureHint, "review")`**. The ceiling is load-bearing:
+absent it, a brand-new source with no matching max would get whatever it
+hinted — the exact cold-start hole §4.2's tier 1 forbids. Raising above
+the ceiling happens only through policy mins, under §4.2's raise-authority
+tiers (shipped verified-fact defaults up to `heads-up`; `interrupt`
+user-adopted only). Learned demotion needs no term of its own: learned
+policies *are* maxes, absorbed by `min(matching maxes)`. **Maxes dominate
+mins** on conflict, with one exception — a user-authored min marked
+`bypassQuietHours` survives the quiet-hours max. `quietHours` is defined
+as nothing more than a time-conditional max (default `"review"`; `days`
+scopes it — "work sources suppressed on weekends" is `{quietHours:
+{start: "00:00", end: "24:00", days: ["sat","sun"], max: "suppress"}}`).
+The canonical case — "quiet hours 22:00–07:00, but the babysitter thread
+always breaks through" — is two records and zero ambiguity.
 
-- Policies live in the user's home space (`PerUser` scope). The core ships a
-  handful of defaults: messages from **verified human actors with an
-  established relationship** (rosters, prior threads — and rosters are
-  seeded by contact import at onboarding, so this default works on day
-  one, not after weeks of thread history) → `heads-up`; **first contact
-  from a verified human actor with no established relationship** →
-  `review`, grouped in a distinguished **requests** shelf (the
-  message-requests idiom), quota-bounded per source, where the notice
-  carries a one-tap promote affordance that writes `{match: {actor},
-  clamp: {min: "heads-up"}}` through the trusted surface — legitimate
-  strangers (the marketplace buyer, the new-school-year parent) are
-  distinguishable from importer noise without being handed loudness;
-  agent-completions → `silent` (visible as seen-state, never buzzing). Per
-  §4.2, shipped defaults above `silent` key on steward-verified facts only
-  — never on self-declared `kind` (declaring `kind: "group-chat"` must not
-  buy the human-messages baseline; "first contact from a verified human"
-  is verifiable — DID checked, roster/thread absence checked). There is
-  deliberately **no default that maps any emitter-supplied field to
-  `interrupt`**.
+- **User attention policies live in the user's home space** as ordinary
+  cells (the space is single-user; no scope wrapper is needed). Two other
+  policy kinds live *with the shared space they govern*, as `PerSpace`
+  cells: the disclosure policy and escalation proposals (§8) — see §8 for
+  how they reach the fold. The core ships a handful of defaults: messages
+  from **verified human actors with an established relationship** (rosters,
+  prior threads — rosters seeded by contact import at onboarding, so this
+  works on day one) → `heads-up`; **first contact** from a verified human
+  actor with no established relationship → `review`, presented as a
+  distinct requests grouping in the review lane (§9.1) with a one-tap
+  promote affordance that writes `{match: {actor}, clamp: {min:
+  "heads-up"}}` through the trusted surface — legitimate strangers (the
+  marketplace buyer, the new-school-year parent) are distinguishable from
+  importer noise without being handed loudness, and both facts are
+  steward-verifiable (DID checked; roster/thread absence checked);
+  agent-completions → `silent` (visible as seen-state, never buzzing).
+  All defaults obey §4.2's raise-authority tiers; there is deliberately
+  no default involving `interrupt`.
 - **Mute is a policy, not a special relation** (and not a disposition).
   "Mute this thread" writes `{match: {threadKey}, effect: {clamp: {max:
   "suppress"}}}`; the re-fold rule (§4.7) demotes existing notices too.
@@ -1040,27 +928,28 @@ records and zero ambiguity.
   writes — adoption *is* the write, and unadopted proposals never enter the
   fold. Two idioms this primitive must carry, because users won't write
   these policies unaided:
-  - **The emergency pack.** Nobody writes an interrupt floor for their
-    kid's school until the day it's too late. Products should propose a
-    small break-glass set at onboarding — school/daycare numbers and
-    alarm/fraud *sources* — as `{match: {actor | subject | spaceDid},
-    clamp: {min: "interrupt"}, bypassQuietHours: true}` through this same
-    adopt flow. Bind these floors to **verified identities** (`actor`,
-    `subject`, `spaceDid`), never to `kind`: a kind-matched interrupt
-    floor is first-declaration-spoofable by any new source that declares
-    the magic kind. The runtime's part: those adopted policies compile to
-    the OS's highest available interruption level (§9.3's reserved
-    mapping). Honest residual: an emergency from a source the user never
-    adopted and doesn't know lands at `review` (first-contact shelf at
-    best) — the price of the inversion, which the pack exists to shrink,
-    not erase.
-  - **The deadline ladder.** Long-lived obligations post their whole
-    escalation ladder ahead of time: three candidates with `notBefore` =
-    T-90/T-30/T-7, same `threadKey` (each new admission displaces the
-    prior rung), ascending posture hints, plus a proposed min the user
-    adopts once. Obligation met → subject advances → the steward retracts
-    the pending rungs (§4.7's EMBARGOED retraction).
-- **Learned policies: the reputation loop, made legible.** The downward
+  - **The emergency pack** (product guidance; the runtime carries two
+    invariants). Nobody writes an interrupt floor for their kid's school
+    until the day it's too late, so products should propose a small
+    break-glass set at onboarding — `{match: {actor | subject | spaceDid},
+    clamp: {min: "interrupt"}, bypassQuietHours: true}` per source. The
+    runtime invariants: interrupt floors bind to **verified identities**,
+    never `kind` (a kind-matched floor is first-declaration-spoofable by a
+    new source — the schema comment in `match` is this rule's home), and
+    adopted floors compile to the OS's highest available interruption
+    level (§9.3's reserved mapping). Honest residual: an emergency from a
+    source the user never adopted and doesn't know lands at `review` — the
+    price of the inversion, which the pack shrinks, not erases
+    (walkthrough: `stories.md` B.1).
+  - **The deadline ladder** (pure composition, zero new mechanism):
+    long-lived obligations post their escalation ladder ahead of time —
+    candidates at `notBefore` T-90/T-30/T-7, same `threadKey` (each new
+    admission displaces the prior rung), ascending hints, plus a proposed
+    min adopted once. Obligation met → subject advances → the steward
+    retracts the pending rungs (§4.7). Walkthrough: `stories.md` B.9.
+- **Learned policies: the reputation loop, made legible** *(phase 2 — the
+  adaptive loop needs signal volume and its dynamics are open, §12.8;
+  phase 1 ships only the invariant and the `author` slot)*. The downward
   feedback the spec promises (dismiss-without-open, quota pressure ⇒ the
   source's notices sink) has to live *somewhere*, and hidden steward state
   would break the inspectability goal. It lives here: the steward — which is
@@ -1069,10 +958,10 @@ records and zero ambiguity.
   = the evidence, e.g. "7 of 8 notices dismissed without open over 30d")
   into a designated **learned** section of the policy store. They are
   visible, editable, and deletable exactly like hand-written policies; a
-  user deleting one is itself a signal. Learned policies may only *lower*
-  (set maxes / lower the baseline) — raising posture remains exclusively
-  user-authored (§4.2). This follows the platform's existing precedent for
-  system-inferred-but-user-owned data (`packages/home-schemas/learned.ts`).
+  user deleting one is itself a signal. **Learned policies are maxes** —
+  §4.2 tier 4: the system's own adaptation only lowers. This follows the
+  platform's existing precedent for system-inferred-but-user-owned data
+  (`packages/home-schemas/learned.ts`).
 - **Product policy dimensions compile down.** Stance-like vocabularies
   (Loom's `attention-policy-v1`) do not ride an opaque field on runtime
   policies — there is deliberately no `AttentionPolicy.ext`, because an
@@ -1118,9 +1007,17 @@ relation" plus existing constraints:
   want receipts, some don't); a member who discloses nothing simply doesn't
   appear — and, corollary, silently opts out of collective quiet, which the
   space's members should understand when choosing the policy.
-- **Escalation across people is a policy.** "If nobody attends to this
-  within 2h, raise it to `heads-up` for the space owner" is a policy cell on
-  the shared space, evaluated by the owner's steward against contributed
+- **Escalation across people is a policy — adopted, not imposed.** "If
+  nobody attends to this within 2h, raise it to `heads-up` for the space
+  owner" is a policy cell on the shared space. But a shared-space cell must
+  not be able to raise posture for a member who never agreed (§4.2 tier 3),
+  so escalation records are **proposals**: they enter a member's fold only
+  once that member adopts them (a home-space policy referencing the space,
+  written through the ordinary adopt flow — for the owner, typically at
+  space creation). Shared-space policy cells (disclosure, escalation) reach
+  the fold the same way candidates do: forwarded/read through the member's
+  ordinary sessions (§6.1) — no new cross-space capability. Once adopted,
+  it is evaluated by the owner's steward against contributed
   state. No siloed notification system can express this; here it is one
   record. (Escalation is a posture *raise* after admission; §9.3's
   transition rule makes it alert exactly once. Deadline-shaped escalation —
@@ -1128,8 +1025,8 @@ relation" plus existing constraints:
 
 **Profiles.** A user with multiple profiles (work, personal) has one
 attention system *per profile*: profile ≡ its own space graph ≡ its own
-home space, so attention state, policies, steward, and learned baselines
-are independent per profile by construction — nothing new to build, and no
+home space, so attention state, policies, and steward are independent per
+profile by construction — nothing new to build, and no
 cross-profile leakage to prevent (a work source cannot learn it's quiet on
 the personal profile because it never met the personal profile). Merging
 the two into one device's shell — one bell over N profiles' lanes — is a
@@ -1186,16 +1083,15 @@ there:
   coalesce — new message in the thread, progress tick, content refresh —
   **replaces silently** on every surface (Android `setOnlyAlertOnce`
   semantics, made unconditional: the emitter cannot choose to re-buzz).
-  The invariant bends in exactly **two consented ways**, both bounded by
-  user grants: a user-authored `realert` policy (§7) re-alerts a live
-  matched notice on its cadence and exempts it from seen-satisfaction —
+  The invariant bends in exactly **one consented way**: a user-authored
+  `realert` policy (§7) re-alerts a live matched notice on its cadence —
   nag-until-done for medication-grade obligations, grantable only by the
-  user; and a *fresh* notice (new event key, new `id`) first materializing
-  at an alert-bearing rung alerts — which means a source holding a
-  user-granted floor can alert once per genuinely new event, bounded by
-  intake quotas (§6.1) and revocable by editing the floor. Name that
-  honestly: alert-once is per-*notice*; per-*source* alert frequency is
-  governed by quotas plus the user's grant, not by the coalesce rule.
+  user. (A *fresh* notice first materializing at an alert-bearing rung
+  alerting is the base rule, not an exception — but state its consequence
+  honestly: alert-once is per-*notice*, so a source holding a user-granted
+  floor can alert once per genuinely new event; per-*source* frequency is
+  governed by intake quotas (§6.1) plus the user's grant, revocable by
+  editing the floor.)
   Posture *demotion* and visibility flips are retraction triggers: the
   dispatcher retracts or downgrades the delivered surface when either
   occurs. And on device (re)registration after an offline gap, the
@@ -1259,35 +1155,20 @@ This design mostly composes existing primitives, but not entirely. Naming
 the gaps is the point of this section — each is a prerequisite of the phase
 that first needs it (§11), and each needs its own (small) design pass.
 
-1. **Changes projection** *(phase 0)*. Patterns and the shell cannot read an
-   entity's memory-v2 head `seq` — `Cell` exposes no version, deliberately —
-   yet `seq` already crosses the wire in every query result
-   (`FactEntry.seq`, memory-v2 §5.7.1), and changed-since-a-basis is
-   precisely the session catch-up computation (memory-v2 §5.4.2,
-   `SessionSync.fromSeq/toSeq`). Rather than a Cell method, seen-state
-   needs one small **read-only, one-shot, session-independent query**:
+1. **Changes projection** *(phase 0)*. One read-only, one-shot,
+   session-independent memory-v2 query —
+   `changes(roots, branch, sinceSeq?, attribution?) → {toSeq, entries:
+   [{id, seq, deleted?, author?}]}` — giving a non-reactive head read, the
+   changed-since enumeration behind "while you were away", and
+   session-grain "by whom" from the commit log's persisted `sessionId`.
+   Small because every load-bearing piece is shipped (the `head` table, the
+   session catch-up delta, `FactEntry.seq`); a **security surface** because
+   it exposes versions to pattern-space and adds an enumeration read, gated
+   by exactly the read authority of the entities themselves. Full
+   mini-spec, CFC story, and non-attention consumers:
+   [`changes-projection.md`](./changes-projection.md) — deliberately
+   independently approvable.
 
-   `graph.changes(roots, branch, sinceSeq?, attribution?) →
-   { toSeq, entries: [{id, seq, deleted?, author?}] }`
-
-   (a) With a single root and no basis it is the **non-reactive head read**
-   — a one-shot query, not a watch, so re-renders never re-fire. (b) With
-   the watch set as roots and the seen watermark as basis it is the
-   **"while you were away" enumeration** — one indexed scan of the `head`
-   table (add a `(branch, seq)` index). (c) With `attribution: true` it
-   joins the commit log's already-persisted `sessionId` — **session-grain,
-   server-asserted "by whom" from day one**, upgrading in place to
-   `invocationRef`-backed proof when the signed-write pass lands (a join,
-   not a cryptography project). CFC: an entity may appear in a changes
-   result iff the caller may read the entity on that branch — strictly less
-   than a materialized read reveals. Not attention-specific: offline
-   catch-up UIs, activity/audit views, incremental derived indexes, and
-   retention watermarks consume the same query. It is the entity-grain,
-   payload-free member of the projection family memory-v2 §07 sketches —
-   and deliberately *not* built on §07's annotations plane, which is
-   range-anchored collaborative-field machinery, self-declared future work;
-   the one annotation prototype's review (PR #4132) documents why
-   side-table indexes invisible to the reactive graph are the wrong shape.
 2. **Notice inbox append gate** *(phase 1; hardened by phase 2)*. A
    home-space inbox cell with **restricted cross-principal append**: other
    principals' patterns may append candidates (the rosters
@@ -1327,27 +1208,35 @@ that first needs it (§11), and each needs its own (small) design pass.
 Each phase is independently shippable and none re-shapes the data model.
 
 - **Phase 0 — seen-state.** The changes projection (§10.1), the seen store
-  with its write discipline (§4.5.3), unseen dots in the shell, and a
+  with its write discipline (§4.5, seen store), unseen dots in the shell, and a
   "while you were away" home pattern. No steward, no candidates, no push.
   Acceptance bar: the user can see *what changed, by whom (session-grain),
-  and since when*, and jump in with the changed region emphasized — not
-  merely that a dot exists. This makes agent work **visible** — the single
-  most-requested product gap — while run-level *legibility* (one notice per
-  agent run, not twelve dots) is explicitly phase 1's follow-through.
+  and since when*, and jump in — not merely that a dot exists.
+  (Changed-region emphasis at the destination is a phase-1 stretch.) This
+  makes agent work **visible** — the single most-requested product gap —
+  while run-level *legibility* (one notice per agent run, not twelve dots)
+  is explicitly phase 1's follow-through. Rough cost: ~9–13 eng-weeks,
+  dominated by the changes projection's CFC review and focused-open
+  instrumentation across shell and pattern surfaces.
 - **Phase 1 — ledger + lanes.** Envelope, home-space `notices` (array cell
   + `writeAuthorizedBy`) and `dispositions` stores, notice intake (inbox
   gate §10.2, or interim source-space cells), a minimal client-executed
-  steward under lease (verified-fact defaults + clamp composition + learned
-  policies + thread displacement), shell bell/lanes with notice actions
-  (§4.6), receipt-shaped notices for agent runs with attribution folding
-  (§5). Policies v0 (including the emergency-pack and deadline-ladder
-  propose/adopt idioms, §7).
+  steward under lease (verified-fact defaults + clamp composition + thread
+  displacement), shell bell/lanes with notice actions (§4.6),
+  receipt-shaped notices for agent runs with attribution folding (§5), the
+  changed-region-emphasis stretch from phase 0. Policies v0: hand-written
+  and proposed/adopted only (emergency-pack and deadline-ladder idioms,
+  §7) — the learned-policy loop is phase 2. Rough cost: ~19–24 eng-weeks;
+  the sleeper is the propose/adopt trusted-surface UX. Fund against a
+  named first consumer surface (Appendix A note).
 - **Phase 2 — server steward + first transport.** Steward as a standing
   registration on the home space under server-primary execution
-  (dependencies named in §6.3); Web Push with device registration,
-  redaction rules, and retraction; digest queries; timer wake (§10.5),
-  which activates `realert`, escalation deadlines, and timely `notBefore`
-  materialization.
+  (dependencies named in §6.3 — high schedule risk: this sits behind
+  another in-flight spec's later phases); Web Push with device
+  registration, redaction rules, and retraction; digest queries; timer
+  wake (§10.5), which activates `realert`, escalation deadlines, and
+  timely `notBefore` materialization; the learned-policy loop (§7), which
+  by now has signal volume to learn from.
 - **Phase 3 — breadth.** Wrapped-app APNs/FCM; shared seen-state +
   disclosed terminal dispositions + escalation policies (§8); the ledger
   on sqlite once §10.3 lands; snooze/archive surfaced fully; `progress`
@@ -1393,7 +1282,7 @@ Each phase is independently shippable and none re-shapes the data model.
     seen-timestamps. Appendix A is the field mapping; the remaining
     question is sequencing — which loom surface adopts the runtime ledger
     first, and whether loom's materializer becomes the trusted source or a
-    second steward (§Division of labor says: trusted source).
+    second steward (the Division of labor section says: trusted source).
 11. **`realert` bounds.** Minimum cadence, maximum duration, and whether a
     realert policy requires re-confirmation after N fires — the exception
     to alert-once must not become a resharpened nag machine (§7, §9.3).
@@ -1404,35 +1293,16 @@ Each phase is independently shippable and none re-shapes the data model.
     (importer attestation? user confirmation on first sight?) decides how
     much of B.1 and B.11 external sources can actually reach.
 
-## Appendix A — mapping Loom's `attention-candidate-v1`
+## Appendix A — Loom mapping (pointer)
 
-For the first consumer's adoption review. Loom fields → envelope. (Naming
-flag: Loom's `claim_kind` vocabulary includes a value `notice`; product-side
-that value should be renamed — e.g. `fyi` — before the runtime noun lands.)
+The field-by-field mapping of Loom's `attention-candidate-v1` onto the
+envelope — including what deliberately does *not* cross the boundary
+(Work-start Policies, continuity owners, stance vocabularies) — lives in
+[`loom-mapping.md`](./loom-mapping.md). It is the first consumer's adoption
+review artifact and churns on Loom's schedule. Adoption sequencing is open
+question §12.10; phase-1 funding should be contingent on a named first Loom
+surface (durable seen-state, then digest or bell — not the Today block).
 
-| Loom candidate field | Envelope home |
-|---|---|
-| `id` / source identity | `id` (re-derived by steward from verified provenance) |
-| subject / focused target | `subject` (cell link); distinct destination → `target`; `focused_view_fallback` → `ext` |
-| prepared material | `attachment` |
-| `title`, body copy | `title`, `body` (+ `redacted` where the product wants lockscreen-safe copy) |
-| `why_now` | `ext.why_now` (product copy, runtime-opaque) |
-| `claim_kind` (act-now / review / notice→fyi / …) | `kind` + `postureHint` (kind is classification; the hint is the loudness request derived from it) |
-| `channel` (important-and-urgent / yours-in-progress / might-interest-you) | `ext.channel` — audience/genre, orthogonal to posture; product lanes render it |
-| `relation_to_trigger` (augments / supersedes / resolves / …) | `ext.relation_to_trigger`, whole; *supersedes* additionally = share the trigger's `threadKey` (thread displacement, §6.4, does the retraction) |
-| `authorization_state: proposal-required` | `actions: [{key:"approve"…},{key:"deny"…}]` (§4.6) + `ext.authorization_state` — the approval affordance travels with the notice |
-| `authority_class` | `ext` (work-start domain, product-side per §Division of labor) |
-| `not_before` | `notBefore` |
-| sender / subject person | `actor` |
-| delivery/interrupt eligibility | `postureHint`, clamped by user policy (§7) |
-| feedback: done / later | dispositions `acted` / `snoozed` |
-| feedback: never-for-this-class | a policy write (`clamp.max`) via the trusted surface |
-| feedback: not-useful | disposition `dismissed` + `ext.feedback: "not-useful"` (calibration signal round-trips to the product) |
-
-Not mapped, deliberately: Work-start Policies, continuity owners, typed
-receipts' internals, stance vocabularies — upstream product machinery
-(§Division of labor); stance policies compile down to plain clamps/watches
-(§7). A receipt *summary* enters as an ordinary candidate.
 
 ## Appendix B — fourteen worked stories
 
@@ -1453,234 +1323,19 @@ almost immediately.
 | B.3 | On-call triage | multi-user coordination | A− | D (shared state is phase 3) |
 | B.4 | Overnight agent run | quiet agent work | A | A− |
 | B.5 | 2FA code | time-critical, brief | B | B− |
-| B.6 | Social stream | high-volume, low-value | A | A |
+| B.6 | Social stream | high-volume, low-value | A | A− (quotas only; learning is P2) |
 | B.7 | Medical privacy | lockscreen leakage | A | A− (trivially — no push yet) |
 | B.8 | Approve rebooking | act from the surface | A− | B (shell only) |
 | B.9 | Visa renewal | long-lived deadline ladder | B | C+ (evaluate-on-read only) |
 | B.10 | Adversarial source | spam defense | A− | A− |
-| B.11 | Marketplace stranger | first contact, unknown human | B+ (requests shelf + promote) | B− (shell only) |
+| B.11 | Marketplace stranger | first contact, unknown human | B+ (requests grouping + promote) | B− (shell only) |
 | B.12 | Return from vacation | bulk catch-up boundedness | B (aging + reconnect damping) | B− |
 | B.13 | Work/personal split | context separation | B (per-profile state + day-scoped quietHours) | B− |
 | B.14 | Day-one cold start | defaults before any learning | B− (ceiling + roster seeding) | C+ |
 
-### B.1 The school emergency (must-interrupt, novel source)
+The fourteen walkthroughs live in [`stories.md`](./stories.md); the table
+above is the index and the honest summary.
 
-Priya's kid has an allergic reaction at school; the office texts "come now."
-Quiet is the failure mode — and the *novel* emergency is downward bias's
-structural blind spot, because interrupt requires a pre-adopted floor that
-by definition doesn't exist for a first-time source. The design's answer is
-two-part, and honest about its limits: (1) the **emergency pack** (§7) —
-onboarding proposes break-glass floors for school/daycare/alarm/fraud
-sources at the moment the user is thinking about setup, via the ordinary
-propose/adopt flow, **bound to verified identities** (`match.actor` /
-`subject` / `spaceDid` — never spoofable `kind`); (2) the **reserved
-break-glass mapping** (§9.3) — that adopted policy compiles to the OS's
-highest granted interruption level, upgrading to
-`time-sensitive`/`critical` when entitlements land, with no policy
-migration. What the design will *not* do is let the message's own urgency
-raise its posture — that lever, once granted to emergencies, is granted to
-everyone claiming to be one. The residual, stated without varnish: an
-emergency from a source the user never adopted and has no relationship
-with lands at **`review`** (the first-contact requests shelf if it's a
-verified human; §7) — a full miss until the next check-in. That is the
-price of the inversion; the pack exists to shrink it, and how an
-SMS-ingress phone number gets verified as a known actor at all is open
-question §12.12.
-
-### B.2 The medication reminder (seeing must not satisfy)
-
-Elena must take tacrolimus by 9pm; a glance must not silence the reminder.
-Her one-time adopted policy carries `{clamp: {min: "interrupt"},
-bypassQuietHours: true, realert: {everyMs: 600_000}}`, and `realert` does
-the whole job on its own: a matched notice is **exempt from
-seen-satisfaction** — glancing at the reminder does not clear it; only a
-terminal disposition (logging the dose → `acted`, or an explicit dismiss)
-does — and it re-alerts on the cadence while live (§7, §9.3). The med
-pattern may still re-post as the deadline nears (fresh event key, same
-`threadKey`, each rung displacing the last), but that is *content
-escalation* ("30 minutes left"), not liveness — the nag no longer depends
-on the source's own timer discipline. Logging the dose advances the
-subject artifact and the steward terminally retracts every pending rung,
-including embargoed ones (§4.7). Phase gating is real: the cadence firing
-between commits needs timer wake (§10.5) — before phase 2 this story is
-not safely servable and products should not pretend otherwise.
-
-### B.3 On-call triage (exactly one person must act)
-
-A pager event lands in a three-person ops space at 11pm. Each on-call
-member's rotation adopted `{match: {spaceDid: ops-space, kind: "pager"},
-clamp: {min: "interrupt"}, bypassQuietHours: true}` — the `spaceDid` bound
-matters: a bare kind-matched interrupt floor would be claimable by any new
-source declaring `kind: "pager"` (§7). Bea acks from her lockscreen via
-`actions` (§4.6): terminal `acted`, appended to the pattern's `replyTo`
-cell under her session authority. Her runtime discloses the disposition
-into `PerSpace` state; the space's opt-in policy "acted-by-any demotes to
-silent for all" re-lanes Dana's and Sam's notices; posture demotion
-retracts their banners (§9.3). If nobody acts in 15 minutes, the space's
-escalation policy raises the owner's notice — a deadline evaluation that
-needs timer wake (§10.5). One pager event, three independent ledgers,
-collective quiet from one policy record — the part no siloed platform can
-express.
-
-### B.4 The overnight agent run (quiet work, visible)
-
-Tomás's filing agent renames 200 documents at 3am. It posts *one*
-receipt-shaped notice (`threadKey` = run id, `progress` ticking silently),
-laned `silent` by the agent-completions default. The 200 changes are never
-posted at all — they are derived: the while-you-were-away view runs one
-`changes(watchSet, basis, attribution: true)` call and folds every entity
-whose change `author` is the run's session under the receipt. Tomás sees
-one line, expands it, jumps into anything suspicious with the changed
-region emphasized. Zero buzz, full visibility, and the trust that makes
-overnight agents acceptable — the design's home turf, strong from phase 1
-(phase 0 gives the dots without the run grouping).
-
-### B.5 The 2FA code (time-critical, worthless in minutes)
-
-Marcus is mid-login on his laptop; the code arrives via his SMS forwarder.
-Webhook ingress persists durably at the handler (§6.1); the candidate
-carries `expiresAt: +5min` and a `postureHint: "heads-up"` (or `interrupt`
-via a one-time adopted policy the OTP pattern proposed at setup — a
-realistic single config). A second code coalesces silently over the first
-(`id`-keyed replace, §9.3). Expiry hides the notice immediately on read;
-the OS tray copy goes stale until timer wake lands — the spec's own §9.3
-honesty note, and tolerable here because the user is at a client by
-construction (they're logging in). One friction worth product attention: a
-cautious confidentiality label pushes the code behind the generic envelope
-— the rare notice whose whole value is lockscreen visibility; the OTP
-pattern should set `redacted` to carry the code deliberately.
-
-### B.6 The social stream (high-volume, low-value; downward bias earns its keep)
-
-Nina's social importer posts ~80 like/follow events daily; she never opens
-them. Intake quotas bound the flood at the write gate against verified
-writer identity (§10.2). Her dismiss-without-open pattern becomes a
-**learned policy** she can read — `{match: {kind: "social"}, clamp: {max:
-"silent"}, author: steward, reason: "37 of 40 dismissed without open over
-30d"}` — and the source can never buy its way back up (learned policies
-only lower; §7). The review lane stays bounded; the weekly digest groups
-the residue by `kind`. This is the reputation loop as a legible artifact
-rather than a black-box feed model — strong from phase 1.
-
-### B.7 Medical results on a shared-visibility lockscreen (privacy)
-
-Ray's clinic portal posts test results; his partner sometimes sees his
-lockscreen. The notice's confidentiality labels forbid egress to the push
-relay, so the adapter sends the generic envelope unconditionally — full
-content fetched on unlock/app-open (§9.3) — and `redacted` lets the product
-choose neutral copy. Tray-dismiss on the shared-visibility device is
-per-device (§9.3), so dismissing there doesn't clear his laptop. Muting the
-thread is a policy write in his home space — never readable by the clinic
-or anyone else, with the behavioral-inference bound §7 states honestly.
-
-### B.8 Approving the agent's rebooking (act from the surface)
-
-Grace's travel agent drafted a rebooking; the fare hold expires soon. The
-notice carries `attachment` (the itinerary diff), `expiresAt` (the hold),
-and `actions: [approve, deny]` with a `replyTo` cell (§4.6). Approve from
-the lockscreen: terminal `acted` disposition + `{key: "approve", noticeId,
-at}` appended to the pattern's reply cell under her ordinary session
-authority; the acted terminal retracts the notice on every device. Two
-honest caveats: acting from a locked device presumes an authenticated
-session on-device, and a stale tray (§9.3) means she could approve a
-just-expired fare between wakes — the reply cell's consumer must treat
-replies as requests, not facts.
-
-### B.9 The visa renewal (long-lived deadline ladder)
-
-Hana's visa expires in October; she wants `review` at T−90, `heads-up` at
-T−30, `interrupt` at T−7. The **deadline ladder** idiom (§7): the pattern
-posts all three candidates ahead of time with ascending `notBefore` dates,
-the same `threadKey` (each admission displaces the prior rung), ascending
-hints, plus a proposed min she adopts once — at setup, when she's thinking
-about it. Renewal filed → subject advances → the steward retracts every
-pending rung including embargoed ones (§4.7). The gate is timeliness:
-`notBefore` materialization is evaluate-on-read until timer wake (§10.5) —
-nearly harmless at 90-day horizons for a daily shell user, unacceptable for
-B.2's same-day cadence, which is why both stories hang on the same §10.5
-line item.
-
-### B.10 The adversarial source (spam defense)
-
-"DealBlaster," installed for price tracking, turns hostile: floods
-candidates, hints `interrupt` with `ext.urgency: "CRITICAL"`, tries to
-collide the banking source's notification id, re-declares its kind as
-"group-chat" to catch the human-messages default. Every defense is
-structural, not heuristic: hints can't raise (§4.2); `ext` is quarantined
-from routing (§4.4); `id` is steward-derived from verified provenance, so the
-collision is impossible by construction; quotas bind to verified writer
-identity (§10.2); dismiss-without-open writes a legible learned max (§7);
-unconditional alert-once means even fresh-event-key spam can't re-buzz past
-its clamped rung; and the kind-lie fails because above-`review` defaults
-key on verified facts, never self-declared `kind` (§4.2) — declaring
-yourself "group-chat" buys nothing without a verified human `actor` the
-user actually knows.
-
-### B.11 The marketplace stranger (first contact from an unknown human)
-
-Maya lists a couch; a legitimate buyer — verified human DID, zero prior
-relationship — messages her, and the first responder wins the sale. Before
-the first-contact default existed, this story graded C: the buyer failed
-the established-relationship test and sank indistinguishably into `review`
-alongside importer noise, and Maya couldn't even hand-write a fix because
-`match` had no `actor` dimension. As specced now: the message lands in the
-**requests shelf** (`review`, distinguished grouping, quota-bounded — §7),
-where it reads as a person, not noise; one tap on the promote affordance
-writes `{match: {actor}, clamp: {min: "heads-up"}}` and the conversation is
-loud thereafter. For time-critical listings, the sanctioned louder path is
-the pattern proposing a listing-scoped min at listing time (the
-moment-of-intent idiom). Downward bias holds: minting DIDs buys a stranger
-nothing above the requests shelf. Note `threadKey` must be per-buyer, not
-per-listing — thread displacement (§6.4) would otherwise let buyer #2's
-inquiry retract buyer #1's.
-
-### B.12 Return from vacation (bulk catch-up must be bounded)
-
-Jonas is offline 16 days: ~300 notices, ~80 unseen artifact changes across
-12 spaces. The joins do most of the collapsing for free — 16 days of one
-chat is *one* notice (coalescing + thread displacement), everything he
-handled from his phone abroad is already satisfied everywhere (seen-join),
-expired 2FA/fare-holds are hidden and swept, matured ladder rungs displaced
-each other. Two rules close the rest: the sweep's **aging** demotes
-unhandled `heads-up` older than 7 days to `review` (§4.5), so the bell
-shows this week, not a 16-day wall; and the dispatcher's **reconnect
-damping** (§9.3) alerts only for notices newer than the gap — the return is
-a quiet shelf plus one "while you were away" view (which is *specified* as
-the every-return view, §5), not a buzz storm. Residual: whether
-"touched-recently" survives 16 days in the watch set is open question
-§12.2 — the vacation is the case that forces that answer.
-
-### B.13 Work and personal (context separation)
-
-Sofia keeps work and personal profiles and wants work quiet on evenings
-and weekends, family always through, one device. Profiles are the coarse
-cut: profile ≡ own home space ≡ own attention state (§8) — her work
-steward and personal steward are independent by construction, and one
-shell merging two ledgers is presentation, not runtime. Within the work
-profile, context is ordinary policy: `{match: {spaceDid: work-space},
-effect: {quietHours: {start: "18:00", end: "09:00"}}}` for evenings plus
-`{quietHours: {start: "00:00", end: "24:00", days: ["sat","sun"], max:
-"suppress"}}` for weekends (§7's day-scoped, max-bearing quietHours), and
-`{match: {threadKey: family}, clamp: {min: "heads-up"}, bypassQuietHours:
-true}` for the always-through exception. Every piece is a legible record
-she can read back.
-
-### B.14 Day one (defaults before any learning)
-
-Riley is brand new: no learned policies, no adopted packs, defaults only.
-The load-bearing line is §7's composition ceiling — `baseline =
-min(postureHint, "review")` — without which a day-one source hinting
-`interrupt` would simply get it (no learned history, no matching max: the
-formula's original cold-start hole, now closed). The week then looks like:
-messages from imported contacts → `heads-up` from day one (rosters are
-seeded by contact import, §7 — without that, the established-relationship
-default fires for nobody and the app reads as broken silence exactly when
-it's being judged); strangers → the requests shelf; importers and agents →
-`review`/`silent`, bounded by intake quotas until learned clamps
-accumulate evidence. Honest weakness: the review lane is at its noisiest
-in week one, before any learning — the propose/adopt idiom (patterns
-proposing their own sensible clamps at install) is the mitigation, and
-§12.8's evidence thresholds decide how fast learning kicks in.
 
 ## References
 
@@ -1699,8 +1354,7 @@ proposing their own sensible clamps at install) is the mitigation, and
   `08-conflict-granularity.md` (mergeable ops).
 - `docs/specs/sqlite-builtin/` (esp. `05-reactivity.md`, `06-cfc.md`) —
   seen-store backing; why trust-bearing tables wait on §10.3; `reactOn`
-  coarseness; the rev-serialized write path; the `tryClaimMutex` shape §10.4
-  borrows.
+  coarseness; the rev-serialized write path.
 - `docs/specs/space-model/4-cells.md` — stream-cell ephemerality.
 - `docs/specs/pull-based-scheduler/README.md` — demand-driven evaluation
   (and its limits for observed queries, §4.4).

--- a/docs/specs/attention-system/README.md
+++ b/docs/specs/attention-system/README.md
@@ -366,7 +366,7 @@ exist only on the admitted type.
 // An entity version: memory-v2 seq is per-space (a space-global Lamport
 // clock, monotone per entity), so versions are only comparable within the
 // same space. Read via the changes projection (§10.1). Used by the
-// seen-state track (§5) and by watchers (§5.5); never by the notice
+// seen-state track (§5) and by watchers (§5.1); never by the notice
 // lifecycle itself.
 type EntityVersion = { space: string; seq: number };
 
@@ -502,7 +502,7 @@ type NoticeDisposition = {
   surface: string;
   // Who did it: the user's DID, or the steward's module identity for
   // system dispositions (expiry sweep, thread displacement, watcher
-  // retraction — §4.7, §5.5).
+  // retraction — §4.7, §5.1).
   actor: string;
   ext?: Record<string, unknown>; // product extension (e.g. calibration
                               // feedback like "not-useful"); same

--- a/docs/specs/attention-system/README.md
+++ b/docs/specs/attention-system/README.md
@@ -30,6 +30,15 @@ merged phantom concepts, and split this spec into its current directory
 form: [`changes-projection.md`](./changes-projection.md) — independently
 approvable — plus [`prior-art.md`](./prior-art.md),
 [`stories.md`](./stories.md), and [`loom-mapping.md`](./loom-mapping.md)).
+Revised 2026-07-13 on framework-author review (PR #4691): the notice
+lifecycle is decoupled from version machinery (once disposed, disposed;
+new news is a new notice; **watchers** — §5.1 — bridge entity changes to
+notices, with the generic seen watcher preserving cross-device
+auto-retract); intake is split space-wide vs directed-via-profile with
+home-space aggregation (§6.1); the pattern-author surface is specified
+(§6.1b and [`authoring.md`](./authoring.md)); sqlite write-authorization
+is assessed easy and the ledger's steady-state backing accordingly
+(§4.5, §10.3).
 
 ## Last Updated
 
@@ -63,8 +72,9 @@ Five load-bearing moves:
    the wire on every query result; exposing it is one small read-only
    primitive, the changes projection (§10.1). Seen-state is one small
    relation — last observed version per (user, entity) — and "unseen
-   change", "while you were away", notice currency, and the artifact
-   lifecycle all fall out as joins against it (§5). For in-fabric sources, a
+   change", "while you were away", and the artifact lifecycle all fall out
+   as joins against it (§5), while **watchers** (§5.1) bridge it to
+   notices without version machinery ever entering the notice contract. For in-fabric sources, a
    notice is a *view over* "an artifact you care about changed", which
    dissolves the "every pattern must remember to send notifications"
    problem.
@@ -107,7 +117,10 @@ auto-surfacing system — this is a routing fold, not a suggestion engine.)
 of stores (notices, dispositions, seen — §4.5). *Lane* — a shell projection
 over attention state (most lanes correspond to a posture rung; some, like
 the snoozed lane, are lifecycle views). *Watch set* — the entity set whose
-changes the user's attention system observes (§5). *Artifact* — a
+changes the user's attention system observes (§5). *Watcher* — steward-run
+logic that turns watched changes into posted notices and reports moot
+claims for retraction (§5.1); the generic seen watcher is built in,
+per-kind watchers refine it. *Artifact* — a
 user-meaningful entity, typically a piece's result cell; the spec says
 "entity" where the memory-v2 identity (versioning, `seq`) is what matters.
 
@@ -192,9 +205,15 @@ feature branch as of 2026-07-12) defines *prepared claims*, an
 attention-posture ladder, a capacity-bounded Today block, and a
 default-weekly digest — materialized in product-local storage; its current
 "unseen" affordance is a localStorage last-seen timestamp per browser.
-Pond's donut prototype ranks pieces spatially by an attention score. Both
-need the same substrate: durable per-user seen-state, a trustworthy
-canonical ledger, and per-user routing policy. This spec is that substrate —
+Pond's donut prototype ranks pieces spatially by an attention score. And
+one surface is already *live*: Loom mobile's **Home Briefing** pipeline (a
+curator agent authors a briefing; the daemon projects it into a fabric
+cell; the mobile home renders headline + items) — a digest adapter waiting
+for a ledger, whose `BriefingItem` is a near-degenerate notice and whose
+recap section is a natural early changes-projection consumer
+([`loom-mapping.md`](./loom-mapping.md)). All of them need the same
+substrate: durable per-user seen-state, a trustworthy canonical ledger,
+and per-user routing policy. This spec is that substrate —
 and only that substrate; Loom's work-start machinery and stance-bearing
 judgment policies stay product-side (Division of labor, in the Summary).
 
@@ -344,9 +363,11 @@ exist only on the admitted type.
 
 ```ts
 // Shown for illustration only.
-// A subject-entity version: memory-v2 seq is per-space (a space-global
-// Lamport clock, monotone per entity), so versions are only comparable
-// within the same space. Read via the changes projection (§10.1).
+// An entity version: memory-v2 seq is per-space (a space-global Lamport
+// clock, monotone per entity), so versions are only comparable within the
+// same space. Read via the changes projection (§10.1). Used by the
+// seen-state track (§5) and by watchers (§5.5); never by the notice
+// lifecycle itself.
 type EntityVersion = { space: string; seq: number };
 
 // What a source posts (into the notice inbox, §6.1). Everything on the
@@ -354,19 +375,25 @@ type EntityVersion = { space: string; seq: number };
 // raise loudness (§4.2).
 type NoticeCandidate = {
   // THE entity this notice is about (a stored cell link, not a query
-  // string). The notice is the invitation; the subject is the truth.
-  // Satisfaction, coalescing, and re-emergence all key on it: once your
-  // seen mark on subject reaches subjectVersion, the notice retracts
-  // everywhere (alreadySeen, below).
+  // string). The notice is the invitation; the subject is the truth —
+  // navigation, policy matching, and watcher-driven retraction (§5.1)
+  // all key on it.
   subject: unknown;           // asCell: ["cell"]
-  // The subject's version at posting. Drives coalescing (same id,
-  // advancing version) and re-emergence tombstones (§4.7).
-  subjectVersion: EntityVersion;
+  // OPTIONAL watcher metadata: the subject's version at posting, stamped
+  // by watchers that derive notices from entity changes (§5.1) so the
+  // generic seen watcher can retract on observation. Deliberately NOT
+  // part of the notice contract — a notice's lifecycle never requires
+  // reading versions (the contract: once disposed, disposed; new news is
+  // a new notice).
+  subjectVersion?: EntityVersion;
   // Source classification ("group-chat", "importer", "agent-run", ...).
-  // BOUND BY THE STEWARD to the source's verified identity: the first-seen
-  // kind for a given source sticks; a source changing its declared kind
-  // is itself a reputation signal (and does not escape kind-matched
-  // clamps, which follow the source identity). Policy matching (§7) and
+  // BOUND BY THE STEWARD to the source's verified identity as a per-source
+  // SET: first use of a kind adds it to the source's set (set growth is
+  // itself a reputation signal), so a multi-genre trusted source (one
+  // product emitting agent-run, calendar-prep, email-draft, ...) is
+  // first-class, while kind churn still cannot launder anything —
+  // kind-matched clamps follow the source identity, and kind can never
+  // raise posture regardless (§4.2). Policy matching (§7) and
   // digest grouping (§9.2) key on it. Self-declared — see §4.2's
   // raise-authority tiers and the match-schema comment (§7) for what may
   // therefore never key on it.
@@ -460,11 +487,12 @@ type NoticeAction = {
 };
 
 // Append-only per-notice disposition log — what the user (or the steward,
-// on the user's behalf) did with the notice. Deliberately small: "seen"
-// is NOT a disposition (it lives in the seen store, §4.5/§5, and
-// notice-seen is a join); "muted" is NOT a disposition (mute IS a policy
-// write, §7). Cause-preservation across the three terminal types is the
-// point: undo, history, and calibration all key on it.
+// on the user's behalf) did with the notice. Deliberately small: opening
+// a notice records as acted {key: "open"}; entity-level seen-state is NOT
+// notice state (it lives in the seen store, §5, and feeds the generic
+// seen watcher); "muted" is NOT a disposition (mute IS a policy write,
+// §7). Cause-preservation across the three terminal types is the point:
+// undo, history, and calibration all key on it.
 type NoticeDisposition = {
   noticeId: string;
   at: number;
@@ -473,15 +501,9 @@ type NoticeDisposition = {
   // only" (§9.3).
   surface: string;
   // Who did it: the user's DID, or the steward's module identity for
-  // system dispositions (expiry sweep, thread displacement — §4.7).
+  // system dispositions (expiry sweep, thread displacement, watcher
+  // retraction — §4.7, §5.5).
   actor: string;
-  // The subjectVersion this disposition was taken against. A dismissal
-  // tombstones that version; if the subject advances past it, the notice
-  // re-emerges (the steward's coalesce advances subjectVersion past the
-  // tombstone — one operation, not a separate mechanism) and the old
-  // dismissal no longer applies. Comparable only within
-  // subjectVersion.space.
-  againstVersion: EntityVersion;
   ext?: Record<string, unknown>; // product extension (e.g. calibration
                               // feedback like "not-useful"); same
                               // discipline as NoticeCandidate.ext
@@ -494,41 +516,38 @@ type NoticeDisposition = {
 ```
 
 Nothing stores `active`, `dismissed`, or `unread` flags — dispositions are
-derived. And critically, **currency is a local join, not a cross-space
-read**: a notice is satisfied once the user's own seen mark on its *subject*
-reaches the notice's version. This is the Android behavioral gold standard —
-view the source anywhere, the notification retracts everywhere — computed
-entirely from the user's own stores:
+derived, and the lifecycle contract is deliberately simple (framework-author
+review tightened it): **once a notice is disposed, it stays disposed; new
+news is a new notice** (fresh event key, same `threadKey` — thread
+displacement retires the old one, §6.4). No tombstone versioning, no
+re-emergence, no version reads anywhere in the read path:
 
 ```ts
 // Shown for illustration only.
-const sameSpaceGte = (a: EntityVersion, b: EntityVersion) =>
-  a.space === b.space && a.seq >= b.seq;
 const terminal = (n: Notice, log: NoticeDisposition[]) =>
   log.some((d) =>
-    (d.type === "dismissed" || d.type === "archived" || d.type === "acted") &&
-    sameSpaceGte(d.againstVersion, n.subjectVersion)
+    d.type === "dismissed" || d.type === "archived" || d.type === "acted"
   );
-const alreadySeen = (n: Notice, seen: SeenStore) =>
-  sameSpaceGte(seen.versionOf(n.subject), n.subjectVersion);
-const visible = (
-  n: Notice, log: NoticeDisposition[], seen: SeenStore, now: number,
-) =>
-  // realert-matched notices skip the alreadySeen term (§7): they clear
-  // only on a terminal disposition.
-  !terminal(n, log) && !alreadySeen(n, seen) && !snoozed(log, now) &&
+const visible = (n: Notice, log: NoticeDisposition[], now: number) =>
+  !terminal(n, log) && !snoozed(log, now) &&
   (n.notBefore === undefined || now >= n.notBefore) &&
   (n.expiresAt === undefined || now < n.expiresAt);
 ```
 
-Notices that should outlive observation (a todo is not done because you
-looked at it; a medication reminder must nag) are handled by a user-adopted
-`realert` policy — semantics in §7: matched notices are exempt from
-seen-satisfaction and clear only terminally. Sources re-post at newer
-versions for *content* escalation, not liveness.
-Satisfaction that doesn't involve the user looking (someone else handled it;
-the trip ended) is the steward's job: its fold observes the subject change and
-terminally retracts the notice (system disposition by module identity).
+Opening a notice (focused open of its target, from any surface) writes an
+`acted {key: "open"}` disposition — terminal, so a notice handled on one
+device retracts on every device and OS tray via ordinary store sync.
+Satisfaction that doesn't go through the notice — you read the conversation
+in the source UI; someone else handled it; the trip ended — is
+**watcher-driven** (§5.1): the steward retracts with a system disposition
+when a watcher reports the claim moot. The generic seen watcher covers the
+common case (your own seen mark on the subject advanced past the notice's
+posting) without any per-kind code; the Android auto-retract behavior —
+view the source anywhere, the notification clears everywhere — survives
+intact, just steward-side instead of read-path-side. Notices that must
+outlive observation (medication must nag) carry a user-adopted `realert`
+policy (§7): matched notices are exempt from watcher retraction and clear
+only on an explicit terminal disposition.
 
 A caveat on "cheap": pull-based scheduling makes *unobserved* queries free
 (`docs/specs/pull-based-scheduler/README.md`), not observed ones. A mounted
@@ -556,14 +575,16 @@ three stores, and the three backings are not ad-hoc — they derive from a
    `packages/runner/src/cfc/prepare.ts`). Coalescing (same `id`, subject
    advanced) is an in-place element update by the single leased steward
    instance (§6.2); coalescing **refreshes** content, `expiresAt`, and
-   `progress` — a re-emerged notice carries the new posting's lifetime, not
-   a stale one. This is deliberately *not* sqlite yet: `writeAuthorizedBy`
-   is enforced on the cell-write prepare path and **does not gate
-   `db.exec`** today — sqlite's implemented CFC covers confidentiality
-   ceilings and row-label rules, not write authorization
-   (`docs/specs/sqlite-builtin/06-cfc.md`). Migrating `notices` to a sqlite
-   table (better ranking/pagination/retention at volume) is gated on the
-   net-new work item in §10.3, and on giving it **its own database**: every
+   `progress` — but never resurrects a disposed notice: a dismissed `id`
+   stays dismissed, and genuinely new news arrives as a new notice. This starts as an array cell rather than sqlite because
+   `writeAuthorizedBy` is enforced on the cell-write prepare path and
+   **does not gate `db.exec`** today — sqlite's implemented CFC covers
+   confidentiality ceilings and row-label rules, not write authorization
+   (`docs/specs/sqlite-builtin/06-cfc.md`). Framework-author review
+   assessed adding that gate as easy (§10.3), so sqlite (better
+   ranking/pagination/retention at volume) is the likely steady-state
+   backing rather than a distant maybe; the remaining constraint is giving
+   the ledger **its own database**: every
    `db.exec` serializes on the database handle cell's `rev`, so one shared
    db cannot hold both a steward-only table and an everyone-writes table
    without gating both or neither.
@@ -590,8 +611,11 @@ three stores, and the three backings are not ad-hoc — they derive from a
    when it advances** (`newSeq > seenSeq` — re-renders and repeat views are
    no-ops, which is also what breaks any render→write→render cycle) and
    **debounced per focus session** (at most one write per entity per
-   focused open). A focused open writes *only* the seen mark — notice-seen
-   is a join (`alreadySeen`, §4.4), not a second record.
+   focused open). A focused open of an entity writes the seen mark;
+   opening *via a notice* additionally writes that notice's
+   `acted {key: "open"}` disposition (§4.4) — two stores, two facts, no
+   duplication: the mark is about the entity, the disposition about the
+   notice.
 
 Two rules regardless of backing:
 
@@ -611,8 +635,8 @@ is the read-side shadow of it, so an expired notice is hidden immediately
 and reaped eventually), **ages the bell** — unhandled `heads-up` notices
 older than N days (default 7; realert-matched notices exempt) demote to
 `review` as a posture transition, so a long absence returns to a digest,
-not a wall of stale urgency — and reaps notices that are terminal with
-`subjectVersion` below a watermark, plus their dispositions. Sweeping is an
+not a wall of stale urgency — and reaps notices that have been terminal
+longer than a retention window, plus their dispositions. Sweeping is an
 steward duty (it owns the ledger), bounded and boring by design. Because
 sweeping only reaps terminal rows, per-source intake quotas (§6.1) are what
 bound a flooding source, not retention.
@@ -650,19 +674,17 @@ transition named once:
 ADMITTED --now < notBefore--> EMBARGOED --time--> VISIBLE
 EMBARGOED --steward: subject satisfied / superseded--> TERMINAL
          (a pre-scheduled reminder is retracted when its reason ends)
-VISIBLE --user: dismissed|archived|acted--> TERMINAL
-VISIBLE --steward: subject satisfied / thread displaced / expiry sweep
-         (system disposition)--> TERMINAL
+VISIBLE --user: dismissed|archived|acted (incl. acted{open})--> TERMINAL
+VISIBLE --steward: watcher reports claim moot (§5.1) / thread displaced /
+         expiry sweep (system disposition)--> TERMINAL
+         (realert-matched notices are exempt from watcher retraction —
+         they clear only on an explicit terminal disposition, §7)
 VISIBLE --user: snoozed--> SNOOZED --until--> VISIBLE
-VISIBLE --seen mark on subject reaches subjectVersion--> SATISFIED
-         (hidden; no disposition row — pure join; does NOT apply to
-         realert-matched notices, which clear only terminally, §7)
 VISIBLE --now ≥ expiresAt--> hidden immediately (read-side),
          TERMINAL at next sweep (write-side)
-TERMINAL --steward coalesce advances subjectVersion past tombstone-->
-         VISIBLE (re-emergence: a consequence of coalescing, not a
-         separate mechanism; silent unless a realert policy applies, §9.3)
-TERMINAL + below watermark --sweep--> reaped
+TERMINAL --(no exit for this id: disposed stays disposed; new news is a
+         new notice in the same threadKey)
+TERMINAL + past retention window --sweep--> reaped
 ```
 
 Posture may change after admission (escalation raises it, collective
@@ -717,11 +739,12 @@ Everything else is the **changes projection** (§10.1) joined against marks:
 
 **Derivation beats posting.** For in-fabric sources, a candidate is *derived
 from* artifact-change + watch set — the attention system watches; patterns
-just write their artifacts. Explicit posting remains for sources with no
-artifact (external ingress, transient events), but it is the minority path.
-This is the platform's grain: derived state over stored state, and no
-parallel event journal duplicating what memory-v2's commit log already
-records.
+just write their artifacts. The mechanism is the watcher (§5.1): version
+machinery stays inside watchers and the seen-state track, never in the
+notice contract. Explicit posting remains for sources with no artifact
+(external ingress, transient events), but it is the minority path. This is
+the platform's grain: derived state over stored state, and no parallel
+event journal duplicating what memory-v2's commit log already records.
 
 **Run-level grouping.** One agent run touching twelve artifacts must not be
 twelve scattered dots. From phase 1, agent-shaped sources post one
@@ -741,38 +764,100 @@ watch/unwatch policies (§7). Getting the defaults right is an open question
 (§12.2); getting them wrong in the "too broad" direction is the failure
 mode to avoid (dots everywhere = dots nowhere).
 
+### 5.1 Watchers — turning changes into notices
+
+The bridge between the two tracks (seen-state over entities; notices) is
+the **watcher**: steward-run logic that observes sources and, when a change
+is *newsworthy for this user*, posts a notice — and, when a claim has
+become moot, reports it so the steward retracts (system disposition). This
+is the framework-author-preferred shape: entity watching is scoped out of
+the notice contract entirely; a watcher per kind turns changes into
+messages.
+
+- **Per-kind watchers** know their world: a chat watcher posts one notice
+  per burst of unread messages (fresh event key per burst, thread-displaced
+  by the next) and reports the claim moot when the conversation's own
+  read-marker advances; a deadline watcher posts the ladder rungs; an
+  agent-run watcher posts the receipt. Watchers are ordinary pattern code
+  folded by the steward — proposable, inspectable, per-source.
+- **The generic seen watcher** is built in and covers every source with no
+  per-kind watcher: it compares the user's seen marks against the
+  `subjectVersion` stamps on derived notices and reports moot any notice
+  whose subject the user has since focused-open. This is what preserves
+  the cross-device auto-retract (read it anywhere → clears everywhere)
+  as a default, with zero source cooperation. One carve-out: it **skips
+  notices that carry `actions`** — an approval must not vanish because
+  the user glanced at the itinerary; action-bearing notices clear on a
+  disposition, expiry, thread displacement, or a per-kind watcher's moot
+  report (someone else approved). The residual gaming surface — adding a
+  decorative button to extend liveness — buys an emitter nothing above
+  the `review` ceiling and spends the same quota and reputation as any
+  other notice.
+- Watchers run *in the steward's fold* (wake-on-commit / on-lease), read
+  through the changes projection (§10.1), and write nothing directly —
+  they produce candidates and mootness reports; the steward remains the
+  only ledger writer (§6.2).
+
 ## 6. The steward
 
 **One logical steward per user.** It admits candidates, folds policies,
-assigns postures and weights, coalesces (same `id` when the same subject
-advances — re-emergence is this same operation crossing a tombstone),
-applies thread displacement (§6.4), retracts satisfied notices, and sweeps
-retention (§4.5).
+assigns postures and weights, coalesces (same `id`, content refresh only —
+never resurrection), applies thread displacement (§6.4), runs watchers and
+retracts moot notices on their reports (§5.1), and sweeps retention (§4.5).
 
-### 6.1 The notice inbox
+### 6.1 Intake: space-wide, directed, derived
 
 Candidates must be **durable before admission**: the steward may be asleep or
 absent (interim mode, closed clients), and ephemeral candidates would be
-silently lost, not delayed. Intake shape:
+silently lost, not delayed. Three intake shapes, split by *addressing* —
+the key multi-user fact being that another user's home space is unknowable
+(only their **profile** is addressable):
 
-- In-fabric artifact changes need no *posting* — they are derived (§5).
-  (They do need *reach*: until server-side cross-space wake exists, changes
-  in other spaces reach a server-side steward via the same forwarding path as
-  posted candidates below; a client-side steward reads them directly through
-  the user's ordinary sessions.)
-- Posted candidates land in the **notice inbox in the user's home space** —
-  a cross-principal, quota-gated append surface, named net-new work
-  (§10.2), because it is the one place untrusted-ish writers meet the
-  user's home space: the write gate enforces per-source quotas against the
-  *verified writer identity*, not against self-reported fields. Until
-  §10.2 lands, candidates rest in a durable per-source cell in the space
-  where they arise and the steward reads them there (client-side interim),
-  with quotas enforced at fold time — weaker (a flood bloats the
-  source-space cell, not the home space) but sound.
+- **Space-wide candidates** (the default): the poster stores the candidate
+  **in the shared space itself** — a durable per-space notice list, written
+  once under the poster's ordinary authority (Alice's DID posts; she never
+  enumerates recipients, which the platform forbids anyway). Every member's
+  steward reads the spaces the user has joined and lanes per its own
+  policies. This is the cheap path and scales to public and
+  many-reader spaces: posting cost is O(1), and paying attention is the
+  *reader's* choice, which is the whole design.
+- **Directed candidates** (mentions, DMs, explicit shares): addressed to a
+  **profile** — the recipient's addressable identity — via the profile's
+  notice inbox, a cross-principal, quota-gated append surface (net-new,
+  §10.2): the write gate enforces per-source quotas against the *verified
+  writer identity*, not self-reported fields. The user's home space
+  **aggregates across their profiles' inboxes** (a user with work and
+  personal profiles has two inboxes feeding two independent stewards, §8).
+  Until §10.2 lands, directed candidates rest in a durable per-source cell
+  in the space where they arise and the steward reads them there
+  (client-side interim), with quotas enforced at fold time — weaker (a
+  flood bloats the source-space cell, not the inbox) but sound.
+- **Derived candidates** need no posting at all — watchers turn watched
+  changes into notices (§5, §5.1). They do need *reach*: a client-side
+  steward reads joined spaces directly through the user's ordinary
+  sessions; a server-side steward needs change notifications from other
+  spaces, which is the **space-to-space change-notification** need —
+  moving just a dirty bit between spaces — noted in §10.2 as shared
+  infrastructure (the same need surfaces in other cross-space contexts;
+  it should be designed once, not as an attention special).
 - Webhook ingress: the receiving handler persists the payload durably at
   ingress (§4.5); the ephemeral stream is transport, not storage.
 - Quota pressure and dismiss-without-open feed the same **learned-policy**
   signal (§7): the source's baseline clamps down, legibly.
+
+### 6.1b Posting from a pattern
+
+The authoring surface is deliberately the platform's most ordinary shape —
+**a stream returned by a handler**: a pattern wishes or is handed a posting
+endpoint; calling `.send()` with a `NoticeCandidate` invokes the endpoint's
+handler, which appends the candidate to the right durable list (the shared
+space's notice list, or a profile inbox for directed notices). The stream
+is transport; the handler owns durability (§4.5's stream rule); the
+steward folds from the durable lists. Pattern authors never touch the
+ledger, never pick posture, and never track recipients — post once,
+per-viewer routing is not their business. The full pattern-author guide —
+what to post, threading, actions/replyTo, proposing policies, what you
+cannot do — is [`authoring.md`](./authoring.md).
 
 ### 6.2 Trust and instance discipline
 
@@ -837,10 +922,11 @@ explicitly an edge adapter fed by wake-on-commit, not a hot loop.
 
 Two mechanisms at two altitudes:
 
-- **`id` is identity**: the same notice at a newer subject version.
-  Coalescing updates the notice in place (refreshing content, expiry,
-  progress); crossing a dismissal tombstone is re-emergence. Identity is
-  steward-derived from verified provenance (§4.4), so it cannot be forged.
+- **`id` is identity**: the same claim, refreshed. Coalescing updates the
+  notice in place (content, expiry, progress) and never resurrects a
+  disposed one — a source with genuinely new news posts a new event key.
+  Identity is steward-derived from verified provenance (§4.4), so it
+  cannot be forged.
 - **`threadKey` is the thread**, and displacement is a *derived rule over
   it*: **within a threadKey, only the newest live notice is visible**;
   older live notices in the thread are terminally retracted by the steward
@@ -884,12 +970,13 @@ type AttentionPolicy = {
     // Exempts this policy's min from quiet-hours clamping (the babysitter
     // thread breaks through). User-authored only.
     bypassQuietHours?: boolean;
-    // Nag-until-done: a matched notice is EXEMPT from seen-satisfaction —
-    // it clears only on a terminal disposition (acted/dismissed/archived),
-    // never because the user glanced at the subject — and re-alerts on
-    // this cadence while live. The one consented exception to §9.3's
-    // alert-once rule. User-authored only; the cadence needs timer
-    // wake (§10.5) to fire between commits.
+    // Nag-until-done: a matched notice is EXEMPT from watcher retraction
+    // (§5.1) — it clears only on an explicit terminal disposition
+    // (acted/dismissed/archived), never because a watcher judged it moot
+    // or the user glanced at the subject — and re-alerts on this cadence
+    // while live. The one consented exception to §9.3's alert-once rule.
+    // User-authored only; the cadence needs timer wake (§10.5) to fire
+    // between commits.
     realert?: { everyMs: number };
     coalesceWindowMs?: number;
     // Time-conditional clamp sugar: during these hours/days, apply
@@ -1115,9 +1202,9 @@ there:
   **replaces silently** on every surface (Android `setOnlyAlertOnce`
   semantics, made unconditional: the emitter cannot choose to re-buzz).
   The invariant bends in exactly **one consented way**: a user-authored
-  `realert` policy (§7) re-alerts a live matched notice on its cadence —
-  nag-until-done for medication-grade obligations, grantable only by the
-  user. (A *fresh* notice first materializing at an alert-bearing rung
+  `realert` policy (§7) re-alerts a live matched notice on its cadence
+  (and exempts it from watcher retraction, §5.1) — nag-until-done for
+  medication-grade obligations, grantable only by the user. (A *fresh* notice first materializing at an alert-bearing rung
   alerting is the base rule, not an exception — but state its consequence
   honestly: alert-once is per-*notice*, so a source holding a user-granted
   floor can alert once per genuinely new event; per-*source* frequency is
@@ -1200,23 +1287,29 @@ that first needs it (§11), and each needs its own (small) design pass.
    [`changes-projection.md`](./changes-projection.md) — deliberately
    independently approvable.
 
-2. **Notice inbox append gate** *(phase 1; hardened by phase 2)*. A
-   home-space inbox cell with **restricted cross-principal append**: other
-   principals' patterns may append candidates (the rosters
-   contribute-your-own idiom, reversed) but the write gate enforces
-   per-source quotas against the verified writer identity. This is what
-   makes dead-device delivery an authority question with an answer instead
-   of an open question — the full chain "someone messages me while all my
-   devices are closed → my phone buzzes" is inbox append → home-space
-   wake → steward fold → dispatcher push.
+2. **Profile notice inbox append gate** *(phase 1; hardened by phase 2)*.
+   A **profile-space** inbox cell with **restricted cross-principal
+   append**: other principals' patterns may append directed candidates
+   (the rosters contribute-your-own idiom, reversed) but the write gate
+   enforces per-source quotas against the verified writer identity. It
+   lives on the profile because that is the recipient's only addressable
+   identity — home spaces are unknowable to others — and the home space
+   aggregates across the user's profiles (§6.1). This is what makes
+   dead-device delivery an authority question with an answer: "someone
+   DMs me while all my devices are closed → my phone buzzes" is inbox
+   append → aggregation → steward fold → dispatcher push. Related shared
+   infrastructure, needed for derived candidates to reach a server-side
+   steward at scale: **space-to-space change notification** (moving a
+   dirty bit between spaces) — wanted in other cross-space contexts too;
+   design once.
 3. **Write-authorization for sqlite** *(pre-migration of the ledger to
    sqlite; not needed for phase 1's array-cell backing)*.
    `writeAuthorizedBy` is enforced on the cell-write prepare path only;
    `db.exec` today checks confidentiality ceilings and row-label rules but
-   not write authorization. Gating `db.exec` per database handle (the `rev`
-   bump is a cell write, so the prepare path sees it) needs specification
-   and a security review of its own, including whether any sqlite write
-   path bypasses the rev write.
+   not write authorization. Framework-author review (PR #4691) assessed
+   adding this gate as easy — so treat it as near-term, not speculative;
+   it still needs a short security review of its own (whether any sqlite
+   write path bypasses the `rev` cell write the prepare path would gate).
 4. **Steward lease** *(phase 1)*. A small mutex-cell convention (claim with
    expiry, renew, steal-on-expiry) for single-instance election of the
    interim client-side steward (§6.2). Generalizes beyond attention.

--- a/docs/specs/attention-system/README.md
+++ b/docs/specs/attention-system/README.md
@@ -279,12 +279,33 @@ Two invariants:
   `heads-up` with its uncertainty stated (product copy; `ext` if
   structured); certain-but-routine stays in `review`.
 
-The rung names deliberately match the posture vocabulary the Loom product
-already uses (silent memory → daily review → timely heads-up → interrupt), so
-product surfaces map 1:1 onto runtime postures. Within a rung, ordering is
-the steward-assigned `weight` (§4.4) — an opaque scalar that never crosses
-rungs and never gates delivery; it exists so continuous surfaces (Pond's
-radial layout, "ordered by the steward" lists) don't have to invent one.
+**Why these names.** The rungs match the posture vocabulary the Loom
+product already uses (silent memory → daily review → timely heads-up →
+interrupt), so the first consumer maps 1:1; each is an everyday English
+word whose plain meaning *is* the promise; and the scale is ordinal in
+exactly one dimension — how much of the user's present moment the notice
+claims (none / none-unless-sought / a scheduled batch / the next voluntary
+check-in / right now). That is deliberate contrast with the OS
+vocabularies: Android's `MIN < LOW < DEFAULT < HIGH` are magnitudes in an
+unnamed dimension, and iOS names its sound-making default `active` — a
+word that conceals the cost. Naming the top rung `interrupt` makes the
+cost legible where it matters most: **the name is the consent dialog**
+("allow this source to *interrupt* you?"). Where the wider ecosystem has
+converged on a word, we use it: `silent` is Web Push's `silent: true` and
+Android's shade section of the same name (iOS calls this `passive`). One
+term-of-art collision, named so no adapter author discovers it the hard
+way: Android's "heads-up notification" is their *peek banner* — loudest
+delivery, our `interrupt` — whereas this spec's `heads-up` is the plain
+English idiom ("just a heads-up"): quiet, held, non-interrupting; the
+compile targets in §9.3 disambiguate. And `review` has no OS analog
+because the capability doesn't exist there: no OS has a party that can
+batch across sources (prior-art.md, structural gap 4); the tier exists
+here because the steward does.
+
+Within a rung, ordering is the steward-assigned `weight` (§4.4) — an
+opaque scalar that never crosses rungs and never gates delivery; it exists
+so continuous surfaces (Pond's radial layout, "ordered by the steward"
+lists) don't have to invent one.
 
 ### 4.3 The pipeline
 
@@ -1073,6 +1094,16 @@ policy decision, default no.
 ### 9.3 OS delivery
 
 Only `interrupt` (and optionally `heads-up`, quietly) ever reaches the OS.
+The posture → platform compile table (which also disambiguates the
+Android "heads-up notification" term-of-art collision, §4.2):
+
+| Posture | iOS | Android | Web Push |
+|---|---|---|---|
+| `suppress`, `silent`, `review` | not delivered to the OS — in-fabric projections only (dots, lanes, digest) | — | — |
+| `heads-up` | `passive` interruption level (quiet, Notification Center) | Silent-section importance (`LOW`) — **never** the "heads-up" peek banner | `silent: true` |
+| `interrupt` | `active` | `DEFAULT`/`HIGH` (the peek banner Android calls a heads-up notification) | standard `showNotification` |
+| `interrupt` + user-adopted break-glass floor (§7) | `timeSensitive` / `critical` (entitlement-gated; reserved mapping) | `HIGH` + DND-bypass channel | `requireInteraction` (weak approximation) |
+
 Adapters compile the envelope down; the ledger stays canonical and
 "Android-shaped" (live update + auto-retract), and platforms degrade from
 there:

--- a/docs/specs/attention-system/README.md
+++ b/docs/specs/attention-system/README.md
@@ -363,12 +363,15 @@ exist only on the admitted type.
 
 ```ts
 // Shown for illustration only.
-// An entity version: memory-v2 seq is per-space (a space-global Lamport
-// clock, monotone per entity), so versions are only comparable within the
-// same space. Read via the changes projection (§10.1). Used by the
-// seen-state track (§5) and by watchers (§5.1); never by the notice
-// lifecycle itself.
-type EntityVersion = { space: string; seq: number };
+// An entity version: an OPAQUE per-entity token read via the changes
+// projection (§10.1) — the runtime provides ordering within one entity
+// and equality; tokens from different entities are not comparable, and
+// the encoding is not part of the contract (internally the space's commit
+// clock, opaque precisely so global commit activity is not
+// pattern-observable — see changes-projection.md). Used by the seen-state
+// track (§5) and by watchers (§5.1); never by the notice lifecycle
+// itself.
+type EntityVersion = { space: string; token: string };
 
 // What a source posts (into the notice inbox, §6.1). Everything on the
 // candidate is descriptive or advisory — no field a source writes can
@@ -379,13 +382,24 @@ type NoticeCandidate = {
   // navigation, policy matching, and watcher-driven retraction (§5.1)
   // all key on it.
   subject: unknown;           // asCell: ["cell"]
-  // OPTIONAL watcher metadata: the subject's version at posting, stamped
-  // by watchers that derive notices from entity changes (§5.1) so the
-  // generic seen watcher can retract on observation. Deliberately NOT
-  // part of the notice contract — a notice's lifecycle never requires
-  // reading versions (the contract: once disposed, disposed; new news is
-  // a new notice).
+  // OPTIONAL seen-watcher metadata: the subject's version, stamped by the
+  // deriving watcher (§5.1) — or, for explicitly posted candidates, BY THE
+  // STEWARD AT ADMISSION (one head read through the changes projection,
+  // in the fold where cross-space reads already happen) whenever the
+  // subject resolves to a versioned entity. That admission stamp is what
+  // makes the generic seen watcher's auto-retract cover explicit posters
+  // too (§5.1, authoring.md). Deliberately NOT part of the notice
+  // contract — a notice's lifecycle never requires reading versions (the
+  // contract: once disposed, disposed; new news is a new notice).
   subjectVersion?: EntityVersion;
+  // Distinguishes claims from the same source about the same subject —
+  // THE coalesce-vs-new-news switch: re-posting with the same eventKey
+  // (or none) refreshes the prior claim in place; a new eventKey is a new
+  // notice (which thread displacement then reconciles, §6.4). Feeds the
+  // steward's id derivation (provenance × subject × eventKey), so it can
+  // scope only your own claims. Contract-testable: same key never
+  // re-alerts, new key never silently merges.
+  eventKey?: string;
   // Source classification ("group-chat", "importer", "agent-run", ...).
   // BOUND BY THE STEWARD to the source's verified identity as a per-source
   // SET: first use of a kind adds it to the source's set (set growth is
@@ -459,7 +473,8 @@ type Notice = NoticeCandidate & {
   // for replace/retract (iOS UNNotificationRequest.identifier +
   // apns-collapse-id, Android notify(id), Web Push options.tag). Derived
   // by the STEWARD from verified provenance (source space DID + entity id
-  // [+ event key]) — never from candidate-supplied strings, so a hostile
+  // + eventKey) — never from raw candidate-supplied strings alone, so a
+  // hostile
   // source cannot collide another source's id to hijack coalescing or OS
   // replace/retract.
   id: string;
@@ -720,7 +735,7 @@ type SeenMark = {
 
 Everything else is the **changes projection** (§10.1) joined against marks:
 
-- `unseen(entity)` = `changes([entity], sinceSeq: seenVersion.seq)` is
+- `unseen(entity)` = `changes([entity], sinceBasis: seenMark.basis)` is
   non-empty → change dots on artifacts and their containers (space lists,
   home).
 - **"While you were away"** = one `changes(watchSet, basis: seenWatermark,
@@ -728,7 +743,8 @@ Everything else is the **changes projection** (§10.1) joined against marks:
   the steward. Renders as a pattern on the home context. This is the
   first-run view and the every-return view — the same query. The affordance
   must answer *what changed, by whom, since you looked* — the projection's
-  `author` field gives session-grain attribution from day one (§10.1) —
+  `author` token gives session-grain, equality-comparable attribution
+  from day one (§10.1; identity resolution is separately gated) —
   with a jump-in to the destination. Emphasizing the changed region at the
   destination (memory-v2 holds both versions; the diff is derivable) is
   the phase-1 stretch of this bar, not its phase-0 gate — but a bare dot
@@ -781,9 +797,11 @@ messages.
   agent-run watcher posts the receipt. Watchers are ordinary pattern code
   folded by the steward — proposable, inspectable, per-source.
 - **The generic seen watcher** is built in and covers every source with no
-  per-kind watcher: it compares the user's seen marks against the
-  `subjectVersion` stamps on derived notices and reports moot any notice
-  whose subject the user has since focused-open. This is what preserves
+  per-kind watcher: it compares the user's seen marks against
+  `subjectVersion` stamps — placed by the deriving watcher, or by the
+  steward at admission for explicitly posted candidates with a versioned
+  subject (§4.4) — and reports moot any notice whose subject the user has
+  since focused-open. This is what preserves
   the cross-device auto-retract (read it anywhere → clears everywhere)
   as a default, with zero source cooperation. One carve-out: it **skips
   notices that carry `actions`** — an approval must not vanish because
@@ -825,9 +843,12 @@ the key multi-user fact being that another user's home space is unknowable
   **profile** — the recipient's addressable identity — via the profile's
   notice inbox, a cross-principal, quota-gated append surface (net-new,
   §10.2): the write gate enforces per-source quotas against the *verified
-  writer identity*, not self-reported fields. The user's home space
-  **aggregates across their profiles' inboxes** (a user with work and
-  personal profiles has two inboxes feeding two independent stewards, §8).
+  writer identity*, not self-reported fields. Each profile's inbox feeds
+  **that profile's own steward and ledger** — there is no cross-profile
+  aggregation in the runtime (a work source never learns the personal
+  profile exists, §8); what looks like aggregation is the *device shell*
+  holding sessions for all the user's profiles and rendering one bell over
+  N independent ledgers.
   Until §10.2 lands, directed candidates rest in a durable per-source cell
   in the space where they arise and the steward reads them there
   (client-side interim), with quotas enforced at fold time — weaker (a
@@ -928,9 +949,16 @@ Two mechanisms at two altitudes:
   Identity is steward-derived from verified provenance (§4.4), so it
   cannot be forged.
 - **`threadKey` is the thread**, and displacement is a *derived rule over
-  it*: **within a threadKey, only the newest live notice is visible**;
-  older live notices in the thread are terminally retracted by the steward
-  (system disposition) when a newer one is admitted. A prepared result
+  it* — **scoped per verified source**: within (source identity ×
+  threadKey), only the newest live notice is visible; older live notices
+  in that scope are terminally retracted by the steward (system
+  disposition) when a newer one is admitted. The scoping is load-bearing:
+  `threadKey` is emitter-chosen and guessable (`conv:<id>`), so an
+  unscoped rule would let a hostile source terminally retract a victim's
+  live notice by posting into its thread — a quota-cheap
+  denial-of-attention. Scoped, a source can only displace *its own*
+  claims. `threadKey` may still *group* notices from different sources
+  for presentation (§9.1); displacement never crosses sources. A prepared result
   therefore displaces the raw occurrence by *sharing its thread*, not by
   naming notice ids — no displacement chains, no tombstone bookkeeping for
   the emitter, and "the displaced notice's subject advances again" needs no
@@ -1275,10 +1303,15 @@ that first needs it (§11), and each needs its own (small) design pass.
 
 1. **Changes projection** *(phase 0)*. One read-only, one-shot,
    session-independent memory-v2 query —
-   `changes(roots, branch, sinceSeq?, attribution?) → {toSeq, entries:
-   [{id, seq, deleted?, author?}]}` — giving a non-reactive head read, the
-   changed-since enumeration behind "while you were away", and
-   session-grain "by whom" from the commit log's persisted `sessionId`.
+   `changes(roots, branch, sinceBasis?, attribution?) → {basis, entries:
+   [{id, version, deleted?, author?}]}` — giving a non-reactive head read,
+   the changed-since enumeration behind "while you were away", and
+   session-grain, equality-comparable "by whom" via opaque author tokens
+   derived from the commit log. Versions and basis are **opaque tokens**
+   (per-entity ordering only; the space's commit clock is deliberately not
+   pattern-observable), the basis never samples the branch head (empty
+   results return the caller's basis; late-readable entities replay), and
+   unauthorized entities are indistinguishable from unchanged ones.
    Small because every load-bearing piece is shipped (the `head` table, the
    session catch-up delta, `FactEntry.seq`); a **security surface** because
    it exposes versions to pattern-space and adds an enumeration read, gated

--- a/docs/specs/attention-system/authoring.md
+++ b/docs/specs/attention-system/authoring.md
@@ -1,0 +1,155 @@
+# Posting notices from a pattern — the author's guide
+
+Companion to [`README.md`](./README.md); the pattern-author's view of the
+attention system. Section references (§n) refer to the main spec. Code is
+illustrative shape, not compiled API.
+
+## Rule zero: you probably don't have to do anything
+
+If your pattern produces artifacts — a packing list, a research doc, a game
+state — **you already participate without writing a line**. You write your
+cells like always; the runtime versions every entity; the user's seen-state
+and the steward's watchers (§5, §5.1) do the rest. When your pattern (or an
+agent driving it) updates an artifact while the user is away, they get an
+unseen dot and a line in "while you were away" — what changed, by whom,
+since they looked.
+
+This is the deliberate inversion of every notification API you've used:
+there is no `notify()` call you can forget. Your artifact *is* the signal.
+
+## When you have a genuine claim: post a candidate
+
+Sometimes there's no artifact, or the event deserves more than a dot. The
+posting surface is a **stream returned by a handler** (§6.1b) — you wish or
+are handed an endpoint, and `.send()` a `NoticeCandidate`:
+
+```text
+post.send({
+  subject: message,            // cell link to the truth
+  kind: "group-chat",
+  title: "Ana",
+  body: "running late, start without me",
+  actor: anaDid,
+  threadKey: `conv:${conversationId}`,
+  postureHint: "heads-up",     // a REQUEST, nothing more
+})
+```
+
+The endpoint's handler appends your candidate to the right durable list —
+the **shared space's notice list** for space-wide notices (the default:
+post once, never enumerate recipients, each member's steward routes for
+its own user), or a **profile inbox** for directed notices (mentions, DMs
+— a profile is the only addressable identity another user has; §6.1). The
+stream is transport; the handler owns durability; you never touch anyone's
+ledger.
+
+What to internalize about the envelope:
+
+- **`postureHint` is advisory.** You're stating what your event deserves
+  *within your world*; the user's steward assigns the real posture under
+  their policies (§7). Request honestly: users who keep dismissing your
+  notices unopened teach their stewards to clamp you down — visibly, in a
+  learned-policy record they can read (§7). Your loudness budget is
+  reputation, spent in public.
+- **You cannot reach `interrupt`. Ever.** No field you control gets you
+  there (§4.2's raise-authority tiers). If your pattern legitimately deals
+  in time-critical events, *propose a policy* and let the user grant the
+  floor.
+- **You don't pick your `id`.** Notice identity is steward-derived from
+  your verified provenance; you cannot collide with another source's
+  notifications, and nobody can collide with yours.
+- **`kind` is sticky.** First-seen kind binds to your verified identity;
+  renaming yourself doesn't shed clamps, and kind buys no loudness
+  (defaults key on verified facts, §4.2).
+- **There are quotas** at intake, per verified writer (§6.1, §10.2). A
+  flood reaches your reputation, not the user.
+
+## Disposed stays disposed; new news is a new notice
+
+The lifecycle contract (§4.4) is deliberately simple. Re-posting with the
+same event key **coalesces**: the delivered notice updates in place —
+content, `expiresAt`, `progress` — always silently (§9.3). It never
+resurrects: a dismissed id stays dismissed. When something genuinely new
+happens, post a **new event key in the same `threadKey`** — thread
+displacement (§6.4) retires your older claim so the user sees one notice
+per thread, and the fresh notice alerts (once) if its rung warrants.
+
+So the canonical agent-run shape:
+
+```text
+post.send({ threadKey: `run:${runId}`, title: "Looking into your flight…",
+            postureHint: "silent", progress: {done: 0}, ... })
+// ...progress ticks: same event key, silent coalesce...
+post.send({ threadKey: `run:${runId}`,          // NEW event key
+            title: "Rebooking drafted — needs your OK",
+            attachment: draftCell, postureHint: "review",
+            actions: [{key: "approve", label: "Approve", replyTo: myInbox},
+                      {key: "deny",    label: "Deny",    replyTo: myInbox}] })
+```
+
+The second post displaces the first automatically. One run = one
+`threadKey` = one visible claim, however many artifacts you touched.
+
+## Retraction: report moot, don't track state
+
+Your notice disappears without your help when the user handles it — opening
+it is terminal, and dispositions sync across devices. For satisfaction that
+doesn't go through the notice (the user read the conversation in your UI;
+the trip ended), supply a **watcher** (§5.1): steward-run logic, part of
+your pattern's contract, that observes your source state and reports the
+claim moot — the steward retracts with a system disposition. If you supply
+none, the built-in **seen watcher** covers you: once the user focus-opens
+your notice's subject anywhere, the claim clears everywhere. Do not build
+your own retract plumbing.
+
+## Actions: close the loop in your own space
+
+`actions` render as buttons (with inline text when `input: "text"`) on
+every surface down to the lockscreen. When the user acts, the notice goes
+terminal and `{key, input?, noticeId, at}` is appended to your `replyTo`
+cell **in your space, under the user's ordinary session authority** — the
+same authority they'd have acting in your UI. Requirements: `replyTo` must
+be a **durable array cell, never a Stream** (stream payloads don't persist,
+§4.5), and treat arriving replies as *requests*, not facts (a tray can be
+stale, §9.3).
+
+## Proposing policies: how you earn loudness
+
+Ship suggested policies with your pattern — "library due dates →
+`heads-up` three days before" — at the *moment of intent* (setup, listing
+time), through the trusted adopt flow. Adoption is the write; unadopted
+proposals do nothing (§7). This is your only path above the ceiling, and
+it's a good one: a user who says yes has granted you a legible, revocable
+floor. Two blessed idioms: the **emergency pack** (interrupt floors on
+verified identities, §7) and the **deadline ladder** (embargoed `notBefore`
+rungs in one thread, §7).
+
+## Multi-user: post once, contribute rather than enumerate
+
+In a shared space, post **one** space-wide candidate per event. Every
+member's steward routes it independently — `interrupt` for whoever floored
+your thread, `suppress` for whoever muted it — and you cannot know which;
+per-viewer routing is structurally none of your business. Directed notices
+(mentions, DMs) go to the mentioned member's *profile* inbox. If your
+pattern wants social attention features ("2 of 5 have seen the plan",
+"Bea's handling it"), build them the roster way: members' runtimes
+contribute their own seen marks and disclosed dispositions into `PerSpace`
+state under the space's disclosure policy (§8) — there is no "who has seen
+this" primitive to call, and absence of a member's marks means nothing
+you're entitled to interpret.
+
+## What you can't do, in one list
+
+Write any ledger (CFC-gated to the steward). Raise posture. Forge or
+collide ids. Shed reputation by renaming. Re-alert via coalesce.
+Resurrect a disposed notice. Read other users' attention state, policies,
+or whether you've been muted. You *can* render your own clearly-attributed
+local view of your own events any way you like — the canonical surfaces
+just won't amplify it.
+
+The mental model: **write good artifacts, post honest claims, thread your
+work, put a reply cell out for actions, supply a watcher for your kind,
+and propose — never grab — the loudness you think you deserve.** The
+system's promise back: your quiet work stays findable, your new news is
+never suppressed by stale dismissals (it's a new notice), and if the user
+wants you loud, nothing stands in their way of saying so.

--- a/docs/specs/attention-system/authoring.md
+++ b/docs/specs/attention-system/authoring.md
@@ -66,21 +66,24 @@ What to internalize about the envelope:
 
 ## Disposed stays disposed; new news is a new notice
 
-The lifecycle contract (§4.4) is deliberately simple. Re-posting with the
-same event key **coalesces**: the delivered notice updates in place —
-content, `expiresAt`, `progress` — always silently (§9.3). It never
-resurrects: a dismissed id stays dismissed. When something genuinely new
-happens, post a **new event key in the same `threadKey`** — thread
-displacement (§6.4) retires your older claim so the user sees one notice
-per thread, and the fresh notice alerts (once) if its rung warrants.
+The lifecycle contract (§4.4) is deliberately simple, and the switch is
+the envelope's `eventKey` field. Re-posting with the same `eventKey` (or
+none) **coalesces**: the delivered notice updates in place — content,
+`expiresAt`, `progress` — always silently (§9.3). It never resurrects: a
+dismissed claim stays dismissed. When something genuinely new happens,
+post a **new `eventKey` in the same `threadKey`** — thread displacement
+(§6.4) retires your older claim (displacement is scoped to your own
+verified identity — you can't retire anyone else's, and nobody can retire
+yours), and the fresh notice alerts (once) if its rung warrants.
 
 So the canonical agent-run shape:
 
 ```text
-post.send({ threadKey: `run:${runId}`, title: "Looking into your flight…",
+post.send({ threadKey: `run:${runId}`, eventKey: "started",
+            title: "Looking into your flight…",
             postureHint: "silent", progress: {done: 0}, ... })
-// ...progress ticks: same event key, silent coalesce...
-post.send({ threadKey: `run:${runId}`,          // NEW event key
+// ...progress ticks: same eventKey ("started"), silent coalesce...
+post.send({ threadKey: `run:${runId}`, eventKey: "result",
             title: "Rebooking drafted — needs your OK",
             attachment: draftCell, postureHint: "review",
             actions: [{key: "approve", label: "Approve", replyTo: myInbox},

--- a/docs/specs/attention-system/changes-projection.md
+++ b/docs/specs/attention-system/changes-projection.md
@@ -96,5 +96,6 @@ process-the-delta); retention/GC watermarks (reap below `toSeq`).
   non-empty → change dots (main spec §5).
 - "While you were away" = one `changes(watchSet, basis, attribution: true)`
   call, grouped by attribution then space (main spec §5).
-- The steward's fold uses head reads to stamp `subjectVersion` and evaluate
-  currency at fold time (main spec §6).
+- Watchers (main spec §5.1) read through it to derive notices from entity
+  changes and to stamp the optional `subjectVersion` metadata the generic
+  seen watcher compares against seen marks.

--- a/docs/specs/attention-system/changes-projection.md
+++ b/docs/specs/attention-system/changes-projection.md
@@ -1,0 +1,100 @@
+# The changes projection
+
+Companion to [`README.md`](./README.md) (the attention-system spec), split
+out because it is **independently approvable**: a small, general, read-only
+memory-v2 query primitive that the attention system consumes but does not
+own. The memory owner can evaluate this file without adopting any attention
+theory; the attention spec's phase 0 depends on it and nothing else here.
+Section references (§n) refer to the main spec.
+
+## Status
+
+Proposed; net-new runtime surface (main spec §10.1). This is a **security
+surface**, not just a feature: it exposes entity versions to pattern-space,
+reversing a deliberate prior decision (`Cell` exposes no version), and it
+adds an enumeration read ("which of these entities changed"). It needs
+framework-author sign-off on the CFC story below, not just implementation
+review.
+
+## The primitive
+
+One read-only, one-shot, session-independent query:
+
+```text
+changes(roots, branch, sinceSeq?, attribution?)
+  → { toSeq, entries: [{id, seq, deleted?, author?}] }
+```
+
+(The receiver/verb name is a placeholder — this belongs to the memory-v2
+query layer, named in that spec's §5 style, not to a `graph` object that
+doesn't exist.)
+
+Three modes, one shape:
+
+1. **Single root, no basis** → a **non-reactive head read**: the entity's
+   current head `seq`. One-shot query, not a watch — re-renders never
+   re-fire, which is the property the seen-store's write discipline
+   requires (main spec §4.5, §5).
+2. **Root set + basis** → the **changed-since enumeration**: entries whose
+   head has advanced past `sinceSeq`, plus a `toSeq` high-water mark that
+   becomes the next basis. This is "while you were away" in one call.
+3. **`attribution: true`** → each entry joins the commit log's persisted
+   `sessionId`: **session-grain, server-asserted "by whom"**, upgrading in
+   place to `invocationRef`-backed proof when the signed-write pass lands.
+   A join, not a cryptography project.
+
+## Why this is small
+
+Every load-bearing piece is shipped, not specced:
+
+- `seq` already crosses the wire in every query result (`FactEntry.seq`,
+  memory-v2 §5.7.1).
+- Changed-since-a-basis is precisely the session catch-up computation
+  (memory-v2 §5.4.2; `SessionSync.fromSeq/toSeq`, §4.2.3) — this primitive
+  re-exposes it one-shot and session-independent, payload-free.
+- Attribution joins `CommitLogEntry.sessionId` (memory-v2 §3.7.2), already
+  persisted; `invocationRef`/`authorizationRef` are reserved there for the
+  later signed-write pass.
+- Implementation: one composite `(branch, seq)` index on the `head` table
+  (only `idx_head_branch` exists today), plus the wire verb.
+
+It is the entity-grain, payload-free member of the projection family
+memory-v2 §07 sketches. It is deliberately **not** built on §07's
+annotations plane — annotations are range-anchored collaborative-field
+machinery, self-declared future work, and the one annotation prototype's
+review (PR #4132) documents why storage-side reverse indexes invisible to
+the reactive graph are the wrong shape.
+
+## CFC / read-authority story
+
+**An entity may appear in a changes result iff the caller may read the
+entity itself on that branch** — strictly less information than a
+materialized read reveals. The genuinely new exposure is *enumeration*
+("that something changed" across a set), which is the same information a
+standing watch already reveals; v1 enforces space-level ACLs (matching
+memory-v2 §5.6's current posture), and when label-based redaction lands,
+changes entries redact wherever the materialized read would. Version reads
+are gated by the same read authority as the entity — observing a head seq
+reveals *that* activity occurred, so it must not be cheaper to obtain than
+the entity itself. Branch scope: v1 serves the default branch only,
+matching the main spec's same-space version-comparability rule (child-
+branch head inheritance is the known hard part — PR #4132's blocker).
+
+## Consumers beyond attention
+
+The generality test, so this earns its place as a platform primitive rather
+than an attention hook: offline catch-up UIs ("what changed while this
+device was closed" without holding a session watch open); activity/audit
+views ("what happened in this space this week, by whom" — the
+state-inspector hand-rolls offline versions of these reads today);
+incremental derived indexes (a basis cursor turns recompute-the-world into
+process-the-delta); retention/GC watermarks (reap below `toSeq`).
+
+## What the attention system builds on it
+
+- `unseen(entity)` = `changes([entity], sinceSeq: seenVersion.seq)`
+  non-empty → change dots (main spec §5).
+- "While you were away" = one `changes(watchSet, basis, attribution: true)`
+  call, grouped by attribution then space (main spec §5).
+- The steward's fold uses head reads to stamp `subjectVersion` and evaluate
+  currency at fold time (main spec §6).

--- a/docs/specs/attention-system/changes-projection.md
+++ b/docs/specs/attention-system/changes-projection.md
@@ -10,19 +10,22 @@ Section references (§n) refer to the main spec.
 ## Status
 
 Proposed; net-new runtime surface (main spec §10.1). This is a **security
-surface**, not just a feature: it exposes entity versions to pattern-space,
-reversing a deliberate prior decision (`Cell` exposes no version), and it
-adds an enumeration read ("which of these entities changed"). It needs
-framework-author sign-off on the CFC story below, not just implementation
-review.
+surface**, not just a feature: it exposes entity-change observability to
+pattern-space, reversing a deliberate prior decision (`Cell` exposes no
+version), and it adds an enumeration read ("which of these entities
+changed"). It needs framework-author sign-off on the confidentiality story
+below, not just implementation review. Revised after external security
+review (PR #4691 feedback): version and author exposure are now **opaque
+tokens**, the basis cursor no longer samples the space's commit clock, and
+unauthorized entries are specified indistinguishable from unchanged ones.
 
 ## The primitive
 
 One read-only, one-shot, session-independent query:
 
 ```text
-changes(roots, branch, sinceSeq?, attribution?)
-  → { toSeq, entries: [{id, seq, deleted?, author?}] }
+changes(roots, branch, sinceBasis?, attribution?)
+  → { basis, entries: [{id, version, deleted?, author?}] }
 ```
 
 (The receiver/verb name is a placeholder — this belongs to the memory-v2
@@ -32,31 +35,59 @@ doesn't exist.)
 Three modes, one shape:
 
 1. **Single root, no basis** → a **non-reactive head read**: the entity's
-   current head `seq`. One-shot query, not a watch — re-renders never
+   current `version`. One-shot query, not a watch — re-renders never
    re-fire, which is the property the seen-store's write discipline
    requires (main spec §4.5, §5).
 2. **Root set + basis** → the **changed-since enumeration**: entries whose
-   head has advanced past `sinceSeq`, plus a `toSeq` high-water mark that
-   becomes the next basis. This is "while you were away" in one call.
-3. **`attribution: true`** → each entry joins the commit log's persisted
-   `sessionId`: **session-grain, server-asserted "by whom"**, upgrading in
-   place to `invocationRef`-backed proof when the signed-write pass lands.
-   A join, not a cryptography project.
+   head has advanced past the basis, plus a returned `basis` cursor for
+   the next call. This is "while you were away" in one call.
+3. **`attribution: true`** → each entry carries an **author token**:
+   session-grain, server-asserted, **equality-comparable** attribution
+   ("these changes came from the same session") — which is all run-grouping
+   (main spec §5) needs. Resolving a token to an identity is a separate,
+   gated step; see the confidentiality story.
+
+## Token opacity — what the caller can and cannot learn
+
+- **`version` is an opaque per-entity token.** The runtime provides
+  ordering *within one entity* (`isAfter(a, b)`) and equality; tokens from
+  different entities are not comparable, and the encoding is explicitly
+  not part of the contract. Internally a token encodes the space's commit
+  clock — opaquely, **precisely so the space-global clock never becomes a
+  pattern-readable traffic oracle**: a caller holding one readable entity
+  in a busy shared space must not be able to sample total commit activity
+  across everything else in it ("this space got 40 commits at 2am").
+  Consumers need exactly two properties — per-entity ordering and a
+  restartable basis — and the tokens grant exactly those.
+- **`basis` is an opaque cursor**, defined as *max(request basis, max
+  version among returned entries)* — never the branch head. Two
+  consequences, both deliberate: an empty result returns the caller's own
+  basis unchanged (no clock sample through empty polls), and an entity
+  that was unreadable at read time but becomes readable later is **not
+  silently skipped** — the basis never advanced past it, so it appears on
+  the next call.
+- **`author` is an opaque token, stable within (space, session).**
+  Equality is the contract; identity is not. This keeps raw session ids
+  from becoming a cross-entity linkability primitive and keeps DIDs (a
+  protected field class) out of the default read path.
 
 ## Why this is small
 
 Every load-bearing piece is shipped, not specced:
 
-- `seq` already crosses the wire in every query result (`FactEntry.seq`,
-  memory-v2 §5.7.1).
+- Head versions already cross the wire in every query result
+  (`FactEntry.seq`, memory-v2 §5.7.1) — this contract *narrows* what that
+  exposes, not widens it.
 - Changed-since-a-basis is precisely the session catch-up computation
-  (memory-v2 §5.4.2; `SessionSync.fromSeq/toSeq`, §4.2.3) — this primitive
-  re-exposes it one-shot and session-independent, payload-free.
-- Attribution joins `CommitLogEntry.sessionId` (memory-v2 §3.7.2), already
-  persisted; `invocationRef`/`authorizationRef` are reserved there for the
-  later signed-write pass.
+  (memory-v2 §5.4.2; `SessionSync.fromSeq/toSeq`, §4.2.3) — re-exposed
+  one-shot, session-independent, payload-free.
+- Attribution tokens derive from `CommitLogEntry.sessionId` (memory-v2
+  §3.7.2), already persisted; `invocationRef`/`authorizationRef` are
+  reserved there for the later signed-write pass, and identity-grade
+  attribution upgrades in place when it lands.
 - Implementation: one composite `(branch, seq)` index on the `head` table
-  (only `idx_head_branch` exists today), plus the wire verb.
+  (only `idx_head_branch` exists today), token encode/decode, and the wire
+  verb.
 
 It is the entity-grain, payload-free member of the projection family
 memory-v2 §07 sketches. It is deliberately **not** built on §07's
@@ -65,20 +96,36 @@ machinery, self-declared future work, and the one annotation prototype's
 review (PR #4132) documents why storage-side reverse indexes invisible to
 the reactive graph are the wrong shape.
 
-## CFC / read-authority story
+## Confidentiality / read-authority story
 
 **An entity may appear in a changes result iff the caller may read the
 entity itself on that branch** — strictly less information than a
-materialized read reveals. The genuinely new exposure is *enumeration*
-("that something changed" across a set), which is the same information a
-standing watch already reveals; v1 enforces space-level ACLs (matching
-memory-v2 §5.6's current posture), and when label-based redaction lands,
-changes entries redact wherever the materialized read would. Version reads
-are gated by the same read authority as the entity — observing a head seq
-reveals *that* activity occurred, so it must not be cheaper to obtain than
-the entity itself. Branch scope: v1 serves the default branch only,
-matching the main spec's same-space version-comparability rule (child-
-branch head inheritance is the known hard part — PR #4132's blocker).
+materialized read reveals, and never cheaper to obtain: a changes entry
+("entity X changed, roughly when, by same-session-as-Y") is a new
+**observation class**, distinct from `value`/`shape` reads, and each
+entry's presence carries the subject entity's effective confidentiality —
+so entries participate in flow joins the same way label metadata does
+(staged in, per the label-metadata confidentiality treatment) rather than
+slipping past them.
+
+**Unauthorized ≡ nonexistent ≡ unchanged.** An entity the caller may not
+read produces no entry, no error, and no per-root status — a denied root
+is indistinguishable from an unchanged one, and (per the basis rule above)
+is replayed rather than skipped if authority is later granted. v1 enforces
+space-level ACLs (matching memory-v2 §5.6's current posture); when
+label-based redaction lands, changes entries redact wherever the
+materialized read would.
+
+**Attribution visibility** is bounded the same way: author tokens appear
+only on entries the caller could read anyway, equality is the only
+operation, and resolving a token to a principal is a separate step gated
+by the same disclosure posture that governs shared attention state (main
+spec §8). Whether members of a space *should* see each other's write
+attribution by default is that space's call, not this primitive's.
+
+Branch scope: v1 serves the default branch only, matching the main spec's
+same-space version-comparability rule (child-branch head inheritance is
+the known hard part — PR #4132's blocker).
 
 ## Consumers beyond attention
 
@@ -88,14 +135,15 @@ device was closed" without holding a session watch open); activity/audit
 views ("what happened in this space this week, by whom" — the
 state-inspector hand-rolls offline versions of these reads today);
 incremental derived indexes (a basis cursor turns recompute-the-world into
-process-the-delta); retention/GC watermarks (reap below `toSeq`).
+process-the-delta); retention/GC watermarks (reap at or below a held
+basis).
 
 ## What the attention system builds on it
 
-- `unseen(entity)` = `changes([entity], sinceSeq: seenVersion.seq)`
+- `unseen(entity)` = `changes([entity], sinceBasis: seenMark.basis)`
   non-empty → change dots (main spec §5).
 - "While you were away" = one `changes(watchSet, basis, attribution: true)`
-  call, grouped by attribution then space (main spec §5).
+  call, grouped by author-token equality then space (main spec §5).
 - Watchers (main spec §5.1) read through it to derive notices from entity
-  changes and to stamp the optional `subjectVersion` metadata the generic
-  seen watcher compares against seen marks.
+  changes; the steward stamps `subjectVersion` tokens at admission for the
+  generic seen watcher to compare against seen marks.

--- a/docs/specs/attention-system/loom-mapping.md
+++ b/docs/specs/attention-system/loom-mapping.md
@@ -31,3 +31,27 @@ receipts' internals, stance vocabularies — upstream product machinery
 (§Division of labor); stance policies compile down to plain clamps/watches
 (§7). A receipt *summary* enters as an ordinary candidate.
 
+
+## Already live: the Home Briefing pipeline
+
+The mapping above targets the `attention-candidate-v1` draft, but the
+surface actually shipping today is Loom mobile's **Home Briefing**: a
+curator agent authors a briefing (`.Fabric/briefing.json`), the daemon
+validates and projects it into a dedicated fabric cell, and the mobile
+Home renders headline + blocks/items with tap targets and a staleness
+label (`commontoolsinc/loom`: `.ops/prompts/sweep-curator.md`,
+`.ops/patterns/cf-loom-mobile/briefing.ts`,
+`.ops/services/loom-daemon/sync/briefing-cell.ts`). Fit with this spec:
+
+- The curator's governing rules (*write about the user's world, never the
+  machine*; *"you're clear" is a real answer — never manufacture content*)
+  are the calm thesis, currently enforced in a prompt with no runtime
+  underneath.
+- `BriefingItem` (`label`/`sublabel`/`badge`/`target`) is a near-degenerate
+  notice (`title`/`body`/`kind`/`subject`); the briefing's end-state under
+  this spec is a *view over the notice ledger* (a §9.2 digest surface),
+  not a bespoke store.
+- The recap section is a natural early consumer of the changes projection.
+
+Adoption path: the briefing folds into the notice/seen-state model from
+the Loom side as phases land; no spec changes required.

--- a/docs/specs/attention-system/loom-mapping.md
+++ b/docs/specs/attention-system/loom-mapping.md
@@ -1,0 +1,33 @@
+# Adoption mapping: Loom's `attention-candidate-v1`
+
+Companion to [`README.md`](./README.md). Section references (§n) refer to the
+main spec. This file churns on Loom's schedule, not the spec's.
+
+For the first consumer's adoption review. Loom fields → envelope. (Naming
+flag: Loom's `claim_kind` vocabulary includes a value `notice`; product-side
+that value should be renamed — e.g. `fyi` — before the runtime noun lands.)
+
+| Loom candidate field | Envelope home |
+|---|---|
+| `id` / source identity | `id` (re-derived by steward from verified provenance) |
+| subject / focused target | `subject` (cell link); distinct destination → `target`; `focused_view_fallback` → `ext` |
+| prepared material | `attachment` |
+| `title`, body copy | `title`, `body` (+ `redacted` where the product wants lockscreen-safe copy) |
+| `why_now` | `ext.why_now` (product copy, runtime-opaque) |
+| `claim_kind` (act-now / review / notice→fyi / …) | `kind` + `postureHint` (kind is classification; the hint is the loudness request derived from it) |
+| `channel` (important-and-urgent / yours-in-progress / might-interest-you) | `ext.channel` — audience/genre, orthogonal to posture; product lanes render it |
+| `relation_to_trigger` (augments / supersedes / resolves / …) | `ext.relation_to_trigger`, whole; *supersedes* additionally = share the trigger's `threadKey` (thread displacement, §6.4, does the retraction) |
+| `authorization_state: proposal-required` | `actions: [{key:"approve"…},{key:"deny"…}]` (§4.6) + `ext.authorization_state` — the approval affordance travels with the notice |
+| `authority_class` | `ext` (work-start domain, product-side per §Division of labor) |
+| `not_before` | `notBefore` |
+| sender / subject person | `actor` |
+| delivery/interrupt eligibility | `postureHint`, clamped by user policy (§7) |
+| feedback: done / later | dispositions `acted` / `snoozed` |
+| feedback: never-for-this-class | a policy write (`clamp.max`) via the trusted surface |
+| feedback: not-useful | disposition `dismissed` + `ext.feedback: "not-useful"` (calibration signal round-trips to the product) |
+
+Not mapped, deliberately: Work-start Policies, continuity owners, typed
+receipts' internals, stance vocabularies — upstream product machinery
+(§Division of labor); stance policies compile down to plain clamps/watches
+(§7). A receipt *summary* enters as an ordinary candidate.
+

--- a/docs/specs/attention-system/prior-art.md
+++ b/docs/specs/attention-system/prior-art.md
@@ -1,0 +1,161 @@
+# Prior art: the OS notification stacks
+
+Companion to [`README.md`](./README.md) (the attention-system spec); split out
+as reviewer background. Section references (§n) refer to the main spec.
+
+This design borrows deliberately from the OS notification systems — and its
+strongest claims are about what their architecture *cannot* express — so
+reviewers need the minimum shape of those APIs to judge the comparison.
+(Deeper per-field mappings live in the adapter sections, §9.3.)
+
+**The shared architecture.** On every platform, an app granted a one-time
+binary permission constructs a notification payload — title, body, media,
+optional buttons — hands it to the OS, and **chooses its own loudness**.
+Delivery to a device where the app isn't running rides a vendor relay
+(Apple's APNs, Google's FCM, a browser's push service) to an OS daemon. The
+notification is a **snapshot copy**: once posted, it has no live tie to the
+data it describes beyond an app-chosen identifier the app can use to replace
+or cancel it. Seen/dismissed state is **per-device tray state** — dismissing
+on the phone does nothing on the laptop unless the app hand-builds
+push-to-cancel sync. The only cross-app arbitration the user gets is a
+chronological pile in a tray.
+
+**Android — the most capable, and this spec's behavioral reference:**
+
+- **Channels**: an app declares named notification categories; after
+  creation, the *user* controls each channel's importance, sound, and
+  lockscreen visibility, and the app can never raise them — only lower.
+  This is the germ of this spec's inversion, but only the germ: the app
+  still picks every channel's *initial* importance, can mint fresh channels
+  freely (resetting defaults), and the user discovers channels reactively,
+  buried in settings, usually after being annoyed.
+- **Replace/retract**: `notify(id, …)` with the same id replaces the
+  delivered notification in place; `cancel(id)` retracts it.
+  `setOnlyAlertOnce(true)` — *optionally* — makes re-posts update silently.
+  `setTimeoutAfter(ms)` auto-cancels. Groups get a summary notification.
+- **Actions + RemoteInput**: buttons and inline text reply on the
+  notification itself — act without opening the app; the input is delivered
+  back to the app via a broadcast.
+- **Lockscreen visibility tiers**: per notification, public / private /
+  secret, with an app-supplied redacted `publicVersion` for untrusted
+  displays.
+- **Ongoing + progress** notifications; full-screen intents for calls and
+  alarms; per-channel do-not-disturb bypass flags.
+- **Delivery**: FCM wakes the app process; notifications post with the app
+  dead and survive reboot.
+
+**iOS:**
+
+- **Interruption levels** — `passive` (no wake), `active` (default),
+  `time-sensitive` (breaks through Focus; requires an entitlement),
+  `critical` (breaks mute; Apple-granted entitlement, effectively
+  medical/safety only). An OS-enforced ceiling on loudness classes — but
+  the *app* picks the level per notification, subject only to those gates.
+- **Replace** via `UNNotificationRequest.identifier` (local) and
+  `apns-collapse-id` (push). Content freezes at delivery — it refreshes
+  when the user reopens the shade but never ticks live; genuinely live UI
+  is a separate API surface (Live Activities).
+- **Notification Service Extension**: a slice of app code runs on receipt
+  and may mutate content before display — the platform's hook for
+  decrypt-on-device and fetch-on-receive (the shape §9.3's redaction rule
+  compiles to).
+- **Focus modes**: user-side routing — which apps and which *people* may
+  break through — but coarse: app-grain and contact-grain, with no
+  conditions, and each app self-reports what a "person" is.
+
+**Web Push**: VAPID-authenticated push to a service worker;
+`showNotification` with `tag` for replace and `actions` for buttons;
+payloads are encrypted to the subscription, so the browser vendor's relay
+cannot read content (alone among the three). The most constrained surface —
+which is exactly why it is this spec's envelope floor (§9.3).
+
+**What the architecture structurally cannot do.** These are not missing
+features; they are consequences of "emitter-priced snapshot copies delivered
+to per-device trays," and they are the holes this design exists to fill:
+
+1. **The emitter prices its own loudness.** Android's channel initial
+   importance and iOS's interruption level are chosen by the party with the
+   incentive to interrupt. The user's recourse is reactive and blunt:
+   per-app or per-channel toggles, discovered after the annoyance.
+2. **Permission is binary and app-grain.** Allow-or-deny at first run.
+   There is no "this thread, quietly", no "this source, only until I've
+   handled one", no conditional grant — unless the app builds its own
+   settings screen, which the OS cannot verify it honors.
+3. **The notification is a dead copy.** Nothing retracts it when the
+   underlying thing is handled elsewhere; read-state doesn't cross devices;
+   the email you answered on your laptop still sits on your phone's
+   lockscreen. Well-engineered apps simulate liveness with push-to-cancel;
+   most don't.
+4. **No cross-source arbitration.** The tray is a chronological pile.
+   Nothing sees "forty things are competing for this person right now" —
+   notification fatigue is unaddressable at the system level because no
+   system-level party holds the queue.
+5. **No cross-person semantics.** "Someone on the team handled it" and
+   "escalate if nobody does" are unexpressible; every paging product is a
+   SaaS control plane bolted on top to compensate.
+6. **The relay reads the payload** (APNs and FCM; Web Push excepted).
+   Confidentiality requires per-app heroics — end-to-end encryption plus
+   on-device decrypt in an extension — rather than being a property of the
+   flow.
+7. **User policy is not data.** The user cannot write, inspect, or port a
+   routing rule. What the OS learned about their preferences (if anything)
+   is invisible and vendor-locked.
+
+### 3.3 What this design adopts, inverts, and adds
+
+**Adopted — the mechanics that earned their keep** (this spec's ledger stays
+"Android-shaped" so adapters compile 1:1):
+
+- Stable-identity replace/retract → `id`, steward-derived (§4.4).
+- Only-alert-once → made *unconditional*: alerting rides posture
+  transitions, and the emitter cannot opt back into re-buzzing (§9.3).
+- Lockscreen visibility tiers → `redacted`, generalized from an app choice
+  to CFC label enforcement at the push boundary (§9.3).
+- Actions + inline reply → `actions`/`replyTo`, with the broadcast-back
+  replaced by an append to a source-space cell under the user's ordinary
+  session authority (§4.6) — same UX, radically simpler trust story.
+- iOS's interruption-level vocabulary → the posture scale's rungs map onto
+  it (and Android channel importance) so OS compilation is a table lookup,
+  and the reserved break-glass mapping (§9.3) targets `time-sensitive` /
+  `critical` when entitlements land.
+- Channels-as-classification → `kind`, but bound to verified source
+  identity instead of self-declared (§4.4).
+
+**Inverted — the same levers, moved to the user's side:**
+
+- Android lets the user *lower* a channel after the app priced it; here the
+  emitter never prices at all — `postureHint` is advisory, the steward
+  assigns, and raising is exclusively user-authored (§4.2). The one lever
+  Android proved users understand (per-channel importance) becomes the
+  *whole* model rather than the escape hatch.
+- Binary app permission becomes per-source, condition-bearing policy data:
+  clamps, quiet hours with named exceptions, watches — proposable by
+  patterns at the moment of intent, adopted by the user, editable forever
+  (§7). Focus modes' "which people break through" becomes a verified-actor
+  policy rather than app-self-reported metadata.
+- The OS's invisible ML ranking (Android's notification assistant) becomes
+  **learned policies**: the same adaptive demotion, materialized as
+  records the user can read, edit, and delete (§7).
+
+**Added — expressible here, structurally impossible there:**
+
+- A notice is live-tied to its `subject`: handle the thing *anywhere* and
+  the notice retracts *everywhere* — the seen-join (§4.4) gives every
+  source the auto-retract behavior only the best-engineered apps simulate,
+  cross-device, for free.
+- Derived notices: in-fabric changes need no posting at all (§5) — there is
+  no "the app forgot to notify" failure mode, and quiet agent work is
+  visible at zero notification cost.
+- Cross-person semantics as single policy records: collective quiet
+  ("acted-by-any demotes for all") and escalation ("nobody in 2h → raise
+  for the owner") (§8).
+- One canonical, queryable ledger with the OS trays as degraded
+  projections — digests, audit, and coverage measurement read the ledger,
+  not N device states.
+
+**Inherited, honestly:** dead-device delivery still rides APNs/FCM/Web Push
+and their gates — the break-glass ceilings (`time-sensitive`, `critical`,
+DND-bypass) are the platforms' to grant, not ours to declare (§9.3), and
+push timing is theirs. This design compiles down to the OS stacks; it does
+not pretend to replace them.
+

--- a/docs/specs/attention-system/stories.md
+++ b/docs/specs/attention-system/stories.md
@@ -32,8 +32,8 @@ question §12.12.
 Elena must take tacrolimus by 9pm; a glance must not silence the reminder.
 Her one-time adopted policy carries `{clamp: {min: "interrupt"},
 bypassQuietHours: true, realert: {everyMs: 600_000}}`, and `realert` does
-the whole job on its own: a matched notice is **exempt from
-seen-satisfaction** — glancing at the reminder does not clear it; only a
+the whole job on its own: a matched notice is **exempt from watcher
+retraction** (§5.1) — glancing at the reminder does not clear it; only a
 terminal disposition (logging the dose → `acted`, or an explicit dismiss)
 does — and it re-alerts on the cadence while live (§7, §9.3). The med
 pattern may still re-post as the deadline nears (fresh event key, same
@@ -179,7 +179,7 @@ inquiry retract buyer #1's.
 Jonas is offline 16 days: ~300 notices, ~80 unseen artifact changes across
 12 spaces. The joins do most of the collapsing for free — 16 days of one
 chat is *one* notice (coalescing + thread displacement), everything he
-handled from his phone abroad is already satisfied everywhere (seen-join),
+handled from his phone abroad is already retracted everywhere (the seen watcher, §5.1),
 expired 2FA/fare-holds are hidden and swept, matured ladder rungs displaced
 each other. Two rules close the rest: the sweep's **aging** demotes
 unhandled `heads-up` older than 7 days to `review` (§4.5), so the bell

--- a/docs/specs/attention-system/stories.md
+++ b/docs/specs/attention-system/stories.md
@@ -1,0 +1,224 @@
+# Worked stories: the fourteen walkthroughs
+
+Companion to [`README.md`](./README.md), which keeps the grade table as the
+index. Section references (§n) refer to the main spec.
+
+### B.1 The school emergency (must-interrupt, novel source)
+
+Priya's kid has an allergic reaction at school; the office texts "come now."
+Quiet is the failure mode — and the *novel* emergency is downward bias's
+structural blind spot, because interrupt requires a pre-adopted floor that
+by definition doesn't exist for a first-time source. The design's answer is
+two-part, and honest about its limits: (1) the **emergency pack** (§7) —
+onboarding proposes break-glass floors for school/daycare/alarm/fraud
+sources at the moment the user is thinking about setup, via the ordinary
+propose/adopt flow, **bound to verified identities** (`match.actor` /
+`subject` / `spaceDid` — never spoofable `kind`); (2) the **reserved
+break-glass mapping** (§9.3) — that adopted policy compiles to the OS's
+highest granted interruption level, upgrading to
+`time-sensitive`/`critical` when entitlements land, with no policy
+migration. What the design will *not* do is let the message's own urgency
+raise its posture — that lever, once granted to emergencies, is granted to
+everyone claiming to be one. The residual, stated without varnish: an
+emergency from a source the user never adopted and has no relationship
+with lands at **`review`** (the first-contact requests grouping if it's a
+verified human; §7) — a full miss until the next check-in. That is the
+price of the inversion; the pack exists to shrink it, and how an
+SMS-ingress phone number gets verified as a known actor at all is open
+question §12.12.
+
+### B.2 The medication reminder (seeing must not satisfy)
+
+Elena must take tacrolimus by 9pm; a glance must not silence the reminder.
+Her one-time adopted policy carries `{clamp: {min: "interrupt"},
+bypassQuietHours: true, realert: {everyMs: 600_000}}`, and `realert` does
+the whole job on its own: a matched notice is **exempt from
+seen-satisfaction** — glancing at the reminder does not clear it; only a
+terminal disposition (logging the dose → `acted`, or an explicit dismiss)
+does — and it re-alerts on the cadence while live (§7, §9.3). The med
+pattern may still re-post as the deadline nears (fresh event key, same
+`threadKey`, each rung displacing the last), but that is *content
+escalation* ("30 minutes left"), not liveness — the nag no longer depends
+on the source's own timer discipline. Logging the dose advances the
+subject artifact and the steward terminally retracts every pending rung,
+including embargoed ones (§4.7). Phase gating is real: the cadence firing
+between commits needs timer wake (§10.5) — before phase 2 this story is
+not safely servable and products should not pretend otherwise.
+
+### B.3 On-call triage (exactly one person must act)
+
+A pager event lands in a three-person ops space at 11pm. Each on-call
+member's rotation adopted `{match: {spaceDid: ops-space, kind: "pager"},
+clamp: {min: "interrupt"}, bypassQuietHours: true}` — the `spaceDid` bound
+matters: a bare kind-matched interrupt floor would be claimable by any new
+source declaring `kind: "pager"` (§7). Bea acks from her lockscreen via
+`actions` (§4.6): terminal `acted`, appended to the pattern's `replyTo`
+cell under her session authority. Her runtime discloses the disposition
+into `PerSpace` state; the space's opt-in policy "acted-by-any demotes to
+silent for all" re-lanes Dana's and Sam's notices; posture demotion
+retracts their banners (§9.3). If nobody acts in 15 minutes, the space's
+escalation policy raises the owner's notice — a deadline evaluation that
+needs timer wake (§10.5). One pager event, three independent ledgers,
+collective quiet from one policy record — the part no siloed platform can
+express.
+
+### B.4 The overnight agent run (quiet work, visible)
+
+Tomás's filing agent renames 200 documents at 3am. It posts *one*
+receipt-shaped notice (`threadKey` = run id, `progress` ticking silently),
+laned `silent` by the agent-completions default. The 200 changes are never
+posted at all — they are derived: the while-you-were-away view runs one
+`changes(watchSet, basis, attribution: true)` call and folds every entity
+whose change `author` is the run's session under the receipt. Tomás sees
+one line, expands it, jumps into anything suspicious with the changed
+region emphasized. Zero buzz, full visibility, and the trust that makes
+overnight agents acceptable — the design's home turf, strong from phase 1
+(phase 0 gives the dots without the run grouping).
+
+### B.5 The 2FA code (time-critical, worthless in minutes)
+
+Marcus is mid-login on his laptop; the code arrives via his SMS forwarder.
+Webhook ingress persists durably at the handler (§6.1); the candidate
+carries `expiresAt: +5min` and a `postureHint: "heads-up"` (or `interrupt`
+via a one-time adopted policy the OTP pattern proposed at setup — a
+realistic single config). A second code coalesces silently over the first
+(`id`-keyed replace, §9.3). Expiry hides the notice immediately on read;
+the OS tray copy goes stale until timer wake lands — the spec's own §9.3
+honesty note, and tolerable here because the user is at a client by
+construction (they're logging in). One friction worth product attention: a
+cautious confidentiality label pushes the code behind the generic envelope
+— the rare notice whose whole value is lockscreen visibility; the OTP
+pattern should set `redacted` to carry the code deliberately.
+
+### B.6 The social stream (high-volume, low-value; downward bias earns its keep)
+
+Nina's social importer posts ~80 like/follow events daily; she never opens
+them. Intake quotas bound the flood at the write gate against verified
+writer identity (§10.2). Her dismiss-without-open pattern becomes a
+**learned policy** she can read — `{match: {kind: "social"}, clamp: {max:
+"silent"}, author: steward, reason: "37 of 40 dismissed without open over
+30d"}` — and the source can never buy its way back up (learned policies
+only lower; §7). The review lane stays bounded; the weekly digest groups
+the residue by `kind`. This is the reputation loop as a legible artifact
+rather than a black-box feed model — strong from phase 1.
+
+### B.7 Medical results on a shared-visibility lockscreen (privacy)
+
+Ray's clinic portal posts test results; his partner sometimes sees his
+lockscreen. The notice's confidentiality labels forbid egress to the push
+relay, so the adapter sends the generic envelope unconditionally — full
+content fetched on unlock/app-open (§9.3) — and `redacted` lets the product
+choose neutral copy. Tray-dismiss on the shared-visibility device is
+per-device (§9.3), so dismissing there doesn't clear his laptop. Muting the
+thread is a policy write in his home space — never readable by the clinic
+or anyone else, with the behavioral-inference bound §7 states honestly.
+
+### B.8 Approving the agent's rebooking (act from the surface)
+
+Grace's travel agent drafted a rebooking; the fare hold expires soon. The
+notice carries `attachment` (the itinerary diff), `expiresAt` (the hold),
+and `actions: [approve, deny]` with a `replyTo` cell (§4.6). Approve from
+the lockscreen: terminal `acted` disposition + `{key: "approve", noticeId,
+at}` appended to the pattern's reply cell under her ordinary session
+authority; the acted terminal retracts the notice on every device. Two
+honest caveats: acting from a locked device presumes an authenticated
+session on-device, and a stale tray (§9.3) means she could approve a
+just-expired fare between wakes — the reply cell's consumer must treat
+replies as requests, not facts.
+
+### B.9 The visa renewal (long-lived deadline ladder)
+
+Hana's visa expires in October; she wants `review` at T−90, `heads-up` at
+T−30, `interrupt` at T−7. The **deadline ladder** idiom (§7): the pattern
+posts all three candidates ahead of time with ascending `notBefore` dates,
+the same `threadKey` (each admission displaces the prior rung), ascending
+hints, plus a proposed min she adopts once — at setup, when she's thinking
+about it. Renewal filed → subject advances → the steward retracts every
+pending rung including embargoed ones (§4.7). The gate is timeliness:
+`notBefore` materialization is evaluate-on-read until timer wake (§10.5) —
+nearly harmless at 90-day horizons for a daily shell user, unacceptable for
+B.2's same-day cadence, which is why both stories hang on the same §10.5
+line item.
+
+### B.10 The adversarial source (spam defense)
+
+"DealBlaster," installed for price tracking, turns hostile: floods
+candidates, hints `interrupt` with `ext.urgency: "CRITICAL"`, tries to
+collide the banking source's notification id, re-declares its kind as
+"group-chat" to catch the human-messages default. Every defense is
+structural, not heuristic: hints can't raise (§4.2); `ext` is quarantined
+from routing (§4.4); `id` is steward-derived from verified provenance, so the
+collision is impossible by construction; quotas bind to verified writer
+identity (§10.2); dismiss-without-open writes a legible learned max (§7);
+unconditional alert-once means even fresh-event-key spam can't re-buzz past
+its clamped rung; and the kind-lie fails because above-`review` defaults
+key on verified facts, never self-declared `kind` (§4.2) — declaring
+yourself "group-chat" buys nothing without a verified human `actor` the
+user actually knows.
+
+### B.11 The marketplace stranger (first contact from an unknown human)
+
+Maya lists a couch; a legitimate buyer — verified human DID, zero prior
+relationship — messages her, and the first responder wins the sale. Before
+the first-contact default existed, this story graded C: the buyer failed
+the established-relationship test and sank indistinguishably into `review`
+alongside importer noise, and Maya couldn't even hand-write a fix because
+`match` had no `actor` dimension. As specced now: the message lands in the
+**requests grouping** (`review` lane, distinguished presentation, quota-bounded — §7),
+where it reads as a person, not noise; one tap on the promote affordance
+writes `{match: {actor}, clamp: {min: "heads-up"}}` and the conversation is
+loud thereafter. For time-critical listings, the sanctioned louder path is
+the pattern proposing a listing-scoped min at listing time (the
+moment-of-intent idiom). Downward bias holds: minting DIDs buys a stranger
+nothing above the requests grouping. Note `threadKey` must be per-buyer, not
+per-listing — thread displacement (§6.4) would otherwise let buyer #2's
+inquiry retract buyer #1's.
+
+### B.12 Return from vacation (bulk catch-up must be bounded)
+
+Jonas is offline 16 days: ~300 notices, ~80 unseen artifact changes across
+12 spaces. The joins do most of the collapsing for free — 16 days of one
+chat is *one* notice (coalescing + thread displacement), everything he
+handled from his phone abroad is already satisfied everywhere (seen-join),
+expired 2FA/fare-holds are hidden and swept, matured ladder rungs displaced
+each other. Two rules close the rest: the sweep's **aging** demotes
+unhandled `heads-up` older than 7 days to `review` (§4.5), so the bell
+shows this week, not a 16-day wall; and the dispatcher's **reconnect
+damping** (§9.3) alerts only for notices newer than the gap — the return is
+a quiet shelf plus one "while you were away" view (which is *specified* as
+the every-return view, §5), not a buzz storm. Residual: whether
+"touched-recently" survives 16 days in the watch set is open question
+§12.2 — the vacation is the case that forces that answer.
+
+### B.13 Work and personal (context separation)
+
+Sofia keeps work and personal profiles and wants work quiet on evenings
+and weekends, family always through, one device. Profiles are the coarse
+cut: profile ≡ own home space ≡ own attention state (§8) — her work
+steward and personal steward are independent by construction, and one
+shell merging two ledgers is presentation, not runtime. Within the work
+profile, context is ordinary policy: `{match: {spaceDid: work-space},
+effect: {quietHours: {start: "18:00", end: "09:00"}}}` for evenings plus
+`{quietHours: {start: "00:00", end: "24:00", days: ["sat","sun"], max:
+"suppress"}}` for weekends (§7's day-scoped, max-bearing quietHours), and
+`{match: {threadKey: family}, clamp: {min: "heads-up"}, bypassQuietHours:
+true}` for the always-through exception. Every piece is a legible record
+she can read back.
+
+### B.14 Day one (defaults before any learning)
+
+Riley is brand new: no learned policies, no adopted packs, defaults only.
+The load-bearing line is §7's composition ceiling — `baseline =
+min(postureHint, "review")` — without which a day-one source hinting
+`interrupt` would simply get it (no learned history, no matching max: the
+formula's original cold-start hole, now closed). The week then looks like:
+messages from imported contacts → `heads-up` from day one (rosters are
+seeded by contact import, §7 — without that, the established-relationship
+default fires for nobody and the app reads as broken silence exactly when
+it's being judged); strangers → the requests grouping; importers and agents →
+`review`/`silent`, bounded by intake quotas until learned clamps
+accumulate evidence. Honest weakness: the review lane is at its noisiest
+in week one, before any learning — the propose/adopt idiom (patterns
+proposing their own sensible clamps at install) is the mitigation, and
+§12.8's evidence thresholds decide how fast learning kicks in.
+

--- a/docs/specs/attention-system/stories.md
+++ b/docs/specs/attention-system/stories.md
@@ -151,7 +151,9 @@ from routing (§4.4); `id` is steward-derived from verified provenance, so the
 collision is impossible by construction; quotas bind to verified writer
 identity (§10.2); dismiss-without-open writes a legible learned max (§7);
 unconditional alert-once means even fresh-event-key spam can't re-buzz past
-its clamped rung; and the kind-lie fails because above-`review` defaults
+its clamped rung; thread displacement is scoped per verified source
+(§6.4), so posting into the victim's `threadKey` cannot retract the
+victim's live notices; and the kind-lie fails because above-`review` defaults
 key on verified facts, never self-declared `kind` (§4.2) — declaring
 yourself "group-chat" buys nothing without a verified human `actor` the
 user actually knows.


### PR DESCRIPTION
## Why

Two products are already hand-rolling attention state without runtime support: Loom's attention framework materializes candidates in product-local storage with a localStorage per-browser last-seen timestamp, and Pond's donut ranks pieces by an attention score of its own. Meanwhile the runtime has nothing — no seen-state, no bell, no push, no canonical place for "an agent did work on your behalf and you should be able to see that it happened." As agents do more background work, that gap becomes the product: quiet work that is invisible destroys trust, and quiet work that notifies destroys calm.

This spec defines the runtime substrate both products should compile onto: a per-user ledger of **notices** written by a single trusted **steward** under the user's own **policies** (CFC `writeAuthorizedBy`-gated), **seen-state over artifacts** derived from the version history memory-v2 already keeps, and surface adapters down to OS push — where an OS notification is explicitly the *most degraded projection* of the system, not its model. The founding inversion: sources post notices with an advisory hint; the user's steward decides the posture, and no emitter-controlled field can raise it.

Phase 0 needs exactly one net-new runtime primitive — the **changes projection** ([`changes-projection.md`](https://github.com/commontoolsinc/labs/blob/attention-design-doc/docs/specs/attention-system/changes-projection.md)), a read-only one-shot query re-exposing shipped machinery (the `head` table, the session catch-up delta, commit-log `sessionId`) — split out so it can be approved independently of any attention theory.

## What Changed

New spec directory `docs/specs/attention-system/`:
- `README.md` — the core spec: posture scale + raise-authority tiers, the notice envelope, three stores with a writer-authority × reactivity derivation, seen-state and derived notices, the steward (trust binding, lease, execution home on server-primary standing registrations), policies (clamp composition with a hard cold-start ceiling), multi-user (contributed state, adopted escalation), surfaces and OS delivery (alert-once on posture transitions, redaction at the push boundary, posture → iOS/Android/Web compile table), net-new runtime surface, phasing with rough costs, open questions.
- `changes-projection.md` — the phase-0 primitive, independently approvable; CFC story front and center.
- `prior-art.md` — the OS notification stacks for reviewers, and the seven things their architecture structurally cannot do.
- `stories.md` — fourteen worked user stories with honest dual grades (fully-built vs phase-1), failures included.
- `loom-mapping.md` — field-by-field `attention-candidate-v1` adoption mapping.

The design went through five adversarial review rounds before this PR (runtime + product; Android-as-gold-standard + primitive-shape + parsimony; naming + story grading; fix re-verification + four more stories; coherence + idiomaticness + pragmatism) — the commit history preserves each round.

## Test plan

- `deno task check-docs specs` green (all embedded code blocks type-check; proposed-API sketches are marked illustration-only).
- No runtime code changes in this PR — docs only.

**Do not land yet** — seeking framework-author review; the changes projection needs explicit sign-off as a security surface (it exposes entity versions to pattern-space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the canonical attention system spec: notices + steward + policies + seen-state, with adapters down to OS notifications so Loom and Pond share one runtime substrate. Latest updates harden the `changes` projection’s security, add `eventKey` to the notice envelope, scope thread displacement per verified source, and clarify per‑profile intake and ledger wiring.

- **New Features**
  - Core spec in `README.md`: version‑free notice contract; per‑kind watchers (plus a built‑in seen watcher) bridging changes→notices; intake routing (space‑wide vs profile inbox; home aggregates); sqlite as the likely ledger.
  - `authoring.md`: pattern‑author guide; posting runs as a returned stream.
  - `changes-projection.md`: phase‑0 read‑only `changes` query over memory‑v2.
  - `prior-art.md`, `stories.md`, and `loom-mapping.md`: OS stack mapping, 14 stories, and Loom adoption (Home Briefing pipeline).
  - Notice envelope: adds `eventKey`; thread displacement scoped per verified source × `threadKey`.
  - Steward stamps `subjectVersion` at admission for explicitly posted candidates to keep generic seen‑watcher behavior.
  - Profile intake clarified: each profile has its own inbox, steward, and ledger; the shell shows one bell across N ledgers (no cross‑profile merge).

- **Bug Fixes**
  - `changes` projection hardened: opaque version/author tokens; basis cursor = max(request, returned) to avoid sampling gaps; entries are a confidentiality‑carrying observation class with unauthorized ≡ nonexistent ≡ unchanged.
  - Fixed two stale section cross‑references in `README.md` (watchers: §5.5 → §5.1).

<sup>Written for commit 17a3e3c3b89e7343daf06882d95c81495370cd9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

