### PR TITLE
fix(runner): cap recursive query traversal

### DIFF
--- a/docs/specs/space-model/8-traversal.md
+++ b/docs/specs/space-model/8-traversal.md
@@ -91,6 +91,11 @@ Top-level `$ref` is resolved before traversal decisions. Defaults are applied fr
 - Arrays validate per item schema
 - Objects validate per property schema
 - Required properties must be present in the filtered result
+- When an explicit property schema rejects a value, an optional property is
+  omitted from the filtered result, while a required property causes the
+  containing object to reject. In particular, an optional `false` property
+  excludes a link without loading or tracking its target; making that property
+  required makes the object unsatisfiable when the property is present.
 
 `additionalProperties` handling is intentionally specialized:
 

--- a/docs/specs/space-model/8-traversal.md
+++ b/docs/specs/space-model/8-traversal.md
@@ -121,8 +121,14 @@ Defaults:
 
 `SchemaObjectTraverser.hasAsCell(schema)` controls boundary behavior.
 
-- With `traverseCells = false` (runtime transforms), `asCell` boundaries produce cell/stream objects without deep traversal of nested content
-- With `traverseCells = true` (query traversal), linked content is traversed to register dependencies
+- With `traverseCells = false` (runtime transforms), ordinary `asCell`
+  boundaries produce cell/stream objects without deep traversal of nested
+  content.
+- With `traverseCells = true` (query traversal), ordinary `asCell` content is
+  traversed to register dependencies.
+- `asCell: ["opaque"]` is a hard boundary in both modes. Inline values are not
+  descended into; pointer targets are not loaded, traversed, or added to
+  `schemaTracker`.
 
 ### Detection Rules
 
@@ -142,7 +148,8 @@ Notes:
 | Value shape | `traverseCells = false` (runtime transform path) | `traverseCells = true` (query path) |
 | --- | --- | --- |
 | Primitive value with `asCell/asStream` | Boundary at current node. Traverser calls `createObject(link, value)` and does not descend. In runtime object creator this yields a cell-like wrapper. | No boundary shortcut from `traverseCells`; traversal still resolves value normally and query object creator returns plain traversed data. |
-| Object property, inline non-link value, schema has `asCell | Boundary at property. Property value is replaced by `createObject(propertyLink, undefined)` and nested fields are not traversed. | No boundary shortcut; traverses/validates nested object content. |
+| Any value with `asCell: ["opaque"]` | Hard boundary before nested traversal. Produces the runtime's opaque cell representation. | Same hard boundary. The query object creator preserves the raw inline value or pointer; linked targets are neither loaded nor tracked. |
+| Object property, inline non-link value, schema has `asCell` | Boundary at property. Property value is replaced by `createObject(propertyLink, undefined)` and nested fields are not traversed. | No boundary shortcut; traverses/validates nested object content. |
 | Object property, link value, schema has `asCell` | Follows write redirects to stable target, then creates boundary object from resolved link (`getNextCellLink` path). | Follows redirects and continues traversal into resolved target content. |
 | Array element, link value, schema has `asCell` | Resolves write redirects first, then follows one additional link step for array semantics, then emits boundary object for the resolved target link. | Performs same link resolution, then continues schema traversal into the resolved element value. |
 | Array element, inline non-link object, schema has `asCell` | Boundary at element index. Emits `createObject(indexLink, undefined)`; no nested traversal for element fields. | No boundary shortcut; element object is traversed against element schema. |
@@ -150,7 +157,13 @@ Notes:
 
 ### Pointer and Redirect Details at Boundaries
 
-For pointer values, boundary behavior is based on the write-redirect-resolved document:
+For a pointer whose first `asCell` entry is `"opaque"`, traversal calls the
+active object creator at the boundary before resolving write redirects or
+reading the target. Runtime transforms produce an opaque cell representation;
+query traversal preserves the raw pointer. This rule applies in both modes.
+
+For ordinary, non-opaque `asCell` pointer values, runtime boundary behavior is
+based on the write-redirect-resolved document:
 
 1. Resolve only write-redirect links (`lastNode = "writeRedirect"`).
 2. If runtime boundary mode (`traverseCells = false`) and schema is `asCell`, compute cell link from that resolved location:
@@ -160,11 +173,17 @@ For pointer values, boundary behavior is based on the write-redirect-resolved do
 
 Broken redirect case:
 
-- If redirect target is `undefined` and schema is `asCell`, traversal returns an error/invalid result (no boundary object is emitted).
+- If a non-opaque redirect target is `undefined` and schema is `asCell`,
+  traversal returns an error/invalid result (no boundary object is emitted).
+- An opaque pointer's target is not read, so its existence is not validated at
+  the boundary.
 
 ### Missing Values and Defaults at `asCell` Paths
 
-- Missing linked value + `asCell`: treated as invalid for boundary creation.
+- Missing linked value + non-opaque `asCell`: treated as invalid for boundary
+  creation.
+- Opaque pointer targets are not read and therefore are not checked for a
+  missing value.
 - Property defaults with `asCell`:
   - when a property schema default exists, traversal enters `traverseWithSchema({ value: undefined }, propSchema)`
   - default application uses the resolved schema, including defaults behind top-level `$ref`

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4278,7 +4278,13 @@ export class SchemaObjectTraverser<V extends FabricValue>
         // not by error code: an absent target surfaces as INVALID_TYPE (the
         // undefined value fails the target schema's type check), the same
         // code a present-but-wrong-shaped target produces.
+        // A false property schema deliberately excludes this subtree. Do not
+        // resolve its link merely to distinguish an absent target from a type
+        // mismatch: that would load and track the very document the selector
+        // excludes. False optional properties are simply omitted below;
+        // false required properties still fail the required check.
         const absentLinkTarget = elementGrace && error !== undefined &&
+          !ContextualFlowControl.isFalseSchema(propSchema) &&
           isSigilLink(propValue) &&
           this.linkTargetAbsent(propDoc, propSchema);
         if (absentLinkTarget) {

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -14,6 +14,7 @@ import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
   canBranchMatch,
+  combineSchema,
   CompoundCycleTracker,
   createDefaultTraversalContext,
   createTraversalContext,
@@ -2608,6 +2609,76 @@ describe("link schema path narrowing", () => {
     };
   }
 
+  function makeRecursiveFriendsGraph(
+    prefix: string,
+    linkFriendsRequired: boolean,
+  ) {
+    const store = new Map<string, Revision<State>>();
+    const rootUri = `of:${prefix}-friends-root` as URI;
+    const directFriendsUri = `of:${prefix}-direct-friends` as URI;
+    const directFriendUri = `of:${prefix}-direct-friend` as URI;
+    const nestedFriendsUri = `of:${prefix}-nested-friends` as URI;
+    const secondDegreeFriendUri = `of:${prefix}-second-degree-friend` as URI;
+
+    const fullUserSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+      },
+      required: linkFriendsRequired ? ["id", "friends"] : ["id"],
+    } as const satisfies JSONSchema;
+    const fullFriendsSchema = {
+      type: "array",
+      items: fullUserSchema,
+    } as const satisfies JSONSchema;
+
+    const rootValue = {
+      id: "root",
+      friends: makeLink(directFriendsUri, [], fullFriendsSchema),
+    };
+    const directFriendsValue = [
+      makeLink(directFriendUri, [], fullUserSchema),
+    ];
+    const directFriendValue = {
+      id: "direct",
+      friends: makeLink(nestedFriendsUri, [], fullFriendsSchema),
+    };
+    const nestedFriendsValue = [
+      makeLink(secondDegreeFriendUri, [], fullUserSchema),
+    ];
+
+    putDoc(store, rootUri, rootValue);
+    putDoc(store, directFriendsUri, directFriendsValue);
+    putDoc(store, directFriendUri, directFriendValue);
+    putDoc(store, nestedFriendsUri, nestedFriendsValue);
+    putDoc(store, secondDegreeFriendUri, {
+      id: "second-degree",
+      friends: [],
+    });
+
+    return {
+      store,
+      rootUri,
+      directFriendsUri,
+      directFriendUri,
+      nestedFriendsUri,
+      secondDegreeFriendUri,
+      fullUserSchema,
+      fullFriendsSchema,
+      rootValue,
+      directFriendValue,
+      trackerKey: (id: URI) => `${SPACE}/space/${id}`,
+    };
+  }
+
   const cases: Array<{
     name: string;
     targetPath: string[];
@@ -2766,53 +2837,19 @@ describe("link schema path narrowing", () => {
   // non-opaque control at the end proves that the deeper documents are
   // reachable and are excluded specifically because of the boundary.
   it("limits a recursive friends query to one hop with an opaque boundary", () => {
-    const store = new Map<string, Revision<State>>();
-    const rootUri = "of:opaque-friends-root" as URI;
-    const directFriendsUri = "of:opaque-direct-friends" as URI;
-    const directFriendUri = "of:opaque-direct-friend" as URI;
-    const nestedFriendsUri = "of:opaque-nested-friends" as URI;
-    const secondDegreeFriendUri = "of:opaque-second-degree-friend" as URI;
-
-    const fullUserSchema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        friends: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: { id: { type: "string" } },
-            required: ["id"],
-          },
-        },
-      },
-      required: ["id", "friends"],
-    } as const satisfies JSONSchema;
-    const fullFriendsSchema = {
-      type: "array",
-      items: fullUserSchema,
-    } as const satisfies JSONSchema;
-
-    const rootValue = {
-      id: "root",
-      friends: makeLink(directFriendsUri, [], fullFriendsSchema),
-    };
-    const directFriendsValue = [
-      makeLink(directFriendUri, [], fullUserSchema),
-    ];
-    const directFriendValue = {
-      id: "direct",
-      friends: makeLink(nestedFriendsUri, [], fullFriendsSchema),
-    };
-    const nestedFriendsValue = [
-      makeLink(secondDegreeFriendUri, [], fullUserSchema),
-    ];
-
-    putDoc(store, rootUri, rootValue);
-    putDoc(store, directFriendsUri, directFriendsValue);
-    putDoc(store, directFriendUri, directFriendValue);
-    putDoc(store, nestedFriendsUri, nestedFriendsValue);
-    putDoc(store, secondDegreeFriendUri, { id: "second-degree", friends: [] });
+    const {
+      store,
+      rootUri,
+      directFriendsUri,
+      directFriendUri,
+      nestedFriendsUri,
+      secondDegreeFriendUri,
+      fullUserSchema,
+      fullFriendsSchema,
+      rootValue,
+      directFriendValue,
+      trackerKey,
+    } = makeRecursiveFriendsGraph("opaque", true);
 
     const directFriendSchema = {
       type: "object",
@@ -2860,7 +2897,6 @@ describe("link schema path narrowing", () => {
       friends: [{ id: "direct", friends: directFriendValue.friends }],
     });
 
-    const trackerKey = (id: URI) => `${SPACE}/space/${id}`;
     expect(context.schemaTracker.has(trackerKey(rootUri))).toBe(true);
     expect(context.schemaTracker.has(trackerKey(directFriendsUri))).toBe(true);
     expect(context.schemaTracker.has(trackerKey(directFriendUri))).toBe(true);
@@ -2909,6 +2945,87 @@ describe("link schema path narrowing", () => {
     expect(
       nonOpaqueContext.schemaTracker.has(trackerKey(secondDegreeFriendUri)),
     ).toBe(true);
+  });
+
+  // This parent schema corresponds to the projected type
+  // `{ id: string; friends?: never }`. The stored link still carries a full
+  // User schema with an optional friends list. Intersecting the two should
+  // keep `friends: false` without making it required. Traversal can then omit
+  // that property while retaining the direct friend record itself.
+  it("omits an optional nested friends property narrowed to false", () => {
+    const {
+      store,
+      rootUri,
+      directFriendsUri,
+      directFriendUri,
+      nestedFriendsUri,
+      secondDegreeFriendUri,
+      fullUserSchema,
+      rootValue,
+      trackerKey,
+    } = makeRecursiveFriendsGraph("false-schema", false);
+    const directFriendSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: false,
+      },
+      required: ["id"],
+    } as const satisfies JSONSchema;
+
+    expect(combineSchema(directFriendSchema, fullUserSchema)).toEqual({
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: false,
+      },
+      required: ["id"],
+    });
+
+    const querySchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: {
+          type: "array",
+          items: directFriendSchema,
+        },
+      },
+      required: ["id", "friends"],
+    } as const satisfies JSONSchema;
+    const context = createDefaultTraversalContext();
+    const traverser = getTraverser(
+      store,
+      { path: ["value"], schema: querySchema },
+      context,
+    );
+
+    const { ok: result, error } = traverser.traverse({
+      address: {
+        space: SPACE,
+        id: rootUri,
+        type: TYPE,
+        path: ["value"],
+      },
+      value: rootValue,
+    });
+
+    expect(error).toBeUndefined();
+    expect(result).toEqual({
+      id: "root",
+      friends: [{ id: "direct" }],
+    });
+    const directFriend = (result as { friends: Record<string, unknown>[] })
+      .friends[0];
+    expect(Object.hasOwn(directFriend, "friends")).toBe(false);
+
+    expect(context.schemaTracker.has(trackerKey(rootUri))).toBe(true);
+    expect(context.schemaTracker.has(trackerKey(directFriendsUri))).toBe(true);
+    expect(context.schemaTracker.has(trackerKey(directFriendUri))).toBe(true);
+    expect(context.schemaTracker.has(trackerKey(nestedFriendsUri))).toBe(false);
+    expect(context.schemaTracker.has(trackerKey(secondDegreeFriendUri))).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -2753,7 +2753,19 @@ describe("link schema path narrowing", () => {
     expect(error).toBeDefined();
   });
 
-  it("stops query traversal at an opaque nested cell boundary", () => {
+  // A graph can contain records of one recursive type: for example, every
+  // User has a friends Cell whose elements are links to other Users. Each
+  // link legitimately carries the full User schema, including its required
+  // friends property. A query for "me and my direct friends" must therefore
+  // override that nested friends edge with an opaque boundary; otherwise the
+  // schema carried by each friend link makes traversal continue to friends of
+  // friends (and then onward through the recursive graph).
+  //
+  // The boundary should retain the direct friend's raw friends pointer in the
+  // query result, but must not load or subscribe to the pointer's target. The
+  // non-opaque control at the end proves that the deeper documents are
+  // reachable and are excluded specifically because of the boundary.
+  it("limits a recursive friends query to one hop with an opaque boundary", () => {
     const store = new Map<string, Revision<State>>();
     const rootUri = "of:opaque-friends-root" as URI;
     const directFriendsUri = "of:opaque-direct-friends" as URI;
@@ -2857,6 +2869,8 @@ describe("link schema path narrowing", () => {
       false,
     );
 
+    // Without the explicit boundary, the same schema-bearing graph expands
+    // through the direct friend's friends list to the second-degree friend.
     const nonOpaqueDirectFriendSchema = {
       ...directFriendSchema,
       properties: {

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -26,6 +26,7 @@ import {
   PointerCycleTracker,
   SchemaObjectTraverser,
   schemaTrackerCoversSelector,
+  type TraversalContext,
 } from "../src/traverse.ts";
 import { StoreObjectManager } from "../src/storage/query.ts";
 import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
@@ -39,11 +40,12 @@ import { IMemorySpaceValueAttestation } from "../src/traverse.ts";
 function getTraverser(
   store: Map<string, Revision<State>>,
   selector: SchemaPathSelector,
+  context: TraversalContext = createDefaultTraversalContext(),
 ): SchemaObjectTraverser<FabricValue> {
   const manager = new StoreObjectManager(store);
   const managedTx = new ManagedStorageTransaction(manager);
   const tx = new ExtendedStorageTransaction(managedTx);
-  return new SchemaObjectTraverser(tx, selector);
+  return new SchemaObjectTraverser(tx, selector, context);
 }
 
 describe("SchemaObjectTraverser.traverseDAG", () => {
@@ -2749,6 +2751,150 @@ describe("link schema path narrowing", () => {
 
     expect(ok).toBeUndefined();
     expect(error).toBeDefined();
+  });
+
+  it("stops query traversal at an opaque nested cell boundary", () => {
+    const store = new Map<string, Revision<State>>();
+    const rootUri = "of:opaque-friends-root" as URI;
+    const directFriendsUri = "of:opaque-direct-friends" as URI;
+    const directFriendUri = "of:opaque-direct-friend" as URI;
+    const nestedFriendsUri = "of:opaque-nested-friends" as URI;
+    const secondDegreeFriendUri = "of:opaque-second-degree-friend" as URI;
+
+    const fullUserSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+      },
+      required: ["id", "friends"],
+    } as const satisfies JSONSchema;
+    const fullFriendsSchema = {
+      type: "array",
+      items: fullUserSchema,
+    } as const satisfies JSONSchema;
+
+    const rootValue = {
+      id: "root",
+      friends: makeLink(directFriendsUri, [], fullFriendsSchema),
+    };
+    const directFriendsValue = [
+      makeLink(directFriendUri, [], fullUserSchema),
+    ];
+    const directFriendValue = {
+      id: "direct",
+      friends: makeLink(nestedFriendsUri, [], fullFriendsSchema),
+    };
+    const nestedFriendsValue = [
+      makeLink(secondDegreeFriendUri, [], fullUserSchema),
+    ];
+
+    putDoc(store, rootUri, rootValue);
+    putDoc(store, directFriendsUri, directFriendsValue);
+    putDoc(store, directFriendUri, directFriendValue);
+    putDoc(store, nestedFriendsUri, nestedFriendsValue);
+    putDoc(store, secondDegreeFriendUri, { id: "second-degree", friends: [] });
+
+    const directFriendSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: {
+          type: "array",
+          items: fullUserSchema,
+          asCell: ["opaque"],
+        },
+      },
+      required: ["id", "friends"],
+    } as const satisfies JSONSchema;
+    const querySchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        friends: {
+          type: "array",
+          items: directFriendSchema,
+        },
+      },
+      required: ["id", "friends"],
+    } as const satisfies JSONSchema;
+    const context = createDefaultTraversalContext();
+    const traverser = getTraverser(
+      store,
+      { path: ["value"], schema: querySchema },
+      context,
+    );
+
+    const { ok: result, error } = traverser.traverse({
+      address: {
+        space: SPACE,
+        id: rootUri,
+        type: TYPE,
+        path: ["value"],
+      },
+      value: rootValue,
+    });
+
+    expect(error).toBeUndefined();
+    expect(result).toEqual({
+      id: "root",
+      friends: [{ id: "direct", friends: directFriendValue.friends }],
+    });
+
+    const trackerKey = (id: URI) => `${SPACE}/space/${id}`;
+    expect(context.schemaTracker.has(trackerKey(rootUri))).toBe(true);
+    expect(context.schemaTracker.has(trackerKey(directFriendsUri))).toBe(true);
+    expect(context.schemaTracker.has(trackerKey(directFriendUri))).toBe(true);
+    expect(context.schemaTracker.has(trackerKey(nestedFriendsUri))).toBe(false);
+    expect(context.schemaTracker.has(trackerKey(secondDegreeFriendUri))).toBe(
+      false,
+    );
+
+    const nonOpaqueDirectFriendSchema = {
+      ...directFriendSchema,
+      properties: {
+        ...directFriendSchema.properties,
+        friends: fullFriendsSchema,
+      },
+    } as const satisfies JSONSchema;
+    const nonOpaqueQuerySchema = {
+      ...querySchema,
+      properties: {
+        ...querySchema.properties,
+        friends: {
+          type: "array",
+          items: nonOpaqueDirectFriendSchema,
+        },
+      },
+    } as const satisfies JSONSchema;
+    const nonOpaqueContext = createDefaultTraversalContext();
+    const nonOpaqueTraverser = getTraverser(
+      store,
+      { path: ["value"], schema: nonOpaqueQuerySchema },
+      nonOpaqueContext,
+    );
+    nonOpaqueTraverser.traverse({
+      address: {
+        space: SPACE,
+        id: rootUri,
+        type: TYPE,
+        path: ["value"],
+      },
+      value: rootValue,
+    });
+
+    expect(nonOpaqueContext.schemaTracker.has(trackerKey(nestedFriendsUri)))
+      .toBe(true);
+    expect(
+      nonOpaqueContext.schemaTracker.has(trackerKey(secondDegreeFriendUri)),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- add a regression covering a user, direct friends, and second-degree friends connected through schema-bearing links
- verify `asCell: ["opaque"]` preserves the nested friends pointer without loading or tracking its target
- include a non-opaque control proving the nested list and second-degree friend would otherwise be tracked
- document ordinary and opaque `asCell` behavior for runtime and query traversal

## Why

Query traversal normally follows ordinary `asCell` values to register dependencies. Opaque cells are the deliberate hard boundary: inline values are not descended into, and linked targets are not loaded or added to `schemaTracker`. This behavior lets a query retrieve direct friends without recursively retrieving each friend's friends.

## Validation

- `deno test --allow-env --allow-read packages/runner/test/traverse.test.ts`
- `deno fmt --check packages/runner/test/traverse.test.ts docs/specs/space-model/8-traversal.md`
- `deno lint packages/runner/test/traverse.test.ts`
- `git diff --check`

PR 4708 is already merged, so this branch was rebased onto current `main` and contains only this regression test and documentation update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests in `packages/runner` for opaque query boundaries with `asCell: ["opaque"]`, confirming nested friends pointers are preserved without loading or tracking targets and the recursive friends graph is limited to one hop. Also fixes traversal to stop at optional `false` links and updates the traversal spec to clarify opaque vs non-opaque behavior, redirect handling, and missing values.

- **Bug Fixes**
  - Do not resolve or track link targets when a property schema is `false` and optional, preventing excluded subtrees from loading during query traversal.

<sup>Written for commit c390b4340311f75fedb9da591b8ad69bc96b9655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7398 lines
---END COPY-PASTE---