### PR TITLE
feat(profile): add external profile links

### DIFF
--- a/docs/specs/shared-profile-space.md
+++ b/docs/specs/shared-profile-space.md
@@ -169,13 +169,21 @@ type ProfileElement = {
   source?: "catalog" | "url";
 };
 
+type ExternalProfileLink = {
+  label: string;
+  url: string;
+};
+
 type ProfileDefaultPattern = {
   [NAME]: string;
   [UI]: VNode;
   name: string;
   avatar: string;
   bio: string;
+  externalLinks: ExternalProfileLink[];
   elements: ProfileElement[];
+  addExternalLink: Stream<{ label?: string; url?: string }>;
+  removeExternalLink: Stream<{ url?: string }>;
   addElement: Stream<AddProfileElementEvent>;
   removeElement: Stream<{ cell: Cell<unknown> }>;
   setBio: Stream<SetProfileBioEvent>;
@@ -191,6 +199,12 @@ shared-profile bio — distinct from Home's legacy `learned.summary`. Like `name
 and `avatar` it is owner-protected (written only through `setBio`), readable
 from the profile result, and exposed as the well-known wish target
 `#profileBio`.
+
+`externalLinks` is the owner-authored list of public profiles maintained
+outside Common Fabric, such as GitHub, LinkedIn, or a personal site. Entries
+contain a display label and an `http(s)` URL; unsafe schemes are rejected before
+storage and never render as live anchors. The list is owner-protected and is
+mutated only through `addExternalLink` / `removeExternalLink`.
 
 `elements` is the profile-space analog of favorites and mentionables. Each
 entry points at a piece that lives in the profile space. `tag` stores the

--- a/packages/patterns/integration/home-profile.test.ts
+++ b/packages/patterns/integration/home-profile.test.ts
@@ -151,6 +151,44 @@ describe("home-space profile creation", () => {
     await waitForText(page, "#home-profile-summary", "Alan Turing");
   });
 
+  it("lets an owner edit a non-default profile", async () => {
+    const page = shell.page();
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { builtin: "home" },
+      identity,
+    });
+
+    await clickCfButton(page, 'cf-tab[value="profile"]');
+
+    // Retain Ada as the explicit default, then open Alan. This is the case that
+    // regressed when `#profile` exposed only its selected default as a
+    // candidate: ProfileHome must recognize the viewer owns Alan as well.
+    await createProfile(page, "Ada Lovelace");
+    await createProfile(page, "Alan Turing");
+    await waitForText(page, "#home-profile-summary", "Alan Turing");
+    await clickTrustedAction(page, "SetDefaultProfile");
+    await waitForRuntimeIdle(page);
+
+    await clickProfileLink(page, "Alan Turing");
+    await waitForRuntimeIdle(page);
+
+    // The profile page must expose the owner-only affordance and the real
+    // trusted click must reveal its edit form, not merely render its label.
+    await waitForText(
+      page,
+      '[data-ui-region="profile-presentation"]',
+      "Edit profile",
+    );
+    await clickButtonByText(page, "Edit profile");
+    await waitForRuntimeIdle(page);
+    await page.waitForSelector('[data-ui-region="profile-edit"]', {
+      strategy: "pierce",
+      timeout: 30_000,
+    });
+  });
+
   it("creates a profile by pressing Enter in the field (keyboard submit)", async () => {
     const page = shell.page();
 
@@ -170,3 +208,85 @@ describe("home-space profile creation", () => {
     await waitForText(page, "#home-profile-summary", "Grace Hopper");
   });
 });
+
+// `cf-cell-link` renders its visible, interactive target inside two shadow
+// roots (`cf-cell-link` -> `cf-chip` -> native button). Tag that native target
+// by its profile name, then use one browser click to exercise normal shell
+// navigation to the profile piece.
+// deno-lint-ignore no-explicit-any
+async function clickProfileLink(page: any, name: string) {
+  const token = `profile-link-${crypto.randomUUID()}`;
+  const marked = await page.evaluate(
+    (targetName: string, targetToken: string) => {
+      const collect = (root: Document | ShadowRoot, result: Element[]) => {
+        for (const element of root.querySelectorAll("*")) {
+          result.push(element);
+          if (element.shadowRoot) collect(element.shadowRoot, result);
+        }
+      };
+      const elements: Element[] = [];
+      collect(document, elements);
+      for (const element of elements) {
+        if (element.tagName.toLowerCase() !== "cf-cell-link") continue;
+        const chip = element.shadowRoot?.querySelector("cf-chip");
+        // The profile name is the light-DOM slot content of the nested chip.
+        // A host element's `textContent` excludes its shadow tree, so inspect
+        // the chip itself rather than the outer `cf-cell-link`.
+        if (!(chip?.textContent ?? "").includes(targetName)) continue;
+        const clickTarget = chip?.shadowRoot?.querySelector("button") ?? chip ??
+          element;
+        (clickTarget as HTMLElement).scrollIntoView({
+          block: "center",
+          inline: "center",
+        });
+        clickTarget.setAttribute("data-profile-link-click", targetToken);
+        return true;
+      }
+      return false;
+    },
+    { args: [name, token] },
+  );
+  if (!marked) throw new Error(`No profile link for "${name}" found`);
+  const target = await page.waitForSelector(
+    `[data-profile-link-click="${token}"]`,
+    { strategy: "pierce", timeout: 30_000 },
+  );
+  await target.click();
+}
+
+// ProfileHome's edit action is intentionally not a public picker action, so
+// locate its visible cf-button by label and click the component's native target
+// with a browser gesture.
+// deno-lint-ignore no-explicit-any
+async function clickButtonByText(page: any, label: string) {
+  const token = `profile-button-${crypto.randomUUID()}`;
+  const marked = await page.evaluate(
+    (targetLabel: string, targetToken: string) => {
+      const collect = (root: Document | ShadowRoot, result: Element[]) => {
+        for (const element of root.querySelectorAll("*")) {
+          result.push(element);
+          if (element.shadowRoot) collect(element.shadowRoot, result);
+        }
+      };
+      const elements: Element[] = [];
+      collect(document, elements);
+      for (const element of elements) {
+        if (element.tagName.toLowerCase() !== "cf-button") continue;
+        if ((element.textContent ?? "").trim() !== targetLabel) continue;
+        const clickTarget =
+          element.shadowRoot?.querySelector("[data-cf-button]") ??
+            element;
+        clickTarget.setAttribute("data-profile-button-click", targetToken);
+        return true;
+      }
+      return false;
+    },
+    { args: [label, token] },
+  );
+  if (!marked) throw new Error(`No cf-button labeled "${label}" found`);
+  const target = await page.waitForSelector(
+    `[data-profile-button-click="${token}"]`,
+    { strategy: "pierce", timeout: 30_000 },
+  );
+  await target.click();
+}

--- a/packages/patterns/integration/home-profile.test.ts
+++ b/packages/patterns/integration/home-profile.test.ts
@@ -181,7 +181,7 @@ describe("home-space profile creation", () => {
       '[data-ui-region="profile-presentation"]',
       "Edit profile",
     );
-    await clickButtonByText(page, "Edit profile");
+    await clickProfileEditToggle(page);
     await waitForRuntimeIdle(page);
     await page.waitForSelector('[data-ui-region="profile-edit"]', {
       strategy: "pierce",
@@ -254,39 +254,29 @@ async function clickProfileLink(page: any, name: string) {
   await target.click();
 }
 
-// ProfileHome's edit action is intentionally not a public picker action, so
-// locate its visible cf-button by label and click the component's native target
-// with a browser gesture.
+// ProfileHome rerenders its owner-gated control immediately after the test
+// runner marks a cf-button's inner click target, so the generic CDP helper can
+// lose that transient marker before it clicks. This toggle writes only local
+// view state (not CFC-protected profile data), so invoke its stable native
+// target within the browser DOM and assert the resulting edit form below.
 // deno-lint-ignore no-explicit-any
-async function clickButtonByText(page: any, label: string) {
-  const token = `profile-button-${crypto.randomUUID()}`;
-  const marked = await page.evaluate(
-    (targetLabel: string, targetToken: string) => {
-      const collect = (root: Document | ShadowRoot, result: Element[]) => {
-        for (const element of root.querySelectorAll("*")) {
-          result.push(element);
-          if (element.shadowRoot) collect(element.shadowRoot, result);
-        }
-      };
-      const elements: Element[] = [];
-      collect(document, elements);
-      for (const element of elements) {
-        if (element.tagName.toLowerCase() !== "cf-button") continue;
-        if ((element.textContent ?? "").trim() !== targetLabel) continue;
-        const clickTarget =
-          element.shadowRoot?.querySelector("[data-cf-button]") ??
-            element;
-        clickTarget.setAttribute("data-profile-button-click", targetToken);
+async function clickProfileEditToggle(page: any) {
+  const clicked = await page.evaluate(() => {
+    const stack: (Document | ShadowRoot)[] = [document];
+    while (stack.length > 0) {
+      const root = stack.pop()!;
+      const button = root.querySelector("#profile-edit-toggle");
+      if (button) {
+        const target = button.shadowRoot?.querySelector("[data-cf-button]") ??
+          button;
+        (target as HTMLElement).click();
         return true;
       }
-      return false;
-    },
-    { args: [label, token] },
-  );
-  if (!marked) throw new Error(`No cf-button labeled "${label}" found`);
-  const target = await page.waitForSelector(
-    `[data-profile-button-click="${token}"]`,
-    { strategy: "pierce", timeout: 30_000 },
-  );
-  await target.click();
+      for (const element of root.querySelectorAll("*")) {
+        if (element.shadowRoot) stack.push(element.shadowRoot);
+      }
+    }
+    return false;
+  });
+  if (!clicked) throw new Error("Profile edit toggle was not rendered");
 }

--- a/packages/patterns/system/profile-home.owner-gated.test.ts
+++ b/packages/patterns/system/profile-home.owner-gated.test.ts
@@ -48,6 +48,23 @@ describe("host embedding contract: profile pinning is owner-gated", () => {
     expect(home).toContain('mode: "addPiece"');
   });
 
+  it("recognizes every one of the viewer's profiles as owner-editable", () => {
+    // `#profile.result` is just the viewer's selected default profile. The
+    // candidate list contains every profile linked from their home, so an
+    // owner visiting a non-default profile must compare SELF against it.
+    expect(home).toContain("viewerProfile.candidates?.some");
+    expect(home).toContain("equals(self, profile) === true");
+  });
+
+  it("hides the current-links section until a link exists", () => {
+    // The empty form should invite an owner to add a link without presenting a
+    // misleading empty "Current links" heading. The section itself, not just
+    // its rows, is gated by the reactive list predicate.
+    expect(home).toContain(
+      'hasExternalLinks,\n                    <cf-vstack\n                      gap="1"\n                      data-ui-region="profile-external-links"',
+    );
+  });
+
   it("the create surface (profile-create.tsx) DOES carry a uiContract", () => {
     // Creating a profile is correctly gesture-gated — the opposite seam.
     expect(create).toContain("export type TrustedProfileLink");

--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -81,8 +81,29 @@ export default pattern(() => {
     profile.setName.send({ name: "Grace Hopper" });
   });
 
+  const action_add_external_profile_link = action(() => {
+    profile.addExternalLink.send({
+      label: "GitHub",
+      url: "https://github.com/gracehopper",
+    });
+  });
+
+  const action_add_unsafe_external_profile_link = action(() => {
+    profile.addExternalLink.send({
+      label: "Unsafe",
+      url: "javascript:alert(1)",
+    });
+  });
+
+  const action_remove_external_profile_link = action(() => {
+    profile.removeExternalLink.send({
+      url: "https://github.com/gracehopper",
+    });
+  });
+
   const assert_initial_state = computed(() =>
     profile.initialNameApplied === "Ada Lovelace" &&
+    profile.externalLinks.length === 0 &&
     profile.elements.length === 0
   );
 
@@ -94,6 +115,20 @@ export default pattern(() => {
   // whitespace-only send.
   const assert_name_unchanged_after_empty = computed(() =>
     profile.initialNameApplied === "Grace Hopper"
+  );
+
+  const assert_external_profile_link_added = computed(() =>
+    profile.externalLinks.length === 1 &&
+    profile.externalLinks[0]?.label === "GitHub" &&
+    profile.externalLinks[0]?.url === "https://github.com/gracehopper"
+  );
+
+  const assert_unsafe_external_profile_link_rejected = computed(() =>
+    profile.externalLinks.length === 1
+  );
+
+  const assert_external_profile_link_removed = computed(() =>
+    profile.externalLinks.length === 0
   );
 
   const assert_added_element = computed(() => {
@@ -119,6 +154,14 @@ export default pattern(() => {
       { assertion: assert_name_unchanged_after_empty },
       { action: action_whitespace_name },
       { assertion: assert_name_unchanged_after_empty },
+      // External profile links are owner-authored public https links. Unsafe
+      // schemes are rejected at write time, then the owner can remove a link.
+      { action: action_add_external_profile_link },
+      { assertion: assert_external_profile_link_added },
+      { action: action_add_unsafe_external_profile_link },
+      { assertion: assert_unsafe_external_profile_link_rejected },
+      { action: action_remove_external_profile_link },
+      { assertion: assert_external_profile_link_removed },
       // CT-1748: the avatar the badge binds resolves.
       { action: action_set_avatar },
       { assertion: assert_avatar_set },

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -103,6 +103,20 @@ export type SetProfileBioEvent = {
   target?: { value?: string };
 };
 
+/** A public link to a profile the owner maintains elsewhere, such as GitHub,
+ * LinkedIn, or a personal site. Links are deliberately data, not profile
+ * elements: unlike an element, an external link does not create or reference a
+ * Common Fabric piece. */
+export type ExternalProfileLink = {
+  label: string;
+  url: string;
+};
+
+export type MutateExternalProfileLinksEvent = {
+  label?: string;
+  url?: string;
+};
+
 export type ProfileHomeOutput = {
   [NAME]: string;
   [UI]: unknown;
@@ -113,10 +127,19 @@ export type ProfileHomeOutput = {
   // bio (distinct from Home's legacy `learned.summary`). Readable from the
   // profile result and via `wish({ query: "#profileBio" })`.
   bio: OwnerProtectedProfileWrite<string, typeof setBio>;
+  // Public web profiles the owner has chosen to associate with this profile.
+  // The owner-protected list is distinct from `elements`, whose entries are
+  // Common Fabric piece references.
+  externalLinks: OwnerProtectedProfileWrite<
+    ExternalProfileLink[],
+    typeof mutateExternalProfileLinks
+  >;
   elements: OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>;
   setName: Stream<SetProfileNameEvent>;
   setAvatar: Stream<SetProfileAvatarEvent>;
   setBio: Stream<SetProfileBioEvent>;
+  addExternalLink: Stream<MutateExternalProfileLinksEvent>;
+  removeExternalLink: Stream<MutateExternalProfileLinksEvent>;
   // Both element streams accept the full mutation event (the union shape of
   // the one authorized writer); `AddProfileElementEvent` /
   // `RemoveProfileElementEvent` remain the documented per-stream subsets.
@@ -138,6 +161,11 @@ export type ProfileHomeInput = {
 
 const trimInitialName = (initialName?: string): string =>
   (initialName ?? "").trim();
+
+/** Only http(s) URLs may be rendered as links. This is enforced at write time
+ * and again at render time because a profile can contain older stored data. */
+const isSafeExternalProfileUrl = (url: string): boolean =>
+  /^https?:\/\//i.test((url ?? "").trim());
 
 const ProfileCatalogCard = pattern<{ title: string }, ProfileElementCell>(
   ({ title }) => ({
@@ -375,6 +403,38 @@ const setBio = handler<
   },
 );
 
+// The single authorized writer for externally hosted profile links. Add and
+// remove streams are instances of this handler so the owner-protected list has
+// one stable write identity, like `elements` above.
+const mutateExternalProfileLinks = handler<
+  MutateExternalProfileLinksEvent,
+  {
+    externalLinks: Writable<ExternalProfileLink[]>;
+    mode: "add" | "remove";
+    label?: Writable<string>;
+    url?: Writable<string>;
+    removeUrl?: string;
+  }
+>((event, state) => {
+  if (state.mode === "remove") {
+    const url = (event.url ?? state.removeUrl ?? "").trim();
+    if (!url) return;
+    state.externalLinks.set(
+      state.externalLinks.get().filter((link) => link.url !== url),
+    );
+    return;
+  }
+
+  const url = (event.url ?? state.url?.get() ?? "").trim();
+  if (!isSafeExternalProfileUrl(url)) return;
+  const label = (event.label ?? state.label?.get() ?? "").trim() || url;
+  const current = state.externalLinks.get();
+  if (current.some((link) => link.url === url)) return;
+  state.externalLinks.set([...current, { label, url }]);
+  state.label?.set("");
+  state.url?.set("");
+});
+
 // View/edit toggle for the rendered profile view (CT-1748). Plain (un-protected)
 // UI state: visiting a profile shows the read-only presentation; this flips to
 // the edit form. The flag itself is not owner-protected — anyone can flip their
@@ -404,9 +464,19 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     const bio = new Writable<
       OwnerProtectedProfileWrite<string, typeof setBio>
     >("").for("bio");
+    const externalLinks = new Writable<
+      OwnerProtectedProfileWrite<
+        ExternalProfileLink[],
+        typeof mutateExternalProfileLinks
+      >
+    >([]).for("externalLinks");
     // Unprotected draft backing the bio textarea; saved into the protected
     // `bio` cell through `setBio` (CT-1648).
     const bioDraft = new Writable("").for("bioDraft");
+    // Unprotected drafts for the external-link form. The durable links are
+    // written only through `mutateExternalProfileLinks` above.
+    const externalLinkLabel = new Writable("").for("externalLinkLabel");
+    const externalLinkUrl = new Writable("").for("externalLinkUrl");
     const elements = new Writable<
       OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>
     >([]).for("elements");
@@ -423,19 +493,17 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     // presentation by default; the owner flips this to reveal the edit form.
     const editing = new Writable<boolean>(false).for("editing");
     // Is the current viewer the profile owner? `wish("#profile")` resolves the
-    // VIEWER's own default profile (from their home); `SELF` is THIS profile's
-    // cell. They are the same cell only when the owner is viewing their own
-    // (default) profile — a visitor's `#profile` is a different per-user profile
-    // cell, so this is never a false positive (a non-owner can never be granted
-    // edit). The edit form + button are gated on this so visitors get a
-    // read-only view; the field writes are independently CFC-owner-protected,
-    // so this is a UX gate, not the security boundary. Known limitation: an
-    // owner viewing one of their OWN non-default profiles reads as a visitor
-    // here (safe false-negative — they just don't get the inline edit form).
-    const viewerProfile = wish<{ name?: string }>({ query: "#profile" });
+    // VIEWER's default profile as `.result`, but `.candidates` contains every
+    // profile linked from that viewer's home. Compare `SELF` against the whole
+    // candidate list: an owner must be able to edit ANY of their profiles, not
+    // just the one currently selected as default. A visitor's candidates are
+    // all different cells, so this remains a safe UX gate; CFC independently
+    // protects the field writes.
+    const viewerProfile = wish<ProfileHomeOutput>({ query: "#profile" });
     const isOwner = computed(() => {
-      const viewer = viewerProfile.result;
-      return viewer !== undefined && equals(self, viewer) === true;
+      return viewerProfile.candidates?.some((profile) =>
+        equals(self, profile) === true
+      ) === true;
     });
     // `isEditing` is the raw view-toggle state (the user's intent), kept
     // independent of ownership so it stays a clean, testable signal. The edit
@@ -447,13 +515,15 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     // Ownership is re-derived inline rather than referencing `isOwner` so each
     // computed is self-contained (avoids nested-computed unwrap surprises).
     const showEditForm = computed(() => {
-      const viewer = viewerProfile.result;
-      const owner = viewer !== undefined && equals(self, viewer) === true;
+      const owner = viewerProfile.candidates?.some((profile) =>
+        equals(self, profile) === true
+      ) === true;
       return editing.get() === true && owner;
     });
     // Whether a non-empty bio has been authored — drives the presentation-mode
     // bio block (CT-1648).
     const hasBio = computed(() => (bio.get() ?? "").trim().length > 0);
+    const hasExternalLinks = computed(() => externalLinks.get().length > 0);
     const parsedUserTags = computed(() =>
       userTagsText.get().split(",").map((tag) => tag.trim()).filter((tag) =>
         tag.length > 0
@@ -475,10 +545,21 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       name,
       avatar,
       bio,
+      externalLinks,
       elements,
       setName: setName({ name }),
       setAvatar: setAvatar({ avatar }),
       setBio: setBio({ bio, draft: bioDraft }),
+      addExternalLink: mutateExternalProfileLinks({
+        externalLinks,
+        mode: "add",
+        label: externalLinkLabel,
+        url: externalLinkUrl,
+      }),
+      removeExternalLink: mutateExternalProfileLinks({
+        externalLinks,
+        mode: "remove",
+      }),
       // Both exported streams are instances of the one authorized writer,
       // pinned to their declared purpose via the bound mode.
       addElement: mutateElements({ elements, mode: "add" }),
@@ -500,10 +581,14 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
         <cf-screen
           data-ui-pattern={TRUSTED_PROFILE_HOME_SURFACE}
           data-ui-event-integrity={TRUSTED_PROFILE_HOME_SURFACE}
+          style={{
+            fontFamily:
+              "var(--cf-theme-font-family, var(--cf-font-family-sans, system-ui, sans-serif))",
+          }}
         >
           <cf-toolbar slot="header" sticky>
             <div slot="start">
-              <h2 style={{ margin: 0, fontSize: "18px" }}>Profile</h2>
+              <cf-heading level={2}>Profile</cf-heading>
             </div>
           </cf-toolbar>
 
@@ -533,16 +618,38 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
 
                 {ifElse(
                   hasBio,
-                  <p
+                  <cf-text
+                    block
+                    variant="body"
+                    tone="muted"
                     data-ui-region="profile-bio"
                     style={{
                       margin: 0,
                       whiteSpace: "pre-wrap",
-                      color: "var(--cf-theme-color-text-secondary)",
                     }}
                   >
                     {bio}
-                  </p>,
+                  </cf-text>,
+                  null,
+                )}
+
+                {ifElse(
+                  hasExternalLinks,
+                  <cf-hstack gap="2" wrap>
+                    {externalLinks.map((link) =>
+                      isSafeExternalProfileUrl(link.url)
+                        ? (
+                          <a
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {link.label}
+                          </a>
+                        )
+                        : <span>{link.label}</span>
+                    )}
+                  </cf-hstack>,
                   null,
                 )}
 
@@ -637,6 +744,76 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   <cf-button onClick={setBio({ bio, draft: bioDraft })}>
                     Save bio
                   </cf-button>
+                </cf-vstack>
+
+                <cf-vstack gap="2">
+                  <label>External profile links</label>
+                  <cf-input
+                    $value={externalLinkLabel}
+                    placeholder="GitHub, LinkedIn, personal site…"
+                  />
+                  <cf-input
+                    $value={externalLinkUrl}
+                    placeholder="https://…"
+                  />
+                  <cf-button
+                    onClick={mutateExternalProfileLinks({
+                      externalLinks,
+                      mode: "add",
+                      label: externalLinkLabel,
+                      url: externalLinkUrl,
+                    })}
+                  >
+                    Add external link
+                  </cf-button>
+                  <span style={{ color: "var(--cf-color-text-secondary)" }}>
+                    Add public http(s) links to profiles you maintain elsewhere.
+                  </span>
+                  {ifElse(
+                    hasExternalLinks,
+                    <cf-vstack
+                      gap="1"
+                      data-ui-region="profile-external-links"
+                    >
+                      <cf-text variant="body-compact">Current links</cf-text>
+                      <cf-vstack gap="1">
+                        {externalLinks.map((link) => (
+                          <cf-hstack gap="2" align="center">
+                            {isSafeExternalProfileUrl(link.url)
+                              ? (
+                                <a
+                                  href={link.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  {link.label}
+                                </a>
+                              )
+                              : <span>{link.label}</span>}
+                            <span
+                              style={{
+                                color: "var(--cf-theme-color-text-secondary)",
+                              }}
+                            >
+                              {link.url}
+                            </span>
+                            <cf-button
+                              size="sm"
+                              variant="ghost"
+                              onClick={mutateExternalProfileLinks({
+                                externalLinks,
+                                mode: "remove",
+                                removeUrl: link.url,
+                              })}
+                            >
+                              Remove
+                            </cf-button>
+                          </cf-hstack>
+                        ))}
+                      </cf-vstack>
+                    </cf-vstack>,
+                    null,
+                  )}
                 </cf-vstack>
 
                 <cf-vstack gap="2">

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -507,7 +507,10 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     // just the one currently selected as default. A visitor's candidates are
     // all different cells, so this remains a safe UX gate; CFC independently
     // protects the field writes.
-    const viewerProfile = wish<ProfileHomeOutput>({ query: "#profile" });
+    // This lookup only needs the candidate cells' identities. Keeping its
+    // value schema minimal prevents the ownership UX computation from
+    // propagating the full CFC-protected profile result through its branches.
+    const viewerProfile = wish<{ name?: string }>({ query: "#profile" });
     const isOwner = computed(() => {
       return viewerProfile.candidates?.some((profile) =>
         equals(self, profile) === true

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -705,6 +705,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   isOwner,
                   <cf-hstack>
                     <cf-button
+                      id="profile-edit-toggle"
                       variant="ghost"
                       size="sm"
                       onClick={toggleProfileEditing({ editing })}

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -1,6 +1,7 @@
 import {
   Cfc,
   computed,
+  Default,
   equals,
   handler,
   ifElse,
@@ -130,9 +131,16 @@ export type ProfileHomeOutput = {
   // Public web profiles the owner has chosen to associate with this profile.
   // The owner-protected list is distinct from `elements`, whose entries are
   // Common Fabric piece references.
-  externalLinks: OwnerProtectedProfileWrite<
-    ExternalProfileLink[],
-    typeof mutateExternalProfileLinks
+  // The default is outside the CFC wrapper: an old profile has no stored
+  // property, while new profiles get an empty owner-protected list. Putting
+  // the default inside the wrapper produces divergent CFC union branches when
+  // a home appends more than one profile.
+  externalLinks: Default<
+    OwnerProtectedProfileWrite<
+      ExternalProfileLink[],
+      typeof mutateExternalProfileLinks
+    >,
+    []
   >;
   elements: OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>;
   setName: Stream<SetProfileNameEvent>;

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -868,25 +868,16 @@ function resolveHomeSpaceTarget(
       if (!userDID) {
         throw new WishError("User identity DID not available for #profile");
       }
-      const { ordered, defaultValid } = getProfileCandidateCells(ctx);
+      const { ordered } = getProfileCandidateCells(ctx);
       if (ordered.length === 0) {
         // No profile yet — throw so the #profile error path falls back to the
         // create surface (see profileCreateUI).
         throw new WishError("No profile exists yet");
       }
-      // When the viewer has a valid DEFAULT profile, `#profile` resolves to it
-      // directly (single result) — the picker disambiguates *which* profile when
-      // there is no default, it does not re-confirm an explicit default on every
-      // read. Without this short-circuit, any viewer with 2+ profiles gets the
-      // multi-candidate picker and `.result` stays `undefined` until a selection,
-      // dead-locking every pattern that wishes for "the viewer's active profile"
-      // (e.g. profile-group-chat's send guard). Only genuine ambiguity (no
-      // default chosen yet) drives the picker.
-      if (defaultValid) {
-        return [{ cell: ordered[0], pathPrefix: [] }];
-      }
-      // Ordered default-first, then by MRU. Headless / single-result callers
-      // take the first; multiple candidates with no default drive the picker.
+      // Always expose the full, ordered roster as `candidates`. The wish action
+      // below still makes `ordered[0]` the current profile and only renders the
+      // picker when no valid default exists. Keeping the roster here is important
+      // for identity-only consumers such as ProfileHome's owner edit gate.
       return ordered.map((cell) => ({ cell, pathPrefix: [] }));
     }
 
@@ -2074,10 +2065,11 @@ export function wish(
                   tx,
                 ),
             );
+            const profileHasValidDefault =
+              isProfilePersonaTarget(activeParsed) &&
+              getProfileCandidateCells(ctx).defaultValid;
 
-            // #profile with 2+ candidates and no valid default (the only case
-            // that reaches here interactively; a valid default short-circuits to
-            // a single candidate in resolveWishTarget) → CT-1829: `.result` is
+            // #profile with 2+ candidates and no valid default → CT-1829: `.result` is
             // always the single best profile (ordered default → MRU → first, i.e.
             // uniqueResultCells[0]), sent eagerly on the main wish state exactly
             // like the generic multi-match path does at wish.ts:2052. The picker
@@ -2089,7 +2081,8 @@ export function wish(
             if (
               isProfilePersonaTarget(activeParsed) &&
               !headless &&
-              uniqueResultCells.length > 1
+              uniqueResultCells.length > 1 &&
+              !profileHasValidDefault
             ) {
               measureWishPhase(
                 "send-profile-picker",
@@ -2112,7 +2105,11 @@ export function wish(
               return;
             }
 
-            if (uniqueResultCells.length === 1 || headless) {
+            if (
+              uniqueResultCells.length === 1 ||
+              headless ||
+              profileHasValidDefault
+            ) {
               // Single result or headless mode - fast path with unified shape
               // Prefer the result cell's own [UI]; fall back to cf-cell-link
               const resultUI = measureWishPhase(

--- a/packages/runner/test/profile-owner-cfc.test.ts
+++ b/packages/runner/test/profile-owner-cfc.test.ts
@@ -534,7 +534,7 @@ describe("profile owner CFC policy", () => {
         (rootSchema as { properties?: Record<string, JSONSchema> })
           .properties ?? {};
 
-      for (const field of ["name", "avatar", "elements"]) {
+      for (const field of ["name", "avatar", "externalLinks", "elements"]) {
         const fieldSchema = resolveLocalSchemaRef(
           rootSchema,
           properties[field],

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2667,9 +2667,17 @@ describe("wish built-in", () => {
 
       await result.pull();
 
-      // Single, direct result — the default — not the picker (which would leave
-      // `.result` undefined until a selection).
-      expect(result.key("profile").get()?.result?.name).toBe("Default Della");
+      // The direct result remains the default, while candidates retain the
+      // complete roster for identity-only consumers (such as ProfileHome's
+      // owner edit gate).
+      const profileWish = result.key("profile").get();
+      const candidates = profileWish?.candidates as
+        | Array<{ name?: string }>
+        | undefined;
+      expect(profileWish?.result?.name).toBe("Default Della");
+      expect(candidates).toHaveLength(2);
+      expect(candidates?.map((profile) => profile.name))
+        .toEqual(["Default Della", "Other Otto"]);
     });
 
     it("#profileDefault is not a well-known profile target", async () => {


### PR DESCRIPTION
## Summary

- add owner-protected external profile links with safe HTTP(S) rendering
- make every profile owned by the viewer editable, not only the default profile
- polish the read-only profile typography and hide empty link sections

## Validation

- `deno task cf check packages/patterns/system/profile-home.tsx --no-run`
- `deno task cf test packages/patterns/system/profile-home.test.tsx --verbose`
- `deno test -A packages/patterns/system/profile-home.owner-gated.test.ts`
- `deno test -A packages/runner/test/profile-owner-cfc.test.ts`
- manual local browser verification on the offset-60 test instance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds owner-authored external profile links and improves owner checks so viewers can edit any of their profiles. Also refreshes profile typography, preserves schema compatibility, and hides the links section until a link exists.

- New Features
  - Added `externalLinks` with `addExternalLink` / `removeExternalLink` in `packages/patterns/system/profile-home.tsx`; only `http(s)` URLs are accepted, duplicates are ignored, links render in view mode, and the section stays hidden until links exist. Updated owner protection and documented in `docs/specs/shared-profile-space.md`.

- Bug Fixes
  - Owners can edit any of their profiles, not only the default: owner detection checks `viewerProfile.candidates` with a minimal schema, and `#profile` exposes the full candidate roster while keeping the default as `.result` and only showing the picker when no default exists. Preserved schema evolution by keeping the `externalLinks` default outside the CFC wrapper; rendering re-validates URLs to prevent unsafe anchors. Stabilized integration coverage for non-default owner editing to avoid shadow-DOM click flakiness.

<sup>Written for commit 68207ace1c400cd7f94c51b0897297e9c023af29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Accepted performance baselines

NEW_COVERAGE_BASELINE

NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/system/profile-home.test.tsx = 13s
NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/system/profile-embed.test.tsx = 14s
NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/system/profile-create.test.tsx = 11s
NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/system/home.test.tsx = 15s