### PR TITLE
perf(runner): coalesce in-flight watch refreshes

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1649,6 +1649,7 @@ class SpaceReplica implements ISpaceReplica {
   #staleFloor = new Map<string, number>();
   #queuedWatchRefresh: WatchRefreshBatch | null = null;
   #queuedWatchRefreshScheduled = false;
+  #watchRefreshFlushing = false;
 
   constructor(options: ProviderOptions) {
     this.#space = options.space;
@@ -2238,16 +2239,29 @@ class SpaceReplica implements ISpaceReplica {
       pending: Promise.withResolvers<Result<Unit, PullError>>(),
     };
     this.#queuedWatchRefresh = batch;
+    this.scheduleWatchRefreshFlush();
+    return batch.pending.promise;
+  }
+
+  private scheduleWatchRefreshFlush(): void {
+    if (
+      this.#queuedWatchRefresh === null ||
+      this.#queuedWatchRefreshScheduled ||
+      this.#watchRefreshFlushing
+    ) {
+      return;
+    }
     this.#queuedWatchRefreshScheduled = true;
     queueMicrotask(() => {
       this.#queuedWatchRefreshScheduled = false;
-      if (this.#queuedWatchRefresh !== batch) {
+      if (this.#watchRefreshFlushing || this.#queuedWatchRefresh === null) {
         return;
       }
+      const batch = this.#queuedWatchRefresh;
       this.#queuedWatchRefresh = null;
+      this.#watchRefreshFlushing = true;
       void this.flushWatchRefreshBatch(batch);
     });
-    return batch.pending.promise;
   }
 
   private async flushWatchRefreshBatch(
@@ -2259,6 +2273,9 @@ class SpaceReplica implements ISpaceReplica {
       );
     } catch (error) {
       batch.pending.resolve({ error: toConnectionError(error) });
+    } finally {
+      this.#watchRefreshFlushing = false;
+      this.scheduleWatchRefreshFlush();
     }
   }
 

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -387,6 +387,87 @@ Deno.test("memory v2 runner does not resend prior pending watches in later batch
   }
 });
 
+Deno.test("memory v2 runner coalesces refreshes queued during an in-flight watch add", async () => {
+  const docA = `of:watch-next-batch-a-${crypto.randomUUID()}` as URI;
+  const docB = `of:watch-next-batch-b-${crypto.randomUUID()}` as URI;
+  const docC = `of:watch-next-batch-c-${crypto.randomUUID()}` as URI;
+  const transport = new DelayedWatchAddTransport();
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-add-next-batch"),
+  }, sessionFactory);
+  const provider = storageManager.open(space) as TestProvider;
+  let inlineSyncs = 0;
+  const subscription = {
+    next(notification: { type: string }) {
+      if (notification.type === "pull") {
+        inlineSyncs += 1;
+      }
+      return undefined;
+    },
+  };
+
+  try {
+    storageManager.subscribe(subscription);
+    const firstSync = provider.sync(docA, { path: [], schema: false });
+    await transport.firstWatchAddSent.promise;
+
+    const secondSync = provider.sync(docB, { path: [], schema: false });
+    await Promise.resolve();
+    const thirdSync = provider.sync(docC, { path: [], schema: false });
+    transport.releaseFirstWatchAdd.resolve({ value: { label: docA } });
+
+    await Promise.all([firstSync, secondSync, thirdSync]);
+
+    assertEquals(transport.watchAddCount, 2);
+    assertEquals(transport.rootCounts, [1, 2]);
+    assertEquals(inlineSyncs, 2);
+    assertEquals(getObjectValue(provider, docA), { label: docA });
+    assertEquals(getObjectValue(provider, docB), { label: docB });
+    assertEquals(getObjectValue(provider, docC), { label: docC });
+  } finally {
+    storageManager.unsubscribe(subscription);
+    await storageManager.close();
+  }
+});
+
+Deno.test("memory v2 runner cancels a retained watch-refresh batch on close", async () => {
+  const docA = `of:watch-close-batch-a-${crypto.randomUUID()}` as URI;
+  const docB = `of:watch-close-batch-b-${crypto.randomUUID()}` as URI;
+  const docC = `of:watch-close-batch-c-${crypto.randomUUID()}` as URI;
+  const transport = new DelayedWatchAddTransport();
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-close-batch"),
+  }, sessionFactory);
+  const provider = storageManager.open(space) as TestProvider;
+
+  const firstSync = provider.sync(docA, { path: [], schema: false });
+  await transport.firstWatchAddSent.promise;
+  const secondSync = provider.sync(docB, { path: [], schema: false });
+  const thirdSync = provider.sync(docC, { path: [], schema: false });
+
+  const [secondResult, thirdResult] = await Promise.all([
+    secondSync,
+    thirdSync,
+    storageManager.close(),
+    firstSync,
+  ]);
+
+  assertEquals(
+    (secondResult as { error?: Error }).error?.message,
+    "memory replica closed",
+  );
+  assertEquals(
+    (thirdResult as { error?: Error }).error?.message,
+    "memory replica closed",
+  );
+  assertEquals(transport.watchAddCount, 1);
+  assertEquals(transport.rootCounts, [1]);
+});
+
 Deno.test("memory v2 runner resolves synced on a microtask when idle", async () => {
   const transport = new CountingWatchSetTransport();
   const sessionFactory = new SingleSessionFactory(transport);


### PR DESCRIPTION
## Summary

- retain one pending runner watch-refresh batch while a prior `session.watch.add` is in flight
- merge later same-space pulls into that retained batch by canonical watch ID
- flush the retained batch after success or error, while preserving the Memory client's one-call/one-sync behavior
- settle retained pulls on close without sending a late watch-add frame

This stays at the runner's existing logical refresh queue rather than adding a client-wide send lane, so unrelated sessions, queries, transactions, and spaces keep their existing concurrency.

## Deterministic batching evidence

The regression test withholds refresh A, starts refresh B, crosses a microtask boundary, and then starts refresh C:

| Implementation | watch-add frames | roots per frame |
| --- | ---: | --- |
| `main` | 3 | `[1, 1, 1]` |
| this PR | 2 | `[1, 2]` |

The control test fails on `main` with actual frame count 3 versus expected 2. On this branch all three pulls settle, both coalesced documents are applied, and each wire sync is integrated exactly once. A separate close test verifies a retained B/C batch resolves with `memory replica closed` and emits no second frame.

## Safety boundary

This coalescing is limited to pending watch-add refreshes within a single `SpaceReplica`. Watch additions are monotonic, so unioning queued requests by the existing canonical watch identity—while retaining existing selector-superset compaction—does not remove prior watches or change transaction semantics. Once the current refresh settles, whether successfully or with an error, the queued union is sent through the existing `refreshWatchSet`/`watchAddSync` path and its returned sync is integrated exactly once.

Retained callers complete together with that batch's result, which intentionally couples their transport failure and completion timing; on close, unsent callers instead resolve as closed and no late frame is emitted. This argument does not extend to transactions, which retain independent sequence numbers, read dependencies, preconditions, conflict/revert outcomes, atomic commit boundaries, and scheduler/action boundaries.
## Fully proxied latency matrix

Real two-browser Lunch Poll integration routed **both shell assets and the API/memory WebSocket** through per-variant Docker TCP proxies with namespace-local `tc netem`. A payload-free Toolshed trace recorded frame type, aggregate watch/root counts, connection-local arrival time, and no IDs, schemas, or application values. The runner separately recorded queue dwell, compacted batch size, and browser-worker `watchAddSync()` duration.

Each RTT cell has three randomized paired A/B trials (24 arms total), 20 Mbit/s shaping, no configured packet loss, fixed seed 4735, and 25% correlated normally distributed jitter (10/20/30 ms at 80/200/300 ms nominal RTT).

An additional **unproxied, unshaped direct-local control** used 10 randomized paired trials. Timed total was 3.155 s on `main` versus 3.103 s on the PR (head/base ratio 0.974, bootstrap CI95 0.950–0.999); navigate + login was neutral at 1.172 s versus 1.178 s (ratio 1.016, CI95 0.997–1.036); post-dispatch convergence was 537 ms versus 403 ms (ratio 0.815, CI95 0.700–0.955). Watch-add frames fell from a median 208 to 75 while both carried a median 1,143 watches. The implementation adds no fixed timeout: retained work waits only for the currently in-flight watch refresh to settle. This control found no local total-time or navigation regression for this workload.

| Nominal RTT | Timed total: `main` → PR | Paired head/base ratio | Post-dispatch convergence: `main` → PR | Paired ratio |
| ---: | ---: | ---: | ---: | ---: |
| near-native (~2 ms) | 5.660 s → 5.535 s | 0.967 | 620 ms → 563 ms | 0.809 |
| 80 ms | 17.412 s → 10.717 s | 0.612 | 3.503 s → 936 ms | 0.263 |
| 200 ms | 37.808 s → 20.508 s | 0.543 | 7.274 s → 1.696 s | 0.223 |
| 300 ms | 56.431 s → 31.805 s | 0.559 | 10.789 s → 2.628 s | 0.252 |

The convergence timer starts **after both concurrent click dispatches complete** and ends when both browsers render `2 love it`; it is not click-to-render. With the corrected path, the base sent about 209–210 browser `session.watch.add` frames and the PR sent 70–75 while carrying the same ~1,144–1,145 watches. At 300 ms nominal RTT, aggregate browser-worker watch-add p50 fell from 2.837 s to 493 ms and p95 from 8.237 s to 1.233 s, showing that the base's concurrent requests pile up under delay while the PR retains one follow-on batch.

In this controlled topology, the large and consistent high-RTT paired effects are strong diagnostic evidence for this workload, not a production latency estimate. The near-native difference is small and underpowered.

An exploratory 300 ms CDP sample covered 24.3 s of post-load interaction per browser. V8 attributed 94.9–95.6% to internal `(program)` time, 2.8–3.2% to `worker-runtime.js`, 0.9–1.1% to shared bundle helpers, and about 0.5% to GC; no application frame exceeded 0.1% self time. This argues against browser-worker JavaScript CPU saturation during that sampled interval. CDP's `(program)` bucket does not identify network waiting; the network/queue interpretation instead comes from RTT sensitivity, watch timing, and convergence behavior.

These latency cells are deliberately small (`n=3` pairs each), so the stable paired ratios are useful diagnostic evidence, not production confidence intervals. Because the proxy terminates TCP, the browser and backend communicate over separate TCP legs; the 20 Mbit/s cap can interact with burst behavior, so this does not isolate RTT alone. The data do not establish physical byte savings or predict a particular user's latency. Independent, unpaired `n=3` follow-ups found that a temporary 2 ms extra watch linger reduced residual watch frames to 52–53 but had mixed latency results; 8 ms reduced them only to ~51 and more often delayed convergence. This PR therefore keeps its existing microtask behavior, and the current evidence does not support RTT-derived adaptive linger.
## Verification

- full Runner package: **932 passed / 4,954 steps / 0 failed**
- focused watch-refresh race suite: **12 passed / 0 failed**
- root `deno task check`
- `deno fmt --check`
- `deno lint`
- normal two-browser Lunch Poll integration without injected delay
- unproxied direct-local control: 10 randomized paired A/B trials
- fully proxied network-shaped matrix: 24 randomized A/B arms across near-native, 80 ms, 200 ms, and 300 ms nominal RTT
- zero LSP diagnostics; `git diff --check`; unchanged `deno.lock`
- five-angle post-implementation review: goal, code quality, security, hands-on QA, and repository context all PASS

## Relationship to #4712

This PR is independent of #4712: it changes only runner refresh scheduling and its race test. #4712 owns Memory schema/accounting/CAS work and now contains the separate byte measurements.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesce in-flight watch refreshes in the runner so multiple `session.watch.add` for the same space are batched into one frame, reducing latency and wire frames. Preserves one-call/one-sync behavior and existing concurrency for other sessions, queries, and transactions.

- **Refactors**
  - Maintain a single pending watch-refresh batch and merge later pulls by canonical watch ID; flush after success or error.
  - Add `#watchRefreshFlushing` and a microtask-based `scheduleWatchRefreshFlush()` to prevent resends and chain batches safely.
  - Cancel any retained batch on close so pending pulls resolve with "memory replica closed" and no late watch-add is sent; add tests for deterministic batching and close behavior.

<sup>Written for commit 13ee95911bdfb7fd5114d2e71b40e4a5de539269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

