### PR TITLE
fix(ui): cf-calendar — resync view on cell writes, configurable week start

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3479,6 +3479,7 @@ interface CFCalendarAttributes<T> extends CFHTMLAttributes<T> {
   "min"?: string;
   "max"?: string;
   "disabled"?: boolean;
+  "weekStart"?: "sunday" | "monday" | CellLike<string>;
   "oncf-change"?: EventHandler<{ value: string; oldValue: string }>;
   "oncf-month-change"?: EventHandler<{ year: number; month: number }>;
 }

--- a/packages/patterns/catalog/stories/cf-calendar-story.test.tsx
+++ b/packages/patterns/catalog/stories/cf-calendar-story.test.tsx
@@ -1,0 +1,23 @@
+import { computed, NAME, pattern, UI } from "commonfabric";
+import CalendarStory from "./cf-calendar-story.tsx";
+
+// Lane-2 pattern test (run by `cf test`): instantiating the story runs its body
+// — the [UI] and `controls` JSX, including the new week-start SelectControl — so
+// the story's authored lines are recorded as covered (the point of this test:
+// closing the catalog-story coverage-debt the week-start change added), and the
+// assertion checks the story builds the shape the catalog renderer expects.
+//
+// The assertion covers `[NAME]` and `[UI]` only. Unlike cf-submit-input's plain
+// `<div>` controls, this story's `controls` is a `<Controls>`-wrapped fragment
+// of child control components; that composed value doesn't resolve to a plain
+// non-null inside a computed (the catalog renderer consumes it fine — it just
+// isn't assertion-friendly in the pattern-test harness). Instantiation runs the
+// controls JSX for coverage either way, so a `controls` assertion adds nothing.
+export default pattern(() => {
+  const story = CalendarStory({});
+  const assert_story_built = computed(() =>
+    story[NAME] === "cf-calendar Story" &&
+    story[UI] != null
+  );
+  return { tests: [{ assertion: assert_story_built }] };
+});

--- a/packages/patterns/catalog/stories/cf-calendar-story.tsx
+++ b/packages/patterns/catalog/stories/cf-calendar-story.tsx
@@ -1,6 +1,11 @@
 import { NAME, pattern, UI, type VNode, Writable } from "commonfabric";
 
-import { Controls, SwitchControl, TextControl } from "../ui/controls/index.ts";
+import {
+  Controls,
+  SelectControl,
+  SwitchControl,
+  TextControl,
+} from "../ui/controls/index.ts";
 
 // deno-lint-ignore no-empty-interface
 interface CalendarStoryInput {}
@@ -15,6 +20,7 @@ export default pattern<CalendarStoryInput, CalendarStoryOutput>(() => {
   const disabled = new Writable(false);
   const minDate = new Writable("");
   const maxDate = new Writable("");
+  const weekStart = new Writable<"sunday" | "monday">("sunday");
 
   return {
     [NAME]: "cf-calendar Story",
@@ -38,6 +44,7 @@ export default pattern<CalendarStoryInput, CalendarStoryOutput>(() => {
             disabled={disabled}
             min={minDate}
             max={maxDate}
+            weekStart={weekStart}
           />
           <div
             style={{
@@ -72,6 +79,16 @@ export default pattern<CalendarStoryInput, CalendarStoryOutput>(() => {
             description="Maximum selectable date (YYYY-MM-DD)"
             defaultValue=""
             value={maxDate}
+          />
+          <SelectControl
+            label="week-start"
+            description="First day of the week"
+            defaultValue="sunday"
+            value={weekStart}
+            items={[
+              { label: "Sunday", value: "sunday" },
+              { label: "Monday", value: "monday" },
+            ]}
           />
         </>
       </Controls>

--- a/packages/ui/src/v2/components/cf-calendar/cf-calendar.test.ts
+++ b/packages/ui/src/v2/components/cf-calendar/cf-calendar.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for CFCalendar component
+ *
+ * Focus areas:
+ * - View-month resync when the BOUND CELL's content changes (not just when
+ *   the `value` property is reassigned), without clobbering manual month
+ *   navigation on unrelated redeliveries/re-renders.
+ * - Configurable week start (`week-start` attribute): grid leading-day math
+ *   and weekday header labels, Sunday-first by default.
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { CFCalendar } from "./index.ts";
+import {
+  createMockCellHandle,
+  pushUpdate,
+} from "../../test-utils/mock-cell-handle.ts";
+
+/** Access to internals that are private in the component's public API. */
+type CalendarInternals = {
+  _navigatePrev(): void;
+  _navigateNext(): void;
+  _selectDate(dateStr: string): void;
+};
+
+function internals(el: CFCalendar): CalendarInternals {
+  return el as unknown as CalendarInternals;
+}
+
+describe("CFCalendar", () => {
+  it("should be defined", () => {
+    expect(CFCalendar).toBeDefined();
+  });
+
+  it("should have customElement definition", () => {
+    expect(customElements.get("cf-calendar")).toBe(CFCalendar);
+  });
+
+  it("should create element instance", () => {
+    const element = new CFCalendar();
+    expect(element).toBeInstanceOf(CFCalendar);
+  });
+
+  it("should default weekStart to sunday", () => {
+    const element = new CFCalendar();
+    expect(element.weekStart).toBe("sunday");
+  });
+
+  it("should map weekStart to the week-start attribute", () => {
+    const props = (CFCalendar as unknown as {
+      properties: Record<string, { attribute?: string }>;
+    }).properties;
+    expect(props.weekStart.attribute).toBe("week-start");
+  });
+});
+
+describe("CFCalendar view-month resync on cell writes", () => {
+  function createBoundCalendar(initialValue: string) {
+    const element = new CFCalendar();
+    const cell = createMockCellHandle(initialValue);
+    element.value = cell;
+    // Simulate Lit's first update: binds the cell controller and syncs the
+    // view to the bound value.
+    element.firstUpdated();
+    return { element, cell };
+  }
+
+  it("syncs the view to the bound value on first update", () => {
+    const { element } = createBoundCalendar("2026-03-15");
+    expect(element._viewYear).toBe(2026);
+    expect(element._viewMonth).toBe(2); // March
+  });
+
+  it("follows an external cell write into another month", () => {
+    const { element, cell } = createBoundCalendar("2026-03-15");
+
+    // Backend push: host app selects a date in another month by writing to
+    // the same bound cell (no `value` property reassignment).
+    pushUpdate(cell, "2026-07-04");
+
+    expect(element._viewYear).toBe(2026);
+    expect(element._viewMonth).toBe(6); // July
+  });
+
+  it("follows an external cell write across a year boundary", () => {
+    const { element, cell } = createBoundCalendar("2026-12-20");
+    pushUpdate(cell, "2027-01-05");
+
+    expect(element._viewYear).toBe(2027);
+    expect(element._viewMonth).toBe(0); // January
+  });
+
+  it("does not clobber manual navigation on a redelivery of the same value", () => {
+    const { element, cell } = createBoundCalendar("2026-03-15");
+
+    internals(element)._navigateNext();
+    expect(element._viewMonth).toBe(3); // April
+
+    // Unrelated redelivery (same content) — e.g. subscription echo — must
+    // not yank the view back to the selected date's month.
+    pushUpdate(cell, "2026-03-15");
+
+    expect(element._viewYear).toBe(2026);
+    expect(element._viewMonth).toBe(3); // still April
+  });
+
+  it("does not clobber manual navigation on an unrelated re-render", () => {
+    const { element } = createBoundCalendar("2026-03-15");
+
+    internals(element)._navigatePrev();
+    expect(element._viewMonth).toBe(1); // February
+
+    // A plain re-render (no value change) must leave the view alone.
+    element.render();
+    expect(element._viewMonth).toBe(1); // still February
+  });
+
+  it("moves the view back when an external write follows manual navigation", () => {
+    const { element, cell } = createBoundCalendar("2026-03-15");
+
+    internals(element)._navigateNext(); // April
+    pushUpdate(cell, "2026-01-10"); // external write: January
+
+    expect(element._viewMonth).toBe(0); // January wins — value changed
+  });
+
+  it("keeps the view steady when the user selects a day in the viewed month", () => {
+    const { element } = createBoundCalendar("2026-03-15");
+
+    internals(element)._selectDate("2026-03-20");
+
+    expect(element._viewYear).toBe(2026);
+    expect(element._viewMonth).toBe(2); // March, no jump
+  });
+
+  it("moves the view when the user selects a leading other-month day", () => {
+    const { element } = createBoundCalendar("2026-03-15");
+
+    // Leading cell from February shown in the March grid.
+    internals(element)._selectDate("2026-02-28");
+
+    expect(element._viewMonth).toBe(1); // February
+  });
+});
+
+describe("CFCalendar week start", () => {
+  // March 2026: the 1st falls on a Sunday.
+  // June 2026: the 1st falls on a Monday.
+
+  it("builds a Sunday-first grid by default", () => {
+    const element = new CFCalendar();
+    const grid = element._buildGrid(2026, 2); // March 2026
+
+    expect(grid.length).toBe(42);
+    expect(grid[0].dateStr).toBe("2026-03-01"); // Sunday, no leading days
+    expect(grid[0].isCurrentMonth).toBe(true);
+  });
+
+  it("adds one leading day for a Monday 1st when Sunday-first", () => {
+    const element = new CFCalendar();
+    const grid = element._buildGrid(2026, 5); // June 2026
+
+    expect(grid[0].dateStr).toBe("2026-05-31"); // Sunday before Mon June 1
+    expect(grid[0].isCurrentMonth).toBe(false);
+    expect(grid[1].dateStr).toBe("2026-06-01");
+    expect(grid[1].isCurrentMonth).toBe(true);
+  });
+
+  it("rotates leading days when weekStart is monday", () => {
+    const element = new CFCalendar();
+    element.weekStart = "monday";
+
+    // March 2026 starts on a Sunday → six leading days from February.
+    const march = element._buildGrid(2026, 2);
+    expect(march.length).toBe(42);
+    expect(march[0].dateStr).toBe("2026-02-23"); // Monday
+    expect(march[0].isCurrentMonth).toBe(false);
+    expect(march[6].dateStr).toBe("2026-03-01");
+    expect(march[6].isCurrentMonth).toBe(true);
+
+    // June 2026 starts on a Monday → no leading days.
+    const june = element._buildGrid(2026, 5);
+    expect(june[0].dateStr).toBe("2026-06-01");
+    expect(june[0].isCurrentMonth).toBe(true);
+  });
+
+  it("orders weekday header labels Sunday-first by default", () => {
+    const element = new CFCalendar();
+    expect(element._weekdayLabels()).toEqual([
+      "Su",
+      "Mo",
+      "Tu",
+      "We",
+      "Th",
+      "Fr",
+      "Sa",
+    ]);
+  });
+
+  it("orders weekday header labels Monday-first when weekStart is monday", () => {
+    const element = new CFCalendar();
+    element.weekStart = "monday";
+    expect(element._weekdayLabels()).toEqual([
+      "Mo",
+      "Tu",
+      "We",
+      "Th",
+      "Fr",
+      "Sa",
+      "Su",
+    ]);
+  });
+});

--- a/packages/ui/src/v2/components/cf-calendar/cf-calendar.ts
+++ b/packages/ui/src/v2/components/cf-calendar/cf-calendar.ts
@@ -20,6 +20,8 @@ import { type CellHandle } from "@commonfabric/runtime-client";
  * @attr {boolean} disabled - Whether the calendar is disabled
  * @attr {string} min - YYYY-MM-DD minimum selectable date
  * @attr {string} max - YYYY-MM-DD maximum selectable date
+ * @attr {string} week-start - First day of the week: "sunday" (default) or
+ *   "monday"
  *
  * @prop {CellHandle<string> | string} value - Selected date in YYYY-MM-DD format
  * @prop {CellHandle<string[]> | string[]} markedDates - Dates with dot indicators
@@ -206,6 +208,7 @@ export class CFCalendar extends BaseElement {
     min: { type: String },
     max: { type: String },
     disabled: { type: Boolean, reflect: true },
+    weekStart: { type: String, attribute: "week-start" },
   };
 
   declare value: CellHandle<string> | string;
@@ -213,13 +216,26 @@ export class CFCalendar extends BaseElement {
   declare min: string;
   declare max: string;
   declare disabled: boolean;
+  declare weekStart: "sunday" | "monday";
 
   _viewYear: number;
   _viewMonth: number;
 
+  /**
+   * Last value content the view month was synced against. Lets cell-change
+   * notifications distinguish "the bound value actually changed" (resync the
+   * view month) from a mere redelivery/re-render (leave the view alone, so a
+   * user who navigated to another month isn't yanked back).
+   */
+  private _lastSyncedValue: string | undefined;
+
   private _valueCellController = createCellController<string>(this, {
     timing: { strategy: "immediate" },
     onChange: (_newValue) => {
+      // Follow the bound value's month when its CONTENT changes — e.g. the
+      // host app writes a date in another month to the same cell. Without
+      // this, only reassigning the `value` property resynced the view.
+      this._resyncViewIfValueChanged();
       this.requestUpdate();
     },
   });
@@ -239,6 +255,7 @@ export class CFCalendar extends BaseElement {
     this.disabled = false;
     this.min = "";
     this.max = "";
+    this.weekStart = "sunday";
   }
 
   override connectedCallback() {
@@ -274,11 +291,23 @@ export class CFCalendar extends BaseElement {
 
   private _syncViewToValue(): void {
     const val = this._getValue();
+    this._lastSyncedValue = val;
     if (val && /^\d{4}-\d{2}-\d{2}$/.test(val)) {
       const [y, m] = val.split("-").map(Number);
       this._viewYear = y;
       this._viewMonth = m - 1;
     }
+  }
+
+  /**
+   * Resync the view month only if the bound value's content changed since we
+   * last synced. Redeliveries of an unchanged value (or unrelated re-renders)
+   * must not move the view: the user may have navigated elsewhere with the
+   * prev/next buttons.
+   */
+  private _resyncViewIfValueChanged(): void {
+    if (this._getValue() === this._lastSyncedValue) return;
+    this._syncViewToValue();
   }
 
   private _getValue(): string {
@@ -300,7 +329,9 @@ export class CFCalendar extends BaseElement {
     }> = [];
 
     const firstDay = new Date(year, month, 1);
-    const startDow = firstDay.getDay(); // 0=Sun
+    // Rotate the raw day-of-week (0=Sun) so column 0 is the configured week
+    // start: number of leading previous-month cells before the 1st.
+    const startDow = (firstDay.getDay() - this._weekStartOffset() + 7) % 7;
 
     const daysInMonth = new Date(year, month + 1, 0).getDate();
 
@@ -341,6 +372,20 @@ export class CFCalendar extends BaseElement {
     }
 
     return cells;
+  }
+
+  /** Offset from Sunday of the configured first day of the week. */
+  private _weekStartOffset(): number {
+    return this.weekStart === "monday" ? 1 : 0;
+  }
+
+  /** Weekday header labels, rotated to start at the configured week start. */
+  _weekdayLabels(): string[] {
+    const labels = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+    const offset = this._weekStartOffset();
+    return offset === 0
+      ? labels
+      : [...labels.slice(offset), ...labels.slice(0, offset)];
   }
 
   private _toDateStr(date: Date): string {
@@ -476,7 +521,7 @@ export class CFCalendar extends BaseElement {
     const selectedValue = this._getValue();
     const markedDatesSet = new Set(this._getMarkedDates());
     const grid = this._buildGrid(this._viewYear, this._viewMonth);
-    const weekdays = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+    const weekdays = this._weekdayLabels();
 
     return html`
       <div class="calendar" data-cf-calendar>


### PR DESCRIPTION
## Why

Loom (downstream consumer; pins this repo via vendoring) wants to adopt `cf-calendar` for its mobile month view, but its mobile-ui-audit records the swap as blocked upstream: "H8 cf-calendar swap — blocked upstream: no controlled-month resync on cell writes, Sunday-first hard-coded." This PR fixes both blockers:

1. **No controlled-month resync on cell writes.** `_syncViewToValue()` was only called from `updated()` when the `value` *property* was reassigned to a different cell handle. When the *bound cell's content* changed — e.g. the host app writes a selected date in another month to the same cell — the cell controller re-rendered the component, but `_viewYear`/`_viewMonth` were never resynced, so the calendar kept showing the stale month.
2. **Sunday-first hard-coded.** `_buildGrid()` used the raw `getDay()` (0=Sun) for leading-day math and the weekday header labels were a fixed Sunday-first array. Downstream wants Monday-first.

## What Changed

- The value cell controller's `onChange` now resyncs the view month, guarded by the last-synced value (`_lastSyncedValue`): the view only moves when the bound value's content actually changed since the last sync. Redeliveries of an unchanged value and unrelated re-renders leave the view alone, so a user who navigated to another month with the prev/next buttons is not yanked back. A user's own day-click in the viewed month causes no jump; clicking a leading/trailing other-month day legitimately moves the view.
- New `week-start` attribute (`weekStart` property): `"sunday"` (default, back-compat) or `"monday"`. Rotates both the grid leading-day math (`(getDay() - offset + 7) % 7`) and the weekday header labels.
- Focused tests for both fixes in `cf-calendar.test.ts` (external cell write into another month / across a year boundary follows; same-value redelivery and plain re-render don't clobber manual navigation; grid leading days and header order for both week starts).
- Catalog story gains a `week-start` select control; `weekStart` added to the `cf-calendar` JSX typings.

No existing issue was found for these defects (`gh issue list --search "cf-calendar"` is empty).

## Test plan

- `packages/ui` test task: 136 passed (779 steps) + 41 browser-run tests, 0 failed.
- `deno task cf check packages/patterns/catalog/stories/cf-calendar-story.tsx --no-run` passes.
- `deno check` on `packages/html/src/index.ts` and the calendar files; `deno fmt` / `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cf-calendar` not resyncing the visible month on bound cell writes and adds a `week-start` option for Monday-first calendars. Includes a catalog story test to cover the new control and keep coverage green.

- **Bug Fixes**
  - Resync the view when the bound cell’s content changes, guarded by a last-synced value to avoid jumps on same-value updates or unrelated re-renders.

- **New Features**
  - Add `week-start` attribute/property (`"sunday"` default, `"monday"` supported) that rotates grid leading-day math and weekday header labels.
  - Add catalog story control and pattern test; update JSX typing (`weekStart` in `jsx.d.ts`).

<sup>Written for commit 98dcee49bdf742ae60eea8a6a471a4f7e1f71074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

