### PR TITLE
test: cover the intermittently-covered lines that flap the coverage-debt gate

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -907,6 +907,40 @@ Deno.test("memory v2 client coalesces watch ack bursts", async () => {
   }
 });
 
+Deno.test("memory v2 client reschedules an ack after a failed send while still connected", async () => {
+  const transport = new FailFirstAckTransport();
+  const client = await connect({ transport });
+  const session = await client.mount("did:key:z6Mk-memory-v2-ack-retry");
+
+  try {
+    // A watch result acks the observed server seq. The first ack send fails
+    // with an error response (the connection stays up), so the ack flush's
+    // finally reschedules a retry.
+    await session.watchAdd([{
+      id: "root:1",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:doc:1",
+          selector: {
+            path: [],
+            schema: false,
+          },
+        }],
+      },
+    }]);
+
+    // Wait for the rescheduled retry to be accepted — event-driven, no sleep.
+    await transport.ackSucceeded;
+    // One failed attempt, then the rescheduled attempt that succeeded.
+    assertEquals(transport.ackAttempts, 2);
+    // A failed ack while connected must not drop the connection.
+    assertEquals(client.isConnected(), true);
+  } finally {
+    await client.close();
+  }
+});
+
 Deno.test("memory v2 watch view keeps emitted snapshots incrementally ordered", async () => {
   const view = WatchView.fromSync({
     type: "sync",
@@ -1644,6 +1678,100 @@ class AckCountingTransport implements Transport {
             serverSeq: this.#watchSeq,
           },
         });
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled message ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    this.#closeReceiver();
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+// Rejects the FIRST session.ack with an error response but stays connected, so
+// the ack flush throws and its finally reschedules a retry (client scheduleAck).
+// The second ack is accepted.
+class FailFirstAckTransport implements Transport {
+  ackAttempts = 0;
+  #watchSeq = 0;
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #ackSucceeded = defer<void>();
+
+  /** Resolves when a session.ack is accepted (the retry after the first fails). */
+  get ackSucceeded(): Promise<void> {
+    return this.#ackSucceeded.promise;
+  }
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.#respond(HELLO_OK);
+        return Promise.resolve();
+      case "session.open":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: "session:fail-first-ack",
+            serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
+          },
+        });
+        return Promise.resolve();
+      case "session.watch.add":
+        this.#watchSeq += 1;
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: this.#watchSeq,
+            sync: {
+              type: "sync",
+              fromSeq: this.#watchSeq - 1,
+              toSeq: this.#watchSeq,
+              upserts: [],
+              removes: [],
+            },
+          },
+        });
+        return Promise.resolve();
+      case "session.ack":
+        this.ackAttempts += 1;
+        if (this.ackAttempts === 1) {
+          // Reject the ack, but leave the connection open.
+          this.#respond({
+            type: "response",
+            requestId: message.requestId!,
+            error: { name: "AckRejected", message: "ack rejected once" },
+          });
+        } else {
+          this.#respond({
+            type: "response",
+            requestId: message.requestId!,
+            ok: { serverSeq: this.#watchSeq },
+          });
+          this.#ackSucceeded.resolve();
+        }
         return Promise.resolve();
       default:
         throw new Error(`Unhandled message ${message.type}`);

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -87,7 +87,7 @@ export const createStorageAddressResolver = (
   };
 };
 
-class WebSocketTransport implements MemoryClient.Transport {
+export class WebSocketTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
   #socket: WebSocket | null = null;

--- a/packages/runner/test/compiled-js-parser.test.ts
+++ b/packages/runner/test/compiled-js-parser.test.ts
@@ -172,6 +172,18 @@ describe("scanner helpers", () => {
     );
   });
 
+  it("scans single bitwise operators and reads a regex after them", () => {
+    // A single `&` or `|` is its own token (distinct from `&&`/`||`), and each
+    // marks the scanner so a following `/.../ ` is a regex literal, not division
+    // or a comment.
+    expect(stripJsTrivia("a & b")).toBe("a&b");
+    expect(stripJsTrivia("a | b")).toBe("a|b");
+    expect(stripJsTrivia("a & /b/g")).toBe("a&/b/g");
+    expect(stripJsTrivia("a | /b/ // tail")).toBe("a|/b/");
+    // The doubled forms `&&`/`||` advance two characters as one token.
+    expect(stripJsTrivia("a && b || c")).toBe("a&&b||c");
+  });
+
   it("splits comma lists without splitting nested structures", () => {
     const source =
       `first, call(1, [2, 3]), { nested: /a,b/g }, \`hi, ${"${name}"}\``;

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -7,6 +7,7 @@ import {
   MEMORY_STORAGE_PATH,
   toSpaceWebSocketAddress,
   toWebSocketAddress,
+  WebSocketTransport,
 } from "../src/storage/v2-remote-session.ts";
 import { StorageManager } from "../src/storage/v2.ts";
 
@@ -239,5 +240,100 @@ describe("StorageManager.registerSpaceHost", () => {
     const manager = await makeManager();
     expect(() => manager.registerSpaceHost(spaceLearned, "not a url"))
       .toThrow(`Invalid host for space ${spaceLearned}`);
+  });
+});
+
+describe("WebSocketTransport failure signalling", () => {
+  // A socket the test opens, closes, and errors by hand. Nothing here waits on
+  // a real connection or a timer: the transport reaches its close and error
+  // handlers because the test dispatches those events synchronously.
+  class DrivableWebSocket extends EventTarget {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    static instances: DrivableWebSocket[] = [];
+    readyState = DrivableWebSocket.CONNECTING;
+    constructor(readonly url: string | URL) {
+      super();
+      DrivableWebSocket.instances.push(this);
+    }
+    send(_payload: string): void {}
+    close(): void {}
+  }
+
+  // Install the drivable socket, hand the body a transport and its socket, then
+  // always restore the real global. `send()` reaches `open()`, which constructs
+  // the socket synchronously, so `socket()` is available before any event.
+  function withTransport(
+    body: (
+      transport: WebSocketTransport,
+      socket: () => DrivableWebSocket,
+    ) => Promise<void>,
+  ): Promise<void> {
+    const realWebSocket = globalThis.WebSocket;
+    DrivableWebSocket.instances.length = 0;
+    (globalThis as { WebSocket: unknown }).WebSocket = DrivableWebSocket;
+    const transport = new WebSocketTransport(
+      new URL("wss://memory.test/api/storage/memory"),
+    );
+    return body(transport, () => DrivableWebSocket.instances.at(-1)!)
+      .finally(() => {
+        (globalThis as { WebSocket: unknown }).WebSocket = realWebSocket;
+      });
+  }
+
+  it("rejects the in-flight send and closes cleanly when the socket closes before opening", async () => {
+    await withTransport(async (transport, socket) => {
+      let closeCalled = false;
+      let closeError: Error | undefined;
+      transport.setCloseReceiver((error) => {
+        closeCalled = true;
+        closeError = error;
+      });
+
+      const send = transport.send("frame");
+      socket().readyState = DrivableWebSocket.CLOSED;
+      socket().dispatchEvent(new Event("close"));
+
+      await expect(send).rejects.toThrow(
+        "memory websocket transport closed before opening",
+      );
+      // A close before opening is not an error, so the receiver gets none.
+      expect(closeCalled).toBe(true);
+      expect(closeError).toBeUndefined();
+    });
+  });
+
+  it("surfaces the underlying Error of a socket error to the close receiver", async () => {
+    await withTransport(async (transport, socket) => {
+      let closeError: Error | undefined;
+      transport.setCloseReceiver((error) => {
+        closeError = error;
+      });
+
+      const boom = new Error("connection refused");
+      const send = transport.send("frame");
+      socket().dispatchEvent(new ErrorEvent("error", { error: boom }));
+
+      await expect(send).rejects.toBeDefined();
+      expect(closeError).toBe(boom);
+    });
+  });
+
+  it("reports a generic transport error when the error event carries no Error", async () => {
+    await withTransport(async (transport, socket) => {
+      let closeError: Error | undefined;
+      transport.setCloseReceiver((error) => {
+        closeError = error;
+      });
+
+      const send = transport.send("frame");
+      socket().dispatchEvent(new Event("error"));
+
+      await expect(send).rejects.toBeDefined();
+      expect(closeError).toBeInstanceOf(Error);
+      expect(closeError?.message).toContain("memory websocket transport error");
+    });
   });
 });

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -11,6 +11,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
+import { createCell } from "../src/cell.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -217,9 +218,186 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
       ),
     ).toBe("space");
   });
+
+  // Drive a query to its terminal state through `settled()` and read the result
+  // cell — the event-driven wait, with no sleep or polling loop. `settled()`
+  // stays open until the post-commit flush writes the result (or error) back, so
+  // the write-back handlers run every time rather than depending on whether the
+  // async flush lands inside the observation window.
+  async function runQueryToSettled(sql: string, label: string) {
+    const queryPattern = cf.pattern(() => {
+      const db = cf.sqliteDatabase({
+        tables: {
+          notes: cf.table({ id: "integer primary key", body: "text" }),
+        },
+      });
+      return cf.sqliteQuery({ db, sql, reactOn: db });
+    });
+    const resultCell = runtime.getCell(
+      space,
+      label,
+      queryPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, queryPattern, {}, resultCell);
+    await tx.commit();
+
+    const view = result as unknown as {
+      get: () => QueryState;
+      sink: (f: () => void) => () => void;
+    };
+    const cancel = view.sink(() => {});
+    try {
+      await runtime.idle();
+      await runtime.settled();
+      return view.get();
+    } finally {
+      cancel();
+    }
+  }
+
+  it("writes a successful query result back through the post-commit flush", async () => {
+    const q = await runQueryToSettled(
+      "SELECT body FROM notes",
+      "sqlite-success-writeback",
+    );
+    expect(q.pending).toBe(false);
+    expect(q.error).toBeUndefined();
+    expect(q.result).toEqual([]);
+  });
+
+  it("writes an error result when the sqlite read fails, rather than staying pending", async () => {
+    // Force the server read to fail. The builtin must surface that as a settled
+    // error result on the query cell, not leave the query pending forever.
+    const provider = runtime.storageManager.open(space) as unknown as {
+      sqliteQuery: (...a: unknown[]) => Promise<unknown>;
+    };
+    const original = provider.sqliteQuery.bind(provider);
+    provider.sqliteQuery = () =>
+      Promise.reject(new Error("sqlite backend unavailable"));
+    try {
+      const q = await runQueryToSettled(
+        "SELECT body FROM notes",
+        "sqlite-error-writeback",
+      );
+      expect(q.pending).toBe(false);
+      expect(q.error).toBeDefined();
+      expect(q.result).toBeUndefined();
+    } finally {
+      provider.sqliteQuery = original;
+    }
+  });
+
+  // Issue a query and hold its server read in flight on `gate` (a Promise the
+  // test resolves by hand — no sleep or timer). While it is held, a write bumps
+  // the db revision, so the query re-issues with a new request hash: a genuine
+  // supersede. When the held read finally finishes, its flush must notice the
+  // hash changed and leave the newer query's state alone.
+  async function runStaleFlush(
+    outcome: "resolve" | "reject",
+    label: string,
+  ): Promise<{ q: QueryState; secondHash: string }> {
+    const provider = runtime.storageManager.open(space) as unknown as {
+      sqliteQuery: (...a: unknown[]) => Promise<unknown>;
+    };
+    const original = provider.sqliteQuery.bind(provider);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    provider.sqliteQuery = async (...a) => {
+      await gate;
+      if (outcome === "reject") throw new Error("sqlite read failed late");
+      return await original(...a);
+    };
+    try {
+      const pattern = cf.pattern(() => {
+        const db = cf.sqliteDatabase({
+          tables: {
+            notes: cf.table({ id: "integer primary key", body: "text" }),
+          },
+        });
+        const q = cf.sqliteQuery({
+          db,
+          sql: "SELECT body FROM notes",
+          reactOn: db,
+        });
+        return { db, q };
+      });
+      const resultCell = runtime.getCell(space, label, undefined, tx);
+      runtime.run(tx, pattern, {}, resultCell);
+      await tx.commit();
+
+      const qCell = resultCell.key("q").resolveAsCell() as unknown as {
+        get: () => QueryState;
+        sink: (f: () => void) => () => void;
+      };
+      const cancel = qCell.sink(() => {});
+      try {
+        // The first query is issued; its server read now waits on the gate.
+        await runtime.idle();
+        const firstHash = qCell.get().requestHash;
+        expect(typeof firstHash).toBe("string");
+        expect(qCell.get().pending).toBe(true);
+
+        // A write bumps the db revision, re-issuing the query with a new hash
+        // while the first read is still held.
+        const execTx = runtime.edit();
+        const handleLink = resultCell.key("db").resolveAsCell()
+          .getAsNormalizedFullLink();
+        const db = createCell(
+          runtime,
+          { ...handleLink, schema: undefined },
+          execTx,
+          false,
+          "sqlite",
+        ) as unknown as {
+          exec(sql: string, params?: readonly unknown[]): void;
+        };
+        db.exec("INSERT INTO notes (body) VALUES (?)", ["seed"]);
+        expect((await execTx.commit()).error).toBeUndefined();
+        await runtime.idle();
+        const secondHash = qCell.get().requestHash;
+        expect(secondHash).not.toBe(firstHash);
+        expect(typeof secondHash).toBe("string");
+
+        // Release both reads. The first (now stale) flush must find the hash
+        // changed and skip its write-back.
+        release();
+        await runtime.settled();
+        return { q: qCell.get(), secondHash: secondHash! };
+      } finally {
+        cancel();
+      }
+    } finally {
+      provider.sqliteQuery = original;
+    }
+  }
+
+  it("a superseded query's successful flush does not overwrite the newer request", async () => {
+    const { q, secondHash } = await runStaleFlush("resolve", "sqlite-stale-ok");
+    // Only the newer query settled its own result; the stale flush was skipped.
+    expect(q.requestHash).toBe(secondHash);
+    expect(q.pending).toBe(false);
+    expect(q.error).toBeUndefined();
+  });
+
+  it("a superseded query's failed flush does not overwrite the newer request", async () => {
+    const { q, secondHash } = await runStaleFlush("reject", "sqlite-stale-err");
+    // Both reads reject, but only the newer query's error survives — the stale
+    // flush's error write is skipped.
+    expect(q.requestHash).toBe(secondHash);
+    expect(q.pending).toBe(false);
+    expect(q.error).toBeDefined();
+  });
 });
 
-type QueryState = { pending: boolean; result?: unknown[]; error?: unknown };
+type QueryState = {
+  pending: boolean;
+  result?: unknown[];
+  error?: unknown;
+  requestHash?: string;
+};
 
 // Wait until `pred(cell value)` holds. A `sink` keeps the effect chain live so
 // reactOn re-runs are driven (pull-mode runs effects only while observed); the

--- a/packages/schema-generator/test/common-fabric-formatter-flap-coverage.test.ts
+++ b/packages/schema-generator/test/common-fabric-formatter-flap-coverage.test.ts
@@ -1,0 +1,306 @@
+// These branches of the Common Fabric formatter are otherwise exercised only
+// when patterns compile cold through the transformer. When the compile cache is
+// warm those lines are skipped, so they alternate between covered and uncovered
+// across runs of identical code. These unit tests drive the same branches
+// directly so the package's own test job records them on every run.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import ts from "typescript";
+import { createSchemaTransformerV2 } from "../src/plugin.ts";
+import {
+  asObjectSchema,
+  createTestProgram,
+  getTypeFromCode,
+  getTypeFromFiles,
+} from "./utils.ts";
+
+function findInterfaceMemberTypeNode(
+  sourceFile: ts.SourceFile,
+  interfaceName: string,
+  memberName: string,
+): ts.TypeNode {
+  let found: ts.TypeNode | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
+      for (const member of node.members) {
+        if (
+          ts.isPropertySignature(member) &&
+          member.type &&
+          ts.isIdentifier(member.name) &&
+          member.name.text === memberName
+        ) {
+          found = member.type;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Member ${interfaceName}.${memberName} not found`);
+  }
+  return found;
+}
+
+// Locate the inner array TypeNode of a wrapper member (e.g. the `Item[]` inside
+// `Writable<Item[]>`), used to drive the node-based array-items-override path.
+function findWrapperInnerNode(
+  sourceFile: ts.SourceFile,
+  interfaceName: string,
+  memberName: string,
+): { wrapperNode: ts.TypeReferenceNode; innerNode: ts.TypeNode } {
+  const member = findInterfaceMemberTypeNode(
+    sourceFile,
+    interfaceName,
+    memberName,
+  );
+  if (!ts.isTypeReferenceNode(member) || !member.typeArguments?.[0]) {
+    throw new Error(`Member ${interfaceName}.${memberName} is not a wrapper`);
+  }
+  return { wrapperNode: member, innerNode: member.typeArguments[0] };
+}
+
+describe("Common Fabric formatter flap coverage", () => {
+  it(
+    "TrustedActionUiContract defaults required event integrity to the trusted pattern",
+    async () => {
+      // Three type arguments: the requiredEventIntegrity falls back to the
+      // trusted pattern because no integrity argument is supplied.
+      const code = `
+        type Cfc<T, Meta> = T & { readonly __ct_cfc__?: Meta };
+        type TrustedActionUiContract<
+          T,
+          Action extends string,
+          Pattern extends string,
+        > = Cfc<T, {
+          uiContract: {
+            helper: "UiAction";
+            action: Action;
+            trustedPattern: Pattern;
+          };
+        }>;
+
+        interface SchemaRoot {
+          save: TrustedActionUiContract<string, "SaveTitle", "SaveSurface">;
+        }
+      `;
+
+      const { type, checker } = await getTypeFromCode(code, "SchemaRoot");
+      const schema = asObjectSchema(
+        createSchemaTransformerV2().generateSchema(type, checker),
+      );
+
+      const save = schema.properties?.save as any;
+      expect(save.type).toBe("string");
+      expect(save.ifc?.uiContract).toEqual({
+        helper: "UiAction",
+        action: "SaveTitle",
+        trustedPattern: "SaveSurface",
+        requiredEventIntegrity: ["SaveSurface"],
+      });
+    },
+  );
+
+  it(
+    "TrustedActionUiContract uses an explicit required-event-integrity tuple when provided",
+    async () => {
+      const code = `
+        type Cfc<T, Meta> = T & { readonly __ct_cfc__?: Meta };
+        type TrustedActionUiContract<
+          T,
+          Action extends string,
+          Pattern extends string,
+          Integrity extends readonly [string, ...string[]] = [Pattern],
+        > = Cfc<T, {
+          uiContract: {
+            helper: "UiAction";
+            action: Action;
+            trustedPattern: Pattern;
+            requiredEventIntegrity: Integrity;
+          };
+        }>;
+
+        interface SchemaRoot {
+          save: TrustedActionUiContract<
+            string,
+            "SaveTitle",
+            "SaveSurface",
+            ["SaveSurface", "AuditSurface"]
+          >;
+        }
+      `;
+
+      const { type, checker } = await getTypeFromCode(code, "SchemaRoot");
+      const schema = asObjectSchema(
+        createSchemaTransformerV2().generateSchema(type, checker),
+      );
+
+      const save = schema.properties?.save as any;
+      expect(save.type).toBe("string");
+      expect(save.ifc?.uiContract).toEqual({
+        helper: "UiAction",
+        action: "SaveTitle",
+        trustedPattern: "SaveSurface",
+        requiredEventIntegrity: ["SaveSurface", "AuditSurface"],
+      });
+    },
+  );
+
+  it(
+    "resolves a typeof-imported confidentiality tuple through the import alias",
+    async () => {
+      const { type, checker } = await getTypeFromFiles(
+        {
+          "/labels.ts": `
+            export const LABELS = [
+              { kind: "prompt-influence", allowed: false, owner: null },
+              "secret",
+            ] as const;
+          `,
+          "/main.ts": `
+            import { LABELS } from "./labels.ts";
+            type Cfc<T, Meta> = T & { readonly __ct_cfc__?: Meta };
+            type Confidential<T, X extends readonly unknown[]> = Cfc<
+              T,
+              { confidentiality: X }
+            >;
+
+            export interface SchemaRoot {
+              body: Confidential<string, typeof LABELS>;
+            }
+          `,
+        },
+        "/main.ts",
+        "SchemaRoot",
+      );
+
+      const schema = asObjectSchema(
+        createSchemaTransformerV2().generateSchema(type, checker),
+      );
+
+      const body = schema.properties?.body as any;
+      expect(body.type).toBe("string");
+      expect(body.ifc?.confidentiality).toEqual([
+        { kind: "prompt-influence", allowed: false, owner: null },
+        "secret",
+      ]);
+    },
+  );
+
+  it(
+    "preserves an outer cell wrapper via the node-driven array items override with plain items",
+    async () => {
+      const code = `
+        interface SchemaRoot {
+          items: Writable<{ name: string }[]>;
+        }
+      `;
+      const { checker, sourceFile } = await createTestProgram(code);
+      const { wrapperNode, innerNode } = findWrapperInnerNode(
+        sourceFile,
+        "SchemaRoot",
+        "items",
+      );
+
+      // Resolve the wrapper's INNER array type, but format against the WRAPPER
+      // node. The array type is not a cell wrapper, so type-level wrapper
+      // detection finds nothing while the node still says `Writable<...>`, which
+      // is the condition that routes through formatWrapperTypeFromNode.
+      const innerArrayType = checker.getTypeFromTypeNode(innerNode);
+      const schemaHints = new WeakMap<ts.Node, { items?: unknown }>();
+      schemaHints.set(wrapperNode, { items: false });
+
+      const result = createSchemaTransformerV2().generateSchema(
+        innerArrayType,
+        checker,
+        wrapperNode,
+        undefined,
+        schemaHints,
+      ) as Record<string, any>;
+
+      expect(result).toEqual({
+        type: "array",
+        items: { type: "unknown" },
+        asCell: ["cell"],
+      });
+    },
+  );
+
+  it(
+    "recovers item-level cell wrappers via the node-driven array items override",
+    async () => {
+      const code = `
+        interface SchemaRoot {
+          items: Writable<Array<Cell<{ name: string }>>>;
+        }
+      `;
+      const { checker, sourceFile } = await createTestProgram(code);
+      const { wrapperNode, innerNode } = findWrapperInnerNode(
+        sourceFile,
+        "SchemaRoot",
+        "items",
+      );
+
+      const innerArrayType = checker.getTypeFromTypeNode(innerNode);
+      const schemaHints = new WeakMap<ts.Node, { items?: unknown }>();
+      schemaHints.set(wrapperNode, { items: false });
+
+      const result = createSchemaTransformerV2().generateSchema(
+        innerArrayType,
+        checker,
+        wrapperNode,
+        undefined,
+        schemaHints,
+      ) as Record<string, any>;
+
+      expect(result).toEqual({
+        type: "array",
+        items: { type: "unknown", asCell: ["cell"] },
+        asCell: ["cell"],
+      });
+    },
+  );
+
+  it(
+    "node-driven array items override leaves a non-array wrapper inner untouched",
+    async () => {
+      // The items-false hint asks the array-items override to run, but the
+      // wrapper's inner is a string-keyed map rather than an array. Neither the
+      // resolved type nor the inner node yields an array element, and the inner
+      // node is not a union, so the override adds no item-level cell wrapper and
+      // the map schema survives under the outer cell wrapper.
+      const code = `
+        interface SchemaRoot {
+          entries: Writable<Record<string, number>>;
+        }
+      `;
+      const { checker, sourceFile } = await createTestProgram(code);
+      const { wrapperNode, innerNode } = findWrapperInnerNode(
+        sourceFile,
+        "SchemaRoot",
+        "entries",
+      );
+
+      const innerMapType = checker.getTypeFromTypeNode(innerNode);
+      const schemaHints = new WeakMap<ts.Node, { items?: unknown }>();
+      schemaHints.set(wrapperNode, { items: false });
+
+      const result = createSchemaTransformerV2().generateSchema(
+        innerMapType,
+        checker,
+        wrapperNode,
+        undefined,
+        schemaHints,
+      ) as Record<string, any>;
+
+      expect(result).toEqual({
+        type: "object",
+        properties: {},
+        additionalProperties: { type: "number" },
+        asCell: ["cell"],
+      });
+    },
+  );
+});

--- a/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
+++ b/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
@@ -2,11 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import ts from "typescript";
 import { SchemaGenerator } from "../src/schema-generator.ts";
-import {
-  asObjectSchema,
-  createTestProgram,
-  getTypeFromCode,
-} from "./utils.ts";
+import { asObjectSchema, createTestProgram, getTypeFromCode } from "./utils.ts";
 
 // The branches exercised here otherwise run only when a pattern compiles
 // "cold" through the transformer. When the compile cache is warm those code
@@ -107,7 +103,9 @@ interface Root<T> { field: Narrow<T>; }
     const generator = new SchemaGenerator();
 
     const trueNode = ts.factory.createLiteralTypeNode(ts.factory.createTrue());
-    const falseNode = ts.factory.createLiteralTypeNode(ts.factory.createFalse());
+    const falseNode = ts.factory.createLiteralTypeNode(
+      ts.factory.createFalse(),
+    );
 
     expect(
       generator.generateSchemaFromSyntheticTypeNode(trueNode, checker),

--- a/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
+++ b/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
@@ -1,0 +1,169 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import ts from "typescript";
+import { SchemaGenerator } from "../src/schema-generator.ts";
+import {
+  asObjectSchema,
+  createTestProgram,
+  getTypeFromCode,
+} from "./utils.ts";
+
+// The branches exercised here otherwise run only when a pattern compiles
+// "cold" through the transformer. When the compile cache is warm those code
+// paths are skipped, so the lines are recorded as covered in some CI runs and
+// uncovered in others. These unit tests drive the same branches directly with
+// hand-built type declarations so they are covered on every run.
+
+describe("SchemaGenerator flap coverage", () => {
+  it("resolves the element type of an array type alias to the concrete element schema", async () => {
+    // type-utils.ts getArrayElementInfo: when a property's TypeNode is a
+    // reference to a type alias whose right-hand side is `Element[]`, the
+    // element type is read from the alias body. `Element` is a concrete type
+    // (not a type parameter), so its resolved type is used and the array's
+    // items schema is the element type's schema.
+    const code = `
+interface Element { id: number; label: string; }
+type ElementList = Element[];
+interface Root { items: ElementList; }
+`;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "Root");
+    const generator = new SchemaGenerator();
+    const schema = asObjectSchema(
+      generator.generateSchema(type, checker, typeNode),
+    );
+
+    const props = schema.properties as Record<string, unknown>;
+    const itemsSchema = props.items as Record<string, unknown>;
+    expect(itemsSchema.type).toBe("array");
+    // The element type resolves to the concrete `Element` object, hoisted into
+    // $defs and referenced by the array's items.
+    expect(itemsSchema.items).toEqual({ $ref: "#/$defs/Element" });
+
+    const defs = (schema as Record<string, unknown>).$defs as Record<
+      string,
+      unknown
+    >;
+    expect(defs.Element).toEqual({
+      type: "object",
+      properties: {
+        id: { type: "number" },
+        label: { type: "string" },
+      },
+      required: ["id", "label"],
+    });
+  });
+
+  it("uses a type parameter's default type when it has no base constraint", async () => {
+    // schema-generator.ts formatType: for a bare type parameter with no base
+    // constraint but a declared default, the schema is generated from the
+    // default type. Here the parameter `T` defaults to `Preset`, so the alias
+    // `type WithDefault<T = Preset> = T` formats to `Preset`'s schema.
+    const code = `
+interface Preset { name: string; count: number; }
+type WithDefault<T = Preset> = T;
+`;
+    const { type, checker, typeNode } = await getTypeFromCode(
+      code,
+      "WithDefault",
+    );
+    const generator = new SchemaGenerator();
+    const schema = asObjectSchema(
+      generator.generateSchema(type, checker, typeNode),
+    );
+
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toEqual({
+      name: { type: "string" },
+      count: { type: "number" },
+    });
+    expect(schema.required).toEqual(["name", "count"]);
+  });
+
+  it("treats a deferred conditional type as an unconstrained schema", async () => {
+    // schema-generator.ts formatType: a conditional type whose condition
+    // depends on an unresolved type parameter stays deferred (its flags carry
+    // ts.TypeFlags.Conditional). The generator cannot know the concrete branch
+    // at compile time, so the property's schema is the empty (accept-anything)
+    // schema `{}`.
+    const code = `
+type Narrow<T> = T extends string ? number : boolean;
+interface Root<T> { field: Narrow<T>; }
+`;
+    const { type, checker } = await getTypeFromCode(code, "Root");
+    const generator = new SchemaGenerator();
+    const schema = asObjectSchema(generator.generateSchema(type, checker));
+
+    expect(schema.type).toBe("object");
+    const props = schema.properties as Record<string, unknown>;
+    expect(props.field).toEqual({});
+    expect(schema.required).toEqual(["field"]);
+  });
+
+  it("maps synthetic boolean literal type nodes to boolean const schemas", async () => {
+    // schema-generator.ts analyzeTypeNodeStructure: the node-based path maps a
+    // `true` literal type node to { type: "boolean", const: true } and a
+    // `false` literal type node to { type: "boolean", const: false }.
+    const { checker } = await getTypeFromCode("type Dummy = unknown;", "Dummy");
+    const generator = new SchemaGenerator();
+
+    const trueNode = ts.factory.createLiteralTypeNode(ts.factory.createTrue());
+    const falseNode = ts.factory.createLiteralTypeNode(ts.factory.createFalse());
+
+    expect(
+      generator.generateSchemaFromSyntheticTypeNode(trueNode, checker),
+    ).toEqual({ type: "boolean", const: true });
+    expect(
+      generator.generateSchemaFromSyntheticTypeNode(falseNode, checker),
+    ).toEqual({ type: "boolean", const: false });
+  });
+
+  it("resolves a non-keyword type node through the checker when node-based analysis is forced", async () => {
+    // schema-generator.ts analyzeTypeNodeStructure: for a real TypeNode kind
+    // that none of the earlier node branches or the keyword switch handles, the
+    // node is resolved to a Type via the checker; when that Type is not `any`
+    // it is formatted through formatChildType. A `keyof` type operator node is
+    // one such kind. Pairing it with the `any` Type forces the node-based path,
+    // mirroring the transformer's lift-revisit which feeds `any` as the paired
+    // Type alongside a concrete node.
+    const { checker, sourceFile } = await createTestProgram(
+      "interface Options { alpha: string; beta: number; } type Keys = keyof Options;",
+    );
+    let keyofNode: ts.TypeNode | undefined;
+    ts.forEachChild(sourceFile, (node) => {
+      if (ts.isTypeAliasDeclaration(node) && node.name.text === "Keys") {
+        keyofNode = node.type;
+      }
+    });
+    expect(keyofNode).toBeDefined();
+
+    const generator = new SchemaGenerator();
+    const anyType = checker.getAnyType();
+    const schema = generator.generateSchema(anyType, checker, keyofNode);
+
+    // `keyof Options` resolves to the union of its literal keys.
+    expect(schema).toEqual({ enum: ["alpha", "beta"] });
+  });
+
+  it("resolves an indexed-access type node through the checker when node-based analysis is forced", async () => {
+    // schema-generator.ts analyzeTypeNodeStructure: same non-keyword resolution
+    // branch, driven by an indexed-access type node `Options["alpha"]`. The
+    // checker resolves it to the concrete property type, which formats to that
+    // property's schema.
+    const { checker, sourceFile } = await createTestProgram(
+      'interface Options { alpha: string; beta: number; } type Picked = Options["alpha"];',
+    );
+    let indexedNode: ts.TypeNode | undefined;
+    ts.forEachChild(sourceFile, (node) => {
+      if (ts.isTypeAliasDeclaration(node) && node.name.text === "Picked") {
+        indexedNode = node.type;
+      }
+    });
+    expect(indexedNode).toBeDefined();
+
+    const generator = new SchemaGenerator();
+    const anyType = checker.getAnyType();
+    const schema = generator.generateSchema(anyType, checker, indexedNode);
+
+    expect(schema).toEqual({ type: "string" });
+  });
+});

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -72,7 +72,7 @@ function isReactiveHelperWrapperCall(
   return getReactiveHelperWrapperKind(expression, context) !== undefined;
 }
 
-function isSyntheticHelperWrapperInArrayMethodCallback(
+export function isSyntheticHelperWrapperInArrayMethodCallback(
   expression: ts.Expression,
   context: TransformationContext,
 ): boolean {

--- a/packages/ts-transformers/test/call-expression-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-flap-coverage.test.ts
@@ -1,0 +1,197 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+import { StaticCacheFS } from "@commonfabric/static";
+
+import { TransformationContext } from "../src/core/context.ts";
+import { transformCfDirective } from "../src/mod.ts";
+import { emitCallExpression } from "../src/transformers/expression-rewrite/emitters/call-expression.ts";
+import type { EmitterContext } from "../src/transformers/expression-rewrite/types.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// The call-expression emitter's early "no reactive data flows" guard and its
+// zero-arg-IIFE receiver scan run only while a pattern compiles cold through the
+// transformer in CI. When the pattern jobs' compile cache is warm the
+// compilation is skipped, so these lines alternate between covered and uncovered
+// across runs of identical code and destabilize the coverage-debt gate. These
+// tests drive the emitter directly with a real TransformationContext and assert
+// on the node it returns.
+
+const cache = new StaticCacheFS();
+const es2023 = await cache.getText("types/es2023.d.ts");
+const dom = await cache.getText("types/dom.d.ts");
+const jsx = await cache.getText("types/jsx.d.ts");
+
+function buildProgram(
+  source: string,
+): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const fileName = "/test.tsx";
+  const files: Record<string, string> = {
+    [fileName]: transformCfDirective(source),
+    "commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"],
+    "cfc.ts": COMMONFABRIC_TYPES["cfc.ts"],
+    "es2023.d.ts": es2023,
+    "dom.d.ts": dom,
+    "jsx.d.ts": jsx,
+  };
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+    jsx: ts.JsxEmit.React,
+    jsxFactory: "h",
+    strict: true,
+  };
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) =>
+      files[name]
+        ? ts.createSourceFile(name, files[name], compilerOptions.target!, true)
+        : undefined,
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    fileExists: (name) => !!files[name],
+    readFile: (name) => files[name],
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "es2023.d.ts",
+    resolveModuleNames: (names) =>
+      names.map((name) =>
+        name === "commonfabric"
+          ? {
+            resolvedFileName: "commonfabric.d.ts",
+            extension: ts.Extension.Dts,
+            isExternalLibraryImport: false,
+          }
+          : undefined
+      ),
+  };
+  const program = ts.createProgram(Object.keys(files), compilerOptions, host);
+  return { program, sourceFile: program.getSourceFile(fileName)! };
+}
+
+function withContext<T>(
+  program: ts.Program,
+  sourceFile: ts.SourceFile,
+  body: (context: TransformationContext) => T,
+): T {
+  let out!: T;
+  ts.transform(sourceFile, [
+    (tsContext) => (root) => {
+      out = body(new TransformationContext({ program, sourceFile, tsContext }));
+      return root;
+    },
+  ]);
+  return out;
+}
+
+function find<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T,
+  predicate: (node: T) => boolean = () => true,
+): T {
+  let found: T | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && guard(node) && predicate(node)) found = node;
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  if (!found) throw new Error("no matching node");
+  return found;
+}
+
+// Build the emitter context for `expression` using the real data-flow analyzer,
+// so `dataFlows` reflects the expression's actual reactive dependencies.
+function emitterContextFor(
+  expression: ts.Expression,
+  context: TransformationContext,
+): { emit: EmitterContext; dataFlowCount: number } {
+  const analyze = context.getDataFlowAnalyzer();
+  const analysis = analyze(expression);
+  const dataFlows = context.getRelevantDataFlowsFromAnalysis(analysis);
+  const emit = {
+    expression,
+    analysis,
+    context,
+    analyze,
+    dataFlows,
+    inSafeContext: false,
+    reactiveContextKind: "pattern",
+    preferInputBoundWrappers: false,
+    rewriteChildren: (node: ts.Expression) => node,
+    rewriteSubexpression: (node: ts.Expression) => node,
+  } as unknown as EmitterContext;
+  return { emit, dataFlowCount: dataFlows.length };
+}
+
+const HEAD = `/// <cts-enable />
+import { Cell, pattern, UI, VNode } from "commonfabric";
+interface Input { base: Cell<number>; }
+interface Output { [UI]: VNode; }
+`;
+
+Deno.test("emitCallExpression declines a call with no reactive data flows", () => {
+  // A plain call to a non-reactive local function has no reactive dependencies,
+  // so the emitter's `dataFlows.length === 0` guard fires and it emits nothing.
+  const { program, sourceFile } = buildProgram(`${HEAD}
+const plus = (a: number, b: number) => a + b;
+export default pattern<Input, Output>(() => ({
+  [UI]: <div>{plus(1, 2)}</div>,
+}));`);
+  const call = find(
+    sourceFile,
+    ts.isCallExpression,
+    (node) => ts.isIdentifier(node.expression) && node.expression.text === "plus",
+  );
+
+  const { result, dataFlowCount } = withContext(
+    program,
+    sourceFile,
+    (context) => {
+      const { emit, dataFlowCount } = emitterContextFor(call, context);
+      return { result: emitCallExpression(emit), dataFlowCount };
+    },
+  );
+
+  assertEquals(dataFlowCount, 0);
+  assertEquals(result, undefined);
+});
+
+Deno.test("emitCallExpression scans a zero-arg IIFE for captured cell reads and wraps it", () => {
+  // A zero-arg inline IIFE reading a captured pattern-input cell via a bare
+  // identifier (`base.get()`) reaches the IIFE receiver scan. That scan walks the
+  // IIFE body, finds the `.get()` on the identifier `base`, and asks whether
+  // `base` is declared inside the IIFE — it is not (it is a pattern input), so
+  // the receiver is treated as an outer reactive dependency and the emitter
+  // rewrites the IIFE into a reactive wrapper call rather than leaving it as an
+  // immediately-invoked function.
+  const { program, sourceFile } = buildProgram(`${HEAD}
+export default pattern<Input, Output>(({ base }) => ({
+  [UI]: <div>{(() => base.get() + 1)()}</div>,
+}));`);
+  const iife = find(
+    sourceFile,
+    ts.isCallExpression,
+    (node) =>
+      ts.isParenthesizedExpression(node.expression) &&
+      ts.isArrowFunction(node.expression.expression) &&
+      node.arguments.length === 0,
+  );
+
+  const { result, dataFlowCount } = withContext(
+    program,
+    sourceFile,
+    (context) => {
+      const { emit, dataFlowCount } = emitterContextFor(iife, context);
+      return { result: emitCallExpression(emit), dataFlowCount };
+    },
+  );
+
+  // The captured `base` read is a reactive dependency, so the emitter did not
+  // decline.
+  assertEquals(dataFlowCount, 1);
+  assert(result !== undefined, "expected the IIFE to be rewritten");
+  // The authored IIFE was replaced by a call (the reactive wrapper), not left as
+  // the original immediately-invoked function.
+  assert(ts.isCallExpression(result!), "expected a wrapper call expression");
+  assert(result !== iife, "expected a new node, not the original IIFE");
+});

--- a/packages/ts-transformers/test/call-expression-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-flap-coverage.test.ts
@@ -140,7 +140,8 @@ export default pattern<Input, Output>(() => ({
   const call = find(
     sourceFile,
     ts.isCallExpression,
-    (node) => ts.isIdentifier(node.expression) && node.expression.text === "plus",
+    (node) =>
+      ts.isIdentifier(node.expression) && node.expression.text === "plus",
   );
 
   const { result, dataFlowCount } = withContext(

--- a/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import {
+  calleeName,
   callsMatching,
   extractedCallbackBody,
   hasKeyPathRead,
@@ -11,13 +12,16 @@ import {
 } from "./transformed-ast.ts";
 
 // `emitCallExpression` has a dedicated branch for an authored zero-argument
-// inline IIFE — `(() => ...)()` — that appears inside a reactive array-method
-// callback. That branch (and its receiver-scanning helpers) runs today only as
-// a side effect of patterns compiling through the transformer in CI's
-// pattern-integration jobs, because reaching it needs the in-place expression
-// rewrite that array-method callback lowering performs. These tests place such
-// an IIFE inside a `.map()`/`.filter()` callback and assert on how the branch
-// treats it.
+// inline IIFE — `(() => ...)()` — that reads a cell from a reactive position.
+// Outside these tests the branch is reached only as a side effect of patterns
+// compiling through the transformer in CI's pattern-integration jobs, so its
+// coverage flaps in the coverage-debt gate whenever those jobs' compile cache is
+// warm. These tests reach it deterministically from two reactive positions and
+// assert on how it treats the IIFE. Which sub-path runs depends on whether the
+// reactive-wrapper builder can bind the IIFE's receiver: an element cell from a
+// `.map()`/`.filter()` callback lets it succeed and rewrite the read in place,
+// while a top-level cell inside an `ifElse` conditional makes it decline and
+// fall through to the `createLiftAppliedCall` path.
 //
 // The assertions parse the transformer output back into an AST and inspect real
 // nodes (a `__cfLift*` wrapper call, an immediately-invoked function, a
@@ -134,5 +138,77 @@ Deno.test(
     // returned unchanged and not wrapped in a lift.
     assertEquals(iifeCalls(body).length, 1);
     assertEquals(callsMatching(body, /^__cfLift/).length, 0);
+  },
+);
+
+// This test covers the `createLiftAppliedCall` sub-path directly: a zero-arg
+// IIFE reading a top-level pattern cell inside an `ifElse` branch, which the
+// array-method tests above never reach.
+Deno.test(
+  "zero-arg IIFE reading a top-level cell inside an ifElse branch wraps the whole IIFE in a lift applied to that cell",
+  async () => {
+    const output = parseModule(
+      await transformSource(
+        `/// <cts-enable />
+import { Cell, ifElse, pattern, UI, VNode } from "commonfabric";
+interface Input { enabled: Cell<boolean>; show: Cell<boolean>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ enabled, show }) => ({
+  [UI]: (
+    <div>
+      {ifElse(
+        show,
+        <div>
+          {(() => {
+            const rawEnabled = enabled.get();
+            return typeof rawEnabled === "boolean" ? rawEnabled : true;
+          })()}
+        </div>,
+        null,
+      )}
+    </div>
+  ),
+}));`,
+        { types: COMMONFABRIC_TYPES },
+      ),
+    );
+
+    // The authored IIFE was lowered to a `__cfLift*` wrapper applied with the
+    // top-level `enabled` cell hoisted as its input (passed by identifier, not
+    // as an element `.key(...)` path read as the array-method path produces).
+    const appliedWithEnabled = callsMatching(output, /^__cfLift/).filter(
+      (call) => {
+        const arg = call.arguments[0];
+        return !!arg && ts.isObjectLiteralExpression(arg) &&
+          arg.properties.some((p) =>
+            !!p.name && ts.isIdentifier(p.name) && p.name.text === "enabled"
+          );
+      },
+    );
+    assertEquals(appliedWithEnabled.length, 1);
+    const appliedCall = appliedWithEnabled[0]!;
+
+    // That applied lift sits inside a reactive `ifElse` conditional — the
+    // position that makes the wrapper builder decline (no element receiver to
+    // bind) and fall through to `createLiftAppliedCall`.
+    let ancestor: ts.Node | undefined = appliedCall.parent;
+    let insideIfElse = false;
+    while (ancestor) {
+      if (ts.isCallExpression(ancestor) && calleeName(ancestor) === "ifElse") {
+        insideIfElse = true;
+        break;
+      }
+      ancestor = ancestor.parent;
+    }
+    assert(insideIfElse, "expected the lift application inside an ifElse branch");
+
+    // The matching lift definition preserves the whole authored IIFE: its
+    // factory body is still an immediately-invoked function. This is the
+    // `createLiftAppliedCall` fallback wrapping the IIFE wholesale, in contrast
+    // to the array-method path above, which decomposes the IIFE away.
+    const liftName = calleeName(appliedCall);
+    assert(liftName, "expected a named lift wrapper");
+    const liftBody = extractedCallbackBody(output, liftName);
+    assertEquals(iifeCalls(liftBody).length, 1);
   },
 );

--- a/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
@@ -200,7 +200,10 @@ export default pattern<Input, Output>(({ enabled, show }) => ({
       }
       ancestor = ancestor.parent;
     }
-    assert(insideIfElse, "expected the lift application inside an ifElse branch");
+    assert(
+      insideIfElse,
+      "expected the lift application inside an ifElse branch",
+    );
 
     // The matching lift definition preserves the whole authored IIFE: its
     // factory body is still an immediately-invoked function. This is the

--- a/packages/ts-transformers/test/expression-site-lowering-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/expression-site-lowering-flap-coverage.test.ts
@@ -1,0 +1,107 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { callsMatching, callsNamed, parseModule } from "./transformed-ast.ts";
+
+// A few branches in expression-site-lowering.ts run only while a pattern
+// compiles through the transformer from cold. When CI's compile cache is warm
+// the compilation is skipped, so the same code alternates between covered and
+// uncovered across runs of identical source. These unit tests drive each branch
+// directly from small pattern sources and assert on the real transformed
+// output, so the branches stay covered regardless of cache state.
+//
+// The assertions parse the printed output back into an AST and inspect real
+// nodes (a lowered `mapWithPattern` call, a preserved arithmetic binary
+// expression, a helper call's argument list) rather than matching printed text,
+// so a preserved comment or an input substring cannot satisfy them.
+
+function t(source: string): Promise<string> {
+  return transformSource(source, { types: COMMONFABRIC_TYPES });
+}
+
+const HEAD = `/// <cts-enable />
+import { Cell, pattern, ifElse, UI, VNode } from "commonfabric";
+`;
+
+Deno.test(
+  "helper-owned pass leaves a pure-arithmetic ifElse argument unlowered",
+  async () => {
+    // The `1 + 2` and `3 + 4` branch values are arguments of `ifElse`, so the
+    // helper-owned expression-site pass classifies them as owned by the helper.
+    // Neither reads a reactive value, so the pass finds nothing to lift and
+    // returns each argument unchanged (the not-lowerable guard). The arithmetic
+    // survives verbatim as a binary expression inside the emitted `ifElse` call,
+    // and no reactive `__cfLift*` wrapper is introduced for them.
+    const source = `${HEAD}
+interface Input { flag: Cell<boolean>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ flag }) => ({
+  [UI]: <div>{ifElse(flag, 1 + 2, 3 + 4)}</div>,
+}));`;
+    const output = parseModule(await t(source));
+
+    // The `ifElse` call survives (schemas are injected ahead of the runtime
+    // arguments), and its two branch values are still `+` binary expressions.
+    const ifElseCalls = callsNamed(output, "ifElse");
+    assertEquals(ifElseCalls.length, 1);
+    const call = ifElseCalls[0]!;
+    const additions = call.arguments.filter(
+      (arg): arg is ts.BinaryExpression =>
+        ts.isBinaryExpression(arg) &&
+        arg.operatorToken.kind === ts.SyntaxKind.PlusToken,
+    );
+    assertEquals(additions.length, 2);
+
+    // No lift wrapper was produced anywhere: the arithmetic was not lowered.
+    assertEquals(callsMatching(output, /^__cfLift/).length, 0);
+  },
+);
+
+Deno.test(
+  "helper-owned pass lowers a provenance-reactive map nested in a reactive map callback",
+  async () => {
+    // `nums` is the result of a plain function whose argument is a reactive read,
+    // so the type checker sees a plain `number[]` while the value is reactive at
+    // runtime. The outer `items.map(...)` is lowered by the earlier pattern-owned
+    // pass, which does not recurse into its expression-bodied callback. That
+    // leaves the inner `nums.map(...)` un-lowered until the helper-owned pass,
+    // where the late array-method rewrite recognizes its shared reactive
+    // collection provenance and lowers it to `mapWithPattern`.
+    const source = `${HEAD}
+function toNums(s: string): number[] { return [s.length]; }
+interface Row { x: Cell<number>; }
+interface Input { items: Cell<Row[]>; layout: Cell<string>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ items, layout }) => {
+  const eff = layout.get();
+  const nums = toNums(eff);
+  return {
+    [UI]: (
+      <div>{items.map((row) => <span>{nums.map((n) => n + row.x.get())}</span>)}</div>
+    ),
+  };
+});`;
+    const output = parseModule(await t(source));
+
+    // Both the outer (pattern-owned) and inner (helper-owned) array methods were
+    // lowered to their reactive `mapWithPattern` variants.
+    const mapWithPattern = callsNamed(output, "mapWithPattern");
+    assertEquals(mapWithPattern.length, 2);
+
+    // The inner lowered call operates on the provenance-reactive `nums` receiver.
+    const innerReceivers = mapWithPattern
+      .map((call) => call.expression)
+      .filter(ts.isPropertyAccessExpression)
+      .map((access) => access.expression)
+      .filter(ts.isIdentifier)
+      .map((id) => id.text);
+    assert(
+      innerReceivers.includes("nums"),
+      "expected the inner map over `nums` to lower to mapWithPattern",
+    );
+
+    // No plain `.map(` call survives: every reactive array method was lowered.
+    assertEquals(callsNamed(output, "map").length, 0);
+  },
+);

--- a/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
@@ -1,0 +1,344 @@
+import ts from "typescript";
+import { assert, assertEquals } from "@std/assert";
+import { StaticCacheFS } from "@commonfabric/static";
+
+import { TransformationContext } from "../src/core/context.ts";
+import { transformCfDirective } from "../src/mod.ts";
+import { shouldTransformArrayMethod } from "../src/closures/strategies/array-method-policy.ts";
+import { findPreferredNestedLowerableExpressionSite } from "../src/transformers/expression-site-policy.ts";
+import { unwrapOpaqueLikeType } from "../src/ast/type-inference.ts";
+import { symbolDeclaresCommonFabricDefault } from "../src/core/common-fabric-symbols.ts";
+import { emitElementAccessExpression } from "../src/transformers/expression-rewrite/emitters/element-access-expression.ts";
+import type { EmitterContext } from "../src/transformers/expression-rewrite/types.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// Each branch exercised here otherwise runs only while a pattern compiles cold
+// through the transformer in CI's pattern-integration jobs. When that pipeline's
+// compile-cache is warm the branch is skipped, so it flips between covered and
+// uncovered across CI runs of identical code and destabilizes the coverage-debt
+// gate. These tests drive each branch directly through the exported entry point
+// that reaches it, so it is recorded every run. Each test asserts on the real
+// value the branch produces (a decision, a returned node/undefined, a resolved
+// type, or a diagnostic-free classification), not merely that the line ran.
+
+const cache = new StaticCacheFS();
+const es2023 = await cache.getText("types/es2023.d.ts");
+const dom = await cache.getText("types/dom.d.ts");
+const jsx = await cache.getText("types/jsx.d.ts");
+
+/** A TypeScript program that resolves the real `commonfabric` type surface. */
+function buildProgram(
+  source: string,
+): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const fileName = "/test.tsx";
+  const files: Record<string, string> = {
+    [fileName]: transformCfDirective(source),
+    "commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"],
+    "cfc.ts": COMMONFABRIC_TYPES["cfc.ts"],
+    "es2023.d.ts": es2023,
+    "dom.d.ts": dom,
+    "jsx.d.ts": jsx,
+  };
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+    jsx: ts.JsxEmit.React,
+    jsxFactory: "h",
+    strict: true,
+  };
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) =>
+      files[name]
+        ? ts.createSourceFile(name, files[name], compilerOptions.target!, true)
+        : undefined,
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    fileExists: (name) => !!files[name],
+    readFile: (name) => files[name],
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "es2023.d.ts",
+    resolveModuleNames: (names) =>
+      names.map((name) =>
+        name === "commonfabric"
+          ? {
+            resolvedFileName: "commonfabric.d.ts",
+            extension: ts.Extension.Dts,
+            isExternalLibraryImport: false,
+          }
+          : undefined
+      ),
+  };
+  const program = ts.createProgram(Object.keys(files), compilerOptions, host);
+  return { program, sourceFile: program.getSourceFile(fileName)! };
+}
+
+/**
+ * Run `body` with a real TransformationContext for `sourceFile`. The context is
+ * only valid inside a `ts.transform` factory, so the body runs there and its
+ * return value is forwarded out.
+ */
+function withContext<T>(
+  program: ts.Program,
+  sourceFile: ts.SourceFile,
+  body: (context: TransformationContext) => T,
+): T {
+  let out!: T;
+  ts.transform(sourceFile, [
+    (tsContext) => (root) => {
+      out = body(
+        new TransformationContext({ program, sourceFile, tsContext }),
+      );
+      return root;
+    },
+  ]);
+  return out;
+}
+
+/** First descendant matching a type guard. */
+function find<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T,
+  predicate: (node: T) => boolean = () => true,
+): T {
+  let found: T | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && guard(node) && predicate(node)) found = node;
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  if (!found) throw new Error("no matching node");
+  return found;
+}
+
+function unwrapParens(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  return current;
+}
+
+// ===========================================================================
+// closures/strategies/array-method-policy.ts:54-56
+//
+// `isReactiveFallbackLeft` recognizes a `(<reactive> ?? []).map(...)` receiver
+// whose left operand is directly a reactive value. In a compute context the
+// collection-provenance guards above it are evaluated with the type-based root
+// and implicit-parameter roots disabled, so a captured pattern-scope `Cell`
+// slips past them and reaches this recognizer, which returns true from the
+// `isReactiveValueExpression(left)` branch. The array method still does not
+// transform (a compute-context receiver is auto-unwrapped), so the decision is
+// false — but the receiver has been classified as a reactive fallback.
+// ===========================================================================
+
+function fallbackMapDecision(source: string): {
+  kind: string;
+  decision: boolean;
+} {
+  const { program, sourceFile } = buildProgram(source);
+  const mapCall = find(
+    sourceFile,
+    ts.isCallExpression,
+    (call) =>
+      ts.isPropertyAccessExpression(call.expression) &&
+      call.expression.name.text === "map" &&
+      ts.isBinaryExpression(unwrapParens(call.expression.expression)),
+  );
+  return withContext(program, sourceFile, (context) => ({
+    kind: context.getReactiveContext(mapCall).kind,
+    decision: shouldTransformArrayMethod(mapCall, context),
+  }));
+}
+
+Deno.test("array-method-policy: (cell ?? []).map in a compute context is recognized as a reactive fallback receiver but not transformed", () => {
+  const result = fallbackMapDecision(`/// <cts-enable />
+import { Cell, computed, pattern, UI, VNode } from "commonfabric";
+interface Input { tags: Cell<string[]>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ tags }) => {
+  const out = computed(() => (tags ?? []).map((x) => x.length));
+  return { [UI]: <div>{out}</div> };
+});`);
+  // Reaching the fallback branch requires the compute-context path, and that
+  // path returns false (the receiver is auto-unwrapped inside a compute).
+  assertEquals(result.kind, "compute");
+  assertEquals(result.decision, false);
+});
+
+Deno.test("array-method-policy: the same reactive-cell fallback receiver in a pattern context does transform", () => {
+  const result = fallbackMapDecision(`/// <cts-enable />
+import { Cell, pattern, UI, VNode } from "commonfabric";
+interface Input { tags: Cell<string[]>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ tags }) => ({
+  [UI]: <div>{(tags ?? []).map((x) => <em>{x}</em>)}</div>,
+}));`);
+  // A pattern-context reactive fallback receiver is lowered to its WithPattern
+  // form, confirming the left operand is genuinely reactive.
+  assertEquals(result.kind, "pattern");
+  assertEquals(result.decision, true);
+});
+
+// ===========================================================================
+// transformers/expression-site-policy.ts:1341-1343
+//
+// `findPreferredNestedLowerableExpressionSite` scans the descendants of an
+// expression for a nested lowerable site. When it reaches a function-like node
+// that is not the root expression it returns without descending, so candidate
+// sites inside a nested closure are never chosen. An expression whose only
+// lowerable content sits inside an array-method callback therefore yields no
+// nested site.
+// ===========================================================================
+
+Deno.test("expression-site-policy: the nested-site search does not descend into a nested function, so a site behind a closure boundary is not chosen", () => {
+  const { program, sourceFile } = buildProgram(`/// <cts-enable />
+import { Cell, pattern, UI, VNode } from "commonfabric";
+interface Input { flag: Cell<boolean>; items: Cell<number[]>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ flag, items }) => ({
+  [UI]: <div><span>{flag ? items.map((x) => x + 1) : []}</span></div>,
+}));`);
+  // The conditional's consequent is `items.map((x) => x + 1)` — its only inner
+  // content lives inside the arrow-function callback.
+  const conditional = find(sourceFile, ts.isConditionalExpression);
+  const arrow = find(conditional, ts.isArrowFunction);
+
+  const site = withContext(
+    program,
+    sourceFile,
+    (context) =>
+      findPreferredNestedLowerableExpressionSite(
+        conditional,
+        context,
+        context.getDataFlowAnalyzer(),
+      ),
+  );
+
+  // No nested site is returned: the arrow-function boundary is skipped, so the
+  // map-callback body is never offered as a candidate.
+  assertEquals(site, undefined);
+  // Guard against the test silently passing because the arrow was absent.
+  assert(ts.isArrowFunction(arrow));
+});
+
+// ===========================================================================
+// ast/type-inference.ts:313
+//
+// `unwrapOpaqueLikeType` guards against cyclic types with a `seen` set: when a
+// type it is already unwrapping reappears (a self-referential branded cell such
+// as `type R = OpaqueCell<R>`), it returns that type unchanged instead of
+// recursing forever.
+// ===========================================================================
+
+Deno.test("type-inference: unwrapping a self-referential branded cell terminates via the seen-set guard", () => {
+  const { program, sourceFile } = buildProgram(`
+declare const CELL_BRAND: unique symbol;
+interface OpaqueCell<T> { [CELL_BRAND]: "opaque"; value: T; }
+type R = OpaqueCell<R>;
+declare const r: R;
+export const x = r;
+`);
+  const checker = program.getTypeChecker();
+  const decl = find(
+    sourceFile,
+    ts.isVariableDeclaration,
+    (d) => ts.isIdentifier(d.name) && d.name.text === "x",
+  );
+  const recursiveType = checker.getTypeAtLocation(decl.name);
+
+  // Without the cycle guard this would recurse until the stack overflows.
+  const result = unwrapOpaqueLikeType(recursiveType, checker);
+
+  // Unwrapping `OpaqueCell<R>` reaches `R` again; the guard returns the same
+  // type object rather than descending a second time, so unwrapping resolves to
+  // the recursive type itself.
+  assert(result !== undefined);
+  assertEquals(result, recursiveType);
+});
+
+// ===========================================================================
+// core/common-fabric-symbols.ts:159
+//
+// `symbolDeclaresCommonFabricDefault` bails out with `false` when the symbol has
+// no declarations. A synthetic property produced by a mapped type — e.g. the
+// `x` member of `Record<"x", number>` — is exactly such a symbol: it exists on
+// the type but `getDeclarations()` returns undefined.
+// ===========================================================================
+
+Deno.test("common-fabric-symbols: a synthetic mapped-type property with no declarations is not a Common Fabric Default", () => {
+  const { program, sourceFile } = buildProgram(`
+declare const r: Record<"x", number>;
+export const y = r;
+`);
+  const checker = program.getTypeChecker();
+  const decl = find(
+    sourceFile,
+    ts.isVariableDeclaration,
+    (d) => ts.isIdentifier(d.name) && d.name.text === "y",
+  );
+  const recordType = checker.getTypeAtLocation(decl.name);
+  const syntheticProperty = checker.getPropertyOfType(recordType, "x");
+
+  // The mapped-type member is a real symbol but carries no declaration nodes.
+  assert(syntheticProperty !== undefined);
+  assertEquals(syntheticProperty!.getDeclarations(), undefined);
+
+  // With no declarations to inspect, the predicate reports it is not a Default.
+  assertEquals(
+    symbolDeclaresCommonFabricDefault(syntheticProperty, checker),
+    false,
+  );
+});
+
+// ===========================================================================
+// transformers/expression-rewrite/emitters/element-access-expression.ts:19
+//
+// `emitElementAccessExpression` declines (returns undefined) when the element
+// access carries no relevant reactive data flows. An index read on a plain,
+// non-reactive local array produces an empty data-flow set, so the emitter emits
+// nothing and leaves the access untouched.
+// ===========================================================================
+
+Deno.test("element-access-expression: an index read with no reactive data flows is left untouched by the emitter", () => {
+  const { program, sourceFile } = buildProgram(`/// <cts-enable />
+import { pattern, UI, VNode } from "commonfabric";
+interface Input {}
+interface Output { [UI]: VNode; }
+const local: number[] = [1, 2, 3];
+export default pattern<Input, Output>(() => ({
+  [UI]: <div>{local[0]}</div>,
+}));`);
+  const elementAccess = find(sourceFile, ts.isElementAccessExpression);
+
+  const { dataFlowCount, result } = withContext(
+    program,
+    sourceFile,
+    (context) => {
+      const analyze = context.getDataFlowAnalyzer();
+      const analysis = analyze(elementAccess);
+      const dataFlows = context.getRelevantDataFlowsFromAnalysis(analysis);
+      const emitterContext = {
+        expression: elementAccess,
+        analysis,
+        context,
+        analyze,
+        dataFlows,
+        inSafeContext: false,
+        reactiveContextKind: "pattern",
+        preferInputBoundWrappers: false,
+        rewriteChildren: (node: ts.Expression) => node,
+        rewriteSubexpression: (node: ts.Expression) => node,
+      } as unknown as EmitterContext;
+      return {
+        dataFlowCount: dataFlows.length,
+        result: emitElementAccessExpression(emitterContext),
+      };
+    },
+  );
+
+  // The non-reactive `local[0]` read has no reactive dependencies, so the guard
+  // fires and the emitter produces nothing.
+  assertEquals(dataFlowCount, 0);
+  assertEquals(result, undefined);
+});

--- a/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
@@ -1,0 +1,211 @@
+import ts from "typescript";
+import { assert, assertEquals } from "@std/assert";
+import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
+
+// These cases drive `analyzeFunctionCapabilities` through three branches that
+// otherwise run only when a pattern happens to compile cold through the
+// transformer in CI. With a warm compile cache that compilation is skipped, so
+// the branches flip between covered and uncovered across identical CI runs. Each
+// test constructs the smallest callback body that reaches its branch and pins
+// the observable parameter summary the branch produces.
+
+function createProgram(
+  source: string,
+): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const files: Record<string, string> = { "/test.ts": source };
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files[name] !== undefined,
+    readFile: (name) => files[name],
+    directoryExists: () => true,
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => "/",
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "lib.d.ts",
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+    getSourceFile: (name, lv) =>
+      files[name] !== undefined
+        ? ts.createSourceFile(name, files[name]!, lv, true, ts.ScriptKind.TS)
+        : undefined,
+  };
+  const program = ts.createProgram(["/test.ts"], options, host);
+  return { program, sourceFile: program.getSourceFile("/test.ts")! };
+}
+
+function findArrow(
+  sourceFile: ts.SourceFile,
+  variableName: string,
+): ts.ArrowFunction {
+  let cb: ts.ArrowFunction | undefined;
+  const visit = (node: ts.Node): void => {
+    if (cb) return;
+    if (
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+      node.name.text === variableName && node.initializer &&
+      ts.isArrowFunction(node.initializer)
+    ) {
+      cb = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!cb) throw new Error(`Expected arrow function '${variableName}'.`);
+  return cb;
+}
+
+function analyze(source: string, name = "fn") {
+  const { program, sourceFile } = createProgram(source);
+  return analyzeFunctionCapabilities(findArrow(sourceFile, name), {
+    checker: program.getTypeChecker(),
+  });
+}
+
+// Analyze without a type checker (identity-argument callees are then recognized
+// by name, and computed element access widens to a dynamic source).
+function analyzeNoChecker(source: string, name = "fn") {
+  const { sourceFile } = createProgram(source);
+  return analyzeFunctionCapabilities(findArrow(sourceFile, name));
+}
+
+function getPaths(
+  summary: ReturnType<typeof analyzeFunctionCapabilities>,
+  name: string,
+) {
+  const p = summary.params.find((entry) => entry.name === name);
+  if (!p) throw new Error(`Missing parameter summary for '${name}'.`);
+  return {
+    capability: p.capability,
+    readPaths: p.readPaths.map((x) => x.join(".")),
+    writePaths: p.writePaths.map((x) => x.join(".")),
+    wildcard: p.wildcard,
+    passthrough: p.passthrough,
+    identityPaths: (p.identityPaths ?? []).map((x) => x.join(".")),
+  };
+}
+
+const CELL = `declare const CELL_BRAND: unique symbol;
+type Cell<T> = {
+  readonly [CELL_BRAND]: "cell";
+  get(): T;
+  set(value: T): void;
+  push(...items: unknown[]): number;
+};`;
+
+// Branch: the fallthrough `trackReadRef(resolvedSource, { identityOnly: true })`
+// (capability-analysis.ts ~2833-2837). Reached when an alias used as the
+// argument of a known identity call is itself a dynamic source: the three
+// earlier `!dynamic` guards all fall through, and because the ref is dynamic the
+// read widens the whole parameter root to wildcard.
+Deno.test(
+  "identity call on a dynamic alias widens the parameter root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k) => {
+           const v = input[k];
+           navigateTo(v);
+         };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+    assertEquals(input.readPaths.length, 0);
+    assertEquals(input.writePaths.length, 0);
+  },
+);
+
+Deno.test(
+  "equals() on a dynamic alias also widens the parameter root to wildcard",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input, k, other) => {
+           const v = input[k];
+           v.equals(other);
+         };`,
+      ),
+      "input",
+    );
+    assertEquals(input.wildcard, true);
+  },
+);
+
+// Branch: `updateLocalCollectionBinding` deletes the tracked map-value binding
+// when two `.set()` calls store non-equal sources so their merge is undefined
+// (capability-analysis.ts ~1977-1979). Contrast with a single `.set()`, where
+// the binding survives and a later `.get(k).name` resolves through it.
+Deno.test(
+  "a single map .set() lets a later .get().member resolve through the value binding",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+           const m = new Map();
+           m.set("k", input.a);
+           const v = m.get("k");
+           return v.name;
+         };`,
+      ),
+      "input",
+    );
+    // The stored binding survives, so the member read resolves to input.a.name.
+    assert(input.readPaths.includes("a.name"));
+  },
+);
+
+Deno.test(
+  "conflicting map .set() values drop the value binding so .get().member no longer resolves",
+  () => {
+    const input = getPaths(
+      analyzeNoChecker(
+        `const fn = (input) => {
+           const m = new Map();
+           m.set("k", input.a);
+           m.set("k", input.b);
+           const v = m.get("k");
+           return v.name;
+         };`,
+      ),
+      "input",
+    );
+    // Both set arguments are still read at set time.
+    assert(input.readPaths.includes("a"));
+    assert(input.readPaths.includes("b"));
+    // But the merged binding was deleted, so the later `.get("k").name` resolves
+    // to no source: neither a.name nor b.name is recorded.
+    assert(!input.readPaths.includes("a.name"));
+    assert(!input.readPaths.includes("b.name"));
+  },
+);
+
+// Branch: an array-identity writer (`push`) whose argument aliases an
+// array element reads that element's path (capability-analysis.ts ~3128-3130).
+// The `.find()` result carries an array-element binding, so pushing it records a
+// read of the element path rather than treating the pushed value as opaque.
+Deno.test(
+  "push() of an array-element alias reads the element path",
+  () => {
+    const input = getPaths(
+      analyze(
+        `${CELL}
+         const fn = (
+           input: { rows: { id: string }[] },
+           list: Cell<unknown[]>,
+         ) => {
+           const found = input.rows.find((r) => r.id === "x");
+           list.push(found);
+         };`,
+      ),
+      "input",
+    );
+    assert(input.readPaths.includes("rows.0"));
+  },
+);

--- a/packages/ts-transformers/test/schema-injection-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-flap-coverage.test.ts
@@ -1,0 +1,155 @@
+import { assert, assertEquals } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { callSchemas, callsNamed, parseModule } from "./transformed-ast.ts";
+
+// A few branches in schema-injection.ts run only while a pattern compiles
+// through the transformer from cold. When CI's compile cache is warm the
+// compilation is skipped, so the same code alternates between covered and
+// uncovered across runs of identical source. These unit tests drive each branch
+// directly from small pattern sources and assert on the real emitted schema
+// objects, so the branches stay covered regardless of cache state.
+//
+// The assertions parse the printed output back into an AST and evaluate the
+// emitted `... satisfies ...JSONSchema` literals to their JS values, so a
+// preserved comment or an input substring cannot satisfy them.
+
+function t(source: string): Promise<string> {
+  return transformSource(source, { types: COMMONFABRIC_TYPES });
+}
+
+// deno-lint-ignore no-explicit-any
+type Obj = Record<string, any>;
+
+Deno.test(
+  "a lift result recovered as any leaves the downstream capture schema permissive",
+  async () => {
+    // `liftSummary` is applied to build `summary`, which a `computed` closure then
+    // captures. The closure transformer types the captured `summary` as `any`, so
+    // schema injection tries to recover its type from the originating lift factory.
+    // The lift callback is annotated to return `any`, so the recovered result type
+    // is `any` and the recovery declines (the any/unknown result guard returns
+    // undefined). The captured-input schema for `summary` therefore stays the
+    // permissive `true` schema instead of a concrete recovered object shape.
+    const source = `/// <cts-enable />
+import { Cell, computed, lift, pattern, Writable } from "commonfabric";
+const liftSummary = lift<
+  { primary: Writable<number>; secondary: Writable<number> }
+>(
+  // deno-lint-ignore no-explicit-any
+  ({ primary, secondary }): any => primary.get() + secondary.get(),
+);
+export default pattern<{ primary: Cell<number>; secondary: Cell<number> }>(
+  ({ primary, secondary }) => {
+    const summary = liftSummary({ primary, secondary });
+    const difference = computed(() => summary);
+    return { summary, difference };
+  },
+);`;
+    const output = parseModule(await t(source));
+
+    // The `computed` closure captures `summary` reactively via a generated lift.
+    // Its input schema (the first schema argument) keeps `summary` permissive
+    // (`true`) because the recovery could not infer a concrete type for the
+    // any-typed lift result.
+    const liftCalls = callsNamed(output, "lift").filter((c) =>
+      c.arguments.length >= 2
+    );
+    assert(liftCalls.length >= 1);
+    const [inputSchema] = callSchemas(output, "lift");
+    assert(inputSchema, "expected an input schema on the generated lift");
+    const props = inputSchema.properties as Obj;
+    assertEquals(props.summary, true);
+  },
+);
+
+Deno.test(
+  "a lift result recovered as a concrete object keeps its projected schema",
+  async () => {
+    // Companion to the case above: with a concrete lift callback return type the
+    // recovery succeeds (the any/unknown guard is not taken), so the captured
+    // `summary` schema carries the projected object's properties rather than the
+    // permissive `true`.
+    const source = `/// <cts-enable />
+import { Cell, computed, lift, pattern, Writable } from "commonfabric";
+const liftSummary = lift<
+  { primary: Writable<number>; secondary: Writable<number> }
+>(({ primary, secondary }) => {
+  const primaryValue = primary.get();
+  const secondaryValue = secondary.get();
+  return {
+    primary: primaryValue,
+    secondary: secondaryValue,
+    difference: primaryValue - secondaryValue,
+  };
+});
+export default pattern<{ primary: Cell<number>; secondary: Cell<number> }>(
+  ({ primary, secondary }) => {
+    const summary = liftSummary({ primary, secondary });
+    const difference = computed(() => summary.difference);
+    return { summary, difference };
+  },
+);`;
+    const output = parseModule(await t(source));
+    const [inputSchema] = callSchemas(output, "lift");
+    assert(inputSchema, "expected an input schema on the generated lift");
+    const summarySchema = (inputSchema.properties as Obj).summary as Obj;
+    // Unlike the any-result case (where `summary` stays the permissive `true`),
+    // recovery here produced a concrete object schema that projects the read
+    // `difference` property.
+    assert(
+      summarySchema && typeof summarySchema === "object" &&
+        !Array.isArray(summarySchema),
+      "expected a concrete recovered object schema for summary, not `true`",
+    );
+    assertEquals(summarySchema.type, "object");
+    assert(
+      Object.keys(summarySchema.properties as Obj).includes("difference"),
+      "expected the recovered summary schema to project `difference`",
+    );
+    assertEquals(
+      (summarySchema.required as string[]).includes("difference"),
+      true,
+    );
+  },
+);
+
+Deno.test(
+  "a parenthesized scope-wrapper type on a lift object return is unwrapped into a scope marker",
+  async () => {
+    // The lift callback returns `{ v }` where `v` is declared with the
+    // parenthesized type `(PerSpace<number>)`. Building the object-literal return
+    // schema reads that declared type node and unwraps the parentheses before
+    // testing for a scope wrapper. Once unwrapped, `PerSpace` is recognized and
+    // the emitted property schema carries `scope: "space"`.
+    const source = `/// <cts-enable />
+import { Cell, pattern, lift, PerSpace, UI, VNode } from "commonfabric";
+interface Input { seed: Cell<number>; }
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(({ seed }) => {
+  const make = lift((n: number) => {
+    const v: (PerSpace<number>) = n as unknown as PerSpace<number>;
+    return { v };
+  });
+  const r = make(seed);
+  return { [UI]: <div>{r}</div> };
+});`;
+    const output = parseModule(await t(source));
+
+    // The lift's result schema encodes `v` as a space-scoped number, which only
+    // happens if the parenthesized type node was unwrapped and the scope wrapper
+    // recognized.
+    const resultSchemas = callSchemas(output, "lift");
+    const scoped = resultSchemas.find((schema) => {
+      const v = (schema.properties as Obj | undefined)?.v as Obj | undefined;
+      return v?.scope === "space";
+    });
+    assert(
+      scoped,
+      "expected a lift result schema with v marked scope: space",
+    );
+    const v = (scoped!.properties as Obj).v as Obj;
+    assertEquals(v.type, "number");
+    assertEquals(v.scope, "space");
+  },
+);

--- a/packages/ts-transformers/test/synthetic-helper-wrapper-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/synthetic-helper-wrapper-flap-coverage.test.ts
@@ -1,0 +1,130 @@
+import { assertEquals } from "@std/assert";
+import ts from "typescript";
+import { StaticCacheFS } from "@commonfabric/static";
+
+import { TransformationContext } from "../src/core/context.ts";
+import { transformCfDirective } from "../src/mod.ts";
+import { isSyntheticHelperWrapperInArrayMethodCallback } from "../src/transformers/expression-site-lowering.ts";
+import { CF_HELPERS_IDENTIFIER } from "../src/core/cf-helpers.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// `isSyntheticHelperWrapperInArrayMethodCallback` classifies a synthetic
+// reactive-helper wrapper (a `__cfHelpers.ifElse/when/unless`/lift-applied call
+// produced by an earlier lowering pass) by walking up from it to decide whether
+// it sits inside an array-method callback. Its no-enclosing-function fallback
+// runs only when such a synthetic wrapper is reached with a parent chain that
+// holds no function at all — a transient state the transformer produces while
+// compiling patterns cold, but which a compile-cache-warm CI run skips, so the
+// line alternates between covered and uncovered across runs of identical code.
+//
+// This drives that fallback directly: a freshly built synthetic `ifElse` wrapper
+// has a negative text position (marking it synthetic) and no parent, so the
+// upward walk finds no function and the classifier returns false — the wrapper
+// is not treated as living inside an array-method callback.
+
+const cache = new StaticCacheFS();
+const es2023 = await cache.getText("types/es2023.d.ts");
+const dom = await cache.getText("types/dom.d.ts");
+const jsx = await cache.getText("types/jsx.d.ts");
+
+function buildContext<T>(body: (context: TransformationContext) => T): T {
+  const fileName = "/test.tsx";
+  const files: Record<string, string> = {
+    [fileName]: transformCfDirective(`/// <cts-enable />
+import { pattern, UI, VNode } from "commonfabric";
+interface Input {}
+interface Output { [UI]: VNode; }
+export default pattern<Input, Output>(() => ({ [UI]: <div /> }));`),
+    "commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"],
+    "cfc.ts": COMMONFABRIC_TYPES["cfc.ts"],
+    "es2023.d.ts": es2023,
+    "dom.d.ts": dom,
+    "jsx.d.ts": jsx,
+  };
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+    jsx: ts.JsxEmit.React,
+    jsxFactory: "h",
+    strict: true,
+  };
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) =>
+      files[name]
+        ? ts.createSourceFile(name, files[name], compilerOptions.target!, true)
+        : undefined,
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    fileExists: (name) => !!files[name],
+    readFile: (name) => files[name],
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "es2023.d.ts",
+    resolveModuleNames: (names) =>
+      names.map((name) =>
+        name === "commonfabric"
+          ? {
+            resolvedFileName: "commonfabric.d.ts",
+            extension: ts.Extension.Dts,
+            isExternalLibraryImport: false,
+          }
+          : undefined
+      ),
+  };
+  const program = ts.createProgram(Object.keys(files), compilerOptions, host);
+  const sourceFile = program.getSourceFile(fileName)!;
+  let out!: T;
+  ts.transform(sourceFile, [
+    (tsContext) => (root) => {
+      out = body(new TransformationContext({ program, sourceFile, tsContext }));
+      return root;
+    },
+  ]);
+  return out;
+}
+
+/** A synthetic `__cfHelpers.<name>(...)` call, as a lowering pass emits. */
+function syntheticHelperCall(name: string): ts.CallExpression {
+  return ts.factory.createCallExpression(
+    ts.factory.createPropertyAccessExpression(
+      ts.factory.createIdentifier(CF_HELPERS_IDENTIFIER),
+      name,
+    ),
+    undefined,
+    [
+      ts.factory.createTrue(),
+      ts.factory.createNumericLiteral("1"),
+      ts.factory.createNumericLiteral("2"),
+    ],
+  );
+}
+
+Deno.test("a detached synthetic helper wrapper is not classified as inside an array-method callback", () => {
+  // A factory-built node carries a negative position (synthetic) and no parent.
+  const wrapper = syntheticHelperCall("ifElse");
+  assertEquals(wrapper.pos < 0, true);
+  assertEquals(wrapper.parent, undefined);
+
+  const result = buildContext((context) =>
+    isSyntheticHelperWrapperInArrayMethodCallback(wrapper, context)
+  );
+
+  // Recognized as a synthetic reactive-helper wrapper, but with no enclosing
+  // function in its (empty) parent chain, so it is not inside an array-method
+  // callback.
+  assertEquals(result, false);
+});
+
+Deno.test("a non-helper synthetic call is rejected before the ancestor walk", () => {
+  // A `__cfHelpers.notAHelper(...)` call is not a recognized reactive-helper
+  // wrapper, so the classifier declines up front rather than walking ancestors.
+  const notAWrapper = syntheticHelperCall("notAHelper");
+
+  const result = buildContext((context) =>
+    isSyntheticHelperWrapperInArrayMethodCallback(notAWrapper, context)
+  );
+
+  assertEquals(result, false);
+});

--- a/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
@@ -1,0 +1,301 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import type {
+  CapabilityParamSummary,
+  TransformationContext,
+} from "../src/core/mod.ts";
+import {
+  applyShrinkAndWrap,
+  printTypeNode,
+  validateShrinkCoverage,
+} from "../src/transformers/type-shrinking.ts";
+import { collect, parseModule } from "./transformed-ast.ts";
+
+// These branches in type-shrinking run only when a pattern compiles cold through
+// the transformer. When the pattern compile-cache is warm they are skipped, so
+// they flap between covered and uncovered across CI runs of identical code. The
+// tests below drive them directly through the exported shrinking entry points so
+// they are recorded every run.
+
+// ---------------------------------------------------------------------------
+// Structural inspection of printed type nodes (mirrors
+// type-shrinking-coverage.test.ts).
+// ---------------------------------------------------------------------------
+
+/** Reparse a printed type node into a `ts.TypeNode`. */
+function parseType(printed: string): ts.TypeNode {
+  const decl = collect(
+    parseModule(`type __T = ${printed};`),
+    ts.isTypeAliasDeclaration,
+  )[0];
+  if (!decl) throw new Error(`Could not parse type node: ${printed}`);
+  return decl.type;
+}
+
+interface PropInfo {
+  optional: boolean;
+  type: string;
+}
+
+/** Every property signature reachable under `node`, keyed by name. */
+function props(node: ts.Node): Map<string, PropInfo> {
+  const sf = node.getSourceFile();
+  const out = new Map<string, PropInfo>();
+  for (const signature of collect(node, ts.isPropertySignature)) {
+    const name = ts.isIdentifier(signature.name)
+      ? signature.name.text
+      : signature.name.getText(sf);
+    out.set(name, {
+      optional: !!signature.questionToken,
+      type: signature.type ? signature.type.getText(sf) : "",
+    });
+  }
+  return out;
+}
+
+/** Reparse the printed shrink result and return its member map. */
+function shrunkProps(result: ts.TypeNode, sourceFile: ts.SourceFile): {
+  node: ts.TypeNode;
+  props: Map<string, PropInfo>;
+} {
+  const node = parseType(printTypeNode(result, sourceFile));
+  return { node, props: props(node) };
+}
+
+// ---------------------------------------------------------------------------
+// Harness (mirrors type-shrinking-coverage.test.ts so cases stay comparable).
+// ---------------------------------------------------------------------------
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+  };
+
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findTypeAlias(
+  sourceFile: ts.SourceFile,
+  aliasName: string,
+): ts.TypeAliasDeclaration {
+  let found: ts.TypeAliasDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isTypeAliasDeclaration(node) && node.name.text === aliasName) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Type alias ${aliasName} not found`);
+  return found;
+}
+
+function createParamSummary(
+  summary: Partial<CapabilityParamSummary>,
+): CapabilityParamSummary {
+  return {
+    name: "input",
+    capability: "opaque",
+    readPaths: [],
+    writePaths: [],
+    opaquePaths: [],
+    passthrough: false,
+    wildcard: false,
+    identityOnly: false,
+    ...summary,
+  };
+}
+
+interface CollectedDiagnostic {
+  severity: string;
+  type: string;
+  message: string;
+}
+
+function createContext(sourceFile: ts.SourceFile): {
+  context: TransformationContext;
+  diagnostics: CollectedDiagnostic[];
+} {
+  const diagnostics: CollectedDiagnostic[] = [];
+  const context = {
+    sourceFile,
+    factory: ts.factory,
+    options: {
+      state: {
+        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
+      },
+    },
+    reportDiagnostic: (d: CollectedDiagnostic) => {
+      diagnostics.push({
+        severity: d.severity,
+        type: d.type,
+        message: d.message,
+      });
+    },
+  } as unknown as TransformationContext;
+  return { context, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Type-driven shrink descending into an `unknown`/`any` property drops that
+// property rather than widening it (buildShrunkTypeNodeFromType
+// `!hasDirectAccess && isAnyOrUnknownType(propType)` continue, lines 964-967).
+// A synthetic base node forces the type-driven path; a deep path into an
+// `unknown`-typed member reaches the guard.
+// ---------------------------------------------------------------------------
+
+Deno.test("applyShrinkAndWrap drops a deep read into an unknown-typed property under type-driven shrinking", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = { blob: unknown; kept: string };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const syntheticBaseNode = ts.factory.createKeywordTypeNode(
+    ts.SyntaxKind.UnknownKeyword,
+  );
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      // Deep path into `blob` (unknown): the child cannot be materialised, so
+      // `blob` is dropped instead of widened to the full unknown shape.
+      readPaths: [["blob", "inner"], ["kept"]],
+    }),
+    syntheticBaseNode,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const { props: members } = shrunkProps(result, sourceFile);
+  // The unknown-typed `blob` is absent; only the resolvable `kept` leaf remains.
+  assertEquals(members.has("blob"), false);
+  assertEquals(members.get("kept")?.type, "string");
+});
+
+// ---------------------------------------------------------------------------
+// getArrayElementTypeNode fallback: a base node that is a plain type-alias
+// reference (not `T[]`, `Array<T>`, readonly array, union, or type literal)
+// resolves to an array only through the checker, so the element node is built
+// from the resolved element type (lines 1685-1688, 1694, 1699-1709). Validating
+// an item path on such a base runs the fallback and finds the item field.
+// ---------------------------------------------------------------------------
+
+Deno.test("validateShrinkCoverage resolves array element node from an array type-alias reference", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Array<T> { length: number; [n: number]: T; }
+    interface Row { id: string; title: string; }
+    type Rows = Row[];
+    type Input = Rows;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+  // The base node is the bare `Rows` reference — not syntactically an array.
+  const baseTypeNode = alias.type;
+  assert(ts.isTypeReferenceNode(baseTypeNode));
+
+  validateShrinkCoverage(
+    createParamSummary({
+      name: "rows",
+      readPaths: [["0", "id"], ["0", "missing"]],
+    }),
+    baseTypeNode,
+    baseType,
+    [["0", "id"], ["0", "missing"]],
+    // shrunk is undefined so validation resolves the element via the base node's
+    // checker-driven fallback rather than a prebuilt array shape.
+    undefined,
+    context,
+    alias,
+    checker,
+  );
+
+  // `id` resolves on the element type via the fallback; `missing` does not.
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0]!.type, "schema:path-not-in-type");
+  assertStringIncludes(diagnostics[0]!.message, "'.missing'");
+  assertEquals(diagnostics[0]!.message.includes("'.id'"), false);
+});
+
+// ---------------------------------------------------------------------------
+// validateShrinkCoverage over an array base where the shrunk node is NOT
+// array-shaped: array-root paths (`length`) survive and re-drive validation
+// against the array base (line 1832-1833 `paths = arrayRootPaths`), and the
+// array-root head is checked via typeNodeHasHead's array-shape arm (line 1545).
+// A bogus non-array head keeps the top-1763 fast path from firing.
+// ---------------------------------------------------------------------------
+
+Deno.test("validateShrinkCoverage validates array-root paths against the array base when the shrunk node is not array-shaped", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Array<T> { length: number; [n: number]: T; }
+    interface Row { id: string; }
+    type Input = Row[];
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+  const { context, diagnostics } = createContext(sourceFile);
+  const baseTypeNode = alias.type;
+  assert(ts.isArrayTypeNode(baseTypeNode));
+
+  // A non-array shrunk node so the array-compatible fast path (all heads
+  // array-compatible + shrunk array-shaped) does not fire.
+  const nonArrayShrunk = ts.factory.createTypeLiteralNode([]);
+
+  validateShrinkCoverage(
+    createParamSummary({
+      name: "rows",
+      // `length` is an array-root-only path; `bogus` is a non-array head that
+      // both blocks the fast path and is absent from the array element.
+      readPaths: [["length"], ["bogus"]],
+    }),
+    baseTypeNode,
+    baseType,
+    [["length"], ["bogus"]],
+    nonArrayShrunk,
+    context,
+    alias,
+    checker,
+  );
+
+  // `length` validates against the array base (typeNodeHasHead array arm), so
+  // the only diagnostic is for the item path `bogus`, which is absent from Row.
+  const rootDiagnostics = diagnostics.filter((d) =>
+    d.message.includes("'.length'")
+  );
+  assertEquals(rootDiagnostics.length, 0);
+  assert(
+    diagnostics.some((d) => d.message.includes("'.bogus'")),
+    "expected a diagnostic for the missing item field",
+  );
+});


### PR DESCRIPTION
## Why

The coverage-debt gate counts how many source lines are covered and fails when
that number regresses against a recent sample from main. A group of lines were
covered only as a side effect of patterns compiling through the transformer
during the pattern-integration jobs. Those jobs reuse a compile cache, and on a
cache hit the transformer and schema-generator never run, so their lines are not
recorded as covered for that run. The same unchanged code therefore alternates
between covered and uncovered from one run to the next. That flapping shows up in
the gate as a spurious coverage-debt increase, unrelated to the change under
test — for example, a docs-only PR appeared to raise `packages/runner` debt purely
because of which sample it landed against.

## What this does

Add focused unit tests that exercise each of those lines directly, so they are
covered on every run regardless of the compile cache. The tests drive the code
through the real transformer pipeline (via `transformSource`) or call the
emitter and helper functions directly, and they assert on real behavior — parsed
syntax-tree nodes and returned values — rather than just executing the line. They
are quality tests that pin down actual behavior, not coverage stunts.

Areas covered:

- **ts-transformers** — the expression-rewrite emitters (including the zero-arg
  IIFE branch and its `createLiftAppliedCall` fallback, the no-dataflow guard,
  and the receiver scan), expression-site lowering, schema injection, type
  shrinking, capability analysis, the synthetic-helper-wrapper fallback, and
  assorted small emitter and policy branches.
- **schema-generator** — formatter and generator branches that previously ran
  only during cold pattern compiles.
- **runner** — the SQLite query write-back and stale-supersede guards, the
  compiled-JS scanner's bitwise-operator branch, and the memory WebSocket
  transport's close and error paths.
- **memory** — the acknowledgement reschedule after a failed send while
  connected.

## Source changes

Two symbols are exported so the tests can import and drive them directly, with no
behavior change: `WebSocketTransport` in the runner's remote-session storage, and
`isSyntheticHelperWrapperInArrayMethodCallback` in the transformer's
expression-site lowering.

## Scope

This makes each flapping line deterministically covered, which stops it from
destabilizing the gate. It does not change the underlying mechanism — the compile
cache in the pattern jobs combined with a ratchet that compares against a single
recent sample. Reworking that ratchet (for example, taking the minimum over
several recent baselines) is a separate change and is not included here.

## Test plan

- `deno task test` in `packages/ts-transformers`, `packages/schema-generator`,
  `packages/runner`, and `packages/memory` — all green.
- The new ts-transformers tests were verified to cover their target lines under
  V8 coverage on the unmodified source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the coverage-debt gate by adding deterministic unit tests that cover lines previously executed only during cold pattern compiles or timing-dependent paths. No runtime behavior changes; two symbols are exported to enable testing, and the new flap-coverage tests are formatted with `deno fmt`.

- **Bug Fixes**
  - Added deterministic tests across `packages/ts-transformers`, `packages/schema-generator`, `packages/runner`, and `packages/memory` to cover cold-compile and timing-only branches (e.g., call-expression/IIFE paths including the lift-applied fallback, expression-site nested/provenance cases, schema-generator defaults and node-driven overrides, sqlite result write-back and stale-supersede guards, WebSocket close/error handling, compiled-js single `&`/`|`, and ack retry after a failed `session.ack`).
  - Exported `WebSocketTransport` (runner) and `isSyntheticHelperWrapperInArrayMethodCallback` (transformers) for test access only; no behavior changes.
  - Tests are event-driven (no sleeps) to keep coverage stable across runs.

- **Refactors**
  - Applied `deno fmt` to the new flap-coverage tests; no behavior changes.

<sup>Written for commit 6cd92f89842116da456e7e2d2837478afa1c644c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

