### PR TITLE
docs: record durable findings in the repo (sandbox, CI compile-bound,…

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -51,6 +51,11 @@ failure by itself.
 Good CI optimization PRs should reduce critical-path wall time without making
 the workflow harder to reason about.
 
+For the pattern-integration job specifically, the time is dominated by
+per-pattern CFC compile, not by storage or sync — see
+[the profiling snapshot](../history/development/performance/pattern-integration-compile-bound.md)
+before optimizing there.
+
 ## Pulling Timing Data
 
 The labs repository is public, so the GitHub Actions REST API returns run, job,

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -191,6 +191,13 @@ Used by `/routes/sandbox/exec` to execute untrusted pattern code.
 | `SANDBOX_SERVICE_URL` | `https://sandbox.stage.commontools.dev` | External sandbox executor. |
 | `SANDBOX_TOOLSHED_URL` | _(falls back to `API_URL`)_ | URL injected into sandboxes as `CF_API_URL` so they can call back to this toolshed. |
 
+The executor itself is not in this repo; the toolshed only forwards to
+`SANDBOX_SERVICE_URL`. The service is `commontoolsinc/common-cluster` (Go): its
+`node-agent` serves `/v1/sandboxes` and runs each sandbox as a gVisor container
+on a per-node ZFS dataset. The `runsc` runtime and `sandboxexec` library come
+from `commontoolsinc/gvisor` (branch `cfc_v2`), and the cluster is provisioned by
+`commontoolsinc/infra` (Terraform).
+
 ---
 
 ## OpenTelemetry

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -156,9 +156,10 @@ One line per archived document; each document's header carries the fuller
 
 - [settle-wave-2026-03-findings.md](development/debugging/settle-wave-2026-03-findings.md)
   — March 2026 settle-wave measurements.
-- [default-app-note-create.md](development/performance/default-app-note-create.md)
+- [default-app-note-create.md](development/performance/default-app-note-create.md),
+  [two-browsers-cold-start.md](development/performance/two-browsers-cold-start.md),
   and
-  [two-browsers-cold-start.md](development/performance/two-browsers-cold-start.md)
+  [pattern-integration-compile-bound.md](development/performance/pattern-integration-compile-bound.md)
   — June 2026 profiling snapshots.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.

--- a/docs/history/development/performance/pattern-integration-compile-bound.md
+++ b/docs/history/development/performance/pattern-integration-compile-bound.md
@@ -1,0 +1,53 @@
+---
+status: historical
+created: 2026-07-11
+archived: 2026-07-11
+reason: "Profiling snapshot of the pattern-integration CI job, measured June 2026."
+---
+
+# Pattern-integration CI: the long pole is compile, not sync
+
+An investigation, for the [Performance Program](../../../development/PERFORMANCE_PROGRAM.md) and
+the [CI Performance Policy](../../../development/CI_PERFORMANCE.md), into where the wall time goes
+in the "Deno Workflow" pattern-integration job. That job is the usual CI
+critical-path long pole, and its time is dominated by **per-pattern CFC
+compile**, not by storage, networking, or sync.
+
+## What was measured
+
+Profiled June 2026 (one shard was about 228 seconds end to end):
+
+- **Compiling the patterns is the bulk of it.** "Compile all patterns"
+  (`all.test.ts`) was about 90 seconds, and a few patterns dominated that:
+  `record.tsx` and `record-backup.tsx` each took roughly 29 seconds on their
+  own.
+- **Within one pattern compile,** parsing and binding (`createProgram`) is
+  tiny, type-checking is about a quarter, and emit-plus-transform is about
+  two-thirds. Emit-plus-transform is TypeScript running the CF transformer
+  pipeline. About half of that is TypeScript's own checker answering type
+  queries that the transformers make; the rest is spread across roughly six
+  transformers, with the JSX expression-site router the largest. There is no
+  single removable hot spot.
+- **Instantiating a pattern against a live toolshed** (`cc.create`) is itself
+  about 65% compile. Storage was about 63ms, memory about 3ms, and SES about
+  79ms — sync and storage are not the bottleneck.
+
+## What was ruled out as a win
+
+- Caching the lib `.d.ts` parse (about 18ms).
+- `noCheck` (about 8ms once warm).
+- Sharing one dataflow analyzer across the transformers. This is unsafe: each
+  transformer's rewrites invalidate the analysis, so sharing it would break a
+  correctness contract.
+
+## What this means for future work
+
+CI performance work on this job should target the compiler and transformer
+pipeline, or remove redundant compiles, rather than the storage, memory, or sync
+layers. The same compile path is shared by the runner tests, the pattern unit
+tests, `cf check`, and the generated-patterns suite, so a single improvement
+there helps all of them.
+
+Measurement caveat: a local developer machine is roughly ten times faster than
+the CI Ubuntu runners, so reproduce the relative cost structure between phases
+rather than the absolute times.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1964,11 +1964,14 @@ export class CellImpl<T extends FabricValue>
    * and a present-but-undefined read cannot tell a still-loading cell from a
    * settled-empty one, so neither works as a synchronous pending check.
    *
-   * A deferred `sync().then(...)` chain is invisible to `Cell.pull()` and the
-   * scheduler's `idle()` until it is registered, so a convergence waiter can
-   * return before the chain settles and read held, not-yet-loaded state. Wrap
-   * such a chain in `storageManager.trackUntilSettled` to have those waiters
-   * await it.
+   * A deferred `sync().then(...)` chain is not awaited by `Cell.pull()` until it
+   * is registered in the storage manager's cross-space promise set; before that,
+   * a pull can return while the chain is still in flight and read held,
+   * not-yet-loaded state. Register it with `storageManager.trackUntilSettled` so
+   * `Cell.pull()` and `storageManager.synced()` await it. The scheduler's
+   * `idle()` waits for reactive quiescence only, not that set, so it does not
+   * await such a chain even when registered — code gating on `idle()` alone can
+   * still race the deferred sync.
    */
   sync(): Promise<Cell<T>> {
     this.synced = true;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1956,6 +1956,20 @@ export class CellImpl<T extends FabricValue>
     }
   }
 
+  /**
+   * Load this cell's backing doc, returning a promise that resolves once the
+   * doc is confirmed: either its value has arrived or it is confirmed absent.
+   * The return is always a promise (`syncCell` is async), so awaiting it is the
+   * only way it reports pending. `sync() instanceof Promise` is constant-true,
+   * and a present-but-undefined read cannot tell a still-loading cell from a
+   * settled-empty one, so neither works as a synchronous pending check.
+   *
+   * A deferred `sync().then(...)` chain is invisible to `Cell.pull()` and the
+   * scheduler's `idle()` until it is registered, so a convergence waiter can
+   * return before the chain settles and read held, not-yet-loaded state. Wrap
+   * such a chain in `storageManager.trackUntilSettled` to have those waiters
+   * await it.
+   */
   sync(): Promise<Cell<T>> {
     this.synced = true;
     logger.info("sync", this.link);

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -213,17 +213,19 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
 
   /**
    * Register a deferred async chain in the cross-space promise set so
-   * `Cell.pull()` and the scheduler's `idle()` await it, then drop it from the
-   * set once it settles. Until a chain is registered it is invisible to the
-   * convergence waiters: a pull can return before the chain has settled and
-   * observe held, not-yet-loaded state. This is the safe composition of
-   * `addCrossSpacePromise` and `removeCrossSpacePromise` — prefer it over
-   * wiring the self-removing `finally` by hand at each call site.
+   * `Cell.pull()` and `synced()` await it, then drop it from the set once it
+   * settles. Until a chain is registered it is invisible to those waiters: a
+   * pull can return before the chain has settled and observe held,
+   * not-yet-loaded state. The scheduler's `idle()` does not consult this set at
+   * all, so registering a chain does not make `idle()` await it. This is the
+   * safe composition of `addCrossSpacePromise` and `removeCrossSpacePromise` —
+   * prefer it over wiring the self-removing `finally` by hand at each call site.
    *
    * `work` must eventually settle (resolve or reject). A chain that never
-   * settles stays registered and keeps `Cell.pull()`/`idle()` from observing
-   * convergence until the scheduler's convergence bound trips, so a caller that
-   * wraps an external `sync()` should ensure it cannot hang unbounded.
+   * settles stays registered and keeps `Cell.pull()` and `synced()` from
+   * observing convergence — `Cell.pull()` escapes only at its bounded round cap
+   * — so a caller that wraps an external `sync()` should ensure it cannot hang
+   * unbounded.
    */
   trackUntilSettled(work: Promise<unknown>): void;
 


### PR DESCRIPTION
… cell.sync)

Move three findings that were living outside the repository into the docs and code where they belong, each not derivable from the source alone:

- runner: document that Cell.sync() always returns a promise and is therefore an async confirmation, not a synchronous pending signal. Neither `sync() instanceof Promise` nor a present-but-undefined read distinguishes a loading cell from a settled-empty one. Also note that a deferred sync().then(...) chain is invisible to the convergence waiters (Cell.pull() and the scheduler's idle()) until it is registered, and point at storageManager.trackUntilSettled for that case.

- config: record where the external sandbox executor actually lives. The Sandbox service section named SANDBOX_SERVICE_URL as an external executor but not that the service is commontoolsinc/common-cluster (a Go node-agent running each sandbox as a gVisor container on a per-node ZFS dataset), with the runsc runtime and sandboxexec library from commontoolsinc/gvisor and the cluster provisioned by commontoolsinc/infra.

- perf: add a profiling field note that the pattern-integration CI job is dominated by per-pattern CFC compile, not storage or sync, so optimization work there should target the compiler and transformer pipeline. Filed under docs/history following the documentation-reorg convention for point-in-time profiling snapshots, indexed in docs/history/README.md, and linked from the CI performance policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document three durable findings: `Cell.sync()` is async-only and `idle()` never waits on deferred sync chains; the sandbox executor runs in external repos; and the pattern‑integration CI job is compile‑bound.

- **Documentation**
  - Runner: Add JSDoc that `Cell.sync()` always returns a Promise; neither `sync() instanceof Promise` nor an undefined read can detect loading. A deferred `sync().then(...)` is ignored until registered; use `storageManager.trackUntilSettled`. Registered chains are awaited by `Cell.pull()` and `storageManager.synced()`, not by the scheduler’s `idle()` (which can still race). Update `IStorageManager.trackUntilSettled` docs to state the guarantee is for `pull()`/`synced()` only.
  - Sandbox: Clarify that `SANDBOX_SERVICE_URL` forwards to an external executor in `commontoolsinc/common-cluster`; uses `runsc`/`sandboxexec` from `commontoolsinc/gvisor` (branch `cfc_v2`); infra is `commontoolsinc/infra`.
  - CI perf: Add a snapshot showing the pattern‑integration job is dominated by per‑pattern CFC compile, not storage or sync; link it from the CI performance policy and index it in history.

<sup>Written for commit 8f8683e53a4cfab59a29795ecfc9f23063bbd7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

