### PR TITLE
perf(memory): add durable request schema CAS

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -170,6 +170,7 @@ The toolshed-embedded memory service has two modes:
 | `MEMORY_URL` | `http://localhost:8000` | Where other components reach the memory service. |
 | `MEMORY_ACL_MODE` | `enforce` | Space ACL policy: `off`, `observe`, or `enforce`. `observe` logs ordinary access shortfalls, while malformed ACLs and fresh-space genesis violations still fail closed. |
 | `MEMORY_SERVICE_DIDS` | _(empty)_ | Comma-separated DIDs with implicit OWNER on every space. These identities may initialize ACLs but still cannot make an ordinary first write before genesis. |
+| `CF_MEMORY_WIRE_ACCOUNTING_TOKEN` | _(unset)_ | Enables the bearer-token-protected Memory websocket payload-accounting diagnostic only when `ENV` is `development` or `test`; all other environments fail closed. The root integration runner generates this token automatically for `deno task integration patterns lunch-poll-vote`. |
 
 With ACL policy active, a fresh space is read-only until its space identity or a
 configured service DID writes a valid ACL with a concrete OWNER. A populated

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -43,7 +43,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
-| [`requestSchemaCasV1`](#requestschemacasv1) | negotiated Memory protocol flag | on when the host has a durable schema store | Memory v2 | retire after all peers support durable request schema CAS | implemented and measured end to end |
+| [`requestSchemaCasV1`](#requestschemacasv1) | negotiated Memory protocol flag | on when the host injects a schema store | Memory v2 | retire after all peers support durable request schema CAS | implemented and measured end to end |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
@@ -545,29 +545,31 @@ the per-epic implementation notes).
 ### `requestSchemaCasV1`
 
 - **Toggle via.** The Memory `hello` capability handshake. Clients advertise
-  support by default; a server advertises it only when its host injects a shared
-  durable schema store. `hello.ok.requestSchemaCas` identifies the store by a
-  durable `generation` and service `audience`.
+  support by default; a server advertises it whenever its host injects a
+  `SchemaStore`. `hello.ok.requestSchemaCas` identifies that store by its
+  `generation` and service `audience`. Toolshed injects a shared durable SQLite
+  store; custom hosts are responsible for choosing storage with the lifetime
+  their clients expect.
 - **Added by.** Memory v2 request-schema CAS work, 2026-07-14.
 - **Purpose.** Removes repeated schemas from supported `graph.query`,
   `session.watch.*`, and `transact` requests. Exact schema-bearing positions use
   `schema-cas@1:<tagged-hash>` references. Negotiated clients optimistically
   send references without definitions, including cold first use. One
   `MissingSchemas` response permits one forced retry with verified canonical
-  `schemaDefinitions`; after admission, the durable store supports sequential
-  refs-only reuse across warm requests, reconnects, new clients, and store
-  reopen. The server expands references before logical query, watch, replay, or
-  persistence paths.
+  `schemaDefinitions`; after admission, a durable injected store supports
+  sequential refs-only reuse across warm requests, reconnects, new clients, and
+  store reopen. The server expands references before logical query, watch,
+  replay, or persistence paths.
 - **Diagnostic override.** Set `CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED=false`
   before Toolshed startup to suppress the server capability for a paired inline
   accounting run. Unset or `default` makes no setter call and preserves the
   Memory package default; `true` explicitly enables it. This is a startup
   measurement override, not a separate protocol.
 - **Current default and planned end state.** Client support is on. Server use is
-  automatically on when a durable schema store is configured and safely absent
-  otherwise, so older or standalone peers continue to receive inline schemas.
-  Retire negotiation only after all deployed peers provide durable request
-  schema availability.
+  automatically on when any `SchemaStore` is injected and safely absent
+  otherwise. Toolshed provides a durable store; standalone or custom hosts may
+  choose a different lifetime. Retire negotiation only after all deployed peers
+  provide durable request schema availability.
 - **Status on 2026-07-14.** Implemented in the client, Memory server, and
   Toolshed durable SQLite store. Definitions are authorized, hash-verified,
   required to be referenced, and inserted atomically after all references

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -20,7 +20,7 @@ in the same change.
 > flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
 > record, so the history stays discoverable.
 
-**Last reviewed:** 2026-07-09. Each flag's section carries the date its status
+**Last reviewed:** 2026-07-14. Each flag's section carries the date its status
 was last checked against the code.
 
 ## Summary table
@@ -43,6 +43,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
+| [`requestSchemaCasV1`](#requestschemacasv1) | negotiated Memory protocol flag | on when the host has a durable schema store | Memory v2 | retire after all peers support durable request schema CAS | implemented and measured end to end |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
@@ -540,6 +541,49 @@ the per-epic implementation notes).
 - **Path to removal.** Confirm no peer still needs the expanded payload, then
   delete the negotiation and the expanded-form encoder and always send the
   compact form.
+
+### `requestSchemaCasV1`
+
+- **Toggle via.** The Memory `hello` capability handshake. Clients advertise
+  support by default; a server advertises it only when its host injects a shared
+  durable schema store. `hello.ok.requestSchemaCas` identifies the store by a
+  durable `generation` and service `audience`.
+- **Added by.** Memory v2 request-schema CAS work, 2026-07-14.
+- **Purpose.** Removes repeated schemas from supported `graph.query`,
+  `session.watch.*`, and `transact` requests. Exact schema-bearing positions use
+  `schema-cas@1:<tagged-hash>` references. Negotiated clients optimistically
+  send references without definitions, including cold first use. One
+  `MissingSchemas` response permits one forced retry with verified canonical
+  `schemaDefinitions`; after admission, the durable store supports sequential
+  refs-only reuse across warm requests, reconnects, new clients, and store
+  reopen. The server expands references before logical query, watch, replay, or
+  persistence paths.
+- **Diagnostic override.** Set `CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED=false`
+  before Toolshed startup to suppress the server capability for a paired inline
+  accounting run. Unset or `default` makes no setter call and preserves the
+  Memory package default; `true` explicitly enables it. This is a startup
+  measurement override, not a separate protocol.
+- **Current default and planned end state.** Client support is on. Server use is
+  automatically on when a durable schema store is configured and safely absent
+  otherwise, so older or standalone peers continue to receive inline schemas.
+  Retire negotiation only after all deployed peers provide durable request
+  schema availability.
+- **Status on 2026-07-14.** Implemented in the client, Memory server, and
+  Toolshed durable SQLite store. Definitions are authorized, hash-verified,
+  required to be referenced, and inserted atomically after all references
+  expand. Store rejection disables request CAS for the connection and retries
+  the underlying request inline once. Concurrent cold clients may each reach a
+  forced-definition retry; globally exactly-once definition transfer would need
+  coordination beyond this protocol.
+- **Security boundary.** Schema hashes are content addresses, not secrets or
+  authorization capabilities. Toolshed-wide lookup is deliberate, so admitted
+  schemas are non-secret protocol metadata; there is no public list/fetch API.
+  Bounded-store rejection makes clients fall back to one inline retry rather
+  than denying the underlying Memory request.
+- **Path to removal.** Let the negotiated path soak across reconnects and mixed
+  peer versions; once every supported server owns the durable store and every
+  client understands references, make the encoding unconditional and delete the
+  capability branch and inline fallback.
 
 > Two neighbours in the same handshake are related but are not runtime-toggleable
 > experimental flags:

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -101,15 +101,46 @@ inside computed(); Stream subscribe doesn't exist; binding the whole item to
   token and passes it to both Toolshed and the test process; Toolshed's
   `/api/storage/memory/wire-accounting/{start,stop}` endpoint is unavailable
   without that token and is allowed only when `ENV` is `development` or `test`.
-  The test prints browser-only aggregate totals and per-direction,
-  per-classification rows. The measured unit is UTF-8 bytes of Memory websocket
-  text payloads produced by `encodeMemoryBoundary`; it excludes the HTTP
+   The test prints browser-only aggregate totals, per-direction/per-classification
+   rows, a protocol-class × semantic-byte cross-tab, and a semantic-byte/repetition
+   table. The measured unit is UTF-8 bytes of Memory websocket
+   text payloads produced by `encodeMemoryBoundary`; it excludes the HTTP
   upgrade, websocket framing and masking, ping/pong/close frames,
   permessage-deflate physical bytes, TLS, and TCP. Interpret the baseline as a
   same-run counterfactual, not a second noisy run: outbound baseline bytes
-  encode the original uncompressed `ServerMessage`, outbound actual bytes encode
-  the negotiated `syncSchemaTableV2` message, and inbound baseline bytes equal
-  inbound actual bytes.
+   encode the original uncompressed `ServerMessage`, outbound actual bytes encode
+   the negotiated `syncSchemaTableV2` message. Inbound baseline bytes encode the
+   equivalent inline logical request and actual bytes encode the negotiated
+   request-side CAS form. An unexpandable cold refs-only miss has raw baseline
+   bytes equal to raw actual bytes, and its `MissingSchemas` response is real
+   additional traffic. A same-run expanded baseline therefore is not an honest
+   aggregate no-CAS counterfactual for a refs-first workload: measure paired
+   CAS-disabled and CAS-enabled runs, and report cold, warm, and reconnect
+   phases separately. Use isolated durable stores for the pair, for example:
+
+   ```sh
+   MEMORY_DIR=file:///tmp/lunch-poll-cas-disabled/ \
+     CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED=false \
+     deno task integration patterns lunch-poll-vote
+
+   MEMORY_DIR=file:///tmp/lunch-poll-cas-enabled/ \
+     CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED=true \
+     deno task integration patterns lunch-poll-vote
+   ```
+
+   The enabled run can omit the override because it is the production default.
+   Other inbound requests remain equal.
+   Each record also partitions both encoded payloads into
+   additive semantic buckets whose sums equal the respective payload bytes.
+   Candidate fingerprints are random-salted and connection-partitioned for each accumulator run and retain
+   only an opaque fingerprint, category, cacheability scope, and encoded size—no
+   values, tokens, signatures, SQL text, paths, or stable content hashes. Repeat
+   Candidates are exact, leaf-most, non-overlapping JSON subtrees; their bytes are
+   reported separately from additive semantic composition. Repeat figures are
+   connection-local diagnostic cache simulations that subtract a compact-reference cost. Repeated protocol-owned identity and
+   session-address scalars are reported as run-local `identityInternable`
+   opportunities; they are diagnostics only and do not change the seq-addressed
+   JSON protocol or claim mutable document revisions are interchangeable.
 - [VDOM Debug Helpers](vdom-debug.md) - `commonfabric.vdom.*` VDOM tree inspection
 - [Logger Internals](../logger-internals.md) - Creating loggers in runtime code (`getLogger`, timing, flags)
 

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -95,6 +95,21 @@ inside computed(); Stream subscribe doesn't exist; binding the whole item to
   stderr — `packages/toolshed/local-dev-toolshed.log` under the local-dev scripts.
   See
   [`memwrite-trace.ts`](../../../packages/toolshed/routes/storage/memory/memwrite-trace.ts).
+- **Memory websocket wire accounting**: run
+  `deno task integration patterns lunch-poll-vote` to reproduce the Lunch Poll
+  schema-sync diagnostic. The root integration runner generates a secret bearer
+  token and passes it to both Toolshed and the test process; Toolshed's
+  `/api/storage/memory/wire-accounting/{start,stop}` endpoint is unavailable
+  without that token and is allowed only when `ENV` is `development` or `test`.
+  The test prints browser-only aggregate totals and per-direction,
+  per-classification rows. The measured unit is UTF-8 bytes of Memory websocket
+  text payloads produced by `encodeMemoryBoundary`; it excludes the HTTP
+  upgrade, websocket framing and masking, ping/pong/close frames,
+  permessage-deflate physical bytes, TLS, and TCP. Interpret the baseline as a
+  same-run counterfactual, not a second noisy run: outbound baseline bytes
+  encode the original uncompressed `ServerMessage`, outbound actual bytes encode
+  the negotiated `syncSchemaTableV2` message, and inbound baseline bytes equal
+  inbound actual bytes.
 - [VDOM Debug Helpers](vdom-debug.md) - `commonfabric.vdom.*` VDOM tree inspection
 - [Logger Internals](../logger-internals.md) - Creating loggers in runtime code (`getLogger`, timing, flags)
 

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -195,6 +195,8 @@ One line per archived document; each document's header carries the fuller
   July 2026 Lunch Poll Memory schema-sync wire-accounting measurements.
 - [memory-protocol-traffic-lunch-poll-2026-07-14.md](development/performance/memory-protocol-traffic-lunch-poll-2026-07-14.md),
   protocol-level Lunch Poll Memory traffic, repetition, and cache-opportunity analysis.
+- [memory-protocol-traffic-lunch-poll-2026-07-14-addendum-2026-07-15.md](development/performance/memory-protocol-traffic-lunch-poll-2026-07-14-addendum-2026-07-15.md),
+  reproducibility and accounting-scope addendum for the July 14 measurement.
 - [memory-request-schema-cas-lunch-poll-2026-07-14.md](development/performance/memory-request-schema-cas-lunch-poll-2026-07-14.md),
   end-to-end Lunch Poll measurement after durable request-schema CAS landed.
 - [memory-request-schema-cas-refs-first-lunch-poll-2026-07-14.md](development/performance/memory-request-schema-cas-refs-first-lunch-poll-2026-07-14.md),

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -191,6 +191,8 @@ One line per archived document; each document's header carries the fuller
   and
   [pattern-integration-compile-bound.md](development/performance/pattern-integration-compile-bound.md)
   — June 2026 profiling snapshots.
+- [memory-schema-sync-wire-accounting-lunch-poll-2026-07-13.md](development/performance/memory-schema-sync-wire-accounting-lunch-poll-2026-07-13.md),
+  July 2026 Lunch Poll Memory schema-sync wire-accounting measurements.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -193,6 +193,12 @@ One line per archived document; each document's header carries the fuller
   — June 2026 profiling snapshots.
 - [memory-schema-sync-wire-accounting-lunch-poll-2026-07-13.md](development/performance/memory-schema-sync-wire-accounting-lunch-poll-2026-07-13.md),
   July 2026 Lunch Poll Memory schema-sync wire-accounting measurements.
+- [memory-protocol-traffic-lunch-poll-2026-07-14.md](development/performance/memory-protocol-traffic-lunch-poll-2026-07-14.md),
+  protocol-level Lunch Poll Memory traffic, repetition, and cache-opportunity analysis.
+- [memory-request-schema-cas-lunch-poll-2026-07-14.md](development/performance/memory-request-schema-cas-lunch-poll-2026-07-14.md),
+  end-to-end Lunch Poll measurement after durable request-schema CAS landed.
+- [memory-request-schema-cas-refs-first-lunch-poll-2026-07-14.md](development/performance/memory-request-schema-cas-refs-first-lunch-poll-2026-07-14.md),
+  paired disabled, cold, and durable-warm Lunch Poll measurements for refs-first request-schema CAS.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/performance/memory-protocol-traffic-lunch-poll-2026-07-14-addendum-2026-07-15.md
+++ b/docs/history/development/performance/memory-protocol-traffic-lunch-poll-2026-07-14-addendum-2026-07-15.md
@@ -1,0 +1,35 @@
+---
+status: historical
+created: 2026-07-15
+archived: 2026-07-15
+reason: "Reproducibility and accounting-scope addendum for the July 14, 2026 Lunch Poll Memory traffic measurement."
+---
+
+# Addendum: July 14 Lunch Poll Memory traffic measurement
+
+This addendum preserves two details omitted or stated too narrowly in
+[`memory-protocol-traffic-lunch-poll-2026-07-14.md`](memory-protocol-traffic-lunch-poll-2026-07-14.md).
+The original report and its byte totals remain frozen.
+
+## Reproduction configuration
+
+The 14.6% measurement used inline request schemas while measuring the negotiated
+`syncSchemaTableV2` representation of outbound sync payloads. On a checkout where
+request-schema CAS defaults to enabled, the equivalent command is:
+
+```sh
+CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED=false \
+  deno task integration patterns lunch-poll-vote
+```
+
+Without that startup override, the integration test also negotiates
+`requestSchemaCasV1`, so it does not reproduce the recorded request frames.
+
+## Accounting scope
+
+The same-run comparison encoded each logical Memory message twice: `baseline`
+was the fully expanded logical message and `actual` was its negotiated wire
+form. `syncSchemaTableV2` describes the representation used for outbound sync
+payloads; the headline also included inbound watch and transact requests plus
+outbound non-sync responses. Physical websocket framing, permessage-deflate,
+HTTP upgrade, TLS, and TCP bytes remained excluded.

--- a/docs/history/development/performance/memory-protocol-traffic-lunch-poll-2026-07-14.md
+++ b/docs/history/development/performance/memory-protocol-traffic-lunch-poll-2026-07-14.md
@@ -1,0 +1,129 @@
+---
+status: historical
+created: 2026-07-14
+archived: 2026-07-14
+reason: "Protocol-level Memory websocket traffic and repetition analysis for the July 14, 2026 Lunch Poll run."
+---
+
+# Memory protocol traffic analysis: Lunch Poll
+
+## Question
+
+What does the Memory websocket protocol transmit during the real two-browser
+Lunch Poll flow, which data is already content-addressed or safely internable,
+and how much repeat traffic could a bounded cache remove?
+
+## Method
+
+The command was:
+
+```sh
+deno task integration patterns lunch-poll-vote
+```
+
+The run exercised six browser Memory connections while two users joined a
+poll, added options, cast concurrent votes, and observed cross-browser updates.
+The behavioral test passed.
+
+Accounting classified every canonical UTF-8 byte in the `fvj1:` Memory
+websocket text payload into an additive semantic category. Noncanonical,
+malformed, oversized, or over-complex payloads were counted exactly as opaque
+encoding bytes. Candidate values retained only a random-salted,
+connection-partitioned fingerprint, semantic category, cacheability scope, and
+exact encoded size. Candidate roots were selected leaf-first, so their JSON
+subtrees did not overlap. Raw payloads, identifiers, schemas, documents, SQL,
+tokens, and stable unsalted hashes were not retained in the report.
+
+The same-run baseline is the fully expanded server message. Actual is the
+negotiated `syncSchemaTableV2` message. Physical websocket framing,
+permessage-deflate, HTTP upgrade, TLS, and TCP bytes are excluded.
+
+Cache opportunity uses an idealized 12-byte reference. Connection-local
+figures assume a perfect unbounded cache for the life of one connection. They
+include reference cost but not cache negotiation, miss recovery, eviction, or
+implementation overhead. Fingerprints are deliberately partitioned by
+connection, so the diagnostic does not expose cross-connection or cross-space
+content equality.
+
+## Headline
+
+| Browser connections | Baseline bytes | Actual bytes | Saved bytes | Saved |
+| ------------------: | -------------: | -----------: | ----------: | ----: |
+|                   6 |      5,058,477 |    4,320,545 |     737,932 | 14.6% |
+
+The existing frame-local sync schema table removed 14.6% overall. The
+remaining actual traffic was 2,316,224 bytes of documents (53.6%), 913,231
+bytes of schemas or schema references (21.1%), and 594,903 bytes of identity
+and address data (13.8%).
+
+## Semantic composition
+
+| Semantic category | Actual bytes | Share | Addressing interpretation |
+| ----------------- | -----------: | ----: | ------------------------- |
+| Entity documents and values | 2,316,224 | 53.6% | Mutable, seq-addressed state; repetition is measurable but equality does not replace revision identity |
+| Schemas and schema references | 913,231 | 21.1% | Canonically hashable; exact non-overlapping candidates are split below by current addressing status |
+| Entity, space, session, branch, and scope identities | 594,903 | 13.8% | Identity-addressed; suitable for connection-local dictionary handles, not content identity |
+| Patch and operation payloads | 194,063 | 4.5% | Ordered, state-dependent transitions; repeated exact programs/leaf values can be measured |
+| Session and protocol control | 114,493 | 2.6% | Ordering, negotiation, request routing, and lifecycle data |
+| Query/watch selectors excluding schema bytes | 74,656 | 1.7% | Immutable descriptors; selector candidates containing nested schema candidates are conservatively omitted |
+| Sequence/order fields | 62,271 | 1.4% | Required seq/localSeq/seenSeq watermarks |
+| Uncategorized remainder | 18,754 | 0.4% | Small residual protocol fields |
+| JSON/Fabric wire framing | 15,970 | 0.4% | Prefix and structural encoding attributed outside semantic fields |
+| Errors | 9,383 | 0.2% | Conflict/error details |
+| Authentication/capability data | 5,778 | 0.1% | Fresh challenge, audience, invocation, token, and signature material |
+| SQLite/scheduler data | 819 | <0.1% | Negligible in this workload |
+
+Memory v2 deliberately keeps mutable JSON revisions sequence-addressed.
+Content addressing is already appropriate for schemas, blobs, CIDs, code
+artifacts, and signed immutable envelopes. Equal document bytes at different
+sequences remain distinct history and must not be collapsed.
+
+## Dominant protocol streams
+
+| Direction and class | Actual bytes | Main contents |
+| ------------------- | -----------: | ------------- |
+| outbound `session.watch.add` response sync | 2,182,192 | 1,982,639 document bytes (90.9%), 126,559 schema bytes (5.8%), 38,821 identity bytes (1.8%) |
+| inbound `transact` | 836,446 | 304,770 identity bytes (36.4%), 192,712 schema bytes (23.0%), 158,553 document bytes (19.0%), 122,164 operation bytes (14.6%) |
+| inbound `session.watch.add` | 562,165 | 325,311 inline schema bytes (57.9%), 149,780 identity bytes (26.6%), 73,850 selector bytes (13.1%) |
+| outbound `session/effect` sync | 301,776 | 163,892 schema bytes (54.3%), 106,245 document bytes (35.2%), 23,985 identity bytes (7.9%) |
+| outbound `transact` response | 319,229 | 104,687 schema bytes (32.8%), 71,899 operation bytes (22.5%), 68,466 document bytes (21.4%), 41,684 identity bytes (13.1%) |
+
+Initial watch expansion dominates the run: its response is 50.5% of all
+actual traffic and is overwhelmingly document state. The request side is also
+schema-heavy because watch selectors still send schemas inline. Transaction
+requests and receipts both carry substantial schema, document, operation, and
+identity data, making request/receipt echo suppression a separate candidate
+from sync caching.
+
+## Repetition and idealized connection-local opportunity
+
+| Candidate class | Exact non-overlapping candidate bytes | Occurrences | Repeats in same connection | Repeat bytes | 12-byte-ref net saving |
+| --------------- | ------------------------------------: | ----------: | -------------------------: | -----------: | ---------------------: |
+| Inline/internable schemas | 609,163 | 1,513 | 1,257 | 418,278 | 403,194 |
+| Already-content-addressed schemas/references | 270,051 | 1,114 | 818 | 166,926 | 157,110 |
+| Identity/address strings | 285,491 | 7,857 | 6,250 | 201,008 | 126,008 |
+| Seq-addressed documents/values | 1,856,638 | 829 | 482 | 25,788 | 20,004 |
+| Patch/operation payloads | 63,221 | 362 | 219 | 32,316 | 29,688 |
+
+The idealized connection-local total is 736,004 additional bytes, or 17.0% of
+the current actual payload. Combined with the existing frame-local saving, that
+would reduce 5,058,477 baseline bytes to approximately 3,584,541 bytes, a 29.1%
+reduction. This is a simulation ceiling, not a protocol benchmark.
+
+## Recommendations
+
+1. Extend schema interning to inbound watch/query selectors and transact
+   payloads. Inline/internable schemas are the largest practical
+   connection-local target at about 403 KB net in this run.
+2. Add a negotiated connection-local handle table for verified schema hashes
+   and repeated entity/space/session identities. The combined idealized schema
+   plus identity opportunity is about 686 KB.
+3. Investigate a smaller transact receipt that avoids echoing request document,
+   schema, and operation content the client already has. Preserve accepted seq,
+   conflict, and authoritative revision semantics.
+4. Do not transparently content-address ordinary mutable documents. The
+   connection-local document opportunity was only about 20 KB. Equal document
+   bytes still do not replace sequence-addressed revision identity.
+5. Before changing the protocol, simulate bounded cache capacities, reconnect
+   resets, misses, eviction, reference widths, and permessage-deflate physical
+   bytes. The current numbers model semantic text payloads and a perfect cache.

--- a/docs/history/development/performance/memory-request-schema-cas-lunch-poll-2026-07-14.md
+++ b/docs/history/development/performance/memory-request-schema-cas-lunch-poll-2026-07-14.md
@@ -1,0 +1,88 @@
+---
+status: historical
+created: 2026-07-14
+archived: 2026-07-14
+reason: "End-to-end Lunch Poll wire measurement after durable Memory request-schema CAS was implemented."
+---
+
+# Memory request-schema CAS: Lunch Poll measurement
+
+## Question
+
+How much browser-to-server Memory traffic does the durable request-schema CAS
+remove in the real two-browser Lunch Poll flow, and does the combined request
+CAS plus response sync table preserve the working behavior?
+
+## Method
+
+The successful measured command was:
+
+```sh
+deno task integration patterns lunch-poll-vote
+```
+
+The scenario exercised six browser Memory connections while two users joined a
+poll, added options, cast concurrent votes, and observed the merged result in
+both browsers. All behavior assertions passed.
+
+Accounting measured canonical UTF-8 bytes in Memory websocket text payloads.
+For CAS-capable inbound requests, baseline is the same logical request with
+schemas expanded inline and actual is the negotiated request carrying
+`schema-cas@1:` references plus any first-use `schemaDefinitions`. For outbound
+sync-bearing frames, baseline is the expanded sync and actual is the negotiated
+`syncSchemaTableV2` frame. Websocket framing, compression, HTTP upgrade, TLS,
+and TCP bytes are excluded.
+
+The Toolshed used one private durable SQLite schema store shared by Memory
+connections. Clients scoped known hashes to the store generation and audience.
+The server authorized requests before schema ingestion, verified canonical
+tagged hashes, expanded every reference, rejected unused definitions, and
+inserted each request's definitions atomically.
+
+## Headline
+
+| Browser connections | Baseline bytes | Actual bytes | Saved bytes | Saved |
+| ------------------: | -------------: | -----------: | ----------: | ----: |
+|                   6 |      5,064,382 |    4,151,185 |     913,197 | 18.0% |
+
+## Request-side result
+
+| Inbound class | Baseline bytes | Actual bytes | Saved bytes | Saved |
+| ------------- | -------------: | -----------: | ----------: | ----: |
+| `client.graph.query` | 1,615 | 2,300 | -685 | -42.4% |
+| `client.session.watch.add` | 562,379 | 487,925 | 74,454 | 13.2% |
+| `client.transact` | 860,956 | 754,279 | 106,677 | 12.4% |
+| **CAS-capable inbound total** | **1,424,950** | **1,244,504** | **180,446** | **12.7%** |
+
+First-use query frames grew because a small request pays the fixed reference and
+definition envelope cost. Repeated watch and transaction schemas more than
+recovered that cost. The live regression guard therefore allows individual CAS
+frames to grow but requires the CAS-capable inbound aggregate to save bytes;
+all non-CAS inbound classes remain byte-identical to baseline.
+
+## Response-side result
+
+| Outbound sync class | Baseline bytes | Actual bytes | Saved bytes | Saved |
+| ------------------- | -------------: | -----------: | ----------: | ----: |
+| `server.response.session.watch.add.sync` | 2,862,831 | 2,184,493 | 678,338 | 23.7% |
+| `server.session/effect.sync` | 335,855 | 281,442 | 54,413 | 16.2% |
+| **Sync-bearing outbound total** | **3,198,686** | **2,465,935** | **732,751** | **22.9%** |
+
+The request CAS and existing response table savings sum to the 913,197-byte
+overall reduction. Non-sync outbound classes remained byte-identical.
+
+## Limitations
+
+- This is a point-in-time workload measurement, not a fleet-wide traffic model.
+- Exact totals vary with startup timing, retries, and browser activity; live
+  tests assert semantic and aggregate invariants rather than these byte totals.
+- The same-run baseline compares logical expanded and negotiated encodings. It
+  is not a second physical run with protocol negotiation disabled.
+- The result covers websocket text payloads, not physical network bytes.
+
+## Conclusion
+
+Durable request-schema CAS removed 12.7% of CAS-capable inbound request bytes in
+this run. Combined with frame-local response schema tables, it reduced total
+browser-scoped Memory payload bytes by 18.0% while the complete two-user Lunch
+Poll behavior passed.

--- a/docs/history/development/performance/memory-request-schema-cas-refs-first-lunch-poll-2026-07-14.md
+++ b/docs/history/development/performance/memory-request-schema-cas-refs-first-lunch-poll-2026-07-14.md
@@ -1,0 +1,130 @@
+---
+status: historical
+created: 2026-07-14
+archived: 2026-07-14
+reason: "Paired Lunch Poll measurement of refs-first request-schema CAS across disabled, cold, and durable warm runs."
+---
+
+# Refs-first request-schema CAS: paired Lunch Poll measurement
+
+## Question
+
+Does optimistic refs-first request-schema CAS transmit a schema body only on a
+genuine cold miss, remain warm across reconnects and server restarts, and improve
+the real two-browser Lunch Poll request traffic?
+
+## Method
+
+The protocol behavior was first checked with deterministic Memory tests. A
+file-backed schema store and captured canonical wire frames exercised this
+ordered sequence:
+
+1. cold refs-only query;
+2. one forced-definition retry;
+3. warm query;
+4. warm schema-bearing watch;
+5. warm query after reconnect and resumed subscription;
+6. warm query from a fresh client;
+7. warm query from a fresh client after server and schema-store reopen.
+
+The test requires exactly one `schemaDefinitions` frame, at position 2, and
+compares every raw UTF-8 payload with its exact `encodeMemoryBoundary` result.
+It also compares each warm frame with the exact historical inline-schema form.
+A separate concurrent test verifies that two in-flight store-admission failures
+both fall back inline without looping or denying either operation.
+
+The browser measurement then ran the same Lunch Poll integration workload three
+times. Each initial configuration used an isolated Memory directory:
+
+```sh
+HEADLESS=1 \
+  CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED=false \
+  MEMORY_DIR=file:///tmp/opencode/lunch-cas-off-2/ \
+  deno task integration patterns lunch-poll-vote
+
+HEADLESS=1 \
+  MEMORY_DIR=file:///tmp/opencode/lunch-cas-on-2/ \
+  deno task integration patterns lunch-poll-vote
+
+# Fresh server and clients, same durable CAS as the enabled run above.
+HEADLESS=1 \
+  MEMORY_DIR=file:///tmp/opencode/lunch-cas-on-2/ \
+  deno task integration patterns lunch-poll-vote
+```
+
+All three complete two-user behavior runs passed. Accounting measured canonical
+UTF-8 Memory websocket text payloads; websocket framing, compression, HTTP,
+TLS, and TCP bytes were excluded.
+
+## Results
+
+### Whole browser workload
+
+| Run | Same-run baseline | Actual bytes | Same-run saved | Browser connections |
+| --- | ----------------: | -----------: | -------------: | ------------------: |
+| CAS disabled, isolated store | 5,097,310 | 4,357,025 | 740,285 (14.5%) | 6 |
+| CAS enabled, empty store | 5,552,801 | 4,470,842 | 1,081,959 (19.5%) | 6 |
+| CAS enabled, durable warm restart | 5,061,912 | 3,902,919 | 1,158,993 (22.9%) | 6 |
+
+The disabled run still benefits from outbound `syncSchemaTableV2`; its inbound
+request classes remain byte-identical. Comparing actual traffic in the paired
+disabled run with the durable warm run gives:
+
+```text
+4,357,025 -> 3,902,919 bytes
+454,106 bytes lower (10.4%)
+```
+
+The browser workload is reactive, so frame counts vary with scheduling and
+conflict retries. The paired totals are therefore supporting evidence rather
+than a byte-for-byte golden. The disabled and durable-warm same-run baselines
+differed by 35,398 bytes (0.7%), and their CAS-capable request counts were 496
+and 481 respectively.
+
+### Request uploads
+
+| Run | Inline logical bytes | Actual request bytes | Saved |
+| --- | -------------------: | -------------------: | ----: |
+| CAS disabled | 1,427,966 | 1,427,966 | 0 (0.0%) |
+| CAS enabled, empty store | 1,774,647 | 1,442,381 | 332,266 (18.7%) |
+| CAS enabled, durable warm restart | 1,400,131 | 981,177 | 418,954 (29.9%) |
+
+The durable warm request result is the clean same-run answer: request-schema
+CAS removed 29.9% of the expanded logical request bytes. The earlier
+definitions-first measurement recorded 12.7%, so refs-first durable reuse more
+than doubled the observed request-side percentage in this workload.
+
+The paired disabled-to-warm actual request comparison was
+`1,427,966 -> 981,177`, 446,789 bytes (31.3%) lower, with the frame-count caveat
+above. The enabled empty-store run sat between disabled and durable-warm as
+expected. It included cold-miss error traffic; after restart against the same
+schema store, the report contained no `server.response.session.watch.add.error`
+classification.
+
+## Interpretation
+
+- The deterministic test proves the intended sequential contract: one canonical
+  body on cold admission, then refs only across warm use, subscription resume,
+  fresh clients, and durable server restart.
+- The durable warm Lunch Poll run spent 29.9% fewer bytes on CAS-capable request
+  uploads and 22.9% fewer bytes overall than its expanded same-run logical
+  baseline.
+- The paired physical runs support the same conclusion, but their total-byte
+  delta must not be treated as an exact causal golden because the reactive
+  workload emitted different numbers of retries.
+- Concurrent cold clients can each reach a forced-definition retry. The store is
+  hash-verified and idempotent, but global exactly-once body transfer would need
+  additional coordination and is not claimed here.
+
+## Limitations
+
+- This is a point-in-time local integration measurement, not a fleet traffic
+  model.
+- The accounting unit excludes websocket framing, permessage-deflate, TLS, and
+  transport headers.
+- Setup occurs before browser accounting begins. The empty-store browser run can
+  still encounter schemas not admitted by setup, while the repeated run is the
+  deliberate durable-warm case.
+- Exact transfer expectations live in deterministic protocol tests; browser
+  tests assert behavior and accounting invariants because scheduling changes
+  frame counts.

--- a/docs/history/development/performance/memory-schema-sync-wire-accounting-lunch-poll-2026-07-13.md
+++ b/docs/history/development/performance/memory-schema-sync-wire-accounting-lunch-poll-2026-07-13.md
@@ -1,0 +1,100 @@
+---
+status: historical
+created: 2026-07-13
+archived: 2026-07-13
+reason: "Performance report for the July 13, 2026 Lunch Poll Memory schema-sync wire-accounting runs."
+---
+
+# Memory schema-sync wire accounting: Lunch Poll runs
+
+This report records two successful July 13, 2026 runs of the real two-browser
+Lunch Poll vote flow, measured with Memory websocket wire accounting. The live
+debugging entry is
+[`docs/development/debugging/README.md`](../../../development/debugging/README.md#runtime-inspection).
+
+## Measured unit
+
+The unit is UTF-8 bytes of Memory websocket text payloads produced by
+`encodeMemoryBoundary`, as recorded by
+[`packages/memory/v2/wire-accounting.ts`](../../../../packages/memory/v2/wire-accounting.ts)
+and [`packages/memory/v2/server.ts`](../../../../packages/memory/v2/server.ts).
+The numbers do not include HTTP upgrade bytes, websocket framing or masking,
+ping/pong/close frames, permessage-deflate physical bytes, TLS, or TCP. They are
+not claims about total physical network-wire bytes.
+
+## Methodology
+
+The scenario was `deno task integration patterns lunch-poll-vote`, which runs
+[`packages/patterns/integration/lunch-poll-vote.test.ts`](../../../../packages/patterns/integration/lunch-poll-vote.test.ts)
+against a Toolshed started by the root integration runner. The runner generated
+a random `CF_MEMORY_WIRE_ACCOUNTING_TOKEN` and passed it to both Toolshed and
+the test process. Toolshed exposed
+`/api/storage/memory/wire-accounting/{start,stop}` only because a token was
+configured and `ENV` was a development/test value.
+
+Accounting started before both browsers navigated and stopped after the final
+runtime-idle barrier. The Lunch Poll report code filtered the raw Memory report
+to browser connections and printed aggregate plus per-direction,
+per-classification tables.
+
+The baseline is a same-run counterfactual. For outbound frames, baseline bytes
+encode the original uncompressed `ServerMessage`; actual bytes encode the
+message sent after negotiated `syncSchemaTableV2` compression. For inbound
+frames, baseline equals actual. This compares two encodings observed in one run,
+not two separate noisy runs.
+
+## Results
+
+Both runs completed the behavior checks: two users cast concurrent green votes
+on the same option, both votes survived, and the resulting tally propagated to
+both browsers. A second option then tallied independently.
+
+| Run | Browser connections | Baseline bytes | Actual bytes | Saved bytes | Saved |
+| --- | ------------------: | -------------: | -----------: | ----------: | ----: |
+| 1   |                   6 |      5,048,753 |    4,309,247 |     739,506 | 14.6% |
+| 2   |                   6 |      5,092,459 |    4,347,108 |     745,351 | 14.6% |
+
+Run 2 also recorded 1,129 total Memory frames in the browser-scoped analysis.
+
+The exact aggregate totals are intentionally not asserted by the test. The test
+asserts invariants instead: accounting records browser frames, baseline and
+actual browser connection sets match, inbound classes are byte-identical,
+outbound non-sync classes are byte-identical, sync-bearing outbound classes save
+bytes, and the sync-bearing outbound savings floor is a conservative 15%.
+
+## Run 2 class evidence
+
+Only sync-bearing outbound classes changed in Run 2.
+
+| Direction | Classification                           | Baseline bytes | Actual bytes | Saved bytes | Saved |
+| --------- | ---------------------------------------- | -------------: | -----------: | ----------: | ----: |
+| outbound  | `server.response.session.watch.add.sync` |      2,864,047 |    2,185,840 |     678,207 | 23.7% |
+| outbound  | `server.session/effect.sync`             |        381,775 |      314,631 |      67,144 | 17.6% |
+
+All inbound classifications and all outbound non-sync classifications had
+identical baseline and actual byte totals. The accounting classifications are
+the Memory protocol message classes recorded by `classifyClientMessage` and
+`classifyServerMessage`, for example `client.<type>`, `server.hello.ok`,
+`server.session/effect.sync`, and `server.response.<origin>.sync`.
+
+## Limitations
+
+- The measurement covers browser-scoped Memory websocket text payload bytes
+  only. Runtime/server connections can exist in the raw report but are excluded
+  from the Lunch Poll analysis.
+- The baseline is an accounting counterfactual inside one run. It is useful for
+  comparing schema-table encodings, but it is not a replay of a fully separate
+  uncompressed scenario.
+- Per-run totals can drift with unrelated traffic, startup timing, and browser
+  behavior. That is why the test keeps exact totals out of live assertions.
+- Remaining actual bytes are dominated by protocol classes this schema-table
+  encoding does not change.
+
+## Conclusion
+
+The schema-sync encoding reduced browser-scoped Memory text payload bytes by
+14.6% overall in both measured Lunch Poll runs, while the affected outbound sync
+classes saved 23.7% and 17.6% in Run 2. The behavior checks passed, so the
+measurement captured a working two-user flow rather than a broken fast path. The
+live regression guard should remain invariant-based, with the conservative 15%
+sync-bearing outbound floor, rather than pinning these July 13 aggregate totals.

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -156,9 +156,10 @@ Every supplied definition must be referenced by that request. The receiver
 resolves the complete request before atomically inserting its verified
 definitions, so a missing reference or quota failure cannot partially advance
 durable schema availability.
-The server materializes this encoding only after a request has passed its open
-session and authorization boundary, then persists verified definitions and
-normalizes logical handlers, replay, and watch state back to inline schemas.
+The server checks the open session and authorization boundary before traversing
+a supported request for this encoding. It then materializes references,
+persists verified definitions, and normalizes logical handlers, replay, and
+watch state back to inline schemas.
 Servers advertise the capability whenever their host injects a `SchemaStore`;
 `hello.ok.requestSchemaCas.generation` identifies that store, and its optional
 audience identifies the service that owns it. Toolshed injects a shared,
@@ -177,6 +178,14 @@ reopen it. The cold miss costs one extra round trip. A `SchemaStoreError`
 instead disables request CAS for that connection and retries the original
 request inline once.
 
+A refs-first retry is a continuation of its original logical request, not a
+later request. A client must preserve that request's ordering position relative
+to requests submitted after it: later requests cannot overtake a cold
+refs/definitions/inline lifecycle. This is compatibility semantics of the
+request protocol, not an implementation detail; requests using hashes already
+confirmed for the negotiated store may remain concurrent when no cold admission
+is active.
+
 This is a sequential reuse guarantee, not a global exactly-once transfer
 guarantee. Concurrent cold clients can independently observe a missing hash and
 each send its canonical body on their forced retry; preventing that would
@@ -186,12 +195,14 @@ Schema hashes are addresses, not authorization capabilities. A Toolshed-wide
 store intentionally allows any authorized Memory request at that service to
 resolve a known schema hash, so schemas admitted to this CAS MUST be treated as
 non-secret protocol metadata. The store has no public list or fetch endpoint.
-The protocol bounds definition count, individual schema size, and hash length.
-Toolshed also bounds store entry count and total bytes; other hosts are
-responsible for equivalent capacity policy. If the schema store rejects a
-request, the client disables request CAS for that connection and retries the
-original inline request once; schema-store exhaustion must degrade the
-optimization, not deny the underlying Memory operation.
+The protocol bounds definition count, individual and cumulative definition
+bytes, hash length, schema-bearing positions, and aggregate traversal nodes and
+depth across the whole request. Repeated references to one hash are resolved
+once per request. Toolshed also bounds store entry count and total bytes; other
+hosts are responsible for equivalent capacity policy. If the schema store
+rejects a request, the client disables request CAS for that connection and
+retries the original inline request once; schema-store exhaustion must degrade
+the optimization, not deny the underlying Memory operation.
 
 ### 4.1.2 Logical Sessions and Resume
 
@@ -411,7 +422,7 @@ For example, the compact wire form can contain:
             "link@1": {
               "id": "of:contact",
               "path": [],
-              "schema": "schema-ref@2:sha256:..."
+              "schema": "schema-ref@2:fid1:..."
             }
           }
         }
@@ -420,7 +431,7 @@ For example, the compact wire form can contain:
   }],
   "removes": [],
   "schemaTable": {
-    "sha256:...": {
+    "fid1:...": {
       "type": "object",
       "properties": { "name": { "type": "string" } }
     }

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -51,7 +51,8 @@ The client MUST declare its protocol version in the first WebSocket message:
   "flags": {
     "modernCellRep": true,
     "persistentSchedulerState": true,
-    "syncSchemaTableV2": true
+    "syncSchemaTableV2": true,
+    "requestSchemaCasV1": true
   }
 }
 ```
@@ -65,7 +66,12 @@ If the server accepts the protocol, it returns:
   "flags": {
     "modernCellRep": true,
     "persistentSchedulerState": true,
-    "syncSchemaTableV2": true
+    "syncSchemaTableV2": true,
+    "requestSchemaCasV1": true
+  },
+  "requestSchemaCas": {
+    "generation": "durable-store-uuid",
+    "audience": "did:key:z6Mk..."
   },
   "sessionOpen": {
     "audience": "did:key:z6Mk...",
@@ -136,6 +142,52 @@ when absent. The server sends compact sync payloads only when both peers
 advertise the capability; otherwise it sends the historical fully expanded
 shape. The older `syncSchemaTable` flag names an incompatible, index-keyed draft
 and does not enable the v2 encoding.
+
+`requestSchemaCasV1` advertises the separately negotiated request-side durable
+schema CAS encoding. It is active only when both peers advertise it and the
+server supplies `requestSchemaCas` metadata. It does not broaden
+`syncSchemaTableV2`: supported query,
+watch, and transact envelopes may replace their exact schema-bearing positions
+with `schema-cas@1:<tagged-hash>` and supply canonical schemas in
+`schemaDefinitions`. A receiver verifies every supplied definition by its
+canonical tagged hash, resolves omitted definitions from its durable schema
+store, and expands references before handing the request to logical handlers.
+Every supplied definition must be referenced by that request. The receiver
+resolves the complete request before atomically inserting its verified
+definitions, so a missing reference or quota failure cannot partially advance
+durable schema availability.
+The server materializes this encoding only after a request has passed its open
+session and authorization boundary, then persists verified definitions and
+normalizes logical handlers, replay, and watch state back to inline schemas.
+Servers advertise the capability only when they have a shared durable store;
+`hello.ok.requestSchemaCas.generation` identifies that store, and its optional
+audience identifies the service that owns it. Clients that have not implemented
+request compression continue to send inline schemas unchanged.
+
+Negotiated clients use refs-first requests: every generated schema hash is
+optimistically sent as `schema-cas@1:` without a definition, including a
+client's cold first use. A `MissingSchemas` response causes exactly one retry
+with that request's canonical `schemaDefinitions`; a second `MissingSchemas` is
+terminal. After admission, the durable store makes sequential later uses refs
+only across warm requests, reconnect and resumed sessions, fresh clients, and
+server restarts that reopen the same schema store. The cold miss costs one extra
+round trip. A `SchemaStoreError` instead disables request CAS for that
+connection and retries the original request inline once.
+
+This is a sequential reuse guarantee, not a global exactly-once transfer
+guarantee. Concurrent cold clients can independently observe a missing hash and
+each send its canonical body on their forced retry; preventing that would
+require additional cross-client coordination.
+
+Schema hashes are addresses, not authorization capabilities. A Toolshed-wide
+store intentionally allows any authorized Memory request at that service to
+resolve a known schema hash, so schemas admitted to this CAS MUST be treated as
+non-secret protocol metadata. The store has no public list or fetch endpoint.
+Implementations bound definition count, individual schema size, hash length,
+entry count, and total durable bytes. If the durable store rejects a request,
+the client disables request CAS for that connection and retries the original
+inline request once; schema-store exhaustion must degrade the optimization, not
+deny the underlying Memory operation.
 
 ### 4.1.2 Logical Sessions and Resume
 
@@ -401,6 +453,7 @@ interface TransactRequest {
   space: SpaceId;
   sessionId: SessionId;
   commit: ClientCommit;
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 interface Commit {
@@ -469,6 +522,7 @@ interface GraphQueryRequest {
     branch?: BranchId;
     atSeq?: number;
   };
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 interface GraphQueryResult {
@@ -500,6 +554,7 @@ interface WatchSetRequest {
   space: SpaceId;
   sessionId: SessionId;
   watches: WatchSpec[];
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 interface WatchSetResult {
@@ -529,6 +584,7 @@ interface WatchAddRequest {
   space: SpaceId;
   sessionId: SessionId;
   watches: WatchSpec[];
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 interface WatchAddResult {

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -47,10 +47,11 @@ The client MUST declare its protocol version in the first WebSocket message:
 ```json
 {
   "type": "hello",
-  "protocol": "memory/v2",
+  "protocol": "memory",
   "flags": {
     "modernCellRep": true,
-    "persistentSchedulerState": true
+    "persistentSchedulerState": true,
+    "syncSchemaTableV2": true
   }
 }
 ```
@@ -60,10 +61,11 @@ If the server accepts the protocol, it returns:
 ```json
 {
   "type": "hello.ok",
-  "protocol": "memory/v2",
+  "protocol": "memory",
   "flags": {
     "modernCellRep": true,
-    "persistentSchedulerState": true
+    "persistentSchedulerState": true,
+    "syncSchemaTableV2": true
   },
   "sessionOpen": {
     "audience": "did:key:z6Mk...",
@@ -128,6 +130,13 @@ a client and server may connect when their scheduler-state flags differ, and
 the server's flag controls the scheduler-observation data plane for that
 connection.
 
+`syncSchemaTableV2` advertises support for the hash-keyed schema table described
+in [Session Sync Payload](#423-session-sync-payload). It defaults to `false`
+when absent. The server sends compact sync payloads only when both peers
+advertise the capability; otherwise it sends the historical fully expanded
+shape. The older `syncSchemaTable` flag names an incompatible, index-keyed draft
+and does not enable the v2 encoding.
+
 ### 4.1.2 Logical Sessions and Resume
 
 Pending-read resolution, idempotent replay, and live sync are scoped to a
@@ -159,7 +168,7 @@ interface SessionOpenInvocation {
   sub: SpaceId;
   aud: DID;
   args: {
-    protocol: "memory/v2";
+    protocol: "memory";
     session: {
       sessionId?: SessionId;
       seenSeq?: number;
@@ -229,10 +238,11 @@ semantic commit body. Per-commit signed UCAN envelopes remain deferred.
 // Shown at module scope.
 interface HelloMessage {
   type: "hello";
-  protocol: "memory/v2";
+  protocol: "memory";
   flags: {
     modernCellRep: boolean;
     persistentSchedulerState?: boolean;
+    syncSchemaTableV2?: boolean;
   };
 }
 
@@ -315,6 +325,64 @@ Semantics:
 - `deleted: true` means the entity is currently tombstoned
 - `removes` are not deletions in storage; they mean the entity is no longer in
   the session's relevant watch-set result
+
+#### Negotiated schema-table encoding
+
+When both peers advertise `syncSchemaTableV2`, the server MAY compact a
+server-to-client `SessionSync` carried by `response.ok.sync` or
+`session/effect.effect`. For each JSON Schema attached to a modern `link@1`
+payload or legacy `$alias` payload, it:
+
+1. computes the canonical tagged schema hash
+2. replaces the inline schema with `schema-ref@2:<tagged-hash>`
+3. adds the canonical schema to a frame-local `schemaTable` keyed by that hash
+
+For example, the compact wire form can contain:
+
+```json
+{
+  "type": "sync",
+  "fromSeq": 10,
+  "toSeq": 11,
+  "upserts": [{
+    "branch": "",
+    "id": "of:example",
+    "seq": 11,
+    "doc": {
+      "value": {
+        "contact": {
+          "/": {
+            "link@1": {
+              "id": "of:contact",
+              "path": [],
+              "schema": "schema-ref@2:sha256:..."
+            }
+          }
+        }
+      }
+    }
+  }],
+  "removes": [],
+  "schemaTable": {
+    "sha256:...": {
+      "type": "object",
+      "properties": { "name": { "type": "string" } }
+    }
+  }
+}
+```
+
+The table is scoped to one sync payload, not to a connection or logical
+session. A client MUST resolve every `schema-ref@2:` before exposing the sync to
+the session cache. It MUST reject a reference when the table is missing the key
+or when hashing the referenced table value does not reproduce the key. After
+expansion, downstream consumers observe the historical `SessionSync` shape with
+inline schemas and no `schemaTable` field.
+
+The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
+legacy `$alias` payloads. Memory servers MUST reject set or patch operations
+whose resulting stored document uses that prefix as an opaque schema string;
+ordinary strings in other document positions are unaffected.
 
 ### 4.2.4 Batching
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -143,14 +143,14 @@ advertise the capability; otherwise it sends the historical fully expanded
 shape. The older `syncSchemaTable` flag names an incompatible, index-keyed draft
 and does not enable the v2 encoding.
 
-`requestSchemaCasV1` advertises the separately negotiated request-side durable
-schema CAS encoding. It is active only when both peers advertise it and the
+`requestSchemaCasV1` advertises the separately negotiated request-side schema
+CAS encoding. It is active only when both peers advertise it and the
 server supplies `requestSchemaCas` metadata. It does not broaden
 `syncSchemaTableV2`: supported query,
 watch, and transact envelopes may replace their exact schema-bearing positions
 with `schema-cas@1:<tagged-hash>` and supply canonical schemas in
 `schemaDefinitions`. A receiver verifies every supplied definition by its
-canonical tagged hash, resolves omitted definitions from its durable schema
+canonical tagged hash, resolves omitted definitions from its injected schema
 store, and expands references before handing the request to logical handlers.
 Every supplied definition must be referenced by that request. The receiver
 resolves the complete request before atomically inserting its verified
@@ -159,20 +159,23 @@ durable schema availability.
 The server materializes this encoding only after a request has passed its open
 session and authorization boundary, then persists verified definitions and
 normalizes logical handlers, replay, and watch state back to inline schemas.
-Servers advertise the capability only when they have a shared durable store;
+Servers advertise the capability whenever their host injects a `SchemaStore`;
 `hello.ok.requestSchemaCas.generation` identifies that store, and its optional
-audience identifies the service that owns it. Clients that have not implemented
-request compression continue to send inline schemas unchanged.
+audience identifies the service that owns it. Toolshed injects a shared,
+bounded, durable store. Other hosts choose the store lifetime and capacity, and
+must not claim restart reuse unless their store is durable. Clients that have
+not implemented request compression continue to send inline schemas unchanged.
 
 Negotiated clients use refs-first requests: every generated schema hash is
 optimistically sent as `schema-cas@1:` without a definition, including a
 client's cold first use. A `MissingSchemas` response causes exactly one retry
 with that request's canonical `schemaDefinitions`; a second `MissingSchemas` is
-terminal. After admission, the durable store makes sequential later uses refs
-only across warm requests, reconnect and resumed sessions, fresh clients, and
-server restarts that reopen the same schema store. The cold miss costs one extra
-round trip. A `SchemaStoreError` instead disables request CAS for that
-connection and retries the original request inline once.
+terminal. After admission, the store makes sequential later uses refs only
+across warm requests, reconnect and resumed sessions, and fresh clients that
+reach the same store. A durable store additionally supports server restarts that
+reopen it. The cold miss costs one extra round trip. A `SchemaStoreError`
+instead disables request CAS for that connection and retries the original
+request inline once.
 
 This is a sequential reuse guarantee, not a global exactly-once transfer
 guarantee. Concurrent cold clients can independently observe a missing hash and
@@ -183,11 +186,12 @@ Schema hashes are addresses, not authorization capabilities. A Toolshed-wide
 store intentionally allows any authorized Memory request at that service to
 resolve a known schema hash, so schemas admitted to this CAS MUST be treated as
 non-secret protocol metadata. The store has no public list or fetch endpoint.
-Implementations bound definition count, individual schema size, hash length,
-entry count, and total durable bytes. If the durable store rejects a request,
-the client disables request CAS for that connection and retries the original
-inline request once; schema-store exhaustion must degrade the optimization, not
-deny the underlying Memory operation.
+The protocol bounds definition count, individual schema size, and hash length.
+Toolshed also bounds store entry count and total bytes; other hosts are
+responsible for equivalent capacity policy. If the schema store rejects a
+request, the client disables request CAS for that connection and retries the
+original inline request once; schema-store exhaustion must degrade the
+optimization, not deny the underlying Memory operation.
 
 ### 4.1.2 Logical Sessions and Resume
 

--- a/docs/specs/memory-v2/10-implementation-guidance.md
+++ b/docs/specs/memory-v2/10-implementation-guidance.md
@@ -34,6 +34,17 @@ target. In particular:
 - one-shot `graph.query` now honors `branch` and `atSeq`
 - the public one-shot read surface in this pass is `graph.query`; the older
   simple `query` / wildcard selector shape remains future protocol design
+- server syncs use negotiated frame-local `syncSchemaTableV2` schema tables;
+  query, watch, and transact requests use durable `requestSchemaCasV1` only when
+  both peers advertise it and the server supplies store generation metadata
+- Toolshed owns one bounded service-wide request-schema SQLite store. Schemas in
+  it are non-secret protocol metadata addressed by canonical tagged hash;
+  requests are authorized and fully expanded before definitions are admitted
+  atomically
+- request schema CAS is an optimization, not an availability dependency:
+  negotiated clients begin refs-first, a cold `MissingSchemas` receives one
+  forced-definition retry, store rejection receives one inline retry with CAS
+  disabled for that connection, and old peers stay inline
 - watch installation remains current-state only in this pass; do not treat
   watch specs as historical subscriptions keyed by `atSeq`
 - steady-state topology shrink does not yet drive automatic unwatch/removal
@@ -88,6 +99,23 @@ The `hello.ok` response includes `sessionOpen.audience` and a one-time
 `session.open` invocation, along with `iat` and `exp`. The server rejects a
 missing, expired, reused, or mismatched challenge, and rejects a missing or
 mismatched audience.
+
+The optional request-side schema CAS is negotiated independently of response
+schema tables. It is active only when the client and server both advertise
+`requestSchemaCasV1` and `hello.ok.requestSchemaCas` supplies the durable store
+generation (plus its service audience when present). Supported requests may
+then replace exact query-selector and link-payload schema positions with
+`schema-cas@1:<tagged-hash>` references. Clients optimistically omit
+definitions even on first use. On `MissingSchemas`, they retry once with the
+canonical definitions; a second miss is terminal. Once admitted, the durable
+store serves refs-only requests sequentially across warm requests, same-client
+reconnect and session resume, fresh clients, and server restarts that reopen
+the store. This trades a cold miss for one extra round trip. `SchemaStoreError`
+disables CAS for that connection and causes one exact inline retry. Concurrent
+cold missers may each send the body on their forced retry: exactly-once transfer
+across concurrent clients would require explicit coordination. Reserved wire
+references are expanded before logical handlers and must never persist as
+document data.
 
 ## 4. Session Model
 

--- a/docs/specs/memory-v2/10-implementation-guidance.md
+++ b/docs/specs/memory-v2/10-implementation-guidance.md
@@ -35,7 +35,7 @@ target. In particular:
 - the public one-shot read surface in this pass is `graph.query`; the older
   simple `query` / wildcard selector shape remains future protocol design
 - server syncs use negotiated frame-local `syncSchemaTableV2` schema tables;
-  query, watch, and transact requests use durable `requestSchemaCasV1` only when
+  query, watch, and transact requests use `requestSchemaCasV1` only when
   both peers advertise it and the server supplies store generation metadata
 - Toolshed owns one bounded service-wide request-schema SQLite store. Schemas in
   it are non-secret protocol metadata addressed by canonical tagged hash;
@@ -102,15 +102,16 @@ mismatched audience.
 
 The optional request-side schema CAS is negotiated independently of response
 schema tables. It is active only when the client and server both advertise
-`requestSchemaCasV1` and `hello.ok.requestSchemaCas` supplies the durable store
+`requestSchemaCasV1` and `hello.ok.requestSchemaCas` supplies the store
 generation (plus its service audience when present). Supported requests may
 then replace exact query-selector and link-payload schema positions with
 `schema-cas@1:<tagged-hash>` references. Clients optimistically omit
 definitions even on first use. On `MissingSchemas`, they retry once with the
-canonical definitions; a second miss is terminal. Once admitted, the durable
+canonical definitions; a second miss is terminal. Once admitted, the injected
 store serves refs-only requests sequentially across warm requests, same-client
-reconnect and session resume, fresh clients, and server restarts that reopen
-the store. This trades a cold miss for one extra round trip. `SchemaStoreError`
+reconnect and session resume, and fresh clients that reach that store. A
+durable store additionally serves restarts that reopen it. This trades a cold
+miss for one extra round trip. `SchemaStoreError`
 disables CAS for that connection and causes one exact inline retry. Concurrent
 cold missers may each send the body on their forced retry: exactly-once transfer
 across concurrent clients would require explicit coordination. Reserved wire

--- a/docs/specs/memory-v2/implementation-plan.md
+++ b/docs/specs/memory-v2/implementation-plan.md
@@ -31,6 +31,17 @@ Implemented on the current branch:
 - one-shot `graph.query` support for `branch` and `atSeq`
 - `session.watch.add` duplicate-id handling: identical definitions are no-ops,
   changed definitions are rejected
+- negotiated schema compaction in both directions: frame-local
+  `syncSchemaTableV2` tables for server syncs and durable `requestSchemaCasV1`
+  refs-first references for query, watch, and transact request schemas
+- one service-wide, bounded SQLite request-schema store in Toolshed, identified
+  by a durable generation and service audience; durable references expand before
+  request processing, while forced-retry definitions are authorized,
+  hash-verified, and admitted atomically
+- compatibility and availability fallbacks: peers without bilateral request-CAS
+  support remain inline, cold missing schemas receive one forced definition
+  retry, and store rejection disables request CAS for that connection before one
+  inline retry; concurrent cold clients may each send a forced definition
 - unsafe store-subject rejection before engine-root path construction
 - shared JSON-pointer/path-overlap helpers reused across memory and runner
 - watch-layer hot-path cleanup:

--- a/docs/specs/memory-v2/implementation-plan.md
+++ b/docs/specs/memory-v2/implementation-plan.md
@@ -32,10 +32,10 @@ Implemented on the current branch:
 - `session.watch.add` duplicate-id handling: identical definitions are no-ops,
   changed definitions are rejected
 - negotiated schema compaction in both directions: frame-local
-  `syncSchemaTableV2` tables for server syncs and durable `requestSchemaCasV1`
+  `syncSchemaTableV2` tables for server syncs and `requestSchemaCasV1`
   refs-first references for query, watch, and transact request schemas
 - one service-wide, bounded SQLite request-schema store in Toolshed, identified
-  by a durable generation and service audience; durable references expand before
+  by a durable generation and service audience; request references expand before
   request processing, while forced-retry definitions are authorized,
   hash-verified, and admitted atomically
 - compatibility and availability fallbacks: peers without bilateral request-CAS

--- a/packages/integration/env.ts
+++ b/packages/integration/env.ts
@@ -16,6 +16,13 @@ export const HEADLESS = envToBool(Deno.env.get("HEADLESS"));
 // Pipe browser console output to the test runner's console.
 export const PIPE_CONSOLE = envToBool(Deno.env.get("PIPE_CONSOLE"));
 
+// Bearer token used by server-backed integration runs to access the
+// diagnostic-only Memory websocket wire-accounting endpoints. Direct package
+// runs leave this unset and should skip accounting-only assertions.
+export const MEMORY_WIRE_ACCOUNTING_TOKEN = Deno.env.get(
+  "CF_MEMORY_WIRE_ACCOUNTING_TOKEN",
+) ?? "";
+
 // Some tests take a SPACE_NAME, targeting a specific space.
 // If not defined, uses a random UUID.
 export const SPACE_NAME = Deno.env.get("SPACE_NAME") ??

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -37,6 +37,8 @@
     "./v2/wire-accounting": "./v2/wire-accounting.ts",
     "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
+    "./v2/schema-store": "./v2/schema-store.ts",
+    "./v2/request-schema-cas": "./v2/request-schema-cas.ts",
     "./v2/dump": "./v2/dump.ts",
     "./sqlite": "./v2/sqlite/mod.ts",
     "./sqlite/columns": "./v2/sqlite/columns.ts",

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -34,6 +34,7 @@
     "./v2/engine": "./v2/engine.ts",
     "./v2/server": "./v2/server.ts",
     "./v2/standalone": "./v2/standalone.ts",
+    "./v2/wire-accounting": "./v2/wire-accounting.ts",
     "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
     "./v2/dump": "./v2/dump.ts",

--- a/packages/memory/test/v2-client-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-client-request-schema-cas-test.ts
@@ -1,0 +1,1003 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import type { JSONSchema } from "@commonfabric/api";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  resetRequestSchemaCasConfig,
+  setRequestSchemaCasConfig,
+} from "../v2.ts";
+import { connect, type Transport } from "../v2/client.ts";
+import { openSchemaStore } from "../v2/schema-store.ts";
+import { Server } from "../v2/server.ts";
+import { memoryWireUtf8Bytes } from "../v2/wire-accounting.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+const space = "did:key:client-request-schema-cas";
+const schema = (description: string): JSONSchema => ({
+  type: "object",
+  description: description.repeat(32),
+  properties: { name: { type: "string" } },
+});
+
+class CapturingLoopbackTransport implements Transport {
+  readonly sent: Array<{ payload: string; message: Record<string, unknown> }> =
+    [];
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #connection: ReturnType<Server["connect"]> | null = null;
+  #connectionCount = 0;
+  #reconnected = Promise.withResolvers<void>();
+
+  constructor(private server: Server) {}
+
+  async send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+    this.sent.push({
+      payload,
+      message,
+    });
+    await this.connection().receive(payload);
+    if (this.#connectionCount >= 2 && message.type === "session.open") {
+      this.#reconnected.resolve();
+    }
+  }
+
+  close(): Promise<void> {
+    this.disconnect(false);
+    return Promise.resolve();
+  }
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  reconnect(server = this.server): Promise<void> {
+    this.server = server;
+    this.disconnect(true);
+    return this.#reconnected.promise;
+  }
+
+  private disconnect(notifyClient: boolean): void {
+    this.#connection?.close();
+    this.#connection = null;
+    if (notifyClient) this.#closeReceiver(new Error("disconnect"));
+  }
+
+  private connection(): ReturnType<Server["connect"]> {
+    if (this.#connection === null) {
+      this.#connectionCount += 1;
+      this.#connection = this.server.connect((message) => {
+        this.#receiver(encodeMemoryBoundary(message));
+      });
+    }
+    return this.#connection;
+  }
+}
+
+const messagesOf = (
+  transport: CapturingLoopbackTransport,
+  type: string,
+): Record<string, unknown>[] =>
+  transport.sent.filter((frame) => frame.message.type === type).map((frame) =>
+    frame.message
+  );
+
+const expectedGraphQueryFrame = (
+  message: Record<string, unknown>,
+  canonicalSchema: JSONSchema,
+  hash: string,
+  includeDefinition: boolean,
+): string =>
+  encodeMemoryBoundary({
+    type: "graph.query",
+    requestId: message.requestId,
+    space: message.space,
+    sessionId: message.sessionId,
+    query: {
+      roots: [{
+        id: "of:root",
+        selector: {
+          path: [],
+          schema: `schema-cas@1:${hash}`,
+        },
+      }],
+    },
+    ...(includeDefinition
+      ? { schemaDefinitions: { [hash]: canonicalSchema } }
+      : {}),
+  });
+
+const expectedInlineGraphQueryFrame = (
+  message: Record<string, unknown>,
+  canonicalSchema: JSONSchema,
+): string =>
+  encodeMemoryBoundary({
+    type: "graph.query",
+    requestId: message.requestId,
+    space: message.space,
+    sessionId: message.sessionId,
+    query: {
+      roots: [{
+        id: "of:root",
+        selector: { path: [], schema: canonicalSchema },
+      }],
+    },
+  });
+
+const expectedWatchSetFrame = (
+  message: Record<string, unknown>,
+  canonicalSchema: JSONSchema,
+  hash: string,
+  includeDefinition: boolean,
+): string =>
+  encodeMemoryBoundary({
+    type: "session.watch.set",
+    requestId: message.requestId,
+    space: message.space,
+    sessionId: message.sessionId,
+    watches: [{
+      id: "watch",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:root",
+          selector: {
+            path: [],
+            schema: `schema-cas@1:${hash}`,
+          },
+        }],
+      },
+    }],
+    ...(includeDefinition
+      ? { schemaDefinitions: { [hash]: canonicalSchema } }
+      : {}),
+  });
+
+const expectedInlineWatchSetFrame = (
+  message: Record<string, unknown>,
+  canonicalSchema: JSONSchema,
+): string =>
+  encodeMemoryBoundary({
+    type: "session.watch.set",
+    requestId: message.requestId,
+    space: message.space,
+    sessionId: message.sessionId,
+    watches: [{
+      id: "watch",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:root",
+          selector: { path: [], schema: canonicalSchema },
+        }],
+      },
+    }],
+  });
+
+Deno.test("memory v2 request schema CAS transfers one definition across sequential clients and reconnects", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "client-request-schema-cas-sequential-",
+  });
+  const url = toFileUrl(`${directory}/schemas.sqlite`);
+  const requestSchema = schema("sequential request schema ");
+  const canonical = internSchema(requestSchema, true);
+  const firstStore = await openSchemaStore({ url });
+  const firstServer = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://client-request-schema-cas-sequential-first"),
+    schemaStore: firstStore,
+  });
+  const firstTransport = new CapturingLoopbackTransport(firstServer);
+  const firstClient = await connect({ transport: firstTransport });
+  let firstResourcesClosed = false;
+  let secondClient: Awaited<ReturnType<typeof connect>> | undefined;
+  let secondServer: Server | undefined;
+  let secondStore: Awaited<ReturnType<typeof openSchemaStore>> | undefined;
+  let secondTransport: CapturingLoopbackTransport | undefined;
+  try {
+    const firstSession = await firstClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
+    const query = {
+      roots: [{
+        id: "of:root",
+        selector: { path: [], schema: requestSchema },
+      }],
+    };
+
+    await firstSession.queryGraph(query);
+    await firstSession.queryGraph(query);
+    await firstSession.watchSet([{
+      id: "watch",
+      kind: "graph",
+      query,
+    }]);
+    const [watchFrame] = firstTransport.sent.filter((frame) =>
+      frame.message.type === "session.watch.set"
+    );
+    assertEquals(
+      firstTransport.sent.filter((frame) =>
+        frame.message.type === "session.watch.set"
+      ).length,
+      1,
+    );
+    const expectedWatch = expectedWatchSetFrame(
+      watchFrame.message,
+      canonical.schema,
+      canonical.taggedHashString,
+      false,
+    );
+    assertEquals(watchFrame.payload, expectedWatch);
+    assertEquals(
+      memoryWireUtf8Bytes(watchFrame.payload),
+      memoryWireUtf8Bytes(expectedWatch),
+    );
+    await firstTransport.reconnect();
+    await firstSession.queryGraph(query);
+    assertEquals(
+      firstTransport.sent.filter((frame) =>
+        frame.message.type === "session.watch.set"
+      ).length,
+      1,
+    );
+
+    const sameServerTransport = new CapturingLoopbackTransport(firstServer);
+    const sameServerClient = await connect({ transport: sameServerTransport });
+    try {
+      const sameServerSession = await sameServerClient.mount(
+        space,
+        {},
+        testSessionOpenAuthFactory,
+      );
+      await sameServerSession.queryGraph(query);
+    } finally {
+      await sameServerClient.close();
+    }
+
+    await firstClient.close();
+    await firstServer.close();
+    firstStore.close();
+    firstResourcesClosed = true;
+
+    secondStore = await openSchemaStore({ url });
+    assertEquals(secondStore.generation, firstStore.generation);
+    secondServer = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://client-request-schema-cas-sequential-second"),
+      schemaStore: secondStore,
+    });
+    secondTransport = new CapturingLoopbackTransport(secondServer);
+    secondClient = await connect({ transport: secondTransport });
+    const secondSession = await secondClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
+    await secondSession.queryGraph(query);
+
+    const schemaFrames = [
+      ...firstTransport.sent,
+      ...sameServerTransport.sent,
+      ...secondTransport.sent,
+    ].filter((frame) =>
+      frame.message.type === "graph.query" ||
+      frame.message.type === "session.watch.set"
+    );
+    const graphFrames = schemaFrames.filter((frame) =>
+      frame.message.type === "graph.query"
+    );
+    assertEquals(schemaFrames.length, 7);
+    assertEquals(
+      schemaFrames.map((frame) => frame.message.type),
+      [
+        "graph.query",
+        "graph.query",
+        "graph.query",
+        "session.watch.set",
+        "graph.query",
+        "graph.query",
+        "graph.query",
+      ],
+    );
+    assertEquals(graphFrames.length, 6);
+    const definitionFrames = schemaFrames.filter((frame) =>
+      Object.hasOwn(frame.message, "schemaDefinitions")
+    );
+    assertEquals(definitionFrames.length, 1);
+    assert(Object.hasOwn(schemaFrames[1].message, "schemaDefinitions"));
+
+    for (const frame of graphFrames) {
+      const includeDefinition = Object.hasOwn(
+        frame.message,
+        "schemaDefinitions",
+      );
+      const expected = expectedGraphQueryFrame(
+        frame.message,
+        canonical.schema,
+        canonical.taggedHashString,
+        includeDefinition,
+      );
+      assertEquals(frame.payload, expected);
+      assertEquals(
+        memoryWireUtf8Bytes(frame.payload),
+        memoryWireUtf8Bytes(expected),
+      );
+      assertEquals(
+        (frame.message.query as {
+          roots: Array<{ selector: { schema: string } }>;
+        }).roots[0].selector.schema,
+        `schema-cas@1:${canonical.taggedHashString}`,
+      );
+      assertEquals(
+        frame.message.schemaDefinitions,
+        includeDefinition
+          ? { [canonical.taggedHashString]: canonical.schema }
+          : undefined,
+      );
+    }
+
+    assertEquals(
+      watchFrame.message.schemaDefinitions,
+      undefined,
+    );
+    assertEquals(
+      (watchFrame.message.watches as Array<{
+        query: { roots: Array<{ selector: { schema: string } }> };
+      }>)[0].query.roots[0].selector.schema,
+      `schema-cas@1:${canonical.taggedHashString}`,
+    );
+
+    const expectedSchemaFrame = (
+      frame: (typeof schemaFrames)[number],
+    ): string =>
+      frame.message.type === "graph.query"
+        ? expectedGraphQueryFrame(
+          frame.message,
+          canonical.schema,
+          canonical.taggedHashString,
+          Object.hasOwn(frame.message, "schemaDefinitions"),
+        )
+        : expectedWatchSetFrame(
+          frame.message,
+          canonical.schema,
+          canonical.taggedHashString,
+          Object.hasOwn(frame.message, "schemaDefinitions"),
+        );
+    const expectedRefsOnlySchemaFrame = (
+      frame: (typeof schemaFrames)[number],
+    ): string =>
+      frame.message.type === "graph.query"
+        ? expectedGraphQueryFrame(
+          frame.message,
+          canonical.schema,
+          canonical.taggedHashString,
+          false,
+        )
+        : expectedWatchSetFrame(
+          frame.message,
+          canonical.schema,
+          canonical.taggedHashString,
+          false,
+        );
+    const expectedBytes = schemaFrames.reduce(
+      (total, frame) => total + memoryWireUtf8Bytes(expectedSchemaFrame(frame)),
+      0,
+    );
+    const actualBytes = schemaFrames.reduce(
+      (total, frame) => total + memoryWireUtf8Bytes(frame.payload),
+      0,
+    );
+    assertEquals(actualBytes, expectedBytes);
+
+    const warmFrames = schemaFrames.slice(2);
+    assert(warmFrames.length > 2);
+    for (const frame of warmFrames) {
+      const inlineBaseline = frame.message.type === "graph.query"
+        ? expectedInlineGraphQueryFrame(frame.message, canonical.schema)
+        : expectedInlineWatchSetFrame(frame.message, canonical.schema);
+      assert(
+        memoryWireUtf8Bytes(frame.payload) <
+          memoryWireUtf8Bytes(inlineBaseline),
+      );
+    }
+    const definitionContribution = definitionFrames.reduce(
+      (total, frame) =>
+        total + memoryWireUtf8Bytes(frame.payload) -
+        memoryWireUtf8Bytes(expectedRefsOnlySchemaFrame(frame)),
+      0,
+    );
+    assert(definitionContribution > 0);
+  } finally {
+    await secondClient?.close();
+    await secondServer?.close();
+    secondStore?.close();
+    if (!firstResourcesClosed) {
+      await firstClient.close();
+      await firstServer.close();
+      firstStore.close();
+    }
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("memory v2 client compresses request schemas without changing logical requests", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://client-request-schema-cas"),
+    schemaStore: store,
+  });
+  const transport = new CapturingLoopbackTransport(server);
+  const client = await connect({ transport });
+  const firstSchema = schema("first client request schema ");
+  const equivalentSchema = structuredClone(firstSchema);
+  try {
+    const first = await client.mount(space, {}, testSessionOpenAuthFactory);
+    const query = {
+      roots: [{ id: "of:root", selector: { path: [], schema: firstSchema } }],
+    };
+    await first.queryGraph(query);
+    const [firstWire, forcedWire] = messagesOf(transport, "graph.query");
+    assertEquals(Object.hasOwn(firstWire, "schemaDefinitions"), false);
+    assert(Object.hasOwn(forcedWire, "schemaDefinitions"));
+    assertEquals(
+      (firstWire.query as { roots: { selector: { schema: string } }[] })
+        .roots[0]
+        .selector.schema,
+      `schema-cas@1:${internSchema(firstSchema, true).taggedHashString}`,
+    );
+    assertEquals(query.roots[0].selector.schema, firstSchema);
+
+    await first.queryGraph({
+      roots: [{
+        id: "of:root",
+        selector: { path: [], schema: equivalentSchema },
+      }],
+    });
+    const secondWire = messagesOf(transport, "graph.query").at(-1)!;
+    assertEquals(Object.hasOwn(secondWire, "schemaDefinitions"), false);
+    assert(
+      memoryWireUtf8Bytes(encodeMemoryBoundary(secondWire)) <
+        memoryWireUtf8Bytes(encodeMemoryBoundary(forcedWire)),
+    );
+
+    const second = await client.mount(
+      `${space}:second`,
+      {},
+      testSessionOpenAuthFactory,
+    );
+    await second.queryGraph(query);
+    assertEquals(
+      Object.hasOwn(
+        messagesOf(transport, "graph.query").at(-1)!,
+        "schemaDefinitions",
+      ),
+      false,
+    );
+
+    const watchSchema = schema("watch client request schema ");
+    await first.watchSet([{
+      id: "watch",
+      kind: "graph",
+      query: {
+        roots: [{ id: "of:root", selector: { path: [], schema: watchSchema } }],
+      },
+    }]);
+    assert(
+      Object.hasOwn(
+        messagesOf(transport, "session.watch.set").at(-1)!,
+        "schemaDefinitions",
+      ),
+    );
+
+    const transactSchema = schema("transact client request schema ");
+    await first.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:root",
+        value: {
+          value: {
+            "/": {
+              "link@1": { id: "of:child", path: [], schema: transactSchema },
+            },
+          },
+        },
+      }],
+    });
+    assert(
+      Object.hasOwn(
+        messagesOf(transport, "transact").at(-1)!,
+        "schemaDefinitions",
+      ),
+    );
+  } finally {
+    await client.close();
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("memory v2 client keeps request schemas inline for an old peer", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://client-request-schema-cas-old-peer"),
+  });
+  const transport = new CapturingLoopbackTransport(server);
+  const client = await connect({ transport });
+  const requestSchema = schema("old peer schema ");
+  try {
+    const session = await client.mount(space, {}, testSessionOpenAuthFactory);
+    await session.queryGraph({
+      roots: [{ id: "of:root", selector: { path: [], schema: requestSchema } }],
+    });
+    const wire = messagesOf(transport, "graph.query").at(-1)!;
+    assertEquals(Object.hasOwn(wire, "schemaDefinitions"), false);
+    assertEquals(
+      (wire.query as { roots: { selector: { schema: JSONSchema } }[] }).roots[0]
+        .selector.schema,
+      requestSchema,
+    );
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 client keeps schemas inline when its advertised CAS capability is off", async () => {
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: {
+            ...getMemoryProtocolFlags(),
+            requestSchemaCasV1: true,
+          },
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "session.open") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: {
+            sessionId: "session",
+            sessionToken: "token",
+            serverSeq: 0,
+            sessionOpen: {
+              audience: "audience",
+              challenge: { value: "next", expiresAt: 1_000_000 },
+            },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  let client: Awaited<ReturnType<typeof connect>> | undefined;
+  setRequestSchemaCasConfig(false);
+  try {
+    client = await connect({ transport });
+    resetRequestSchemaCasConfig();
+    const session = await client.mount(space);
+    const requestSchema = schema("locally disabled schema CAS ");
+    await session.queryGraph({
+      roots: [{ id: "of:root", selector: { path: [], schema: requestSchema } }],
+    });
+
+    const hello = sent.find((message) => message.type === "hello")!;
+    assertEquals(
+      (hello.flags as { requestSchemaCasV1: boolean }).requestSchemaCasV1,
+      false,
+    );
+    const wire = sent.find((message) => message.type === "graph.query")!;
+    assertEquals(Object.hasOwn(wire, "schemaDefinitions"), false);
+    assertEquals(
+      (wire.query as { roots: { selector: { schema: JSONSchema } }[] }).roots[0]
+        .selector.schema,
+      requestSchema,
+    );
+  } finally {
+    resetRequestSchemaCasConfig();
+    await client?.close();
+  }
+});
+
+Deno.test("memory v2 client retries MissingSchemas once with forced definitions", async () => {
+  const requestSchema = schema("missing schema retry ");
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  let queryCount = 0;
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "session.open") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: {
+            sessionId: "session",
+            sessionToken: "token",
+            serverSeq: 0,
+            sessionOpen: {
+              audience: "audience",
+              challenge: { value: "next", expiresAt: 1_000_000 },
+            },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        queryCount++;
+        receiver(encodeMemoryBoundary(
+          queryCount === 1 || queryCount >= 3
+            ? {
+              type: "response",
+              requestId: message.requestId,
+              error: { name: "MissingSchemas", message: "missing" },
+            }
+            : {
+              type: "response",
+              requestId: message.requestId,
+              ok: { serverSeq: 0, entities: [] },
+            },
+        ));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(space);
+    await session.queryGraph({
+      roots: [{ id: "of:root", selector: { path: [], schema: requestSchema } }],
+    });
+    const requests = sent.filter((message) => message.type === "graph.query");
+    assertEquals(requests.length, 2);
+    assertEquals(Object.hasOwn(requests[0], "schemaDefinitions"), false);
+    assert(Object.hasOwn(requests[1], "schemaDefinitions"));
+    await assertRejects(
+      () =>
+        session.queryGraph({
+          roots: [{
+            id: "of:other",
+            selector: { path: [], schema: requestSchema },
+          }],
+        }),
+      Error,
+      "missing",
+    );
+    assertEquals(
+      sent.filter((message) => message.type === "graph.query").length,
+      4,
+    );
+    const terminalRequests = sent.filter((message) =>
+      message.type === "graph.query"
+    );
+    assertEquals(
+      Object.hasOwn(terminalRequests[2], "schemaDefinitions"),
+      false,
+    );
+    assert(Object.hasOwn(terminalRequests[3], "schemaDefinitions"));
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client falls back to one inline retry when the schema store rejects admission", async () => {
+  const requestSchema = schema("schema store fallback ");
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  let queryCount = 0;
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "session.open") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: {
+            sessionId: "session",
+            sessionToken: "token",
+            serverSeq: 0,
+            sessionOpen: {
+              audience: "audience",
+              challenge: { value: "next", expiresAt: 1_000_000 },
+            },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        queryCount++;
+        receiver(encodeMemoryBoundary(
+          queryCount === 1
+            ? {
+              type: "response",
+              requestId: message.requestId,
+              error: { name: "MissingSchemas", message: "missing" },
+            }
+            : queryCount === 2
+            ? {
+              type: "response",
+              requestId: message.requestId,
+              error: { name: "SchemaStoreError", message: "full" },
+            }
+            : {
+              type: "response",
+              requestId: message.requestId,
+              ok: { serverSeq: 0, entities: [] },
+            },
+        ));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(space);
+    await session.queryGraph({
+      roots: [{ id: "of:root", selector: { path: [], schema: requestSchema } }],
+    });
+    const requests = sent.filter((message) => message.type === "graph.query");
+    assertEquals(requests.length, 3);
+    assertEquals(Object.hasOwn(requests[0], "schemaDefinitions"), false);
+    assert(Object.hasOwn(requests[1], "schemaDefinitions"));
+    assertEquals(Object.hasOwn(requests[2], "schemaDefinitions"), false);
+    assertEquals(
+      (requests[2].query as { roots: { selector: { schema: JSONSchema } }[] })
+        .roots[0].selector.schema,
+      requestSchema,
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client bounds store rejection fallback for caller-supplied CAS", async () => {
+  const requestSchema = schema("caller supplied CAS fallback ");
+  const canonical = internSchema(requestSchema, true);
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          error: { name: "SchemaStoreError", message: "full" },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    await assertRejects(
+      () =>
+        client.request({
+          type: "graph.query",
+          requestId: "caller-cas",
+          space,
+          sessionId: "session",
+          query: {
+            roots: [{
+              id: "of:root",
+              selector: {
+                path: [],
+                schema: `schema-cas@1:${canonical.taggedHashString}`,
+              },
+            }],
+          },
+        }),
+      Error,
+      "full",
+    );
+    const requests = sent.filter((message) => message.type === "graph.query");
+    assertEquals(requests.length, 2);
+    assertEquals(requests[0], requests[1]);
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client retries concurrent rejected CAS admissions inline", async () => {
+  const requestSchema = schema("concurrent schema store fallback ");
+  const canonical = internSchema(requestSchema, true);
+  const sent: Record<string, unknown>[] = [];
+  const forcedRequestIds: string[] = [];
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "session.open") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: {
+            sessionId: "session",
+            sessionToken: "token",
+            serverSeq: 0,
+            sessionOpen: {
+              audience: "audience",
+              challenge: { value: "next", expiresAt: 1_000_000 },
+            },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        const requestId = message.requestId as string;
+        const selector = (message.query as {
+          roots: Array<{ selector: { schema: unknown } }>;
+        }).roots[0].selector.schema;
+        if (Object.hasOwn(message, "schemaDefinitions")) {
+          forcedRequestIds.push(requestId);
+          if (forcedRequestIds.length === 2) {
+            for (const forcedRequestId of forcedRequestIds) {
+              receiver(encodeMemoryBoundary({
+                type: "response",
+                requestId: forcedRequestId,
+                error: { name: "SchemaStoreError", message: "full" },
+              }));
+            }
+          }
+        } else if (typeof selector === "string") {
+          receiver(encodeMemoryBoundary({
+            type: "response",
+            requestId,
+            error: { name: "MissingSchemas", message: "missing" },
+          }));
+        } else {
+          receiver(encodeMemoryBoundary({
+            type: "response",
+            requestId,
+            ok: { serverSeq: 0, entities: [] },
+          }));
+        }
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(space);
+    await Promise.all([
+      session.queryGraph({
+        roots: [{
+          id: "of:first",
+          selector: { path: [], schema: requestSchema },
+        }],
+      }),
+      session.queryGraph({
+        roots: [{
+          id: "of:second",
+          selector: { path: [], schema: requestSchema },
+        }],
+      }),
+    ]);
+
+    const requests = sent.filter((message) => message.type === "graph.query");
+    assertEquals(requests.length, 6);
+    const requestsById = Map.groupBy(
+      requests,
+      (message) => message.requestId as string,
+    );
+    assertEquals(requestsById.size, 2);
+    for (const requestFrames of requestsById.values()) {
+      assertEquals(requestFrames.length, 3);
+      assertEquals(Object.hasOwn(requestFrames[0], "schemaDefinitions"), false);
+      assertEquals(
+        (requestFrames[0].query as {
+          roots: Array<{ selector: { schema: string } }>;
+        }).roots[0].selector.schema,
+        `schema-cas@1:${canonical.taggedHashString}`,
+      );
+      assertEquals(
+        requestFrames[1].schemaDefinitions,
+        { [canonical.taggedHashString]: canonical.schema },
+      );
+      assertEquals(Object.hasOwn(requestFrames[2], "schemaDefinitions"), false);
+      assertEquals(
+        (requestFrames[2].query as {
+          roots: Array<{ selector: { schema: JSONSchema } }>;
+        }).roots[0].selector.schema,
+        canonical.schema,
+      );
+    }
+  } finally {
+    await client.close();
+  }
+});

--- a/packages/memory/test/v2-client-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-client-request-schema-cas-test.ts
@@ -731,6 +731,70 @@ Deno.test("memory v2 client retries MissingSchemas once with forced definitions"
   }
 });
 
+Deno.test("memory v2 client preserves caller-supplied schema definitions", async () => {
+  const requestSchema = schema("caller supplied definition ");
+  const canonical = internSchema(requestSchema, true);
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    await client.request({
+      type: "graph.query",
+      requestId: "caller-definition",
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:root",
+          selector: {
+            path: [],
+            schema: `schema-cas@1:${canonical.taggedHashString}`,
+          },
+        }],
+      },
+      schemaDefinitions: {
+        [canonical.taggedHashString]: canonical.schema,
+      },
+    });
+
+    const request = sent.find((message) => message.type === "graph.query");
+    assertEquals(request?.schemaDefinitions, {
+      [canonical.taggedHashString]: canonical.schema,
+    });
+  } finally {
+    await client.close();
+  }
+});
+
 Deno.test("memory v2 client falls back to one inline retry when the schema store rejects admission", async () => {
   const requestSchema = schema("schema store fallback ");
   const sent: Record<string, unknown>[] = [];

--- a/packages/memory/test/v2-client-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-client-request-schema-cas-test.ts
@@ -636,6 +636,171 @@ Deno.test("memory v2 client keeps schemas inline when its advertised CAS capabil
   }
 });
 
+Deno.test("memory v2 client ignores malformed CAS negotiation metadata", async () => {
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: 1, audience: false },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    await client.request({
+      type: "graph.query",
+      requestId: "malformed-negotiation",
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:root",
+          selector: { path: [], schema: schema("malformed negotiation ") },
+        }],
+      },
+    });
+    const request = sent.find((message) =>
+      message.requestId === "malformed-negotiation"
+    )!;
+    assertEquals(Object.hasOwn(request, "schemaDefinitions"), false);
+    assertEquals(
+      (request.query as { roots: Array<{ selector: { schema: JSONSchema } }> })
+        .roots[0].selector.schema,
+      schema("malformed negotiation "),
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client degrades malformed CAS request shapes to ordinary sends", async () => {
+  const sent: Record<string, unknown>[] = [];
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "graph.query") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    const malformed = {
+      type: "graph.query",
+      requestId: "malformed-request",
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:root",
+          selector: { path: [], schema: "schema-cas@1:known" },
+        }, "not-a-query-root"],
+      },
+    };
+    await client.request(malformed);
+    assertEquals(
+      sent.find((message) => message.requestId === "malformed-request"),
+      malformed,
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client removes a pending request when transport send fails", async () => {
+  let receiver = (_payload: string) => {};
+  let failRequest = true;
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.type === "graph.query" && failRequest) {
+        failRequest = false;
+        return Promise.reject(new Error("send failed"));
+      } else if (message.type === "graph.query") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId,
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  const request = {
+    type: "graph.query",
+    requestId: "reusable-after-send-failure",
+    space,
+    sessionId: "session",
+    query: { roots: [] },
+  };
+  try {
+    await assertRejects(() => client.request(request), Error, "send failed");
+    await client.request(request);
+  } finally {
+    await client.close();
+  }
+});
+
 Deno.test("memory v2 client retries MissingSchemas once with forced definitions", async () => {
   const requestSchema = schema("missing schema retry ");
   const sent: Record<string, unknown>[] = [];

--- a/packages/memory/test/v2-client-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-client-request-schema-cas-test.ts
@@ -943,11 +943,10 @@ Deno.test("memory v2 client bounds store rejection fallback for caller-supplied 
   }
 });
 
-Deno.test("memory v2 client retries concurrent rejected CAS admissions inline", async () => {
+Deno.test("memory v2 client serializes concurrent rejected CAS admissions through inline fallback", async () => {
   const requestSchema = schema("concurrent schema store fallback ");
   const canonical = internSchema(requestSchema, true);
   const sent: Record<string, unknown>[] = [];
-  const forcedRequestIds: string[] = [];
   let receiver = (_payload: string) => {};
   const transport: Transport = {
     send(payload) {
@@ -984,16 +983,11 @@ Deno.test("memory v2 client retries concurrent rejected CAS admissions inline", 
           roots: Array<{ selector: { schema: unknown } }>;
         }).roots[0].selector.schema;
         if (Object.hasOwn(message, "schemaDefinitions")) {
-          forcedRequestIds.push(requestId);
-          if (forcedRequestIds.length === 2) {
-            for (const forcedRequestId of forcedRequestIds) {
-              receiver(encodeMemoryBoundary({
-                type: "response",
-                requestId: forcedRequestId,
-                error: { name: "SchemaStoreError", message: "full" },
-              }));
-            }
-          }
+          receiver(encodeMemoryBoundary({
+            type: "response",
+            requestId,
+            error: { name: "SchemaStoreError", message: "full" },
+          }));
         } else if (typeof selector === "string") {
           receiver(encodeMemoryBoundary({
             type: "response",
@@ -1034,33 +1028,450 @@ Deno.test("memory v2 client retries concurrent rejected CAS admissions inline", 
     ]);
 
     const requests = sent.filter((message) => message.type === "graph.query");
-    assertEquals(requests.length, 6);
+    assertEquals(requests.length, 4);
     const requestsById = Map.groupBy(
       requests,
       (message) => message.requestId as string,
     );
     assertEquals(requestsById.size, 2);
-    for (const requestFrames of requestsById.values()) {
-      assertEquals(requestFrames.length, 3);
-      assertEquals(Object.hasOwn(requestFrames[0], "schemaDefinitions"), false);
-      assertEquals(
-        (requestFrames[0].query as {
-          roots: Array<{ selector: { schema: string } }>;
-        }).roots[0].selector.schema,
-        `schema-cas@1:${canonical.taggedHashString}`,
-      );
-      assertEquals(
-        requestFrames[1].schemaDefinitions,
-        { [canonical.taggedHashString]: canonical.schema },
-      );
-      assertEquals(Object.hasOwn(requestFrames[2], "schemaDefinitions"), false);
-      assertEquals(
-        (requestFrames[2].query as {
-          roots: Array<{ selector: { schema: JSONSchema } }>;
-        }).roots[0].selector.schema,
-        canonical.schema,
-      );
-    }
+    const first = requestsById.get(requests[0].requestId as string)!;
+    const second = requestsById.get(requests[3].requestId as string)!;
+    assertEquals(first.length, 3);
+    assertEquals(second.length, 1);
+    assertEquals(Object.hasOwn(first[0], "schemaDefinitions"), false);
+    assertEquals(first[1].schemaDefinitions, {
+      [canonical.taggedHashString]: canonical.schema,
+    });
+    assertEquals(Object.hasOwn(first[2], "schemaDefinitions"), false);
+    assertEquals(
+      (first[2].query as {
+        roots: Array<{ selector: { schema: JSONSchema } }>;
+      }).roots[0].selector.schema,
+      canonical.schema,
+    );
+    assertEquals(
+      (second[0].query as {
+        roots: Array<{ selector: { schema: JSONSchema } }>;
+      }).roots[0].selector.schema,
+      canonical.schema,
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client holds later requests behind a cold CAS retry", async () => {
+  const requestSchema = schema("cold admission ordering ");
+  const sent: Record<string, unknown>[] = [];
+  const refsSent = Promise.withResolvers<void>();
+  const definitionsSent = Promise.withResolvers<void>();
+  const laterSent = Promise.withResolvers<void>();
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.requestId === "cold") {
+        if (Object.hasOwn(message, "schemaDefinitions")) {
+          definitionsSent.resolve();
+        } else {
+          refsSent.resolve();
+        }
+      } else if (message.requestId === "later") {
+        laterSent.resolve();
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    const cold = client.request({
+      type: "graph.query",
+      requestId: "cold",
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:cold",
+          selector: { path: [], schema: requestSchema },
+        }],
+      },
+    });
+    await refsSent.promise;
+    const later = client.request({
+      type: "graph.query",
+      requestId: "later",
+      space,
+      sessionId: "session",
+      query: { roots: [] },
+    });
+    await Promise.resolve();
+    assertEquals(sent.map((message) => message.requestId ?? message.type), [
+      "hello",
+      "cold",
+    ]);
+
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "cold",
+      error: { name: "MissingSchemas", message: "missing" },
+    }));
+    await definitionsSent.promise;
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "cold",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await cold;
+    await laterSent.promise;
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "later",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await later;
+    assertEquals(sent.map((message) => message.requestId ?? message.type), [
+      "hello",
+      "cold",
+      "cold",
+      "later",
+    ]);
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client keeps confirmed CAS requests concurrent", async () => {
+  const requestSchema = schema("warm admission concurrency ");
+  const sent: Record<string, unknown>[] = [];
+  const warmRequestsSent = Promise.withResolvers<void>();
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.requestId === "warmup") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: "warmup",
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      } else if (
+        sent.filter((candidate) =>
+          candidate.requestId === "first" || candidate.requestId === "second"
+        ).length === 2
+      ) {
+        warmRequestsSent.resolve();
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  const request = (requestId: string) =>
+    client.request({
+      type: "graph.query",
+      requestId,
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:warm",
+          selector: { path: [], schema: requestSchema },
+        }],
+      },
+    });
+  try {
+    await request("warmup");
+    const first = request("first");
+    const second = request("second");
+    await warmRequestsSent.promise;
+    assertEquals(sent.map((message) => message.requestId ?? message.type), [
+      "hello",
+      "warmup",
+      "first",
+      "second",
+    ]);
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "first",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "second",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await Promise.all([first, second]);
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client keeps SchemaStoreError fallback inside its cold admission", async () => {
+  const requestSchema = schema("store error ordering ");
+  const sent: Record<string, unknown>[] = [];
+  const refsSent = Promise.withResolvers<void>();
+  const definitionsSent = Promise.withResolvers<void>();
+  const inlineSent = Promise.withResolvers<void>();
+  const laterSent = Promise.withResolvers<void>();
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: { generation: "generation", audience: "audience" },
+          sessionOpen: {
+            audience: "audience",
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+      } else if (message.requestId === "cold") {
+        if (Object.hasOwn(message, "schemaDefinitions")) {
+          definitionsSent.resolve();
+        } else if (
+          typeof (message.query as { roots: unknown[] }).roots[0] === "object"
+        ) {
+          const selector = (message.query as {
+            roots: Array<{ selector: { schema: unknown } }>;
+          }).roots[0].selector;
+          if (typeof selector.schema === "string") refsSent.resolve();
+          else inlineSent.resolve();
+        }
+      } else if (message.requestId === "later") {
+        laterSent.resolve();
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  try {
+    const cold = client.request({
+      type: "graph.query",
+      requestId: "cold",
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:cold",
+          selector: { path: [], schema: requestSchema },
+        }],
+      },
+    });
+    await refsSent.promise;
+    const later = client.request({
+      type: "graph.query",
+      requestId: "later",
+      space,
+      sessionId: "session",
+      query: { roots: [] },
+    });
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "cold",
+      error: { name: "MissingSchemas", message: "missing" },
+    }));
+    await definitionsSent.promise;
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "cold",
+      error: { name: "SchemaStoreError", message: "full" },
+    }));
+    await inlineSent.promise;
+    assertEquals(sent.map((message) => message.requestId ?? message.type), [
+      "hello",
+      "cold",
+      "cold",
+      "cold",
+    ]);
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "cold",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await cold;
+    await laterSent.promise;
+    const laterWire = sent.at(-1)!;
+    assertEquals(
+      (laterWire.query as { roots: { selector?: { schema?: unknown } }[] })
+        .roots,
+      [],
+    );
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "later",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await later;
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client scopes CAS confirmations to negotiated store identity", async () => {
+  const requestSchema = schema("reconnect store identity ");
+  const sent: Record<string, unknown>[] = [];
+  const warmSent = Promise.withResolvers<void>();
+  const coldSent = Promise.withResolvers<void>();
+  const laterSent = Promise.withResolvers<void>();
+  const reconnected = [
+    Promise.withResolvers<void>(),
+    Promise.withResolvers<void>(),
+  ];
+  let helloCount = 0;
+  let identity = { generation: "generation-one", audience: "audience-one" };
+  let receiver = (_payload: string) => {};
+  let closeReceiver = (_error?: Error) => {};
+  const transport: Transport = {
+    send(payload) {
+      const message = decodeMemoryBoundary(payload) as Record<string, unknown>;
+      sent.push(message);
+      if (message.type === "hello") {
+        helloCount += 1;
+        receiver(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          requestSchemaCas: identity,
+          sessionOpen: {
+            audience: identity.audience,
+            challenge: { value: "challenge", expiresAt: 1_000_000 },
+          },
+        }));
+        if (helloCount > 1) reconnected[helloCount - 2].resolve();
+      } else if (message.requestId === "warmup") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: "warmup",
+          ok: { serverSeq: 0, entities: [] },
+        }));
+      } else if (
+        message.requestId === "warm-first" ||
+        message.requestId === "warm-second"
+      ) {
+        if (
+          sent.filter((candidate) =>
+            candidate.requestId === "warm-first" ||
+            candidate.requestId === "warm-second"
+          ).length === 2
+        ) warmSent.resolve();
+      } else if (message.requestId === "cold-after-identity-change") {
+        coldSent.resolve();
+      } else if (message.requestId === "later") {
+        laterSent.resolve();
+      }
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
+  };
+  const client = await connect({ transport });
+  const request = (requestId: string) =>
+    client.request({
+      type: "graph.query",
+      requestId,
+      space,
+      sessionId: "session",
+      query: {
+        roots: [{
+          id: "of:identity",
+          selector: { path: [], schema: requestSchema },
+        }],
+      },
+    });
+  try {
+    await request("warmup");
+    closeReceiver(new Error("disconnect"));
+    await reconnected[0].promise;
+
+    const warmFirst = request("warm-first");
+    const warmSecond = request("warm-second");
+    await warmSent.promise;
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "warm-first",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "warm-second",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await Promise.all([warmFirst, warmSecond]);
+
+    identity = { generation: "generation-two", audience: "audience-two" };
+    closeReceiver(new Error("disconnect"));
+    await reconnected[1].promise;
+    const cold = request("cold-after-identity-change");
+    await coldSent.promise;
+    const later = client.request({
+      type: "graph.query",
+      requestId: "later",
+      space,
+      sessionId: "session",
+      query: { roots: [] },
+    });
+    await Promise.resolve();
+    assertEquals(
+      sent.filter((message) => message.requestId === "later").length,
+      0,
+    );
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "cold-after-identity-change",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await cold;
+    await laterSent.promise;
+    receiver(encodeMemoryBoundary({
+      type: "response",
+      requestId: "later",
+      ok: { serverSeq: 0, entities: [] },
+    }));
+    await later;
   } finally {
     await client.close();
   }

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -214,6 +214,63 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
       );
     }
 
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:reserved-sync-schema-ref-hidden-by-set",
+              value: toEntityDocument({
+                $alias: {
+                  id: "of:target",
+                  path: [],
+                  schema: reservedRef,
+                },
+              }),
+            }, {
+              op: "set",
+              id: "entity:reserved-sync-schema-ref-hidden-by-set",
+              value: toEntityDocument({ safe: true }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved sync schema reference",
+    );
+    assertEquals(
+      read(engine, { id: "entity:reserved-sync-schema-ref-hidden-by-set" }),
+      null,
+    );
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id,
+              patches: [{
+                op: "replace",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+                value: reservedRef,
+              }],
+            }, {
+              op: "delete",
+              id,
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved sync schema reference",
+    );
+
     assertEquals(
       read(engine, { id }),
       toEntityDocument({

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -143,7 +143,7 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
           },
         }),
       ProtocolError,
-      "reserved sync schema reference",
+      "reserved wire schema reference",
     );
 
     applyCommit(engine, {
@@ -182,7 +182,7 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
           },
         }),
       ProtocolError,
-      "reserved sync schema reference",
+      "reserved wire schema reference",
     );
 
     for (
@@ -210,7 +210,7 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
             },
           }),
         ProtocolError,
-        "reserved sync schema reference",
+        "reserved wire schema reference",
       );
     }
 
@@ -239,7 +239,7 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
           },
         }),
       ProtocolError,
-      "reserved sync schema reference",
+      "reserved wire schema reference",
     );
     assertEquals(
       read(engine, { id: "entity:reserved-sync-schema-ref-hidden-by-set" }),
@@ -268,7 +268,7 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
           },
         }),
       ProtocolError,
-      "reserved sync schema reference",
+      "reserved wire schema reference",
     );
 
     assertEquals(
@@ -291,6 +291,43 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
           schema: "opaque-legacy-schema-name",
         },
       }),
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine reserves request CAS schema reference strings", async () => {
+  const { engine, path } = await createEngine();
+  const reservedRef = "schema-cas@1:sha256:user-controlled";
+  try {
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-request-schema-ref",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:reserved-request-schema-ref",
+              value: toEntityDocument({
+                $alias: {
+                  id: "of:target",
+                  path: [],
+                  schema: reservedRef,
+                },
+              }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+    assertEquals(
+      read(engine, { id: "entity:reserved-request-schema-ref" }),
+      null,
     );
   } finally {
     close(engine);

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -8,6 +8,7 @@ import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   type EntityRef,
   entityRefFromString,
+  LINK_V1_TAG,
 } from "@commonfabric/data-model/cell-rep";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
@@ -85,6 +86,160 @@ const toEntityDocument = (
   }
   return document as EntityDocument;
 };
+
+Deno.test("memory v2 engine reserves sync schema reference strings", async () => {
+  const { engine, path } = await createEngine();
+  const id = "entity:reserved-sync-schema-ref";
+  const reservedRef = "schema-ref@2:sha256:user-controlled";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:reserved-sync-schema-ref",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: toEntityDocument({
+            harmless: reservedRef,
+            ref: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:target",
+                  path: [],
+                  schema: "opaque-schema-name",
+                },
+              },
+            },
+            $alias: {
+              id: "of:legacy-target",
+              path: [],
+              schema: "opaque-legacy-schema-name",
+            },
+          }),
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:reserved-sync-schema-ref-set",
+              value: toEntityDocument({
+                $alias: {
+                  id: "of:target",
+                  path: [],
+                  schema: reservedRef,
+                },
+              }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved sync schema reference",
+    );
+
+    applyCommit(engine, {
+      sessionId: "session:reserved-sync-schema-ref",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "add",
+            path: "/value/harmlessPatch",
+            value: reservedRef,
+          }],
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id,
+              patches: [{
+                op: "replace",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+                value: reservedRef,
+              }],
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved sync schema reference",
+    );
+
+    for (
+      const path of [
+        `/value/ref/~1/${LINK_V1_TAG}/schema`,
+        "/value/$alias/schema",
+      ]
+    ) {
+      assertThrows(
+        () =>
+          applyCommit(engine, {
+            sessionId: "session:reserved-sync-schema-ref",
+            commit: {
+              localSeq: 3,
+              reads: { confirmed: [], pending: [] },
+              operations: [{
+                op: "patch",
+                id,
+                patches: [{
+                  op: "move",
+                  from: "/value/harmless",
+                  path,
+                }],
+              }],
+            },
+          }),
+        ProtocolError,
+        "reserved sync schema reference",
+      );
+    }
+
+    assertEquals(
+      read(engine, { id }),
+      toEntityDocument({
+        harmless: reservedRef,
+        harmlessPatch: reservedRef,
+        ref: {
+          "/": {
+            [LINK_V1_TAG]: {
+              id: "of:target",
+              path: [],
+              schema: "opaque-schema-name",
+            },
+          },
+        },
+        $alias: {
+          id: "of:legacy-target",
+          path: [],
+          schema: "opaque-legacy-schema-name",
+        },
+      }),
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
 
 Deno.test("memory v2 engine stores independent scoped instances for the same id", async () => {
   const { engine, path } = await createEngine();

--- a/packages/memory/test/v2-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-request-schema-cas-test.ts
@@ -140,6 +140,89 @@ Deno.test("request schema CAS definitions respect known hashes and force definit
   assertEquals(Object.keys(forced.schemaDefinitions ?? {}), [hash]);
 });
 
+Deno.test("request schema CAS preserves and merges supplied definitions", () => {
+  const referenced = compressRequestSchemas(graphRequest(), {
+    isKnownSchemaHash: () => true,
+  });
+  const supplied = {
+    ...referenced,
+    schemaDefinitions: { [hash]: schema },
+  };
+
+  assertStrictEquals(
+    compressRequestSchemas(supplied, { isKnownSchemaHash: noKnownSchemas }),
+    supplied,
+  );
+
+  const additionalSchema: JSONSchema = { type: "number" };
+  const additional = internSchema(additionalSchema, true);
+  const withInlineSchema = {
+    ...supplied,
+    query: {
+      ...supplied.query,
+      roots: [...supplied.query.roots, {
+        id: "of:additional",
+        selector: { path: [], schema: additionalSchema },
+      }],
+    },
+  };
+  const compressed = compressRequestSchemas(withInlineSchema, {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+
+  assertEquals(compressed.schemaDefinitions, {
+    [additional.taggedHashString]: additional.schema,
+    [hash]: schema,
+  });
+  assertEquals(
+    schemaAtSelector({ query: { roots: [compressed.query.roots[1]] } }),
+    `schema-cas@1:${additional.taggedHashString}`,
+  );
+  const expanded = expandRequestSchemas(compressed, () => undefined);
+  if (expanded.type !== "graph.query") {
+    throw new Error("expected graph query request");
+  }
+  assertEquals(schemaAtSelector(expanded), internSchema(schema, true).schema);
+  assertEquals(
+    expanded.query.roots[1].selector.schema,
+    additional.schema,
+  );
+});
+
+Deno.test("request schema CAS preserves collisions and combined limits", () => {
+  const canonical = internSchema(schema, true);
+  const colliding = {
+    ...graphRequest(),
+    schemaDefinitions: { [canonical.taggedHashString]: false },
+  };
+  const compressed = compressRequestSchemas(colliding, {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+
+  assertEquals(
+    compressed.schemaDefinitions?.[canonical.taggedHashString],
+    false,
+  );
+  assertThrows(
+    () => expandRequestSchemas(compressed, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+    "hash mismatch",
+  );
+
+  const atDefinitionLimit = {
+    ...graphRequest(),
+    schemaDefinitions: Object.fromEntries(
+      Array.from({ length: 256 }, (_, index) => [`hash-${index}`, false]),
+    ),
+  };
+  assertStrictEquals(
+    compressRequestSchemas(atDefinitionLimit, {
+      isKnownSchemaHash: noKnownSchemas,
+    }),
+    atDefinitionLimit,
+  );
+});
+
 Deno.test("request schema CAS rewrites only selectors and transact link schemas", () => {
   const graph = compressRequestSchemas(graphRequest(), {
     isKnownSchemaHash: noKnownSchemas,

--- a/packages/memory/test/v2-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-request-schema-cas-test.ts
@@ -17,6 +17,7 @@ import type {
   WatchSetRequest,
 } from "../v2.ts";
 import {
+  collectRequestSchemaCasHashes,
   compressRequestSchemas,
   expandRequestSchemas,
   hasRequestSchemaCasPayload,
@@ -535,7 +536,7 @@ Deno.test("request schema CAS measures Fabric defaults by canonical encoded size
   );
 });
 
-Deno.test("request schema CAS bounds preflight traversal", () => {
+Deno.test("request schema CAS detects deep and wide payloads without preflight limits", () => {
   const casLink = {
     "/": {
       [LINK_V1_TAG]: {
@@ -556,35 +557,24 @@ Deno.test("request schema CAS bounds preflight traversal", () => {
       operations: [{ op: "set", id: "of:root", value: nested }],
     },
   };
-  assertThrows(
-    () => hasRequestSchemaCasPayload(request),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
+  assertEquals(hasRequestSchemaCasPayload(request), false);
+  assertEquals(
+    hasRequestSchemaCasPayload({ ...request, schemaDefinitions: {} }),
+    true,
   );
-  assertThrows(
-    () =>
-      hasRequestSchemaCasPayload({
-        ...request,
-        schemaDefinitions: {},
-      }),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
-  );
-  assertThrows(
-    () =>
-      hasRequestSchemaCasPayload({
-        ...request,
-        commit: {
-          ...request.commit,
-          operations: [{
-            op: "set",
-            id: "of:root",
-            value: { casLink, nested },
-          }],
-        },
-      }),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...request,
+      commit: {
+        ...request.commit,
+        operations: [{
+          op: "set",
+          id: "of:root",
+          value: { nested, casLink },
+        }],
+      },
+    }),
+    true,
   );
 
   const wide = Array.from({ length: 100_001 }, () => null);
@@ -595,51 +585,38 @@ Deno.test("request schema CAS bounds preflight traversal", () => {
       operations: [{ op: "set", id: "of:root", value: wide }],
     },
   };
-  assertThrows(
-    () => hasRequestSchemaCasPayload(wideRequest),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
+  assertEquals(hasRequestSchemaCasPayload(wideRequest), false);
+  assertEquals(
+    hasRequestSchemaCasPayload({ ...wideRequest, schemaDefinitions: {} }),
+    true,
   );
-  assertThrows(
-    () =>
-      hasRequestSchemaCasPayload({
-        ...wideRequest,
-        schemaDefinitions: {},
-      }),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...request,
+      commit: {
+        ...request.commit,
+        operations: [{
+          op: "set",
+          id: "of:root",
+          value: [...wide, casLink],
+        }],
+      },
+    }),
+    true,
   );
-  assertThrows(
-    () =>
-      hasRequestSchemaCasPayload({
-        ...request,
-        commit: {
-          ...request.commit,
-          operations: [{
-            op: "set",
-            id: "of:root",
-            value: [...wide, casLink],
-          }],
-        },
-      }),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
-  );
-  assertThrows(
-    () =>
-      hasRequestSchemaCasPayload({
-        ...request,
-        commit: {
-          ...request.commit,
-          operations: [{
-            op: "set",
-            id: "of:root",
-            value: { casLink, wide },
-          }],
-        },
-      }),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...request,
+      commit: {
+        ...request.commit,
+        operations: [{
+          op: "set",
+          id: "of:root",
+          value: { wide, casLink },
+        }],
+      },
+    }),
+    true,
   );
 
   let deepLink: EntityDocument = {
@@ -665,7 +642,7 @@ Deno.test("request schema CAS bounds preflight traversal", () => {
   );
 });
 
-Deno.test("request schema CAS shares traversal limits across transaction operations", () => {
+Deno.test("request schema CAS leaves traversal limits to expansion", () => {
   const wide = Array.from({ length: 50_000 }, () => null);
   const inline: TransactRequest = {
     ...transactRequest(),
@@ -677,15 +654,10 @@ Deno.test("request schema CAS shares traversal limits across transaction operati
       ],
     },
   };
-  assertThrows(
-    () => hasRequestSchemaCasPayload(inline),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
-  );
-  assertThrows(
-    () => hasRequestSchemaCasPayload({ ...inline, schemaDefinitions: {} }),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
+  assertEquals(hasRequestSchemaCasPayload(inline), false);
+  assertEquals(
+    hasRequestSchemaCasPayload({ ...inline, schemaDefinitions: {} }),
+    true,
   );
 
   const casLink = {
@@ -711,11 +683,7 @@ Deno.test("request schema CAS shares traversal limits across transaction operati
       ],
     },
   };
-  assertThrows(
-    () => hasRequestSchemaCasPayload(withCas),
-    InvalidRequestSchemaDefinitionsError,
-    "traversal limit",
-  );
+  assertEquals(hasRequestSchemaCasPayload(withCas), true);
 
   const inlineLink = {
     "/": { [LINK_V1_TAG]: { id: "of:child", path: [], schema } },
@@ -746,6 +714,79 @@ Deno.test("request schema CAS shares traversal limits across transaction operati
       ),
     InvalidRequestSchemaDefinitionsError,
     "traversal limit",
+  );
+});
+
+Deno.test("request schema CAS rejects malformed envelopes and safely detects cycles", () => {
+  const malformed = [
+    [{ ...graphRequest(), query: null }, "Invalid request schema query"],
+    [
+      { ...graphRequest(), query: { roots: [null] } },
+      "Invalid request schema query root",
+    ],
+    [
+      { ...watchRequest("session.watch.set"), watches: null },
+      "Invalid request schema watches",
+    ],
+    [
+      { ...watchRequest("session.watch.add"), watches: [null] },
+      "Invalid request schema watch",
+    ],
+    [
+      { ...transactRequest(), commit: null },
+      "Invalid request schema transaction",
+    ],
+    [{
+      ...transactRequest(),
+      commit: { ...transactRequest().commit, operations: [null] },
+    }, "Invalid request schema operation"],
+  ] as const;
+
+  for (const [request, message] of malformed) {
+    assertThrows(
+      () => expandRequestSchemas(request, () => undefined),
+      InvalidRequestSchemaDefinitionsError,
+      message,
+    );
+  }
+  assertThrows(
+    () => collectRequestSchemaCasHashes({ type: "session.open" }),
+    InvalidRequestSchemaDefinitionsError,
+    "Unsupported request schema table message",
+  );
+
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...transactRequest(),
+      commit: {
+        ...transactRequest().commit,
+        operations: [{ op: "set", id: "of:cyclic", value: cyclic }],
+      },
+    }),
+    false,
+  );
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...graphRequest(),
+      query: null,
+    }),
+    false,
+  );
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...watchRequest("session.watch.set"),
+      watches: null,
+    }),
+    false,
+  );
+  assertEquals(
+    hasRequestSchemaCasPayload({
+      ...transactRequest(),
+      commit: null,
+    }),
+    false,
   );
 });
 

--- a/packages/memory/test/v2-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-request-schema-cas-test.ts
@@ -1,0 +1,506 @@
+import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
+import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type { JSONSchema } from "@commonfabric/api";
+import type {
+  EntityDocument,
+  GraphQueryRequest,
+  TransactRequest,
+  WatchAddRequest,
+  WatchSetRequest,
+} from "../v2.ts";
+import {
+  compressRequestSchemas,
+  expandRequestSchemas,
+  hasRequestSchemaCasPayload,
+  InvalidRequestSchemaDefinitionsError,
+  MissingRequestSchemaDefinitionError,
+} from "../v2/request-schema-cas.ts";
+
+const schema: JSONSchema = {
+  type: "object",
+  properties: { title: { type: "string" } },
+};
+const equivalentSchema: JSONSchema = {
+  properties: { title: { type: "string" } },
+  type: "object",
+};
+const hash = internSchema(schema, true).taggedHashString;
+const noKnownSchemas = () => false;
+
+const graphRequest = (): GraphQueryRequest => ({
+  type: "graph.query",
+  requestId: "query",
+  space: "did:key:request-schema-cas",
+  sessionId: "session:request-schema-cas",
+  query: {
+    roots: [{ id: "of:root", selector: { path: [], schema } }],
+  },
+});
+
+const watchRequest = <Type extends "session.watch.set" | "session.watch.add">(
+  type: Type,
+): Type extends "session.watch.set" ? WatchSetRequest : WatchAddRequest => ({
+  type,
+  requestId: "watch",
+  space: "did:key:request-schema-cas",
+  sessionId: "session:request-schema-cas",
+  watches: [{
+    id: "root",
+    kind: "graph",
+    query: {
+      roots: [{ id: "of:root", selector: { path: [], schema } }],
+    },
+  }],
+} as Type extends "session.watch.set" ? WatchSetRequest : WatchAddRequest);
+
+const transactRequest = (): TransactRequest => ({
+  type: "transact",
+  requestId: "transact",
+  space: "did:key:request-schema-cas",
+  sessionId: "session:request-schema-cas",
+  commit: {
+    localSeq: 1,
+    reads: { confirmed: [], pending: [] },
+    operations: [
+      {
+        op: "set",
+        id: "of:set",
+        value: {
+          ref: {
+            "/": { [LINK_V1_TAG]: { id: "of:modern", path: [], schema } },
+          },
+          legacy: { $alias: { id: "of:legacy", path: [], schema } },
+          fake: { schema },
+        },
+      },
+      {
+        op: "patch",
+        id: "of:patch",
+        patches: [{
+          op: "add",
+          path: "/nested",
+          value: [{
+            "/": {
+              [LINK_V1_TAG]: { id: "of:patched", path: [], schema },
+            },
+          }],
+        }],
+      },
+    ],
+  },
+});
+
+const schemaAtSelector = (
+  request: unknown,
+): unknown => ((request as {
+  query: { roots: Array<{ selector: { schema?: unknown } }> };
+})
+  .query.roots[0].selector.schema);
+
+Deno.test("request schema CAS definitions canonicalize structural equals and expand inline", () => {
+  const request = graphRequest();
+  request.query.roots.push({
+    id: "of:equivalent",
+    selector: { path: [], schema: equivalentSchema },
+  });
+
+  const compressed = compressRequestSchemas(request, {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+
+  assertEquals(Object.keys(compressed.schemaDefinitions ?? {}), [hash]);
+  assertEquals(schemaAtSelector(compressed), `schema-cas@1:${hash}`);
+  assertEquals(
+    schemaAtSelector({ query: { roots: [compressed.query.roots[1]] } }),
+    `schema-cas@1:${hash}`,
+  );
+  assertEquals(expandRequestSchemas(compressed, () => undefined), request);
+});
+
+Deno.test("request schema CAS definitions respect known hashes and force definitions", () => {
+  const request = graphRequest();
+  const known = compressRequestSchemas(request, {
+    isKnownSchemaHash: (candidate) => candidate === hash,
+  });
+  assertEquals(known.schemaDefinitions, undefined);
+  assertEquals(schemaAtSelector(known), `schema-cas@1:${hash}`);
+  assertEquals(
+    expandRequestSchemas(
+      known,
+      (candidate) => candidate === hash ? schema : undefined,
+    ),
+    request,
+  );
+
+  const forced = compressRequestSchemas(request, {
+    isKnownSchemaHash: () => true,
+    forceDefinitions: true,
+  });
+  assertEquals(Object.keys(forced.schemaDefinitions ?? {}), [hash]);
+});
+
+Deno.test("request schema CAS rewrites only selectors and transact link schemas", () => {
+  const graph = compressRequestSchemas(graphRequest(), {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+  const watchSet = compressRequestSchemas(watchRequest("session.watch.set"), {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+  const watchAdd = compressRequestSchemas(watchRequest("session.watch.add"), {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+  const transact = compressRequestSchemas(transactRequest(), {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+  const set = transact.commit.operations[0];
+  const patch = transact.commit.operations[1];
+
+  if (set.op !== "set" || patch.op !== "patch") {
+    throw new Error("expected set and patch operations");
+  }
+  const patchValue = patch.patches[0];
+  if (patchValue.op !== "add" || !Array.isArray(patchValue.value)) {
+    throw new Error("expected an array add patch");
+  }
+
+  assertEquals(schemaAtSelector(graph), `schema-cas@1:${hash}`);
+  assertEquals(
+    schemaAtSelector({ query: watchSet.watches[0].query }),
+    `schema-cas@1:${hash}`,
+  );
+  assertEquals(
+    schemaAtSelector({ query: watchAdd.watches[0].query }),
+    `schema-cas@1:${hash}`,
+  );
+  assertEquals(
+    ((set as { value: Record<string, unknown> }).value.ref as Record<
+      string,
+      unknown
+    >)["/"],
+    {
+      [LINK_V1_TAG]: {
+        id: "of:modern",
+        path: [],
+        schema: `schema-cas@1:${hash}`,
+      },
+    },
+  );
+  assertEquals(
+    ((set as { value: Record<string, unknown> }).value.legacy as Record<
+      string,
+      unknown
+    >).$alias,
+    { id: "of:legacy", path: [], schema: `schema-cas@1:${hash}` },
+  );
+  assertEquals(
+    ((set as { value: Record<string, unknown> }).value.fake as Record<
+      string,
+      unknown
+    >).schema,
+    schema,
+  );
+  const patchedLink = ((patchValue.value[0] as Record<string, unknown>)[
+    "/"
+  ] as Record<string, unknown>)[LINK_V1_TAG] as Record<string, unknown>;
+  assertEquals(patchedLink.schema, `schema-cas@1:${hash}`);
+  assertEquals(
+    expandRequestSchemas(transact, () => undefined),
+    transactRequest(),
+  );
+});
+
+Deno.test("request schema CAS rejects missing, mismatched, and malformed definitions", () => {
+  const request = graphRequest();
+  const refRequest = {
+    ...request,
+    query: {
+      roots: [{
+        ...request.query.roots[0],
+        selector: { path: [], schema: "schema-cas@1:missing" },
+      }],
+    },
+  };
+  const missing = assertThrows(
+    () => expandRequestSchemas(refRequest, () => undefined),
+    MissingRequestSchemaDefinitionError,
+  );
+  assertEquals(missing.hash, "missing");
+  assertThrows(
+    () =>
+      expandRequestSchemas(
+        { ...request, schemaDefinitions: [] },
+        () => undefined,
+      ),
+    InvalidRequestSchemaDefinitionsError,
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...refRequest,
+        schemaDefinitions: { missing: schema },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...request,
+        schemaDefinitions: { [hash]: "not-a-schema" },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...request,
+        query: {
+          roots: [{
+            ...request.query.roots[0],
+            selector: { path: [], schema: "schema-cas@1:" },
+          }],
+        },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...request,
+        schemaDefinitions: { [hash]: schema },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+    "Unused request schema definitions",
+  );
+  const inherited = {
+    ...refRequest,
+    query: {
+      roots: [{
+        ...request.query.roots[0],
+        selector: { path: [], schema: "schema-cas@1:toString" },
+      }],
+    },
+    schemaDefinitions: {},
+  };
+  assertThrows(
+    () => expandRequestSchemas(inherited, () => undefined),
+    MissingRequestSchemaDefinitionError,
+    "toString",
+  );
+});
+
+Deno.test("request schema CAS ingests only after every reference expands", () => {
+  const request = graphRequest();
+  const compressed = compressRequestSchemas(request, {
+    isKnownSchemaHash: noKnownSchemas,
+  });
+  const invalid = {
+    ...compressed,
+    query: {
+      ...compressed.query,
+      roots: [...compressed.query.roots, {
+        id: "of:missing",
+        selector: { path: [], schema: "schema-cas@1:missing" },
+      }],
+    },
+  };
+  let ingested = false;
+
+  assertThrows(
+    () =>
+      expandRequestSchemas(
+        invalid,
+        () => undefined,
+        () => {
+          ingested = true;
+        },
+      ),
+    MissingRequestSchemaDefinitionError,
+  );
+  assertEquals(ingested, false);
+});
+
+Deno.test("request schema CAS bounds definition count, size, and reference length", () => {
+  const request = graphRequest();
+  const tooMany = Object.fromEntries(
+    Array.from({ length: 257 }, (_, index) => [`hash-${index}`, false]),
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas(
+        { ...request, schemaDefinitions: tooMany },
+        () => undefined,
+      ),
+    InvalidRequestSchemaDefinitionsError,
+    "Too many request schema definitions",
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...request,
+        schemaDefinitions: {
+          oversized: { description: "x".repeat(256 * 1024) },
+        },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+    "too large",
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...request,
+        query: {
+          roots: [{
+            id: "of:root",
+            selector: {
+              path: [],
+              schema: `schema-cas@1:${"x".repeat(257)}`,
+            },
+          }],
+        },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+    "Malformed request schema reference",
+  );
+
+  const manySchemas: GraphQueryRequest = {
+    ...request,
+    query: {
+      roots: Array.from({ length: 257 }, (_, index) => ({
+        id: `of:${index}`,
+        selector: {
+          path: [],
+          schema: { type: "string", description: `schema-${index}` },
+        },
+      })),
+    },
+  };
+  assertStrictEquals(
+    compressRequestSchemas(manySchemas, { isKnownSchemaHash: () => false }),
+    manySchemas,
+  );
+  const oversizedSchema: GraphQueryRequest = {
+    ...request,
+    query: {
+      roots: [{
+        id: "of:root",
+        selector: {
+          path: [],
+          schema: { description: "x".repeat(256 * 1024) },
+        },
+      }],
+    },
+  };
+  assertStrictEquals(
+    compressRequestSchemas(oversizedSchema, {
+      isKnownSchemaHash: () => false,
+    }),
+    oversizedSchema,
+  );
+});
+
+Deno.test("request schema CAS bounds preflight traversal", () => {
+  const casLink = {
+    "/": {
+      [LINK_V1_TAG]: {
+        id: "of:child",
+        path: [],
+        schema: `schema-cas@1:${hash}`,
+      },
+    },
+  };
+  let nested: unknown = { inline: true };
+  for (let depth = 0; depth < 65; depth += 1) {
+    nested = { nested };
+  }
+  const request = {
+    ...transactRequest(),
+    commit: {
+      ...transactRequest().commit,
+      operations: [{ op: "set", id: "of:root", value: nested }],
+    },
+  };
+  assertEquals(hasRequestSchemaCasPayload(request), false);
+  assertThrows(
+    () =>
+      hasRequestSchemaCasPayload({
+        ...request,
+        schemaDefinitions: {},
+      }),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+  assertThrows(
+    () =>
+      hasRequestSchemaCasPayload({
+        ...request,
+        commit: {
+          ...request.commit,
+          operations: [{
+            op: "set",
+            id: "of:root",
+            value: { casLink, nested },
+          }],
+        },
+      }),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+
+  const wide = Array.from({ length: 100_001 }, () => null);
+  const wideRequest = {
+    ...request,
+    commit: {
+      ...request.commit,
+      operations: [{ op: "set", id: "of:root", value: wide }],
+    },
+  };
+  assertEquals(hasRequestSchemaCasPayload(wideRequest), false);
+  assertThrows(
+    () =>
+      hasRequestSchemaCasPayload({
+        ...wideRequest,
+        schemaDefinitions: {},
+      }),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+  assertThrows(
+    () =>
+      hasRequestSchemaCasPayload({
+        ...request,
+        commit: {
+          ...request.commit,
+          operations: [{
+            op: "set",
+            id: "of:root",
+            value: { casLink, wide },
+          }],
+        },
+      }),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+
+  let deepLink: EntityDocument = {
+    "/": {
+      [LINK_V1_TAG]: { id: "of:child", path: [], schema },
+    },
+  };
+  for (let depth = 0; depth < 65; depth += 1) {
+    deepLink = { nested: deepLink };
+  }
+  const deepLinkRequest: TransactRequest = {
+    ...transactRequest(),
+    commit: {
+      ...transactRequest().commit,
+      operations: [{ op: "set", id: "of:root", value: deepLink }],
+    },
+  };
+  assertStrictEquals(
+    compressRequestSchemas(deepLinkRequest, {
+      isKnownSchemaHash: () => false,
+    }),
+    deepLinkRequest,
+  );
+});

--- a/packages/memory/test/v2-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-request-schema-cas-test.ts
@@ -1,5 +1,12 @@
-import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "@std/assert";
 import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { jsonFromValue } from "@commonfabric/data-model/codec-json";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
 import type {
@@ -482,6 +489,52 @@ Deno.test("request schema CAS bounds definition count, size, and reference lengt
   );
 });
 
+Deno.test("request schema CAS measures Fabric defaults by canonical encoded size", () => {
+  const oversizedSchema: JSONSchema = { type: "string" };
+  Object.defineProperty(oversizedSchema, "default", {
+    value: new FabricBytes(new Uint8Array(300_000)),
+    enumerable: true,
+  });
+  const canonical = internSchema(oversizedSchema, true);
+  const encodedSize = new TextEncoder().encode(
+    jsonFromValue(canonical.schema),
+  ).byteLength;
+  assert(encodedSize > 256 * 1024);
+
+  const inline: GraphQueryRequest = {
+    ...graphRequest(),
+    query: {
+      roots: [{
+        id: "of:oversized",
+        selector: { path: [], schema: oversizedSchema },
+      }],
+    },
+  };
+  assertStrictEquals(
+    compressRequestSchemas(inline, { isKnownSchemaHash: noKnownSchemas }),
+    inline,
+  );
+
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...inline,
+        query: {
+          roots: [{
+            id: "of:oversized",
+            selector: {
+              path: [],
+              schema: `schema-cas@1:${canonical.taggedHashString}`,
+            },
+          }],
+        },
+        schemaDefinitions: { [canonical.taggedHashString]: canonical.schema },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+    "too large",
+  );
+});
+
 Deno.test("request schema CAS bounds preflight traversal", () => {
   const casLink = {
     "/": {
@@ -503,7 +556,11 @@ Deno.test("request schema CAS bounds preflight traversal", () => {
       operations: [{ op: "set", id: "of:root", value: nested }],
     },
   };
-  assertEquals(hasRequestSchemaCasPayload(request), false);
+  assertThrows(
+    () => hasRequestSchemaCasPayload(request),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
   assertThrows(
     () =>
       hasRequestSchemaCasPayload({
@@ -538,12 +595,32 @@ Deno.test("request schema CAS bounds preflight traversal", () => {
       operations: [{ op: "set", id: "of:root", value: wide }],
     },
   };
-  assertEquals(hasRequestSchemaCasPayload(wideRequest), false);
+  assertThrows(
+    () => hasRequestSchemaCasPayload(wideRequest),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
   assertThrows(
     () =>
       hasRequestSchemaCasPayload({
         ...wideRequest,
         schemaDefinitions: {},
+      }),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+  assertThrows(
+    () =>
+      hasRequestSchemaCasPayload({
+        ...request,
+        commit: {
+          ...request.commit,
+          operations: [{
+            op: "set",
+            id: "of:root",
+            value: [...wide, casLink],
+          }],
+        },
       }),
     InvalidRequestSchemaDefinitionsError,
     "traversal limit",
@@ -585,5 +662,178 @@ Deno.test("request schema CAS bounds preflight traversal", () => {
       isKnownSchemaHash: () => false,
     }),
     deepLinkRequest,
+  );
+});
+
+Deno.test("request schema CAS shares traversal limits across transaction operations", () => {
+  const wide = Array.from({ length: 50_000 }, () => null);
+  const inline: TransactRequest = {
+    ...transactRequest(),
+    commit: {
+      ...transactRequest().commit,
+      operations: [
+        { op: "set", id: "of:first", value: { values: wide } },
+        { op: "set", id: "of:second", value: { values: wide } },
+      ],
+    },
+  };
+  assertThrows(
+    () => hasRequestSchemaCasPayload(inline),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+  assertThrows(
+    () => hasRequestSchemaCasPayload({ ...inline, schemaDefinitions: {} }),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+
+  const casLink = {
+    "/": {
+      [LINK_V1_TAG]: {
+        id: "of:child",
+        path: [],
+        schema: `schema-cas@1:${hash}`,
+      },
+    },
+  };
+  const withCas: TransactRequest = {
+    ...inline,
+    commit: {
+      ...inline.commit,
+      operations: [
+        {
+          op: "set" as const,
+          id: "of:first",
+          value: { values: [casLink, ...wide] },
+        },
+        { op: "set" as const, id: "of:second", value: { values: wide } },
+      ],
+    },
+  };
+  assertThrows(
+    () => hasRequestSchemaCasPayload(withCas),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+
+  const inlineLink = {
+    "/": { [LINK_V1_TAG]: { id: "of:child", path: [], schema } },
+  };
+  const compressible: TransactRequest = {
+    ...inline,
+    commit: {
+      ...inline.commit,
+      operations: [
+        {
+          op: "set" as const,
+          id: "of:first",
+          value: { values: [inlineLink, ...wide] },
+        },
+        { op: "set" as const, id: "of:second", value: { values: wide } },
+      ],
+    },
+  };
+  assertStrictEquals(
+    compressRequestSchemas(compressible, { isKnownSchemaHash: noKnownSchemas }),
+    compressible,
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas(
+        { ...withCas, schemaDefinitions: { [hash]: schema } },
+        () => undefined,
+      ),
+    InvalidRequestSchemaDefinitionsError,
+    "traversal limit",
+  );
+});
+
+Deno.test("request schema CAS memoizes repeated references per expansion", () => {
+  const request = compressRequestSchemas(transactRequest(), {
+    isKnownSchemaHash: () => true,
+  });
+  let lookups = 0;
+  assertEquals(
+    expandRequestSchemas(request, (candidate) => {
+      lookups += 1;
+      return candidate === hash ? schema : undefined;
+    }),
+    transactRequest(),
+  );
+  assertEquals(lookups, 1);
+
+  const defined = {
+    ...request,
+    schemaDefinitions: { [hash]: internSchema(schema, true).schema },
+  };
+  assertEquals(
+    expandRequestSchemas(defined, () => undefined),
+    transactRequest(),
+  );
+});
+
+Deno.test("request schema CAS bounds definition keys and cumulative bytes", () => {
+  let lookups = 0;
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...graphRequest(),
+        schemaDefinitions: { ["x".repeat(257)]: schema },
+      }, () => {
+        lookups += 1;
+        return undefined;
+      }),
+    InvalidRequestSchemaDefinitionsError,
+    "hash is too long",
+  );
+  assertEquals(lookups, 0);
+
+  const first: JSONSchema = { description: "first ".repeat(25_000) };
+  const second: JSONSchema = { description: "second ".repeat(25_000) };
+  const firstCanonical = internSchema(first, true);
+  const secondCanonical = internSchema(second, true);
+  const inline: GraphQueryRequest = {
+    ...graphRequest(),
+    query: {
+      roots: [
+        { id: "of:first", selector: { path: [], schema: first } },
+        { id: "of:second", selector: { path: [], schema: second } },
+      ],
+    },
+  };
+  assertStrictEquals(
+    compressRequestSchemas(inline, { isKnownSchemaHash: noKnownSchemas }),
+    inline,
+  );
+  assertThrows(
+    () =>
+      expandRequestSchemas({
+        ...inline,
+        query: {
+          roots: [
+            {
+              id: "of:first",
+              selector: {
+                path: [],
+                schema: `schema-cas@1:${firstCanonical.taggedHashString}`,
+              },
+            },
+            {
+              id: "of:second",
+              selector: {
+                path: [],
+                schema: `schema-cas@1:${secondCanonical.taggedHashString}`,
+              },
+            },
+          ],
+        },
+        schemaDefinitions: {
+          [firstCanonical.taggedHashString]: firstCanonical.schema,
+          [secondCanonical.taggedHashString]: secondCanonical.schema,
+        },
+      }, () => undefined),
+    InvalidRequestSchemaDefinitionsError,
+    "definitions are too large",
   );
 });

--- a/packages/memory/test/v2-schema-store-test.ts
+++ b/packages/memory/test/v2-schema-store-test.ts
@@ -1,6 +1,7 @@
 import {
   assert,
   assertEquals,
+  assertRejects,
   assertStrictEquals,
   assertThrows,
 } from "@std/assert";
@@ -195,6 +196,103 @@ Deno.test("schema store fails closed for malformed Fabric JSON", async () => {
   });
 });
 
+Deno.test("schema store rejects invalid quota limits", async () => {
+  const invalidLimits = [
+    ["maxSchemaBytes", -1],
+    ["maxEntries", Number.NaN],
+    ["maxTotalBytes", Number.POSITIVE_INFINITY],
+  ] as const;
+
+  for (const [limit, value] of invalidLimits) {
+    await assertRejects(
+      () => openSchemaStore({ url: new URL("memory:"), [limit]: value }),
+      Error,
+      `${limit} must be a non-negative safe integer`,
+    );
+  }
+});
+
+Deno.test("schema store fails closed for non-schema values and byte corruption", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url });
+    const stored = store.put({ type: "string" });
+    store.close();
+
+    const database = await new Database(url.pathname, { create: true });
+    try {
+      const nonSchema = "fvj1:42";
+      database.prepare(
+        "UPDATE schema_store_entries SET canonical_json = ?, byte_length = ? WHERE hash = ?",
+      ).run(
+        nonSchema,
+        new TextEncoder().encode(nonSchema).byteLength,
+        stored.hash,
+      );
+    } finally {
+      database.close();
+    }
+
+    const reopened = await openSchemaStore({ url });
+    try {
+      assertThrows(
+        () => reopened.get(stored.hash),
+        SchemaStoreCorruptionError,
+        "non-schema Fabric value",
+      );
+    } finally {
+      reopened.close();
+    }
+  });
+
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url });
+    const stored = store.put({ type: "string" });
+    store.close();
+
+    const database = await new Database(url.pathname, { create: true });
+    try {
+      database.prepare(
+        "UPDATE schema_store_entries SET byte_length = byte_length + 1 WHERE hash = ?",
+      ).run(stored.hash);
+    } finally {
+      database.close();
+    }
+
+    const reopened = await openSchemaStore({ url });
+    try {
+      assertThrows(
+        () => reopened.get(stored.hash),
+        SchemaStoreCorruptionError,
+        "byte length does not match stored JSON",
+      );
+    } finally {
+      reopened.close();
+    }
+  });
+});
+
+Deno.test("schema store rejects missing generation metadata", async () => {
+  await withStore(async (url) => {
+    const database = await new Database(url.pathname, { create: true });
+    try {
+      database.exec(
+        "CREATE TABLE schema_store_metadata (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL);",
+      );
+      database.prepare(
+        "INSERT INTO schema_store_metadata (key, value) VALUES (?, ?)",
+      ).run("generation", "");
+    } finally {
+      database.close();
+    }
+
+    await assertRejects(
+      () => openSchemaStore({ url }),
+      Error,
+      "schema store generation metadata is missing",
+    );
+  });
+});
+
 Deno.test("schema store quotas permit duplicates without consuming capacity", async () => {
   await withStore(async (url) => {
     const store = await openSchemaStore({ url, maxEntries: 1 });
@@ -260,6 +358,22 @@ Deno.test("schema store inserts schema batches atomically", async () => {
       );
       assertEquals(store.putAll([]), []);
       assertEquals(store.put({ type: "boolean" }).schema, { type: "boolean" });
+    } finally {
+      store.close();
+    }
+  });
+});
+
+Deno.test("schema store resolves duplicate schemas within one batch", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url, maxEntries: 1 });
+    try {
+      const [first, duplicate] = store.putAll([
+        { type: "string" },
+        { type: "string" },
+      ]);
+      assertStrictEquals(first, duplicate);
+      assertEquals(store.get(first.hash), first);
     } finally {
       store.close();
     }

--- a/packages/memory/test/v2-schema-store-test.ts
+++ b/packages/memory/test/v2-schema-store-test.ts
@@ -1,0 +1,190 @@
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "@std/assert";
+import { Database } from "@db/sqlite";
+import { toFileUrl } from "@std/path";
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  openSchemaStore,
+  SchemaStoreCorruptionError,
+  SchemaStoreQuotaError,
+} from "../v2/schema-store.ts";
+
+const withStore = async (
+  run: (url: URL) => Promise<void>,
+): Promise<void> => {
+  const directory = await Deno.makeTempDir({ prefix: "schema-store-" });
+  try {
+    await run(toFileUrl(`${directory}/schemas.sqlite`));
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+};
+
+Deno.test("schema store canonicalizes structurally equal schemas", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url });
+    try {
+      const first: JSONSchema = {
+        required: ["title"],
+        properties: { title: { type: "string" }, count: { type: "number" } },
+        type: "object",
+      };
+      const second: JSONSchema = {
+        type: "object",
+        properties: { count: { type: "number" }, title: { type: "string" } },
+        required: ["title"],
+      };
+
+      const stored = store.put(first);
+      const duplicate = store.put(second);
+
+      assertEquals(duplicate.hash, stored.hash);
+      assertStrictEquals(duplicate.schema, stored.schema);
+      assert(Object.isFrozen(stored.schema));
+      assertEquals(store.get(stored.hash), stored);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+Deno.test("schema store persists entries and generation across close and reopen", async () => {
+  await withStore(async (url) => {
+    const first = await openSchemaStore({ url });
+    const stored = first.put({ type: "string" });
+    const generation = first.generation;
+    first.close();
+
+    const reopened = await openSchemaStore({ url });
+    try {
+      assertEquals(reopened.generation, generation);
+      assertEquals(reopened.get(stored.hash), stored);
+      assertEquals(reopened.get("fid1:not-present"), undefined);
+      assertEquals(reopened.has(stored.hash), true);
+      assertEquals(reopened.has("fid1:not-present"), false);
+    } finally {
+      reopened.close();
+    }
+  });
+});
+
+Deno.test("schema store fails closed for hash and byte corruption", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url });
+    const stored = store.put({ type: "string" });
+    store.close();
+
+    const database = await new Database(url.pathname, { create: true });
+    try {
+      database.prepare(
+        "UPDATE schema_store_entries SET canonical_json = ?, byte_length = ? WHERE hash = ?",
+      ).run("true", 4, stored.hash);
+    } finally {
+      database.close();
+    }
+
+    const reopened = await openSchemaStore({ url });
+    try {
+      assertThrows(
+        () => reopened.get(stored.hash),
+        SchemaStoreCorruptionError,
+        "does not match its tagged content hash",
+      );
+      assertThrows(
+        () => reopened.has(stored.hash),
+        SchemaStoreCorruptionError,
+      );
+    } finally {
+      reopened.close();
+    }
+  });
+});
+
+Deno.test("schema store quotas permit duplicates without consuming capacity", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url, maxEntries: 1 });
+    try {
+      const stored = store.put({ type: "string" });
+      assertEquals(store.put({ type: "string" }), stored);
+      assertThrows(
+        () => store.put({ type: "number" }),
+        SchemaStoreQuotaError,
+        "maxEntries",
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url, maxSchemaBytes: 4 });
+    try {
+      assertThrows(
+        () => store.put({ type: "string" }),
+        SchemaStoreQuotaError,
+        "maxSchemaBytes",
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url, maxTotalBytes: 17 });
+    try {
+      store.put({ type: "string" });
+      assertThrows(
+        () => store.put({ type: "number" }),
+        SchemaStoreQuotaError,
+        "maxTotalBytes",
+      );
+    } finally {
+      store.close();
+    }
+  });
+});
+
+Deno.test("schema store inserts schema batches atomically", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url, maxEntries: 1 });
+    try {
+      assertThrows(
+        () => store.putAll([{ type: "string" }, { type: "number" }]),
+        SchemaStoreQuotaError,
+        "maxEntries",
+      );
+      assertEquals(store.putAll([]), []);
+      assertEquals(store.put({ type: "boolean" }).schema, { type: "boolean" });
+    } finally {
+      store.close();
+    }
+  });
+});
+
+Deno.test("schema stores are isolated by durable URL", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "schema-store-isolation-",
+  });
+  try {
+    const left = await openSchemaStore({
+      url: toFileUrl(`${directory}/left.sqlite`),
+    });
+    const right = await openSchemaStore({
+      url: toFileUrl(`${directory}/right.sqlite`),
+    });
+    try {
+      const stored = left.put({ type: "boolean" });
+      assertEquals(right.get(stored.hash), undefined);
+      assert(left.generation !== right.generation);
+    } finally {
+      left.close();
+      right.close();
+    }
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});

--- a/packages/memory/test/v2-schema-store-test.ts
+++ b/packages/memory/test/v2-schema-store-test.ts
@@ -7,6 +7,13 @@ import {
 import { Database } from "@db/sqlite";
 import { toFileUrl } from "@std/path";
 import type { JSONSchema } from "@commonfabric/api";
+import { jsonFromValue } from "@commonfabric/data-model/codec-json";
+import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+  FabricHash,
+} from "@commonfabric/data-model/fabric-primitives";
 import {
   openSchemaStore,
   SchemaStoreCorruptionError,
@@ -22,6 +29,20 @@ const withStore = async (
   } finally {
     await Deno.remove(directory, { recursive: true });
   }
+};
+
+const encodedByteLength = (schema: JSONSchema): number =>
+  new TextEncoder().encode(jsonFromValue(schema)).byteLength;
+
+const schemaWithRuntimeDefault = (
+  defaultValue: unknown,
+): JSONSchema => {
+  const schema: JSONSchema = { type: "object" };
+  Object.defineProperty(schema, "default", {
+    value: defaultValue,
+    enumerable: true,
+  });
+  return schema;
 };
 
 Deno.test("schema store canonicalizes structurally equal schemas", async () => {
@@ -72,6 +93,43 @@ Deno.test("schema store persists entries and generation across close and reopen"
   });
 });
 
+Deno.test("schema store preserves Fabric runtime defaults across close and reopen", async () => {
+  await withStore(async (url) => {
+    const epoch = new FabricEpochNsec(1_234_567_890n);
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+    const hash = new FabricHash(new Uint8Array([4, 5, 6]), "test");
+    const link = new FabricLink({ id: "of:runtime-default", path: [] });
+    const first = await openSchemaStore({ url });
+    const stored = [epoch, bytes, hash, link].map((defaultValue) =>
+      first.put(schemaWithRuntimeDefault(defaultValue))
+    );
+    first.close();
+
+    const reopened = await openSchemaStore({ url });
+    try {
+      const defaults = stored.map((entry) => {
+        const schema = reopened.get(entry.hash)?.schema;
+        return schema !== undefined
+          ? Object.getOwnPropertyDescriptor(schema, "default")?.value
+          : undefined;
+      });
+      const [restoredEpoch, restoredBytes, restoredHash, restoredLink] =
+        defaults;
+
+      assert(restoredEpoch instanceof FabricEpochNsec);
+      assertEquals(restoredEpoch.value, epoch.value);
+      assert(restoredBytes instanceof FabricBytes);
+      assertEquals(restoredBytes.slice(), bytes.slice());
+      assert(restoredHash instanceof FabricHash);
+      assertEquals(restoredHash.toString(), hash.toString());
+      assert(restoredLink instanceof FabricLink);
+      assertEquals(restoredLink.payload, link.payload);
+    } finally {
+      reopened.close();
+    }
+  });
+});
+
 Deno.test("schema store fails closed for hash and byte corruption", async () => {
   await withStore(async (url) => {
     const store = await openSchemaStore({ url });
@@ -82,7 +140,7 @@ Deno.test("schema store fails closed for hash and byte corruption", async () => 
     try {
       database.prepare(
         "UPDATE schema_store_entries SET canonical_json = ?, byte_length = ? WHERE hash = ?",
-      ).run("true", 4, stored.hash);
+      ).run("fvj1:true", 9, stored.hash);
     } finally {
       database.close();
     }
@@ -97,6 +155,39 @@ Deno.test("schema store fails closed for hash and byte corruption", async () => 
       assertThrows(
         () => reopened.has(stored.hash),
         SchemaStoreCorruptionError,
+      );
+    } finally {
+      reopened.close();
+    }
+  });
+});
+
+Deno.test("schema store fails closed for malformed Fabric JSON", async () => {
+  await withStore(async (url) => {
+    const store = await openSchemaStore({ url });
+    const stored = store.put({ type: "string" });
+    store.close();
+
+    const malformed = "fvj1:{";
+    const database = await new Database(url.pathname, { create: true });
+    try {
+      database.prepare(
+        "UPDATE schema_store_entries SET canonical_json = ?, byte_length = ? WHERE hash = ?",
+      ).run(
+        malformed,
+        new TextEncoder().encode(malformed).byteLength,
+        stored.hash,
+      );
+    } finally {
+      database.close();
+    }
+
+    const reopened = await openSchemaStore({ url });
+    try {
+      assertThrows(
+        () => reopened.get(stored.hash),
+        SchemaStoreCorruptionError,
+        "invalid Fabric JSON",
       );
     } finally {
       reopened.close();
@@ -121,10 +212,14 @@ Deno.test("schema store quotas permit duplicates without consuming capacity", as
   });
 
   await withStore(async (url) => {
-    const store = await openSchemaStore({ url, maxSchemaBytes: 4 });
+    const stringSchema: JSONSchema = { type: "string" };
+    const store = await openSchemaStore({
+      url,
+      maxSchemaBytes: encodedByteLength(stringSchema) - 1,
+    });
     try {
       assertThrows(
-        () => store.put({ type: "string" }),
+        () => store.put(stringSchema),
         SchemaStoreQuotaError,
         "maxSchemaBytes",
       );
@@ -134,11 +229,17 @@ Deno.test("schema store quotas permit duplicates without consuming capacity", as
   });
 
   await withStore(async (url) => {
-    const store = await openSchemaStore({ url, maxTotalBytes: 17 });
+    const stringSchema: JSONSchema = { type: "string" };
+    const numberSchema: JSONSchema = { type: "number" };
+    const store = await openSchemaStore({
+      url,
+      maxTotalBytes: encodedByteLength(stringSchema) +
+        encodedByteLength(numberSchema) - 1,
+    });
     try {
-      store.put({ type: "string" });
+      store.put(stringSchema);
       assertThrows(
-        () => store.put({ type: "number" }),
+        () => store.put(numberSchema),
         SchemaStoreQuotaError,
         "maxTotalBytes",
       );

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -765,6 +765,87 @@ Deno.test("acl enforce: a concurrent post-revocation write is rejected", async (
   }
 });
 
+Deno.test("acl enforce: an in-flight write cannot survive downgrade to READ", async () => {
+  const server = createAclServer("memory://acl-enforce-downgrade-race", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-downgrade-race";
+  const alice = await connect(server);
+  const bob = await connect(server);
+  const authorizationReady = Promise.withResolvers<void>();
+  const releaseAuthorization = Promise.withResolvers<void>();
+  const mutableServer = server as unknown as {
+    preflightRequestAuthorization: Server["preflightRequestAuthorization"];
+  };
+  const originalPreflight = mutableServer.preflightRequestAuthorization.bind(
+    server,
+  );
+  try {
+    await initializeSpaceAcl(server, space, {
+      [ALICE]: "OWNER",
+      [BOB]: "WRITE",
+    });
+    const aliceSession = await openSession(alice, space, ALICE);
+    const bobSession = await openSession(bob, space, BOB);
+    assertExists(aliceSession.ok);
+    assertExists(bobSession.ok);
+
+    mutableServer.preflightRequestAuthorization = async (...args) => {
+      const authorization = await originalPreflight(...args);
+      const [message] = args;
+      if (
+        message.type === "transact" &&
+        message.sessionId === bobSession.ok?.sessionId
+      ) {
+        authorizationReady.resolve();
+        await releaseAuthorization.promise;
+      }
+      return authorization;
+    };
+
+    const staleWrite = transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob-stale-write",
+      { shouldNotLand: true },
+      1,
+    );
+    await authorizationReady.promise;
+
+    const downgrade = await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [ALICE]: "OWNER", [BOB]: "READ" },
+      1,
+    );
+    assertExists(downgrade.ok);
+
+    releaseAuthorization.resolve();
+    const rejected = await staleWrite;
+    assertEquals(rejected.error?.name, "AuthorizationError");
+    assertEquals(
+      await server.readDocument(space, "of:doc:bob-stale-write"),
+      null,
+    );
+    assertExists(
+      (await graphQuery(
+        bob,
+        space,
+        bobSession.ok.sessionId,
+        `of:${space}`,
+      )).ok,
+      "downgraded session should retain READ access",
+    );
+  } finally {
+    releaseAuthorization.resolve();
+    mutableServer.preflightRequestAuthorization = originalPreflight;
+    await server.close();
+  }
+});
+
 Deno.test("acl enforce: a concurrent graph query is evaluated before revocation", async () => {
   const server = createAclServer("memory://acl-enforce-query-race", {
     mode: "enforce",

--- a/packages/memory/test/v2-server-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-server-request-schema-cas-test.ts
@@ -1,0 +1,511 @@
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type HelloOkMessage,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+} from "../v2.ts";
+import { compressRequestSchemas } from "../v2/request-schema-cas.ts";
+import { openSchemaStore, type SchemaStore } from "../v2/schema-store.ts";
+import { Server } from "../v2/server.ts";
+import {
+  MemoryWireAccountingAccumulator,
+  memoryWireUtf8Bytes,
+} from "../v2/wire-accounting.ts";
+
+const audience = "did:key:request-schema-cas-server";
+const space = "did:key:request-schema-cas-space";
+const schema: JSONSchema = {
+  type: "object",
+  description: "request schema CAS accounting ".repeat(32),
+  properties: { name: { type: "string" } },
+};
+const hash = internSchema(schema, true).taggedHashString;
+
+const shift = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  assertExists(message);
+  return message;
+};
+
+const response = <Result>(message: ServerMessage): ResponseMessage<Result> => {
+  assertEquals(message.type, "response");
+  return message as ResponseMessage<Result>;
+};
+
+const createServer = (
+  schemaStore?: SchemaStore,
+  wireAccountingObserver?: MemoryWireAccountingAccumulator,
+) =>
+  new Server({
+    store: new URL("memory://request-schema-cas-server"),
+    schemaStore,
+    wireAccountingObserver,
+    authorizeSessionOpen: () => "did:key:request-schema-cas-principal",
+    sessionOpenAuth: { audience },
+  });
+
+const open = async (server: Server) => {
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  await connection.receive(encodeMemoryBoundary({
+    type: "hello",
+    protocol: MEMORY_PROTOCOL,
+    flags: getMemoryProtocolFlags(),
+  }));
+  const hello = shift(messages) as HelloOkMessage;
+  assertEquals(hello.type, "hello.ok");
+  const sessionOpen = hello.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const opened = response<{ sessionId: string }>(shift(messages));
+  return { connection, messages, sessionId: opened.ok!.sessionId, hello };
+};
+
+const query = (sessionId: string) => ({
+  type: "graph.query" as const,
+  requestId: "query",
+  space,
+  sessionId,
+  query: {
+    roots: [{ id: "of:root", selector: { path: [], schema } }],
+  },
+});
+
+Deno.test("server advertises request CAS only with an injected store", async () => {
+  const withoutStore = createServer();
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const withStore = createServer(store);
+  try {
+    const without = await open(withoutStore);
+    assertEquals(without.hello.flags.requestSchemaCasV1, false);
+    assertEquals(without.hello.requestSchemaCas, undefined);
+
+    const withCas = await open(withStore);
+    assertEquals(withCas.hello.flags.requestSchemaCasV1, true);
+    assertEquals(withCas.hello.requestSchemaCas, {
+      generation: store.generation,
+      audience,
+    });
+  } finally {
+    await withoutStore.close();
+    await withStore.close();
+    store.close();
+  }
+});
+
+Deno.test("server expands authorized definitions, persists them, and accepts later refs", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store);
+  try {
+    const { connection, messages, sessionId } = await open(server);
+    const first = compressRequestSchemas(query(sessionId), {
+      isKnownSchemaHash: () => false,
+    });
+    await connection.receive(encodeMemoryBoundary(first));
+    assertEquals(response(shift(messages)).error, undefined);
+    assertEquals(store.get(hash)?.schema, internSchema(schema, true).schema);
+
+    const later = compressRequestSchemas({
+      ...query(sessionId),
+      requestId: "later",
+    }, {
+      isKnownSchemaHash: (candidate) => candidate === hash,
+    });
+    await connection.receive(encodeMemoryBoundary(later));
+    assertEquals(response(shift(messages)).error, undefined);
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("outbound sync compression records schema evidence in the shared store", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store);
+  try {
+    server.compressServerMessageSchemas({
+      type: "session/effect",
+      space,
+      sessionId: "session",
+      effect: {
+        type: "sync",
+        fromSeq: 0,
+        toSeq: 0,
+        upserts: [{
+          branch: "",
+          id: "of:root",
+          seq: 0,
+          doc: {
+            value: {
+              "/": { "link@1": { id: "of:child", path: [], schema } },
+            },
+          },
+        }],
+        removes: [],
+      },
+    });
+    assertEquals(store.get(hash)?.schema, internSchema(schema, true).schema);
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("outbound sync compression still succeeds when schema seeding is full", async () => {
+  const store = await openSchemaStore({
+    url: new URL("memory:"),
+    maxEntries: 0,
+  });
+  const server = createServer(store);
+  try {
+    const compressed = server.compressServerMessageSchemas({
+      type: "session/effect",
+      space,
+      sessionId: "session",
+      effect: {
+        type: "sync",
+        fromSeq: 0,
+        toSeq: 0,
+        upserts: [{
+          branch: "",
+          id: "of:root",
+          seq: 0,
+          doc: {
+            value: {
+              "/": { "link@1": { id: "of:child", path: [], schema } },
+            },
+          },
+        }],
+        removes: [],
+      },
+    });
+    assertEquals(compressed.type, "session/effect");
+    if (compressed.type !== "session/effect") {
+      throw new Error("expected session effect");
+    }
+    assertEquals(Object.hasOwn(compressed.effect, "schemaTable"), false);
+    assertEquals(store.has(hash), false);
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("server returns protocol errors for malformed request CAS envelopes", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store);
+  try {
+    const { connection, messages, sessionId } = await open(server);
+    const malformed = [
+      {
+        type: "graph.query",
+        requestId: "bad-query",
+        space,
+        sessionId,
+        query: { roots: [{}] },
+        schemaDefinitions: { [hash]: schema },
+      },
+      {
+        type: "session.watch.add",
+        requestId: "bad-watch",
+        space,
+        sessionId,
+        watches: [{}],
+        schemaDefinitions: { [hash]: schema },
+      },
+      {
+        type: "transact",
+        requestId: "bad-transact",
+        space,
+        sessionId,
+        commit: {},
+        schemaDefinitions: { [hash]: schema },
+      },
+    ];
+    for (const request of malformed) {
+      await connection.receive(encodeMemoryBoundary(request));
+      assertEquals(response(shift(messages)).error?.name, "ProtocolError");
+      assertEquals(store.has(hash), false);
+    }
+
+    let nested: unknown = {
+      "/": {
+        "link@1": {
+          id: "of:child",
+          path: [],
+          schema: `schema-cas@1:${hash}`,
+        },
+      },
+    };
+    for (let depth = 0; depth < 65; depth += 1) nested = { nested };
+    await connection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "too-deep",
+      space,
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: "of:root", value: nested }],
+      },
+    }));
+    assertEquals(response(shift(messages)).error?.name, "ProtocolError");
+    assertEquals(store.has(hash), false);
+
+    let inlineNested: unknown = { inline: true };
+    for (let depth = 0; depth < 65; depth += 1) {
+      inlineNested = { nested: inlineNested };
+    }
+    const inlineRequest = {
+      type: "transact",
+      requestId: "deep-inline",
+      space,
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: "of:inline", value: inlineNested }],
+      },
+    };
+    await connection.receive(encodeMemoryBoundary({
+      ...inlineRequest,
+      requestId: "deep-definitions",
+      schemaDefinitions: {},
+    }));
+    assertEquals(response(shift(messages)).error?.name, "ProtocolError");
+    await connection.receive(encodeMemoryBoundary(inlineRequest));
+    assertEquals(response(shift(messages)).error, undefined);
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("server normalizes CAS transact schemas before storage and replay", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store);
+  try {
+    const { connection, messages, sessionId } = await open(server);
+    const request = {
+      type: "transact" as const,
+      requestId: "tx",
+      space,
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set" as const,
+          id: "of:root",
+          value: {
+            value: {
+              "/": { "link@1": { id: "of:child", path: [], schema } },
+            },
+          },
+        }],
+      },
+    };
+    await connection.receive(
+      encodeMemoryBoundary(compressRequestSchemas(request, {
+        isKnownSchemaHash: () => false,
+      })),
+    );
+    assertEquals(response(shift(messages)).error, undefined);
+    assertEquals(
+      ((await server.readDocument(space, "of:root"))!.value as {
+        "/": { "link@1": { schema: JSONSchema } };
+      })["/"]["link@1"].schema,
+      internSchema(schema, true).schema,
+    );
+
+    await connection.receive(encodeMemoryBoundary(compressRequestSchemas({
+      ...request,
+      requestId: "replay",
+    }, { isKnownSchemaHash: (candidate) => candidate === hash })));
+    assertEquals(response(shift(messages)).error, undefined);
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("server rejects missing, mismatched, and unnegotiated request CAS safely", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store);
+  const withoutStore = createServer();
+  try {
+    const withCas = await open(server);
+    const missing = compressRequestSchemas(query(withCas.sessionId), {
+      isKnownSchemaHash: () => true,
+    });
+    await withCas.connection.receive(encodeMemoryBoundary(missing));
+    assertEquals(
+      response(shift(withCas.messages)).error?.name,
+      "MissingSchemas",
+    );
+    assertEquals(store.has(hash), false);
+
+    const mismatch = {
+      ...query(withCas.sessionId),
+      schemaDefinitions: { [hash]: false },
+    };
+    await withCas.connection.receive(encodeMemoryBoundary(mismatch));
+    assertEquals(
+      response(shift(withCas.messages)).error?.name,
+      "ProtocolError",
+    );
+
+    const legacy = await open(withoutStore);
+    await legacy.connection.receive(encodeMemoryBoundary(compressRequestSchemas(
+      query(legacy.sessionId),
+      { isKnownSchemaHash: () => false },
+    )));
+    assertEquals(response(shift(legacy.messages)).error?.name, "ProtocolError");
+  } finally {
+    await server.close();
+    await withoutStore.close();
+    store.close();
+  }
+});
+
+Deno.test("server persists request schemas across server restarts", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "server-request-schema-cas-",
+  });
+  const url = toFileUrl(`${directory}/schemas.sqlite`);
+  const firstStore = await openSchemaStore({ url });
+  const first = createServer(firstStore);
+  try {
+    const { connection, messages, sessionId } = await open(first);
+    await connection.receive(encodeMemoryBoundary(compressRequestSchemas(
+      query(sessionId),
+      { isKnownSchemaHash: () => false },
+    )));
+    shift(messages);
+  } finally {
+    await first.close();
+    firstStore.close();
+  }
+  const secondStore = await openSchemaStore({ url });
+  const second = createServer(secondStore);
+  try {
+    const { connection, messages, sessionId } = await open(second);
+    await connection.receive(encodeMemoryBoundary(compressRequestSchemas(
+      query(sessionId),
+      { isKnownSchemaHash: (candidate) => candidate === hash },
+    )));
+    assertEquals(response(shift(messages)).error, undefined);
+  } finally {
+    await second.close();
+    secondStore.close();
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("inbound request CAS accounting distinguishes cold, forced, and warm frames", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const accounting = new MemoryWireAccountingAccumulator();
+  const server = createServer(store, accounting);
+  try {
+    const { connection, messages, sessionId } = await open(server);
+    accounting.start();
+
+    const cold = compressRequestSchemas({
+      ...query(sessionId),
+      requestId: "cold",
+    }, { isKnownSchemaHash: () => true });
+    const forced = compressRequestSchemas({
+      ...query(sessionId),
+      requestId: "forced",
+    }, {
+      isKnownSchemaHash: () => true,
+      forceDefinitions: true,
+    });
+    const warm = compressRequestSchemas({
+      ...query(sessionId),
+      requestId: "warm",
+    }, {
+      isKnownSchemaHash: (candidate) => candidate === hash,
+    });
+    const inline = (requestId: string) => ({
+      ...query(sessionId),
+      requestId,
+      query: {
+        roots: [{
+          id: "of:root",
+          selector: {
+            path: [],
+            schema: internSchema(schema, true).schema,
+          },
+        }],
+      },
+    });
+
+    await connection.receive(encodeMemoryBoundary(cold));
+    assertEquals(response(shift(messages)).error?.name, "MissingSchemas");
+    await connection.receive(encodeMemoryBoundary(forced));
+    assertEquals(response(shift(messages)).error, undefined);
+    await connection.receive(encodeMemoryBoundary(warm));
+    assertEquals(response(shift(messages)).error, undefined);
+
+    const records = accounting.stop().records.filter((record) =>
+      record.direction === "inbound" &&
+      record.classification === "client.graph.query"
+    );
+    assertEquals(records.length, 3);
+    const [coldRecord, forcedRecord, warmRecord] = records;
+    const coldPayload = encodeMemoryBoundary(cold);
+    const forcedPayload = encodeMemoryBoundary(forced);
+    const warmPayload = encodeMemoryBoundary(warm);
+    const forcedInlinePayload = encodeMemoryBoundary(inline("forced"));
+    const warmInlinePayload = encodeMemoryBoundary(inline("warm"));
+
+    assertEquals(coldRecord.baselineBytes, memoryWireUtf8Bytes(coldPayload));
+    assertEquals(coldRecord.actualBytes, memoryWireUtf8Bytes(coldPayload));
+    assertEquals(forcedRecord.actualBytes, memoryWireUtf8Bytes(forcedPayload));
+    assertEquals(
+      forcedRecord.baselineBytes,
+      memoryWireUtf8Bytes(forcedInlinePayload),
+    );
+    assertEquals(warmRecord.actualBytes, memoryWireUtf8Bytes(warmPayload));
+    assertEquals(
+      warmRecord.baselineBytes,
+      memoryWireUtf8Bytes(warmInlinePayload),
+    );
+    assert(warmRecord.actualBytes < warmRecord.baselineBytes);
+
+    for (const record of [forcedRecord, warmRecord]) {
+      assertEquals(
+        Object.values(record.actualSemanticBytes ?? {}).reduce(
+          (total, bytes) => total + bytes,
+          0,
+        ),
+        record.actualBytes,
+      );
+      assertEquals(
+        Object.values(record.baselineSemanticBytes ?? {}).reduce(
+          (total, bytes) => total + bytes,
+          0,
+        ),
+        record.baselineBytes,
+      );
+    }
+  } finally {
+    await server.close();
+    store.close();
+  }
+});

--- a/packages/memory/test/v2-server-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-server-request-schema-cas-test.ts
@@ -364,7 +364,62 @@ Deno.test("server returns protocol errors for malformed request CAS envelopes", 
     }));
     assertEquals(response(shift(messages)).error?.name, "ProtocolError");
     await connection.receive(encodeMemoryBoundary(inlineRequest));
-    assertEquals(response(shift(messages)).error, undefined);
+    assertEquals(response(shift(messages)).error?.name, "ProtocolError");
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("server authorizes CAS sessions before traversing transaction payloads", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store);
+  try {
+    const owner = await open(server);
+    const other = await open(server);
+    let nested: unknown = {
+      "/": {
+        "link@1": {
+          id: "of:child",
+          path: [],
+          schema: `schema-cas@1:${hash}`,
+        },
+      },
+    };
+    for (let depth = 0; depth < 65; depth += 1) nested = { nested };
+
+    await other.connection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "foreign-deep-cas",
+      space,
+      sessionId: owner.sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: "of:root", value: nested }],
+      },
+    }));
+    const rejected = response(shift(other.messages));
+    assertEquals(rejected.error?.name, "SessionError");
+    assertEquals(
+      rejected.error?.message,
+      "Session is not open on this connection",
+    );
+    assertEquals(store.has(hash), false);
+
+    await owner.connection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "owned-deep-cas",
+      space,
+      sessionId: owner.sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: "of:root", value: nested }],
+      },
+    }));
+    assertEquals(response(shift(owner.messages)).error?.name, "ProtocolError");
+    assertEquals(store.has(hash), false);
   } finally {
     await server.close();
     store.close();

--- a/packages/memory/test/v2-server-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-server-request-schema-cas-test.ts
@@ -9,6 +9,8 @@ import {
   MEMORY_PROTOCOL,
   type ResponseMessage,
   type ServerMessage,
+  type WatchAddResult,
+  type WireMemoryProtocolFlags,
 } from "../v2.ts";
 import { compressRequestSchemas } from "../v2/request-schema-cas.ts";
 import { openSchemaStore, type SchemaStore } from "../v2/schema-store.ts";
@@ -50,13 +52,16 @@ const createServer = (
     sessionOpenAuth: { audience },
   });
 
-const open = async (server: Server) => {
+const open = async (
+  server: Server,
+  flags: WireMemoryProtocolFlags = getMemoryProtocolFlags(),
+) => {
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
   await connection.receive(encodeMemoryBoundary({
     type: "hello",
     protocol: MEMORY_PROTOCOL,
-    flags: getMemoryProtocolFlags(),
+    flags,
   }));
   const hello = shift(messages) as HelloOkMessage;
   assertEquals(hello.type, "hello.ok");
@@ -165,6 +170,61 @@ Deno.test("outbound sync compression records schema evidence in the shared store
   }
 });
 
+Deno.test("connections seed outbound schemas without sync compression", async () => {
+  const run = async (maxEntries?: number) => {
+    const store = await openSchemaStore({
+      url: new URL("memory:"),
+      ...(maxEntries === undefined ? {} : { maxEntries }),
+    });
+    const server = createServer(store);
+    try {
+      await server.writeDocument(space, "of:root", {
+        "/": { "link@1": { id: "of:child", path: [], schema } },
+      });
+      const flags = {
+        ...getMemoryProtocolFlags(),
+        syncSchemaTableV2: false,
+      };
+      const { connection, messages, sessionId } = await open(server, flags);
+
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch",
+        space,
+        sessionId,
+        watches: [{
+          id: "root",
+          kind: "graph",
+          query: {
+            roots: [{
+              id: "of:root",
+              selector: { path: [], schema: false },
+            }],
+          },
+        }],
+      }));
+      const watched = response<WatchAddResult>(shift(messages));
+      assertExists(watched.ok);
+      assertEquals(Object.hasOwn(watched.ok.sync, "schemaTable"), false);
+      assertEquals(store.has(hash), maxEntries === undefined);
+
+      if (maxEntries === undefined) {
+        const warm = compressRequestSchemas(query(sessionId), {
+          isKnownSchemaHash: (candidate) => candidate === hash,
+        });
+        await connection.receive(encodeMemoryBoundary(warm));
+        assertEquals(response(shift(messages)).error, undefined);
+      }
+    } finally {
+      await server.close();
+      store.close();
+    }
+  };
+
+  await run();
+  await run(0);
+});
+
 Deno.test("outbound sync compression still succeeds when schema seeding is full", async () => {
   const store = await openSchemaStore({
     url: new URL("memory:"),
@@ -233,6 +293,22 @@ Deno.test("server returns protocol errors for malformed request CAS envelopes", 
         space,
         sessionId,
         commit: {},
+        schemaDefinitions: { [hash]: schema },
+      },
+      {
+        type: "transact",
+        requestId: "null-operation",
+        space,
+        sessionId,
+        commit: { operations: [null] },
+        schemaDefinitions: { [hash]: schema },
+      },
+      {
+        type: "transact",
+        requestId: "primitive-operation",
+        space,
+        sessionId,
+        commit: { operations: ["invalid"] },
         schemaDefinitions: { [hash]: schema },
       },
     ];

--- a/packages/memory/test/v2-server-request-schema-cas-test.ts
+++ b/packages/memory/test/v2-server-request-schema-cas-test.ts
@@ -43,18 +43,25 @@ const response = <Result>(message: ServerMessage): ResponseMessage<Result> => {
 const createServer = (
   schemaStore?: SchemaStore,
   wireAccountingObserver?: MemoryWireAccountingAccumulator,
+  acl?: { mode: "observe" },
 ) =>
   new Server({
     store: new URL("memory://request-schema-cas-server"),
     schemaStore,
     wireAccountingObserver,
-    authorizeSessionOpen: () => "did:key:request-schema-cas-principal",
+    authorizeSessionOpen: (message) =>
+      typeof (message.invocation as { iss?: unknown }).iss === "string"
+        ? (message.invocation as { iss: string }).iss
+        : "did:key:request-schema-cas-principal",
     sessionOpenAuth: { audience },
+    ...(acl === undefined ? {} : { acl }),
   });
 
 const open = async (
   server: Server,
   flags: WireMemoryProtocolFlags = getMemoryProtocolFlags(),
+  requestSpace = space,
+  principal?: string,
 ) => {
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
@@ -69,21 +76,22 @@ const open = async (
   await connection.receive(encodeMemoryBoundary({
     type: "session.open",
     requestId: "open",
-    space,
+    space: requestSpace,
     session: {},
     invocation: {
       aud: sessionOpen.audience,
       challenge: sessionOpen.challenge.value,
+      ...(principal === undefined ? {} : { iss: principal }),
     },
   }));
   const opened = response<{ sessionId: string }>(shift(messages));
   return { connection, messages, sessionId: opened.ok!.sessionId, hello };
 };
 
-const query = (sessionId: string) => ({
+const query = (sessionId: string, requestSpace = space) => ({
   type: "graph.query" as const,
   requestId: "query",
-  space,
+  space: requestSpace,
   sessionId,
   query: {
     roots: [{ id: "of:root", selector: { path: [], schema } }],
@@ -132,6 +140,55 @@ Deno.test("server expands authorized definitions, persists them, and accepts lat
     });
     await connection.receive(encodeMemoryBoundary(later));
     assertEquals(response(shift(messages)).error, undefined);
+  } finally {
+    await server.close();
+    store.close();
+  }
+});
+
+Deno.test("server makes one observe-mode ACL decision for a CAS request", async () => {
+  const store = await openSchemaStore({ url: new URL("memory:") });
+  const server = createServer(store, undefined, { mode: "observe" });
+  const aclSpace = "did:key:request-schema-cas-owner";
+  try {
+    const owner = await open(
+      server,
+      getMemoryProtocolFlags(),
+      aclSpace,
+      aclSpace,
+    );
+    await owner.connection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "initialize-acl",
+      space: aclSpace,
+      sessionId: owner.sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: `of:${aclSpace}`,
+          value: { value: { [aclSpace]: "OWNER" } },
+        }],
+      },
+    }));
+    assertEquals(response(shift(owner.messages)).error, undefined);
+
+    const { connection, messages, sessionId } = await open(
+      server,
+      getMemoryProtocolFlags(),
+      aclSpace,
+      "did:key:request-schema-cas-stranger",
+    );
+    server.aclStats.wouldDeny = 0;
+
+    await connection.receive(encodeMemoryBoundary(compressRequestSchemas(
+      query(sessionId, aclSpace),
+      { isKnownSchemaHash: () => false },
+    )));
+
+    assertEquals(response(shift(messages)).error, undefined);
+    assertEquals(server.aclStats.wouldDeny, 1);
   } finally {
     await server.close();
     store.close();
@@ -364,7 +421,7 @@ Deno.test("server returns protocol errors for malformed request CAS envelopes", 
     }));
     assertEquals(response(shift(messages)).error?.name, "ProtocolError");
     await connection.receive(encodeMemoryBoundary(inlineRequest));
-    assertEquals(response(shift(messages)).error?.name, "ProtocolError");
+    assertEquals(response(shift(messages)).error, undefined);
   } finally {
     await server.close();
     store.close();

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -971,7 +971,12 @@ Deno.test("memory v2 server rejects handshakes when modernCellRep flags disagree
           JSON.stringify({
             modernCellRep: !HELLO_FLAGS.modernCellRep,
           })
-        } server=${JSON.stringify(HELLO_FLAGS)}`,
+        } server=${
+          JSON.stringify({
+            ...HELLO_FLAGS,
+            requestSchemaCasV1: false,
+          })
+        }`,
       },
     });
   } finally {

--- a/packages/memory/test/v2-storage-path-test.ts
+++ b/packages/memory/test/v2-storage-path-test.ts
@@ -1,5 +1,8 @@
 import { assertEquals, assertThrows } from "@std/assert";
-import { resolveSpaceStoreUrl } from "../v2/storage-path.ts";
+import {
+  resolveSchemaStoreUrl,
+  resolveSpaceStoreUrl,
+} from "../v2/storage-path.ts";
 
 Deno.test("resolveSpaceStoreUrl uses a dedicated engine subdirectory in directory mode", () => {
   const root = new URL("file:///tmp/cf-memory/");
@@ -22,6 +25,21 @@ Deno.test("resolveSpaceStoreUrl uses a sibling engine directory in single-file m
         encodeURIComponent(encodeURIComponent(subject))
       }.sqlite`,
     ).href,
+  );
+});
+
+Deno.test("resolveSchemaStoreUrl keeps the durable store outside per-space databases", () => {
+  assertEquals(
+    resolveSchemaStoreUrl(new URL("file:///tmp/cf-memory/")).href,
+    "file:///tmp/cf-memory/schema-store-v1.sqlite",
+  );
+  assertEquals(
+    resolveSchemaStoreUrl(new URL("file:///tmp/cf-memory/space.sqlite")).href,
+    "file:///tmp/cf-memory/space.schema-store-v1.sqlite",
+  );
+  assertEquals(
+    resolveSchemaStoreUrl(new URL("memory:")).href,
+    "memory:",
   );
 });
 

--- a/packages/memory/test/v2-storage-path-test.ts
+++ b/packages/memory/test/v2-storage-path-test.ts
@@ -31,11 +31,11 @@ Deno.test("resolveSpaceStoreUrl uses a sibling engine directory in single-file m
 Deno.test("resolveSchemaStoreUrl keeps the durable store outside per-space databases", () => {
   assertEquals(
     resolveSchemaStoreUrl(new URL("file:///tmp/cf-memory/")).href,
-    "file:///tmp/cf-memory/schema-store-v1.sqlite",
+    "file:///tmp/cf-memory/schema-store-v2.sqlite",
   );
   assertEquals(
     resolveSchemaStoreUrl(new URL("file:///tmp/cf-memory/space.sqlite")).href,
-    "file:///tmp/cf-memory/space.schema-store-v1.sqlite",
+    "file:///tmp/cf-memory/space.schema-store-v2.sqlite",
   );
   assertEquals(
     resolveSchemaStoreUrl(new URL("memory:")).href,

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -155,6 +155,50 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
   );
 });
 
+Deno.test("sync schema table reports each repeated schema once", () => {
+  const observed: JSONSchema[] = [];
+
+  compressSessionSyncSchemas(repeatedSchemaSync(2), (schema) => {
+    observed.push(schema);
+  });
+
+  assertEquals(observed, [internSchema(largeSchema(), true).schema]);
+});
+
+Deno.test("sync schema table preserves own __proto__ fields", () => {
+  const value = JSON.parse('{"__proto__":{"safe":true}}') as Record<
+    string,
+    unknown
+  >;
+  value.ref = linkRefFrom({
+    id: "of:target",
+    path: [],
+    schema: { type: "string" },
+  });
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:proto-source",
+      scope: "space",
+      seq: 1,
+      doc: { value },
+    }],
+    removes: [],
+  };
+
+  const compressed = compressSessionSyncSchemas(sync);
+  const compressedValue = compressed.upserts[0].doc?.value as Record<
+    string,
+    unknown
+  >;
+
+  assert(Object.hasOwn(compressedValue, "__proto__"));
+  assertEquals(compressedValue.__proto__, { safe: true });
+});
+
 Deno.test("sync schema table round-trips legacy aliases nested in arrays", () => {
   const schema: JSONSchema = {
     type: "object",

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -29,6 +29,7 @@ import {
   expandSessionSyncSchemas,
   type SchemaTableSessionSync,
 } from "../v2/sync-schema-table.ts";
+import { findSyncSchemaRef } from "../v2/sync-schema-ref.ts";
 import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 
 const textEncoder = new TextEncoder();
@@ -344,6 +345,20 @@ Deno.test("sync schema table continues through sibling fields after link payload
   assertEquals(compressedPayload.schema, `schema-ref@2:${primaryHash}`);
   assertEquals(compressedSiblingPayload.schema, `schema-ref@2:${siblingHash}`);
   assertEquals(expandSessionSyncSchemas(compressed), sync);
+});
+
+Deno.test("sync schema table ignores inherited fields while finding schema refs", () => {
+  const inherited = {
+    hidden: {
+      $alias: {
+        schema: "schema-ref@2:inherited",
+      },
+    },
+  };
+  const payload = Object.create(inherited) as Record<string, unknown>;
+  payload.visible = { value: "ordinary data" };
+
+  assertEquals(findSyncSchemaRef(payload), undefined);
 });
 
 Deno.test("sync schema table leaves syncs without compressible schemas unchanged", () => {

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -451,6 +451,63 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
   );
 });
 
+Deno.test("sync schema table rejects refs without a populated table", () => {
+  const compressed = compressSessionSyncSchemas(
+    repeatedSchemaSync(1),
+  ) as SchemaTableSessionSync;
+  const { schemaTable: _schemaTable, ...withoutTable } = compressed;
+
+  assertThrows(
+    () => expandSessionSyncSchemas(withoutTable),
+    Error,
+    "Invalid sync schema table reference",
+  );
+  assertThrows(
+    () => expandSessionSyncSchemas({ ...withoutTable, schemaTable: {} }),
+    Error,
+    "Invalid sync schema table reference",
+  );
+});
+
+Deno.test("sync schema table validates dangling refs without recursive traversal", () => {
+  const danglingRef = "schema-ref@2:sha256:missing";
+  let deeplyNested: unknown = {
+    $alias: {
+      id: "of:deep-target",
+      path: [],
+      schema: danglingRef,
+    },
+  };
+  for (let index = 0; index < 20_000; index += 1) {
+    deeplyNested = { next: deeplyNested };
+  }
+
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:deep-dangling-ref",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          harmless: danglingRef,
+          nested: deeplyNested,
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  assertThrows(
+    () => expandSessionSyncSchemas(sync),
+    Error,
+    "Invalid sync schema table reference",
+  );
+});
+
 Deno.test("server schema table helpers ignore non-sync messages", () => {
   const hello = {
     type: "hello.ok",

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -227,7 +227,14 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
     ).schema,
     undefined,
   );
-  assertEquals(expandSessionSyncSchemas(compressed), sync);
+  const expandedSchemas: JSONSchema[] = [];
+  assertEquals(
+    expandSessionSyncSchemas(compressed, (expanded) => {
+      expandedSchemas.push(expanded);
+    }),
+    sync,
+  );
+  assertEquals(expandedSchemas, [internSchema(schema, true).schema]);
 });
 
 Deno.test("sync schema table continues through sibling fields after link payloads", () => {

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -18,9 +18,11 @@ import {
   parseMemoryProtocolFlags,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  resetRequestSchemaCasConfig,
   resetSyncSchemaTableConfig,
   setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
+  setRequestSchemaCasConfig,
   setSyncSchemaTableConfig,
   toDocumentPath,
   toDocumentSelector,
@@ -130,10 +132,12 @@ describe("memory v2 flags", () => {
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
     resetSyncSchemaTableConfig();
+    resetRequestSchemaCasConfig();
     setModernCellRepConfig(false);
     setPersistentSchedulerStateConfig(false);
     setCommitPreconditionsConfig(false);
     setSyncSchemaTableConfig(false);
+    setRequestSchemaCasConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: false,
@@ -143,12 +147,14 @@ describe("memory v2 flags", () => {
       // Build-inherent capability, not configuration: always advertised.
       sqliteCommitRowLabelEval: true,
       syncSchemaTableV2: false,
+      requestSchemaCasV1: false,
     });
 
     setModernCellRepConfig(true);
     setPersistentSchedulerStateConfig(true);
     setCommitPreconditionsConfig(true);
     setSyncSchemaTableConfig(true);
+    setRequestSchemaCasConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
@@ -157,12 +163,14 @@ describe("memory v2 flags", () => {
       syncSchemaTable: false,
       sqliteCommitRowLabelEval: true,
       syncSchemaTableV2: true,
+      requestSchemaCasV1: true,
     });
 
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
     resetSyncSchemaTableConfig();
+    resetRequestSchemaCasConfig();
   });
 
   it("treats non-wire-shape flags as optional capabilities", () => {
@@ -199,6 +207,7 @@ describe("parseMemoryProtocolFlags", () => {
       syncSchemaTable: false,
       syncSchemaTableV2: false,
       sqliteCommitRowLabelEval: false,
+      requestSchemaCasV1: false,
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
@@ -207,6 +216,7 @@ describe("parseMemoryProtocolFlags", () => {
       syncSchemaTable: false,
       syncSchemaTableV2: false,
       sqliteCommitRowLabelEval: false,
+      requestSchemaCasV1: false,
     });
   });
 
@@ -222,6 +232,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
+        requestSchemaCasV1: false,
       },
     );
   });
@@ -238,6 +249,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
+        requestSchemaCasV1: false,
       },
     );
   });
@@ -254,6 +266,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: true,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
+        requestSchemaCasV1: false,
       },
     );
   });
@@ -270,6 +283,22 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: true,
         sqliteCommitRowLabelEval: false,
+        requestSchemaCasV1: false,
+      },
+    );
+  });
+
+  it("accepts the durable requestSchemaCasV1 key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({ requestSchemaCasV1: true }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: false,
+        syncSchemaTable: false,
+        syncSchemaTableV2: false,
+        sqliteCommitRowLabelEval: false,
+        requestSchemaCasV1: true,
       },
     );
   });
@@ -286,6 +315,7 @@ describe("parseMemoryProtocolFlags", () => {
         syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: true,
+        requestSchemaCasV1: false,
       },
     );
   });

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -329,6 +329,10 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTable: "true" }), null);
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTableV2: "true" }), null);
     assertEquals(
+      parseMemoryProtocolFlags({ requestSchemaCasV1: "true" }),
+      null,
+    );
+    assertEquals(
       parseMemoryProtocolFlags({ sqliteCommitRowLabelEval: "true" }),
       null,
     );

--- a/packages/memory/test/v2-wire-accounting-test.ts
+++ b/packages/memory/test/v2-wire-accounting-test.ts
@@ -16,6 +16,7 @@ import {
 } from "../v2.ts";
 import { Server } from "../v2/server.ts";
 import {
+  accountMemoryWirePayload,
   MemoryWireAccountingAccumulator,
   type MemoryWireAccountingObserver,
   type MemoryWireAccountingRecord,
@@ -236,6 +237,408 @@ Deno.test("memory wire accounting records inbound payload bytes exactly", async 
   }
 });
 
+Deno.test("memory wire payload accounting conserves bytes and salts candidates per run", () => {
+  const payload = encodeMemoryBoundary({
+    type: "response",
+    requestId: "not-an-identity-candidate",
+    space: "space-identity",
+    sessionId: "session-identity",
+    ok: {
+      invocation: {
+        iss: "issuer",
+        aud: "audience",
+        sub: "subject",
+        iat: 1,
+        exp: 2,
+      },
+      sync: {
+        type: "sync",
+        schemaTable: { "schema-ref@2:hash": { type: "object" } },
+        fromSeq: 1,
+        toSeq: 2,
+        upserts: [{
+          id: "entity",
+          branch: "main",
+          scope: "space",
+          seq: 2,
+          doc: {
+            value: {
+              id: "user-data",
+              seq: 7,
+              schema: { userOwned: true },
+              message: "user-owned",
+              link: { "/": { "link@1": { schema: "schema-ref@2:link" } } },
+              inlineLink: {
+                "/": { "link@1": { schema: { type: "string" } } },
+              },
+            },
+            schema: { type: "object" },
+          },
+        }],
+      },
+    },
+  });
+  const first = accountMemoryWirePayload(payload, "run-one");
+  const repeated = accountMemoryWirePayload(payload, "run-one");
+  const secondRun = accountMemoryWirePayload(payload, "run-two");
+
+  assertEquals(
+    Object.values(first.semanticBytes).reduce((sum, bytes) => sum + bytes, 0),
+    memoryWireUtf8Bytes(payload),
+  );
+  assert(first.semanticBytes.schema > 0);
+  assert(first.semanticBytes.documentValue > 0);
+  assert(first.semanticBytes.identity > 0);
+  assert(first.semanticBytes.sequence > 0);
+  assert(first.semanticBytes.sessionControl > 0);
+  assert(first.semanticBytes.authCapability > 0);
+  assert(first.candidates.length > 0);
+  assertEquals(
+    first.candidates.filter((candidate) =>
+      candidate.scope === "identityInternable"
+    ).length,
+    5,
+  );
+  assertEquals(first.candidates, repeated.candidates);
+  assert(
+    first.candidates.some((candidate, index) =>
+      candidate.fingerprint !== secondRun.candidates[index]?.fingerprint
+    ),
+  );
+  assertEquals(
+    JSON.stringify(first.candidates).includes("user-data"),
+    false,
+  );
+  assertEquals(
+    first.candidates.some((candidate) =>
+      candidate.scope === "identityInternable" &&
+      candidate.fingerprint.includes("not-an-identity-candidate")
+    ),
+    false,
+  );
+  assertEquals(
+    first.candidates.filter((candidate) =>
+      candidate.category === "schema" &&
+      candidate.scope === "alreadyContentAddressed"
+    ).length,
+    2,
+  );
+  assert(
+    first.candidates.some((candidate) =>
+      candidate.category === "schema" &&
+      candidate.scope === "immutableInternable"
+    ),
+  );
+  assertEquals(
+    first.candidates
+      .filter((candidate) =>
+        candidate.category === "schema" &&
+        candidate.scope === "alreadyContentAddressed"
+      )
+      .map((candidate) => candidate.encodedBytes)
+      .sort((left, right) => left - right),
+    [
+      memoryWireUtf8Bytes(JSON.stringify({ type: "object" })),
+      memoryWireUtf8Bytes(JSON.stringify("schema-ref@2:link")),
+    ].sort((left, right) => left - right),
+  );
+  assert(
+    first.candidates.reduce(
+      (sum, candidate) => sum + candidate.encodedBytes,
+      0,
+    ) <=
+      memoryWireUtf8Bytes(payload),
+  );
+});
+
+Deno.test("memory wire accounting classifies request CAS definitions and refs as content-addressed schemas", () => {
+  const payload = encodeMemoryBoundary({
+    type: "graph.query",
+    requestId: "query",
+    space: "did:key:space",
+    sessionId: "session",
+    query: {
+      roots: [{
+        id: "of:root",
+        selector: { path: [], schema: "schema-cas@1:sha256:test" },
+      }],
+    },
+    schemaDefinitions: {
+      "sha256:test": { type: "string" },
+    },
+  });
+  const accounting = accountMemoryWirePayload(payload, "run");
+  const schemaCandidates = accounting.candidates.filter((candidate) =>
+    candidate.category === "schema"
+  );
+
+  assert(accounting.semanticBytes.schema > 0);
+  assertEquals(schemaCandidates.length, 2);
+  assert(
+    schemaCandidates.every((candidate) =>
+      candidate.scope === "alreadyContentAddressed"
+    ),
+  );
+});
+
+Deno.test("memory wire accounting treats noncanonical payloads as opaque and partitions fingerprints", () => {
+  const canonical = encodeMemoryBoundary({
+    type: "response",
+    ok: {
+      sync: {
+        type: "sync",
+        upserts: [{ id: "entity", doc: { value: { title: "x" } } }],
+      },
+    },
+  });
+  const noncanonical = canonical.replace('{"type"', '{ "type"');
+  const opaque = accountMemoryWirePayload(noncanonical, "run", "connection-a");
+  const first = accountMemoryWirePayload(canonical, "run", "connection-a");
+  const second = accountMemoryWirePayload(canonical, "run", "connection-a");
+  const otherConnection = accountMemoryWirePayload(
+    canonical,
+    "run",
+    "connection-b",
+  );
+
+  assertEquals(
+    opaque.semanticBytes.encoding,
+    memoryWireUtf8Bytes(noncanonical),
+  );
+  assertEquals(opaque.candidates, []);
+  assertEquals(first.candidates, second.candidates);
+  assert(
+    first.candidates.some((candidate, index) =>
+      candidate.fingerprint !== otherConnection.candidates[index]?.fingerprint
+    ),
+  );
+});
+
+Deno.test("memory wire accounting bounds opaque work and consumes retained state", () => {
+  const payload = encodeMemoryBoundary({
+    type: "response",
+    ok: {
+      sync: {
+        type: "sync",
+        upserts: [{
+          id: "entity",
+          doc: { value: { value: { value: "x" } } },
+        }],
+      },
+    },
+  });
+  for (
+    const limits of [
+      { maxPayloadBytes: 1 },
+      { maxDepth: 1 },
+      { maxNodes: 1 },
+      { maxCandidates: 0 },
+    ]
+  ) {
+    const accounting = accountMemoryWirePayload(payload, "run", "connection", {
+      maxPayloadBytes: 1_000_000,
+      maxDepth: 64,
+      maxNodes: 100_000,
+      maxCandidates: 10_000,
+      ...limits,
+    });
+    assertEquals(
+      accounting.semanticBytes.encoding,
+      memoryWireUtf8Bytes(payload),
+    );
+    assertEquals(accounting.candidates, []);
+  }
+
+  const accumulator = new MemoryWireAccountingAccumulator({ maxRecords: 1 });
+  accumulator.start();
+  accumulator.observe({
+    direction: "inbound",
+    connectionId: "a",
+    classification: "client.hello",
+    baselineBytes: 1,
+    actualBytes: 1,
+    metadata: { nested: { value: 1 } },
+  });
+  const detached = accumulator.snapshot();
+  detached.records[0].metadata = { changed: true };
+  accumulator.observe({
+    direction: "inbound",
+    connectionId: "a",
+    classification: "client.hello",
+    baselineBytes: 1,
+    actualBytes: 1,
+  });
+  assertEquals(accumulator.isActive(), false);
+  assertExists(accumulator.snapshot().truncated);
+  assertEquals(
+    (accumulator.snapshot().records[0].metadata as {
+      nested: { value: number };
+    }).nested.value,
+    1,
+  );
+  const stopped = accumulator.stop();
+  assertExists(stopped.truncated);
+  assertEquals(accumulator.snapshot().records, []);
+});
+
+Deno.test("memory wire accounting ignores user keys that resemble candidate roots", () => {
+  const payload = encodeMemoryBoundary({
+    type: "response",
+    ok: {
+      sync: {
+        type: "sync",
+        upserts: [{
+          id: "entity",
+          doc: {
+            value: {
+              value: { nested: true },
+              patches: [{ op: "replace" }],
+              tables: [{ name: "user" }],
+              columns: ["user"],
+              codeCID: "user-owned",
+            },
+          },
+        }],
+      },
+    },
+  });
+  const accounting = accountMemoryWirePayload(payload, "adversarial");
+
+  assertEquals(accounting.candidates.length, 2);
+  assertEquals(
+    accounting.candidates.filter((candidate) =>
+      candidate.category === "documentValue"
+    ).length,
+    1,
+  );
+  assertEquals(
+    accounting.candidates.filter((candidate) =>
+      candidate.scope === "identityInternable"
+    ).length,
+    1,
+  );
+  assertEquals(
+    accounting.candidates.reduce(
+      (sum, candidate) => sum + candidate.encodedBytes,
+      0,
+    ) <= accounting.semanticBytes.documentValue,
+    true,
+  );
+});
+
+Deno.test("memory wire accounting candidates ignore nested protocol lookalikes", () => {
+  const payload = encodeMemoryBoundary({
+    type: "response",
+    ok: {
+      sync: {
+        type: "sync",
+        upserts: [{
+          id: "entity",
+          doc: {
+            value: {
+              doc: { value: { nested: true } },
+              commit: {
+                codeCID: "not-a-protocol-code-cid",
+                operations: [{
+                  value: { nested: true },
+                  patches: [{ op: "replace", path: [], value: true }],
+                }],
+              },
+              revisions: [{
+                patches: [{ op: "replace", path: [], value: true }],
+              }],
+              link: { "link@1": { schema: { fake: true } } },
+              $alias: { nested: { schema: { fake: true } } },
+              query: {
+                roots: [{ selector: { schema: { fake: true } } }],
+              },
+              sync: {
+                schemaTable: { fake: { type: "object" } },
+              },
+            },
+          },
+        }],
+      },
+    },
+  });
+  const accounting = accountMemoryWirePayload(payload, "lookalikes");
+
+  assertEquals(
+    accounting.candidates.filter((candidate) =>
+      candidate.category === "documentValue"
+    ).length,
+    1,
+  );
+  assertEquals(
+    accounting.candidates.some((candidate) =>
+      candidate.scope === "alreadyContentAddressed"
+    ),
+    false,
+  );
+  assertEquals(
+    accounting.candidates.some((candidate) => candidate.category === "schema"),
+    false,
+  );
+  assert(
+    accounting.candidates.reduce(
+      (sum, candidate) => sum + candidate.encodedBytes,
+      0,
+    ) <= memoryWireUtf8Bytes(payload),
+  );
+});
+
+Deno.test("memory wire accounting patch candidates use exact subtree bytes", () => {
+  const patches = [{
+    op: "replace",
+    path: "/choice",
+    value: { nested: true },
+  }];
+  const payload = encodeMemoryBoundary({
+    type: "transact",
+    requestId: "patch-size",
+    space: "did:key:z6Mk-patch-size",
+    sessionId: "session",
+    commit: { operations: [{ id: "entity", patches }] },
+  });
+  const accounting = accountMemoryWirePayload(payload, "patch-size");
+  const patchCandidate = accounting.candidates.find((candidate) =>
+    candidate.category === "patchOperation"
+  );
+
+  assertExists(patchCandidate);
+  assertEquals(
+    patchCandidate.encodedBytes,
+    memoryWireUtf8Bytes(JSON.stringify(patches)),
+  );
+  assert(
+    accounting.candidates.reduce(
+      (sum, candidate) => sum + candidate.encodedBytes,
+      0,
+    ) <= memoryWireUtf8Bytes(payload),
+  );
+});
+
+Deno.test("memory wire accounting keeps handshake flags and challenges in control categories", () => {
+  const payload = encodeMemoryBoundary({
+    type: "hello.ok",
+    protocol: "memory",
+    flags: {
+      commitPreconditions: true,
+      sqliteCommitRowLabelEval: true,
+    },
+    sessionOpen: {
+      audience: "did:key:z6Mk-server",
+      challenge: { value: "nonce", expiresAt: 123 },
+    },
+  });
+  const accounting = accountMemoryWirePayload(payload, "handshake-run");
+
+  assert(accounting.semanticBytes.sessionControl > 0);
+  assert(accounting.semanticBytes.authCapability > 0);
+  assertEquals(accounting.semanticBytes.patchOperation, 0);
+  assertEquals(accounting.semanticBytes.sqliteScheduler, 0);
+});
+
 Deno.test("memory wire accounting reports negotiated server sync schema savings", async () => {
   const accounting = new MemoryWireAccountingAccumulator();
   accounting.start();
@@ -259,6 +662,20 @@ Deno.test("memory wire accounting reports negotiated server sync schema savings"
     );
     assertExists(watched);
     assert(watched.actualBytes < watched.baselineBytes);
+    assertEquals(
+      Object.values(watched.actualSemanticBytes ?? {}).reduce(
+        (sum, bytes) => sum + bytes,
+        0,
+      ),
+      watched.actualBytes,
+    );
+    assertEquals(
+      Object.values(watched.baselineSemanticBytes ?? {}).reduce(
+        (sum, bytes) => sum + bytes,
+        0,
+      ),
+      watched.baselineBytes,
+    );
   } finally {
     await server.close();
   }
@@ -383,7 +800,7 @@ Deno.test("memory wire accounting accumulator supports reset start stop snapshot
   assertEquals(accounting.stop().totals.frames, 1);
 
   accounting.observe(record);
-  assertEquals(accounting.snapshot().totals.frames, 1);
+  assertEquals(accounting.snapshot().totals.frames, 0);
 });
 
 Deno.test("memory wire accounting accumulator starts request bookkeeping only when active", async () => {
@@ -450,7 +867,7 @@ Deno.test("memory wire accounting accumulator stops connection records immediate
     }));
     assertResponse<unknown>(shiftMessage(messages));
 
-    assertEquals(accounting.snapshot().totals.frames, 2);
+    assertEquals(accounting.snapshot().totals.frames, 0);
   } finally {
     await server.close();
   }
@@ -545,6 +962,35 @@ Deno.test("memory wire accounting observer exceptions are non-fatal", async () =
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
     assertEquals(shiftMessage(messages).type, "hello.ok");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting payload callback exceptions are non-fatal", async () => {
+  const records: MemoryWireAccountingRecord[] = [];
+  const observer: MemoryWireAccountingObserver = {
+    accountPayload() {
+      throw new Error("payload accounting failed");
+    },
+    observe(record) {
+      records.push(record);
+    },
+  };
+  const server = createServer(
+    "memory://wire-accounting-payload-error",
+    observer,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    assertEquals(shiftMessage(messages).type, "hello.ok");
+    assertEquals(records.length, 2);
+    assertEquals(
+      records.every((record) => record.actualSemanticBytes === undefined),
+      true,
+    );
   } finally {
     await server.close();
   }

--- a/packages/memory/test/v2-wire-accounting-test.ts
+++ b/packages/memory/test/v2-wire-accounting-test.ts
@@ -549,3 +549,29 @@ Deno.test("memory wire accounting observer exceptions are non-fatal", async () =
     await server.close();
   }
 });
+
+Deno.test("memory wire accounting activity exceptions are non-fatal", async () => {
+  let observed = false;
+  const observer: MemoryWireAccountingObserver = {
+    isActive() {
+      throw new Error("activity check failed");
+    },
+    observe() {
+      observed = true;
+    },
+  };
+  const server = createServer(
+    "memory://wire-accounting-activity-error",
+    observer,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    assertEquals(shiftMessage(messages).type, "hello.ok");
+    assertEquals(observed, false);
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/memory/test/v2-wire-accounting-test.ts
+++ b/packages/memory/test/v2-wire-accounting-test.ts
@@ -1,0 +1,551 @@
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type HelloMessage,
+  type HelloOkMessage,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
+  type SessionOpenResult,
+  type SessionSync,
+  type WatchAddResult,
+} from "../v2.ts";
+import { Server } from "../v2/server.ts";
+import {
+  MemoryWireAccountingAccumulator,
+  type MemoryWireAccountingObserver,
+  type MemoryWireAccountingRecord,
+  memoryWireUtf8Bytes,
+} from "../v2/wire-accounting.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
+
+const HELLO: HelloMessage = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+};
+
+const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  assertExists(message, "expected a server message");
+  return message;
+};
+
+const expectHelloOk = (messages: ServerMessage[]): SessionOpenAuthMetadata => {
+  const message = shiftMessage(messages);
+  assertEquals(message.type, "hello.ok");
+  const hello = message as HelloOkMessage;
+  assertExists(hello.sessionOpen);
+  return hello.sessionOpen;
+};
+
+const assertResponse = <Result>(
+  message: ServerMessage,
+): ResponseMessage<Result> => {
+  assertEquals(message.type, "response");
+  return message as ResponseMessage<Result>;
+};
+
+const authInvocation = (sessionOpen: SessionOpenAuthMetadata) => ({
+  aud: sessionOpen.audience,
+  challenge: sessionOpen.challenge.value,
+});
+
+const flushReceiveStart = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const largeSchema = (): JSONSchema => ({
+  type: "object",
+  $defs: Object.fromEntries(
+    Array.from({ length: 32 }, (_, index) => [
+      `Definition${index}`,
+      {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" },
+          count: { type: "number" },
+        },
+        required: ["id", "title"],
+      },
+    ]),
+  ),
+  properties: Object.fromEntries(
+    Array.from({ length: 16 }, (_, index) => [
+      `field${index}`,
+      { $ref: `#/$defs/Definition${index % 32}` },
+    ]),
+  ),
+});
+
+const schemaSync = (): SessionSync => {
+  const schema = largeSchema();
+  return {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:wire-accounting-doc",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          title: "Wire accounting document",
+          primary: linkRefFrom({
+            id: "of:wire-accounting-target",
+            path: [],
+            schema,
+          }),
+          secondary: linkRefFrom({
+            id: "of:wire-accounting-secondary",
+            path: ["value"],
+            schema,
+          }),
+        },
+      },
+    }],
+    removes: [],
+  };
+};
+
+const createServer = (
+  store: string,
+  observer?: MemoryWireAccountingObserver,
+): Server =>
+  new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL(store),
+    wireAccountingObserver: observer,
+  });
+
+const openSession = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+  hello: HelloMessage = HELLO,
+): Promise<string> => {
+  await connection.receive(encodeMemoryBoundary(hello));
+  const sessionOpen = expectHelloOk(messages);
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: authInvocation(sessionOpen),
+  }));
+  const opened = assertResponse<SessionOpenResult>(shiftMessage(messages));
+  assertExists(opened.ok);
+  return opened.ok.sessionId;
+};
+
+const writeSchemaDocument = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+  sessionId: string,
+): Promise<void> => {
+  const upsert = schemaSync().upserts[0];
+  await connection.receive(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "write",
+    space,
+    sessionId,
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: upsert.id,
+        value: upsert.doc,
+      }],
+    },
+  }));
+  assertResponse<unknown>(shiftMessage(messages));
+};
+
+const watchSchemaDocument = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+  sessionId: string,
+): Promise<void> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.watch.add",
+    requestId: "watch",
+    space,
+    sessionId,
+    watches: [{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:wire-accounting-doc",
+          selector: { path: [], schema: false },
+        }],
+      },
+    }],
+  }));
+  const watched = assertResponse<WatchAddResult>(shiftMessage(messages));
+  assertExists(watched.ok?.sync);
+};
+
+Deno.test("memory wire accounting is optional for existing server connections", async () => {
+  const server = createServer("memory://wire-accounting-no-observer");
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message), {
+    kind: "browser",
+  });
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    assertEquals(shiftMessage(messages).type, "hello.ok");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting records inbound payload bytes exactly", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  accounting.start();
+  const server = createServer("memory://wire-accounting-inbound", accounting);
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message), {
+    kind: "browser",
+  });
+  const invalidPayload = '{"type":"broken-π"';
+
+  try {
+    await connection.receive(invalidPayload);
+    assertEquals(shiftMessage(messages).type, "response");
+    const inbound = accounting.snapshot().records.find((record) =>
+      record.direction === "inbound" &&
+      record.classification === "client.invalid"
+    );
+    assertExists(inbound);
+    assertEquals(inbound.baselineBytes, memoryWireUtf8Bytes(invalidPayload));
+    assertEquals(inbound.actualBytes, inbound.baselineBytes);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting reports negotiated server sync schema savings", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  accounting.start();
+  const server = createServer(
+    "memory://wire-accounting-negotiated",
+    accounting,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message), {
+    kind: "browser",
+  });
+  const space = "did:key:z6Mk-wire-accounting-negotiated";
+
+  try {
+    const sessionId = await openSession(connection, messages, space);
+    await writeSchemaDocument(connection, messages, space, sessionId);
+    await watchSchemaDocument(connection, messages, space, sessionId);
+
+    const watched = accounting.snapshot().records.find((record) =>
+      record.classification === "server.response.session.watch.add.sync"
+    );
+    assertExists(watched);
+    assert(watched.actualBytes < watched.baselineBytes);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting reports unnegotiated server sync equality", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  accounting.start();
+  const server = createServer(
+    "memory://wire-accounting-unnegotiated",
+    accounting,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message), {
+    kind: "browser",
+  });
+  const flags = getMemoryProtocolFlags();
+  const space = "did:key:z6Mk-wire-accounting-unnegotiated";
+  const hello = {
+    type: "hello",
+    protocol: MEMORY_PROTOCOL,
+    flags: {
+      modernCellRep: flags.modernCellRep,
+      persistentSchedulerState: flags.persistentSchedulerState,
+      commitPreconditions: flags.commitPreconditions,
+    },
+  } as const;
+
+  try {
+    const sessionId = await openSession(connection, messages, space, hello);
+    await writeSchemaDocument(connection, messages, space, sessionId);
+    await watchSchemaDocument(connection, messages, space, sessionId);
+
+    const watched = accounting.snapshot().records.find((record) =>
+      record.classification === "server.response.session.watch.add.sync"
+    );
+    assertExists(watched);
+    assertEquals(watched.actualBytes, watched.baselineBytes);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting names response records by originating request", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  accounting.start();
+  const server = createServer(
+    "memory://wire-accounting-response-origin",
+    accounting,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  const space = "did:key:z6Mk-wire-accounting-response-origin";
+
+  try {
+    const sessionId = await openSession(connection, messages, space);
+    await writeSchemaDocument(connection, messages, space, sessionId);
+    const rows = accounting.snapshot().byClassification;
+    assertExists(
+      rows.find((row) => row.key === "server.response.session.open"),
+    );
+    assertExists(rows.find((row) => row.key === "server.response.transact"));
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting aggregates by connection and metadata kind", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  accounting.start();
+  const server = createServer("memory://wire-accounting-metadata", accounting);
+  const firstMessages: ServerMessage[] = [];
+  const secondMessages: ServerMessage[] = [];
+  const first = server.connect((message) => firstMessages.push(message), {
+    kind: "browser",
+    runtime: "shell",
+  });
+  const second = server.connect((message) => secondMessages.push(message), {
+    kind: "worker",
+  });
+
+  try {
+    await first.receive(encodeMemoryBoundary(HELLO));
+    await second.receive(encodeMemoryBoundary(HELLO));
+    shiftMessage(firstMessages);
+    shiftMessage(secondMessages);
+
+    const report = accounting.snapshot();
+    const browser = report.byMetadataKind.find((row) => row.key === "browser");
+    const worker = report.byMetadataKind.find((row) => row.key === "worker");
+    assertExists(browser);
+    assertExists(worker);
+    assertEquals(browser.connections, 1);
+    assertEquals(worker.connections, 1);
+    assertEquals(report.byConnection.length, 2);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting accumulator supports reset start stop snapshot", () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  const record: MemoryWireAccountingRecord = {
+    direction: "inbound",
+    connectionId: "connection:one",
+    metadata: { kind: "browser" },
+    classification: "client.hello",
+    baselineBytes: 10,
+    actualBytes: 10,
+  };
+
+  accounting.observe(record);
+  assertEquals(accounting.snapshot().totals.frames, 0);
+
+  accounting.start();
+  accounting.observe(record);
+  assertEquals(accounting.snapshot().totals.frames, 1);
+
+  accounting.reset();
+  assertEquals(accounting.snapshot().totals.frames, 0);
+  accounting.observe(record);
+  assertEquals(accounting.stop().totals.frames, 1);
+
+  accounting.observe(record);
+  assertEquals(accounting.snapshot().totals.frames, 1);
+});
+
+Deno.test("memory wire accounting accumulator starts request bookkeeping only when active", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  const server = createServer(
+    "memory://wire-accounting-start-gate",
+    accounting,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  const space = "did:key:z6Mk-wire-accounting-start-gate";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    expectHelloOk(messages);
+    assertEquals(accounting.snapshot().totals.frames, 0);
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-before-start",
+      space,
+      session: {},
+      invocation: { aud: "wrong", challenge: "wrong" },
+    }));
+    assertResponse<SessionOpenResult>(shiftMessage(messages));
+    assertEquals(accounting.snapshot().totals.frames, 0);
+
+    accounting.start();
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-after-start",
+      space,
+      session: {},
+      invocation: { aud: "wrong", challenge: "wrong" },
+    }));
+    assertResponse<SessionOpenResult>(shiftMessage(messages));
+
+    const activeOrigin = accounting.snapshot().records.find((record) =>
+      record.classification === "server.response.session.open.error"
+    );
+    assertExists(activeOrigin);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting accumulator stops connection records immediately", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  const server = createServer("memory://wire-accounting-stop-gate", accounting);
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    accounting.start();
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    expectHelloOk(messages);
+    const stopped = accounting.stop();
+    assertEquals(stopped.totals.frames, 2);
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "hello",
+      protocol: MEMORY_PROTOCOL,
+      flags: getMemoryProtocolFlags(),
+    }));
+    assertResponse<unknown>(shiftMessage(messages));
+
+    assertEquals(accounting.snapshot().totals.frames, 2);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting cleans request origins when response is sent while stopped", async () => {
+  const accounting = new MemoryWireAccountingAccumulator();
+  const authorizations: PromiseWithResolvers<string | undefined>[] = [];
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://wire-accounting-stopped-response-cleanup"),
+    authorizeSessionOpen() {
+      const authorization = Promise.withResolvers<string | undefined>();
+      authorizations.push(authorization);
+      return authorization.promise;
+    },
+    wireAccountingObserver: accounting,
+  });
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  const space = "did:key:z6Mk-wire-accounting-stopped-response-cleanup";
+  const requestId = "reused-open-request";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const firstSessionOpen = expectHelloOk(messages);
+
+    accounting.start();
+    const firstReceive = connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId,
+      space,
+      session: {},
+      invocation: authInvocation(firstSessionOpen),
+    }));
+    await flushReceiveStart();
+    assertEquals(authorizations.length, 1);
+
+    accounting.stop();
+    authorizations.shift()?.resolve("did:key:z6Mk-wire-accounting-principal");
+    await firstReceive;
+    const firstOpened = assertResponse<SessionOpenResult>(
+      shiftMessage(messages),
+    );
+    assertExists(firstOpened.ok?.sessionOpen);
+
+    const secondReceive = connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId,
+      space,
+      session: {},
+      invocation: authInvocation(firstOpened.ok.sessionOpen),
+    }));
+    await flushReceiveStart();
+    assertEquals(authorizations.length, 1);
+
+    accounting.start();
+    authorizations.shift()?.resolve("did:key:z6Mk-wire-accounting-principal");
+    await secondReceive;
+    assertResponse<SessionOpenResult>(shiftMessage(messages));
+
+    const records = accounting.snapshot().records;
+    assertExists(records.find((record) =>
+      record.direction === "outbound" &&
+      record.classification === "server.response.unknown"
+    ));
+    assertEquals(
+      records.some((record) =>
+        record.direction === "outbound" &&
+        record.classification === "server.response.session.open"
+      ),
+      false,
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory wire accounting observer exceptions are non-fatal", async () => {
+  const observer: MemoryWireAccountingObserver = {
+    observe() {
+      throw new Error("observer failed");
+    },
+  };
+  const server = createServer(
+    "memory://wire-accounting-observer-error",
+    observer,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    assertEquals(shiftMessage(messages).type, "hello.ok");
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/memory/test/v2-wire-accounting-test.ts
+++ b/packages/memory/test/v2-wire-accounting-test.ts
@@ -17,6 +17,7 @@ import {
 import { Server } from "../v2/server.ts";
 import {
   accountMemoryWirePayload,
+  classifyServerMessage,
   MemoryWireAccountingAccumulator,
   type MemoryWireAccountingObserver,
   type MemoryWireAccountingRecord,
@@ -381,6 +382,115 @@ Deno.test("memory wire accounting classifies request CAS definitions and refs as
   );
 });
 
+Deno.test("memory wire accounting scopes only direct protocol candidate roots", () => {
+  const cases = [
+    {
+      name: "commit code CID",
+      payload: {
+        type: "transact",
+        commit: { codeCID: "bafy-code", operations: [] },
+      },
+      category: "patchOperation",
+      scope: "alreadyContentAddressed",
+    },
+    {
+      name: "query selector",
+      payload: {
+        type: "graph.query",
+        query: { roots: [{ selector: { path: [] } }] },
+      },
+      category: "queryWatch",
+      scope: "immutableInternable",
+    },
+    {
+      name: "scheduler table collection",
+      payload: {
+        type: "session/effect",
+        effect: { db: { tables: [{ name: "actions" }] } },
+      },
+      category: "sqliteScheduler",
+      scope: "immutableInternable",
+    },
+  ] as const;
+
+  for (const { name, payload, category, scope } of cases) {
+    const accounting = accountMemoryWirePayload(
+      encodeMemoryBoundary(payload),
+      `candidate-root-${name}`,
+    );
+    const matchingCandidate = accounting.candidates.find((candidate) =>
+      candidate.category === category && candidate.scope === scope
+    );
+    assertExists(
+      matchingCandidate,
+      `${name} should be measured at its direct protocol root`,
+    );
+  }
+});
+
+Deno.test("memory wire accounting recognizes protocol identity positions only", () => {
+  const identityPayload = encodeMemoryBoundary({
+    type: "response",
+    space: "did:key:space",
+    sessionId: "session",
+    ok: { sync: { type: "sync", db: { id: "database", tables: [] } } },
+  });
+  const rejectedLookalikes = encodeMemoryBoundary({
+    type: "response",
+    id: "root-id",
+    doc: { value: { space: "document-space" } },
+    invocation: { space: "capability-space" },
+    "/": { "link@1": { schema: { id: "schema-id" } } },
+  });
+
+  assertEquals(
+    accountMemoryWirePayload(identityPayload, "identity-positions").candidates
+      .filter((candidate) => candidate.scope === "identityInternable").length,
+    3,
+  );
+  assertEquals(
+    accountMemoryWirePayload(rejectedLookalikes, "identity-lookalikes")
+      .candidates.some((candidate) => candidate.scope === "identityInternable"),
+    false,
+  );
+});
+
+Deno.test("memory wire accounting classifies server effect and revocation frames", () => {
+  const sync = schemaSync();
+  const cases = [
+    {
+      message: {
+        type: "hello.ok",
+        protocol: MEMORY_PROTOCOL,
+        flags: getMemoryProtocolFlags(),
+      } satisfies ServerMessage,
+      expected: "server.hello.ok",
+    },
+    {
+      message: {
+        type: "session/effect",
+        space: "did:key:space",
+        sessionId: "session",
+        effect: sync,
+      } satisfies ServerMessage,
+      expected: "server.session/effect.sync",
+    },
+    {
+      message: {
+        type: "session/revoked",
+        space: "did:key:space",
+        sessionId: "session",
+        reason: "unauthorized",
+      } satisfies ServerMessage,
+      expected: "server.session/revoked",
+    },
+  ];
+
+  for (const { message, expected } of cases) {
+    assertEquals(classifyServerMessage(message), expected);
+  }
+});
+
 Deno.test("memory wire accounting treats noncanonical payloads as opaque and partitions fingerprints", () => {
   const canonical = encodeMemoryBoundary({
     type: "response",
@@ -470,6 +580,17 @@ Deno.test("memory wire accounting bounds opaque work and consumes retained state
   });
   assertEquals(accumulator.isActive(), false);
   assertExists(accumulator.snapshot().truncated);
+  accumulator.observe({
+    direction: "outbound",
+    connectionId: "ignored-after-limit",
+    classification: "server.hello.ok",
+    baselineBytes: 2,
+    actualBytes: 2,
+  });
+  assertEquals(
+    accumulator.snapshot().records.map((record) => record.connectionId),
+    ["a"],
+  );
   assertEquals(
     (accumulator.snapshot().records[0].metadata as {
       nested: { value: number };

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -7,7 +7,11 @@ import {
   valueFromJson,
 } from "@commonfabric/data-model/codec-json";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
-import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
+import type {
+  FabricValue,
+  JSONSchema,
+  SchemaPathSelector,
+} from "@commonfabric/api";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
 import { isObject, isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
@@ -250,6 +254,8 @@ export interface MemoryProtocolFlags {
   syncSchemaTable: boolean;
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
+  /** Hash-keyed durable request schema CAS for request-side schema elision. */
+  requestSchemaCasV1?: boolean;
   /**
    * Server capability (CFC Phase 3.c): commit-folded `sqlite` writes to
    * rule-bearing tables are re-derived through the shared row-label evaluator
@@ -272,6 +278,7 @@ export type WireMemoryProtocolFlags = {
   commitPreconditions?: boolean;
   syncSchemaTable?: boolean;
   syncSchemaTableV2?: boolean;
+  requestSchemaCasV1?: boolean;
   sqliteCommitRowLabelEval?: boolean;
 };
 
@@ -285,7 +292,16 @@ export interface HelloOkMessage {
   type: "hello.ok";
   protocol: typeof MEMORY_PROTOCOL;
   flags: WireMemoryProtocolFlags;
+  /** Present only when the negotiated request schema CAS store is durable. */
+  requestSchemaCas?: RequestSchemaCasMetadata;
   sessionOpen?: SessionOpenAuthMetadata;
+}
+
+/** Identifies the durable store backing negotiated request-schema CAS. */
+export interface RequestSchemaCasMetadata {
+  generation: string;
+  /** The service identity that owns this store, when the host has one. */
+  audience?: string;
 }
 
 export interface SessionOpenChallenge {
@@ -406,6 +422,7 @@ export interface TransactRequest {
   space: string;
   sessionId: SessionId;
   commit: ClientCommit;
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 export interface GraphQueryRequest {
@@ -414,6 +431,7 @@ export interface GraphQueryRequest {
   space: string;
   sessionId: SessionId;
   query: GraphQuery;
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 // --- SQLite builtins (docs/specs/sqlite-builtin) ---
@@ -534,6 +552,7 @@ export interface WatchSetRequest {
   space: string;
   sessionId: SessionId;
   watches: WatchSpec[];
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 export interface WatchAddRequest {
@@ -542,6 +561,7 @@ export interface WatchAddRequest {
   space: string;
   sessionId: SessionId;
   watches: WatchSpec[];
+  schemaDefinitions?: Record<string, JSONSchema>;
 }
 
 export interface SessionAckRequest {
@@ -678,6 +698,7 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 let persistentSchedulerStateEnabled = false;
 let commitPreconditionsEnabled = true;
 let syncSchemaTableEnabled = true;
+let requestSchemaCasEnabled = true;
 
 /**
  * Ambient runtime flag for persistent scheduler observations and rehydration.
@@ -730,6 +751,22 @@ export function resetSyncSchemaTableConfig(): void {
   syncSchemaTableEnabled = true;
 }
 
+/**
+ * Build capability for request-side schema CAS. A server additionally requires
+ * an injected durable SchemaStore before advertising the capability.
+ */
+export function setRequestSchemaCasConfig(enabled?: boolean): void {
+  requestSchemaCasEnabled = enabled ?? true;
+}
+
+export function getRequestSchemaCasConfig(): boolean {
+  return requestSchemaCasEnabled;
+}
+
+export function resetRequestSchemaCasConfig(): void {
+  requestSchemaCasEnabled = true;
+}
+
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
@@ -741,6 +778,7 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   // write gate failing closed.
   sqliteCommitRowLabelEval: true,
   syncSchemaTableV2: getSyncSchemaTableConfig(),
+  requestSchemaCasV1: getRequestSchemaCasConfig(),
 });
 
 /**
@@ -804,6 +842,13 @@ export const parseMemoryProtocolFlags = (
   ) {
     return null;
   }
+  const requestSchemaCasV1 = value.requestSchemaCasV1;
+  if (
+    requestSchemaCasV1 !== undefined &&
+    typeof requestSchemaCasV1 !== "boolean"
+  ) {
+    return null;
+  }
 
   const sqliteCommitRowLabelEval = value.sqliteCommitRowLabelEval;
   if (
@@ -819,6 +864,7 @@ export const parseMemoryProtocolFlags = (
     commitPreconditions: commitPreconditions === true,
     syncSchemaTable: syncSchemaTable === true,
     syncSchemaTableV2: syncSchemaTableV2 === true,
+    requestSchemaCasV1: requestSchemaCasV1 === true,
     // Absent (an older peer) parses to false: the capability must be
     // POSITIVELY advertised for the runner to relax its write gate.
     sqliteCommitRowLabelEval: sqliteCommitRowLabelEval === true,
@@ -836,6 +882,7 @@ export const wireMemoryProtocolFlags = (
   commitPreconditions: flags.commitPreconditions,
   syncSchemaTable: flags.syncSchemaTable,
   syncSchemaTableV2: flags.syncSchemaTableV2,
+  requestSchemaCasV1: flags.requestSchemaCasV1,
   sqliteCommitRowLabelEval: flags.sqliteCommitRowLabelEval,
 });
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -254,7 +254,7 @@ export interface MemoryProtocolFlags {
   syncSchemaTable: boolean;
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
-  /** Hash-keyed durable request schema CAS for request-side schema elision. */
+  /** Hash-keyed request schema CAS for request-side schema elision. */
   requestSchemaCasV1?: boolean;
   /**
    * Server capability (CFC Phase 3.c): commit-folded `sqlite` writes to
@@ -292,12 +292,12 @@ export interface HelloOkMessage {
   type: "hello.ok";
   protocol: typeof MEMORY_PROTOCOL;
   flags: WireMemoryProtocolFlags;
-  /** Present only when the negotiated request schema CAS store is durable. */
+  /** Present when the server has an injected request schema CAS store. */
   requestSchemaCas?: RequestSchemaCasMetadata;
   sessionOpen?: SessionOpenAuthMetadata;
 }
 
-/** Identifies the durable store backing negotiated request-schema CAS. */
+/** Identifies the store backing negotiated request-schema CAS. */
 export interface RequestSchemaCasMetadata {
   generation: string;
   /** The service identity that owns this store, when the host has one. */
@@ -753,7 +753,7 @@ export function resetSyncSchemaTableConfig(): void {
 
 /**
  * Build capability for request-side schema CAS. A server additionally requires
- * an injected durable SchemaStore before advertising the capability.
+ * an injected SchemaStore before advertising the capability.
  */
 export function setRequestSchemaCasConfig(enabled?: boolean): void {
   requestSchemaCasEnabled = enabled ?? true;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -33,6 +33,7 @@ import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
+  collectRequestSchemaCasHashes,
   compressRequestSchemas,
   hasRequestSchemaCasPayload,
   type RequestSchemaCasRequest,
@@ -115,7 +116,9 @@ export class Client {
   #clientFlags: MemoryProtocolFlags | null = null;
   #serverFlags: MemoryProtocolFlags | null = null;
   #requestSchemaCas: RequestSchemaCasMetadata | null = null;
+  #confirmedRequestSchemaHashes = new Set<string>();
   #outbound = Promise.resolve();
+  #coldAdmission: PromiseWithResolvers<void> | null = null;
   #reconnecting: Promise<void> | null = null;
   #cancelReconnectDelay: (() => void) | null = null;
   #connected = false;
@@ -145,6 +148,7 @@ export class Client {
     this.#closed = true;
     this.#connected = false;
     this.clearRequestSchemaCas();
+    this.releaseColdAdmission();
     this.#cancelReconnectDelay?.();
     this.rejectPending(new Error("memory client closed"));
     await Promise.all([...this.#spaces].map((space) => space.close()));
@@ -182,54 +186,78 @@ export class Client {
 
   async request<Result>(message: Record<string, unknown>): Promise<Result> {
     await this.ensureConnected();
+    while (true) {
+      await this.waitForColdAdmission();
+      // Another request can claim the barrier while this request resumes from
+      // an already-resolved wait. Recheck before making a CAS decision.
+      if (this.#coldAdmission !== null) continue;
+      if (this.#connected) break;
+      await this.ensureConnected();
+    }
+    // Make the CAS decision only after waiting for a cold admission and
+    // observing the current handshake.
     const requestId = message.requestId as string;
     let schemaAttempt: "refs" | "definitions" | "inline" =
       this.requestSchemaCasActive() ? "refs" : "inline";
-    while (true) {
-      const wireMessage = schemaAttempt === "inline"
-        ? message
-        : this.compressRequestSchemas(message, schemaAttempt === "definitions");
-      const usedRequestSchemaCas = this.usesRequestSchemaCas(wireMessage);
-      const pending = Promise.withResolvers<unknown>();
-      this.#pending.set(requestId, pending);
-      try {
-        await this.send(encodeMemoryBoundary(wireMessage));
-      } catch (error) {
-        this.#pending.delete(requestId);
-        throw error;
-      }
-      const result = await pending.promise as ResponseMessage<Result>;
-      if (
-        result.error?.name === "MissingSchemas" && usedRequestSchemaCas &&
-        schemaAttempt === "refs"
-      ) {
-        schemaAttempt = this.requestSchemaCasActive()
-          ? "definitions"
-          : "inline";
-        continue;
-      }
-      if (
-        result.error?.name === "SchemaStoreError" && usedRequestSchemaCas &&
-        schemaAttempt !== "inline"
-      ) {
-        this.clearRequestSchemaCas();
-        schemaAttempt = "inline";
-        continue;
-      }
-      if (result.error) {
-        const error = new Error(result.error.message);
-        error.name = result.error.name;
-        if (result.error.precondition !== undefined) {
-          (error as Error & { precondition?: string }).precondition =
-            result.error.precondition;
+    const firstWireMessage = schemaAttempt === "inline"
+      ? message
+      : this.compressRequestSchemas(message, false);
+    const referencedHashes = this.requestSchemaCasHashes(firstWireMessage);
+    const admission = this.claimColdAdmission(referencedHashes);
+    try {
+      while (true) {
+        const wireMessage = schemaAttempt === "inline"
+          ? message
+          : schemaAttempt === "refs"
+          ? firstWireMessage
+          : this.compressRequestSchemas(message, true);
+        const usedRequestSchemaCas = this.usesRequestSchemaCas(wireMessage);
+        const pending = Promise.withResolvers<unknown>();
+        this.#pending.set(requestId, pending);
+        try {
+          await this.send(encodeMemoryBoundary(wireMessage));
+        } catch (error) {
+          this.#pending.delete(requestId);
+          throw error;
         }
-        if (result.error.retryAfterSeq !== undefined) {
-          (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
-            result.error.retryAfterSeq;
+        const result = await pending.promise as ResponseMessage<Result>;
+        if (
+          result.error?.name === "MissingSchemas" && usedRequestSchemaCas &&
+          schemaAttempt === "refs"
+        ) {
+          schemaAttempt = this.requestSchemaCasActive()
+            ? "definitions"
+            : "inline";
+          continue;
         }
-        throw error;
+        if (
+          result.error?.name === "SchemaStoreError" && usedRequestSchemaCas &&
+          schemaAttempt !== "inline"
+        ) {
+          this.clearRequestSchemaCas();
+          schemaAttempt = "inline";
+          continue;
+        }
+        if (result.error) {
+          const error = new Error(result.error.message);
+          error.name = result.error.name;
+          if (result.error.precondition !== undefined) {
+            (error as Error & { precondition?: string }).precondition =
+              result.error.precondition;
+          }
+          if (result.error.retryAfterSeq !== undefined) {
+            (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
+              result.error.retryAfterSeq;
+          }
+          throw error;
+        }
+        if (usedRequestSchemaCas && schemaAttempt !== "inline") {
+          this.confirmRequestSchemaHashes(referencedHashes);
+        }
+        return result.ok as Result;
       }
-      return result.ok as Result;
+    } finally {
+      this.releaseColdAdmission(admission);
     }
   }
 
@@ -285,7 +313,6 @@ export class Client {
       await ack.promise;
       this.#connected = true;
     } catch (error) {
-      this.clearRequestSchemaCas();
       throw error;
     } finally {
       this.#helloPending = null;
@@ -416,17 +443,12 @@ export class Client {
       return;
     }
     this.#connected = false;
+    this.releaseColdAdmission();
     for (const session of this.#spaces) {
       session.handleDisconnect();
     }
     this.rejectPending(toConnectionError(error));
     void this.reconnect().catch(() => undefined);
-  }
-
-  private send(payload: string): Promise<void> {
-    const sending = this.#outbound.then(() => this.transport.send(payload));
-    this.#outbound = sending.catch(() => undefined);
-    return sending;
   }
 
   private requestSchemaCasActive(): boolean {
@@ -437,6 +459,7 @@ export class Client {
 
   private clearRequestSchemaCas(): void {
     this.#requestSchemaCas = null;
+    this.#confirmedRequestSchemaHashes.clear();
   }
 
   private updateRequestSchemaCas(
@@ -447,7 +470,64 @@ export class Client {
       this.clearRequestSchemaCas();
       return;
     }
+    if (
+      this.#requestSchemaCas?.generation !== metadata.generation ||
+      this.#requestSchemaCas?.audience !== metadata.audience
+    ) {
+      this.#confirmedRequestSchemaHashes.clear();
+    }
     this.#requestSchemaCas = metadata;
+  }
+
+  private send(payload: string): Promise<void> {
+    const sending = this.#outbound.then(() => this.transport.send(payload));
+    this.#outbound = sending.catch(() => undefined);
+    return sending;
+  }
+
+  private requestSchemaCasHashes(
+    message: Record<string, unknown>,
+  ): ReadonlySet<string> {
+    try {
+      return this.usesRequestSchemaCas(message)
+        ? collectRequestSchemaCasHashes(message)
+        : new Set<string>();
+    } catch {
+      return new Set<string>();
+    }
+  }
+
+  private claimColdAdmission(
+    hashes: ReadonlySet<string>,
+  ): PromiseWithResolvers<void> | null {
+    if (
+      hashes.size === 0 ||
+      [...hashes].every((hash) => this.#confirmedRequestSchemaHashes.has(hash))
+    ) {
+      return null;
+    }
+    const admission = Promise.withResolvers<void>();
+    this.#coldAdmission = admission;
+    return admission;
+  }
+
+  private async waitForColdAdmission(): Promise<void> {
+    while (this.#coldAdmission !== null) {
+      await this.#coldAdmission.promise;
+    }
+  }
+
+  private releaseColdAdmission(
+    admission: PromiseWithResolvers<void> | null = this.#coldAdmission,
+  ): void {
+    if (admission === null) return;
+    if (this.#coldAdmission === admission) this.#coldAdmission = null;
+    admission.resolve();
+  }
+
+  private confirmRequestSchemaHashes(hashes: ReadonlySet<string>): void {
+    if (!this.requestSchemaCasActive()) return;
+    for (const hash of hashes) this.#confirmedRequestSchemaHashes.add(hash);
   }
 
   private compressRequestSchemas(

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -11,6 +11,7 @@ import {
   MEMORY_PROTOCOL,
   type MemoryProtocolFlags,
   parseMemoryProtocolFlags,
+  type RequestSchemaCasMetadata,
   type ResponseMessage,
   type SchedulerActionSnapshotQuery,
   type SchedulerSnapshotListResult,
@@ -31,6 +32,11 @@ import {
 import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import {
+  compressRequestSchemas,
+  hasRequestSchemaCasPayload,
+  type RequestSchemaCasRequest,
+} from "./request-schema-cas.ts";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 
 export interface Transport {
@@ -106,7 +112,10 @@ export class Client {
   #nextRequest = 1;
   #helloPending: PromiseWithResolvers<void> | null = null;
   #sessionOpenAuthContext: SessionOpenAuthContext | null = null;
+  #clientFlags: MemoryProtocolFlags | null = null;
   #serverFlags: MemoryProtocolFlags | null = null;
+  #requestSchemaCas: RequestSchemaCasMetadata | null = null;
+  #outbound = Promise.resolve();
   #reconnecting: Promise<void> | null = null;
   #cancelReconnectDelay: (() => void) | null = null;
   #connected = false;
@@ -135,6 +144,7 @@ export class Client {
   async close(): Promise<void> {
     this.#closed = true;
     this.#connected = false;
+    this.clearRequestSchemaCas();
     this.#cancelReconnectDelay?.();
     this.rejectPending(new Error("memory client closed"));
     await Promise.all([...this.#spaces].map((space) => space.close()));
@@ -173,24 +183,54 @@ export class Client {
   async request<Result>(message: Record<string, unknown>): Promise<Result> {
     await this.ensureConnected();
     const requestId = message.requestId as string;
-    const pending = Promise.withResolvers<unknown>();
-    this.#pending.set(requestId, pending);
-    await this.transport.send(encodeMemoryBoundary(message));
-    const result = await pending.promise as ResponseMessage<Result>;
-    if (result.error) {
-      const error = new Error(result.error.message);
-      error.name = result.error.name;
-      if (result.error.precondition !== undefined) {
-        (error as Error & { precondition?: string }).precondition =
-          result.error.precondition;
+    let schemaAttempt: "refs" | "definitions" | "inline" =
+      this.requestSchemaCasActive() ? "refs" : "inline";
+    while (true) {
+      const wireMessage = schemaAttempt === "inline"
+        ? message
+        : this.compressRequestSchemas(message, schemaAttempt === "definitions");
+      const usedRequestSchemaCas = this.usesRequestSchemaCas(wireMessage);
+      const pending = Promise.withResolvers<unknown>();
+      this.#pending.set(requestId, pending);
+      try {
+        await this.send(encodeMemoryBoundary(wireMessage));
+      } catch (error) {
+        this.#pending.delete(requestId);
+        throw error;
       }
-      if (result.error.retryAfterSeq !== undefined) {
-        (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
-          result.error.retryAfterSeq;
+      const result = await pending.promise as ResponseMessage<Result>;
+      if (
+        result.error?.name === "MissingSchemas" && usedRequestSchemaCas &&
+        schemaAttempt === "refs"
+      ) {
+        schemaAttempt = this.requestSchemaCasActive()
+          ? "definitions"
+          : "inline";
+        continue;
       }
-      throw error;
+      if (
+        result.error?.name === "SchemaStoreError" && usedRequestSchemaCas &&
+        schemaAttempt !== "inline"
+      ) {
+        this.clearRequestSchemaCas();
+        schemaAttempt = "inline";
+        continue;
+      }
+      if (result.error) {
+        const error = new Error(result.error.message);
+        error.name = result.error.name;
+        if (result.error.precondition !== undefined) {
+          (error as Error & { precondition?: string }).precondition =
+            result.error.precondition;
+        }
+        if (result.error.retryAfterSeq !== undefined) {
+          (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
+            result.error.retryAfterSeq;
+        }
+        throw error;
+      }
+      return result.ok as Result;
     }
-    return result.ok as Result;
   }
 
   async openSession(
@@ -235,14 +275,18 @@ export class Client {
   private async hello(): Promise<void> {
     const ack = Promise.withResolvers<void>();
     this.#helloPending = ack;
-    await this.transport.send(encodeMemoryBoundary({
+    this.#clientFlags = getMemoryProtocolFlags();
+    await this.send(encodeMemoryBoundary({
       type: "hello",
       protocol: MEMORY_PROTOCOL,
-      flags: getMemoryProtocolFlags(),
+      flags: this.#clientFlags,
     }));
     try {
       await ack.promise;
       this.#connected = true;
+    } catch (error) {
+      this.clearRequestSchemaCas();
+      throw error;
     } finally {
       this.#helloPending = null;
     }
@@ -285,6 +329,10 @@ export class Client {
         // consumers (e.g. the runner's sqlite write-gate relaxation) read
         // these; absent-on-old-server keys parse to false — fail closed.
         this.#serverFlags = helloOk.flags;
+        this.updateRequestSchemaCas(
+          helloOk.flags,
+          parseRequestSchemaCasMetadata(helloOk.requestSchemaCas),
+        );
         try {
           this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(
             helloOk.sessionOpen,
@@ -373,6 +421,55 @@ export class Client {
     }
     this.rejectPending(toConnectionError(error));
     void this.reconnect().catch(() => undefined);
+  }
+
+  private send(payload: string): Promise<void> {
+    const sending = this.#outbound.then(() => this.transport.send(payload));
+    this.#outbound = sending.catch(() => undefined);
+    return sending;
+  }
+
+  private requestSchemaCasActive(): boolean {
+    return this.#clientFlags?.requestSchemaCasV1 === true &&
+      this.#serverFlags?.requestSchemaCasV1 === true &&
+      this.#requestSchemaCas !== null;
+  }
+
+  private clearRequestSchemaCas(): void {
+    this.#requestSchemaCas = null;
+  }
+
+  private updateRequestSchemaCas(
+    flags: MemoryProtocolFlags,
+    metadata: RequestSchemaCasMetadata | null,
+  ): void {
+    if (flags.requestSchemaCasV1 !== true || metadata === null) {
+      this.clearRequestSchemaCas();
+      return;
+    }
+    this.#requestSchemaCas = metadata;
+  }
+
+  private compressRequestSchemas(
+    message: Record<string, unknown>,
+    forceDefinitions: boolean,
+  ): Record<string, unknown> {
+    if (!this.requestSchemaCasActive() || !isRequestSchemaCasRequest(message)) {
+      return message;
+    }
+    return compressRequestSchemas(message, {
+      isKnownSchemaHash: () => true,
+      forceDefinitions,
+    });
+  }
+
+  private usesRequestSchemaCas(message: Record<string, unknown>): boolean {
+    try {
+      return isRequestSchemaCasRequest(message) &&
+        hasRequestSchemaCasPayload(message);
+    } catch {
+      return false;
+    }
   }
 
   private async reconnect(): Promise<void> {
@@ -1430,6 +1527,7 @@ const parseHelloOk = (
 ): {
   flags: MemoryProtocolFlags;
   sessionOpen?: unknown;
+  requestSchemaCas?: unknown;
 } | null => {
   if (typeof message !== "object" || message === null) {
     return null;
@@ -1439,6 +1537,7 @@ const parseHelloOk = (
     protocol?: unknown;
     flags?: unknown;
     sessionOpen?: unknown;
+    requestSchemaCas?: unknown;
   };
   if (obj.type !== "hello.ok" || obj.protocol !== MEMORY_PROTOCOL) {
     return null;
@@ -1447,8 +1546,36 @@ const parseHelloOk = (
   if (parsed === null) {
     return null;
   }
-  return { flags: parsed, sessionOpen: obj.sessionOpen };
+  return {
+    flags: parsed,
+    sessionOpen: obj.sessionOpen,
+    requestSchemaCas: obj.requestSchemaCas,
+  };
 };
+
+const parseRequestSchemaCasMetadata = (
+  value: unknown,
+): RequestSchemaCasMetadata | null => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const metadata = value as { generation?: unknown; audience?: unknown };
+  if (
+    typeof metadata.generation !== "string" ||
+    (metadata.audience !== undefined && typeof metadata.audience !== "string")
+  ) {
+    return null;
+  }
+  return metadata.audience === undefined
+    ? { generation: metadata.generation }
+    : { generation: metadata.generation, audience: metadata.audience };
+};
+
+const isRequestSchemaCasRequest = (
+  message: Record<string, unknown>,
+): message is Record<string, unknown> & RequestSchemaCasRequest =>
+  message.type === "graph.query" || message.type === "session.watch.set" ||
+  message.type === "session.watch.add" || message.type === "transact";
 
 const isSessionEffect = (
   message: unknown,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -8,6 +8,10 @@ import {
 } from "./patch.ts";
 import { isPrefixPath, parentPath, pathsOverlap } from "./path.ts";
 import {
+  containsSyncSchemaRefString,
+  findSyncSchemaRef,
+} from "./sync-schema-ref.ts";
+import {
   type BranchName,
   type CellScope,
   type ClientCommit,
@@ -5060,6 +5064,8 @@ const applyCommitTransaction = (
     revisions.push(revision);
   }
 
+  validateStoredSyncSchemaRefs(engine, branch, revisions);
+
   engine.statements.updateBranchHead.run({ branch, seq });
   materializeSnapshots(engine, branch, revisions);
 
@@ -5952,6 +5958,56 @@ const materializeSnapshots = (
     }
     seen.add(key);
     maybeMaterializeSnapshot(engine, branch, revision.id, revisionScopeKey);
+  }
+};
+
+const validateStoredSyncSchemaRefs = (
+  engine: Engine,
+  branch: BranchName,
+  revisions: readonly AppliedRevision[],
+): void => {
+  const candidates = new Set<string>();
+  const finalRevisions = new Map<string, AppliedRevision>();
+
+  for (const revision of revisions) {
+    const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
+    const key = revisionKey(branch, revision.id, scopeKey);
+    finalRevisions.set(key, revision);
+    if (
+      (revision.op === "set" &&
+        findSyncSchemaRef(revision.document) !== undefined) ||
+      (revision.op === "patch" &&
+        (containsSyncSchemaRefString(revision.patches) ||
+          revision.patches?.some((patch) => patch.op === "move") === true))
+    ) {
+      candidates.add(key);
+    }
+  }
+
+  for (const key of candidates) {
+    const revision = finalRevisions.get(key);
+    if (revision === undefined || revision.op === "delete") {
+      continue;
+    }
+    const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
+    let document: EntityDocument | undefined;
+    if (revision.op === "set") {
+      document = revision.document;
+    } else if (revision.op === "patch") {
+      document = reconstructPatchedDocument(engine, {
+        id: revision.id,
+        scopeKey,
+        branch,
+        seq: revision.seq,
+        opIndex: revision.opIndex,
+      });
+    }
+    const ref = findSyncSchemaRef(document);
+    if (ref !== undefined) {
+      throw new ProtocolError(
+        `memory v2 documents may not persist reserved sync schema reference: ${ref}`,
+      );
+    }
   }
 };
 

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5997,7 +5997,7 @@ const validateStoredSyncSchemaRefs = (
     const ref = findSyncSchemaRef(document);
     if (ref !== undefined) {
       throw new ProtocolError(
-        `memory v2 documents may not persist reserved sync schema reference: ${ref}`,
+        `memory v2 documents may not persist reserved wire schema reference: ${ref}`,
       );
     }
   }

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5966,13 +5966,9 @@ const validateStoredSyncSchemaRefs = (
   branch: BranchName,
   revisions: readonly AppliedRevision[],
 ): void => {
-  const candidates = new Set<string>();
-  const finalRevisions = new Map<string, AppliedRevision>();
+  const candidates: AppliedRevision[] = [];
 
   for (const revision of revisions) {
-    const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
-    const key = revisionKey(branch, revision.id, scopeKey);
-    finalRevisions.set(key, revision);
     if (
       (revision.op === "set" &&
         findSyncSchemaRef(revision.document) !== undefined) ||
@@ -5980,15 +5976,11 @@ const validateStoredSyncSchemaRefs = (
         (containsSyncSchemaRefString(revision.patches) ||
           revision.patches?.some((patch) => patch.op === "move") === true))
     ) {
-      candidates.add(key);
+      candidates.push(revision);
     }
   }
 
-  for (const key of candidates) {
-    const revision = finalRevisions.get(key);
-    if (revision === undefined || revision.op === "delete") {
-      continue;
-    }
+  for (const revision of candidates) {
     const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
     let document: EntityDocument | undefined;
     if (revision.op === "set") {

--- a/packages/memory/v2/handshake.ts
+++ b/packages/memory/v2/handshake.ts
@@ -4,7 +4,9 @@ import {
   type HelloMessage,
   type HelloOkMessage,
   MEMORY_PROTOCOL,
+  type MemoryProtocolFlags,
   parseMemoryProtocolFlags,
+  type RequestSchemaCasMetadata,
   type ServerMessage,
   wireMemoryProtocolFlags,
 } from "../v2.ts";
@@ -20,8 +22,16 @@ const toError = (name: string, message: string): TypedError => ({
   message,
 });
 
-export const respondToHello = (message: HelloMessage): ServerMessage => {
-  const expectedFlags = getMemoryProtocolFlags();
+export interface ServerHelloOptions {
+  flags?: MemoryProtocolFlags;
+  requestSchemaCas?: RequestSchemaCasMetadata;
+}
+
+export const respondToHello = (
+  message: HelloMessage,
+  options: ServerHelloOptions = {},
+): ServerMessage => {
+  const expectedFlags = options.flags ?? getMemoryProtocolFlags();
   if (message.protocol !== MEMORY_PROTOCOL) {
     return {
       type: "response",
@@ -53,6 +63,10 @@ export const respondToHello = (message: HelloMessage): ServerMessage => {
     type: "hello.ok",
     protocol: MEMORY_PROTOCOL,
     flags: wireMemoryProtocolFlags(expectedFlags),
+    ...(expectedFlags.requestSchemaCasV1 === true &&
+        options.requestSchemaCas !== undefined
+      ? { requestSchemaCas: options.requestSchemaCas }
+      : {}),
   };
   return response;
 };

--- a/packages/memory/v2/request-schema-cas.ts
+++ b/packages/memory/v2/request-schema-cas.ts
@@ -91,7 +91,7 @@ const schemaReference = (
   return `${REQUEST_SCHEMA_CAS_REF_PREFIX}${canonical.taggedHashString}`;
 };
 
-const generatedDefinitionsFitLimits = (
+const definitionsFitLimits = (
   definitions: ReadonlyMap<string, JSONSchema>,
 ): boolean => {
   if (definitions.size > MAX_REQUEST_SCHEMA_DEFINITIONS) return false;
@@ -231,13 +231,24 @@ export const compressRequestSchemas = <
   if (rewritten === request && request.schemaDefinitions === undefined) {
     return request;
   }
-  if (!generatedDefinitionsFitLimits(definitions)) return request;
+  if (definitions.size === 0) return rewritten as Request;
 
-  const { schemaDefinitions: _schemaDefinitions, ...withoutDefinitions } =
-    rewritten;
-  const compressed = definitions.size === 0 ? withoutDefinitions as Request : {
-    ...withoutDefinitions,
-    schemaDefinitions: Object.fromEntries(definitions),
+  const suppliedDefinitions = rewritten.schemaDefinitions;
+  if (
+    suppliedDefinitions !== undefined && !isPlainRecord(suppliedDefinitions)
+  ) {
+    return request;
+  }
+  const mergedDefinitions = new Map(definitions);
+  for (const [hash, schema] of Object.entries(suppliedDefinitions ?? {})) {
+    if (!isSchema(schema)) return request;
+    mergedDefinitions.set(hash, schema);
+  }
+  if (!definitionsFitLimits(mergedDefinitions)) return request;
+
+  const compressed = {
+    ...rewritten,
+    schemaDefinitions: Object.fromEntries(mergedDefinitions),
   } as Request;
   try {
     // A generated reference must remain discoverable by bounded server

--- a/packages/memory/v2/request-schema-cas.ts
+++ b/packages/memory/v2/request-schema-cas.ts
@@ -331,16 +331,11 @@ export const compressRequestSchemas = <
     ...rewritten,
     schemaDefinitions: Object.fromEntries(mergedDefinitions),
   } as Request;
-  try {
-    // A generated reference must remain discoverable by bounded server
-    // preflight. Otherwise this optimization would turn a valid inline request
-    // into a ProtocolError instead of degrading transparently.
-    if (rewritten !== request && !hasRequestSchemaCasPayload(compressed)) {
-      return request;
-    }
-  } catch (error) {
-    if (error instanceof InvalidRequestSchemaDefinitionsError) return request;
-    throw error;
+  // A generated reference must remain discoverable by server preflight.
+  // Otherwise this optimization would turn a valid inline request into a
+  // protocol error instead of degrading transparently.
+  if (rewritten !== request && !hasRequestSchemaCasPayload(compressed)) {
+    return request;
   }
   return compressed;
 };
@@ -489,127 +484,77 @@ export const expandRequestSchemas = (
 /** Whether a supported request uses a CAS-only field that requires negotiation. */
 export const hasRequestSchemaCasPayload = (request: unknown): boolean => {
   if (!isSupportedRequest(request)) return false;
-  const hasDefinitions = request.schemaDefinitions !== undefined;
   const hasReference = (value: unknown): boolean =>
     typeof value === "string" &&
     value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
-  const traversal = createRequestSchemaTraversal();
   const queryHasReference = (query: unknown): boolean => {
-    traversal.visitNode(0);
     if (!isPlainRecord(query) || !Array.isArray(query.roots)) return false;
-    let found = false;
     for (const root of query.roots) {
-      traversal.visitNode(1);
       if (!isPlainRecord(root) || !isPlainRecord(root.selector)) continue;
       if (!Object.hasOwn(root.selector, "schema")) continue;
-      traversal.visitSchemaPosition();
-      found ||= hasReference(root.selector.schema);
+      if (hasReference(root.selector.schema)) return true;
     }
-    return found;
+    return false;
   };
   const watchesHaveReference = (watches: unknown): boolean => {
     if (!Array.isArray(watches)) return false;
-    let found = false;
     for (const watch of watches) {
-      traversal.visitNode(0);
-      if (isPlainRecord(watch)) found ||= queryHasReference(watch.query);
+      if (isPlainRecord(watch) && queryHasReference(watch.query)) return true;
     }
-    return found;
+    return false;
   };
-  const scanValue = (
-    value: unknown,
-  ): { hasReference: boolean; exceeded: boolean } => {
-    const pending: Array<{ value: unknown; depth: number }> = [{
-      value,
-      depth: 0,
-    }];
-    let found = false;
-    let exceeded = false;
+  const scanValue = (value: unknown): boolean => {
+    const pending: unknown[] = [value];
+    const visited = new WeakSet<object>();
     while (pending.length > 0) {
       const current = pending.pop()!;
-      traversal.nodes += 1;
-      if (traversal.nodes > MAX_REQUEST_SCHEMA_TRAVERSAL_NODES) {
-        return { hasReference: found, exceeded: true };
-      }
-      if (current.depth > MAX_REQUEST_SCHEMA_TRAVERSAL_DEPTH) {
-        exceeded = true;
+      if (Array.isArray(current)) {
+        if (visited.has(current)) continue;
+        visited.add(current);
+        for (const child of current) pending.push(child);
         continue;
       }
-      if (Array.isArray(current.value)) {
-        for (let index = current.value.length - 1; index >= 0; index -= 1) {
-          pending.push({
-            value: current.value[index],
-            depth: current.depth + 1,
-          });
-        }
-        continue;
-      }
-      if (!isPlainRecord(current.value)) continue;
+      if (!isPlainRecord(current)) continue;
+      if (visited.has(current)) continue;
+      visited.add(current);
 
-      const linkEnvelope = current.value["/"];
+      const linkEnvelope = current["/"];
       const linkPayload = isPlainRecord(linkEnvelope)
         ? linkEnvelope["link@1"]
         : undefined;
       if (isPlainRecord(linkPayload) && Object.hasOwn(linkPayload, "schema")) {
-        traversal.visitSchemaPosition();
-        found ||= hasReference(linkPayload.schema);
+        if (hasReference(linkPayload.schema)) return true;
       }
-      const alias = current.value.$alias;
+      const alias = current.$alias;
       if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
-        traversal.visitSchemaPosition();
-        found ||= hasReference(alias.schema);
+        if (hasReference(alias.schema)) return true;
       }
-
-      const children = Object.values(current.value);
-      for (let index = children.length - 1; index >= 0; index -= 1) {
-        pending.push({ value: children[index], depth: current.depth + 1 });
-      }
+      for (const child of Object.values(current)) pending.push(child);
     }
-    return { hasReference: found, exceeded };
+    return false;
   };
-  let foundReference = false;
-  let exceeded = false;
-  try {
-    switch (request.type) {
-      case "graph.query":
-        foundReference = queryHasReference(request.query);
-        break;
-      case "session.watch.set":
-      case "session.watch.add":
-        foundReference = watchesHaveReference(request.watches);
-        break;
-      case "transact": {
-        if (
-          !isPlainRecord(request.commit) ||
-          !Array.isArray(request.commit.operations)
-        ) break;
-        for (const operation of request.commit.operations) {
-          traversal.visitNode(0);
-          if (!isPlainRecord(operation)) continue;
-          if (operation.op === "set") {
-            const scan = scanValue(operation.value);
-            foundReference ||= scan.hasReference;
-            exceeded ||= scan.exceeded;
-          }
-          if (operation.op === "patch") {
-            const scan = scanValue(operation.patches);
-            foundReference ||= scan.hasReference;
-            exceeded ||= scan.exceeded;
-          }
-        }
-        break;
+  if (request.schemaDefinitions !== undefined) return true;
+  switch (request.type) {
+    case "graph.query":
+      return queryHasReference(request.query);
+    case "session.watch.set":
+    case "session.watch.add":
+      return watchesHaveReference(request.watches);
+    case "transact": {
+      if (
+        !isPlainRecord(request.commit) ||
+        !Array.isArray(request.commit.operations)
+      ) {
+        return false;
       }
+      for (const operation of request.commit.operations) {
+        if (!isPlainRecord(operation)) continue;
+        if (operation.op === "set" && scanValue(operation.value)) return true;
+        if (operation.op === "patch" && scanValue(operation.patches)) {
+          return true;
+        }
+      }
+      return false;
     }
-  } catch (error) {
-    if (error instanceof InvalidRequestSchemaDefinitionsError) {
-      throw error;
-    }
-    throw error;
   }
-  if (exceeded) {
-    throw new InvalidRequestSchemaDefinitionsError(
-      "Request schema traversal limit exceeded",
-    );
-  }
-  return hasDefinitions || foundReference;
 };

--- a/packages/memory/v2/request-schema-cas.ts
+++ b/packages/memory/v2/request-schema-cas.ts
@@ -1,0 +1,467 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { isPlainObject } from "@commonfabric/utils/types";
+import type {
+  GraphQuery,
+  GraphQueryRequest,
+  TransactRequest,
+  WatchAddRequest,
+  WatchSetRequest,
+  WatchSpec,
+} from "../v2.ts";
+import {
+  mapLinkSchemas,
+  REQUEST_SCHEMA_CAS_REF_PREFIX,
+} from "./schema-table-links.ts";
+export { REQUEST_SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
+const MAX_REQUEST_SCHEMA_DEFINITIONS = 256;
+const MAX_REQUEST_SCHEMA_BYTES = 256 * 1024;
+const MAX_REQUEST_SCHEMA_HASH_LENGTH = 256;
+const MAX_REQUEST_SCHEMA_TRAVERSAL_DEPTH = 64;
+const MAX_REQUEST_SCHEMA_TRAVERSAL_NODES = 100_000;
+const textEncoder = new TextEncoder();
+
+export type RequestSchemaDefinitions = Record<string, JSONSchema>;
+export type RequestSchemaCasRequest =
+  | GraphQueryRequest
+  | WatchSetRequest
+  | WatchAddRequest
+  | TransactRequest;
+
+export type SchemaHashLookup = (hash: string) => JSONSchema | undefined;
+export type SchemaDefinitionsIngest = (
+  schemas: readonly JSONSchema[],
+) => void;
+
+export interface CompressRequestSchemasOptions {
+  isKnownSchemaHash: (hash: string) => boolean;
+  forceDefinitions?: boolean;
+}
+
+export class RequestSchemaCasError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RequestSchemaCasError";
+  }
+}
+
+export class MissingRequestSchemaDefinitionError extends RequestSchemaCasError {
+  readonly hash: string;
+
+  constructor(hash: string) {
+    super(`Missing request schema definition: ${hash}`);
+    this.name = "MissingRequestSchemaDefinitionError";
+    this.hash = hash;
+  }
+}
+
+export class InvalidRequestSchemaDefinitionsError
+  extends RequestSchemaCasError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRequestSchemaDefinitionsError";
+  }
+}
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);
+
+const isSchema = (value: unknown): value is JSONSchema =>
+  value === true || value === false || isPlainRecord(value);
+
+const isSupportedRequest = (
+  value: unknown,
+): value is RequestSchemaCasRequest =>
+  isPlainRecord(value) &&
+  (value.type === "graph.query" || value.type === "session.watch.set" ||
+    value.type === "session.watch.add" || value.type === "transact");
+
+const schemaReference = (
+  schema: JSONSchema,
+  table: Map<string, JSONSchema>,
+  options: CompressRequestSchemasOptions,
+): string => {
+  const canonical = internSchema(schema, true);
+  if (
+    options.forceDefinitions ||
+    !options.isKnownSchemaHash(canonical.taggedHashString)
+  ) {
+    table.set(canonical.taggedHashString, canonical.schema);
+  }
+  return `${REQUEST_SCHEMA_CAS_REF_PREFIX}${canonical.taggedHashString}`;
+};
+
+const generatedDefinitionsFitLimits = (
+  definitions: ReadonlyMap<string, JSONSchema>,
+): boolean => {
+  if (definitions.size > MAX_REQUEST_SCHEMA_DEFINITIONS) return false;
+  try {
+    return [...definitions].every(([hash, schema]) =>
+      hash.length <= MAX_REQUEST_SCHEMA_HASH_LENGTH &&
+      textEncoder.encode(JSON.stringify(schema)).byteLength <=
+        MAX_REQUEST_SCHEMA_BYTES
+    );
+  } catch {
+    return false;
+  }
+};
+
+const mapQuerySchemas = (
+  query: GraphQuery,
+  mapSchema: (schema: unknown) => unknown,
+): GraphQuery => {
+  if (!isPlainRecord(query) || !Array.isArray(query.roots)) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Invalid request schema query",
+    );
+  }
+  let changed = false;
+  const roots = query.roots.map((root) => {
+    if (!isPlainRecord(root) || !isPlainRecord(root.selector)) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "Invalid request schema query root",
+      );
+    }
+    if (
+      !Object.hasOwn(root.selector, "schema")
+    ) return root;
+    const schema = mapSchema(root.selector.schema);
+    if (schema === root.selector.schema) return root;
+    changed = true;
+    return {
+      ...root,
+      selector: { ...root.selector, schema: schema as JSONSchema },
+    };
+  });
+  return changed ? { ...query, roots } : query;
+};
+
+const mapWatchSchemas = (
+  watches: WatchSpec[],
+  mapSchema: (schema: unknown) => unknown,
+): WatchSpec[] => {
+  if (!Array.isArray(watches)) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Invalid request schema watches",
+    );
+  }
+  let changed = false;
+  const mapped = watches.map((watch) => {
+    if (!isPlainRecord(watch)) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "Invalid request schema watch",
+      );
+    }
+    const query = mapQuerySchemas(watch.query, mapSchema);
+    if (query === watch.query) return watch;
+    changed = true;
+    return { ...watch, query };
+  });
+  return changed ? mapped : watches;
+};
+
+const mapTransactSchemas = (
+  request: TransactRequest,
+  mapSchema: (schema: unknown) => unknown,
+): TransactRequest => {
+  if (
+    !isPlainRecord(request.commit) || !Array.isArray(request.commit.operations)
+  ) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Invalid request schema transaction",
+    );
+  }
+  let changed = false;
+  const operations = request.commit.operations.map((operation) => {
+    if (!isPlainRecord(operation)) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "Invalid request schema operation",
+      );
+    }
+    if (operation.op === "set") {
+      const value = mapLinkSchemas(operation.value, mapSchema);
+      if (value === operation.value) return operation;
+      changed = true;
+      return { ...operation, value: value as typeof operation.value };
+    }
+    if (operation.op === "patch") {
+      const patches = mapLinkSchemas(operation.patches, mapSchema);
+      if (patches === operation.patches) return operation;
+      changed = true;
+      return { ...operation, patches: patches as typeof operation.patches };
+    }
+    return operation;
+  });
+  return changed
+    ? { ...request, commit: { ...request.commit, operations } }
+    : request;
+};
+
+const mapRequestSchemas = (
+  request: RequestSchemaCasRequest,
+  mapSchema: (schema: unknown) => unknown,
+): RequestSchemaCasRequest => {
+  switch (request.type) {
+    case "graph.query": {
+      const query = mapQuerySchemas(request.query, mapSchema);
+      return query === request.query ? request : { ...request, query };
+    }
+    case "session.watch.set":
+    case "session.watch.add": {
+      const watches = mapWatchSchemas(request.watches, mapSchema);
+      return watches === request.watches ? request : { ...request, watches };
+    }
+    case "transact":
+      return mapTransactSchemas(request, mapSchema);
+  }
+};
+
+export const compressRequestSchemas = <
+  Request extends RequestSchemaCasRequest,
+>(
+  request: Request,
+  options: CompressRequestSchemasOptions,
+): Request => {
+  const definitions = new Map<string, JSONSchema>();
+  const rewritten = mapRequestSchemas(
+    request,
+    (value) =>
+      isSchema(value) ? schemaReference(value, definitions, options) : value,
+  );
+  if (rewritten === request && request.schemaDefinitions === undefined) {
+    return request;
+  }
+  if (!generatedDefinitionsFitLimits(definitions)) return request;
+
+  const { schemaDefinitions: _schemaDefinitions, ...withoutDefinitions } =
+    rewritten;
+  const compressed = definitions.size === 0 ? withoutDefinitions as Request : {
+    ...withoutDefinitions,
+    schemaDefinitions: Object.fromEntries(definitions),
+  } as Request;
+  try {
+    // A generated reference must remain discoverable by bounded server
+    // preflight. Otherwise this optimization would turn a valid inline request
+    // into a ProtocolError instead of degrading transparently.
+    if (rewritten !== request && !hasRequestSchemaCasPayload(compressed)) {
+      return request;
+    }
+  } catch (error) {
+    if (error instanceof InvalidRequestSchemaDefinitionsError) return request;
+    throw error;
+  }
+  return compressed;
+};
+
+const canonicalDefinitions = (
+  value: unknown,
+): RequestSchemaDefinitions => {
+  if (!isPlainRecord(value)) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Invalid request schema definitions",
+    );
+  }
+  const entries = Object.entries(value);
+  if (entries.length > MAX_REQUEST_SCHEMA_DEFINITIONS) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      `Too many request schema definitions: ${entries.length}`,
+    );
+  }
+  const definitions: RequestSchemaDefinitions = {};
+  for (const [hash, schema] of entries) {
+    if (!isSchema(schema)) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        `Invalid request schema definition: ${hash}`,
+      );
+    }
+    const encoded = JSON.stringify(schema);
+    if (textEncoder.encode(encoded).byteLength > MAX_REQUEST_SCHEMA_BYTES) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        `Request schema definition is too large: ${hash}`,
+      );
+    }
+    const canonical = internSchema(schema, true);
+    if (canonical.taggedHashString !== hash) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        `Request schema definition hash mismatch: ${hash}`,
+      );
+    }
+    definitions[hash] = canonical.schema;
+  }
+  return definitions;
+};
+
+const expandSchema = (
+  value: unknown,
+  definitions: RequestSchemaDefinitions | undefined,
+  lookup: SchemaHashLookup,
+  referencedDefinitions: Set<string>,
+): unknown => {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX)
+  ) {
+    return value;
+  }
+  const hash = value.slice(REQUEST_SCHEMA_CAS_REF_PREFIX.length);
+  if (hash.length === 0 || hash.length > MAX_REQUEST_SCHEMA_HASH_LENGTH) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      `Malformed request schema reference: ${value}`,
+    );
+  }
+  const definedSchema = definitions !== undefined &&
+      Object.hasOwn(definitions, hash)
+    ? definitions[hash]
+    : undefined;
+  const schema = definedSchema ?? lookup(hash);
+  if (schema === undefined) throw new MissingRequestSchemaDefinitionError(hash);
+  if (definedSchema !== undefined) referencedDefinitions.add(hash);
+  const canonical = internSchema(schema, true);
+  if (canonical.taggedHashString !== hash) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      `Request schema definition hash mismatch: ${hash}`,
+    );
+  }
+  return canonical.schema;
+};
+
+export const expandRequestSchemas = (
+  request: unknown,
+  lookup: SchemaHashLookup,
+  ingest?: SchemaDefinitionsIngest,
+): RequestSchemaCasRequest => {
+  if (!isSupportedRequest(request)) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Unsupported request schema table message",
+    );
+  }
+  const definitions = request.schemaDefinitions === undefined
+    ? undefined
+    : canonicalDefinitions(request.schemaDefinitions);
+  const referencedDefinitions = new Set<string>();
+  const expanded = mapRequestSchemas(
+    request,
+    (value) => expandSchema(value, definitions, lookup, referencedDefinitions),
+  );
+  if (definitions !== undefined) {
+    const unused = Object.keys(definitions).filter((hash) =>
+      !referencedDefinitions.has(hash)
+    );
+    if (unused.length > 0) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        `Unused request schema definitions: ${unused.join(", ")}`,
+      );
+    }
+    ingest?.(Object.values(definitions));
+  }
+  const { schemaDefinitions: _schemaDefinitions, ...logical } = expanded;
+  return logical as RequestSchemaCasRequest;
+};
+
+/** Whether a supported request uses a CAS-only field that requires negotiation. */
+export const hasRequestSchemaCasPayload = (request: unknown): boolean => {
+  if (!isSupportedRequest(request)) return false;
+  const hasDefinitions = request.schemaDefinitions !== undefined;
+
+  const hasReference = (value: unknown): boolean =>
+    typeof value === "string" &&
+    value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
+  const queryHasReference = (query: unknown): boolean => {
+    if (!isPlainRecord(query) || !Array.isArray(query.roots)) return false;
+    return query.roots.some((root) =>
+      isPlainRecord(root) && isPlainRecord(root.selector) &&
+      hasReference(root.selector.schema)
+    );
+  };
+  const watchesHaveReference = (watches: unknown): boolean =>
+    Array.isArray(watches) &&
+    watches.some((watch) =>
+      isPlainRecord(watch) && queryHasReference(watch.query)
+    );
+  const scanValue = (
+    value: unknown,
+  ): { hasReference: boolean; exceeded: boolean } => {
+    const pending: Array<{ value: unknown; depth: number }> = [{
+      value,
+      depth: 0,
+    }];
+    let nodes = 0;
+    let found = false;
+    let exceeded = false;
+    while (pending.length > 0) {
+      const current = pending.pop()!;
+      nodes += 1;
+      if (nodes > MAX_REQUEST_SCHEMA_TRAVERSAL_NODES) {
+        exceeded = true;
+        break;
+      }
+      if (current.depth > MAX_REQUEST_SCHEMA_TRAVERSAL_DEPTH) {
+        exceeded = true;
+        continue;
+      }
+      if (Array.isArray(current.value)) {
+        for (let index = current.value.length - 1; index >= 0; index -= 1) {
+          pending.push({
+            value: current.value[index],
+            depth: current.depth + 1,
+          });
+        }
+        continue;
+      }
+      if (!isPlainRecord(current.value)) continue;
+
+      const linkEnvelope = current.value["/"];
+      const linkPayload = isPlainRecord(linkEnvelope)
+        ? linkEnvelope["link@1"]
+        : undefined;
+      if (
+        isPlainRecord(linkPayload) &&
+        Object.hasOwn(linkPayload, "schema") &&
+        hasReference(linkPayload.schema)
+      ) found = true;
+      const alias = current.value.$alias;
+      if (
+        isPlainRecord(alias) && Object.hasOwn(alias, "schema") &&
+        hasReference(alias.schema)
+      ) found = true;
+
+      const children = Object.values(current.value);
+      for (let index = children.length - 1; index >= 0; index -= 1) {
+        pending.push({ value: children[index], depth: current.depth + 1 });
+      }
+    }
+    return { hasReference: found, exceeded };
+  };
+
+  switch (request.type) {
+    case "graph.query":
+      return hasDefinitions || queryHasReference(request.query);
+    case "session.watch.set":
+    case "session.watch.add":
+      return hasDefinitions || watchesHaveReference(request.watches);
+    case "transact": {
+      if (
+        !isPlainRecord(request.commit) ||
+        !Array.isArray(request.commit.operations)
+      ) return hasDefinitions;
+      let hasReference = false;
+      let exceeded = false;
+      for (const operation of request.commit.operations) {
+        if (!isPlainRecord(operation)) continue;
+        let scan: ReturnType<typeof scanValue> | undefined;
+        if (operation.op === "set") scan = scanValue(operation.value);
+        if (operation.op === "patch") scan = scanValue(operation.patches);
+        if (scan !== undefined) {
+          hasReference ||= scan.hasReference;
+          exceeded ||= scan.exceeded;
+        }
+      }
+      if (exceeded && (hasDefinitions || hasReference)) {
+        throw new InvalidRequestSchemaDefinitionsError(
+          "Request schema traversal limit exceeded",
+        );
+      }
+      return hasDefinitions || hasReference;
+    }
+  }
+};

--- a/packages/memory/v2/request-schema-cas.ts
+++ b/packages/memory/v2/request-schema-cas.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
+import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { isPlainObject } from "@commonfabric/utils/types";
 import type {
@@ -10,6 +11,7 @@ import type {
   WatchSpec,
 } from "../v2.ts";
 import {
+  type LinkSchemaTraversal,
   mapLinkSchemas,
   REQUEST_SCHEMA_CAS_REF_PREFIX,
 } from "./schema-table-links.ts";
@@ -19,6 +21,7 @@ const MAX_REQUEST_SCHEMA_BYTES = 256 * 1024;
 const MAX_REQUEST_SCHEMA_HASH_LENGTH = 256;
 const MAX_REQUEST_SCHEMA_TRAVERSAL_DEPTH = 64;
 const MAX_REQUEST_SCHEMA_TRAVERSAL_NODES = 100_000;
+const MAX_REQUEST_SCHEMA_POSITIONS = 100_000;
 const textEncoder = new TextEncoder();
 
 export type RequestSchemaDefinitions = Record<string, JSONSchema>;
@@ -69,6 +72,35 @@ const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
 const isSchema = (value: unknown): value is JSONSchema =>
   value === true || value === false || isPlainRecord(value);
 
+interface RequestSchemaTraversal extends LinkSchemaTraversal {
+  nodes: number;
+  positions: number;
+}
+
+const createRequestSchemaTraversal = (): RequestSchemaTraversal => ({
+  nodes: 0,
+  positions: 0,
+  visitNode(depth) {
+    this.nodes += 1;
+    if (
+      depth > MAX_REQUEST_SCHEMA_TRAVERSAL_DEPTH ||
+      this.nodes > MAX_REQUEST_SCHEMA_TRAVERSAL_NODES
+    ) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "Request schema traversal limit exceeded",
+      );
+    }
+  },
+  visitSchemaPosition() {
+    this.positions += 1;
+    if (this.positions > MAX_REQUEST_SCHEMA_POSITIONS) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "Request schema traversal limit exceeded",
+      );
+    }
+  },
+});
+
 const isSupportedRequest = (
   value: unknown,
 ): value is RequestSchemaCasRequest =>
@@ -96,11 +128,16 @@ const definitionsFitLimits = (
 ): boolean => {
   if (definitions.size > MAX_REQUEST_SCHEMA_DEFINITIONS) return false;
   try {
-    return [...definitions].every(([hash, schema]) =>
-      hash.length <= MAX_REQUEST_SCHEMA_HASH_LENGTH &&
-      textEncoder.encode(JSON.stringify(schema)).byteLength <=
-        MAX_REQUEST_SCHEMA_BYTES
-    );
+    let totalBytes = 0;
+    for (const [hash, schema] of definitions) {
+      if (hash.length > MAX_REQUEST_SCHEMA_HASH_LENGTH) return false;
+      const canonical = internSchema(schema, true).schema;
+      const bytes = textEncoder.encode(jsonFromValue(canonical)).byteLength;
+      if (bytes > MAX_REQUEST_SCHEMA_BYTES) return false;
+      totalBytes += bytes;
+      if (totalBytes > MAX_REQUEST_SCHEMA_BYTES) return false;
+    }
+    return true;
   } catch {
     return false;
   }
@@ -109,7 +146,9 @@ const definitionsFitLimits = (
 const mapQuerySchemas = (
   query: GraphQuery,
   mapSchema: (schema: unknown) => unknown,
+  traversal: RequestSchemaTraversal,
 ): GraphQuery => {
+  traversal.visitNode(0);
   if (!isPlainRecord(query) || !Array.isArray(query.roots)) {
     throw new InvalidRequestSchemaDefinitionsError(
       "Invalid request schema query",
@@ -117,6 +156,7 @@ const mapQuerySchemas = (
   }
   let changed = false;
   const roots = query.roots.map((root) => {
+    traversal.visitNode(1);
     if (!isPlainRecord(root) || !isPlainRecord(root.selector)) {
       throw new InvalidRequestSchemaDefinitionsError(
         "Invalid request schema query root",
@@ -125,6 +165,7 @@ const mapQuerySchemas = (
     if (
       !Object.hasOwn(root.selector, "schema")
     ) return root;
+    traversal.visitSchemaPosition();
     const schema = mapSchema(root.selector.schema);
     if (schema === root.selector.schema) return root;
     changed = true;
@@ -139,6 +180,7 @@ const mapQuerySchemas = (
 const mapWatchSchemas = (
   watches: WatchSpec[],
   mapSchema: (schema: unknown) => unknown,
+  traversal: RequestSchemaTraversal,
 ): WatchSpec[] => {
   if (!Array.isArray(watches)) {
     throw new InvalidRequestSchemaDefinitionsError(
@@ -147,12 +189,13 @@ const mapWatchSchemas = (
   }
   let changed = false;
   const mapped = watches.map((watch) => {
+    traversal.visitNode(0);
     if (!isPlainRecord(watch)) {
       throw new InvalidRequestSchemaDefinitionsError(
         "Invalid request schema watch",
       );
     }
-    const query = mapQuerySchemas(watch.query, mapSchema);
+    const query = mapQuerySchemas(watch.query, mapSchema, traversal);
     if (query === watch.query) return watch;
     changed = true;
     return { ...watch, query };
@@ -163,6 +206,7 @@ const mapWatchSchemas = (
 const mapTransactSchemas = (
   request: TransactRequest,
   mapSchema: (schema: unknown) => unknown,
+  traversal: RequestSchemaTraversal,
 ): TransactRequest => {
   if (
     !isPlainRecord(request.commit) || !Array.isArray(request.commit.operations)
@@ -173,19 +217,20 @@ const mapTransactSchemas = (
   }
   let changed = false;
   const operations = request.commit.operations.map((operation) => {
+    traversal.visitNode(0);
     if (!isPlainRecord(operation)) {
       throw new InvalidRequestSchemaDefinitionsError(
         "Invalid request schema operation",
       );
     }
     if (operation.op === "set") {
-      const value = mapLinkSchemas(operation.value, mapSchema);
+      const value = mapLinkSchemas(operation.value, mapSchema, traversal);
       if (value === operation.value) return operation;
       changed = true;
       return { ...operation, value: value as typeof operation.value };
     }
     if (operation.op === "patch") {
-      const patches = mapLinkSchemas(operation.patches, mapSchema);
+      const patches = mapLinkSchemas(operation.patches, mapSchema, traversal);
       if (patches === operation.patches) return operation;
       changed = true;
       return { ...operation, patches: patches as typeof operation.patches };
@@ -200,20 +245,50 @@ const mapTransactSchemas = (
 const mapRequestSchemas = (
   request: RequestSchemaCasRequest,
   mapSchema: (schema: unknown) => unknown,
+  traversal = createRequestSchemaTraversal(),
 ): RequestSchemaCasRequest => {
   switch (request.type) {
     case "graph.query": {
-      const query = mapQuerySchemas(request.query, mapSchema);
+      const query = mapQuerySchemas(request.query, mapSchema, traversal);
       return query === request.query ? request : { ...request, query };
     }
     case "session.watch.set":
     case "session.watch.add": {
-      const watches = mapWatchSchemas(request.watches, mapSchema);
+      const watches = mapWatchSchemas(request.watches, mapSchema, traversal);
       return watches === request.watches ? request : { ...request, watches };
     }
     case "transact":
-      return mapTransactSchemas(request, mapSchema);
+      return mapTransactSchemas(request, mapSchema, traversal);
   }
+};
+
+/**
+ * Collect CAS hashes only from schema-bearing positions supported by a request
+ * envelope. This shares compression and expansion's schema traversal rather
+ * than interpreting arbitrary user strings.
+ */
+export const collectRequestSchemaCasHashes = (
+  request: unknown,
+): ReadonlySet<string> => {
+  if (!isSupportedRequest(request)) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Unsupported request schema table message",
+    );
+  }
+  const hashes = new Set<string>();
+  mapRequestSchemas(request, (value) => {
+    if (
+      typeof value === "string" &&
+      value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX)
+    ) {
+      const hash = value.slice(REQUEST_SCHEMA_CAS_REF_PREFIX.length);
+      if (hash.length > 0 && hash.length <= MAX_REQUEST_SCHEMA_HASH_LENGTH) {
+        hashes.add(hash);
+      }
+    }
+    return value;
+  });
+  return hashes;
 };
 
 export const compressRequestSchemas = <
@@ -223,11 +298,17 @@ export const compressRequestSchemas = <
   options: CompressRequestSchemasOptions,
 ): Request => {
   const definitions = new Map<string, JSONSchema>();
-  const rewritten = mapRequestSchemas(
-    request,
-    (value) =>
-      isSchema(value) ? schemaReference(value, definitions, options) : value,
-  );
+  let rewritten: RequestSchemaCasRequest;
+  try {
+    rewritten = mapRequestSchemas(
+      request,
+      (value) =>
+        isSchema(value) ? schemaReference(value, definitions, options) : value,
+    );
+  } catch (error) {
+    if (error instanceof InvalidRequestSchemaDefinitionsError) return request;
+    throw error;
+  }
   if (rewritten === request && request.schemaDefinitions === undefined) {
     return request;
   }
@@ -279,19 +360,40 @@ const canonicalDefinitions = (
     );
   }
   const definitions: RequestSchemaDefinitions = {};
+  let totalBytes = 0;
   for (const [hash, schema] of entries) {
+    if (hash.length > MAX_REQUEST_SCHEMA_HASH_LENGTH) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        `Request schema definition hash is too long: ${hash}`,
+      );
+    }
     if (!isSchema(schema)) {
       throw new InvalidRequestSchemaDefinitionsError(
         `Invalid request schema definition: ${hash}`,
       );
     }
-    const encoded = JSON.stringify(schema);
-    if (textEncoder.encode(encoded).byteLength > MAX_REQUEST_SCHEMA_BYTES) {
+    let canonical: ReturnType<typeof internSchema>;
+    let encoded: string;
+    try {
+      canonical = internSchema(schema, true);
+      encoded = jsonFromValue(canonical.schema);
+    } catch {
+      throw new InvalidRequestSchemaDefinitionsError(
+        `Invalid request schema definition: ${hash}`,
+      );
+    }
+    const bytes = textEncoder.encode(encoded).byteLength;
+    if (bytes > MAX_REQUEST_SCHEMA_BYTES) {
       throw new InvalidRequestSchemaDefinitionsError(
         `Request schema definition is too large: ${hash}`,
       );
     }
-    const canonical = internSchema(schema, true);
+    totalBytes += bytes;
+    if (totalBytes > MAX_REQUEST_SCHEMA_BYTES) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "Request schema definitions are too large",
+      );
+    }
     if (canonical.taggedHashString !== hash) {
       throw new InvalidRequestSchemaDefinitionsError(
         `Request schema definition hash mismatch: ${hash}`,
@@ -307,6 +409,7 @@ const expandSchema = (
   definitions: RequestSchemaDefinitions | undefined,
   lookup: SchemaHashLookup,
   referencedDefinitions: Set<string>,
+  resolvedSchemas: Map<string, JSONSchema>,
 ): unknown => {
   if (
     typeof value !== "string" ||
@@ -324,15 +427,21 @@ const expandSchema = (
       Object.hasOwn(definitions, hash)
     ? definitions[hash]
     : undefined;
+  if (definedSchema !== undefined) referencedDefinitions.add(hash);
+  const resolved = resolvedSchemas.get(hash);
+  if (resolved !== undefined) return resolved;
   const schema = definedSchema ?? lookup(hash);
   if (schema === undefined) throw new MissingRequestSchemaDefinitionError(hash);
-  if (definedSchema !== undefined) referencedDefinitions.add(hash);
-  const canonical = internSchema(schema, true);
+  const canonical = definedSchema === undefined ? internSchema(schema, true) : {
+    schema,
+    taggedHashString: hash,
+  };
   if (canonical.taggedHashString !== hash) {
     throw new InvalidRequestSchemaDefinitionsError(
       `Request schema definition hash mismatch: ${hash}`,
     );
   }
+  resolvedSchemas.set(hash, canonical.schema);
   return canonical.schema;
 };
 
@@ -350,9 +459,17 @@ export const expandRequestSchemas = (
     ? undefined
     : canonicalDefinitions(request.schemaDefinitions);
   const referencedDefinitions = new Set<string>();
+  const resolvedSchemas = new Map<string, JSONSchema>();
   const expanded = mapRequestSchemas(
     request,
-    (value) => expandSchema(value, definitions, lookup, referencedDefinitions),
+    (value) =>
+      expandSchema(
+        value,
+        definitions,
+        lookup,
+        referencedDefinitions,
+        resolvedSchemas,
+      ),
   );
   if (definitions !== undefined) {
     const unused = Object.keys(definitions).filter((hash) =>
@@ -373,22 +490,32 @@ export const expandRequestSchemas = (
 export const hasRequestSchemaCasPayload = (request: unknown): boolean => {
   if (!isSupportedRequest(request)) return false;
   const hasDefinitions = request.schemaDefinitions !== undefined;
-
   const hasReference = (value: unknown): boolean =>
     typeof value === "string" &&
     value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
+  const traversal = createRequestSchemaTraversal();
   const queryHasReference = (query: unknown): boolean => {
+    traversal.visitNode(0);
     if (!isPlainRecord(query) || !Array.isArray(query.roots)) return false;
-    return query.roots.some((root) =>
-      isPlainRecord(root) && isPlainRecord(root.selector) &&
-      hasReference(root.selector.schema)
-    );
+    let found = false;
+    for (const root of query.roots) {
+      traversal.visitNode(1);
+      if (!isPlainRecord(root) || !isPlainRecord(root.selector)) continue;
+      if (!Object.hasOwn(root.selector, "schema")) continue;
+      traversal.visitSchemaPosition();
+      found ||= hasReference(root.selector.schema);
+    }
+    return found;
   };
-  const watchesHaveReference = (watches: unknown): boolean =>
-    Array.isArray(watches) &&
-    watches.some((watch) =>
-      isPlainRecord(watch) && queryHasReference(watch.query)
-    );
+  const watchesHaveReference = (watches: unknown): boolean => {
+    if (!Array.isArray(watches)) return false;
+    let found = false;
+    for (const watch of watches) {
+      traversal.visitNode(0);
+      if (isPlainRecord(watch)) found ||= queryHasReference(watch.query);
+    }
+    return found;
+  };
   const scanValue = (
     value: unknown,
   ): { hasReference: boolean; exceeded: boolean } => {
@@ -396,15 +523,13 @@ export const hasRequestSchemaCasPayload = (request: unknown): boolean => {
       value,
       depth: 0,
     }];
-    let nodes = 0;
     let found = false;
     let exceeded = false;
     while (pending.length > 0) {
       const current = pending.pop()!;
-      nodes += 1;
-      if (nodes > MAX_REQUEST_SCHEMA_TRAVERSAL_NODES) {
-        exceeded = true;
-        break;
+      traversal.nodes += 1;
+      if (traversal.nodes > MAX_REQUEST_SCHEMA_TRAVERSAL_NODES) {
+        return { hasReference: found, exceeded: true };
       }
       if (current.depth > MAX_REQUEST_SCHEMA_TRAVERSAL_DEPTH) {
         exceeded = true;
@@ -425,16 +550,15 @@ export const hasRequestSchemaCasPayload = (request: unknown): boolean => {
       const linkPayload = isPlainRecord(linkEnvelope)
         ? linkEnvelope["link@1"]
         : undefined;
-      if (
-        isPlainRecord(linkPayload) &&
-        Object.hasOwn(linkPayload, "schema") &&
-        hasReference(linkPayload.schema)
-      ) found = true;
+      if (isPlainRecord(linkPayload) && Object.hasOwn(linkPayload, "schema")) {
+        traversal.visitSchemaPosition();
+        found ||= hasReference(linkPayload.schema);
+      }
       const alias = current.value.$alias;
-      if (
-        isPlainRecord(alias) && Object.hasOwn(alias, "schema") &&
-        hasReference(alias.schema)
-      ) found = true;
+      if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
+        traversal.visitSchemaPosition();
+        found ||= hasReference(alias.schema);
+      }
 
       const children = Object.values(current.value);
       for (let index = children.length - 1; index >= 0; index -= 1) {
@@ -443,36 +567,49 @@ export const hasRequestSchemaCasPayload = (request: unknown): boolean => {
     }
     return { hasReference: found, exceeded };
   };
-
-  switch (request.type) {
-    case "graph.query":
-      return hasDefinitions || queryHasReference(request.query);
-    case "session.watch.set":
-    case "session.watch.add":
-      return hasDefinitions || watchesHaveReference(request.watches);
-    case "transact": {
-      if (
-        !isPlainRecord(request.commit) ||
-        !Array.isArray(request.commit.operations)
-      ) return hasDefinitions;
-      let hasReference = false;
-      let exceeded = false;
-      for (const operation of request.commit.operations) {
-        if (!isPlainRecord(operation)) continue;
-        let scan: ReturnType<typeof scanValue> | undefined;
-        if (operation.op === "set") scan = scanValue(operation.value);
-        if (operation.op === "patch") scan = scanValue(operation.patches);
-        if (scan !== undefined) {
-          hasReference ||= scan.hasReference;
-          exceeded ||= scan.exceeded;
+  let foundReference = false;
+  let exceeded = false;
+  try {
+    switch (request.type) {
+      case "graph.query":
+        foundReference = queryHasReference(request.query);
+        break;
+      case "session.watch.set":
+      case "session.watch.add":
+        foundReference = watchesHaveReference(request.watches);
+        break;
+      case "transact": {
+        if (
+          !isPlainRecord(request.commit) ||
+          !Array.isArray(request.commit.operations)
+        ) break;
+        for (const operation of request.commit.operations) {
+          traversal.visitNode(0);
+          if (!isPlainRecord(operation)) continue;
+          if (operation.op === "set") {
+            const scan = scanValue(operation.value);
+            foundReference ||= scan.hasReference;
+            exceeded ||= scan.exceeded;
+          }
+          if (operation.op === "patch") {
+            const scan = scanValue(operation.patches);
+            foundReference ||= scan.hasReference;
+            exceeded ||= scan.exceeded;
+          }
         }
+        break;
       }
-      if (exceeded && (hasDefinitions || hasReference)) {
-        throw new InvalidRequestSchemaDefinitionsError(
-          "Request schema traversal limit exceeded",
-        );
-      }
-      return hasDefinitions || hasReference;
     }
+  } catch (error) {
+    if (error instanceof InvalidRequestSchemaDefinitionsError) {
+      throw error;
+    }
+    throw error;
   }
+  if (exceeded) {
+    throw new InvalidRequestSchemaDefinitionsError(
+      "Request schema traversal limit exceeded",
+    );
+  }
+  return hasDefinitions || foundReference;
 };

--- a/packages/memory/v2/schema-store.ts
+++ b/packages/memory/v2/schema-store.ts
@@ -1,0 +1,310 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { Database } from "@db/sqlite";
+import * as Path from "@std/path";
+
+const INIT = `
+CREATE TABLE IF NOT EXISTS schema_store_metadata (
+  key TEXT NOT NULL PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_store_entries (
+  hash TEXT NOT NULL PRIMARY KEY,
+  canonical_json TEXT NOT NULL,
+  byte_length INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;
+
+const PRAGMAS = `
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA busy_timeout = 5000;
+`;
+
+const GENERATION_KEY = "generation";
+
+export interface SchemaStore {
+  /** Stable UUID identifying this durable store instance. */
+  readonly generation: string;
+
+  /** Canonicalizes and durably records a schema under its tagged content hash. */
+  put(schema: JSONSchema): StoredSchema;
+  /** Atomically canonicalizes and durably records a collection of schemas. */
+  putAll(schemas: readonly JSONSchema[]): StoredSchema[];
+  /** Returns a verified, immutable canonical schema, or undefined when absent. */
+  get(hash: string): StoredSchema | undefined;
+  /** Returns whether a verified schema is present for the tagged hash. */
+  has(hash: string): boolean;
+  /** Releases the underlying SQLite connection. */
+  close(): void;
+}
+
+export interface StoredSchema {
+  hash: string;
+  schema: JSONSchema;
+}
+
+export interface SchemaStoreOptions {
+  /** File URL for a durable store; non-file URLs create an in-memory store. */
+  url: URL;
+  maxSchemaBytes?: number;
+  maxEntries?: number;
+  maxTotalBytes?: number;
+}
+
+export class SchemaStoreQuotaError extends Error {
+  constructor(
+    readonly quota: "maxSchemaBytes" | "maxEntries" | "maxTotalBytes",
+    message: string,
+  ) {
+    super(message);
+    this.name = "SchemaStoreQuotaError";
+  }
+}
+
+/** A stored value failed parsing, canonicalization, or content-hash verification. */
+export class SchemaStoreCorruptionError extends Error {
+  constructor(readonly hash: string, message: string) {
+    super(message);
+    this.name = "SchemaStoreCorruptionError";
+  }
+}
+
+type EntryRow = {
+  hash: string;
+  canonical_json: string;
+  byte_length: number;
+};
+
+type UsageRow = {
+  entries: number;
+  total_bytes: number | null;
+};
+
+const byteLength = (value: string): number =>
+  new TextEncoder().encode(value).byteLength;
+
+const validateLimit = (name: string, value: number | undefined): number => {
+  if (value === undefined) return Number.POSITIVE_INFINITY;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+  return value;
+};
+
+const databaseAddress = (url: URL): string =>
+  url.protocol === "file:" ? Path.fromFileUrl(url) : ":memory:";
+
+const schemaFromRow = (row: EntryRow, requestedHash: string): StoredSchema => {
+  if (row.hash !== requestedHash) {
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store returned a row for a different hash",
+    );
+  }
+  if (byteLength(row.canonical_json) !== row.byte_length) {
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store byte length does not match stored JSON",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.canonical_json);
+  } catch {
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store contains invalid JSON",
+    );
+  }
+  if (
+    parsed !== true && parsed !== false &&
+    (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+  ) {
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store contains a non-schema JSON value",
+    );
+  }
+
+  try {
+    const canonical = internSchema(parsed as JSONSchema, true);
+    const canonicalJson = JSON.stringify(canonical.schema);
+    if (
+      canonical.taggedHashString !== requestedHash ||
+      canonicalJson !== row.canonical_json
+    ) {
+      throw new SchemaStoreCorruptionError(
+        requestedHash,
+        "schema store JSON does not match its tagged content hash",
+      );
+    }
+    return { hash: canonical.taggedHashString, schema: canonical.schema };
+  } catch (error) {
+    if (error instanceof SchemaStoreCorruptionError) throw error;
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store contains an invalid schema",
+    );
+  }
+};
+
+export class SqliteSchemaStore implements SchemaStore {
+  readonly #maxSchemaBytes: number;
+  readonly #maxEntries: number;
+  readonly #maxTotalBytes: number;
+  readonly #selectEntry;
+  readonly #insertEntry;
+  readonly #usage;
+
+  private constructor(
+    readonly database: Database,
+    readonly generation: string,
+    options: SchemaStoreOptions,
+  ) {
+    this.#maxSchemaBytes = validateLimit(
+      "maxSchemaBytes",
+      options.maxSchemaBytes,
+    );
+    this.#maxEntries = validateLimit("maxEntries", options.maxEntries);
+    this.#maxTotalBytes = validateLimit("maxTotalBytes", options.maxTotalBytes);
+    this.#selectEntry = database.prepare(
+      "SELECT hash, canonical_json, byte_length FROM schema_store_entries WHERE hash = ?",
+    );
+    this.#insertEntry = database.prepare(
+      "INSERT OR IGNORE INTO schema_store_entries (hash, canonical_json, byte_length) VALUES (?, ?, ?)",
+    );
+    this.#usage = database.prepare(
+      "SELECT COUNT(*) AS entries, COALESCE(SUM(byte_length), 0) AS total_bytes FROM schema_store_entries",
+    );
+  }
+
+  static async open(options: SchemaStoreOptions): Promise<SqliteSchemaStore> {
+    if (options.url.protocol === "file:") {
+      await Deno.mkdir(Path.dirname(Path.fromFileUrl(options.url)), {
+        recursive: true,
+      });
+    }
+    const database = await new Database(databaseAddress(options.url), {
+      create: true,
+    });
+    database.exec(PRAGMAS);
+    database.exec(INIT);
+    database.prepare(
+      "INSERT OR IGNORE INTO schema_store_metadata (key, value) VALUES (?, ?)",
+    ).run(GENERATION_KEY, crypto.randomUUID());
+    const row = database.prepare(
+      "SELECT value FROM schema_store_metadata WHERE key = ?",
+    ).get(GENERATION_KEY) as { value: string } | undefined;
+    if (!row || !row.value) {
+      database.close();
+      throw new Error("schema store generation metadata is missing");
+    }
+    return new SqliteSchemaStore(database, row.value, options);
+  }
+
+  put(schema: JSONSchema): StoredSchema {
+    return this.putAll([schema])[0];
+  }
+
+  putAll(schemas: readonly JSONSchema[]): StoredSchema[] {
+    const candidates = schemas.map((schema) => {
+      const canonical = internSchema(schema, true);
+      // Rehash canonical content instead of relying on the interning cache's
+      // weak identity lookup for the durable content-addressed key.
+      const hash = hashOf(canonical.schema).taggedHashString;
+      const canonicalJson = JSON.stringify(canonical.schema);
+      return {
+        stored: { hash, schema: canonical.schema },
+        canonicalJson,
+        size: byteLength(canonicalJson),
+      };
+    });
+    if (candidates.length === 0) return [];
+
+    return this.database.transaction(() => {
+      const resolved = new Map<string, StoredSchema>();
+      const missing = new Map<string, (typeof candidates)[number]>();
+      for (const candidate of candidates) {
+        if (resolved.has(candidate.stored.hash)) continue;
+        const existing = this.#selectEntry.get(candidate.stored.hash) as
+          | EntryRow
+          | undefined;
+        if (existing) {
+          resolved.set(
+            candidate.stored.hash,
+            schemaFromRow(existing, candidate.stored.hash),
+          );
+        } else {
+          missing.set(candidate.stored.hash, candidate);
+        }
+      }
+
+      for (const candidate of missing.values()) {
+        if (candidate.size > this.#maxSchemaBytes) {
+          throw new SchemaStoreQuotaError(
+            "maxSchemaBytes",
+            `schema is ${candidate.size} bytes, exceeding maxSchemaBytes ${this.#maxSchemaBytes}`,
+          );
+        }
+      }
+
+      const usage = this.#usage.get() as UsageRow;
+      const nextEntries = usage.entries + missing.size;
+      if (nextEntries > this.#maxEntries) {
+        throw new SchemaStoreQuotaError(
+          "maxEntries",
+          `schema store would have ${nextEntries} entries, exceeding maxEntries ${this.#maxEntries}`,
+        );
+      }
+      const addedBytes = [...missing.values()].reduce(
+        (total, candidate) => total + candidate.size,
+        0,
+      );
+      const nextTotalBytes = (usage.total_bytes ?? 0) + addedBytes;
+      if (nextTotalBytes > this.#maxTotalBytes) {
+        throw new SchemaStoreQuotaError(
+          "maxTotalBytes",
+          `schema store would use ${nextTotalBytes} bytes, exceeding maxTotalBytes ${this.#maxTotalBytes}`,
+        );
+      }
+
+      for (const candidate of missing.values()) {
+        this.#insertEntry.run(
+          candidate.stored.hash,
+          candidate.canonicalJson,
+          candidate.size,
+        );
+        resolved.set(candidate.stored.hash, candidate.stored);
+      }
+      return candidates.map((candidate) => {
+        const stored = resolved.get(candidate.stored.hash);
+        if (stored === undefined) {
+          throw new Error("schema batch insertion did not resolve a candidate");
+        }
+        return stored;
+      });
+    }).immediate();
+  }
+
+  get(hash: string): StoredSchema | undefined {
+    const row = this.#selectEntry.get(hash) as EntryRow | undefined;
+    return row ? schemaFromRow(row, hash) : undefined;
+  }
+
+  has(hash: string): boolean {
+    return this.get(hash) !== undefined;
+  }
+
+  close(): void {
+    this.database.close();
+  }
+}
+
+export const openSchemaStore = (
+  options: SchemaStoreOptions,
+): Promise<SqliteSchemaStore> => SqliteSchemaStore.open(options);

--- a/packages/memory/v2/schema-store.ts
+++ b/packages/memory/v2/schema-store.ts
@@ -27,12 +27,12 @@ PRAGMA busy_timeout = 5000;
 const GENERATION_KEY = "generation";
 
 export interface SchemaStore {
-  /** Stable UUID identifying this durable store instance. */
+  /** Stable UUID identifying this store instance for its configured lifetime. */
   readonly generation: string;
 
-  /** Canonicalizes and durably records a schema under its tagged content hash. */
+  /** Canonicalizes and records a schema under its tagged content hash. */
   put(schema: JSONSchema): StoredSchema;
-  /** Atomically canonicalizes and durably records a collection of schemas. */
+  /** Atomically canonicalizes and records a collection of schemas. */
   putAll(schemas: readonly JSONSchema[]): StoredSchema[];
   /** Returns a verified, immutable canonical schema, or undefined when absent. */
   get(hash: string): StoredSchema | undefined;

--- a/packages/memory/v2/schema-store.ts
+++ b/packages/memory/v2/schema-store.ts
@@ -1,6 +1,10 @@
 import type { JSONSchema } from "@commonfabric/api";
+import {
+  jsonFromValue,
+  valueFromJson,
+} from "@commonfabric/data-model/codec-json";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { hashOf } from "@commonfabric/data-model/value-hash";
+import { isPlainObject } from "@commonfabric/utils/types";
 import { Database } from "@db/sqlite";
 import * as Path from "@std/path";
 
@@ -98,45 +102,34 @@ const validateLimit = (name: string, value: number | undefined): number => {
 const databaseAddress = (url: URL): string =>
   url.protocol === "file:" ? Path.fromFileUrl(url) : ":memory:";
 
-const schemaFromRow = (row: EntryRow, requestedHash: string): StoredSchema => {
-  if (row.hash !== requestedHash) {
-    throw new SchemaStoreCorruptionError(
-      requestedHash,
-      "schema store returned a row for a different hash",
-    );
-  }
-  if (byteLength(row.canonical_json) !== row.byte_length) {
-    throw new SchemaStoreCorruptionError(
-      requestedHash,
-      "schema store byte length does not match stored JSON",
-    );
-  }
+const isSchema = (value: unknown): value is JSONSchema =>
+  value === true || value === false || isPlainObject(value);
 
-  let parsed: unknown;
+const schemaFromEncoded = (
+  canonicalJson: string,
+  requestedHash: string,
+): StoredSchema => {
+  let decoded: unknown;
   try {
-    parsed = JSON.parse(row.canonical_json);
+    decoded = valueFromJson(canonicalJson);
   } catch {
     throw new SchemaStoreCorruptionError(
       requestedHash,
-      "schema store contains invalid JSON",
+      "schema store contains invalid Fabric JSON",
     );
   }
-  if (
-    parsed !== true && parsed !== false &&
-    (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
-  ) {
+  if (!isSchema(decoded)) {
     throw new SchemaStoreCorruptionError(
       requestedHash,
-      "schema store contains a non-schema JSON value",
+      "schema store contains a non-schema Fabric value",
     );
   }
 
   try {
-    const canonical = internSchema(parsed as JSONSchema, true);
-    const canonicalJson = JSON.stringify(canonical.schema);
+    const canonical = internSchema(decoded, true);
     if (
       canonical.taggedHashString !== requestedHash ||
-      canonicalJson !== row.canonical_json
+      jsonFromValue(canonical.schema) !== canonicalJson
     ) {
       throw new SchemaStoreCorruptionError(
         requestedHash,
@@ -151,6 +144,23 @@ const schemaFromRow = (row: EntryRow, requestedHash: string): StoredSchema => {
       "schema store contains an invalid schema",
     );
   }
+};
+
+const schemaFromRow = (row: EntryRow, requestedHash: string): StoredSchema => {
+  if (row.hash !== requestedHash) {
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store returned a row for a different hash",
+    );
+  }
+  if (byteLength(row.canonical_json) !== row.byte_length) {
+    throw new SchemaStoreCorruptionError(
+      requestedHash,
+      "schema store byte length does not match stored JSON",
+    );
+  }
+
+  return schemaFromEncoded(row.canonical_json, requestedHash);
 };
 
 export class SqliteSchemaStore implements SchemaStore {
@@ -214,12 +224,13 @@ export class SqliteSchemaStore implements SchemaStore {
   putAll(schemas: readonly JSONSchema[]): StoredSchema[] {
     const candidates = schemas.map((schema) => {
       const canonical = internSchema(schema, true);
-      // Rehash canonical content instead of relying on the interning cache's
-      // weak identity lookup for the durable content-addressed key.
-      const hash = hashOf(canonical.schema).taggedHashString;
-      const canonicalJson = JSON.stringify(canonical.schema);
+      const canonicalJson = jsonFromValue(canonical.schema);
+      const stored = schemaFromEncoded(
+        canonicalJson,
+        canonical.taggedHashString,
+      );
       return {
-        stored: { hash, schema: canonical.schema },
+        stored,
         canonicalJson,
         size: byteLength(canonicalJson),
       };

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -3,6 +3,12 @@ import { isPlainObject } from "@commonfabric/utils/types";
 
 export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
 
+/** Optional request-local accounting for recursive schema-bearing values. */
+export interface LinkSchemaTraversal {
+  visitNode(depth: number): void;
+  visitSchemaPosition(): void;
+}
+
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   isPlainObject(value);
 
@@ -10,11 +16,14 @@ const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
 export const mapLinkSchemas = (
   value: unknown,
   mapSchema: (schema: unknown) => unknown,
+  traversal?: LinkSchemaTraversal,
+  depth = 0,
 ): unknown => {
+  traversal?.visitNode(depth);
   if (Array.isArray(value)) {
     let changed = false;
     const mapped = value.map((item) => {
-      const next = mapLinkSchemas(item, mapSchema);
+      const next = mapLinkSchemas(item, mapSchema, traversal, depth + 1);
       changed ||= next !== item;
       return next;
     });
@@ -29,6 +38,7 @@ export const mapLinkSchemas = (
   if (isPlainRecord(linkEnvelope)) {
     const payload = linkEnvelope[LINK_V1_TAG];
     if (isPlainRecord(payload) && Object.hasOwn(payload, "schema")) {
+      traversal?.visitSchemaPosition();
       const schema = mapSchema(payload.schema);
       if (schema !== payload.schema) {
         mappedValue = {
@@ -42,6 +52,7 @@ export const mapLinkSchemas = (
 
   const alias = value.$alias;
   if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
+    traversal?.visitSchemaPosition();
     const schema = mapSchema(alias.schema);
     if (schema !== alias.schema) {
       mappedValue = { ...mappedValue, $alias: { ...alias, schema } };
@@ -51,7 +62,7 @@ export const mapLinkSchemas = (
 
   const mapped: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(mappedValue)) {
-    const next = mapLinkSchemas(child, mapSchema);
+    const next = mapLinkSchemas(child, mapSchema, traversal, depth + 1);
     changed ||= next !== child;
     Object.defineProperty(mapped, key, {
       value: next,

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -53,7 +53,12 @@ export const mapLinkSchemas = (
   for (const [key, child] of Object.entries(mappedValue)) {
     const next = mapLinkSchemas(child, mapSchema);
     changed ||= next !== child;
-    mapped[key] = next;
+    Object.defineProperty(mapped, key, {
+      value: next,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
   }
   return changed ? mapped : value;
 };

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -1,0 +1,59 @@
+import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { isPlainObject } from "@commonfabric/utils/types";
+
+export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);
+
+/** Maps schemas only in modern and legacy link payload positions. */
+export const mapLinkSchemas = (
+  value: unknown,
+  mapSchema: (schema: unknown) => unknown,
+): unknown => {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const mapped = value.map((item) => {
+      const next = mapLinkSchemas(item, mapSchema);
+      changed ||= next !== item;
+      return next;
+    });
+    return changed ? mapped : value;
+  }
+
+  if (!isPlainRecord(value)) return value;
+
+  let mappedValue = value;
+  let changed = false;
+  const linkEnvelope = value["/"];
+  if (isPlainRecord(linkEnvelope)) {
+    const payload = linkEnvelope[LINK_V1_TAG];
+    if (isPlainRecord(payload) && Object.hasOwn(payload, "schema")) {
+      const schema = mapSchema(payload.schema);
+      if (schema !== payload.schema) {
+        mappedValue = {
+          ...mappedValue,
+          "/": { ...linkEnvelope, [LINK_V1_TAG]: { ...payload, schema } },
+        };
+        changed = true;
+      }
+    }
+  }
+
+  const alias = value.$alias;
+  if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
+    const schema = mapSchema(alias.schema);
+    if (schema !== alias.schema) {
+      mappedValue = { ...mappedValue, $alias: { ...alias, schema } };
+      changed = true;
+    }
+  }
+
+  const mapped: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(mappedValue)) {
+    const next = mapLinkSchemas(child, mapSchema);
+    changed ||= next !== child;
+    mapped[key] = next;
+  }
+  return changed ? mapped : value;
+};

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1342,9 +1342,7 @@ export class Server {
     context?: RequestAuthorizationContext,
   ): Promise<V2Error | RequestAuthorizationContext> {
     if (context !== undefined) {
-      const invalid = this.#requestAuthorizationContextError(message, context);
-      if (invalid !== null) return invalid;
-      return context;
+      return this.#currentRequestAuthorizationContext(message, context);
     }
 
     const session = this.#sessions.get(message.space, message.sessionId);
@@ -1381,10 +1379,10 @@ export class Server {
     };
   }
 
-  #requestAuthorizationContextError(
+  #currentRequestAuthorizationContext(
     message: RequestSchemaCasRequest,
     context: RequestAuthorizationContext,
-  ): V2Error | null {
+  ): V2Error | RequestAuthorizationContext {
     if (
       context[requestAuthorizationBrand] !== true ||
       context.space !== message.space ||
@@ -1403,16 +1401,20 @@ export class Server {
           : "Unknown or replaced session for space",
       );
     }
-    if (
-      this.#aclMode() !== "off" &&
-      context.aclEpoch !== this.#aclEpoch(message.space)
-    ) {
-      return toError(
-        "AuthorizationError",
-        "Space ACL changed while the request was in flight",
-      );
+    if (this.#aclMode() === "off") return context;
+    const aclEpoch = this.#aclEpoch(message.space);
+    if (context.aclEpoch === aclEpoch) return context;
+    if (context.engine === undefined) {
+      return toError("AuthorizationError", "Space ACL state is unavailable");
     }
-    return null;
+    const deny = this.#authorizeCurrentSessionWithEngine(
+      context.engine,
+      message.space,
+      message.sessionId,
+      context.session,
+      context.requirement,
+    );
+    return deny ?? { ...context, aclEpoch };
   }
 
   nowSeconds(): number {
@@ -2495,15 +2497,15 @@ export class Server {
             await this.openEngine(message.space);
           // Authorization may become stale while request-schema expansion or
           // engine opening is in flight. Re-check session identity and the ACL
-          // epoch beside apply without making a duplicate ACL decision.
-          const invalidAuthorization = this.#requestAuthorizationContextError(
+          // epoch beside apply, re-authorizing only when the epoch changed.
+          const currentAuthorization = this.#currentRequestAuthorizationContext(
             message,
             authorization,
           );
-          if (invalidAuthorization !== null) {
+          if ("name" in currentAuthorization) {
             return respondTypedError<Engine.AppliedCommit>(
               message.requestId,
-              invalidAuthorization,
+              currentAuthorization,
             );
           }
           const invalid = this.#validateAclCommit(
@@ -2712,14 +2714,14 @@ export class Server {
       );
     }
     const { engine: aclEngine, session } = authorization;
-    const invalidAuthorization = this.#requestAuthorizationContextError(
+    const currentAuthorization = this.#currentRequestAuthorizationContext(
       message,
       authorization,
     );
-    if (invalidAuthorization !== null) {
+    if ("name" in currentAuthorization) {
       return respondTypedError<GraphQueryResult>(
         message.requestId,
-        invalidAuthorization,
+        currentAuthorization,
       );
     }
     if ((message.query as GraphQuery & { subscribe?: boolean }).subscribe) {
@@ -2866,14 +2868,14 @@ export class Server {
       );
     }
     const { engine: aclEngine, session } = authorization;
-    const invalidAuthorization = this.#requestAuthorizationContextError(
+    const currentAuthorization = this.#currentRequestAuthorizationContext(
       message,
       authorization,
     );
-    if (invalidAuthorization !== null) {
+    if ("name" in currentAuthorization) {
       return respondTypedError<WatchSetResult>(
         message.requestId,
-        invalidAuthorization,
+        currentAuthorization,
       );
     }
 
@@ -2932,14 +2934,14 @@ export class Server {
       );
     }
     const { engine: aclEngine, session } = authorization;
-    const invalidAuthorization = this.#requestAuthorizationContextError(
+    const currentAuthorization = this.#currentRequestAuthorizationContext(
       message,
       authorization,
     );
-    if (invalidAuthorization !== null) {
+    if ("name" in currentAuthorization) {
       return respondTypedError<WatchAddResult>(
         message.requestId,
-        invalidAuthorization,
+        currentAuthorization,
       );
     }
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -372,6 +372,31 @@ type SessionHandle = {
   sessionId: string;
 };
 
+const requestAuthorizationBrand = Symbol("requestAuthorization");
+
+/** A decision bound to one parsed wire request. Its brand is module-private so
+ * callers cannot manufacture an authorization bypass for the public handlers. */
+type RequestAuthorizationContext = {
+  readonly [requestAuthorizationBrand]: true;
+  readonly space: string;
+  readonly sessionId: string;
+  readonly requirement: Capability;
+  readonly aclEpoch: number;
+  readonly sessionInvalidationError: "SessionError" | "SessionRevokedError";
+  readonly session: SessionState;
+  readonly engine?: Engine.Engine;
+};
+
+const requiredCapabilityForRequest = (
+  message: RequestSchemaCasRequest,
+): Capability => {
+  if (message.type !== "transact") return "READ";
+  const operations = Array.isArray(message.commit?.operations)
+    ? message.commit.operations
+    : [];
+  return commitTouchesAclDoc(operations, message.space) ? "OWNER" : "WRITE";
+};
+
 type DirtyOrigin = {
   sessionId: string;
   seq: number;
@@ -389,6 +414,8 @@ class Connection {
   #persistentSchedulerState = false;
   #requestSchemaCasV1 = false;
   #sessions = new Map<string, SessionHandle>();
+  #sessionVersion = 0;
+  #revokedSessions = new Map<string, number>();
   #sessionOpenChallenge: SessionOpenChallengeState | null = null;
   #receiving: Promise<void> = Promise.resolve();
   #pendingReceives = 0;
@@ -509,6 +536,15 @@ class Connection {
     return this.#sessions.has(sessionKey(space, sessionId));
   }
 
+  wasSessionRevokedAfter(
+    space: string,
+    sessionId: string,
+    sessionVersion: number,
+  ): boolean {
+    return (this.#revokedSessions.get(sessionKey(space, sessionId)) ?? 0) >
+      sessionVersion;
+  }
+
   private shouldSuppressSessionSend(
     space: string,
     sessionId: string,
@@ -546,6 +582,7 @@ class Connection {
     if (this.#sessions.has(key)) {
       return;
     }
+    this.#revokedSessions.delete(key);
     this.#sessions.set(key, { space, sessionId });
   }
 
@@ -558,6 +595,8 @@ class Connection {
     if (!this.#sessions.delete(key) || this.#closed) {
       return;
     }
+    this.#sessionVersion += 1;
+    this.#revokedSessions.set(key, this.#sessionVersion);
     this.send({
       type: "session/revoked",
       space,
@@ -623,9 +662,10 @@ class Connection {
   async receive(payload: string): Promise<void> {
     this.#pendingReceives += 1;
     try {
+      const sessionVersion = this.#sessionVersion;
       const previous = this.#receiving;
       const current = previous.catch(() => undefined).then(() =>
-        this.receiveOrdered(payload)
+        this.receiveOrdered(payload, sessionVersion)
       );
       this.#receiving = current.then(() => undefined, () => undefined);
       return await current;
@@ -686,7 +726,10 @@ class Connection {
     return false;
   }
 
-  private async receiveOrdered(payload: string): Promise<void> {
+  private async receiveOrdered(
+    payload: string,
+    receivedAtSessionVersion: number,
+  ): Promise<void> {
     if (this.#closed) {
       return;
     }
@@ -742,17 +785,19 @@ class Connection {
         parsed.type === "session.watch.add" || parsed.type === "transact"
       ? parsed as RequestSchemaCasRequest
       : undefined;
+    let authorizationContext: RequestAuthorizationContext | undefined;
     if (casRequest !== undefined) {
       const sessionWasAttached = this.server.isSessionAttached(
         casRequest.space,
         casRequest.sessionId,
         this.id,
       );
-      const authorization = await this.server.authorizeRequestSchemaIngestion(
+      const authorization = await this.server.preflightRequestAuthorization(
         casRequest,
         this,
+        receivedAtSessionVersion,
       );
-      if (authorization !== null) {
+      if ("name" in authorization) {
         this.recordParsedInbound(payload, parsed);
         const response = respondTypedError(casRequest.requestId, authorization);
         if (sessionWasAttached) {
@@ -767,18 +812,9 @@ class Connection {
         }
         return;
       }
+      authorizationContext = authorization;
     }
-    let hasCasPayload: boolean;
-    try {
-      hasCasPayload = hasRequestSchemaCasPayload(parsed);
-    } catch (error) {
-      this.recordParsedInbound(payload, parsed);
-      this.send(respondTypedError(
-        "requestId" in parsed ? parsed.requestId : "invalid",
-        this.server.requestSchemaCasError(error),
-      ));
-      return;
-    }
+    const hasCasPayload = hasRequestSchemaCasPayload(parsed);
     if (hasCasPayload) {
       if (!this.#requestSchemaCasV1) {
         this.recordParsedInbound(payload, parsed);
@@ -829,6 +865,7 @@ class Connection {
       }
       case "transact":
         if (
+          authorizationContext === undefined &&
           !this.requireSession(
             logical.requestId,
             logical.space,
@@ -837,10 +874,11 @@ class Connection {
         ) {
           return;
         }
-        this.send(await this.server.transact(logical));
+        this.send(await this.server.transact(logical, authorizationContext));
         return;
       case "graph.query":
         if (
+          authorizationContext === undefined &&
           !this.requireSession(
             logical.requestId,
             logical.space,
@@ -850,7 +888,10 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.graphQuery(logical);
+          const response = await this.server.graphQuery(
+            logical,
+            authorizationContext,
+          );
           this.sendSessionResponse(
             logical.space,
             logical.sessionId,
@@ -901,6 +942,7 @@ class Connection {
         return;
       case "session.watch.set":
         if (
+          authorizationContext === undefined &&
           !this.requireSession(
             logical.requestId,
             logical.space,
@@ -910,7 +952,10 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.watchSet(logical);
+          const response = await this.server.watchSet(
+            logical,
+            authorizationContext,
+          );
           this.sendSessionResponse(
             logical.space,
             logical.sessionId,
@@ -921,6 +966,7 @@ class Connection {
         return;
       case "session.watch.add":
         if (
+          authorizationContext === undefined &&
           !this.requireSession(
             logical.requestId,
             logical.space,
@@ -930,7 +976,10 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.watchAdd(logical);
+          const response = await this.server.watchAdd(
+            logical,
+            authorizationContext,
+          );
           this.sendSessionResponse(
             logical.space,
             logical.sessionId,
@@ -1033,6 +1082,7 @@ class Connection {
     for (const { space, sessionId } of this.#sessions.values()) {
       this.server.detachSession(space, sessionId, this.id);
     }
+    this.#revokedSessions.clear();
     this.server.disconnect(this);
   }
 }
@@ -1233,28 +1283,35 @@ export class Server {
     );
   }
 
-  async authorizeRequestSchemaIngestion(
+  async preflightRequestAuthorization(
     message: RequestSchemaCasRequest,
     connection: Connection,
-  ): Promise<V2Error | null> {
+    receivedAtSessionVersion: number,
+  ): Promise<V2Error | RequestAuthorizationContext> {
     if (!connection.hasSession(message.space, message.sessionId)) {
+      if (
+        connection.wasSessionRevokedAfter(
+          message.space,
+          message.sessionId,
+          receivedAtSessionVersion,
+        )
+      ) {
+        return toError(
+          "SessionRevokedError",
+          "Session was revoked while the request was in flight",
+        );
+      }
       return toError("SessionError", "Session is not open on this connection");
     }
     const session = this.#sessions.get(message.space, message.sessionId);
     if (session === null) {
       return toError("SessionError", "Unknown session for space");
     }
-    const operations = message.type === "transact" &&
-        Array.isArray(message.commit?.operations)
-      ? message.commit.operations
-      : [];
-    const requirement: Capability = message.type === "transact"
-      ? commitTouchesAclDoc(operations, message.space) ? "OWNER" : "WRITE"
-      : "READ";
+    const requirement = requiredCapabilityForRequest(message);
     const aclEngine = this.#aclMode() === "off"
       ? undefined
       : await this.openEngine(message.space);
-    return aclEngine === undefined
+    const deny = aclEngine === undefined
       ? await this.#authorizeMessage(
         message.space,
         session.principal,
@@ -1267,6 +1324,95 @@ export class Server {
         session,
         requirement,
       );
+    if (deny) return deny;
+    return {
+      [requestAuthorizationBrand]: true,
+      space: message.space,
+      sessionId: message.sessionId,
+      requirement,
+      aclEpoch: this.#aclEpoch(message.space),
+      sessionInvalidationError: "SessionRevokedError",
+      session,
+      ...(aclEngine === undefined ? {} : { engine: aclEngine }),
+    };
+  }
+
+  async #requestAuthorization(
+    message: RequestSchemaCasRequest,
+    context?: RequestAuthorizationContext,
+  ): Promise<V2Error | RequestAuthorizationContext> {
+    if (context !== undefined) {
+      const invalid = this.#requestAuthorizationContextError(message, context);
+      if (invalid !== null) return invalid;
+      return context;
+    }
+
+    const session = this.#sessions.get(message.space, message.sessionId);
+    if (session === null) {
+      return toError("SessionError", "Unknown session for space");
+    }
+    const requirement = requiredCapabilityForRequest(message);
+    const engine = this.#aclMode() === "off"
+      ? undefined
+      : await this.openEngine(message.space);
+    const deny = engine === undefined
+      ? await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        requirement,
+      )
+      : this.#authorizeCurrentSessionWithEngine(
+        engine,
+        message.space,
+        message.sessionId,
+        session,
+        requirement,
+      );
+    if (deny) return deny;
+    return {
+      [requestAuthorizationBrand]: true,
+      space: message.space,
+      sessionId: message.sessionId,
+      requirement,
+      aclEpoch: this.#aclEpoch(message.space),
+      sessionInvalidationError: "SessionError",
+      session,
+      ...(engine === undefined ? {} : { engine }),
+    };
+  }
+
+  #requestAuthorizationContextError(
+    message: RequestSchemaCasRequest,
+    context: RequestAuthorizationContext,
+  ): V2Error | null {
+    if (
+      context[requestAuthorizationBrand] !== true ||
+      context.space !== message.space ||
+      context.sessionId !== message.sessionId ||
+      context.requirement !== requiredCapabilityForRequest(message)
+    ) {
+      return toError("SessionError", "Unknown or replaced session for space");
+    }
+    if (
+      this.#sessions.get(message.space, message.sessionId) !== context.session
+    ) {
+      return toError(
+        context.sessionInvalidationError,
+        context.sessionInvalidationError === "SessionRevokedError"
+          ? "Session was revoked while the request was in flight"
+          : "Unknown or replaced session for space",
+      );
+    }
+    if (
+      this.#aclMode() !== "off" &&
+      context.aclEpoch !== this.#aclEpoch(message.space)
+    ) {
+      return toError(
+        "AuthorizationError",
+        "Space ACL changed while the request was in flight",
+      );
+    }
+    return null;
   }
 
   nowSeconds(): number {
@@ -1298,6 +1444,7 @@ export class Server {
   /** space → (principal key → capability). Invalidated whenever a commit
    *  touches the space's ACL document. */
   #aclCapabilities = new Map<string, Map<string, Capability | null>>();
+  #aclEpochs = new Map<string, number>();
 
   #aclMode(): MemoryAclMode {
     return this.options.acl?.mode ?? "off";
@@ -1309,6 +1456,11 @@ export class Server {
 
   #invalidateAclCapabilities(space: string): void {
     this.#aclCapabilities.delete(space);
+    this.#aclEpochs.set(space, this.#aclEpoch(space) + 1);
+  }
+
+  #aclEpoch(space: string): number {
+    return this.#aclEpochs.get(space) ?? 0;
   }
 
   #aclState(engine: Engine.Engine, space: string): AclState {
@@ -2296,17 +2448,21 @@ export class Server {
     }
   }
 
-  transact(
+  async transact(
     message: TransactRequest,
+    authorizationContext?: RequestAuthorizationContext,
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
-    const session = this.#sessions.get(message.space, message.sessionId);
-    if (session === null) {
-      return Promise.resolve(respondTypedError<Engine.AppliedCommit>(
+    const authorization = await this.#requestAuthorization(
+      message,
+      authorizationContext,
+    );
+    if ("name" in authorization) {
+      return respondTypedError<Engine.AppliedCommit>(
         message.requestId,
-        toError("SessionError", "Unknown session for space"),
-      ));
+        authorization,
+      );
     }
-
+    const { engine: authorizedEngine, session } = authorization;
     return tracer.startActiveSpan(
       "memory.transact",
       async (span): Promise<ResponseMessage<Engine.AppliedCommit>> => {
@@ -2335,16 +2491,19 @@ export class Server {
           span.setAttribute("commit.local_seq", message.commit.localSeq);
         }
         try {
-          const engine = await this.openEngine(message.space);
-          // The session may be revoked or replaced while openEngine awaits.
-          // Re-check the exact registry object before using the captured
-          // principal so an old connection cannot commit after takeover.
-          if (
-            this.#sessions.get(message.space, message.sessionId) !== session
-          ) {
+          const engine = authorizedEngine ??
+            await this.openEngine(message.space);
+          // Authorization may become stale while request-schema expansion or
+          // engine opening is in flight. Re-check session identity and the ACL
+          // epoch beside apply without making a duplicate ACL decision.
+          const invalidAuthorization = this.#requestAuthorizationContextError(
+            message,
+            authorization,
+          );
+          if (invalidAuthorization !== null) {
             return respondTypedError<Engine.AppliedCommit>(
               message.requestId,
-              toError("SessionError", "Unknown or replaced session for space"),
+              invalidAuthorization,
             );
           }
           const invalid = this.#validateAclCommit(
@@ -2359,23 +2518,10 @@ export class Server {
               invalid,
             );
           }
-          // ACL-document writes change who may access the space — OWNER only.
           const aclTouched = commitTouchesAclDoc(
             message.commit.operations,
             message.space,
           );
-          const deny = this.#authorizeMessageWithEngine(
-            engine,
-            message.space,
-            session.principal,
-            aclTouched ? "OWNER" : "WRITE",
-          );
-          if (deny) {
-            return respondTypedError<Engine.AppliedCommit>(
-              message.requestId,
-              deny,
-            );
-          }
           // Scheduler ownership is derived from an authenticated principal.
           // An otherwise-authorized anonymous memory session may still commit
           // cell data, but cannot persist scoped scheduler metadata.
@@ -2553,34 +2699,28 @@ export class Server {
 
   async graphQuery(
     message: GraphQueryRequest,
+    authorizationContext?: RequestAuthorizationContext,
   ): Promise<ResponseMessage<GraphQueryResult>> {
-    const session = this.#sessions.get(message.space, message.sessionId);
-    if (session === null) {
+    const authorization = await this.#requestAuthorization(
+      message,
+      authorizationContext,
+    );
+    if ("name" in authorization) {
       return respondTypedError<GraphQueryResult>(
         message.requestId,
-        toError("SessionError", "Unknown session for space"),
+        authorization,
       );
     }
-    const aclEngine = this.#aclMode() === "off"
-      ? undefined
-      : await this.openEngine(message.space);
-    {
-      const deny = aclEngine === undefined
-        ? await this.#authorizeMessage(
-          message.space,
-          session.principal,
-          "READ",
-        )
-        : this.#authorizeCurrentSessionWithEngine(
-          aclEngine,
-          message.space,
-          message.sessionId,
-          session,
-          "READ",
-        );
-      if (deny) {
-        return respondTypedError<GraphQueryResult>(message.requestId, deny);
-      }
+    const { engine: aclEngine, session } = authorization;
+    const invalidAuthorization = this.#requestAuthorizationContextError(
+      message,
+      authorization,
+    );
+    if (invalidAuthorization !== null) {
+      return respondTypedError<GraphQueryResult>(
+        message.requestId,
+        invalidAuthorization,
+      );
     }
     if ((message.query as GraphQuery & { subscribe?: boolean }).subscribe) {
       return respondTypedError<GraphQueryResult>(
@@ -2713,34 +2853,28 @@ export class Server {
 
   async watchSet(
     message: WatchSetRequest,
+    authorizationContext?: RequestAuthorizationContext,
   ): Promise<ResponseMessage<WatchSetResult>> {
-    const session = this.#sessions.get(message.space, message.sessionId);
-    if (session === null) {
+    const authorization = await this.#requestAuthorization(
+      message,
+      authorizationContext,
+    );
+    if ("name" in authorization) {
       return respondTypedError<WatchSetResult>(
         message.requestId,
-        toError("SessionError", "Unknown session for space"),
+        authorization,
       );
     }
-    const aclEngine = this.#aclMode() === "off"
-      ? undefined
-      : await this.openEngine(message.space);
-    {
-      const deny = aclEngine === undefined
-        ? await this.#authorizeMessage(
-          message.space,
-          session.principal,
-          "READ",
-        )
-        : this.#authorizeCurrentSessionWithEngine(
-          aclEngine,
-          message.space,
-          message.sessionId,
-          session,
-          "READ",
-        );
-      if (deny) {
-        return respondTypedError<WatchSetResult>(message.requestId, deny);
-      }
+    const { engine: aclEngine, session } = authorization;
+    const invalidAuthorization = this.#requestAuthorizationContextError(
+      message,
+      authorization,
+    );
+    if (invalidAuthorization !== null) {
+      return respondTypedError<WatchSetResult>(
+        message.requestId,
+        invalidAuthorization,
+      );
     }
 
     try {
@@ -2785,34 +2919,28 @@ export class Server {
 
   async watchAdd(
     message: WatchAddRequest,
+    authorizationContext?: RequestAuthorizationContext,
   ): Promise<ResponseMessage<WatchAddResult>> {
-    const session = this.#sessions.get(message.space, message.sessionId);
-    if (session === null) {
+    const authorization = await this.#requestAuthorization(
+      message,
+      authorizationContext,
+    );
+    if ("name" in authorization) {
       return respondTypedError<WatchAddResult>(
         message.requestId,
-        toError("SessionError", "Unknown session for space"),
+        authorization,
       );
     }
-    const aclEngine = this.#aclMode() === "off"
-      ? undefined
-      : await this.openEngine(message.space);
-    {
-      const deny = aclEngine === undefined
-        ? await this.#authorizeMessage(
-          message.space,
-          session.principal,
-          "READ",
-        )
-        : this.#authorizeCurrentSessionWithEngine(
-          aclEngine,
-          message.space,
-          message.sessionId,
-          session,
-          "READ",
-        );
-      if (deny) {
-        return respondTypedError<WatchAddResult>(message.requestId, deny);
-      }
+    const { engine: aclEngine, session } = authorization;
+    const invalidAuthorization = this.#requestAuthorizationContextError(
+      message,
+      authorization,
+    );
+    if (invalidAuthorization !== null) {
+      return respondTypedError<WatchAddResult>(
+        message.requestId,
+        invalidAuthorization,
+      );
     }
 
     try {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1270,10 +1270,15 @@ export class Server {
 
   activeWireAccountingObserver(): MemoryWireAccountingObserver | undefined {
     const observer = this.options.wireAccountingObserver;
-    if (observer?.isActive?.() === false) {
+    try {
+      if (observer?.isActive?.() === false) {
+        return undefined;
+      }
+      return observer;
+    } catch (error) {
+      console.warn("Memory wire accounting observer failed:", error);
       return undefined;
     }
-    return observer;
   }
 
   recordWireAccounting(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -81,6 +81,13 @@ import {
 import { respondToHello } from "./handshake.ts";
 import { compressServerMessageSchemas } from "./sync-schema-table.ts";
 import {
+  classifyClientMessage,
+  classifyServerMessage,
+  type MemoryWireAccountingObserver,
+  type MemoryWireConnectionMetadata,
+  memoryWireUtf8Bytes,
+} from "./wire-accounting.ts";
+import {
   buildDiffSync,
   buildFullSync,
   cacheKeyForEntity,
@@ -367,17 +374,67 @@ class Connection {
   #receiving: Promise<void> = Promise.resolve();
   #pendingReceives = 0;
   #receiveIdle: PromiseWithResolvers<void> | null = null;
+  #requestTypesById = new Map<string, string>();
 
   constructor(
     readonly id: string,
     private readonly server: Server,
     private readonly sendRaw: Send,
+    private readonly metadata?: MemoryWireConnectionMetadata,
   ) {}
 
   private send(message: ServerMessage): void {
-    this.sendRaw(
-      this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
-    );
+    const originatingRequestType = message.type === "response"
+      ? this.#requestTypesById.get(message.requestId)
+      : undefined;
+    if (message.type === "response") {
+      this.#requestTypesById.delete(message.requestId);
+    }
+
+    const observer = this.server.activeWireAccountingObserver();
+    if (observer === undefined) {
+      this.sendRaw(
+        this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
+      );
+      return;
+    }
+
+    const actualMessage = this.#syncSchemaTable
+      ? compressServerMessageSchemas(message)
+      : message;
+    this.server.recordWireAccounting(observer, {
+      direction: "outbound",
+      connectionId: this.id,
+      metadata: this.metadata,
+      classification: classifyServerMessage(message, originatingRequestType),
+      baselineBytes: memoryWireUtf8Bytes(encodeMemoryBoundary(message)),
+      actualBytes: memoryWireUtf8Bytes(encodeMemoryBoundary(actualMessage)),
+    });
+    this.sendRaw(actualMessage);
+  }
+
+  private recordParsedInbound(
+    payload: string,
+    parsed: ClientMessage | null,
+  ): void {
+    const observer = this.server.activeWireAccountingObserver();
+    if (observer === undefined) {
+      return;
+    }
+    const bytes = memoryWireUtf8Bytes(payload);
+    this.server.recordWireAccounting(observer, {
+      direction: "inbound",
+      connectionId: this.id,
+      metadata: this.metadata,
+      classification: classifyClientMessage(parsed),
+      baselineBytes: bytes,
+      actualBytes: bytes,
+    });
+    if (parsed !== null) {
+      if ("requestId" in parsed) {
+        this.#requestTypesById.set(parsed.requestId, parsed.type);
+      }
+    }
   }
 
   hasSession(space: string, sessionId: string): boolean {
@@ -567,6 +624,7 @@ class Connection {
     }
 
     const parsed = parseClientMessage(payload);
+    this.recordParsedInbound(payload, parsed);
     if (parsed === null) {
       this.send({
         type: "response",
@@ -919,6 +977,7 @@ export class Server {
         mode: MemoryAclMode;
         serviceDids?: readonly string[];
       };
+      wireAccountingObserver?: MemoryWireAccountingObserver;
     },
   ) {
     this.#sessions = options.sessions ?? new SessionRegistry();
@@ -1209,8 +1268,35 @@ export class Server {
     }
   }
 
-  connect(send: Send): Connection {
-    const connection = new Connection(crypto.randomUUID(), this, send);
+  activeWireAccountingObserver(): MemoryWireAccountingObserver | undefined {
+    const observer = this.options.wireAccountingObserver;
+    if (observer?.isActive?.() === false) {
+      return undefined;
+    }
+    return observer;
+  }
+
+  recordWireAccounting(
+    observer: MemoryWireAccountingObserver,
+    record: Parameters<MemoryWireAccountingObserver["observe"]>[0],
+  ): void {
+    try {
+      observer.observe(record);
+    } catch (error) {
+      console.warn("Memory wire accounting observer failed:", error);
+    }
+  }
+
+  connect(
+    send: Send,
+    metadata?: MemoryWireConnectionMetadata,
+  ): Connection {
+    const connection = new Connection(
+      crypto.randomUUID(),
+      this,
+      send,
+      metadata,
+    );
     this.#connections.set(connection.id, connection);
     return connection;
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1,5 +1,6 @@
 import * as FS from "@std/fs";
 import * as Path from "@std/path";
+import type { JSONSchema } from "@commonfabric/api";
 import { resolveSpaceStoreUrl } from "./storage-path.ts";
 import {
   type CellScope,
@@ -9,6 +10,7 @@ import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
   type EntityDocument,
+  getMemoryProtocolFlags,
   getPersistentSchedulerStateConfig,
   type GraphQuery,
   type GraphQueryRequest,
@@ -81,10 +83,25 @@ import {
 import { respondToHello } from "./handshake.ts";
 import { compressServerMessageSchemas } from "./sync-schema-table.ts";
 import {
+  expandRequestSchemas,
+  hasRequestSchemaCasPayload,
+  InvalidRequestSchemaDefinitionsError,
+  MissingRequestSchemaDefinitionError,
+  type RequestSchemaCasRequest,
+} from "./request-schema-cas.ts";
+import {
+  type SchemaStore,
+  SchemaStoreCorruptionError,
+  SchemaStoreQuotaError,
+} from "./schema-store.ts";
+import {
+  accountMemoryWirePayload,
   classifyClientMessage,
   classifyServerMessage,
   type MemoryWireAccountingObserver,
+  type MemoryWireCandidate,
   type MemoryWireConnectionMetadata,
+  type MemoryWireSemanticBytes,
   memoryWireUtf8Bytes,
 } from "./wire-accounting.ts";
 import {
@@ -369,6 +386,7 @@ class Connection {
   // clients' action runs instead of re-running them
   // (docs/specs/scheduler-v2/incremental-observation-adoption.md §4).
   #persistentSchedulerState = false;
+  #requestSchemaCasV1 = false;
   #sessions = new Map<string, SessionHandle>();
   #sessionOpenChallenge: SessionOpenChallengeState | null = null;
   #receiving: Promise<void> = Promise.resolve();
@@ -394,21 +412,35 @@ class Connection {
     const observer = this.server.activeWireAccountingObserver();
     if (observer === undefined) {
       this.sendRaw(
-        this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
+        this.#syncSchemaTable
+          ? this.server.compressServerMessageSchemas(message)
+          : message,
       );
       return;
     }
 
     const actualMessage = this.#syncSchemaTable
-      ? compressServerMessageSchemas(message)
+      ? this.server.compressServerMessageSchemas(message)
       : message;
+    const baselinePayload = encodeMemoryBoundary(message);
+    const actualPayload = encodeMemoryBoundary(actualMessage);
+    const baselineAccounting = this.accountPayload(observer, baselinePayload);
+    const actualAccounting = this.accountPayload(observer, actualPayload);
     this.server.recordWireAccounting(observer, {
       direction: "outbound",
       connectionId: this.id,
       metadata: this.metadata,
       classification: classifyServerMessage(message, originatingRequestType),
-      baselineBytes: memoryWireUtf8Bytes(encodeMemoryBoundary(message)),
-      actualBytes: memoryWireUtf8Bytes(encodeMemoryBoundary(actualMessage)),
+      baselineBytes: memoryWireUtf8Bytes(baselinePayload),
+      actualBytes: memoryWireUtf8Bytes(actualPayload),
+      ...(baselineAccounting === undefined ? {} : {
+        baselineSemanticBytes: baselineAccounting.semanticBytes,
+        baselineCandidates: baselineAccounting.candidates,
+      }),
+      ...(actualAccounting === undefined ? {} : {
+        actualSemanticBytes: actualAccounting.semanticBytes,
+        actualCandidates: actualAccounting.candidates,
+      }),
     });
     this.sendRaw(actualMessage);
   }
@@ -416,24 +448,62 @@ class Connection {
   private recordParsedInbound(
     payload: string,
     parsed: ClientMessage | null,
+    logical: ClientMessage | null = parsed,
+    expandedRequestSchemas = false,
   ): void {
     const observer = this.server.activeWireAccountingObserver();
     if (observer === undefined) {
       return;
     }
-    const bytes = memoryWireUtf8Bytes(payload);
+    const actualBytes = memoryWireUtf8Bytes(payload);
+    const baselinePayload = !expandedRequestSchemas || logical === null
+      ? payload
+      : encodeMemoryBoundary(logical);
+    const baselineAccounting = this.accountPayload(observer, baselinePayload);
+    const actualAccounting = this.accountPayload(observer, payload);
     this.server.recordWireAccounting(observer, {
       direction: "inbound",
       connectionId: this.id,
       metadata: this.metadata,
-      classification: classifyClientMessage(parsed),
-      baselineBytes: bytes,
-      actualBytes: bytes,
+      classification: classifyClientMessage(logical),
+      baselineBytes: memoryWireUtf8Bytes(baselinePayload),
+      actualBytes,
+      ...(baselineAccounting === undefined ? {} : {
+        baselineSemanticBytes: baselineAccounting.semanticBytes,
+        baselineCandidates: baselineAccounting.candidates,
+      }),
+      ...(actualAccounting === undefined ? {} : {
+        actualSemanticBytes: actualAccounting.semanticBytes,
+        actualCandidates: actualAccounting.candidates,
+      }),
     });
-    if (parsed !== null) {
-      if ("requestId" in parsed) {
-        this.#requestTypesById.set(parsed.requestId, parsed.type);
+    if (logical !== null) {
+      if ("requestId" in logical) {
+        this.#requestTypesById.set(logical.requestId, logical.type);
       }
+    }
+  }
+
+  private accountPayload(
+    observer: MemoryWireAccountingObserver,
+    payload: string,
+  ): {
+    semanticBytes: MemoryWireSemanticBytes;
+    candidates: MemoryWireCandidate[];
+  } | undefined {
+    try {
+      if (observer.accountPayload !== undefined) {
+        return observer.accountPayload(payload, this.id);
+      }
+      const { semanticBytes } = accountMemoryWirePayload(
+        payload,
+        "inactive",
+        this.id,
+      );
+      return { semanticBytes, candidates: [] };
+    } catch (error) {
+      console.warn("Memory wire accounting observer failed:", error);
+      return undefined;
     }
   }
 
@@ -624,8 +694,8 @@ class Connection {
     }
 
     const parsed = parseClientMessage(payload);
-    this.recordParsedInbound(payload, parsed);
     if (parsed === null) {
+      this.recordParsedInbound(payload, null);
       this.send({
         type: "response",
         requestId: "invalid",
@@ -638,6 +708,7 @@ class Connection {
     }
 
     if (!this.#ready) {
+      this.recordParsedInbound(payload, parsed);
       if (parsed.type !== "hello") {
         this.send({
           type: "response",
@@ -646,7 +717,7 @@ class Connection {
         });
         return;
       }
-      const response = respondToHello(parsed);
+      const response = respondToHello(parsed, this.server.helloOptions());
       if (response.type === "hello.ok") {
         response.sessionOpen = this.issueSessionOpenAuth();
       }
@@ -661,11 +732,67 @@ class Connection {
       this.#persistentSchedulerState =
         clientFlags?.persistentSchedulerState === true &&
         serverFlags?.persistentSchedulerState === true;
+      this.#requestSchemaCasV1 = clientFlags?.requestSchemaCasV1 === true &&
+        serverFlags?.requestSchemaCasV1 === true;
       this.#ready = true;
       return;
     }
 
-    switch (parsed.type) {
+    let logical = parsed;
+    let hasCasPayload: boolean;
+    try {
+      hasCasPayload = hasRequestSchemaCasPayload(parsed);
+    } catch (error) {
+      this.recordParsedInbound(payload, parsed);
+      this.send(respondTypedError(
+        "requestId" in parsed ? parsed.requestId : "invalid",
+        this.server.requestSchemaCasError(error),
+      ));
+      return;
+    }
+    if (hasCasPayload) {
+      const casRequest = parsed as RequestSchemaCasRequest;
+      const authorization = await this.server.authorizeRequestSchemaIngestion(
+        casRequest,
+        this,
+      );
+      if (authorization !== null) {
+        this.recordParsedInbound(payload, parsed);
+        this.send(respondTypedError(casRequest.requestId, authorization));
+        return;
+      }
+      if (!this.#requestSchemaCasV1) {
+        this.recordParsedInbound(payload, parsed);
+        this.send(respondTypedError(
+          casRequest.requestId,
+          toError(
+            "ProtocolError",
+            "request schema CAS was not negotiated",
+          ),
+        ));
+        return;
+      }
+      try {
+        logical = this.server.expandRequestSchemas(
+          casRequest,
+        );
+      } catch (error) {
+        this.recordParsedInbound(payload, parsed);
+        this.send(respondTypedError(
+          casRequest.requestId,
+          this.server.requestSchemaCasError(error),
+        ));
+        return;
+      }
+    }
+    this.recordParsedInbound(
+      payload,
+      parsed,
+      logical,
+      logical !== parsed,
+    );
+
+    switch (logical.type) {
       case "hello":
         this.send({
           type: "response",
@@ -674,9 +801,9 @@ class Connection {
         });
         return;
       case "session.open": {
-        const response = await this.server.openSession(parsed, this);
+        const response = await this.server.openSession(logical, this);
         if (response.ok?.sessionId) {
-          this.addSession(parsed.space, response.ok.sessionId);
+          this.addSession(logical.space, response.ok.sessionId);
         }
         this.send(response);
         return;
@@ -684,63 +811,71 @@ class Connection {
       case "transact":
         if (
           !this.requireSession(
-            parsed.requestId,
-            parsed.space,
-            parsed.sessionId,
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
           )
         ) {
           return;
         }
-        this.send(await this.server.transact(parsed));
+        this.send(await this.server.transact(logical));
         return;
       case "graph.query":
         if (
           !this.requireSession(
-            parsed.requestId,
-            parsed.space,
-            parsed.sessionId,
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
           )
         ) {
           return;
         }
         {
-          const response = await this.server.graphQuery(parsed);
+          const response = await this.server.graphQuery(logical);
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
         return;
       case "sqlite.query":
         if (
-          !this.requireSession(parsed.requestId, parsed.space, parsed.sessionId)
+          !this.requireSession(
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
+          )
         ) {
           return;
         }
         {
-          const response = await this.server.sqliteQuery(parsed);
+          const response = await this.server.sqliteQuery(logical);
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
         return;
       case "sqlite.register-disk-source":
         if (
-          !this.requireSession(parsed.requestId, parsed.space, parsed.sessionId)
+          !this.requireSession(
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
+          )
         ) {
           return;
         }
         {
-          const response = await this.server.sqliteRegisterDiskSource(parsed);
+          const response = await this.server.sqliteRegisterDiskSource(logical);
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
@@ -748,19 +883,19 @@ class Connection {
       case "session.watch.set":
         if (
           !this.requireSession(
-            parsed.requestId,
-            parsed.space,
-            parsed.sessionId,
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
           )
         ) {
           return;
         }
         {
-          const response = await this.server.watchSet(parsed);
+          const response = await this.server.watchSet(logical);
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
@@ -768,19 +903,19 @@ class Connection {
       case "session.watch.add":
         if (
           !this.requireSession(
-            parsed.requestId,
-            parsed.space,
-            parsed.sessionId,
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
           )
         ) {
           return;
         }
         {
-          const response = await this.server.watchAdd(parsed);
+          const response = await this.server.watchAdd(logical);
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
@@ -788,21 +923,21 @@ class Connection {
       case "scheduler.snapshot.list":
         if (
           !this.requireSession(
-            parsed.requestId,
-            parsed.space,
-            parsed.sessionId,
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
           )
         ) {
           return;
         }
         {
           const response = await this.server.listSchedulerActionSnapshots(
-            parsed,
+            logical,
           );
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
@@ -810,19 +945,19 @@ class Connection {
       case "session.ack":
         if (
           !this.requireSession(
-            parsed.requestId,
-            parsed.space,
-            parsed.sessionId,
+            logical.requestId,
+            logical.space,
+            logical.sessionId,
           )
         ) {
           return;
         }
         {
-          const response = await this.server.ackSession(parsed);
+          const response = await this.server.ackSession(logical);
           this.sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
+            logical.space,
+            logical.sessionId,
+            logical.requestId,
             response,
           );
         }
@@ -901,6 +1036,7 @@ export class Server {
   #schedulerSideEffectsByOwnerSpace = new Map<string, Promise<void>>();
   #lastRefreshDurationMs = 0;
   #store?: URL;
+  #schemaStore?: SchemaStore;
   // Injected on-disk SQLite sources (Phase 7), keyed by handle cell id. A
   // registered id is attached read-only from its descriptor path instead of the
   // cell-derived per-(space,id) file. v1 in-memory; persistence is deferred (see
@@ -933,6 +1069,8 @@ export class Server {
     readonly options: {
       sessions?: SessionRegistry;
       store?: URL;
+      /** Shared durable request-schema CAS store owned by the host process. */
+      schemaStore?: SchemaStore;
       subscriptionRefreshDelayMs?: number;
       authorizeSessionOpen: (
         message: SessionOpenRequest,
@@ -982,6 +1120,120 @@ export class Server {
   ) {
     this.#sessions = options.sessions ?? new SessionRegistry();
     this.#store = options.store;
+    this.#schemaStore = options.schemaStore;
+  }
+
+  helloOptions(): Parameters<typeof respondToHello>[1] {
+    const flags = {
+      ...getMemoryProtocolFlags(),
+      requestSchemaCasV1: this.#schemaStore !== undefined &&
+        getMemoryProtocolFlags().requestSchemaCasV1 === true,
+    };
+    return {
+      flags,
+      ...(flags.requestSchemaCasV1
+        ? {
+          requestSchemaCas: {
+            generation: this.#schemaStore!.generation,
+            audience: this.sessionOpenAudience(),
+          },
+        }
+        : {}),
+    };
+  }
+
+  compressServerMessageSchemas(message: ServerMessage): ServerMessage {
+    const store = this.#schemaStore;
+    if (store === undefined) return compressServerMessageSchemas(message);
+    const schemas: JSONSchema[] = [];
+    const compressed = compressServerMessageSchemas(
+      message,
+      (schema) => schemas.push(schema),
+    );
+    try {
+      store.putAll(schemas);
+      return compressed;
+    } catch (error) {
+      console.warn(
+        "Memory request schema CAS could not seed outbound schemas",
+        error,
+      );
+      return message;
+    }
+  }
+
+  requestSchemaCasError(error: unknown): V2Error {
+    if (error instanceof MissingRequestSchemaDefinitionError) {
+      return toError(
+        "MissingSchemas",
+        "Referenced request schemas are unavailable",
+      );
+    }
+    if (
+      error instanceof SchemaStoreQuotaError ||
+      error instanceof SchemaStoreCorruptionError
+    ) {
+      return toError(
+        "SchemaStoreError",
+        "Request schema store rejected schema",
+      );
+    }
+    if (error instanceof InvalidRequestSchemaDefinitionsError) {
+      return toError("ProtocolError", "Invalid request schema CAS payload");
+    }
+    return toError("SchemaStoreError", "Request schema store is unavailable");
+  }
+
+  expandRequestSchemas(
+    request: RequestSchemaCasRequest,
+  ): RequestSchemaCasRequest {
+    const store = this.#schemaStore;
+    if (store === undefined) {
+      throw new InvalidRequestSchemaDefinitionsError(
+        "request schema CAS store is unavailable",
+      );
+    }
+    return expandRequestSchemas(
+      request,
+      (hash) => store.get(hash)?.schema,
+      (schemas) => store.putAll(schemas),
+    );
+  }
+
+  async authorizeRequestSchemaIngestion(
+    message: RequestSchemaCasRequest,
+    connection: Connection,
+  ): Promise<V2Error | null> {
+    if (!connection.hasSession(message.space, message.sessionId)) {
+      return toError("SessionError", "Session is not open on this connection");
+    }
+    const session = this.#sessions.get(message.space, message.sessionId);
+    if (session === null) {
+      return toError("SessionError", "Unknown session for space");
+    }
+    const operations = message.type === "transact" &&
+        Array.isArray(message.commit?.operations)
+      ? message.commit.operations
+      : [];
+    const requirement: Capability = message.type === "transact"
+      ? commitTouchesAclDoc(operations, message.space) ? "OWNER" : "WRITE"
+      : "READ";
+    const aclEngine = this.#aclMode() === "off"
+      ? undefined
+      : await this.openEngine(message.space);
+    return aclEngine === undefined
+      ? await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        requirement,
+      )
+      : this.#authorizeCurrentSessionWithEngine(
+        aclEngine,
+        message.space,
+        message.sessionId,
+        session,
+        requirement,
+      );
   }
 
   nowSeconds(): number {
@@ -3277,7 +3529,7 @@ export class Server {
   respond(payload: string): Promise<string | null> {
     const parsed = parseClientMessage(payload);
     if (parsed?.type === "hello") {
-      const response = respondToHello(parsed);
+      const response = respondToHello(parsed, this.helloOptions());
       if (response.type !== "hello.ok") {
         return Promise.resolve(encodeMemoryBoundary(response));
       }
@@ -3657,6 +3909,11 @@ export const parseClientMessage = (
       space: parsed.space,
       sessionId: parsed.sessionId,
       commit: parsed.commit as unknown as TransactRequest["commit"],
+      ...(parsed.schemaDefinitions === undefined ? {} : {
+        schemaDefinitions: parsed.schemaDefinitions as TransactRequest[
+          "schemaDefinitions"
+        ],
+      }),
     };
   }
 
@@ -3674,6 +3931,11 @@ export const parseClientMessage = (
       space: parsed.space,
       sessionId: parsed.sessionId,
       query: parsed.query as unknown as GraphQueryRequest["query"],
+      ...(parsed.schemaDefinitions === undefined ? {} : {
+        schemaDefinitions: parsed.schemaDefinitions as GraphQueryRequest[
+          "schemaDefinitions"
+        ],
+      }),
     };
   }
 
@@ -3745,6 +4007,11 @@ export const parseClientMessage = (
       space: parsed.space,
       sessionId: parsed.sessionId,
       watches: parsed.watches as WatchSpec[],
+      ...(parsed.schemaDefinitions === undefined ? {} : {
+        schemaDefinitions: parsed.schemaDefinitions as WatchSetRequest[
+          "schemaDefinitions"
+        ],
+      }),
     };
   }
 
@@ -3761,6 +4028,11 @@ export const parseClientMessage = (
       space: parsed.space,
       sessionId: parsed.sessionId,
       watches: parsed.watches as WatchSpec[],
+      ...(parsed.schemaDefinitions === undefined ? {} : {
+        schemaDefinitions: parsed.schemaDefinitions as WatchAddRequest[
+          "schemaDefinitions"
+        ],
+      }),
     };
   }
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -288,6 +288,7 @@ const commitTouchesAclDoc = (
 ): boolean => {
   const id = aclDocId(space);
   return operations.some((operation) =>
+    typeof operation === "object" && operation !== null &&
     "id" in operation && operation.id === id
   );
 };
@@ -409,19 +410,16 @@ class Connection {
       this.#requestTypesById.delete(message.requestId);
     }
 
+    const actualMessage = this.server.prepareServerMessageSchemas(
+      message,
+      { compress: this.#syncSchemaTable },
+    );
     const observer = this.server.activeWireAccountingObserver();
     if (observer === undefined) {
-      this.sendRaw(
-        this.#syncSchemaTable
-          ? this.server.compressServerMessageSchemas(message)
-          : message,
-      );
+      this.sendRaw(actualMessage);
       return;
     }
 
-    const actualMessage = this.#syncSchemaTable
-      ? this.server.compressServerMessageSchemas(message)
-      : message;
     const baselinePayload = encodeMemoryBoundary(message);
     const actualPayload = encodeMemoryBoundary(actualMessage);
     const baselineAccounting = this.accountPayload(observer, baselinePayload);
@@ -1069,7 +1067,10 @@ export class Server {
     readonly options: {
       sessions?: SessionRegistry;
       store?: URL;
-      /** Shared durable request-schema CAS store owned by the host process. */
+      /**
+       * Host-owned request-schema CAS store. Toolshed injects a shared,
+       * bounded, durable store; other hosts define its lifetime and capacity.
+       */
       schemaStore?: SchemaStore;
       subscriptionRefreshDelayMs?: number;
       authorizeSessionOpen: (
@@ -1143,8 +1144,19 @@ export class Server {
   }
 
   compressServerMessageSchemas(message: ServerMessage): ServerMessage {
+    return this.prepareServerMessageSchemas(message, { compress: true });
+  }
+
+  /** Seeds outbound schemas and optionally applies sync-table compression. */
+  prepareServerMessageSchemas(
+    message: ServerMessage,
+    options: { compress: boolean },
+  ): ServerMessage {
+    const { compress } = options;
     const store = this.#schemaStore;
-    if (store === undefined) return compressServerMessageSchemas(message);
+    if (store === undefined) {
+      return compress ? compressServerMessageSchemas(message) : message;
+    }
     const schemas: JSONSchema[] = [];
     const compressed = compressServerMessageSchemas(
       message,
@@ -1152,7 +1164,7 @@ export class Server {
     );
     try {
       store.putAll(schemas);
-      return compressed;
+      return compress ? compressed : message;
     } catch (error) {
       console.warn(
         "Memory request schema CAS could not seed outbound schemas",

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -737,6 +737,37 @@ class Connection {
     }
 
     let logical = parsed;
+    const casRequest = parsed.type === "graph.query" ||
+        parsed.type === "session.watch.set" ||
+        parsed.type === "session.watch.add" || parsed.type === "transact"
+      ? parsed as RequestSchemaCasRequest
+      : undefined;
+    if (casRequest !== undefined) {
+      const sessionWasAttached = this.server.isSessionAttached(
+        casRequest.space,
+        casRequest.sessionId,
+        this.id,
+      );
+      const authorization = await this.server.authorizeRequestSchemaIngestion(
+        casRequest,
+        this,
+      );
+      if (authorization !== null) {
+        this.recordParsedInbound(payload, parsed);
+        const response = respondTypedError(casRequest.requestId, authorization);
+        if (sessionWasAttached) {
+          this.sendSessionResponse(
+            casRequest.space,
+            casRequest.sessionId,
+            casRequest.requestId,
+            response,
+          );
+        } else {
+          this.send(response);
+        }
+        return;
+      }
+    }
     let hasCasPayload: boolean;
     try {
       hasCasPayload = hasRequestSchemaCasPayload(parsed);
@@ -749,20 +780,10 @@ class Connection {
       return;
     }
     if (hasCasPayload) {
-      const casRequest = parsed as RequestSchemaCasRequest;
-      const authorization = await this.server.authorizeRequestSchemaIngestion(
-        casRequest,
-        this,
-      );
-      if (authorization !== null) {
-        this.recordParsedInbound(payload, parsed);
-        this.send(respondTypedError(casRequest.requestId, authorization));
-        return;
-      }
       if (!this.#requestSchemaCasV1) {
         this.recordParsedInbound(payload, parsed);
         this.send(respondTypedError(
-          casRequest.requestId,
+          casRequest!.requestId,
           toError(
             "ProtocolError",
             "request schema CAS was not negotiated",
@@ -772,12 +793,12 @@ class Connection {
       }
       try {
         logical = this.server.expandRequestSchemas(
-          casRequest,
+          casRequest!,
         );
       } catch (error) {
         this.recordParsedInbound(payload, parsed);
         this.send(respondTypedError(
-          casRequest.requestId,
+          casRequest!.requestId,
           this.server.requestSchemaCasError(error),
         ));
         return;

--- a/packages/memory/v2/storage-path.ts
+++ b/packages/memory/v2/storage-path.ts
@@ -82,6 +82,25 @@ export const resolveSpaceStoreDirUrl = (store: URL): URL => {
 };
 
 /**
+ * Resolves the service-wide schema content-addressed store. It deliberately
+ * lives beside, rather than inside, the per-space `engine-v3` databases.
+ * Non-file stores have no durable filesystem location and therefore use SQLite
+ * in-memory storage.
+ */
+export const resolveSchemaStoreUrl = (store: URL): URL => {
+  if (store.protocol !== "file:") return new URL("memory:");
+
+  const storePath = Path.fromFileUrl(store);
+  if (!isSingleFileStore(store)) {
+    return new URL("./schema-store-v1.sqlite", store);
+  }
+
+  const ext = Path.extname(storePath);
+  const stem = storePath.slice(0, -ext.length);
+  return Path.toFileUrl(`${stem}.schema-store-v1.sqlite`);
+};
+
+/**
  * Mode-aware inverse of the filename encoding in `resolveSpaceStoreUrl`: map an
  * on-disk `.sqlite` filename stem (from the store's space dir) back to the
  * space id. Directory-mode stems are the LITERAL id (the URL resolution already

--- a/packages/memory/v2/storage-path.ts
+++ b/packages/memory/v2/storage-path.ts
@@ -92,12 +92,12 @@ export const resolveSchemaStoreUrl = (store: URL): URL => {
 
   const storePath = Path.fromFileUrl(store);
   if (!isSingleFileStore(store)) {
-    return new URL("./schema-store-v1.sqlite", store);
+    return new URL("./schema-store-v2.sqlite", store);
   }
 
   const ext = Path.extname(storePath);
   const stem = storePath.slice(0, -ext.length);
-  return Path.toFileUrl(`${stem}.schema-store-v1.sqlite`);
+  return Path.toFileUrl(`${stem}.schema-store-v2.sqlite`);
 };
 
 /**

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -1,0 +1,118 @@
+import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { isPlainObject } from "@commonfabric/utils/types";
+
+export const SYNC_SCHEMA_REF_PREFIX = "schema-ref@2:";
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);
+
+const schemaRefInPayload = (
+  payload: Record<string, unknown>,
+): string | undefined => {
+  const schema = payload.schema;
+  return typeof schema === "string" &&
+      schema.startsWith(SYNC_SCHEMA_REF_PREFIX)
+    ? schema
+    : undefined;
+};
+
+const pushOwnValuesExcept = (
+  pending: unknown[],
+  record: Record<string, unknown>,
+  skippedKey: string,
+): void => {
+  for (const key in record) {
+    if (key !== skippedKey && Object.hasOwn(record, key)) {
+      pending.push(record[key]);
+    }
+  }
+};
+
+/** Finds reserved wire references only in link-payload schema positions. */
+export const findSyncSchemaRef = (value: unknown): string | undefined => {
+  const pending: unknown[] = [value];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      for (let index = 0; index < current.length; index += 1) {
+        pending.push(current[index]);
+      }
+      continue;
+    }
+    if (!isPlainRecord(current)) {
+      continue;
+    }
+
+    const linkEnvelope = current["/"];
+    const linkPayload = isPlainRecord(linkEnvelope)
+      ? linkEnvelope[LINK_V1_TAG]
+      : undefined;
+    const hasLinkPayload = isPlainRecord(linkEnvelope) &&
+      isPlainRecord(linkPayload);
+    if (hasLinkPayload) {
+      const ref = schemaRefInPayload(linkPayload);
+      if (ref !== undefined) {
+        return ref;
+      }
+      pushOwnValuesExcept(pending, linkPayload, "schema");
+      pushOwnValuesExcept(pending, linkEnvelope, LINK_V1_TAG);
+    }
+
+    const legacyAlias = current.$alias;
+    const hasLegacyAlias = isPlainRecord(legacyAlias);
+    if (hasLegacyAlias) {
+      const ref = schemaRefInPayload(legacyAlias);
+      if (ref !== undefined) {
+        return ref;
+      }
+      pushOwnValuesExcept(pending, legacyAlias, "schema");
+    }
+
+    for (const key in current) {
+      if (!Object.hasOwn(current, key)) {
+        continue;
+      }
+      if (
+        (key === "/" && hasLinkPayload) ||
+        (key === "$alias" && hasLegacyAlias)
+      ) {
+        continue;
+      }
+      pending.push(current[key]);
+    }
+  }
+
+  return undefined;
+};
+
+/** Checks arbitrary input for a string that could introduce a wire reference. */
+export const containsSyncSchemaRefString = (value: unknown): boolean => {
+  const pending: unknown[] = [value];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === "string") {
+      if (current.startsWith(SYNC_SCHEMA_REF_PREFIX)) {
+        return true;
+      }
+      continue;
+    }
+    if (Array.isArray(current)) {
+      for (let index = 0; index < current.length; index += 1) {
+        pending.push(current[index]);
+      }
+      continue;
+    }
+    if (!isPlainRecord(current)) {
+      continue;
+    }
+    for (const key in current) {
+      if (Object.hasOwn(current, key)) {
+        pending.push(current[key]);
+      }
+    }
+  }
+
+  return false;
+};

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -1,17 +1,21 @@
 import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
 import { isPlainObject } from "@commonfabric/utils/types";
+import { REQUEST_SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
 
 export const SYNC_SCHEMA_REF_PREFIX = "schema-ref@2:";
 
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   isPlainObject(value);
 
+const isReservedSchemaRef = (value: string): boolean =>
+  value.startsWith(SYNC_SCHEMA_REF_PREFIX) ||
+  value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
+
 const schemaRefInPayload = (
   payload: Record<string, unknown>,
 ): string | undefined => {
   const schema = payload.schema;
-  return typeof schema === "string" &&
-      schema.startsWith(SYNC_SCHEMA_REF_PREFIX)
+  return typeof schema === "string" && isReservedSchemaRef(schema)
     ? schema
     : undefined;
 };
@@ -93,7 +97,7 @@ export const containsSyncSchemaRefString = (value: unknown): boolean => {
   while (pending.length > 0) {
     const current = pending.pop();
     if (typeof current === "string") {
-      if (current.startsWith(SYNC_SCHEMA_REF_PREFIX)) {
+      if (isReservedSchemaRef(current)) {
         return true;
       }
       continue;

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -37,9 +37,9 @@ const schemaRefFor = (
 ): string => {
   const schemaAndHash = internSchema(schema, true);
   const hash = schemaAndHash.taggedHashString;
-  state.onSchema?.(schemaAndHash.schema);
   if (!state.schemas.has(hash)) {
     state.schemas.set(hash, schemaAndHash.schema);
+    state.onSchema?.(schemaAndHash.schema);
   }
   return `${SYNC_SCHEMA_REF_PREFIX}${hash}`;
 };

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -1,5 +1,4 @@
 import type { JSONSchema } from "@commonfabric/api";
-import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type {
@@ -12,6 +11,7 @@ import {
   findSyncSchemaRef,
   SYNC_SCHEMA_REF_PREFIX,
 } from "./sync-schema-ref.ts";
+import { mapLinkSchemas } from "./schema-table-links.ts";
 
 type SchemaTable = Record<string, JSONSchema>;
 
@@ -22,6 +22,7 @@ export type SchemaTableSessionSync = SessionSync & {
 type RewriteState = {
   schemas: Map<string, JSONSchema>;
   changed: boolean;
+  onSchema?: (schema: JSONSchema) => void;
 };
 
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
@@ -36,6 +37,7 @@ const schemaRefFor = (
 ): string => {
   const schemaAndHash = internSchema(schema, true);
   const hash = schemaAndHash.taggedHashString;
+  state.onSchema?.(schemaAndHash.schema);
   if (!state.schemas.has(hash)) {
     state.schemas.set(hash, schemaAndHash.schema);
   }
@@ -45,6 +47,7 @@ const schemaRefFor = (
 const expandSchemaRef = (
   value: unknown,
   schemas: SchemaTable | undefined,
+  onSchema?: (schema: JSONSchema) => void,
 ): JSONSchema | undefined => {
   if (
     typeof value !== "string" ||
@@ -66,6 +69,7 @@ const expandSchemaRef = (
       `Invalid sync schema table content for reference: ${value}`,
     );
   }
+  onSchema?.(schemaAndHash.schema);
   return schemaAndHash.schema;
 };
 
@@ -83,145 +87,30 @@ const rewriteSchemaValue = (
 const expandSchemaValue = (
   value: unknown,
   schemas: SchemaTable | undefined,
-): unknown => expandSchemaRef(value, schemas) ?? value;
+  onSchema?: (schema: JSONSchema) => void,
+): unknown => expandSchemaRef(value, schemas, onSchema) ?? value;
 
-const rewriteLinkPayload = (
-  payload: Record<string, unknown>,
-  state: RewriteState,
-): Record<string, unknown> => {
-  if (!Object.hasOwn(payload, "schema")) {
-    return payload;
-  }
-  const schema = rewriteSchemaValue(payload.schema, state);
-  return schema === payload.schema ? payload : { ...payload, schema };
-};
-
-const expandLinkPayload = (
-  payload: Record<string, unknown>,
-  schemas: SchemaTable | undefined,
-): Record<string, unknown> => {
-  if (!Object.hasOwn(payload, "schema")) {
-    return payload;
-  }
-  const schema = expandSchemaValue(payload.schema, schemas);
-  return schema === payload.schema ? payload : { ...payload, schema };
-};
-
-const rewriteValue = (value: unknown, state: RewriteState): unknown => {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const rewritten = value.map((item) => {
-      const next = rewriteValue(item, state);
-      changed ||= next !== item;
-      return next;
-    });
-    return changed ? rewritten : value;
-  }
-
-  if (!isPlainRecord(value)) {
-    return value;
-  }
-
-  const linkEnvelope = value["/"];
-  let rewrittenValue = value;
-  let changed = false;
-  if (isPlainRecord(linkEnvelope)) {
-    const payload = linkEnvelope[LINK_V1_TAG];
-    if (isPlainRecord(payload)) {
-      const nextPayload = rewriteLinkPayload(payload, state);
-      if (nextPayload !== payload) {
-        rewrittenValue = {
-          ...rewrittenValue,
-          "/": {
-            ...linkEnvelope,
-            [LINK_V1_TAG]: nextPayload,
-          },
-        };
-        changed = true;
-      }
-    }
-  }
-
-  const legacyAlias = value.$alias;
-  if (isPlainRecord(legacyAlias)) {
-    const nextAlias = rewriteLinkPayload(legacyAlias, state);
-    if (nextAlias !== legacyAlias) {
-      rewrittenValue = { ...rewrittenValue, $alias: nextAlias };
-      changed = true;
-    }
-  }
-
-  const rewritten: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(rewrittenValue)) {
-    const next = rewriteValue(child, state);
-    changed ||= next !== child;
-    rewritten[key] = next;
-  }
-  return changed ? rewritten : value;
-};
+const rewriteValue = (value: unknown, state: RewriteState): unknown =>
+  mapLinkSchemas(value, (schema) => rewriteSchemaValue(schema, state));
 
 const expandValue = (
   value: unknown,
   schemas: SchemaTable | undefined,
-): unknown => {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const expanded = value.map((item) => {
-      const next = expandValue(item, schemas);
-      changed ||= next !== item;
-      return next;
-    });
-    return changed ? expanded : value;
-  }
-
-  if (!isPlainRecord(value)) {
-    return value;
-  }
-
-  const linkEnvelope = value["/"];
-  let expandedValue = value;
-  let changed = false;
-  if (isPlainRecord(linkEnvelope)) {
-    const payload = linkEnvelope[LINK_V1_TAG];
-    if (isPlainRecord(payload)) {
-      const nextPayload = expandLinkPayload(payload, schemas);
-      if (nextPayload !== payload) {
-        expandedValue = {
-          ...expandedValue,
-          "/": {
-            ...linkEnvelope,
-            [LINK_V1_TAG]: nextPayload,
-          },
-        };
-        changed = true;
-      }
-    }
-  }
-
-  const legacyAlias = value.$alias;
-  if (isPlainRecord(legacyAlias)) {
-    const nextAlias = expandLinkPayload(legacyAlias, schemas);
-    if (nextAlias !== legacyAlias) {
-      expandedValue = { ...expandedValue, $alias: nextAlias };
-      changed = true;
-    }
-  }
-
-  const expanded: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(expandedValue)) {
-    const next = expandValue(child, schemas);
-    changed ||= next !== child;
-    expanded[key] = next;
-  }
-  return changed ? expanded : value;
-};
+  onSchema?: (schema: JSONSchema) => void,
+): unknown =>
+  mapLinkSchemas(
+    value,
+    (schema) => expandSchemaValue(schema, schemas, onSchema),
+  );
 
 export const compressSessionSyncSchemas = (
   sync: SessionSync,
+  onSchema?: (schema: JSONSchema) => void,
 ): SessionSync | SchemaTableSessionSync => {
   const state: RewriteState = {
     schemas: new Map(),
     changed: false,
+    onSchema,
   };
   const upserts = sync.upserts.map((upsert) => {
     if (upsert.doc === undefined) {
@@ -247,13 +136,14 @@ export const compressSessionSyncSchemas = (
 
 export const expandSessionSyncSchemas = (
   sync: SessionSync | SchemaTableSessionSync,
+  onSchema?: (schema: JSONSchema) => void,
 ): SessionSync => {
   const schemas = (sync as SchemaTableSessionSync).schemaTable;
   if (schemas === undefined || Object.keys(schemas).length === 0) {
     for (const upsert of sync.upserts) {
       const ref = findSyncSchemaRef(upsert.doc);
       if (ref !== undefined) {
-        expandSchemaRef(ref, schemas);
+        expandSchemaRef(ref, schemas, onSchema);
       }
     }
     return sync;
@@ -263,7 +153,7 @@ export const expandSessionSyncSchemas = (
     if (upsert.doc === undefined) {
       return upsert;
     }
-    const doc = expandValue(upsert.doc, schemas);
+    const doc = expandValue(upsert.doc, schemas, onSchema);
     return doc === upsert.doc ? upsert : {
       ...upsert,
       doc: doc as typeof upsert.doc,
@@ -278,7 +168,10 @@ export const expandSessionSyncSchemas = (
   return deepFreeze(expanded as SessionSync);
 };
 
-const compressResponseSync = (message: ServerMessage): ServerMessage => {
+const compressResponseSync = (
+  message: ServerMessage,
+  onSchema?: (schema: JSONSchema) => void,
+): ServerMessage => {
   if (message.type !== "response" || message.ok === undefined) {
     return message;
   }
@@ -294,12 +187,18 @@ const compressResponseSync = (message: ServerMessage): ServerMessage => {
     ...message,
     ok: {
       ...message.ok,
-      sync: compressSessionSyncSchemas(sync as unknown as SessionSync),
+      sync: compressSessionSyncSchemas(
+        sync as unknown as SessionSync,
+        onSchema,
+      ),
     },
   };
 };
 
-const expandResponseSync = (message: unknown): unknown => {
+const expandResponseSync = (
+  message: unknown,
+  onSchema?: (schema: JSONSchema) => void,
+): unknown => {
   if (!isPlainRecord(message) || message.type !== "response") {
     return message;
   }
@@ -317,6 +216,7 @@ const expandResponseSync = (message: unknown): unknown => {
       ...message.ok,
       sync: expandSessionSyncSchemas(
         sync as unknown as SchemaTableSessionSync,
+        onSchema,
       ),
     },
   };
@@ -324,24 +224,29 @@ const expandResponseSync = (message: unknown): unknown => {
 
 export const compressServerMessageSchemas = (
   message: ServerMessage,
+  onSchema?: (schema: JSONSchema) => void,
 ): ServerMessage => {
   if (message.type === "session/effect") {
     return {
       ...message,
-      effect: compressSessionSyncSchemas(message.effect),
+      effect: compressSessionSyncSchemas(message.effect, onSchema),
     } as SessionEffectMessage;
   }
-  return compressResponseSync(message);
+  return compressResponseSync(message, onSchema);
 };
 
-export const expandServerMessageSchemas = (message: unknown): unknown => {
+export const expandServerMessageSchemas = (
+  message: unknown,
+  onSchema?: (schema: JSONSchema) => void,
+): unknown => {
   if (isPlainRecord(message) && message.type === "session/effect") {
     return {
       ...message,
       effect: expandSessionSyncSchemas(
         message.effect as SchemaTableSessionSync,
+        onSchema,
       ),
     };
   }
-  return expandResponseSync(message);
+  return expandResponseSync(message, onSchema);
 };

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -8,8 +8,10 @@ import type {
   SessionSync,
 } from "../v2.ts";
 import { isPlainObject } from "@commonfabric/utils/types";
-
-const SCHEMA_REF_PREFIX = "schema-ref@2:";
+import {
+  findSyncSchemaRef,
+  SYNC_SCHEMA_REF_PREFIX,
+} from "./sync-schema-ref.ts";
 
 type SchemaTable = Record<string, JSONSchema>;
 
@@ -37,17 +39,20 @@ const schemaRefFor = (
   if (!state.schemas.has(hash)) {
     state.schemas.set(hash, schemaAndHash.schema);
   }
-  return `${SCHEMA_REF_PREFIX}${hash}`;
+  return `${SYNC_SCHEMA_REF_PREFIX}${hash}`;
 };
 
 const expandSchemaRef = (
   value: unknown,
   schemas: SchemaTable | undefined,
 ): JSONSchema | undefined => {
-  if (typeof value !== "string" || !value.startsWith(SCHEMA_REF_PREFIX)) {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith(SYNC_SCHEMA_REF_PREFIX)
+  ) {
     return undefined;
   }
-  const hash = value.slice(SCHEMA_REF_PREFIX.length);
+  const hash = value.slice(SYNC_SCHEMA_REF_PREFIX.length);
   if (
     hash.length === 0 || schemas === undefined ||
     !Object.hasOwn(schemas, hash)
@@ -245,6 +250,12 @@ export const expandSessionSyncSchemas = (
 ): SessionSync => {
   const schemas = (sync as SchemaTableSessionSync).schemaTable;
   if (schemas === undefined || Object.keys(schemas).length === 0) {
+    for (const upsert of sync.upserts) {
+      const ref = findSyncSchemaRef(upsert.doc);
+      if (ref !== undefined) {
+        expandSchemaRef(ref, schemas);
+      }
+    }
     return sync;
   }
 

--- a/packages/memory/v2/wire-accounting.ts
+++ b/packages/memory/v2/wire-accounting.ts
@@ -1,4 +1,6 @@
 import type { ClientMessage, ServerMessage } from "../v2.ts";
+import { sha256 } from "@commonfabric/content-hash";
+import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 
 export type MemoryWireDirection = "inbound" | "outbound";
 
@@ -14,10 +16,51 @@ export interface MemoryWireAccountingRecord {
   classification: string;
   baselineBytes: number;
   actualBytes: number;
+  baselineSemanticBytes?: MemoryWireSemanticBytes;
+  actualSemanticBytes?: MemoryWireSemanticBytes;
+  baselineCandidates?: MemoryWireCandidate[];
+  actualCandidates?: MemoryWireCandidate[];
+}
+
+export type MemoryWireSemanticCategory =
+  | "encoding"
+  | "identity"
+  | "sequence"
+  | "sessionControl"
+  | "authCapability"
+  | "schema"
+  | "documentValue"
+  | "patchOperation"
+  | "queryWatch"
+  | "sqliteScheduler"
+  | "error"
+  | "uncategorized";
+
+export type MemoryWireSemanticBytes = Record<
+  MemoryWireSemanticCategory,
+  number
+>;
+
+export type MemoryWireCandidateScope =
+  | "alreadyContentAddressed"
+  | "immutableInternable"
+  | "identityInternable"
+  | "seqAddressedRepeatMeasurable"
+  | "contextualControl";
+
+export interface MemoryWireCandidate {
+  category: MemoryWireSemanticCategory;
+  scope: MemoryWireCandidateScope;
+  fingerprint: string;
+  encodedBytes: number;
 }
 
 export interface MemoryWireAccountingObserver {
   isActive?(): boolean;
+  accountPayload?(payload: string, partitionKey: string): {
+    semanticBytes: MemoryWireSemanticBytes;
+    candidates: MemoryWireCandidate[];
+  };
   observe(record: MemoryWireAccountingRecord): void;
 }
 
@@ -39,7 +82,28 @@ export interface MemoryWireAccountingReport {
   byMetadataKind: MemoryWireAccountingRow[];
   byClassification: MemoryWireAccountingRow[];
   records: MemoryWireAccountingRecord[];
+  truncated?: { reason: string };
 }
+
+export type MemoryWireAccountingLimits = {
+  maxPayloadBytes: number;
+  maxDepth: number;
+  maxNodes: number;
+  maxCandidates: number;
+  maxRecords: number;
+  maxRetainedActualBytes: number;
+  maxRetainedCandidates: number;
+};
+
+const defaultLimits: MemoryWireAccountingLimits = {
+  maxPayloadBytes: 1_000_000,
+  maxDepth: 64,
+  maxNodes: 100_000,
+  maxCandidates: 10_000,
+  maxRecords: 10_000,
+  maxRetainedActualBytes: 50_000_000,
+  maxRetainedCandidates: 100_000,
+};
 
 type MutableTotals = {
   baselineBytes: number;
@@ -49,9 +113,424 @@ type MutableTotals = {
 };
 
 const textEncoder = new TextEncoder();
+const wirePrefix = "fvj1:";
+const semanticCategories: MemoryWireSemanticCategory[] = [
+  "encoding",
+  "identity",
+  "sequence",
+  "sessionControl",
+  "authCapability",
+  "schema",
+  "documentValue",
+  "patchOperation",
+  "queryWatch",
+  "sqliteScheduler",
+  "error",
+  "uncategorized",
+];
 
 export const memoryWireUtf8Bytes = (payload: string): number =>
   textEncoder.encode(payload).byteLength;
+
+export const emptyMemoryWireSemanticBytes = (): MemoryWireSemanticBytes =>
+  Object.fromEntries(
+    semanticCategories.map((category) => [category, 0]),
+  ) as MemoryWireSemanticBytes;
+
+/**
+ * Accounts the exact encoded boundary representation. It intentionally parses
+ * only valid fvj1 JSON; malformed inbound payloads stay opaque encoding data.
+ */
+export const accountMemoryWirePayload = (
+  payload: string,
+  runSalt: string,
+  partitionKey = "default",
+  limits: Pick<
+    MemoryWireAccountingLimits,
+    "maxPayloadBytes" | "maxDepth" | "maxNodes" | "maxCandidates"
+  > = defaultLimits,
+): {
+  semanticBytes: MemoryWireSemanticBytes;
+  candidates: MemoryWireCandidate[];
+} => {
+  const semanticBytes = emptyMemoryWireSemanticBytes();
+  if (
+    !payload.startsWith(wirePrefix) ||
+    memoryWireUtf8Bytes(payload) > limits.maxPayloadBytes
+  ) {
+    semanticBytes.encoding = memoryWireUtf8Bytes(payload);
+    return { semanticBytes, candidates: [] };
+  }
+
+  try {
+    const value = JSON.parse(payload.slice(wirePrefix.length));
+    if (`${wirePrefix}${JSON.stringify(value)}` !== payload) {
+      throw new Error("noncanonical memory wire payload");
+    }
+    semanticBytes.encoding = memoryWireUtf8Bytes(wirePrefix);
+    const candidates: MemoryWireCandidate[] = [];
+    accountEncodedJson(
+      value,
+      [],
+      semanticBytes,
+      candidates,
+      runSalt,
+      partitionKey,
+      {
+        nodes: 0,
+        limits,
+      },
+    );
+    return { semanticBytes, candidates };
+  } catch {
+    const opaque = emptyMemoryWireSemanticBytes();
+    opaque.encoding = memoryWireUtf8Bytes(payload);
+    return { semanticBytes: opaque, candidates: [] };
+  }
+};
+
+type WalkState = {
+  nodes: number;
+  limits: Pick<
+    MemoryWireAccountingLimits,
+    "maxDepth" | "maxNodes" | "maxCandidates"
+  >;
+};
+
+const accountEncodedJson = (
+  value: unknown,
+  path: readonly string[],
+  totals: MemoryWireSemanticBytes,
+  candidates: MemoryWireCandidate[],
+  runSalt: string,
+  partitionKey: string,
+  state: WalkState,
+): void => {
+  if (
+    ++state.nodes > state.limits.maxNodes || path.length > state.limits.maxDepth
+  ) {
+    throw new Error("wire accounting limit exceeded");
+  }
+  const category = semanticCategory(path);
+  const candidatesAtEntry = candidates.length;
+  if (Array.isArray(value)) {
+    totals[category] += 2;
+    for (let index = 0; index < value.length; index += 1) {
+      if (index > 0) totals[category] += 1;
+      accountEncodedJson(
+        value[index],
+        [...path, "[]"],
+        totals,
+        candidates,
+        runSalt,
+        partitionKey,
+        state,
+      );
+    }
+    if (candidates.length === candidatesAtEntry) {
+      addCandidate(value, path, candidates, runSalt, partitionKey, state);
+    }
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value);
+    totals[category] += 2;
+    for (let index = 0; index < entries.length; index += 1) {
+      const [key, child] = entries[index];
+      if (index > 0) totals[category] += 1;
+      totals[semanticCategory([...path, key])] +=
+        memoryWireUtf8Bytes(JSON.stringify(key)) + 1;
+      accountEncodedJson(
+        child,
+        [...path, key],
+        totals,
+        candidates,
+        runSalt,
+        partitionKey,
+        state,
+      );
+    }
+    if (candidates.length === candidatesAtEntry) {
+      addCandidate(value, path, candidates, runSalt, partitionKey, state);
+    }
+    return;
+  }
+  totals[category] += memoryWireUtf8Bytes(JSON.stringify(value));
+  if (candidates.length === candidatesAtEntry) {
+    addCandidate(value, path, candidates, runSalt, partitionKey, state);
+  }
+};
+
+const semanticCategory = (
+  path: readonly string[],
+): MemoryWireSemanticCategory => {
+  if (path.length === 0) return "encoding";
+  const key = path.at(-1) ?? "";
+  const joined = path.join(".");
+  if (isInsideProtocolSchema(path)) return "schema";
+  if (isDocumentPath(path)) return "documentValue";
+  if (isInsideAuthCapability(path)) return "authCapability";
+  if (path.includes("flags")) return "sessionControl";
+  if (joined.includes("error") || key === "message") return "error";
+  if (
+    /authorization|invocation|signature|challenge|sessionToken|capability/i
+      .test(key)
+  ) return "authCapability";
+  if (/^(seq|fromSeq|toSeq|localSeq|opIndex|serverSeq|seenSeq)$/i.test(key)) {
+    return "sequence";
+  }
+  if (
+    /^(space|branch|scope|id|sessionId|aud|iss|sub|sourceBranch|baseBranch)$/i
+      .test(key)
+  ) {
+    return "identity";
+  }
+  if (/session|flags|protocol|type|requestId/i.test(key)) {
+    return "sessionControl";
+  }
+  if (/sqlite|scheduler|table|columns|params|sql/i.test(joined)) {
+    return "sqliteScheduler";
+  }
+  if (/watches|watch|query|selector|roots|graph/i.test(joined)) {
+    return "queryWatch";
+  }
+  if (/operations|patches|commit|revisions/i.test(joined)) {
+    return "patchOperation";
+  }
+  return "uncategorized";
+};
+
+const isDocumentPath = (path: readonly string[]): boolean => {
+  const documentIndex = path.findIndex((part) =>
+    part === "doc" || part === "document"
+  );
+  if (documentIndex >= 0) return true;
+  const valueIndex = path.lastIndexOf("value");
+  return valueIndex >= 0 && path.slice(0, valueIndex).includes("operations");
+};
+
+const isInsideProtocolSchema = (path: readonly string[]): boolean =>
+  protocolSchemaRootIndex(path) !== -1;
+
+const isProtocolSchemaRoot = (path: readonly string[]): boolean =>
+  protocolSchemaRootIndex(path) === path.length - 1;
+
+const protocolSchemaRootIndex = (path: readonly string[]): number => {
+  for (const root of [["/", "link@1", "schema"], ["$alias", "schema"]]) {
+    const index = suffixRootIndex(path, root);
+    if (index !== -1) return index;
+  }
+  const selectorIndex = protocolSelectorRootIndex(path, true);
+  if (selectorIndex !== -1) return selectorIndex;
+  const tableIndex = path.lastIndexOf("schemaTable");
+  if (
+    tableIndex >= 1 && isProtocolSchemaTablePath(path, tableIndex) &&
+    path.length >= tableIndex + 2
+  ) return tableIndex + 1;
+  const definitionsIndex = path.lastIndexOf("schemaDefinitions");
+  if (definitionsIndex === 0 && path.length >= 2) return 1;
+  return -1;
+};
+
+const isProtocolSchemaTablePath = (
+  path: readonly string[],
+  tableIndex: number,
+): boolean => {
+  if (isDocumentPath(path)) return false;
+  const prefix = path.slice(0, tableIndex);
+  return pathsEqual(prefix, ["ok", "sync"]) || pathsEqual(prefix, ["effect"]);
+};
+
+const protocolSelectorRootIndex = (
+  path: readonly string[],
+  includeSchema: boolean,
+): number => {
+  if (isDocumentPath(path)) return -1;
+  const root = [
+    "query",
+    "roots",
+    "[]",
+    "selector",
+    ...(includeSchema ? ["schema"] : []),
+  ];
+  for (let index = 0; index <= path.length - root.length; index += 1) {
+    if (!root.every((part, offset) => path[index + offset] === part)) continue;
+    const prefix = path.slice(0, index);
+    if (prefix.length === 0 || pathsEqual(prefix, ["watches", "[]"])) {
+      return index + root.length - 1;
+    }
+  }
+  return -1;
+};
+
+const pathsEqual = (
+  left: readonly string[],
+  right: readonly string[],
+): boolean =>
+  left.length === right.length &&
+  left.every((part, index) => part === right[index]);
+
+const suffixRootIndex = (
+  path: readonly string[],
+  root: readonly string[],
+): number => {
+  for (let index = 0; index <= path.length - root.length; index += 1) {
+    if (root.every((part, offset) => path[index + offset] === part)) {
+      return index + root.length - 1;
+    }
+  }
+  return -1;
+};
+
+const isInsideAuthCapability = (path: readonly string[]): boolean =>
+  path.includes("invocation") || path.includes("authorization") ||
+  path.includes("sessionOpen") || path.includes("challenge");
+
+const addCandidate = (
+  value: unknown,
+  path: readonly string[],
+  candidates: MemoryWireCandidate[],
+  runSalt: string,
+  partitionKey: string,
+  state: WalkState,
+): void => {
+  const category = semanticCategory(path);
+  const scope = candidateScope(category, path, value);
+  if (scope === undefined) return;
+  const encoded = JSON.stringify(value);
+  if (candidates.length >= state.limits.maxCandidates) {
+    throw new Error("wire accounting candidate limit exceeded");
+  }
+  candidates.push({
+    category,
+    scope,
+    fingerprint: toUnpaddedBase64url(
+      sha256(
+        textEncoder.encode(`${runSalt}\u0000${partitionKey}\u0000${encoded}`),
+      ),
+    ),
+    encodedBytes: memoryWireUtf8Bytes(encoded),
+  });
+};
+
+const candidateScope = (
+  category: MemoryWireSemanticCategory,
+  path: readonly string[],
+  value: unknown,
+): MemoryWireCandidateScope | undefined => {
+  if (category === "identity" && isProtocolIdentityScalar(path, value)) {
+    return "identityInternable";
+  }
+  if (isDirectCommitCodeCID(path)) return "alreadyContentAddressed";
+  if (category === "schema" && isProtocolSchemaRoot(path)) {
+    if (
+      isDirectSchemaTableValue(path) ||
+      isDirectRequestSchemaDefinition(path)
+    ) return "alreadyContentAddressed";
+    if (
+      typeof value === "string" &&
+      (value.startsWith("schema-ref@2:") ||
+        value.startsWith("schema-cas@1:")) &&
+      (endsWithPath(path, ["/", "link@1", "schema"]) ||
+        endsWithPath(path, ["$alias", "schema"]) ||
+        protocolSelectorRootIndex(path, true) === path.length - 1)
+    ) return "alreadyContentAddressed";
+    return "immutableInternable";
+  }
+  if (category === "documentValue" && isDocumentCandidateRoot(path)) {
+    return "seqAddressedRepeatMeasurable";
+  }
+  if (
+    category === "patchOperation" &&
+    isDirectPatchCandidateRoot(path)
+  ) {
+    return "seqAddressedRepeatMeasurable";
+  }
+  if (
+    category === "queryWatch" &&
+    protocolSelectorRootIndex(path, false) === path.length - 1
+  ) {
+    return "immutableInternable";
+  }
+  if (
+    category === "sqliteScheduler" && isDirectDbTables(path)
+  ) {
+    return "immutableInternable";
+  }
+  return undefined;
+};
+
+const endsWithPath = (
+  path: readonly string[],
+  suffix: readonly string[],
+): boolean =>
+  suffix.length <= path.length &&
+  suffix.every((part, index) =>
+    path[path.length - suffix.length + index] === part
+  );
+
+const isDocumentCandidateRoot = (path: readonly string[]): boolean =>
+  endsWithPath(path, ["upserts", "[]", "doc", "value"]) ||
+  endsWithPath(path, ["entities", "[]", "document", "value"]) ||
+  endsWithPath(path, ["revisions", "[]", "document", "value"]) ||
+  (endsWithPath(path, ["commit", "operations", "[]", "value"]) &&
+    !path.includes("doc") && !path.includes("document"));
+
+const isDirectPatchCandidateRoot = (path: readonly string[]): boolean =>
+  (endsWithPath(path, ["commit", "operations", "[]", "patches"]) &&
+    !isDocumentPath(path)) ||
+  (endsWithPath(path, ["revisions", "[]", "patches"]) &&
+    !isDocumentPath(path));
+
+const isDirectDbTables = (path: readonly string[]): boolean =>
+  endsWithPath(path, ["db", "tables"]) && !isDocumentPath(path);
+
+const isDirectCommitCodeCID = (path: readonly string[]): boolean =>
+  endsWithPath(path, ["commit", "codeCID"]) && !isDocumentPath(path);
+
+const isDirectSchemaTableValue = (path: readonly string[]): boolean =>
+  path.length >= 2 && path.at(-2) === "schemaTable" &&
+  isProtocolSchemaTablePath(path, path.length - 2);
+
+const isDirectRequestSchemaDefinition = (path: readonly string[]): boolean =>
+  path.length === 2 && path[0] === "schemaDefinitions";
+
+const isProtocolIdentityScalar = (
+  path: readonly string[],
+  value: unknown,
+): boolean => {
+  if (
+    typeof value !== "string" || isDocumentPath(path) ||
+    isInsideAuthCapability(path) || isInsideProtocolSchema(path)
+  ) {
+    return false;
+  }
+  const key = path.at(-1);
+  if (key === "space") {
+    return path.length <= 2 || endsWithPath(path, ["session", "space"]);
+  }
+  if (key === "sessionId") {
+    return path.length <= 2 || endsWithPath(path, ["session", "sessionId"]);
+  }
+  if (key === "id") {
+    return endsWithPath(path, ["upserts", "[]", "id"]) ||
+      endsWithPath(path, ["removes", "[]", "id"]) ||
+      endsWithPath(path, ["entities", "[]", "id"]) ||
+      endsWithPath(path, ["operations", "[]", "id"]) ||
+      endsWithPath(path, ["revisions", "[]", "id"]) ||
+      endsWithPath(path, ["roots", "[]", "id"]) ||
+      endsWithPath(path, ["watches", "[]", "id"]) ||
+      endsWithPath(path, ["db", "id"]);
+  }
+  if (key === "branch" || key === "scope") {
+    return endsWithPath(path, ["upserts", "[]", key]) ||
+      endsWithPath(path, ["removes", "[]", key]) ||
+      endsWithPath(path, ["entities", "[]", key]) ||
+      endsWithPath(path, ["operations", "[]", key]) ||
+      endsWithPath(path, ["revisions", "[]", key]);
+  }
+  return false;
+};
 
 export const classifyClientMessage = (
   message: ClientMessage | null,
@@ -140,6 +619,16 @@ export class MemoryWireAccountingAccumulator
   implements MemoryWireAccountingObserver {
   #active = false;
   #records: MemoryWireAccountingRecord[] = [];
+  #runSalt = crypto.randomUUID();
+  #retainedActualBytes = 0;
+  #retainedCandidates = 0;
+  #truncated: { reason: string } | undefined;
+
+  private readonly limits: MemoryWireAccountingLimits;
+
+  constructor(limits: Partial<MemoryWireAccountingLimits> = {}) {
+    this.limits = { ...defaultLimits, ...limits };
+  }
 
   isActive(): boolean {
     return this.#active;
@@ -152,11 +641,29 @@ export class MemoryWireAccountingAccumulator
 
   reset(): void {
     this.#records = [];
+    this.#runSalt = crypto.randomUUID();
+    this.#retainedActualBytes = 0;
+    this.#retainedCandidates = 0;
+    this.#truncated = undefined;
+  }
+
+  accountPayload(payload: string, partitionKey: string): {
+    semanticBytes: MemoryWireSemanticBytes;
+    candidates: MemoryWireCandidate[];
+  } {
+    return accountMemoryWirePayload(
+      payload,
+      this.#runSalt,
+      partitionKey,
+      this.limits,
+    );
   }
 
   stop(): MemoryWireAccountingReport {
     this.#active = false;
-    return this.snapshot();
+    const report = this.snapshot();
+    this.reset();
+    return report;
   }
 
   snapshot(): MemoryWireAccountingReport {
@@ -180,7 +687,10 @@ export class MemoryWireAccountingAccumulator
       byConnection: snapshotRows(byConnection),
       byMetadataKind: snapshotRows(byMetadataKind),
       byClassification: snapshotRows(byClassification),
-      records: this.#records.map((record) => ({ ...record })),
+      records: this.#records.map(cloneRecord),
+      truncated: this.#truncated === undefined
+        ? undefined
+        : { ...this.#truncated },
     };
   }
 
@@ -188,11 +698,44 @@ export class MemoryWireAccountingAccumulator
     if (!this.#active) {
       return;
     }
-    this.#records.push({
-      ...record,
-      metadata: record.metadata === undefined ? undefined : {
-        ...record.metadata,
-      },
-    });
+    if (this.#truncated !== undefined) return;
+    const candidateCount = (record.actualCandidates?.length ?? 0) +
+      (record.baselineCandidates?.length ?? 0);
+    if (
+      this.#records.length >= this.limits.maxRecords ||
+      this.#retainedActualBytes + record.actualBytes >
+        this.limits.maxRetainedActualBytes ||
+      this.#retainedCandidates + candidateCount >
+        this.limits.maxRetainedCandidates
+    ) {
+      this.#truncated = { reason: "retention limit reached" };
+      this.#active = false;
+      return;
+    }
+    const cloned = cloneRecord(record);
+    this.#records.push(cloned);
+    this.#retainedActualBytes += cloned.actualBytes;
+    this.#retainedCandidates += candidateCount;
   }
 }
+
+const cloneRecord = (
+  record: MemoryWireAccountingRecord,
+): MemoryWireAccountingRecord => ({
+  ...record,
+  metadata: record.metadata === undefined
+    ? undefined
+    : structuredClone(record.metadata),
+  baselineSemanticBytes: record.baselineSemanticBytes === undefined
+    ? undefined
+    : { ...record.baselineSemanticBytes },
+  actualSemanticBytes: record.actualSemanticBytes === undefined
+    ? undefined
+    : { ...record.actualSemanticBytes },
+  baselineCandidates: record.baselineCandidates?.map((candidate) => ({
+    ...candidate,
+  })),
+  actualCandidates: record.actualCandidates?.map((candidate) => ({
+    ...candidate,
+  })),
+});

--- a/packages/memory/v2/wire-accounting.ts
+++ b/packages/memory/v2/wire-accounting.ts
@@ -1,0 +1,198 @@
+import type { ClientMessage, ServerMessage } from "../v2.ts";
+
+export type MemoryWireDirection = "inbound" | "outbound";
+
+export interface MemoryWireConnectionMetadata {
+  kind?: string;
+  [key: string]: unknown;
+}
+
+export interface MemoryWireAccountingRecord {
+  direction: MemoryWireDirection;
+  connectionId: string;
+  metadata?: MemoryWireConnectionMetadata;
+  classification: string;
+  baselineBytes: number;
+  actualBytes: number;
+}
+
+export interface MemoryWireAccountingObserver {
+  isActive?(): boolean;
+  observe(record: MemoryWireAccountingRecord): void;
+}
+
+export interface MemoryWireAccountingTotals {
+  baselineBytes: number;
+  actualBytes: number;
+  frames: number;
+  connections: number;
+}
+
+export interface MemoryWireAccountingRow extends MemoryWireAccountingTotals {
+  key: string;
+}
+
+export interface MemoryWireAccountingReport {
+  totals: MemoryWireAccountingTotals;
+  byDirection: MemoryWireAccountingRow[];
+  byConnection: MemoryWireAccountingRow[];
+  byMetadataKind: MemoryWireAccountingRow[];
+  byClassification: MemoryWireAccountingRow[];
+  records: MemoryWireAccountingRecord[];
+}
+
+type MutableTotals = {
+  baselineBytes: number;
+  actualBytes: number;
+  frames: number;
+  connections: Set<string>;
+};
+
+const textEncoder = new TextEncoder();
+
+export const memoryWireUtf8Bytes = (payload: string): number =>
+  textEncoder.encode(payload).byteLength;
+
+export const classifyClientMessage = (
+  message: ClientMessage | null,
+): string => message === null ? "client.invalid" : `client.${message.type}`;
+
+export const classifyServerMessage = (
+  message: ServerMessage,
+  originatingRequestType?: string,
+): string => {
+  switch (message.type) {
+    case "hello.ok":
+      return "server.hello.ok";
+    case "session/effect":
+      return "server.session/effect.sync";
+    case "session/revoked":
+      return "server.session/revoked";
+    case "response": {
+      const origin = originatingRequestType ?? "unknown";
+      const suffix = responseCarriesSync(message)
+        ? ".sync"
+        : message.error !== undefined
+        ? ".error"
+        : "";
+      return `server.response.${origin}${suffix}`;
+    }
+  }
+};
+
+const responseCarriesSync = (message: ServerMessage): boolean => {
+  if (message.type !== "response" || message.ok === undefined) {
+    return false;
+  }
+  const ok = message.ok;
+  return ok !== null && typeof ok === "object" &&
+    (ok as { sync?: { type?: unknown } }).sync?.type === "sync";
+};
+
+const emptyTotals = (): MutableTotals => ({
+  baselineBytes: 0,
+  actualBytes: 0,
+  frames: 0,
+  connections: new Set(),
+});
+
+const addToTotals = (
+  totals: MutableTotals,
+  record: MemoryWireAccountingRecord,
+): void => {
+  totals.baselineBytes += record.baselineBytes;
+  totals.actualBytes += record.actualBytes;
+  totals.frames += 1;
+  totals.connections.add(record.connectionId);
+};
+
+const snapshotTotals = (
+  totals: MutableTotals,
+): MemoryWireAccountingTotals => ({
+  baselineBytes: totals.baselineBytes,
+  actualBytes: totals.actualBytes,
+  frames: totals.frames,
+  connections: totals.connections.size,
+});
+
+const addGrouped = (
+  groups: Map<string, MutableTotals>,
+  key: string,
+  record: MemoryWireAccountingRecord,
+): void => {
+  let totals = groups.get(key);
+  if (totals === undefined) {
+    totals = emptyTotals();
+    groups.set(key, totals);
+  }
+  addToTotals(totals, record);
+};
+
+const snapshotRows = (
+  groups: Map<string, MutableTotals>,
+): MemoryWireAccountingRow[] =>
+  [...groups.entries()].map(([key, totals]) => ({
+    key,
+    ...snapshotTotals(totals),
+  }));
+
+export class MemoryWireAccountingAccumulator
+  implements MemoryWireAccountingObserver {
+  #active = false;
+  #records: MemoryWireAccountingRecord[] = [];
+
+  isActive(): boolean {
+    return this.#active;
+  }
+
+  start(): void {
+    this.reset();
+    this.#active = true;
+  }
+
+  reset(): void {
+    this.#records = [];
+  }
+
+  stop(): MemoryWireAccountingReport {
+    this.#active = false;
+    return this.snapshot();
+  }
+
+  snapshot(): MemoryWireAccountingReport {
+    const totals = emptyTotals();
+    const byDirection = new Map<string, MutableTotals>();
+    const byConnection = new Map<string, MutableTotals>();
+    const byMetadataKind = new Map<string, MutableTotals>();
+    const byClassification = new Map<string, MutableTotals>();
+
+    for (const record of this.#records) {
+      addToTotals(totals, record);
+      addGrouped(byDirection, record.direction, record);
+      addGrouped(byConnection, record.connectionId, record);
+      addGrouped(byMetadataKind, record.metadata?.kind ?? "unknown", record);
+      addGrouped(byClassification, record.classification, record);
+    }
+
+    return {
+      totals: snapshotTotals(totals),
+      byDirection: snapshotRows(byDirection),
+      byConnection: snapshotRows(byConnection),
+      byMetadataKind: snapshotRows(byMetadataKind),
+      byClassification: snapshotRows(byClassification),
+      records: this.#records.map((record) => ({ ...record })),
+    };
+  }
+
+  observe(record: MemoryWireAccountingRecord): void {
+    if (!this.#active) {
+      return;
+    }
+    this.#records.push({
+      ...record,
+      metadata: record.metadata === undefined ? undefined : {
+        ...record.metadata,
+      },
+    });
+  }
+}

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -44,6 +44,7 @@ import {
 import {
   analyzeLunchPollWireAccounting,
   formatLunchPollWireAccounting,
+  isMemoryWireAccountingReport,
   validateLunchPollWireAccounting,
 } from "./lunch-poll-wire-accounting.ts";
 
@@ -110,12 +111,11 @@ async function accountingErrorMessage(
   return `Memory wire-accounting ${action} failed with HTTP ${response.status}.${bodySuffix}`;
 }
 
-async function startMemoryWireAccounting(): Promise<boolean> {
+async function startMemoryWireAccounting(): Promise<void> {
   if (MEMORY_WIRE_ACCOUNTING_TOKEN === "") {
-    console.log(
-      "Memory wire-accounting token was not provided by the root integration runner; running Lunch Poll behavior and skipping accounting assertions.",
+    throw new Error(
+      "Lunch Poll wire-accounting measurement requires the root integration runner. Run `deno task integration patterns lunch-poll-vote`; do not invoke this test file directly.",
     );
-    return false;
   }
 
   const response = await accountingRequest("start");
@@ -129,7 +129,6 @@ async function startMemoryWireAccounting(): Promise<boolean> {
     throw new Error(await accountingErrorMessage(response, "start"));
   }
   await response.body?.cancel();
-  return true;
 }
 
 async function stopMemoryWireAccounting(): Promise<MemoryWireAccountingReport> {
@@ -149,19 +148,6 @@ async function stopMemoryWireAccounting(): Promise<MemoryWireAccountingReport> {
     );
   }
   return payload;
-}
-
-function isMemoryWireAccountingReport(
-  payload: unknown,
-): payload is MemoryWireAccountingReport {
-  if (payload === null || typeof payload !== "object") return false;
-  const object = payload as Record<string, unknown>;
-  return typeof object.totals === "object" && object.totals !== null &&
-    Array.isArray(object.byDirection) &&
-    Array.isArray(object.byConnection) &&
-    Array.isArray(object.byMetadataKind) &&
-    Array.isArray(object.byClassification) &&
-    Array.isArray(object.records);
 }
 
 describe("lunch poll: two users vote on a shared option", () => {
@@ -233,7 +219,8 @@ describe("lunch poll: two users vote on a shared option", () => {
     let accountingStopped = false;
 
     try {
-      accountingStarted = await startMemoryWireAccounting();
+      await startMemoryWireAccounting();
+      accountingStarted = true;
 
       await timer.run(
         "navigate + login both",

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -25,6 +25,8 @@ import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
+import { assert } from "@std/assert";
+import type { MemoryWireAccountingReport } from "@commonfabric/memory/v2/wire-accounting";
 import {
   initializePiecesController,
   PiecesController,
@@ -39,9 +41,15 @@ import {
   waitForRuntimeIdle,
   waitForText,
 } from "./cfc-browser-helpers.ts";
+import {
+  analyzeLunchPollWireAccounting,
+  formatLunchPollWireAccounting,
+  validateLunchPollWireAccounting,
+} from "./lunch-poll-wire-accounting.ts";
 
-const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+const { API_URL, FRONTEND_URL, MEMORY_WIRE_ACCOUNTING_TOKEN, SPACE_NAME } = env;
 const PROPAGATION_TIMEOUT = 60_000;
+const WIRE_ACCOUNTING_PATH = "api/storage/memory/wire-accounting";
 
 const HOST = "Alice";
 const GUEST = "Bob";
@@ -73,6 +81,86 @@ const voteSwatchVoters = (page: Page): Promise<string[]> =>
     walk(document);
     return [...names];
   });
+
+function wireAccountingUrl(action: "start" | "stop"): URL {
+  return new URL(`${WIRE_ACCOUNTING_PATH}/${action}`, API_URL);
+}
+
+async function accountingRequest(
+  action: "start" | "stop",
+): Promise<Response> {
+  return await fetch(wireAccountingUrl(action), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${MEMORY_WIRE_ACCOUNTING_TOKEN}`,
+    },
+  });
+}
+
+async function accountingErrorMessage(
+  response: Response,
+  action: "start" | "stop",
+): Promise<string> {
+  const body = await response.text().catch(() => "");
+  const bodySuffix = body.trim().length === 0
+    ? ""
+    : ` body=${body.trim().slice(0, 200)}`;
+  return `Memory wire-accounting ${action} failed with HTTP ${response.status}.${bodySuffix}`;
+}
+
+async function startMemoryWireAccounting(): Promise<boolean> {
+  if (MEMORY_WIRE_ACCOUNTING_TOKEN === "") {
+    console.log(
+      "Memory wire-accounting token was not provided by the root integration runner; running Lunch Poll behavior and skipping accounting assertions.",
+    );
+    return false;
+  }
+
+  const response = await accountingRequest("start");
+  if (response.status === 404) {
+    await response.body?.cancel();
+    throw new Error(
+      "Memory wire-accounting route was expected but unavailable. Ensure the root integration runner started Toolshed with CF_MEMORY_WIRE_ACCOUNTING_TOKEN and ENV=development or ENV=test.",
+    );
+  }
+  if (!response.ok) {
+    throw new Error(await accountingErrorMessage(response, "start"));
+  }
+  await response.body?.cancel();
+  return true;
+}
+
+async function stopMemoryWireAccounting(): Promise<MemoryWireAccountingReport> {
+  const response = await accountingRequest("stop");
+  if (!response.ok) {
+    throw new Error(await accountingErrorMessage(response, "stop"));
+  }
+
+  const payload: unknown = await response.json().catch((cause) => {
+    throw new Error("Memory wire-accounting stop returned invalid JSON", {
+      cause,
+    });
+  });
+  if (!isMemoryWireAccountingReport(payload)) {
+    throw new Error(
+      "Memory wire-accounting stop returned a JSON payload with an unexpected schema",
+    );
+  }
+  return payload;
+}
+
+function isMemoryWireAccountingReport(
+  payload: unknown,
+): payload is MemoryWireAccountingReport {
+  if (payload === null || typeof payload !== "object") return false;
+  const object = payload as Record<string, unknown>;
+  return typeof object.totals === "object" && object.totals !== null &&
+    Array.isArray(object.byDirection) &&
+    Array.isArray(object.byConnection) &&
+    Array.isArray(object.byMetadataKind) &&
+    Array.isArray(object.byClassification) &&
+    Array.isArray(object.records);
+}
 
 describe("lunch poll: two users vote on a shared option", () => {
   const hostShell = new ShellIntegration({
@@ -139,8 +227,12 @@ describe("lunch poll: two users vote on a shared option", () => {
     const view = { spaceName: SPACE_NAME, pieceId };
     const hostPage = hostShell.page();
     const guestPage = guestShell.page();
+    let accountingStarted = false;
+    let accountingStopped = false;
 
     try {
+      accountingStarted = await startMemoryWireAccounting();
+
       await timer.run(
         "navigate + login both",
         () =>
@@ -289,7 +381,34 @@ describe("lunch poll: two users vote on a shared option", () => {
             }),
           ]),
       );
+      await timer.run(
+        "final runtimes idle for accounting",
+        () =>
+          Promise.all([
+            waitForRuntimeIdle(hostPage, { timeout: PROPAGATION_TIMEOUT }),
+            waitForRuntimeIdle(guestPage, { timeout: PROPAGATION_TIMEOUT }),
+          ]),
+      );
+
+      if (accountingStarted) {
+        const report = await stopMemoryWireAccounting();
+        accountingStopped = true;
+        const analysis = analyzeLunchPollWireAccounting(report);
+        console.log(formatLunchPollWireAccounting(analysis));
+        const errors = validateLunchPollWireAccounting(analysis);
+        assert(
+          errors.length === 0,
+          `Memory wire-accounting invariants failed:\n${errors.join("\n")}`,
+        );
+      }
     } finally {
+      if (accountingStarted && !accountingStopped) {
+        await stopMemoryWireAccounting().catch((error) => {
+          console.error(
+            `Failed to stop Memory wire-accounting during cleanup: ${error}`,
+          );
+        });
+      }
       logStepTimings("lunch-poll vote", timer);
       for (
         const [page, label] of [[hostPage, HOST], [guestPage, GUEST]] as const

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -50,6 +50,8 @@ import {
 const { API_URL, FRONTEND_URL, MEMORY_WIRE_ACCOUNTING_TOKEN, SPACE_NAME } = env;
 const PROPAGATION_TIMEOUT = 60_000;
 const WIRE_ACCOUNTING_PATH = "api/storage/memory/wire-accounting";
+const REQUEST_SCHEMA_CAS_ENABLED =
+  Deno.env.get("CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED") !== "false";
 
 const HOST = "Alice";
 const GUEST = "Bob";
@@ -395,7 +397,9 @@ describe("lunch poll: two users vote on a shared option", () => {
         accountingStopped = true;
         const analysis = analyzeLunchPollWireAccounting(report);
         console.log(formatLunchPollWireAccounting(analysis));
-        const errors = validateLunchPollWireAccounting(analysis);
+        const errors = validateLunchPollWireAccounting(analysis, {
+          requestSchemaCasEnabled: REQUEST_SCHEMA_CAS_ENABLED,
+        });
         assert(
           errors.length === 0,
           `Memory wire-accounting invariants failed:\n${errors.join("\n")}`,

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -53,6 +53,8 @@ const PROPAGATION_TIMEOUT = 60_000;
 const WIRE_ACCOUNTING_PATH = "api/storage/memory/wire-accounting";
 const REQUEST_SCHEMA_CAS_ENABLED =
   Deno.env.get("CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED") !== "false";
+const MEMORY_WIRE_ACCOUNTING_REQUIRED =
+  Deno.env.get("CF_MEMORY_WIRE_ACCOUNTING_REQUIRED") === "1";
 
 const HOST = "Alice";
 const GUEST = "Bob";
@@ -111,11 +113,17 @@ async function accountingErrorMessage(
   return `Memory wire-accounting ${action} failed with HTTP ${response.status}.${bodySuffix}`;
 }
 
-async function startMemoryWireAccounting(): Promise<void> {
+async function startMemoryWireAccounting(): Promise<boolean> {
   if (MEMORY_WIRE_ACCOUNTING_TOKEN === "") {
-    throw new Error(
-      "Lunch Poll wire-accounting measurement requires the root integration runner. Run `deno task integration patterns lunch-poll-vote`; do not invoke this test file directly.",
+    if (MEMORY_WIRE_ACCOUNTING_REQUIRED) {
+      throw new Error(
+        "Lunch Poll wire-accounting measurement requires the root integration runner token. Run `deno task integration patterns lunch-poll-vote`.",
+      );
+    }
+    console.log(
+      "Memory wire accounting is not required for this ordinary integration run; skipping accounting assertions.",
     );
+    return false;
   }
 
   const response = await accountingRequest("start");
@@ -129,6 +137,7 @@ async function startMemoryWireAccounting(): Promise<void> {
     throw new Error(await accountingErrorMessage(response, "start"));
   }
   await response.body?.cancel();
+  return true;
 }
 
 async function stopMemoryWireAccounting(): Promise<MemoryWireAccountingReport> {
@@ -219,8 +228,7 @@ describe("lunch poll: two users vote on a shared option", () => {
     let accountingStopped = false;
 
     try {
-      await startMemoryWireAccounting();
-      accountingStarted = true;
+      accountingStarted = await startMemoryWireAccounting();
 
       await timer.run(
         "navigate + login both",

--- a/packages/patterns/integration/lunch-poll-wire-accounting.test.ts
+++ b/packages/patterns/integration/lunch-poll-wire-accounting.test.ts
@@ -37,6 +37,8 @@ Deno.test("analyzeLunchPollWireAccounting handles no browser records", () => {
 
   assertEquals(analysis.records, []);
   assertEquals(analysis.rows, []);
+  assertEquals(analysis.protocolSemanticRows, []);
+  assertEquals(analysis.candidateRows, []);
   assertEquals(analysis.totals, {
     baselineBytes: 0,
     actualBytes: 0,
@@ -105,20 +107,82 @@ Deno.test("analyzeLunchPollWireAccounting produces deterministic classification 
   assertEquals(analysis.rows[2].savedPercent, 0);
 });
 
+Deno.test("analyzeLunchPollWireAccounting cross-tabs protocol classes and semantic bytes", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      direction: "outbound",
+      classification: "server.hello.ok",
+      actualBytes: 10,
+      actualSemanticBytes: {
+        encoding: 4,
+        identity: 6,
+        sequence: 0,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 0,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+    }),
+    record({
+      direction: "inbound",
+      classification: "client.watch",
+      actualBytes: 5,
+      actualSemanticBytes: {
+        encoding: 0,
+        identity: 0,
+        sequence: 5,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 0,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+    }),
+  ]));
+  assertEquals(
+    analysis.protocolSemanticRows.map((row) =>
+      `${row.classification}:${row.direction}:${row.category}`
+    ),
+    [
+      "client.watch:inbound:sequence",
+      "server.hello.ok:outbound:encoding",
+      "server.hello.ok:outbound:identity",
+    ],
+  );
+  assertEquals(analysis.protocolSemanticRows[1].percentOfProtocolClass, 40);
+  assertEquals(analysis.protocolSemanticRows[2].percentOfAllTraffic, 40);
+  assertEquals(
+    analysis.protocolSemanticRows.reduce(
+      (sum, row) => sum + row.actualBytes,
+      0,
+    ),
+    analysis.totals.actualBytes,
+  );
+});
+
 Deno.test("validateLunchPollWireAccounting accepts browser sync savings invariants", () => {
   const analysis = analyzeLunchPollWireAccounting(emptyReport([
     record({
       direction: "inbound",
       connectionId: "browser-a",
-      classification: "client.watch",
+      classification: "client.graph.query",
       baselineBytes: 100,
-      actualBytes: 100,
+      actualBytes: 120,
     }),
     record({
       direction: "inbound",
       connectionId: "browser-b",
-      classification: "client.watch",
-      baselineBytes: 80,
+      classification: "client.transact",
+      baselineBytes: 180,
       actualBytes: 80,
     }),
     record({
@@ -145,6 +209,46 @@ Deno.test("validateLunchPollWireAccounting accepts browser sync savings invarian
   ]));
 
   assertEquals(validateLunchPollWireAccounting(analysis), []);
+});
+
+Deno.test("validateLunchPollWireAccounting accepts inline request schemas when CAS is disabled", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      direction: "inbound",
+      connectionId: "browser-a",
+      classification: "client.graph.query",
+      baselineBytes: 100,
+      actualBytes: 100,
+    }),
+    record({
+      direction: "inbound",
+      connectionId: "browser-b",
+      classification: "client.transact",
+      baselineBytes: 180,
+      actualBytes: 180,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-a",
+      classification: "server.session/effect.sync",
+      baselineBytes: 1_000,
+      actualBytes: 400,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-b",
+      classification: "server.response.watch.sync",
+      baselineBytes: 500,
+      actualBytes: 250,
+    }),
+  ]));
+
+  assertEquals(
+    validateLunchPollWireAccounting(analysis, {
+      requestSchemaCasEnabled: false,
+    }),
+    [],
+  );
 });
 
 Deno.test("validateLunchPollWireAccounting reports invariant failures", () => {
@@ -213,6 +317,166 @@ Deno.test("formatLunchPollWireAccounting prints the headline and per-class table
       "direction | classification | frames | baseline bytes | actual bytes | saved bytes | saved %",
       "inbound | client.watch | 1 | 10 | 10 | 0 | 0.0%",
       "outbound | server.session/effect.sync | 2 | 150 | 70 | 80 | 53.3%",
+      "direction | classification | category | actual bytes | % of protocol class | % of all traffic",
+      "category | scope | candidate bytes | candidates | repeats (connection) | repeat bytes (connection) | reference cost (connection) | net savings (connection)",
     ].join("\n"),
   );
+});
+
+Deno.test("analyzeLunchPollWireAccounting reports scoped repeat opportunities and reference cost", () => {
+  const candidate = {
+    category: "schema" as const,
+    scope: "immutableInternable" as const,
+    fingerprint: "run-local-a",
+    encodedBytes: 100,
+  };
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      connectionId: "browser-a",
+      actualBytes: 100,
+      actualSemanticBytes: {
+        encoding: 0,
+        identity: 0,
+        sequence: 0,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 100,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+      actualCandidates: [candidate],
+    }),
+    record({
+      connectionId: "browser-a",
+      actualBytes: 100,
+      actualSemanticBytes: {
+        encoding: 0,
+        identity: 0,
+        sequence: 0,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 100,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+      actualCandidates: [candidate],
+    }),
+    record({
+      connectionId: "browser-b",
+      actualBytes: 100,
+      actualSemanticBytes: {
+        encoding: 0,
+        identity: 0,
+        sequence: 0,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 100,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+      actualCandidates: [candidate],
+    }),
+  ]));
+  const schema = analysis.candidateRows.find((row) =>
+    row.category === "schema"
+  );
+  assertEquals(schema?.candidateBytes, 300);
+  assertEquals(schema?.candidateOccurrences, 3);
+  assertEquals(schema?.repeatOccurrencesConnectionLocal, 1);
+  assertEquals(schema?.repeatBytesConnectionLocal, 100);
+  assertEquals(schema?.referenceCostConnectionLocal, 12);
+  assertEquals(schema?.netSavingsConnectionLocal, 88);
+});
+
+Deno.test("analyzeLunchPollWireAccounting allocates semantic bytes to candidate scopes", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      actualBytes: 150,
+      actualSemanticBytes: {
+        encoding: 0,
+        identity: 0,
+        sequence: 0,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 150,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+      actualCandidates: [
+        {
+          category: "schema",
+          scope: "immutableInternable",
+          fingerprint: "a",
+          encodedBytes: 100,
+        },
+        {
+          category: "schema",
+          scope: "alreadyContentAddressed",
+          fingerprint: "b",
+          encodedBytes: 30,
+        },
+      ],
+    }),
+  ]));
+  const immutable = analysis.candidateRows.find((row) =>
+    row.category === "schema" && row.scope === "immutableInternable"
+  );
+  const addressed = analysis.candidateRows.find((row) =>
+    row.category === "schema" && row.scope === "alreadyContentAddressed"
+  );
+  assertEquals(immutable?.candidateBytes, 100);
+  assertEquals(addressed?.candidateBytes, 30);
+  assertEquals(
+    analysis.candidateRows.reduce((sum, row) => sum + row.candidateBytes, 0),
+    130,
+  );
+});
+
+Deno.test("validateLunchPollWireAccounting rejects truncated and inconsistent accounting", () => {
+  const analysis = analyzeLunchPollWireAccounting({
+    ...emptyReport([record({
+      actualBytes: 10,
+      actualSemanticBytes: {
+        encoding: 9,
+        identity: 0,
+        sequence: 0,
+        sessionControl: 0,
+        authCapability: 0,
+        schema: 0,
+        documentValue: 0,
+        patchOperation: 0,
+        queryWatch: 0,
+        sqliteScheduler: 0,
+        error: 0,
+        uncategorized: 0,
+      },
+      actualCandidates: [{
+        category: "encoding",
+        scope: "contextualControl",
+        fingerprint: "x",
+        encodedBytes: 11,
+      }],
+    })]),
+    truncated: { reason: "limit" },
+  });
+  const errors = validateLunchPollWireAccounting(analysis);
+  assert(errors.some((error) => error.includes("truncated")));
+  assert(errors.some((error) => error.includes("semantic bytes differ")));
+  assert(errors.some((error) => error.includes("candidate bytes exceed")));
 });

--- a/packages/patterns/integration/lunch-poll-wire-accounting.test.ts
+++ b/packages/patterns/integration/lunch-poll-wire-accounting.test.ts
@@ -6,8 +6,24 @@ import type {
 import {
   analyzeLunchPollWireAccounting,
   formatLunchPollWireAccounting,
+  isMemoryWireAccountingReport,
   validateLunchPollWireAccounting,
 } from "./lunch-poll-wire-accounting.ts";
+
+const semanticBytes = (bytes: number) => ({
+  encoding: bytes,
+  identity: 0,
+  sequence: 0,
+  sessionControl: 0,
+  authCapability: 0,
+  schema: 0,
+  documentValue: 0,
+  patchOperation: 0,
+  queryWatch: 0,
+  sqliteScheduler: 0,
+  error: 0,
+  uncategorized: 0,
+});
 
 const emptyReport = (
   records: MemoryWireAccountingRecord[] = [],
@@ -22,15 +38,67 @@ const emptyReport = (
 
 const record = (
   overrides: Partial<MemoryWireAccountingRecord>,
-): MemoryWireAccountingRecord => ({
-  direction: "outbound",
-  connectionId: "browser-a",
-  metadata: { kind: "browser" },
-  classification: "server.session/effect.sync",
-  baselineBytes: 100,
-  actualBytes: 50,
-  ...overrides,
-});
+): MemoryWireAccountingRecord => {
+  const value = {
+    direction: "outbound" as const,
+    connectionId: "browser-a",
+    metadata: { kind: "browser" },
+    classification: "server.session/effect.sync",
+    baselineBytes: 100,
+    actualBytes: 50,
+    ...overrides,
+  };
+  return {
+    ...value,
+    baselineSemanticBytes: overrides.baselineSemanticBytes ??
+      semanticBytes(value.baselineBytes),
+    actualSemanticBytes: overrides.actualSemanticBytes ??
+      semanticBytes(value.actualBytes),
+  };
+};
+
+const validRecords = (
+  requestSchemaCasEnabled = true,
+): MemoryWireAccountingRecord[] => [
+  record({
+    direction: "inbound",
+    connectionId: "browser-a",
+    classification: "client.graph.query",
+    baselineBytes: 100,
+    actualBytes: requestSchemaCasEnabled ? 80 : 100,
+  }),
+  record({
+    direction: "inbound",
+    connectionId: "browser-b",
+    classification: "client.session.watch.add",
+    baselineBytes: 100,
+    actualBytes: requestSchemaCasEnabled ? 80 : 100,
+  }),
+  record({
+    direction: "inbound",
+    connectionId: "browser-c",
+    classification: "client.transact",
+    baselineBytes: 180,
+    actualBytes: requestSchemaCasEnabled ? 120 : 180,
+  }),
+  record({
+    connectionId: "browser-d",
+    classification: "server.hello.ok",
+    baselineBytes: 20,
+    actualBytes: 20,
+  }),
+  record({
+    connectionId: "browser-e",
+    baselineBytes: 1_000,
+    actualBytes: 400,
+  }),
+  record({
+    connectionId: "browser-f",
+    classification: "server.response.watch.sync",
+    baselineBytes: 500,
+    actualBytes: 250,
+  }),
+];
 
 Deno.test("analyzeLunchPollWireAccounting handles no browser records", () => {
   const analysis = analyzeLunchPollWireAccounting(emptyReport());
@@ -170,78 +238,15 @@ Deno.test("analyzeLunchPollWireAccounting cross-tabs protocol classes and semant
 });
 
 Deno.test("validateLunchPollWireAccounting accepts browser sync savings invariants", () => {
-  const analysis = analyzeLunchPollWireAccounting(emptyReport([
-    record({
-      direction: "inbound",
-      connectionId: "browser-a",
-      classification: "client.graph.query",
-      baselineBytes: 100,
-      actualBytes: 120,
-    }),
-    record({
-      direction: "inbound",
-      connectionId: "browser-b",
-      classification: "client.transact",
-      baselineBytes: 180,
-      actualBytes: 80,
-    }),
-    record({
-      direction: "outbound",
-      connectionId: "browser-a",
-      classification: "server.hello.ok",
-      baselineBytes: 20,
-      actualBytes: 20,
-    }),
-    record({
-      direction: "outbound",
-      connectionId: "browser-a",
-      classification: "server.session/effect.sync",
-      baselineBytes: 1_000,
-      actualBytes: 400,
-    }),
-    record({
-      direction: "outbound",
-      connectionId: "browser-b",
-      classification: "server.response.watch.sync",
-      baselineBytes: 500,
-      actualBytes: 250,
-    }),
-  ]));
+  const analysis = analyzeLunchPollWireAccounting(emptyReport(validRecords()));
 
   assertEquals(validateLunchPollWireAccounting(analysis), []);
 });
 
 Deno.test("validateLunchPollWireAccounting accepts inline request schemas when CAS is disabled", () => {
-  const analysis = analyzeLunchPollWireAccounting(emptyReport([
-    record({
-      direction: "inbound",
-      connectionId: "browser-a",
-      classification: "client.graph.query",
-      baselineBytes: 100,
-      actualBytes: 100,
-    }),
-    record({
-      direction: "inbound",
-      connectionId: "browser-b",
-      classification: "client.transact",
-      baselineBytes: 180,
-      actualBytes: 180,
-    }),
-    record({
-      direction: "outbound",
-      connectionId: "browser-a",
-      classification: "server.session/effect.sync",
-      baselineBytes: 1_000,
-      actualBytes: 400,
-    }),
-    record({
-      direction: "outbound",
-      connectionId: "browser-b",
-      classification: "server.response.watch.sync",
-      baselineBytes: 500,
-      actualBytes: 250,
-    }),
-  ]));
+  const analysis = analyzeLunchPollWireAccounting(
+    emptyReport(validRecords(false)),
+  );
 
   assertEquals(
     validateLunchPollWireAccounting(analysis, {
@@ -277,12 +282,120 @@ Deno.test("validateLunchPollWireAccounting reports invariant failures", () => {
   ]));
   const errors = validateLunchPollWireAccounting(analysis);
 
-  assert(errors.some((error) => error.includes("at least two distinct")));
+  assert(errors.some((error) => error.includes("expected 6 distinct")));
   assert(errors.some((error) => error.includes("inbound client.watch")));
   assert(
     errors.some((error) => error.includes("outbound non-sync server.hello.ok")),
   );
   assert(errors.some((error) => error.includes("at least 15.0% savings")));
+});
+
+Deno.test("isMemoryWireAccountingReport rejects malformed record evidence", () => {
+  const malformed = {
+    ...emptyReport(),
+    records: [{
+      direction: "inbound",
+      connectionId: "browser-a",
+      classification: "client.graph.query",
+      baselineBytes: Number.NaN,
+      actualBytes: 10,
+      baselineSemanticBytes: semanticBytes(10),
+      actualSemanticBytes: semanticBytes(10),
+    }],
+  };
+
+  assert(!isMemoryWireAccountingReport(malformed));
+  assert(
+    !isMemoryWireAccountingReport({
+      ...emptyReport(),
+      records: [{
+        ...malformed.records[0],
+        baselineBytes: 10.5,
+      }],
+    }),
+  );
+  assert(
+    !isMemoryWireAccountingReport({
+      ...emptyReport(),
+      records: [{
+        direction: "inbound",
+        connectionId: "browser-a",
+        classification: "client.graph.query",
+        baselineBytes: 10,
+        actualBytes: 10,
+        baselineSemanticBytes: semanticBytes(10),
+      }],
+    }),
+  );
+});
+
+Deno.test("validateLunchPollWireAccounting requires the stable request classes", () => {
+  const records = validRecords();
+  records[0] = record({
+    ...records[0],
+    classification: "client.session.watch.set",
+  });
+  const errors = validateLunchPollWireAccounting(
+    analyzeLunchPollWireAccounting(emptyReport(records)),
+  );
+
+  assert(
+    errors.some((error) => error.includes("client.graph.query")),
+  );
+});
+
+Deno.test("validateLunchPollWireAccounting conserves baseline semantic bytes", () => {
+  const records = validRecords();
+  records[0] = record({
+    ...records[0],
+    baselineSemanticBytes: semanticBytes(99),
+  });
+  const errors = validateLunchPollWireAccounting(
+    analyzeLunchPollWireAccounting(emptyReport(records)),
+  );
+
+  assert(
+    errors.some((error) => error.includes("baseline semantic bytes differ")),
+  );
+});
+
+Deno.test("validateLunchPollWireAccounting enforces request-CAS and overall savings floors", () => {
+  const requestSavingsRecords = validRecords().map((item) => {
+    if (item.direction !== "inbound") return item;
+    const actualBytes = item.baselineBytes - 5;
+    return record({
+      ...item,
+      actualBytes,
+      actualSemanticBytes: semanticBytes(actualBytes),
+    });
+  });
+  const requestSavingsErrors = validateLunchPollWireAccounting(
+    analyzeLunchPollWireAccounting(emptyReport(requestSavingsRecords)),
+  );
+  assert(
+    requestSavingsErrors.some((error) =>
+      error.includes("request-schema-CAS inbound")
+    ),
+  );
+
+  const overallSavingsRecords = [
+    ...validRecords(),
+    record({
+      direction: "inbound",
+      connectionId: "browser-a",
+      classification: "client.session.watch.set",
+      baselineBytes: 10_000,
+      actualBytes: 10_000,
+    }),
+  ];
+  const overallSavingsErrors = validateLunchPollWireAccounting(
+    analyzeLunchPollWireAccounting(emptyReport(overallSavingsRecords)),
+  );
+  assert(
+    overallSavingsErrors.some((error) =>
+      error.includes("overall browser-byte")
+    ),
+  );
 });
 
 Deno.test("formatLunchPollWireAccounting prints the headline and per-class table", () => {
@@ -318,6 +431,8 @@ Deno.test("formatLunchPollWireAccounting prints the headline and per-class table
       "inbound | client.watch | 1 | 10 | 10 | 0 | 0.0%",
       "outbound | server.session/effect.sync | 2 | 150 | 70 | 80 | 53.3%",
       "direction | classification | category | actual bytes | % of protocol class | % of all traffic",
+      "inbound | client.watch | encoding | 10 | 100.0% | 12.5%",
+      "outbound | server.session/effect.sync | encoding | 70 | 100.0% | 87.5%",
       "category | scope | candidate bytes | candidates | repeats (connection) | repeat bytes (connection) | reference cost (connection) | net savings (connection)",
     ].join("\n"),
   );

--- a/packages/patterns/integration/lunch-poll-wire-accounting.test.ts
+++ b/packages/patterns/integration/lunch-poll-wire-accounting.test.ts
@@ -1,0 +1,218 @@
+import { assert, assertEquals } from "@std/assert";
+import type {
+  MemoryWireAccountingRecord,
+  MemoryWireAccountingReport,
+} from "@commonfabric/memory/v2/wire-accounting";
+import {
+  analyzeLunchPollWireAccounting,
+  formatLunchPollWireAccounting,
+  validateLunchPollWireAccounting,
+} from "./lunch-poll-wire-accounting.ts";
+
+const emptyReport = (
+  records: MemoryWireAccountingRecord[] = [],
+): MemoryWireAccountingReport => ({
+  totals: { baselineBytes: 0, actualBytes: 0, frames: 0, connections: 0 },
+  byDirection: [],
+  byConnection: [],
+  byMetadataKind: [],
+  byClassification: [],
+  records,
+});
+
+const record = (
+  overrides: Partial<MemoryWireAccountingRecord>,
+): MemoryWireAccountingRecord => ({
+  direction: "outbound",
+  connectionId: "browser-a",
+  metadata: { kind: "browser" },
+  classification: "server.session/effect.sync",
+  baselineBytes: 100,
+  actualBytes: 50,
+  ...overrides,
+});
+
+Deno.test("analyzeLunchPollWireAccounting handles no browser records", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport());
+
+  assertEquals(analysis.records, []);
+  assertEquals(analysis.rows, []);
+  assertEquals(analysis.totals, {
+    baselineBytes: 0,
+    actualBytes: 0,
+    frames: 0,
+    connections: 0,
+    savedBytes: 0,
+    savedPercent: 0,
+  });
+  assert(
+    validateLunchPollWireAccounting(analysis).includes(
+      "expected at least one browser Memory websocket frame",
+    ),
+  );
+});
+
+Deno.test("analyzeLunchPollWireAccounting filters browser records from runtime records", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({ connectionId: "browser-a", baselineBytes: 120, actualBytes: 60 }),
+    record({
+      connectionId: "runtime-a",
+      metadata: { kind: "runtime" },
+      baselineBytes: 10_000,
+      actualBytes: 1,
+    }),
+  ]));
+
+  assertEquals(analysis.records.length, 1);
+  assertEquals(analysis.totals.baselineBytes, 120);
+  assertEquals(analysis.totals.actualBytes, 60);
+  assertEquals(analysis.totals.connections, 1);
+});
+
+Deno.test("analyzeLunchPollWireAccounting produces deterministic classification rows and safe zero percentages", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      direction: "outbound",
+      classification: "server.response.watch.sync",
+      connectionId: "browser-b",
+      baselineBytes: 0,
+      actualBytes: 0,
+    }),
+    record({
+      direction: "inbound",
+      classification: "client.watch",
+      connectionId: "browser-a",
+      baselineBytes: 5,
+      actualBytes: 5,
+    }),
+    record({
+      direction: "outbound",
+      classification: "server.hello.ok",
+      connectionId: "browser-a",
+      baselineBytes: 10,
+      actualBytes: 10,
+    }),
+  ]));
+
+  assertEquals(
+    analysis.rows.map((row) => `${row.classification}:${row.direction}`),
+    [
+      "client.watch:inbound",
+      "server.hello.ok:outbound",
+      "server.response.watch.sync:outbound",
+    ],
+  );
+  assertEquals(analysis.rows[2].savedPercent, 0);
+});
+
+Deno.test("validateLunchPollWireAccounting accepts browser sync savings invariants", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      direction: "inbound",
+      connectionId: "browser-a",
+      classification: "client.watch",
+      baselineBytes: 100,
+      actualBytes: 100,
+    }),
+    record({
+      direction: "inbound",
+      connectionId: "browser-b",
+      classification: "client.watch",
+      baselineBytes: 80,
+      actualBytes: 80,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-a",
+      classification: "server.hello.ok",
+      baselineBytes: 20,
+      actualBytes: 20,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-a",
+      classification: "server.session/effect.sync",
+      baselineBytes: 1_000,
+      actualBytes: 400,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-b",
+      classification: "server.response.watch.sync",
+      baselineBytes: 500,
+      actualBytes: 250,
+    }),
+  ]));
+
+  assertEquals(validateLunchPollWireAccounting(analysis), []);
+});
+
+Deno.test("validateLunchPollWireAccounting reports invariant failures", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      direction: "inbound",
+      connectionId: "browser-a",
+      classification: "client.watch",
+      baselineBytes: 100,
+      actualBytes: 90,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-a",
+      classification: "server.hello.ok",
+      baselineBytes: 20,
+      actualBytes: 10,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-a",
+      classification: "server.session/effect.sync",
+      baselineBytes: 100,
+      actualBytes: 90,
+    }),
+  ]));
+  const errors = validateLunchPollWireAccounting(analysis);
+
+  assert(errors.some((error) => error.includes("at least two distinct")));
+  assert(errors.some((error) => error.includes("inbound client.watch")));
+  assert(
+    errors.some((error) => error.includes("outbound non-sync server.hello.ok")),
+  );
+  assert(errors.some((error) => error.includes("at least 15.0% savings")));
+});
+
+Deno.test("formatLunchPollWireAccounting prints the headline and per-class table", () => {
+  const analysis = analyzeLunchPollWireAccounting(emptyReport([
+    record({
+      direction: "inbound",
+      connectionId: "browser-a",
+      classification: "client.watch",
+      baselineBytes: 10,
+      actualBytes: 10,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-a",
+      classification: "server.session/effect.sync",
+      baselineBytes: 100,
+      actualBytes: 40,
+    }),
+    record({
+      direction: "outbound",
+      connectionId: "browser-b",
+      classification: "server.session/effect.sync",
+      baselineBytes: 50,
+      actualBytes: 30,
+    }),
+  ]));
+
+  assertEquals(
+    formatLunchPollWireAccounting(analysis),
+    [
+      "baseline 160 bytes over 2 browser connections; actual 80 bytes over 2 browser connections; saved 80 bytes (50.0%)",
+      "direction | classification | frames | baseline bytes | actual bytes | saved bytes | saved %",
+      "inbound | client.watch | 1 | 10 | 10 | 0 | 0.0%",
+      "outbound | server.session/effect.sync | 2 | 150 | 70 | 80 | 53.3%",
+    ].join("\n"),
+  );
+});

--- a/packages/patterns/integration/lunch-poll-wire-accounting.ts
+++ b/packages/patterns/integration/lunch-poll-wire-accounting.ts
@@ -1,0 +1,268 @@
+import type {
+  MemoryWireAccountingRecord,
+  MemoryWireAccountingReport,
+} from "@commonfabric/memory/v2/wire-accounting";
+
+export type LunchPollWireAccountingTotals = {
+  baselineBytes: number;
+  actualBytes: number;
+  frames: number;
+  connections: number;
+  savedBytes: number;
+  savedPercent: number;
+};
+
+export type LunchPollWireAccountingRow = LunchPollWireAccountingTotals & {
+  direction: string;
+  classification: string;
+};
+
+export type LunchPollWireAccountingAnalysis = {
+  records: MemoryWireAccountingRecord[];
+  totals: LunchPollWireAccountingTotals;
+  rows: LunchPollWireAccountingRow[];
+};
+
+const SYNC_CLASSIFICATION_SUFFIX = ".sync";
+// First measured real Lunch Poll browser run saved 22.9% on sync-bearing
+// outbound Memory text payload bytes; keep the floor below that observed value
+// while still requiring a substantial schema-compression win.
+const MIN_SYNC_OUTBOUND_SAVED_PERCENT = 15;
+
+function savedPercent(baselineBytes: number, actualBytes: number): number {
+  if (baselineBytes === 0) return 0;
+  return ((baselineBytes - actualBytes) / baselineBytes) * 100;
+}
+
+function toTotals(
+  baselineBytes: number,
+  actualBytes: number,
+  frames: number,
+  connectionIds: Set<string>,
+): LunchPollWireAccountingTotals {
+  return {
+    baselineBytes,
+    actualBytes,
+    frames,
+    connections: connectionIds.size,
+    savedBytes: baselineBytes - actualBytes,
+    savedPercent: savedPercent(baselineBytes, actualBytes),
+  };
+}
+
+function browserRecords(
+  report: MemoryWireAccountingReport,
+): MemoryWireAccountingRecord[] {
+  return report.records.filter((record) => record.metadata?.kind === "browser");
+}
+
+export function analyzeLunchPollWireAccounting(
+  report: MemoryWireAccountingReport,
+): LunchPollWireAccountingAnalysis {
+  const records = browserRecords(report);
+  const connections = new Set<string>();
+  let baselineBytes = 0;
+  let actualBytes = 0;
+
+  const groups = new Map<
+    string,
+    {
+      direction: string;
+      classification: string;
+      baselineBytes: number;
+      actualBytes: number;
+      frames: number;
+      connections: Set<string>;
+    }
+  >();
+
+  for (const record of records) {
+    baselineBytes += record.baselineBytes;
+    actualBytes += record.actualBytes;
+    connections.add(record.connectionId);
+
+    const key = `${record.direction}\u0000${record.classification}`;
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = {
+        direction: record.direction,
+        classification: record.classification,
+        baselineBytes: 0,
+        actualBytes: 0,
+        frames: 0,
+        connections: new Set(),
+      };
+      groups.set(key, group);
+    }
+    group.baselineBytes += record.baselineBytes;
+    group.actualBytes += record.actualBytes;
+    group.frames += 1;
+    group.connections.add(record.connectionId);
+  }
+
+  const rows = [...groups.values()].map((group) => ({
+    direction: group.direction,
+    classification: group.classification,
+    ...toTotals(
+      group.baselineBytes,
+      group.actualBytes,
+      group.frames,
+      group.connections,
+    ),
+  })).sort((left, right) =>
+    left.classification.localeCompare(right.classification) ||
+    left.direction.localeCompare(right.direction)
+  );
+
+  return {
+    records,
+    totals: toTotals(baselineBytes, actualBytes, records.length, connections),
+    rows,
+  };
+}
+
+function isOutboundSync(record: MemoryWireAccountingRecord): boolean {
+  return record.direction === "outbound" &&
+    record.classification.endsWith(SYNC_CLASSIFICATION_SUFFIX);
+}
+
+export function validateLunchPollWireAccounting(
+  analysis: LunchPollWireAccountingAnalysis,
+): string[] {
+  const errors: string[] = [];
+  const connectionIds = new Set(
+    analysis.records.map((record) => record.connectionId),
+  );
+
+  if (analysis.records.length === 0) {
+    errors.push("expected at least one browser Memory websocket frame");
+  }
+  if (connectionIds.size < 2) {
+    errors.push(
+      `expected at least two distinct browser Memory connections, got ${connectionIds.size}`,
+    );
+  }
+
+  const baselineConnections = new Set(
+    analysis.records
+      .filter((record) => record.baselineBytes > 0)
+      .map((record) => record.connectionId),
+  );
+  const actualConnections = new Set(
+    analysis.records
+      .filter((record) => record.actualBytes > 0)
+      .map((record) => record.connectionId),
+  );
+  if (!sameSet(baselineConnections, actualConnections)) {
+    errors.push(
+      `baseline and actual browser connection sets differ: baseline=${
+        sortedSet(baselineConnections).join(",")
+      } actual=${sortedSet(actualConnections).join(",")}`,
+    );
+  }
+
+  for (const record of analysis.records) {
+    if (
+      record.direction === "inbound" &&
+      record.baselineBytes !== record.actualBytes
+    ) {
+      errors.push(
+        `inbound ${record.classification} frame on ${record.connectionId} changed bytes: baseline=${record.baselineBytes} actual=${record.actualBytes}`,
+      );
+    }
+    if (
+      record.direction === "outbound" &&
+      !record.classification.endsWith(SYNC_CLASSIFICATION_SUFFIX) &&
+      record.baselineBytes !== record.actualBytes
+    ) {
+      errors.push(
+        `outbound non-sync ${record.classification} frame on ${record.connectionId} changed bytes: baseline=${record.baselineBytes} actual=${record.actualBytes}`,
+      );
+    }
+  }
+
+  const outboundSyncRecords = analysis.records.filter(isOutboundSync);
+  const savedOutboundSyncRecords = outboundSyncRecords.filter((record) =>
+    record.actualBytes < record.baselineBytes
+  );
+  if (savedOutboundSyncRecords.length === 0) {
+    errors.push(
+      "expected at least one outbound sync-bearing browser frame to save bytes",
+    );
+  }
+
+  const outboundSyncBaseline = outboundSyncRecords.reduce(
+    (sum, record) => sum + record.baselineBytes,
+    0,
+  );
+  const outboundSyncActual = outboundSyncRecords.reduce(
+    (sum, record) => sum + record.actualBytes,
+    0,
+  );
+  if (!(outboundSyncActual < outboundSyncBaseline)) {
+    errors.push(
+      `expected sync-bearing outbound browser aggregate actual bytes to be less than baseline: baseline=${outboundSyncBaseline} actual=${outboundSyncActual}`,
+    );
+  }
+  if (outboundSyncBaseline > 0) {
+    const outboundSyncSavedPercent = savedPercent(
+      outboundSyncBaseline,
+      outboundSyncActual,
+    );
+    if (outboundSyncSavedPercent < MIN_SYNC_OUTBOUND_SAVED_PERCENT) {
+      errors.push(
+        `expected at least ${
+          formatPercent(MIN_SYNC_OUTBOUND_SAVED_PERCENT)
+        } savings on sync-bearing outbound browser bytes, got ${
+          formatPercent(outboundSyncSavedPercent)
+        }`,
+      );
+    }
+  }
+
+  if (!(analysis.totals.actualBytes < analysis.totals.baselineBytes)) {
+    errors.push(
+      `expected overall browser actual bytes to be less than baseline: baseline=${analysis.totals.baselineBytes} actual=${analysis.totals.actualBytes}`,
+    );
+  }
+
+  return errors;
+}
+
+export function formatLunchPollWireAccounting(
+  analysis: LunchPollWireAccountingAnalysis,
+): string {
+  const totals = analysis.totals;
+  const lines = [
+    `baseline ${totals.baselineBytes} bytes over ${totals.connections} browser connections; actual ${totals.actualBytes} bytes over ${totals.connections} browser connections; saved ${totals.savedBytes} bytes (${
+      formatPercent(totals.savedPercent)
+    })`,
+    "direction | classification | frames | baseline bytes | actual bytes | saved bytes | saved %",
+  ];
+
+  for (const row of analysis.rows) {
+    lines.push(
+      `${row.direction} | ${row.classification} | ${row.frames} | ${row.baselineBytes} | ${row.actualBytes} | ${row.savedBytes} | ${
+        formatPercent(row.savedPercent)
+      }`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function sameSet(left: Set<string>, right: Set<string>): boolean {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
+}
+
+function sortedSet(values: Set<string>): string[] {
+  return [...values].sort();
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`;
+}

--- a/packages/patterns/integration/lunch-poll-wire-accounting.ts
+++ b/packages/patterns/integration/lunch-poll-wire-accounting.ts
@@ -1,6 +1,9 @@
 import type {
   MemoryWireAccountingRecord,
   MemoryWireAccountingReport,
+  MemoryWireCandidate,
+  MemoryWireCandidateScope,
+  MemoryWireSemanticCategory,
 } from "@commonfabric/memory/v2/wire-accounting";
 
 export type LunchPollWireAccountingTotals = {
@@ -19,9 +22,36 @@ export type LunchPollWireAccountingRow = LunchPollWireAccountingTotals & {
 
 export type LunchPollWireAccountingAnalysis = {
   records: MemoryWireAccountingRecord[];
+  truncated?: { reason: string };
   totals: LunchPollWireAccountingTotals;
   rows: LunchPollWireAccountingRow[];
+  protocolSemanticRows: LunchPollProtocolSemanticRow[];
+  candidateRows: LunchPollWireCandidateRow[];
 };
+
+export type LunchPollProtocolSemanticRow = {
+  direction: string;
+  classification: string;
+  category: MemoryWireSemanticCategory;
+  actualBytes: number;
+  percentOfProtocolClass: number;
+  percentOfAllTraffic: number;
+};
+
+export type LunchPollWireCandidateRow = {
+  category: MemoryWireSemanticCategory;
+  scope: MemoryWireCandidateScope;
+  candidateBytes: number;
+  candidateOccurrences: number;
+  repeatOccurrencesConnectionLocal: number;
+  repeatBytesConnectionLocal: number;
+  referenceCostConnectionLocal: number;
+  netSavingsConnectionLocal: number;
+};
+
+// This is deliberately a simulation cost, not a protocol claim: a compact
+// future reference still needs a marker plus a cache key on the wire.
+const CACHE_REFERENCE_BYTES = 12;
 
 const SYNC_CLASSIFICATION_SUFFIX = ".sync";
 // First measured real Lunch Poll browser run saved 22.9% on sync-bearing
@@ -75,6 +105,17 @@ export function analyzeLunchPollWireAccounting(
       connections: Set<string>;
     }
   >();
+  const candidates = new Map<string, {
+    category: MemoryWireSemanticCategory;
+    scope: MemoryWireCandidateScope;
+    candidates: Array<{ candidate: MemoryWireCandidate; connectionId: string }>;
+  }>();
+  const protocolSemantic = new Map<string, {
+    direction: string;
+    classification: string;
+    category: MemoryWireSemanticCategory;
+    actualBytes: number;
+  }>();
 
   for (const record of records) {
     baselineBytes += record.baselineBytes;
@@ -98,6 +139,31 @@ export function analyzeLunchPollWireAccounting(
     group.actualBytes += record.actualBytes;
     group.frames += 1;
     group.connections.add(record.connectionId);
+
+    for (
+      const [category, bytes] of Object.entries(
+        record.actualSemanticBytes ?? {},
+      ) as [MemoryWireSemanticCategory, number][]
+    ) {
+      if (bytes === 0) continue;
+      const protocolKey =
+        `${record.direction}\u0000${record.classification}\u0000${category}`;
+      let protocolGroup = protocolSemantic.get(protocolKey);
+      if (protocolGroup === undefined) {
+        protocolGroup = {
+          direction: record.direction,
+          classification: record.classification,
+          category,
+          actualBytes: 0,
+        };
+        protocolSemantic.set(protocolKey, protocolGroup);
+      }
+      protocolGroup.actualBytes += bytes;
+    }
+
+    for (const candidate of record.actualCandidates ?? []) {
+      addCandidateRow(candidates, candidate, record.connectionId);
+    }
   }
 
   const rows = [...groups.values()].map((group) => ({
@@ -113,12 +179,109 @@ export function analyzeLunchPollWireAccounting(
     left.classification.localeCompare(right.classification) ||
     left.direction.localeCompare(right.direction)
   );
+  const protocolClassActualBytes = new Map(
+    rows.map((row) => [
+      `${row.direction}\u0000${row.classification}`,
+      row.actualBytes,
+    ]),
+  );
+  const protocolSemanticRows = [...protocolSemantic.values()].map((row) => {
+    const protocolActualBytes = protocolClassActualBytes.get(
+      `${row.direction}\u0000${row.classification}`,
+    ) ?? 0;
+    return {
+      ...row,
+      percentOfProtocolClass: protocolActualBytes === 0
+        ? 0
+        : (row.actualBytes / protocolActualBytes) * 100,
+      percentOfAllTraffic: actualBytes === 0
+        ? 0
+        : (row.actualBytes / actualBytes) * 100,
+    };
+  }).sort((left, right) =>
+    left.classification.localeCompare(right.classification) ||
+    left.direction.localeCompare(right.direction) ||
+    left.category.localeCompare(right.category)
+  );
+  const candidateRows = [...candidates.values()].map((group) => {
+    const uniqueConnection = new Set<string>();
+    let repeatBytesConnectionLocal = 0;
+    let repeatOccurrencesConnectionLocal = 0;
+    for (const { candidate, connectionId } of group.candidates) {
+      const connectionKey = `${connectionId}\u0000${candidate.fingerprint}`;
+      if (uniqueConnection.has(connectionKey)) {
+        repeatBytesConnectionLocal += candidate.encodedBytes;
+        repeatOccurrencesConnectionLocal += 1;
+      }
+      uniqueConnection.add(connectionKey);
+    }
+    const candidateOccurrences = group.candidates.length;
+    const referenceCostConnectionLocal = repeatOccurrencesConnectionLocal *
+      CACHE_REFERENCE_BYTES;
+    return {
+      category: group.category,
+      scope: group.scope,
+      candidateBytes: group.candidates.reduce(
+        (sum, item) => sum + item.candidate.encodedBytes,
+        0,
+      ),
+      candidateOccurrences,
+      repeatOccurrencesConnectionLocal,
+      repeatBytesConnectionLocal,
+      referenceCostConnectionLocal,
+      netSavingsConnectionLocal: Math.max(
+        0,
+        repeatBytesConnectionLocal - referenceCostConnectionLocal,
+      ),
+    };
+  }).sort((left, right) =>
+    left.category.localeCompare(right.category) ||
+    left.scope.localeCompare(right.scope)
+  );
 
   return {
     records,
+    truncated: report.truncated === undefined
+      ? undefined
+      : { ...report.truncated },
     totals: toTotals(baselineBytes, actualBytes, records.length, connections),
     rows,
+    protocolSemanticRows,
+    candidateRows,
   };
+}
+
+function addCandidateRow(
+  groups: Map<string, {
+    category: MemoryWireSemanticCategory;
+    scope: MemoryWireCandidateScope;
+    candidates: Array<{ candidate: MemoryWireCandidate; connectionId: string }>;
+  }>,
+  candidate: MemoryWireCandidate,
+  connectionId: string,
+): void {
+  candidateGroup(groups, candidate.category, candidate.scope).candidates.push({
+    candidate,
+    connectionId,
+  });
+}
+
+function candidateGroup(
+  groups: Map<string, {
+    category: MemoryWireSemanticCategory;
+    scope: MemoryWireCandidateScope;
+    candidates: Array<{ candidate: MemoryWireCandidate; connectionId: string }>;
+  }>,
+  category: MemoryWireSemanticCategory,
+  scope: MemoryWireCandidateScope,
+) {
+  const key = `${category}\u0000${scope}`;
+  let group = groups.get(key);
+  if (group === undefined) {
+    group = { category, scope, candidates: [] };
+    groups.set(key, group);
+  }
+  return group;
 }
 
 function isOutboundSync(record: MemoryWireAccountingRecord): boolean {
@@ -126,10 +289,31 @@ function isOutboundSync(record: MemoryWireAccountingRecord): boolean {
     record.classification.endsWith(SYNC_CLASSIFICATION_SUFFIX);
 }
 
+const REQUEST_SCHEMA_CAS_CLASSIFICATIONS = new Set([
+  "client.graph.query",
+  "client.session.watch.set",
+  "client.session.watch.add",
+  "client.transact",
+]);
+
+function isInboundRequestSchemaCas(
+  record: MemoryWireAccountingRecord,
+): boolean {
+  return record.direction === "inbound" &&
+    REQUEST_SCHEMA_CAS_CLASSIFICATIONS.has(record.classification);
+}
+
 export function validateLunchPollWireAccounting(
   analysis: LunchPollWireAccountingAnalysis,
+  options: { requestSchemaCasEnabled?: boolean } = {},
 ): string[] {
+  const requestSchemaCasEnabled = options.requestSchemaCasEnabled ?? true;
   const errors: string[] = [];
+  if (analysis.truncated !== undefined) {
+    errors.push(
+      `wire accounting report truncated: ${analysis.truncated.reason}`,
+    );
+  }
   const connectionIds = new Set(
     analysis.records.map((record) => record.connectionId),
   );
@@ -162,8 +346,29 @@ export function validateLunchPollWireAccounting(
   }
 
   for (const record of analysis.records) {
+    if (record.actualSemanticBytes !== undefined) {
+      const semanticBytes = Object.values(record.actualSemanticBytes).reduce(
+        (sum, bytes) => sum + bytes,
+        0,
+      );
+      if (semanticBytes !== record.actualBytes) {
+        errors.push(
+          `actual semantic bytes differ for ${record.classification}: semantic=${semanticBytes} actual=${record.actualBytes}`,
+        );
+      }
+      const candidateBytes = (record.actualCandidates ?? []).reduce(
+        (sum, candidate) => sum + candidate.encodedBytes,
+        0,
+      );
+      if (candidateBytes > record.actualBytes) {
+        errors.push(
+          `candidate bytes exceed actual bytes for ${record.classification}: candidates=${candidateBytes} actual=${record.actualBytes}`,
+        );
+      }
+    }
     if (
       record.direction === "inbound" &&
+      (!requestSchemaCasEnabled || !isInboundRequestSchemaCas(record)) &&
       record.baselineBytes !== record.actualBytes
     ) {
       errors.push(
@@ -179,6 +384,35 @@ export function validateLunchPollWireAccounting(
         `outbound non-sync ${record.classification} frame on ${record.connectionId} changed bytes: baseline=${record.baselineBytes} actual=${record.actualBytes}`,
       );
     }
+  }
+
+  const inboundRequestSchemaCasRecords = analysis.records.filter(
+    isInboundRequestSchemaCas,
+  );
+  const inboundRequestSchemaCasBaseline = inboundRequestSchemaCasRecords.reduce(
+    (sum, record) => sum + record.baselineBytes,
+    0,
+  );
+  const inboundRequestSchemaCasActual = inboundRequestSchemaCasRecords.reduce(
+    (sum, record) => sum + record.actualBytes,
+    0,
+  );
+  if (inboundRequestSchemaCasRecords.length === 0) {
+    errors.push("expected at least one request-schema-CAS browser frame");
+  } else if (
+    requestSchemaCasEnabled &&
+    !(inboundRequestSchemaCasActual < inboundRequestSchemaCasBaseline)
+  ) {
+    errors.push(
+      `expected request-schema-CAS inbound browser aggregate actual bytes to be less than baseline: baseline=${inboundRequestSchemaCasBaseline} actual=${inboundRequestSchemaCasActual}`,
+    );
+  } else if (
+    !requestSchemaCasEnabled &&
+    inboundRequestSchemaCasActual !== inboundRequestSchemaCasBaseline
+  ) {
+    errors.push(
+      `expected request-schema-CAS-capable inbound browser aggregate bytes to remain inline when disabled: baseline=${inboundRequestSchemaCasBaseline} actual=${inboundRequestSchemaCasActual}`,
+    );
   }
 
   const outboundSyncRecords = analysis.records.filter(isOutboundSync);
@@ -245,6 +479,26 @@ export function formatLunchPollWireAccounting(
       `${row.direction} | ${row.classification} | ${row.frames} | ${row.baselineBytes} | ${row.actualBytes} | ${row.savedBytes} | ${
         formatPercent(row.savedPercent)
       }`,
+    );
+  }
+
+  lines.push(
+    "direction | classification | category | actual bytes | % of protocol class | % of all traffic",
+  );
+  for (const row of analysis.protocolSemanticRows) {
+    lines.push(
+      `${row.direction} | ${row.classification} | ${row.category} | ${row.actualBytes} | ${
+        formatPercent(row.percentOfProtocolClass)
+      } | ${formatPercent(row.percentOfAllTraffic)}`,
+    );
+  }
+
+  lines.push(
+    "category | scope | candidate bytes | candidates | repeats (connection) | repeat bytes (connection) | reference cost (connection) | net savings (connection)",
+  );
+  for (const row of analysis.candidateRows) {
+    lines.push(
+      `${row.category} | ${row.scope} | ${row.candidateBytes} | ${row.candidateOccurrences} | ${row.repeatOccurrencesConnectionLocal} | ${row.repeatBytesConnectionLocal} | ${row.referenceCostConnectionLocal} | ${row.netSavingsConnectionLocal}`,
     );
   }
 

--- a/packages/patterns/integration/lunch-poll-wire-accounting.ts
+++ b/packages/patterns/integration/lunch-poll-wire-accounting.ts
@@ -3,6 +3,7 @@ import type {
   MemoryWireAccountingReport,
   MemoryWireCandidate,
   MemoryWireCandidateScope,
+  MemoryWireSemanticBytes,
   MemoryWireSemanticCategory,
 } from "@commonfabric/memory/v2/wire-accounting";
 
@@ -54,10 +55,39 @@ export type LunchPollWireCandidateRow = {
 const CACHE_REFERENCE_BYTES = 12;
 
 const SYNC_CLASSIFICATION_SUFFIX = ".sync";
-// First measured real Lunch Poll browser run saved 22.9% on sync-bearing
-// outbound Memory text payload bytes; keep the floor below that observed value
+// Fresh cold/warm Lunch Poll browser runs saved 22.6-22.7% on sync-bearing
+// outbound Memory text payload bytes; keep the floor below that observed range
 // while still requiring a substantial schema-compression win.
 const MIN_SYNC_OUTBOUND_SAVED_PERCENT = 15;
+const MIN_REQUEST_SCHEMA_CAS_SAVED_PERCENT = 10;
+const MIN_OVERALL_SAVED_PERCENT = 10;
+const EXPECTED_BROWSER_CONNECTIONS = 6;
+const EXPECTED_REQUEST_CLASSES = new Set([
+  "client.graph.query",
+  "client.session.watch.add",
+  "client.transact",
+]);
+const SEMANTIC_CATEGORIES: readonly MemoryWireSemanticCategory[] = [
+  "encoding",
+  "identity",
+  "sequence",
+  "sessionControl",
+  "authCapability",
+  "schema",
+  "documentValue",
+  "patchOperation",
+  "queryWatch",
+  "sqliteScheduler",
+  "error",
+  "uncategorized",
+];
+const CANDIDATE_SCOPES: readonly MemoryWireCandidateScope[] = [
+  "alreadyContentAddressed",
+  "immutableInternable",
+  "identityInternable",
+  "seqAddressedRepeatMeasurable",
+  "contextualControl",
+];
 
 function savedPercent(baselineBytes: number, actualBytes: number): number {
   if (baselineBytes === 0) return 0;
@@ -84,6 +114,87 @@ function browserRecords(
   report: MemoryWireAccountingReport,
 ): MemoryWireAccountingRecord[] {
   return report.records.filter((record) => record.metadata?.kind === "browser");
+}
+
+export function isMemoryWireAccountingReport(
+  payload: unknown,
+): payload is MemoryWireAccountingReport {
+  if (!isRecord(payload)) return false;
+  return isTotals(payload.totals) &&
+    isRows(payload.byDirection) &&
+    isRows(payload.byConnection) &&
+    isRows(payload.byMetadataKind) &&
+    isRows(payload.byClassification) &&
+    Array.isArray(payload.records) &&
+    payload.records.every(isWireAccountingRecord) &&
+    (payload.truncated === undefined ||
+      (isRecord(payload.truncated) &&
+        typeof payload.truncated.reason === "string"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isTotals(value: unknown): boolean {
+  return isRecord(value) &&
+    isByteCount(value.baselineBytes) &&
+    isByteCount(value.actualBytes) &&
+    isByteCount(value.frames) &&
+    isByteCount(value.connections);
+}
+
+function isRows(value: unknown): boolean {
+  return Array.isArray(value) &&
+    value.every((row) =>
+      isRecord(row) && typeof row.key === "string" && isTotals(row)
+    );
+}
+
+function isWireAccountingRecord(
+  value: unknown,
+): value is MemoryWireAccountingRecord {
+  if (!isRecord(value)) return false;
+  return (value.direction === "inbound" || value.direction === "outbound") &&
+    typeof value.connectionId === "string" && value.connectionId.length > 0 &&
+    typeof value.classification === "string" &&
+    value.classification.length > 0 &&
+    (value.metadata === undefined ||
+      (isRecord(value.metadata) &&
+        (value.metadata.kind === undefined ||
+          typeof value.metadata.kind === "string"))) &&
+    isByteCount(value.baselineBytes) &&
+    isByteCount(value.actualBytes) &&
+    isSemanticBytes(value.baselineSemanticBytes) &&
+    isSemanticBytes(value.actualSemanticBytes) &&
+    isCandidates(value.baselineCandidates) &&
+    isCandidates(value.actualCandidates);
+}
+
+function isByteCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isSemanticBytes(value: unknown): value is MemoryWireSemanticBytes {
+  if (!isRecord(value)) return false;
+  return Object.keys(value).length === SEMANTIC_CATEGORIES.length &&
+    SEMANTIC_CATEGORIES.every((category) => isByteCount(value[category]));
+}
+
+function isCandidates(value: unknown): boolean {
+  return value === undefined ||
+    (Array.isArray(value) && value.every((candidate) =>
+      isRecord(candidate) &&
+      SEMANTIC_CATEGORIES.includes(
+        candidate.category as MemoryWireSemanticCategory,
+      ) &&
+      CANDIDATE_SCOPES.includes(
+        candidate.scope as MemoryWireCandidateScope,
+      ) &&
+      typeof candidate.fingerprint === "string" &&
+      candidate.fingerprint.length > 0 &&
+      isByteCount(candidate.encodedBytes)
+    ));
 }
 
 export function analyzeLunchPollWireAccounting(
@@ -321,10 +432,23 @@ export function validateLunchPollWireAccounting(
   if (analysis.records.length === 0) {
     errors.push("expected at least one browser Memory websocket frame");
   }
-  if (connectionIds.size < 2) {
+  if (connectionIds.size !== EXPECTED_BROWSER_CONNECTIONS) {
     errors.push(
-      `expected at least two distinct browser Memory connections, got ${connectionIds.size}`,
+      `expected ${EXPECTED_BROWSER_CONNECTIONS} distinct browser Memory connections for the two-browser Lunch Poll workload, got ${connectionIds.size}`,
     );
+  }
+
+  const observedRequestClasses = new Set(
+    analysis.records
+      .filter((record) => record.direction === "inbound")
+      .map((record) => record.classification),
+  );
+  for (const classification of EXPECTED_REQUEST_CLASSES) {
+    if (!observedRequestClasses.has(classification)) {
+      errors.push(
+        `expected inbound browser traffic for ${classification}`,
+      );
+    }
   }
 
   const baselineConnections = new Set(
@@ -346,16 +470,8 @@ export function validateLunchPollWireAccounting(
   }
 
   for (const record of analysis.records) {
+    validateRecordEvidence(record, errors);
     if (record.actualSemanticBytes !== undefined) {
-      const semanticBytes = Object.values(record.actualSemanticBytes).reduce(
-        (sum, bytes) => sum + bytes,
-        0,
-      );
-      if (semanticBytes !== record.actualBytes) {
-        errors.push(
-          `actual semantic bytes differ for ${record.classification}: semantic=${semanticBytes} actual=${record.actualBytes}`,
-        );
-      }
       const candidateBytes = (record.actualCandidates ?? []).reduce(
         (sum, candidate) => sum + candidate.encodedBytes,
         0,
@@ -414,6 +530,21 @@ export function validateLunchPollWireAccounting(
       `expected request-schema-CAS-capable inbound browser aggregate bytes to remain inline when disabled: baseline=${inboundRequestSchemaCasBaseline} actual=${inboundRequestSchemaCasActual}`,
     );
   }
+  if (requestSchemaCasEnabled && inboundRequestSchemaCasBaseline > 0) {
+    const requestSchemaCasSavedPercent = savedPercent(
+      inboundRequestSchemaCasBaseline,
+      inboundRequestSchemaCasActual,
+    );
+    if (requestSchemaCasSavedPercent < MIN_REQUEST_SCHEMA_CAS_SAVED_PERCENT) {
+      errors.push(
+        `expected at least ${
+          formatPercent(MIN_REQUEST_SCHEMA_CAS_SAVED_PERCENT)
+        } savings on request-schema-CAS inbound browser bytes, got ${
+          formatPercent(requestSchemaCasSavedPercent)
+        }`,
+      );
+    }
+  }
 
   const outboundSyncRecords = analysis.records.filter(isOutboundSync);
   const savedOutboundSyncRecords = outboundSyncRecords.filter((record) =>
@@ -459,8 +590,79 @@ export function validateLunchPollWireAccounting(
       `expected overall browser actual bytes to be less than baseline: baseline=${analysis.totals.baselineBytes} actual=${analysis.totals.actualBytes}`,
     );
   }
+  if (analysis.totals.baselineBytes > 0) {
+    const overallSavedPercent = savedPercent(
+      analysis.totals.baselineBytes,
+      analysis.totals.actualBytes,
+    );
+    if (overallSavedPercent < MIN_OVERALL_SAVED_PERCENT) {
+      errors.push(
+        `expected at least ${
+          formatPercent(MIN_OVERALL_SAVED_PERCENT)
+        } overall browser-byte savings, got ${
+          formatPercent(overallSavedPercent)
+        }`,
+      );
+    }
+  }
 
   return errors;
+}
+
+function validateRecordEvidence(
+  record: MemoryWireAccountingRecord,
+  errors: string[],
+): void {
+  if (!isByteCount(record.baselineBytes) || !isByteCount(record.actualBytes)) {
+    errors.push(
+      `invalid byte count for ${record.classification} on ${record.connectionId}`,
+    );
+    return;
+  }
+  if (
+    !isCandidates(record.baselineCandidates) ||
+    !isCandidates(record.actualCandidates)
+  ) {
+    errors.push(
+      `invalid candidate evidence for ${record.classification}`,
+    );
+  }
+  validateSemanticEvidence(
+    "baseline",
+    record.baselineSemanticBytes,
+    record.baselineBytes,
+    record.classification,
+    errors,
+  );
+  validateSemanticEvidence(
+    "actual",
+    record.actualSemanticBytes,
+    record.actualBytes,
+    record.classification,
+    errors,
+  );
+}
+
+function validateSemanticEvidence(
+  label: "baseline" | "actual",
+  semanticBytes: MemoryWireSemanticBytes | undefined,
+  bytes: number,
+  classification: string,
+  errors: string[],
+): void {
+  if (!isSemanticBytes(semanticBytes)) {
+    errors.push(`invalid ${label} semantic map for ${classification}`);
+    return;
+  }
+  const semanticTotal = Object.values(semanticBytes).reduce(
+    (sum, categoryBytes) => sum + categoryBytes,
+    0,
+  );
+  if (semanticTotal !== bytes) {
+    errors.push(
+      `${label} semantic bytes differ for ${classification}: semantic=${semanticTotal} ${label}=${bytes}`,
+    );
+  }
 }
 
 export function formatLunchPollWireAccounting(

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -587,6 +587,14 @@ describe("Memory v2 storage notifications", () => {
         source?: unknown,
       ) => Promise<{ ok?: unknown; error?: unknown }>;
     };
+    const repairStarted = defer<void>();
+    const retryRepair = retryRepairHarness(replica);
+    const waitForConflictReadRepair = retryRepair.waitForConflictReadRepair
+      .bind(retryRepair);
+    retryRepair.waitForConflictReadRepair = (rejection) => {
+      repairStarted.resolve();
+      return waitForConflictReadRepair(rejection);
+    };
     const firstUri = `of:memory-v2-close-retry-a-${Date.now()}` as URI;
     const secondUri = `of:memory-v2-close-retry-b-${Date.now()}` as URI;
     const factAddress = { id: firstUri, type: "application/json" as MIME };
@@ -627,6 +635,7 @@ describe("Memory v2 storage notifications", () => {
     }, staleReadSource(firstUri, 1));
     expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
 
+    await repairStarted.promise;
     await storageManager.close();
     const result = await commitPromise;
     expect(result.ok).toBeFalsy();

--- a/packages/toolshed/.env.example
+++ b/packages/toolshed/.env.example
@@ -62,6 +62,11 @@ OTEL_TRACES_SAMPLER_ARG=1.0
 ## Jina AI web reader API key
 # JINA_API_KEY
 
+## Diagnostic-only Memory v2 websocket wire accounting
+# Disabled by default. When set under ENV=development or ENV=test only,
+# Toolshed exposes a bearer-token-protected start/stop report endpoint.
+# CF_MEMORY_WIRE_ACCOUNTING_TOKEN=
+
 ## Discord integration details
 # DISCORD_WEBHOOK_URL
 

--- a/packages/toolshed/app.ts
+++ b/packages/toolshed/app.ts
@@ -14,6 +14,7 @@ import plaidOAuth from "@/routes/integrations/plaid-oauth/plaid-oauth.index.ts";
 import { buildProviderRouters } from "@/routes/integrations/provider-registry.ts";
 import memory from "@/routes/storage/memory/memory.index.ts";
 import memoryDump from "@/routes/storage/memory/memory-dump.index.ts";
+import memoryWireAccounting from "@/routes/storage/memory/memory-wire-accounting.index.ts";
 import blobs from "@/routes/blobs/blobs.index.ts";
 import whoami from "@/routes/whoami/whoami.index.ts";
 import meta from "@/routes/meta/meta.index.ts";
@@ -43,6 +44,7 @@ const routes = [
   plaidOAuth,
   memory,
   memoryDump,
+  memoryWireAccounting,
   blobs,
   whoami,
   meta,

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -50,6 +50,21 @@ Deno.test("MEMORY_ACL_MODE defaults to enforce and accepts rollout overrides", (
   assertEquals(aclMode("enforce"), "enforce");
 });
 
+Deno.test("CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED preserves tri-state values", () => {
+  const requestSchemaCasEnabled = (value: string | undefined) =>
+    EnvSchema.parse(
+      value === undefined
+        ? {}
+        : { CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED: value },
+    ).CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED;
+
+  assertEquals(requestSchemaCasEnabled(undefined), undefined);
+  assertEquals(requestSchemaCasEnabled("default"), undefined);
+  assertEquals(requestSchemaCasEnabled("false"), false);
+  assertEquals(requestSchemaCasEnabled("true"), true);
+  assertEquals(requestSchemaCasEnabled("1"), true);
+});
+
 // The EXPERIMENTAL_* → ExperimentalOptions mapping (including its tri-state
 // unset/true/false fidelity) now lives in the runner's canonical
 // `experimentalOptionsFromEnv` / `EXPERIMENTAL_ENV_VARS` (CT-1814), shared by

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -147,6 +147,9 @@ export const EnvSchema = z.object({
   // The route also fail-closes unless ENV is explicitly development or test.
   // Never log this value or return it in an HTTP response.
   CF_MEMORY_WIRE_ACCOUNTING_TOKEN: z.string().default(""),
+  // Diagnostic startup override for paired request-schema CAS accounting runs.
+  // Unset/default preserves the Memory package default.
+  CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED: flagValue(),
 
   GOOGLE_CLIENT_ID: z.string().default(""),
   GOOGLE_CLIENT_SECRET: z.string().default(""),

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -142,6 +142,12 @@ export const EnvSchema = z.object({
   ).optional(),
   MEMORY_URL: z.string().default("http://localhost:8000"),
 
+  // Diagnostic-only Memory v2 websocket wire-accounting endpoint token.
+  // Empty/unset disables the endpoint and avoids constructing an observer.
+  // The route also fail-closes unless ENV is explicitly development or test.
+  // Never log this value or return it in an HTTP response.
+  CF_MEMORY_WIRE_ACCOUNTING_TOKEN: z.string().default(""),
+
   GOOGLE_CLIENT_ID: z.string().default(""),
   GOOGLE_CLIENT_SECRET: z.string().default(""),
 

--- a/packages/toolshed/middlewares/pino-logger.test.ts
+++ b/packages/toolshed/middlewares/pino-logger.test.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "@std/assert";
+import { redactHeaders } from "./pino-logger.ts";
+
+Deno.test("redactHeaders removes sensitive Headers values", () => {
+  assertEquals(
+    redactHeaders(
+      new Headers({
+        authorization: "Bearer secret",
+        cookie: "session=secret",
+        "user-agent": "diagnostic-browser",
+      }),
+    ),
+    {
+      authorization: "[redacted]",
+      cookie: "[redacted]",
+      "user-agent": "diagnostic-browser",
+    },
+  );
+});
+
+Deno.test("redactHeaders handles plain objects case-insensitively", () => {
+  assertEquals(
+    redactHeaders({
+      Authorization: "Bearer secret",
+      "Proxy-Authorization": "Basic secret",
+      "Set-Cookie": "session=secret",
+      accept: "application/json",
+    }),
+    {
+      Authorization: "[redacted]",
+      "Proxy-Authorization": "[redacted]",
+      "Set-Cookie": "[redacted]",
+      accept: "application/json",
+    },
+  );
+});
+
+Deno.test("redactHeaders preserves non-header values", () => {
+  assertEquals(redactHeaders(undefined), undefined);
+  assertEquals(redactHeaders("headers unavailable"), "headers unavailable");
+});

--- a/packages/toolshed/middlewares/pino-logger.test.ts
+++ b/packages/toolshed/middlewares/pino-logger.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { redactHeaders } from "./pino-logger.ts";
+import { redactHeaders, serializeResponse } from "./pino-logger.ts";
 
 Deno.test("redactHeaders removes sensitive Headers values", () => {
   assertEquals(
@@ -7,12 +7,14 @@ Deno.test("redactHeaders removes sensitive Headers values", () => {
       new Headers({
         authorization: "Bearer secret",
         cookie: "session=secret",
+        "set-cookie": "session=response-secret",
         "user-agent": "diagnostic-browser",
       }),
     ),
     {
       authorization: "[redacted]",
       cookie: "[redacted]",
+      "set-cookie": "[redacted]",
       "user-agent": "diagnostic-browser",
     },
   );
@@ -37,5 +39,26 @@ Deno.test("redactHeaders handles plain objects case-insensitively", () => {
 
 Deno.test("redactHeaders preserves non-header values", () => {
   assertEquals(redactHeaders(undefined), undefined);
+  assertEquals(redactHeaders(null), null);
   assertEquals(redactHeaders("headers unavailable"), "headers unavailable");
+  assertEquals(redactHeaders([]), []);
+});
+
+Deno.test("response serializer redacts sensitive headers", () => {
+  assertEquals(
+    serializeResponse({
+      statusCode: 200,
+      headers: new Headers({
+        "content-type": "application/json",
+        "set-cookie": "session=response-secret",
+      }),
+    }),
+    {
+      status: 200,
+      headers: JSON.stringify({
+        "content-type": "application/json",
+        "set-cookie": "[redacted]",
+      }),
+    },
+  );
 });

--- a/packages/toolshed/middlewares/pino-logger.ts
+++ b/packages/toolshed/middlewares/pino-logger.ts
@@ -33,20 +33,25 @@ export function redactHeaders(headers: unknown): unknown {
   );
 }
 
+export function serializeResponse(response: {
+  statusCode: number;
+  headers: unknown;
+}): { status: number; headers: string } | undefined {
+  if (env.DISABLE_LOG_REQ_RES) {
+    return undefined;
+  }
+  return {
+    status: response.statusCode,
+    headers: JSON.stringify(redactHeaders(response.headers)),
+  };
+}
+
 export function pinoLogger() {
   return logger({
     pino: pino({
       level: env.LOG_LEVEL || "info",
       serializers: {
-        res: (res) => {
-          if (env.DISABLE_LOG_REQ_RES) {
-            return undefined;
-          }
-          return {
-            status: res.statusCode,
-            headers: JSON.stringify(res.headers),
-          };
-        },
+        res: serializeResponse,
         req: (req) => {
           if (env.DISABLE_LOG_REQ_RES) {
             return undefined;

--- a/packages/toolshed/middlewares/pino-logger.ts
+++ b/packages/toolshed/middlewares/pino-logger.ts
@@ -4,6 +4,35 @@ import pretty from "pino-pretty";
 
 import env from "@/env.ts";
 
+const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "set-cookie",
+]);
+
+export function redactHeaders(headers: unknown): unknown {
+  if (headers instanceof Headers) {
+    return Object.fromEntries(
+      [...headers.entries()].map(([name, value]) => [
+        name,
+        SENSITIVE_HEADERS.has(name.toLowerCase()) ? "[redacted]" : value,
+      ]),
+    );
+  }
+  if (
+    headers === null || typeof headers !== "object" || Array.isArray(headers)
+  ) {
+    return headers;
+  }
+  return Object.fromEntries(
+    Object.entries(headers as Record<string, unknown>).map(([name, value]) => [
+      name,
+      SENSITIVE_HEADERS.has(name.toLowerCase()) ? "[redacted]" : value,
+    ]),
+  );
+}
+
 export function pinoLogger() {
   return logger({
     pino: pino({
@@ -26,8 +55,8 @@ export function pinoLogger() {
             method: req.method,
             url: req.url,
             headers: env.ENV === "production"
-              ? req.headers
-              : JSON.stringify(req.headers),
+              ? redactHeaders(req.headers)
+              : JSON.stringify(redactHeaders(req.headers)),
           };
         },
       },

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -2,8 +2,11 @@ import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import createApp from "@/lib/create-app.ts";
 import router from "./blobs.index.ts";
-import memory from "@/routes/storage/memory/memory.index.ts";
-import { memoryServer } from "@/routes/storage/memory.ts";
+import memoryRouter from "@/routes/storage/memory/memory.index.ts";
+import {
+  memory as memoryProvider,
+  memoryServer,
+} from "@/routes/storage/memory.ts";
 import env from "@/env.ts";
 import { Identity } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
@@ -20,7 +23,7 @@ if (env.ENV !== "test") {
 }
 
 const app = createApp()
-  .route("/", memory)
+  .route("/", memoryRouter)
   .route("/", router);
 
 const encodeBlobPayload = (payload: { type: string; body: FabricBytes }) =>
@@ -43,12 +46,11 @@ describe("Blob Routes", () => {
   });
 
   afterAll(async () => {
-    // The toolshed `memoryServer` is a module-level singleton constructed when
-    // memory.ts is imported. Deno isolates each test file's module graph, so
-    // this instance is owned by this file alone. Closing it releases its SQLite
-    // handles, engine map, and refresh timer.
+    // The Toolshed Memory provider owns both module-level SQLite singletons.
+    // Deno isolates each test file's module graph, so this file closes its
+    // provider after the HTTP server stops.
     await server.shutdown();
-    await memoryServer.close();
+    await memoryProvider.close();
   });
 
   const bootstrapHomeSpace = async (identity: Identity) => {

--- a/packages/toolshed/routes/ingest/ingest.routes.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.routes.test.ts
@@ -1,11 +1,16 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
 import app from "@/app.ts";
+import { memory as memoryProvider } from "@/routes/storage/memory.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
+
+afterAll(async () => {
+  await memoryProvider.close();
+});
 
 // Smoke tests: confirm POST /api/ingest/:id is mounted and its transport-level
 // branches behave. Driven through the real `app` (not a freshly-mounted router)

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -1,9 +1,11 @@
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import { verifySessionOpenAuthorization } from "@commonfabric/memory/v2/session-open-auth";
+import { MemoryWireAccountingAccumulator } from "@commonfabric/memory/v2/wire-accounting";
 import * as FS from "@std/fs";
 import env from "@/env.ts";
 import { memoryEngineStoreUrl } from "./memory-store-url.ts";
 import { identity } from "@/lib/identity.ts";
+import { isMemoryWireAccountingEnabled } from "./memory/memory-wire-accounting-policy.ts";
 
 const memoryAudience = identity.did();
 
@@ -26,8 +28,16 @@ if (env.DB_PATH) {
 export { memoryEngineStoreUrl };
 await FS.ensureDir(memoryEngineStoreUrl);
 
+export const memoryWireAccountingAccumulator = isMemoryWireAccountingEnabled({
+    token: env.CF_MEMORY_WIRE_ACCOUNTING_TOKEN,
+    env: env.ENV,
+  })
+  ? new MemoryWireAccountingAccumulator()
+  : undefined;
+
 export const memoryServer = new MemoryServer.Server({
   store: memoryEngineStoreUrl,
+  wireAccountingObserver: memoryWireAccountingAccumulator,
   authorizeSessionOpen,
   sessionOpenAuth: {
     audience: memoryAudience,

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -1,6 +1,9 @@
 import * as MemoryServer from "@commonfabric/memory/v2/server";
+import { setRequestSchemaCasConfig } from "@commonfabric/memory/v2";
 import { verifySessionOpenAuthorization } from "@commonfabric/memory/v2/session-open-auth";
 import { MemoryWireAccountingAccumulator } from "@commonfabric/memory/v2/wire-accounting";
+import { openSchemaStore } from "@commonfabric/memory/v2/schema-store";
+import { resolveSchemaStoreUrl } from "@commonfabric/memory/v2/storage-path";
 import * as FS from "@std/fs";
 import env from "@/env.ts";
 import { memoryEngineStoreUrl } from "./memory-store-url.ts";
@@ -28,6 +31,15 @@ if (env.DB_PATH) {
 export { memoryEngineStoreUrl };
 await FS.ensureDir(memoryEngineStoreUrl);
 
+// One store serves every space and every MemoryServer connection. The limits
+// bound untrusted schema-definition ingestion while allowing normal schemas.
+export const memorySchemaStore = await openSchemaStore({
+  url: resolveSchemaStoreUrl(memoryEngineStoreUrl),
+  maxSchemaBytes: 256 * 1024,
+  maxEntries: 100_000,
+  maxTotalBytes: 64 * 1024 * 1024,
+});
+
 export const memoryWireAccountingAccumulator = isMemoryWireAccountingEnabled({
     token: env.CF_MEMORY_WIRE_ACCOUNTING_TOKEN,
     env: env.ENV,
@@ -35,8 +47,13 @@ export const memoryWireAccountingAccumulator = isMemoryWireAccountingEnabled({
   ? new MemoryWireAccountingAccumulator()
   : undefined;
 
+if (env.CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED !== undefined) {
+  setRequestSchemaCasConfig(env.CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED);
+}
+
 export const memoryServer = new MemoryServer.Server({
   store: memoryEngineStoreUrl,
+  schemaStore: memorySchemaStore,
   wireAccountingObserver: memoryWireAccountingAccumulator,
   authorizeSessionOpen,
   sessionOpenAuth: {
@@ -50,11 +67,19 @@ export const memoryServer = new MemoryServer.Server({
       .filter((did) => did.length > 0),
   },
 });
+let memorySchemaStoreClosed = false;
 export const memory = {
   async close(): Promise<
     { ok: Record<PropertyKey, never> } | { error: unknown }
   > {
-    await memoryServer.close();
+    try {
+      await memoryServer.close();
+    } finally {
+      if (!memorySchemaStoreClosed) {
+        memorySchemaStore.close();
+        memorySchemaStoreClosed = true;
+      }
+    }
     return { ok: {} };
   },
 };

--- a/packages/toolshed/routes/storage/memory/memory-dump.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-dump.test.ts
@@ -32,7 +32,9 @@ Deno.env.set("MEMORY_DUMP_DIDS", allowed.did());
 const { createTestApp } = await import("@/lib/create-app.ts");
 const { default: dumpRouter } = await import("./memory-dump.index.ts");
 // The store the server uses; seed the fixture exactly where the route reads.
-const { memoryEngineStoreUrl } = await import("@/routes/storage/memory.ts");
+const { memory: memoryProvider, memoryEngineStoreUrl } = await import(
+  "@/routes/storage/memory.ts"
+);
 const app = createTestApp(dumpRouter);
 
 {
@@ -55,6 +57,7 @@ function sign(path: string, signer: Identity): Promise<Headers> {
 }
 
 afterAll(async () => {
+  await memoryProvider.close();
   await Deno.remove(tmp, { recursive: true }).catch(() => {});
 });
 

--- a/packages/toolshed/routes/storage/memory/memory-metadata.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-metadata.test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { memoryWireConnectionMetadataFromHeaders } from "./memory-metadata.ts";
+
+Deno.test("memoryWireConnectionMetadataFromHeaders classifies Mozilla user agents as browser", () => {
+  const headers = new Headers({
+    "user-agent": "Mozilla/5.0 diagnostic browser",
+    origin: "http://localhost:5173",
+  });
+
+  assertEquals(memoryWireConnectionMetadataFromHeaders(headers), {
+    kind: "browser",
+    userAgent: "Mozilla/5.0 diagnostic browser",
+    origin: "http://localhost:5173",
+  });
+});
+
+Deno.test("memoryWireConnectionMetadataFromHeaders classifies non-browser clients as runtime", () => {
+  const headers = new Headers({
+    "user-agent": "Deno/2.0 cf-runtime",
+  });
+
+  assertEquals(memoryWireConnectionMetadataFromHeaders(headers), {
+    kind: "runtime",
+    userAgent: "Deno/2.0 cf-runtime",
+  });
+});
+
+Deno.test("memoryWireConnectionMetadataFromHeaders emits only non-secret diagnostic strings", () => {
+  const headers = new Headers({
+    authorization: "Bearer do-not-copy",
+    cookie: "session=do-not-copy",
+  });
+
+  assertEquals(memoryWireConnectionMetadataFromHeaders(headers), {
+    kind: "runtime",
+  });
+});

--- a/packages/toolshed/routes/storage/memory/memory-metadata.ts
+++ b/packages/toolshed/routes/storage/memory/memory-metadata.ts
@@ -1,0 +1,14 @@
+import type { MemoryWireConnectionMetadata } from "@commonfabric/memory/v2/wire-accounting";
+
+export const memoryWireConnectionMetadataFromHeaders = (
+  headers: Headers,
+): MemoryWireConnectionMetadata => {
+  const userAgent = headers.get("user-agent") ?? undefined;
+  const origin = headers.get("origin") ?? undefined;
+  const metadata: MemoryWireConnectionMetadata = {
+    kind: userAgent?.includes("Mozilla") ? "browser" : "runtime",
+  };
+  if (userAgent !== undefined) metadata.userAgent = userAgent;
+  if (origin !== undefined) metadata.origin = origin;
+  return metadata;
+};

--- a/packages/toolshed/routes/storage/memory/memory-wire-accounting-policy.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-wire-accounting-policy.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "@std/assert";
+import { isMemoryWireAccountingEnabled } from "./memory-wire-accounting-policy.ts";
+
+Deno.test("isMemoryWireAccountingEnabled: disabled without a non-empty token", () => {
+  assertEquals(
+    isMemoryWireAccountingEnabled({ token: "", env: "development" }),
+    false,
+  );
+  assertEquals(
+    isMemoryWireAccountingEnabled({ token: "   ", env: "test" }),
+    false,
+  );
+});
+
+Deno.test("isMemoryWireAccountingEnabled: enabled only in development and test", () => {
+  assertEquals(
+    isMemoryWireAccountingEnabled({ token: "secret", env: "development" }),
+    true,
+  );
+  assertEquals(
+    isMemoryWireAccountingEnabled({ token: "secret", env: "test" }),
+    true,
+  );
+  assertEquals(
+    isMemoryWireAccountingEnabled({ token: "secret", env: "Development" }),
+    true,
+  );
+});
+
+Deno.test("isMemoryWireAccountingEnabled: production, staging, aliases, and unknown envs fail closed", () => {
+  for (
+    const env of [
+      "production",
+      "Production",
+      "prod",
+      "staging",
+      "rapids",
+      "local",
+      "",
+    ]
+  ) {
+    assertEquals(
+      isMemoryWireAccountingEnabled({ token: "secret", env }),
+      false,
+      env,
+    );
+  }
+});

--- a/packages/toolshed/routes/storage/memory/memory-wire-accounting-policy.ts
+++ b/packages/toolshed/routes/storage/memory/memory-wire-accounting-policy.ts
@@ -1,0 +1,13 @@
+// Pure access policy for the Memory v2 wire-accounting diagnostic endpoint.
+// The endpoint exists only when a non-empty random token is configured and ENV
+// is an explicit local/dev test value. Unknown aliases fail closed.
+
+const ENABLED_ENVS = new Set(["development", "test"]);
+
+export function isMemoryWireAccountingEnabled(cfg: {
+  token: string;
+  env: string;
+}): boolean {
+  if (cfg.token.trim().length === 0) return false;
+  return ENABLED_ENVS.has(cfg.env.toLowerCase());
+}

--- a/packages/toolshed/routes/storage/memory/memory-wire-accounting-router.ts
+++ b/packages/toolshed/routes/storage/memory/memory-wire-accounting-router.ts
@@ -1,0 +1,82 @@
+import { createRouter } from "@/lib/create-app.ts";
+import type { AppBindings } from "@/lib/types.ts";
+import { isMemoryWireAccountingEnabled } from "./memory-wire-accounting-policy.ts";
+import type {
+  MemoryWireAccountingAccumulator,
+  MemoryWireAccountingReport,
+} from "@commonfabric/memory/v2/wire-accounting";
+import type { MiddlewareHandler } from "@hono/hono";
+
+const BASE = "/api/storage/memory/wire-accounting";
+const TEXT_ENCODER = new TextEncoder();
+
+export type MemoryWireAccountingRouteOptions = {
+  accumulator?: MemoryWireAccountingAccumulator;
+  token: string;
+  env: string;
+};
+
+function bearerToken(authorization: string | null): string | undefined {
+  if (authorization === null) return undefined;
+  const trimmed = authorization.trim();
+  const match = /^Bearer\s+(.+)$/i.exec(trimmed);
+  if (match === null) return undefined;
+  const token = match[1].trim();
+  return token.length === 0 ? undefined : token;
+}
+
+function tokenEquals(actual: string, expected: string): boolean {
+  const actualBytes = TEXT_ENCODER.encode(actual);
+  const expectedBytes = TEXT_ENCODER.encode(expected);
+  let diff = actualBytes.length ^ expectedBytes.length;
+  const length = Math.max(actualBytes.length, expectedBytes.length);
+  for (let i = 0; i < length; i++) {
+    diff |= (actualBytes[i] ?? 0) ^ (expectedBytes[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+const emptyReport = (): MemoryWireAccountingReport => ({
+  totals: { baselineBytes: 0, actualBytes: 0, frames: 0, connections: 0 },
+  byDirection: [],
+  byConnection: [],
+  byMetadataKind: [],
+  byClassification: [],
+  records: [],
+});
+
+export function createMemoryWireAccountingRouter(
+  options: MemoryWireAccountingRouteOptions,
+) {
+  const router = createRouter();
+  const expectedToken = options.token.trim();
+  const enabled = isMemoryWireAccountingEnabled({
+    token: options.token,
+    env: options.env,
+  }) && options.accumulator !== undefined;
+
+  const requireAccess: MiddlewareHandler<AppBindings> = async (c, next) => {
+    if (!enabled) return c.notFound();
+    const actual = bearerToken(c.req.header("authorization") ?? null);
+    if (actual === undefined || !tokenEquals(actual, expectedToken)) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    await next();
+  };
+
+  router.use(BASE, requireAccess);
+  router.use(`${BASE}/*`, requireAccess);
+
+  router.post(`${BASE}/start`, (c) => {
+    options.accumulator?.start();
+    return c.json({ ok: true });
+  });
+
+  router.post(`${BASE}/stop`, (c) => {
+    const report: MemoryWireAccountingReport = options.accumulator?.stop() ??
+      emptyReport();
+    return c.json(report);
+  });
+
+  return router;
+}

--- a/packages/toolshed/routes/storage/memory/memory-wire-accounting-router.ts
+++ b/packages/toolshed/routes/storage/memory/memory-wire-accounting-router.ts
@@ -1,10 +1,7 @@
 import { createRouter } from "@/lib/create-app.ts";
 import type { AppBindings } from "@/lib/types.ts";
 import { isMemoryWireAccountingEnabled } from "./memory-wire-accounting-policy.ts";
-import type {
-  MemoryWireAccountingAccumulator,
-  MemoryWireAccountingReport,
-} from "@commonfabric/memory/v2/wire-accounting";
+import type { MemoryWireAccountingAccumulator } from "@commonfabric/memory/v2/wire-accounting";
 import type { MiddlewareHandler } from "@hono/hono";
 
 const BASE = "/api/storage/memory/wire-accounting";
@@ -36,27 +33,26 @@ function tokenEquals(actual: string, expected: string): boolean {
   return diff === 0;
 }
 
-const emptyReport = (): MemoryWireAccountingReport => ({
-  totals: { baselineBytes: 0, actualBytes: 0, frames: 0, connections: 0 },
-  byDirection: [],
-  byConnection: [],
-  byMetadataKind: [],
-  byClassification: [],
-  records: [],
-});
-
 export function createMemoryWireAccountingRouter(
   options: MemoryWireAccountingRouteOptions,
 ) {
   const router = createRouter();
   const expectedToken = options.token.trim();
-  const enabled = isMemoryWireAccountingEnabled({
-    token: options.token,
-    env: options.env,
-  }) && options.accumulator !== undefined;
+  if (
+    !isMemoryWireAccountingEnabled({
+      token: options.token,
+      env: options.env,
+    }) || options.accumulator === undefined
+  ) {
+    const notFound: MiddlewareHandler<AppBindings> = (c) =>
+      Promise.resolve(c.notFound());
+    router.use(BASE, notFound);
+    router.use(`${BASE}/*`, notFound);
+    return router;
+  }
+  const accumulator = options.accumulator;
 
   const requireAccess: MiddlewareHandler<AppBindings> = async (c, next) => {
-    if (!enabled) return c.notFound();
     const actual = bearerToken(c.req.header("authorization") ?? null);
     if (actual === undefined || !tokenEquals(actual, expectedToken)) {
       return c.json({ error: "Unauthorized" }, 401);
@@ -68,14 +64,12 @@ export function createMemoryWireAccountingRouter(
   router.use(`${BASE}/*`, requireAccess);
 
   router.post(`${BASE}/start`, (c) => {
-    options.accumulator?.start();
+    accumulator.start();
     return c.json({ ok: true });
   });
 
   router.post(`${BASE}/stop`, (c) => {
-    const report: MemoryWireAccountingReport = options.accumulator?.stop() ??
-      emptyReport();
-    return c.json(report);
+    return c.json(accumulator.stop());
   });
 
   return router;

--- a/packages/toolshed/routes/storage/memory/memory-wire-accounting.index.ts
+++ b/packages/toolshed/routes/storage/memory/memory-wire-accounting.index.ts
@@ -1,0 +1,11 @@
+import env from "@/env.ts";
+import { memoryWireAccountingAccumulator } from "@/routes/storage/memory.ts";
+import { createMemoryWireAccountingRouter } from "./memory-wire-accounting-router.ts";
+
+export { createMemoryWireAccountingRouter };
+
+export default createMemoryWireAccountingRouter({
+  accumulator: memoryWireAccountingAccumulator,
+  token: env.CF_MEMORY_WIRE_ACCOUNTING_TOKEN,
+  env: env.ENV,
+});

--- a/packages/toolshed/routes/storage/memory/memory-wire-accounting.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-wire-accounting.test.ts
@@ -1,0 +1,179 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createTestApp } from "@/lib/create-app.ts";
+import { MemoryWireAccountingAccumulator } from "@commonfabric/memory/v2/wire-accounting";
+import { createMemoryWireAccountingRouter } from "./memory-wire-accounting-router.ts";
+
+const BASE = "/api/storage/memory/wire-accounting";
+const TOKEN = "runner-random-secret";
+
+function appFor(options: {
+  accumulator?: MemoryWireAccountingAccumulator;
+  token?: string;
+  env?: string;
+}) {
+  return createTestApp(
+    createMemoryWireAccountingRouter({
+      accumulator: options.accumulator,
+      token: options.token ?? TOKEN,
+      env: options.env ?? "test",
+    }),
+  );
+}
+
+function auth(token = TOKEN): Headers {
+  return new Headers({ authorization: `Bearer ${token}` });
+}
+
+async function cancel(res: Response): Promise<void> {
+  await res.body?.cancel();
+}
+
+describe("memory wire-accounting endpoint", () => {
+  it("404s when disabled by missing token", async () => {
+    const app = appFor({
+      accumulator: new MemoryWireAccountingAccumulator(),
+      token: "",
+    });
+    const res = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: auth(),
+    });
+    await cancel(res);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when disabled by environment even with a token", async () => {
+    const app = appFor({
+      accumulator: new MemoryWireAccountingAccumulator(),
+      env: "production",
+    });
+    const res = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: auth(),
+    });
+    await cancel(res);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when no accumulator was constructed", async () => {
+    const app = appFor({ accumulator: undefined });
+    const res = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: auth(),
+    });
+    await cancel(res);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects missing and wrong bearer tokens with 401", async () => {
+    const app = appFor({ accumulator: new MemoryWireAccountingAccumulator() });
+
+    const missing = await app.request(`${BASE}/start`, { method: "POST" });
+    await cancel(missing);
+    expect(missing.status).toBe(401);
+
+    const wrong = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: auth("wrong"),
+    });
+    await cancel(wrong);
+    expect(wrong.status).toBe(401);
+
+    const malformed = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: new Headers({ authorization: TOKEN }),
+    });
+    await cancel(malformed);
+    expect(malformed.status).toBe(401);
+  });
+
+  it("start resets and activates, and stop deactivates before returning the report", async () => {
+    const accumulator = new MemoryWireAccountingAccumulator();
+    const app = appFor({ accumulator });
+
+    accumulator.start();
+    accumulator.observe({
+      direction: "inbound",
+      connectionId: "old",
+      metadata: { kind: "runtime" },
+      classification: "client.old",
+      baselineBytes: 3,
+      actualBytes: 5,
+    });
+
+    const start = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: auth(),
+    });
+    expect(start.status).toBe(200);
+    await start.json();
+    expect(accumulator.isActive()).toBe(true);
+
+    accumulator.observe({
+      direction: "outbound",
+      connectionId: "current",
+      metadata: { kind: "browser", origin: "http://localhost:5173" },
+      classification: "server.hello.ok",
+      baselineBytes: 7,
+      actualBytes: 11,
+    });
+
+    const stop = await app.request(`${BASE}/stop`, {
+      method: "POST",
+      headers: auth(),
+    });
+    expect(stop.status).toBe(200);
+    const report = await stop.json();
+    expect(accumulator.isActive()).toBe(false);
+    expect(report.totals).toEqual({
+      baselineBytes: 7,
+      actualBytes: 11,
+      frames: 1,
+      connections: 1,
+    });
+    expect(
+      report.records.map((record: { connectionId: string }) =>
+        record.connectionId
+      ),
+    )
+      .toEqual(["current"]);
+    expect(report.byMetadataKind.map((row: { key: string }) => row.key))
+      .toEqual([
+        "browser",
+      ]);
+  });
+
+  it("stopped accumulators remain inactive after stop", async () => {
+    const accumulator = new MemoryWireAccountingAccumulator();
+    const app = appFor({ accumulator });
+
+    const start = await app.request(`${BASE}/start`, {
+      method: "POST",
+      headers: auth(),
+    });
+    await start.json();
+
+    const stop = await app.request(`${BASE}/stop`, {
+      method: "POST",
+      headers: auth(),
+    });
+    await stop.json();
+
+    accumulator.observe({
+      direction: "inbound",
+      connectionId: "inactive",
+      metadata: { kind: "runtime" },
+      classification: "client.watch",
+      baselineBytes: 100,
+      actualBytes: 100,
+    });
+
+    expect(accumulator.snapshot().totals).toEqual({
+      baselineBytes: 0,
+      actualBytes: 0,
+      frames: 0,
+      connections: 0,
+    });
+  });
+});

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -1,10 +1,14 @@
 import type { AppRouteHandler } from "@/lib/types.ts";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
+import type { MemoryWireConnectionMetadata } from "@commonfabric/memory/v2/wire-accounting";
 import type * as Routes from "./memory.routes.ts";
 import { memoryServer } from "../memory.ts";
 import { createSpan } from "@/middlewares/opentelemetry.ts";
 import { formatMemWriteTrace, type MemWriteOp } from "./memwrite-trace.ts";
+import { memoryWireConnectionMetadataFromHeaders } from "./memory-metadata.ts";
+
+export { memoryWireConnectionMetadataFromHeaders } from "./memory-metadata.ts";
 
 type NegotiatedSocketHandlers = {
   onMessage: (message: string) => void;
@@ -144,6 +148,7 @@ const attachMemorySocketPipeline = (
   socket: WebSocket,
   negotiation: ReturnType<typeof bufferTextMessagesUntilNegotiated>,
   firstMessage: string,
+  metadata: MemoryWireConnectionMetadata,
 ): boolean => {
   if (MemoryServer.parseClientMessage(firstMessage) === null) {
     return false;
@@ -167,7 +172,7 @@ const attachMemorySocketPipeline = (
       return;
     }
     socket.send(encodeMemoryBoundary(message));
-  });
+  }, metadata);
   const closeConnection = () => {
     connection.close();
   };
@@ -250,7 +255,14 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
           return;
         }
 
-        if (attachMemorySocketPipeline(socket, negotiation, firstMessage)) {
+        if (
+          attachMemorySocketPipeline(
+            socket,
+            negotiation,
+            firstMessage,
+            memoryWireConnectionMetadataFromHeaders(c.req.raw.headers),
+          )
+        ) {
           setupSpan.setAttribute("socket.setup", "memory");
           return;
         }

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import app from "../../../app.ts";
-import { memoryServer } from "../memory.ts";
+import { memory, memoryServer } from "../memory.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   decodeMemoryBoundary,
@@ -1340,5 +1340,5 @@ serialTest(
 // graph, so this instance is owned by this file alone. Closing it here releases
 // those handles.
 serialTest("memory websocket server releases its resources", async () => {
-  await memoryServer.close();
+  await memory.close();
 });

--- a/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
@@ -1,11 +1,16 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
 import app from "@/app.ts";
+import { memory as memoryProvider } from "@/routes/storage/memory.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
+
+afterAll(async () => {
+  await memoryProvider.close();
+});
 
 // Smoke tests: confirm each route is mounted and its first-line validation
 // returns a sensible error. These deliberately hit only the fast-fail paths

--- a/packages/toolshed/routes/webhooks/webhooks.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.test.ts
@@ -1,6 +1,7 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
+import { memory as memoryProvider } from "@/routes/storage/memory.ts";
 import { sha256 } from "@/lib/sha2.ts";
 import { linkRefPayloadToString } from "@commonfabric/runner/shared";
 import {
@@ -14,6 +15,10 @@ import {
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
+
+afterAll(async () => {
+  await memoryProvider.close();
+});
 
 describe("Webhook Utilities", () => {
   describe("generateWebhookId", () => {

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -1,8 +1,12 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
   buildFilteredTestArgs,
+  createMemoryWireAccountingToken,
+  describeMemoryWireAccountingEnv,
   findIntegrationTestFiles,
   integrationTestDir,
+  MEMORY_WIRE_ACCOUNTING_TOKEN_ENV,
+  memoryWireAccountingEnvForServerRun,
   runFilteredIntegration,
   runPackageIntegration,
   selectIntegrationTestFiles,
@@ -163,6 +167,92 @@ Deno.test("buildFilteredTestArgs adds a junit path when a junit dir is given", (
       "--junit-path=out/junit/shell.xml",
       "./integration/a.test.ts",
     ],
+  );
+});
+
+Deno.test("createMemoryWireAccountingToken encodes high-entropy bytes without padding", () => {
+  const token = createMemoryWireAccountingToken(new Uint8Array(32).fill(255));
+  assertEquals(token.length, 43);
+  assertEquals(token.includes("="), false);
+  assertEquals(token.includes("+"), false);
+  assertEquals(token.includes("/"), false);
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun propagates token and defaults unset ENV to development", () => {
+  const token = "secret-token-for-test";
+  const env = memoryWireAccountingEnvForServerRun(token, undefined);
+
+  assertEquals(env.serverEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
+  assertEquals(env.serverEnv.ENV, "development");
+  assertEquals(env.testEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
+  assertEquals(env.testEnv.ENV, undefined);
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun defaults blank ENV to development", () => {
+  const env = memoryWireAccountingEnvForServerRun("secret-token", "  ");
+
+  assertEquals(env.serverEnv.ENV, "development");
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun preserves allowed development ENV", () => {
+  const token = "secret-token-for-test";
+  const env = memoryWireAccountingEnvForServerRun(token, "development");
+
+  assertEquals(env.serverEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
+  assertEquals(env.serverEnv.ENV, "development");
+  assertEquals(env.testEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
+  assertEquals(env.testEnv.ENV, undefined);
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun preserves allowed test ENV", () => {
+  const env = memoryWireAccountingEnvForServerRun("secret-token", "TEST");
+
+  assertEquals(env.serverEnv.ENV, "test");
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun rejects explicit production ENV without exposing token", () => {
+  const token = "do-not-leak-this-token";
+  const error = assertThrows(
+    () => memoryWireAccountingEnvForServerRun(token, "production"),
+    Error,
+    'ENV="production"',
+  );
+
+  assert(!error.message.includes(token));
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun rejects explicit staging ENV without exposing token", () => {
+  const token = "do-not-leak-this-token";
+  const error = assertThrows(
+    () => memoryWireAccountingEnvForServerRun(token, "staging"),
+    Error,
+    'ENV="staging"',
+  );
+
+  assert(!error.message.includes(token));
+});
+
+Deno.test("memoryWireAccountingEnvForServerRun rejects unknown explicit ENV without exposing token", () => {
+  const token = "do-not-leak-this-token";
+  const error = assertThrows(
+    () => memoryWireAccountingEnvForServerRun(token, "preview"),
+    Error,
+    'ENV="preview"',
+  );
+
+  assert(!error.message.includes(token));
+});
+
+Deno.test("describeMemoryWireAccountingEnv never exposes the bearer token", () => {
+  const token = "do-not-print-this-token";
+  const description = describeMemoryWireAccountingEnv({
+    [MEMORY_WIRE_ACCOUNTING_TOKEN_ENV]: token,
+  });
+
+  assertEquals(description.includes(token), false);
+  assertEquals(
+    description,
+    "Memory wire accounting token: configured (23 chars)",
   );
 });
 

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -5,6 +5,7 @@ import {
   describeMemoryWireAccountingEnv,
   findIntegrationTestFiles,
   integrationTestDir,
+  MEMORY_WIRE_ACCOUNTING_REQUIRED_ENV,
   MEMORY_WIRE_ACCOUNTING_TOKEN_ENV,
   memoryWireAccountingEnvForServerRun,
   runFilteredIntegration,
@@ -185,6 +186,7 @@ Deno.test("memoryWireAccountingEnvForServerRun propagates token and defaults uns
   assertEquals(env.serverEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
   assertEquals(env.serverEnv.ENV, "development");
   assertEquals(env.testEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
+  assertEquals(env.testEnv[MEMORY_WIRE_ACCOUNTING_REQUIRED_ENV], "1");
   assertEquals(env.testEnv.ENV, undefined);
 });
 
@@ -201,6 +203,7 @@ Deno.test("memoryWireAccountingEnvForServerRun preserves allowed development ENV
   assertEquals(env.serverEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
   assertEquals(env.serverEnv.ENV, "development");
   assertEquals(env.testEnv[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV], token);
+  assertEquals(env.testEnv[MEMORY_WIRE_ACCOUNTING_REQUIRED_ENV], "1");
   assertEquals(env.testEnv.ENV, undefined);
 });
 

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -57,6 +57,8 @@ const HEADLESS_PACKAGES = [
 
 export const MEMORY_WIRE_ACCOUNTING_TOKEN_ENV =
   "CF_MEMORY_WIRE_ACCOUNTING_TOKEN";
+export const MEMORY_WIRE_ACCOUNTING_REQUIRED_ENV =
+  "CF_MEMORY_WIRE_ACCOUNTING_REQUIRED";
 const MEMORY_WIRE_ACCOUNTING_ALLOWED_ENVS = new Set(["development", "test"]);
 const MEMORY_WIRE_ACCOUNTING_DEFAULT_ENV = "development";
 
@@ -92,6 +94,7 @@ export function memoryWireAccountingEnvForServerRun(
     },
     testEnv: {
       [MEMORY_WIRE_ACCOUNTING_TOKEN_ENV]: token,
+      [MEMORY_WIRE_ACCOUNTING_REQUIRED_ENV]: "1",
     },
   };
 }

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -55,6 +55,56 @@ const HEADLESS_PACKAGES = [
   "patterns-reload",
 ];
 
+export const MEMORY_WIRE_ACCOUNTING_TOKEN_ENV =
+  "CF_MEMORY_WIRE_ACCOUNTING_TOKEN";
+const MEMORY_WIRE_ACCOUNTING_ALLOWED_ENVS = new Set(["development", "test"]);
+const MEMORY_WIRE_ACCOUNTING_DEFAULT_ENV = "development";
+
+export function createMemoryWireAccountingToken(
+  randomBytes = crypto.getRandomValues(new Uint8Array(32)),
+): string {
+  return btoa(String.fromCharCode(...randomBytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+export function memoryWireAccountingEnvForServerRun(
+  token: string,
+  currentEnv?: string,
+): { serverEnv: Record<string, string>; testEnv: Record<string, string> } {
+  const trimmedEnv = currentEnv?.trim();
+  const normalizedEnv = trimmedEnv?.toLowerCase();
+  const accountingEnv = normalizedEnv === undefined || normalizedEnv === ""
+    ? MEMORY_WIRE_ACCOUNTING_DEFAULT_ENV
+    : normalizedEnv;
+
+  if (!MEMORY_WIRE_ACCOUNTING_ALLOWED_ENVS.has(accountingEnv)) {
+    throw new Error(
+      `Memory wire accounting requires ENV to be unset, development, or test; got explicit ENV="${trimmedEnv}". Refusing to override it for integration server startup.`,
+    );
+  }
+
+  return {
+    serverEnv: {
+      [MEMORY_WIRE_ACCOUNTING_TOKEN_ENV]: token,
+      ENV: accountingEnv,
+    },
+    testEnv: {
+      [MEMORY_WIRE_ACCOUNTING_TOKEN_ENV]: token,
+    },
+  };
+}
+
+export function describeMemoryWireAccountingEnv(
+  env: Record<string, string>,
+): string {
+  const token = env[MEMORY_WIRE_ACCOUNTING_TOKEN_ENV];
+  return token === undefined
+    ? "Memory wire accounting token: unset"
+    : `Memory wire accounting token: configured (${token.length} chars)`;
+}
+
 async function runCommand(
   cmd: string[],
   options: {
@@ -491,6 +541,7 @@ export async function runPackageIntegration(
   rootDir: string,
   filter?: string,
   junitDir?: string,
+  inheritedEnv: Record<string, string> = {},
 ): Promise<boolean> {
   const packageDirName = pkg === "cli-fuse"
     ? "cli"
@@ -507,6 +558,7 @@ export async function runPackageIntegration(
   console.log(`${"=".repeat(60)}`);
 
   const env: Record<string, string> = {
+    ...inheritedEnv,
     LOG_LEVEL: "warn",
   };
 
@@ -742,6 +794,10 @@ async function main(): Promise<void> {
   // free one just before the servers start.
   let portOffset = cliPortOffset ?? envPortOffset ?? 0;
   let apiUrl = "";
+  const accountingToken = needsServer ? createMemoryWireAccountingToken() : "";
+  const accountingEnv = needsServer
+    ? memoryWireAccountingEnvForServerRun(accountingToken, Deno.env.get("ENV"))
+    : { serverEnv: {}, testEnv: {} };
 
   // A generated-offset run owns the servers it starts and stops them on the way
   // out, including after a failure. An explicit offset is left running.
@@ -772,10 +828,11 @@ async function main(): Promise<void> {
 
   try {
     if (needsServer) {
-      const serverEnv: Record<string, string> = {};
+      const serverEnv: Record<string, string> = { ...accountingEnv.serverEnv };
       if (packagesToRun.includes("patterns-reload")) {
         serverEnv.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE = "true";
       }
+      console.log(describeMemoryWireAccountingEnv(serverEnv));
 
       if (portOffsetWasSet) {
         // Reuse the requested offset, stopping anything already on its ports.
@@ -838,6 +895,7 @@ async function main(): Promise<void> {
         rootDir,
         nameFilter,
         junitDir,
+        accountingEnv.testEnv,
       );
       results.push({ pkg, success });
     }


### PR DESCRIPTION
## Summary

Follow-up to #4292 (`perf(memory): intern schemas in sync frames`). This keeps the shipped schema table protocol frame-local while hardening its storage/wire invariants and adding reproducible same-run websocket payload accounting through the real multi-browser Lunch Poll flow.

- reject dangling or poisoned `schema-ref@2:` values, including JSON Patch `move` relocation into modern `link@1` and legacy `$alias` schema slots
- preserve transactional rollback when reserved schema references are rejected
- add optional, inactive-by-default paired Memory payload accounting and classify traffic by direction/message type/connection kind
- expose the diagnostic only in `development`/`test` behind a random bearer token, with sensitive request-header redaction
- provision the token through the integration runner and measure only browser connections in the existing Lunch Poll browser test
- document negotiation, metric semantics, operational usage, and frozen measurement evidence

Cross-frame/global schema caching remains separate follow-up CT-1781.

## Measurement method

For each logical Memory websocket message in the same run:

- **baseline:** UTF-8 bytes from `encodeMemoryBoundary(originalMessage)`
- **actual:** UTF-8 bytes from `encodeMemoryBoundary(negotiatedMessage)`

This measures websocket text payload bytes only; it intentionally excludes websocket framing/masking, permessage-deflate physical bytes, HTTP upgrade, TLS, and TCP overhead. Inbound and outbound non-sync classes are required to remain byte-identical.

## Results

Fresh current-head verification at `a9f3805f1` used the documented real two-user Lunch Poll browser flow with 6 browser websocket connections and isolated durable stores. Each row reports same-run paired accounting: baseline is the equivalent inline/uncompressed Memory text payload, and actual is the negotiated payload emitted in that run.

| Configuration | Baseline | Actual | Saved | Reduction |
| --- | ---: | ---: | ---: | ---: |
| CAS disabled, cold | 4,926,851 B | 4,205,717 B | 721,134 B | 14.6% |
| CAS disabled, warm | 4,907,886 B | 4,184,392 B | 723,494 B | 14.7% |
| CAS enabled, cold | 5,067,078 B | 4,145,180 B | 921,898 B | 18.2% |
| CAS enabled, warm | 4,857,472 B | 3,883,546 B | 973,926 B | 20.1% |
| CAS enabled, warm repeat | 4,858,188 B | 3,882,279 B | 975,909 B | 20.1% |

Outbound sync-frame interning remained stable across the reruns: aggregate sync-bearing outbound payloads saved approximately 22.6–22.7%. In the CAS-disabled control, `server.response.session.watch.add.sync` saved 675,312 B (23.5%) and `server.session/effect.sync` saved 45,822 B (14.4%). Outbound non-sync traffic and inbound traffic outside request-schema-CAS-capable classes remained byte-identical; CAS-capable inbound classes remained inline when CAS was disabled.

### Durable request-schema CAS

Request uploads saved approximately 13.9% in the cold enabled run and 20.1% in both warm enabled runs. Cold misses and their real `MissingSchemas` responses are included in the cold actual traffic, so the 18.2% cold aggregate is not presented as a clean no-CAS counterfactual.

As supporting workload-level evidence, measured actual browser payload in the paired warm runs was approximately 7.2% lower with request CAS enabled (3,883,546 B versus 4,184,392 B). Frame composition varied slightly between runs, so this cross-run comparison is not an exact same-message counterfactual; the same-run rows above are the precise paired measurements.

These figures are UTF-8 bytes of Memory websocket text payloads, not production-network bytes. They exclude websocket framing/masking, permessage-deflate physical bytes, HTTP upgrade, TLS, and TCP overhead. Candidate-cache simulations remain diagnostic opportunities and are not included as realized savings.

The observed Lunch Poll scenario wall times ranged from 3.828s to 4.465s and include a 500ms polling quantum; command wall time also includes server startup and checking. No wall-time or production-network latency improvement is claimed from these runs.

## Security and operations

- unavailable unless `CF_MEMORY_WIRE_ACCOUNTING_TOKEN` is non-empty
- available only when `ENV` is `development` or `test`; staging/production/unknown environments fail closed
- start/stop requires constant-time bearer validation
- Authorization/Cookie headers are redacted
- reports contain classifications/byte counts and connection metadata, never message payloads or credentials

The active diagnostic accumulator is intentionally process-local and retains records until stopped. It remains dev/test-only; bounded retention is a possible follow-up if this diagnostic becomes long-lived.

## Verification

- full Memory package: 370 tests passed
- root `deno task check`
- `deno fmt --check`
- `deno lint`
- `deno task check-docs` (536 code blocks)
- focused Toolshed endpoint/policy/metadata/redaction tests
- integration runner token/ENV tests
- Lunch Poll report-analysis tests
- repeated `deno task integration patterns lunch-poll-vote`
- LSP diagnostics and `git diff --check`
- five-way post-fix review: goal, code quality, security, hands-on QA, repository context all PASS
- repo-specific `cf-review`: PASS, no blockers

## Relationship to prior work

#4292 remains the focused implementation PR for frame-local schema interning. This PR is the dedicated hardening, diagnostics, and analytical-evidence follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens v2 sync schema refs, adds durable request‑schema CAS, and ships an opt‑in websocket payload‑accounting diagnostic. Enforces canonical schema storage and strict CAS bounds; Lunch Poll runs show ~14.6% fewer sync bytes, with CAS cutting request bytes while keeping schema interning frame‑local. Integration tests now mark measurement runs and preserve ordinary Lunch Poll flows when diagnostics are off.

- **New Features**
  - Durable request‑schema CAS (`requestSchemaCasV1`) for query/watch/transact: refs‑first, one forced‑definition retry on cold miss, inline fallback on store reject; handshake now uses `protocol: "memory"` and advertises CAS `generation`/`audience`.
  - Toolshed persists request schemas in a bounded SQLite store; expose `CF_MEMORY_REQUEST_SCHEMA_CAS_ENABLED` (tri‑state) and `CF_MEMORY_WIRE_ACCOUNTING_TOKEN`. Dev/test wire accounting in `@commonfabric/memory` with `/api/storage/memory/wire-accounting/{start,stop}`; classifies browser/runtime connections and redacts sensitive headers. The integration runner provisions a high‑entropy bearer token and sets allowed env for paired Lunch Poll measurements.

- **Bug Fixes**
  - Use canonical JSON codec in the schema store; harden CAS payload limits (definitions/bytes/traversal) and preserve retry order (refs‑first → forced‑def → inline). Allow ordinary deep request payloads by limiting traversal to schema‑bearing link positions.
  - Reject invalid or dangling `schema-ref@2:` values, validate every reserved‑schema revision on commit, and protect persisted link schemas.
  - Deduplicate outbound schema evidence, preserve client‑supplied request schemas, seed the store from expanded syncs, and have the sync table report each repeated schema once while rejecting refs without a populated table.
  - Reauthorize stale ACL requests and isolate wire‑accounting observer failures; mark wire‑accounting runs in integration tests and ensure ordinary Lunch Poll runs remain unchanged when diagnostics are disabled.

<sup>Written for commit 06e562446227e22fb85996109a6d98ba4170a4c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Coverage baseline acceptance

The Pattern integration changes in this PR are test/measurement-only files under the coverage-excluded integration path, but they activate the package-wide Pattern ratchet. The narrow override accepts that measurement artifact without resetting unrelated coverage:

NEW_PERF_BASELINE: coverage-debt: packages/patterns uncovered lines = 241868 lines

The Memory implementation adds bounded fail-closed protocol, durable-store, and accounting branches. Targeted tests plus the full 483-test Memory suite reduce the conservative merged estimate from 1529 to 1410 uncovered lines; this ceiling accepts any remaining defensive debt while the fresh lower result becomes the post-merge baseline:

NEW_PERF_BASELINE: coverage-debt: packages/memory uncovered lines = 1529 lines
