### PR TITLE
fix(runner): pull same-space link targets a fresh replica never synced (fresh-replica read asymmetry)

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1067,25 +1067,28 @@ export class CellImpl<T extends FabricValue>
       });
 
       // Wait for the scheduler to process all pending work, then resolve.
-      // If the read kicked async loads of cross-space link targets, await
-      // them and re-idle — each arrival re-runs the read and can reveal the
-      // next hop — bounded. Pulls that kicked nothing take the
-      // zero-iteration path and keep their previous timing.
+      // If the read kicked async loads of absent link targets (cross-space,
+      // or same-space docs a fresh replica never pulled), await them and
+      // re-idle — each arrival re-runs the read and can reveal the next hop.
+      // Every kicked doc is deduped once-per-session, so the total number of
+      // rounds is bounded by the reachable-doc depth; the fixed cap is only
+      // a backstop against a pathological graph. Pulls that kicked nothing
+      // take the zero-iteration path and keep their previous timing.
       this.runtime.scheduler.idle().then(async () => {
         const storage = this.runtime.storageManager;
         // The pending pool is manager-global (same semantics as `synced()`):
         // this pull may also wait on loads kicked by concurrent readers.
         let round = 0;
-        for (; round < 10; round++) {
+        for (; round < 100; round++) {
           if ((storage.pendingCrossSpacePromiseCount?.() ?? 0) === 0) break;
           await (storage.crossSpaceSettled?.() ?? Promise.resolve());
           await this.runtime.scheduler.idle();
         }
         if (
-          round === 10 && (storage.pendingCrossSpacePromiseCount?.() ?? 0) > 0
+          round === 100 && (storage.pendingCrossSpacePromiseCount?.() ?? 0) > 0
         ) {
           logger.warn("pull", () => [
-            "pull() convergence bound exhausted with cross-space loads still",
+            "pull() convergence bound exhausted with link-target loads still",
             `pending: ${this.sourceURI}`,
           ]);
         }

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -317,9 +317,23 @@ export function resolveLink(
       } else {
         link = nextLink;
       }
-      // If we're crossing spaces, force fetching data from server, as the
-      // original server will not have pushed the data to the client yet.
-      if (crossSpace) {
+      // Force fetching data from the server when the local replica cannot
+      // serve the hop target: crossing spaces (the origin server never pushes
+      // other-space docs), or a same-space doc this replica has never pulled.
+      // The second arm is the fresh-replica read-asymmetry fix: selector
+      // driven syncs only deliver what a schema covered, so a link can point
+      // at a same-space doc no selector ever walked — without this kick such
+      // reads mask as `undefined`, indistinguishable from absence. The kick
+      // is async; one-shot reads still return the masked value, but
+      // `Cell.pull()`'s convergence loop awaits the tracked sync and re-reads.
+      if (
+        crossSpace ||
+        runtime.storageManager.shouldPullDoc?.(
+            link.space,
+            link.id,
+            link.scope,
+          ) === true
+      ) {
         // Swallow sync failures: this kick is best-effort (the read still
         // resolves from the local replica) and an unhandled rejection here
         // would otherwise escape the resolution path.

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -328,15 +328,19 @@ export function resolveLink(
       // `Cell.pull()`'s convergence loop awaits the tracked sync and re-reads.
       const mgr = runtime.storageManager;
       const { space, id, scope } = link;
-      if (crossSpace || mgr.shouldPullDoc?.(space, id, scope) === true) {
+      const reserved = !crossSpace &&
+        mgr.shouldPullDoc?.(space, id, scope) === true;
+      if (crossSpace || reserved) {
         // Swallow sync failures: this kick is best-effort (the read still
         // resolves from the local replica) and an unhandled rejection here
-        // would otherwise escape the resolution path. Retract the
-        // shouldPullDoc reservation on failure so a later read may retry
-        // (no-op for the cross-space arm, which never reserved).
+        // would otherwise escape the resolution path. On failure, retract
+        // the shouldPullDoc reservation so a later read may retry — but only
+        // when THIS kick took it: a failed cross-space kick never reserved,
+        // and must not clear a reservation a concurrent same-space read
+        // holds for the same target (that would permit duplicate syncs).
         mgr.trackUntilSettled(
           runtime.getCellFromLink(link).sync().catch(() => {
-            mgr.retractDocPullKick?.(space, id, scope);
+            if (reserved) mgr.retractDocPullKick?.(space, id, scope);
           }),
         );
       }

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -326,19 +326,18 @@ export function resolveLink(
       // reads mask as `undefined`, indistinguishable from absence. The kick
       // is async; one-shot reads still return the masked value, but
       // `Cell.pull()`'s convergence loop awaits the tracked sync and re-reads.
-      if (
-        crossSpace ||
-        runtime.storageManager.shouldPullDoc?.(
-            link.space,
-            link.id,
-            link.scope,
-          ) === true
-      ) {
+      const mgr = runtime.storageManager;
+      const { space, id, scope } = link;
+      if (crossSpace || mgr.shouldPullDoc?.(space, id, scope) === true) {
         // Swallow sync failures: this kick is best-effort (the read still
         // resolves from the local replica) and an unhandled rejection here
-        // would otherwise escape the resolution path.
-        runtime.storageManager.trackUntilSettled(
-          runtime.getCellFromLink(link).sync().catch(() => {}),
+        // would otherwise escape the resolution path. Retract the
+        // shouldPullDoc reservation on failure so a later read may retry
+        // (no-op for the cross-space arm, which never reserved).
+        mgr.trackUntilSettled(
+          runtime.getCellFromLink(link).sync().catch(() => {
+            mgr.retractDocPullKick?.(space, id, scope);
+          }),
         );
       }
     } else {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1247,18 +1247,38 @@ export class Runtime {
   private missingDocLoadKicks = new Set<string>();
 
   /**
-   * Asynchronously load a cross-space link target that a read found absent
-   * from the local replica (CT-1667): per-space server queries cannot follow
-   * links across space boundaries, so the client must fetch such targets
-   * itself. Fire-and-forget, but registered as a cross-space promise so
+   * Asynchronously load a link target that a read found absent from the
+   * local replica. Cross-space targets (CT-1667): per-space server queries
+   * cannot follow links across space boundaries, so the client must fetch
+   * such targets itself. Same-space targets (fresh-replica read asymmetry):
+   * a rejecting-selector sync delivers only the root doc, so a link can
+   * point at a doc no selector ever walked — those are fetched only when
+   * the local replica has never seen the doc (`shouldPullDoc`), so reads of
+   * genuinely absent optional values do not become repeated server queries.
+   * Fire-and-forget, but registered as a cross-space promise so
    * `storageManager.synced()` and `Cell.pull()`'s convergence loop can await
    * it; the absent doc is a tracked read, so the reader re-runs on arrival.
    * Deduped per (space, id): the kicked sync leaves a live subscription
    * behind, so repeat kicks add nothing.
    */
-  ensureLinkedDocLoaded(link: NormalizedFullLink): void {
+  ensureLinkedDocLoaded(
+    link: NormalizedFullLink,
+    sourceSpace?: MemorySpace,
+  ): void {
     const key = `${link.space}\0${link.id}`;
     if (this.missingDocLoadKicks.has(key)) return;
+    if (
+      sourceSpace === link.space &&
+      this.storageManager.shouldPullDoc?.(
+          link.space,
+          link.id,
+          link.scope,
+        ) !== true
+    ) {
+      // Same-space target the replica already has state for (or a manager
+      // without lazy replication) — nothing to fetch.
+      return;
+    }
     this.missingDocLoadKicks.add(key);
     this.storageManager.trackUntilSettled(
       this.getCellFromLink(link).sync().catch(() => {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1274,15 +1274,18 @@ export class Runtime {
     // without lazy replication) needs no fetch.
     const sameSpace = sourceSpace === space;
     const mgr = this.storageManager;
-    if (sameSpace && mgr.shouldPullDoc?.(space, id, scope) !== true) return;
+    const reserved = sameSpace &&
+      mgr.shouldPullDoc?.(space, id, scope) === true;
+    if (sameSpace && !reserved) return;
     this.missingDocLoadKicks.add(key);
     mgr.trackUntilSettled(
       this.getCellFromLink(link).sync().catch(() => {
-        // Allow a retry on failure (e.g. transient disconnect) — in this
-        // dedup set and in the storage manager's kick set, which was marked
-        // when shouldPullDoc approved the same-space fetch above.
+        // Allow a retry on failure (e.g. transient disconnect): clear this
+        // dedup set, and hand back the storage manager's reservation when
+        // THIS kick took it — a cross-space kick never reserved, and must
+        // not clear a reservation a concurrent same-space read holds.
         this.missingDocLoadKicks.delete(key);
-        mgr.retractDocPullKick?.(space, id, scope);
+        if (reserved) mgr.retractDocPullKick?.(space, id, scope);
       }),
     );
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1241,9 +1241,11 @@ export class Runtime {
     return wrapped;
   }
 
-  // (space, id) pairs for which a missing-link-target load has been kicked
-  // this session. The kicked sync establishes a live per-doc subscription, so
-  // a later creation of the doc still arrives — one kick per doc suffices.
+  // (space, scope, id) triples for which a missing-link-target load has been
+  // kicked this session. The kicked sync establishes a live per-doc
+  // subscription, so a later creation of the doc still arrives — one kick per
+  // doc suffices. Scope is part of the key: scoped instances (user/session)
+  // are distinct docs, and a kick for one scope must not suppress another's.
   private missingDocLoadKicks = new Set<string>();
 
   /**
@@ -1265,25 +1267,22 @@ export class Runtime {
     link: NormalizedFullLink,
     sourceSpace?: MemorySpace,
   ): void {
-    const key = `${link.space}\0${link.id}`;
+    const { space, id, scope } = link;
+    const key = `${space}\0${normalizeCellScope(scope)}\0${id}`;
     if (this.missingDocLoadKicks.has(key)) return;
-    if (
-      sourceSpace === link.space &&
-      this.storageManager.shouldPullDoc?.(
-          link.space,
-          link.id,
-          link.scope,
-        ) !== true
-    ) {
-      // Same-space target the replica already has state for (or a manager
-      // without lazy replication) — nothing to fetch.
-      return;
-    }
+    // A same-space target the replica already has state for (or a manager
+    // without lazy replication) needs no fetch.
+    const sameSpace = sourceSpace === space;
+    const mgr = this.storageManager;
+    if (sameSpace && mgr.shouldPullDoc?.(space, id, scope) !== true) return;
     this.missingDocLoadKicks.add(key);
-    this.storageManager.trackUntilSettled(
+    mgr.trackUntilSettled(
       this.getCellFromLink(link).sync().catch(() => {
-        // Allow a retry on failure (e.g. transient disconnect).
+        // Allow a retry on failure (e.g. transient disconnect) — in this
+        // dedup set and in the storage manager's kick set, which was marked
+        // when shouldPullDoc approved the same-space fetch above.
         this.missingDocLoadKicks.delete(key);
+        mgr.retractDocPullKick?.(space, id, scope);
       }),
     );
   }

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1078,9 +1078,11 @@ export function validateAndTransform(
       options?.traverseCells ?? false,
       undefined,
       undefined,
-      // Absent cross-space link targets get an async load kicked; the
+      // Absent link targets get an async load kicked (cross-space always;
+      // same-space only when the replica has never seen the doc); the
       // tracked read re-runs the reader on arrival.
-      (missing) => runtime.ensureLinkedDocLoaded(missing),
+      (missing, sourceSpace) =>
+        runtime.ensureLinkedDocLoaded(missing, sourceSpace),
     ),
     objectCreator,
   );

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -249,6 +249,15 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   shouldPullDoc?(space: MemorySpace, id: URI, scope?: CellScope): boolean;
 
   /**
+   * Undo a `shouldPullDoc` reservation after the kicked sync FAILED, so a
+   * later read may retry the pull. Without this, one transient sync failure
+   * would mask the doc for the manager's whole lifetime (the reservation is
+   * taken before the async pull settles). No-op when the doc was never
+   * reserved. Callers pair it with the failure path of the sync they kicked.
+   */
+  retractDocPullKick?(space: MemorySpace, id: URI, scope?: CellScope): void;
+
+  /**
    * Wait for the currently pending cross-space promises (and any they
    * transitively kick) to settle, WITHOUT waiting for full provider sync the
    * way `synced()` does. Used by `Cell.pull()`'s convergence loop so pulls

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -236,6 +236,19 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   pendingCrossSpacePromiseCount?(): number;
 
   /**
+   * Whether a link target in `space` should be background-pulled because this
+   * replica has never seen the doc (fresh-replica read asymmetry): selector
+   * driven syncs only deliver what a schema covered, so a link can point at a
+   * same-space doc no selector ever walked — without a pull such reads mask
+   * as `undefined`, indistinguishable from absence. Returns true exactly once
+   * per (space, id, scope) per manager lifetime and only when the local
+   * replica holds no state for the doc; the caller kicks the actual sync (see
+   * the link-resolution hop loop). Optional: managers without lazy remote
+   * replication (e.g. test mocks) simply don't implement it.
+   */
+  shouldPullDoc?(space: MemorySpace, id: URI, scope?: CellScope): boolean;
+
+  /**
    * Wait for the currently pending cross-space promises (and any they
    * transitively kick) to settle, WITHOUT waiting for full provider sync the
    * way `synced()` does. Used by `Cell.pull()`'s convergence loop so pulls

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -718,6 +718,13 @@ export class StorageManager implements IStorageManager {
   #providers = new Map<MemorySpace, Provider>();
   #subscription = SubscriptionManager.create();
   #crossSpacePromises = new Set<Promise<void>>();
+  // Docs already offered a link-target pull via shouldPullDoc. One entry per
+  // (space, scope, id) for the manager's lifetime: the first pull registers a
+  // server-side watch that keeps the doc flowing afterwards, so a second kick
+  // is never needed — and never re-kicking is what keeps reads of genuinely
+  // absent targets (dangling links, deleted docs) from churning the
+  // cross-space convergence loop on every read.
+  #docPullKicks = new Set<string>();
   // In-flight commits, registered synchronously by the transaction layer at
   // commit() entry (see IStorageManager.trackPendingCommit). This is the
   // write-durability barrier: distinct from #crossSpacePromises, which also
@@ -1019,6 +1026,26 @@ export class StorageManager implements IStorageManager {
         console.error("pending-commits subscriber threw:", error);
       }
     }
+  }
+
+  shouldPullDoc(space: MemorySpace, id: URI, scope?: CellScope): boolean {
+    if (id.startsWith("data:")) {
+      return false;
+    }
+    const key = `${space}\0${docKey(id, scope)}`;
+    if (this.#docPullKicks.has(key)) {
+      return false;
+    }
+    this.#docPullKicks.add(key);
+    // State the local replica can already serve needs no pull. getState is
+    // undefined both for never-pulled docs and for docs known to hold no
+    // value (deleted / genuinely absent) — the second kind gets one harmless
+    // kick and is then held off by the kick set above.
+    return this.open(space).replica.get({
+      id,
+      type: DOCUMENT_MIME as MIME,
+      scope,
+    }) === undefined;
   }
 
   addCrossSpacePromise(promise: Promise<void>): void {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1048,6 +1048,10 @@ export class StorageManager implements IStorageManager {
     }) === undefined;
   }
 
+  retractDocPullKick(space: MemorySpace, id: URI, scope?: CellScope): void {
+    this.#docPullKicks.delete(`${space}\0${docKey(id, scope)}`);
+  }
+
   addCrossSpacePromise(promise: Promise<void>): void {
     this.#crossSpacePromises.add(promise);
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -909,13 +909,17 @@ export type TraversalContext = {
   metaDocsVisited: Set<string>;
   /**
    * Reports a followed link whose target document is absent from the local
-   * replica and lives in ANOTHER space. Per-space server queries cannot
-   * follow links across space boundaries, so such a target is never covered
-   * by the subscription that loaded the source doc — the client must fetch
-   * it itself (see `Runtime.ensureLinkedDocLoaded`). Optional: server-side
-   * schema traversals have no replica gap.
+   * replica. Cross-space targets (target space !== `sourceSpace`) can never
+   * be covered by the source doc's per-space subscription; same-space
+   * targets can still be absent when no selector ever walked them (the
+   * fresh-replica read asymmetry). The receiver decides whether to fetch —
+   * see `Runtime.ensureLinkedDocLoaded`. Optional: server-side schema
+   * traversals have no replica gap.
    */
-  onMissingLinkTarget?: (link: NormalizedFullLink) => void;
+  onMissingLinkTarget?: (
+    link: NormalizedFullLink,
+    sourceSpace: MemorySpace,
+  ) => void;
 };
 
 export function createTraversalContext(
@@ -924,7 +928,10 @@ export function createTraversalContext(
   schemaTracker: MapSet<string, SchemaPathSelector>,
   includeMeta: boolean = false,
   metaDocsVisited: Set<string> = new Set<string>(),
-  onMissingLinkTarget?: (link: NormalizedFullLink) => void,
+  onMissingLinkTarget?: (
+    link: NormalizedFullLink,
+    sourceSpace: MemorySpace,
+  ) => void,
 ): TraversalContext {
   return {
     tracker,
@@ -941,7 +948,10 @@ export function createDefaultTraversalContext(
   schemaTracker: MapSet<string, SchemaPathSelector> =
     new MapSetStringToPathSelectors(true),
   metaDocsVisited: Set<string> = new Set<string>(),
-  onMissingLinkTarget?: (link: NormalizedFullLink) => void,
+  onMissingLinkTarget?: (
+    link: NormalizedFullLink,
+    sourceSpace: MemorySpace,
+  ) => void,
 ): TraversalContext {
   return createTraversalContext(
     new CompoundCycleTracker<
@@ -1858,17 +1868,22 @@ function followPointer(
         "traverse",
         () => ["followPointer found missing/retracted fact", valueEntry],
       );
-      // A CROSS-SPACE target absent from the replica cannot have been
-      // covered by the source doc's per-space subscription — report it for
-      // an async load. This read still resolves notFound; the absent doc is
-      // a tracked read, so the reader re-runs when it arrives. Same-space
-      // absent targets are NOT reported: they are either covered by the
-      // originating query or genuinely absent, and kicking them turns every
-      // read of an optional value into a server query. The reported link
-      // carries the selector's target-rooted path (minus its "value"
-      // prefix) and schema so the fetch covers the shape this read needs.
-      if (link.space !== doc.address.space) {
-        context.onMissingLinkTarget?.({
+      // A target absent from the replica may simply never have been pulled —
+      // report it for an async load. This read still resolves notFound; the
+      // absent doc is a tracked read, so the reader re-runs when it arrives.
+      // Cross-space targets can never be covered by the source doc's
+      // per-space subscription. Same-space targets are reported too (the
+      // fresh-replica read asymmetry: a rejecting-selector sync delivers
+      // only the root doc, so a link can point at a doc no selector ever
+      // walked); the receiver decides whether a fetch is actually needed —
+      // Runtime.ensureLinkedDocLoaded kicks same-space targets only when
+      // the replica has never seen the doc, and at most once, so reads of
+      // genuinely absent optional values do not turn into repeated server
+      // queries. The reported link carries the selector's target-rooted
+      // path (minus its "value" prefix) and schema so the fetch covers the
+      // shape this read needs.
+      context.onMissingLinkTarget?.(
+        {
           space: link.space,
           id: link.id,
           path: selector !== undefined
@@ -1882,8 +1897,9 @@ function followPointer(
                 | undefined,
             }
             : {}),
-        } as NormalizedFullLink);
-      }
+        } as NormalizedFullLink,
+        doc.address.space,
+      );
       // We include the path in the address, so that information is available,
       return [notFound(target), selector];
     } else if (error.name !== "NotFoundError") {
@@ -3437,8 +3453,17 @@ export class SchemaObjectTraverser<V extends FabricValue>
     // upstream computations in pull mode.
     this.tx.read(doc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
 
-    // We use `every` here so if our input is a sparse array, so is our output.
-    const valid = docArray.every((item, index) => {
+    // Evaluate EVERY element even after one fails: a failing element voids
+    // the whole array below, but each element's traversal is also what kicks
+    // async loads for absent link targets (fresh-replica read asymmetry).
+    // Short-circuiting at the first failure would serialize those kicks —
+    // one element per convergence round — and `Cell.pull()`'s round budget
+    // exhausts long before a many-element array converges. Walking the rest
+    // keeps convergence proportional to link DEPTH, and on the server side
+    // keeps the selector walk covering (and thus delivering + watching) the
+    // remaining element docs. `forEach` skips sparse holes like `every` did.
+    let valid = true;
+    docArray.forEach((item, index) => {
       const itemSchema = schemaAtPathCanonical(this.cfc, schema, [
         index.toString(),
       ]);
@@ -3488,7 +3513,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         ) {
           this.tx.read(curDoc.address, READ_FOR_SCHEDULING);
           arrayObj[index] = null;
-          return true;
+          return;
         }
         this.tx.read(curDoc.address, READ_FOR_SCHEDULING);
         const [redirDoc, selector] = this.getDocAtPath(
@@ -3603,13 +3628,12 @@ export class SchemaObjectTraverser<V extends FabricValue>
               "traverse",
               () => ["Item doesn't match array schema", curDoc, curSelector],
             );
-            return undefined;
+            valid = false;
           }
         } else {
           arrayObj[index] = val;
         }
       }
-      return true;
     });
     return valid ? arrayObj : undefined;
   }

--- a/packages/runner/test/fresh-replica-read-asymmetry.test.ts
+++ b/packages/runner/test/fresh-replica-read-asymmetry.test.ts
@@ -1,0 +1,366 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import { resolveCellPath } from "../src/piece-helpers.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+// Fresh-replica read asymmetry: writes from one replica commit durably, but a
+// second (fresh) replica's reads of the same data used to come back masked —
+// `undefined` / "property not found" — whenever the read path carried no
+// schema. A schema-less sync normalizes to the rejecting selector and
+// delivers only the root doc; link targets the selector never walked read as
+// `unclaimed` (silently undefined). The fix kicks a background pull for
+// same-space link targets the local replica has never seen (see the hop loop
+// in link-resolution.ts and IStorageManager.shouldPullDoc), which
+// `Cell.pull()`'s convergence loop awaits — so schema-less pulls now resolve
+// to the true value. This suite mirrors the CLI `piece get` read path
+// (schema-less cell -> pull() -> resolveCellPath).
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const signer = await Identity.fromPassphrase("fresh-replica-read-asymmetry");
+const space = signer.did();
+
+const entrySchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    body: { type: "string" },
+  },
+} as const satisfies JSONSchema;
+
+const containerSchema = {
+  type: "object",
+  properties: {
+    boardTitle: { type: "string" },
+    myName: { type: "string" },
+    topics: { type: "array", items: entrySchema },
+  },
+} as const satisfies JSONSchema;
+
+const CONTAINER_CAUSE = "asymmetry-container";
+
+describe("fresh-replica read asymmetry", () => {
+  let server: MemoryV2Server.Server;
+  let writerStorage: SharedServerStorageManager;
+  let writerRt: Runtime;
+
+  beforeEach(async () => {
+    server = newSharedServer();
+    writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    writerRt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+
+    // Writer replica: container whose `topics` entries are LINKS to separate
+    // entry cells (the shape addTopic-style handlers produce).
+    const tx = writerRt.edit();
+    const entry0 = writerRt.getCell(space, "entry-0", entrySchema, tx);
+    entry0.set({ title: "T0", body: "B0" });
+    const entry1 = writerRt.getCell(space, "entry-1", entrySchema, tx);
+    entry1.set({ title: "T1", body: "B1" });
+    const entry2 = writerRt.getCell(space, "entry-2", entrySchema, tx);
+    entry2.set({ title: "T2", body: "B2" });
+    const container = writerRt.getCell(
+      space,
+      CONTAINER_CAUSE,
+      containerSchema,
+      tx,
+    );
+    container.set({
+      boardTitle: "the board",
+      myName: "gideon-c",
+      topics: [entry0, entry1, entry2],
+    });
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+    await writerStorage.synced();
+  });
+
+  afterEach(async () => {
+    await writerRt?.dispose();
+    await writerStorage?.close();
+    await server?.close();
+  });
+
+  function freshReader(): { rt: Runtime; close: () => Promise<void> } {
+    const storage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    return {
+      rt,
+      close: async () => {
+        await rt.dispose();
+        await storage.close();
+      },
+    };
+  }
+
+  it("writer's own replica reads everything (control)", async () => {
+    const container = writerRt.getCell(space, CONTAINER_CAUSE, containerSchema);
+    const value = await container.pull();
+    expect(value?.boardTitle).toBe("the board");
+    expect(value?.topics?.length).toBe(3);
+    expect(value?.topics?.[1]?.title).toBe("T1");
+  });
+
+  it("fresh replica, schema'd sync + get resolves linked entries", async () => {
+    const { rt, close } = freshReader();
+    try {
+      const container = rt.getCell(space, CONTAINER_CAUSE, containerSchema);
+      await container.sync();
+      const value = container.get();
+      expect(value?.boardTitle).toBe("the board");
+      expect(value?.topics?.length).toBe(3);
+      expect(value?.topics?.[0]?.title).toBe("T0");
+      expect(value?.topics?.[1]?.title).toBe("T1");
+      expect(value?.topics?.[2]?.body).toBe("B2");
+    } finally {
+      await close();
+    }
+  });
+
+  it("fresh replica, SCHEMA-LESS pull resolves linked entries", async () => {
+    const { rt, close } = freshReader();
+    try {
+      const container = rt.getCell<Record<string, unknown>>(
+        space,
+        CONTAINER_CAUSE,
+        undefined,
+      );
+      const value = (await container.pull()) as {
+        boardTitle?: string;
+        topics?: { title?: string; body?: string }[];
+      };
+      expect(value?.boardTitle).toBe("the board");
+      // Before the shouldPullDoc kick, these read [null, null, null]: the
+      // schema-less sync's rejecting selector delivered only the container
+      // root, and the never-pulled entry docs masked as null.
+      expect(value?.topics?.length).toBe(3);
+      expect(value?.topics?.[0]?.title).toBe("T0");
+      expect(value?.topics?.[1]?.title).toBe("T1");
+      expect(value?.topics?.[2]?.body).toBe("B2");
+    } finally {
+      await close();
+    }
+  });
+
+  it("fresh replica, SCHEMA-LESS pull + per-index path reads (CLI piece get shape)", async () => {
+    const { rt, close } = freshReader();
+    try {
+      const container = rt.getCell<Record<string, unknown>>(
+        space,
+        CONTAINER_CAUSE,
+        undefined,
+      );
+      await container.pull();
+      // Before the fix each of these threw `Cannot access path ... -
+      // property "title" not found` — the CLI's manufactured-data-loss
+      // signature (indistinguishable from past-array-end errors).
+      expect(resolveCellPath(container, ["boardTitle"])).toBe("the board");
+      expect(resolveCellPath(container, ["topics", 0, "title"])).toBe("T0");
+      expect(resolveCellPath(container, ["topics", 1, "title"])).toBe("T1");
+      expect(resolveCellPath(container, ["topics", 2, "title"])).toBe("T2");
+    } finally {
+      await close();
+    }
+  });
+
+  it("fresh replica, schema-less pull converges across a two-hop link chain", async () => {
+    // container.topics[N] -> entry doc -> entry.detail -> detail doc: each
+    // hop is a doc the rejecting selector never delivered, so convergence
+    // needs one kick round per depth level.
+    const chainSchema = {
+      type: "object",
+      properties: {
+        detail: {
+          type: "object",
+          properties: { note: { type: "string" } },
+        },
+      },
+    } as const satisfies JSONSchema;
+
+    const tx = writerRt.edit();
+    const detail = writerRt.getCell(
+      space,
+      "chain-detail",
+      { type: "object", properties: { note: { type: "string" } } } as const,
+      tx,
+    );
+    detail.set({ note: "deep note" });
+    const chainEntry = writerRt.getCell(space, "chain-entry", chainSchema, tx);
+    chainEntry.set({ detail });
+    const chainContainer = writerRt.getCell(
+      space,
+      "chain-container",
+      {
+        type: "object",
+        properties: { entry: chainSchema },
+      } as const,
+      tx,
+    );
+    chainContainer.set({ entry: chainEntry });
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+    await writerStorage.synced();
+
+    const { rt, close } = freshReader();
+    try {
+      const container = rt.getCell<Record<string, unknown>>(
+        space,
+        "chain-container",
+        undefined,
+      );
+      const value = (await container.pull()) as {
+        entry?: { detail?: { note?: string } };
+      };
+      expect(value?.entry?.detail?.note).toBe("deep note");
+    } finally {
+      await close();
+    }
+  });
+
+  it("fresh replica, dangling link reads as absent without stalling pull", async () => {
+    // A link to a cell that was never written: the kick pulls, the server
+    // reports nothing, and the read settles as undefined/null — one kick
+    // only (the shouldPullDoc set), so pull's convergence loop terminates.
+    const tx = writerRt.edit();
+    const ghost = writerRt.getCell(space, "ghost-entry", entrySchema, tx);
+    const holder = writerRt.getCell(
+      space,
+      "dangling-holder",
+      {
+        type: "object",
+        properties: { present: { type: "string" }, ghost: entrySchema },
+      } as const,
+      tx,
+    );
+    holder.set({ present: "here", ghost });
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+    await writerStorage.synced();
+
+    const { rt, close } = freshReader();
+    try {
+      const cell = rt.getCell<Record<string, unknown>>(
+        space,
+        "dangling-holder",
+        undefined,
+      );
+      const value = (await cell.pull()) as {
+        present?: string;
+        ghost?: unknown;
+      };
+      expect(value?.present).toBe("here");
+      expect(value?.ghost ?? null).toBeNull();
+    } finally {
+      await close();
+    }
+  });
+
+  it("fresh replica, whole-array read under a strict required items schema converges", async () => {
+    // Models the topics board: items schema with `required` (strict, not
+    // nullable), entries as links. One absent element used to void the WHOLE
+    // array (traverseArrayWithSchema's every -> undefined), so a fresh
+    // replica read the board's topics as []/undefined while every per-index
+    // leaf read worked. The pull must converge to the full array.
+    const strictContainerSchema = {
+      type: "object",
+      properties: {
+        topics: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              body: { type: "string" },
+            },
+            required: ["title", "body"],
+          },
+          default: [],
+        },
+      },
+    } as const satisfies JSONSchema;
+
+    const { rt, close } = freshReader();
+    try {
+      const container = rt.getCell(
+        space,
+        CONTAINER_CAUSE,
+        strictContainerSchema,
+      );
+      const value = await container.pull();
+      expect(value?.topics?.length).toBe(3);
+      expect(value?.topics?.[0]?.title).toBe("T0");
+      expect(value?.topics?.[1]?.title).toBe("T1");
+      expect(value?.topics?.[2]?.body).toBe("B2");
+    } finally {
+      await close();
+    }
+  });
+
+  it("characterization: schema-less sync + one-shot get still shows root only", async () => {
+    // get() is synchronous: the hop kick is async, so the FIRST get() after a
+    // bare schema-less sync() still masks linked entries. pull() (above) is
+    // the converging read; this test documents the remaining get()-vs-pull()
+    // semantic so a future change that heals or breaks it is visible.
+    const { rt, close } = freshReader();
+    try {
+      const container = rt.getCell<Record<string, unknown>>(
+        space,
+        CONTAINER_CAUSE,
+        undefined,
+      );
+      await container.sync();
+      const value = container.get() as {
+        boardTitle?: string;
+        topics?: unknown[];
+      };
+      expect(value?.boardTitle).toBe("the board");
+      expect(value?.topics?.length).toBe(3);
+      expect(value?.topics?.every((entry) => entry == null)).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/runner/test/fresh-replica-read-asymmetry.test.ts
+++ b/packages/runner/test/fresh-replica-read-asymmetry.test.ts
@@ -339,6 +339,203 @@ describe("fresh-replica read asymmetry", () => {
     }
   });
 
+  it("shouldPullDoc reserves once per doc+scope; retractDocPullKick re-enables", async () => {
+    // Reservation lifecycle (cubic P2): the kick set is taken before the
+    // async pull settles, so a failed pull must be able to hand the
+    // reservation back — otherwise one transient failure masks the doc for
+    // the manager's lifetime. Scope is part of the key: scoped instances
+    // are distinct docs.
+    const storage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    try {
+      const id = writerRt.getCell(space, "reserve-probe", entrySchema)
+        .getAsNormalizedFullLink().id;
+      expect(storage.shouldPullDoc(space, id)).toBe(true);
+      expect(storage.shouldPullDoc(space, id)).toBe(false);
+      storage.retractDocPullKick(space, id);
+      expect(storage.shouldPullDoc(space, id)).toBe(true);
+      // A different scope is an independent reservation.
+      expect(storage.shouldPullDoc(space, id, "user")).toBe(true);
+      // data: URIs are always locally materializable — never pulled.
+      expect(storage.shouldPullDoc(space, "data:application/json,{}")).toBe(
+        false,
+      );
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("a transiently failed kick is retried instead of masking forever", async () => {
+    // Integration of the retract-on-failure semantics: the first kick for
+    // one entry doc fails (injected). The failure hands back the
+    // shouldPullDoc reservation, so a later resolution pass re-kicks — in
+    // practice within the SAME pull when sibling arrivals re-run the read
+    // effect, and at latest on the next read. Without the retract, the
+    // entry would be masked for the replica's lifetime.
+    const { rt, close } = freshReader();
+    try {
+      const entry1Id = writerRt.getCell(space, "entry-1", entrySchema)
+        .getAsNormalizedFullLink().id;
+      const storage = rt.storageManager;
+      const provider = storage.open(space);
+      const origSync = provider.sync.bind(provider);
+      let injections = 0;
+      provider.sync = ((uri, selector, scope) => {
+        if (uri === entry1Id && injections === 0) {
+          injections++;
+          return Promise.reject(new Error("injected transient failure"));
+        }
+        return origSync(uri, selector, scope);
+      }) as typeof provider.sync;
+
+      const container = rt.getCell<Record<string, unknown>>(
+        space,
+        CONTAINER_CAUSE,
+        undefined,
+      );
+      const first = (await container.pull()) as {
+        topics?: ({ title?: string } | null | undefined)[];
+      };
+      // Unpoisoned entries always converge on the first pull.
+      expect(first?.topics?.[0]?.title).toBe("T0");
+      expect(first?.topics?.[2]?.title).toBe("T2");
+
+      // The poisoned entry heals by the second pull at the latest.
+      const second = (await container.pull()) as {
+        topics?: ({ title?: string } | null | undefined)[];
+      };
+      expect(second?.topics?.[1]?.title).toBe("T1");
+      // Exactly one injected failure, exactly one successful retry: the
+      // reservation really was taken, failed, and handed back.
+      expect(injections).toBe(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it("ensureLinkedDocLoaded hands back both reservations on a failed kick", async () => {
+    // The traverse-side kick path: a failed sync must clear the runtime's
+    // dedup set AND retract the storage manager's shouldPullDoc reservation,
+    // so the next report retries; after a successful kick the dedup holds.
+    const { rt, close } = freshReader();
+    try {
+      const storage = rt.storageManager;
+      const provider = storage.open(space);
+      const origSync = provider.sync.bind(provider);
+      const ghostId = writerRt.getCell(space, "eldl-ghost", entrySchema)
+        .getAsNormalizedFullLink().id;
+      let calls = 0;
+      let failures = 0;
+      provider.sync = ((uri, selector, scope) => {
+        if (uri !== ghostId) return origSync(uri, selector, scope);
+        calls++;
+        if (failures === 0) {
+          failures++;
+          return Promise.reject(new Error("injected transient failure"));
+        }
+        return origSync(uri, selector, scope);
+      }) as typeof provider.sync;
+
+      const link = {
+        space,
+        id: ghostId,
+        path: [] as readonly string[],
+      } as Parameters<typeof rt.ensureLinkedDocLoaded>[0];
+
+      rt.ensureLinkedDocLoaded(link, space);
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+      expect(failures).toBe(1);
+
+      // The failure handed back both reservations: a second report re-kicks.
+      rt.ensureLinkedDocLoaded(link, space);
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+      expect(calls).toBe(2);
+
+      // After the successful kick the dedup holds: a third report is a no-op.
+      rt.ensureLinkedDocLoaded(link, space);
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+      expect(calls).toBe(2);
+
+      // A same-space doc the replica already holds takes the early return:
+      // reported missing (e.g. a stale traversal), but never re-kicked.
+      const container = rt.getCell<Record<string, unknown>>(
+        space,
+        CONTAINER_CAUSE,
+        undefined,
+      );
+      await container.sync();
+      const containerLink = container.getAsNormalizedFullLink();
+      const containerSyncs: number[] = [];
+      const counting = provider.sync;
+      provider.sync = ((uri, selector, scope) => {
+        if (uri === containerLink.id) containerSyncs.push(1);
+        return counting(uri, selector, scope);
+      }) as typeof provider.sync;
+      rt.ensureLinkedDocLoaded(
+        {
+          space,
+          id: containerLink.id,
+          path: [] as readonly string[],
+        } as Parameters<typeof rt.ensureLinkedDocLoaded>[0],
+        space,
+      );
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+      expect(containerSyncs.length).toBe(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it("missing-target kicks are scope-keyed: one scope does not suppress another", async () => {
+    // Cubic P1: Runtime.ensureLinkedDocLoaded dedupes kicks; scoped
+    // instances (user/session) are distinct docs, so a kick for one scope
+    // must not swallow a later kick for another.
+    const { rt, close } = freshReader();
+    try {
+      const storage = rt.storageManager;
+      const provider = storage.open(space);
+      const origSync = provider.sync.bind(provider);
+      const synced: string[] = [];
+      provider.sync = ((uri, selector, scope) => {
+        synced.push(`${scope ?? "space"}\0${uri}`);
+        return origSync(uri, selector, scope);
+      }) as typeof provider.sync;
+
+      const ghostId = writerRt.getCell(space, "p1-scoped-ghost", entrySchema)
+        .getAsNormalizedFullLink().id;
+      const baseLink = {
+        space,
+        id: ghostId,
+        path: [] as readonly string[],
+      };
+      rt.ensureLinkedDocLoaded(
+        baseLink as Parameters<typeof rt.ensureLinkedDocLoaded>[0],
+        space,
+      );
+      rt.ensureLinkedDocLoaded(
+        { ...baseLink, scope: "user" } as Parameters<
+          typeof rt.ensureLinkedDocLoaded
+        >[0],
+        space,
+      );
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+      const forGhost = synced.filter((entry) => entry.endsWith(`\0${ghostId}`));
+      expect(forGhost.some((entry) => entry.startsWith("space\0"))).toBe(true);
+      expect(forGhost.some((entry) => entry.startsWith("user\0"))).toBe(true);
+      // And the dedup still holds within a scope: repeat is a no-op.
+      const before = synced.length;
+      rt.ensureLinkedDocLoaded(
+        baseLink as Parameters<typeof rt.ensureLinkedDocLoaded>[0],
+        space,
+      );
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+      expect(synced.length).toBe(before);
+    } finally {
+      await close();
+    }
+  });
+
   it("characterization: schema-less sync + one-shot get still shows root only", async () => {
     // get() is synchronous: the hop kick is async, so the FIRST get() after a
     // bare schema-less sync() still masks linked entries. pull() (above) is

--- a/packages/runner/test/fresh-replica-read-asymmetry.test.ts
+++ b/packages/runner/test/fresh-replica-read-asymmetry.test.ts
@@ -5,6 +5,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import { resolveCellPath } from "../src/piece-helpers.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
@@ -482,6 +483,48 @@ describe("fresh-replica read asymmetry", () => {
       );
       await (storage.crossSpaceSettled?.() ?? Promise.resolve());
       expect(containerSyncs.length).toBe(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it("a failed cross-space kick does not clear another read's reservation", async () => {
+    // Retract-only-if-owned: a cross-space kick never takes the
+    // shouldPullDoc reservation, so its failure must not hand back a
+    // reservation a concurrent same-space read holds for the same target —
+    // that would permit duplicate syncs while the first is still pending.
+    const { rt, close } = freshReader();
+    try {
+      const storage = rt.storageManager;
+      const provider = storage.open(space);
+      const origSync = provider.sync.bind(provider);
+      const ghostId = writerRt.getCell(space, "xspace-ghost", entrySchema)
+        .getAsNormalizedFullLink().id;
+      provider.sync = ((uri, selector, scope) => {
+        if (uri === ghostId) {
+          return Promise.reject(new Error("injected failure"));
+        }
+        return origSync(uri, selector, scope);
+      }) as typeof provider.sync;
+
+      // A same-space read holds the reservation (as if its kick is in
+      // flight).
+      expect(storage.shouldPullDoc?.(space, ghostId)).toBe(true);
+
+      // A cross-space-sourced report for the same target fails its kick.
+      const otherSource = "did:key:zOtherSourceSpace" as MemorySpace;
+      rt.ensureLinkedDocLoaded(
+        {
+          space,
+          id: ghostId,
+          path: [] as readonly string[],
+        } as Parameters<typeof rt.ensureLinkedDocLoaded>[0],
+        otherSource,
+      );
+      await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+
+      // The same-space reservation survives: no duplicate kick permitted.
+      expect(storage.shouldPullDoc?.(space, ghostId)).toBe(false);
     } finally {
       await close();
     }


### PR DESCRIPTION
## The bug

The deepest open platform bug in the Topics work-line: from a fresh CLI replica, **writes commit reliably but reads of cross-replica-written data come back masked** — `undefined`, schema defaults, or `property not found` — indistinguishable from absence. Twice it manufactured data-loss illusions that invited destructive "repair" writes (see the "Fresh-replica read asymmetry" and "Board outage 2026-07-10" topics on `topics-dev-476ea34f`), and it corrupted writes-that-read (topics filed with `createdByName: "someone"` because `myName.get()` read masked).

## Root cause (three legs)

1. **Schema-less syncs normalize to the rejecting selector** ([v2-watch.ts `normalizeSyncSelector`](../blob/main/packages/runner/src/storage/v2-watch.ts)) → the server delivers only the root doc. CLI read paths (argument cells via meta link, path reads) are schema-less, so linked sub-docs (array entries, argument members) never reach the replica.
2. **Reads of never-pulled docs fall back to `unclaimed`** ([v2-transaction.ts `loadRoot`](../blob/main/packages/runner/src/storage/v2-transaction.ts)) — silently `undefined`. There is no "not synced here" state at the read layer.
3. **Only cross-space absent link targets got background loads kicked** (link-resolution hop loop, traverse `followPointer`). Same-space targets were assumed "covered by the originating query or genuinely absent" — false after a rejecting-selector sync. Own writes are locally present, hence the write/read asymmetry; renderers carry pattern schemas and never notice.

## The fix

Extend both kick sites to same-space targets **the replica has never seen**, gated by a new optional `IStorageManager.shouldPullDoc` — true at most once per (space, scope, id) per manager lifetime, and only when the replica holds no state for the doc (dangling links / deleted docs cannot churn the loop). `Cell.pull()`'s existing convergence loop awaits the kicked syncs and re-reads; schema-less pulls now converge to the true value. **Client-side only — no server change required** (a redeployed server additionally regains one-shot delivery via the traversal fix below).

Two convergence enablers:
- `traverseArrayWithSchema` evaluates **every** element instead of short-circuiting at the first failure. Semantics unchanged (a failing element still voids the array for that round), but all absent element docs kick in the same round → convergence proportional to link **depth**, not element-count × depth. The 19-entry production board exhausted the old budget serially.
- `pull()`'s round cap becomes a generous backstop (10 → 100); kicks are once-per-doc so rounds are naturally bounded by reachable-doc depth.

## Verification

- New regression suite `packages/runner/test/fresh-replica-read-asymmetry.test.ts` (two `StorageManager`s loopback-connected to one in-process memory server): schema-less pull, CLI-shaped per-index path reads, two-hop link chains, dangling links, strict-`required` array items schemas, plus a characterization of the remaining one-shot `get()` semantic.
- **End-to-end against the production board** (`topics-dev-476ea34f`, fresh CLI replica per invocation): `--input topics` returns the full 19-topic array (was `undefined`); `topics/N/title` reads all indices (was property-not-found for N≥1); result-cell `topics` reads (was property-not-found); `myName` reads `"Fable"` (was masked → the "someone" corruption).
- Gates: fmt + lint + typecheck clean; full suites green — runner 876/876, memory 354/354, piece 15/15, cli 20/20.

## Remaining sharp edges (follow-ups, tracked as topics on the board)

- One-shot `get()` after a bare schema-less `sync()` still returns the masked view (kick is async; `pull()` is the converging read — all CLI surfaces use it). Loud sync-state in reads is the deeper reform.
- Handler-execution reads (`myName.get()` inside `addTopic`) run mid-transaction and cannot await kicks — presync coverage for user-scoped docs is a separate leg.
- Why the deployed server's schema'd walk under-delivers the argument graph (client kicks compensate; after redeploy the array-walk fix restores one-shot coverage) deserves its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where fresh replicas read linked docs as missing after schema-less syncs. `pull()` now fetches same-space link targets a replica has never seen (scoped, deduped, and retriable), and only retracts reservations when the current kick took them.

- **Bug Fixes**
  - Extend link resolution to kick background pulls for same-space targets, gated by `IStorageManager.shouldPullDoc` (once per space/scope/id and only when no local state); on failure, `retractDocPullKick` is called only if this kick reserved it, so a failed cross-space kick cannot clear another read’s reservation.
  - Scope-key the missing-target dedup in `Runtime.ensureLinkedDocLoaded`; early-return when the doc is already locally known; clear the runtime dedup on failure and retract the storage reservation only if this invocation reserved it.
  - Update traversal/`Runtime.ensureLinkedDocLoaded` to pass `sourceSpace` and let the runtime decide whether to fetch; treat missing same-space targets like cross-space when never seen; protect reservations across concurrent reads.
  - Increase `Cell.pull()` convergence cap to 100; traverse arrays by evaluating every element to kick all needed loads in the same round (semantics unchanged).
  - Expand tests in `fresh-replica-read-asymmetry.test.ts` to cover reservation ownership, cross-space failure isolation, transient failure retry, scope isolation, and traverse-side failure handling.

<sup>Written for commit aa7208352d3469c243b8863cde198069a8f8fa0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

