### PR TITLE
feat(patterns): add shared profile lobby

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -67,7 +67,7 @@ App and integration directories: `activity-log/`, `agent/`, `airtable/`,
 `auth/`, `base/`, `battleship/`, `budget-tracker/`, `calendar/`, `card-piles/`,
 `contacts/`, `cozy-poll/`, `examples/`, `experimental/` (explicitly unhardened
 explorations), `github-activity/`, `google/` (the `core/` tree; `google/WIP/` is
-legacy), `habit-tracker/`, `lunch-poll/`, `profile-group-chat/`,
+legacy), `habit-tracker/`, `lobby/`, `lunch-poll/`, `profile-group-chat/`,
 `project-list/`, `router/`, `scoped-group-chat/`, `scoped-user-directory/`,
 `scrabble/`, `shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
 `weekly-calendar/`.
@@ -980,6 +980,45 @@ interface LobbyOutput {
   messages: Message[];
   users: User[];
   sessionId: string;
+}
+```
+
+## `lobby/main.tsx`
+
+Simple multiplayer presence lobby. Each viewer joins by contributing their live
+Fabric profile cell from `wish({ query: "#profile" })`; every participant is
+rendered with `cf-profile-badge`. Admin membership uses the shared trusted admin
+registry flow: an empty registry defaults to everyone being an admin, and
+turning that fallback off seeds the acting participant as the first explicit
+admin. Admins can promote other participants and remove people. Agents can call
+the no-payload `addSelf` action and read the profile-free `allParticipants`
+snapshot for downstream processing.
+
+**Keywords:** multiplayer, lobby, roster, profile, wish, trusted admin, CFC
+
+### Input Schema
+
+```ts
+interface LobbyInput {
+  roster?: PerSpace<LobbyRosterValue>;
+  adminRegistry?: PerSpace<LobbyAdminRegistryCell>;
+}
+```
+
+### Output Schema
+
+```ts
+interface LobbyOutput {
+  addSelf: Stream<void>;
+  allParticipants: readonly LobbyParticipantView[];
+  participants: readonly LobbyParticipantView[];
+  participantCount: number;
+  currentUserIsAdmin: boolean;
+  everyoneIsAdmin: boolean;
+  join: Stream<LobbyTrustedActionEvent>;
+  removeParticipant: Stream<LobbyTrustedActionEvent>;
+  toggleParticipantAdmin: Stream<LobbyTrustedActionEvent>;
+  setEveryoneIsAdmin: Stream<LobbyTrustedActionEvent>;
 }
 ```
 

--- a/packages/patterns/lobby/main.test.tsx
+++ b/packages/patterns/lobby/main.test.tsx
@@ -11,6 +11,7 @@ import Lobby, {
   type LobbyProfile,
   type LobbyRosterCell,
   type LobbyRosterValue,
+  LobbyViewerState,
   TRUSTED_LOBBY_ACTION,
   TRUSTED_LOBBY_SURFACE,
 } from "./main.tsx";
@@ -35,6 +36,35 @@ export default pattern(() => {
   const firstAlexProfile = Writable.of<LobbyProfile>({ name: "Alex" });
   const secondAlexProfile = Writable.of<LobbyProfile>({ name: "Alex" });
   const blankProfile = Writable.of<LobbyProfile>({ name: "   " });
+
+  const viewerRoster = Writable.of<LobbyRosterValue>(DEFAULT_LOBBY_ROSTER);
+  const viewerAdminRegistry = Writable.of<LobbyAdminRegistryValue>(
+    {} as LobbyAdminRegistryValue,
+  );
+  const selectedProfile = Writable.of<LobbyProfile>({
+    initialNameApplied: "Selected Profile",
+  });
+  const selectedViewer = LobbyViewerState({
+    viewerProfile: selectedProfile,
+    roster: viewerRoster,
+    adminRegistry: viewerAdminRegistry,
+  });
+  const missingProfileViewer = LobbyViewerState({
+    roster: viewerRoster,
+    adminRegistry: viewerAdminRegistry,
+  });
+  const selectedAddSelf = addSelfToLobby({
+    roster: viewerRoster,
+    viewerProfile: selectedProfile,
+    viewerName: selectedViewer.myName,
+  });
+  const selectedSetEveryone = commitTrustedLobbyAction({
+    kind: "set-everyone-admin",
+    roster: viewerRoster,
+    adminRegistry: viewerAdminRegistry,
+    viewerProfile: selectedProfile,
+    viewerName: selectedViewer.myName,
+  });
 
   const aliceAddSelf = addSelfToLobby({
     roster,
@@ -111,6 +141,41 @@ export default pattern(() => {
 
   const lobby = Lobby({ roster, adminRegistry } as LobbyInputArg);
 
+  const assert_selected_profile_drives_viewer_state = computed(() =>
+    selectedViewer.myName === "Selected Profile" &&
+    selectedViewer.hasProfile === true &&
+    selectedViewer.hasJoined === false &&
+    selectedViewer.joinLabel === "Join as Selected Profile" &&
+    selectedViewer.joinDisabled === false &&
+    selectedViewer.everyoneIsAdmin === true &&
+    selectedViewer.currentUserIsAdmin === false &&
+    selectedViewer.adminSummary ===
+      "Open fallback: every joined person is an admin." &&
+    selectedViewer.adminBadgeColor === "accent" &&
+    selectedViewer.adminBadgeLabel === "Open" &&
+    missingProfileViewer.myName === "" &&
+    missingProfileViewer.hasProfile === false &&
+    missingProfileViewer.hasJoined === false &&
+    missingProfileViewer.joinLabel === "Choose a profile" &&
+    missingProfileViewer.joinDisabled === true &&
+    missingProfileViewer.currentUserIsAdmin === false
+  );
+  const assert_selected_profile_joined = computed(() =>
+    participantNames(viewerRoster).join(",") === "Selected Profile" &&
+    selectedViewer.hasJoined === true &&
+    selectedViewer.joinLabel === "You’re here" &&
+    selectedViewer.joinDisabled === true &&
+    selectedViewer.currentUserIsAdmin === true
+  );
+  const assert_selected_admin_lockdown = computed(() =>
+    selectedViewer.everyoneIsAdmin === false &&
+    selectedViewer.currentUserIsAdmin === true &&
+    selectedViewer.adminSummary ===
+      "Only explicitly named admins can manage this lobby." &&
+    selectedViewer.adminBadgeColor === "neutral" &&
+    selectedViewer.adminBadgeLabel === "Explicit admins"
+  );
+
   const assert_initial_open_fallback = computed(() =>
     lobbyParticipantsValue(roster).length === 0 &&
     lobbyAdminRolesValue(adminRegistry).length === 0 &&
@@ -145,6 +210,11 @@ export default pattern(() => {
     lobbyAdminRolesValue(adminRegistry).length === 2 &&
     currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
   );
+  const assert_public_output_explicit_policy = computed(() =>
+    lobby.everyoneIsAdmin === false &&
+    lobby.allParticipants[0]?.isAdmin === true &&
+    lobby.allParticipants[1]?.isAdmin === true
+  );
   const assert_bob_removed_alice_and_role = computed(() =>
     participantNames(roster).join(",") === "Bob" &&
     lobbyAdminRolesValue(adminRegistry).length === 1 &&
@@ -178,6 +248,15 @@ export default pattern(() => {
 
   return {
     tests: [
+      { assertion: assert_selected_profile_drives_viewer_state },
+      { action: selectedAddSelf },
+      { assertion: assert_selected_profile_joined },
+      {
+        action: selectedSetEveryone,
+        event: { everyoneIsAdmin: false },
+        trustedUi: trustedLobbyGesture,
+      },
+      { assertion: assert_selected_admin_lockdown },
       { assertion: assert_initial_open_fallback },
       { action: aliceAddSelf },
       { action: aliceAddSelf },
@@ -199,6 +278,9 @@ export default pattern(() => {
       { assertion: assert_non_admin_remove_is_blocked },
       { action: aliceToggleBobAdmin, trustedUi: trustedLobbyGesture },
       { assertion: assert_bob_promoted },
+      { assertion: assert_public_output_explicit_policy },
+      // Materialize rows while explicit-role checks are active.
+      { render: lobby[UI] },
       { action: bobRemoveAlice, trustedUi: trustedLobbyGesture },
       { assertion: assert_bob_removed_alice_and_role },
       { action: bobToggleSelfAdmin, trustedUi: trustedLobbyGesture },

--- a/packages/patterns/lobby/main.test.tsx
+++ b/packages/patterns/lobby/main.test.tsx
@@ -215,6 +215,7 @@ export default pattern(() => {
       { assertion: assert_public_output_count },
       { assertion: assert_public_output_policy },
       { assertion: assert_public_output_is_profile_free },
+      // With no profile wish resolved, this materializes the non-admin branch.
       { render: lobby[UI] },
     ],
     roster,

--- a/packages/patterns/lobby/main.test.tsx
+++ b/packages/patterns/lobby/main.test.tsx
@@ -1,0 +1,223 @@
+import { computed, pattern, UI, Writable } from "commonfabric";
+import Lobby, {
+  addSelfToLobby,
+  commitTrustedLobbyAction,
+  currentLobbyUserIsAdmin,
+  DEFAULT_LOBBY_ROSTER,
+  type LobbyAdminRegistryValue,
+  lobbyAdminRolesValue,
+  lobbyEveryoneIsAdmin,
+  lobbyParticipantsValue,
+  type LobbyProfile,
+  type LobbyRosterCell,
+  type LobbyRosterValue,
+  TRUSTED_LOBBY_ACTION,
+  TRUSTED_LOBBY_SURFACE,
+} from "./main.tsx";
+
+const trustedLobbyGesture = {
+  surface: TRUSTED_LOBBY_SURFACE,
+  action: TRUSTED_LOBBY_ACTION,
+};
+
+type LobbyInputArg = Parameters<typeof Lobby>[0];
+
+const participantNames = (roster: LobbyRosterCell): string[] =>
+  lobbyParticipantsValue(roster).map((participant) => participant.name);
+
+export default pattern(() => {
+  const roster = Writable.of<LobbyRosterValue>(DEFAULT_LOBBY_ROSTER);
+  const adminRegistry = Writable.of<LobbyAdminRegistryValue>(
+    {} as LobbyAdminRegistryValue,
+  );
+  const aliceProfile = Writable.of<LobbyProfile>({ name: "Alice" });
+  const bobProfile = Writable.of<LobbyProfile>({ name: "Bob" });
+  const firstAlexProfile = Writable.of<LobbyProfile>({ name: "Alex" });
+  const secondAlexProfile = Writable.of<LobbyProfile>({ name: "Alex" });
+  const blankProfile = Writable.of<LobbyProfile>({ name: "   " });
+
+  const aliceAddSelf = addSelfToLobby({
+    roster,
+    viewerProfile: aliceProfile,
+    viewerName: "Alice",
+  });
+  const bobJoin = commitTrustedLobbyAction({
+    kind: "join",
+    roster,
+    adminRegistry,
+    viewerProfile: bobProfile,
+    viewerName: "Bob",
+  });
+  const blankJoin = commitTrustedLobbyAction({
+    kind: "join",
+    roster,
+    adminRegistry,
+    viewerProfile: blankProfile,
+    viewerName: "",
+  });
+  const firstAlexJoin = commitTrustedLobbyAction({
+    kind: "join",
+    roster,
+    adminRegistry,
+    viewerProfile: firstAlexProfile,
+    viewerName: "Alex",
+  });
+  const secondAlexJoin = commitTrustedLobbyAction({
+    kind: "join",
+    roster,
+    adminRegistry,
+    viewerProfile: secondAlexProfile,
+    viewerName: "Alex",
+  });
+
+  const aliceSetEveryone = commitTrustedLobbyAction({
+    kind: "set-everyone-admin",
+    roster,
+    adminRegistry,
+    viewerProfile: aliceProfile,
+    viewerName: "Alice",
+  });
+  const bobSetEveryone = commitTrustedLobbyAction({
+    kind: "set-everyone-admin",
+    roster,
+    adminRegistry,
+    viewerProfile: bobProfile,
+    viewerName: "Bob",
+  });
+  const bobRemoveAlice = commitTrustedLobbyAction({
+    kind: "remove",
+    roster,
+    adminRegistry,
+    viewerProfile: bobProfile,
+    viewerName: "Bob",
+    targetProfile: aliceProfile,
+  });
+  const aliceToggleBobAdmin = commitTrustedLobbyAction({
+    kind: "toggle-admin",
+    roster,
+    adminRegistry,
+    viewerProfile: aliceProfile,
+    viewerName: "Alice",
+    targetProfile: bobProfile,
+  });
+  const bobToggleSelfAdmin = commitTrustedLobbyAction({
+    kind: "toggle-admin",
+    roster,
+    adminRegistry,
+    viewerProfile: bobProfile,
+    viewerName: "Bob",
+    targetProfile: bobProfile,
+  });
+
+  const lobby = Lobby({ roster, adminRegistry } as LobbyInputArg);
+
+  const assert_initial_open_fallback = computed(() =>
+    lobbyParticipantsValue(roster).length === 0 &&
+    lobbyAdminRolesValue(adminRegistry).length === 0 &&
+    lobbyEveryoneIsAdmin(adminRegistry) === true
+  );
+  const assert_alice_joined_once = computed(() =>
+    participantNames(roster).join(",") === "Alice" &&
+    currentLobbyUserIsAdmin(aliceProfile, roster, adminRegistry)
+  );
+  const assert_blank_profile_rejected = computed(() =>
+    participantNames(roster).join(",") === "Alice"
+  );
+  const assert_both_are_admin_by_fallback = computed(() =>
+    participantNames(roster).join(",") === "Alice,Bob" &&
+    currentLobbyUserIsAdmin(aliceProfile, roster, adminRegistry) &&
+    currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
+  );
+  const assert_bob_removed_alice_while_open = computed(() =>
+    participantNames(roster).join(",") === "Bob"
+  );
+  const assert_lockdown_bootstraps_alice = computed(() => {
+    const roles = lobbyAdminRolesValue(adminRegistry);
+    return lobbyEveryoneIsAdmin(adminRegistry) === false &&
+      roles.length === 1 &&
+      currentLobbyUserIsAdmin(aliceProfile, roster, adminRegistry) &&
+      !currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry);
+  });
+  const assert_non_admin_remove_is_blocked = computed(() =>
+    participantNames(roster).join(",") === "Bob,Alice"
+  );
+  const assert_bob_promoted = computed(() =>
+    lobbyAdminRolesValue(adminRegistry).length === 2 &&
+    currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
+  );
+  const assert_bob_removed_alice_and_role = computed(() =>
+    participantNames(roster).join(",") === "Bob" &&
+    lobbyAdminRolesValue(adminRegistry).length === 1 &&
+    currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
+  );
+  const assert_last_admin_removal_blocked = computed(() =>
+    lobbyAdminRolesValue(adminRegistry).length === 1 &&
+    currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
+  );
+  const assert_open_policy_restored = computed(() =>
+    lobbyEveryoneIsAdmin(adminRegistry) === true &&
+    currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
+  );
+  const assert_same_name_profiles_both_join = computed(() =>
+    participantNames(roster).filter((name) => name === "Alex").length === 2
+  );
+  const assert_public_output_count = computed(() =>
+    lobby.participantCount === 3 &&
+    lobby.allParticipants.length === 3 &&
+    lobby.participants.length === 3
+  );
+  const assert_public_output_policy = computed(() =>
+    lobby.everyoneIsAdmin === true
+  );
+  const assert_public_output_is_profile_free = computed(() =>
+    lobby.allParticipants[0]?.name === "Bob" &&
+    lobby.allParticipants[1]?.name === "Alex" &&
+    lobby.allParticipants[2]?.name === "Alex" &&
+    lobby.participants[0]?.name === lobby.allParticipants[0]?.name
+  );
+
+  return {
+    tests: [
+      { assertion: assert_initial_open_fallback },
+      { action: aliceAddSelf },
+      { action: aliceAddSelf },
+      { assertion: assert_alice_joined_once },
+      { action: blankJoin, trustedUi: trustedLobbyGesture },
+      { assertion: assert_blank_profile_rejected },
+      { action: bobJoin, trustedUi: trustedLobbyGesture },
+      { assertion: assert_both_are_admin_by_fallback },
+      { action: bobRemoveAlice, trustedUi: trustedLobbyGesture },
+      { assertion: assert_bob_removed_alice_while_open },
+      { action: aliceAddSelf },
+      {
+        action: aliceSetEveryone,
+        event: { everyoneIsAdmin: false },
+        trustedUi: trustedLobbyGesture,
+      },
+      { assertion: assert_lockdown_bootstraps_alice },
+      { action: bobRemoveAlice, trustedUi: trustedLobbyGesture },
+      { assertion: assert_non_admin_remove_is_blocked },
+      { action: aliceToggleBobAdmin, trustedUi: trustedLobbyGesture },
+      { assertion: assert_bob_promoted },
+      { action: bobRemoveAlice, trustedUi: trustedLobbyGesture },
+      { assertion: assert_bob_removed_alice_and_role },
+      { action: bobToggleSelfAdmin, trustedUi: trustedLobbyGesture },
+      { assertion: assert_last_admin_removal_blocked },
+      {
+        action: bobSetEveryone,
+        event: { everyoneIsAdmin: true },
+        trustedUi: trustedLobbyGesture,
+      },
+      { assertion: assert_open_policy_restored },
+      { action: firstAlexJoin, trustedUi: trustedLobbyGesture },
+      { action: secondAlexJoin, trustedUi: trustedLobbyGesture },
+      { assertion: assert_same_name_profiles_both_join },
+      { assertion: assert_public_output_count },
+      { assertion: assert_public_output_policy },
+      { assertion: assert_public_output_is_profile_free },
+      { render: lobby[UI] },
+    ],
+    roster,
+    adminRegistry,
+  };
+});

--- a/packages/patterns/lobby/main.tsx
+++ b/packages/patterns/lobby/main.tsx
@@ -38,6 +38,7 @@ export const TRUSTED_LOBBY_ACTION = "TrustedLobbyAction";
 export const LOBBY_ADMIN_INTEGRITY = "lobby-admin" as const;
 
 export interface LobbyProfile {
+  readonly initialNameApplied?: string;
   readonly name?: string;
   readonly avatar?: string;
   readonly bio?: string;
@@ -118,6 +119,10 @@ export type LobbyAdminRegistryCell = Writable<LobbyAdminRegistryValue>;
 
 const EMPTY_PARTICIPANTS: LobbyParticipant[] = [];
 const EMPTY_PARTICIPANT_VIEWS: LobbyParticipantView[] = [];
+
+export const lobbyProfileDisplayName = (
+  profile: LobbyProfile | undefined,
+): string => (profile?.initialNameApplied ?? profile?.name ?? "").trim();
 
 export const lobbyParticipantsValue = (
   roster: LobbyRosterCell,
@@ -275,7 +280,8 @@ const addLobbyParticipant = (
   profile: LobbyProfileCell | undefined,
   name: string,
 ): void => {
-  const participantName = name.trim() || (profile?.get()?.name ?? "").trim();
+  const participantName = name.trim() ||
+    lobbyProfileDisplayName(profile?.get());
   if (profile === undefined || !participantName) return;
 
   const participants = roster.key("participants");
@@ -324,7 +330,7 @@ export const commitTrustedLobbyAction = handler<
   const participants = roster.key("participants");
   const actorProfile = viewerProfile ?? event?.profile;
   const actorName = viewerName.trim() ||
-    (actorProfile?.get()?.name ?? "").trim();
+    lobbyProfileDisplayName(actorProfile?.get());
 
   if (kind === "join") {
     addLobbyParticipant(roster, actorProfile, actorName);
@@ -482,6 +488,76 @@ interface LobbyParticipantRowOutput {
   [UI]: VNode;
 }
 
+export interface LobbyViewerStateInput {
+  viewerProfile?: LobbyProfileCell;
+  roster: LobbyRosterCell;
+  adminRegistry: LobbyAdminRegistryCell;
+}
+
+export interface LobbyViewerStateOutput {
+  myName: string;
+  hasProfile: boolean;
+  hasJoined: boolean;
+  joinLabel: string;
+  joinDisabled: boolean;
+  everyoneIsAdmin: boolean;
+  currentUserIsAdmin: boolean;
+  adminSummary: string;
+  adminBadgeColor: "accent" | "neutral";
+  adminBadgeLabel: "Open" | "Explicit admins";
+}
+
+/** Viewer-specific state, split from the wish wrapper so it is testable. */
+export const LobbyViewerState = pattern<
+  LobbyViewerStateInput,
+  LobbyViewerStateOutput
+>(({ viewerProfile, roster, adminRegistry }) => {
+  const myName = computed(() => lobbyProfileDisplayName(viewerProfile?.get()));
+  const hasProfile = computed(() => myName !== "");
+  const hasJoined = computed(() =>
+    viewerProfile !== undefined &&
+    lobbyParticipantsValue(roster).some((participant) =>
+      equals(participant.profile, viewerProfile)
+    )
+  );
+  const everyoneIsAdmin = computed(() => lobbyEveryoneIsAdmin(adminRegistry));
+  const currentUserIsAdmin = computed(() =>
+    currentLobbyUserIsAdmin(viewerProfile, roster, adminRegistry)
+  );
+  const joinLabel = computed(() =>
+    hasJoined
+      ? "You’re here"
+      : hasProfile
+      ? `Join as ${myName}`
+      : "Choose a profile"
+  );
+  const joinDisabled = computed(() => !hasProfile || hasJoined);
+  const adminSummary = computed(() =>
+    everyoneIsAdmin
+      ? "Open fallback: every joined person is an admin."
+      : "Only explicitly named admins can manage this lobby."
+  );
+  const adminBadgeColor = computed(() =>
+    everyoneIsAdmin ? "accent" as const : "neutral" as const
+  );
+  const adminBadgeLabel = computed(() =>
+    everyoneIsAdmin ? "Open" as const : "Explicit admins" as const
+  );
+
+  return {
+    myName,
+    hasProfile,
+    hasJoined,
+    joinLabel,
+    joinDisabled,
+    everyoneIsAdmin,
+    currentUserIsAdmin,
+    adminSummary,
+    adminBadgeColor,
+    adminBadgeLabel,
+  };
+});
+
 /** Stable subgraph per participant; keeps row-specific handler bindings calm. */
 const LobbyParticipantRow = pattern<
   LobbyParticipantRowInput,
@@ -580,43 +656,16 @@ const LobbyParticipantRow = pattern<
 const Lobby = pattern<LobbyInput, LobbyOutput>(({ roster, adminRegistry }) => {
   const adminRegistryCell: LobbyAdminRegistryCell = adminRegistry!;
   const profileWish = wish<LobbyProfile>({ query: "#profile" });
-  const profileNameWish = wish<string>({ query: "#profileName" });
   const myProfile = profileWish.result;
-  const myName = computed(() => (profileNameWish.result ?? "").trim());
-  const hasProfile = computed(() => myName !== "");
-  const hasJoined = computed(() =>
-    myProfile !== undefined &&
-    roster.participants.some((participant) =>
-      equals(participant.profile, myProfile)
-    )
-  );
-  const participantCount = roster.participants.length;
-  const everyoneIsAdmin = computed(() =>
-    lobbyEveryoneIsAdmin(adminRegistryCell)
-  );
-  const currentUserIsAdmin = computed(() => {
-    if (myProfile === undefined) return false;
-    const isParticipant = roster.participants.some((participant) =>
-      equals(participant.profile, myProfile)
-    );
-    if (!isParticipant) return false;
-    return everyoneIsAdmin ||
-      lobbyAdminRolesValue(adminRegistryCell).some((role) =>
-        equals(role.subject, myProfile)
-      );
+  const viewerState = LobbyViewerState({
+    viewerProfile: myProfile,
+    roster,
+    adminRegistry: adminRegistryCell,
   });
-  const joinLabel = computed(() =>
-    hasJoined
-      ? "You’re here"
-      : hasProfile
-      ? `Join as ${myName}`
-      : "Choose a profile"
-  );
-  const adminSummary = computed(() =>
-    everyoneIsAdmin
-      ? "Open fallback: every joined person is an admin."
-      : "Only explicitly named admins can manage this lobby."
-  );
+  const myName = viewerState.myName;
+  const participantCount = roster.participants.length;
+  const everyoneIsAdmin = viewerState.everyoneIsAdmin;
+  const currentUserIsAdmin = viewerState.currentUserIsAdmin;
 
   const participants = roster.participants;
   const participantViews = computed(() => {
@@ -695,9 +744,9 @@ const Lobby = pattern<LobbyInput, LobbyOutput>(({ roster, adminRegistry }) => {
                 <cf-button
                   data-ui-action={TRUSTED_LOBBY_ACTION}
                   onClick={addSelf}
-                  disabled={computed(() => !hasProfile || hasJoined)}
+                  disabled={viewerState.joinDisabled}
                 >
-                  {joinLabel}
+                  {viewerState.joinLabel}
                 </cf-button>
               </cf-vstack>
             </cf-card>
@@ -747,16 +796,12 @@ const Lobby = pattern<LobbyInput, LobbyOutput>(({ roster, adminRegistry }) => {
                     >
                       <cf-vstack gap="1">
                         <cf-heading level={3}>Admin access</cf-heading>
-                        <cf-text tone="muted">{adminSummary}</cf-text>
+                        <cf-text tone="muted">
+                          {viewerState.adminSummary}
+                        </cf-text>
                       </cf-vstack>
-                      <cf-badge
-                        color={computed(() =>
-                          everyoneIsAdmin ? "accent" : "neutral"
-                        )}
-                      >
-                        {computed(() =>
-                          everyoneIsAdmin ? "Open" : "Explicit admins"
-                        )}
+                      <cf-badge color={viewerState.adminBadgeColor}>
+                        {viewerState.adminBadgeLabel}
                       </cf-badge>
                     </cf-hstack>
                     <cf-checkbox

--- a/packages/patterns/lobby/main.tsx
+++ b/packages/patterns/lobby/main.tsx
@@ -1,0 +1,785 @@
+import {
+  type AddIntegrity,
+  type Cell,
+  computed,
+  Default,
+  equals,
+  handler,
+  NAME,
+  pattern,
+  type PerSpace,
+  RequiresIntegrity,
+  Stream,
+  type TrustedActionWrite,
+  UI,
+  type VNode,
+  wish,
+  Writable,
+} from "commonfabric";
+import {
+  activeAdminRoleForSubject,
+  adminRegistryEntries,
+  adminRegistryEveryoneIsAdmin,
+  type EmptyAdminRegistryValue,
+} from "../cfc/admin/mod.ts";
+
+/**
+ * A small shared lobby: people join with their Fabric profile, everyone can
+ * see who is present, and trusted admins can remove people or change the admin
+ * policy.
+ *
+ * The empty admin registry intentionally means "everyone is admin". Turning
+ * that fallback off seeds the acting participant as the first explicit admin,
+ * so the lobby cannot be locked accidentally with no administrator.
+ */
+
+export const TRUSTED_LOBBY_SURFACE = "TrustedLobbySurface";
+export const TRUSTED_LOBBY_ACTION = "TrustedLobbyAction";
+export const LOBBY_ADMIN_INTEGRITY = "lobby-admin" as const;
+
+export interface LobbyProfile {
+  readonly name?: string;
+  readonly avatar?: string;
+  readonly bio?: string;
+}
+
+/** Stable participant identity: the contributor's live `#profile` cell. */
+export type LobbyProfileCell = Cell<LobbyProfile>;
+
+export interface LobbyParticipant {
+  readonly profile: LobbyProfileCell;
+  /** Durable fallback label for policy rows if the live profile is offline. */
+  readonly name: string;
+}
+
+export interface LobbyAdminRoleAssignment {
+  readonly subject: LobbyProfileCell;
+  readonly displayName: string;
+}
+
+export type LobbyAdminRole = AddIntegrity<
+  LobbyAdminRoleAssignment,
+  readonly [typeof LOBBY_ADMIN_INTEGRITY]
+>;
+
+/**
+ * Membership stays open for joins. The same trusted handler performs removals,
+ * but its admin decision is enforced against the protected role registry.
+ */
+export type LobbyParticipantList = LobbyParticipant[] | Default<[]>;
+
+export interface LobbyRoster {
+  readonly participants: LobbyParticipantList;
+}
+
+export const DEFAULT_LOBBY_ROSTER = {
+  participants: [] as LobbyParticipantList,
+} satisfies LobbyRoster;
+
+export type LobbyRosterValue =
+  | LobbyRoster
+  | Default<typeof DEFAULT_LOBBY_ROSTER>;
+export type LobbyRosterCell = Writable<LobbyRosterValue>;
+
+export type LobbyAdminList = RequiresIntegrity<
+  TrustedActionWrite<
+    LobbyAdminRole[],
+    typeof commitTrustedLobbyAction,
+    typeof TRUSTED_LOBBY_ACTION,
+    typeof TRUSTED_LOBBY_SURFACE
+  >,
+  readonly [typeof LOBBY_ADMIN_INTEGRITY]
+>;
+
+/** First explicit role minted while leaving the open bootstrap policy. */
+export type LobbyAdminBootstrapRole = AddIntegrity<
+  LobbyAdminRoleAssignment,
+  readonly [typeof LOBBY_ADMIN_INTEGRITY]
+>;
+
+/** Both directions are committed by the role-checking trusted handler. */
+export type LobbyEveryoneAdminFlag = TrustedActionWrite<
+  boolean,
+  typeof commitTrustedLobbyAction,
+  typeof TRUSTED_LOBBY_ACTION,
+  typeof TRUSTED_LOBBY_SURFACE
+>;
+
+export interface LobbyAdminRegistryStoredValue {
+  readonly admins?: LobbyAdminList;
+  readonly bootstrapAdmin?: LobbyAdminBootstrapRole;
+  readonly everyoneIsAdmin?: LobbyEveryoneAdminFlag;
+}
+
+export type LobbyAdminRegistryValue =
+  | LobbyAdminRegistryStoredValue
+  | Default<EmptyAdminRegistryValue>;
+export type LobbyAdminRegistryCell = Writable<LobbyAdminRegistryValue>;
+
+const EMPTY_PARTICIPANTS: LobbyParticipant[] = [];
+const EMPTY_PARTICIPANT_VIEWS: LobbyParticipantView[] = [];
+
+export const lobbyParticipantsValue = (
+  roster: LobbyRosterCell,
+): LobbyParticipant[] => {
+  const stored = roster.get() as LobbyRoster | undefined;
+  const participants = stored?.participants as
+    | readonly LobbyParticipant[]
+    | undefined;
+  return participants?.length ? Array.from(participants) : EMPTY_PARTICIPANTS;
+};
+
+export const lobbyAdminRolesValue = (
+  adminRegistry: LobbyAdminRegistryCell,
+): LobbyAdminRole[] => {
+  const explicitAdmins = adminRegistryEntries<LobbyAdminRole>(adminRegistry);
+  if (explicitAdmins.length > 0) return explicitAdmins;
+
+  const bootstrapAdmin = (
+    adminRegistry.get() as LobbyAdminRegistryStoredValue | undefined
+  )?.bootstrapAdmin;
+  if (bootstrapAdmin === undefined) return [];
+
+  const subject: LobbyProfileCell = adminRegistry.key("bootstrapAdmin").key(
+    "subject",
+  ).resolveAsCell();
+  return [{ ...bootstrapAdmin, subject } as LobbyAdminRole];
+};
+
+export const lobbyEveryoneIsAdmin = (
+  adminRegistry: LobbyAdminRegistryCell,
+): boolean => adminRegistryEveryoneIsAdmin<LobbyAdminRole>(adminRegistry);
+
+export const currentLobbyAdminRole = (
+  profile: LobbyProfileCell | undefined,
+  roster: LobbyRosterCell,
+  adminRegistry: LobbyAdminRegistryCell,
+): LobbyAdminRole | undefined => {
+  if (profile === undefined) return undefined;
+
+  const participant = lobbyParticipantsValue(roster).find((entry) =>
+    equals(entry.profile, profile)
+  );
+  if (participant === undefined) return undefined;
+
+  const explicitRole = activeAdminRoleForSubject(
+    lobbyAdminRolesValue(adminRegistry),
+    profile,
+  );
+  if (explicitRole !== undefined) return explicitRole;
+  if (!lobbyEveryoneIsAdmin(adminRegistry)) return undefined;
+
+  return {
+    subject: profile,
+    displayName: participant.name,
+  } as LobbyAdminRole;
+};
+
+/**
+ * Render-time authorization check. Inside `computed()`, a captured profile
+ * cell is observed as its current object value; `equals(cell, cell.get())`
+ * intentionally preserves the same graph identity for this boolean lookup.
+ */
+export const currentLobbyUserIsAdmin = (
+  profile: LobbyProfileCell | LobbyProfile | undefined,
+  roster: LobbyRosterCell,
+  adminRegistry: LobbyAdminRegistryCell,
+): boolean => {
+  if (profile === undefined) return false;
+  const isParticipant = lobbyParticipantsValue(roster).some((participant) =>
+    equals(participant.profile, profile)
+  );
+  if (!isParticipant) return false;
+  return lobbyEveryoneIsAdmin(adminRegistry) ||
+    lobbyAdminRolesValue(adminRegistry).some((role) =>
+      equals(role.subject, profile)
+    );
+};
+
+export interface LobbyTrustedActionEvent {
+  /** Headless/test seam; real UI bindings supply profile cells as state. */
+  readonly profile?: LobbyProfileCell;
+  readonly everyoneIsAdmin?: boolean;
+  readonly detail?: { readonly checked?: boolean };
+}
+
+export type LobbyTrustedActionKind =
+  | "join"
+  | "remove"
+  | "toggle-admin"
+  | "set-everyone-admin";
+
+export interface LobbyTrustedActionState {
+  readonly kind: LobbyTrustedActionKind;
+  readonly roster: LobbyRosterCell;
+  readonly adminRegistry: LobbyAdminRegistryCell;
+  readonly viewerProfile?: LobbyProfileCell;
+  readonly viewerName: string;
+  readonly targetProfile?: LobbyProfileCell;
+}
+
+export interface LobbyAddSelfState {
+  readonly roster: LobbyRosterCell;
+  readonly viewerProfile?: LobbyProfileCell;
+  readonly viewerName: string;
+}
+
+interface LobbyAdminPolicyChange {
+  readonly admins?: LobbyAdminRole[];
+  readonly bootstrapAdmin?: LobbyAdminRole;
+  readonly everyoneIsAdmin?: boolean;
+}
+
+export const prepareTrustedLobbyAdminChange = (
+  currentAdminRole: LobbyAdminRole | undefined,
+  adminRegistry: LobbyAdminRegistryCell,
+  targetProfile: LobbyProfileCell | undefined,
+  targetName: string | undefined,
+  nextEveryoneIsAdmin?: boolean,
+): LobbyAdminPolicyChange | null => {
+  if (currentAdminRole === undefined) return null;
+
+  const adminRoles = lobbyAdminRolesValue(adminRegistry);
+  if (nextEveryoneIsAdmin !== undefined) {
+    if (nextEveryoneIsAdmin) return { everyoneIsAdmin: true };
+    return {
+      ...(adminRoles.length === 0 ? { bootstrapAdmin: currentAdminRole } : {}),
+      everyoneIsAdmin: false,
+    };
+  }
+
+  if (lobbyEveryoneIsAdmin(adminRegistry)) return null;
+  if (targetProfile === undefined || !targetName) return null;
+
+  const withoutTarget = adminRoles.filter((role) =>
+    !equals(role.subject, targetProfile)
+  );
+  if (withoutTarget.length !== adminRoles.length) {
+    // Never leave an explicit policy with no administrator.
+    return withoutTarget.length === 0 ? null : { admins: withoutTarget };
+  }
+
+  return {
+    admins: [
+      ...adminRoles,
+      {
+        subject: targetProfile,
+        displayName: targetName,
+      } as LobbyAdminRole,
+    ],
+  };
+};
+
+const addLobbyParticipant = (
+  roster: LobbyRosterCell,
+  profile: LobbyProfileCell | undefined,
+  name: string,
+): void => {
+  const participantName = name.trim() || (profile?.get()?.name ?? "").trim();
+  if (profile === undefined || !participantName) return;
+
+  const participants = roster.key("participants");
+  const currentParticipants =
+    (participants.get() as LobbyParticipant[] | undefined) ?? [];
+  const alreadyJoined = currentParticipants.some((participant) =>
+    equals(participant.profile, profile)
+  );
+  if (alreadyJoined) return;
+
+  // The append depends on the identity read above. A read-modify-write is
+  // deliberate: concurrent joins conflict and retry instead of bypassing the
+  // uniqueness check.
+  participants.set([
+    ...currentParticipants,
+    { profile, name: participantName },
+  ]);
+};
+
+/** Agent-facing, no-payload action that joins as the active Fabric profile. */
+export const addSelfToLobby = handler<void, LobbyAddSelfState>((_, {
+  roster,
+  viewerProfile,
+  viewerName,
+}) => {
+  addLobbyParticipant(roster, viewerProfile, viewerName);
+});
+
+/**
+ * One reviewed binding owns the trusted admin writes. The legacy join branch
+ * shares the same open membership operation as `addSelfToLobby`; removal and
+ * policy branches fail closed unless the acting profile is both in the roster
+ * and active under the current admin policy.
+ */
+export const commitTrustedLobbyAction = handler<
+  LobbyTrustedActionEvent,
+  LobbyTrustedActionState
+>((event, {
+  kind,
+  roster,
+  adminRegistry,
+  viewerProfile,
+  viewerName,
+  targetProfile,
+}) => {
+  const participants = roster.key("participants");
+  const actorProfile = viewerProfile ?? event?.profile;
+  const actorName = viewerName.trim() ||
+    (actorProfile?.get()?.name ?? "").trim();
+
+  if (kind === "join") {
+    addLobbyParticipant(roster, actorProfile, actorName);
+    return;
+  }
+
+  const currentAdminRole = currentLobbyAdminRole(
+    actorProfile,
+    roster,
+    adminRegistry,
+  );
+  if (currentAdminRole === undefined) return;
+
+  const selectedProfile = targetProfile ?? event?.profile;
+  const selectedParticipant = selectedProfile === undefined
+    ? undefined
+    : ((participants.get() as LobbyParticipant[] | undefined) ?? []).find(
+      (participant) => equals(participant.profile, selectedProfile),
+    );
+
+  if (kind === "remove") {
+    if (selectedParticipant === undefined) return;
+
+    // Address the stored element itself. Rewriting the whole list would also
+    // rewrite every surviving cross-space profile link.
+    const selectedIndex = (
+      (participants.get() as LobbyParticipant[] | undefined) ?? []
+    ).findIndex((participant) =>
+      equals(participant.profile, selectedParticipant.profile)
+    );
+    if (selectedIndex < 0) return;
+    participants.removeByValue(participants.key(selectedIndex));
+
+    // A removed participant also loses an explicit admin role when another
+    // role remains. The final role is retained to avoid a policy lockout.
+    const adminRoles = lobbyAdminRolesValue(adminRegistry);
+    const remainingAdmins = adminRoles.filter((role) =>
+      !equals(role.subject, selectedParticipant.profile)
+    );
+    if (
+      remainingAdmins.length > 0 &&
+      remainingAdmins.length !== adminRoles.length
+    ) {
+      adminRegistry.key("admins").set(remainingAdmins as LobbyAdminList);
+    }
+    return;
+  }
+
+  const nextEveryoneIsAdmin = kind === "set-everyone-admin"
+    ? event?.everyoneIsAdmin ?? event?.detail?.checked ??
+      !lobbyEveryoneIsAdmin(adminRegistry)
+    : undefined;
+  const nextPolicy = prepareTrustedLobbyAdminChange(
+    currentAdminRole,
+    adminRegistry,
+    selectedParticipant?.profile,
+    selectedParticipant?.name,
+    nextEveryoneIsAdmin,
+  );
+  if (nextPolicy === null) return;
+
+  if (nextPolicy.bootstrapAdmin !== undefined) {
+    adminRegistry.key("bootstrapAdmin").set(
+      nextPolicy.bootstrapAdmin as LobbyAdminBootstrapRole,
+    );
+  }
+  if (nextPolicy.admins !== undefined) {
+    adminRegistry.key("admins").set(nextPolicy.admins as LobbyAdminList);
+  }
+  if (nextPolicy.everyoneIsAdmin !== undefined) {
+    adminRegistry.key("everyoneIsAdmin").set(
+      nextPolicy.everyoneIsAdmin as LobbyEveryoneAdminFlag,
+    );
+  }
+});
+
+export interface LobbyInput {
+  /** Shared durable presence list. */
+  roster?: PerSpace<LobbyRosterValue>;
+  /** Shared durable trusted-admin policy. */
+  adminRegistry?: PerSpace<LobbyAdminRegistryCell>;
+}
+
+export interface LobbyParticipantView {
+  readonly name: string;
+  readonly isAdmin: boolean;
+}
+
+export interface LobbyOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  /** Agent-facing action: add the active Fabric profile, with no payload. */
+  addSelf: Stream<void>;
+  /** Agent-facing, profile-free snapshot for downstream processing. */
+  allParticipants: readonly LobbyParticipantView[];
+  /** Backward-compatible alias for `allParticipants`. */
+  participants: readonly LobbyParticipantView[];
+  participantCount: number;
+  currentUserIsAdmin: boolean;
+  everyoneIsAdmin: boolean;
+  join: Stream<LobbyTrustedActionEvent>;
+  removeParticipant: Stream<LobbyTrustedActionEvent>;
+  toggleParticipantAdmin: Stream<LobbyTrustedActionEvent>;
+  setEveryoneIsAdmin: Stream<LobbyTrustedActionEvent>;
+}
+
+const LOBBY_THEME = {
+  fontFamily: "'Avenir Next', 'Trebuchet MS', sans-serif",
+  borderRadius: "18px",
+  density: "comfortable" as const,
+  colorScheme: "light" as const,
+  colors: {
+    primary: "#174c4a",
+    primaryForeground: "#fffdf7",
+    secondary: "#d9e8df",
+    secondaryForeground: "#173a36",
+    background: "#f3eee3",
+    surface: "#fffaf0",
+    surfaceHover: "#f6efdf",
+    text: "#18312f",
+    textMuted: "#6f7d75",
+    border: "#d9d2c3",
+    borderMuted: "#e9e2d5",
+    accent: "#d97736",
+    accentForeground: "#fffaf0",
+    success: "#2e7d5b",
+    successForeground: "#ffffff",
+    error: "#a33b36",
+    errorForeground: "#ffffff",
+    warning: "#a96b21",
+    warningForeground: "#ffffff",
+  },
+};
+
+const PORCH_LIGHT = {
+  width: "12px",
+  height: "12px",
+  borderRadius: "999px",
+  background: "#d97736",
+  boxShadow: "0 0 0 6px rgba(217, 119, 54, 0.14)",
+  flexShrink: "0",
+};
+
+interface LobbyParticipantRowInput {
+  participant: LobbyParticipant;
+  roster: LobbyRosterCell;
+  adminRegistry: LobbyAdminRegistryCell;
+  viewerProfile?: LobbyProfileCell;
+  viewerName: string;
+  currentUserIsAdmin: boolean;
+  everyoneIsAdmin: boolean;
+}
+
+interface LobbyParticipantRowOutput {
+  [UI]: VNode;
+}
+
+/** Stable subgraph per participant; keeps row-specific handler bindings calm. */
+const LobbyParticipantRow = pattern<
+  LobbyParticipantRowInput,
+  LobbyParticipantRowOutput
+>(({
+  participant,
+  roster,
+  adminRegistry,
+  viewerProfile,
+  viewerName,
+  currentUserIsAdmin,
+  everyoneIsAdmin,
+}) => {
+  const rowIsMe = computed(() =>
+    viewerProfile !== undefined &&
+    equals(participant.profile, viewerProfile)
+  );
+  const rowIsAdmin = computed(() =>
+    everyoneIsAdmin ||
+    lobbyAdminRolesValue(adminRegistry).some((role) =>
+      equals(role.subject, participant.profile)
+    )
+  );
+  const adminLabel = computed(() =>
+    everyoneIsAdmin ? "Admin via everyone" : rowIsAdmin ? "Admin" : "Member"
+  );
+  const adminColor = computed(() => rowIsAdmin ? "accent" : "neutral");
+  const toggleLabel = computed(() =>
+    rowIsAdmin ? "Remove admin" : "Make admin"
+  );
+  const remove = commitTrustedLobbyAction({
+    kind: "remove",
+    roster,
+    adminRegistry,
+    viewerProfile,
+    viewerName,
+    targetProfile: participant.profile,
+  });
+  const toggleAdmin = commitTrustedLobbyAction({
+    kind: "toggle-admin",
+    roster,
+    adminRegistry,
+    viewerProfile,
+    viewerName,
+    targetProfile: participant.profile,
+  });
+
+  return {
+    [UI]: (
+      <cf-card>
+        <cf-hstack
+          slot="content"
+          align="center"
+          justify="between"
+          gap="3"
+          wrap
+        >
+          <cf-hstack align="center" gap="2" wrap>
+            <cf-profile-badge $profile={participant.profile} size="md" />
+            {rowIsMe ? <cf-badge color="primary">You</cf-badge> : null}
+            <cf-badge color={adminColor} variant="outline">
+              {adminLabel}
+            </cf-badge>
+          </cf-hstack>
+          <cf-hstack align="center" gap="2" wrap>
+            <cf-button
+              data-ui-action={TRUSTED_LOBBY_ACTION}
+              color="neutral"
+              variant="outline"
+              size="sm"
+              disabled={computed(() => !currentUserIsAdmin || everyoneIsAdmin)}
+              onClick={toggleAdmin}
+            >
+              {toggleLabel}
+            </cf-button>
+            <cf-button
+              data-ui-action={TRUSTED_LOBBY_ACTION}
+              color="danger"
+              variant="ghost"
+              size="sm"
+              disabled={computed(() => !currentUserIsAdmin)}
+              onClick={remove}
+            >
+              Remove
+            </cf-button>
+          </cf-hstack>
+        </cf-hstack>
+      </cf-card>
+    ),
+  };
+});
+
+const Lobby = pattern<LobbyInput, LobbyOutput>(({ roster, adminRegistry }) => {
+  const adminRegistryCell: LobbyAdminRegistryCell = adminRegistry!;
+  const profileWish = wish<LobbyProfile>({ query: "#profile" });
+  const profileNameWish = wish<string>({ query: "#profileName" });
+  const myProfile = profileWish.result;
+  const myName = computed(() => (profileNameWish.result ?? "").trim());
+  const hasProfile = computed(() => myName !== "");
+  const hasJoined = computed(() =>
+    myProfile !== undefined &&
+    roster.participants.some((participant) =>
+      equals(participant.profile, myProfile)
+    )
+  );
+  const participantCount = roster.participants.length;
+  const everyoneIsAdmin = computed(() =>
+    lobbyEveryoneIsAdmin(adminRegistryCell)
+  );
+  const currentUserIsAdmin = computed(() => {
+    if (myProfile === undefined) return false;
+    const isParticipant = roster.participants.some((participant) =>
+      equals(participant.profile, myProfile)
+    );
+    if (!isParticipant) return false;
+    return everyoneIsAdmin ||
+      lobbyAdminRolesValue(adminRegistryCell).some((role) =>
+        equals(role.subject, myProfile)
+      );
+  });
+  const joinLabel = computed(() =>
+    hasJoined
+      ? "You’re here"
+      : hasProfile
+      ? `Join as ${myName}`
+      : "Choose a profile"
+  );
+  const adminSummary = computed(() =>
+    everyoneIsAdmin
+      ? "Open fallback: every joined person is an admin."
+      : currentUserIsAdmin
+      ? "Only explicitly named admins can manage this lobby."
+      : "This lobby is managed by explicit admins."
+  );
+
+  const participants = roster.participants;
+  const participantViews = computed(() => {
+    const values = roster.participants;
+    if (values.length === 0) return EMPTY_PARTICIPANT_VIEWS;
+    const roles = lobbyAdminRolesValue(adminRegistryCell);
+    return values.map((participant) => ({
+      name: participant.name,
+      isAdmin: everyoneIsAdmin ||
+        roles.some((role) => equals(role.subject, participant.profile)),
+    }));
+  });
+
+  const actionState = {
+    roster,
+    adminRegistry: adminRegistryCell,
+    viewerProfile: myProfile,
+    viewerName: myName,
+  };
+  const addSelf = addSelfToLobby({
+    roster,
+    viewerProfile: myProfile,
+    viewerName: myName,
+  });
+  const join = commitTrustedLobbyAction({ kind: "join", ...actionState });
+  const removeParticipant = commitTrustedLobbyAction({
+    kind: "remove",
+    ...actionState,
+  });
+  const toggleParticipantAdmin = commitTrustedLobbyAction({
+    kind: "toggle-admin",
+    ...actionState,
+  });
+  const setEveryoneIsAdmin = commitTrustedLobbyAction({
+    kind: "set-everyone-admin",
+    ...actionState,
+  });
+
+  return {
+    [NAME]: "Lobby",
+    [UI]: (
+      <cf-theme theme={LOBBY_THEME}>
+        <cf-screen
+          data-ui-pattern={TRUSTED_LOBBY_SURFACE}
+          data-ui-event-integrity={TRUSTED_LOBBY_SURFACE}
+        >
+          <cf-hstack slot="header" align="center" justify="between" gap="3">
+            <cf-hstack align="center" gap="3">
+              <span style={PORCH_LIGHT} aria-hidden="true" />
+              <cf-vstack gap="0">
+                <cf-heading level={2}>Lobby</cf-heading>
+                <cf-text variant="caption" tone="muted">
+                  A shared place to arrive
+                </cf-text>
+              </cf-vstack>
+            </cf-hstack>
+            <cf-badge color="accent" variant="outline">
+              {participantCount} here
+            </cf-badge>
+          </cf-hstack>
+
+          <cf-vstack
+            gap="4"
+            padding="4"
+            style={{ width: "min(720px, 100%)", margin: "0 auto" }}
+          >
+            <cf-card>
+              <cf-vstack slot="content" gap="3">
+                <cf-vstack gap="1">
+                  <cf-heading level={3}>Your Fabric profile</cf-heading>
+                  <cf-text tone="muted">
+                    Pick the identity you want to bring into this lobby.
+                  </cf-text>
+                </cf-vstack>
+                {profileWish[UI]}
+                <cf-button
+                  data-ui-action={TRUSTED_LOBBY_ACTION}
+                  onClick={addSelf}
+                  disabled={computed(() => !hasProfile || hasJoined)}
+                >
+                  {joinLabel}
+                </cf-button>
+              </cf-vstack>
+            </cf-card>
+
+            <cf-vstack gap="2">
+              <cf-hstack align="center" justify="between" gap="2">
+                <cf-heading level={3}>Who’s here</cf-heading>
+                <cf-text variant="caption" tone="muted">
+                  Live Fabric identities
+                </cf-text>
+              </cf-hstack>
+
+              {participantCount === 0
+                ? (
+                  <cf-card>
+                    <cf-empty-state message="No one is here yet. Choose your profile and be the first to join.">
+                      <span slot="icon">○</span>
+                    </cf-empty-state>
+                  </cf-card>
+                )
+                : (
+                  <cf-vstack gap="2">
+                    {participants.map((participant) => (
+                      <LobbyParticipantRow
+                        participant={participant}
+                        roster={roster}
+                        adminRegistry={adminRegistryCell}
+                        viewerProfile={myProfile}
+                        viewerName={myName}
+                        currentUserIsAdmin={currentUserIsAdmin}
+                        everyoneIsAdmin={everyoneIsAdmin}
+                      />
+                    ))}
+                  </cf-vstack>
+                )}
+            </cf-vstack>
+
+            <cf-card>
+              <cf-vstack slot="content" gap="3">
+                <cf-hstack align="start" justify="between" gap="3" wrap>
+                  <cf-vstack gap="1">
+                    <cf-heading level={3}>Admin access</cf-heading>
+                    <cf-text tone="muted">{adminSummary}</cf-text>
+                  </cf-vstack>
+                  <cf-badge
+                    color={computed(() =>
+                      everyoneIsAdmin ? "accent" : "neutral"
+                    )}
+                  >
+                    {computed(() =>
+                      everyoneIsAdmin ? "Open" : "Explicit admins"
+                    )}
+                  </cf-badge>
+                </cf-hstack>
+                <cf-checkbox
+                  data-ui-action={TRUSTED_LOBBY_ACTION}
+                  checked={everyoneIsAdmin}
+                  disabled={computed(() => !currentUserIsAdmin)}
+                  onClick={setEveryoneIsAdmin}
+                >
+                  Everyone is admin
+                </cf-checkbox>
+                <cf-text variant="caption" tone="muted">
+                  This is on by default when no explicit admins exist. Turning
+                  it off keeps you as the first admin.
+                </cf-text>
+              </cf-vstack>
+            </cf-card>
+          </cf-vstack>
+        </cf-screen>
+      </cf-theme>
+    ),
+    addSelf,
+    allParticipants: participantViews,
+    participants: participantViews,
+    participantCount,
+    currentUserIsAdmin,
+    everyoneIsAdmin,
+    join,
+    removeParticipant,
+    toggleParticipantAdmin,
+    setEveryoneIsAdmin,
+  };
+});
+
+export default Lobby;

--- a/packages/patterns/lobby/main.tsx
+++ b/packages/patterns/lobby/main.tsx
@@ -546,28 +546,31 @@ const LobbyParticipantRow = pattern<
               {adminLabel}
             </cf-badge>
           </cf-hstack>
-          <cf-hstack align="center" gap="2" wrap>
-            <cf-button
-              data-ui-action={TRUSTED_LOBBY_ACTION}
-              color="neutral"
-              variant="outline"
-              size="sm"
-              disabled={computed(() => !currentUserIsAdmin || everyoneIsAdmin)}
-              onClick={toggleAdmin}
-            >
-              {toggleLabel}
-            </cf-button>
-            <cf-button
-              data-ui-action={TRUSTED_LOBBY_ACTION}
-              color="danger"
-              variant="ghost"
-              size="sm"
-              disabled={computed(() => !currentUserIsAdmin)}
-              onClick={remove}
-            >
-              Remove
-            </cf-button>
-          </cf-hstack>
+          {currentUserIsAdmin
+            ? (
+              <cf-hstack align="center" gap="2" wrap>
+                <cf-button
+                  data-ui-action={TRUSTED_LOBBY_ACTION}
+                  color="neutral"
+                  variant="outline"
+                  size="sm"
+                  disabled={everyoneIsAdmin}
+                  onClick={toggleAdmin}
+                >
+                  {toggleLabel}
+                </cf-button>
+                <cf-button
+                  data-ui-action={TRUSTED_LOBBY_ACTION}
+                  color="danger"
+                  variant="ghost"
+                  size="sm"
+                  onClick={remove}
+                >
+                  Remove
+                </cf-button>
+              </cf-hstack>
+            )
+            : null}
         </cf-hstack>
       </cf-card>
     ),
@@ -612,9 +615,7 @@ const Lobby = pattern<LobbyInput, LobbyOutput>(({ roster, adminRegistry }) => {
   const adminSummary = computed(() =>
     everyoneIsAdmin
       ? "Open fallback: every joined person is an admin."
-      : currentUserIsAdmin
-      ? "Only explicitly named admins can manage this lobby."
-      : "This lobby is managed by explicit admins."
+      : "Only explicitly named admins can manage this lobby."
   );
 
   const participants = roster.participants;
@@ -734,37 +735,45 @@ const Lobby = pattern<LobbyInput, LobbyOutput>(({ roster, adminRegistry }) => {
                 )}
             </cf-vstack>
 
-            <cf-card>
-              <cf-vstack slot="content" gap="3">
-                <cf-hstack align="start" justify="between" gap="3" wrap>
-                  <cf-vstack gap="1">
-                    <cf-heading level={3}>Admin access</cf-heading>
-                    <cf-text tone="muted">{adminSummary}</cf-text>
+            {currentUserIsAdmin
+              ? (
+                <cf-card>
+                  <cf-vstack slot="content" gap="3">
+                    <cf-hstack
+                      align="start"
+                      justify="between"
+                      gap="3"
+                      wrap
+                    >
+                      <cf-vstack gap="1">
+                        <cf-heading level={3}>Admin access</cf-heading>
+                        <cf-text tone="muted">{adminSummary}</cf-text>
+                      </cf-vstack>
+                      <cf-badge
+                        color={computed(() =>
+                          everyoneIsAdmin ? "accent" : "neutral"
+                        )}
+                      >
+                        {computed(() =>
+                          everyoneIsAdmin ? "Open" : "Explicit admins"
+                        )}
+                      </cf-badge>
+                    </cf-hstack>
+                    <cf-checkbox
+                      data-ui-action={TRUSTED_LOBBY_ACTION}
+                      checked={everyoneIsAdmin}
+                      onClick={setEveryoneIsAdmin}
+                    >
+                      Everyone is admin
+                    </cf-checkbox>
+                    <cf-text variant="caption" tone="muted">
+                      This is on by default when no explicit admins exist.
+                      Turning it off keeps you as the first admin.
+                    </cf-text>
                   </cf-vstack>
-                  <cf-badge
-                    color={computed(() =>
-                      everyoneIsAdmin ? "accent" : "neutral"
-                    )}
-                  >
-                    {computed(() =>
-                      everyoneIsAdmin ? "Open" : "Explicit admins"
-                    )}
-                  </cf-badge>
-                </cf-hstack>
-                <cf-checkbox
-                  data-ui-action={TRUSTED_LOBBY_ACTION}
-                  checked={everyoneIsAdmin}
-                  disabled={computed(() => !currentUserIsAdmin)}
-                  onClick={setEveryoneIsAdmin}
-                >
-                  Everyone is admin
-                </cf-checkbox>
-                <cf-text variant="caption" tone="muted">
-                  This is on by default when no explicit admins exist. Turning
-                  it off keeps you as the first admin.
-                </cf-text>
-              </cf-vstack>
-            </cf-card>
+                </cf-card>
+              )
+              : null}
           </cf-vstack>
         </cf-screen>
       </cf-theme>

--- a/packages/patterns/lobby/multi-user.test.tsx
+++ b/packages/patterns/lobby/multi-user.test.tsx
@@ -1,0 +1,162 @@
+/// <cts-enable />
+import { computed, multiUserTest, pattern, Writable } from "commonfabric";
+import {
+  addSelfToLobby,
+  commitTrustedLobbyAction,
+  currentLobbyUserIsAdmin,
+  DEFAULT_LOBBY_ROSTER,
+  type LobbyAdminRegistryCell,
+  type LobbyAdminRegistryValue,
+  type LobbyProfile,
+  type LobbyProfileCell,
+  type LobbyRoster,
+  type LobbyRosterCell,
+  type LobbyRosterValue,
+  TRUSTED_LOBBY_ACTION,
+  TRUSTED_LOBBY_SURFACE,
+} from "./main.tsx";
+
+const trustedLobbyGesture = {
+  surface: TRUSTED_LOBBY_SURFACE,
+  action: TRUSTED_LOBBY_ACTION,
+};
+
+export interface LobbyMultiUserSetup {
+  roster: LobbyRosterCell;
+  adminRegistry: LobbyAdminRegistryCell;
+  aliceProfile: LobbyProfileCell;
+  bobProfile: LobbyProfileCell;
+}
+
+export const setup = pattern<Record<string, never>, LobbyMultiUserSetup>(() => {
+  const roster = Writable.of<LobbyRosterValue>(DEFAULT_LOBBY_ROSTER);
+  const adminRegistry = Writable.of<LobbyAdminRegistryValue>(
+    {} as LobbyAdminRegistryValue,
+  );
+  const aliceProfile = Writable.of<LobbyProfile>({ name: "Alice" });
+  const bobProfile = Writable.of<LobbyProfile>({ name: "Bob" });
+  return { roster, adminRegistry, aliceProfile, bobProfile };
+});
+
+export const alice = pattern<{ setup: LobbyMultiUserSetup }>(({ setup }) => {
+  const addSelf = addSelfToLobby({
+    roster: setup.roster,
+    viewerProfile: setup.aliceProfile,
+    viewerName: "Alice",
+  });
+  const closeOpenFallback = commitTrustedLobbyAction({
+    kind: "set-everyone-admin",
+    roster: setup.roster,
+    adminRegistry: setup.adminRegistry,
+    viewerProfile: setup.aliceProfile,
+    viewerName: "Alice",
+  });
+  const promoteBob = commitTrustedLobbyAction({
+    kind: "toggle-admin",
+    roster: setup.roster,
+    adminRegistry: setup.adminRegistry,
+    viewerProfile: setup.aliceProfile,
+    viewerName: "Alice",
+    targetProfile: setup.bobProfile,
+  });
+
+  const assert_sees_both = computed(() => {
+    const roster = setup.roster.get() as LobbyRoster | undefined;
+    return roster?.participants?.[0]?.name === "Alice" &&
+      roster?.participants?.[1]?.name === "Bob";
+  });
+  const assert_alice_is_bootstrap_admin = computed(() =>
+    currentLobbyUserIsAdmin(
+      setup.aliceProfile,
+      setup.roster,
+      setup.adminRegistry,
+    )
+  );
+  const assert_only_bob_remains = computed(() => {
+    const roster = setup.roster.get() as LobbyRoster | undefined;
+    return roster?.participants?.length === 1 &&
+      roster?.participants?.[0]?.name === "Bob";
+  });
+
+  return {
+    tests: [
+      { action: addSelf },
+      { label: "alice-joined" },
+      { await: "bob-joined" },
+      { assertion: assert_sees_both },
+      {
+        action: closeOpenFallback,
+        event: { everyoneIsAdmin: false },
+        trustedUi: trustedLobbyGesture,
+      },
+      { assertion: assert_alice_is_bootstrap_admin },
+      { label: "fallback-closed" },
+      { await: "bob-remove-blocked" },
+      { action: promoteBob, trustedUi: trustedLobbyGesture },
+      { label: "bob-promoted" },
+      { await: "alice-removed" },
+      { assertion: assert_only_bob_remains },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: LobbyMultiUserSetup }>(({ setup }) => {
+  const addSelf = addSelfToLobby({
+    roster: setup.roster,
+    viewerProfile: setup.bobProfile,
+    viewerName: "Bob",
+  });
+  const removeAlice = commitTrustedLobbyAction({
+    kind: "remove",
+    roster: setup.roster,
+    adminRegistry: setup.adminRegistry,
+    viewerProfile: setup.bobProfile,
+    viewerName: "Bob",
+    targetProfile: setup.aliceProfile,
+  });
+
+  const assert_bob_is_not_admin = computed(() =>
+    !currentLobbyUserIsAdmin(
+      setup.bobProfile,
+      setup.roster,
+      setup.adminRegistry,
+    )
+  );
+  const assert_remove_was_blocked = computed(() => {
+    const roster = setup.roster.get() as LobbyRoster | undefined;
+    return roster?.participants?.[0]?.name === "Alice" &&
+      roster?.participants?.[1]?.name === "Bob";
+  });
+  const assert_bob_is_admin = computed(() =>
+    currentLobbyUserIsAdmin(
+      setup.bobProfile,
+      setup.roster,
+      setup.adminRegistry,
+    )
+  );
+  const assert_only_bob_remains = computed(() => {
+    const roster = setup.roster.get() as LobbyRoster | undefined;
+    return roster?.participants?.length === 1 &&
+      roster?.participants?.[0]?.name === "Bob";
+  });
+
+  return {
+    tests: [
+      { await: "alice-joined" },
+      { action: addSelf },
+      { label: "bob-joined" },
+      { await: "fallback-closed" },
+      { assertion: assert_bob_is_not_admin },
+      { action: removeAlice, trustedUi: trustedLobbyGesture },
+      { assertion: assert_remove_was_blocked },
+      { label: "bob-remove-blocked" },
+      { await: "bob-promoted" },
+      { assertion: assert_bob_is_admin },
+      { action: removeAlice, trustedUi: trustedLobbyGesture },
+      { assertion: assert_only_bob_remains },
+      { label: "alice-removed" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });


### PR DESCRIPTION
## Summary

- add a simple multiplayer lobby backed by each participant's live Fabric profile
- use the trusted admin registry flow, including the default everyone-is-admin fallback and explicit-admin bootstrap
- let admins promote, demote, and remove participants
- expose `addSelf` and `allParticipants` for agent-driven membership and downstream processing
- add focused single-runtime and multiplayer coverage plus the pattern catalog entry

## User impact

People can join a shared lobby with their Fabric identity and see everyone present. Admin controls remain safe under both the open fallback and explicit-admin modes, while agents get a no-payload self-join action and a profile-free participant list.

## Validation

- `deno task cf check packages/patterns/lobby/main.tsx`
- `deno task cf test packages/patterns/lobby/ --root packages/patterns` — 22 passed
- `deno lint packages/patterns/lobby/main.tsx packages/patterns/lobby/main.test.tsx packages/patterns/lobby/multi-user.test.tsx`
- `deno fmt --check packages/patterns/lobby/main.tsx packages/patterns/lobby/main.test.tsx packages/patterns/lobby/multi-user.test.tsx packages/patterns/index.md`
- `deno task check-docs` — 510 code blocks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared multiplayer lobby where people join with their live Fabric profile, see who’s here, and trusted admins can manage participants. Members no longer see admin controls.

- **New Features**
  - New pattern at `packages/patterns/lobby/main.tsx` with per-space `roster` and `adminRegistry`.
  - Everyone-is-admin by default; turning it off bootstraps the acting user as the first explicit admin.
  - Trusted actions on `TRUSTED_LOBBY_SURFACE`/`TRUSTED_LOBBY_ACTION`: `join`, `remove`, `toggle-admin`, `set-everyone-admin`.
  - Agent APIs: `addSelf`, profile-free `allParticipants`, plus `participantCount`, `currentUserIsAdmin`, `everyoneIsAdmin`. Added `LobbyViewerState` for join/admin UI labels and tests covering profile and admin states, plus a catalog entry in `packages/patterns/index.md`.

- **Bug Fixes**
  - Hide admin controls from non-admin members in the lobby UI.

<sup>Written for commit 5f337c7644a517c63ae56603e5f7e698880e1aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

