### PR TITLE
docs: fix stale scheduler file pointers after the scheduler-v2 cutover (#4288)

### DIFF
--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -194,7 +194,7 @@ the full durable stack, not just shapes. Per-action observations
 `implementationFingerprint`, `observedAtSeq`, `reads`, `currentKnownWrites`,
 `declaredWrites`, gate options, status —
 `packages/runner/src/scheduler/persistent-observation.ts:22`) are attached
-to the live commit tx (`action-run.ts:646/708`) and persisted **inside the
+to the live commit tx (`run.ts:516`) and persisted **inside the
 single `applyCommit` SQLite transaction** (`packages/memory/v2/engine.ts:1554`
 → `upsertSchedulerObservationTransaction` `:3285`) across five tables
 (`scheduler_observation`, `scheduler_action_snapshot` LWW,
@@ -202,7 +202,7 @@ single `applyCommit` SQLite transaction** (`packages/memory/v2/engine.ts:1554`
 DDL `engine.ts:206`+). Cold start reads them back
 (`listSchedulerActionSnapshots` through the provider seam) and rehydrates
 without re-running unchanged actions. On #4288, the runner loads the
-snapshots and the facade in `packages/runner/src/scheduler.ts` applies
+snapshots and the facade in `packages/runner/src/scheduler/facade.ts` applies
 fingerprint-gated, fail-open
 rehydration. Restart-skip is proven by `reload-rehydration.test.ts` and
 `v2-scheduler-state-test.ts`.

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -346,7 +346,7 @@ that it settled.
 
 **Read first:**
 
-- packages/runner/src/scheduler/action-run.ts read tracking, transaction open,
+- packages/runner/src/scheduler/run.ts read tracking, transaction open,
   no-op elision, and observation construction
 - Scheduler-v2 commit gates and bounded settle
 - Memory-v2 revision sequence assignment and feed ordering

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -643,7 +643,9 @@ canonical lift-applied form:
 
 - `computed(fn)` -> `__cfHelpers.lift(fn)({})` before schema injection
 - no-input computed-origin calls are schema-injected as
-  `__cfHelpers.lift(false, fn)()`
+  `__cfHelpers.lift(fn, false, undefined, { completeSchedulerScopeSummary: true })()`
+  (function first; the trailing scheduler-options object is emitted only when
+  the callback's scope is provably complete)
 - **does not** forward `computed`'s type argument to `lift`: `computed<R>` has a
   single result type param, while `lift<T, R>` takes input `T` first, so
   forwarding `[R]` would place `R` in `lift`'s input slot. Type args are

--- a/docs/tutorial/11-deployed-system.md
+++ b/docs/tutorial/11-deployed-system.md
@@ -92,7 +92,7 @@ ran `cf piece link` long ago to feed the list into a dashboard piece.
 2. **Transaction** (Ch. 8). The write lands in a transaction journal in the
    worker-hosted runtime. On commit, the replica applies it optimistically;
    the trigger index dirties the `activeItems`/`completedItems` computeds;
-   pull-execution re-runs them; UI sinks fire; the row moves to "Completed"
+   the settle pass re-runs them; UI sinks fire; the row moves to "Completed"
    in Alice's DOM — all before any network round trip.
 3. **Commit** (Ch. 9). The storage manager emits a `ClientCommit` — a
    `patch` op on the item document — over the session opened at login


### PR DESCRIPTION
## What

#4288 (scheduler-v2 cutover) renamed `action-run.ts` → `run.ts`, deleted `pull-execution.ts`, and turned `scheduler.ts` into a one-line re-export of `scheduler/facade.ts`. That PR's own doc sweep updated the docs it touched, but a few **adjacent live docs** still pointed at the old names. This is the follow-up sweep — docs-only, no code.

| File | Change |
|---|---|
| `specs/server-side-execution/README.md` | `action-run.ts:646/708` → `run.ts:516` (the observation attach); facade is `scheduler/facade.ts`, not `scheduler.ts` |
| `specs/server-side-execution/implementation-plan.md` | `action-run.ts` → `run.ts` |
| `tutorial/11-deployed-system.md` | "pull-execution re-runs them" → "the settle pass re-runs them" (matches the already-updated tutorial 08) |
| `specs/ts-transformer/ts_transformers_current_behavior_spec.md` | no-input `lift` emission is function-first and now carries the scheduler-scope-summary options object |

## Deliberately left alone

`specs/verifiable-execution/*` uses "staleness detection" — but that's an **unbuilt** feature's own read-freshness concept (comparing `since` values), not a reference to the deleted v1 `staleness.ts`. Rewording it would be presumptuous about a design that hasn't landed. The `scheduler-v2/README.md` and `module-loading.md` "staleness" mentions are deliberate "v1 did X, v2 deleted it" rationale.

## Verification

All new references resolve on current `main`: `run.ts:516` = `attachSchedulerActionObservation` call site, `scheduler/facade.ts` exists, the transformer emission matches the `computed-no-captures` golden. `docs/` is excluded from `deno fmt`, so no formatting gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale scheduler references in docs after the scheduler‑v2 cutover. Updated pointers from `action-run.ts` to `run.ts`, switched `scheduler.ts` to `scheduler/facade.ts`, replaced “pull-execution” with “the settle pass” in the tutorial, and revised the transformer spec to the function‑first no‑input `lift` form with `{ completeSchedulerScopeSummary: true }`.

<sup>Written for commit 9eaeb576196ac0e598eaa87e54e025407611a088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

