### PR TITLE
refactor(runner): remove the vestigial Cell.freeze / isFrozen API

### DIFF
--- a/docs/specs/space-model/4-cells.md
+++ b/docs/specs/space-model/4-cells.md
@@ -58,7 +58,6 @@ Subscription and synchronization:
 
 #### Rarely Used Outside Foundation
 
-- `freeze()`, `isFrozen()`
 - `setInitialValue()`, `setSelfRef()`
 - `connect()`, `export()`
 - `setSchema()` (deprecated)

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -382,8 +382,6 @@ declare module "@commonfabric/api" {
      * register a dependency that could re-trigger the writing computation.
      */
     setRawUntyped(value: FabricValue, onlyIfDifferent?: boolean): void;
-    freeze(reason: string): void;
-    isFrozen(): boolean;
     setSchema(newSchema: JSONSchema): void;
     connect(node: NodeRef): void;
     export(): {
@@ -474,8 +472,6 @@ const cellMethods = new Set<
   "setRaw",
   "setRawUntyped",
   "getArgumentCell",
-  "freeze",
-  "isFrozen",
   "setSchema",
   "connect",
   "export",
@@ -638,8 +634,6 @@ interface CauseContainer {
  */
 export class CellImpl<T extends FabricValue>
   implements ICell<T>, IStreamable<T> {
-  private readOnlyReason: string | undefined;
-
   // Stream-specific fields
   private listeners = new Set<
     (event: AnyCellWrapping<T>) => Cancel | undefined
@@ -2174,14 +2168,6 @@ export class CellImpl<T extends FabricValue>
     const link = parseLink(linkObj, this._link);
     if (link === undefined) return undefined;
     return this.runtime.getCellFromLink(link).asSchema<U>(schema);
-  }
-
-  freeze(reason: string): void {
-    this.readOnlyReason = reason;
-  }
-
-  isFrozen(): boolean {
-    return !!this.readOnlyReason;
   }
 
   getMetaRaw(

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -122,24 +122,6 @@ describe("data-updating", () => {
       expect(changes[0].location.path).toEqual(["b", "c"]);
     });
 
-    // Frozen cells are not freezing the underlying document right now.
-    it.skip("should fail when setting a nested value on a frozen cell", () => {
-      const testCell = runtime.getCell<{ a: number; b: { c: number } }>(
-        space,
-        "should fail when setting a nested value on a frozen cell 1",
-        undefined,
-        tx,
-      );
-      testCell.set({ a: 1, b: { c: 2 } });
-      testCell.freeze("test");
-      expect(() =>
-        diffAndUpdate(runtime, tx, testCell.getAsNormalizedFullLink(), {
-          a: 1,
-          b: { c: 3 },
-        })
-      ).toThrow();
-    });
-
     it("should correctly update with shorter arrays", () => {
       const testCell = runtime.getCell<{ a: number[] }>(
         space,


### PR DESCRIPTION
`Cell.freeze(reason)` and `Cell.isFrozen()` are the leftover shell of a capability that moved elsewhere. Remove them, the `readOnlyReason` field behind them, their `cellMethods` entries, and their interface declarations.

The pair once did something. `freeze()` was enforced inside `DocImpl`, which threw "Cell is read-only: <reason>" from its write path, and it had two real callers in the runner: the inputs handed to an event handler and to a javascript node were frozen so a handler could not write its own inputs. Two later changes retired both halves. CT-497 (#1309) replaced those call sites with `runtime.getImmutableCell()`, which is how the runner states that invariant today (see the two call sites in runner.ts, plus schema.ts). The shim cleanup (#1678) then deleted the `DocImpl` read-only flag and its throw, along with the test that covered it.

What survived was the field and its two accessors on `CellImpl`, with nothing left to enforce them: the whole of `readOnlyReason` was its declaration, the assignment in `freeze()`, and the read in `isFrozen()`. A cell marked with `freeze()` accepted writes through every entry point while `isFrozen()` answered true — the name promised a guarantee that had not existed since the flag was dropped. The API had no callers outside a single skipped test and was never re-exported to pattern authors, so nothing depended on the promise, but it was a trap for the next caller to reach for it by name.

Also removed:

- The skipped test "should fail when setting a nested value on a frozen cell", the API's only caller. It drove `diffAndUpdate` against the cell's link, i.e. document-level freezing, which is what its comment ("not freezing the underlying document right now") described.
- The `freeze()` / `isFrozen()` line from the cells spec, which is live documentation of the current Cell surface.

Dropping the two names from `cellMethods` changes one behavior: that set decides whether a property access on a reactive proxy resolves to a bound cell method or to a data field, so a pattern field named `freeze` or `isFrozen` was previously shadowed by the method and now reads as data.

Note for a later rebase: the unmerged branch claude/nervous-kilby-83b75b builds an enforced write barrier on `readOnlyReason` for the reactive interpreter's read-only cell views. That direction is not being pursued, which is what makes this removal safe; a rebase of that branch will conflict here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the vestigial `Cell.freeze()` and `Cell.isFrozen()` API from the runner. This cleans up a non-enforced flag, updates docs/tests, and stops name shadowing so fields named `freeze` or `isFrozen` on reactive proxies now read as data.

- **Refactors**
  - Remove `Cell.freeze()` / `Cell.isFrozen()`, `readOnlyReason`, related interface declarations, and `cellMethods` entries in `packages/runner/src/cell.ts`.
  - Delete the skipped test that was the only caller.
  - Update the cells spec to drop these methods.

- **Migration**
  - For read-only behavior, use `runtime.getImmutableCell()`.

<sup>Written for commit 1cdbf74113836ee8363bdc50cf227ff369f5f9cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

