### PR TITLE
docs: document CI benchmark tracking and the constraints on bench files

### DIFF
--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -1,0 +1,59 @@
+# Benchmarks
+
+How the repository's `deno bench` files run in CI, where their results are
+charted, and the constraints a bench file must satisfy for that tracking to
+work.
+
+## The pipeline
+
+The Benchmarks workflow (`.github/workflows/benchmarks.yml`) runs every four
+hours on a schedule, on the dedicated runner group so results stay comparable
+across runs. It runs `deno bench --json` over `packages/runner/test/*.bench.ts`
+plus two explicitly listed files in `packages/utils`, and uploads stdout as the
+`bench-results` artifact (90-day retention). A bench file outside those paths
+does not run in CI until it is added to the workflow. The workflow's manual
+trigger measures a specific commit.
+
+The team ops dashboard charts benchmark trends on its `/bench` page, sampling
+one successful run per four-hour window from those artifacts. Each
+benchmark's series is identified by its origin file, group, and name.
+
+Benchmark numbers are not gated: the per-PR performance gate
+(`tasks/perf-check.ts`) covers CI job, step, and test timings plus the
+coverage-debt ratchet, and never ingests benchmark results, so a bench
+regression shows up as trend drift on the dashboard rather than as a failing
+check.
+
+Most packages with benches define a `bench` task for running them locally
+(see `packages/runner/deno.jsonc`); otherwise invoke `deno bench` on a
+single file.
+
+## Constraints on bench files
+
+**Stdout must stay pure JSON.** The workflow redirects all of stdout to
+`results.json`. One stray line printed by any bench file corrupts the
+artifact for every benchmark in the run, not just the offending file. This
+applies to module-scope code as well as bench bodies. Write diagnostics with
+`console.error`, which goes to stderr and shows up in the workflow log. A
+stray diagnostic once corrupted every benchmark artifact for five weeks
+before anyone noticed.
+
+**Names identify chart series.** The dashboard tracks each benchmark by its
+origin file, group, and verbatim name. Renaming a bench or its group breaks
+the series: history stays under the old name and the renamed bench starts
+over. So:
+
+- Keep names stable. Never interpolate values that change as unrelated commits
+  land: content hashes, byte counts, module counts, dates. If a name must
+  identify a module, derive a label from its source filename, not from its
+  content. Log volatile sizes to stderr instead.
+- Keep names short. The dashboard has little horizontal room for series
+  labels, and the origin file and group already carry context, so the name
+  should not repeat them.
+- Keep names unique within a file. `Deno.bench` accepts duplicate names
+  without an error and reports them as a single benchmark whose results array
+  holds one entry per duplicate; a consumer reading one result per name
+  silently drops the rest.
+
+`packages/runner/test/esm-verifier.bench.ts` shows the pattern: short stable
+names, per-module labels derived from source paths, sizes logged to stderr.

--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -54,10 +54,11 @@ step, and we'll ratchet targets down as we improve.
 ## What We Know (and Don't Know)
 
 **What exists today:**
-- 14 micro-benchmark files across runner, memory, utils
+- Dozens of micro-benchmark files across runner, memory, utils, and other
+  packages
 - CI benchmarks every four hours on main (dedicated runner group), JSON
   artifacts with 90-day retention, charted on the team ops dashboard's /bench
-  page
+  page (see [BENCHMARKS.md](BENCHMARKS.md))
 - Per-PR performance gate comparing CI timings against recent main runs
   (median + 3σ or +50%)
 - Recent wins: compilation cache (~100-500ms saved), schema freeze caching,

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -99,6 +99,9 @@ When adding runtime features, consider adding integration tests to `packages/run
   coverage for authored patterns) and how both feed the coverage-debt gate.
 - [CI_PERFORMANCE.md](CI_PERFORMANCE.md) — the CI wall-time policy, and the
   coverage-debt baseline and ratchet markers that gate a pull request.
+- [BENCHMARKS.md](BENCHMARKS.md) — how `*.bench.ts` files run in CI, how the
+  team ops dashboard charts their trends, and the naming and stdout
+  constraints a bench file must satisfy.
 - [LLM_TESTING.md](LLM_TESTING.md) — testing patterns and server routes that
   call the LLM, including the test-environment guard and conversation fixtures.
 - [UI_TESTING.md](UI_TESTING.md) — testing shadow DOM components in browser


### PR DESCRIPTION
Three separate defects in the benchmark pipeline traced back to the same gap: nothing documented how benchmark results are consumed, so bench files kept violating constraints their authors could not have known about. Stray stdout from a bench file corrupted every results.json artifact for five weeks before anyone noticed, and benchmark names interpolated content hashes and byte counts that changed with unrelated commits, splitting their trend history.

Add docs/development/BENCHMARKS.md describing the pipeline — the scheduled Benchmarks workflow, the bench-results artifacts, and the team ops dashboard's /bench page that charts one successful run per four-hour window, keyed by origin file, group, and name — and the two constraints every bench file must satisfy: stdout must stay pure JSON, and names identify chart series so they must be stable, short, and unique. The doc also records what is not covered: the per-PR performance gate checks CI job, step, and test timings plus the coverage-debt ratchet, and never ingests benchmark results, so a bench regression surfaces as dashboard trend drift rather than a failing check.

Link the new doc from TESTING.md's related-documentation list. In PERFORMANCE_PROGRAM.md, correct the stale count of benchmark files and link BENCHMARKS.md from the CI benchmarks entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented how CI benchmarks run and are charted, plus the two required bench-file constraints: stdout must be pure JSON and names must be stable, short, and unique, to prevent corrupted artifacts and split trend histories. Linked the new `BENCHMARKS.md` from `TESTING.md` and updated `PERFORMANCE_PROGRAM.md` to reflect current coverage and include the doc link.

<sup>Written for commit e6ac0b822e94eb546adbf2c7a87590bd8cfee127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

