### PR TITLE
fix(piece): reconcile system root before bootstrap

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -218,12 +218,15 @@ propagate](#how-flags-propagate).
 - **Purpose.** At space open, rolls a space's **non-home** root system pattern
   (default-app) forward in place when its toolshed serves a newer content
   identity: version gate (client vs toolshed build sha) → cached `?identity`
-  compare → in-place `patternIdentity` swap, re-instantiated by the existing
-  pattern watcher onto the same result cell. Best-effort and non-blocking: no
-  failure of the check may break space open. When either build sha is unknown
-  (dev/source servers carry none) the check skips silently; the `versionSkew`
-  IPC signal — which raises the shell's reload banner — fires only on a proven
-  mismatch (both shas known and different). See
+  compare → in-place `patternIdentity` swap. Persisted roots are resolved
+  without starting; the check is awaited and the reconciled identity is
+  committed before root bootstrap, so an unloadable obsolete root cannot block
+  its own repair. The check remains best-effort and converts its own failures
+  to a no-op; if repair is unavailable, the subsequent root start retains its
+  normal loud failure behavior. When either build sha is unknown (dev/source
+  servers carry none) the check skips silently; the `versionSkew` IPC signal —
+  which raises the shell's reload banner — fires only on a proven mismatch
+  (both shas known and different). See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).
 - **Current default and planned end state.** The runner built-in default is off
   like every flag in this category; the shell build injects `true` unless the
@@ -232,8 +235,8 @@ propagate](#how-flags-propagate).
   background piece service) leave it off unless the env var is set. End state:
   graduate to always-on for system roots once golden-replay coverage has soaked
   and the home audit lands, then delete both auto-update flags.
-- **Status on 2026-07-09.** Implemented; on in the shell for non-home roots,
-  off elsewhere.
+- **Status on 2026-07-14.** Implemented; on in the shell for non-home roots,
+  off elsewhere. Root reconciliation runs before bootstrap.
 - **Path to removal.** Graduate the home root (below), make the check
   unconditional, and remove both flags together.
 

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -17,18 +17,16 @@ Home root and published-pattern updates remain design (Phases 2–4).
 
 ## Last Updated
 
-2026-07-08
+2026-07-14
 
 ## Motivation
 
 - **System patterns must self-heal and roll forward.** `home.tsx` /
-  `default-app.tsx` are the most critical patterns to keep current, but today
-  they are **lazy-pinned at creation**: `ensureDefaultPattern`'s fast path
-  returns the existing root piece forever and never re-checks source
-  (`packages/piece/src/ops/pieces-controller.ts:342`). The only roll-forward is
-  a **manual** `recreateDefaultPattern` (shell Debugger button / CLI), which is
-  **not state-preserving** — it mints a new piece (`cause:
-  home-pattern-${Date.now()}`) and relinks (`pieces-controller.ts:222`).
+  `default-app.tsx` are the most critical patterns to keep current. Existing
+  roots are resolved without starting, reconciled against their tracked system
+  source, and only then bootstrapped. The manual `recreateDefaultPattern`
+  (shell Debugger button / CLI) remains a state-losing escape hatch: it mints a
+  new piece and relinks it.
 - **Two hazard cases to handle explicitly.** (1) We shipped a broken system
   pattern — once a fix ships, recovery must be automatic. (2) An
   schema-incompatible update slips through — the damage must be *bounded*
@@ -59,9 +57,9 @@ Home root and published-pattern updates remain design (Phases 2–4).
 | Mechanism | Where | Role here |
 |---|---|---|
 | Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | write `runner.ts:1012`, read `getPatternIdentityRef` `runner.ts:4441` | The thing an update rewrites |
-| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts:1246` (enabled unless `doNotUpdateOnPatternChange`, `runner.ts:1341`) | **The apply mechanism — already built.** An update is a meta write; the watcher does the rest |
+| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts:1246` (enabled unless `doNotUpdateOnPatternChange`, `runner.ts:1341`) | Applies a metadata swap when the piece is already running; at space open, bootstrap reads the reconciled metadata directly |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/manager.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
-| `ensureDefaultPattern` (lazy, pinned-at-creation) / `recreateDefaultPattern` (manual, **not** state-preserving) | `pieces-controller.ts:342` / `:222` | The hook (ensure) and the escape hatch (recreate) |
+| `ensureDefaultPattern` (resolve → reconcile → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The automatic self-heal hook (ensure) and the state-losing escape hatch (recreate) |
 | System patterns = **raw TSX served by path**, bundled via `deno compile --include`; **no name→identity manifest** | `packages/toolshed/routes/patterns/patterns-server.ts`, `patterns.routes.ts` | Where the current system source + its identity come from |
 | Per-space host resolution: `mappedHostFor(space)` / `registerSpaceHost` (3-tier: seed `spaceHostMap` → learned site-table → default) | `runtime.ts:1423` / `:1444`, `storage/v2-remote-session.ts` | Which toolshed a space's source is fetched from |
 | Build identity: `/api/meta` → `{ did, gitSha }` | `packages/toolshed/routes/meta/` | The version-skew signal |
@@ -85,9 +83,11 @@ Two decisions carry the whole design:
    source it tracks for updates. (`patternSource`, *not* `source`: the latter
    is the doc-level producer annotation the server-primary work uses.)
 2. **Update = resolve `patternSource` → current identity; if it differs from
-   the running `patternIdentity.identity`, write the new `{identity, symbol}`
-   to the piece's `patternIdentity` meta.** The existing watcher
-   (`runner.ts:1246`) re-instantiates in place. No new apply machinery.
+   the persisted `patternIdentity.identity`, write the new `{identity, symbol}`
+   to the piece's `patternIdentity` meta.** At space open this happens before
+   root bootstrap, so `start()` loads the reconciled identity. For an already
+   running root, the existing watcher (`runner.ts:1246`) re-instantiates in
+   place. No new apply machinery.
 
 System patterns run this loop automatically at space open (always-update);
 published patterns will run it behind an explicit user action (§ Phasing).
@@ -146,9 +146,11 @@ cf:[[//toolshed.url]/space/][slug]
 
 The apply is: ensure the new closure is loadable in the space
 (`compilePattern(program, { space })` writes source + compiled docs), then
-write `{ identity, symbol }` to the piece's `patternIdentity` meta. The watcher
-cancels the old pattern's reactive nodes and re-instantiates the new pattern
-onto the **same result cell**.
+write `{ identity, symbol }` to the piece's `patternIdentity` meta. During space
+open, `ensureDefaultPattern` performs this write before calling `startPiece`,
+so an obsolete pattern that cannot load never blocks its replacement. If the
+piece is already running, the watcher cancels its old reactive nodes and
+re-instantiates the new pattern onto the **same result cell**.
 
 - **Survives**: the result cell's entity and inbound links; any state cells the
   new pattern still reads (addressed by stable key/cause).
@@ -184,7 +186,9 @@ and `home.tsx`:
   pathname-prefixed names — **not** patterns-root-relative names — or the two
   identities never match and the check re-updates forever.
 
-**Runtime side (at space open, in the per-space worker).**
+**Runtime side (at space open, in the per-space worker).** Resolve the persisted
+root with `runIt=false`, run this loop, re-resolve the cell after any metadata
+transaction, and only then start it:
 
 1. `url` = home space → `home.tsx`; else the root piece's `patternSource`.
    `host` = `mappedHostFor(space) ?? apiUrl`. *(Change from today:
@@ -200,8 +204,10 @@ and `home.tsx`:
    or different toolshed"). Steady state is an in-memory compare, no request.
 4. `currentId === running patternIdentity.identity` → done.
 5. else → fetch `{host}{url}` source, `compilePattern(program, { space })`,
-   write `patternIdentity = { identity: currentId, symbol }`. The watcher
-   re-instantiates in place.
+   write `patternIdentity = { identity: currentId, symbol }`.
+6. Start the reconciled root. A newly created root skips the check because it
+   was compiled from the current source in the same ensure operation; a root
+   discovered after a creation race is treated as persisted and reconciled.
 
 ## Version-skew gate
 
@@ -241,7 +247,7 @@ so no build-dependence and no gate.
   shipping — the primary defense (feasible precisely because the list is short
   and we own the source).
 - **Self-heal from a borked ship**: fix source → new identity → next space open
-  swaps it in place → recovered, automatically.
+  swaps it before bootstrap → recovered even when the old identity cannot load.
 - **Rollback = redeploy**: ship the prior source → toolshed serves the prior
   identity → the same swap rolls back. No per-piece rollback state needed.
 - **Escape hatch**: manual `recreateDefaultPattern` remains (state-losing; last

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -395,10 +395,13 @@ export class PiecesController<T = unknown> {
   async ensureDefaultPattern(): Promise<PieceController<NameSchema>> {
     this.disposeCheck();
 
-    // Fast path: check if pattern already exists (outside transaction)
-    const existingPattern = await this.#manager.getDefaultPattern();
+    // Fast path: resolve the existing root WITHOUT starting it. The updater
+    // must get a chance to replace an obsolete patternIdentity before
+    // bootstrap tries to load that identity; otherwise an unloadable old root
+    // prevents the very repair that would make it loadable.
+    const existingPattern = await this.#manager.getDefaultPattern(false);
     if (existingPattern) {
-      return new PieceController<NameSchema>(this.#manager, existingPattern);
+      return await this.startEnsuredDefaultPattern(existingPattern, true);
     }
 
     // Determine which pattern to use based on space type
@@ -455,9 +458,7 @@ export class PiecesController<T = unknown> {
     // - Reading defaultPattern inside the transaction creates an invariant
     // - If another process creates it first, the commit fails and retries
     // - On retry, we'll see the existing pattern and return early
-    let pieceCell: Cell<NameSchema>;
-
-    await timePiecesPhase(
+    const creationResult = await timePiecesPhase(
       "ensureDefaultPattern.editWithRetry",
       () =>
         this.#manager.runtime.editWithRetry((tx) => {
@@ -472,11 +473,11 @@ export class PiecesController<T = unknown> {
             // Pattern was created by another process - we're done
             // The editWithRetry will complete successfully, and we'll
             // fetch the existing pattern below
-            return;
+            return false;
           }
 
           // Create piece cell within this transaction
-          pieceCell = this.#manager.runtime.getCell<NameSchema>(
+          const pieceCell = this.#manager.runtime.getCell<NameSchema>(
             this.#manager.getSpace(),
             patternConfig.cause,
             nameSchema,
@@ -492,8 +493,10 @@ export class PiecesController<T = unknown> {
 
           // Link as default pattern within same transaction
           defaultPatternCell.set(pieceCell.withTx(tx));
+          return true;
         }),
     );
+    const createdByThisCall = creationResult.ok === true;
 
     // After transaction commits, fetch the final result
     // (either we created it, or another process did)
@@ -505,10 +508,35 @@ export class PiecesController<T = unknown> {
       throw new Error("Failed to create or find default pattern");
     }
 
-    // Start the piece after successful creation/discovery
+    // A root created by this successful attempt was compiled from the current
+    // source immediately above. If another writer won the race, treat the
+    // discovered root like every other persisted root and reconcile it before
+    // start.
+    return await this.startEnsuredDefaultPattern(
+      finalPattern,
+      !createdByThisCall,
+    );
+  }
+
+  private async startEnsuredDefaultPattern(
+    root: Cell<NameSchema>,
+    reconcileBeforeStart: boolean,
+  ): Promise<PieceController<NameSchema>> {
+    let rootToStart = root;
+    if (reconcileBeforeStart) {
+      await timePiecesPhase(
+        "ensureDefaultPattern.checkAndUpdateDefaultPattern",
+        () => this.checkAndUpdateDefaultPattern(root),
+      );
+      // The metadata swap committed through a transaction view. Resolve the
+      // root again so start() observes the committed patternIdentity rather
+      // than the pre-transaction snapshot held by the caller's cell.
+      rootToStart = await this.#manager.getDefaultPattern(false) ?? root;
+    }
+
     await timePiecesPhase(
       "ensureDefaultPattern.startPiece",
-      () => this.#manager.startPiece(finalPattern),
+      () => this.#manager.startPiece(rootToStart),
     );
     await timePiecesPhase(
       "ensureDefaultPattern.runtime.idle",
@@ -519,22 +547,22 @@ export class PiecesController<T = unknown> {
       () => this.#manager.synced(),
     );
 
-    return new PieceController<NameSchema>(this.#manager, finalPattern);
+    return new PieceController<NameSchema>(this.#manager, rootToStart);
   }
 
   /**
    * Roll the space's system root pattern forward in place if its toolshed
-   * serves a newer content identity than the running one. Best-effort: every
-   * failure logs and returns without throwing — a failed check must never break
-   * space open. The apply is a `patternIdentity` meta write; the existing
-   * pattern watcher (runner.ts) cancels the old nodes and re-instantiates the
-   * new pattern onto the SAME result cell (no new piece, state preserved by
-   * stable key). Never calls run()/stop()/recreateDefaultPattern.
+   * serves a newer content identity. Best-effort: every failure logs and
+   * returns without throwing. During {@link ensureDefaultPattern}, this runs
+   * before the persisted root is started, so an unloadable obsolete identity
+   * can be replaced before bootstrap. If the root is already running, its
+   * watcher applies the same metadata swap in place.
    *
-   * Call it AFTER {@link ensureDefaultPattern} has resolved (the root must be
-   * running for the watcher to be live).
+   * Never calls run()/stop()/recreateDefaultPattern.
    */
-  async checkAndUpdateDefaultPattern(): Promise<UpdateOutcome> {
+  async checkAndUpdateDefaultPattern(
+    resolvedRoot?: Cell<NameSchema>,
+  ): Promise<UpdateOutcome> {
     const runtime = this.#manager.runtime;
     const space = this.#manager.getSpace();
 
@@ -549,8 +577,10 @@ export class PiecesController<T = unknown> {
     }
 
     try {
-      // 2. The running root piece's result cell (no re-run).
-      const root = await this.#manager.getDefaultPattern(false);
+      // 2. The root piece's result cell, resolved without starting it. Ensure
+      // passes the cell it already found; explicit checks resolve it here.
+      const root = resolvedRoot ??
+        await this.#manager.getDefaultPattern(false);
       if (!root) return "current";
 
       // 3. Provenance + per-space host (NOT the global apiUrl — a foreign-homed

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -214,6 +214,49 @@ describe("checkAndUpdateDefaultPattern", () => {
     );
   });
 
+  it("reconciles a persisted root discovered after a creation race", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const existing = await controller.ensureDefaultPattern();
+    const rootLinkBefore = JSON.stringify(existing.getCell().getAsLink());
+    const originalGetDefaultPattern = manager.getDefaultPattern;
+    const originalGetSpaceCellContents = manager.getSpaceCellContents;
+    const originalCheck = controller.checkAndUpdateDefaultPattern;
+    let firstLookup = true;
+    let updateChecks = 0;
+
+    // Model the retry after another writer wins: the first pre-transaction
+    // lookup saw no root, while the transaction's double-check now sees one.
+    manager.getDefaultPattern = ((runIt?: boolean) => {
+      if (firstLookup) {
+        firstLookup = false;
+        return Promise.resolve(undefined);
+      }
+      return originalGetDefaultPattern.call(manager, runIt);
+    }) as typeof manager.getDefaultPattern;
+    manager.getSpaceCellContents = (() => ({
+      withTx: () => ({
+        key: (key: string) => {
+          expect(key).toBe("defaultPattern");
+          return { get: () => ({ get: () => ({}) }) };
+        },
+      }),
+    })) as unknown as typeof manager.getSpaceCellContents;
+    controller.checkAndUpdateDefaultPattern = ((root) => {
+      updateChecks++;
+      return originalCheck.call(controller, root);
+    }) as typeof controller.checkAndUpdateDefaultPattern;
+
+    try {
+      const raced = await controller.ensureDefaultPattern();
+      expect(JSON.stringify(raced.getCell().getAsLink())).toBe(rootLinkBefore);
+      expect(updateChecks).toBe(1);
+    } finally {
+      manager.getDefaultPattern = originalGetDefaultPattern;
+      manager.getSpaceCellContents = originalGetSpaceCellContents;
+      controller.checkAndUpdateDefaultPattern = originalCheck;
+    }
+  });
+
   it("skips and reports version skew when builds differ", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.ensureDefaultPattern();
@@ -283,13 +326,25 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(stub.identityFetches()).toBe(2);
   });
 
-  it("never throws when a fetch fails (space open is not broken)", async () => {
+  it("never throws when identity lookup fails or rejects unexpectedly", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.ensureDefaultPattern();
     const before = getPatternIdentityRef(piece.getCell())?.identity;
 
     stub.failIdentity(true);
     expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+
+    // The Runtime normally converts fetch failures to undefined. Also defend
+    // the controller boundary against an unexpected rejected lookup.
+    const originalCachedIdentity = runtime.cachedPatternIdentity;
+    runtime.cachedPatternIdentity = () =>
+      Promise.reject(new Error("unexpected identity lookup rejection"));
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    } finally {
+      runtime.cachedPatternIdentity = originalCachedIdentity;
+    }
+
     expect(getPatternIdentityRef(piece.getCell())?.identity).toBe(before);
   });
 

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -177,6 +177,43 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(idV2).not.toBe(idV1);
   });
 
+  it("reconciles an unloadable stale root before ensure starts it", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    const rootLinkBefore = JSON.stringify(root.getAsLink());
+
+    // Simulate a root left behind by an older runtime whose stored pattern can
+    // no longer be loaded by this one. The identity is well-formed but its
+    // source closure was never persisted, so any attempt to start it fails.
+    const staleIdentity = await identityForSource(
+      patternSource("unloadable-stale-root"),
+    );
+    await manager.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: staleIdentity,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+    const staleRoot = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(staleRoot)?.identity).toBe(staleIdentity);
+
+    // A newer system root is available from the matching toolshed build. The
+    // ensure path must install this identity before start() sees the stale one.
+    stub.setSource(SOURCE_V2);
+    runtime.clearPatternUpdateCaches();
+
+    const updated = await controller.ensureDefaultPattern();
+    await runtime.idle();
+
+    expect(JSON.stringify(updated.getCell().getAsLink())).toBe(rootLinkBefore);
+    expect(getPatternIdentityRef(updated.getCell())?.identity).toBe(
+      await identityForSource(SOURCE_V2),
+    );
+  });
+
   it("skips and reports version skew when builds differ", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.ensureDefaultPattern();

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -5,10 +5,9 @@ import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { PiecesController } from "@commonfabric/piece/ops";
 import {
   browserWorkerParamsFromInitializationData,
-  checkUpdateInBackground,
-  maybeCheckHomeUpdate,
   postVersionSkew,
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
@@ -1064,40 +1063,71 @@ describe("RuntimeProcessor home pattern IPC", () => {
     expect(idleCalled).toBe(true);
   });
 
-  it("maybeCheckHomeUpdate no-ops unless both flags are on", () => {
-    let built = false;
-    const runtime = {
-      userIdentityDID: "did:key:test-home",
-      experimental: { systemPatternAutoUpdate: true }, // home flag off
-      getHomeSpaceCell: () => {
-        built = true;
-        return { sync: () => Promise.resolve() };
-      },
-    } as unknown as Parameters<typeof maybeCheckHomeUpdate>[1];
-    maybeCheckHomeUpdate(cfcSigner, runtime);
-    // No controller built (the home flag gates it before any construction).
-    expect(built).toBe(false);
-  });
-
-  it("maybeCheckHomeUpdate builds a home controller and kicks a check when enabled", async () => {
+  it("routes an update-enabled home root through ensure before start", async () => {
+    const defaultPatternRef: CellRef = {
+      id: "of:update-enabled-home-root" as CellRef["id"],
+      space: "did:key:test-home" as CellRef["space"],
+      scope: "space",
+      path: [],
+    };
+    const patternRef: CellRef = {
+      id: "of:update-enabled-home-pattern" as CellRef["id"],
+      space: "did:key:test-home" as CellRef["space"],
+      scope: "space",
+      path: [],
+    };
+    const defaultPatternCell = {
+      ...defaultPatternRef,
+      getAsLink: () => cellRefToSigilLink(defaultPatternRef),
+      getMetaRaw: (metaField: string) =>
+        metaField === "pattern" ? cellRefToSigilLink(patternRef) : undefined,
+      sync: () => Promise.resolve(),
+    };
+    let startedDirectly = false;
     const runtime = {
       userIdentityDID: "did:key:test-home",
       experimental: {
         systemPatternAutoUpdate: true,
         systemPatternAutoUpdateHome: true,
       },
-      // PieceManager reads userIdentityDID + getHomeSpaceCell().sync();
-      // the update check itself is best-effort and fails closed on this mock.
       getHomeSpaceCell: () => ({
         sync: () => Promise.resolve(),
-        key: () => ({ get: () => undefined }),
+        key: () => ({
+          get: () => ({ resolveAsCell: () => defaultPatternCell }),
+        }),
       }),
-    } as unknown as Parameters<typeof maybeCheckHomeUpdate>[1];
+      storageManager: { synced: () => Promise.resolve() },
+      start: () => {
+        startedDirectly = true;
+        return Promise.resolve(true);
+      },
+    };
+    const processor = {
+      identity: cfcSigner,
+      runtime,
+    } as unknown as RuntimeProcessor;
 
-    // Constructs the home controller and kicks the background check without
-    // throwing; let the fire-and-forget check settle.
-    maybeCheckHomeUpdate(cfcSigner, runtime);
-    await new Promise((r) => setTimeout(r, 0));
+    const originalEnsure = PiecesController.prototype.ensureDefaultPattern;
+    let ensured = false;
+    PiecesController.prototype.ensureDefaultPattern = function () {
+      ensured = true;
+      return Promise.resolve({
+        getCell: () => defaultPatternCell,
+      } as unknown as Awaited<ReturnType<typeof originalEnsure>>);
+    };
+    try {
+      await expect(
+        RuntimeProcessor.prototype.handleEnsureHomePatternRunning.call(
+          processor,
+          { type: RequestType.EnsureHomePatternRunning },
+        ),
+      ).resolves.toEqual({ cell: defaultPatternRef });
+    } finally {
+      PiecesController.prototype.ensureDefaultPattern = originalEnsure;
+    }
+
+    expect(ensured).toBe(true);
+    expect(startedDirectly).toBe(false);
   });
 });
 
@@ -1135,41 +1165,7 @@ describe("system-pattern update wiring", () => {
     }]);
   });
 
-  it("checkUpdateInBackground logs a non-current outcome and swallows a rejection", async () => {
-    const logs: string[] = [];
-    const warns: string[] = [];
-    const origLog = console.log;
-    const origWarn = console.warn;
-    console.log = (...a: unknown[]) => logs.push(a.join(" "));
-    console.warn = (...a: unknown[]) => warns.push(a.join(" "));
-    try {
-      checkUpdateInBackground(
-        { checkAndUpdateDefaultPattern: () => Promise.resolve("updated") },
-        "did:key:a",
-      );
-      checkUpdateInBackground(
-        { checkAndUpdateDefaultPattern: () => Promise.resolve("current") },
-        "did:key:b",
-      );
-      checkUpdateInBackground(
-        {
-          checkAndUpdateDefaultPattern: () => Promise.reject(new Error("boom")),
-        },
-        "did:key:c",
-      );
-      // Let the fire-and-forget promises settle.
-      await new Promise((r) => setTimeout(r, 0));
-    } finally {
-      console.log = origLog;
-      console.warn = origWarn;
-    }
-    expect(logs.some((l) => l.includes("did:key:a") && l.includes("updated")))
-      .toBe(true);
-    expect(logs.some((l) => l.includes("did:key:b"))).toBe(false);
-    expect(warns.some((w) => w.includes("did:key:c"))).toBe(true);
-  });
-
-  it("handleGetSpaceRootPattern returns the page ref and kicks the background check", async () => {
+  it("handleGetSpaceRootPattern returns the root ensured by the controller", async () => {
     const ref: CellRef = {
       id: "of:root-result" as CellRef["id"],
       space: "did:key:test-space" as CellRef["space"],
@@ -1177,13 +1173,8 @@ describe("system-pattern update wiring", () => {
       path: [],
     };
     const rootCell = { getAsLink: () => cellRefToSigilLink(ref) };
-    let checked = false;
     const cc = {
       ensureDefaultPattern: () => Promise.resolve({ getCell: () => rootCell }),
-      checkAndUpdateDefaultPattern: () => {
-        checked = true;
-        return Promise.resolve("current");
-      },
     };
     const processor = {
       getSpaceCtx: () => ({ cc }),
@@ -1195,8 +1186,6 @@ describe("system-pattern update wiring", () => {
         space: "did:key:test-space",
       });
     expect(result.page.cell).toEqual(ref);
-    // The background check was kicked (fire-and-forget).
-    expect(checked).toBe(true);
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -13,6 +13,7 @@ import {
   renderMembershipProviderFor,
   RuntimeProcessor,
   sanitizeForPostMessage,
+  shouldReconcileHomeRoot,
   versionSkewNotification,
 } from "./runtime-processor.ts";
 import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
@@ -999,6 +1000,19 @@ describe("RuntimeProcessor blob upload IPC", () => {
 });
 
 describe("RuntimeProcessor home pattern IPC", () => {
+  it("reconciles the home root only when both update flags are enabled", () => {
+    expect(shouldReconcileHomeRoot({ experimental: {} })).toBe(false);
+    expect(shouldReconcileHomeRoot({
+      experimental: { systemPatternAutoUpdate: true },
+    })).toBe(false);
+    expect(shouldReconcileHomeRoot({
+      experimental: {
+        systemPatternAutoUpdate: true,
+        systemPatternAutoUpdateHome: true,
+      },
+    })).toBe(true);
+  });
+
   it("uses the default-pattern metadata fast path when the home pattern is already instantiated", async () => {
     const defaultPatternRef: CellRef = {
       id: "of:default-pattern-result" as CellRef["id"],

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -190,52 +190,6 @@ export function postVersionSkew(info: VersionSkewInfo): void {
 }
 
 /**
- * Best-effort, non-blocking system-pattern update check for a space open. The
- * check itself never throws (it is internally best-effort); this only logs a
- * non-current outcome and defends against an unexpected rejection. Exported for
- * testing.
- */
-export function checkUpdateInBackground(
-  cc: Pick<PiecesController, "checkAndUpdateDefaultPattern">,
-  space: string,
-): void {
-  cc.checkAndUpdateDefaultPattern()
-    .then((outcome) => {
-      if (outcome === "updated" || outcome === "skipped-skew") {
-        console.log(`[space-root] update check for ${space}: ${outcome}`);
-      }
-    })
-    .catch((error) => {
-      console.warn(`[space-root] update check for ${space} threw`, error);
-    });
-}
-
-/**
- * Best-effort update check for the HOME root, gated behind its own flag
- * (pending the stable-addressing audit). No-ops unless both auto-update flags
- * are on — so the hot home fast path pays nothing when disabled — otherwise
- * builds a home PiecesController and kicks a non-blocking check. Exported for
- * testing.
- */
-export function maybeCheckHomeUpdate(
-  identity: Identity,
-  runtime: Runtime,
-): void {
-  if (
-    !runtime.experimental?.systemPatternAutoUpdate ||
-    !runtime.experimental?.systemPatternAutoUpdateHome
-  ) {
-    return;
-  }
-  const homeSession: Session = {
-    as: identity,
-    space: runtime.userIdentityDID,
-  };
-  const homeCC = new PiecesController(new PieceManager(homeSession, runtime));
-  void checkUpdateInBackground(homeCC, runtime.userIdentityDID);
-}
-
-/**
  * Map host-decided `InitializationData` onto `runtimePresets.browserWorker`
  * params (CT-1814): the shared first-party posture (CFC pins,
  * patternEnvironment from apiUrl) lives in the preset; this function only
@@ -1106,22 +1060,29 @@ export class RuntimeProcessor {
       .resolveAsCell();
     await defaultPatternCell.sync();
 
-    // Fast path: pattern already exists
+    // Fast path: pattern already exists. When home auto-update is enabled,
+    // deliberately fall through to PiecesController.ensureDefaultPattern():
+    // it reconciles the persisted identity before starting the root. Starting
+    // here first would recreate the stale-root bootstrap dependency.
     // (Value is a Cell itself, and pattern metadata means it's instantiated)
     // We've followed all the links from "defaultPattern", so our cell should
     // be the result cell for the default pattern.
-    if (getMetaLink(defaultPatternCell, "pattern")) {
+    const reconcileHomeBeforeStart =
+      this.runtime.experimental?.systemPatternAutoUpdate === true &&
+      this.runtime.experimental?.systemPatternAutoUpdateHome === true;
+    if (
+      getMetaLink(defaultPatternCell, "pattern") &&
+      !reconcileHomeBeforeStart
+    ) {
       await this.runtime.start(defaultPatternCell);
       await this.runtime.idle();
-      // The home root is held behind its own flag (pending the stable-addressing
-      // audit); the helper no-ops on this hot fast path unless enabled.
-      maybeCheckHomeUpdate(this.identity, this.runtime);
       return {
         cell: createCellRef(defaultPatternCell),
       };
     }
 
-    // Pattern doesn't exist - create it via home space PieceController
+    // Pattern is absent, or update-enabled and must be reconciled before start:
+    // use the home-space PiecesController for the complete ensure sequence.
     const homeSession: Session = {
       as: this.identity,
       space: this.runtime.userIdentityDID,
@@ -1184,10 +1145,6 @@ export class RuntimeProcessor {
   ): Promise<PageResponse> {
     const { cc } = this.getSpaceCtx(request.space);
     const piece = await cc.ensureDefaultPattern();
-    // Best-effort, non-blocking: roll the root forward if its toolshed serves a
-    // newer identity. The watcher re-instantiates in place; a failed check
-    // never breaks space open, and we never block the response on it.
-    void checkUpdateInBackground(cc, request.space);
     return {
       page: createPageRef(piece.getCell()),
     };

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -189,6 +189,14 @@ export function postVersionSkew(info: VersionSkewInfo): void {
   self.postMessage(versionSkewNotification(info));
 }
 
+/** Whether the home root must take the reconcile-before-start path. */
+export function shouldReconcileHomeRoot(
+  runtime: Pick<Runtime, "experimental">,
+): boolean {
+  return runtime.experimental?.systemPatternAutoUpdate === true &&
+    runtime.experimental?.systemPatternAutoUpdateHome === true;
+}
+
 /**
  * Map host-decided `InitializationData` onto `runtimePresets.browserWorker`
  * params (CT-1814): the shared first-party posture (CFC pins,
@@ -1067,13 +1075,8 @@ export class RuntimeProcessor {
     // (Value is a Cell itself, and pattern metadata means it's instantiated)
     // We've followed all the links from "defaultPattern", so our cell should
     // be the result cell for the default pattern.
-    const reconcileHomeBeforeStart =
-      this.runtime.experimental?.systemPatternAutoUpdate === true &&
-      this.runtime.experimental?.systemPatternAutoUpdateHome === true;
-    if (
-      getMetaLink(defaultPatternCell, "pattern") &&
-      !reconcileHomeBeforeStart
-    ) {
+    const reconcileHome = shouldReconcileHomeRoot(this.runtime);
+    if (getMetaLink(defaultPatternCell, "pattern") && !reconcileHome) {
       await this.runtime.start(defaultPatternCell);
       await this.runtime.idle();
       return {


### PR DESCRIPTION
## Summary

- resolve persisted system roots without starting them
- await the system-pattern identity check, then re-resolve the committed root before bootstrap
- keep newly created roots on the fast path while reconciling roots discovered after a creation race
- route update-enabled home roots through the same pre-bootstrap ensure path
- remove the obsolete post-start background update wiring
- add regression coverage for a persisted root whose stale pattern identity is no longer loadable
- update the system-pattern update documentation

## Why

Follow-up to #4574.

The updater previously ran only after `ensureDefaultPattern()` had started the persisted root. If that root referenced an old pattern identity that the current runtime could no longer load, bootstrap failed before the updater had a chance to replace the identity. This moves reconciliation ahead of bootstrap so the root can self-heal on load while preserving its existing entity and state.

The check remains best-effort. If reconciliation itself cannot complete, the subsequent start retains its existing loud failure behavior.

## Validation

- `deno task check`
- `deno task check-docs`
- full `packages/piece` test suite
- full `packages/runtime-client` test suite
- runtime-client integration suite (40 steps)
- coverage-instrumented package suites and CI LCOV conversion
- targeted lint, formatting, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the system root’s `patternIdentity` before bootstrap so stale or unloadable roots self-heal on space open while preserving state. Home roots with both auto-update flags enabled take the same ensure-before-start path; background update wiring is removed.

- **Bug Fixes**
  - Resolve persisted roots without starting; await identity check, re-resolve, then start so stale identities can’t block bootstrap.
  - Treat race-discovered roots as persisted and reconcile before start; newly created roots stay on the fast path.
  - Defend against unexpected identity-lookup rejections; reconciliation remains best-effort and failures still surface on start.
  - Add regression coverage for unloadable stale roots and creation-race reconciliation.

- **Refactors**
  - `packages/piece`: introduce `startEnsuredDefaultPattern`; `checkAndUpdateDefaultPattern` accepts an optional pre-resolved root and runs before start.
  - `packages/runtime-client`: remove `checkUpdateInBackground` and `maybeCheckHomeUpdate`; add `shouldReconcileHomeRoot` and route home ensure via `PiecesController.ensureDefaultPattern` (no direct start); stop background checks in `handleGetSpaceRootPattern`.
  - Docs: update status (2026-07-14) and clarify pre-bootstrap reconciliation flow.
  - Tests: expand `packages/piece` and `packages/runtime-client` to the new flow.

<sup>Written for commit 932b6717864d2c5f35fdb9783b9f7a759c3edc39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

