### PR TITLE
fix(html): reconcile Cell elements in direct array roots

### DIFF
--- a/packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
@@ -1,0 +1,8 @@
+import { computed, pattern } from "commonfabric";
+
+export default pattern(() => ({
+  tests: [
+    { render: [null, undefined, "text", 1, true, false, []] },
+    { assertion: computed(() => true) },
+  ],
+}));

--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -96,6 +96,15 @@ describe(
       expect(passed).toBe(1);
     });
 
+    it("accepts a direct-array VDOM root", async () => {
+      const { failed, passed } = await runTests(
+        fixture("direct-array-render.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBe(0);
+      expect(passed).toBe(1);
+    });
+
     it("preserves the headless default when no render step is present", async () => {
       const result = await withCoverage("no-render.test.tsx");
       expect(result.lateHitCount).toBe(0);

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -2822,26 +2822,11 @@ export class WorkerReconciler {
     };
     addCancel(() => this.cleanupNodeHandlers(state));
 
-    // Render each child and insert it
-    for (const childNode of nodes) {
-      const childState = this.renderNode(
-        ctx,
-        childNode,
-        new Set(visited),
-        policy,
-      );
-      if (childState) {
-        addCancel(childState.cancel);
-        this.queueOps([
-          {
-            op: "insert-child",
-            parentId: nodeId,
-            childId: childState.nodeId,
-            beforeId: null,
-          },
-        ]);
-      }
-    }
+    // Array items use the same Cell-aware child path as VNode children.
+    // rendererVDOMSchema projects array items as Cells, including at the root,
+    // so handing them directly to renderNode would violate its invariant that
+    // Cell children have already passed through renderCellChild.
+    addCancel(this.bindChildren(ctx, state, nodes, visited, policy));
 
     return state;
   }

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -73,6 +73,57 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
   }
 
   await t.step(
+    "renders, updates, and cleans up Cells in a direct array root",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+      const textCell = new MockCell("before");
+      const nestedTextCell = new MockCell("nested before");
+      const nestedArrayCell = new MockCell([nestedTextCell]);
+      const rootCell = new MockCell([textCell, nestedArrayCell]);
+
+      const cancel = reconciler.mount(
+        rootCell as unknown as Cell<unknown>,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const initialText = collector.getOpsOfType("create-text");
+      assertEquals(
+        initialText.some((op) => "text" in op && op.text === "before"),
+        true,
+      );
+      assertEquals(
+        initialText.some((op) => "text" in op && op.text === "nested before"),
+        true,
+      );
+
+      collector.clear();
+      textCell.set("after");
+      nestedTextCell.set("nested after");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updatedText = collector.getOpsOfType("update-text");
+      assertEquals(
+        updatedText.some((op) => "text" in op && op.text === "after"),
+        true,
+      );
+      assertEquals(
+        updatedText.some((op) => "text" in op && op.text === "nested after"),
+        true,
+      );
+
+      cancel();
+      collector.clear();
+      textCell.set("ignored");
+      nestedTextCell.set("nested ignored");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assertEquals(collector.getOps(), []);
+    },
+  );
+
+  await t.step(
     "updates child Cell VNode in place when tag matches",
     async () => {
       const collector = createOpsCollector();


### PR DESCRIPTION
## Why

The explicit `cf test` UI-demand work in [#4715](https://github.com/commontoolsinc/labs/pull/4715) intentionally accepts arrays as renderable roots, but a direct-array root currently crosses an unsupported reactive representation boundary.

This was discovered during closeout and is recorded on the original [Estuary Topic](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:biRPdv6-A4QZiP7i_8W0LhfOe3VJzFYhKolzLd60yd0).

A step such as:

```tsx
{ render: [null, undefined, "text", 1, true, false, []] }
```

passes the harness's root validation, then fails inside `WorkerReconciler` with:

```text
Unexpected Cell in renderNode - this code path was thought to be unreachable.
Please report this issue.
```

This draft deliberately adds the desired contract as a **red test without a fix**, so we can agree on the intended array-root contract and ownership of the normalization before changing runtime behavior.

## What this PR adds

- A minimal pattern fixture whose render step is a direct array of otherwise-supported primitive roots.
- One CLI contract assertion that expects the pattern test to pass.

There are no production-code changes.

## Confirmed mechanism

1. `isRenderableRoot()` pulls and recursively validates the plain-looking array, so validation succeeds.
2. The harness mounts `vdomCell.asSchema(rendererVDOMSchema)`, not the already-pulled value.
3. `rendererVDOMSchema` declares array items with `asCell: ["cell"]`, so the reconciler receives an array whose elements are Cells.
4. `renderArrayAsFragment()` iterates those elements and calls `renderNode()` directly.
5. `renderNode()` rejects a Cell as an internal invariant: ordinary VNode children are expected to use the Cell-aware `renderChild() -> renderCellChild()` path.

That is why separate primitive roots and ordinary VNode roots pass while the same primitives inside a direct root array fail.

## Plausible fix directions

### 1. Make array-fragment reconciliation Cell-aware — recommended

Route direct-array elements through the same Cell-aware child machinery used by VNode children, or provide an equivalent adapter within `renderArrayAsFragment()`.

Why I recommend this:

- The renderer schema already explicitly models arrays and Cell-projected array items.
- It fixes the canonical renderer boundary rather than teaching `cf test` a renderer-specific normalization rule.
- It preserves reactivity, cancellation, policy/label checks, and parity between production mounting and headless test mounting.

The implementation needs focused coverage for fragment insertion/order, cancellation, nested arrays, reactive element updates, and single-/multi-user harnesses.

### 2. Normalize or unwrap nested array Cells in the test harness

This is localized to the new feature, but risks making `cf test` subtly unlike production rendering. Eager pulls may also collapse reactivity or bypass Cell-level policy/label handling, and the harness would duplicate renderer responsibilities.

### 3. Reject direct-array roots at the harness boundary

This is the smallest and safest behavioral change if direct arrays are not intended public input. It would require narrowing `isRenderableRoot()`, the public error text, and the testing documentation so the harness stops advertising array support.

The downside is that the renderer schema currently describes arrays as legitimate render nodes, so rejection would formalize a narrower test-harness contract rather than resolving the underlying renderer/schema mismatch.

### 4. Change schema projection for root arrays

Removing `asCell` projection from array items could avoid the immediate invariant, but the same schema is used recursively for VDOM children. Distinguishing root-array semantics from nested child semantics would likely require a new schema boundary and could have broader reactivity consequences. I do not recommend starting here.

## Desired outcome

Either:

- this test becomes green because direct arrays are supported through the canonical Cell-aware reconciliation path; or
- consensus is that arrays are unsupported, and this test is replaced by a precise public rejection contract with matching validation and docs.

In either case, callers should not receive an internal “thought to be unreachable” renderer error.

## Validation

```text
deno check packages/cli/test/test-runner-render-step.test.ts \
  packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
# passes
```

Focused contract suite:

```text
deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env \
  --allow-net=127.0.0.1 --no-check \
  packages/cli/test/test-runner-render-step.test.ts \
  --filter 'cf test UI demand'
```

All existing cases pass. The new `accepts a direct-array VDOM root` case is the sole failure, with the expected `Unexpected Cell in renderNode` error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support direct-array VDOM roots by making the HTML reconciler handle Cell array roots, and add tests to lock the contract. Fixes the “Unexpected Cell in renderNode” crash seen with array roots in `cf test`.

- **Bug Fixes**
  - In `packages/html`, route array items through `bindChildren(...)` so Cell-projected items use the Cell-aware child path.
  - Covers nested arrays, updates, and cleanup to preserve reactivity and proper teardown.

- **Tests**
  - In `packages/cli`, add `direct-array-render.test.tsx` and a test that expects passing for a direct-array root.
  - In `packages/html`, add a unit test ensuring array-root Cells render, update, and clean up correctly.

<sup>Written for commit 8bb96d2a9ac56b446c95284e6462a5b270553481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

