### PR TITLE
docs: record the identity assumption behind counting active users

### DIFF
--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -12,6 +12,23 @@ available when they authenticate.
 Home Space DID = User Identity DID = runtime.storageManager.as.did()
 ```
 
+## Identities, Home Spaces, and People
+
+Because the home space DID and the identity DID are the same value, home spaces
+and identities are one-to-one by construction. Every identity has one home
+space, and every home space belongs to one identity.
+
+An identity is a keypair, not a person. There are no accounts, so the system has
+no way to know that two identities belong to the same human, or that one
+identity is driven by several humans or by automation. Treating an identity as a
+person is an assumption a caller layers on top, not a property the system
+provides.
+
+Work that counts people — daily active users, for example — rests on that
+assumption. What the assumption costs, and what the server records about the
+identity behind a session, are covered in
+[`docs/development/active-user-counting.md`](../../development/active-user-counting.md).
+
 ## Purpose
 
 The home space provides a persistent, user-owned storage location for:

--- a/docs/development/SHARED_IDENTITY.md
+++ b/docs/development/SHARED_IDENTITY.md
@@ -5,6 +5,12 @@ when testing identity-sensitive behavior. Scoped cells make this important:
 `PerUser<T>` and `PerSession<T>` data is keyed by the active user DID, not only
 by the space DID.
 
+The workflows here are also the reason an identity is not a reliable stand-in
+for a person: one human routinely holds several identities, and one identity is
+routinely driven by several actors. See
+[`active-user-counting.md`](active-user-counting.md) for what that means when
+counting users.
+
 > **Use a unique key (`id new`) for your own identity.** `cf id derive "implicit
 > trust"` produces a *fixed, publicly-derivable* DID — the one the local toolshed
 > runs as in dev mode — so every developer who derives it shares the exact same

--- a/docs/development/active-user-counting.md
+++ b/docs/development/active-user-counting.md
@@ -1,0 +1,126 @@
+# Counting Active Users
+
+What signal the server offers for counting active people, and the assumption any
+such count rests on.
+
+## Identities Are Not People
+
+The home space DID and the identity DID are the same value, so home spaces and
+identities are one-to-one by construction. That equality is described in
+[`docs/common/conventions/HOME_SPACE.md`](../common/conventions/HOME_SPACE.md).
+
+An identity is a keypair, not a person. There are no accounts, so the system has
+no way to know that two identities belong to the same human, or that one
+identity is driven by several humans or by automation. Counting people therefore
+assumes that one identity DID stands for one human. That assumption is a
+deliberate approximation, not something the system enforces, and it is wrong in
+three known ways:
+
+- **One human, several identities.** The browser derives its identity with
+  `Identity.fromMnemonic()`, while `cf id derive` uses
+  `Identity.fromPassphrase()`, so the same input yields different DIDs. A second
+  browser profile, a passkey on another device, or a fresh `cf id new` key each
+  mint another identity. Each one adds to a count of people.
+- **Several actors, one identity.** One key imported into the browser, the CLI,
+  a FUSE mount, and a browser-driving agent is the recommended local workflow,
+  and all of those actors count as a single identity. The publicly derivable
+  `implicit trust` identity collapses every caller that derives it into one
+  principal. See [`SHARED_IDENTITY.md`](SHARED_IDENTITY.md).
+- **Principals that are not people.** The toolshed server identity, the DIDs
+  listed in `MEMORY_SERVICE_DIDS`, and background services act as principals in
+  the same way a user does. Exclude them explicitly when counting people.
+
+A count of distinct identity DIDs measures active identities. Treat it as a
+proxy for active people that is only as good as the assumption above.
+
+## How The Server Learns The Identity DID
+
+The memory server does not have to derive or look up the home space DID, because
+the identity DID already is the home space DID.
+
+When a client opens a memory session it sends a signed `session.open`
+invocation. The server verifies the signature and returns the issuer DID, which
+becomes the session's `principal` (`packages/memory/v2/server.ts`,
+`openSession`). The principal is held on the session state and is fixed for the
+life of the session: resuming a session under a different principal is rejected
+(`packages/memory/v2/session-registry.ts`, `SessionRegistry.open`). The value is
+established by signature verification, so it is not something a client can
+assert on its own.
+
+## The Available Signal
+
+Tracing produces nothing unless `OTEL_ENABLED` is set. It defaults to false
+(`packages/toolshed/env.ts`), and both the tracer provider and the HTTP
+middleware are gated on it (`packages/toolshed/lib/otel.ts`,
+`packages/toolshed/lib/create-app.ts`). While it is unset the tracer is a no-op
+and none of the spans below exist, so enabling it on a deployment is a
+precondition for counting anything there.
+
+Two memory spans carry the session principal as a `user.did` attribute,
+alongside `space.did`:
+
+- `memory.transact`, on every write.
+- `memory.subscriber.sync`, on session resume and on write-driven fanout.
+
+Both spans are exported through the OTLP collector
+(`packages/toolshed/lib/otel.ts`). Privileged first-party HTTP routes also
+record the verified caller: the auth middleware stores it on the Hono context as
+`verifiedUserDid` and sets the same `user.did` span attribute
+(`packages/toolshed/middlewares/first-party-http-auth.ts`). Most other HTTP
+routes are unauthenticated and carry no user attribution at all.
+
+## The Signal Does Not Cover Readers
+
+`syncSessionForConnection` is reached from two places. `openSession` calls it
+only when the session is resumed rather than freshly opened. `refreshDirty`
+calls it from the fanout path, which runs after a commit has made the space
+dirty. Opening a session emits no span of its own, and `watchSet`, `watchAdd`,
+and query handling emit none either.
+
+An identity is therefore attributed only when it writes, when it resumes a
+session, or when it is connected to a space that somebody else writes to. A
+session that opens fresh, reads a quiet space, and leaves emits no `user.did` at
+all. A count of distinct `user.did` per day is a count of identities that wrote
+or were present for someone else's write, and it undercounts readers by a margin
+that depends on how much writing happened. A quiet day can report zero while
+real people were present.
+
+Attributing readers needs instrumentation that does not exist yet. The natural
+place for it is `session.open`, which is where an identity is verified and where
+the intent to be active is expressed.
+
+## Properties Of The Signal
+
+- **Trace sampling changes the meaning of the count.** `OTEL_TRACES_SAMPLER`
+  defaults to `always_on` with `OTEL_TRACES_SAMPLER_ARG` of `1.0`
+  (`packages/toolshed/env.ts`), and nothing in the repository overrides them, so
+  a deployment samples everything unless its environment says otherwise. Head
+  sampling below 1.0 does not scale a distinct count the way it scales a volume
+  metric, because an identity whose few spans are all dropped leaves the count
+  entirely, and the loss cannot be corrected afterwards. `samplerFromEnv` falls
+  back to `always_on` for an unknown sampler name and to a ratio of 1 for a
+  malformed argument (`packages/toolshed/lib/otel-sampler.ts`), so the count
+  degrades only through a deliberate, valid ratio sampler.
+- **Readers are missing entirely.** See the section above. This is the largest
+  known error in the count, and unlike the others its size is not knowable from
+  the count itself.
+- **Sessions with the `"*"` principal are omitted.** The attribute is set only
+  for a concrete principal.
+- **Span retention bounds the lookback.** Traces are a rolling window rather
+  than a record, and the retention period is a property of the trace store
+  rather than of this repository. History beyond that window exists only if
+  something aggregates and stores it as it goes.
+
+## Traces Are A Poor Substrate For This Number
+
+Three of the properties above have the same root: the count is derived from
+traces, and traces are built for debugging rather than for record-keeping. They
+are sampled for cost, they exist only where instrumentation happened to be
+placed, and they are deleted on a retention schedule that no commit governs.
+
+A count that has to be correct, complete, and durable wants a signal with the
+opposite properties: emitted once per session open, never sampled away, and
+aggregated into storage that outlives the trace window. Adding a span at
+`session.open` fixes the coverage gap on its own, but it leaves the count riding
+on sampling and retention. Treat trace-derived counting as a way to learn the
+shape of the number, not as the mechanism to keep reporting it.

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -74,6 +74,10 @@ export const EnvSchema = z.object({
   // traceidratio, parentbased_always_on, parentbased_always_off,
   // parentbased_traceidratio. OTEL_TRACES_SAMPLER_ARG is the ratio for the
   // *ratio variants. Defaults (always_on / 1.0) keep 100% sampling.
+  // Trace-based distinct counts depend on full sampling: the active identity
+  // count reads the user.did attribute on the memory spans, and a ratio sampler
+  // drops identities from that count instead of thinning it proportionally.
+  // See docs/development/active-user-counting.md.
   OTEL_TRACES_SAMPLER: z.string().default("always_on"),
   OTEL_TRACES_SAMPLER_ARG: z.string().default("1.0"),
   // ===========================================================================


### PR DESCRIPTION
Counting active users needs a server-side notion of who is active, and the platform has no accounts. A principal is an Ed25519 keypair named by its DID, and a home space DID is that same value, so home spaces and identities are one-to-one by construction. That makes an identity DID look like a usable stand-in for a person. It is not one, and nothing in the repository said so.

An identity is a keypair, not a person. One human can hold several: the browser derives with Identity.fromMnemonic while cf id derive uses Identity.fromPassphrase, so the same input yields different DIDs, and a second browser profile, a passkey on another device, or a fresh key each mint another identity. One identity can equally be driven by several actors, which is what the recommended shared-key workflow does deliberately and what the publicly derivable "implicit trust" identity does accidentally. Service DIDs and the server identity are principals in the same way a user is.

Add docs/development/active-user-counting.md, recording that assumption as an assumption rather than as a property of the system, together with the signal that already exists to act on it. The session principal is the verified session.open issuer, pinned for the life of the session, and it is already exported as the user.did span attribute on the memory.transact and memory.subscriber.sync spans, so a distinct count per day needs no new instrumentation. The document also records the four properties of that signal that change what the resulting number means: trace sampling does not scale a distinct count the way it scales a volume metric, session.open emits no span of its own, sessions with the "*" principal are omitted, and span retention bounds the lookback.

Keep the identity-model half in HOME_SPACE.md, which already defines the home space DID and the identity DID as the same value, and point it at the new document. Point SHARED_IDENTITY.md there as well, since the workflows it describes are precisely what break the one-identity-one-human assumption.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `docs/development/active-user-counting.md` documenting that identity DIDs are not people and how to count daily active identities from `user.did` on `memory.transact` and `memory.subscriber.sync` (requires `OTEL_ENABLED`; readers are not counted since `session.open` emits no span).
Link from `HOME_SPACE.md` and `SHARED_IDENTITY.md`, and note in `packages/toolshed/env.ts` that trace sampling (`OTEL_TRACES_SAMPLER`) drops identities and retention bounds lookback.

<sup>Written for commit cf4b71e9791db350fb099f78c703a53d01ec378f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

