### PR TITLE
feat(cli): add explicit and continuous test UI demand

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -103,6 +103,73 @@ export default pattern(() => {
 - test a sub-pattern before building the next dependent layer when that helps
   isolate failures
 
+## Headless VDOM Materialization
+
+`cf test` remains headless and does not demand a pattern's `$UI` by default.
+That is important under the pull scheduler: state and assertion computations
+run because the harness pulls them, but conditional or nested VDOM can remain
+dirty unless a renderer asks for it.
+
+When a test specifically needs the VDOM evaluated at the current step, add an
+explicit render step after the action that creates that state:
+
+```tsx
+// Shown for illustration only.
+const subject = Pattern({});
+
+return {
+  tests: [
+    { action: actionReachLateState },
+    { render: subject[UI] },
+    { assertion: assertLateState },
+  ],
+};
+```
+
+The step runs the target through the same worker reconciler implementation used
+by the renderer, discards the generated DOM operations, waits for recursively
+discovered VDOM cells to settle, and immediately unmounts. It is transparent
+to assertion counts, honors `skip: true`, and is supported in both single- and
+multi-user tests.
+
+This primitive does not create a browser DOM. Use browser tests for element
+queries, layout, screenshots, accessibility-tree behavior, or real event
+dispatch. Keep render steps targeted: each one evaluates a full VDOM subtree
+and costs more than pulling a state assertion.
+
+### Continuous `$UI` Stress Mode
+
+For occasional stress, coverage, or performance runs, a test can also export
+the subject's UI from its own descriptor:
+
+```tsx
+// Shown for illustration only.
+return {
+  [UI]: subject[UI],
+  tests: [
+    { action: actionReachLateState },
+    { assertion: assertLateState },
+  ],
+};
+```
+
+Then enable a renderer-lifetime demand for that exported UI:
+
+```bash
+CF_TEST_CONTINUOUS_UI=1 deno task cf test <pattern>.test.tsx
+```
+
+The harness mounts `$UI` before its initial settle, keeps it demanded through
+every action and assertion, and unmounts during cleanup. In multi-user tests,
+each participant may export its own `[UI]`, which is mounted in that
+participant's worker. The flag does not change `{ render: ... }` semantics;
+those remain one-step checkpoints.
+
+Continuous mode is deliberately opt-in because it broadens work and can expose
+timing or performance behavior outside the deterministic unit-style contract.
+For a detailed performance run, combine it with
+`--verbose --stats-threshold 0` and pattern coverage as needed.
+
 ## Console Errors and Warnings Fail Tests
 
 `cf test` fails a test when anything is logged at error or warn level during

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -1,12 +1,16 @@
 # Pattern Testing System Specification
 
-**Status:** Implemented (v2.1 - Discriminated Union Format)
+**Status:** Implemented (v2.3 - Explicit and Continuous VDOM Demand)
 **Author:** Claude (with Gideon, Jordan, Berni)
 **Date:** 2026-01-13
 
 ## Executive Summary
 
-This specification defines a **pattern-native testing system** where tests are themselves patterns. Test patterns (`.test.tsx` files) import and instantiate the patterns they test, define test steps using a **discriminated union format** (`{ action: ... }` or `{ assertion: ... }`), and are run via `cf test`.
+This specification defines a **pattern-native testing system** where tests are
+themselves patterns. Test patterns (`.test.tsx` files) import and instantiate
+the patterns they test, define test steps using a **discriminated union
+format** (`{ action: ... }`, `{ assertion: ... }`, or an explicit harness
+primitive), and are run via `cf test`.
 
 **Key insight:** Tests should be patterns too. This dogfoods the pattern system, keeps testing infrastructure in userland, and allows test patterns to be inspected via CLI for debugging.
 
@@ -22,7 +26,7 @@ This specification defines a **pattern-native testing system** where tests are t
 
 - Replacing existing CI integration tests
 - Testing cross-piece linking (requires deployment)
-- Testing UI rendering (requires browser)
+- Testing browser DOM rendering, layout, or interaction
 - External test runners (Jest, Vitest, etc.)
 
 ---
@@ -67,7 +71,7 @@ A test pattern is a regular pattern file with `.test.tsx` extension that:
 2. **Instantiates it with test data**
 3. **Defines test actions using `action()`** (for triggering events on the pattern)
 4. **Defines assertions as `computed(() => boolean)`** computed from pattern state
-5. **Returns a `tests` array** of discriminated union objects: `{ action: ... }` or `{ assertion: ... }`
+5. **Returns a `tests` array** of discriminated union objects
 
 ### Test Step Format (Discriminated Union)
 
@@ -77,10 +81,24 @@ The `tests` array uses a discriminated union to avoid TypeScript declaration emi
 // Shown at module scope.
 type TestStep =
   | { assertion: Reactive<boolean> }  // from computed(() => condition)
-  | { action: Stream<void> };          // from action(() => handler.send())
+  | { action: Stream<void> }           // from action(() => handler.send())
+  | { render: VNode }                  // one headless VDOM demand window
+  | { settle: true };                  // wait for full async settlement
 ```
 
 This format keeps `action()` streams and `computed()` cells separate in the type system.
+
+`cf test` does not mount a renderer by default. Under the pull scheduler, a
+pattern's `$UI` is therefore not continuously demanded. A
+`{ render: subject[UI] }` step materializes that VDOM through the worker
+reconciler at the current test state, discards the resulting DOM operations,
+waits for the recursively discovered UI computations to settle, and unmounts
+before the next step. This is VDOM evaluation, not browser rendering.
+
+For stress and performance runs, `CF_TEST_CONTINUOUS_UI=1` mounts the test
+descriptor's exported `[UI]` before initial settlement and keeps it demanded
+until cleanup. This opt-in mode applies independently to every multi-user
+participant and does not change the semantics of explicit `render` steps.
 
 ### Example Test Pattern
 
@@ -251,8 +269,8 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
   await tx.commit();
   await runtime.idle();
 
-  // Keep pattern reactive
-  const sinkCancel = patternResult.sink(() => {});
+  // No renderer is mounted by default. Values run only when a test step
+  // explicitly demands them.
 
   // 4. Get the tests array from pattern output
   const testsCell = patternResult.key("tests") as Cell<unknown>;
@@ -268,14 +286,21 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
   let actionCount = 0;
 
   for (let i = 0; i < testsValue.length; i++) {
-    const stepValue = testsValue[i] as { action?: unknown; assertion?: unknown };
+    const stepValue = testsValue[i] as {
+      action?: unknown;
+      assertion?: unknown;
+      render?: unknown;
+      settle?: boolean;
+    };
 
     // Check discriminated union keys
     const isAction = "action" in stepValue;
     const isAssertion = "assertion" in stepValue;
+    const isRender = "render" in stepValue;
+    const isSettle = "settle" in stepValue;
 
-    if (!isAction && !isAssertion) {
-      throw new Error(`Test step at index ${i} must have 'action' or 'assertion' key`);
+    if (!isAction && !isAssertion && !isRender && !isSettle) {
+      throw new Error(`Test step at index ${i} has no supported discriminant`);
     }
 
     if (isAction) {
@@ -290,7 +315,7 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
         timeout(TIMEOUT, `Action at index ${i} timed out after ${TIMEOUT}ms`)
       ]);
 
-    } else {
+    } else if (isAssertion) {
       // It's an assertion - check the boolean value via .key() access
       assertionCount++;
       const assertCell = testsCell.key(i).key("assertion") as Cell<unknown>;
@@ -303,11 +328,14 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
         afterAction: lastActionIndex !== null ? `action_${actionCount}` : null,
         error: passed ? undefined : `Expected true, got ${JSON.stringify(value)}`,
       });
+    } else if (isRender) {
+      await materializeTestVDOM(testsCell.key(i).key("render"), settleRuntime);
+    } else {
+      await runtime.settled();
     }
   }
 
   // 6. Cleanup
-  sinkCancel();
   engine.dispose();
   await storageManager.close();
 
@@ -320,6 +348,8 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
 - **Discriminated union detection:** Check `"action" in step` vs `"assertion" in step`
 - **Cell access via `.key()`:** Access test steps through reactive cell interface
 - **Void stream `.send()`:** No argument required for `Stream<void>`
+- **Explicit VDOM demand:** A `render` step mounts the worker reconciler only
+  for that step; DOM operations are discarded and demand is cleaned up
 
 ---
 

--- a/packages/cli/commands/test.ts
+++ b/packages/cli/commands/test.ts
@@ -150,6 +150,7 @@ export const test = new Command()
       storageStats: options.storageStats,
       storageStatsLimit: options.storageStatsLimit,
       patternCoverageDir,
+      continuousUI: Deno.env.get("CF_TEST_CONTINUOUS_UI") === "1",
     });
 
     // Exit with error code if any tests failed

--- a/packages/cli/lib/materialize-test-vdom.ts
+++ b/packages/cli/lib/materialize-test-vdom.ts
@@ -1,0 +1,66 @@
+import { isWorkerVNode, WorkerReconciler } from "@commonfabric/html/worker";
+import { type Cell, isCell } from "@commonfabric/runner";
+import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
+
+function isRenderableRoot(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (
+    typeof value === "string" || typeof value === "number" ||
+    typeof value === "boolean"
+  ) return true;
+  if (isCell(value) || isWorkerVNode(value)) return true;
+  if (Array.isArray(value)) return value.every(isRenderableRoot);
+  return typeof value === "object" && "$UI" in value;
+}
+
+/**
+ * Materialize a test step's VDOM through the worker reconciler.
+ *
+ * The emitted DOM operations are intentionally discarded: pattern tests stay
+ * headless, while the reconciler installs the same recursive demand graph that
+ * a mounted renderer would. The demand exists only for the duration of this
+ * call and is removed before the next test step begins.
+ */
+export async function materializeTestVDOM(
+  vdomCell: Cell<unknown>,
+  settle: () => Promise<void>,
+): Promise<void> {
+  const errors: Error[] = [];
+  let cancel: (() => void) | undefined;
+
+  try {
+    cancel = await mountTestVDOM(vdomCell, (error) => errors.push(error));
+    await settle();
+    if (errors.length > 0) {
+      throw new Error(`VDOM materialization failed: ${errors[0]!.message}`, {
+        cause: errors[0],
+      });
+    }
+  } finally {
+    cancel?.();
+  }
+}
+
+/**
+ * Mount a headless VDOM demand that remains active until the caller cancels it.
+ * Reconciliation errors are reported for the caller to fold into its own test
+ * health channel.
+ */
+export async function mountTestVDOM(
+  vdomCell: Cell<unknown>,
+  onError: (error: Error) => void,
+): Promise<() => void> {
+  const root = await vdomCell.pull();
+  if (!isRenderableRoot(root)) {
+    throw new Error(
+      `VDOM materialization failed: Invalid VDOM content: expected ` +
+        `WorkerVNode, string, number, boolean, array, or $UI object, got ${typeof root}`,
+    );
+  }
+
+  const reconciler = new WorkerReconciler({
+    onOps: () => {},
+    onError,
+  });
+  return reconciler.mount(vdomCell.asSchema(rendererVDOMSchema));
+}

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -229,6 +229,7 @@ export async function runMultiUserTestPattern(
           testPath,
           root: options.root,
           patternCoverageDir: options.patternCoverageDir,
+          continuousUI: options.continuousUI,
           participant: spec.name,
           seedDefaults: index === 0,
         }) as ParticipantInitResult;
@@ -299,6 +300,18 @@ export async function runMultiUserTestPattern(
             if (options.verbose) {
               console.log(
                 `  [${participant.spec.name}] ${participant.lastActionName} (${
+                  Math.round(performance.now() - stepStart)
+                }ms)`,
+              );
+            }
+            continue;
+          }
+          if (step.kind === "render") {
+            const stepStart = performance.now();
+            await participant.worker.call("render", { index }, stepTimeout);
+            if (options.verbose) {
+              console.log(
+                `  [${participant.spec.name}] ◇ render (${
                   Math.round(performance.now() - stepStart)
                 }ms)`,
               );

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -44,6 +44,7 @@ import {
   Identity,
   type KeyPairRaw,
 } from "@commonfabric/identity";
+import { materializeTestVDOM, mountTestVDOM } from "./materialize-test-vdom.ts";
 
 export interface WorkerRequest {
   id: number;
@@ -55,7 +56,7 @@ export type WorkerResponse =
   | { id: number; ok: unknown }
   | { id: number; error: string };
 
-export type StepKind = "action" | "assertion" | "label" | "await";
+export type StepKind = "action" | "assertion" | "render" | "label" | "await";
 
 export interface StepMeta {
   kind: StepKind;
@@ -88,6 +89,8 @@ const runtimeErrors: string[] = [];
 /** Channel 1: console.error/warn captured via the harness console event. */
 const consoleErrors: string[] = [];
 const consoleWarnings: string[] = [];
+const continuousUiErrors: Error[] = [];
+let continuousUiCancel: (() => void) | undefined;
 // Run-phase gate for channel 1 (mirrors test-runner.ts): flips true at the
 // post-compile point where the channel-2 snapshot is taken, so compile-time
 // module-evaluation console output does not fail tests.
@@ -114,6 +117,7 @@ const stepPeekSchema = {
   properties: {
     action: { type: "unknown" },
     assertion: { type: "unknown" },
+    render: { type: "unknown" },
     label: { type: "string" },
     await: { type: "string" },
     event: { type: "unknown" },
@@ -132,6 +136,7 @@ function classifyStep(stepCell: Cell<unknown>, index: number): StepMeta {
   const peek = stepCell.asSchema(stepPeekSchema).get() as {
     action?: unknown;
     assertion?: unknown;
+    render?: unknown;
     label?: string;
     await?: string;
     skip?: boolean;
@@ -144,12 +149,13 @@ function classifyStep(stepCell: Cell<unknown>, index: number): StepMeta {
     return { kind: "await", marker: peek.await, ...skip };
   }
   // Streams/computeds peek as present-but-opaque; key presence is the signal.
+  if (Object.hasOwn(peek ?? {}, "render")) return { kind: "render", ...skip };
   if (Object.hasOwn(peek ?? {}, "action")) return { kind: "action", ...skip };
   if (Object.hasOwn(peek ?? {}, "assertion")) {
     return { kind: "assertion", ...skip };
   }
   throw new Error(
-    `Test step ${index} has none of action/assertion/label/await ` +
+    `Test step ${index} has none of action/assertion/render/label/await ` +
       `(keys: ${Object.keys(peek ?? {}).join(",") || "none"})`,
   );
 }
@@ -312,6 +318,12 @@ const handlers: Record<
     );
     rt().prepareTxForCommit?.(tx);
     await tx.commit();
+    if (args.continuousUI === true) {
+      continuousUiCancel = await mountTestVDOM(
+        resultCell.key("$UI") as Cell<unknown>,
+        (error) => continuousUiErrors.push(error),
+      );
+    }
     await settle();
 
     const stepsValue = resultCell.key("tests").asSchema(
@@ -372,6 +384,16 @@ const handlers: Record<
     return { passed: value === true };
   },
 
+  /** Materialize one VDOM target, then remove its renderer demand. */
+  async render({ index }) {
+    const stepCell = stepCells[index as number];
+    await materializeTestVDOM(
+      stepCell.key("render" as never) as Cell<unknown>,
+      () => settle(),
+    );
+    return {};
+  },
+
   /** Let in-flight work and incoming subscription pushes land. */
   async settle() {
     await settle(6);
@@ -388,7 +410,12 @@ const handlers: Record<
       consoleWarnings,
     );
     return Promise.resolve({
-      runtimeErrors: [...runtimeErrors],
+      runtimeErrors: [
+        ...runtimeErrors,
+        ...continuousUiErrors.map((error) =>
+          `[continuous $UI] ${String(error)}`
+        ),
+      ],
       consoleErrors: [...consoleErrors],
       consoleWarnings: [...consoleWarnings],
       nonIdempotent: rt().getIdempotencyViolations?.()?.map((violation) => {
@@ -417,6 +444,9 @@ const handlers: Record<
 
   async dispose() {
     stepCells = [];
+    continuousUiCancel?.();
+    continuousUiCancel = undefined;
+    continuousUiErrors.length = 0;
     // `engine` is the runtime's own harness; runtime.dispose() disposes it.
     await runtime?.dispose();
     await storageManager?.close();

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -69,6 +69,7 @@ import {
   makeMockFetch,
   readFetchMocks,
 } from "./fetch-mock.ts";
+import { materializeTestVDOM, mountTestVDOM } from "./materialize-test-vdom.ts";
 import {
   type CDFPoint,
   getLogger,
@@ -121,7 +122,8 @@ function formatError(error: unknown): string {
 }
 
 /**
- * A test step is an object with an 'assertion', 'action', or 'settle' property.
+ * A test step is an object with an 'assertion', 'action', 'render', or 'settle'
+ * property.
  * This discriminated union avoids TypeScript trying to unify incompatible Cell/Stream types.
  * Add `skip: true` to temporarily disable a step (like it.skip in other frameworks).
  *
@@ -145,6 +147,7 @@ export type TestStep =
     trustedUi?: TrustedUiDescriptor;
     skip?: boolean;
   }
+  | { render: unknown; skip?: boolean }
   | { settle: true; skip?: boolean };
 
 type HarnessTestStepMeta = {
@@ -152,6 +155,7 @@ type HarnessTestStepMeta = {
   assertion?: unknown;
   event?: unknown;
   trustedUi?: unknown;
+  render?: unknown;
   skip?: boolean;
   // `{ settle: true }` step: wait for full settlement (scheduler + storage +
   // in-flight async builtin I/O) via `runtime.settled()` before the next step.
@@ -174,6 +178,7 @@ const testStepPeekSchema = internSchema(
           action: { type: "string" },
         },
       },
+      render: { type: "unknown" },
       skip: { type: "boolean" },
       settle: { type: "boolean" },
     },
@@ -276,6 +281,8 @@ export interface TestRunnerOptions {
   storageStatsLimit?: number;
   /** Directory for pattern runtime coverage LCOV artifacts. */
   patternCoverageDir?: string;
+  /** Keep the test descriptor's `$UI` demanded for the full test run. */
+  continuousUI?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -888,6 +895,8 @@ export async function runTestPattern(
     ? new PatternCoverageCollector()
     : undefined;
   let writeLocalPatternCoverage = patternCoverage !== undefined;
+  let continuousUiCancel: (() => void) | undefined;
+  const continuousUiErrors: Error[] = [];
 
   // Collect pattern-code console.error / console.warn calls (channel 1: harness
   // console event) and logger-level error/warn activity (channel 2: logger count
@@ -1113,6 +1122,20 @@ export async function runTestPattern(
       },
     );
 
+    if (options.continuousUI) {
+      continuousUiCancel = await withPhase(
+        ["runTestPattern", "continuousUI", "mount"],
+        () =>
+          mountTestVDOM(
+            patternResult.key("$UI") as Cell<unknown>,
+            (error) => continuousUiErrors.push(error),
+          ),
+      );
+      if (options.verbose) {
+        console.log("  Continuous $UI demand enabled");
+      }
+    }
+
     await withPhase(["runTestPattern", "initialSettle"], async () => {
       // Wait for initial setup to complete
       await runtime.idle();
@@ -1261,6 +1284,7 @@ export async function runTestPattern(
     let lastActionIndex: number | null = null;
     let assertionCount = 0;
     let actionCount = 0;
+    let renderCount = 0;
 
     for (let i = 0; i < testSteps.length; i++) {
       if (options.verbose) {
@@ -1272,9 +1296,10 @@ export async function runTestPattern(
       const stepValue = stepCell.asSchema(testStepPeekSchema)
         .get() as HarnessTestStepMeta;
 
-      // Check if this step has 'action', 'assertion', or 'settle' key
+      // Check which discriminant this step carries.
       const isAction = Object.hasOwn(stepValue, "action");
       const isAssertion = Object.hasOwn(stepValue, "assertion");
+      const isRender = Object.hasOwn(stepValue, "render");
       const isSettle = Object.hasOwn(stepValue, "settle");
 
       // `{ settle: true }` step: wait for FULL settlement (scheduler + storage +
@@ -1288,10 +1313,29 @@ export async function runTestPattern(
         continue;
       }
 
+      // `{ render: subject[UI] }` is a headless, per-step demand window. Run
+      // the VDOM through the worker reconciler, discard its DOM
+      // operations, wait for all recursively discovered UI cells, then remove
+      // the demand before advancing to the next step.
+      if (isRender) {
+        renderCount++;
+        const renderName = `render_${renderCount}`;
+        if (!stepValue.skip) {
+          await materializeTestVDOM(
+            stepCell.key("render") as Cell<unknown>,
+            () => settleRuntime(i, renderName, 20),
+          );
+          if (options.verbose) console.log(`  ◇ ${renderName}`);
+        } else if (options.verbose) {
+          console.log(`  ⊘ ${renderName} (skipped)`);
+        }
+        continue;
+      }
+
       if (!isAction && !isAssertion) {
         throw new Error(
-          `Test step at index ${i} must have an 'action', 'assertion', or ` +
-            `'settle' key. Got: ${
+          `Test step at index ${i} must have an 'action', 'assertion', ` +
+            `'render', or 'settle' key. Got: ${
               toCompactDebugString(Object.keys(stepValue))
             }`,
         );
@@ -1642,7 +1686,10 @@ export async function runTestPattern(
       consoleWarnings,
     );
 
-    const errorMessages = runtimeErrors.map((e) => String(e));
+    const errorMessages = [
+      ...runtimeErrors.map((e) => String(e)),
+      ...continuousUiErrors.map((e) => `[continuous $UI] ${String(e)}`),
+    ];
     return {
       path: testPath,
       results,
@@ -1670,7 +1717,10 @@ export async function runTestPattern(
         "\n    Hint: If the test imports from sibling directories (e.g., ../shared/), use --root to specify a common ancestor.";
     }
 
-    const errorMessages = runtimeErrors.map((e) => String(e));
+    const errorMessages = [
+      ...runtimeErrors.map((e) => String(e)),
+      ...continuousUiErrors.map((e) => `[continuous $UI] ${String(e)}`),
+    ];
     return {
       path: testPath,
       results: [],
@@ -1704,6 +1754,8 @@ export async function runTestPattern(
       });
     }
     // 6. Cleanup
+    continuousUiCancel?.();
+    continuousUiCancel = undefined;
     await withPhase(["runTestPattern", "cleanup", "engineDispose"], () => {
       engine.dispose();
     });

--- a/packages/cli/test/fixtures/render-step/continuous-multi-user.test.tsx
+++ b/packages/cli/test/fixtures/render-step/continuous-multi-user.test.tsx
@@ -1,0 +1,34 @@
+import {
+  action,
+  computed,
+  multiUserTest,
+  pattern,
+  UI,
+  Writable,
+} from "commonfabric";
+import { lateVDOMBranch } from "./subject.tsx";
+
+const alice = pattern(() => {
+  const phase = new Writable("initial");
+  const advance = action(() => phase.set("late"));
+  const view = (
+    <div>
+      {computed(() =>
+        phase.get() === "late"
+          ? <span>{computed(() => lateVDOMBranch())}</span>
+          : null
+      )}
+    </div>
+  );
+  const isLate = computed(() => phase.get() === "late");
+
+  return {
+    [UI]: view,
+    tests: [
+      { action: advance },
+      { assertion: isLate },
+    ],
+  };
+});
+
+export default multiUserTest({ participants: { alice } });

--- a/packages/cli/test/fixtures/render-step/continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/continuous-ui.test.tsx
@@ -1,0 +1,25 @@
+import { action, computed, pattern, UI, Writable } from "commonfabric";
+import { lateVDOMBranch } from "./subject.tsx";
+
+export default pattern(() => {
+  const phase = new Writable("initial");
+  const advance = action(() => phase.set("late"));
+  const view = (
+    <div>
+      {computed(() =>
+        phase.get() === "late"
+          ? <span>{computed(() => lateVDOMBranch())}</span>
+          : null
+      )}
+    </div>
+  );
+  const isLate = computed(() => phase.get() === "late");
+
+  return {
+    [UI]: view,
+    tests: [
+      { action: advance },
+      { assertion: isLate },
+    ],
+  };
+});

--- a/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
@@ -1,0 +1,6 @@
+import { computed, pattern, UI } from "commonfabric";
+
+export default pattern(() => ({
+  [UI]: {},
+  tests: [{ assertion: computed(() => true) }],
+}));

--- a/packages/cli/test/fixtures/render-step/invalid-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/invalid-render.test.tsx
@@ -1,0 +1,5 @@
+import { pattern } from "commonfabric";
+
+export default pattern(() => ({
+  tests: [{ render: {} }],
+}));

--- a/packages/cli/test/fixtures/render-step/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/render-step/multi-user.test.tsx
@@ -1,0 +1,33 @@
+import {
+  action,
+  computed,
+  multiUserTest,
+  pattern,
+  Writable,
+} from "commonfabric";
+import { lateVDOMBranch } from "./subject.tsx";
+
+const alice = pattern(() => {
+  const phase = new Writable("initial");
+  const advance = action(() => phase.set("late"));
+  const view = (
+    <div>
+      {computed(() =>
+        phase.get() === "late"
+          ? <span>{computed(() => lateVDOMBranch())}</span>
+          : null
+      )}
+    </div>
+  );
+  const isLate = computed(() => phase.get() === "late");
+
+  return {
+    tests: [
+      { action: advance },
+      { render: view },
+      { assertion: isLate },
+    ],
+  };
+});
+
+export default multiUserTest({ participants: { alice } });

--- a/packages/cli/test/fixtures/render-step/no-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/no-render.test.tsx
@@ -1,0 +1,25 @@
+import { action, computed, pattern, Writable } from "commonfabric";
+import { lateVDOMBranch } from "./subject.tsx";
+
+export default pattern(() => {
+  const phase = new Writable("initial");
+  const advance = action(() => phase.set("late"));
+  const view = (
+    <div>
+      {computed(() =>
+        phase.get() === "late"
+          ? <span>{computed(() => lateVDOMBranch())}</span>
+          : null
+      )}
+    </div>
+  );
+  const isLate = computed(() => phase.get() === "late");
+  void view;
+
+  return {
+    tests: [
+      { action: advance },
+      { assertion: isLate },
+    ],
+  };
+});

--- a/packages/cli/test/fixtures/render-step/primitive-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/primitive-render.test.tsx
@@ -1,0 +1,11 @@
+import { computed, pattern } from "commonfabric";
+
+export default pattern(() => ({
+  tests: [
+    { render: null },
+    { render: "text" },
+    { render: 1 },
+    { render: true },
+    { assertion: computed(() => true) },
+  ],
+}));

--- a/packages/cli/test/fixtures/render-step/render-cleanup.test.tsx
+++ b/packages/cli/test/fixtures/render-step/render-cleanup.test.tsx
@@ -1,0 +1,31 @@
+import { action, computed, pattern, Writable } from "commonfabric";
+import { afterRenderBranch, lateVDOMBranch } from "./subject.tsx";
+
+export default pattern(() => {
+  const phase = new Writable("initial");
+  const reachLate = action(() => phase.set("late"));
+  const advanceAfterRender = action(() => phase.set("after-render"));
+  const view = (
+    <div>
+      {computed(() => {
+        if (phase.get() === "late") {
+          return <span>{computed(() => lateVDOMBranch())}</span>;
+        }
+        if (phase.get() === "after-render") {
+          return <span>{computed(() => afterRenderBranch())}</span>;
+        }
+        return null;
+      })}
+    </div>
+  );
+  const isAfterRender = computed(() => phase.get() === "after-render");
+
+  return {
+    tests: [
+      { action: reachLate },
+      { render: view },
+      { action: advanceAfterRender },
+      { assertion: isAfterRender },
+    ],
+  };
+});

--- a/packages/cli/test/fixtures/render-step/render-step.test.tsx
+++ b/packages/cli/test/fixtures/render-step/render-step.test.tsx
@@ -1,0 +1,25 @@
+import { action, computed, pattern, Writable } from "commonfabric";
+import { lateVDOMBranch } from "./subject.tsx";
+
+export default pattern(() => {
+  const phase = new Writable("initial");
+  const advance = action(() => phase.set("late"));
+  const view = (
+    <div>
+      {computed(() =>
+        phase.get() === "late"
+          ? <span>{computed(() => lateVDOMBranch())}</span>
+          : null
+      )}
+    </div>
+  );
+  const isLate = computed(() => phase.get() === "late");
+
+  return {
+    tests: [
+      { action: advance },
+      { render: view },
+      { assertion: isLate },
+    ],
+  };
+});

--- a/packages/cli/test/fixtures/render-step/skipped-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/skipped-render.test.tsx
@@ -1,0 +1,25 @@
+import { action, computed, pattern, Writable } from "commonfabric";
+import { lateVDOMBranch } from "./subject.tsx";
+
+export default pattern(() => {
+  const phase = new Writable("initial");
+  const advance = action(() => phase.set("late"));
+  const view = (
+    <div>
+      {computed(() =>
+        phase.get() === "late"
+          ? <span>{computed(() => lateVDOMBranch())}</span>
+          : null
+      )}
+    </div>
+  );
+  const isLate = computed(() => phase.get() === "late");
+
+  return {
+    tests: [
+      { action: advance },
+      { render: view, skip: true },
+      { assertion: isLate },
+    ],
+  };
+});

--- a/packages/cli/test/fixtures/render-step/subject.tsx
+++ b/packages/cli/test/fixtures/render-step/subject.tsx
@@ -1,0 +1,7 @@
+export function lateVDOMBranch(): string {
+  return "late VDOM branch";
+}
+
+export function afterRenderBranch(): string {
+  return "post-render VDOM branch";
+}

--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Contract tests for explicit, per-step VDOM materialization in `cf test`.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join, resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+import { cf, checkStderr, withEnv } from "./utils.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/render-step");
+const SUBJECT = join(FIXTURES, "subject.tsx").replaceAll("\\", "/");
+const SUBJECT_SOURCE = await Deno.readTextFile(SUBJECT);
+
+function fixture(name: string): string {
+  return resolve(FIXTURES, name);
+}
+
+async function withCoverage(
+  name: string,
+  continuousUI = false,
+): Promise<{
+  lateHitCount: number;
+  afterRenderHitCount: number;
+  stepResultCount: number;
+  passed: number;
+}> {
+  const coverageDir = await Deno.makeTempDir();
+  try {
+    const result = await runTests(fixture(name), {
+      root: FIXTURES,
+      patternCoverageDir: coverageDir,
+      continuousUI,
+    });
+    const files: string[] = [];
+    for await (const entry of Deno.readDir(coverageDir)) {
+      if (entry.isFile && entry.name.endsWith(".pattern-coverage.lcov")) {
+        files.push(await Deno.readTextFile(join(coverageDir, entry.name)));
+      }
+    }
+    expect(files.length).toBe(1);
+    const hitCount = (sourceText: string): number => {
+      const sourceLine = SUBJECT_SOURCE.split("\n").findIndex((line) =>
+        line.includes(sourceText)
+      ) + 1;
+      expect(sourceLine).toBeGreaterThan(0);
+
+      let inSubject = false;
+      let count = -1;
+      for (const line of files[0]!.split("\n")) {
+        if (line.startsWith("SF:")) {
+          inSubject = line === `SF:${SUBJECT}`;
+        }
+        if (line === "end_of_record") {
+          inSubject = false;
+        }
+        if (inSubject && line.startsWith(`DA:${sourceLine},`)) {
+          count = Number(line.split(",")[1]);
+        }
+      }
+      expect(count).toBeGreaterThanOrEqual(0);
+      return count;
+    };
+    return {
+      lateHitCount: hitCount('return "late VDOM branch"'),
+      afterRenderHitCount: hitCount('return "post-render VDOM branch"'),
+      stepResultCount: result.results.flatMap((entry) =>
+        entry.results
+      ).length,
+      passed: result.passed,
+    };
+  } finally {
+    await Deno.remove(coverageDir, { recursive: true });
+  }
+}
+
+describe(
+  "cf test UI demand",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("materializes late-state VDOM and stays transparent to results", async () => {
+      const result = await withCoverage("render-step.test.tsx");
+      expect(result.lateHitCount).toBeGreaterThan(0);
+      expect(result.stepResultCount).toBe(1);
+      expect(result.passed).toBe(1);
+    });
+
+    it("preserves the headless default when no render step is present", async () => {
+      const result = await withCoverage("no-render.test.tsx");
+      expect(result.lateHitCount).toBe(0);
+      expect(result.passed).toBe(1);
+    });
+
+    it("does not materialize a skipped render step", async () => {
+      const result = await withCoverage("skipped-render.test.tsx");
+      expect(result.lateHitCount).toBe(0);
+      expect(result.passed).toBe(1);
+    });
+
+    it("removes renderer demand before the following action", async () => {
+      const result = await withCoverage("render-cleanup.test.tsx");
+      expect(result.lateHitCount).toBeGreaterThan(0);
+      expect(result.afterRenderHitCount).toBe(0);
+      expect(result.passed).toBe(1);
+    });
+
+    it("reports invalid VDOM content as a harness error", async () => {
+      const { failed, results } = await runTests(
+        fixture("invalid-render.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBe(1);
+      expect(results[0]!.error ?? "").toContain(
+        "VDOM materialization failed: Invalid VDOM content",
+      );
+    });
+
+    it("uses the same primitive in multi-user workers", async () => {
+      const result = await withCoverage("multi-user.test.tsx");
+      expect(result.lateHitCount).toBeGreaterThan(0);
+      expect(result.stepResultCount).toBe(1);
+      expect(result.passed).toBe(1);
+    });
+
+    it("leaves an exported $UI undemanded without the stress option", async () => {
+      const result = await withCoverage("continuous-ui.test.tsx");
+      expect(result.lateHitCount).toBe(0);
+      expect(result.passed).toBe(1);
+    });
+
+    it("continuously demands an exported $UI for the full run", async () => {
+      const result = await withCoverage("continuous-ui.test.tsx", true);
+      expect(result.lateHitCount).toBeGreaterThan(0);
+      expect(result.passed).toBe(1);
+    });
+
+    it("continuously demands each multi-user participant's $UI", async () => {
+      const result = await withCoverage(
+        "continuous-multi-user.test.tsx",
+        true,
+      );
+      expect(result.lateHitCount).toBeGreaterThan(0);
+      expect(result.passed).toBe(1);
+    });
+
+    it("rejects invalid continuous $UI content", async () => {
+      const { failed, results } = await runTests(
+        fixture("invalid-continuous-ui.test.tsx"),
+        { root: FIXTURES, continuousUI: true },
+      );
+      expect(failed).toBe(1);
+      expect(results[0]!.error ?? "").toContain(
+        "VDOM materialization failed: Invalid VDOM content",
+      );
+    });
+
+    it("enables continuous $UI demand through CF_TEST_CONTINUOUS_UI", async () => {
+      const coverageDir = await Deno.makeTempDir();
+      try {
+        await withEnv("CF_TEST_CONTINUOUS_UI", "1", async () => {
+          const { code, stderr } = await cf(
+            `test "${
+              fixture("continuous-ui.test.tsx")
+            }" --root "${FIXTURES}" --pattern-coverage-dir "${coverageDir}"`,
+          );
+          expect(code).toBe(0);
+          checkStderr(stderr);
+        });
+
+        const files: string[] = [];
+        for await (const entry of Deno.readDir(coverageDir)) {
+          if (entry.isFile && entry.name.endsWith(".pattern-coverage.lcov")) {
+            files.push(await Deno.readTextFile(join(coverageDir, entry.name)));
+          }
+        }
+        expect(files.length).toBe(1);
+        const sourceLine = SUBJECT_SOURCE.split("\n").findIndex((line) =>
+          line.includes('return "late VDOM branch"')
+        ) + 1;
+        expect(files[0]).toContain(`DA:${sourceLine},`);
+        const hit = files[0]!.split("\n").find((line) =>
+          line.startsWith(`DA:${sourceLine},`)
+        );
+        expect(Number(hit?.split(",")[1] ?? 0)).toBeGreaterThan(0);
+      } finally {
+        await Deno.remove(coverageDir, { recursive: true });
+      }
+    });
+  },
+);

--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -17,7 +17,7 @@ function fixture(name: string): string {
 
 async function withCoverage(
   name: string,
-  continuousUI = false,
+  options: { continuousUI?: boolean; verbose?: boolean } = {},
 ): Promise<{
   lateHitCount: number;
   afterRenderHitCount: number;
@@ -29,7 +29,8 @@ async function withCoverage(
     const result = await runTests(fixture(name), {
       root: FIXTURES,
       patternCoverageDir: coverageDir,
-      continuousUI,
+      continuousUI: options.continuousUI,
+      verbose: options.verbose,
     });
     const files: string[] = [];
     for await (const entry of Deno.readDir(coverageDir)) {
@@ -78,10 +79,21 @@ describe(
   { sanitizeOps: false, sanitizeResources: false },
   () => {
     it("materializes late-state VDOM and stays transparent to results", async () => {
-      const result = await withCoverage("render-step.test.tsx");
+      const result = await withCoverage("render-step.test.tsx", {
+        verbose: true,
+      });
       expect(result.lateHitCount).toBeGreaterThan(0);
       expect(result.stepResultCount).toBe(1);
       expect(result.passed).toBe(1);
+    });
+
+    it("accepts primitive VDOM roots", async () => {
+      const { failed, passed } = await runTests(
+        fixture("primitive-render.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBe(0);
+      expect(passed).toBe(1);
     });
 
     it("preserves the headless default when no render step is present", async () => {
@@ -91,7 +103,9 @@ describe(
     });
 
     it("does not materialize a skipped render step", async () => {
-      const result = await withCoverage("skipped-render.test.tsx");
+      const result = await withCoverage("skipped-render.test.tsx", {
+        verbose: true,
+      });
       expect(result.lateHitCount).toBe(0);
       expect(result.passed).toBe(1);
     });
@@ -115,7 +129,9 @@ describe(
     });
 
     it("uses the same primitive in multi-user workers", async () => {
-      const result = await withCoverage("multi-user.test.tsx");
+      const result = await withCoverage("multi-user.test.tsx", {
+        verbose: true,
+      });
       expect(result.lateHitCount).toBeGreaterThan(0);
       expect(result.stepResultCount).toBe(1);
       expect(result.passed).toBe(1);
@@ -128,7 +144,10 @@ describe(
     });
 
     it("continuously demands an exported $UI for the full run", async () => {
-      const result = await withCoverage("continuous-ui.test.tsx", true);
+      const result = await withCoverage("continuous-ui.test.tsx", {
+        continuousUI: true,
+        verbose: true,
+      });
       expect(result.lateHitCount).toBeGreaterThan(0);
       expect(result.passed).toBe(1);
     });
@@ -136,7 +155,7 @@ describe(
     it("continuously demands each multi-user participant's $UI", async () => {
       const result = await withCoverage(
         "continuous-multi-user.test.tsx",
-        true,
+        { continuousUI: true },
       );
       expect(result.lateHitCount).toBeGreaterThan(0);
       expect(result.passed).toBe(1);

--- a/packages/cli/test/test-runner-settle.test.ts
+++ b/packages/cli/test/test-runner-settle.test.ts
@@ -34,13 +34,13 @@ describe(
       );
     });
 
-    it("rejects a step with no action/assertion/settle key", async () => {
+    it("rejects a step with no supported discriminant", async () => {
       const { results } = await runTests(
         fixture("invalid-step.test.tsx"),
         { root: FIXTURES },
       );
       expect(results[0].error ?? "").toContain(
-        "must have an 'action', 'assertion', or 'settle'",
+        "must have an 'action', 'assertion', 'render', or 'settle'",
       );
     });
   },

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -7,7 +7,7 @@
  * is set), the unsafe-scheme link rejection, label defaulting, body Edit→Save
  * via setBody, activity-based sorting, and the exported pure helpers.
  */
-import { action, computed, NAME } from "commonfabric";
+import { action, computed, NAME, UI } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics, { openTopic, type TopicPiece } from "./main.tsx";
 import { isSafeLinkUrl, snippet, whenLabel } from "./topic.tsx";
@@ -225,6 +225,7 @@ export default pattern(() => {
   );
 
   return {
+    [UI]: board[UI],
     tests: [
       { assertion: assert_initial },
       { action: action_add_blank_topic },


### PR DESCRIPTION
## Why

The pull scheduler evaluates `$UI` only when something demands it. `cf test` is intentionally unit-like and headless, so its state and action assertions can pass while late or conditional VDOM branches never execute. That makes VDOM behavior effectively untestable from a pattern test unless the harness silently takes on full renderer parity.

This PR makes the contract explicit instead: the default remains headless, a test can deterministically request one-shot VDOM materialization at a chosen step, and occasional stress or performance runs can opt into permanent UI demand.

## What changed

- Add a transparent `{ render: subject[UI] }` test step that mounts a headless `WorkerReconciler`, waits for recursive VDOM settlement, discards DOM operations, and removes the demand before the next step.
- Add `CF_TEST_CONTINUOUS_UI=1` to mount an exported `[UI]` for the full test run, covering Berni's proposed stress/performance mode.
- Apply both modes consistently to single-user and multi-user tests, including cleanup and invalid-VDOM error propagation.
- Export the Topics test UI as a representative continuous-mode target.
- Document the default, explicit, and continuous UI-demand contracts in the pattern testing guide and specification.

## Behavior and impact

Existing tests keep their current headless behavior unless they opt in. Explicit render steps are deterministic and do not count as assertions. Continuous mode is deliberately environment-gated so it can be run periodically for broader scheduler/renderer stress without adding renderer cost or behavior to every normal `cf test` run.

During investigation, the original crossrefs reproducer passed all state assertions without UI demand. Targeted materialization exercised the previously dormant branch, while continuous demand exercised it repeatedly; those are complementary signals rather than interchangeable test modes.

## Validation

- `deno task check`
- `deno task check-docs` — all 510 checked code blocks passed
- `deno fmt --check` and `deno lint` across all changed source, fixture, and documentation files
- `deno test -A --no-check packages/cli/test/test-runner-render-step.test.ts packages/cli/test/test-runner-settle.test.ts packages/cli/test/test-runner-pattern-coverage.test.ts` — 3 files / 21 steps passed
- `deno task cf test packages/patterns/topics/topics.test.tsx --root packages/patterns/topics` — 19 passed
- `CF_TEST_CONTINUOUS_UI=1 deno task cf test packages/patterns/topics/topics.test.tsx --root packages/patterns/topics` — 19 passed

Background: https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:biRPdv6-A4QZiP7i_8W0LhfOe3VJzFYhKolzLd60yd0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit `{ render: subject[UI] }` test step and an opt-in continuous `$UI` mode to `cf test` so VDOM branches can be exercised deterministically without a browser, while keeping the default headless.

- **New Features**
  - `{ render: subject[UI] }` mounts a headless reconciler for one step, waits for VDOM settlement, discards DOM ops, then unmounts. Honors `skip`, works in single- and multi-user tests, accepts VNodes/cells/primitives/arrays, and fails invalid content with a clear harness error.
  - `CF_TEST_CONTINUOUS_UI=1` mounts the test’s exported `[UI]` for the full run (per participant in multi-user). Reconciliation errors are folded into runtime errors alongside other test failures.
  - CLI reads `CF_TEST_CONTINUOUS_UI`, and docs/specs describe the `render` discriminant and continuous `$UI` contract. Added contract tests covering render, skip, cleanup, primitives, invalid content, multi-user, and the env flag.

- **Migration**
  - No changes needed for existing tests.
  - To exercise late or conditional VDOM, add `{ render: subject[UI] }` after the action that reaches that state.
  - For stress/perf runs, export `[UI]` from the test descriptor and run with `CF_TEST_CONTINUOUS_UI=1` (e.g., Topics now exports `[UI]`).

<sup>Written for commit de38e232056e7354dcec668ff525eedad95b5acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

