### PR TITLE
fuse: correct the kernel-invalidation claims for FUSE-T

### DIFF
--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -264,8 +264,10 @@ Handlers remain writable through the mounted `.handler` file. Both mounted
 ### macOS: NFS client cache tuning
 
 FUSE-T serves the mount through the macOS NFS client, which caches attributes,
-negative name lookups, and directory listings on the client side. FUSE-T ignores
-the cache timeouts the filesystem implementation returns, so without tuning the
+negative name lookups, and directory listings on the client side. Neither lever
+a FUSE filesystem normally has reaches that cache: FUSE-T ignores the cache
+timeouts the filesystem implementation returns, and it returns success for the
+invalidation notifications without acting on them. So without tuning, the
 client's age-based 5-60 second defaults apply: a name that was once looked up
 and not found can keep reporting `NotFound` for up to a minute after the file
 appears daemon-side, and a directory listing can be served stale for tens of
@@ -355,8 +357,15 @@ independently from libfuse. FUSE callbacks are registered via
 subscriptions and FUSE requests run concurrently on Deno's event loop.
 
 Cell data is cached in an in-memory tree (`FsTree`). Subscriptions rebuild
-affected subtrees on cell changes and invalidate the kernel cache via
-`fuse_lowlevel_notify_inval_entry`.
+affected subtrees on cell changes and ask the kernel to drop what it cached for
+them, naming the stale directory entries with `fuse_lowlevel_notify_inval_entry`
+and each stale inode with `fuse_lowlevel_notify_inval_inode`.
+
+Those notifications reach the kernel on Linux. FUSE-T returns success for both
+calls but its NFS backend does not act on either, so a rebuilt subtree stays
+cached on macOS until the NFS client's attribute cache expires. That is what the
+mount's attribute-cache bound is for; see
+[macOS: NFS client cache tuning](#macos-nfs-client-cache-tuning).
 
 Writes are fire-and-forget: the FUSE reply is sent before the cell write
 completes, so subscription rebuilds don't block the callback chain (required to

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -1491,9 +1491,9 @@ export class CellBridge {
     this.hydrationEpochs.set(key, (this.hydrationEpochs.get(key) ?? 0) + 1);
     this.markPiecePropCleared(rootIno, propName);
 
-    // Collect all descendant inodes BEFORE clearing (tree.clear removes them).
-    // FUSE-T doesn't support notify_inval_entry, so we must invalidate each
-    // cached inode individually via notify_inval_inode.
+    // Collect all descendant inodes BEFORE clearing (tree.clear removes
+    // them), so the invalidation below can name every inode whose cached
+    // data is about to go stale, not just the entries under this prop.
     const staleInos: bigint[] = [];
     const propIno = this.tree.lookup(rootIno, propName);
     if (propIno !== undefined) {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -930,11 +930,13 @@ export async function main(argv: string[] = Deno.args) {
     ino: bigint,
     node: ReturnType<typeof tree.getNode>,
   ) {
-    // FUSE-T (macOS NFS translation) ignores notify_inval_entry and
-    // notify_inval_inode, so the only way to ensure reads see fresh data
-    // after writes is to keep cache timeouts short. Piece content inodes
-    // (under pieces/ and entities/) use 0 so every read hits our callbacks.
-    // Static inodes (root, space.json, .status) use 1s.
+    // These timeouts govern the Linux kernel's entry and attribute caches.
+    // Piece content inodes (under pieces/ and entities/) use 0 so every read
+    // hits our callbacks. Static inodes (root, space.json, .status) use 1s.
+    // FUSE-T (macOS NFS translation) ignores the timeouts a reply carries,
+    // along with notify_inval_entry and notify_inval_inode. A macOS mount
+    // bounds staleness with an NFS attribute-cache mount option instead; see
+    // mount-options.ts.
     const isDynamic = bridge?.shouldPrepareDirectory(ino) ||
       bridge?.shouldPrepareLookup(
         tree.parents.get(ino) ?? 0n,
@@ -3293,9 +3295,10 @@ export async function main(argv: string[] = Deno.args) {
                 BigInt(nameBuf.length - 1),
               );
               if (rc === -38) {
-                // ENOSYS — FUSE-T doesn't support notify_inval_entry.
+                // ENOSYS — this libfuse has no entry invalidation. FUSE-T
+                // instead accepts the call and does nothing with it.
                 console.log(
-                  "notify_inval_entry not supported (FUSE-T); relying on short timeouts",
+                  "notify_inval_entry not supported; skipping entry invalidation",
                 );
                 entryNotifySupported = false;
                 break;
@@ -3327,7 +3330,8 @@ export async function main(argv: string[] = Deno.args) {
               -1n,
             );
             if (ret === -38) {
-              // ENOSYS — FUSE-T doesn't support notify_inval_inode.
+              // ENOSYS — this libfuse has no inode invalidation. FUSE-T
+              // instead accepts the call and does nothing with it.
               inodeNotifySupported = false;
               break;
             }

--- a/packages/fuse/mount-options.ts
+++ b/packages/fuse/mount-options.ts
@@ -96,9 +96,10 @@ export function resolveMountCacheOptions(
  * 5-60 second defaults), and attrcache-timeout=N mounts with every
  * attribute-cache bound (the acreg and acdir minima and maxima) fixed at N
  * seconds, which caps how long stale attributes, negative name entries, and
- * directory listings are served. FUSE-T ignores the entry and attribute timeouts the filesystem
- * returns, so these mount options are the only cache controls available on
- * macOS.
+ * directory listings are served. FUSE-T ignores the entry and attribute
+ * timeouts the filesystem returns, and returns success for
+ * notify_inval_entry and notify_inval_inode without acting on either, so
+ * these mount options are the only cache controls available on macOS.
  *
  * When neither flag is given, FUSE-T mounts default to attrcache-timeout=
  * DEFAULT_FUSE_T_ATTRCACHE_TIMEOUT_SECONDS; an explicit value of 0 leaves


### PR DESCRIPTION
The fuse package described two mechanisms for keeping reads fresh that do not work on FUSE-T, which is the recommended macOS provider. The README's architecture section said subscriptions invalidate the kernel cache via notify_inval_entry, while the cache-tuning section a few screens earlier said FUSE-T ignores what the filesystem tells it about caching. Both cannot be true, and the second one is the one the mount default is built on.

Measured on FUSE-T 1.2.7 / macOS 26 against a live mount with debug logging: fuse_lowlevel_notify_inval_entry and
fuse_lowlevel_notify_inval_inode each returned 0 for every call, and never ENOSYS. The notifications are accepted and then dropped. The same mounts served a daemon-side change stale for 3 to 56 seconds, which is the NFS client's attribute cache expiring on its own schedule rather than any invalidation landing. So on FUSE-T neither the reply timeouts nor the notifications reach the client, and the attribute-cache mount option is the only lever, as the cache-tuning section says.

Correct the claims where they are made:

- The README architecture section now says the daemon names both the stale entries and the stale inodes, that this reaches the kernel on Linux, and that on macOS a rebuilt subtree stays cached until the attribute cache expires, pointing at the tuning section.
- The cell-bridge comment above the descendant-inode walk said FUSE-T lacks notify_inval_entry "so we must invalidate each cached inode individually". The premise is wrong and the remedy does not work on FUSE-T either. It now describes what the walk collects and why it runs before the tree is cleared.
- The replyEntry comment said short timeouts are the only way to keep reads fresh. They are, on Linux, which is what the timeouts govern.
- The two ENOSYS branches named FUSE-T as the provider that returns ENOSYS, and one logged "relying on short timeouts" when it fired. On FUSE-T neither branch can fire. They stay as fallbacks for a provider that does report ENOSYS, without naming FUSE-T as that provider.

Comments and documentation only; no behavior changes. The follow-up was first raised in PR #4654.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects `fuse` docs and comments about kernel cache invalidation on macOS FUSE-T. Clarifies that invalidation notifications and reply timeouts don’t affect clients on FUSE-T; staleness is bounded only by the NFS attribute cache. No behavior changes.

- **Bug Fixes**
  - README: explain Linux vs macOS behavior; note FUSE-T accepts but drops `fuse_lowlevel_notify_inval_entry`/`_inode`; link to macOS cache tuning.
  - `cell-bridge.ts`: clarify descendant-inode collection purpose without claiming FUSE-T-specific invalidation.
  - `mod.ts`: note timeouts apply to Linux; make ENOSYS handling generic and adjust log message.
  - `mount-options.ts`: document that FUSE-T ignores reply timeouts and invalidations; attribute-cache mount option is the only lever on macOS.

<sup>Written for commit 3f95521b0f12baf117431ac71db815c154012f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

