### PR TITLE
ci: fail the Benchmarks run when results.json is not valid JSON

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,10 +1,10 @@
 name: Benchmarks
 
 # The bench-results artifacts feed the benchmark trend charts on the team ops
-# dashboard (its /bench page), which samples one run per four-hour window, so
-# per-push samples add no resolution beyond a four-hourly cadence. Scheduled
-# runs stay on the dedicated runner group so results remain comparable across
-# runs; use the manual trigger to measure a specific commit.
+# dashboard (its /bench page), which samples one successful run per four-hour
+# window, so per-push samples add no resolution beyond a four-hourly cadence.
+# Scheduled runs stay on the dedicated runner group so results remain
+# comparable across runs; use the manual trigger to measure a specific commit.
 on:
   schedule:
     - cron: "0 */4 * * *" # Every 4 hours
@@ -37,6 +37,23 @@ jobs:
             packages/utils/src/cache.bench.ts \
             packages/utils/test/deep-equal.bench.ts \
             > bench-results/results.json
+
+      # Fail the run if any bench file wrote non-JSON to stdout, or if the
+      # report lists no benches. The dashboard samples successful runs only,
+      # so a corrupt artifact never reaches the charts and the failure is a
+      # visible red run. The script rides in a single-quoted shell argument —
+      # keep apostrophes out of it.
+      - name: ✅ Validate benchmark results
+        run: |
+          deno eval '
+            const data = JSON.parse(
+              Deno.readTextFileSync("bench-results/results.json"),
+            );
+            if (!Array.isArray(data.benches) || data.benches.length === 0) {
+              throw new Error("results.json parsed but contains no benches");
+            }
+            console.log(`results.json OK: ${data.benches.length} benches`);
+          '
 
       - name: 📤 Upload benchmark results
         if: always()

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -32,8 +32,11 @@ single file.
 
 **Stdout must stay pure JSON.** The workflow redirects all of stdout to
 `results.json`. One stray line printed by any bench file corrupts the
-artifact for every benchmark in the run, not just the offending file. This
-applies to module-scope code as well as bench bodies. Write diagnostics with
+artifact for every benchmark in the run, not just the offending file. A
+validation step fails the run when the artifact is not valid JSON or lists
+no benches; since the dashboard samples successful runs only, corruption
+never reaches the charts and shows up as a red run in the Actions tab. This applies to module-scope
+code as well as bench bodies. Write diagnostics with
 `console.error`, which goes to stderr and shows up in the workflow log. A
 stray diagnostic once corrupted every benchmark artifact for five weeks
 before anyone noticed.


### PR DESCRIPTION
The Benchmarks workflow redirects deno bench --json stdout into the bench-results artifact. A stray print from any bench file corrupts the artifact, and nothing noticed: the workflow still exited green, and the artifact consumers coped quietly. One such stray diagnostic corrupted every benchmark artifact for five weeks in mid-2026 before anyone saw it.

Add a validation step after the bench step that parses results.json and fails the run when it is not valid JSON or contains no benches. The team ops dashboard samples one successful run per four-hour window, so a corrupt artifact now surfaces as a red run in the Actions tab and never reaches the charts. The upload step keeps if: always() so the corrupt artifact remains available for debugging a failed run.

Also say "successful" in the workflow's header comment where it describes the dashboard's sampling, matching the dashboard's actual filter, and update BENCHMARKS.md to describe the new failure mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the Benchmarks workflow when `results.json` is invalid JSON or lists zero benches, so bad or empty artifacts never reach the dashboard and show up as red runs.

- **Bug Fixes**
  - Add a validation step that parses `bench-results/results.json` and fails on JSON errors or when the `benches` array is missing/empty (covers green-but-empty reports).
  - Keep artifact upload with `if: always()` so corrupt artifacts are available for debugging.
  - Update the workflow header to say “successful” runs only, and BENCHMARKS.md to describe the validation and failure conditions and to use `console.error` for diagnostics.

<sup>Written for commit 3ee16cd38f3189e1ec0a8f571e0d85eaeeda4ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

