### PR TITLE
docs(patterns): drop the stale compiler.tsx bug note from the catalog

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -53,9 +53,7 @@ note under legacy).
 
 Capability and app demos (root files): `annotation.tsx`,
 `annotation-manager.tsx`, `aside.tsx`, `bookmarks.tsx`, `chatbot.tsx`,
-`cheeseboard.tsx`, `compiler.tsx` (known issue: the December 2025 survey in
-`docs/history/packages/patterns/PREEXISTING_BUGS.md` found its "Navigate To
-Piece" button broken; unverified since), `deep-research.tsx`, `dice.tsx` (+
+`cheeseboard.tsx`, `compiler.tsx`, `deep-research.tsx`, `dice.tsx` (+
 `dice-handlers.ts`), `group-chat-lobby.tsx`, `group-chat-room.tsx`, `image.tsx`,
 `image-analysis.tsx`, `link-preview.tsx`, `map-demo.tsx`, `mobile-app-demo.tsx`,
 `pattern-index.tsx`, `profile-roster-live-demo.tsx` (demo: live multi-user


### PR DESCRIPTION
The December 2025 pattern bug survey (archived at
docs/history/packages/patterns/PREEXISTING_BUGS.md, Bug 1) reported that compiler.tsx's "Navigate To Piece" button did nothing when clicked after a successful compile. It suspected the visit handler called navigateTo() on the result cell before that cell was ready. The catalog entry for compiler.tsx carried the finding with an "unverified since" caveat.

Retested by hand against current main: deploy compiler.tsx to a local dev server and drive it through the shell. The default code compiles, the button appears, and clicking it navigates to the compiled counter piece, which works. Editing the source, letting it recompile, and clicking again navigates to the same result piece — compileAndRun reuses one stable result cell and swaps the program in place — now running the edited program with prior state preserved. The bug does not reproduce.

The navigateTo builtin was reworked after the survey (scheduler-v2, commit-boundary navigation) and now navigates on the target cell's identity without waiting for its value to materialize, which is the exact failure mode the survey suspected.

Remove the parenthetical rather than rewriting it to say "verified working". The catalog records which patterns exist and which are worth imitating; a note that an old survey found a bug that is no longer there says nothing about the pattern as it stands, and sends readers to a frozen historical document to reach the same conclusion. The survey stays in docs/history/ for anyone tracing the finding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale bug note for `compiler.tsx` in the patterns catalog. The "Navigate To Piece" button now works after `navigateTo` (scheduler-v2) changes, so we no longer point readers to the old survey.

<sup>Written for commit 23f2f76521cc3298beecee0ad9bd84c4e49a586c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

