### PR TITLE
build(toolchain): make mise.toml the canonical Deno version pin

### DIFF
--- a/.claude/commands/deps.md
+++ b/.claude/commands/deps.md
@@ -1,5 +1,7 @@
 MUST HAVE:
-- deno 2 https://docs.deno.com/runtime/getting_started/installation/
+- deno 2, pinned in mise.toml — install via mise https://mise.jdx.dev/
+  (`mise trust && mise install` in the repo); a manually installed deno 2
+  within the `tasks/check.sh` range also works
 
 REALLY SHOULD HAVE:
 - gh https://github.com/cli/cli

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -25,7 +25,16 @@ runs:
             echo "::error::mise.toml not found; cannot resolve the Deno version. This action requires the repository to be checked out first."
             exit 1
           fi
-          version="$(sed -n 's/^deno = "\([^"]*\)"$/\1/p' mise.toml | head -1)"
+          pins="$(sed -n 's/^deno = "\([^"]*\)"$/\1/p' mise.toml)"
+          # Counted rather than taking the first: TOML rejects a key defined
+          # twice, so a second pin means mise cannot load the file, and reading
+          # past it would install a version no developer actually gets.
+          count="$(printf '%s' "$pins" | grep -c . || true)"
+          if [ "$count" -gt 1 ]; then
+            echo "::error::mise.toml defines the Deno pin $count times; TOML rejects a key defined twice, so mise cannot load it."
+            exit 1
+          fi
+          version="$pins"
         fi
         if [ -z "$version" ]; then
           echo "::error::No deno-version input and no Deno pin found in mise.toml."

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -5,12 +5,41 @@ inputs:
     description: "Load deno dependencies from github cache"
     default: true
   deno-version:
-    description: "Deno version to install"
-    # Keep in sync with `./tasks/check.sh` version
-    default: "2.8.1"
+    description: "Deno version to install. Defaults to the pin in mise.toml."
+    default: ""
 runs:
   using: "composite"
   steps:
+    # The repository's Deno version is pinned once, in mise.toml. This step
+    # reads it so the rest of the action (and any caller that leaves the
+    # deno-version input empty) follows the pin.
+    - name: 📌 Resolve pinned Deno version
+      id: resolve
+      shell: bash
+      env:
+        DENO_VERSION_INPUT: ${{ inputs.deno-version }}
+      run: |
+        version="${DENO_VERSION_INPUT}"
+        if [ -z "$version" ]; then
+          if [ ! -f mise.toml ]; then
+            echo "::error::mise.toml not found; cannot resolve the Deno version. This action requires the repository to be checked out first."
+            exit 1
+          fi
+          version="$(sed -n 's/^deno = "\([^"]*\)"$/\1/p' mise.toml | head -1)"
+        fi
+        if [ -z "$version" ]; then
+          echo "::error::No deno-version input and no Deno pin found in mise.toml."
+          exit 1
+        fi
+        # The toolchain cache below is keyed on this version, so a range would
+        # never hit: setup-deno installs under the version it resolves against
+        # deno.com, not under the range.
+        if ! echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::Deno version '$version' is not an exact MAJOR.MINOR.PATCH version."
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     # Cache the Deno toolchain binary. denoland/setup-deno resolves the version
     # against deno.com/versions.json and downloads the binary at job time, so a
     # deno.com outage breaks every job. A cache hit installs the binary from disk
@@ -20,29 +49,29 @@ runs:
     # below (which gates the module/dependency cache) so jobs that pass
     # `cache: false` are covered too.
     # Cache version: bump the `deno-bin-v1` token to invalidate all toolchain caches.
-    - name: 💾 Restore Deno toolchain ${{ inputs.deno-version }}
+    - name: 💾 Restore Deno toolchain ${{ steps.resolve.outputs.version }}
       id: deno-toolchain-cache
       uses: actions/cache@v6
       with:
-        path: ${{ runner.tool_cache }}/deno/${{ inputs.deno-version }}
-        key: deno-bin-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}
+        path: ${{ runner.tool_cache }}/deno/${{ steps.resolve.outputs.version }}
+        key: deno-bin-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}
 
-    - name: 🦕 Download Deno ${{ inputs.deno-version }}
+    - name: 🦕 Download Deno ${{ steps.resolve.outputs.version }}
       # Cache miss: download the toolchain from upstream. setup-deno installs it
       # into the cached path above, so actions/cache saves it at job end and
       # later runs hit.
       if: steps.deno-toolchain-cache.outputs.cache-hit != 'true'
       uses: denoland/setup-deno@v2
       with:
-        deno-version: ${{ inputs.deno-version }}
+        deno-version: ${{ steps.resolve.outputs.version }}
 
-    - name: 🦕 Use cached Deno ${{ inputs.deno-version }}
+    - name: 🦕 Use cached Deno ${{ steps.resolve.outputs.version }}
       # Cache hit: add the restored binary to PATH and verify, with no deno.com
       # contact.
       if: steps.deno-toolchain-cache.outputs.cache-hit == 'true'
       shell: bash
       env:
-        TOOLCHAIN_DIR: ${{ runner.tool_cache }}/deno/${{ inputs.deno-version }}
+        TOOLCHAIN_DIR: ${{ runner.tool_cache }}/deno/${{ steps.resolve.outputs.version }}
       run: |
         # setup-deno extracts the binary into <tool_cache>/deno/<version>/<arch>/.
         # The arch subdir name comes from the runner's node arch, so find the
@@ -65,7 +94,7 @@ runs:
           ~/.deno
           ~/.cache/deno
           ~/Library/Caches/deno
-        key: deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}-${{ hashFiles('**/deno.jsonc', '**/deno.lock') }}
+        key: deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}-${{ hashFiles('**/deno.jsonc', '**/deno.lock') }}
         restore-keys: |
-          deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}-
+          deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}-
           deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -13,7 +13,7 @@ runs:
     # The repository's Deno version is pinned once, in mise.toml. This step
     # reads it so the rest of the action (and any caller that leaves the
     # deno-version input empty) follows the pin.
-    - name: 📌 Resolve pinned Deno version
+    - name: 🔍 Resolve pinned Deno version
       id: resolve
       shell: bash
       env:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -65,7 +65,7 @@ jobs:
       - name: 🚧 Guard against new polling waitFor in integration tests
         run: deno task check-no-waitfor
 
-      - name: 📌 Check Deno toolchain pins are aligned
+      - name: 🔎 Check Deno toolchain pins are aligned
         run: deno task check-deno-pins
 
       - name: 🔎 Check generated commonfabric/cfc types are up to date

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -65,6 +65,9 @@ jobs:
       - name: 🚧 Guard against new polling waitFor in integration tests
         run: deno task check-no-waitfor
 
+      - name: 📌 Check Deno toolchain pins are aligned
+        run: deno task check-deno-pins
+
       - name: 🔎 Check generated commonfabric/cfc types are up to date
         working-directory: packages/static
         run: deno task check-cfc-types

--- a/Dockerfile.toolshed
+++ b/Dockerfile.toolshed
@@ -2,7 +2,8 @@
 #
 # Build context must be the labs repo ROOT (workspace imports resolve from the
 # root deno.jsonc). Modeled on clusterduck's Dockerfile.worker labs-builder
-# stage, pinned to the Deno version tasks/check.sh requires.
+# stage, pinned to the Deno version in mise.toml (the FROM lines below cannot
+# read it, so tasks/check-deno-pins.ts verifies they match).
 #
 #   docker build -f Dockerfile.toolshed --build-arg COMMIT_SHA=$(git rev-parse HEAD) \
 #     -t us-central1-docker.pkg.dev/commontools-core/containers/toolshed:m0 .

--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ can run their own spaces or use hosted versions.
 
 ## Quick Start (Development)
 
-1. Install [Deno 2](https://docs.deno.com/runtime/getting_started/installation/)
+1. Install [mise](https://mise.jdx.dev/getting-started.html) and activate it in
+   your shell
 2. Clone this repo
-3. Install the Git hooks: `deno task install-hooks` (optional)
-4. Start local dev servers: `./scripts/start-local-dev.sh`
-5. Access the application at <http://localhost:8000>
+3. Run `mise trust && mise install` in the repo to install the pinned Deno
+   version (see
+   [DEVELOPMENT.md](./docs/development/DEVELOPMENT.md#installing-deno) for
+   details, including installing Deno without mise)
+4. Install the Git hooks: `deno task install-hooks` (optional)
+5. Start local dev servers: `./scripts/start-local-dev.sh`
+6. Access the application at <http://localhost:8000>
 
 For Claude Code users, run [`/deps`](.claude/commands/deps.md) to verify
 prerequisites, [`/start-local-dev`](.claude/commands/start-local-dev.md) to
@@ -97,7 +102,14 @@ through `/.agents/skills/`, while Claude compatibility preserves the existing
 **Required**:
 
 - [Deno 2](https://docs.deno.com/runtime/getting_started/installation/) -
-  Runtime for backend and tooling
+  Runtime for backend and tooling. The version is pinned in `mise.toml`.
+
+**Recommended for installing Deno**:
+
+- [mise](https://mise.jdx.dev/) - Installs the pinned version and keeps you on
+  it (run `mise trust && mise install` in the repo). Installing Deno yourself
+  also works: `deno task check` accepts the range in `tasks/check.sh`, and warns
+  when your version is off the pin.
 
 **Recommended Integrations**:
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -43,6 +43,7 @@
     "check": "./tasks/check.sh",
     "check-docs": "deno run --allow-read --allow-write --allow-run --allow-env ./docs/check.ts",
     "check-no-waitfor": "deno run --allow-read ./tasks/check-no-waitfor.ts",
+    "check-deno-pins": "deno run --allow-read ./tasks/check-deno-pins.ts",
     "cfcheck": "deno run -A ./tasks/cfcheck.ts",
     "check-skill-facts": "deno run --allow-read --allow-run=git ./tasks/check-skill-facts.ts",
     "cf": "deno run --allow-run --allow-env --allow-read ./packages/cli/launcher.ts",

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -355,19 +355,60 @@ export const set = (cache: Cache, key: string, value: string) =>
 
 #### Installing Deno
 
-If Deno is not installed, install it using the official installer:
+The repository pins its Deno version in `mise.toml` at the repository root.
+Install [mise](https://mise.jdx.dev/) and let it manage Deno:
 
 ```bash
-curl -fsSL https://deno.land/install.sh | sh
+brew install mise    # or: curl https://mise.run | sh
 ```
 
-This installs Deno to `~/.deno/bin/deno`. Add it to your PATH:
+Activate mise in your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) following
+the [getting-started guide](https://mise.jdx.dev/getting-started.html), for
+example:
 
 ```bash
-export PATH="$HOME/.deno/bin:$PATH"
+eval "$(mise activate zsh)"
 ```
 
-For persistent configuration, add this to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.).
+Then, from the repository root:
+
+```bash
+mise trust      # approve this repository's mise.toml (first time only)
+mise install    # install the pinned Deno version
+```
+
+While your working directory is inside the repository, `deno` resolves to the
+pinned version. When a commit bumps the pin, run `mise install` again; mise
+warns about the missing version until you do.
+
+Installing Deno directly (for example with the
+[official installer](https://docs.deno.com/runtime/getting_started/installation/))
+also works: `deno task check` accepts versions within the range set in
+`tasks/check.sh`, and prints a warning when the version differs from the pin.
+
+#### Where the Deno version is pinned
+
+`mise.toml` is the canonical pin. Everything else follows it or is checked
+against it:
+
+- `.github/actions/deno-setup` reads `mise.toml` at job time, so CI uses the
+  pinned version.
+- `tasks/check.sh` (run by `deno task check`, the pre-commit hook, and CI)
+  reads the pin for its version warning, and accepts the surrounding range set
+  in its `DENO_VERSION_MIN`/`DENO_VERSION_MAX` variables.
+- `Dockerfile.toolshed` repeats the version in its `FROM` lines, which cannot
+  read another file.
+
+To bump the toolchain: update the version in `mise.toml` and both `FROM` lines
+in `Dockerfile.toolshed`, and move the `tasks/check.sh` range if the new
+version falls outside it.
+
+`deno task check-deno-pins` (also a CI step) catches a bump that misses one of
+those. It checks that every `denoland/deno` tag in `Dockerfile.toolshed` equals
+the pin, that the `tasks/check.sh` range contains the pin, that `check.sh` and
+the `deno-setup` action both still read `mise.toml` rather than a hardcoded
+version, and that the action holds no version literal that disagrees with the
+pin.
 
 #### SSL Certificate Issues
 

--- a/tasks/check-deno-pins.test.ts
+++ b/tasks/check-deno-pins.test.ts
@@ -9,6 +9,7 @@ import {
   parseCheckShRange,
   parseDockerfileDenoVersions,
   parseMisePin,
+  parseMisePins,
   versionInRange,
 } from "./check-deno-pins.ts";
 
@@ -26,7 +27,7 @@ function alignedFiles() {
       "FROM denoland/deno:2.8.1\n",
     checkSh: "# The exact Deno version is pinned in mise.toml.\n" +
       'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.9.0"\n' +
-      `DENO_VERSION_PINNED="$(sed -n 's/^deno = "\\([^"]*\\)"$/\\1/p' mise.toml | head -1)"\n`,
+      `DENO_PINS="$(sed -n 's/^deno = "\\([^"]*\\)"$/\\1/p' mise.toml)"\n`,
     denoSetupAction: '    description: "Defaults to the pin in mise.toml."\n' +
       "    # The repository's Deno version is pinned once, in mise.toml.\n" +
       "      run: |\n" +
@@ -40,6 +41,38 @@ Deno.test("parseMisePin extracts the pinned version", () => {
 
 Deno.test("parseMisePin returns undefined when there is no pin", () => {
   assertEquals(parseMisePin('[tools]\nnode = "22.0.0"\n'), undefined);
+});
+
+Deno.test("parseMisePin returns undefined when the pin is defined twice", () => {
+  assertEquals(
+    parseMisePin('[tools]\ndeno = "2.8.1"\ndeno = "2.8.1"\n'),
+    undefined,
+  );
+});
+
+Deno.test("parseMisePins returns every pin in order", () => {
+  assertEquals(parseMisePins('[tools]\ndeno = "2.8.1"\n'), ["2.8.1"]);
+  assertEquals(parseMisePins('[tools]\nnode = "22.0.0"\n'), []);
+  assertEquals(
+    parseMisePins('[tools]\ndeno = "2.8.1"\ndeno = "2.9.0"\n'),
+    ["2.8.1", "2.9.0"],
+  );
+});
+
+// TOML rejects a key defined twice even when both values agree, so mise fails
+// to load the file. Reading only the first pin would report the toolchain as
+// aligned while `mise install` — the documented way to get it — is broken.
+Deno.test("findProblems flags a Deno pin defined twice", () => {
+  for (
+    const miseToml of [
+      '[tools]\ndeno = "2.8.1"\ndeno = "2.8.1"\n',
+      '[tools]\ndeno = "2.8.1"\ndeno = "2.9.0"\n',
+    ]
+  ) {
+    const problems = findProblems({ ...alignedFiles(), miseToml });
+    assertEquals(problems.length, 1, miseToml);
+    assert(problems[0].includes("defined 2 times"), problems[0]);
+  }
 });
 
 Deno.test("parseDockerfileDenoVersions finds every FROM line", () => {

--- a/tasks/check-deno-pins.test.ts
+++ b/tasks/check-deno-pins.test.ts
@@ -1,0 +1,199 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  compareVersions,
+  findProblems,
+  main,
+  parseCheckShRange,
+  parseDockerfileDenoVersions,
+  parseMisePin,
+  versionInRange,
+} from "./check-deno-pins.ts";
+
+// A consistent set of file contents, mirroring the real files' shapes. The
+// action and check.sh fixtures carry the prose mentions of mise.toml that the
+// real files have (a description, a comment), so a check that matched the
+// file name alone would pass here for a reason production could not reproduce.
+function alignedFiles() {
+  return {
+    miseToml: '[tools]\ndeno = "2.8.1"\n',
+    dockerfile: "FROM denoland/deno:2.8.1 AS builder\n" +
+      "RUN deno install --frozen\n" +
+      "FROM denoland/deno:2.8.1\n",
+    checkSh: "# The exact Deno version is pinned in mise.toml.\n" +
+      'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.9.0"\n' +
+      `DENO_VERSION_PINNED="$(sed -n 's/^deno = "\\([^"]*\\)"$/\\1/p' mise.toml | head -1)"\n`,
+    denoSetupAction: '    description: "Defaults to the pin in mise.toml."\n' +
+      "    # The repository's Deno version is pinned once, in mise.toml.\n" +
+      "      run: |\n" +
+      `        version="$(sed -n 's/^deno = "\\([^"]*\\)"$/\\1/p' mise.toml | head -1)"\n`,
+  };
+}
+
+Deno.test("parseMisePin extracts the pinned version", () => {
+  assertEquals(parseMisePin('[tools]\ndeno = "2.8.1"\n'), "2.8.1");
+});
+
+Deno.test("parseMisePin returns undefined when there is no pin", () => {
+  assertEquals(parseMisePin('[tools]\nnode = "22.0.0"\n'), undefined);
+});
+
+Deno.test("parseDockerfileDenoVersions finds every FROM line", () => {
+  const versions = parseDockerfileDenoVersions(alignedFiles().dockerfile);
+  assertEquals(versions, ["2.8.1", "2.8.1"]);
+});
+
+Deno.test("parseDockerfileDenoVersions reads past flags and a lowercase FROM", () => {
+  assertEquals(
+    parseDockerfileDenoVersions(
+      "FROM --platform=linux/amd64 denoland/deno:2.5.0 AS builder\n" +
+        "from denoland/deno:2.6.0\n",
+    ),
+    ["2.5.0", "2.6.0"],
+  );
+});
+
+Deno.test("parseDockerfileDenoVersions drops a digest", () => {
+  assertEquals(
+    parseDockerfileDenoVersions("FROM denoland/deno:2.8.1@sha256:abc123\n"),
+    ["2.8.1"],
+  );
+});
+
+Deno.test("parseCheckShRange extracts min and max", () => {
+  assertEquals(parseCheckShRange(alignedFiles().checkSh), {
+    min: "2.8.0",
+    max: "2.9.0",
+  });
+});
+
+Deno.test("parseCheckShRange returns undefined when a bound is missing", () => {
+  assertEquals(parseCheckShRange('DENO_VERSION_MIN="2.8.0"\n'), undefined);
+});
+
+Deno.test("compareVersions compares components numerically", () => {
+  assert(compareVersions("2.10.0", "2.9.0") > 0);
+  assert(compareVersions("2.9.0", "2.10.0") < 0);
+  assertEquals(compareVersions("2.8.1", "2.8.1"), 0);
+});
+
+Deno.test("versionInRange includes the minimum and excludes the maximum", () => {
+  assert(versionInRange("2.8.0", "2.8.0", "2.9.0"));
+  assert(versionInRange("2.8.1", "2.8.0", "2.9.0"));
+  assert(!versionInRange("2.9.0", "2.8.0", "2.9.0"));
+  assert(!versionInRange("2.7.9", "2.8.0", "2.9.0"));
+});
+
+Deno.test("findProblems accepts aligned files", () => {
+  assertEquals(findProblems(alignedFiles()), []);
+});
+
+Deno.test("findProblems flags a missing pin", () => {
+  const files = { ...alignedFiles(), miseToml: "[tools]\n" };
+  assertEquals(findProblems(files).length, 1);
+});
+
+Deno.test("findProblems flags a non-exact pin", () => {
+  const files = { ...alignedFiles(), miseToml: '[tools]\ndeno = "2.8"\n' };
+  assertEquals(findProblems(files).length, 1);
+});
+
+Deno.test("findProblems flags a mismatched Dockerfile image", () => {
+  const files = {
+    ...alignedFiles(),
+    dockerfile: "FROM denoland/deno:2.8.0 AS builder\n" +
+      "FROM denoland/deno:2.8.1\n",
+  };
+  const problems = findProblems(files);
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("2.8.0"));
+});
+
+Deno.test("findProblems flags a Dockerfile without deno images", () => {
+  const files = { ...alignedFiles(), dockerfile: "FROM debian:12\n" };
+  assertEquals(findProblems(files).length, 1);
+});
+
+Deno.test("findProblems flags a range that excludes the pin", () => {
+  const files = {
+    ...alignedFiles(),
+    checkSh: alignedFiles().checkSh
+      .replace('DENO_VERSION_MIN="2.8.0"', 'DENO_VERSION_MIN="2.9.0"')
+      .replace('DENO_VERSION_MAX="2.9.0"', 'DENO_VERSION_MAX="2.10.0"'),
+  };
+  const problems = findProblems(files);
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("range"));
+});
+
+// The name mise.toml stays in the action's description and comments after the
+// read is replaced by a literal, so this fixture is what a "just inline the
+// version" refactor actually leaves behind.
+Deno.test("findProblems flags an action that stops reading mise.toml", () => {
+  const files = {
+    ...alignedFiles(),
+    denoSetupAction: '    description: "Defaults to the pin in mise.toml."\n' +
+      "    # The repository's Deno version is pinned once, in mise.toml.\n" +
+      "      run: |\n" +
+      '        version="2.8.1"\n',
+  };
+  const problems = findProblems(files);
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("does not read"));
+});
+
+Deno.test("findProblems flags a check.sh that stops reading mise.toml", () => {
+  const files = {
+    ...alignedFiles(),
+    checkSh: "# The exact Deno version is pinned in mise.toml.\n" +
+      'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.9.0"\n',
+  };
+  const problems = findProblems(files);
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("does not read"));
+});
+
+Deno.test("findProblems flags a Dockerfile stage stale behind a flag", () => {
+  const files = {
+    ...alignedFiles(),
+    dockerfile: "FROM --platform=linux/amd64 denoland/deno:2.5.0 AS builder\n" +
+      "FROM denoland/deno:2.8.1\n",
+  };
+  const problems = findProblems(files);
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("2.5.0"));
+});
+
+Deno.test("findProblems accepts a digest-pinned image on the pin", () => {
+  const files = {
+    ...alignedFiles(),
+    dockerfile: "FROM denoland/deno:2.8.1@sha256:abc123 AS builder\n" +
+      "FROM denoland/deno:2.8.1\n",
+  };
+  assertEquals(findProblems(files), []);
+});
+
+Deno.test("findProblems flags a mismatched literal in the action", () => {
+  const files = {
+    ...alignedFiles(),
+    denoSetupAction: alignedFiles().denoSetupAction +
+      'default: "2.7.9"\n',
+  };
+  const problems = findProblems(files);
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("2.7.9"));
+});
+
+Deno.test("findProblems accepts a literal in the action equal to the pin", () => {
+  const files = {
+    ...alignedFiles(),
+    denoSetupAction: alignedFiles().denoSetupAction +
+      'default: "2.8.1"\n',
+  };
+  assertEquals(findProblems(files), []);
+});
+
+// The repository's actual files must be aligned; this is the same check CI
+// runs via `deno task check-deno-pins`.
+Deno.test("the repository's pins are aligned", async () => {
+  assertEquals(await main(), 0);
+});

--- a/tasks/check-deno-pins.test.ts
+++ b/tasks/check-deno-pins.test.ts
@@ -1,13 +1,18 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
   compareVersions,
   findProblems,
+  isExactVersion,
   main,
   parseCheckShRange,
   parseDockerfileDenoVersions,
   parseMisePin,
   versionInRange,
 } from "./check-deno-pins.ts";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
 // A consistent set of file contents, mirroring the real files' shapes. The
 // action and check.sh fixtures carry the prose mentions of mise.toml that the
@@ -76,6 +81,32 @@ Deno.test("compareVersions compares components numerically", () => {
   assertEquals(compareVersions("2.8.1", "2.8.1"), 0);
 });
 
+// Reading only the leading components would compare "2.8.0.1" as "2.8.0" and
+// answer as though the trailing component were not there.
+Deno.test("compareVersions rejects a version that is not exact", () => {
+  for (const bad of ["2.8.0.1", "2.8", "abc", "", "v2.8.0"]) {
+    assertThrows(
+      () => compareVersions(bad, "2.8.0"),
+      Error,
+      "Not an exact",
+    );
+    assertThrows(
+      () => compareVersions("2.8.0", bad),
+      Error,
+      "Not an exact",
+    );
+  }
+});
+
+Deno.test("isExactVersion accepts only MAJOR.MINOR.PATCH", () => {
+  assert(isExactVersion("2.8.1"));
+  assert(isExactVersion("10.0.100"));
+  assert(!isExactVersion("2.8"));
+  assert(!isExactVersion("2.8.0.1"));
+  assert(!isExactVersion("2.8.x"));
+  assert(!isExactVersion("latest"));
+});
+
 Deno.test("versionInRange includes the minimum and excludes the maximum", () => {
   assert(versionInRange("2.8.0", "2.8.0", "2.9.0"));
   assert(versionInRange("2.8.1", "2.8.0", "2.9.0"));
@@ -111,6 +142,44 @@ Deno.test("findProblems flags a mismatched Dockerfile image", () => {
 Deno.test("findProblems flags a Dockerfile without deno images", () => {
   const files = { ...alignedFiles(), dockerfile: "FROM debian:12\n" };
   assertEquals(findProblems(files).length, 1);
+});
+
+// check.sh reads the bounds with shell arithmetic, which aborts on a bound
+// carrying anything beyond MAJOR.MINOR.PATCH. Comparing such a bound loosely
+// would report "aligned" for a range that makes check.sh fail for everyone.
+Deno.test("findProblems flags a range bound that is not exact", () => {
+  for (const bad of ["2.8.0.1", "2.8", "abc"]) {
+    const withMin = findProblems({
+      ...alignedFiles(),
+      checkSh: alignedFiles().checkSh.replace(
+        'DENO_VERSION_MIN="2.8.0"',
+        `DENO_VERSION_MIN="${bad}"`,
+      ),
+    });
+    assertEquals(withMin.length, 1, `MIN=${bad}`);
+    assert(withMin[0].includes("DENO_VERSION_MIN"), `MIN=${bad}`);
+    assert(withMin[0].includes("not an exact"), `MIN=${bad}`);
+
+    const withMax = findProblems({
+      ...alignedFiles(),
+      checkSh: alignedFiles().checkSh.replace(
+        'DENO_VERSION_MAX="2.9.0"',
+        `DENO_VERSION_MAX="${bad}"`,
+      ),
+    });
+    assertEquals(withMax.length, 1, `MAX=${bad}`);
+    assert(withMax[0].includes("DENO_VERSION_MAX"), `MAX=${bad}`);
+  }
+});
+
+Deno.test("findProblems flags both range bounds when both are malformed", () => {
+  const problems = findProblems({
+    ...alignedFiles(),
+    checkSh: alignedFiles().checkSh
+      .replace('DENO_VERSION_MIN="2.8.0"', 'DENO_VERSION_MIN="2.8"')
+      .replace('DENO_VERSION_MAX="2.9.0"', 'DENO_VERSION_MAX="2.9"'),
+  });
+  assertEquals(problems.length, 2);
 });
 
 Deno.test("findProblems flags a range that excludes the pin", () => {
@@ -192,8 +261,119 @@ Deno.test("findProblems accepts a literal in the action equal to the pin", () =>
   assertEquals(findProblems(files), []);
 });
 
+Deno.test("findProblems flags a check.sh with no range at all", () => {
+  const problems = findProblems({
+    ...alignedFiles(),
+    checkSh: "# The exact Deno version is pinned in mise.toml.\n" +
+      `DENO_VERSION_PINNED="$(sed -n 's/^deno = "\\([^"]*\\)"$/\\1/p' mise.toml | head -1)"\n`,
+  });
+  assertEquals(problems.length, 1);
+  assert(problems[0].includes("DENO_VERSION_MIN/DENO_VERSION_MAX not found"));
+});
+
+// Writes the four files main() reads into a fresh temp tree and returns its
+// root. The caller removes the tree.
+async function fixtureTree(
+  files: ReturnType<typeof alignedFiles>,
+): Promise<string> {
+  const root = await Deno.makeTempDir({ prefix: "check-deno-pins-" });
+  await Deno.mkdir(join(root, "tasks"), { recursive: true });
+  await Deno.mkdir(join(root, ".github", "actions", "deno-setup"), {
+    recursive: true,
+  });
+  await Deno.writeTextFile(join(root, "mise.toml"), files.miseToml);
+  await Deno.writeTextFile(join(root, "Dockerfile.toolshed"), files.dockerfile);
+  await Deno.writeTextFile(join(root, "tasks", "check.sh"), files.checkSh);
+  await Deno.writeTextFile(
+    join(root, ".github", "actions", "deno-setup", "action.yml"),
+    files.denoSetupAction,
+  );
+  return root;
+}
+
+// Runs `body` with console.log and console.error captured, returning what each
+// received. Restores the originals afterward.
+async function captureConsole(
+  body: () => Promise<void>,
+): Promise<{ out: string; err: string }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args) => out.push(args.map(String).join(" "));
+  console.error = (...args) => err.push(args.map(String).join(" "));
+  try {
+    await body();
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+  return { out: out.join("\n"), err: err.join("\n") };
+}
+
+Deno.test("main reports the pin and returns 0 on aligned files", async () => {
+  const root = await fixtureTree(alignedFiles());
+  try {
+    let code = -1;
+    const { out } = await captureConsole(async () => {
+      code = await main(root);
+    });
+    assertEquals(code, 0);
+    assert(out.includes("Deno toolchain pins are aligned: 2.8.1"));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("main reports each problem and returns 1 when misaligned", async () => {
+  const root = await fixtureTree({
+    ...alignedFiles(),
+    dockerfile: "FROM denoland/deno:2.5.0 AS builder\n",
+    checkSh: alignedFiles().checkSh.replace(
+      'DENO_VERSION_MAX="2.9.0"',
+      'DENO_VERSION_MAX="2.9"',
+    ),
+  });
+  try {
+    let code = -1;
+    const { err } = await captureConsole(async () => {
+      code = await main(root);
+    });
+    assertEquals(code, 1);
+    assert(err.includes("Deno toolchain pins are misaligned:"));
+    assert(err.includes("2.5.0"));
+    assert(err.includes("DENO_VERSION_MAX"));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
 // The repository's actual files must be aligned; this is the same check CI
 // runs via `deno task check-deno-pins`.
 Deno.test("the repository's pins are aligned", async () => {
   assertEquals(await main(), 0);
+});
+
+// Runs the script the way `deno task check-deno-pins` does, which the calls to
+// main() above do not: they would still pass if the entry point never ran it,
+// or if the task's declared permissions were too narrow to read the files.
+Deno.test("running the script as a command reports the aligned pin", async () => {
+  const output = await runDenoCommandWithTemporaryLock({
+    root: REPO_ROOT,
+    args: (lockPath) => [
+      "run",
+      "--config",
+      join(REPO_ROOT, "deno.jsonc"),
+      "--lock",
+      lockPath,
+      "--allow-read",
+      join(REPO_ROOT, "tasks/check-deno-pins.ts"),
+    ],
+  });
+  assertEquals(output.code, 0);
+  assert(
+    new TextDecoder().decode(output.stdout).includes(
+      "Deno toolchain pins are aligned",
+    ),
+  );
 });

--- a/tasks/check-deno-pins.ts
+++ b/tasks/check-deno-pins.ts
@@ -59,10 +59,26 @@ export function parseCheckShRange(
   return min !== undefined && max !== undefined ? { min, max } : undefined;
 }
 
+// An exact MAJOR.MINOR.PATCH version, which is the only shape check.sh's
+// arithmetic can read and the only shape the toolchain cache can be keyed on.
+const EXACT_VERSION = /^\d+\.\d+\.\d+$/;
+
+/** Reports whether `version` is an exact MAJOR.MINOR.PATCH version. */
+export function isExactVersion(version: string): boolean {
+  return EXACT_VERSION.test(version);
+}
+
 // Compares two MAJOR.MINOR.PATCH versions numerically per component. Returns
 // a negative number, zero, or a positive number as `a` is less than, equal
-// to, or greater than `b`.
+// to, or greater than `b`. Throws on anything that is not an exact version:
+// comparing only the leading components would silently ignore the rest and
+// answer as though the trailing garbage were not there.
 export function compareVersions(a: string, b: string): number {
+  for (const version of [a, b]) {
+    if (!isExactVersion(version)) {
+      throw new Error(`Not an exact MAJOR.MINOR.PATCH version: ${version}`);
+    }
+  }
   const aParts = a.split(".").map(Number);
   const bParts = b.split(".").map(Number);
   for (let i = 0; i < 3; i++) {
@@ -95,7 +111,7 @@ export function findProblems(files: {
   if (pin === undefined) {
     return [`${MISE_TOML}: no Deno pin found (expected a 'deno = "..."' line)`];
   }
-  if (!/^\d+\.\d+\.\d+$/.test(pin)) {
+  if (!isExactVersion(pin)) {
     return [
       `${MISE_TOML}: pin "${pin}" is not an exact MAJOR.MINOR.PATCH version`,
     ];
@@ -119,11 +135,29 @@ export function findProblems(files: {
     problems.push(
       `${CHECK_SH}: DENO_VERSION_MIN/DENO_VERSION_MAX not found`,
     );
-  } else if (!versionInRange(pin, range.min, range.max)) {
-    problems.push(
-      `${CHECK_SH}: accepted range [${range.min}, ${range.max}) does not ` +
-        `contain the ${MISE_TOML} pin ${pin}`,
+  } else {
+    // Bounds are checked before they are compared. check.sh reads them with
+    // shell arithmetic, which aborts on a bound carrying anything beyond
+    // MAJOR.MINOR.PATCH — so a bound this check merely compared loosely could
+    // be reported as aligned while making check.sh fail for everyone.
+    const malformed = (["min", "max"] as const).filter(
+      (bound) => !isExactVersion(range[bound]),
     );
+    if (malformed.length > 0) {
+      for (const bound of malformed) {
+        problems.push(
+          `${CHECK_SH}: DENO_VERSION_${bound.toUpperCase()} "${
+            range[bound]
+          }" is not an exact MAJOR.MINOR.PATCH version, which check.sh ` +
+            `cannot compare`,
+        );
+      }
+    } else if (!versionInRange(pin, range.min, range.max)) {
+      problems.push(
+        `${CHECK_SH}: accepted range [${range.min}, ${range.max}) does not ` +
+          `contain the ${MISE_TOML} pin ${pin}`,
+      );
+    }
   }
 
   if (!READS_MISE_TOML.test(files.checkSh)) {
@@ -153,8 +187,8 @@ export function findProblems(files: {
   return problems;
 }
 
-export async function main(): Promise<number> {
-  const read = (path: string) => Deno.readTextFile(join(REPO_ROOT, path));
+export async function main(root: string = REPO_ROOT): Promise<number> {
+  const read = (path: string) => Deno.readTextFile(join(root, path));
   const files = {
     miseToml: await read(MISE_TOML),
     dockerfile: await read(DOCKERFILE),
@@ -177,6 +211,4 @@ export async function main(): Promise<number> {
   return 0;
 }
 
-if (import.meta.main) {
-  Deno.exit(await main());
-}
+if (import.meta.main) Deno.exit(await main());

--- a/tasks/check-deno-pins.ts
+++ b/tasks/check-deno-pins.ts
@@ -33,9 +33,19 @@ const DENO_SETUP_ACTION = ".github/actions/deno-setup/action.yml";
 // pass after the read itself had been replaced with a hardcoded version.
 const READS_MISE_TOML = /sed[^\n]*\bmise\.toml\b/;
 
-// Extracts the pinned Deno version from mise.toml contents.
+// Every `deno = "..."` assignment in mise.toml, in order. TOML rejects a key
+// defined twice, so more than one means mise cannot load the file at all —
+// reading only the first would report a pin no developer actually gets.
+export function parseMisePins(miseToml: string): string[] {
+  return [...miseToml.matchAll(/^deno = "([^"]+)"$/gm)].map((match) =>
+    match[1]
+  );
+}
+
+// The pinned Deno version. Undefined unless the file defines exactly one.
 export function parseMisePin(miseToml: string): string | undefined {
-  return miseToml.match(/^deno = "([^"]+)"$/m)?.[1];
+  const pins = parseMisePins(miseToml);
+  return pins.length === 1 ? pins[0] : undefined;
 }
 
 // Extracts the version tag of each denoland/deno base image in a Dockerfile.
@@ -107,10 +117,17 @@ export function findProblems(files: {
 }): string[] {
   const problems: string[] = [];
 
-  const pin = parseMisePin(files.miseToml);
-  if (pin === undefined) {
+  const pins = parseMisePins(files.miseToml);
+  if (pins.length === 0) {
     return [`${MISE_TOML}: no Deno pin found (expected a 'deno = "..."' line)`];
   }
+  if (pins.length > 1) {
+    return [
+      `${MISE_TOML}: the Deno pin is defined ${pins.length} times; TOML ` +
+      `rejects a key defined twice, so mise cannot load the file`,
+    ];
+  }
+  const pin = pins[0];
   if (!isExactVersion(pin)) {
     return [
       `${MISE_TOML}: pin "${pin}" is not an exact MAJOR.MINOR.PATCH version`,

--- a/tasks/check-deno-pins.ts
+++ b/tasks/check-deno-pins.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env -S deno run --allow-read
+//
+// Verifies that every place that encodes a Deno toolchain version agrees with
+// the pin in mise.toml.
+//
+// mise.toml is the canonical pin: mise installs that version for developers,
+// and .github/actions/deno-setup reads it at job time for CI. Two other places
+// encode a version and can drift, so this script checks them:
+//
+// - Dockerfile.toolshed bakes the version into its FROM lines, which cannot
+//   read a file. Each denoland/deno image tag must equal the pin.
+// - tasks/check.sh accepts a range of versions (so a developer without mise
+//   can still build, at the cost of a warning). The range must contain the
+//   pin, otherwise the version mise installs would fail the check.
+//
+// The deno-setup action is also inspected: it must keep reading mise.toml,
+// and any literal version in it must equal the pin.
+//
+// Usage: deno run --allow-read ./tasks/check-deno-pins.ts
+
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+const MISE_TOML = "mise.toml";
+const DOCKERFILE = "Dockerfile.toolshed";
+const CHECK_SH = "tasks/check.sh";
+const DENO_SETUP_ACTION = ".github/actions/deno-setup/action.yml";
+
+// Matches a command that reads the pin out of mise.toml. The checks below
+// match on this rather than on the file name alone: the name also appears in
+// the action's description and comments, so a check for the name would still
+// pass after the read itself had been replaced with a hardcoded version.
+const READS_MISE_TOML = /sed[^\n]*\bmise\.toml\b/;
+
+// Extracts the pinned Deno version from mise.toml contents.
+export function parseMisePin(miseToml: string): string | undefined {
+  return miseToml.match(/^deno = "([^"]+)"$/m)?.[1];
+}
+
+// Extracts the version tag of each denoland/deno base image in a Dockerfile.
+// Tolerates flags before the image (`FROM --platform=... denoland/deno:X`)
+// and a lowercase `from`, and drops any `@sha256:...` digest so a
+// digest-pinned image compares on its version tag.
+export function parseDockerfileDenoVersions(dockerfile: string): string[] {
+  return [
+    ...dockerfile.matchAll(/^FROM\s+(?:--\S+\s+)*denoland\/deno:(\S+)/gim),
+  ].map((match) => match[1].split("@")[0]);
+}
+
+// Extracts the accepted version range from tasks/check.sh contents. The
+// minimum is inclusive and the maximum is exclusive, matching the comparison
+// in that script.
+export function parseCheckShRange(
+  checkSh: string,
+): { min: string; max: string } | undefined {
+  const min = checkSh.match(/^DENO_VERSION_MIN="([^"]+)"$/m)?.[1];
+  const max = checkSh.match(/^DENO_VERSION_MAX="([^"]+)"$/m)?.[1];
+  return min !== undefined && max !== undefined ? { min, max } : undefined;
+}
+
+// Compares two MAJOR.MINOR.PATCH versions numerically per component. Returns
+// a negative number, zero, or a positive number as `a` is less than, equal
+// to, or greater than `b`.
+export function compareVersions(a: string, b: string): number {
+  const aParts = a.split(".").map(Number);
+  const bParts = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (aParts[i] !== bParts[i]) return aParts[i] - bParts[i];
+  }
+  return 0;
+}
+
+// Reports whether `version` is within [min, max).
+export function versionInRange(
+  version: string,
+  min: string,
+  max: string,
+): boolean {
+  return compareVersions(version, min) >= 0 &&
+    compareVersions(version, max) < 0;
+}
+
+// Checks all the pinned versions against each other, returning a description
+// of each misalignment found. An empty result means everything agrees.
+export function findProblems(files: {
+  miseToml: string;
+  dockerfile: string;
+  checkSh: string;
+  denoSetupAction: string;
+}): string[] {
+  const problems: string[] = [];
+
+  const pin = parseMisePin(files.miseToml);
+  if (pin === undefined) {
+    return [`${MISE_TOML}: no Deno pin found (expected a 'deno = "..."' line)`];
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(pin)) {
+    return [
+      `${MISE_TOML}: pin "${pin}" is not an exact MAJOR.MINOR.PATCH version`,
+    ];
+  }
+
+  const dockerVersions = parseDockerfileDenoVersions(files.dockerfile);
+  if (dockerVersions.length === 0) {
+    problems.push(`${DOCKERFILE}: no denoland/deno FROM lines found`);
+  }
+  for (const version of dockerVersions) {
+    if (version !== pin) {
+      problems.push(
+        `${DOCKERFILE}: FROM denoland/deno:${version} does not match the ` +
+          `${MISE_TOML} pin ${pin}`,
+      );
+    }
+  }
+
+  const range = parseCheckShRange(files.checkSh);
+  if (range === undefined) {
+    problems.push(
+      `${CHECK_SH}: DENO_VERSION_MIN/DENO_VERSION_MAX not found`,
+    );
+  } else if (!versionInRange(pin, range.min, range.max)) {
+    problems.push(
+      `${CHECK_SH}: accepted range [${range.min}, ${range.max}) does not ` +
+        `contain the ${MISE_TOML} pin ${pin}`,
+    );
+  }
+
+  if (!READS_MISE_TOML.test(files.checkSh)) {
+    problems.push(
+      `${CHECK_SH}: does not read ${MISE_TOML}; it would no longer warn ` +
+        `when the running Deno is off the pin`,
+    );
+  }
+
+  if (!READS_MISE_TOML.test(files.denoSetupAction)) {
+    problems.push(
+      `${DENO_SETUP_ACTION}: does not read ${MISE_TOML}; CI would no longer ` +
+        `follow the pin`,
+    );
+  }
+  for (
+    const [literal] of files.denoSetupAction.matchAll(/\b\d+\.\d+\.\d+\b/g)
+  ) {
+    if (literal !== pin) {
+      problems.push(
+        `${DENO_SETUP_ACTION}: contains version literal ${literal}, which ` +
+          `does not match the ${MISE_TOML} pin ${pin}`,
+      );
+    }
+  }
+
+  return problems;
+}
+
+export async function main(): Promise<number> {
+  const read = (path: string) => Deno.readTextFile(join(REPO_ROOT, path));
+  const files = {
+    miseToml: await read(MISE_TOML),
+    dockerfile: await read(DOCKERFILE),
+    checkSh: await read(CHECK_SH),
+    denoSetupAction: await read(DENO_SETUP_ACTION),
+  };
+
+  const problems = findProblems(files);
+  if (problems.length > 0) {
+    console.error("Deno toolchain pins are misaligned:");
+    for (const problem of problems) {
+      console.error(`  - ${problem}`);
+    }
+    return 1;
+  }
+
+  console.log(
+    `Deno toolchain pins are aligned: ${parseMisePin(files.miseToml)}`,
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(await main());
+}

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -2,21 +2,6 @@
 set -e
 shopt -s extglob nullglob
 
-DENO_VERSION_MIN="2.8.0"
-DENO_VERSION_MAX="2.9.0"
-# This is more portable than parsing `deno --version`
-DENO_VERSION=$(echo "console.log(Deno.version.deno)" | deno run -)
-IFS='.' read -r DENO_MAJOR DENO_MINOR DENO_PATCH <<<"${DENO_VERSION}"
-if [[ ! "${DENO_MAJOR}" =~ ^[0-9]+$ || ! "${DENO_MINOR}" =~ ^[0-9]+$ || ! "${DENO_PATCH}" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: Unexpected Deno version format: ${DENO_VERSION}"
-  exit 1
-fi
-
-if (( DENO_MAJOR != 2 || DENO_MINOR < 8 || DENO_MINOR >= 9 )); then
-  echo "ERROR: Deno version is ${DENO_VERSION}, expected >= ${DENO_VERSION_MIN} and < ${DENO_VERSION_MAX}."
-  exit 1
-fi
-
 # Figure out the symlink-resolved program name and directory.
 cmdName="$(readlink -f "$0")" || exit "$?"
 cmdDir="${cmdName%/*}"
@@ -27,6 +12,50 @@ baseDir="${cmdDir%/*}" # Parent of `cmdDir`, repo root in this case.
 # `cd`ed anywhere. This is especially useful because the LLM agents often like
 # to do `git commit` (which triggers this) in a project subdirectory.
 cd "${baseDir}"
+
+# The exact Deno version for this repository is pinned in mise.toml, which mise
+# installs (see README.md). Versions inside the range below are accepted, with
+# a warning when the version differs from the pin.
+# tasks/check-deno-pins.ts verifies that the range contains the pin.
+DENO_VERSION_MIN="2.8.0"
+DENO_VERSION_MAX="2.9.0"
+if [[ ! -f mise.toml ]]; then
+  # Checked before the read: `set -e` would otherwise abort on sed's exit
+  # status with only sed's own message.
+  echo "ERROR: mise.toml not found; cannot read the pinned Deno version."
+  exit 1
+fi
+DENO_VERSION_PINNED="$(sed -n 's/^deno = "\([^"]*\)"$/\1/p' mise.toml | head -1)"
+if [[ -z "${DENO_VERSION_PINNED}" ]]; then
+  echo "ERROR: Could not read the pinned Deno version from mise.toml."
+  exit 1
+fi
+# This is more portable than parsing `deno --version`
+DENO_VERSION=$(echo "console.log(Deno.version.deno)" | deno run -)
+IFS='.' read -r DENO_MAJOR DENO_MINOR DENO_PATCH <<<"${DENO_VERSION}"
+if [[ ! "${DENO_MAJOR}" =~ ^[0-9]+$ || ! "${DENO_MINOR}" =~ ^[0-9]+$ || ! "${DENO_PATCH}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: Unexpected Deno version format: ${DENO_VERSION}"
+  exit 1
+fi
+
+# Maps a MAJOR.MINOR.PATCH version to a single integer for range comparison.
+# Components are read as base-10 and must be below 1000.
+version_num() {
+  local major minor patch
+  IFS='.' read -r major minor patch <<<"$1"
+  echo $(( (10#${major} * 1000 + 10#${minor}) * 1000 + 10#${patch} ))
+}
+
+if (( $(version_num "${DENO_VERSION}") < $(version_num "${DENO_VERSION_MIN}") ||
+      $(version_num "${DENO_VERSION}") >= $(version_num "${DENO_VERSION_MAX}") )); then
+  echo "ERROR: Deno version is ${DENO_VERSION}, expected >= ${DENO_VERSION_MIN} and < ${DENO_VERSION_MAX}."
+  exit 1
+fi
+
+if [[ "${DENO_VERSION}" != "${DENO_VERSION_PINNED}" ]]; then
+  echo "WARNING: Deno version is ${DENO_VERSION}; this repository pins ${DENO_VERSION_PINNED} (mise.toml)."
+  echo "WARNING: To use the pinned version, install mise <https://mise.jdx.dev/> and run 'mise install'."
+fi
 
 # Collect all paths to check. Glob patterns will be expanded by bash.
 #

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -25,11 +25,20 @@ if [[ ! -f mise.toml ]]; then
   echo "ERROR: mise.toml not found; cannot read the pinned Deno version."
   exit 1
 fi
-DENO_VERSION_PINNED="$(sed -n 's/^deno = "\([^"]*\)"$/\1/p' mise.toml | head -1)"
-if [[ -z "${DENO_VERSION_PINNED}" ]]; then
+DENO_PINS="$(sed -n 's/^deno = "\([^"]*\)"$/\1/p' mise.toml)"
+# Counted rather than taking the first: TOML rejects a key defined twice, so a
+# second pin means mise cannot load the file, and reading past it would report
+# a version no developer actually gets.
+DENO_PIN_COUNT="$(printf '%s' "${DENO_PINS}" | grep -c . || true)"
+if (( DENO_PIN_COUNT == 0 )); then
   echo "ERROR: Could not read the pinned Deno version from mise.toml."
   exit 1
 fi
+if (( DENO_PIN_COUNT > 1 )); then
+  echo "ERROR: mise.toml defines the Deno pin ${DENO_PIN_COUNT} times; TOML rejects a key defined twice, so mise cannot load it."
+  exit 1
+fi
+DENO_VERSION_PINNED="${DENO_PINS}"
 # This is more portable than parsing `deno --version`
 DENO_VERSION=$(echo "console.log(Deno.version.deno)" | deno run -)
 IFS='.' read -r DENO_MAJOR DENO_MINOR DENO_PATCH <<<"${DENO_VERSION}"


### PR DESCRIPTION
Developers run whatever Deno happens to be installed, because nothing in the repository points them at the pinned version. The version is also encoded in four places kept in sync by hand — mise.toml, the deno-setup CI action, Dockerfile.toolshed, and the tasks/check.sh range — with a comment asking whoever edits one to remember the others.

Make mise.toml the single source of truth:

- .github/actions/deno-setup reads the pin from mise.toml at job time instead of carrying its own hardcoded default, so CI follows the pin with no second place to update. An explicit deno-version input still overrides it. The step requires an exact MAJOR.MINOR.PATCH version: the toolchain cache is keyed on the version and setup-deno installs under whatever a range resolves to, so a range would never hit the cache and every job would contact deno.com again — the failure the cache exists to avoid.
- tasks/check.sh reads the pin and warns, naming mise, when the running Deno differs from it. The accepted range (DENO_VERSION_MIN and DENO_VERSION_MAX) stays the pass/fail gate, so a manually installed Deno keeps working; the range comparison now derives from those variables rather than a separate hardcoded expression that could drift from them.
- tasks/check-deno-pins.ts (deno task check-deno-pins, run as a CI step and covered by the tasks/ unit tests) checks what cannot read mise.toml for itself: every denoland/deno tag in Dockerfile.toolshed must equal the pin, and the check.sh range must contain it.
- README.md, docs/development/DEVELOPMENT.md, and the /deps command describe installing the toolchain through mise (mise trust and mise install), keeping manual installation as a supported fallback.

The checks are built to fail closed. A check that reports "aligned" when it cannot find what it is looking for is worse than no check, because it is trusted. So rather than testing for the string "mise.toml" — which also appears in the action's description and comments, and would still be there after someone replaced the read with a literal — they match the command that performs the read, in both the action and check.sh. The Dockerfile scan tolerates flags before the image name and a lowercase FROM, so a stale stage cannot hide behind either, and compares on the version tag with any digest stripped, so digest pinning is not reported as a mismatch. Both reads stop at the closing quote and take the first match: a pin with a trailing comment would otherwise yield a garbage version that satisfies an emptiness check, and a second deno line would produce a multi-line value that corrupts GITHUB_OUTPUT. Each read checks that mise.toml exists first, because under set -e the read would otherwise abort the script with only sed's own message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `mise.toml` the single source of truth for the Deno version. CI, local checks, and Docker now follow this pin with strict validation (exact versions, duplicate-pin rejection) to prevent drift and flaky toolchain installs.

- **New Features**
  - `.github/actions/deno-setup` reads the pinned version from `mise.toml` by default, enforces exact MAJOR.MINOR.PATCH, and keys caches on the resolved version; explicit `deno-version` still overrides. Step names use registered phase markers.
  - `tasks/check.sh` reads the pin, warns when the running Deno differs, errors if `mise.toml` is missing or defines `deno` twice, and compares the accepted `DENO_VERSION_MIN`/`DENO_VERSION_MAX` range via a single numeric helper.
  - Added `tasks/check-deno-pins.ts` (+ tests) and wired `deno task check-deno-pins` into CI to verify `Dockerfile.toolshed` `denoland/deno` tags equal the pin, the range contains it, both `check.sh` and the action still read `mise.toml`, and no action literals disagree with the pin.
  - Docs updated to install Deno via `mise` (`mise trust && mise install`); `/deps`, README, and DEVELOPMENT reflect this.

- **Bug Fixes**
  - Validate range bounds as exact versions and reject non-exact inputs in `compareVersions`; error messages name the offending bound.
  - Reject a `mise.toml` that defines `deno` more than once across the action, `check.sh`, and the checker; all fail closed with clear errors.

<sup>Written for commit b72ca8b28c9732723141e4555da61b0df7c289d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

