### PR TITLE
fuse: add NFS cache tuning mount flags and default FUSE-T mounts to a one-second attribute cache

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -44,6 +44,7 @@ was last checked against the code.
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
+| [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
 Removed or never-shipped flags that documentation elsewhere still references are
 recorded in [Appendix A](#appendix-a-removed-and-never-shipped-flags). Toggles
@@ -584,6 +585,54 @@ the per-epic implementation notes).
 - **Path to removal.** Land exchange resolution so the ceiling stops
   over-blocking, turn it on by default, and then remove the localStorage toggle
   and make the ceiling unconditional.
+
+## Category 5: Fuse mount cache tuning
+
+### `fuseNfsCacheTuning`
+
+- **Toggle via.** `cf fuse mount --attrcache-timeout <seconds>` or
+  `cf fuse mount --noattrcache` (mutually exclusive). Both plumb through the
+  background supervisor and the compiled binary's hidden
+  `fuse-daemon`/`fuse-supervisor` subcommands to `-o attrcache-timeout=<n>` /
+  `-o noattrcache` in the args handed to FUSE-T's `fuse_mount`
+  ([`packages/fuse/mount-options.ts`](../../packages/fuse/mount-options.ts),
+  `buildMountFuseArgs`). The options are applied only when the loaded
+  provider is FUSE-T; Linux and macFUSE mounts accept and ignore the flags,
+  matching `--allow-other`'s Linux-only handling in reverse.
+- **Added by.** Ian Hickson (noattrcache evaluation following #4642/#4654).
+- **Purpose.** FUSE-T serves mounts through the macOS NFS client and ignores
+  the entry/attribute timeouts the filesystem returns, so the client's
+  age-based 5-60 second caching defaults apply: a daemon-side `ENOENT` seeds
+  a negative name cache entry served without daemon round-trips, and cached
+  directory listings are served stale. Measured against a live space on
+  FUSE-T 1.2.7 / macOS 26 (2026-07-14, recorded in
+  [the evaluation](../history/packages/fuse/noattrcache-mount-option-evaluation.md)):
+  untuned mounts showed stale-`NotFound` windows of 3.2-56.3 s and listing
+  staleness of 0.8-53.4 s, while `attrcache-timeout=1` bounded both below
+  half a second at no measurable stat cost (about 2 microseconds per stat,
+  cache-served) and with zero read errors through sustained rebuild storms.
+  `noattrcache` on FUSE-T 1.2.x maps to the NFS `nonegnamecache` flag only;
+  it left 7.5-29 s windows and is kept as a diagnostic dial.
+- **Current default and planned end state.** The flag value is a whole
+  number of seconds. When neither flag is given, cf itself adds
+  `-o attrcache-timeout=1` (one second) to every FUSE-T mount — the default
+  lives in cf's `buildMountFuseArgs`, not in FUSE-T, whose own default is
+  the untuned NFS client caching. `--attrcache-timeout 0` turns cf's
+  addition off and leaves that untuned caching in place. Separately, the
+  `cf exec` listing-recheck delay in
+  [`packages/cli/lib/exec.ts`](../../packages/cli/lib/exec.ts)
+  (`DIR_LISTING_RECHECK_DELAY_MS`, 3.5 seconds) remains as the backstop for
+  untuned, macFUSE, and pre-1.0.29 FUSE-T mounts. That delay is sized for
+  the untuned client's multi-second listing staleness; once field use
+  confirms most mounts run with the one-second cache bound, the delay can
+  be reduced to just over one second to match.
+- **Status on 2026-07-14.** Implemented, on by default for FUSE-T mounts.
+  Validated by a 5-minute live-space soak (1296 daemon-side writes, ~2790
+  reads per probe target, p99 read latency 4 ms, worst transient 110 ms,
+  zero stale-negative false positives, daemon CPU ≤3%, no livelock).
+- **Path to removal.** Fold the default into permanent documented behavior
+  and shrink the exec.ts recheck delay, or retire the NFS dial entirely if
+  FUSE-T's FSKit backend (macOS 26+) replaces the NFS backend.
 
 ---
 

--- a/docs/history/packages/fuse/noattrcache-mount-option-evaluation.md
+++ b/docs/history/packages/fuse/noattrcache-mount-option-evaluation.md
@@ -1,0 +1,189 @@
+---
+status: historical
+created: 2026-07-13
+archived: 2026-07-14
+reason: "Point-in-time record of the evaluation and live-stack measurements behind defaulting FUSE-T mounts to attrcache-timeout=1"
+---
+
+# Evaluation: mounting cf FUSE filesystems with FUSE-T's `noattrcache`
+
+This records the evaluation of whether cf fuse mounts on macOS should use
+FUSE-T's `-o noattrcache` mount option (or equivalent `actimeo` tuning) by
+default, behind a flag, or not at all. The evaluation ran in two stages. The
+first stage (2026-07-13, no FUSE-T available on the working machine) decided
+on opt-in flags. The second stage (2026-07-14, FUSE-T 1.2.7 installed,
+measurements against a live space) revised that: **FUSE-T mounts default to
+`attrcache-timeout=1`**, with `--attrcache-timeout 0` restoring untuned
+caching and `--noattrcache` kept as a diagnostic dial. The live registry
+entry is `docs/development/EXPERIMENTAL_OPTIONS.md`, `fuseNfsCacheTuning`.
+
+## Background
+
+PR #4642 replaced `cf exec`'s mounted-callable stat poll with a single stat
+plus a parent-directory-listing fallback and a bounded recheck delay
+(`DIR_LISTING_RECHECK_DELAY_MS`, 3.5 s, in `packages/cli/lib/exec.ts`). The
+experiments recorded in PR #4654's verification document
+(`CACHE_SEMANTICS_VERIFICATION.md` on that branch; FUSE-T 1.0.49, macOS 15,
+arm64) established:
+
+- The stale `NotFound` after a daemon-side `ENOENT` is the macOS NFS
+  client's negative name cache. On an aged mount it persisted ~50 s, during
+  which ~100 stats produced zero daemon traffic.
+- Cached parent directory listings are served without a daemon round-trip
+  for up to ~3 s, which produced a reproduced false negative in the exec
+  fallback (stale listing answered inside its validity window).
+- Mounting with `-o noattrcache` shrank the negative-cache window from ~50 s
+  to ~0.25 s and eliminated the false negative entirely. Cost: one NFS RPC
+  per stat.
+- FUSE-T ignores the entry/attribute timeouts the filesystem returns, so the
+  bridge cannot tune caching from its side; mount options are the only dial.
+
+## What this evaluation added
+
+### The option plumbing is sound
+
+FUSE-T's open-source client library (`macos-fuse-t/libfuse`,
+`lib/mount_darwin.c`) parses `noattrcache` as a mount option
+(`FUSE_OPT_KEY("noattrcache", KEY_NOATTRCACHE)`) and forwards it to the
+closed-source NFS daemon as `--attrcache=false`. The #4654 harness passed it
+through the same `fuse_mount` args vector that `packages/fuse/mod.ts` builds,
+so pushing `-o noattrcache` into the args handed to `fuse_mount` is the
+correct and empirically validated mechanism.
+
+### There is a middle ground after all
+
+The premise that FUSE-T offers no setting between full caching and
+`noattrcache` turned out to be wrong. `lib/mount_darwin.c` also parses
+`attrcache-timeout=%d`, forwarded to the daemon as `--attrcache-timeout=N`,
+and FUSE-T's v1.0.29 release notes state it "controls nfs mount `actimeo`
+parameter". It is absent from the wiki's mount-option list but present in
+the current (March 2026) source. `actimeo=N` caps all four attribute-cache
+bounds (`acregmin/acregmax/acdirmin/acdirmax`), which also bounds how long a
+negative name entry survives behind a cached directory attribute and how
+long a cached listing is served. A ~1 s setting would bound the measured
+50 s staleness at ~1 s while keeping hot stat loops served from cache — a
+much better default candidate than paying one RPC per stat.
+
+### The livelock risk was misattributed, but a CF-specific exposure exists
+
+The livelock concern came from macos-fuse-t/fuse-t#61 (restic on Sonoma:
+the NFS client looping endlessly on open/close). Reading the full issue
+thread showed the failing configuration had attribute caching at its
+default — the livelock was **not** triggered by `noattrcache`. The
+maintainer's root cause: restic's Go FUSE library (`anacrolix/fuse`)
+returned a fresh inode number for every lookup of the same file; FUSE-T maps
+inode numbers 1:1 to NFS file handles, and macOS issues double lookups —
+seeing two different handles for the same name sent it into an infinite
+relookup loop. The fix landed in `anacrolix/fuse` PR #11 (stable node
+identities, November 2024), not in FUSE-T.
+
+That reattribution mostly de-risks `noattrcache`, with one CF-specific
+caveat: the cf fuse bridge also does not keep inode numbers stable across
+piece-prop rebuilds. `FsTree.clear` drops the subtree's inodes and
+rehydration allocates fresh ones (`allocInode` is monotonic; `tree.ts`), so
+the same path presents a new NFS file handle after every rebuild. Between
+rebuilds handles are stable, so cf is not in the pathological
+every-lookup-a-new-handle regime — but a cell rebuilding rapidly while a
+client stats the same path could let the double-lookup observe two handles,
+the #61 shape. Client-side caching currently absorbs most of those
+double-lookups; `noattrcache` removes that absorption. This is the concrete
+reason the flag should soak under real agent workloads before becoming a
+default, and inode stability across rebuilds is the mitigation to pursue if
+the soak ever reproduces looping.
+
+### Upstream has moved since the measurements
+
+- FUSE-T 1.0.39d (August 2024) "Remove NFS `noac` mount options because it
+  seems not to be working as expected" — the daemon's internal mechanism for
+  `--attrcache=false` was reworked and is not inspectable (closed source).
+  The 1.0.49 measurements postdate that rework, so the option demonstrably
+  still disables caching effectively, but the exact mount flags used are
+  unverifiable.
+- Current FUSE-T is 1.2.7 (June 2026). No changelog entry since 1.0.49
+  touches attribute caching for the NFS backend.
+- FUSE-T 1.1.0+ adds an experimental FSKit backend (`-o backend=fskit`,
+  macOS 26+) that bypasses the NFS client entirely; the whole NFS cache
+  analysis is NFS-backend-specific.
+
+## Stage-one decision (2026-07-13, superseded)
+
+With no FUSE-T on the working machine (the installer needs an admin
+password), the first stage decided: expose both options as opt-in flags and
+adopt neither as default, because the exec-level workaround already covered
+correctness, every empirical number predated the current FUSE-T and macOS,
+and the rebuild-unstable-inode exposure deserved a soak before any default.
+The suggested soak: agents hammering a live mounted space under each
+setting, comparing overhead and watching for lookup loops.
+
+## Stage two: measurements on the live stack (2026-07-14)
+
+FUSE-T 1.2.7 was installed (system-wide, via Homebrew) and the soak ran
+against a real space on the local toolshed: a deployed counter piece, writes
+driven exclusively through the cf CLI (never through the mount), and probes
+(stat, open/read, readdir) through fresh mounts per setting. macOS 26.5,
+arm64. Key findings:
+
+- **The 1.2.7 option semantics differ from the 1.0.49-era analysis.**
+  `nfsstat -m` shows `-o noattrcache` mounts with only `nonegnamecache`
+  (negative name lookups uncached; positive attribute caching keeps the
+  5-60 s defaults), and `-o attrcache-timeout=1` mounts with every
+  attribute-cache bound fixed at 1 s (`acregmin=1 ... acrootdirmax=1`),
+  negative name cache retained.
+- **The original problem reproduces exactly on the real stack.** Untuned
+  mounts served a stale `NotFound` for 56.3 s in one run and 3.2 s in
+  another (the age-based 5-60 s lottery); listing staleness ranged
+  0.8-53.4 s. Daemon-side instrumentation (`CF_FUSE_DEBUG`) showed the
+  bridge applied the CLI write within ~150 ms in every case — all remaining
+  latency was client-side cache staleness.
+- **`noattrcache` no longer fixes it.** Windows of 7.5 s and 29.3 s
+  remained (the directory attribute cache still serves the old listing);
+  only the negative-entry pinning is gone. The #4654-era claim of one RPC
+  per stat is also gone: stats cost ~2 microseconds, cache-served.
+- **`attrcache-timeout=1` fixes it.** Stale-`NotFound` windows of 0.18 s
+  and 0.42 s; listing staleness 0.8 s; stats ~1.7 microseconds.
+- **No livelock under rebuild storms in any setting.** 60 s storms
+  (~3 writes/s driving piece-prop rebuilds, two 20 Hz read loops): zero
+  read errors under `attrcache-timeout=1`; a handful of sub-110 ms honest
+  ENOENT transients elsewhere; go-nfsv4 CPU at most 3%.
+- **5-minute endurance under `attrcache-timeout=1`:** 1296 daemon-side
+  writes, ~2790 probes per target (open/read on two files, readdir, plus a
+  stat of a permanently absent name), p50 1.03 ms / p99 4.01 ms / max
+  28.5 ms, four ENOENT blips with worst streak 110 ms while a rebuilt file
+  reappeared, zero false "exists" answers for the absent name, no hangs.
+
+| Measured on the live stack | untuned | `--noattrcache` | `--attrcache-timeout 1` |
+| --- | --- | --- | --- |
+| Stale-`NotFound` window | 3.2 s / 56.3 s | 7.5 s / 29.3 s | 0.18 s / 0.42 s |
+| Listing staleness | 0.8 s / 53.4 s | 26.7 s | 0.8 s |
+| Stat cost (hot loop) | 1.9 us | 2.0 us | 1.7 us |
+| Storm read errors (60 s) | 3 blips ≤60 ms | 1 blip ≤60 ms | 0 |
+| Livelock / daemon CPU | none / 3% | none / 3% | none / 3% |
+
+## Final decision
+
+FUSE-T mounts default to `attrcache-timeout=1`. `--attrcache-timeout 0`
+restores the NFS client's untuned caching, `--attrcache-timeout <n>` picks a
+different bound, and `--noattrcache` remains available as a diagnostic dial.
+The default applies only when the loaded provider is FUSE-T — macFUSE
+rejects unknown mount options, and Linux ignores the flags. FUSE-T versions
+older than 1.0.29 (October 2023) predate the `attrcache-timeout` option and
+need `--attrcache-timeout 0`.
+
+## What was implemented alongside this evaluation
+
+- `cf fuse mount --noattrcache` and `--attrcache-timeout <seconds>`
+  (mutually exclusive), plumbed through the foreground command, the
+  background supervisor, and the compiled binary's hidden subcommands to
+  `fuse_mount` via `buildMountFuseArgs` in
+  `packages/fuse/mount-options.ts`, with the FUSE-T default of 1 second
+  applied there, gated on the loaded provider.
+- Probing of FUSE-T's per-user install location
+  (`~/.fuse-t/usr/local/lib`) in `packages/fuse/platform-darwin.ts`.
+- Registry entry `fuseNfsCacheTuning` in
+  `docs/development/EXPERIMENTAL_OPTIONS.md`; user-facing docs in
+  `packages/fuse/README.md`; a staleness note in the fuse-workflow skill.
+- The `DIR_LISTING_RECHECK_DELAY_MS` recheck in `packages/cli/lib/exec.ts`
+  is unchanged: it still covers untuned, macFUSE, and old-FUSE-T mounts,
+  and mounts on the new default stop hitting the miss path it guards.
+  Shrinking it toward the one-second bound is a follow-up once the default
+  has field-soaked.

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -17,6 +17,7 @@ import {
   removeMountStateFile,
   writeMountState,
 } from "../lib/fuse.ts";
+import { parseAttrcacheTimeoutSeconds } from "../../fuse/mount-options.ts";
 import { cliText } from "../lib/cli-name.ts";
 
 export function isFuseProcessCommand(command: string): boolean {
@@ -327,6 +328,15 @@ export const fuse = new Command()
     "Linux only: export the mount to other users such as Docker daemon. Requires user_allow_other in /etc/fuse.conf.",
   )
   .option(
+    "--noattrcache",
+    "macOS/FUSE-T only: mount with FUSE-T's noattrcache option (the NFS nonegnamecache flag on current FUSE-T). Negative name lookups are never cached; positive attribute caching keeps the NFS client's 5-60 second defaults.",
+    { conflicts: ["attrcache-timeout"] },
+  )
+  .option(
+    "--attrcache-timeout <seconds:integer>",
+    "macOS/FUSE-T only: bound every NFS client attribute-cache window to the given whole seconds (0-86400). FUSE-T mounts default to 1; 0 keeps the NFS client's age-based 5-60 second default caching.",
+  )
+  .option(
     "--cfc-mode <mode:string>",
     "Enable FUSE-side CFC mode: disabled, observe, enforce-explicit, or enforce-strict.",
   )
@@ -377,6 +387,13 @@ export const fuse = new Command()
     const identity = options.identity ? resolve(options.identity) : "";
     const absMountpoint = resolve(mountpoint);
 
+    // cliffy's integer type accepts any whole number; enforce the daemon's
+    // range here so the error surfaces at the command line rather than in
+    // the (possibly backgrounded) FUSE child.
+    if (options.attrcacheTimeout !== undefined) {
+      parseAttrcacheTimeoutSeconds(String(options.attrcacheTimeout));
+    }
+
     if (identity) {
       let stat: Deno.FileInfo;
       try {
@@ -410,6 +427,10 @@ export const fuse = new Command()
       if (apiUrl) spawnArgs.push("--api-url", apiUrl);
       if (identity) spawnArgs.push("--identity", identity);
       if (options.allowOther) spawnArgs.push("--allow-other");
+      if (options.noattrcache) spawnArgs.push("--noattrcache");
+      if (options.attrcacheTimeout !== undefined) {
+        spawnArgs.push("--attrcache-timeout", String(options.attrcacheTimeout));
+      }
       if (options.cfcMode) spawnArgs.push("--cfc-mode", options.cfcMode);
       if (options.cfcAnnotations) spawnArgs.push("--cfc-annotations");
       if (options.cfcXattrNamespace) {
@@ -433,6 +454,10 @@ export const fuse = new Command()
         identity,
         execCli,
         allowOther: options.allowOther,
+        noattrcache: options.noattrcache,
+        attrcacheTimeout: options.attrcacheTimeout !== undefined
+          ? String(options.attrcacheTimeout)
+          : undefined,
         cfcMode: options.cfcMode,
         cfcAnnotations: options.cfcAnnotations,
         cfcXattrNamespace: options.cfcXattrNamespace,
@@ -464,6 +489,13 @@ export const fuse = new Command()
         if (apiUrl) spawnArgs.push("--api-url", apiUrl);
         if (identity) spawnArgs.push("--identity", identity);
         if (options.allowOther) spawnArgs.push("--allow-other");
+        if (options.noattrcache) spawnArgs.push("--noattrcache");
+        if (options.attrcacheTimeout !== undefined) {
+          spawnArgs.push(
+            "--attrcache-timeout",
+            String(options.attrcacheTimeout),
+          );
+        }
         if (options.cfcMode) spawnArgs.push("--cfc-mode", options.cfcMode);
         if (options.cfcAnnotations) spawnArgs.push("--cfc-annotations");
         if (options.cfcXattrNamespace) {
@@ -492,6 +524,10 @@ export const fuse = new Command()
           logFile,
           spaces: options.space ?? [],
           allowOther: options.allowOther,
+          noattrcache: options.noattrcache,
+          attrcacheTimeout: options.attrcacheTimeout !== undefined
+            ? String(options.attrcacheTimeout)
+            : undefined,
           cfcMode: options.cfcMode,
           cfcAnnotations: options.cfcAnnotations,
           cfcXattrNamespace: options.cfcXattrNamespace,

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -4,6 +4,7 @@ import ports from "@commonfabric/ports" with { type: "json" };
 import {
   buildBackgroundSupervisorDenoArgs,
   buildDenoArgs,
+  buildFuseBinaryArgs,
   defaultStateDir,
   ensureExecShim,
   fuseMod,
@@ -390,8 +391,11 @@ export const fuse = new Command()
     // cliffy's integer type accepts any whole number; enforce the daemon's
     // range here so the error surfaces at the command line rather than in
     // the (possibly backgrounded) FUSE child.
-    if (options.attrcacheTimeout !== undefined) {
-      parseAttrcacheTimeoutSeconds(String(options.attrcacheTimeout));
+    const attrcacheTimeout = options.attrcacheTimeout !== undefined
+      ? String(options.attrcacheTimeout)
+      : undefined;
+    if (attrcacheTimeout !== undefined) {
+      parseAttrcacheTimeoutSeconds(attrcacheTimeout);
     }
 
     if (identity) {
@@ -419,52 +423,37 @@ export const fuse = new Command()
     const execBase = basename(execPath);
     const isCompiledBinary = execBase !== "deno" && execBase !== "deno.exe";
 
+    // The mount flags every spawn path forwards, whichever entrypoint runs.
+    const mountFlags = {
+      mountpoint: absMountpoint,
+      apiUrl,
+      identity,
+      execCli,
+      spaces: options.space ?? [],
+      allowOther: options.allowOther,
+      noattrcache: options.noattrcache,
+      attrcacheTimeout,
+      cfcMode: options.cfcMode,
+      cfcAnnotations: options.cfcAnnotations,
+      cfcXattrNamespace: options.cfcXattrNamespace,
+      cfcWritebackXattrs: options.cfcWritebackXattrs,
+      cfcWritebackState: options.cfcWritebackState,
+    };
+
     let spawnCmd: string;
     let spawnArgs: string[];
     if (isCompiledBinary) {
       spawnCmd = execPath;
-      spawnArgs = ["fuse-daemon", absMountpoint];
-      if (apiUrl) spawnArgs.push("--api-url", apiUrl);
-      if (identity) spawnArgs.push("--identity", identity);
-      if (options.allowOther) spawnArgs.push("--allow-other");
-      if (options.noattrcache) spawnArgs.push("--noattrcache");
-      if (options.attrcacheTimeout !== undefined) {
-        spawnArgs.push("--attrcache-timeout", String(options.attrcacheTimeout));
-      }
-      if (options.cfcMode) spawnArgs.push("--cfc-mode", options.cfcMode);
-      if (options.cfcAnnotations) spawnArgs.push("--cfc-annotations");
-      if (options.cfcXattrNamespace) {
-        spawnArgs.push("--cfc-xattr-namespace", options.cfcXattrNamespace);
-      }
-      if (options.cfcWritebackXattrs) {
-        spawnArgs.push("--cfc-writeback-xattrs");
-      }
-      if (options.cfcWritebackState) {
-        spawnArgs.push("--cfc-writeback-state", options.cfcWritebackState);
-      }
-      if (execCli) spawnArgs.push("--exec-cli", execCli);
-      for (const s of options.space ?? []) spawnArgs.push("--space", s);
+      spawnArgs = buildFuseBinaryArgs({
+        subcommand: "fuse-daemon",
+        ...mountFlags,
+      });
     } else {
-      const modPath = fuseMod(import.meta.url);
       spawnCmd = "deno";
       spawnArgs = buildDenoArgs({
-        modPath,
-        mountpoint: absMountpoint,
-        apiUrl,
-        identity,
-        execCli,
-        allowOther: options.allowOther,
-        noattrcache: options.noattrcache,
-        attrcacheTimeout: options.attrcacheTimeout !== undefined
-          ? String(options.attrcacheTimeout)
-          : undefined,
-        cfcMode: options.cfcMode,
-        cfcAnnotations: options.cfcAnnotations,
-        cfcXattrNamespace: options.cfcXattrNamespace,
-        cfcWritebackXattrs: options.cfcWritebackXattrs,
-        cfcWritebackState: options.cfcWritebackState,
+        modPath: fuseMod(import.meta.url),
+        ...mountFlags,
       });
-      for (const s of options.space ?? []) spawnArgs.push("--space", s);
     }
 
     if (options.background) {
@@ -483,61 +472,23 @@ export const fuse = new Command()
         if (!(error instanceof Deno.errors.NotFound)) throw error;
       }
 
-      if (isCompiledBinary) {
-        spawnCmd = execPath;
-        spawnArgs = ["fuse-supervisor", absMountpoint];
-        if (apiUrl) spawnArgs.push("--api-url", apiUrl);
-        if (identity) spawnArgs.push("--identity", identity);
-        if (options.allowOther) spawnArgs.push("--allow-other");
-        if (options.noattrcache) spawnArgs.push("--noattrcache");
-        if (options.attrcacheTimeout !== undefined) {
-          spawnArgs.push(
-            "--attrcache-timeout",
-            String(options.attrcacheTimeout),
-          );
-        }
-        if (options.cfcMode) spawnArgs.push("--cfc-mode", options.cfcMode);
-        if (options.cfcAnnotations) spawnArgs.push("--cfc-annotations");
-        if (options.cfcXattrNamespace) {
-          spawnArgs.push("--cfc-xattr-namespace", options.cfcXattrNamespace);
-        }
-        if (options.cfcWritebackXattrs) {
-          spawnArgs.push("--cfc-writeback-xattrs");
-        }
-        if (options.cfcWritebackState) {
-          spawnArgs.push("--cfc-writeback-state", options.cfcWritebackState);
-        }
-        if (execCli) spawnArgs.push("--exec-cli", execCli);
-        spawnArgs.push("--log-file", logFile);
-        spawnArgs.push("--state-path", statePath);
-        spawnArgs.push("--supervisor-status", childStatusPath);
-        spawnArgs.push("--supervisor-token", childStatusToken);
-        for (const s of options.space ?? []) spawnArgs.push("--space", s);
-      } else {
-        spawnCmd = execPath;
-        spawnArgs = buildBackgroundSupervisorDenoArgs({
+      const supervisorFlags = {
+        ...mountFlags,
+        logFile,
+        statePath,
+        supervisorStatusPath: childStatusPath,
+        supervisorToken: childStatusToken,
+      };
+      spawnCmd = execPath;
+      spawnArgs = isCompiledBinary
+        ? buildFuseBinaryArgs({
+          subcommand: "fuse-supervisor",
+          ...supervisorFlags,
+        })
+        : buildBackgroundSupervisorDenoArgs({
           cliModPath: fuseSupervisorMod(import.meta.url),
-          mountpoint: absMountpoint,
-          apiUrl,
-          identity,
-          execCli,
-          logFile,
-          spaces: options.space ?? [],
-          allowOther: options.allowOther,
-          noattrcache: options.noattrcache,
-          attrcacheTimeout: options.attrcacheTimeout !== undefined
-            ? String(options.attrcacheTimeout)
-            : undefined,
-          cfcMode: options.cfcMode,
-          cfcAnnotations: options.cfcAnnotations,
-          cfcXattrNamespace: options.cfcXattrNamespace,
-          cfcWritebackXattrs: options.cfcWritebackXattrs,
-          cfcWritebackState: options.cfcWritebackState,
-          statePath,
-          supervisorStatusPath: childStatusPath,
-          supervisorToken: childStatusToken,
+          ...supervisorFlags,
         });
-      }
 
       // Detached background process
       const cmd = new Deno.Command(spawnCmd, {

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -109,6 +109,11 @@ export const main = new Command()
       .option("--exec-cli <path:string>", "Path to the cf exec shim.")
       .option("--log-file <path:string>", "Path to the FUSE child log file.")
       .option("--allow-other", "Pass allow_other through to the FUSE child.")
+      .option("--noattrcache", "Pass noattrcache through to the FUSE child.")
+      .option(
+        "--attrcache-timeout <seconds:string>",
+        "Pass attrcache-timeout through to the FUSE child.",
+      )
       .option("--cfc-mode <mode:string>", "FUSE-side CFC mode.")
       .option("--cfc-annotations", "Publish CFC annotation xattrs.")
       .option(
@@ -142,6 +147,8 @@ export const main = new Command()
           logFile: options.logFile ?? "",
           spaces: options.space ?? [],
           allowOther: options.allowOther,
+          noattrcache: options.noattrcache,
+          attrcacheTimeout: options.attrcacheTimeout,
           cfcMode: options.cfcMode,
           cfcAnnotations: options.cfcAnnotations,
           cfcXattrNamespace: options.cfcXattrNamespace,

--- a/packages/cli/lib/fuse-supervisor.ts
+++ b/packages/cli/lib/fuse-supervisor.ts
@@ -225,12 +225,14 @@ export async function cleanupFuseChild(
   await child.status.catch(() => undefined);
 }
 
-interface ParsedSupervisorArgs {
+export interface ParsedSupervisorArgs {
   options: FuseSupervisorOptions;
   help: boolean;
 }
 
-function parseSupervisorArgs(rawArgs: string[]): ParsedSupervisorArgs {
+export function parseSupervisorArgs(
+  rawArgs: string[],
+): ParsedSupervisorArgs {
   const options: FuseSupervisorOptions = {
     mountpoint: "",
     apiUrl: "",
@@ -319,7 +321,7 @@ function requireValue(args: string[], index: number, flag: string): string {
   return value;
 }
 
-function supervisorHelp(): string {
+export function supervisorHelp(): string {
   return `Usage: fuse-supervisor <mountpoint> [options]
 
 Internal: supervise a background FUSE child process.

--- a/packages/cli/lib/fuse-supervisor.ts
+++ b/packages/cli/lib/fuse-supervisor.ts
@@ -9,6 +9,8 @@ export interface FuseSupervisorOptions {
   logFile: string;
   spaces: string[];
   allowOther?: boolean;
+  noattrcache?: boolean;
+  attrcacheTimeout?: string;
   cfcMode?: string;
   cfcAnnotations?: boolean;
   cfcXattrNamespace?: string;
@@ -60,6 +62,10 @@ export function buildFuseChildCommand(
     if (options.execCli) args.push("--exec-cli", options.execCli);
     if (options.logFile) args.push("--log-file", options.logFile);
     if (options.allowOther) args.push("--allow-other");
+    if (options.noattrcache) args.push("--noattrcache");
+    if (options.attrcacheTimeout) {
+      args.push("--attrcache-timeout", options.attrcacheTimeout);
+    }
     if (options.cfcMode) args.push("--cfc-mode", options.cfcMode);
     if (options.cfcAnnotations) args.push("--cfc-annotations");
     if (options.cfcXattrNamespace) {
@@ -90,6 +96,8 @@ export function buildFuseChildCommand(
       logFile: options.logFile,
       spaces: options.spaces,
       allowOther: options.allowOther,
+      noattrcache: options.noattrcache,
+      attrcacheTimeout: options.attrcacheTimeout,
       cfcMode: options.cfcMode,
       cfcAnnotations: options.cfcAnnotations,
       cfcXattrNamespace: options.cfcXattrNamespace,
@@ -255,6 +263,12 @@ function parseSupervisorArgs(rawArgs: string[]): ParsedSupervisorArgs {
       case "--allow-other":
         options.allowOther = true;
         break;
+      case "--noattrcache":
+        options.noattrcache = true;
+        break;
+      case "--attrcache-timeout":
+        options.attrcacheTimeout = requireValue(rawArgs, ++i, arg);
+        break;
       case "--cfc-mode":
         options.cfcMode = requireValue(rawArgs, ++i, arg);
         break;
@@ -316,6 +330,8 @@ Options:
   --exec-cli <path>               Path to the cf exec shim
   --log-file <path>               Path to the FUSE child log file
   --allow-other                   Pass allow_other through to the FUSE child
+  --noattrcache                   Pass noattrcache through to the FUSE child
+  --attrcache-timeout <seconds>   Pass attrcache-timeout through to the FUSE child
   --cfc-mode <mode>               FUSE-side CFC mode
   --cfc-annotations               Publish CFC annotation xattrs
   --cfc-xattr-namespace <ns>      CFC xattr namespace

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -30,6 +30,8 @@ export interface FuseChildDenoArgsOptions {
   logFile?: string;
   spaces?: string[];
   allowOther?: boolean;
+  noattrcache?: boolean;
+  attrcacheTimeout?: string;
   cfcMode?: string;
   cfcAnnotations?: boolean;
   cfcXattrNamespace?: string;
@@ -361,6 +363,10 @@ export function buildFuseChildDenoArgs(
   if (opts.execCli) args.push("--exec-cli", opts.execCli);
   if (opts.logFile) args.push("--log-file", opts.logFile);
   if (opts.allowOther) args.push("--allow-other");
+  if (opts.noattrcache) args.push("--noattrcache");
+  if (opts.attrcacheTimeout) {
+    args.push("--attrcache-timeout", opts.attrcacheTimeout);
+  }
   if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
   if (opts.cfcAnnotations) args.push("--cfc-annotations");
   if (opts.cfcXattrNamespace) {
@@ -403,6 +409,10 @@ export function buildBackgroundSupervisorDenoArgs(
   if (opts.execCli) args.push("--exec-cli", opts.execCli);
   if (opts.logFile) args.push("--log-file", opts.logFile);
   if (opts.allowOther) args.push("--allow-other");
+  if (opts.noattrcache) args.push("--noattrcache");
+  if (opts.attrcacheTimeout) {
+    args.push("--attrcache-timeout", opts.attrcacheTimeout);
+  }
   if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
   if (opts.cfcAnnotations) args.push("--cfc-annotations");
   if (opts.cfcXattrNamespace) {

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -47,6 +47,12 @@ export interface BackgroundSupervisorDenoArgsOptions
   statePath?: string;
 }
 
+export interface FuseBinaryArgsOptions
+  extends Omit<FuseChildDenoArgsOptions, "modPath"> {
+  subcommand: "fuse-daemon" | "fuse-supervisor";
+  statePath?: string;
+}
+
 export async function canonicalizeMountLookupPath(
   path: string,
 ): Promise<string> {
@@ -376,6 +382,44 @@ export function buildFuseChildDenoArgs(
   if (opts.cfcWritebackState) {
     args.push("--cfc-writeback-state", opts.cfcWritebackState);
   }
+  if (opts.supervisorStatusPath) {
+    args.push("--supervisor-status", opts.supervisorStatusPath);
+  }
+  if (opts.supervisorToken) {
+    args.push("--supervisor-token", opts.supervisorToken);
+  }
+  for (const space of opts.spaces ?? []) args.push("--space", space);
+
+  return args;
+}
+
+/**
+ * Build the args for the compiled cf binary's hidden fuse subcommands. The
+ * compiled binary takes the mountpoint and mount flags directly, where a
+ * deno invocation needs a script path and permission flags first.
+ */
+export function buildFuseBinaryArgs(opts: FuseBinaryArgsOptions): string[] {
+  const args = [opts.subcommand, opts.mountpoint];
+
+  if (opts.apiUrl) args.push("--api-url", opts.apiUrl);
+  if (opts.identity) args.push("--identity", opts.identity);
+  if (opts.allowOther) args.push("--allow-other");
+  if (opts.noattrcache) args.push("--noattrcache");
+  if (opts.attrcacheTimeout) {
+    args.push("--attrcache-timeout", opts.attrcacheTimeout);
+  }
+  if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
+  if (opts.cfcAnnotations) args.push("--cfc-annotations");
+  if (opts.cfcXattrNamespace) {
+    args.push("--cfc-xattr-namespace", opts.cfcXattrNamespace);
+  }
+  if (opts.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
+  if (opts.cfcWritebackState) {
+    args.push("--cfc-writeback-state", opts.cfcWritebackState);
+  }
+  if (opts.execCli) args.push("--exec-cli", opts.execCli);
+  if (opts.logFile) args.push("--log-file", opts.logFile);
+  if (opts.statePath) args.push("--state-path", opts.statePath);
   if (opts.supervisorStatusPath) {
     args.push("--supervisor-status", opts.supervisorStatusPath);
   }

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -993,6 +993,88 @@ describe("buildDenoArgs", () => {
     expect(args).toContain("--cfc-writeback-state");
     expect(args).toContain("/tmp/cf-writeback.json");
   });
+
+  it("passes noattrcache through to the daemon", () => {
+    const args = buildDenoArgs({
+      modPath: "/mod.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      noattrcache: true,
+    });
+    expect(args).toContain("--noattrcache");
+    expect(args).not.toContain("--attrcache-timeout");
+  });
+
+  it("passes attrcache-timeout through to the daemon", () => {
+    const args = buildDenoArgs({
+      modPath: "/mod.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      attrcacheTimeout: "2",
+    });
+    const flagIndex = args.indexOf("--attrcache-timeout");
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args[flagIndex + 1]).toBe("2");
+    expect(args).not.toContain("--noattrcache");
+  });
+
+  it("forwards an attrcache-timeout of zero to the daemon", () => {
+    // "0" selects untuned caching in the daemon and must survive every
+    // forwarding layer even though the layers test the field for truthiness.
+    const args = buildDenoArgs({
+      modPath: "/mod.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      attrcacheTimeout: "0",
+    });
+    const flagIndex = args.indexOf("--attrcache-timeout");
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args[flagIndex + 1]).toBe("0");
+
+    const supervisorArgs = buildBackgroundSupervisorDenoArgs({
+      cliModPath: "/repo/packages/cli/lib/fuse-supervisor.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      attrcacheTimeout: "0",
+    });
+    const supIndex = supervisorArgs.indexOf("--attrcache-timeout");
+    expect(supIndex).toBeGreaterThan(-1);
+    expect(supervisorArgs[supIndex + 1]).toBe("0");
+
+    const child = buildFuseChildCommand({
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      logFile: "",
+      spaces: [],
+      execPath: "/usr/local/bin/cf",
+      attrcacheTimeout: "0",
+    });
+    const childIndex = child.args.indexOf("--attrcache-timeout");
+    expect(childIndex).toBeGreaterThan(-1);
+    expect(child.args[childIndex + 1]).toBe("0");
+  });
+
+  it("omits NFS cache mount options when unset", () => {
+    const args = buildDenoArgs({
+      modPath: "/mod.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+    });
+    expect(args).not.toContain("--noattrcache");
+    expect(args).not.toContain("--attrcache-timeout");
+  });
 });
 
 describe("FUSE supervisor command construction", () => {
@@ -1027,6 +1109,7 @@ describe("FUSE supervisor command construction", () => {
       supervisorStatusPath: "/tmp/cf-state.json.child-status",
       supervisorToken: "token-1",
       allowOther: true,
+      noattrcache: true,
       cfcMode: "observe",
       cfcAnnotations: true,
       cfcXattrNamespace: "both",
@@ -1055,6 +1138,7 @@ describe("FUSE supervisor command construction", () => {
     expect(args).toContain("/tmp/cf-state.json.child-status");
     expect(args).toContain("--supervisor-token");
     expect(args).toContain("token-1");
+    expect(args).toContain("--noattrcache");
     expect(args.filter((arg) => arg === "--space").length).toBe(2);
   });
 
@@ -1127,6 +1211,7 @@ describe("FUSE supervisor command construction", () => {
       execPath: "/usr/local/bin/cf",
       supervisorStatusPath: "/tmp/cf-status",
       supervisorToken: "token-1",
+      attrcacheTimeout: "2",
     });
 
     expect(child.command).toBe("/usr/local/bin/cf");
@@ -1135,6 +1220,9 @@ describe("FUSE supervisor command construction", () => {
     expect(child.args).toContain("/tmp/cf-status");
     expect(child.args).toContain("--supervisor-token");
     expect(child.args).toContain("token-1");
+    const flagIndex = child.args.indexOf("--attrcache-timeout");
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(child.args[flagIndex + 1]).toBe("2");
   });
 
   it("terminates the spawned FUSE child during supervisor cleanup", async () => {

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   buildBackgroundSupervisorDenoArgs,
   buildDenoArgs,
+  buildFuseBinaryArgs,
   buildFuseChildDenoArgs,
   ensureExecShim,
   findMountForPath,
@@ -27,8 +28,10 @@ import {
 import {
   buildFuseChildCommand,
   cleanupFuseChild,
+  parseSupervisorArgs,
   recordFuseChildPid,
   runFuseSupervisor,
+  supervisorHelp,
 } from "../lib/fuse-supervisor.ts";
 import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
 import { withEnv } from "./utils.ts";
@@ -1495,5 +1498,178 @@ describe("FUSE supervisor command construction", () => {
     } finally {
       await Deno.remove(statePath).catch(() => undefined);
     }
+  });
+});
+
+describe("buildFuseBinaryArgs", () => {
+  const base = {
+    mountpoint: "/mnt",
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/id.key",
+    execCli: "/tmp/cf-exec",
+  };
+
+  it("builds a compiled-binary daemon invocation", () => {
+    const args = buildFuseBinaryArgs({
+      subcommand: "fuse-daemon",
+      ...base,
+      spaces: ["home", "work"],
+    });
+
+    expect(args.slice(0, 2)).toEqual(["fuse-daemon", "/mnt"]);
+    expect(args).not.toContain("run");
+    expect(args).not.toContain("--allow-ffi");
+    expect(args).not.toContain("fuse-supervisor");
+    const apiIndex = args.indexOf("--api-url");
+    expect(args[apiIndex + 1]).toBe("http://localhost:8000");
+    const identityIndex = args.indexOf("--identity");
+    expect(args[identityIndex + 1]).toBe("/tmp/id.key");
+    const execIndex = args.indexOf("--exec-cli");
+    expect(args[execIndex + 1]).toBe("/tmp/cf-exec");
+    expect(args.filter((arg) => arg === "--space").length).toBe(2);
+  });
+
+  it("builds a compiled-binary supervisor invocation with its lifecycle paths", () => {
+    const args = buildFuseBinaryArgs({
+      subcommand: "fuse-supervisor",
+      ...base,
+      logFile: "/tmp/cf-fuse.log",
+      statePath: "/tmp/state.json",
+      supervisorStatusPath: "/tmp/state.json.child-status",
+      supervisorToken: "token-1",
+    });
+
+    expect(args.slice(0, 2)).toEqual(["fuse-supervisor", "/mnt"]);
+    const logIndex = args.indexOf("--log-file");
+    expect(args[logIndex + 1]).toBe("/tmp/cf-fuse.log");
+    const stateIndex = args.indexOf("--state-path");
+    expect(args[stateIndex + 1]).toBe("/tmp/state.json");
+    const statusIndex = args.indexOf("--supervisor-status");
+    expect(args[statusIndex + 1]).toBe("/tmp/state.json.child-status");
+    const tokenIndex = args.indexOf("--supervisor-token");
+    expect(args[tokenIndex + 1]).toBe("token-1");
+  });
+
+  it("omits every optional flag that was not requested", () => {
+    const args = buildFuseBinaryArgs({
+      subcommand: "fuse-daemon",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+    });
+
+    expect(args).toEqual(["fuse-daemon", "/mnt"]);
+  });
+
+  it("forwards the mount and CFC flags", () => {
+    const args = buildFuseBinaryArgs({
+      subcommand: "fuse-daemon",
+      ...base,
+      allowOther: true,
+      noattrcache: true,
+      cfcMode: "enforce-explicit",
+      cfcAnnotations: true,
+      cfcXattrNamespace: "both",
+      cfcWritebackXattrs: true,
+      cfcWritebackState: "/tmp/cfc.json",
+    });
+
+    expect(args).toContain("--allow-other");
+    expect(args).toContain("--noattrcache");
+    const modeIndex = args.indexOf("--cfc-mode");
+    expect(args[modeIndex + 1]).toBe("enforce-explicit");
+    expect(args).toContain("--cfc-annotations");
+    const nsIndex = args.indexOf("--cfc-xattr-namespace");
+    expect(args[nsIndex + 1]).toBe("both");
+    expect(args).toContain("--cfc-writeback-xattrs");
+    const stateIndex = args.indexOf("--cfc-writeback-state");
+    expect(args[stateIndex + 1]).toBe("/tmp/cfc.json");
+  });
+
+  it("forwards an attrcache-timeout of zero", () => {
+    const args = buildFuseBinaryArgs({
+      subcommand: "fuse-daemon",
+      ...base,
+      attrcacheTimeout: "0",
+    });
+
+    const flagIndex = args.indexOf("--attrcache-timeout");
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args[flagIndex + 1]).toBe("0");
+    expect(args).not.toContain("--noattrcache");
+  });
+});
+
+describe("parseSupervisorArgs", () => {
+  it("parses the mountpoint and cache flags", () => {
+    const { options, help } = parseSupervisorArgs([
+      "/mnt",
+      "--api-url",
+      "http://localhost:8000",
+      "--noattrcache",
+      "--space",
+      "home",
+    ]);
+
+    expect(help).toBe(false);
+    expect(options.mountpoint).toBe("/mnt");
+    expect(options.apiUrl).toBe("http://localhost:8000");
+    expect(options.noattrcache).toBe(true);
+    expect(options.attrcacheTimeout).toBeUndefined();
+    expect(options.spaces).toEqual(["home"]);
+  });
+
+  it("parses an attrcache-timeout value, including zero", () => {
+    expect(
+      parseSupervisorArgs(["/mnt", "--attrcache-timeout", "2"]).options
+        .attrcacheTimeout,
+    ).toBe("2");
+    expect(
+      parseSupervisorArgs(["/mnt", "--attrcache-timeout", "0"]).options
+        .attrcacheTimeout,
+    ).toBe("0");
+  });
+
+  it("rejects an attrcache-timeout with no value", () => {
+    expect(() => parseSupervisorArgs(["/mnt", "--attrcache-timeout"]))
+      .toThrow("Missing value for --attrcache-timeout");
+  });
+
+  it("rejects unknown options", () => {
+    expect(() => parseSupervisorArgs(["/mnt", "--nosuchflag"]))
+      .toThrow("Unknown fuse supervisor option: --nosuchflag");
+  });
+
+  it("reports help without requiring a mountpoint", () => {
+    expect(parseSupervisorArgs(["--help"]).help).toBe(true);
+    expect(supervisorHelp()).toContain("--attrcache-timeout <seconds>");
+    expect(supervisorHelp()).toContain("--noattrcache");
+  });
+});
+
+describe("fuse mount option validation", () => {
+  // The mount action validates before it resolves an identity, creates the
+  // mountpoint, or spawns anything, so these never reach a real mount.
+  const neverMounted = "/tmp/cf-fuse-never-mounted";
+
+  it("rejects an attrcache-timeout below the supported range", async () => {
+    await expect(
+      fuse.parse(["mount", neverMounted, "--attrcache-timeout", "-1"]),
+    ).rejects.toThrow("Invalid --attrcache-timeout value: -1");
+    await expect(Deno.stat(neverMounted)).rejects.toThrow(Deno.errors.NotFound);
+  });
+
+  it("rejects an attrcache-timeout above the supported range", async () => {
+    await expect(
+      fuse.parse(["mount", neverMounted, "--attrcache-timeout", "86401"]),
+    ).rejects.toThrow("Invalid --attrcache-timeout value: 86401");
+  });
+
+  it("documents both cache flags in the mount help", () => {
+    const help = fuse.getCommand("mount")!.getHelp();
+    expect(help).toContain("--noattrcache");
+    expect(help).toContain("--attrcache-timeout");
+    expect(help).toContain("Conflicts");
   });
 });

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -261,6 +261,47 @@ also have `user_allow_other` enabled in `/etc/fuse.conf`.
 Handlers remain writable through the mounted `.handler` file. Both mounted
 `.handler` and `.tool` files can be executed directly or via `cf exec`.
 
+### macOS: NFS client cache tuning
+
+FUSE-T serves the mount through the macOS NFS client, which caches attributes,
+negative name lookups, and directory listings on the client side. FUSE-T ignores
+the cache timeouts the filesystem implementation returns, so without tuning the
+client's age-based 5-60 second defaults apply: a name that was once looked up
+and not found can keep reporting `NotFound` for up to a minute after the file
+appears daemon-side, and a directory listing can be served stale for tens of
+seconds.
+
+FUSE-T mounts therefore default to `attrcache-timeout=1`, which fixes every NFS
+attribute-cache window at one second. Measured against a live space (FUSE-T
+1.2.7, macOS 26): the stale-`NotFound` window drops from 3-56 seconds to under
+half a second, listing staleness drops the same way, stats stay cache-served
+(about 2 microseconds each), and sustained daemon-side write storms produce zero
+read errors through the mount.
+
+Two flags adjust this; both take effect on macOS/FUSE-T mounts only and are
+ignored on Linux and macFUSE, and they are mutually exclusive:
+
+```bash
+# Bound cache validity to N whole seconds (default 1). 0 disables the
+# tuning and keeps the NFS client's age-based 5-60 second caching.
+cf fuse mount /tmp/cf --attrcache-timeout 5
+cf fuse mount /tmp/cf --attrcache-timeout 0
+
+# Mount with FUSE-T's noattrcache option instead. On current FUSE-T this
+# maps to the NFS nonegnamecache flag: negative name lookups are never
+# cached, while positive attribute caching keeps the client defaults.
+cf fuse mount /tmp/cf --noattrcache
+```
+
+`--attrcache-timeout` relies on a FUSE-T mount option that is present in the
+FUSE-T source and release notes but absent from its wiki's option list. The
+option was added in FUSE-T 1.0.29 (October 2023); on older FUSE-T installs mount
+with `--attrcache-timeout 0` if the default is not accepted. `--noattrcache`
+bounds only the negative-lookup staleness; measured on the same stack it left
+multi-second stale-`NotFound` windows (the directory attribute cache still
+serves the old listing), so prefer the timeout for freshness-sensitive
+workloads.
+
 ### CFC Annotations
 
 `cf fuse mount --cfc-mode=<mode>` selects the FUSE-side CFC guardrail mode:
@@ -370,6 +411,10 @@ command ls /tmp/cf/home/pieces/
 # Or use a stat-based tool
 find /tmp/cf/home/pieces/ -maxdepth 1
 ```
+
+If stale listings or stale `NotFound` results are a recurring problem for a
+workload, mount with `--noattrcache` or `--attrcache-timeout` (see
+[macOS: NFS client cache tuning](#macos-nfs-client-cache-tuning)).
 
 ### Permission denied / Operation not permitted
 

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -18,6 +18,7 @@ import {
   buildMountFuseArgs,
   DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS,
   parseAttrcacheTimeoutSeconds,
+  resolveMountCacheOptions,
 } from "./mount-options.ts";
 import darwinPlatform, { libfusePaths } from "./platform-darwin.ts";
 import linuxPlatform from "./platform-linux.ts";
@@ -490,5 +491,91 @@ Deno.test("libfuse search includes the FUSE-T per-user install location", () => 
       "/usr/local/lib/libfuse-t.dylib",
       "/usr/local/lib/libfuse.2.dylib",
     ],
+  );
+});
+
+Deno.test("mount cache options resolve from their command-line spellings", () => {
+  assertEquals(
+    resolveMountCacheOptions({ noattrcache: false, attrcacheTimeout: "" }),
+    { noattrcache: false, attrcacheTimeoutSeconds: undefined },
+  );
+  assertEquals(
+    resolveMountCacheOptions({ noattrcache: false, attrcacheTimeout: "5" }),
+    { noattrcache: false, attrcacheTimeoutSeconds: 5 },
+  );
+  assertEquals(
+    resolveMountCacheOptions({ noattrcache: true, attrcacheTimeout: "" }),
+    { noattrcache: true, attrcacheTimeoutSeconds: undefined },
+  );
+  // An explicit 0 selects untuned caching and is not a "no value" sentinel.
+  assertEquals(
+    resolveMountCacheOptions({ noattrcache: false, attrcacheTimeout: "0" }),
+    { noattrcache: false, attrcacheTimeoutSeconds: 0 },
+  );
+});
+
+Deno.test("mount cache options reject the mutually exclusive combination", () => {
+  assertThrows(
+    () =>
+      resolveMountCacheOptions({ noattrcache: true, attrcacheTimeout: "1" }),
+    Error,
+    "mutually exclusive",
+  );
+  // Even the untuning 0 conflicts: it still asks for a cache regime.
+  assertThrows(
+    () =>
+      resolveMountCacheOptions({ noattrcache: true, attrcacheTimeout: "0" }),
+    Error,
+    "mutually exclusive",
+  );
+});
+
+Deno.test("mount cache options reject a flag whose value was dropped", () => {
+  // The daemon's parser yields no value for `--attrcache-timeout -1`; that
+  // must fail rather than resolve to the default cache regime.
+  assertThrows(
+    () =>
+      resolveMountCacheOptions({
+        noattrcache: false,
+        attrcacheTimeout: "",
+        attrcacheTimeoutGiven: true,
+      }),
+    Error,
+    "Missing value for --attrcache-timeout",
+  );
+  // Without the flag, an empty value still means "no cache tuning requested".
+  assertEquals(
+    resolveMountCacheOptions({
+      noattrcache: false,
+      attrcacheTimeout: "",
+      attrcacheTimeoutGiven: false,
+    }),
+    { noattrcache: false, attrcacheTimeoutSeconds: undefined },
+  );
+});
+
+Deno.test("mount cache options surface an out-of-range timeout", () => {
+  assertThrows(
+    () =>
+      resolveMountCacheOptions({ noattrcache: false, attrcacheTimeout: "-1" }),
+    Error,
+    "Invalid --attrcache-timeout value",
+  );
+});
+
+Deno.test("platform provider reports the implementation openFuse loaded", () => {
+  // Neither platform's library is opened by unit tests, so both report the
+  // pre-openFuse state. buildMountFuseArgs treats that as "not FUSE-T".
+  assertEquals(darwinPlatform.provider(), "unknown");
+  assertEquals(linuxPlatform.provider(), "unknown");
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: darwinPlatform.provider(),
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+    }),
+    ["fuse_ct"],
   );
 });

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -13,7 +13,7 @@ import {
   sourceRelPathToTreeSegments,
   writeUnavailableErrno,
 } from "./mod.ts";
-import darwinPlatform from "./platform-darwin.ts";
+import darwinPlatform, { libfusePaths } from "./platform-darwin.ts";
 import linuxPlatform from "./platform-linux.ts";
 import { EACCES, EINVAL, EROFS } from "./platform.ts";
 
@@ -307,4 +307,22 @@ Deno.test("root space lookup decodes request names and replies with canonical na
     spaceName: "home",
     directoryName: "home",
   });
+});
+
+Deno.test("libfuse search includes the FUSE-T per-user install location", () => {
+  assertEquals(
+    libfusePaths(env({ HOME: "/Users/alice" })),
+    [
+      "/usr/local/lib/libfuse-t.dylib",
+      "/Users/alice/.fuse-t/usr/local/lib/libfuse-t.dylib",
+      "/usr/local/lib/libfuse.2.dylib",
+    ],
+  );
+  assertEquals(
+    libfusePaths(env({})),
+    [
+      "/usr/local/lib/libfuse-t.dylib",
+      "/usr/local/lib/libfuse.2.dylib",
+    ],
+  );
 });

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   appendDecodedJsonPath,
   bufferForNoHandleTruncate,
@@ -13,6 +13,12 @@ import {
   sourceRelPathToTreeSegments,
   writeUnavailableErrno,
 } from "./mod.ts";
+import {
+  ATTRCACHE_TIMEOUT_MAX_SECONDS,
+  buildMountFuseArgs,
+  DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS,
+  parseAttrcacheTimeoutSeconds,
+} from "./mount-options.ts";
 import darwinPlatform, { libfusePaths } from "./platform-darwin.ts";
 import linuxPlatform from "./platform-linux.ts";
 import { EACCES, EINVAL, EROFS } from "./platform.ts";
@@ -307,6 +313,166 @@ Deno.test("root space lookup decodes request names and replies with canonical na
     spaceName: "home",
     directoryName: "home",
   });
+});
+
+Deno.test("mount fuse args apply allow_other on Linux only", () => {
+  assertEquals(
+    buildMountFuseArgs({
+      os: "linux",
+      provider: "linux-libfuse",
+      allowOther: true,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+    }),
+    ["fuse_ct", "-o", "allow_other", "-o", "default_permissions"],
+  );
+  assertEquals(
+    buildMountFuseArgs({
+      os: "linux",
+      provider: "linux-libfuse",
+      allowOther: true,
+      cfcWritebackXattrs: true,
+      noattrcache: false,
+    }),
+    ["fuse_ct", "-o", "allow_other"],
+  );
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: "fuse-t",
+      allowOther: true,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+      attrcacheTimeoutSeconds: 0,
+    }),
+    ["fuse_ct"],
+  );
+});
+
+Deno.test("mount fuse args apply noattrcache to FUSE-T mounts only", () => {
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: "fuse-t",
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: true,
+    }),
+    ["fuse_ct", "-o", "noattrcache"],
+  );
+  for (
+    const [os, provider] of [
+      ["linux", "linux-libfuse"],
+      ["darwin", "macfuse"],
+      ["darwin", "unknown"],
+    ] as const
+  ) {
+    assertEquals(
+      buildMountFuseArgs({
+        os,
+        provider,
+        allowOther: false,
+        cfcWritebackXattrs: false,
+        noattrcache: true,
+      }),
+      ["fuse_ct"],
+    );
+  }
+});
+
+Deno.test("FUSE-T mounts default to a one-second attrcache-timeout", () => {
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: "fuse-t",
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+    }),
+    ["fuse_ct", "-o", "attrcache-timeout=1"],
+  );
+  assertEquals(DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS, 1);
+  // Explicit zero restores the NFS client's default caching.
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: "fuse-t",
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+      attrcacheTimeoutSeconds: 0,
+    }),
+    ["fuse_ct"],
+  );
+  // noattrcache suppresses the timeout default.
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: "fuse-t",
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: true,
+      attrcacheTimeoutSeconds: 5,
+    }),
+    ["fuse_ct", "-o", "noattrcache"],
+  );
+  // macFUSE rejects the option, so no default is applied there, and an
+  // unresolved provider gets no default either.
+  for (const provider of ["macfuse", "unknown"] as const) {
+    assertEquals(
+      buildMountFuseArgs({
+        os: "darwin",
+        provider,
+        allowOther: false,
+        cfcWritebackXattrs: false,
+        noattrcache: false,
+      }),
+      ["fuse_ct"],
+    );
+  }
+});
+
+Deno.test("mount fuse args apply attrcache-timeout to FUSE-T mounts only", () => {
+  assertEquals(
+    buildMountFuseArgs({
+      os: "darwin",
+      provider: "fuse-t",
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+      attrcacheTimeoutSeconds: 30,
+    }),
+    ["fuse_ct", "-o", "attrcache-timeout=30"],
+  );
+  assertEquals(
+    buildMountFuseArgs({
+      os: "linux",
+      provider: "linux-libfuse",
+      allowOther: false,
+      cfcWritebackXattrs: false,
+      noattrcache: false,
+      attrcacheTimeoutSeconds: 30,
+    }),
+    ["fuse_ct"],
+  );
+});
+
+Deno.test("attrcache-timeout parses whole seconds within bounds", () => {
+  assertEquals(parseAttrcacheTimeoutSeconds(""), undefined);
+  assertEquals(parseAttrcacheTimeoutSeconds("1"), 1);
+  assertEquals(parseAttrcacheTimeoutSeconds("30"), 30);
+  assertEquals(
+    parseAttrcacheTimeoutSeconds(String(ATTRCACHE_TIMEOUT_MAX_SECONDS)),
+    ATTRCACHE_TIMEOUT_MAX_SECONDS,
+  );
+  assertEquals(parseAttrcacheTimeoutSeconds("0"), 0);
+  assertThrows(() => parseAttrcacheTimeoutSeconds("-1"));
+  assertThrows(() => parseAttrcacheTimeoutSeconds("1.5"));
+  assertThrows(() => parseAttrcacheTimeoutSeconds("abc"));
+  assertThrows(() =>
+    parseAttrcacheTimeoutSeconds(String(ATTRCACHE_TIMEOUT_MAX_SECONDS + 1))
+  );
+  assertThrows(() => parseAttrcacheTimeoutSeconds("1e21"));
 });
 
 Deno.test("libfuse search includes the FUSE-T per-user install location", () => {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -77,7 +77,8 @@ import {
 import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
 import {
   buildMountFuseArgs,
-  parseAttrcacheTimeoutSeconds,
+  type MountCacheOptions,
+  resolveMountCacheOptions,
 } from "./mount-options.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
@@ -367,21 +368,18 @@ export async function main(argv: string[] = Deno.args) {
     Deno.exit(1);
   }
 
-  const noattrcache = Boolean(args.noattrcache);
-  let attrcacheTimeoutSeconds: number | undefined;
+  let cacheOptions: MountCacheOptions;
   try {
-    attrcacheTimeoutSeconds = parseAttrcacheTimeoutSeconds(
-      String(args["attrcache-timeout"] ?? ""),
-    );
+    cacheOptions = resolveMountCacheOptions({
+      noattrcache: Boolean(args.noattrcache),
+      attrcacheTimeout: String(args["attrcache-timeout"] ?? ""),
+      attrcacheTimeoutGiven: argv.some((arg) =>
+        arg === "--attrcache-timeout" || arg.startsWith("--attrcache-timeout=")
+      ),
+    });
   } catch (e) {
     console.error(`[FUSE] ${e instanceof Error ? e.message : e}`);
-    Deno.exit(1);
-  }
-  if (noattrcache && attrcacheTimeoutSeconds !== undefined) {
-    console.error(
-      "[FUSE] --noattrcache and --attrcache-timeout are mutually exclusive",
-    );
-    Deno.exit(1);
+    return Deno.exit(1);
   }
 
   const mountpoint = args._[0] as string;
@@ -3220,8 +3218,7 @@ export async function main(argv: string[] = Deno.args) {
     provider: platform.provider(),
     allowOther: Boolean(args["allow-other"]),
     cfcWritebackXattrs,
-    noattrcache,
-    attrcacheTimeoutSeconds,
+    ...cacheOptions,
   });
   const { argsBuf, argv: _argv, encodedArgs: _ea } = platform.createFuseArgs(
     fuseArgs,

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -75,6 +75,10 @@ import {
   validateVirtualFileRange,
 } from "./handles.ts";
 import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
+import {
+  buildMountFuseArgs,
+  parseAttrcacheTimeoutSeconds,
+} from "./mount-options.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
 const encoder = new TextEncoder();
@@ -264,12 +268,14 @@ export async function main(argv: string[] = Deno.args) {
       "cfc-xattr-namespace",
       "cfc-mode",
       "cfc-writeback-state",
+      "attrcache-timeout",
     ],
     boolean: [
       "debug",
       "cfc-annotations",
       "cfc-writeback-xattrs",
       "allow-other",
+      "noattrcache",
     ],
     collect: ["space"],
     default: {
@@ -283,10 +289,12 @@ export async function main(argv: string[] = Deno.args) {
       "cfc-xattr-namespace": DEFAULT_CFC_XATTR_NAMESPACE,
       "cfc-mode": "",
       "cfc-writeback-state": "",
+      "attrcache-timeout": "",
       debug: false,
       "cfc-annotations": false,
       "cfc-writeback-xattrs": false,
       "allow-other": false,
+      noattrcache: false,
     },
   });
 
@@ -355,6 +363,23 @@ export async function main(argv: string[] = Deno.args) {
       `[FUSE] Unknown --cfc-xattr-namespace=${
         args["cfc-xattr-namespace"]
       }; expected trusted, compat, or both`,
+    );
+    Deno.exit(1);
+  }
+
+  const noattrcache = Boolean(args.noattrcache);
+  let attrcacheTimeoutSeconds: number | undefined;
+  try {
+    attrcacheTimeoutSeconds = parseAttrcacheTimeoutSeconds(
+      String(args["attrcache-timeout"] ?? ""),
+    );
+  } catch (e) {
+    console.error(`[FUSE] ${e instanceof Error ? e.message : e}`);
+    Deno.exit(1);
+  }
+  if (noattrcache && attrcacheTimeoutSeconds !== undefined) {
+    console.error(
+      "[FUSE] --noattrcache and --attrcache-timeout are mutually exclusive",
     );
     Deno.exit(1);
   }
@@ -3190,13 +3215,14 @@ export async function main(argv: string[] = Deno.args) {
   setOp(OPS_OFFSETS.create, createCb);
 
   // --- Mount ---
-  const fuseArgs = ["fuse_ct"];
-  if (Deno.build.os === "linux" && args["allow-other"]) {
-    fuseArgs.push("-o", "allow_other");
-    if (!cfcWritebackXattrs) {
-      fuseArgs.push("-o", "default_permissions");
-    }
-  }
+  const fuseArgs = buildMountFuseArgs({
+    os: Deno.build.os,
+    provider: platform.provider(),
+    allowOther: Boolean(args["allow-other"]),
+    cfcWritebackXattrs,
+    noattrcache,
+    attrcacheTimeoutSeconds,
+  });
   const { argsBuf, argv: _argv, encodedArgs: _ea } = platform.createFuseArgs(
     fuseArgs,
   );

--- a/packages/fuse/mount-cli.test.ts
+++ b/packages/fuse/mount-cli.test.ts
@@ -1,0 +1,111 @@
+// The daemon entrypoint's option contract, exercised through a real process.
+//
+// main() validates the cache mount flags before it opens libfuse or creates
+// the mountpoint, so these runs need no FUSE provider and mount nothing. The
+// checks cannot run in-process: main() reports a rejected flag by exiting.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { existsSync } from "@std/fs";
+
+const packageDir = dirname(fromFileUrl(import.meta.url));
+const repoRoot = join(packageDir, "..", "..");
+const modPath = join(packageDir, "mod.ts");
+const decoder = new TextDecoder();
+
+/** Run the daemon entrypoint and capture how it exited. */
+async function runDaemon(
+  args: string[],
+): Promise<{ code: number; stderr: string }> {
+  const output = await runDenoCommandWithTemporaryLock({
+    root: repoRoot,
+    args: (lockPath) => [
+      "run",
+      `--lock=${lockPath}`,
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-net",
+      modPath,
+      ...args,
+    ],
+  });
+  return { code: output.code, stderr: decoder.decode(output.stderr) };
+}
+
+/** A mountpoint path the daemon must reject before ever creating. */
+function unusedMountpoint(): string {
+  return join(
+    Deno.makeTempDirSync({ prefix: "cf-fuse-cli-test-" }),
+    "never-mounted",
+  );
+}
+
+Deno.test("daemon rejects an out-of-range attrcache-timeout", async () => {
+  const mountpoint = unusedMountpoint();
+  const { code, stderr } = await runDaemon([
+    mountpoint,
+    "--attrcache-timeout=-1",
+  ]);
+
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "Invalid --attrcache-timeout value: -1");
+  // The flags are rejected before the mountpoint is created.
+  assertEquals(existsSync(mountpoint), false);
+});
+
+Deno.test("daemon rejects an attrcache-timeout whose value was dropped", async () => {
+  // The argument parser does not read "-1" as this flag's value, and a mount
+  // must not silently fall back to the default cache regime.
+  const { code, stderr } = await runDaemon([
+    unusedMountpoint(),
+    "--attrcache-timeout",
+    "-1",
+  ]);
+
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "Missing value for --attrcache-timeout");
+});
+
+Deno.test("daemon rejects a non-integer attrcache-timeout", async () => {
+  const { code, stderr } = await runDaemon([
+    unusedMountpoint(),
+    "--attrcache-timeout",
+    "1.5",
+  ]);
+
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "Invalid --attrcache-timeout value: 1.5");
+});
+
+Deno.test("daemon rejects both cache flags together", async () => {
+  const { code, stderr } = await runDaemon([
+    unusedMountpoint(),
+    "--noattrcache",
+    "--attrcache-timeout",
+    "1",
+  ]);
+
+  assertEquals(code, 1);
+  assertStringIncludes(
+    stderr,
+    "--noattrcache and --attrcache-timeout are mutually exclusive",
+  );
+});
+
+Deno.test("daemon accepts the cache flags it supports", async () => {
+  // A missing mountpoint is reported only once the flags have parsed, so
+  // reaching the usage message proves the flags themselves were accepted.
+  for (
+    const accepted of [
+      ["--noattrcache"],
+      ["--attrcache-timeout", "0"],
+      ["--attrcache-timeout", "86400"],
+    ]
+  ) {
+    const { code, stderr } = await runDaemon(accepted);
+    assertEquals(code, 1, `expected usage exit for ${accepted.join(" ")}`);
+    assertStringIncludes(stderr, "Usage: mod.ts <mountpoint>");
+  }
+});

--- a/packages/fuse/mount-options.ts
+++ b/packages/fuse/mount-options.ts
@@ -1,0 +1,96 @@
+// mount-options.ts — mount-argv construction and option validation shared
+// by the FUSE daemon and the CLI mount command. Kept free of runtime
+// imports so the CLI can validate options without loading the daemon
+// module.
+
+import type { FuseProvider } from "./platform.ts";
+
+/**
+ * Bounds for --attrcache-timeout: zero (leave the NFS client's default
+ * caching untouched) or one second to one day.
+ */
+export const ATTRCACHE_TIMEOUT_MIN_SECONDS = 0;
+export const ATTRCACHE_TIMEOUT_MAX_SECONDS = 86_400;
+
+/**
+ * The attrcache-timeout applied to FUSE-T mounts when neither cache flag is
+ * given. The macOS NFS client's default attribute caching serves a stale
+ * NotFound for up to a minute after a daemon-side ENOENT and serves stale
+ * directory listings for seconds; a one-second bound removes both windows
+ * while keeping reads within the window served from cache.
+ */
+export const DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS = 1;
+
+/**
+ * Parse the --attrcache-timeout value: a whole number of seconds. Zero
+ * means no cache tuning (the NFS client keeps its age-based 5-60 second
+ * defaults). Returns undefined for an empty value. The upper bound keeps
+ * the value inside the integer range FUSE-T's attrcache-timeout=%d option
+ * parse accepts.
+ */
+export function parseAttrcacheTimeoutSeconds(
+  value: string,
+): number | undefined {
+  if (value === "") return undefined;
+  const seconds = Number(value);
+  if (
+    !Number.isInteger(seconds) ||
+    seconds < ATTRCACHE_TIMEOUT_MIN_SECONDS ||
+    seconds > ATTRCACHE_TIMEOUT_MAX_SECONDS
+  ) {
+    throw new Error(
+      `Invalid --attrcache-timeout value: ${value} (expected a whole number of seconds between ${ATTRCACHE_TIMEOUT_MIN_SECONDS} and ${ATTRCACHE_TIMEOUT_MAX_SECONDS}; 0 means no cache tuning)`,
+    );
+  }
+  return seconds;
+}
+
+/**
+ * Build the argv handed to fuse_mount.
+ *
+ * allow_other and default_permissions are Linux mount options.
+ *
+ * noattrcache and attrcache-timeout are FUSE-T mount options controlling
+ * the macOS NFS client's cache. Measured on FUSE-T 1.2.7: noattrcache
+ * mounts with the NFS nonegnamecache option (negative name lookups are not
+ * cached; positive attribute and directory caching keeps the age-based
+ * 5-60 second defaults), and attrcache-timeout=N mounts with every
+ * attribute-cache bound (the acreg and acdir minima and maxima) fixed at N
+ * seconds, which caps how long stale attributes, negative name entries, and
+ * directory listings are served. FUSE-T ignores the entry and attribute timeouts the filesystem
+ * returns, so these mount options are the only cache controls available on
+ * macOS.
+ *
+ * When neither flag is given, FUSE-T mounts default to attrcache-timeout=
+ * DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS; an explicit value of 0 leaves
+ * the NFS client defaults. macFUSE rejects both options, so the default
+ * applies only when the loaded provider is FUSE-T.
+ */
+export function buildMountFuseArgs(opts: {
+  os: string;
+  provider: FuseProvider;
+  allowOther: boolean;
+  cfcWritebackXattrs: boolean;
+  noattrcache: boolean;
+  attrcacheTimeoutSeconds?: number;
+}): string[] {
+  const fuseArgs = ["fuse_ct"];
+  if (opts.os === "linux" && opts.allowOther) {
+    fuseArgs.push("-o", "allow_other");
+    if (!opts.cfcWritebackXattrs) {
+      fuseArgs.push("-o", "default_permissions");
+    }
+  }
+  if (opts.os === "darwin" && opts.provider === "fuse-t") {
+    if (opts.noattrcache) {
+      fuseArgs.push("-o", "noattrcache");
+    } else {
+      const seconds = opts.attrcacheTimeoutSeconds ??
+        DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS;
+      if (seconds !== 0) {
+        fuseArgs.push("-o", `attrcache-timeout=${seconds}`);
+      }
+    }
+  }
+  return fuseArgs;
+}

--- a/packages/fuse/mount-options.ts
+++ b/packages/fuse/mount-options.ts
@@ -45,6 +45,45 @@ export function parseAttrcacheTimeoutSeconds(
   return seconds;
 }
 
+/** The cache mount options a mount request resolves to. */
+export interface MountCacheOptions {
+  noattrcache: boolean;
+  attrcacheTimeoutSeconds?: number;
+}
+
+/**
+ * Resolve the cache options from their raw command-line spellings, rejecting
+ * an out-of-range timeout or the mutually exclusive combination. Throws an
+ * Error whose message names the offending flags.
+ *
+ * `attrcacheTimeoutGiven` reports whether the flag appeared in argv at all.
+ * The daemon's argument parser does not read a leading-dash token as an
+ * option value, so `--attrcache-timeout -1` parses as no value; the flag
+ * present with no value is rejected.
+ */
+export function resolveMountCacheOptions(
+  args: {
+    noattrcache: boolean;
+    attrcacheTimeout: string;
+    attrcacheTimeoutGiven?: boolean;
+  },
+): MountCacheOptions {
+  if (args.attrcacheTimeoutGiven && args.attrcacheTimeout === "") {
+    throw new Error(
+      `Missing value for --attrcache-timeout (expected a whole number of seconds between ${ATTRCACHE_TIMEOUT_MIN_SECONDS} and ${ATTRCACHE_TIMEOUT_MAX_SECONDS}; write a value that starts with "-" as --attrcache-timeout=<value>)`,
+    );
+  }
+  const attrcacheTimeoutSeconds = parseAttrcacheTimeoutSeconds(
+    args.attrcacheTimeout,
+  );
+  if (args.noattrcache && attrcacheTimeoutSeconds !== undefined) {
+    throw new Error(
+      "--noattrcache and --attrcache-timeout are mutually exclusive",
+    );
+  }
+  return { noattrcache: args.noattrcache, attrcacheTimeoutSeconds };
+}
+
 /**
  * Build the argv handed to fuse_mount.
  *

--- a/packages/fuse/platform-darwin.ts
+++ b/packages/fuse/platform-darwin.ts
@@ -9,6 +9,7 @@ import {
   type FileInfo,
   type FuseLib,
   type FusePlatform,
+  type FuseProvider,
   makeWriteEntryParam,
   type MountHandle,
   type StatOpts,
@@ -179,10 +180,15 @@ const FUSE_ARGS_STRUCT_SIZE = 24;
 // --- Module state ---
 
 let fullLib: DarwinLib | null = null;
+let loadedProvider: FuseProvider = "unknown";
 
 // --- Platform implementation ---
 
 const darwinPlatform: FusePlatform = {
+  provider() {
+    return loadedProvider;
+  },
+
   openFuse(): FuseLib {
     if (fullLib) return fullLib as unknown as FuseLib;
 
@@ -190,6 +196,7 @@ const darwinPlatform: FusePlatform = {
     for (const path of libfusePaths()) {
       try {
         fullLib = Deno.dlopen(path, DARWIN_SYMBOLS);
+        loadedProvider = path.includes("libfuse-t") ? "fuse-t" : "macfuse";
         console.log(`Loaded ${path}`);
         return fullLib as unknown as FuseLib;
       } catch (e) {

--- a/packages/fuse/platform-darwin.ts
+++ b/packages/fuse/platform-darwin.ts
@@ -16,10 +16,24 @@ import {
 
 // --- Library paths ---
 
-const LIBFUSE_PATHS = [
-  "/usr/local/lib/libfuse-t.dylib", // FUSE-T (kext-less, NFS v4 based)
-  "/usr/local/lib/libfuse.2.dylib", // macFUSE (kernel extension)
-];
+/**
+ * Candidate libfuse locations, in preference order. FUSE-T's installer
+ * supports two layouts: the root install symlinks the library into
+ * /usr/local/lib, and the per-user install (running the installer's
+ * postinstall as a non-root user) places it under
+ * ~/.fuse-t/usr/local/lib. macFUSE installs into /usr/local/lib only.
+ */
+export function libfusePaths(
+  env: { get(name: string): string | undefined } = Deno.env,
+): string[] {
+  const paths = ["/usr/local/lib/libfuse-t.dylib"];
+  const home = env.get("HOME");
+  if (home) {
+    paths.push(`${home}/.fuse-t/usr/local/lib/libfuse-t.dylib`);
+  }
+  paths.push("/usr/local/lib/libfuse.2.dylib"); // macFUSE (kernel extension)
+  return paths;
+}
 
 // --- Darwin-specific FFI symbols (FUSE v2) ---
 
@@ -173,7 +187,7 @@ const darwinPlatform: FusePlatform = {
     if (fullLib) return fullLib as unknown as FuseLib;
 
     const errors: string[] = [];
-    for (const path of LIBFUSE_PATHS) {
+    for (const path of libfusePaths()) {
       try {
         fullLib = Deno.dlopen(path, DARWIN_SYMBOLS);
         console.log(`Loaded ${path}`);

--- a/packages/fuse/platform-linux.ts
+++ b/packages/fuse/platform-linux.ts
@@ -185,6 +185,10 @@ let fullLib: LinuxLib | null = null;
 // --- Platform implementation ---
 
 const linuxPlatform: FusePlatform = {
+  provider() {
+    return fullLib ? "linux-libfuse" : "unknown";
+  },
+
   openFuse(): FuseLib {
     if (fullLib) return fullLib as unknown as FuseLib;
 

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -119,9 +119,15 @@ export type FuseLib = Deno.DynamicLibrary<typeof COMMON_SYMBOLS>;
 // deno-lint-ignore no-explicit-any
 type AnyCallback = Deno.UnsafeCallback<any>;
 
+/** Which FUSE implementation openFuse() loaded. */
+export type FuseProvider = "fuse-t" | "macfuse" | "linux-libfuse" | "unknown";
+
 export interface FusePlatform {
   /** Open the platform-appropriate libfuse and return a lib with common symbols. */
   openFuse(): FuseLib;
+
+  /** The implementation loaded by openFuse(); "unknown" before it runs. */
+  provider(): FuseProvider;
 
   // Struct sizes
   STAT_SIZE: number;

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -231,6 +231,15 @@ Changes from the browser appear in the filesystem within ~1 second (FUSE-T NFS
 cache). Not instant. If you need to force a re-read, `cat` the `.json` file (not
 the exploded directory).
 
+FUSE-T mounts default to `attrcache-timeout=1`, which bounds all client-side
+staleness (attributes, negative name lookups, directory listings) at about one
+second — measured p99 read latency during daemon-side write storms is a few
+milliseconds, with sub-second transients while a subtree rebuilds. If a mount
+was created with `--attrcache-timeout 0` (untuned), a path stat'd while absent
+can keep reporting `NotFound` for up to a minute and `ls` can be tens of seconds
+stale; remount with the default before debugging "missing" files. See
+`packages/fuse/README.md` "macOS: NFS client cache tuning".
+
 ### Large Pieces
 
 Pieces with large `$UI` trees or complex schemas produce huge `result.json`


### PR DESCRIPTION
## Problem

FUSE-T serves macOS mounts through the NFS client and ignores the entry and
attribute cache timeouts the filesystem returns, so the client's age-based
5-60 second caching defaults apply. After a daemon-side ENOENT, the negative
name cache keeps answering NotFound without a daemon round-trip, and
directory listings are served stale. #4642 worked around this inside the
`cf exec` existence check with a listing fallback plus a bounded 3.5 second
recheck delay, and #4654 verified the mechanism on a synthetic filesystem —
but the staleness affects every consumer of the mount, and agents see it as
intermittent "file not found" failures and stale `ls` output.

## What was measured

Both candidate mount options were measured against a live space (FUSE-T
1.2.7, macOS 26, arm64), with all writes driven through the cf CLI and
probes issued through fresh mounts per setting. Daemon-side instrumentation
showed the fuse bridge applied each CLI write within about 150 milliseconds;
everything beyond that is client-side cache staleness.

| Measured | untuned | `noattrcache` | `attrcache-timeout=1` |
| --- | --- | --- | --- |
| Stale NotFound after a daemon-side create | 3.2 s / 56.3 s | 7.5 s / 29.3 s | 0.18 s / 0.42 s |
| Stale directory listing | 0.8 s / 53.4 s | 26.7 s | 0.8 s |
| Stat cost (hot loop) | 1.9 µs | 2.0 µs | 1.7 µs |
| Read errors during a 60 s rebuild storm | 3 blips ≤ 60 ms | 1 blip ≤ 60 ms | 0 |

Two findings changed the plan from what #4654 recommended:

- **`noattrcache` no longer closes the window.** On FUSE-T 1.2.x it maps to
  the NFS `nonegnamecache` flag only (confirmed with `nfsstat -m`): negative
  name lookups stop being cached, but directory attribute caching keeps its
  defaults, which still serves the stale listing for tens of seconds. The
  historically reported cost of one RPC per stat is also gone — stats are
  cache-served at about two microseconds in every setting.
- **`attrcache-timeout=N`** (a FUSE-T option present in its source and
  release notes but absent from its wiki) fixes every NFS attribute-cache
  bound at N seconds. At one second it removes the staleness entirely at no
  measurable cost. A five-minute endurance run under sustained daemon-side
  writes (1296 writes, ~2790 probes per target) held p99 read latency at
  4 ms with a worst transient of 110 ms, no stale-negative false positives,
  daemon CPU at most 3%, and no sign of the NFS client lookup livelock
  reported in macos-fuse-t/fuse-t#61 (whose root cause turned out to be
  unstable inode numbers in an unrelated FUSE library, not cache tuning).

The full evaluation, including the upstream research and the soak
methodology, is recorded in
`docs/history/packages/fuse/noattrcache-mount-option-evaluation.md`.

## The change

- `cf fuse mount` gains two mutually exclusive flags, plumbed through the
  background supervisor and the compiled binary's hidden subcommands to the
  args handed to `fuse_mount`:
  - `--attrcache-timeout <whole seconds>` selects the cache bound. FUSE-T
    mounts now default to 1; an explicit 0 restores the NFS client's
    untuned caching. Values are validated at the command line and again in
    the daemon, so errors surface where the user typed them rather than
    inside a detached child.
  - `--noattrcache` mounts with FUSE-T's option of that name, kept as a
    diagnostic dial.
- The default is applied in `packages/fuse/mount-options.ts` and gated on a
  new `FusePlatform.provider()`: macFUSE rejects unknown mount options, so
  only FUSE-T mounts receive it, and Linux accepts and ignores both flags.
- A separate first commit teaches the library loader to probe FUSE-T's
  per-user install location (`~/.fuse-t/usr/local/lib`), which the FUSE-T
  installer supports but the loader previously missed.
- Documentation: fuse README section on macOS cache tuning, a
  `fuseNfsCacheTuning` entry in the experimental-flags registry, and a
  staleness note in the fuse-workflow skill.

## What this does not change

The `cf exec` listing-recheck delay (`DIR_LISTING_RECHECK_DELAY_MS`) stays:
it still covers untuned, macFUSE, and pre-1.0.29 FUSE-T mounts (older
FUSE-T predates the `attrcache-timeout` option; the escape hatch there is
`--attrcache-timeout 0`). Mounts on the new default stop hitting the miss
path the delay guards. Reducing the delay toward the one-second bound is a
follow-up tracked in the registry entry once the default has field-soaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds NFS cache tuning to macOS FUSE-T mounts and defaults them to a one-second attribute cache to eliminate stale NotFound/listings without a performance penalty. Also makes the loader find per-user FUSE-T installs.

- New Features
  - `cf fuse mount` adds `--attrcache-timeout <seconds>` and `--noattrcache` (mutually exclusive).
  - Default: FUSE-T mounts apply `attrcache-timeout=1`; `0` keeps the NFS client’s untuned caching. Applied only when the provider is FUSE-T; Linux/macFUSE ignore these flags.
  - Validates `--attrcache-timeout` at the CLI and in the daemon (whole seconds, 0–86400), and rejects a flag present with no value.
  - Mount option construction moved to `packages/fuse/mount-options.ts`; platforms now expose `provider()`; compiled binary and supervisor subcommands use `buildFuseBinaryArgs`.
  - Darwin loader searches `~/.fuse-t/usr/local/lib` for `libfuse-t.dylib` in addition to `/usr/local/lib`.

- Migration
  - No changes required; remounts pick up the default automatically.
  - To keep existing behavior or for FUSE-T versions before 1.0.29, use `--attrcache-timeout 0`. Use `--noattrcache` only for diagnostics.

<sup>Written for commit 26619cf7ad7976dbb60d2ce4f71231dd0ac440f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

