### PR TITLE
deps: roll typescript from 5.9.x to 6.0.3

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -148,9 +148,7 @@
     "npm:source-map-js@^1.2.1": "1.2.1",
     "npm:stoker@^1.4.2": "1.4.3_@hono+zod-openapi@0.18.4__hono@4.10.5__zod@3.25.76_hono@4.10.5_zod@3.25.76",
     "npm:turndown@^7.1.2": "7.2.2",
-    "npm:typescript@*": "5.9.3",
-    "npm:typescript@5.9.2": "5.9.2",
-    "npm:typescript@5.9.3": "5.9.3",
+    "npm:typescript@6.0.3": "6.0.3",
     "npm:zod@^3.24.1": "3.25.76"
   },
   "jsr": {
@@ -1985,12 +1983,8 @@
         "@mixmark-io/domino"
       ]
     },
-    "typescript@5.9.2": {
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "bin": true
-    },
-    "typescript@5.9.3": {
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+    "typescript@6.0.3": {
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "bin": true
     },
     "undici-types@7.10.0": {
@@ -2110,12 +2104,12 @@
         "dependencies": [
           "jsr:@cliffy/table@^1.0.0-rc.8",
           "jsr:@db/sqlite@0.12",
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/deno-web-test": {
         "dependencies": [
-          "npm:typescript@5.9.2"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/felt": {
@@ -2141,7 +2135,7 @@
       "packages/js-compiler": {
         "dependencies": [
           "npm:source-map-js@^1.2.1",
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/llm": {
@@ -2166,12 +2160,12 @@
         "dependencies": [
           "npm:@opentelemetry/api@^1.7.0",
           "npm:ses@^1.15.0",
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/schema-generator": {
         "dependencies": [
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/shell": {
@@ -2192,12 +2186,12 @@
       },
       "packages/static": {
         "dependencies": [
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/test-support": {
         "dependencies": [
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/toolshed": {
@@ -2239,7 +2233,7 @@
       },
       "packages/ts-transformers": {
         "dependencies": [
-          "npm:typescript@*"
+          "npm:typescript@6.0.3"
         ]
       },
       "packages/ui": {

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -390,6 +390,71 @@ apk add --no-cache ca-certificates
 sudo update-ca-certificates
 ```
 
+### The TypeScript compiler dependency
+
+The runtime compiles patterns itself, using the TypeScript compiler API at
+runtime. Eight packages (`js-compiler`, `ts-transformers`, `schema-generator`,
+`runner`, `cli`, `static`, `test-support`, `deno-web-test`) import
+`npm:typescript` and pin the same version in their `deno.jsonc` import maps.
+This npm dependency is separate from the TypeScript that `deno check` uses:
+Deno bundles its own copy of the compiler. Keeping the npm pin on the same
+minor version as the Deno-bundled compiler (`deno --version` prints it) avoids
+the two disagreeing about what type-checks.
+
+To roll the version, update every pin and the lockfile in one step, then verify:
+
+```bash
+deno outdated --update --recursive typescript@<version>
+deno task check
+deno task test
+(cd packages/static && deno task check-cfc-types)
+```
+
+The last of those is a CI gate that `deno task test` does not cover; see the
+note on `cfc.ts` below.
+
+#### Why the pin stops at 6.x
+
+The `typescript` npm package now serves two different compilers. The 6.x line is
+the original JavaScript implementation, developed in `microsoft/TypeScript`. The
+7.x line is the Go rewrite, developed in `microsoft/typescript-go` and intended
+to replace the JavaScript one rather than sit alongside it permanently; upstream
+expects to merge that repository back into `microsoft/TypeScript` in time.
+
+Only the 6.x line works here. The 7.x package ships platform binaries, and its
+main entry point exports nothing but a version constant, so the in-process
+compiler API that our packages are built on is absent. The replacement drives
+the native binary from a separate process, and upstream currently marks that API
+"not ready", meaning not yet worth building against. So this is not a port we
+could choose to do early: until that API is ready there is nothing to port onto.
+Treat 6.x as a holding position, and treat the Go compiler's API reaching a
+usable state as the signal to re-evaluate.
+
+The practical trap is that a bare `npm:typescript` specifier resolves to the
+newest version on npm, which is now the Go line — hence the explicit 6.x pins.
+
+#### The vendored type libraries
+
+Pattern compilation runs outside Node and cannot read the compiler's type
+libraries off disk, so it uses ambient libraries vendored in
+`packages/static/assets/types`. The two have different provenance:
+`es2023.d.ts` is flattened from the `lib` directory of a TypeScript source
+checkout by `packages/static/scripts/compile-type-lib.ts`, while `dom.d.ts` is
+a hand-maintained subset of the web APIs the runtime actually provides.
+
+A compiler roll does not regenerate either one. They declare the API surface
+patterns are allowed to use, which is a product decision rather than a
+compiler-version one, and the compiler type-checks against whatever ambient
+declarations it is handed. The `js-compiler` tests exercise the rolled compiler
+against these files.
+
+The third file in that directory, `cfc.ts`, is different: it comes out of the
+compiler's declaration emit, via `packages/static/scripts/generate-cfc-types.ts`.
+A roll can therefore change it, which is why `check-cfc-types` is part of the
+sequence above. It reports whether the committed file still matches what the new
+compiler emits. If it does not, regenerate with `deno task gen-cfc-types` and
+commit the result.
+
 ### Running Tests
 
 > **Note:** CI enforces that `main` always type-checks and all tests pass, so

--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -14,6 +14,6 @@
   "imports": {
     "@cliffy/table": "jsr:@cliffy/table@^1.0.0-rc.8",
     "@db/sqlite": "jsr:@db/sqlite@^0.12.0",
-    "typescript": "npm:typescript"
+    "typescript": "npm:typescript@6.0.3"
   }
 }

--- a/packages/deno-web-test/deno.jsonc
+++ b/packages/deno-web-test/deno.jsonc
@@ -5,7 +5,7 @@
     "test": "deno test --no-check --allow-env --allow-read --allow-write --allow-run --allow-net test/*.test.ts"
   },
   "imports": {
-    "typescript": "npm:typescript@5.9.2"
+    "typescript": "npm:typescript@6.0.3"
   },
   "exports": {
     ".": "./mod.ts",

--- a/packages/js-compiler/deno.jsonc
+++ b/packages/js-compiler/deno.jsonc
@@ -5,7 +5,7 @@
     "test": "deno test --no-check --allow-read --allow-write --allow-run --allow-env=UPDATE_GOLDENS,API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/*.test.ts"
   },
   "imports": {
-    "typescript": "npm:typescript",
+    "typescript": "npm:typescript@6.0.3",
     "source-map-js": "npm:source-map-js@^1.2.1"
   },
   "exports": {

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -11,7 +11,7 @@
   "imports": {
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.7.0",
     "ses": "npm:ses@^1.15.0",
-    "typescript": "npm:typescript"
+    "typescript": "npm:typescript@6.0.3"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/schema-generator/deno.jsonc
+++ b/packages/schema-generator/deno.jsonc
@@ -11,7 +11,7 @@
     "./property-name": "./src/typescript/property-name.ts"
   },
   "imports": {
-    "typescript": "npm:typescript"
+    "typescript": "npm:typescript@6.0.3"
   },
   "tasks": {
     "test": "deno test --parallel --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK test/**/*.test.ts",

--- a/packages/static/deno.jsonc
+++ b/packages/static/deno.jsonc
@@ -14,7 +14,7 @@
     "check-cfc-types": "./scripts/generate-cfc-types.ts --check"
   },
   "imports": {
-    "typescript": "npm:typescript"
+    "typescript": "npm:typescript@6.0.3"
   },
   "exports": {
     ".": "./index.ts",

--- a/packages/test-support/deno.jsonc
+++ b/packages/test-support/deno.jsonc
@@ -8,7 +8,7 @@
     "./isolated-deno": "./src/isolated-deno.ts"
   },
   "imports": {
-    "typescript": "npm:typescript"
+    "typescript": "npm:typescript@6.0.3"
   },
   "tasks": {
     "test": "deno test --allow-env=CF_COMPILE_CACHE_FILE --allow-read --allow-write src/*.test.ts",

--- a/packages/ts-transformers/deno.jsonc
+++ b/packages/ts-transformers/deno.jsonc
@@ -10,7 +10,7 @@
     "./runtime-contract": "./src/core/runtime-contract.ts"
   },
   "imports": {
-    "typescript": "npm:typescript"
+    "typescript": "npm:typescript@6.0.3"
   },
   "tasks": {
     "test": "deno test --parallel --allow-read --allow-write --allow-env test/**/*.test.ts",


### PR DESCRIPTION
The workspace depended on the TypeScript compiler through a bare `npm:typescript` specifier in most import maps, locked to 5.9.3, plus one explicit 5.9.2 pin in deno-web-test. Deno 2.8 bundles TypeScript 6.0.3 for `deno check`, so the compiler the runtime uses to compile patterns lagged behind the compiler that type-checks the repository.

Pin `npm:typescript@6.0.3` explicitly in all eight packages that import it, and update the lockfile.

The pins are explicit because the `typescript` npm package now serves two different compilers. The 6.x line is the original JavaScript implementation from microsoft/TypeScript. The 7.x line is the Go rewrite from microsoft/typescript-go, published under the same npm name, so a bare specifier now resolves to a compiler this repository cannot use: it ships platform binaries, its main entry point exports nothing but a version constant, and the in-process compiler API that js-compiler, ts-transformers, schema-generator and the other consumers are built on is absent. The replacement API drives the native binary from a separate process, and upstream marks it "not ready", which their own definition glosses as not yet worth building against. The 6.x line is therefore not a preference but the only line carrying the API we need, and 6.0.3 is its newest release.

The vendored ambient type libraries in packages/static/assets/types are not regenerated. They declare the API surface patterns are allowed to use, which is a product decision rather than a compiler-version one, and the js-compiler tests exercise the new compiler against them. The one compiler-derived file in that directory, cfc.ts, still matches what 6.0.3 emits, so declaration emit for that input is unchanged across the roll.

Document the dependency in docs/development/DEVELOPMENT.md: which packages carry it and why it is separate from the compiler Deno bundles, the roll procedure and the checks that verify it, why the pin stops at 6.x, and the signal that would justify revisiting that ceiling — the Go compiler's API reaching a usable state.

No code changes were needed. Type checking and the full test suite pass unchanged on 6.0.3, as does the CFC type-generation gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `npm:typescript@6.0.3` across the workspace to match Deno 2.8’s bundled compiler and avoid the 7.x Go rewrite so the in-process compiler API keeps working. No code changes; type checking, tests, and the CFC type-generation gate pass.

- **Dependencies**
  - Pin `npm:typescript@6.0.3` in `cli`, `deno-web-test`, `js-compiler`, `runner`, `schema-generator`, `static`, `test-support`, `ts-transformers`.
  - Update `deno.lock`; keep vendored ambient libs in `packages/static/assets/types` unchanged (`cfc.ts` still matches 6.0.3 emit).
  - Add docs in `docs/development/DEVELOPMENT.md` covering the separate compiler dependency, roll steps and checks, the 6.x cap, and when to revisit it.

<sup>Written for commit 2d1c95b4502139a3112b9cfb4b756b30f0749e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

