### PR TITLE
cf-tabs: fix the plain-value one-behind highlight desync

### DIFF
--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -570,3 +570,118 @@ describe("CFTabs plain-string value contract (one-behind regression)", () => {
     expect(h.selectedTab()).toBe("notes");
   });
 });
+
+/**
+ * Deferred-retry supersession + slot-listener lifetime.
+ *
+ * Review follow-ups on the one-behind fix (PR #4711): the deferred rAF retry
+ * now CAPTURES its call's valueOverride, so a retry left armed across a newer
+ * synchronous pass would replay the older delivery next frame; and the
+ * cf-tab-list slotchange listener must survive the VDOM replacing the
+ * tab-list element (previously a one-shot boolean pinned it to the first).
+ */
+describe("CFTabs deferred retry + slot listener lifetime", () => {
+  it("a newer sync pass cancels a pending deferred retry (stale delivery must not replay)", () => {
+    // Capturable rAF: the module-level shim swallows callbacks; these stubs
+    // record them so the test can fire (or prove the cancellation of) the
+    // deferred retry deterministically.
+    const rafCbs = new Map<number, () => void>();
+    let nextRafId = 1;
+    const origRaf = g.requestAnimationFrame;
+    const origCaf = g.cancelAnimationFrame;
+    g.requestAnimationFrame = (cb: () => void) => {
+      const id = nextRafId++;
+      rafCbs.set(id, cb);
+      return id;
+    };
+    g.cancelAnimationFrame = (id: number) => {
+      rafCbs.delete(id);
+    };
+    try {
+      const cell = createMockCellHandle<string>("");
+      const h = makeTabs(cell, ["a", "b"]);
+      // Simulate the VDOM timing gap: tab elements exist, properties not yet
+      // assigned — the condition that arms the deferred retry.
+      h.fakeTabs.forEach((t) => {
+        (t as unknown as { value?: string }).value = undefined;
+      });
+
+      pushUpdate(cell, "a"); // delivery "a" can't apply → arms a retry carrying "a"
+      expect(rafCbs.size).toBe(1);
+
+      // Properties arrive, then a NEWER delivery applies synchronously.
+      h.fakeTabs[0].value = "a";
+      h.fakeTabs[1].value = "b";
+      pushUpdate(cell, "b");
+      expect(h.selectedTab()).toBe("b");
+
+      // The stale "a" retry must be gone — pre-fix it survived here...
+      expect(rafCbs.size).toBe(0);
+      // ...and firing any survivor must not overwrite the latest selection
+      // (pre-fix this replayed "a" over "b" on the next frame).
+      for (const cb of [...rafCbs.values()]) cb();
+      expect(h.selectedTab()).toBe("b");
+    } finally {
+      g.requestAnimationFrame = origRaf;
+      g.cancelAnimationFrame = origCaf;
+    }
+  });
+
+  it("re-attaches the slotchange listener when the cf-tab-list element is replaced, and its slotchange re-syncs", () => {
+    // Fake cf-tab-list: just the surface setupTabListSlotListener touches — a
+    // shadow root exposing a <slot> that records slotchange listeners.
+    function makeFakeTabList() {
+      const listeners: Array<() => void> = [];
+      const slot = {
+        addEventListener: (_type: string, cb: () => void) => {
+          listeners.push(cb);
+        },
+        // Empty: skip the "tabs already present" immediate-sync branch so the
+        // test exercises the LISTENER path explicitly via fireSlotChange.
+        assignedElements: () => [] as unknown[],
+      };
+      return {
+        el: {
+          tagName: "CF-TAB-LIST",
+          shadowRoot: {
+            querySelector: (sel: string) => (sel === "slot" ? slot : null),
+          },
+        },
+        listeners,
+        fireSlotChange: () => listeners.forEach((cb) => cb()),
+      };
+    }
+
+    const cell = createMockCellHandle<string>("a");
+    const h = makeTabs(cell, ["a", "b"]);
+    const listA = makeFakeTabList();
+    const listB = makeFakeTabList();
+    let currentTabList: unknown = listA.el;
+    (h.tabs as unknown as {
+      querySelector: (sel: string) => unknown;
+    }).querySelector = (sel: string) =>
+      sel === "cf-tab-list" ? currentTabList : null;
+    const setup = (h.tabs as unknown as {
+      setupTabListSlotListener: () => void;
+    }).setupTabListSlotListener.bind(h.tabs);
+
+    setup();
+    expect(listA.listeners.length).toBe(1);
+    setup(); // same element: idempotent, no duplicate listener
+    expect(listA.listeners.length).toBe(1);
+
+    // The VDOM re-renders the consumer's tab row, re-creating cf-tab-list.
+    currentTabList = listB.el;
+    setup();
+    // Pre-fix the one-shot boolean left the replacement without a listener
+    // (0 here) — cf-tabs went deaf to every subsequent tab change.
+    expect(listB.listeners.length).toBe(1);
+
+    // And the re-attached listener actually re-syncs: knock the selection out
+    // from under the component (as freshly created, unselected children would
+    // be), then fire B's slotchange.
+    h.fakeTabs.forEach((t) => (t.selected = false));
+    listB.fireSlotChange();
+    expect(h.selectedTab()).toBe("a");
+  });
+});

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -151,7 +151,7 @@ import { CFTabs } from "./index.ts";
  * cell controller bound (as firstUpdated would do). Returns helpers to drive
  * and observe it.
  */
-function makeTabs(cell: CellHandle<string>, tabValues: string[]) {
+function makeTabs(cell: CellHandle<string> | string, tabValues: string[]) {
   const tabs = new CFTabs();
   const fakeTabs = tabValues.map((v) => new FakeTab(v));
   const fakePanels = tabValues.map((v) => new FakeTabPanel(v));
@@ -166,10 +166,10 @@ function makeTabs(cell: CellHandle<string>, tabValues: string[]) {
   };
 
   // Bind the cell the way firstUpdated() does, and seed initial selection.
-  (tabs as unknown as { value: CellHandle<string> }).value = cell;
+  (tabs as unknown as { value: CellHandle<string> | string }).value = cell;
   const ctrl = (tabs as unknown as {
     _cellController: {
-      bind: (v: CellHandle<string>, s: unknown) => void;
+      bind: (v: CellHandle<string> | string, s: unknown) => void;
     };
   })._cellController;
   ctrl.bind(cell, stringSchema);
@@ -469,5 +469,104 @@ describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
 
     expect(writes()).toBe(0);
     expect(h.selectedTab()).toBe(undefined); // no enabled tab to default to
+  });
+});
+
+/**
+ * Plain-string `value` contract (the "one-behind" highlight regression).
+ *
+ * A consumer whose selection truth is NOT a single string cell (e.g. Loom
+ * mobile's PageViewer, which keys per-page selections in a map) binds a PLAIN
+ * string value and listens to oncf-change:
+ *
+ *   <cf-tabs value={activeId} oncf-change={writeSelectionState}>
+ *
+ * — typically re-created inside a render computed, so each state write
+ * re-renders cf-tabs with the string the click just produced. Two defects
+ * stranded the highlight one state behind on every tap:
+ *
+ * 1. Click-time: emitUserChange → setValue has no backing store for a plain
+ *    binding, so the onChange sync's getValue() re-read returned the STALE
+ *    bound literal and the visual update no-oped. (Fixed: onChange syncs from
+ *    the delivered value.)
+ * 2. Re-render-time: the consumer's recompute re-creates the tab children
+ *    (all unselected) and patches `value` to the clicked string — but
+ *    updated()'s `currentValue !== _lastKnownValue` guard saw the value it
+ *    had already recorded at click time and skipped the re-sync entirely.
+ *    (Fixed: a changed `value` PROPERTY always re-syncs.)
+ */
+describe("CFTabs plain-string value contract (one-behind regression)", () => {
+  // Simulate the consumer's recompute: replace every cf-tab child with a
+  // fresh, unselected element (the VDOM re-creates them), patch the `value`
+  // property, and drive the lit lifecycle the way a property change does.
+  function reRender(
+    h: ReturnType<typeof makeTabs>,
+    newValue: string,
+    oldValue: string,
+  ) {
+    const fresh = h.fakeTabs.map((t) => {
+      const nt = new FakeTab(t.value);
+      nt.onClickDispatch = t.onClickDispatch;
+      return nt;
+    });
+    h.fakeTabs.splice(0, h.fakeTabs.length, ...fresh);
+    (h.tabs as unknown as { value: string }).value = newValue;
+    const changed = new Map<string | number | symbol, unknown>([[
+      "value",
+      oldValue,
+    ]]);
+    (h.tabs as unknown as {
+      willUpdate: (c: Map<string | number | symbol, unknown>) => void;
+    }).willUpdate(changed);
+    (h.tabs as unknown as {
+      updated: (c: Map<string | number | symbol, unknown>) => void;
+    }).updated(changed);
+  }
+
+  it("a user click highlights the clicked tab immediately (no cell to write back through)", () => {
+    const h = makeTabs("steps", ["steps", "notes", "log"]);
+    expect(h.selectedTab()).toBe("steps");
+
+    h.clickTab("notes");
+
+    // One gesture event, and the highlight tracks the tap at click time —
+    // pre-fix the onChange getValue() re-read left "steps" selected.
+    expect(h.changes.length).toBe(1);
+    expect(h.changes[0]).toEqual({ value: "notes", oldValue: "steps" });
+    expect(h.selectedTab()).toBe("notes");
+  });
+
+  it("consumer re-render carrying the clicked value re-syncs freshly created tabs", () => {
+    const h = makeTabs("steps", ["steps", "notes", "log"]);
+
+    h.clickTab("notes");
+    // The oncf-change consumer writes its state; its computed re-runs and
+    // re-creates the tab row with value="notes" — the SAME string the click
+    // produced. Pre-fix, updated() read this as no-change and left the fresh
+    // (unselected) children unselected: the visible highlight was whatever
+    // the PREVIOUS render carried — one behind, forever.
+    reRender(h, "notes", "steps");
+    expect(h.selectedTab()).toBe("notes");
+
+    // And it stays correct across the next tap: the exact reported repro
+    // (each render used to show the previous click's target).
+    h.clickTab("log");
+    reRender(h, "log", "notes");
+    expect(h.selectedTab()).toBe("log");
+
+    h.clickTab("steps");
+    reRender(h, "steps", "log");
+    expect(h.selectedTab()).toBe("steps");
+  });
+
+  it("re-render to a DIFFERENT value than the click (controlled rejection) wins", () => {
+    // The consumer is authoritative: if its state write resolves to another
+    // id (e.g. a guard/fallback), the re-rendered value must override the
+    // click-time highlight.
+    const h = makeTabs("steps", ["steps", "notes", "log"]);
+
+    h.clickTab("log");
+    reRender(h, "notes", "steps"); // consumer resolved the tap to "notes"
+    expect(h.selectedTab()).toBe("notes");
   });
 });

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -124,8 +124,14 @@ export class CFTabs extends BaseElement {
       // "cf-change" is emitted only from the user-gesture paths
       // (handleTabClick / handleKeydown via emitUserChange). Here we just keep
       // the visual selection in sync with the cell.
+      //
+      // Sync from the DELIVERED value, not a getValue() re-read: with a PLAIN
+      // string binding there is no backing store for a user click's setValue
+      // to write, so getValue() still returns the stale bound literal here —
+      // re-reading it made the click-time sync a silent no-op (the
+      // "one-behind" highlight bug; see updated() for the second half).
       this._lastKnownValue = newValue;
-      this.updateTabSelection();
+      this.updateTabSelection(newValue);
     },
   });
 
@@ -181,9 +187,22 @@ export class CFTabs extends BaseElement {
   override updated(changedProperties: Map<string | number | symbol, unknown>) {
     super.updated(changedProperties);
 
-    // Always check if the cell value changed (handles both property changes
-    // and external cell updates that trigger requestUpdate via sink)
     const currentValue = this._cellController.getValue();
+    if (changedProperties.has("value")) {
+      // The consumer explicitly re-rendered the `value` prop — ALWAYS re-sync,
+      // even when currentValue equals _lastKnownValue. With a plain string
+      // binding, a user click updates only internal state (there is no cell to
+      // write), so the consumer's next render typically carries the SAME
+      // string the click produced; the old `!==` guard read that as a no-op
+      // while the DOM children had just been re-rendered unselected, stranding
+      // the highlight one state behind on every tap (dynamic tabs re-created
+      // inside a render computed with a plain `value`).
+      this._lastKnownValue = currentValue;
+      this.updateTabSelection();
+      return;
+    }
+    // Other updates (requestUpdate via the cell sink, orientation, …): keep
+    // the change detection so unrelated updates don't repaint selection.
     if (currentValue !== this._lastKnownValue) {
       this._lastKnownValue = currentValue;
       this.updateTabSelection();
@@ -208,10 +227,17 @@ export class CFTabs extends BaseElement {
 
   private _pendingRetry: number | null = null;
 
-  private updateTabSelection(): void {
+  // `valueOverride` carries an authoritative just-delivered value (a user
+  // click or a cell delivery via the controller's onChange). It matters for
+  // PLAIN string bindings, where a click's setValue has no backing store to
+  // write — a getValue() re-read here would return the stale bound literal
+  // and silently no-op the sync.
+  private updateTabSelection(valueOverride?: string): void {
     const tabs = this.getTabs();
     const panels = this.getTabPanels();
-    const currentValue = this._cellController.getValue();
+    const currentValue = valueOverride !== undefined
+      ? valueOverride
+      : this._cellController.getValue();
 
     // When tabs exist in DOM but the VDOM framework hasn't set their properties yet,
     // defer selection until the next frame when properties will be available.
@@ -222,7 +248,7 @@ export class CFTabs extends BaseElement {
       }
       this._pendingRetry = requestAnimationFrame(() => {
         this._pendingRetry = null;
-        this.updateTabSelection();
+        this.updateTabSelection(valueOverride);
       });
       return;
     }
@@ -303,7 +329,13 @@ export class CFTabs extends BaseElement {
     this.updateTabSelection();
   };
 
-  private _tabListSlotListenerSetup = false;
+  // The cf-tab-list element whose internal slot currently carries our
+  // slotchange listener. Tracked by ELEMENT (not a one-shot boolean): a VDOM
+  // consumer that re-renders its tab list re-CREATES the cf-tab-list element,
+  // and a listener left on the discarded element observes nothing — cf-tabs
+  // then never hears about the replacement tabs (part of the plain-value
+  // "one-behind" highlight bug).
+  private _tabListWithSlotListener: Element | null = null;
 
   /**
    * Sets up a slotchange listener on cf-tab-list's internal slot.
@@ -312,12 +344,10 @@ export class CFTabs extends BaseElement {
    * tabs are actually added to the DOM.
    */
   private setupTabListSlotListener(): void {
-    if (this._tabListSlotListenerSetup) return;
-
     const tabList = this.querySelector("cf-tab-list") as
       | (Element & { updateComplete?: Promise<boolean> })
       | null;
-    if (!tabList) return;
+    if (!tabList || tabList === this._tabListWithSlotListener) return;
 
     // Wait for cf-tab-list to have its shadow DOM ready
     const tabListSlot = tabList.shadowRoot?.querySelector("slot");
@@ -329,7 +359,7 @@ export class CFTabs extends BaseElement {
       return;
     }
 
-    this._tabListSlotListenerSetup = true;
+    this._tabListWithSlotListener = tabList;
 
     tabListSlot.addEventListener("slotchange", () => {
       this.updateTabSelection();

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -233,6 +233,17 @@ export class CFTabs extends BaseElement {
   // write — a getValue() re-read here would return the stale bound literal
   // and silently no-op the sync.
   private updateTabSelection(valueOverride?: string): void {
+    // Every sync pass supersedes any pending deferred retry. The retry
+    // captures its call's valueOverride, so a retry left armed across a NEWER
+    // pass would replay the older delivery next frame, overwriting the latest
+    // selection (delivery "a" defers → delivery "b" applies synchronously →
+    // stale "a" fires). If THIS pass still can't apply, the defer branch
+    // below re-arms with the current value.
+    if (this._pendingRetry !== null) {
+      cancelAnimationFrame(this._pendingRetry);
+      this._pendingRetry = null;
+    }
+
     const tabs = this.getTabs();
     const panels = this.getTabPanels();
     const currentValue = valueOverride !== undefined
@@ -243,9 +254,6 @@ export class CFTabs extends BaseElement {
     // defer selection until the next frame when properties will be available.
     // This handles the timing gap between DOM element creation and property assignment.
     if (tabs.length > 0 && (tabs[0] as CFTab).value === undefined) {
-      if (this._pendingRetry !== null) {
-        cancelAnimationFrame(this._pendingRetry);
-      }
       this._pendingRetry = requestAnimationFrame(() => {
         this._pendingRetry = null;
         this.updateTabSelection(valueOverride);


### PR DESCRIPTION
## Why

A consumer whose selection truth is not a single string cell (e.g. Loom mobile's PageViewer, which keys per-page tab selections in a map) binds a **plain string** `value` plus `oncf-change`, typically re-created inside a render `computed()`. On every tap the highlight ended up **one state behind** — each render showed the *previous* click's target, permanently. Content and the raw `value` prop were correct; only the visual selection was stranded, which made the component unusable for this binding shape and kept Loom mobile on a hand-rolled chip-row workaround.

This is the last blocker in the cf-tabs rehabilitation arc after #4134 (gesture-only `cf-change`), #4151 (no cell write on mount/selection-sync), and #4221 (mount flicker).

## What Changed

Three coordinated fixes in `CFTabs`, none touching the CT-1746/CT-1752 contracts:

1. **Click-time sync** — `emitUserChange → setValue` has no backing store on a plain binding, so the controller `onChange`'s `getValue()` re-read returned the stale bound literal and the visual update no-oped. `onChange` now syncs from the **delivered** value (`updateTabSelection(newValue)`).
2. **Re-render sync** — the consumer's recompute re-creates the tab children (all unselected) and patches `value` to the very string the click produced; `updated()`'s `currentValue !== _lastKnownValue` guard read that as no-change and skipped the re-sync. A changed `value` **property** now always re-syncs; other updates keep the guard.
3. **Slot listener lifetime** — the cf-tab-list slotchange listener was a one-shot boolean keyed to the *first* tab-list element; a VDOM that re-creates the list left the listener on the discarded element. It's now keyed by element and re-attaches when the tab-list changes.

## Test plan

- New `CFTabs plain-string value contract (one-behind regression)` suite drives the exact repro (click → consumer re-render carrying the clicked value → freshly created children must highlight it, across successive taps), plus immediate click-time highlight and controlled-rejection override. Both regression tests **fail before the fix**.
- All pre-existing cf-tabs suites (CT-1746 emission contract, CT-1752 pure-on-mount, mount-flicker) pass unchanged: `deno test packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts` → 3 suites / 17 steps ok.
- Verified live in a Loom acceptance instance: PageViewer section tabs (plain value + oncf-change inside a render computed) track every tap with no console errors and no scheduler loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "one-behind" highlight in `cf-tabs` when using a plain string `value` with `oncf-change`. The highlight updates on click, stays in sync after re-renders, and ignores stale deferred retries.

- **Bug Fixes**
  - Click sync uses the delivered value and cancels any pending deferred retry to prevent stale rAF overwriting newer selection on plain string bindings.
  - Always re-sync when the `value` property changes to handle freshly re-created tab children.
  - Re-attach the `cf-tab-list` slotchange listener when the element is replaced to keep tracking new tabs.

<sup>Written for commit e0ffd83c4c6ab92d3e73fac733bbae2fc574d270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

