### PR TITLE
test(lunch-poll): import shared VNode helpers instead of local copies

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -12,56 +12,18 @@
  */
 
 import { action, computed, pattern, safeDateNow, UI } from "commonfabric";
+import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
 import CozyPoll, { dayKeyOf, type Option, type Vote } from "./main.tsx";
-
-const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
-  typeof value === "object" && value !== null;
-
-const readValue = (value: unknown): unknown => {
-  if (!isRecord(value) || typeof value.get !== "function") {
-    return value;
-  }
-  return (value.get as () => unknown)();
-};
-
-const propsOf = (node: unknown): Record<PropertyKey, unknown> | undefined => {
-  const value = readValue(node);
-  if (!isRecord(value)) return undefined;
-  const props = readValue(value.props);
-  return isRecord(props) ? props : undefined;
-};
-
-const childrenArray = (children: unknown): unknown[] => {
-  const value = readValue(children);
-  if (Array.isArray(value)) return value;
-  return value === undefined || value === null || typeof value === "boolean"
-    ? []
-    : [value];
-};
-
-const childNodes = (node: unknown): unknown[] => {
-  const value = readValue(node);
-  if (Array.isArray(value)) return value;
-  if (!isRecord(value)) return [];
-  const ui = value[UI];
-  return [
-    ...(ui === undefined || ui === value ? [] : [ui]),
-    ...childrenArray(value.children),
-  ];
-};
 
 const findNodeByProp = (
   root: unknown,
   prop: string,
   expected: unknown,
-): unknown | undefined => {
-  const value = readValue(root);
-  const props = propsOf(value);
-  if (props && readValue(props[prop]) === expected) return value;
-  return childNodes(value)
-    .map((child) => findNodeByProp(child, prop, expected))
-    .find((child) => child !== undefined);
-};
+): unknown | undefined =>
+  findNode(root, (node) => {
+    const props = propsOf(node);
+    return props !== undefined && readValue(props[prop]) === expected;
+  });
 
 const SEEDED_OPTION: Option = {
   id: "opt-seeded",

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -6,6 +6,7 @@ import {
   UI,
   Writable,
 } from "commonfabric";
+import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
 import PollOptionCard from "./poll-option-card.tsx";
 import type {
   CastVoteEvent,
@@ -17,54 +18,15 @@ import type {
 
 type EmptyState = Record<PropertyKey, never>;
 
-const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
-  typeof value === "object" && value !== null;
-
-const readValue = (value: unknown): unknown => {
-  if (!isRecord(value) || typeof value.get !== "function") {
-    return value;
-  }
-  return (value.get as () => unknown)();
-};
-
-const propsOf = (node: unknown): Record<PropertyKey, unknown> | undefined => {
-  const value = readValue(node);
-  if (!isRecord(value)) return undefined;
-  const props = readValue(value.props);
-  return isRecord(props) ? props : undefined;
-};
-
-const childrenArray = (children: unknown): unknown[] => {
-  const value = readValue(children);
-  if (Array.isArray(value)) return value;
-  return value === undefined || value === null || typeof value === "boolean"
-    ? []
-    : [value];
-};
-
-const childNodes = (node: unknown): unknown[] => {
-  const value = readValue(node);
-  if (Array.isArray(value)) return value;
-  if (!isRecord(value)) return [];
-  const ui = value[UI];
-  return [
-    ...(ui === undefined || ui === value ? [] : [ui]),
-    ...childrenArray(value.children),
-  ];
-};
-
 const findNodeByProp = (
   root: unknown,
   prop: string,
   expected: unknown,
-): unknown | undefined => {
-  const value = readValue(root);
-  const props = propsOf(value);
-  if (props && readValue(props[prop]) === expected) return value;
-  return childNodes(value)
-    .map((child) => findNodeByProp(child, prop, expected))
-    .find((child) => child !== undefined);
-};
+): unknown | undefined =>
+  findNode(root, (node) => {
+    const props = propsOf(node);
+    return props !== undefined && readValue(props[prop]) === expected;
+  });
 
 const propValue = (node: unknown, prop: string): unknown => {
   const props = propsOf(node);


### PR DESCRIPTION
The lunch-poll unit tests each carried their own byte-for-byte copy of the VNode-walking helpers (isRecord, readValue, propsOf, childrenArray, childNodes) used to search a rendered UI tree, duplicating a set that already lives as an exported module at packages/patterns/test/vnode-helpers.ts and that the auth, google, and airtable test directories already import.

Replace those local copies in main.test.tsx and poll-option-card.test.tsx with an import from ../test/vnode-helpers.ts. The one helper with no exact shared equivalent, the prop-based finder findNodeByProp, is now a small wrapper composed from the shared findNode and propsOf rather than a hand-rolled recursive walk; poll-option-card's propValue is likewise composed from the shared propsOf and readValue.

These cross-directory imports resolve only when the test runner's --root is packages/patterns, which the pattern-unit CI job already passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates VNode helper code in lunch-poll tests by importing shared helpers from `packages/patterns/test/vnode-helpers.ts`. Simplifies prop-based node lookup by composing `findNode`, `propsOf`, and `readValue`.

- **Refactors**
  - Import shared `findNode`, `propsOf`, `readValue` and remove local `isRecord`, `childrenArray`, `childNodes` in `main.test.tsx` and `poll-option-card.test.tsx`.
  - Rework `findNodeByProp` to use `findNode` + `propsOf`; build `propValue` from `propsOf` + `readValue`.

- **Migration**
  - Run tests with `--root packages/patterns` so cross-directory imports resolve (CI `pattern-unit` already does this).

<sup>Written for commit 7df696482d19860500752928dd2e55807288d966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

