### PR TITLE
Fix content-dependent appends and document the migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,9 @@ If you are developing runtime code, read the following documentation:
 - `docs/development/patch-operations.md` - The patch-operation family (the
   single logical changes a commit carries), the registries that define each op
   once, and how to add a new one across the memory / runner / api / transformer
-  layers
+  layers. Its neighbour `mergeable-collection-writes.md` covers why the
+  mergeable ops exist and what they do to conflict detection; read it before
+  changing how a handler writes to a list
 - `docs/development/UI_TESTING.md` - How to work with shadow dom in our
   integration tests
 - `docs/development/EXPERIMENTAL_OPTIONS.md` - The central registry of every

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -23,7 +23,7 @@ export default pattern<MyInput, MyOutput>(({ count }) => {
 });
 ```
 
-If your pattern uses `pattern<State>()` or doesn't export actions, fix the pattern first. See [Pattern Types](../concepts/pattern.md#always-use-dual-type-parameters).
+If your pattern uses `pattern<State>()`, fix the pattern first. See [Pattern Types](../concepts/pattern.md#always-use-dual-type-parameters). A pattern that doesn't export its actions can still be driven through its UI — see [Firing a handler the pattern does not export](#firing-a-handler-the-pattern-does-not-export).
 
 ## Overview
 
@@ -119,6 +119,41 @@ const action_setup_game = action(() => {
   game.startGame.send();
 });
 ```
+
+### Firing a handler the pattern does not export
+
+A handler bound only in JSX can still be fired, so a pattern that keeps its
+behaviour behind a button does not have to change to be tested. The prop carries
+a stream whether the handler was written inline or bound from module scope. Walk
+the rendered tree to the node, read the prop, and send it an event:
+
+```tsx
+// Shown at module scope.
+import { action, pattern, UI } from "commonfabric";
+import { findElementByText, propsOf } from "../test/vnode-helpers.ts";
+import MapDemo from "./map-demo.tsx";
+
+export default pattern(() => {
+  const subject = MapDemo({ areasOfInterest: [] });
+
+  const action_add_area = action(() => {
+    const button = findElementByText(subject[UI], "cf-button", "+ Add Area");
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  return { tests: [{ action: action_add_area }], subject };
+});
+```
+
+`packages/patterns/map-demo.test.tsx` drives both an inline arrow and a bound
+handler this way.
+
+Prefer an exported `Stream<T>` when you own the pattern: it states the entry
+point in the output type. Use the tree walk when the handler belongs to the UI
+and exporting it would only serve the test.
 
 ## Writing Assertions
 

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -42,7 +42,7 @@ in front of each authored statement, and the collector writes one
 `*.pattern-coverage.lcov` file per test. The line numbers in that file point
 back at the authored pattern source.
 
-Two properties of this mechanism are worth keeping in mind.
+These properties of this mechanism are worth keeping in mind:
 
 - The counters are statement based. A single statement that spans several lines
   marks its whole source range as run the moment the statement is reached. The
@@ -51,6 +51,14 @@ Two properties of this mechanism are worth keeping in mind.
 - Coverage records that a line ran. It never records that a test checked the
   result of running that line. A test that drives a pattern through a flow
   without asserting anything still marks those lines covered.
+- Handler bodies and derived expressions run only when a test drives them, and a
+  pattern unit test can drive both. A JSX handler, inline or bound, compiles to a
+  stream on the node's prop: a test walks the rendered tree to the node, reads
+  the prop, and sends it an event. A derived expression such as `{count * 2}`
+  runs when a test reads the node it builds. So UI raises the uncovered-line
+  count only until a test drives it; write that test rather than taking a
+  `NEW_PERF_BASELINE` marker.
+  [pattern-testing.md](../common/workflows/pattern-testing.md) shows how.
 
 `CF_PATTERN_COVERAGE_DIR` is read in exactly one place: the `cf test` command in
 `packages/cli/commands/test-command.ts`. A job that runs patterns through a
@@ -182,18 +190,6 @@ positives and a less faithful, more gameable gate.
   expanded, normalizing the denominator (always scoring a pattern file against
   the same line set whether or not it has a record) would make the numbers
   easier to trust.
-
-- Event-handler bodies are never covered by the pattern-unit gate. A JSX handler
-  such as `onClick={() => stream.send({})}` compiles to a handler that the
-  runtime materializes as an opaque reference, not a callable function. A pattern
-  unit test can walk the rendered tree to pull reactive computeds, but it cannot
-  fire that handler, because firing needs the runtime's event dispatch and
-  `cf test` has no DOM. So the statements inside every event handler count as
-  uncovered. A change that adds UI buttons therefore raises the group's
-  uncovered-line count by an amount no unit test can bring back down. Accept that
-  rise with a `NEW_PERF_BASELINE` marker (see
-  [CI_PERFORMANCE.md](CI_PERFORMANCE.md)); do not restructure the handler to move
-  the counter, because that changes wiring no test exercises.
 
 ## Related documentation
 

--- a/docs/development/keyed-collection-writes.md
+++ b/docs/development/keyed-collection-writes.md
@@ -8,6 +8,10 @@ key, delete the record with a given key. The driving example is the lunch poll,
 whose handlers are almost entirely keyed mutations of lists of records; it is
 migrated to this approach as the worked example.
 
+For how to change an existing handler over to keyed addressing, and the mistakes
+that make such a migration look finished while it is not, see
+[migrating-collection-writes.md](./migrating-collection-writes.md).
+
 ## The lunch poll's read-then-write inventory
 
 Every mutating handler in `packages/patterns/lunch-poll`, by shape, and the

--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -3,7 +3,9 @@
 > For how a patch operation is put together across the codebase — the registries
 > that define each op once and how to add a new one — see
 > [patch-operations.md](./patch-operations.md). This note covers *why* the
-> mergeable ops exist.
+> mergeable ops exist. For how to change an existing handler over to them, and
+> the mistakes that make a migration look finished while it is not, see
+> [migrating-collection-writes.md](./migrating-collection-writes.md).
 
 ## The problem
 

--- a/docs/development/migrating-collection-writes.md
+++ b/docs/development/migrating-collection-writes.md
@@ -1,0 +1,226 @@
+# Migrating a collection write
+
+This note is for someone changing a handler that reads a collection and then
+writes to it — most often because the compiler reported
+`mergeable-push:read-then-push`. It says which replacement to pick, and it
+describes the mistakes that make a migration look finished while it is not.
+
+For why the mergeable operations exist, see
+[mergeable-collection-writes.md](./mergeable-collection-writes.md). For how a
+keyed element is addressed, see
+[keyed-collection-writes.md](./keyed-collection-writes.md). This note assumes
+both and covers the migration itself.
+
+## Pick the replacement from what the read is for
+
+Read the handler and decide what the read actually decides. There are four
+answers and they do not share a remedy.
+
+**The read is a uniqueness check.** The handler asks "is this thing already in
+the list?" and appends when it is not. Give the element a deterministic address
+with `elementById(key)` and add it with `addUnique`. The dedup then happens on
+the server by link, so two clients adding the same key resolve to one entity
+with no retry, and adds of different keys merge.
+
+**The appended value is derived from the list.** The handler numbers the new
+element, labels it from the existing entries, caps the list at a maximum
+length, or reports the new element's index back to its caller. None of that is
+expressible as an append, because an append carries no condition and the server
+resolves it at the durable tail, which need not match the snapshot the handler
+read. Use one read-modify-write `set` over the snapshot the handler already
+read. The read stays in the conflict set, which is what makes the retry correct.
+
+**The read feeds a different write to the same collection.** The handler
+appends an entry and then separately trims or reorders the list. Keep the
+independent read-modify-write in its own handler so the append stays mergeable.
+A transaction that both appends and reshapes the whole array may drop the
+reshape — see "Mixed whole-array reshape" in
+[mergeable-collection-writes.md](./mergeable-collection-writes.md).
+
+**The read is unrelated to the write.** Leave the `push` alone. The append
+forfeits merging, and there is no better expression to move to.
+
+Picking the wrong one of these is a regression, not a neutral choice. Replacing
+a `push` with `set([...current, value])` when the read was a uniqueness check
+makes the write strictly worse: the uniqueness is still not enforced, and the
+whole-array write can now clobber a durable tail that the append would have
+respected.
+
+## `addUnique` and `removeByValue` need an actual cell
+
+This is the rule that breaks migrations, and it fails silently in both
+directions.
+
+Both methods compare the argument against the array's **stored** elements. An
+element that is an object is its own entity, so the stored element is a link,
+not the object's content. The methods choose how to compare by asking whether
+the argument is a cell — `isCell` is an `instanceof` check against the cell
+implementation, nothing more:
+
+```ts
+// Shown for illustration only.
+isCell(candidate)
+  ? areLinksSame(element, candidate, ...)  // compares by link identity
+  : deepEqual(element, candidate)          // compares against the stored link
+```
+
+A value read back out of `.get()` is a query-result proxy. It carries a link,
+but it is not a cell, so it takes the `deepEqual` branch and is compared
+against a link sigil, which it never equals. The consequences:
+
+```ts
+// Shown for illustration only.
+// Silently removes nothing. `row` is a proxy, not a cell.
+for (const row of items.get().filter((r) => r.name === name)) {
+  items.removeByValue(row);
+}
+
+// Silently adds a duplicate, for the same reason.
+items.addUnique(items.get().find((r) => r.name === name));
+```
+
+The compiler reports both, as `mergeable-write:value-argument`. It reports the
+call whenever the collection's elements are objects and the argument is
+certainly not a cell, and it stays quiet where the value form is right: an
+argument it cannot decide, and a collection of scalars, which store inline
+rather than as links and so do compare by value. The check exists because
+neither the type system nor the runtime can: the parameter is declared
+`U | AnyCell<U>`, so both forms type-check, and the call succeeds either way.
+
+Neither call reports anything. The first is a no-op, so code that reads as a
+cleanup does nothing at all. The second is worse than a no-op: it appends a
+second element for a key that already has one.
+
+Pass a cell instead — the cell from `elementById(key)`, or the element cell
+from `key(index)`:
+
+```ts
+// Shown for illustration only.
+const entry = items.elementById(key);
+entry.set({ name, description: "" });
+items.addUnique(entry);        // compares by link, dedups correctly
+items.removeByValue(entry);    // compares by link, removes correctly
+```
+
+### Event data is a cell only if its type says so
+
+The same rule catches handler inputs. A handler whose event type names a plain
+type receives a proxy, and `addUnique` on it silently duplicates:
+
+```ts
+// Shown for illustration only.
+// The event field is a plain type, so `piece` arrives as a proxy and this
+// never dedups.
+handler<{ piece: MentionablePiece }, { allPieces: Writable<MentionablePiece[]> }>(
+  ({ piece }, { allPieces }) => {
+    allPieces.addUnique(piece);
+  },
+);
+
+// Declaring the field as a cell makes the same call compare by link.
+handler<
+  { piece: Writable<MentionablePiece> },
+  { allPieces: Writable<MentionablePiece[]> }
+>(({ piece }, { allPieces }) => {
+  allPieces.addUnique(piece);
+});
+```
+
+If a handler nearby compares the same value with `equals(a, b)` rather than by
+identity, that is a sign the value is a link-carrying proxy rather than a cell:
+`equals` resolves links before comparing, so it works where `addUnique` does
+not.
+
+## Finish the migration: remove the read
+
+The compiler inspects `push`. It does not inspect `addUnique` or
+`removeByValue`, because those are the recommended replacements. So swapping
+`push` for `addUnique` while keeping the `.get()` of the same list silences the
+diagnostic without changing what the handler does under contention: the
+handler's own explicit read stays in the conflict set, and the write still
+conflicts and retries exactly as it did before.
+
+A migration that keeps the whole-list read has not bought anything. It has
+moved the shape out of the compiler's view. When the keyed form is the right
+answer, read the keyed entity rather than the array:
+
+```ts
+// Shown for illustration only.
+const entry = items.elementById(key);
+if (entry.get()) return;       // reads one entity, not the list
+entry.set(value);
+items.addUnique(entry);
+```
+
+If the read genuinely has to stay, keep it deliberately and say so in a
+comment, so the next reader knows the write still contends.
+
+## Clear the entity when you drop the membership
+
+A keyed element is a membership link in the array and an entity the link points
+at. Removing the link does not delete the entity. A handler that decides
+anything by reading the entity must clear it when it removes the membership:
+
+```ts
+// Shown for illustration only.
+items.removeByValue(entry);
+entry.set(undefined);
+```
+
+Without the clear, the entity outlives its link and a later read returns the
+removed value's content. The failure is silent and shaped like data loss: a
+handler that asks "does this already exist?" finds the orphan, takes the
+already-exists branch, and never restores the membership, so the element can
+never come back.
+
+## Do not invent a per-handler legacy migration
+
+An element appended by `push` takes its entity identity from an append counter
+folded with the event cause. An element addressed by `elementById` derives its
+identity from the key. The two derivations never coincide, so changing a
+collection to keyed addressing makes elements written by the old code
+unreachable from the new code. The decision already taken for this repository
+is that there is no data migration for pattern instances: existing instances
+would need to be recreated. See "Back-compatibility: addressing scheme changes"
+in [keyed-collection-writes.md](./keyed-collection-writes.md).
+
+Writing a legacy fallback into each handler is not a free improvement on that
+decision, and it costs more than it looks.
+
+The fallback needs the whole-list read to find the legacy element. That read
+stays in the conflict set, so the migration does not buy the merge behaviour it
+was for: writers still conflict and retry, exactly as they did before.
+
+A legacy element can be removed, but only through a cell. `elementById` does not
+address one — that is what makes it legacy — and `removeByValue` of its content
+is the silent no-op above. The scan that found the element also gives its index,
+and `items.key(index)` is a cell for it, so `removeByValue(items.key(index))`
+removes it. That cell is positional: it resolves against the snapshot the
+handler read, so a concurrent insert or removal ahead of it addresses a
+different element. The retained read is what keeps that from being wrong — a
+commit carrying a stale read is rejected and retries — and it is the same read
+that costs the merge behaviour. The fallback is contended by construction, not
+broken.
+
+The failure to avoid is handing `removeByValue` the element's content rather
+than its cell. The scan has just produced the content, so it is the natural
+thing to reach for, and it removes nothing. The keyed write beside it does
+something, so the result is a permanent duplicate: the legacy element and the
+keyed element both live in the list, both render, and both feed whatever reads
+the list. Nothing reports any of it.
+
+If existing data really must be carried across, prefer a one-shot repair to a
+scan in every handler. It pays the whole-list read once rather than on every
+write, and it keeps the positional addressing in one place.
+
+## Test the path you added
+
+A pattern's test suite usually starts from an empty collection, so it exercises
+only the freshly-keyed path. A legacy fallback, and any handler that branches on
+whether an element already exists, is invisible to a suite shaped that way — the
+suite passes and the branch has never run.
+
+Seed the pre-existing element the branch is written for, then drive the handler
+and assert on the whole collection, not just the element you were looking for. A
+duplicate is the expected failure here, and an assertion that only checks "my
+element is present" will not see it.

--- a/docs/specs/shared-profile-rosters.md
+++ b/docs/specs/shared-profile-rosters.md
@@ -132,8 +132,8 @@ elsewhere in the repo:
 - `wish<string>({ query: "#profileName" | "#profileAvatar" })` and reading
   `.result` — `packages/patterns/shared-profile-demo/main.tsx`,
   `packages/patterns/chatbot.tsx`.
-- `PerSpace` / `PerUser` roster + writable-cell aliases + a `push`ing join
-  handler — `packages/patterns/scrabble/scrabble.tsx`,
+- `PerSpace` / `PerUser` roster + writable-cell aliases + a join handler that
+  writes the roster — `packages/patterns/scrabble/scrabble.tsx`,
   `packages/patterns/scoped-group-chat/main-plain-inputs.tsx`.
 - `safeDateNow()` for timestamps in handlers —
   `packages/patterns/scoped-group-chat/main-plain-inputs.tsx`.
@@ -217,7 +217,19 @@ export type JoinEvent = Record<PropertyKey, never>;
 // appends a snapshot to the shared roster and records that this viewer joined.
 // Identity is keyed on the `profile` CELL — never the display name, which is
 // mutable and may collide between distinct users. `profile` round-trips through
-// `push` as a link and is compared with `equals()`, the cell-identity idiom.
+// the roster write as a link and is compared with `equals()`, the cell-identity
+// idiom.
+//
+// The join reads the roster to decide whether to append, so it is a
+// read-modify-write `set` and not a mergeable `push`: a push drops its own read
+// of the list from conflict detection, which is what makes disjoint appends
+// merge, and pairing it with a dedup read of the same list is what the
+// mergeable-push diagnostic reports (see
+// docs/development/migrating-collection-writes.md). The keyed `elementById` +
+// `addUnique` form does not apply here — it needs a key derived from the
+// element, and pattern code cannot read a profile cell's link. Two viewers
+// joining at once therefore conflict and the loser retries, which is what makes
+// the dedup hold.
 
 const join = handler<JoinEvent, {
   roster: RosterCell;
@@ -235,14 +247,15 @@ const join = handler<JoinEvent, {
   // still counts as joined, and two distinct users sharing a display name don't
   // block each other.
   const participants = roster.key("participants");
-  const already = participants.get().some((p) => equals(p.profile, profile));
+  const existing = participants.get();
+  const already = existing.some((p) => equals(p.profile, profile));
   if (!already) {
-    participants.push({
+    participants.set([...existing, {
       profile,
       name: trimmed,
       avatar: (avatar ?? "").trim(),
       joinedAt: safeDateNow(),
-    });
+    }]);
   }
   viewer.set({ joined: true, joinedName: trimmed });
 });

--- a/packages/patterns/gideon-tests/proxy-length-repro.tsx
+++ b/packages/patterns/gideon-tests/proxy-length-repro.tsx
@@ -34,7 +34,8 @@ export interface Output {
 
 export default pattern<Input, Output>(({ items }) => {
   const addItem = action(() => {
-    items.push({ name: `Item ${items.get().length + 1}` });
+    const current = items.get();
+    items.set([...current, { name: `Item ${current.length + 1}` }]);
   });
 
   // Computed array derived from the input

--- a/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx
+++ b/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Test: the "Update All Values" button drives every reactive value.
+ *
+ * The demo binds updateAllValues to a button rather than exporting it, so the
+ * test reaches the handler the way the runtime does: walk the rendered tree to
+ * the button and send an event to the stream bound to its onClick.
+ *
+ * Run: deno task cf test packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx --root packages/patterns --verbose
+ */
+import { action, computed, pattern, UI } from "commonfabric";
+import {
+  findElementByText,
+  propsOf,
+  textContent,
+} from "../test/vnode-helpers.ts";
+import JsxAutomaticReactivity from "./test-reactivity-jsx-automatic.tsx";
+
+export default pattern(() => {
+  const subject = JsxAutomaticReactivity({
+    count: 0,
+    user: { name: "Alice", age: 30 },
+    items: [{ title: "Item 1" }, { title: "Item 2" }, { title: "Item 3" }],
+  });
+
+  const action_click_update = action(() => {
+    const button = findElementByText(subject[UI], "cf-button", "Update All");
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  const assert_initial_count = computed(() => subject.count === 0);
+  const assert_initial_user = computed(() => subject.user.name === "Alice");
+  const assert_initial_items = computed(() => [...subject.items].length === 3);
+
+  // The pattern's claim is that an expression in JSX tracks its inputs with no
+  // computed() wrapper, so read it from the rendered tree rather than from the
+  // output.
+  const assert_initial_inline_expression = computed(() =>
+    textContent(findElementByText(subject[UI], "div", "Count x 2 ="))
+      .includes("Count x 2 = 0")
+  );
+
+  const assert_count_after_first = computed(() => subject.count === 1);
+  const assert_user_after_first = computed(() => subject.user.name === "Bob");
+  const assert_inline_expression_after_first = computed(() =>
+    textContent(findElementByText(subject[UI], "div", "Count x 2 ="))
+      .includes("Count x 2 = 2")
+  );
+
+  // The append derives the new title from the same snapshot the length guard
+  // read, so the fourth item is titled from a length of 3.
+  const assert_items_after_first = computed(() => {
+    const items = [...subject.items];
+    return items.length === 4 && items[3].title === "Item 4";
+  });
+
+  // Each further click appends one item, titled from the growing snapshot,
+  // until the guard stops the append at five.
+  const assert_items_after_second = computed(() => {
+    const items = [...subject.items];
+    return items.length === 5 && items[4].title === "Item 5";
+  });
+  const assert_user_after_second = computed(() =>
+    subject.user.name === "Alice"
+  );
+
+  // At five entries the guard takes the other branch and truncates to three.
+  const assert_items_after_third = computed(() => {
+    const items = [...subject.items];
+    return items.length === 3 && items[2].title === "Item 3";
+  });
+  const assert_count_after_third = computed(() => subject.count === 3);
+
+  return {
+    tests: [
+      { assertion: assert_initial_count },
+      { assertion: assert_initial_user },
+      { assertion: assert_initial_items },
+      { assertion: assert_initial_inline_expression },
+
+      { action: action_click_update },
+      { assertion: assert_count_after_first },
+      { assertion: assert_user_after_first },
+      { assertion: assert_items_after_first },
+      { assertion: assert_inline_expression_after_first },
+
+      { action: action_click_update },
+      { assertion: assert_items_after_second },
+      { assertion: assert_user_after_second },
+
+      { action: action_click_update },
+      { assertion: assert_items_after_third },
+      { assertion: assert_count_after_third },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.tsx
+++ b/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.tsx
@@ -59,7 +59,7 @@ const updateAllValues = handler<
   // Add or remove an item
   const currentItems = items.get();
   if (currentItems.length < 5) {
-    items.push({ title: `Item ${currentItems.length + 1}` });
+    items.set([...currentItems, { title: `Item ${currentItems.length + 1}` }]);
   } else {
     items.set(currentItems.slice(0, 3));
   }

--- a/packages/patterns/map-demo.test.tsx
+++ b/packages/patterns/map-demo.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Test: adding an area of interest derives its title and colour from the same
+ * snapshot it is appended to.
+ *
+ * The handler picks a colour by the list's length and titles the area from that
+ * same length, so title, colour and position have to agree with the slot the
+ * area actually lands in. The demo binds the handler to a button rather than
+ * exporting it, so the test walks the rendered tree to the button and sends an
+ * event to the stream bound to its onClick.
+ *
+ * Run: deno task cf test packages/patterns/map-demo.test.tsx --root packages/patterns --verbose
+ */
+import { action, computed, pattern, UI } from "commonfabric";
+import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
+import MapDemo from "./map-demo.tsx";
+
+// The colour cycle the handler indexes with the list's length.
+const COLORS = ["#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#8b5cf6"];
+
+export default pattern(() => {
+  // Start from an empty map: no stops, no areas and no tracked centre, so the
+  // first add exercises the handler's own centre fallback.
+  const subject = MapDemo({
+    tripName: "Test Trip",
+    stops: [],
+    areasOfInterest: [],
+    showRoute: true,
+    center: null,
+    zoom: 9,
+    selectedStopIndex: null,
+    fitBoundsTrigger: 0,
+    initialized: false,
+  });
+
+  const action_add_area = action(() => {
+    const button = findElementByText(subject[UI], "cf-button", "+ Add Area");
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  // "Fit to All Stops" holds its body in an inline arrow rather than a bound
+  // handler. It reaches the same way: the prop carries a stream either way.
+  const action_fit_bounds = action(() => {
+    const button = findElementByText(
+      subject[UI],
+      "cf-button",
+      "Fit to All Stops",
+    );
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  const assert_no_areas_initially = computed(() =>
+    [...subject.areasOfInterest].length === 0
+  );
+
+  const assert_first_area = computed(() => {
+    const areas = [...subject.areasOfInterest];
+    if (areas.length !== 1) return false;
+    const area = areas[0];
+    return area.title === "Area 1" &&
+      area.color === COLORS[0] &&
+      area.radius === 2000 &&
+      area.description === "New area of interest";
+  });
+
+  // With no centre tracked yet the handler falls back to its own default rather
+  // than leaving the area without a position.
+  const assert_first_area_uses_default_center = computed(() => {
+    const areas = [...subject.areasOfInterest];
+    return areas.length === 1 &&
+      areas[0].center.lat === 37.6 &&
+      areas[0].center.lng === -122.2;
+  });
+
+  // The second add reads a one-entry list, so it titles itself "Area 2" and
+  // takes the next colour. Both have to match the slot it appends into.
+  const assert_second_area = computed(() => {
+    const areas = [...subject.areasOfInterest];
+    if (areas.length !== 2) return false;
+    return areas[1].title === "Area 2" && areas[1].color === COLORS[1];
+  });
+
+  // The first area is untouched by the second add.
+  const assert_first_area_unchanged = computed(() => {
+    const areas = [...subject.areasOfInterest];
+    return areas.length === 2 &&
+      areas[0].title === "Area 1" &&
+      areas[0].color === COLORS[0];
+  });
+
+  const assert_third_area = computed(() => {
+    const areas = [...subject.areasOfInterest];
+    if (areas.length !== 3) return false;
+    return areas[2].title === "Area 3" && areas[2].color === COLORS[2];
+  });
+
+  // Every area's title numbers the slot it sits in, which is what the append
+  // has to preserve.
+  const assert_titles_match_positions = computed(() => {
+    const areas = [...subject.areasOfInterest];
+    return areas.every((area, index) => area.title === `Area ${index + 1}`);
+  });
+
+  const assert_area_count_tracks_list = computed(() =>
+    [...subject.areasOfInterest].length === 3
+  );
+
+  // The map component watches this counter rather than taking a call, so the
+  // button's only job is to move it.
+  const assert_fit_bounds_not_triggered = computed(() =>
+    subject.fitBoundsTrigger === 0
+  );
+  const assert_fit_bounds_triggered = computed(() =>
+    subject.fitBoundsTrigger === 1
+  );
+
+  return {
+    tests: [
+      { assertion: assert_no_areas_initially },
+      { assertion: assert_fit_bounds_not_triggered },
+
+      { action: action_fit_bounds },
+      { assertion: assert_fit_bounds_triggered },
+
+      { action: action_add_area },
+      { assertion: assert_first_area },
+      { assertion: assert_first_area_uses_default_center },
+
+      { action: action_add_area },
+      { assertion: assert_second_area },
+      { assertion: assert_first_area_unchanged },
+
+      { action: action_add_area },
+      { assertion: assert_third_area },
+      { assertion: assert_titles_match_positions },
+      { assertion: assert_area_count_tracks_list },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/map-demo.tsx
+++ b/packages/patterns/map-demo.tsx
@@ -7,6 +7,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
 } from "commonfabric";
 
 /**
@@ -56,6 +57,7 @@ interface Input {
 }
 
 export interface Output {
+  [UI]: VNode;
   tripName: string;
   stops: TripStop[];
   areasOfInterest: AreaOfInterest[];
@@ -170,15 +172,16 @@ const addAreaHandler = handler<
   { areas: Cell<AreaOfInterest[]>; center: Cell<LatLng | null> }
 >((_event, { areas, center }) => {
   const colors = ["#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#8b5cf6"];
-  const colorIndex = areas.get().length % colors.length;
+  const currentAreas = areas.get();
+  const colorIndex = currentAreas.length % colors.length;
   const currentCenter = center.get() ?? { lat: 37.6, lng: -122.2 };
-  areas.push({
+  areas.set([...currentAreas, {
     center: currentCenter,
     radius: 2000,
-    title: `Area ${areas.get().length + 1}`,
+    title: `Area ${currentAreas.length + 1}`,
     description: "New area of interest",
     color: colors[colorIndex],
-  });
+  }]);
 });
 
 // Format coordinates for display (handles undefined during reactive updates)

--- a/packages/patterns/record.test.tsx
+++ b/packages/patterns/record.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Test: adding a module reports the position the module actually occupies.
+ *
+ * handleAddModule reads the sub-piece list once and depends on that read twice:
+ * getNextUnusedLabel derives the new module's label by scanning the existing
+ * entries of the same type, and the handler reports the new module's position
+ * to its caller. The append has to land at the position the handler reports, so
+ * these tests drive successive adds and check each reported index against the
+ * entry sitting at it.
+ *
+ * The label half is not asserted. An entry holds its module as a piece typed
+ * `unknown`, which carries no schema, so the runner reads a module's label back
+ * as undefined and a test cannot see which label the handler chose. Replacing
+ * getNextUnusedLabel's body with `return undefined` still passes these tests.
+ *
+ * The list starts empty. The lift that seeds a notes module and a type picker
+ * assigns its result to a variable nothing reads, and an unconsumed lift does
+ * not run; the list stays empty here even with `$UI` mounted.
+ *
+ * Run: deno task cf test packages/patterns/record.test.tsx --root packages/patterns --verbose
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+import RecordPattern from "./record.tsx";
+
+interface AddResult {
+  success?: boolean;
+  moduleIndex?: number;
+  type?: string;
+  error?: string;
+  message?: string;
+}
+
+export default pattern(() => {
+  const subject = RecordPattern({
+    title: "Test Record",
+    subPieces: [],
+    trashedSubPieces: [],
+  });
+
+  // Each add reports into its own cell so the assertions can tell the adds
+  // apart rather than reading whichever one wrote last.
+  const firstEmail = new Writable<AddResult>();
+  const secondEmail = new Writable<AddResult>();
+  const phone = new Writable<AddResult>();
+  const withInitialData = new Writable<AddResult>();
+  const unknownType = new Writable<AddResult>();
+  const missingType = new Writable<AddResult>();
+  const notesType = new Writable<AddResult>();
+
+  const action_add_first_email = action(() => {
+    subject.addModule!.send({ type: "email", result: firstEmail });
+  });
+  const action_add_second_email = action(() => {
+    subject.addModule!.send({ type: "email", result: secondEmail });
+  });
+  const action_add_phone = action(() => {
+    subject.addModule!.send({ type: "phone", result: phone });
+  });
+  const action_add_with_initial_data = action(() => {
+    subject.addModule!.send({
+      type: "address",
+      initialData: { label: "Chosen", street: "1 Main St" },
+      result: withInitialData,
+    });
+  });
+  const action_add_unknown = action(() => {
+    subject.addModule!.send({
+      type: "no-such-type",
+      result: unknownType,
+    });
+  });
+  const action_add_missing_type = action(() => {
+    subject.addModule!.send({ type: "", result: missingType });
+  });
+  const action_add_notes = action(() => {
+    subject.addModule!.send({ type: "notes", result: notesType });
+  });
+
+  const assert_starts_empty = computed(() =>
+    [...(subject.subPieces ?? [])].length === 0
+  );
+
+  // The first add lands in the empty list and reports slot 0.
+  const assert_first_email_appended = computed(() => {
+    const current = [...(subject.subPieces ?? [])];
+    return current.length === 1 && current[0].type === "email";
+  });
+  const assert_first_email_result = computed(() => {
+    const result = firstEmail.get();
+    return result?.success === true &&
+      result?.type === "email" &&
+      result?.moduleIndex === 0;
+  });
+
+  // The second add reads a list that already holds the first, so it has to
+  // report the next slot rather than the one it read.
+  const assert_second_email_appended = computed(() => {
+    const current = [...(subject.subPieces ?? [])];
+    return current.length === 2 && current[1].type === "email";
+  });
+  const assert_second_email_result = computed(() =>
+    secondEmail.get()?.moduleIndex === 1
+  );
+
+  const assert_phone_appended = computed(() => {
+    const current = [...(subject.subPieces ?? [])];
+    return current.length === 3 && current[2].type === "phone";
+  });
+  const assert_phone_result = computed(() => phone.get()?.moduleIndex === 2);
+
+  const assert_initial_data_accepted = computed(() => {
+    const result = withInitialData.get();
+    return result?.success === true && result?.moduleIndex === 3;
+  });
+
+  // Adds land in the order they were sent, and nothing earlier moved.
+  const assert_entries_in_add_order = computed(() => {
+    const types = [...(subject.subPieces ?? [])].map((entry) => entry.type);
+    return types.length === 4 &&
+      types[0] === "email" &&
+      types[1] === "email" &&
+      types[2] === "phone" &&
+      types[3] === "address";
+  });
+
+  // Every reported index addresses the module that its own add created.
+  const assert_reported_indices_address_their_modules = computed(() => {
+    const current = [...(subject.subPieces ?? [])];
+    const reported = [
+      { index: firstEmail.get()?.moduleIndex, type: "email" },
+      { index: secondEmail.get()?.moduleIndex, type: "email" },
+      { index: phone.get()?.moduleIndex, type: "phone" },
+      { index: withInitialData.get()?.moduleIndex, type: "address" },
+    ];
+    return reported.every(({ index, type }) =>
+      typeof index === "number" && current[index]?.type === type
+    );
+  });
+
+  // The rejection paths report the reason and leave the list alone.
+  const assert_unknown_type_rejected = computed(() => {
+    const result = unknownType.get();
+    return result?.success === false &&
+      typeof result?.error === "string" &&
+      result.error.includes("Unknown module type");
+  });
+  const assert_missing_type_rejected = computed(() => {
+    const result = missingType.get();
+    return result?.success === false &&
+      typeof result?.error === "string" &&
+      result.error.includes("Module type is required");
+  });
+  const assert_notes_type_rejected = computed(() => {
+    const result = notesType.get();
+    return result?.success === false &&
+      typeof result?.error === "string" &&
+      result.error.includes("Notes modules must be added via UI");
+  });
+  const assert_rejections_appended_nothing = computed(() =>
+    [...(subject.subPieces ?? [])].length === 4
+  );
+
+  return {
+    tests: [
+      { assertion: assert_starts_empty },
+
+      { action: action_add_first_email },
+      { assertion: assert_first_email_appended },
+      { assertion: assert_first_email_result },
+
+      { action: action_add_second_email },
+      { assertion: assert_second_email_appended },
+      { assertion: assert_second_email_result },
+
+      { action: action_add_phone },
+      { assertion: assert_phone_appended },
+      { assertion: assert_phone_result },
+
+      { action: action_add_with_initial_data },
+      { assertion: assert_initial_data_accepted },
+      { assertion: assert_entries_in_add_order },
+      { assertion: assert_reported_indices_address_their_modules },
+
+      { action: action_add_unknown },
+      { assertion: assert_unknown_type_rejected },
+      { action: action_add_missing_type },
+      { assertion: assert_missing_type_rejected },
+      { action: action_add_notes },
+      { assertion: assert_notes_type_rejected },
+      { assertion: assert_rejections_appended_nothing },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -22,6 +22,7 @@ import {
   safeDateNow,
   SELF,
   str,
+  type Stream,
   toCompactDebugString,
   UI,
   Writable,
@@ -93,6 +94,12 @@ export interface RecordOutput {
   trashedSubPieces?: TrashedSubPieceEntry[] | Default<[]>;
   /** Self-reference for sub-pieces to access their parent Record */
   parentRecord?: RecordOutput | null;
+  /** Adds a module of the named type to this record's sub-pieces. */
+  addModule?: Stream<{
+    type: string;
+    initialData?: Record<string, unknown>;
+    result?: Writable<unknown>;
+  }>;
 }
 
 // ===== Auto-Initialize Notes + TypePicker (Two-Lift Pattern) =====
@@ -629,13 +636,13 @@ const handleAddModule = handler<
   // Capture schema at creation time
   const schema = getResultSchema(piece);
 
-  sc.push({
+  sc.set([...current, {
     type,
     pinned: false,
     collapsed: false,
     piece,
     schema,
-  });
+  }]);
 
   if (result) {
     result.set({

--- a/packages/runner/test/remove-by-value-argument-kind.test.ts
+++ b/packages/runner/test/remove-by-value-argument-kind.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+
+// `removeByValue` and `addUnique` compare by link when handed a cell and by
+// stored-value equality otherwise. An array element that is an object is its
+// own entity, so the stored element is a link: a plain object read back out of
+// `.get()` carries a link but is not a cell, and comparing it against the
+// stored link never matches. The existing coverage in
+// array-push-mergeable.test.ts uses string elements, which store inline, so the
+// value form works there and this distinction does not show up.
+//
+// These cases pin the distinction for object elements, and pin that an element
+// with no deterministic address is still removable through its positional cell.
+// See docs/development/migrating-collection-writes.md.
+
+const signer = await Identity.fromPassphrase("remove-by-value-argument-kind");
+const space = signer.did();
+
+interface Row {
+  name: string;
+}
+
+const rowListSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: { name: { type: "string" } },
+  },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+function withRuntime(
+  cause: string,
+  run: (rt: Runtime) => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    const storage = EmulatedStorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    try {
+      const tx = rt.edit();
+      const seed = rt.getCell<Row[]>(space, cause, rowListSchema, tx);
+      // Appended, so each entity id comes from the append counter rather than
+      // from a key: the shape a collection holds before a keyed migration.
+      seed.push({ name: "alice" });
+      seed.push({ name: "bob" });
+      await tx.commit();
+      await run(rt);
+    } finally {
+      await rt.dispose();
+      await storage.close();
+    }
+  };
+}
+
+describe("removeByValue argument kind, for object elements", () => {
+  it(
+    "a plain object read back from get() removes nothing",
+    withRuntime("value-form", async (rt) => {
+      const tx = rt.edit();
+      const cell = rt.getCell<Row[]>(space, "value-form", rowListSchema, tx);
+      const row = cell.get().find((r) => r.name === "alice");
+      cell.removeByValue(row!);
+      await tx.commit();
+
+      const after = rt.getCell<Row[]>(space, "value-form", rowListSchema).get();
+      expect(after.map((r) => r.name)).toEqual(["alice", "bob"]);
+    }),
+  );
+
+  it(
+    "the element's positional cell removes it",
+    withRuntime("cell-form", async (rt) => {
+      const tx = rt.edit();
+      const cell = rt.getCell<Row[]>(space, "cell-form", rowListSchema, tx);
+      const index = cell.get().findIndex((r) => r.name === "alice");
+      cell.removeByValue(cell.key(index));
+      await tx.commit();
+
+      const after = rt.getCell<Row[]>(space, "cell-form", rowListSchema).get();
+      expect(after.map((r) => r.name)).toEqual(["bob"]);
+    }),
+  );
+
+  it(
+    "a plain object read back from get() is added again by addUnique",
+    withRuntime("add-unique", async (rt) => {
+      const tx = rt.edit();
+      const cell = rt.getCell<Row[]>(space, "add-unique", rowListSchema, tx);
+      const row = cell.get().find((r) => r.name === "alice");
+      cell.addUnique(row!);
+      await tx.commit();
+
+      const after = rt.getCell<Row[]>(space, "add-unique", rowListSchema).get();
+      expect(after.map((r) => r.name)).toEqual(["alice", "bob", "alice"]);
+    }),
+  );
+
+  it(
+    "the element's own cell is deduped by addUnique",
+    withRuntime("add-unique-cell", async (rt) => {
+      const tx = rt.edit();
+      const cell = rt.getCell<Row[]>(
+        space,
+        "add-unique-cell",
+        rowListSchema,
+        tx,
+      );
+      cell.addUnique(cell.key(0));
+      await tx.commit();
+
+      const after = rt.getCell<Row[]>(space, "add-unique-cell", rowListSchema)
+        .get();
+      expect(after.map((r) => r.name)).toEqual(["alice", "bob"]);
+    }),
+  );
+});


### PR DESCRIPTION
Two handlers appended to a list with a mergeable push while depending on the list snapshot they had just read. A push commits as a tail-relative append and drops its own read of the array from conflict detection, which is what lets disjoint appends merge. It carries no condition, and the server resolves it at the durable tail. Neither handler's intent survives that.

The record pattern's add-module handler reads the current sub-piece list and depends on that read twice: getNextUnusedLabel derives the new module's label by scanning the existing entries of the same type, and the handler reports the new module's position to its caller as moduleIndex: current.length. The server appends at the live durable tail, which need not equal current.length when the read was stale or a concurrent add landed, so the reported index can address a different module; and two concurrent adds each scan the same snapshot, so both pick the first unused label. Build the next list from the snapshot the handler already read and write it with set. The new entry then sits at current.length by construction, and the read stays in the commit's conflict set, so a concurrent add rejects this commit and it retries against fresh state and picks the next free label. This is the shape the sibling add-module handler in the same file already uses. The unconditional append in restoreSubPiece stays a push: it reads only the trash list, never the sub-piece list it appends to, so it is a pure append and keeps merging.

The JSX automatic reactivity test adds an item only while the list holds fewer than five entries, and titles each new item from the current count. Both the guard and the title derive from the snapshot, so the same reasoning applies. Its neighbouring remove branch was already a whole-list set over that snapshot, so both branches now write from one read. The pattern is a manual demo with no assertion on the collection write, so this changes how the item is added and not what the demo shows.

Add a note covering the migration itself. The existing collection-write notes describe why the mergeable ops exist and how an element is addressed, but neither covers the change: what to do when a handler already reads a collection and writes to it. Migrations written against those two notes go wrong in a small number of repeated ways, and each of them fails silently, so the migrated code reads as finished and its tests pass.

The note gives a decision guide from what the read is for, since a uniqueness check, a value derived from the list, an independent second write, and an unrelated read have four different remedies, and picking the wrong one is a regression rather than a neutral choice. It then documents the failure that breaks migrations in practice. addUnique and removeByValue compare by link only when the argument is a cell, because they branch on an instanceof check. A value read back out of get() is a query-result proxy: it carries a link, but it is not a cell, so it is compared by deep equality against the array's stored link and never matches. Passing one to removeByValue removes nothing, and passing one to addUnique appends a duplicate, with no diagnostic either way. The same applies to a handler input whose event type names a plain type rather than a cell. The existing notes state the value-versus-link half of this rule but not the cell-versus-link-carrying-value half, which is the half that bites.

The note also records three consequences of that rule that are otherwise found only by hitting them: swapping push for addUnique while keeping the whole-list read silences the compiler without changing the write's behaviour under contention, because the checker inspects push alone; a keyed entity outlives its membership link and must be cleared when the link is dropped, or a later existence check finds the orphan and never restores the membership; and a per-handler legacy fallback cannot remove a legacy element, because a legacy element is exactly the one with no deterministic address, so the fallback leaves a permanent duplicate rather than migrating anything. Finally it notes that a pattern suite starting from an empty collection never runs the branch such a fallback adds, which is why this class of defect passes tests.

Link the note from both existing collection-write documents so it is reachable from either starting point, and add one clause to the AGENTS.md patch-operations entry pointing at the mergeable note, since the two describe the same op family from opposite ends. Keep the AGENTS.md change to that: the shape of an individual migration is what a compiler diagnostic says when it is relevant, and does not belong in the file every agent reads.

Verified by type-checking the workspace, by compiling both patterns through the pattern pipeline, and with check-docs, which type-checks the note's embedded code blocks.

NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-call) = 123s
NEW_PERF_BASELINE: job: CLI Integration Tests (core) = 123s




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced content-dependent `push` appends with single-read `set` writes so derived labels/titles and reported indices are correct under contention. Added a migration guide, linked it from related docs, updated the roster join sample, and added tests (including UI-driven ones) plus a runner test to pin `addUnique`/`removeByValue` cell semantics.

- **Bug Fixes**
  - `record` add-module: build next list from the snapshot and write with `set([...current, entry])` so the new item’s label and reported index match; concurrent adds retry.
  - JSX automatic reactivity demo: switch the guarded append to `set([...current, ...])` so guard and new title read the same snapshot.
  - Map demo and proxy-length repro: use `set([...current, ...])` so titles/colors derived from length match the slot written; map demo `Output` now exposes `[UI]: VNode` to enable tests.

- **Migration**
  - New `docs/development/migrating-collection-writes.md`: decision tree (uniqueness vs derived values vs independent reshapes vs unrelated reads) and pitfalls:
    - `addUnique`/`removeByValue` compare by link only with cells (not proxies); event inputs must be cells to dedup; clear entities when dropping membership; avoid per-handler legacy fallbacks; remove stale whole‑list reads.
  - Linked from `mergeable-collection-writes.md`, `keyed-collection-writes.md`, and `AGENTS.md`. Updated `docs/specs/shared-profile-rosters.md` to a read‑modify‑write `set` for join and explain why keyed `addUnique` doesn’t apply.
  - Tests and docs: added runner test `remove-by-value-argument-kind.test.ts`; added pattern tests for `record`, `map-demo`, and JSX demo that walk the rendered `[UI]` tree and send events to `onClick` streams (inline or bound); updated `docs/common/workflows/pattern-testing.md` with this technique and corrected `docs/development/COVERAGE.md` to note handlers and inline expressions are unit-testable. Declared `addModule` `Stream` in `record` output.

<sup>Written for commit afadb689503b22cbf49903286858a5f1a910bc34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





NEW_PERF_BASELINE: job: Runner Tests (1/5) = 266s
NEW_COVERAGE_BASELINE