### PR TITLE
fix(demo): prefer exact integration test filters

### DIFF
--- a/tasks/demo.test.ts
+++ b/tasks/demo.test.ts
@@ -124,6 +124,7 @@ Deno.test("resolveDemoTest requires exactly one file", async () => {
   try {
     const dir = `${root}/packages/patterns/integration`;
     await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(`${dir}/demo.test.ts`, "");
     await Deno.writeTextFile(`${dir}/one-demo.test.ts`, "");
     await Deno.writeTextFile(`${dir}/two-demo.test.ts`, "");
     const base = parseDemoArgs(["patterns", "one-demo"]);
@@ -131,8 +132,12 @@ Deno.test("resolveDemoTest requires exactly one file", async () => {
       await resolveDemoTest(root, base.packageName, base.filters[0]),
       "one-demo.test.ts",
     );
+    assertEquals(
+      await resolveDemoTest(root, base.packageName, "demo.test.ts"),
+      "demo.test.ts",
+    );
     await assertRejects(
-      () => resolveDemoTest(root, base.packageName, "demo"),
+      () => resolveDemoTest(root, base.packageName, "emo"),
       Error,
       "ambiguous",
     );

--- a/tasks/demo.ts
+++ b/tasks/demo.ts
@@ -92,6 +92,8 @@ export async function resolveDemoTest(
     integrationDir,
     filter,
   );
+  const exactName = filter.endsWith(".test.ts") ? filter : `${filter}.test.ts`;
+  if (matches.includes(exactName)) return exactName;
   if (matches.length !== 1) {
     throw new Error(
       matches.length === 0

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -28,6 +28,16 @@ Deno.test("selectIntegrationTestFiles matches a single file by name", () => {
   ]);
 });
 
+Deno.test("selectIntegrationTestFiles prefers an exact filename match", () => {
+  const files = ["counter.test.ts", "nested-counter.test.ts"];
+  assertEquals(selectIntegrationTestFiles(files, "counter"), [
+    "counter.test.ts",
+  ]);
+  assertEquals(selectIntegrationTestFiles(files, "counter.test.ts"), [
+    "counter.test.ts",
+  ]);
+});
+
 Deno.test("selectIntegrationTestFiles returns empty when nothing matches", () => {
   assertEquals(
     selectIntegrationTestFiles(["counter.test.ts"], "nonexistent"),

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -367,8 +367,12 @@ export function selectIntegrationTestFiles(
   fileNames: string[],
   filter: string,
 ): string[] {
-  return fileNames
-    .filter((name) => name.endsWith(".test.ts") && name.includes(filter))
+  const testFiles = fileNames
+    .filter((name) => name.endsWith(".test.ts"));
+  const exactName = filter.endsWith(".test.ts") ? filter : `${filter}.test.ts`;
+  if (testFiles.includes(exactName)) return [exactName];
+  return testFiles
+    .filter((name) => name.includes(filter))
     .sort();
 }
 


### PR DESCRIPTION
## Summary

Prefer an exact `*.test.ts` filename (or exact basename) before falling back to substring matching in both the integration runner and the video-demo selector.

This prevents filters such as `counter` or `counter.test.ts` from also running `nested-counter.test.ts`, which otherwise creates mislabeled combined recordings in batch galleries. Broad substring filters still work when no exact test exists.

## Validation

- `deno task check`
- `deno task test` in `tasks` — 255 tests
- focused demo and integration selector tests — 35 tests
- live batch recording confirmed `counter` and `nested-counter` produce separate named MP4s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer exact test filename matches in the integration runner and video-demo selector to avoid running similarly named tests. Falls back to substring matching only when no exact match exists.

- **Bug Fixes**
  - Prioritize an exact filename match (e.g., `counter` or `counter.test.ts` → `counter.test.ts`).
  - Prevent `counter` filters from matching `nested-counter.test.ts`, avoiding mislabeled batch recordings.
  - Added tests to cover exact-match behavior in both selectors; validated locally and in a live batch run.

<sup>Written for commit a48017a2971319e8e29768bf16b01e4761b5fa41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

