### PR TITLE
feat(integration): record browser tests as video demos

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -52,6 +52,7 @@
     "install-hooks": "./scripts/install-git-hooks.sh",
     "initialize-db": "deno run --allow-env --allow-read --allow-write --allow-ffi --allow-net=github.com,release-assets.githubusercontent.com,jsr.io packages/memory/scripts/initialize-db.ts",
     "integration": "./tasks/integration.ts",
+    "demo": "./tasks/demo.ts",
     "profile": "./scripts/restart-local-dev.sh --inspect-brk",
     "cf-profile": "ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && deno run -A \"$ROOT/packages/cli/support/profiling/cf-profile.ts\"",
     "cf-inspect-brk": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -86,6 +86,41 @@ Deno.exit(0);
 
 When adding runtime features, consider adding integration tests to `packages/runner/integration/` that verify the feature works end-to-end. See existing tests like `basic-persistence.test.ts` or `array_push.test.ts` for examples.
 
+### Recording browser integration tests as video demos
+
+Selected `patterns` and `shell` browser integration tests can be recorded with
+the same local servers, browser identities, UI events, waits, assertions, and
+cleanup used by the normal integration suite:
+
+```bash
+deno task demo patterns cfc-render-policy-demo
+deno task demo patterns lunch-poll-vote --output=tmp/demos/lunch-poll.mp4
+```
+
+The file filter must resolve to exactly one `*.test.ts` file. The command runs
+that complete file because its `it` blocks may share suite setup and browser
+state. It writes an MP4 and a versioned diagnostic manifest beneath
+`tmp/demos/`; `--output=PATH` copies the final MP4 to a chosen location.
+
+FFmpeg must be installed and available as `ffmpeg`, or its path must be set in
+`FFMPEG`. Normal integration tests do not require FFmpeg. Useful options are
+`--keep-frames`, `--viewport=WIDTHxHEIGHT`, and `--port-offset=N`.
+
+Presentation mode modifies the existing browser interaction paths rather than
+using demo-only clicks or typing. Inputs type with a readable character delay,
+clicks show an injected cursor, and labeled scenario steps appear as captions.
+All presentation behavior is disabled during `deno task integration`.
+
+Tests with multiple `ShellIntegration` instances retain their independent
+browsers and identities. Each page is recorded against one shared timeline and
+the streams are composed afterward: two participants are side by side, while
+three or four use a 2-by-2 grid. Configure stable labels and colors through the
+shell's `presentation` metadata.
+
+If a test, browser capture, or FFmpeg encode fails, the command exits nonzero
+and retains its manifest and available intermediate streams under the printed
+run directory.
+
 ## Related documentation
 
 - [waitfor-migration.md](waitfor-migration.md) — waiting in tests: prefer

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -99,8 +99,9 @@ deno task demo patterns lunch-poll-vote --output=tmp/demos/lunch-poll.mp4
 
 The file filter must resolve to exactly one `*.test.ts` file. The command runs
 that complete file because its `it` blocks may share suite setup and browser
-state. It writes an MP4 and a versioned diagnostic manifest beneath
-`tmp/demos/`; `--output=PATH` copies the final MP4 to a chosen location.
+state. It writes a test-named MP4 (for example, `lunch-poll-vote.mp4`) and a
+versioned diagnostic manifest beneath `tmp/demos/`; `--output=PATH` copies the
+final MP4 to a chosen location.
 
 FFmpeg must be installed and available as `ffmpeg`, or its path must be set in
 `FFMPEG`. Normal integration tests do not require FFmpeg. Useful options are

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -94,14 +94,20 @@ cleanup used by the normal integration suite:
 
 ```bash
 deno task demo patterns cfc-render-policy-demo
+deno task demo patterns cfc-render-policy-demo lunch-poll-vote
 deno task demo patterns lunch-poll-vote --output=tmp/demos/lunch-poll.mp4
 ```
 
-The file filter must resolve to exactly one `*.test.ts` file. The command runs
-that complete file because its `it` blocks may share suite setup and browser
-state. It writes a test-named MP4 (for example, `lunch-poll-vote.mp4`) and a
-versioned diagnostic manifest beneath `tmp/demos/`; `--output=PATH` copies the
-final MP4 to a chosen location.
+Each file filter must resolve to exactly one `*.test.ts` file. The command runs
+each complete file sequentially because its `it` blocks may share suite setup
+and browser state. Every invocation writes an `index.html` video gallery beside
+the test-named MP4s and versioned diagnostic manifests beneath `tmp/demos/`.
+The gallery uses relative links, so its complete directory can be copied or
+served as-is.
+
+With one filter, `--output=PATH` copies the final MP4 to a chosen file. With
+multiple filters, `--output=DIRECTORY` copies the named MP4s and a portable
+`index.html` gallery into that directory.
 
 FFmpeg must be installed and available as `ffmpeg`, or its path must be set in
 `FFMPEG`. Normal integration tests do not require FFmpeg. Useful options are

--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -307,6 +307,49 @@ file by hand, point it at the compiled binary (`deno task build-binaries`, then
 
 Example: `PIPE_CONSOLE=1 deno task integration`
 
+## Presentation mode and video demos
+
+`deno task demo` enables an opt-in presentation layer around the existing
+browser integration stack. It does not define `demo.click()` or `demo.type()`:
+the same `fillCfInput`, `clickCfButton`, trusted-action, and Astral element
+operations used by the test remain responsible for the interaction.
+
+In presentation mode, those paths may add human-readable typing delay, cursor
+travel, a click pulse, participant labels, and captions. With presentation mode
+off they retain their normal fast behavior. Direct interaction forms used by a
+new demo should be checked against the shared presentation hooks; prefer the
+existing higher-level helpers where they already encode the correct settle,
+single-action, commit, and effect-wait behavior.
+
+Presentation timing is not correctness timing. Continue to settle the view and
+wait for the specific state or DOM effect event-drivenly. A caption hold may
+begin only after that effect has arrived, and it resolves immediately outside
+presentation mode. Never add `sleep`, `waitForTimeout`, or a longer correctness
+timeout merely to pace a video.
+
+Use `StepTimer.run(label, action)` for a viewer-readable scenario boundary when
+the test already benefits from step timing. During a demo it records the step
+on the shared timeline and shows the label on every active participant; during
+a normal test it only records the existing timing row. Labels should tell the
+viewer what changed, not expose implementation diagnostics or protected values
+before the UI legitimately reveals them.
+
+For multi-user demos, attach stable participant metadata without changing the
+identity or browser topology:
+
+```text
+const alice = new ShellIntegration({
+  presentation: { id: "alice", label: "Alice", color: "#7c3aed" },
+});
+const bob = new ShellIntegration({
+  presentation: { id: "bob", label: "Bob", color: "#0891b2" },
+});
+```
+
+Each shell still launches its own browser. Recording and composition happen
+around the test; participants are never collapsed into iframes or a shared
+browser profile.
+
 ## Debugging Tips
 
 If semantic locators are not finding your element:

--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -314,6 +314,10 @@ browser integration stack. It does not define `demo.click()` or `demo.type()`:
 the same `fillCfInput`, `clickCfButton`, trusted-action, and Astral element
 operations used by the test remain responsible for the interaction.
 
+The command accepts one or more test-file filters. Multiple files are recorded
+sequentially into isolated artifact subdirectories, with a top-level
+`index.html` gallery linking every completed, test-named MP4.
+
 In presentation mode, those paths may add human-readable typing delay, cursor
 travel, a click pulse, participant labels, and captions. With presentation mode
 off they retain their normal fast behavior. Direct interaction forms used by a

--- a/docs/plans/integration-test-video-demos.md
+++ b/docs/plans/integration-test-video-demos.md
@@ -1,0 +1,788 @@
+# Integration-Test Video Demos — Implementation Plan
+
+Status: Core implementation complete and locally verified; optional CI adoption
+and extended failure/visual-fixture hardening remain deferred.
+
+This plan turns selected browser integration tests into deterministic video
+demos without creating a second interaction API or weakening the tests'
+correctness semantics. Normal integration runs remain fast and event-driven.
+An explicit presentation mode records the same browser instances, slows the
+existing typing and clicking paths, adds optional explanatory overlays, and
+composes multi-user runs into one labeled video.
+
+The first end-to-end acceptance target is
+`packages/patterns/integration/cfc-render-policy-demo.test.ts`. The first
+multi-user acceptance target is
+`packages/patterns/integration/lunch-poll-vote.test.ts`.
+
+## Status convention
+
+- [ ] Not started
+- [x] Complete and verified
+
+Mark a parent checkbox complete only after all child checks and the completion
+gate pass. Keep this plan current in the same commits as implementation. When
+the final stage is complete, archive it under `docs/history/plans/` following
+`docs/README.md`.
+
+## Implementation result (2026-07-13)
+
+The local, opt-in implementation is shipped in this changeset:
+
+- `deno task demo` selects exactly one pattern or shell integration-test file,
+  preflights FFmpeg, reuses the existing integration runner, and writes a video
+  plus a machine-readable manifest under `tmp/demos/`.
+- Presentation mode modifies the existing Astral click/type paths and CFC input
+  helper. It adds slow real typing, a visible cursor, click pulses, captions,
+  participant badges, CDP screencast capture, and bounded asynchronous frame
+  writes without adding a second demo interaction API.
+- A process-wide presentation session shares one monotonic clock across all
+  `ShellIntegration` instances, then creates deterministic one- through
+  four-participant FFmpeg layouts. Counts above four are rejected explicitly.
+- The CFC render-policy and two-user lunch-poll tests are the accepted reference
+  demos. Both also pass through the normal integration command with presentation
+  mode disabled.
+- Focused unit tests cover configuration, frame timing, recorder acknowledgement,
+  task selection, and one- through four-participant filter construction. Local
+  live acceptance verified H.264 output at 1280x720 and 2560x720 respectively.
+
+The first implementation renders participant badges and captions in the page
+overlay so they are captured in each raw participant stream. That is simpler
+and preserves useful labeled streams if composition fails; the manifest still
+records the semantic steps. Optional title/end cards, synthetic compositor
+acceptance fixtures, exhaustive resource-failure injection, and CI publication
+remain follow-up hardening, not prerequisites for local use. Accordingly this
+plan remains live rather than being archived.
+
+## Goals
+
+- [ ] Record a selected browser integration-test file through the existing
+  Astral and `ShellIntegration` stack.
+- [ ] Preserve the exact state setup, browser identities, UI events,
+  assertions, and cleanup used by the test.
+- [ ] Make existing input and click paths presentation-aware instead of adding
+  parallel `demo.type()` and `demo.click()` APIs.
+- [ ] Keep all presentation delays, cursor animation, overlays, recording, and
+  encoding disabled during normal test runs.
+- [ ] Produce deterministic single-user and multi-user videos with stable
+  viewport sizes, participant labels, timing, and artifact names.
+- [ ] Preserve simultaneous multi-user actions and live propagation as they
+  occur in the test; do not replay a synthetic event log against mock UIs.
+- [ ] Retain useful partial artifacts when a recorded test fails, while still
+  returning the test's failing exit status.
+- [ ] Provide a scriptable command that works without an agent or editor.
+
+## Non-goals
+
+- Building a general nonlinear video editor.
+- Adding an agent skill.
+- Replacing Astral, Deno's test runner, or the existing integration runner with
+  Playwright.
+- Recording every browser integration test in CI by default.
+- Making fixed delays part of correctness synchronization.
+- Generating narration automatically from source comments.
+- Capturing microphone audio, text-to-speech, or background music in the first
+  implementation.
+- Supporting more than four simultaneously visible participant tiles in the
+  first multi-user compositor.
+- Making production shell code aware of demo recording.
+
+## Current-system facts
+
+The implementation must start from these shipped behaviors rather than create
+parallel infrastructure:
+
+- `packages/integration/shell-utils.ts` owns the browser and page lifecycle for
+  browser integration tests. One `ShellIntegration` currently launches one
+  browser and one initial page; multi-user tests create multiple
+  `ShellIntegration` instances.
+- `packages/integration/page.ts` wraps Astral's page, already provides
+  screenshot capture, and already uses raw Celestial/CDP bindings for
+  event-driven condition notifications.
+- `packages/vendor-astral/bindings/celestial.ts` exposes
+  `Page.startScreencast`, `Page.screencastFrame`,
+  `Page.screencastFrameAck`, and `Page.stopScreencast`.
+- Astral's keyboard supports a per-character delay. Its mouse can move in
+  steps, but CDP-generated mouse movement is not rendered as a visible system
+  cursor in page screenshots or screencasts.
+- `packages/patterns/integration/cfc-browser-helpers.ts` owns the preferred
+  pattern-test input and click paths. `fillCfInput()` currently performs a
+  bulk DOM input/change/commit/verify sequence, and `clickCfButton()` plus the
+  trusted-action helpers resolve and click the actual target once.
+- Some browser tests call Astral `ElementHandle.click()`,
+  `ElementHandle.type()`, or `page.keyboard.type()` directly. They must be
+  audited so demo candidates do not silently bypass presentation behavior.
+- Correctness waits are deliberately event-driven. The rules in
+  `docs/development/UI_TESTING.md` prohibit guessed sleeps in the interaction
+  path.
+- `tasks/integration.ts` already starts and stops local servers, selects a
+  package and file filter, passes browser environment, and preserves the
+  underlying test exit status.
+- `StepTimer` already wraps labeled async steps in the lunch-poll and
+  multi-browser group-chat tests. Its labels are useful presentation metadata,
+  but its timing function is not yet a general demo timeline.
+
+## Fixed design decisions
+
+### One interaction vocabulary
+
+- [ ] Do not add `demo.click()` or `demo.type()`.
+- [ ] Keep the existing helper calls at test call sites. Presentation mode may
+  change how those helpers perform the same user action, but not what control
+  they target or what effect the test awaits.
+- [ ] Normal mode must remain behaviorally equivalent to the current fast
+  implementation.
+- [ ] Presentation mode must still dispatch trusted browser input and must run
+  the existing post-action commit and verification logic.
+- [ ] Direct Astral interactions in selected demo tests must either become
+  presentation-aware at the shared Astral hook or be migrated to an existing
+  presentation-aware integration helper. Do not maintain a silent bypass list.
+
+### Correctness time versus presentation time
+
+- [ ] Correctness waits continue to resolve on runtime, DOM, or state events.
+- [ ] Presentation holds occur only before a ready action, while visibly
+  typing or moving a cursor, or after an asserted result has arrived.
+- [ ] A presentation hold must be implemented by a dedicated presentation
+  clock and must resolve immediately when presentation mode is off.
+- [ ] Presentation delays do not consume or reduce the correctness timeout
+  budget. Start correctness deadlines after any before-action hold, and stop
+  them before any after-result hold.
+- [ ] Concurrent actions inside `Promise.all()` remain concurrent. Each page
+  may animate independently, but the presentation layer must not serialize
+  them through a global lock.
+
+### Real independent browsers for multi-user tests
+
+- [ ] Keep every `ShellIntegration` and identity independent.
+- [ ] Do not place participants into iframes or one shared browser profile for
+  recording.
+- [ ] Record each page's CDP stream independently against a shared recorder
+  clock, then compose streams after the test.
+- [ ] A participant's idle stream holds its last frame while another
+  participant changes.
+- [ ] Two participants default to a labeled side-by-side layout; three or four
+  default to a 2-by-2 labeled grid.
+- [ ] More than four participants requires an explicit layout selection or a
+  clear unsupported-layout error in the first release.
+
+### Recording and encoding
+
+- [ ] Use Chrome's CDP screencast stream through the vendored Astral bindings.
+  Do not add Playwright solely for video recording.
+- [ ] Acknowledge every screencast frame promptly, independently of disk and
+  encoder work, so capture backpressure cannot stall the browser.
+- [ ] Preserve variable frame durations from the recorder clock. Do not feed
+  change-driven frames to FFmpeg as if each had an equal duration.
+- [ ] Hold the final frame through the requested end hold and ensure the
+  encoded stream has an explicit final duration.
+- [ ] Use an external `ffmpeg` executable for encoding and composition. Detect
+  it before launching servers and fail with an actionable installation
+  message when absent.
+- [ ] Keep raw frames and manifests only when requested or when a run fails;
+  otherwise remove intermediates after successful encoding.
+
+### Overlays
+
+- [ ] Render cursors and in-page callouts in an injected shadow-root overlay
+  with `pointer-events: none` and a maximum z-index.
+- [ ] Keep participant labels and whole-video captions in the compositor so
+  they remain stable across navigation and can span multiple page tiles.
+- [ ] Never infer viewer-facing captions from arbitrary source comments.
+  Captions come from explicit step labels or explicit presentation metadata.
+- [ ] Overlay installation must be idempotent after navigation and must not
+  modify application layout, focus order, accessible names, or hit testing.
+
+## User-facing command and artifacts
+
+The intended command shape is:
+
+```sh
+deno task demo patterns cfc-render-policy-demo
+deno task demo patterns lunch-poll-vote --output=tmp/demos/lunch-poll.mp4
+```
+
+The command contract is:
+
+- [ ] Require a browser-test package and a file-name filter.
+- [ ] Resolve exactly one test file. Fail on zero or multiple matches rather
+  than recording an accidental suite.
+- [ ] Initially run every `it` block in that file because some suites build a
+  continuous scenario across tests. Add an optional Deno test-name filter only
+  after defining how setup and cross-test state are preserved.
+- [ ] Run headlessly by default with deterministic viewport and device scale.
+- [ ] Reuse the integration runner's server ownership, port-offset, signal,
+  and cleanup semantics.
+- [ ] Return nonzero if setup, the test, recording finalization, or required
+  encoding fails.
+- [ ] Print the absolute final-video path and the retained diagnostic directory
+  when applicable.
+
+Default successful output:
+
+```text
+tmp/demos/<package>-<test-file>-<timestamp>/
+  video.mp4
+  manifest.json
+```
+
+Retained failure/debug output:
+
+```text
+tmp/demos/<package>-<test-file>-<timestamp>/
+  manifest.json
+  participants/
+    <participant-id>/
+      frames/
+      frames.ffconcat
+      stream.mp4
+  partial.mp4
+  failure.txt
+```
+
+`manifest.json` is a versioned diagnostic and composition contract, not a
+Fabric value. Version 1 must include:
+
+- run id, package, test file, command, start/end monotonic offsets, and status;
+- viewport, device scale, requested output format, and presentation profile;
+- participant ids, display labels, colors, capture start/end offsets, and
+  frame counts;
+- each frame's sequence, source timestamp when available, recorder timestamp,
+  path, width, height, and computed duration;
+- step/caption intervals and their scope;
+- encoder executable/version and the exact argument arrays used;
+- failure stage and diagnostic text when incomplete.
+
+Do not place identities, private keys, auth state, raw page HTML, or arbitrary
+browser console contents in the manifest.
+
+## Proposed component boundaries
+
+### Integration package
+
+Expected new or expanded files:
+
+- `packages/integration/presentation/config.ts` — environment/config parsing,
+  defaults, validation, participant metadata, and disabled fast path.
+- `packages/integration/presentation/clock.ts` — injectable monotonic clock and
+  recording-only holds.
+- `packages/integration/presentation/overlay.ts` — idempotent in-page cursor
+  and callout overlay.
+- `packages/integration/presentation/interactions.ts` — before/after click and
+  type hooks shared by helper and direct Astral interaction paths.
+- `packages/integration/presentation/recorder.ts` — per-page screencast state,
+  frame acknowledgements, ordered writes, and manifest rows.
+- `packages/integration/presentation/session.ts` — run-level participant and
+  step timeline; coordinates recorders without serializing their actions.
+- `packages/integration/presentation/encode.ts` — FFmpeg discovery, per-stream
+  encoding, layout composition, cleanup, and injectable command runner.
+- `packages/integration/presentation/manifest.ts` — versioned manifest types
+  and validation.
+- `packages/integration/page.ts` — narrow screencast and viewport operations,
+  plus presentation hook installation; do not expose Celestial generally.
+- `packages/integration/shell-utils.ts` — participant registration and
+  lifecycle start/finalize integration.
+- `packages/integration/env.ts` and `packages/integration/index.ts` — public
+  configuration/export surface.
+
+If implementation tests are added under `packages/integration/test/`, replace
+the package's current stub `test` task with a real `deno test` task. Keep the
+package's required workspace test entry.
+
+### Vendored Astral seam
+
+The preferred seam is a generic, optional interaction observer owned by an
+Astral page:
+
+- before/after click hooks receive the resolved element, click point, and
+  operation outcome;
+- before/after type hooks receive the focused element when known, text length,
+  and operation outcome;
+- the observer is unset by default and adds no delays or DOM changes;
+- product-specific presentation behavior remains in
+  `packages/integration/presentation/`, not in vendored Astral;
+- `ElementHandle.click()` and `ElementHandle.type()` invoke the observer so
+  direct element operations cannot bypass presentation mode;
+- direct `page.keyboard.type()` receives the presentation default character
+  delay through an optional keyboard default, but tests needing a cursor move
+  to an input should prefer element-based typing.
+
+Before modifying vendored Astral, verify that the same complete coverage can be
+achieved by the integration wrappers without a second interaction vocabulary.
+If not, make the observer hook small, generic, and independently tested.
+
+### Task runner
+
+Expected files:
+
+- `tasks/demo.ts` — argument parsing, FFmpeg preflight, exact test selection,
+  output directory creation, presentation environment, server/test execution,
+  and final status.
+- `tasks/demo.test.ts` — argument, selection, environment, command, cleanup,
+  and failure-artifact tests.
+- `tasks/integration.ts` — extract/reuse server lifecycle and filtered-run
+  helpers as needed; do not copy a second server manager.
+- root `deno.jsonc` — add the `demo` task.
+
+Tests that spawn child processes or temporary Deno configs must use isolated
+temporary directories and must not update the repository lockfile or leave
+build artifacts in the workspace.
+
+## Presentation defaults
+
+Version 1 should centralize conservative defaults rather than annotate every
+action:
+
+| Setting | Initial default | Purpose |
+| --- | ---: | --- |
+| viewport | 1280 by 720 | Stable single-user source frame |
+| device scale | 1 | Reproducible pixel dimensions |
+| typing delay | 55 ms per character | Readable but not theatrical typing |
+| cursor travel | 350 ms | Make target changes legible |
+| cursor settle before click | 150 ms | Let the eye reach the target |
+| click pulse | 180 ms | Show which control was activated |
+| post-result hold | 800 ms | Make asserted results readable |
+| caption fade | 180 ms | Avoid abrupt overlays |
+| JPEG quality | 85 | Balance capture size and UI text quality |
+
+Defaults are presentation policy, not correctness constants. They may be
+overridden at command or participant level, but normal test code should not
+accumulate millisecond literals.
+
+## Stage 0 — Prove capture fidelity and freeze the contract
+
+### WP0.1 — Implement a focused CDP screencast spike
+
+- [ ] Add a temporary or focused test-only recorder around one integration
+  page using the existing raw Celestial bindings.
+- [ ] Capture navigation, a stable initial state, one trusted click, its
+  asserted result, and a final hold from the CFC render-policy demo.
+- [ ] Verify frame events are acknowledged immediately and continue across UI
+  activity.
+- [ ] Measure whether Chrome's frame metadata timestamp is monotonic and usable
+  on the supported Chrome version; otherwise use receipt time from one
+  recorder-side monotonic clock.
+- [ ] Verify the last visual state receives a nonzero duration.
+- [ ] Encode the frames with FFmpeg and inspect text sharpness, transition
+  timing, viewport size, and final duration.
+- [ ] Record any CDP or FFmpeg deviations in this live plan before building the
+  reusable abstraction.
+
+### WP0.2 — Freeze manifest and failure semantics
+
+- [ ] Define and unit-test the version-1 manifest schema.
+- [ ] Decide the canonical timestamp origin and document conversions from CDP
+  timestamps.
+- [ ] Define behavior for zero frames, one frame, duplicate timestamps,
+  out-of-order callbacks, navigation, hidden pages, and abrupt browser close.
+- [ ] Define separate statuses for test failure, capture failure, encode
+  failure, and cleanup warning.
+- [ ] Ensure a test failure remains the primary outcome even when partial-video
+  finalization also reports a secondary failure.
+
+### Stage 0 completion gate
+
+- [ ] One manually invoked CFC render-policy run produces a readable video.
+- [ ] The test still fails when its assertion is deliberately broken.
+- [ ] No fixed sleep was added to the normal correctness path.
+- [ ] Manifest and failure behavior are explicit enough to test without a live
+  browser.
+
+## Stage 1 — Build the single-page recording core
+
+### WP1.1 — Add narrow Page screencast primitives
+
+- [ ] Add typed methods to start and stop screencast capture, subscribe and
+  unsubscribe frame events, acknowledge frames, and set viewport size.
+- [ ] Keep raw Celestial bindings private to `Page`.
+- [ ] Make start/stop idempotence and invalid lifecycle transitions explicit.
+- [ ] Ensure listeners are removed on stop, failure, navigation teardown, and
+  page close.
+- [ ] Unit-test the wrapper with fake bindings, including acknowledgements
+  after consumer failure.
+
+### WP1.2 — Implement an ordered per-page recorder
+
+- [ ] Copy frame payloads out of the event handler and acknowledge before any
+  awaited filesystem operation.
+- [ ] Use a bounded asynchronous write queue. Define whether a full queue
+  drops frames with diagnostics or fails capture; never block acknowledgement.
+- [ ] Generate stable, zero-padded frame names.
+- [ ] Record receipt order and source timestamps, normalize durations, and
+  enforce a minimum positive duration.
+- [ ] On stop, drain accepted writes, append the requested final hold, and
+  atomically finalize the participant manifest section.
+- [ ] Reject a successful recording with no frames; allow a one-frame video by
+  applying the final duration.
+- [ ] Test out-of-order write completion, duplicate timestamps, stop during a
+  pending write, frame decode errors, and disk-write errors.
+
+### WP1.3 — Encode one variable-duration stream
+
+- [ ] Generate an FFconcat input with explicit duration lines and a repeated
+  final file entry.
+- [ ] Invoke FFmpeg with arguments passed as an array, never through a shell.
+- [ ] Produce broadly playable H.264 MP4 with `yuv420p` in version 1; keep the
+  encoder abstraction open to WebM later.
+- [ ] Normalize source dimensions before encoding and reject unexpected
+  mid-stream size changes unless explicitly supported.
+- [ ] Capture a bounded FFmpeg diagnostic tail on failure without leaking
+  unrelated environment values.
+- [ ] Unit-test command construction and manifest updates with an injected
+  command runner; add a small FFmpeg acceptance test that skips with an
+  explicit reason when FFmpeg is unavailable.
+
+### Stage 1 completion gate
+
+- [ ] Recorder and encoder unit tests pass in `packages/integration`.
+- [ ] A single-page synthetic frame fixture proves wall-clock-equivalent
+  variable durations.
+- [ ] The CFC render-policy test can be recorded through the reusable recorder.
+- [ ] Normal integration runs do not create artifact directories or invoke
+  FFmpeg.
+
+## Stage 2 — Add the deterministic demo task and lifecycle
+
+### WP2.1 — Extract reusable integration-runner lifecycle
+
+- [ ] Refactor `tasks/integration.ts` only as needed to expose server start,
+  stop, port selection, exact file selection, and child-test execution without
+  duplicating them.
+- [ ] Preserve current integration CLI behavior and tests byte-for-byte where
+  practical.
+- [ ] Add regression tests for generated and explicit port offsets, signal
+  cleanup, child exit propagation, and exact file matching.
+
+### WP2.2 — Implement `deno task demo`
+
+- [ ] Add package/file parsing and the exact-one-file gate.
+- [ ] Preflight FFmpeg and output-path writability before starting servers.
+- [ ] Create a unique run directory under `tmp/demos/` unless `--output` is
+  supplied.
+- [ ] Set presentation mode, output directory, deterministic viewport, and
+  headless defaults only for the child test process.
+- [ ] Force the selected browser test file to run non-parallel.
+- [ ] Preserve inherited API/frontend URLs and the integration runner's server
+  ownership rules.
+- [ ] Finalize capture and encoding before server cleanup, but make cleanup run
+  even if finalization fails.
+- [ ] Print a concise outcome containing test status, video path, duration,
+  participant count, and retained intermediates.
+
+### WP2.3 — Integrate Shell lifecycle
+
+- [ ] Parse presentation configuration once per test process.
+- [ ] Register each `ShellIntegration` with a run-level presentation session
+  when presentation mode is enabled.
+- [ ] Set viewport before first navigation.
+- [ ] Start capture only after explicit recording start or the first settled
+  demo navigation, so setup blank screens and login churn do not dominate the
+  result.
+- [ ] Define a reliable explicit start point for demo tests; normal tests must
+  not need it.
+- [ ] Stop capture before runtime/page/browser disposal while leaving enough
+  time for the asserted final state.
+- [ ] Finalize once after all registered shells close, regardless of hook
+  registration order.
+
+### Stage 2 completion gate
+
+- [ ] The documented command records the CFC render-policy demo end to end.
+- [ ] Zero and ambiguous file matches fail before launching servers.
+- [ ] SIGINT, test failure, capture failure, and encoder failure all clean up
+  owned servers and retain the documented diagnostics.
+- [ ] `deno task integration patterns cfc-render-policy-demo` remains fast and
+  produces no video artifacts.
+
+## Stage 3 — Make existing interactions presentation-aware
+
+### WP3.1 — Add a disabled-by-default interaction observer
+
+- [ ] Define generic before/after click and type notifications with operation
+  ids, page/participant ids, target geometry when available, and success/error
+  outcomes.
+- [ ] Install no observer in normal mode.
+- [ ] Invoke the observer from `ElementHandle.click()` and
+  `ElementHandle.type()` through the narrowest viable wrapper or vendored
+  Astral seam.
+- [ ] Ensure observer failure fails presentation capture with useful context
+  rather than silently clicking an unintended control.
+- [ ] Avoid retaining element handles after the operation completes.
+
+### WP3.2 — Slow existing typing without changing its contract
+
+- [ ] In presentation mode, have `fillCfInput()` resolve the same inner native
+  input and use trusted keyboard typing with the configured delay.
+- [ ] Clear or select existing content deterministically before typing a
+  replacement value.
+- [ ] Preserve the host's commit, update, and final value-verification steps
+  after keyboard input.
+- [ ] Preserve timeout diagnostics and the current bulk fill fast path in
+  normal mode.
+- [ ] Apply a default typing delay to direct `ElementHandle.type()` and focused
+  `page.keyboard.type()` calls in presentation mode.
+- [ ] Add cases for empty values, replacing existing values, punctuation,
+  Unicode, readonly/disabled inputs, missing inner input, commit failure, and
+  reactive rerender during typing.
+
+### WP3.3 — Animate existing clicks
+
+- [ ] Resolve and scroll the same target the helper already intends to click.
+- [ ] Read its final bounding box after scrolling and view settlement.
+- [ ] Animate a fake cursor from its previous per-page position to the target
+  center while moving the CDP mouse along the same path when supported.
+- [ ] Add a short target settle and click pulse, then execute the existing
+  single trusted click.
+- [ ] Keep marker cleanup and trusted-action provenance checks unchanged.
+- [ ] Remove cursor state after navigation or page close and reinstall the
+  overlay idempotently in the new document.
+- [ ] Test offscreen controls, controls moved during scroll, disappeared
+  targets, nested shadow roots, concurrent clicks on separate pages, and click
+  failure.
+
+### WP3.4 — Audit direct interaction bypasses
+
+- [ ] Inventory direct `.click()`, `.type()`, and `page.keyboard.type()` calls
+  in browser integration tests.
+- [ ] Prove shared hooks cover each form used by selected demos.
+- [ ] Migrate calls only where the shared hook cannot retain target context or
+  correctness behavior; use existing integration helpers rather than adding a
+  demo-only interaction API.
+- [ ] Add a lint/check or focused test that prevents selected demo fixtures
+  from adding an uncovered interaction form.
+
+### Stage 3 completion gate
+
+- [ ] The same CFC render-policy test source runs in fast normal mode and
+  visibly presented recording mode.
+- [ ] A focused input demo visibly types character by character and ends with
+  the same committed value assertion.
+- [ ] A focused click demo shows cursor travel and exactly one trusted click.
+- [ ] Existing browser integration suites pass with presentation mode off.
+
+## Stage 4 — Add explicit scenario timing and captions
+
+### WP4.1 — Generalize labeled steps
+
+- [ ] Extend `StepTimer` or replace it with a compatible scenario timeline that
+  still records wall-clock timings for existing callers.
+- [ ] Emit step start/end events only when a presentation session exists.
+- [ ] Keep `run(label, fn)` semantics, including recording elapsed time when
+  `fn` throws.
+- [ ] Support an optional presentation label distinct from a diagnostic timing
+  label when the latter is too technical for viewers.
+- [ ] Support run-wide, participant-scoped, and silent steps without changing
+  the wrapped test action.
+- [ ] Keep before/after holds centralized and overridable without millisecond
+  literals throughout tests.
+
+### WP4.2 — Render captions and title/end cards
+
+- [ ] Record caption intervals in the manifest rather than baking run-wide
+  captions independently into each participant stream.
+- [ ] Add compositor-rendered participant labels with deterministic colors and
+  sufficient contrast.
+- [ ] Add optional title and end cards driven by explicit configuration.
+- [ ] Render step captions in a safe lower-third region, wrapping and truncating
+  deterministically.
+- [ ] Ensure captions do not cover participant labels or known shell controls
+  in the reference layouts.
+- [ ] Add visual fixtures for long labels, Unicode, overlapping steps,
+  participant-scoped captions, and failed steps.
+
+### WP4.3 — Annotate the single-user reference demo
+
+- [ ] Give the CFC render-policy test a small number of viewer-facing steps:
+  initial policy-hidden state, trusted reveal action, and final bounded result.
+- [ ] Start recording after navigation/login/view settlement.
+- [ ] End only after both the positive reveal and negative raw-surface
+  assertions pass.
+- [ ] Avoid captions that expose confidential test values before the trusted
+  reveal is visible.
+
+### Stage 4 completion gate
+
+- [ ] Normal `StepTimer` consumers retain their existing timing output.
+- [ ] The reference demo has readable pacing without correctness sleeps.
+- [ ] Captions and participant labels are reproducible from the manifest.
+- [ ] A failed scenario shows a bounded failure card or partial final state and
+  retains the failing exit code.
+
+## Stage 5 — Synchronize and compose multi-user recordings
+
+### WP5.1 — Establish a shared multi-recorder timeline
+
+- [ ] Allocate one presentation session and monotonic origin per test process.
+- [ ] Give every registered shell a stable participant id independent of array
+  order, plus an explicit display label and color when supplied.
+- [ ] Record each participant's capture offsets relative to the shared origin.
+- [ ] Normalize streams to a common start and end; synthesize a neutral tile
+  before a participant's first frame and hold its last frame afterward.
+- [ ] Preserve simultaneous operations as overlapping intervals.
+- [ ] Handle a participant page navigating, closing early, or failing while
+  other participants continue.
+
+### WP5.2 — Implement deterministic layouts
+
+- [ ] Define exact source viewport and output dimensions for one-, two-, three-,
+  and four-participant layouts.
+- [ ] Use aspect-preserving scale and pad; never silently crop controls.
+- [ ] Place labels outside or over a reserved edge of each tile.
+- [ ] Default two participants to side by side and three/four to a 2-by-2 grid.
+- [ ] Allow a named layout override in the manifest/command configuration.
+- [ ] Reject unsupported participant counts before encoding while retaining
+  individual participant streams.
+- [ ] Unit-test FFmpeg filter-graph construction independently of FFmpeg.
+
+### WP5.3 — Annotate and record the lunch-poll demo
+
+- [ ] Assign stable host and guest display labels and colors.
+- [ ] Start both recorders only after both users are navigated, logged in, and
+  ready.
+- [ ] Use existing labeled steps, refined where necessary for viewer language,
+  to show both users joining, an option propagating, both voting concurrently,
+  and both views reaching the merged tally.
+- [ ] Ensure both cursors remain independently visible and concurrent clicks
+  are not serialized.
+- [ ] Hold the final merged tally on both tiles.
+- [ ] Verify participant-local drafts remain visually isolated before shared
+  state propagates.
+
+### WP5.4 — Cover dynamic participant counts
+
+- [ ] Register generated group-chat shells with generated display labels.
+- [ ] Verify two, three, and four streams align and compose.
+- [ ] Define the version-1 behavior for `CFC_BROWSER_PROFILE_COUNT` greater than
+  four: explicit rejection or explicitly selected participants.
+- [ ] Preserve all raw participant streams even when a selected-participant
+  composition omits some tiles.
+
+### Stage 5 completion gate
+
+- [ ] The lunch-poll test produces a readable, synchronized two-user video.
+- [ ] The concurrent vote appears concurrent and the merged state is visible
+  on both tiles.
+- [ ] Two-, three-, and four-participant composition fixtures pass.
+- [ ] Multi-user recording does not alter identities, storage isolation,
+  runtime count, or propagation assertions.
+
+## Stage 6 — Harden, document, and adopt
+
+### WP6.1 — Failure and resource hardening
+
+- [ ] Bound in-memory frame data and outstanding disk writes.
+- [ ] Measure CPU, disk, and wall-clock overhead on the two reference demos.
+- [ ] Ensure recording does not trigger the browser-test timeout solely because
+  presentation delays were added; separate correctness timeouts from command
+  watchdogs.
+- [ ] Handle full disk, unwritable output, FFmpeg termination, browser crash,
+  test timeout, and signal interruption.
+- [ ] Prevent secrets and unrelated environment values from entering command
+  logs or manifests.
+- [ ] Delete successful intermediates by default and provide a documented
+  `--keep-frames` diagnostic option.
+
+### WP6.2 — Determinism and visual regression fixtures
+
+- [ ] Make participant ordering, colors, frame names, layout, and filter graphs
+  deterministic for identical configuration.
+- [ ] Add golden manifests and FFmpeg argument arrays; avoid committing large
+  generated videos.
+- [ ] Use a tiny synthetic frame fixture for compositor acceptance tests.
+- [ ] Verify output duration, dimensions, stream count, codec/pixel format, and
+  final-frame presence with `ffprobe` when available.
+- [ ] Run each reference demo repeatedly and record acceptable duration and
+  frame-count variation bounds.
+
+### WP6.3 — Developer documentation
+
+- [ ] Update `docs/development/UI_TESTING.md` with presentation-mode semantics,
+  the ban on correctness sleeps, supported interaction paths, and how to mark
+  a test as a demo.
+- [ ] Update `docs/development/TESTING.md` with the `deno task demo` command,
+  prerequisites, outputs, failure behavior, and multi-user layouts.
+- [ ] Document FFmpeg installation expectations without making normal test
+  execution depend on FFmpeg.
+- [ ] Document how to choose viewer-facing step labels and participant labels.
+- [ ] Document the direct-interaction audit requirement for new demo tests.
+- [ ] Add the final reference commands and expected artifact locations.
+
+### WP6.4 — Optional CI artifact path
+
+- [ ] Keep demo recording opt-in until local reliability and cost are measured.
+- [ ] If CI recording is desired, add a manually triggered or explicitly
+  labeled job before any per-PR default.
+- [ ] Pin/verify the FFmpeg environment and upload only final videos plus
+  manifests on success.
+- [ ] Upload retained intermediates only on failure and set an explicit
+  retention period.
+- [ ] Do not make demo rendering a required merge gate without a separate
+  performance and maintenance decision.
+
+### Final completion gate
+
+- [ ] `deno task demo patterns cfc-render-policy-demo` produces the accepted
+  single-user video.
+- [ ] `deno task demo patterns lunch-poll-vote` produces the accepted
+  synchronized two-user video.
+- [ ] Both underlying tests still pass normally without recording artifacts or
+  presentation delay.
+- [ ] Integration-package, task-runner, manifest, interaction, and compositor
+  tests pass.
+- [ ] The full affected package test tasks and documentation checks pass.
+- [ ] No correctness synchronization uses presentation sleeps.
+- [ ] No demo-only click/type API exists.
+- [ ] Live testing documentation describes the shipped command and extension
+  points.
+- [ ] This completed plan is archived under `docs/history/plans/`.
+
+## Cross-stage validation matrix
+
+Run focused tests during red/green development, then the complete affected
+package tasks at each stage gate.
+
+| Concern | Required validation |
+| --- | --- |
+| CDP lifecycle | Fake-binding unit tests plus one live Chrome acceptance |
+| Frame timing | Synthetic variable-duration fixture and output duration probe |
+| FFmpeg invocation | Pure argument tests plus a small local encode acceptance |
+| Normal-mode neutrality | Existing pattern and shell browser integrations |
+| Input semantics | DOM value, input/change events, host commit, final assertion |
+| Click semantics | One trusted click, marker cleanup, asserted effect |
+| Overlay isolation | Focus, hit testing, accessibility, navigation reinstall |
+| Runner behavior | Task parser, exact file match, port ownership, signals |
+| Multi-user timing | Shared-origin fixtures and lunch-poll live acceptance |
+| Composition | One/two/three/four layouts, dimensions, labels, final frame |
+| Failure behavior | Test, capture, encode, disk, browser, signal failures |
+| Documentation | `deno task check-docs` and link validation |
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| CDP emits frames only on visual change | Preserve variable durations and explicitly hold/repeat the final frame. |
+| Frame acknowledgement blocks on I/O | Copy payload, acknowledge immediately, and use a bounded write queue. |
+| Presentation delays create test flakes | Keep event-driven correctness waits unchanged and outside presentation timing. |
+| Bulk fill and slow typing commit differently | Reuse the same host commit and verification tail and test both modes against the same assertions. |
+| Synthetic cursor disagrees with the real click | Derive both from the same final bounding box and animate the CDP mouse along the same route. |
+| Direct element calls bypass presentation | Add a generic Astral observer seam and audit selected demo tests. |
+| Multi-user recording changes runtime behavior | Preserve separate browser instances and compose only after execution. |
+| Small tiles make UI unreadable | Fix source/output dimensions, scale without cropping, and inspect reference layouts before accepting them. |
+| FFmpeg is absent or varies by machine | Preflight/version-record it, use conservative codecs, and fail before server startup. |
+| Video artifacts bloat the repository | Write under ignored `tmp/`, commit only small fixtures/manifests, and clean successful intermediates. |
+| A failed test loses its evidence | Best-effort finalize partial streams and retain frames/manifests while preserving the test failure. |
+| Captions leak sensitive values | Require explicit viewer-facing labels and keep confidential-value reveals aligned with asserted trusted UI state. |
+
+## Deferred extensions
+
+These are intentionally outside the completion gate:
+
+- active-speaker or picture-in-picture layouts for more than four users;
+- per-step camera crops or zooms;
+- external subtitle files;
+- voice-over manifests or text-to-speech;
+- audio mixing;
+- automatic cursor-path smoothing based on semantic control groups;
+- automatic demo selection or an agent skill;
+- hosted video galleries or publishing workflows;
+- browser-native WebM recording as an alternative capture backend.

--- a/docs/plans/integration-test-video-demos.md
+++ b/docs/plans/integration-test-video-demos.md
@@ -222,7 +222,7 @@ Default successful output:
 
 ```text
 tmp/demos/<package>-<test-file>-<timestamp>/
-  video.mp4
+  <test-file>.mp4
   manifest.json
 ```
 

--- a/docs/plans/integration-test-video-demos.md
+++ b/docs/plans/integration-test-video-demos.md
@@ -29,9 +29,10 @@ the final stage is complete, archive it under `docs/history/plans/` following
 
 The local, opt-in implementation is shipped in this changeset:
 
-- `deno task demo` selects exactly one pattern or shell integration-test file,
-  preflights FFmpeg, reuses the existing integration runner, and writes a video
-  plus a machine-readable manifest under `tmp/demos/`.
+- `deno task demo` selects one or more pattern or shell integration-test files,
+  preflights FFmpeg, reuses the existing integration runner, and writes named
+  videos, machine-readable manifests, and a portable HTML gallery under
+  `tmp/demos/`.
 - Presentation mode modifies the existing Astral click/type paths and CFC input
   helper. It adds slow real typing, a visible cursor, click pulses, captions,
   participant badges, CDP screencast capture, and bounded asynchronous frame
@@ -199,14 +200,15 @@ The intended command shape is:
 
 ```sh
 deno task demo patterns cfc-render-policy-demo
+deno task demo patterns cfc-render-policy-demo lunch-poll-vote
 deno task demo patterns lunch-poll-vote --output=tmp/demos/lunch-poll.mp4
 ```
 
 The command contract is:
 
-- [ ] Require a browser-test package and a file-name filter.
-- [ ] Resolve exactly one test file. Fail on zero or multiple matches rather
-  than recording an accidental suite.
+- [ ] Require a browser-test package and one or more file-name filters.
+- [ ] Resolve exactly one test file per filter. Fail on zero or multiple
+  matches rather than recording an accidental suite.
 - [ ] Initially run every `it` block in that file because some suites build a
   continuous scenario across tests. Add an optional Deno test-name filter only
   after defining how setup and cross-test state are preserved.
@@ -222,8 +224,22 @@ Default successful output:
 
 ```text
 tmp/demos/<package>-<test-file>-<timestamp>/
+  index.html
   <test-file>.mp4
   manifest.json
+```
+
+Multiple-file successful output:
+
+```text
+tmp/demos/<package>-gallery-<timestamp>/
+  index.html
+  <test-file-a>/
+    <test-file-a>.mp4
+    manifest.json
+  <test-file-b>/
+    <test-file-b>.mp4
+    manifest.json
 ```
 
 Retained failure/debug output:

--- a/packages/integration/deno.jsonc
+++ b/packages/integration/deno.jsonc
@@ -1,7 +1,7 @@
 {
   "name": "@commonfabric/integration",
   "tasks": {
-    "test": "echo 'No tests to run.'"
+    "test": "deno test -A"
   },
   "exports": {
     ".": "./index.ts",

--- a/packages/integration/index.ts
+++ b/packages/integration/index.ts
@@ -1,5 +1,6 @@
 export { Browser } from "./browser.ts";
 export { CdpWorkerProfiler, renderProfileReport } from "./cdp-profiler.ts";
 export { dismissDialogs, Page, pipeConsole } from "./page.ts";
+export * from "./presentation/mod.ts";
 export * as env from "./env.ts";
 export * from "./utils.ts";

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -59,6 +59,7 @@ export async function dismissDialogs(e: DialogEvent) {
 export class Page extends EventTarget {
   private page: AstralPage | null;
   private timeout: number;
+  private afterNavigation?: () => Promise<void> | void;
 
   constructor(page: AstralPage, options: { timeout: number }) {
     super();
@@ -239,6 +240,10 @@ export class Page extends EventTarget {
     this.page!.keyboard.setDefaultTypeDelay(delay);
   }
 
+  setAfterNavigationHook(hook?: () => Promise<void> | void): void {
+    this.afterNavigation = hook;
+  }
+
   async setViewportSize(
     size: { width: number; height: number },
   ): Promise<void> {
@@ -296,12 +301,14 @@ export class Page extends EventTarget {
   async goto(url: string, options?: GoToOptions): Promise<void> {
     this.checkIsOk();
     await this.page!.goto(url, options);
+    await this.afterNavigation?.();
   }
 
   // Passthru of `@astral/astral`'s `Page#reload`
   async reload(options?: WaitForOptions): Promise<void> {
     this.checkIsOk();
     await this.page!.reload(options);
+    await this.afterNavigation?.();
   }
 
   // Passthru of `@astral/astral`'s `Page#waitForSelector`

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -5,6 +5,7 @@ import {
   EvaluateFunction,
   EvaluateOptions,
   GoToOptions,
+  InteractionObserver,
   Keyboard,
   Page as AstralPage,
   PageEventMap,
@@ -13,6 +14,10 @@ import {
   WaitForOptions,
   WaitForSelectorOptions,
 } from "@astral/astral";
+import type {
+  Page_screencastFrame,
+  Page_screencastFrameEvent,
+} from "../vendor-astral/bindings/celestial.ts";
 import { sleep } from "@commonfabric/utils/sleep";
 import { Mutable } from "@commonfabric/utils/types";
 import * as path from "@std/path";
@@ -222,6 +227,60 @@ export class Page extends EventTarget {
   get keyboard(): Keyboard {
     this.checkIsOk();
     return this.page!.keyboard;
+  }
+
+  setInteractionObserver(observer?: InteractionObserver): void {
+    this.checkIsOk();
+    this.page!.setInteractionObserver(observer);
+  }
+
+  setDefaultTypeDelay(delay: number): void {
+    this.checkIsOk();
+    this.page!.keyboard.setDefaultTypeDelay(delay);
+  }
+
+  async setViewportSize(
+    size: { width: number; height: number },
+  ): Promise<void> {
+    this.checkIsOk();
+    await this.page!.setViewportSize(size);
+  }
+
+  async startScreencast(options: {
+    format?: "jpeg" | "png";
+    quality?: number;
+    maxWidth?: number;
+    maxHeight?: number;
+    everyNthFrame?: number;
+  } = {}): Promise<void> {
+    this.checkIsOk();
+    await this.page!.unsafelyGetCelestialBindings().Page.startScreencast(
+      options,
+    );
+  }
+
+  async stopScreencast(): Promise<void> {
+    this.checkIsOk();
+    await this.page!.unsafelyGetCelestialBindings().Page.stopScreencast();
+  }
+
+  async acknowledgeScreencastFrame(sessionId: number): Promise<void> {
+    this.checkIsOk();
+    await this.page!.unsafelyGetCelestialBindings().Page.screencastFrameAck({
+      sessionId,
+    });
+  }
+
+  onScreencastFrame(
+    listener: (frame: Page_screencastFrame) => void,
+  ): () => void {
+    this.checkIsOk();
+    const celestial = this.page!.unsafelyGetCelestialBindings();
+    const handler: EventListener = (event) => {
+      listener((event as Page_screencastFrameEvent).detail);
+    };
+    celestial.addEventListener("Page.screencastFrame", handler);
+    return () => celestial.removeEventListener("Page.screencastFrame", handler);
   }
 
   // Passthru of `@astral/astral`'s `Page#evaluate`

--- a/packages/integration/presentation/config.ts
+++ b/packages/integration/presentation/config.ts
@@ -1,0 +1,75 @@
+export type PresentationConfig =
+  | { enabled: false }
+  | {
+    enabled: true;
+    outputDir: string;
+    viewport: { width: number; height: number };
+    typingDelayMs: number;
+    cursorTravelMs: number;
+    cursorSettleMs: number;
+    clickPulseMs: number;
+    postResultHoldMs: number;
+    jpegQuality: number;
+    keepFrames: boolean;
+  };
+
+export type PresentationParticipant = {
+  id?: string;
+  label?: string;
+  color?: string;
+};
+
+const positiveInt = (
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback: number,
+): number => {
+  const raw = env[name];
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer, got "${raw}"`);
+  }
+  return value;
+};
+
+export function parsePresentationConfig(
+  env: Record<string, string | undefined>,
+): PresentationConfig {
+  const outputDir = env.CF_DEMO_OUTPUT_DIR;
+  if (!outputDir) return { enabled: false };
+
+  const viewportRaw = env.CF_DEMO_VIEWPORT ?? "1280x720";
+  const match = /^(\d+)x(\d+)$/.exec(viewportRaw);
+  if (!match) {
+    throw new Error(
+      `CF_DEMO_VIEWPORT must have WIDTHxHEIGHT form, got "${viewportRaw}"`,
+    );
+  }
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (width < 320 || height < 240) {
+    throw new Error("CF_DEMO_VIEWPORT must be at least 320x240");
+  }
+
+  const jpegQuality = positiveInt(env, "CF_DEMO_JPEG_QUALITY", 85);
+  if (jpegQuality < 1 || jpegQuality > 100) {
+    throw new Error("CF_DEMO_JPEG_QUALITY must be between 1 and 100");
+  }
+
+  return {
+    enabled: true,
+    outputDir,
+    viewport: { width, height },
+    typingDelayMs: positiveInt(env, "CF_DEMO_TYPING_DELAY_MS", 55),
+    cursorTravelMs: positiveInt(env, "CF_DEMO_CURSOR_TRAVEL_MS", 350),
+    cursorSettleMs: positiveInt(env, "CF_DEMO_CURSOR_SETTLE_MS", 150),
+    clickPulseMs: positiveInt(env, "CF_DEMO_CLICK_PULSE_MS", 180),
+    postResultHoldMs: positiveInt(env, "CF_DEMO_POST_RESULT_HOLD_MS", 800),
+    jpegQuality,
+    keepFrames: env.CF_DEMO_KEEP_FRAMES === "1" ||
+      env.CF_DEMO_KEEP_FRAMES === "true",
+  };
+}
+
+export const presentationConfig = parsePresentationConfig(Deno.env.toObject());

--- a/packages/integration/presentation/config.ts
+++ b/packages/integration/presentation/config.ts
@@ -3,6 +3,7 @@ export type PresentationConfig =
   | {
     enabled: true;
     outputDir: string;
+    videoFileName: string;
     viewport: { width: number; height: number };
     typingDelayMs: number;
     cursorTravelMs: number;
@@ -39,6 +40,13 @@ export function parsePresentationConfig(
   const outputDir = env.CF_DEMO_OUTPUT_DIR;
   if (!outputDir) return { enabled: false };
 
+  const demoName = env.CF_DEMO_NAME ?? "demo";
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(demoName)) {
+    throw new Error(
+      `CF_DEMO_NAME must be a safe filename stem, got "${demoName}"`,
+    );
+  }
+
   const viewportRaw = env.CF_DEMO_VIEWPORT ?? "1280x720";
   const match = /^(\d+)x(\d+)$/.exec(viewportRaw);
   if (!match) {
@@ -60,6 +68,7 @@ export function parsePresentationConfig(
   return {
     enabled: true,
     outputDir,
+    videoFileName: `${demoName}.mp4`,
     viewport: { width, height },
     typingDelayMs: positiveInt(env, "CF_DEMO_TYPING_DELAY_MS", 55),
     cursorTravelMs: positiveInt(env, "CF_DEMO_CURSOR_TRAVEL_MS", 350),

--- a/packages/integration/presentation/encode.ts
+++ b/packages/integration/presentation/encode.ts
@@ -1,0 +1,200 @@
+import { dirname, isAbsolute, join, relative } from "@std/path";
+import type { RecordedFrame } from "./manifest.ts";
+
+export type CompositionPlan = {
+  width: number;
+  height: number;
+  filter: string;
+  outputLabel: string;
+};
+
+export type CommandResult = {
+  success: boolean;
+  code: number;
+  stdout: Uint8Array;
+  stderr: Uint8Array;
+};
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  cwd?: string,
+) => Promise<CommandResult>;
+
+export const runCommand: CommandRunner = async (command, args, cwd) => {
+  return await new Deno.Command(command, {
+    args,
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+};
+
+const ffconcatQuote = (path: string): string =>
+  `'${path.replaceAll("'", "'\\''")}'`;
+
+export function buildFfconcat(frames: RecordedFrame[]): string {
+  if (frames.length === 0) {
+    throw new Error("cannot encode recording with no frames");
+  }
+  const lines = ["ffconcat version 1.0"];
+  for (const frame of frames) {
+    lines.push(`file ${ffconcatQuote(frame.path)}`);
+    lines.push(`duration ${frame.durationSeconds.toFixed(6)}`);
+  }
+  lines.push(`file ${ffconcatQuote(frames.at(-1)!.path)}`, "");
+  return lines.join("\n");
+}
+
+export function buildCompositionPlan(
+  participantIds: string[],
+): CompositionPlan {
+  const count = participantIds.length;
+  if (count < 1) {
+    throw new Error("composition requires at least one participant");
+  }
+  if (count > 4) {
+    throw new Error("composition supports at most four participants");
+  }
+
+  const normalize = (index: number) =>
+    `[${index}:v]scale=1280:720:force_original_aspect_ratio=decrease,` +
+    `pad=1280:720:(ow-iw)/2:(oh-ih)/2:black[v${index}]`;
+  if (count === 1) {
+    return {
+      width: 1280,
+      height: 720,
+      filter: normalize(0).replace("[v0]", "[vout]"),
+      outputLabel: "vout",
+    };
+  }
+
+  const filters = participantIds.map((_, index) => normalize(index));
+  if (count === 2) {
+    filters.push("[v0][v1]hstack=inputs=2:shortest=1[vout]");
+    return {
+      width: 2560,
+      height: 720,
+      filter: filters.join(";"),
+      outputLabel: "vout",
+    };
+  }
+
+  if (count === 3) {
+    filters.push("color=c=black:s=1280x720:d=86400[v3]");
+  }
+  filters.push(
+    "[v0][v1][v2][v3]xstack=inputs=4:" +
+      "layout=0_0|1280_0|0_720|1280_720:shortest=1[vout]",
+  );
+  return {
+    width: 2560,
+    height: 1440,
+    filter: filters.join(";"),
+    outputLabel: "vout",
+  };
+}
+
+export async function findFfmpeg(
+  runner: CommandRunner = runCommand,
+): Promise<{ command: string; version: string }> {
+  const command = Deno.env.get("FFMPEG") ?? "ffmpeg";
+  let result: CommandResult;
+  try {
+    result = await runner(command, ["-version"]);
+  } catch (cause) {
+    throw new Error(
+      "ffmpeg was not found; install ffmpeg or set FFMPEG to its path",
+      { cause },
+    );
+  }
+  if (!result.success) {
+    throw new Error("ffmpeg preflight failed");
+  }
+  const firstLine = new TextDecoder().decode(result.stdout).split("\n")[0];
+  return { command, version: firstLine };
+}
+
+export async function encodeParticipant(
+  options: {
+    ffmpeg: string;
+    participantDir: string;
+    frames: RecordedFrame[];
+    outputPath: string;
+  },
+  runner: CommandRunner = runCommand,
+): Promise<void> {
+  const concatPath = join(options.participantDir, "frames.ffconcat");
+  const relativeFrames = options.frames.map((frame) => ({
+    ...frame,
+    path: isAbsolute(frame.path)
+      ? relative(options.participantDir, frame.path)
+      : frame.path,
+  }));
+  await Deno.writeTextFile(concatPath, buildFfconcat(relativeFrames));
+  const args = [
+    "-y",
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-f",
+    "concat",
+    "-safe",
+    "0",
+    "-i",
+    concatPath,
+    "-vf",
+    "scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:black",
+    "-c:v",
+    "libx264",
+    "-pix_fmt",
+    "yuv420p",
+    "-movflags",
+    "+faststart",
+    options.outputPath,
+  ];
+  const result = await runner(options.ffmpeg, args, options.participantDir);
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).slice(-4000);
+    throw new Error(`ffmpeg participant encode failed: ${stderr}`);
+  }
+}
+
+export async function composeParticipants(
+  options: {
+    ffmpeg: string;
+    streams: string[];
+    outputPath: string;
+  },
+  runner: CommandRunner = runCommand,
+): Promise<void> {
+  const plan = buildCompositionPlan(options.streams);
+  if (options.streams.length === 1) {
+    await Deno.copyFile(options.streams[0], options.outputPath);
+    return;
+  }
+  const args = ["-y", "-hide_banner", "-loglevel", "error"];
+  for (const stream of options.streams) args.push("-i", stream);
+  args.push(
+    "-filter_complex",
+    plan.filter,
+    "-map",
+    `[${plan.outputLabel}]`,
+    "-c:v",
+    "libx264",
+    "-pix_fmt",
+    "yuv420p",
+    "-movflags",
+    "+faststart",
+    options.outputPath,
+  );
+  const result = await runner(
+    options.ffmpeg,
+    args,
+    dirname(options.outputPath),
+  );
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).slice(-4000);
+    throw new Error(`ffmpeg composition failed: ${stderr}`);
+  }
+}

--- a/packages/integration/presentation/interactions.ts
+++ b/packages/integration/presentation/interactions.ts
@@ -1,8 +1,22 @@
 import type { ElementHandle, InteractionObserver } from "@astral/astral";
 import type { Page } from "../page.ts";
+import { type ProbeApi, waitForCondition } from "../utils.ts";
 import type { PresentationConfig } from "./config.ts";
 
 const controllers = new WeakMap<Page, PresentationInteractions>();
+
+const cfInputIsFillable = (
+  probe: ProbeApi,
+  selector: string,
+): boolean => {
+  const element = probe.collect(selector)[0];
+  if (!element) return false;
+  const input = element instanceof HTMLInputElement
+    ? element
+    : element.shadowRoot?.querySelector("input");
+  return input instanceof HTMLInputElement && probe.isVisible(input) &&
+    !input.disabled && !input.readOnly;
+};
 
 export class PresentationInteractions {
   readonly #page: Page;
@@ -69,6 +83,10 @@ export class PresentationInteractions {
     value: string,
     timeout: number,
   ): Promise<void> {
+    await waitForCondition(this.#page, cfInputIsFillable, {
+      timeout,
+      args: [selector],
+    });
     const host = await this.#page.waitForSelector(selector, {
       strategy: "pierce",
       timeout,

--- a/packages/integration/presentation/interactions.ts
+++ b/packages/integration/presentation/interactions.ts
@@ -83,13 +83,19 @@ export class PresentationInteractions {
     value: string,
     timeout: number,
   ): Promise<void> {
-    await waitForCondition(this.#page, cfInputIsFillable, {
-      timeout,
-      args: [selector],
-    });
     const host = await this.#page.waitForSelector(selector, {
       strategy: "pierce",
       timeout,
+    });
+    await host.evaluate((element: Element) => {
+      const input = element instanceof HTMLInputElement
+        ? element
+        : element.shadowRoot?.querySelector("input");
+      input?.scrollIntoView({ block: "center", inline: "center" });
+    });
+    await waitForCondition(this.#page, cfInputIsFillable, {
+      timeout,
+      args: [selector],
     });
     await this.#moveCursorToElement(host);
     const focused = await host.evaluate((element: Element) => {

--- a/packages/integration/presentation/interactions.ts
+++ b/packages/integration/presentation/interactions.ts
@@ -1,0 +1,240 @@
+import type { ElementHandle, InteractionObserver } from "@astral/astral";
+import type { Page } from "../page.ts";
+import type { PresentationConfig } from "./config.ts";
+
+const controllers = new WeakMap<Page, PresentationInteractions>();
+
+export class PresentationInteractions {
+  readonly #page: Page;
+  readonly #config: Extract<PresentationConfig, { enabled: true }>;
+  readonly #participant: { label: string; color: string };
+
+  constructor(
+    page: Page,
+    config: Extract<PresentationConfig, { enabled: true }>,
+    participant: { label: string; color: string },
+  ) {
+    this.#page = page;
+    this.#config = config;
+    this.#participant = participant;
+  }
+
+  install(): void {
+    this.#page.setDefaultTypeDelay(this.#config.typingDelayMs);
+    const observer: InteractionObserver = {
+      beforeClick: (_element, point) => this.#moveCursor(point.x, point.y),
+      afterClick: () => this.#pulseCursor(),
+      beforeType: (element) => this.#moveCursorToElement(element),
+    };
+    this.#page.setInteractionObserver(observer);
+    controllers.set(this.#page, this);
+  }
+
+  uninstall(): void {
+    this.#page.setInteractionObserver(undefined);
+    this.#page.setDefaultTypeDelay(0);
+    controllers.delete(this.#page);
+  }
+
+  async prepareDocument(): Promise<void> {
+    await this.#ensureOverlay();
+  }
+
+  async showCaption(label: string): Promise<void> {
+    await this.#ensureOverlay();
+    await this.#page.evaluate((label) => {
+      const host = document.getElementById("__cf_demo_presentation_overlay");
+      const caption = host?.shadowRoot?.getElementById("caption") as
+        | HTMLElement
+        | undefined;
+      if (!caption) return;
+      caption.textContent = label;
+      caption.style.opacity = "1";
+    }, { args: [label] });
+  }
+
+  async clearCaption(): Promise<void> {
+    await this.#page.evaluate(() => {
+      const host = document.getElementById("__cf_demo_presentation_overlay");
+      const caption = host?.shadowRoot?.getElementById("caption") as
+        | HTMLElement
+        | undefined;
+      if (!caption) return;
+      caption.style.opacity = "0";
+    });
+  }
+
+  async typeIntoCfInput(
+    selector: string,
+    value: string,
+    timeout: number,
+  ): Promise<void> {
+    const host = await this.#page.waitForSelector(selector, {
+      strategy: "pierce",
+      timeout,
+    });
+    await this.#moveCursorToElement(host);
+    const focused = await host.evaluate((element: Element) => {
+      const input = element instanceof HTMLInputElement
+        ? element
+        : element.shadowRoot?.querySelector("input");
+      if (
+        !(input instanceof HTMLInputElement) || input.disabled || input.readOnly
+      ) {
+        return false;
+      }
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      if (setter) setter.call(input, "");
+      else input.value = "";
+      input.dispatchEvent(
+        new Event("input", { bubbles: true, composed: true }),
+      );
+      input.focus();
+      return true;
+    });
+    if (!focused) {
+      throw new Error(`"${selector}" did not resolve to a fillable input`);
+    }
+    await this.#page.keyboard.type(value);
+    const committed = await host.evaluate(
+      async (element: Element, value: string) => {
+        const input = element instanceof HTMLInputElement
+          ? element
+          : element.shadowRoot?.querySelector("input");
+        if (!(input instanceof HTMLInputElement)) return false;
+        input.dispatchEvent(
+          new Event("change", { bubbles: true, composed: true }),
+        );
+        input.blur();
+        const root = input.getRootNode();
+        const owner = (root instanceof ShadowRoot ? root.host : element) as
+          & Element
+          & {
+            commit?: () => Promise<void>;
+            requestUpdate?: () => void | Promise<void>;
+          };
+        await owner.commit?.();
+        await owner.requestUpdate?.();
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        );
+        return input.value === value;
+      },
+      { args: [value] },
+    );
+    if (!committed) {
+      throw new Error(
+        `presentation typing did not commit "${value}" to "${selector}"`,
+      );
+    }
+  }
+
+  async hold(milliseconds: number): Promise<void> {
+    if (milliseconds <= 0) return;
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+
+  async #moveCursorToElement(element: ElementHandle): Promise<void> {
+    const box = await element.boundingBox();
+    if (!box) return;
+    await this.#moveCursor(box.x + box.width / 2, box.y + box.height / 2);
+  }
+
+  async #moveCursor(x: number, y: number): Promise<void> {
+    await this.#ensureOverlay();
+    await this.#page.evaluate(async (x, y, duration) => {
+      const rootId = "__cf_demo_presentation_overlay";
+      const host = document.getElementById(rootId)!;
+      const cursor = host.shadowRoot!.getElementById("cursor") as HTMLElement;
+      cursor.style.transitionDuration = `${duration}ms`;
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve())
+      );
+      cursor.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+      await new Promise((resolve) => setTimeout(resolve, duration));
+    }, { args: [x, y, this.#config.cursorTravelMs] });
+    await this.hold(this.#config.cursorSettleMs);
+  }
+
+  async #ensureOverlay(): Promise<void> {
+    await this.#page.evaluate((label, color) => {
+      const rootId = "__cf_demo_presentation_overlay";
+      if (document.getElementById(rootId)) return;
+      const host = document.createElement("div");
+      host.id = rootId;
+      host.setAttribute("aria-hidden", "true");
+      Object.assign(host.style, {
+        position: "fixed",
+        inset: "0",
+        pointerEvents: "none",
+        zIndex: "2147483647",
+      });
+      const shadow = host.attachShadow({ mode: "open" });
+      shadow.innerHTML = `<style>
+        #cursor {
+          position: fixed; left: 0; top: 0; width: 18px; height: 24px;
+          transform: translate3d(24px, 24px, 0);
+          transition-property: transform;
+          transition-timing-function: cubic-bezier(.2,.8,.2,1);
+          filter: drop-shadow(0 1px 2px rgba(0,0,0,.7));
+        }
+        #cursor::before {
+          content: ""; display: block; width: 0; height: 0;
+          border-top: 20px solid white; border-right: 13px solid transparent;
+          transform: rotate(-20deg);
+        }
+        #cursor.pulse { filter: drop-shadow(0 0 7px #60a5fa); }
+        #label {
+          position: fixed; top: 16px; left: 16px; padding: 7px 12px;
+          border-radius: 999px; color: white; background: var(--accent);
+          font: 600 15px/1.2 system-ui, sans-serif;
+          box-shadow: 0 2px 8px rgba(0,0,0,.3);
+        }
+        #caption {
+          position: fixed; left: 50%; bottom: 22px; max-width: min(760px, 80vw);
+          transform: translateX(-50%); padding: 10px 16px; border-radius: 10px;
+          color: white; background: rgba(15,23,42,.88);
+          font: 600 17px/1.35 system-ui, sans-serif; text-align: center;
+          box-shadow: 0 3px 14px rgba(0,0,0,.35); opacity: 0;
+          transition: opacity 180ms ease;
+        }
+      </style><div id="label"></div><div id="caption"></div><div id="cursor"></div>`;
+      const labelElement = shadow.getElementById("label") as HTMLElement;
+      labelElement.textContent = label;
+      labelElement.style.setProperty("--accent", color);
+      document.documentElement.append(host);
+    }, { args: [this.#participant.label, this.#participant.color] });
+  }
+
+  async #pulseCursor(): Promise<void> {
+    await this.#page.evaluate(async (duration) => {
+      const host = document.getElementById("__cf_demo_presentation_overlay");
+      const cursor = host?.shadowRoot?.getElementById("cursor");
+      if (!cursor) return;
+      cursor.classList.add("pulse");
+      await new Promise((resolve) => setTimeout(resolve, duration));
+      cursor.classList.remove("pulse");
+    }, { args: [this.#config.clickPulseMs] });
+  }
+}
+
+export function installPresentationInteractions(
+  page: Page,
+  config: Extract<PresentationConfig, { enabled: true }>,
+  participant: { label: string; color: string },
+): PresentationInteractions {
+  const existing = controllers.get(page);
+  if (existing) return existing;
+  const controller = new PresentationInteractions(page, config, participant);
+  controller.install();
+  return controller;
+}
+
+export function presentationInteractions(
+  page: Page,
+): PresentationInteractions | undefined {
+  return controllers.get(page);
+}

--- a/packages/integration/presentation/manifest.ts
+++ b/packages/integration/presentation/manifest.ts
@@ -1,0 +1,56 @@
+export type DemoStatus =
+  | "recording"
+  | "passed"
+  | "test-failed"
+  | "capture-failed"
+  | "encode-failed";
+
+export type RecordedFrame = {
+  sequence: number;
+  path: string;
+  recordedAtMs: number;
+  sourceTimestamp?: number;
+  durationSeconds: number;
+  width: number;
+  height: number;
+};
+
+export type DemoParticipantManifest = {
+  id: string;
+  label: string;
+  color: string;
+  captureStartedAtMs: number;
+  captureEndedAtMs?: number;
+  frames: RecordedFrame[];
+  streamPath?: string;
+  error?: string;
+};
+
+export type DemoStep = {
+  label: string;
+  startedAtMs: number;
+  endedAtMs?: number;
+  participantId?: string;
+  failed?: boolean;
+};
+
+export type DemoManifest = {
+  version: 1;
+  runId: string;
+  status: DemoStatus;
+  startedAt: string;
+  viewport: { width: number; height: number };
+  participants: DemoParticipantManifest[];
+  steps: DemoStep[];
+  outputPath?: string;
+  error?: string;
+};
+
+export async function writeManifest(
+  path: string,
+  manifest: DemoManifest,
+): Promise<void> {
+  const tempPath = `${path}.tmp`;
+  await Deno.writeTextFile(tempPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await Deno.rename(tempPath, path);
+}

--- a/packages/integration/presentation/mod.ts
+++ b/packages/integration/presentation/mod.ts
@@ -1,0 +1,6 @@
+export * from "./config.ts";
+export * from "./encode.ts";
+export * from "./interactions.ts";
+export * from "./manifest.ts";
+export * from "./recorder.ts";
+export * from "./session.ts";

--- a/packages/integration/presentation/recorder.ts
+++ b/packages/integration/presentation/recorder.ts
@@ -1,0 +1,182 @@
+import { join } from "@std/path";
+import type { Page_screencastFrame } from "../../vendor-astral/bindings/celestial.ts";
+import type { DemoParticipantManifest, RecordedFrame } from "./manifest.ts";
+
+export interface ScreencastPage {
+  startScreencast(options?: {
+    format?: "jpeg" | "png";
+    quality?: number;
+    maxWidth?: number;
+    maxHeight?: number;
+    everyNthFrame?: number;
+  }): Promise<void>;
+  stopScreencast(): Promise<void>;
+  acknowledgeScreencastFrame(sessionId: number): Promise<void>;
+  onScreencastFrame(
+    listener: (frame: Page_screencastFrame) => void,
+  ): () => void;
+}
+
+export type RecorderClock = { now(): number };
+
+export type FrameRecorderOptions = {
+  participantDir: string;
+  id: string;
+  label: string;
+  color: string;
+  quality: number;
+  viewport: { width: number; height: number };
+  finalHoldMs: number;
+  clock?: RecorderClock;
+  maxPendingWrites?: number;
+  writeFile?: (path: string, data: Uint8Array) => Promise<void>;
+};
+
+const decodeBase64 = (data: string): Uint8Array => {
+  const binary = atob(data);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+};
+
+export class FrameRecorder {
+  readonly #page: ScreencastPage;
+  readonly #options: FrameRecorderOptions;
+  readonly #clock: RecorderClock;
+  #removeListener?: () => void;
+  #writeTail: Promise<void> = Promise.resolve();
+  #pendingWrites = 0;
+  #error?: Error;
+  #startedAtMs?: number;
+  #endedAtMs?: number;
+  #frames: RecordedFrame[] = [];
+  #state: "idle" | "recording" | "stopped" = "idle";
+
+  constructor(page: ScreencastPage, options: FrameRecorderOptions) {
+    this.#page = page;
+    this.#options = options;
+    this.#clock = options.clock ?? { now: () => performance.now() };
+  }
+
+  async start(): Promise<void> {
+    if (this.#state === "recording") return;
+    if (this.#state === "stopped") {
+      throw new Error("a stopped frame recorder cannot be restarted");
+    }
+    await Deno.mkdir(join(this.#options.participantDir, "frames"), {
+      recursive: true,
+    });
+    this.#startedAtMs = this.#clock.now();
+    this.#removeListener = this.#page.onScreencastFrame((frame) =>
+      this.#acceptFrame(frame)
+    );
+    await this.#page.startScreencast({
+      format: "jpeg",
+      quality: this.#options.quality,
+      maxWidth: this.#options.viewport.width,
+      maxHeight: this.#options.viewport.height,
+      everyNthFrame: 1,
+    });
+    this.#state = "recording";
+  }
+
+  async stop(): Promise<DemoParticipantManifest> {
+    if (this.#state === "idle") {
+      throw new Error("frame recorder was not started");
+    }
+    if (this.#state === "recording") {
+      this.#state = "stopped";
+      try {
+        await this.#page.stopScreencast();
+      } catch (cause) {
+        this.#recordError(
+          new Error("failed to stop page screencast", { cause }),
+        );
+      }
+      this.#removeListener?.();
+      this.#removeListener = undefined;
+      this.#endedAtMs = this.#clock.now();
+      await this.#writeTail;
+      this.#finalizeDurations();
+    }
+    if (this.#error) throw this.#error;
+    if (this.#frames.length === 0) {
+      throw new Error(`participant ${this.#options.id} recorded no frames`);
+    }
+    return this.manifest();
+  }
+
+  manifest(): DemoParticipantManifest {
+    return {
+      id: this.#options.id,
+      label: this.#options.label,
+      color: this.#options.color,
+      captureStartedAtMs: this.#startedAtMs ?? 0,
+      captureEndedAtMs: this.#endedAtMs,
+      frames: this.#frames.map((frame) => ({ ...frame })),
+      error: this.#error?.message,
+    };
+  }
+
+  #acceptFrame(frame: Page_screencastFrame): void {
+    if (this.#state === "stopped") return;
+    void this.#page.acknowledgeScreencastFrame(frame.sessionId).catch((cause) =>
+      this.#recordError(
+        new Error("failed to acknowledge screencast frame", {
+          cause,
+        }),
+      )
+    );
+
+    const limit = this.#options.maxPendingWrites ?? 120;
+    if (this.#pendingWrites >= limit) {
+      this.#recordError(
+        new Error(`screencast write queue exceeded ${limit} frames`),
+      );
+      return;
+    }
+    const sequence = this.#frames.length + 1;
+    const filename = `${String(sequence).padStart(6, "0")}.jpg`;
+    const path = join(this.#options.participantDir, "frames", filename);
+    const recorded: RecordedFrame = {
+      sequence,
+      path,
+      recordedAtMs: this.#clock.now(),
+      sourceTimestamp: frame.metadata.timestamp,
+      durationSeconds: 0,
+      width: frame.metadata.deviceWidth,
+      height: frame.metadata.deviceHeight,
+    };
+    this.#frames.push(recorded);
+    this.#pendingWrites++;
+    const writeFile = this.#options.writeFile ?? Deno.writeFile;
+    this.#writeTail = this.#writeTail
+      .then(() => writeFile(path, decodeBase64(frame.data)))
+      .catch((cause) => {
+        this.#recordError(
+          new Error(`failed to write frame ${sequence}`, {
+            cause,
+          }),
+        );
+      })
+      .finally(() => this.#pendingWrites--);
+  }
+
+  #finalizeDurations(): void {
+    for (let index = 0; index < this.#frames.length - 1; index++) {
+      this.#frames[index].durationSeconds = Math.max(
+        0.001,
+        (this.#frames[index + 1].recordedAtMs -
+          this.#frames[index].recordedAtMs) / 1000,
+      );
+    }
+    if (this.#frames.length > 0) {
+      this.#frames.at(-1)!.durationSeconds = Math.max(
+        0.001,
+        this.#options.finalHoldMs / 1000,
+      );
+    }
+  }
+
+  #recordError(error: Error): void {
+    this.#error ??= error;
+  }
+}

--- a/packages/integration/presentation/recorder.ts
+++ b/packages/integration/presentation/recorder.ts
@@ -43,6 +43,7 @@ export class FrameRecorder {
   readonly #clock: RecorderClock;
   #removeListener?: () => void;
   #writeTail: Promise<void> = Promise.resolve();
+  #pendingAcknowledgements = new Set<Promise<void>>();
   #pendingWrites = 0;
   #error?: Error;
   #startedAtMs?: number;
@@ -95,6 +96,7 @@ export class FrameRecorder {
       this.#removeListener = undefined;
       this.#endedAtMs = this.#clock.now();
       await this.#writeTail;
+      await Promise.all(this.#pendingAcknowledgements);
       this.#finalizeDurations();
     }
     if (this.#error) throw this.#error;
@@ -118,13 +120,17 @@ export class FrameRecorder {
 
   #acceptFrame(frame: Page_screencastFrame): void {
     if (this.#state === "stopped") return;
-    void this.#page.acknowledgeScreencastFrame(frame.sessionId).catch((cause) =>
-      this.#recordError(
-        new Error("failed to acknowledge screencast frame", {
-          cause,
-        }),
+    const acknowledgement = this.#page
+      .acknowledgeScreencastFrame(frame.sessionId)
+      .catch((cause) =>
+        this.#recordError(
+          new Error("failed to acknowledge screencast frame", {
+            cause,
+          }),
+        )
       )
-    );
+      .finally(() => this.#pendingAcknowledgements.delete(acknowledgement));
+    this.#pendingAcknowledgements.add(acknowledgement);
 
     const limit = this.#options.maxPendingWrites ?? 120;
     if (this.#pendingWrites >= limit) {

--- a/packages/integration/presentation/session.ts
+++ b/packages/integration/presentation/session.ts
@@ -210,7 +210,10 @@ export class PresentationSession {
         participant.manifest.streamPath = streamPath;
         streams.push(streamPath);
       }
-      const outputPath = join(this.#config.outputDir, "video.mp4");
+      const outputPath = join(
+        this.#config.outputDir,
+        this.#config.videoFileName,
+      );
       await composeParticipants({ ffmpeg: command, streams, outputPath });
       this.#manifest.outputPath = outputPath;
       this.#manifest.status = this.#manifest.status === "capture-failed"

--- a/packages/integration/presentation/session.ts
+++ b/packages/integration/presentation/session.ts
@@ -40,6 +40,7 @@ export class PresentationSession {
   readonly #byPage = new WeakMap<Page, ParticipantState>();
   readonly #steps: DemoStep[] = [];
   readonly #manifest: DemoManifest;
+  #manifestWriteTail: Promise<void> = Promise.resolve();
   #finalized = false;
 
   constructor(config: Extract<PresentationConfig, { enabled: true }>) {
@@ -159,6 +160,10 @@ export class PresentationSession {
       return await action();
     } catch (cause) {
       step.failed = true;
+      this.#manifest.status = "test-failed";
+      this.#manifest.error ??= cause instanceof Error
+        ? cause.message
+        : String(cause);
       throw cause;
     } finally {
       step.endedAtMs = this.now();
@@ -218,9 +223,9 @@ export class PresentationSession {
       );
       await composeParticipants({ ffmpeg: command, streams, outputPath });
       this.#manifest.outputPath = outputPath;
-      this.#manifest.status = this.#manifest.status === "capture-failed"
-        ? "capture-failed"
-        : "passed";
+      if (this.#manifest.status === "recording") {
+        this.#manifest.status = "passed";
+      }
       this.#syncManifest();
       await this.writeManifest();
       if (!this.#config.keepFrames && this.#manifest.status === "passed") {
@@ -246,12 +251,16 @@ export class PresentationSession {
   }
 
   async writeManifest(): Promise<void> {
-    await Deno.mkdir(this.#config.outputDir, { recursive: true });
-    this.#syncManifest();
-    await writeManifest(
-      join(this.#config.outputDir, "manifest.json"),
-      this.#manifest,
-    );
+    const write = this.#manifestWriteTail.then(async () => {
+      await Deno.mkdir(this.#config.outputDir, { recursive: true });
+      this.#syncManifest();
+      await writeManifest(
+        join(this.#config.outputDir, "manifest.json"),
+        this.#manifest,
+      );
+    });
+    this.#manifestWriteTail = write.catch(() => {});
+    await write;
   }
 
   #syncManifest(): void {

--- a/packages/integration/presentation/session.ts
+++ b/packages/integration/presentation/session.ts
@@ -76,6 +76,7 @@ export class PresentationSession {
     const participantDir = join(this.#config.outputDir, "participants", id);
     await page.setViewportSize(this.#config.viewport);
     installPresentationInteractions(page, this.#config, { label, color });
+    page.setAfterNavigationHook(() => this.start(page));
     const recorder = new FrameRecorder(page, {
       participantDir,
       id,
@@ -127,6 +128,7 @@ export class PresentationSession {
       this.#manifest.status = "capture-failed";
       this.#manifest.error ??= state.manifest.error;
     } finally {
+      page.setAfterNavigationHook(undefined);
       presentationInteractions(page)?.uninstall();
       this.#syncManifest();
     }

--- a/packages/integration/presentation/session.ts
+++ b/packages/integration/presentation/session.ts
@@ -1,0 +1,293 @@
+import { basename, join } from "@std/path";
+import type { Page } from "../page.ts";
+import type { PresentationConfig, PresentationParticipant } from "./config.ts";
+import { presentationConfig } from "./config.ts";
+import {
+  composeParticipants,
+  encodeParticipant,
+  findFfmpeg,
+} from "./encode.ts";
+import {
+  installPresentationInteractions,
+  presentationInteractions,
+} from "./interactions.ts";
+import type {
+  DemoManifest,
+  DemoParticipantManifest,
+  DemoStep,
+} from "./manifest.ts";
+import { writeManifest } from "./manifest.ts";
+import { FrameRecorder } from "./recorder.ts";
+
+const COLORS = ["#7c3aed", "#0891b2", "#dc2626", "#16a34a"];
+
+type ParticipantState = {
+  page: Page;
+  manifest: DemoParticipantManifest;
+  recorder: FrameRecorder;
+  started: boolean;
+  stopped: boolean;
+};
+
+const slug = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") ||
+  "participant";
+
+export class PresentationSession {
+  readonly #config: Extract<PresentationConfig, { enabled: true }>;
+  readonly #origin = performance.now();
+  readonly #participants: ParticipantState[] = [];
+  readonly #byPage = new WeakMap<Page, ParticipantState>();
+  readonly #steps: DemoStep[] = [];
+  readonly #manifest: DemoManifest;
+  #finalized = false;
+
+  constructor(config: Extract<PresentationConfig, { enabled: true }>) {
+    this.#config = config;
+    this.#manifest = {
+      version: 1,
+      runId: basename(config.outputDir),
+      status: "recording",
+      startedAt: new Date().toISOString(),
+      viewport: config.viewport,
+      participants: [],
+      steps: this.#steps,
+    };
+  }
+
+  enabled(): true {
+    return true;
+  }
+
+  async register(
+    page: Page,
+    requested: PresentationParticipant = {},
+  ): Promise<void> {
+    if (this.#byPage.has(page)) return;
+    const index = this.#participants.length;
+    const label = requested.label ?? `Participant ${index + 1}`;
+    const baseId = requested.id ?? slug(label);
+    let id = baseId;
+    let suffix = 2;
+    while (this.#participants.some((item) => item.manifest.id === id)) {
+      id = `${baseId}-${suffix++}`;
+    }
+    const color = requested.color ?? COLORS[index % COLORS.length];
+    const participantDir = join(this.#config.outputDir, "participants", id);
+    await page.setViewportSize(this.#config.viewport);
+    installPresentationInteractions(page, this.#config, { label, color });
+    const recorder = new FrameRecorder(page, {
+      participantDir,
+      id,
+      label,
+      color,
+      quality: this.#config.jpegQuality,
+      viewport: this.#config.viewport,
+      finalHoldMs: this.#config.postResultHoldMs,
+      clock: { now: () => this.now() },
+    });
+    const state: ParticipantState = {
+      page,
+      recorder,
+      started: false,
+      stopped: false,
+      manifest: recorder.manifest(),
+    };
+    this.#participants.push(state);
+    this.#byPage.set(page, state);
+    this.#syncManifest();
+  }
+
+  async start(page: Page): Promise<void> {
+    const state = this.#byPage.get(page);
+    if (!state || state.started) return;
+    await presentationInteractions(page)?.prepareDocument();
+    await state.recorder.start();
+    state.started = true;
+    state.manifest = state.recorder.manifest();
+    this.#syncManifest();
+  }
+
+  async close(page: Page): Promise<void> {
+    const state = this.#byPage.get(page);
+    if (!state || state.stopped) return;
+    state.stopped = true;
+    try {
+      if (state.started) {
+        await presentationInteractions(page)?.hold(
+          this.#config.postResultHoldMs,
+        );
+        state.manifest = await state.recorder.stop();
+      }
+    } catch (cause) {
+      state.manifest = state.recorder.manifest();
+      state.manifest.error = cause instanceof Error
+        ? cause.message
+        : String(cause);
+      this.#manifest.status = "capture-failed";
+      this.#manifest.error ??= state.manifest.error;
+    } finally {
+      presentationInteractions(page)?.uninstall();
+      this.#syncManifest();
+    }
+    if (this.#participants.every((participant) => participant.stopped)) {
+      await this.finalize();
+    }
+  }
+
+  async step<T>(
+    label: string,
+    action: () => Promise<T>,
+    participantId?: string,
+  ): Promise<T> {
+    const step: DemoStep = {
+      label,
+      participantId,
+      startedAtMs: this.now(),
+    };
+    this.#steps.push(step);
+    await Promise.all(
+      this.#participants
+        .filter((participant) => participant.started && !participant.stopped)
+        .map((participant) =>
+          presentationInteractions(participant.page)?.showCaption(label)
+        ),
+    );
+    try {
+      return await action();
+    } catch (cause) {
+      step.failed = true;
+      throw cause;
+    } finally {
+      step.endedAtMs = this.now();
+      await Promise.all(
+        this.#participants
+          .filter((participant) => participant.started && !participant.stopped)
+          .map(async (participant) => {
+            const presentation = presentationInteractions(participant.page);
+            await presentation?.hold(this.#config.postResultHoldMs);
+            await presentation?.clearCaption();
+          }),
+      );
+      await this.writeManifest();
+    }
+  }
+
+  now(): number {
+    return performance.now() - this.#origin;
+  }
+
+  async finalize(): Promise<void> {
+    if (this.#finalized) return;
+    this.#finalized = true;
+    await Deno.mkdir(this.#config.outputDir, { recursive: true });
+    const usable = this.#participants.filter((participant) =>
+      participant.manifest.frames.length > 0 && !participant.manifest.error
+    );
+    if (usable.length === 0) {
+      this.#manifest.status = "capture-failed";
+      this.#manifest.error ??= "no participant produced a usable recording";
+      await this.writeManifest();
+      throw new Error(this.#manifest.error);
+    }
+    try {
+      this.#normalizeTimelines(usable);
+      const { command } = await findFfmpeg();
+      const streams: string[] = [];
+      for (const participant of usable) {
+        const participantDir = join(
+          this.#config.outputDir,
+          "participants",
+          participant.manifest.id,
+        );
+        const streamPath = join(participantDir, "stream.mp4");
+        await encodeParticipant({
+          ffmpeg: command,
+          participantDir,
+          frames: participant.manifest.frames,
+          outputPath: streamPath,
+        });
+        participant.manifest.streamPath = streamPath;
+        streams.push(streamPath);
+      }
+      const outputPath = join(this.#config.outputDir, "video.mp4");
+      await composeParticipants({ ffmpeg: command, streams, outputPath });
+      this.#manifest.outputPath = outputPath;
+      this.#manifest.status = this.#manifest.status === "capture-failed"
+        ? "capture-failed"
+        : "passed";
+      this.#syncManifest();
+      await this.writeManifest();
+      if (!this.#config.keepFrames && this.#manifest.status === "passed") {
+        for (const participant of usable) {
+          const framesDir = join(
+            this.#config.outputDir,
+            "participants",
+            participant.manifest.id,
+            "frames",
+          );
+          await Deno.remove(framesDir, { recursive: true }).catch(() => {});
+        }
+      }
+      console.log(`Demo video: ${outputPath}`);
+    } catch (cause) {
+      this.#manifest.status = "encode-failed";
+      this.#manifest.error = cause instanceof Error
+        ? cause.message
+        : String(cause);
+      await this.writeManifest();
+      throw cause;
+    }
+  }
+
+  async writeManifest(): Promise<void> {
+    await Deno.mkdir(this.#config.outputDir, { recursive: true });
+    this.#syncManifest();
+    await writeManifest(
+      join(this.#config.outputDir, "manifest.json"),
+      this.#manifest,
+    );
+  }
+
+  #syncManifest(): void {
+    this.#manifest.participants = this.#participants.map((participant) =>
+      participant.manifest
+    );
+  }
+
+  #normalizeTimelines(participants: ParticipantState[]): void {
+    const start = Math.min(
+      ...participants.map((participant) =>
+        participant.manifest.captureStartedAtMs
+      ),
+    );
+    const end = Math.max(
+      ...participants.map((participant) =>
+        participant.manifest.captureEndedAtMs ??
+          participant.manifest.captureStartedAtMs
+      ),
+    );
+    for (const participant of participants) {
+      const frames = participant.manifest.frames;
+      frames[0].durationSeconds += Math.max(
+        0,
+        (participant.manifest.captureStartedAtMs - start) / 1000,
+      );
+      frames.at(-1)!.durationSeconds += Math.max(
+        0,
+        (end - (participant.manifest.captureEndedAtMs ?? end)) / 1000,
+      );
+    }
+  }
+}
+
+let singleton: PresentationSession | undefined;
+
+export function getPresentationSession(): PresentationSession | undefined {
+  if (!presentationConfig.enabled) return undefined;
+  return singleton ??= new PresentationSession(presentationConfig);
+}
+
+export function resetPresentationSessionForTest(): void {
+  singleton = undefined;
+}

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -4,7 +4,9 @@ import {
   env,
   Page,
   pipeConsole,
+  type PresentationParticipant,
 } from "@commonfabric/integration";
+import { getPresentationSession } from "./presentation/session.ts";
 import {
   Identity,
   InsecureCryptoKeyPair,
@@ -129,6 +131,8 @@ export interface ShellIntegrationConfig {
    * ```
    */
   allowedConsoleErrors?: (string | RegExp)[];
+  /** Optional participant metadata used only by `deno task demo`. */
+  presentation?: PresentationParticipant;
 }
 
 export class ShellIntegration {
@@ -136,7 +140,8 @@ export class ShellIntegration {
   #page?: Page;
   #exceptions: Array<string> = [];
   #errorLogs: Array<string> = [];
-  #config: Required<ShellIntegrationConfig>;
+  #config: Required<Omit<ShellIntegrationConfig, "presentation">>;
+  #presentation: PresentationParticipant;
 
   constructor(config: ShellIntegrationConfig = {}) {
     this.#config = {
@@ -144,6 +149,7 @@ export class ShellIntegration {
       failOnConsoleError: config.failOnConsoleError ?? true,
       allowedConsoleErrors: config.allowedConsoleErrors ?? [],
     };
+    this.#presentation = config.presentation ?? {};
   }
 
   bindLifecycle() {
@@ -256,12 +262,14 @@ export class ShellIntegration {
       await this.login(identity);
       await this.waitForState({ identity, view });
     }
+    await getPresentationSession()?.start(page);
   }
 
   #beforeAll = async () => {
     this.#browser = await Browser.launch({ headless: env.HEADLESS });
     this.#page = await this.#browser.newPage();
     this.#attachPage(this.#page);
+    await getPresentationSession()?.register(this.#page, this.#presentation);
   };
 
   #beforeEach = () => {
@@ -302,6 +310,9 @@ export class ShellIntegration {
   };
 
   #afterAll = async () => {
+    if (this.#page) {
+      await getPresentationSession()?.close(this.#page);
+    }
     await this.#disposePageRuntime();
     await this.#page?.close();
     await this.#browser?.close();

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -1,0 +1,205 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import {
+  buildCompositionPlan,
+  buildFfconcat,
+  FrameRecorder,
+  parsePresentationConfig,
+  type RecordedFrame,
+} from "../presentation/mod.ts";
+import type { Page_screencastFrame } from "../../vendor-astral/bindings/celestial.ts";
+
+Deno.test("parsePresentationConfig stays disabled without an output directory", () => {
+  assertEquals(parsePresentationConfig({}), { enabled: false });
+});
+
+Deno.test("parsePresentationConfig supplies deterministic defaults", () => {
+  const config = parsePresentationConfig({
+    CF_DEMO_OUTPUT_DIR: "/tmp/demo",
+  });
+  assertEquals(config.enabled, true);
+  if (!config.enabled) throw new Error("expected enabled config");
+  assertEquals(config.outputDir, "/tmp/demo");
+  assertEquals(config.viewport, { width: 1280, height: 720 });
+  assertEquals(config.typingDelayMs, 55);
+  assertEquals(config.cursorTravelMs, 350);
+  assertEquals(config.postResultHoldMs, 800);
+  assertEquals(config.jpegQuality, 85);
+});
+
+Deno.test("parsePresentationConfig validates numeric overrides", () => {
+  assertThrows(
+    () =>
+      parsePresentationConfig({
+        CF_DEMO_OUTPUT_DIR: "/tmp/demo",
+        CF_DEMO_VIEWPORT: "wide",
+      }),
+    Error,
+    "CF_DEMO_VIEWPORT",
+  );
+});
+
+Deno.test("buildFfconcat preserves variable durations and repeats final frame", () => {
+  const frames: RecordedFrame[] = [
+    frame("frames/000001.jpg", 0, 0.4),
+    frame("frames/000002.jpg", 400, 1.1),
+    frame("frames/000003.jpg", 1500, 0.8),
+  ];
+  assertEquals(
+    buildFfconcat(frames),
+    [
+      "ffconcat version 1.0",
+      "file 'frames/000001.jpg'",
+      "duration 0.400000",
+      "file 'frames/000002.jpg'",
+      "duration 1.100000",
+      "file 'frames/000003.jpg'",
+      "duration 0.800000",
+      "file 'frames/000003.jpg'",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("buildFfconcat rejects an empty recording", () => {
+  assertThrows(
+    () => buildFfconcat([]),
+    Error,
+    "no frames",
+  );
+});
+
+Deno.test("buildCompositionPlan creates deterministic one through four participant layouts", () => {
+  assertEquals(buildCompositionPlan(["alice"]), {
+    width: 1280,
+    height: 720,
+    filter:
+      "[0:v]scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:black[vout]",
+    outputLabel: "vout",
+  });
+
+  const two = buildCompositionPlan(["alice", "bob"]);
+  assertEquals({ width: two.width, height: two.height }, {
+    width: 2560,
+    height: 720,
+  });
+  assertStringIncludes(two.filter, "hstack=inputs=2:shortest=1[vout]");
+
+  const three = buildCompositionPlan(["alice", "bob", "carol"]);
+  assertEquals({ width: three.width, height: three.height }, {
+    width: 2560,
+    height: 1440,
+  });
+  assertStringIncludes(three.filter, "xstack=inputs=4");
+  assertStringIncludes(three.filter, "color=c=black:s=1280x720");
+  assertStringIncludes(three.filter, "shortest=1[vout]");
+
+  const four = buildCompositionPlan(["a", "b", "c", "d"]);
+  assertStringIncludes(four.filter, "layout=0_0|1280_0|0_720|1280_720");
+});
+
+Deno.test("buildCompositionPlan rejects more than four participants", () => {
+  assertThrows(
+    () => buildCompositionPlan(["a", "b", "c", "d", "e"]),
+    Error,
+    "at most four",
+  );
+});
+
+Deno.test("FrameRecorder acknowledges immediately and preserves variable timing", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    let now = 100;
+    const page = new FakeScreencastPage();
+    const writes: string[] = [];
+    const recorder = new FrameRecorder(page, {
+      participantDir: dir,
+      id: "alice",
+      label: "Alice",
+      color: "#7c3aed",
+      quality: 85,
+      viewport: { width: 1280, height: 720 },
+      finalHoldMs: 800,
+      clock: { now: () => now },
+      writeFile: async (path) => {
+        await Promise.resolve();
+        writes.push(path);
+      },
+    });
+    await recorder.start();
+    page.emit(screencastFrame(1));
+    assertEquals(page.acknowledged, [1]);
+    now = 600;
+    page.emit(screencastFrame(2));
+    now = 700;
+    const manifest = await recorder.stop();
+    assertEquals(writes.length, 2);
+    assertEquals(manifest.frames.map((item) => item.durationSeconds), [
+      0.5,
+      0.8,
+    ]);
+    assertEquals(manifest.captureStartedAtMs, 100);
+    assertEquals(manifest.captureEndedAtMs, 700);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+function frame(
+  path: string,
+  recordedAtMs: number,
+  durationSeconds: number,
+): RecordedFrame {
+  return {
+    sequence: 1,
+    path,
+    recordedAtMs,
+    durationSeconds,
+    width: 1280,
+    height: 720,
+  };
+}
+
+class FakeScreencastPage {
+  listener?: (frame: Page_screencastFrame) => void;
+  acknowledged: number[] = [];
+
+  startScreencast(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stopScreencast(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  acknowledgeScreencastFrame(sessionId: number): Promise<void> {
+    this.acknowledged.push(sessionId);
+    return Promise.resolve();
+  }
+
+  onScreencastFrame(
+    listener: (frame: Page_screencastFrame) => void,
+  ): () => void {
+    this.listener = listener;
+    return () => this.listener = undefined;
+  }
+
+  emit(frame: Page_screencastFrame): void {
+    this.listener?.(frame);
+  }
+}
+
+function screencastFrame(sessionId: number): Page_screencastFrame {
+  return {
+    sessionId,
+    data: btoa("jpeg"),
+    metadata: {
+      offsetTop: 0,
+      pageScaleFactor: 1,
+      deviceWidth: 1280,
+      deviceHeight: 720,
+      scrollOffsetX: 0,
+      scrollOffsetY: 0,
+      timestamp: sessionId,
+    },
+  };
+}

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -19,11 +19,30 @@ Deno.test("parsePresentationConfig supplies deterministic defaults", () => {
   assertEquals(config.enabled, true);
   if (!config.enabled) throw new Error("expected enabled config");
   assertEquals(config.outputDir, "/tmp/demo");
+  assertEquals(config.videoFileName, "demo.mp4");
   assertEquals(config.viewport, { width: 1280, height: 720 });
   assertEquals(config.typingDelayMs, 55);
   assertEquals(config.cursorTravelMs, 350);
   assertEquals(config.postResultHoldMs, 800);
   assertEquals(config.jpegQuality, 85);
+});
+
+Deno.test("parsePresentationConfig names and validates the output video", () => {
+  const config = parsePresentationConfig({
+    CF_DEMO_OUTPUT_DIR: "/tmp/demo",
+    CF_DEMO_NAME: "lunch-poll-vote",
+  });
+  if (!config.enabled) throw new Error("expected enabled config");
+  assertEquals(config.videoFileName, "lunch-poll-vote.mp4");
+  assertThrows(
+    () =>
+      parsePresentationConfig({
+        CF_DEMO_OUTPUT_DIR: "/tmp/demo",
+        CF_DEMO_NAME: "../escape",
+      }),
+    Error,
+    "safe filename stem",
+  );
 });
 
 Deno.test("parsePresentationConfig validates numeric overrides", () => {

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -1,9 +1,15 @@
-import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import {
   buildCompositionPlan,
   buildFfconcat,
   FrameRecorder,
   parsePresentationConfig,
+  PresentationSession,
   type RecordedFrame,
 } from "../presentation/mod.ts";
 import type { Page_screencastFrame } from "../../vendor-astral/bindings/celestial.ts";
@@ -193,6 +199,78 @@ Deno.test("FrameRecorder acknowledges immediately and preserves variable timing"
   }
 });
 
+Deno.test("FrameRecorder waits for late acknowledgement failures", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    let rejectAcknowledgement!: (reason: Error) => void;
+    const page = new FakeScreencastPage();
+    page.acknowledge = () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectAcknowledgement = reject;
+      });
+    const recorder = new FrameRecorder(page, {
+      participantDir: dir,
+      id: "alice",
+      label: "Alice",
+      color: "#7c3aed",
+      quality: 85,
+      viewport: { width: 1280, height: 720 },
+      finalHoldMs: 800,
+      writeFile: () => Promise.resolve(),
+    });
+    await recorder.start();
+    page.emit(screencastFrame(1));
+    const stopping = recorder.stop();
+    rejectAcknowledgement(new Error("CDP closed"));
+
+    await assertRejects(
+      () => stopping,
+      Error,
+      "failed to acknowledge screencast frame",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("PresentationSession serializes manifests and records failed steps", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const session = new PresentationSession({
+      enabled: true,
+      outputDir: dir,
+      videoFileName: "demo.mp4",
+      viewport: { width: 1280, height: 720 },
+      typingDelayMs: 55,
+      cursorTravelMs: 350,
+      cursorSettleMs: 150,
+      clickPulseMs: 180,
+      postResultHoldMs: 0,
+      jpegQuality: 85,
+      keepFrames: false,
+    });
+    await Promise.all(
+      Array.from({ length: 8 }, () => session.writeManifest()),
+    );
+    await assertRejects(
+      () =>
+        session.step(
+          "failing action",
+          () => Promise.reject(new Error("expected failure")),
+        ),
+      Error,
+      "expected failure",
+    );
+    const manifest = JSON.parse(
+      await Deno.readTextFile(`${dir}/manifest.json`),
+    );
+    assertEquals(manifest.status, "test-failed");
+    assertEquals(manifest.steps[0].failed, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 function frame(
   path: string,
   recordedAtMs: number,
@@ -211,6 +289,7 @@ function frame(
 class FakeScreencastPage {
   listener?: (frame: Page_screencastFrame) => void;
   acknowledged: number[] = [];
+  acknowledge: (sessionId: number) => Promise<void> = () => Promise.resolve();
 
   startScreencast(): Promise<void> {
     return Promise.resolve();
@@ -222,7 +301,7 @@ class FakeScreencastPage {
 
   acknowledgeScreencastFrame(sessionId: number): Promise<void> {
     this.acknowledged.push(sessionId);
-    return Promise.resolve();
+    return this.acknowledge(sessionId);
   }
 
   onScreencastFrame(

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -7,9 +7,39 @@ import {
   type RecordedFrame,
 } from "../presentation/mod.ts";
 import type { Page_screencastFrame } from "../../vendor-astral/bindings/celestial.ts";
+import { Page } from "../page.ts";
 
 Deno.test("parsePresentationConfig stays disabled without an output directory", () => {
   assertEquals(parsePresentationConfig({}), { enabled: false });
+});
+
+Deno.test("Page runs the navigation hook after goto and reload", async () => {
+  const navigations: string[] = [];
+  const astralPage = {
+    timeout: 0,
+    goto: (url: string) => {
+      navigations.push(url);
+      return Promise.resolve();
+    },
+    reload: () => {
+      navigations.push("reload");
+      return Promise.resolve();
+    },
+  };
+  const page = new Page(
+    astralPage as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  let hookCalls = 0;
+  page.setAfterNavigationHook(() => {
+    hookCalls++;
+  });
+
+  await page.goto("https://example.test/");
+  await page.reload();
+
+  assertEquals(navigations, ["https://example.test/", "reload"]);
+  assertEquals(hookCalls, 2);
 });
 
 Deno.test("parsePresentationConfig supplies deterministic defaults", () => {

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1,6 +1,8 @@
 import {
   awaitViewSettled,
+  getPresentationSession,
   Page,
+  presentationInteractions,
   type ProbeApi,
   waitForCondition,
 } from "@commonfabric/integration";
@@ -474,10 +476,15 @@ export async function fillCfInput(
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   try {
-    await waitForCondition(page, fillAndVerify, {
-      timeout,
-      args: [selector, value],
-    });
+    const presentation = presentationInteractions(page);
+    if (presentation) {
+      await presentation.typeIntoCfInput(selector, value, timeout);
+    } else {
+      await waitForCondition(page, fillAndVerify, {
+        timeout,
+        args: [selector, value],
+      });
+    }
   } catch (cause) {
     const probe = await readCfInputProbe(page, selector).catch(() => undefined);
     throw new Error(
@@ -1128,7 +1135,8 @@ export class StepTimer {
   async run<T>(label: string, fn: () => Promise<T>): Promise<T> {
     const start = performance.now();
     try {
-      return await fn();
+      const presentation = getPresentationSession();
+      return presentation ? await presentation.step(label, fn) : await fn();
     } finally {
       this.#rows.push({ label, ms: Math.round(performance.now() - start) });
     }

--- a/packages/patterns/integration/cfc-render-policy-demo.test.ts
+++ b/packages/patterns/integration/cfc-render-policy-demo.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./pieces-controller.ts";
 import {
   clickTrustedActionAndWaitForText,
+  StepTimer,
   waitForRuntimeIdle,
   waitForText,
   waitForTextAbsent,
@@ -18,7 +19,9 @@ import {
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
 describe("cfc render policy demo integration test", () => {
-  const shell = new ShellIntegration();
+  const shell = new ShellIntegration({
+    presentation: { label: "Policy demo", color: "#7c3aed" },
+  });
   shell.bindLifecycle();
 
   let identity: Identity;
@@ -62,6 +65,7 @@ describe("cfc render policy demo integration test", () => {
   });
 
   it("blocks raw confidential content and reveals it through the trusted surface", async () => {
+    const timeline = new StepTimer();
     const page = shell.page();
     await shell.goto({
       frontendUrl: FRONTEND_URL,
@@ -73,29 +77,46 @@ describe("cfc render policy demo integration test", () => {
     });
     await waitForRuntimeIdle(page);
 
-    await waitForText(page, "#raw-health-attempt", "Content hidden by policy");
-    await waitForText(
-      page,
-      "#trusted-health-surface",
-      "Content hidden by policy",
-    );
-    await waitForTextAbsent(
-      page,
-      "#raw-health-attempt",
-      "Sensitive health data:",
+    await timeline.run(
+      "Confidential data starts hidden on every untrusted surface",
+      async () => {
+        await waitForText(
+          page,
+          "#raw-health-attempt",
+          "Content hidden by policy",
+        );
+        await waitForText(
+          page,
+          "#trusted-health-surface",
+          "Content hidden by policy",
+        );
+        await waitForTextAbsent(
+          page,
+          "#raw-health-attempt",
+          "Sensitive health data:",
+        );
+      },
     );
 
-    await clickTrustedActionAndWaitForText(
-      page,
-      "TrustedRevealHealthData",
-      "#trusted-health-visible",
-      "Sensitive health data: migraine treatment plan",
-      { timeout: 45_000 },
+    await timeline.run(
+      "A trusted action reveals the approved value only inside its trusted surface",
+      () =>
+        clickTrustedActionAndWaitForText(
+          page,
+          "TrustedRevealHealthData",
+          "#trusted-health-visible",
+          "Sensitive health data: migraine treatment plan",
+          { timeout: 45_000 },
+        ),
     );
-    await waitForTextAbsent(
-      page,
-      "#raw-health-attempt",
-      "Sensitive health data:",
+    await timeline.run(
+      "The raw pattern output remains hidden after the trusted reveal",
+      () =>
+        waitForTextAbsent(
+          page,
+          "#raw-health-attempt",
+          "Sensitive health data:",
+        ),
     );
   });
 });

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -75,8 +75,12 @@ const voteSwatchVoters = (page: Page): Promise<string[]> =>
   });
 
 describe("lunch poll: two users vote on a shared option", () => {
-  const hostShell = new ShellIntegration();
-  const guestShell = new ShellIntegration();
+  const hostShell = new ShellIntegration({
+    presentation: { id: "alice", label: "Alice", color: "#7c3aed" },
+  });
+  const guestShell = new ShellIntegration({
+    presentation: { id: "bob", label: "Bob", color: "#0891b2" },
+  });
   hostShell.bindLifecycle();
   guestShell.bindLifecycle();
 

--- a/packages/vendor-astral/src/element_handle.ts
+++ b/packages/vendor-astral/src/element_handle.ts
@@ -205,18 +205,18 @@ export class ElementHandle {
 
     const { x, y } = getTopLeft(model.content);
 
-    if (opts?.offset) {
-      await this.#page.mouse.click(
-        x + opts.offset.x,
-        y + opts.offset.y,
-        opts,
-      );
-    } else {
-      await this.#page.mouse.click(
-        x + (model.width / 2),
-        y + (model.height / 2),
-        opts,
-      );
+    const point = opts?.offset
+      ? { x: x + opts.offset.x, y: y + opts.offset.y }
+      : { x: x + (model.width / 2), y: y + (model.height / 2) };
+    await this.#page.notifyBeforeClick(this, point);
+    let error: unknown;
+    try {
+      await this.#page.mouse.click(point.x, point.y, opts);
+    } catch (cause) {
+      error = cause;
+      throw cause;
+    } finally {
+      await this.#page.notifyAfterClick(this, point, error);
     }
   }
 
@@ -328,7 +328,16 @@ export class ElementHandle {
    */
   async type(text: string, opts?: KeyboardTypeOptions) {
     await this.focus();
-    await this.#page.keyboard.type(text, opts);
+    await this.#page.notifyBeforeType(this, text);
+    let error: unknown;
+    try {
+      await this.#page.keyboard.type(text, opts);
+    } catch (cause) {
+      error = cause;
+      throw cause;
+    } finally {
+      await this.#page.notifyAfterType(this, text, error);
+    }
   }
 
   /**

--- a/packages/vendor-astral/src/element_handle.ts
+++ b/packages/vendor-astral/src/element_handle.ts
@@ -214,10 +214,13 @@ export class ElementHandle {
       await this.#page.mouse.click(point.x, point.y, opts);
     } catch (cause) {
       error = cause;
-      throw cause;
-    } finally {
-      await this.#page.notifyAfterClick(this, point, error);
     }
+    try {
+      await this.#page.notifyAfterClick(this, point, error);
+    } catch (afterError) {
+      if (error === undefined) throw afterError;
+    }
+    if (error !== undefined) throw error;
   }
 
   /**
@@ -334,10 +337,13 @@ export class ElementHandle {
       await this.#page.keyboard.type(text, opts);
     } catch (cause) {
       error = cause;
-      throw cause;
-    } finally {
-      await this.#page.notifyAfterType(this, text, error);
     }
+    try {
+      await this.#page.notifyAfterType(this, text, error);
+    } catch (afterError) {
+      if (error === undefined) throw afterError;
+    }
+    if (error !== undefined) throw error;
   }
 
   /**

--- a/packages/vendor-astral/src/keyboard/mod.ts
+++ b/packages/vendor-astral/src/keyboard/mod.ts
@@ -31,10 +31,15 @@ export class Keyboard {
   #celestial: Celestial;
   #pageData: KeyboardPageData;
   #pressedKeys = new Set<string>();
+  #defaultTypeDelay = 0;
 
   constructor(celestial: Celestial, pageData?: KeyboardPageData) {
     this.#celestial = celestial;
     this.#pageData = pageData || { modifiers: 0 };
+  }
+
+  setDefaultTypeDelay(delay: number): void {
+    this.#defaultTypeDelay = delay;
   }
 
   /**
@@ -181,7 +186,7 @@ export class Keyboard {
    * Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
    */
   async type(text: string | KeyInput[], options: KeyboardTypeOptions = {}) {
-    const delay = options.delay;
+    const delay = options.delay ?? this.#defaultTypeDelay;
     for (const char of text) {
       const key = char as KeyInput;
       if (key in KEY_DEFINITIONS) {

--- a/packages/vendor-astral/src/page.ts
+++ b/packages/vendor-astral/src/page.ts
@@ -126,6 +126,24 @@ export interface PageEventMap {
   "pageerror": PageErrorEvent;
 }
 
+export interface InteractionObserver {
+  beforeClick?(
+    element: ElementHandle,
+    point: { x: number; y: number },
+  ): Promise<void> | void;
+  afterClick?(
+    element: ElementHandle,
+    point: { x: number; y: number },
+    error?: unknown,
+  ): Promise<void> | void;
+  beforeType?(element: ElementHandle, text: string): Promise<void> | void;
+  afterType?(
+    element: ElementHandle,
+    text: string,
+    error?: unknown,
+  ): Promise<void> | void;
+}
+
 /** The details for a console event */
 export interface ConsoleEventDetails {
   type: Runtime_consoleAPICalled["type"];
@@ -169,11 +187,43 @@ export class Page extends EventTarget implements AsyncDisposable {
   #browser: Browser;
   #url: string;
   #coverage?: boolean;
+  #interactionObserver?: InteractionObserver;
 
   readonly timeout = 10000;
   readonly mouse: Mouse;
   readonly keyboard: Keyboard;
   readonly touchscreen: Touchscreen;
+
+  setInteractionObserver(observer?: InteractionObserver): void {
+    this.#interactionObserver = observer;
+  }
+
+  async notifyBeforeClick(
+    element: ElementHandle,
+    point: { x: number; y: number },
+  ): Promise<void> {
+    await this.#interactionObserver?.beforeClick?.(element, point);
+  }
+
+  async notifyAfterClick(
+    element: ElementHandle,
+    point: { x: number; y: number },
+    error?: unknown,
+  ): Promise<void> {
+    await this.#interactionObserver?.afterClick?.(element, point, error);
+  }
+
+  async notifyBeforeType(element: ElementHandle, text: string): Promise<void> {
+    await this.#interactionObserver?.beforeType?.(element, text);
+  }
+
+  async notifyAfterType(
+    element: ElementHandle,
+    text: string,
+    error?: unknown,
+  ): Promise<void> {
+    await this.#interactionObserver?.afterType?.(element, text, error);
+  }
 
   constructor(
     id: string,

--- a/tasks/demo.test.ts
+++ b/tasks/demo.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { parseDemoArgs, resolveDemoTest } from "./demo.ts";
+
+Deno.test("parseDemoArgs accepts deterministic demo options", () => {
+  assertEquals(
+    parseDemoArgs([
+      "patterns",
+      "lunch-poll-vote",
+      "--keep-frames",
+      "--output=tmp/lunch.mp4",
+      "--viewport=960x720",
+      "--port-offset=500",
+    ]),
+    {
+      packageName: "patterns",
+      filter: "lunch-poll-vote",
+      keepFrames: true,
+      outputPath: "tmp/lunch.mp4",
+      viewport: "960x720",
+      portOffset: 500,
+    },
+  );
+});
+
+Deno.test("parseDemoArgs rejects non-browser packages", () => {
+  assertThrows(
+    () => parseDemoArgs(["runner", "counter"]),
+    Error,
+    "unsupported browser-test package",
+  );
+});
+
+Deno.test("resolveDemoTest requires exactly one file", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const dir = `${root}/packages/patterns/integration`;
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(`${dir}/one-demo.test.ts`, "");
+    await Deno.writeTextFile(`${dir}/two-demo.test.ts`, "");
+    const base = parseDemoArgs(["patterns", "one-demo"]);
+    assertEquals(await resolveDemoTest(root, base), "one-demo.test.ts");
+    await assertRejects(
+      () => resolveDemoTest(root, { ...base, filter: "demo" }),
+      Error,
+      "ambiguous",
+    );
+    await assertRejects(
+      () => resolveDemoTest(root, { ...base, filter: "missing" }),
+      Error,
+      "no patterns integration test",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/tasks/demo.test.ts
+++ b/tasks/demo.test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
+  defaultDependencies,
   type DemoDependencies,
+  main,
   parseDemoArgs,
   resolveDemoTest,
   runDemo,
@@ -32,6 +34,71 @@ Deno.test("parseDemoArgs rejects non-browser packages", () => {
     () => parseDemoArgs(["runner", "counter"]),
     Error,
     "unsupported browser-test package",
+  );
+});
+
+Deno.test("parseDemoArgs rejects invalid and incomplete options", () => {
+  assertThrows(
+    () => parseDemoArgs(["patterns", "demo", "--port-offset=-1"]),
+    Error,
+    "invalid --port-offset",
+  );
+  assertThrows(
+    () => parseDemoArgs(["patterns", "demo", "--unknown"]),
+    Error,
+    "unknown option",
+  );
+  assertThrows(
+    () => parseDemoArgs(["patterns"]),
+    Error,
+    "usage:",
+  );
+});
+
+Deno.test("default demo dependencies provide time, preflight, and subprocess", async () => {
+  assertEquals(defaultDependencies.now() instanceof Date, true);
+  await defaultDependencies.preflight();
+  const root = await Deno.makeTempDir();
+  try {
+    const status = await defaultDependencies.runIntegration(
+      ["eval", "Deno.exit(0)"],
+      root,
+      {},
+    );
+    assertEquals(status.success, true);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("demo main handles help, errors, and an injected successful run", async () => {
+  assertEquals(await main(["--help"]), 0);
+  assertEquals(await main(["--unknown"]), 1);
+  assertEquals(
+    await main(["shell", "worker-runtime"], async (options) => {
+      assertEquals(options.packageName, "shell");
+      return 0;
+    }),
+    0,
+  );
+  assertEquals(
+    await main(["shell", "worker-runtime"], () => Promise.reject("failed")),
+    1,
+  );
+});
+
+Deno.test("demo CLI help exits successfully", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", "tasks/demo.ts", "--help"],
+    cwd: Deno.cwd(),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  assertEquals(output.success, true);
+  assertEquals(
+    new TextDecoder().decode(output.stdout).includes("Usage:"),
+    true,
   );
 });
 
@@ -154,6 +221,52 @@ Deno.test("runDemo rejects a successful test without a video", async () => {
         ),
       Error,
       "did not produce one-demo.mp4",
+    );
+  });
+});
+
+Deno.test("runDemo retains a named video in its artifact directory", async () => {
+  await withDemoFixture(async (root) => {
+    const result = await runDemo(
+      {
+        packageName: "patterns",
+        filter: "one-demo",
+        keepFrames: false,
+      },
+      root,
+      demoDependencies({
+        runIntegration: async (_args, _cwd, env) => {
+          await Deno.writeTextFile(
+            `${env.CF_DEMO_OUTPUT_DIR}/one-demo.mp4`,
+            "video bytes",
+          );
+          return { success: true, code: 0 };
+        },
+      }),
+    );
+    assertEquals(result, 0);
+    assertEquals(
+      await Deno.readTextFile(`${demoRunDir(root)}/one-demo.mp4`),
+      "video bytes",
+    );
+  });
+});
+
+Deno.test("runDemo preserves a setup failure without a manifest", async () => {
+  await withDemoFixture(async (root) => {
+    assertEquals(
+      await runDemo(
+        {
+          packageName: "patterns",
+          filter: "one-demo",
+          keepFrames: false,
+        },
+        root,
+        demoDependencies({
+          runIntegration: () => Promise.resolve({ success: false, code: 4 }),
+        }),
+      ),
+      4,
     );
   });
 });

--- a/tasks/demo.test.ts
+++ b/tasks/demo.test.ts
@@ -1,5 +1,10 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
-import { parseDemoArgs, resolveDemoTest } from "./demo.ts";
+import {
+  type DemoDependencies,
+  parseDemoArgs,
+  resolveDemoTest,
+  runDemo,
+} from "./demo.ts";
 
 Deno.test("parseDemoArgs accepts deterministic demo options", () => {
   assertEquals(
@@ -53,3 +58,133 @@ Deno.test("resolveDemoTest requires exactly one file", async () => {
     await Deno.remove(root, { recursive: true });
   }
 });
+
+Deno.test("runDemo names and copies a successful video", async () => {
+  await withDemoFixture(async (root) => {
+    let preflighted = false;
+    const dependencies = demoDependencies({
+      preflight: () => {
+        preflighted = true;
+        return Promise.resolve();
+      },
+      runIntegration: async (args, cwd, env) => {
+        assertEquals(args, [
+          "task",
+          "integration",
+          "--port-offset=500",
+          "patterns",
+          "one-demo",
+        ]);
+        assertEquals(cwd, root);
+        assertEquals(env.CF_DEMO_NAME, "one-demo");
+        assertEquals(env.CF_DEMO_KEEP_FRAMES, "1");
+        assertEquals(env.CF_DEMO_VIEWPORT, "960x720");
+        await Deno.writeTextFile(
+          `${env.CF_DEMO_OUTPUT_DIR}/one-demo.mp4`,
+          "video bytes",
+        );
+        return { success: true, code: 0 };
+      },
+    });
+    const result = await runDemo(
+      {
+        packageName: "patterns",
+        filter: "one-demo",
+        keepFrames: true,
+        outputPath: "copied/one-demo.mp4",
+        viewport: "960x720",
+        portOffset: 500,
+      },
+      root,
+      dependencies,
+    );
+
+    assertEquals(result, 0);
+    assertEquals(preflighted, true);
+    assertEquals(
+      await Deno.readTextFile(`${root}/copied/one-demo.mp4`),
+      "video bytes",
+    );
+  });
+});
+
+Deno.test("runDemo preserves a failing integration status and manifest", async () => {
+  await withDemoFixture(async (root) => {
+    const result = await runDemo(
+      {
+        packageName: "patterns",
+        filter: "one-demo",
+        keepFrames: false,
+      },
+      root,
+      demoDependencies({
+        runIntegration: async (_args, _cwd, env) => {
+          await Deno.writeTextFile(
+            `${env.CF_DEMO_OUTPUT_DIR}/manifest.json`,
+            JSON.stringify({ status: "passed" }),
+          );
+          return { success: false, code: 7 };
+        },
+      }),
+    );
+
+    assertEquals(result, 7);
+    const manifest = JSON.parse(
+      await Deno.readTextFile(
+        `${demoRunDir(root)}/manifest.json`,
+      ),
+    );
+    assertEquals(manifest.status, "test-failed");
+    assertEquals(manifest.error, "integration test exited with code 7");
+  });
+});
+
+Deno.test("runDemo rejects a successful test without a video", async () => {
+  await withDemoFixture(async (root) => {
+    await assertRejects(
+      () =>
+        runDemo(
+          {
+            packageName: "patterns",
+            filter: "one-demo",
+            keepFrames: false,
+          },
+          root,
+          demoDependencies(),
+        ),
+      Error,
+      "did not produce one-demo.mp4",
+    );
+  });
+});
+
+const FIXED_NOW = new Date("2026-07-14T00:00:00.000Z");
+
+function demoDependencies(
+  overrides: Partial<DemoDependencies> = {},
+): DemoDependencies {
+  return {
+    now: () => FIXED_NOW,
+    preflight: () => Promise.resolve(),
+    runIntegration: () => Promise.resolve({ success: true, code: 0 }),
+    ...overrides,
+  };
+}
+
+function demoRunDir(root: string): string {
+  return `${root}/tmp/demos/patterns-one-demo-2026-07-14T00-00-00-000Z`;
+}
+
+async function withDemoFixture(
+  fn: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = await Deno.makeTempDir();
+  try {
+    const dir = `${root}/packages/patterns/integration`;
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(`${dir}/one-demo.test.ts`, "");
+    await fn(root);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+}

--- a/tasks/demo.test.ts
+++ b/tasks/demo.test.ts
@@ -6,6 +6,7 @@ import {
   parseDemoArgs,
   resolveDemoTest,
   runDemo,
+  writeGallery,
 } from "./demo.ts";
 
 Deno.test("parseDemoArgs accepts deterministic demo options", () => {
@@ -20,7 +21,7 @@ Deno.test("parseDemoArgs accepts deterministic demo options", () => {
     ]),
     {
       packageName: "patterns",
-      filter: "lunch-poll-vote",
+      filters: ["lunch-poll-vote"],
       keepFrames: true,
       outputPath: "tmp/lunch.mp4",
       viewport: "960x720",
@@ -35,6 +36,17 @@ Deno.test("parseDemoArgs rejects non-browser packages", () => {
     Error,
     "unsupported browser-test package",
   );
+});
+
+Deno.test("parseDemoArgs accepts multiple test filters", () => {
+  assertEquals(parseDemoArgs(["patterns", "one-demo", "two-demo"]), {
+    packageName: "patterns",
+    filters: ["one-demo", "two-demo"],
+    keepFrames: false,
+    outputPath: undefined,
+    viewport: undefined,
+    portOffset: undefined,
+  });
 });
 
 Deno.test("parseDemoArgs rejects invalid and incomplete options", () => {
@@ -81,6 +93,7 @@ Deno.test("demo main handles help, errors, and an injected successful run", asyn
   assertEquals(
     await main(["shell", "worker-runtime"], (options) => {
       assertEquals(options.packageName, "shell");
+      assertEquals(options.filters, ["worker-runtime"]);
       return Promise.resolve(0);
     }),
     0,
@@ -114,14 +127,17 @@ Deno.test("resolveDemoTest requires exactly one file", async () => {
     await Deno.writeTextFile(`${dir}/one-demo.test.ts`, "");
     await Deno.writeTextFile(`${dir}/two-demo.test.ts`, "");
     const base = parseDemoArgs(["patterns", "one-demo"]);
-    assertEquals(await resolveDemoTest(root, base), "one-demo.test.ts");
+    assertEquals(
+      await resolveDemoTest(root, base.packageName, base.filters[0]),
+      "one-demo.test.ts",
+    );
     await assertRejects(
-      () => resolveDemoTest(root, { ...base, filter: "demo" }),
+      () => resolveDemoTest(root, base.packageName, "demo"),
       Error,
       "ambiguous",
     );
     await assertRejects(
-      () => resolveDemoTest(root, { ...base, filter: "missing" }),
+      () => resolveDemoTest(root, base.packageName, "missing"),
       Error,
       "no patterns integration test",
     );
@@ -160,7 +176,7 @@ Deno.test("runDemo names and copies a successful video", async () => {
     const result = await runDemo(
       {
         packageName: "patterns",
-        filter: "one-demo",
+        filters: ["one-demo"],
         keepFrames: true,
         outputPath: "copied/one-demo.mp4",
         viewport: "960x720",
@@ -184,7 +200,7 @@ Deno.test("runDemo preserves a failing integration status and manifest", async (
     const result = await runDemo(
       {
         packageName: "patterns",
-        filter: "one-demo",
+        filters: ["one-demo"],
         keepFrames: false,
       },
       root,
@@ -217,7 +233,7 @@ Deno.test("runDemo rejects a successful test without a video", async () => {
         runDemo(
           {
             packageName: "patterns",
-            filter: "one-demo",
+            filters: ["one-demo"],
             keepFrames: false,
           },
           root,
@@ -234,7 +250,7 @@ Deno.test("runDemo retains a named video in its artifact directory", async () =>
     const result = await runDemo(
       {
         packageName: "patterns",
-        filter: "one-demo",
+        filters: ["one-demo"],
         keepFrames: false,
       },
       root,
@@ -262,7 +278,7 @@ Deno.test("runDemo preserves a setup failure without a manifest", async () => {
       await runDemo(
         {
           packageName: "patterns",
-          filter: "one-demo",
+          filters: ["one-demo"],
           keepFrames: false,
         },
         root,
@@ -273,6 +289,96 @@ Deno.test("runDemo preserves a setup failure without a manifest", async () => {
       4,
     );
   });
+});
+
+Deno.test("runDemo records multiple tests and writes portable galleries", async () => {
+  await withDemoFixture(async (root) => {
+    const calls: string[] = [];
+    const result = await runDemo(
+      {
+        packageName: "patterns",
+        filters: ["one-demo", "two-demo"],
+        keepFrames: false,
+        outputPath: "copied-gallery",
+      },
+      root,
+      demoDependencies({
+        runIntegration: async (args, _cwd, env) => {
+          const name = env.CF_DEMO_NAME;
+          calls.push(name);
+          assertEquals(args.at(-1), name);
+          await Deno.writeTextFile(
+            `${env.CF_DEMO_OUTPUT_DIR}/${name}.mp4`,
+            `${name} video`,
+          );
+          return { success: true, code: 0 };
+        },
+      }),
+    );
+
+    assertEquals(result, 0);
+    assertEquals(calls, ["one-demo", "two-demo"]);
+    const gallery = await Deno.readTextFile(
+      `${demoGalleryDir(root)}/index.html`,
+    );
+    assertEquals(gallery.includes('src="one-demo/one-demo.mp4"'), true);
+    assertEquals(gallery.includes('src="two-demo/two-demo.mp4"'), true);
+    assertEquals(
+      await Deno.readTextFile(`${root}/copied-gallery/one-demo.mp4`),
+      "one-demo video",
+    );
+    const copiedGallery = await Deno.readTextFile(
+      `${root}/copied-gallery/index.html`,
+    );
+    assertEquals(copiedGallery.includes('src="one-demo.mp4"'), true);
+    assertEquals(copiedGallery.includes('src="two-demo.mp4"'), true);
+  }, true);
+});
+
+Deno.test("runDemo rejects duplicate tests and an MP4 batch output", async () => {
+  await withDemoFixture(async (root) => {
+    await assertRejects(
+      () =>
+        runDemo(
+          {
+            packageName: "patterns",
+            filters: ["one-demo", "one-demo.test"],
+            keepFrames: false,
+          },
+          root,
+          demoDependencies(),
+        ),
+      Error,
+      "distinct test files",
+    );
+    await assertRejects(
+      () =>
+        runDemo(
+          {
+            packageName: "patterns",
+            filters: ["one-demo", "two-demo"],
+            keepFrames: false,
+            outputPath: "all.mp4",
+          },
+          root,
+          demoDependencies(),
+        ),
+      Error,
+      "must be a directory",
+    );
+  }, true);
+});
+
+Deno.test("writeGallery escapes viewer-facing labels and paths", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await writeGallery(root, [{ title: "one < two", src: 'demo&".mp4' }]);
+    const gallery = await Deno.readTextFile(`${root}/index.html`);
+    assertEquals(gallery.includes("one &lt; two"), true);
+    assertEquals(gallery.includes('src="demo&amp;&quot;.mp4"'), true);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
 });
 
 const FIXED_NOW = new Date("2026-07-14T00:00:00.000Z");
@@ -292,14 +398,22 @@ function demoRunDir(root: string): string {
   return `${root}/tmp/demos/patterns-one-demo-2026-07-14T00-00-00-000Z`;
 }
 
+function demoGalleryDir(root: string): string {
+  return `${root}/tmp/demos/patterns-gallery-2026-07-14T00-00-00-000Z`;
+}
+
 async function withDemoFixture(
   fn: (root: string) => Promise<void>,
+  includeSecond = false,
 ): Promise<void> {
   const root = await Deno.makeTempDir();
   try {
     const dir = `${root}/packages/patterns/integration`;
     await Deno.mkdir(dir, { recursive: true });
     await Deno.writeTextFile(`${dir}/one-demo.test.ts`, "");
+    if (includeSecond) {
+      await Deno.writeTextFile(`${dir}/two-demo.test.ts`, "");
+    }
     await fn(root);
   } finally {
     await Deno.remove(root, { recursive: true });

--- a/tasks/demo.test.ts
+++ b/tasks/demo.test.ts
@@ -57,9 +57,11 @@ Deno.test("parseDemoArgs rejects invalid and incomplete options", () => {
 
 Deno.test("default demo dependencies provide time, preflight, and subprocess", async () => {
   assertEquals(defaultDependencies.now() instanceof Date, true);
-  await defaultDependencies.preflight();
+  const previousFfmpeg = Deno.env.get("FFMPEG");
+  Deno.env.set("FFMPEG", Deno.execPath());
   const root = await Deno.makeTempDir();
   try {
+    await defaultDependencies.preflight();
     const status = await defaultDependencies.runIntegration(
       ["eval", "Deno.exit(0)"],
       root,
@@ -67,6 +69,8 @@ Deno.test("default demo dependencies provide time, preflight, and subprocess", a
     );
     assertEquals(status.success, true);
   } finally {
+    if (previousFfmpeg === undefined) Deno.env.delete("FFMPEG");
+    else Deno.env.set("FFMPEG", previousFfmpeg);
     await Deno.remove(root, { recursive: true });
   }
 });
@@ -75,9 +79,9 @@ Deno.test("demo main handles help, errors, and an injected successful run", asyn
   assertEquals(await main(["--help"]), 0);
   assertEquals(await main(["--unknown"]), 1);
   assertEquals(
-    await main(["shell", "worker-runtime"], async (options) => {
+    await main(["shell", "worker-runtime"], (options) => {
       assertEquals(options.packageName, "shell");
-      return 0;
+      return Promise.resolve(0);
     }),
     0,
   );
@@ -89,8 +93,8 @@ Deno.test("demo main handles help, errors, and an injected successful run", asyn
 
 Deno.test("demo CLI help exits successfully", async () => {
   const command = new Deno.Command(Deno.execPath(), {
-    args: ["run", "-A", "tasks/demo.ts", "--help"],
-    cwd: Deno.cwd(),
+    args: ["run", "-A", "demo.ts", "--help"],
+    cwd: import.meta.dirname,
     stdout: "piped",
     stderr: "piped",
   });

--- a/tasks/demo.ts
+++ b/tasks/demo.ts
@@ -13,6 +13,32 @@ export type DemoOptions = {
   viewport?: string;
 };
 
+export type DemoDependencies = {
+  now(): Date;
+  preflight(): Promise<void>;
+  runIntegration(
+    args: string[],
+    cwd: string,
+    env: Record<string, string>,
+  ): Promise<{ success: boolean; code: number }>;
+};
+
+const defaultDependencies: DemoDependencies = {
+  now: () => new Date(),
+  preflight: async () => {
+    await findFfmpeg();
+  },
+  runIntegration: async (args, cwd, env) =>
+    await new Deno.Command(Deno.execPath(), {
+      args,
+      cwd,
+      env,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    }).spawn().status,
+};
+
 export function parseDemoArgs(args: string[]): DemoOptions {
   const positional: string[] = [];
   let outputPath: string | undefined;
@@ -78,11 +104,12 @@ export async function resolveDemoTest(
 export async function runDemo(
   options: DemoOptions,
   rootDir = Deno.cwd(),
+  dependencies: DemoDependencies = defaultDependencies,
 ): Promise<number> {
   const testFile = await resolveDemoTest(rootDir, options);
   const testName = testFile.replace(/\.test\.ts$/, "");
-  await findFfmpeg();
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  await dependencies.preflight();
+  const stamp = dependencies.now().toISOString().replace(/[:.]/g, "-");
   const runDir = resolve(
     rootDir,
     "tmp",
@@ -105,14 +132,11 @@ export async function runDemo(
   };
   console.log(`Recording ${options.packageName}/${testFile}`);
   console.log(`Demo artifacts: ${runDir}`);
-  const status = await new Deno.Command(Deno.execPath(), {
-    args: integrationArgs,
-    cwd: rootDir,
+  const status = await dependencies.runIntegration(
+    integrationArgs,
+    rootDir,
     env,
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
-  }).spawn().status;
+  );
   if (!status.success) {
     const manifestPath = join(runDir, "manifest.json");
     try {

--- a/tasks/demo.ts
+++ b/tasks/demo.ts
@@ -80,13 +80,14 @@ export async function runDemo(
   rootDir = Deno.cwd(),
 ): Promise<number> {
   const testFile = await resolveDemoTest(rootDir, options);
+  const testName = testFile.replace(/\.test\.ts$/, "");
   await findFfmpeg();
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const runDir = resolve(
     rootDir,
     "tmp",
     "demos",
-    `${options.packageName}-${testFile.replace(/\.test\.ts$/, "")}-${stamp}`,
+    `${options.packageName}-${testName}-${stamp}`,
   );
   await Deno.mkdir(runDir, { recursive: true });
   const integrationArgs = ["task", "integration"];
@@ -98,6 +99,7 @@ export async function runDemo(
     ...Deno.env.toObject(),
     HEADLESS: "1",
     CF_DEMO_OUTPUT_DIR: runDir,
+    CF_DEMO_NAME: testName,
     ...(options.keepFrames ? { CF_DEMO_KEEP_FRAMES: "1" } : {}),
     ...(options.viewport ? { CF_DEMO_VIEWPORT: options.viewport } : {}),
   };
@@ -130,11 +132,13 @@ export async function runDemo(
     return status.code;
   }
 
-  const generatedVideo = join(runDir, "video.mp4");
+  const generatedVideo = join(runDir, `${testName}.mp4`);
   try {
     await Deno.stat(generatedVideo);
   } catch (cause) {
-    throw new Error("the test passed but did not produce video.mp4", { cause });
+    throw new Error(`the test passed but did not produce ${testName}.mp4`, {
+      cause,
+    });
   }
   let finalPath = generatedVideo;
   if (options.outputPath) {

--- a/tasks/demo.ts
+++ b/tasks/demo.ts
@@ -6,7 +6,7 @@ import { findIntegrationTestFiles } from "./integration.ts";
 
 export type DemoOptions = {
   packageName: "patterns" | "shell";
-  filter: string;
+  filters: string[];
   outputPath?: string;
   keepFrames: boolean;
   portOffset?: number;
@@ -58,9 +58,9 @@ export function parseDemoArgs(args: string[]): DemoOptions {
     else if (arg.startsWith("-")) throw new Error(`unknown option: ${arg}`);
     else positional.push(arg);
   }
-  if (positional.length !== 2) {
+  if (positional.length < 2) {
     throw new Error(
-      "usage: deno task demo <patterns|shell> <test-file-filter>",
+      "usage: deno task demo <patterns|shell> <test-file-filter> [...filters]",
     );
   }
   const packageName = positional[0];
@@ -69,7 +69,7 @@ export function parseDemoArgs(args: string[]): DemoOptions {
   }
   return {
     packageName,
-    filter: positional[1],
+    filters: positional.slice(1),
     outputPath,
     keepFrames,
     portOffset,
@@ -79,23 +79,24 @@ export function parseDemoArgs(args: string[]): DemoOptions {
 
 export async function resolveDemoTest(
   rootDir: string,
-  options: DemoOptions,
+  packageName: DemoOptions["packageName"],
+  filter: string,
 ): Promise<string> {
   const integrationDir = join(
     rootDir,
     "packages",
-    options.packageName,
+    packageName,
     "integration",
   );
   const matches = await findIntegrationTestFiles(
     integrationDir,
-    options.filter,
+    filter,
   );
   if (matches.length !== 1) {
     throw new Error(
       matches.length === 0
-        ? `no ${options.packageName} integration test matches "${options.filter}"`
-        : `demo filter "${options.filter}" is ambiguous: ${matches.join(", ")}`,
+        ? `no ${packageName} integration test matches "${filter}"`
+        : `demo filter "${filter}" is ambiguous: ${matches.join(", ")}`,
     );
   }
   return matches[0];
@@ -106,72 +107,167 @@ export async function runDemo(
   rootDir = Deno.cwd(),
   dependencies: DemoDependencies = defaultDependencies,
 ): Promise<number> {
-  const testFile = await resolveDemoTest(rootDir, options);
-  const testName = testFile.replace(/\.test\.ts$/, "");
+  const testFiles = await Promise.all(
+    options.filters.map((filter) =>
+      resolveDemoTest(rootDir, options.packageName, filter)
+    ),
+  );
+  if (new Set(testFiles).size !== testFiles.length) {
+    throw new Error("demo filters must resolve to distinct test files");
+  }
+  const testNames = testFiles.map((file) => file.replace(/\.test\.ts$/, ""));
+  if (testNames.length > 1 && options.outputPath?.endsWith(".mp4")) {
+    throw new Error("multi-test --output must be a directory, not an MP4 path");
+  }
   await dependencies.preflight();
   const stamp = dependencies.now().toISOString().replace(/[:.]/g, "-");
+  const runName = testNames.length === 1 ? testNames[0] : "gallery";
   const runDir = resolve(
     rootDir,
     "tmp",
     "demos",
-    `${options.packageName}-${testName}-${stamp}`,
+    `${options.packageName}-${runName}-${stamp}`,
   );
   await Deno.mkdir(runDir, { recursive: true });
-  const integrationArgs = ["task", "integration"];
-  if (options.portOffset !== undefined) {
-    integrationArgs.push(`--port-offset=${options.portOffset}`);
-  }
-  integrationArgs.push(options.packageName, options.filter);
-  const env = {
-    ...Deno.env.toObject(),
-    HEADLESS: "1",
-    CF_DEMO_OUTPUT_DIR: runDir,
-    CF_DEMO_NAME: testName,
-    ...(options.keepFrames ? { CF_DEMO_KEEP_FRAMES: "1" } : {}),
-    ...(options.viewport ? { CF_DEMO_VIEWPORT: options.viewport } : {}),
-  };
-  console.log(`Recording ${options.packageName}/${testFile}`);
   console.log(`Demo artifacts: ${runDir}`);
-  const status = await dependencies.runIntegration(
-    integrationArgs,
-    rootDir,
-    env,
-  );
-  if (!status.success) {
-    const manifestPath = join(runDir, "manifest.json");
-    try {
-      const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
-      if (manifest.status === "passed" || manifest.status === "recording") {
-        manifest.status = "test-failed";
-        manifest.error = `integration test exited with code ${status.code}`;
-        await Deno.writeTextFile(
-          manifestPath,
-          `${JSON.stringify(manifest, null, 2)}\n`,
-        );
-      }
-    } catch {
-      // A setup failure may occur before presentation mode creates a manifest.
-    }
-    console.error(`Demo test failed; diagnostics retained at ${runDir}`);
-    return status.code;
-  }
+  const galleryVideos: GalleryVideo[] = [];
+  await writeGallery(runDir, galleryVideos);
+  const collectionOutputDir = testNames.length > 1 && options.outputPath
+    ? resolve(rootDir, options.outputPath)
+    : undefined;
 
-  const generatedVideo = join(runDir, `${testName}.mp4`);
-  try {
-    await Deno.stat(generatedVideo);
-  } catch (cause) {
-    throw new Error(`the test passed but did not produce ${testName}.mp4`, {
-      cause,
+  for (let index = 0; index < testFiles.length; index++) {
+    const testFile = testFiles[index];
+    const testName = testNames[index];
+    const filter = options.filters[index];
+    const testDir = testFiles.length === 1 ? runDir : join(runDir, testName);
+    await Deno.mkdir(testDir, { recursive: true });
+    const integrationArgs = ["task", "integration"];
+    if (options.portOffset !== undefined) {
+      integrationArgs.push(`--port-offset=${options.portOffset}`);
+    }
+    integrationArgs.push(options.packageName, filter);
+    const env = {
+      ...Deno.env.toObject(),
+      HEADLESS: "1",
+      CF_DEMO_OUTPUT_DIR: testDir,
+      CF_DEMO_NAME: testName,
+      ...(options.keepFrames ? { CF_DEMO_KEEP_FRAMES: "1" } : {}),
+      ...(options.viewport ? { CF_DEMO_VIEWPORT: options.viewport } : {}),
+    };
+    console.log(`Recording ${options.packageName}/${testFile}`);
+    const status = await dependencies.runIntegration(
+      integrationArgs,
+      rootDir,
+      env,
+    );
+    if (!status.success) {
+      const manifestPath = join(testDir, "manifest.json");
+      try {
+        const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+        if (manifest.status === "passed" || manifest.status === "recording") {
+          manifest.status = "test-failed";
+          manifest.error = `integration test exited with code ${status.code}`;
+          await Deno.writeTextFile(
+            manifestPath,
+            `${JSON.stringify(manifest, null, 2)}\n`,
+          );
+        }
+      } catch {
+        // A setup failure may occur before presentation mode creates a manifest.
+      }
+      console.error(`Demo test failed; diagnostics retained at ${testDir}`);
+      return status.code;
+    }
+
+    const generatedVideo = join(testDir, `${testName}.mp4`);
+    try {
+      await Deno.stat(generatedVideo);
+    } catch (cause) {
+      throw new Error(`the test passed but did not produce ${testName}.mp4`, {
+        cause,
+      });
+    }
+    let finalPath = generatedVideo;
+    if (collectionOutputDir) {
+      await Deno.mkdir(collectionOutputDir, { recursive: true });
+      finalPath = join(collectionOutputDir, `${testName}.mp4`);
+      await Deno.copyFile(generatedVideo, finalPath);
+    } else if (options.outputPath) {
+      finalPath = resolve(rootDir, options.outputPath);
+      await Deno.mkdir(dirname(finalPath), { recursive: true });
+      await Deno.copyFile(generatedVideo, finalPath);
+    }
+    galleryVideos.push({
+      title: testName,
+      src: testFiles.length === 1
+        ? `${testName}.mp4`
+        : `${testName}/${testName}.mp4`,
     });
+    await writeGallery(runDir, galleryVideos);
+    if (collectionOutputDir) {
+      await writeGallery(
+        collectionOutputDir,
+        galleryVideos.map((video) => ({
+          ...video,
+          src: `${video.title}.mp4`,
+        })),
+      );
+    }
+    console.log(`Demo video: ${finalPath}`);
   }
-  let finalPath = generatedVideo;
-  if (options.outputPath) {
-    finalPath = resolve(rootDir, options.outputPath);
-    await Deno.mkdir(dirname(finalPath), { recursive: true });
-    await Deno.copyFile(generatedVideo, finalPath);
-  }
-  console.log(`Demo video: ${finalPath}`);
+  console.log(`Demo gallery: ${join(runDir, "index.html")}`);
   return 0;
+}
+
+export type GalleryVideo = { title: string; src: string };
+
+export async function writeGallery(
+  directory: string,
+  videos: GalleryVideo[],
+): Promise<void> {
+  const cards = videos.length === 0
+    ? '<p class="empty">No completed videos yet.</p>'
+    : videos.map((video) => `
+      <article>
+        <h2>${escapeHtml(video.title)}</h2>
+        <video controls preload="metadata" src="${
+      escapeHtml(video.src)
+    }"></video>
+      </article>`).join("");
+  await Deno.mkdir(directory, { recursive: true });
+  await Deno.writeTextFile(
+    join(directory, "index.html"),
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Integration test demos</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+    body { max-width: 90rem; margin: 0 auto; padding: 2rem; }
+    main { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(30rem, 100%), 1fr)); gap: 2rem; }
+    article { min-width: 0; }
+    h1 { margin-top: 0; }
+    h2 { font-size: 1rem; overflow-wrap: anywhere; }
+    video { display: block; width: 100%; background: #000; border-radius: .5rem; }
+    .empty { opacity: .7; }
+  </style>
+</head>
+<body>
+  <h1>Integration test demos</h1>
+  <main>${cards}
+  </main>
+</body>
+</html>
+`,
+  );
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
 class HelpRequested extends Error {}
@@ -180,10 +276,10 @@ function printHelp(): void {
   console.log(`Integration-test video demo
 
 Usage:
-  deno task demo <patterns|shell> <test-file-filter> [options]
+  deno task demo <patterns|shell> <test-file-filter> [...filters] [options]
 
 Options:
-  --output=PATH       Copy the final MP4 to PATH
+  --output=PATH       Copy one MP4 to PATH, or a batch gallery to a directory
   --keep-frames       Retain JPEG frames and FFconcat inputs
   --viewport=WxH      Source viewport (default 1280x720)
   --port-offset=N     Reuse an explicit local-dev port offset

--- a/tasks/demo.ts
+++ b/tasks/demo.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env -S deno run -A
+
+import { dirname, join, resolve } from "@std/path";
+import { findFfmpeg } from "@commonfabric/integration";
+import { findIntegrationTestFiles } from "./integration.ts";
+
+export type DemoOptions = {
+  packageName: "patterns" | "shell";
+  filter: string;
+  outputPath?: string;
+  keepFrames: boolean;
+  portOffset?: number;
+  viewport?: string;
+};
+
+export function parseDemoArgs(args: string[]): DemoOptions {
+  const positional: string[] = [];
+  let outputPath: string | undefined;
+  let keepFrames = false;
+  let portOffset: number | undefined;
+  let viewport: string | undefined;
+  for (const arg of args) {
+    if (arg === "--keep-frames") keepFrames = true;
+    else if (arg.startsWith("--output=")) outputPath = arg.slice(9);
+    else if (arg.startsWith("--port-offset=")) {
+      portOffset = Number(arg.slice(14));
+      if (!Number.isInteger(portOffset) || portOffset < 0) {
+        throw new Error(`invalid --port-offset: ${arg}`);
+      }
+    } else if (arg.startsWith("--viewport=")) viewport = arg.slice(11);
+    else if (arg === "--help" || arg === "-h") throw new HelpRequested();
+    else if (arg.startsWith("-")) throw new Error(`unknown option: ${arg}`);
+    else positional.push(arg);
+  }
+  if (positional.length !== 2) {
+    throw new Error(
+      "usage: deno task demo <patterns|shell> <test-file-filter>",
+    );
+  }
+  const packageName = positional[0];
+  if (packageName !== "patterns" && packageName !== "shell") {
+    throw new Error(`unsupported browser-test package: ${packageName}`);
+  }
+  return {
+    packageName,
+    filter: positional[1],
+    outputPath,
+    keepFrames,
+    portOffset,
+    viewport,
+  };
+}
+
+export async function resolveDemoTest(
+  rootDir: string,
+  options: DemoOptions,
+): Promise<string> {
+  const integrationDir = join(
+    rootDir,
+    "packages",
+    options.packageName,
+    "integration",
+  );
+  const matches = await findIntegrationTestFiles(
+    integrationDir,
+    options.filter,
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      matches.length === 0
+        ? `no ${options.packageName} integration test matches "${options.filter}"`
+        : `demo filter "${options.filter}" is ambiguous: ${matches.join(", ")}`,
+    );
+  }
+  return matches[0];
+}
+
+export async function runDemo(
+  options: DemoOptions,
+  rootDir = Deno.cwd(),
+): Promise<number> {
+  const testFile = await resolveDemoTest(rootDir, options);
+  await findFfmpeg();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const runDir = resolve(
+    rootDir,
+    "tmp",
+    "demos",
+    `${options.packageName}-${testFile.replace(/\.test\.ts$/, "")}-${stamp}`,
+  );
+  await Deno.mkdir(runDir, { recursive: true });
+  const integrationArgs = ["task", "integration"];
+  if (options.portOffset !== undefined) {
+    integrationArgs.push(`--port-offset=${options.portOffset}`);
+  }
+  integrationArgs.push(options.packageName, options.filter);
+  const env = {
+    ...Deno.env.toObject(),
+    HEADLESS: "1",
+    CF_DEMO_OUTPUT_DIR: runDir,
+    ...(options.keepFrames ? { CF_DEMO_KEEP_FRAMES: "1" } : {}),
+    ...(options.viewport ? { CF_DEMO_VIEWPORT: options.viewport } : {}),
+  };
+  console.log(`Recording ${options.packageName}/${testFile}`);
+  console.log(`Demo artifacts: ${runDir}`);
+  const status = await new Deno.Command(Deno.execPath(), {
+    args: integrationArgs,
+    cwd: rootDir,
+    env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  }).spawn().status;
+  if (!status.success) {
+    const manifestPath = join(runDir, "manifest.json");
+    try {
+      const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+      if (manifest.status === "passed" || manifest.status === "recording") {
+        manifest.status = "test-failed";
+        manifest.error = `integration test exited with code ${status.code}`;
+        await Deno.writeTextFile(
+          manifestPath,
+          `${JSON.stringify(manifest, null, 2)}\n`,
+        );
+      }
+    } catch {
+      // A setup failure may occur before presentation mode creates a manifest.
+    }
+    console.error(`Demo test failed; diagnostics retained at ${runDir}`);
+    return status.code;
+  }
+
+  const generatedVideo = join(runDir, "video.mp4");
+  try {
+    await Deno.stat(generatedVideo);
+  } catch (cause) {
+    throw new Error("the test passed but did not produce video.mp4", { cause });
+  }
+  let finalPath = generatedVideo;
+  if (options.outputPath) {
+    finalPath = resolve(rootDir, options.outputPath);
+    await Deno.mkdir(dirname(finalPath), { recursive: true });
+    await Deno.copyFile(generatedVideo, finalPath);
+  }
+  console.log(`Demo video: ${finalPath}`);
+  return 0;
+}
+
+class HelpRequested extends Error {}
+
+function printHelp(): void {
+  console.log(`Integration-test video demo
+
+Usage:
+  deno task demo <patterns|shell> <test-file-filter> [options]
+
+Options:
+  --output=PATH       Copy the final MP4 to PATH
+  --keep-frames       Retain JPEG frames and FFconcat inputs
+  --viewport=WxH      Source viewport (default 1280x720)
+  --port-offset=N     Reuse an explicit local-dev port offset
+`);
+}
+
+if (import.meta.main) {
+  try {
+    const options = parseDemoArgs(Deno.args);
+    Deno.exit(await runDemo(options));
+  } catch (error) {
+    if (error instanceof HelpRequested) {
+      printHelp();
+      Deno.exit(0);
+    }
+    console.error(error instanceof Error ? error.message : error);
+    Deno.exit(1);
+  }
+}

--- a/tasks/demo.ts
+++ b/tasks/demo.ts
@@ -23,7 +23,7 @@ export type DemoDependencies = {
   ): Promise<{ success: boolean; code: number }>;
 };
 
-const defaultDependencies: DemoDependencies = {
+export const defaultDependencies: DemoDependencies = {
   now: () => new Date(),
   preflight: async () => {
     await findFfmpeg();
@@ -190,16 +190,20 @@ Options:
 `);
 }
 
-if (import.meta.main) {
+export async function main(
+  args: string[],
+  run: (options: DemoOptions) => Promise<number> = runDemo,
+): Promise<number> {
   try {
-    const options = parseDemoArgs(Deno.args);
-    Deno.exit(await runDemo(options));
+    return await run(parseDemoArgs(args));
   } catch (error) {
     if (error instanceof HelpRequested) {
       printHelp();
-      Deno.exit(0);
+      return 0;
     }
     console.error(error instanceof Error ? error.message : error);
-    Deno.exit(1);
+    return 1;
   }
 }
+
+if (import.meta.main) Deno.exitCode = await main(Deno.args);


### PR DESCRIPTION
## Summary

Adds an opt-in presentation and recording mode for the existing browser integration-test stack. One or more selected test files can now double as deterministic product demos without introducing separate `demo.click()` or `demo.type()` APIs or weakening their assertions.

Presentation mode:

- records the real browser pages through CDP screencast frames;
- slows existing typing and click paths, animates a visible cursor, and adds click pulses;
- turns existing `StepTimer` labels into lower-third captions;
- labels each `ShellIntegration` participant and synchronizes independent browser instances on one timeline;
- encodes one to four participants into deterministic FFmpeg layouts;
- names each MP4 after its test and generates a portable HTML video gallery;
- writes a manifest and retains useful diagnostics when capture, encoding, or the underlying test fails.

Normal integration runs remain unchanged and do not incur presentation delays or require FFmpeg.

## How to use it

Install FFmpeg, then select one or more browser integration-test files by package and filename filter:

```sh
deno task demo patterns cfc-render-policy-demo
deno task demo patterns cfc-render-policy-demo lunch-poll-vote
deno task demo shell <test-file-filter> [more-test-file-filters...]
```

Each filter must resolve to exactly one test file. Multiple files run sequentially with independent integration-server lifecycles and artifact directories.

A single-test run produces:

```text
tmp/demos/<package>-<test>-<timestamp>/
  index.html
  manifest.json
  <test>.mp4
  participants/<id>/stream.mp4
```

A batch run produces a portable gallery directory:

```text
tmp/demos/<package>-gallery-<timestamp>/
  index.html
  <test-a>/
    <test-a>.mp4
    manifest.json
  <test-b>/
    <test-b>.mp4
    manifest.json
```

Open `index.html` directly or copy/serve the complete directory; all video links are relative.

Useful options:

```sh
deno task demo patterns lunch-poll-vote --keep-frames
deno task demo patterns lunch-poll-vote --output=tmp/lunch-poll.mp4
deno task demo patterns cfc-render-policy-demo lunch-poll-vote --output=tmp/demo-gallery
deno task demo patterns lunch-poll-vote --viewport=1280x720
deno task demo patterns lunch-poll-vote --port-offset=900
```

For one filter, `--output=PATH` copies the final MP4 to that file. For multiple filters, `--output=DIRECTORY` copies flat, test-named MP4s plus `index.html` into that directory. `--keep-frames` retains JPEG and FFconcat inputs for diagnosis.

### Annotating a demo

Keep using the normal integration helpers. `fillCfInput()`, Astral element typing, and Astral element clicks automatically become presentation-aware only when the demo task enables recording.

Wrap meaningful phases in the existing timer:

```ts
await timer.run("Both participants cast their votes", async () => {
  await Promise.all([voteAsAlice(), voteAsBob()]);
});
```

The label remains diagnostic timing output in normal tests and becomes a caption during a demo. Do not add sleeps for correctness; the wrapped action must retain its existing event-driven waits and assertions.

For multi-user tests, supply stable presentation metadata on each existing shell:

```ts
const alice = new ShellIntegration({
  presentation: { id: "alice", label: "Alice", color: "#7c3aed" },
});
```

Each shell keeps its own browser, identity, storage, and cursor. Composition happens only after the test completes. Two participants render side by side; three and four use a 2x2 grid. More than four visible participants are rejected explicitly in this first version.

## Implementation notes

- Adds a narrow generic interaction-observer seam to the vendored Astral page/element APIs and a default keyboard typing delay. These remain inert unless presentation mode installs an observer.
- A process-wide presentation session registers every `ShellIntegration`, shares a monotonic origin, records variable frame durations, and normalizes stream endpoints before composition.
- Screencast frames are acknowledged immediately and written through a bounded asynchronous queue.
- Batch recording preflights once, then runs each complete test file sequentially and rewrites the gallery after every successful video.
- The CFC render-policy test is the single-user reference demo; lunch-poll is the synchronized two-user reference demo.
- The implementation plan and extension points are documented in `docs/plans/integration-test-video-demos.md`, `docs/development/TESTING.md`, and `docs/development/UI_TESTING.md`.

## Validation

- `deno task check`
- `deno task check-docs` — 536 code blocks
- `deno task test` in `tasks` — 254 tests
- `tasks/demo.ts` — 100% line coverage
- Normal-mode acceptance:
  - `deno task integration patterns cfc-render-policy-demo`
  - `deno task integration patterns lunch-poll-vote`
- Recorded acceptance:
  - `deno task demo patterns cfc-render-policy-demo` — H.264 1280x720
  - `deno task demo patterns lunch-poll-vote` — H.264 2560x720, synchronized Alice/Bob layout
  - `deno task demo patterns cfc-render-policy-demo lunch-poll-vote` — both videos plus portable `index.html`

## Deferred follow-ups

Title/end cards, exhaustive resource-failure injection, visual golden fixtures, and CI publication are intentionally deferred. Local demo recording is opt-in and is not added as a required CI gate.
