### PR TITLE
feat(topics): derive the prose reference graph as navigable crossref chips

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -209,6 +209,8 @@ interface TopicsInput {
   topics?: Writable<TopicPiece[] | Default<[]>>;
   myName?: PerUser<Writable<string | Default<"">>>;
 }
+// TopicInput additionally takes mentionable?: Writable<TopicPiece[]> — the
+// board's own list, wired at creation, for detail-page Connections.
 ```
 
 ### Output Schema

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -192,12 +192,15 @@ addPiece.send({ piece: ann });
 **Topics — a multi-user tracker over #topic pieces** (durable units of shared
 attention; CT-1878): title, living body document, flat chronological comment
 thread, typed links out. Deliberately minimal — no statuses, labels, or
-assignees. Demonstrates: reading-list-style piece-in-list composition, `PerUser`
-display-name on a shared piece, mergeable comment appends, session-scoped
-drafts, `multiUserTest` coverage.
+assignees. The board derives the corpus's prose reference graph (topic fids
+pasted in bodies/comments/link URLs → navigable crossref chips, never
+persisted). Demonstrates: reading-list-style piece-in-list composition,
+`PerUser` display-name on a shared piece, mergeable comment appends,
+session-scoped drafts, read-side derived backlinks over sibling pieces
+(`resolveAsCell().entityId` for piece identity), `multiUserTest` coverage.
 
 **Keywords:** topics, issues, tracker, discussion, thread, comments, multi-user,
-PerUser, mergeable
+PerUser, mergeable, backlinks, crossrefs, references, graph
 
 ### Input Schema
 
@@ -215,6 +218,7 @@ interface TopicsOutput {
   topics: TopicPiece[];
   mentionable: TopicPiece[];
   topicCount: number;
+  crossrefs: TopicCrossref[]; // { fid, topic, refsOut, referencedBy }
   myName: string;
   addTopic: Stream<{ title: string }>;
   setMyName: Stream<{ name: string }>;

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -6,6 +6,12 @@ up into the body; the thread holds the deliberation), a flat chronological
 comment thread, and typed links out to other core objects (PRs, agent sessions,
 other topics — URLs in v0).
 
+The board also surfaces the corpus's **prose reference graph**: any topic fid
+pasted in a body, comment, or link URL (bare, `of:`-prefixed, page URL, or
+percent-encoded share link) becomes a navigable "references →" / "← referenced
+by" chip on the topic's card, and the graph is exported as the `crossrefs`
+output for headless consumers.
+
 Deliberately absent until reached for: statuses (not even open/closed), labels,
 assignees, attachments, nesting. What a topic grows next is part of the
 experiment.
@@ -27,6 +33,12 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   Edit→Save toggle rather than a live-bound textarea.
 - **`myName` is `PerUser` on the shared piece** — one tracker, one name per
   authenticated identity, shared with every topic the tracker creates.
+- **Cross-references are derived at read time, never persisted.** The board
+  rescans the whole corpus per render (trivial at board scale) instead of
+  materializing backlinks into topics: an index pattern that writes derived
+  edges back can destroy real data when run from a partial-view replica, and a
+  retracted mention should simply stop being an edge. Any future persisted index
+  needs single-writer + full-view preconditions first.
 - Verified by `multi-user.test.tsx` (two isolated runtimes, one shared board).
 
 ## Headless / agent use
@@ -38,5 +50,9 @@ cf piece call --piece <board> setMyName '{"name":"Fable"}'
 cf piece call --piece <board> addTopic '{"title":"..."}'
 cf piece get  --piece <board> topics --input      # then address a topic piece
 cf piece call --piece <topic> addComment '{"body":"..."}'
-cf piece step --piece <...>                       # after mutations
 ```
+
+Do **not** run `cf piece step` from a fresh CLI replica: a replica with a
+partial view persists deriveds computed from that partial view. Writes commit
+fine on their own; renderers derive for themselves. Verify writes via a renderer
+or post-materialization fid reads.

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -41,6 +41,11 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   read-side from it (SELF + equals to find its own row). Requires the
   path-scoped wildcard fix (#4714) — the derive combines a resolveAsCell chain
   with an equals-only SELF capture in one computed.
+- **Authoring: cf-code-editor in the Edit→Save draft flow.** The editor binds
+  the session-local `bodyDraft` (never live to the shared string — whole-value
+  conflict semantics hold) with `@`-mention autocomplete over `mentionable`;
+  inserted `[Name](/of:fid1:…)` links are matched by the same fid scan as pasted
+  URLs. The read view renders the body as markdown.
 - **Cross-references are derived at read time, never persisted.** The board
   rescans the whole corpus per render (trivial at board scale) instead of
   materializing backlinks into topics: an index pattern that writes derived

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -10,7 +10,10 @@ The board also surfaces the corpus's **prose reference graph**: any topic fid
 pasted in a body, comment, or link URL (bare, `of:`-prefixed, page URL, or
 percent-encoded share link) becomes a navigable "references →" / "← referenced
 by" chip on the topic's card, and the graph is exported as the `crossrefs`
-output for headless consumers.
+output for headless consumers. Each topic also derives its own row of the graph
+on its detail page (a **Connections** card) from the `mentionable` input — a
+reference to the board's own topics list, wired at creation like `myName` and
+backfillable as a one-time link-bind on pre-existing pieces.
 
 Deliberately absent until reached for: statuses (not even open/closed), labels,
 assignees, attachments, nesting. What a topic grows next is part of the
@@ -33,6 +36,11 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   Edit→Save toggle rather than a live-bound textarea.
 - **`myName` is `PerUser` on the shared piece** — one tracker, one name per
   authenticated identity, shared with every topic the tracker creates.
+- **`mentionable` is a structural reference, not derived data.** The board
+  passes its own topics list at creation; the topic derives its Connections
+  read-side from it (SELF + equals to find its own row). Requires the
+  path-scoped wildcard fix (#4714) — the derive combines a resolveAsCell chain
+  with an equals-only SELF capture in one computed.
 - **Cross-references are derived at read time, never persisted.** The board
   rescans the whole corpus per render (trivial at board scale) instead of
   materializing backlinks into topics: an index pattern that writes derived

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -2,6 +2,7 @@ import {
   action,
   computed,
   Default,
+  entityRefToString,
   handler,
   NAME,
   navigateTo,
@@ -17,6 +18,8 @@ import {
 
 import Topic, {
   asArray,
+  extractFidPayloads,
+  fidPayload,
   snippet,
   type TopicPiece,
   TOPICS_THEME,
@@ -40,6 +43,20 @@ export interface TopicsInput {
   myName?: PerUser<Writable<string | Default<"">>>;
 }
 
+/** One topic's place in the prose reference graph. Derived at read time from
+ * fids pasted in bodies, comments, and link URLs — never persisted, so a
+ * partial-view replica can never destroy real edges (the failure class of
+ * index patterns that write backlinks into their targets). */
+export interface TopicCrossref {
+  /** The topic's own fid in tagged form (`fid1:…`); "" until known. */
+  fid: string;
+  topic: TopicPiece;
+  /** Sibling topics whose fids this topic's prose mentions. */
+  refsOut: TopicPiece[];
+  /** Sibling topics whose prose mentions this topic's fid. */
+  referencedBy: TopicPiece[];
+}
+
 /**
  * Topics — a tracker over #topic pieces: durable units of shared attention
  * (CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics
@@ -52,6 +69,10 @@ export interface TopicsOutput {
   topics: TopicPiece[];
   mentionable: TopicPiece[];
   topicCount: number;
+  /** The prose reference graph over the board's own topics, one row per
+   * (non-null) entry of `topics`. Rows carry their topic, so consumers never
+   * need to correlate by index — indices are not a stable address. */
+  crossrefs: TopicCrossref[];
   /** The viewer's display name (normalized to "" until set). */
   myName: string;
   /** Session-local draft for the footer composer (exposed for embedding and
@@ -70,6 +91,36 @@ export const openTopic = handler<void, { topic: TopicPiece }>(
     navigateTo(topic);
   },
 );
+
+/** One row of crossref chips ("references →" / "← referenced by"): each chip
+ * names a sibling topic and navigates to it. Chips bind against direct
+ * elements of the board's `topics` list — a handler bound to a piece nested
+ * inside a derived wrapper object silently keeps the consuming UI computed
+ * from ever running. Module-scope and pure so the single-runtime suite can
+ * also drive the exact markup directly (pinning the no-edges → null branch)
+ * alongside the real card path it renders via continuous UI demand. */
+export const crossrefChipRow = (
+  caption: string,
+  accent: boolean,
+  list: TopicPiece[],
+  indices: number[],
+) =>
+  indices.length === 0
+    ? null
+    : (
+      <cf-hstack gap="1" align="center" style="flex-wrap: wrap;">
+        <cf-text variant="caption" tone="muted">{caption}</cf-text>
+        {indices.map((j) => (
+          <cf-chip
+            label={snippet(list[j]?.title || "(untitled topic)", 40)}
+            size="xs"
+            color={accent ? "accent" : "neutral"}
+            interactive
+            oncf-click={openTopic({ topic: list[j] })}
+          />
+        ))}
+      </cf-hstack>
+    );
 
 export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
   const newTitle = new Writable.perSession("");
@@ -102,13 +153,74 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
 
   const topicCount = computed(() => asArray(topics.get()).length);
 
-  const sortedTopics = computed(() =>
-    asArray(topics.get())
-      .filter((t) => t)
-      .toSorted((a, b) => (b?.lastActivityAt ?? 0) - (a?.lastActivityAt ?? 0))
-  );
+  // The prose reference graph as index edges over `topics` (raw order),
+  // recomputed from the whole corpus on any board change (O(topics × text) —
+  // trivial at board scale; the growth path is per-topic memoization).
+  // Identity is each entry's resolved result-doc fid, so the existing corpus
+  // lights up with zero authoring changes and nothing derived is persisted.
+  // Indices, not pieces: the UI must bind its navigation handlers to direct
+  // `topics` elements — a handler bound to a piece nested inside a derived
+  // wrapper object silently keeps the consuming UI computed from ever
+  // running.
+  const crossrefEdges = computed(() => {
+    const list = asArray(topics.get());
+    // Each entry's own fid payload ("" while unresolved, e.g. mid-sync —
+    // such entries simply hold no edges this render).
+    const payloads = list.map((t, i) => {
+      if (!t) return "";
+      // resolveAsCell/entityId are cell-runtime surface, not on the pattern
+      // Writable type (same cast as notes' appendLink).
+      const ref = (topics.key(i) as any).resolveAsCell?.()?.entityId;
+      return ref ? fidPayload(entityRefToString(ref)) : "";
+    });
+    // Every fid payload each topic's prose mentions.
+    const mentions = list.map((t) => {
+      if (!t) return new Set<string>();
+      const parts = [t.body ?? ""];
+      for (const c of asArray(t.comments)) parts.push(c?.body ?? "");
+      for (const l of asArray(t.links)) parts.push(l?.url ?? "");
+      return new Set(extractFidPayloads(parts.join("\n")));
+    });
+    return list.map((t, i) => {
+      const refsOut: number[] = [];
+      const referencedBy: number[] = [];
+      if (t) {
+        for (let j = 0; j < list.length; j++) {
+          if (j === i || !list[j]) continue;
+          if (payloads[j] && mentions[i].has(payloads[j])) refsOut.push(j);
+          if (payloads[i] && mentions[j].has(payloads[i])) referencedBy.push(j);
+        }
+      }
+      return {
+        fid: payloads[i] ? `fid1:${payloads[i]}` : "",
+        refsOut,
+        referencedBy,
+      };
+    });
+  });
 
-  const hasNoTopics = computed(() => sortedTopics.length === 0);
+  // Piece-valued view of the graph for consumers (tests, embedders, headless
+  // reads) — reading pieces through the wrapper rows is fine, only handler
+  // binds are not.
+  const crossrefs = computed(() => {
+    const list = asArray(topics.get());
+    const rows: TopicCrossref[] = [];
+    crossrefEdges.forEach((e, i) => {
+      const t = list[i];
+      if (!t) return;
+      rows.push({
+        fid: e.fid,
+        topic: t,
+        refsOut: e.refsOut.map((j) => list[j]),
+        referencedBy: e.referencedBy.map((j) => list[j]),
+      });
+    });
+    return rows;
+  });
+
+  const hasNoTopics = computed(() =>
+    asArray(topics.get()).filter((t) => t).length === 0
+  );
 
   return {
     [NAME]: computed(() => `Topics (${asArray(topics.get()).length})`),
@@ -130,37 +242,58 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
           </cf-vstack>
 
           <cf-vstack gap="2" padding="4">
-            {computed(() =>
-              sortedTopics.map((topic) => (
+            {computed(() => {
+              const list = asArray(topics.get());
+              const edges = crossrefEdges;
+              const order = list
+                .map((_, i) => i)
+                .filter((i) => list[i])
+                .toSorted((a, b) =>
+                  (list[b]?.lastActivityAt ?? 0) -
+                  (list[a]?.lastActivityAt ?? 0)
+                );
+              return order.map((i) => (
                 <cf-card>
                   <cf-hstack gap="3" align="center">
                     <cf-vstack gap="0" style="flex: 1; min-width: 0;">
                       <cf-text block style="font-weight: 600;">
-                        {topic.title || "(untitled topic)"}
+                        {list[i].title || "(untitled topic)"}
                       </cf-text>
-                      {topic.body
+                      {list[i].body
                         ? (
                           <cf-text tone="muted" block truncate>
-                            {snippet(topic.body, 120)}
+                            {snippet(list[i].body, 120)}
                           </cf-text>
                         )
                         : null}
                       <cf-text variant="caption" tone="muted">
-                        {topic.commentCount} comments · by{" "}
-                        {topic.createdByName || "someone"} ·{" "}
-                        {whenLabel(topic.lastActivityAt)}
+                        {list[i].commentCount} comments · by{" "}
+                        {list[i].createdByName || "someone"} ·{" "}
+                        {whenLabel(list[i].lastActivityAt)}
                       </cf-text>
+                      {crossrefChipRow(
+                        "references →",
+                        false,
+                        list,
+                        edges[i]?.refsOut ?? [],
+                      )}
+                      {crossrefChipRow(
+                        "← referenced by",
+                        true,
+                        list,
+                        edges[i]?.referencedBy ?? [],
+                      )}
                     </cf-vstack>
                     <cf-button
                       variant="secondary"
-                      onClick={openTopic({ topic })}
+                      onClick={openTopic({ topic: list[i] })}
                     >
                       Open
                     </cf-button>
                   </cf-hstack>
                 </cf-card>
-              ))
-            )}
+              ));
+            })}
 
             {hasNoTopics
               ? (
@@ -188,6 +321,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     topics,
     mentionable: topics,
     topicCount,
+    crossrefs,
     myName: myNameView,
     newTitle,
     addTopic,

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -3,9 +3,7 @@ import {
   computed,
   Default,
   entityRefToString,
-  handler,
   NAME,
-  navigateTo,
   pattern,
   type PerSession,
   type PerUser,
@@ -18,8 +16,10 @@ import {
 
 import Topic, {
   asArray,
+  crossrefChipRow,
   crossrefJoin,
   fidPayload,
+  openTopic,
   snippet,
   topicCorpus,
   type TopicPiece,
@@ -85,43 +85,10 @@ export interface TopicsOutput {
   submitTopic: Stream<void>;
 }
 
-/** Row navigation, bound per topic card. Module-scope handler (not an inline
- * closure) so embedders and tests can bind and drive it directly. */
-export const openTopic = handler<void, { topic: TopicPiece }>(
-  (_, { topic }) => {
-    navigateTo(topic);
-  },
-);
-
-/** One row of crossref chips ("references →" / "← referenced by"): each chip
- * names a sibling topic and navigates to it. Chips bind against direct
- * elements of the board's `topics` list — a handler bound to a piece nested
- * inside a derived wrapper object silently keeps the consuming UI computed
- * from ever running. Module-scope and pure so the single-runtime suite can
- * also drive the exact markup directly (pinning the no-edges → null branch)
- * alongside the real card path it renders via continuous UI demand. */
-export const crossrefChipRow = (
-  caption: string,
-  accent: boolean,
-  list: TopicPiece[],
-  indices: number[],
-) =>
-  indices.length === 0
-    ? null
-    : (
-      <cf-hstack gap="1" align="center" style="flex-wrap: wrap;">
-        <cf-text variant="caption" tone="muted">{caption}</cf-text>
-        {indices.map((j) => (
-          <cf-chip
-            label={snippet(list[j]?.title || "(untitled topic)", 40)}
-            size="xs"
-            color={accent ? "accent" : "neutral"}
-            interactive
-            oncf-click={openTopic({ topic: list[j] })}
-          />
-        ))}
-      </cf-hstack>
-    );
+// Navigation + chip-row live with the other shared pieces in topic.tsx (the
+// detail page renders the same chips); re-exported here so embedders and
+// tests keep importing them from the tracker.
+export { crossrefChipRow, openTopic } from "./topic.tsx";
 
 export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
   const newTitle = new Writable.perSession("");
@@ -134,6 +101,10 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
       createdAt: safeDateNow(),
       createdByName: (myName.get() ?? "").trim() || "someone",
       myName,
+      // The board's own list, so the detail page can derive its connections
+      // and the editor has a mention universe (backfilled as a one-time
+      // link-bind on pieces created before this input existed).
+      mentionable: topics,
     });
     // Mergeable append: concurrent creates from different users all land.
     topics.push(piece);

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -18,9 +18,10 @@ import {
 
 import Topic, {
   asArray,
-  extractFidPayloads,
+  crossrefJoin,
   fidPayload,
   snippet,
+  topicCorpus,
   type TopicPiece,
   TOPICS_THEME,
   whenLabel,
@@ -173,30 +174,15 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
       const ref = (topics.key(i) as any).resolveAsCell?.()?.entityId;
       return ref ? fidPayload(entityRefToString(ref)) : "";
     });
-    // Every fid payload each topic's prose mentions.
-    const mentions = list.map((t) => {
-      if (!t) return new Set<string>();
-      const parts = [t.body ?? ""];
-      for (const c of asArray(t.comments)) parts.push(c?.body ?? "");
-      for (const l of asArray(t.links)) parts.push(l?.url ?? "");
-      return new Set(extractFidPayloads(parts.join("\n")));
-    });
-    return list.map((t, i) => {
-      const refsOut: number[] = [];
-      const referencedBy: number[] = [];
-      if (t) {
-        for (let j = 0; j < list.length; j++) {
-          if (j === i || !list[j]) continue;
-          if (payloads[j] && mentions[i].has(payloads[j])) refsOut.push(j);
-          if (payloads[i] && mentions[j].has(payloads[i])) referencedBy.push(j);
-        }
-      }
-      return {
-        fid: payloads[i] ? `fid1:${payloads[i]}` : "",
-        refsOut,
-        referencedBy,
-      };
-    });
+    const { refsOut, referencedBy } = crossrefJoin(
+      list.map((t) => topicCorpus(t)),
+      payloads,
+    );
+    return list.map((_t, i) => ({
+      fid: payloads[i] ? `fid1:${payloads[i]}` : "",
+      refsOut: refsOut[i],
+      referencedBy: referencedBy[i],
+    }));
   });
 
   // Piece-valued view of the graph for consumers (tests, embedders, headless

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -2,11 +2,16 @@ import {
   action,
   computed,
   Default,
+  entityRefToString,
+  equals,
+  handler,
   NAME,
+  navigateTo,
   pattern,
   type PerSession,
   type PerUser,
   safeDateNow,
+  SELF,
   Stream,
   UI,
   type VNode,
@@ -46,6 +51,12 @@ export interface TopicInput {
    * own value on the same shared piece. The tracker passes its cell down so one
    * name covers the whole board. */
   myName?: PerUser<Writable<string | Default<"">>>;
+  /** The board's own topics list — the sibling set for this topic's derived
+   * crossrefs and the mention universe for authoring. A reference to the
+   * tracker's array, wired at creation like `myName` (and backfillable as a
+   * one-time link-bind on pieces created before it existed). Absent, the
+   * detail page simply derives no connections. */
+  mentionable?: Writable<TopicPiece[] | Default<[]>>;
 }
 
 /**
@@ -71,6 +82,10 @@ export interface TopicPiece {
   commentCount: number;
   /** Max of createdAt and the newest comment — the tracker sorts by this. */
   lastActivityAt: number;
+  /** This topic's own place in the board's prose graph, derived read-side
+   * from `mentionable` (indices into it, so chips can bind its direct
+   * elements). Both sets stay empty until `mentionable` is wired. */
+  crossrefs: { refsOut: number[]; referencedBy: number[] };
   addComment: Stream<{ body: string }>;
   addLink: Stream<{ kind: TopicLinkKind; url: string; label: string }>;
   setBody: Stream<{ body: string }>;
@@ -235,6 +250,45 @@ export const crossrefJoin = (
   return { refsOut, referencedBy };
 };
 
+/** Row navigation, bound per topic card and per crossref chip. Module-scope
+ * handler (not an inline closure) so embedders and tests can bind and drive
+ * it directly. */
+export const openTopic = handler<void, { topic: TopicPiece }>(
+  (_, { topic }) => {
+    navigateTo(topic);
+  },
+);
+
+/** One row of crossref chips ("references →" / "← referenced by"): each chip
+ * names a sibling topic and navigates to it. Chips bind against direct
+ * elements of a topics list — a handler bound to a piece nested inside a
+ * derived wrapper object silently keeps the consuming UI computed from ever
+ * running. Module-scope and pure so the single-runtime suite can also drive
+ * the exact markup directly (pinning the no-edges → null branch) alongside
+ * the real card path it renders via continuous UI demand. */
+export const crossrefChipRow = (
+  caption: string,
+  accent: boolean,
+  list: TopicPiece[],
+  indices: number[],
+) =>
+  indices.length === 0
+    ? null
+    : (
+      <cf-hstack gap="1" align="center" style="flex-wrap: wrap;">
+        <cf-text variant="caption" tone="muted">{caption}</cf-text>
+        {indices.map((j) => (
+          <cf-chip
+            label={snippet(list[j]?.title || "(untitled topic)", 40)}
+            size="xs"
+            color={accent ? "accent" : "neutral"}
+            interactive
+            oncf-click={openTopic({ topic: list[j] })}
+          />
+        ))}
+      </cf-hstack>
+    );
+
 const LINK_KIND_ITEMS = [
   { label: "Web", value: "web" },
   { label: "PR", value: "pr" },
@@ -245,7 +299,19 @@ const LINK_KIND_ITEMS = [
 // ===== The pattern =====
 
 export default pattern<TopicInput, TopicOutput>(
-  ({ title, body, comments, links, createdAt, createdByName, myName }) => {
+  (
+    {
+      title,
+      body,
+      comments,
+      links,
+      createdAt,
+      createdByName,
+      myName,
+      mentionable,
+      [SELF]: self,
+    },
+  ) => {
     // Session-local UI state (new-tab test: none of this should carry over).
     const commentDraft = new Writable.perSession("");
     const editingBody = new Writable.perSession(false);
@@ -344,6 +410,32 @@ export default pattern<TopicInput, TopicOutput>(
     );
 
     const linksView = computed(() => asArray(links.get()).filter((l) => l));
+
+    // This topic's own place in the board's prose graph, derived read-side
+    // from the mentionable siblings — the same join the board's cards use,
+    // reduced to this piece's row (identified via SELF). Nothing persisted;
+    // pre-rev pieces without `mentionable` simply derive empty sets.
+    const crossrefs = computed(() => {
+      const sibs = asArray(mentionable.get());
+      if (sibs.length === 0) return { refsOut: [], referencedBy: [] };
+      // Each sibling's own fid payload ("" while unresolved — such entries
+      // hold no edges this render). Cell-runtime surface cast, as in notes'
+      // appendLink.
+      const payloads = sibs.map((t, i) => {
+        if (!t) return "";
+        const ref = (mentionable.key(i) as any).resolveAsCell?.()?.entityId;
+        return ref ? fidPayload(entityRefToString(ref)) : "";
+      });
+      const joined = crossrefJoin(sibs.map((t) => topicCorpus(t)), payloads);
+      // Self-identification via SELF + equals: needs #4714's path-scoped
+      // wildcard fix — before it, the resolveAsCell chain above silently
+      // erased self's comparable marking and this computed never ran.
+      const me = sibs.findIndex((t) => t && equals(t, self));
+      return me < 0 ? { refsOut: [], referencedBy: [] } : {
+        refsOut: joined.refsOut[me],
+        referencedBy: joined.referencedBy[me],
+      };
+    });
 
     const hasLinks = computed(() => linksView.length > 0);
     const hasComments = computed(() => commentsView.length > 0);
@@ -479,6 +571,28 @@ export default pattern<TopicInput, TopicOutput>(
                 </cf-vstack>
               </cf-card>
 
+              {/* ── Connections (derived crossrefs; nothing persisted) ── */}
+              {computed(() => {
+                const sibs = asArray(mentionable.get());
+                const { refsOut, referencedBy } = crossrefs;
+                return refsOut.length === 0 && referencedBy.length === 0
+                  ? null
+                  : (
+                    <cf-card>
+                      <cf-vstack gap="2">
+                        <cf-heading level={5}>Connections</cf-heading>
+                        {crossrefChipRow("references →", false, sibs, refsOut)}
+                        {crossrefChipRow(
+                          "← referenced by",
+                          true,
+                          sibs,
+                          referencedBy,
+                        )}
+                      </cf-vstack>
+                    </cf-card>
+                  );
+              })}
+
               {/* ── The thread ── */}
               <cf-card>
                 <cf-vstack gap="2">
@@ -549,6 +663,7 @@ export default pattern<TopicInput, TopicOutput>(
       createdByName,
       commentCount,
       lastActivityAt,
+      crossrefs,
       addComment,
       addLink,
       setBody,

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -161,6 +161,30 @@ export const snippet = (text: string, max: number): string => {
 export const isSafeLinkUrl = (url: string): boolean =>
   /^https?:\/\//i.test((url ?? "").trim());
 
+/** Every fid payload referenced anywhere in `text`, in match order,
+ * duplicates included (callers dedupe as needed).
+ *
+ * Matches a fid in every shape people paste: bare `fid1:X`, storage-form
+ * `of:fid1:X`, page URLs `https://host/space/fid1:X`, and share links where
+ * the colon is percent-encoded (`fid1%3AX`). The base64url payload alone is
+ * the identity — hosts and prefixes around it vary, and base64url survives
+ * percent-encoding untouched. The length floor keeps prose that merely
+ * mentions "fid1" from matching (real payloads are 43 chars of hash). The
+ * regex lives inside the function: a module-scope `/g` RegExp is stateful
+ * and the closure verifier rejects it as captured data. */
+export const extractFidPayloads = (text: string): string[] => {
+  const fidInText = /fid1(?::|%3a)([A-Za-z0-9_-]{20,})/gi;
+  const out: string[] = [];
+  for (const m of (text ?? "").matchAll(fidInText)) out.push(m[1]);
+  return out;
+};
+
+/** The payload of a `fid1:…` tagged hash string; "" for anything else. */
+export const fidPayload = (fid: string): string => {
+  const m = /^fid1:([A-Za-z0-9_-]{20,})$/.exec((fid ?? "").trim());
+  return m ? m[1] : "";
+};
+
 const LINK_KIND_ITEMS = [
   { label: "Web", value: "web" },
   { label: "PR", value: "pr" },

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -185,6 +185,56 @@ export const fidPayload = (fid: string): string => {
   return m ? m[1] : "";
 };
 
+/** The prose surfaces of one topic that count as reference edges: the body,
+ * every comment body, and every link URL (the design's scan ∪ TopicLink).
+ * Structurally typed so pure tests can drive it with literals. */
+export const topicCorpus = (
+  t:
+    | {
+      body?: string;
+      comments?: readonly { body?: string }[];
+      links?: readonly { url?: string }[];
+    }
+    | undefined
+    | null,
+): string => {
+  if (!t) return "";
+  const parts = [t.body ?? ""];
+  for (const c of asArray(t.comments ?? [])) parts.push(c?.body ?? "");
+  for (const l of asArray(t.links ?? [])) parts.push(l?.url ?? "");
+  return parts.join("\n");
+};
+
+/** Join each corpus against the set of entry payloads: one shared
+ * payload→index map, one scan per text — the shape a second consumer (notes,
+ * when backlinks-index's write path retires) imports rather than forks.
+ * refsOut[i] lists, in first-mention order, the entries whose fids appear in
+ * corpus i; referencedBy is the inverse view (ascending by referrer).
+ * Self-references, repeat mentions, and payloads no entry owns all drop;
+ * "" payloads (unresolved entries) own nothing. */
+export const crossrefJoin = (
+  corpora: string[],
+  payloads: string[],
+): { refsOut: number[][]; referencedBy: number[][] } => {
+  const byPayload = new Map<string, number>();
+  payloads.forEach((p, i) => {
+    if (p) byPayload.set(p, i);
+  });
+  const refsOut: number[][] = corpora.map(() => []);
+  const referencedBy: number[][] = corpora.map(() => []);
+  corpora.forEach((text, i) => {
+    const seen = new Set<number>();
+    for (const p of extractFidPayloads(text)) {
+      const j = byPayload.get(p);
+      if (j === undefined || j === i || seen.has(j)) continue;
+      seen.add(j);
+      refsOut[i].push(j);
+      referencedBy[j].push(i);
+    }
+  });
+  return { refsOut, referencedBy };
+};
+
 const LINK_KIND_ITEMS = [
   { label: "Web", value: "web" },
   { label: "PR", value: "pr" },

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -478,10 +478,15 @@ export default pattern<TopicInput, TopicOutput>(
                   {editingBody
                     ? (
                       <cf-vstack gap="2">
-                        <cf-textarea
+                        <cf-code-editor
                           $value={bodyDraft}
-                          rows={12}
+                          $mentionable={mentionable}
+                          language="text/markdown"
+                          mode="prose"
+                          wordWrap
+                          tabIndent
                           placeholder="The topic's living document…"
+                          style="min-height: 12rem;"
                         />
                         <cf-hstack gap="2">
                           <cf-button variant="primary" onClick={saveBody}>
@@ -494,11 +499,7 @@ export default pattern<TopicInput, TopicOutput>(
                       </cf-vstack>
                     )
                     : hasBody
-                    ? (
-                      <cf-text block style="white-space: pre-wrap;">
-                        {body}
-                      </cf-text>
-                    )
+                    ? <cf-markdown content={body} />
                     : (
                       <cf-text tone="muted" block>
                         No body yet. The body is this topic's living document —

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -5,12 +5,24 @@
  * merge behavior): this file drives every exposed stream and derived value in
  * one runtime — action guards, authorship fallback ("someone" before a name
  * is set), the unsafe-scheme link rejection, label defaulting, body Edit→Save
- * via setBody, activity-based sorting, and the exported pure helpers.
+ * via setBody, activity-based sorting, the derived crossref graph (edges from
+ * fids pasted in bodies, comments, and link URLs; never persisted), and the
+ * exported pure helpers.
  */
 import { action, computed, NAME, UI } from "commonfabric";
 import { pattern } from "commonfabric";
-import Topics, { openTopic, type TopicPiece } from "./main.tsx";
-import Topic, { isSafeLinkUrl, snippet, whenLabel } from "./topic.tsx";
+import Topics, {
+  crossrefChipRow,
+  openTopic,
+  type TopicPiece,
+} from "./main.tsx";
+import Topic, {
+  extractFidPayloads,
+  fidPayload,
+  isSafeLinkUrl,
+  snippet,
+  whenLabel,
+} from "./topic.tsx";
 
 export default pattern(() => {
   const board = Topics({});
@@ -231,6 +243,124 @@ export default pattern(() => {
     isSafeLinkUrl("   ") === false
   );
 
+  // --- crossrefs: the derived prose reference graph ---
+
+  // Fid-free corpus: rows exist (one per topic, self-describing via `topic`),
+  // every fid is a real tagged hash, and no edges are claimed. Pins the
+  // fid1-tag assumption the prose scan relies on — if entity ids ever stop
+  // being fid1-tagged, this fails loudly instead of edges silently vanishing.
+  // Runs at the two-topic point: the edge that follows must exist while the
+  // harness still evaluates the board's card-list computed, so the chip
+  // branches render (and count as covered), not just the data layer.
+  const assert_crossrefs_baseline = computed(() =>
+    (board.crossrefs ?? []).length === 2 &&
+    board.crossrefs?.[0]?.fid?.startsWith("fid1:") === true &&
+    (board.crossrefs?.[0]?.fid ?? "").length > 25 &&
+    board.crossrefs?.[0]?.topic?.title === "First topic" &&
+    board.crossrefs?.[1]?.topic?.title === "Second topic" &&
+    (board.crossrefs?.[0]?.refsOut ?? []).length === 0 &&
+    (board.crossrefs?.[0]?.referencedBy ?? []).length === 0 &&
+    (board.crossrefs?.[1]?.refsOut ?? []).length === 0 &&
+    (board.crossrefs?.[1]?.referencedBy ?? []).length === 0
+  );
+
+  // A pasted page URL in a body creates the edge on both ends.
+  const action_body_ref_first = action(() => {
+    const fid = board.crossrefs?.[0]?.fid ?? "";
+    board.topics?.[1]?.setBody.send({
+      body: `relates to https://estuary.example/topics-dev/${fid} directly`,
+    });
+  });
+  const assert_body_edge = computed(() =>
+    (board.crossrefs?.[1]?.refsOut ?? []).length === 1 &&
+    board.crossrefs?.[1]?.refsOut?.[0]?.title === "First topic" &&
+    (board.crossrefs?.[0]?.referencedBy ?? []).length === 1 &&
+    board.crossrefs?.[0]?.referencedBy?.[0]?.title === "Second topic" &&
+    (board.crossrefs?.[0]?.refsOut ?? []).length === 0
+  );
+
+  // Drives the exact chip markup the card map emits, independent of UI
+  // demand timing: a populated row yields the hstack vnode — navigation
+  // binds included — and an edgeless row collapses to null so the card
+  // renders nothing for it. The real in-card path renders too: this suite
+  // exports [UI], so the harness demands the vdom continuously (#4715).
+  const assert_chip_row_markup = computed(() => {
+    const list = (board.topics ?? []) as TopicPiece[];
+    if (list.length < 2) return false;
+    const row = crossrefChipRow("references →", false, list, [0, 1]);
+    return row !== null &&
+      crossrefChipRow("← referenced by", true, list, []) === null;
+  });
+
+  // A share link in a comment counts too — its colon is percent-encoded.
+  const action_comment_ref_encoded = action(() => {
+    const enc = (board.crossrefs?.[0]?.fid ?? "").replace(":", "%3A");
+    board.topics?.[2]?.addComment.send({
+      body: `shared as ?shared-pattern=estuary%2Ftopics-dev%2F${enc}`,
+    });
+  });
+  const assert_comment_edge = computed(() =>
+    (board.crossrefs?.[2]?.refsOut ?? []).length === 1 &&
+    board.crossrefs?.[2]?.refsOut?.[0]?.title === "First topic" &&
+    (board.crossrefs?.[0]?.referencedBy ?? []).length === 2
+  );
+
+  // A structured link's URL is part of the corpus (scan ∪ TopicLink).
+  const action_link_ref_second = action(() => {
+    board.topics?.[2]?.addLink.send({
+      kind: "topic",
+      url: `https://estuary.example/topics-dev/${
+        board.crossrefs?.[1]?.fid ?? ""
+      }`,
+      label: "the second topic",
+    });
+  });
+  const assert_link_edge = computed(() =>
+    (board.crossrefs?.[2]?.refsOut ?? []).length === 2 &&
+    board.crossrefs?.[2]?.refsOut?.[1]?.title === "Second topic" &&
+    (board.crossrefs?.[1]?.referencedBy ?? []).length === 1 &&
+    board.crossrefs?.[1]?.referencedBy?.[0]?.title === "Composed topic"
+  );
+
+  // Mentioning yourself or a fid nothing on the board owns adds no edges.
+  const action_self_and_unknown_ref = action(() => {
+    const own = board.crossrefs?.[0]?.fid ?? "";
+    board.topics?.[0]?.setBody.send({
+      body: `self ${own} and unknown fid1:${"Z".repeat(43)} stay edgeless`,
+    });
+  });
+  const assert_self_unknown_ignored = computed(() =>
+    (board.crossrefs?.[0]?.refsOut ?? []).length === 0 &&
+    (board.crossrefs?.[0]?.referencedBy ?? []).length === 2
+  );
+
+  // Nothing is persisted: retract the prose and the edge is simply gone.
+  const action_remove_body_ref = action(() => {
+    board.topics?.[1]?.setBody.send({ body: "no references anymore" });
+  });
+  const assert_edge_removed = computed(() =>
+    (board.crossrefs?.[1]?.refsOut ?? []).length === 0 &&
+    (board.crossrefs?.[0]?.referencedBy ?? []).length === 1 &&
+    board.crossrefs?.[0]?.referencedBy?.[0]?.title === "Composed topic"
+  );
+
+  // The fid-scanning helpers, over every pasted shape (bare, of:-prefixed,
+  // percent-encoded) plus the non-matches (short payloads, non-fid hashes).
+  const P1 = "A".repeat(43);
+  const P2 = "B".repeat(43);
+  const assert_crossref_helpers = computed(() =>
+    extractFidPayloads(
+        `a fid1:${P1} b of:fid1:${P2} c fid1%3A${P1}`,
+      ).join(",") === `${P1},${P2},${P1}` &&
+    extractFidPayloads("no fids here, not even fid1:tooshort").length === 0 &&
+    extractFidPayloads("").length === 0 &&
+    fidPayload(`fid1:${P1}`) === P1 &&
+    fidPayload(` fid1:${P1} `) === P1 &&
+    fidPayload("of:fid1:" + P1) === "" &&
+    fidPayload("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy") === "" &&
+    fidPayload("") === ""
+  );
+
   return {
     [UI]: board[UI],
     tests: [
@@ -255,6 +385,10 @@ export default pattern(() => {
       { assertion: assert_link_added },
       { action: action_add_second_topic },
       { assertion: assert_second_topic },
+      { assertion: assert_crossrefs_baseline },
+      { action: action_body_ref_first },
+      { assertion: assert_body_edge },
+      { assertion: assert_chip_row_markup },
       { action: action_comment_first_again },
       { action: action_submit_topic_via_composer },
       { assertion: assert_composed_topic },
@@ -277,6 +411,15 @@ export default pattern(() => {
       { assertion: assert_link_draft_flow },
       { action: action_open_topic },
       { assertion: assert_pure_helpers },
+      { action: action_comment_ref_encoded },
+      { assertion: assert_comment_edge },
+      { action: action_link_ref_second },
+      { assertion: assert_link_edge },
+      { action: action_self_and_unknown_ref },
+      { assertion: assert_self_unknown_ignored },
+      { action: action_remove_body_ref },
+      { assertion: assert_edge_removed },
+      { assertion: assert_crossref_helpers },
     ],
   };
 });

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -17,10 +17,12 @@ import Topics, {
   type TopicPiece,
 } from "./main.tsx";
 import Topic, {
+  crossrefJoin,
   extractFidPayloads,
   fidPayload,
   isSafeLinkUrl,
   snippet,
+  topicCorpus,
   whenLabel,
 } from "./topic.tsx";
 
@@ -361,6 +363,36 @@ export default pattern(() => {
     fidPayload("") === ""
   );
 
+  // The shared join (the piece notes imports when backlinks-index's write
+  // path retires): one payload→entry map, one scan per corpus. First-mention
+  // order out, ascending referrers in; repeats, self-mentions, and payloads
+  // no entry owns all drop.
+  const assert_crossref_join = computed(() => {
+    const P3 = "C".repeat(43);
+    const joined = crossrefJoin(
+      [
+        `self fid1:${P1} then fid1:${P2}`,
+        "",
+        `fid1:${P2} twice fid1:${P2} then fid1:${P1} unknown fid1:${
+          "Z".repeat(43)
+        }`,
+      ],
+      [P1, P2, P3],
+    );
+    return joined.refsOut[0].join(",") === "1" &&
+      joined.refsOut[1].join(",") === "" &&
+      joined.refsOut[2].join(",") === "1,0" &&
+      joined.referencedBy[0].join(",") === "2" &&
+      joined.referencedBy[1].join(",") === "0,2" &&
+      joined.referencedBy[2].join(",") === "" &&
+      topicCorpus({
+          body: "b",
+          comments: [{ body: "c" }],
+          links: [{ url: "u" }],
+        }) === "b\nc\nu" &&
+      topicCorpus(undefined) === "";
+  });
+
   return {
     [UI]: board[UI],
     tests: [
@@ -420,6 +452,7 @@ export default pattern(() => {
       { action: action_remove_body_ref },
       { assertion: assert_edge_removed },
       { assertion: assert_crossref_helpers },
+      { assertion: assert_crossref_join },
     ],
   };
 });

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -36,6 +36,10 @@ export default pattern(() => {
     body: "line one\nline two",
   });
 
+  // Branch pin for the detail derive: a piece with no `mentionable` wired
+  // (the pre-rev corpus, until backfilled) derives empty connection sets.
+  const lone = Topic({ title: "Lone", createdAt: 1, createdByName: "t" });
+
   // --- actions ---
 
   const action_add_blank_topic = action(() => {
@@ -281,6 +285,22 @@ export default pattern(() => {
     (board.crossrefs?.[0]?.refsOut ?? []).length === 0
   );
 
+  // Detail-page view of the same edge: each board-created topic derives its
+  // own row from the mentionable siblings wired at creation (indices into
+  // `mentionable` = the board's own list), while a piece with no mentionable
+  // derives empty sets.
+  const assert_detail_edges = computed(() => {
+    return (board.topics?.[1]?.crossrefs?.refsOut ?? []).join(",") === "0" &&
+      (board.topics?.[1]?.crossrefs?.referencedBy ?? []).length === 0 &&
+      (board.topics?.[0]?.crossrefs?.referencedBy ?? []).join(",") === "1" &&
+      (board.topics?.[0]?.crossrefs?.refsOut ?? []).length === 0;
+  });
+
+  const assert_lone_edgeless = computed(() => {
+    return (lone.crossrefs?.refsOut ?? []).length === 0 &&
+      (lone.crossrefs?.referencedBy ?? []).length === 0;
+  });
+
   // Drives the exact chip markup the card map emits, independent of UI
   // demand timing: a populated row yields the hstack vnode — navigation
   // binds included — and an edgeless row collapses to null so the card
@@ -394,6 +414,11 @@ export default pattern(() => {
   });
 
   return {
+    // Continuous UI demand (#4715) over the board: its card list — including
+    // the in-card crossref chip rows — renders through the real reconciler
+    // while the suite runs. A board list element is the shared-safe
+    // TopicPiece projection and exposes no [UI]; the topic detail page is
+    // driven directly through the `render` steps below.
     [UI]: board[UI],
     tests: [
       { assertion: assert_initial },
@@ -420,6 +445,8 @@ export default pattern(() => {
       { assertion: assert_crossrefs_baseline },
       { action: action_body_ref_first },
       { assertion: assert_body_edge },
+      { assertion: assert_detail_edges },
+      { assertion: assert_lone_edgeless },
       { assertion: assert_chip_row_markup },
       { action: action_comment_first_again },
       { action: action_submit_topic_via_composer },


### PR DESCRIPTION
> **Rev complete (2026-07-15)** — this PR now carries the full future-oriented scope agreed in review: four commits, each independently gated. ① v1 board chips + `crossrefs` output · ② shared `crossrefJoin`/`topicCorpus` helpers (tier 3 extractable, notes-ready) · ③ `mentionable` input + detail-page **Connections** card (tier 2 — the cells-durable/bundles-swappable model exercised in-PR; needs the merged #4714) · ④ cf-code-editor authoring with `@`-mentions bound to the session-local draft + markdown read view (tier 1). Suites 30/30 + 11/11; pattern coverage 196/196 + 511/511 (zero uncovered, matching baseline).

## What

The Topics board now derives the corpus's **prose reference graph** and renders it: any topic fid pasted in a body, comment, or link URL — bare `fid1:X`, `of:fid1:X`, page URL, or percent-encoded share link — becomes a navigable "references →" / "← referenced by" chip on the topic's card. The graph is also exported as the piece-valued `crossrefs` output for tests, embedders, and headless reads.

Design record: the ["Topic cross-references" topic](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:lfKX1c9GdWRHtQxdEbPELXT-eMDCftlxtbv1XzXitvQ) on topics-dev (the board is its own design doc — this PR implements that body's v1 sketch).

## Design commitments

- **Derived at read time, never persisted.** The notes/mentions prior art (`backlinks-index.tsx`) wipes-and-rewrites `backlinks[]` into target pieces — a partial-view replica running that destroys real edges. Here the board rescans the whole corpus per render (`O(topics × text)`, trivial at board scale), the entire existing corpus lights up retroactively with zero authoring changes, and a retracted mention simply stops being an edge.
- **Identity = fid payload.** `topics.key(i).resolveAsCell().entityId` → `entityRefToString` (the notes-pattern idiom) gives each entry's result-doc fid; prose is scanned for payloads so URL-encoding and host variance don't matter. The fid1-tag assumption is pinned by a test that fails loudly if entity ids stop being fid1-tagged.
- **v1 scope: board cards only.** Detail-page chips would need either a topic-schema change (siblings input) or a board-hosted detail view — both violate the "no schema change, no migration" constraint that makes the corpus light up retroactively. Deferred; noted in the topic.

## Platform finding (cost most of the build time)

**A handler bound to a piece reference nested inside a derived wrapper object silently prevents the consuming UI computed from ever running.** First implementation derived `rows: {topic, refsOut: TopicPiece[], …}[]` and bound `openTopic({topic: row.topic})` — the card-list computed never executed once (no error anywhere; reads through the same wrappers work fine, only binds break). Minimal repro: derive any wrapper array carrying pieces, bind a handler to a nested piece inside the consuming computed's JSX. The shipped shape dissolves it: edges are index arrays over raw `topics` order, and every bind targets a direct `topics` element (`openTopic({topic: list[j]})`) — baseline provenance. **Root-caused and fixed in #4714 (merged)** for the identity-erasure mechanism — the detail-page Connections derive in this PR is its first consumer. The wrapper-bind shape remains a distinct open mechanism (same board topic), so the index-plumbed board core stays quarantined until it falls; the collapse to one piece-valued derive remains the tracked revisit.

Secondary observation — **resolved while this PR was open**: cf-test used to materialize `[UI]` only in narrow windows ([topic](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:biRPdv6-A4QZiP7i_8W0LhfOe3VJzFYhKolzLd60yd0)); #4715 added explicit `{ render: … }` steps and continuous `$UI` demand, and this suite exports `[UI]` so the real in-card chip path now renders under test. The chip row stays a module-scope pure helper (`crossrefChipRow`) driven directly as well — it pins the no-edges → null branch deterministically. Pattern coverage: 0 uncovered lines for both files post-rebase (`CF_PATTERN_COVERAGE_DIR` DA-union, matching baseline's 0).

## Verification

- `topics.test.tsx` 30/30 (was 19) — fid form pinned, edges from all four pasted URL shapes, inversion, self/unknown-fid exclusion, edge removal on prose retraction, chip-row markup incl. binds and empty-collapse. `multi-user.test.tsx` 11/11. fmt/lint/cf-check + full workspace `deno task check` green.
- **Rebased onto main past #4696 (fresh-replica pulls), #4668 (outage fixes), #4708 (combineSchema), #4715 (test UI demand), and #4746 (restore strict required link validation)** — all gates re-run green at the new base. #4746 split `TopicPiece` (the shared-safe list projection: no `[UI]`, session drafts now `PerSession`) from `TopicOutput`; this PR's `mentionable?: Writable<TopicPiece[]>` and read-derived edges sit cleanly on that split (no required link points at an unresolved target). The one reconcile: the single-runtime suite drove the second topic's **detail** `[UI]` off a board-list element — no longer typed to carry `[UI]` post-#4746 — so it now demands the board's own `[UI]` continuously; the detail page is exercised via the `render` steps, and pattern coverage stays 511/511 + 196/196 (zero uncovered).
- **Live done-test on estuary** (throwaway space `topics-crossref-probe-586d71c1`, board `fid1:ENn_1uhOms8HPChKajsiJAvpcPWvm1UlLhHZnJWxtdk`): three topics seeded via CLI, alpha's page URL pasted into beta's body via `setBody` — on next board render beta's card shows "references → [Probe alpha]", alpha's card shows "← referenced by [Probe beta]", the bystander card stays clean, and clicking the chip navigates to alpha's page. Data layer holds only the body text (nothing persisted).

## Notes

- `README.md` also corrects the headless runbook: `cf piece step` from fresh CLI replicas is now explicitly warned against (broken-view steps persist polluted deriveds — the board's own post-outage protocol).
- a11y gap surfaced during verification: interactive `cf-chip` doesn't appear in the accessibility tree as actionable (bare `<div @click>` — no role/tabindex/keys) — [filed on the board](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:mUqF2J4YfEZsQ-2RymsJs0r8T7DN2pKfj57TJH8DZw8). **Fix landed in #4704 (merged 2026-07-14)**; worth a follow-up confirmation that the chip is now keyboard-actionable.
- Self-review note: an `openTopic` dangling-ref guard was attempted and deliberately reverted. Probing showed a dangling bound reference arrives as a **truthy proxy reading schema defaults** (it navigates as "(unnamed)"), and any discriminating read inside the handler trips the runner's error log (console-gated in CI). Per-pattern guarding fights the layer — the protection belongs in `navigateTo`/runner dangling-ref semantics; deferred until topic removal makes it reachable from real UI. Repro of the bind bug itself: #4714.
- Deploy (held for post-merge, per the shared-surface norm) = the instrumented tier-2 experiment: `setsrc` board **and** each topic sub-piece (topic.tsx now carries the detail card + editor), then the one-time `mentionable` link-bind backfill across the existing corpus, with before/after verification reported here.

## Perf baseline — accepted regressions

The two topics pattern-unit subtests grew because this PR adds the crossref-graph test surface (fid-form pin, four pasted-URL shapes, inversion, self/unknown-fid exclusion, edge removal, chip-row markup) on top of #4746's `directTopic`/`lone` instances — more Topic instantiations and assertions, so the suites legitimately do more work. The regression is **stable across two independent CI runs** (`topics.test.tsx` +141% then +57%; `multi-user.test.tsx` +76% then +72%) and **coverage debt is net-0**. Accepting the new baselines (the designed single-metric mechanism, not a blanket reset):

NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/topics/topics.test.tsx = 14s
NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/topics/multi-user.test.tsx = 16s

The two `CLI Integration Tests (core / core-piece-values)` regressions on the latest run — both spiking to an *identical* 3m32s from ~57s/1m8s, and both **OK on the prior run** — are shared-runner contention, unrelated to this patterns-only change; deliberately **not** overridden, cleared by re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds navigable cross‑reference chips to topic cards and a Connections section on topic pages by deriving a read‑only prose reference graph from the board. Also switches body authoring to `cf-code-editor` with `@`‑mentions and renders bodies as markdown.

- **New Features**
  - Scans bodies, comments, and link URLs for sibling topic fids (bare `fid1:X`, `of:fid1:X`, page URLs, percent‑encoded links).
  - Renders “references →” and “← referenced by” chips on cards; chips navigate to the target topic. Topic detail pages show the same as a Connections card.
  - Adds optional `mentionable` input (board’s topics) for detail‑page derives and `@`‑mention autocomplete; backfillable for existing pieces.
  - Exposes `crossrefs: TopicCrossref[]` on `TopicsOutput` (`fid`, `topic`, `refsOut`, `referencedBy`) — derived at read time only.

- **Refactors**
  - Extracts shared helpers: `topicCorpus`, `crossrefJoin`, `extractFidPayloads`, `fidPayload`, and a pure `crossrefChipRow`; `openTopic`/`crossrefChipRow` live in `topic.tsx` and are re‑exported.
  - Computes edges as indices over raw `topics` and binds handlers to direct `topics` elements to avoid wrapper‑bind UI deadlocks.
  - Replaces the body textarea with `cf-code-editor` using `mentionable` for `@`‑mentions; read view uses `cf-markdown`. Docs updated to warn that headless replicas should not persist derived views.

<sup>Written for commit 42b23e24d802ba99c95f6e81a3a67abfb465c82a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


