### PR TITLE
feat(coverage): collect authored-pattern coverage from integration runs

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -646,10 +646,12 @@ jobs:
       - name: 🛡️ Disable AppArmor for browser tests
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      # These tests run with `deno test`, so they collect V8 runtime coverage
-      # (DENO_COVERAGE_DIR) but not authored-pattern coverage. Pattern coverage
-      # is only collected by `cf test` via CF_PATTERN_COVERAGE_DIR, set on the
-      # pattern-unit-test job. See docs/development/COVERAGE.md.
+      # Both kinds of coverage: V8 runtime coverage via DENO_COVERAGE_DIR, and
+      # authored-pattern coverage via CF_PATTERN_COVERAGE_DIR, which the shell
+      # integration harness reads to turn on the browser worker's collector and
+      # to place the LCOV it pulls back at teardown. Absolute, because the
+      # harness resolves it against a working directory that differs between the
+      # two integration jobs. See docs/development/COVERAGE.md.
       - name: 🧩 Run end-to-end patterns integration tests
         working-directory: packages/patterns
         run: |
@@ -663,6 +665,7 @@ jobs:
           API_URL=http://localhost:8000/ \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
+          CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-integration-${{ matrix.shard }}" \
           DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
@@ -672,12 +675,15 @@ jobs:
         if: always()
         run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/pattern-integration-${{ matrix.shard }} coverage/lcov/pattern-integration-${{ matrix.shard }}.lcov
 
+      # The whole directory: the V8 report plus the authored-pattern LCOV the
+      # harness wrote under pattern-runtime/. perf-check joins every .lcov in
+      # the artifact, so both streams reach the gate.
       - name: 📤 Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-profile-pattern-integration-${{ matrix.shard }}
-          path: coverage/lcov/pattern-integration-${{ matrix.shard }}.lcov
+          path: coverage/lcov/
           retention-days: 90
           if-no-files-found: error
 
@@ -709,16 +715,14 @@ jobs:
       - name: 🛡️ Disable AppArmor for browser tests
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      # These tests run with `deno test`, so they collect V8 runtime coverage
-      # (DENO_COVERAGE_DIR) but not authored-pattern coverage. Pattern coverage
-      # is only collected by `cf test` via CF_PATTERN_COVERAGE_DIR, set on the
-      # pattern-unit-test job. See docs/development/COVERAGE.md.
+      # Both kinds of coverage — see the note on pattern-integration-test above.
       - name: 🧩 Run pattern reload integration tests
         run: |
           mkdir -p test-results
           HEADLESS=1 \
           EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true \
           CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1 \
+          CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-reload" \
           DENO_COVERAGE_DIR=coverage/raw/pattern-reload \
           deno task integration --junit-dir=test-results patterns-reload
 
@@ -726,12 +730,13 @@ jobs:
         if: always()
         run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/pattern-reload coverage/lcov/pattern-reload.lcov
 
+      # The whole directory — see the note on pattern-integration-test above.
       - name: 📤 Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-profile-pattern-reload
-          path: coverage/lcov/pattern-reload.lcov
+          path: coverage/lcov/
           retention-days: 90
           if-no-files-found: error
 

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -164,6 +164,19 @@ before the cached module bytes run. The `pattern-unit-test` job wires both
 coverage-transformed module bytes between runs without mixing them with ordinary
 compiled bytes.
 
+The persistent cell cache stores each module's span list as one JSON string.
+This keeps reporting metadata in one value instead of expanding every span
+object into its own derived storage records. Coverage caches use the
+`pattern-coverage` variant. The cell-cache reader accepts only the JSON string
+representation. A covered closure without valid JSON spans is treated as a
+cache miss, recompiled from source, and written back in the scalar format.
+
+The runner remembers persisted closures for the lifetime of the runner session.
+Each entry is identified by its space, cache variant, entry identity, and
+complete module identity set. It skips another persistence operation for the
+same closure. Concurrent requests for the same closure share one persistence
+operation.
+
 ## How the integration jobs collect authored-pattern coverage
 
 For these jobs coverage is a runtime-level capability rather than a `cf test`

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -34,13 +34,22 @@ transformer pipeline and then run inside a sandbox. Deno's V8 coverage never
 sees the authored pattern statements execute, so it cannot report which lines of
 a pattern ran.
 
-To measure that, the `cf test` command can turn on a separate mechanism. When
-the `CF_PATTERN_COVERAGE_DIR` environment variable is set (or the
-`--pattern-coverage-dir` flag is passed), the `cf test` runner builds a
-`PatternCoverageCollector`. The transformer then injects a coverage "hit" call
-in front of each authored statement, and the collector writes one
-`*.pattern-coverage.lcov` file per test. The line numbers in that file point
-back at the authored pattern source.
+To measure that, a `PatternCoverageCollector` is attached to the runtime. The
+transformer then injects a coverage "hit" call in front of each authored
+statement, and the collector receives the hits; the line numbers it records
+point back at the authored pattern source. There are two ways a runtime gets a
+collector:
+
+- The `cf test` command builds one when the `CF_PATTERN_COVERAGE_DIR`
+  environment variable is set (or the `--pattern-coverage-dir` flag is passed)
+  and writes one `*.pattern-coverage.lcov` file per test. This is the pattern
+  unit path.
+- A runtime constructed with `RuntimeOptions.patternCoverage` set instruments
+  every compile it performs, including the content-addressed cell-cache path a
+  piece load takes. The instrumented compile is keyed as a distinct cached
+  variant, so a coverage-on runtime never serves the uninstrumented bytes an
+  ordinary compile stored. This is how the browser worker collects coverage in
+  the integration path (see below).
 
 These properties of this mechanism are worth keeping in mind:
 
@@ -60,11 +69,13 @@ These properties of this mechanism are worth keeping in mind:
   `NEW_PERF_BASELINE` marker.
   [pattern-testing.md](../common/workflows/pattern-testing.md) shows how.
 
-`CF_PATTERN_COVERAGE_DIR` is read in exactly one place: the `cf test` command in
-`packages/cli/commands/test-command.ts`. A job that runs patterns through a
-plain `deno test` invocation, or by talking to a running Toolshed server, does
-not go through `cf test`. Setting the variable on such a job has no effect at
-all.
+`CF_PATTERN_COVERAGE_DIR` names the directory the `*.pattern-coverage.lcov`
+files are written to. The `cf test` command in
+`packages/cli/commands/test-command.ts` reads it directly. The browser
+integration path does not run through `cf test`; there the integration harness
+reads the same variable to decide whether to turn worker coverage on and where to
+write the merged LCOV it pulls back from the browser (see "How the integration
+jobs collect authored-pattern coverage").
 
 ## How the two feed the coverage gate
 
@@ -78,21 +89,29 @@ directory is excluded from this gate. The counts roll up into
 gates a pull request on them.
 
 Authored pattern files under `packages/patterns` are tracked source files, so
-their uncovered lines count toward `coverage-debt: packages/patterns`. The only
-job that currently feeds covered-line data for those authored files is
-`pattern-unit-test`, because it is the only job that runs patterns through
-`cf test` with `CF_PATTERN_COVERAGE_DIR` set.
+their uncovered lines count toward `coverage-debt: packages/patterns`. Every
+authored-pattern coverage stream feeds this one metric: the `pattern-unit-test`
+job's coverage (`TN:pattern-runtime`) and the integration jobs' coverage
+(`TN:pattern-runtime-integration`) both join the combined LCOV, and a line
+covered by either counts covered. Nothing in the accounting reads the test name —
+the two are kept distinct only so a reader of the combined report can tell what
+covered a line.
 
-One detail of the gate's accounting matters when reasoning about pattern
-coverage. For a tracked file that has any LCOV record, the gate counts only the
-lines named in that record that were never hit. For a tracked file with no LCOV
-record at all, every tracked line counts as uncovered. Pattern instrumentation
-emits a record line only for statements it could instrument, which is a subset
-of the file's lines. So the first time any test produces a pattern-coverage
-record for a previously unrecorded pattern file, that file's uncovered-line
-count drops both because real lines became covered and because the lines the
-instrumentation never names leave the denominator. The second effect is an
-accounting artifact, not new test strength.
+One detail of the gate's accounting is worth knowing when reasoning about
+pattern coverage. A file with no LCOV record has every tracked line counted as
+uncovered. A file with a record is scored against the lines that record names.
+For a file measured by Deno's V8 coverage that is every executable line; pattern
+instrumentation names only the statements it could instrument, so a pattern
+file's first record both covers real lines and drops the never-named lines out of
+the count.
+
+The gate absorbs that safely, because it is a ratchet: it fails a pull request
+only when a group's uncovered count *rises* above the latest `main` baseline.
+Gaining a record can only *lower* a file's count, since the record names a subset
+of the file's lines and the rest stop being counted, so it settles at a lower —
+and therefore stricter — bar rather than failing anything. The instrumented
+statements are also the only lines this mechanism can speak to: a line the
+instrumentation cannot reach is not a line a pattern test could cover.
 
 ## A combined report for IDEs
 
@@ -128,12 +147,13 @@ gsutil cp gs://commontools-build-artifacts/workspace-artifacts/labs-<commit-sha>
 | Job | Runtime (V8) coverage | Authored-pattern coverage |
 | --- | --- | --- |
 | `pattern-unit-test` | yes | yes (`cf test` with `CF_PATTERN_COVERAGE_DIR`) |
-| `pattern-integration-test` | yes | no |
-| `pattern-reload-integration-test` | yes | no |
+| `pattern-integration-test` | yes | yes (browser worker collector) |
+| `pattern-reload-integration-test` | yes | yes (browser worker collector) |
 
 The pattern unit job runs each `packages/patterns/**/*.test.tsx` file through
 `cf test` in-process. The two integration jobs run browser-driven `deno test`
-files against a running Toolshed server.
+files against a running Toolshed server. Both kinds of authored-pattern coverage
+feed the same gated metric.
 
 The compile byte cache is available to `cf test` through
 `CF_COMPILE_CACHE_FILE`. Coverage and non-coverage compiles use different cache
@@ -144,52 +164,98 @@ before the cached module bytes run. The `pattern-unit-test` job wires both
 coverage-transformed module bytes between runs without mixing them with ordinary
 compiled bytes.
 
-## Why the two integration jobs do not set `CF_PATTERN_COVERAGE_DIR`
+## How the integration jobs collect authored-pattern coverage
 
-Adding `CF_PATTERN_COVERAGE_DIR` to `pattern-integration-test` or
-`pattern-reload-integration-test` was considered and deliberately not done, for
-four reasons.
+For these jobs coverage is a runtime-level capability rather than a `cf test`
+one, so the worker never reads `CF_PATTERN_COVERAGE_DIR`. In an integration test
+the pattern's event handlers run in the browser's runtime Web Worker, and that
+worker is constructed with `RuntimeOptions.patternCoverage` on — a
+`patternCoverage` flag on the worker's `InitializationData`, which the
+integration harness sets when `CF_PATTERN_COVERAGE_DIR` is present. Every compile
+the worker performs is then instrumented, including the piece-load path through
+the content-addressed cell cache, whose instrumented variant is keyed apart from
+the ordinary one so the worker never runs uninstrumented bytes.
 
-1. It would do nothing as written. Both jobs run their tests with `deno test`,
-   not `cf test`, and `CF_PATTERN_COVERAGE_DIR` is read only by `cf test`. The
-   variable would sit in the job's environment unread, which is worse than
-   absent because it suggests coverage is being collected when none is.
+Keying the variants apart means a piece an ordinary realm authored has no
+instrumented closure to warm-load. That resume falls back to cold recovery — a
+recompile from the stored source closure, which the runtime instruments like any
+other compile — so the resumed piece reports coverage for the handlers it runs
+rather than reporting nothing. The recovery writes its instrumented bodies back
+under the coverage variant, so later coverage-on sessions warm-load them instead
+of recompiling.
 
-2. Making it work would mean crossing a process boundary. These tests run the
-   pattern inside a sandbox in a headless browser that talks to a separate
-   Toolshed server. The "hit" calls happen in that sandbox, with no in-process
-   collector to receive them and write LCOV. Collecting them would require new
-   plumbing to carry hit data back across the browser and server boundaries.
+The cache-key split has a consequence for the test process too. In a
+browser-driven test that process runs a pieces controller
+(`initializePiecesController`) that creates the space's pieces. When the run
+collects coverage, the controller has to collect it too — and this matters beyond
+its own coverage.
 
-3. It would weaken the pressure the gate puts on test quality. The coverage-debt
-   gate currently rewards focused pattern unit tests, which run in-process,
-   assert on results, and are fast. If broad end-to-end flows counted toward
-   pattern coverage, the gate could be satisfied by incidental execution in an
-   integration test that asserts little, so coverage debt would fall without the
-   matching rise in verification strength.
+Here is why. A coverage-on browser reads the instrumented cache variant. An
+uninstrumented controller writes the ordinary one. So if the controller does not
+instrument, every browser misses what the controller wrote and compiles each
+pattern from scratch for itself. That includes the space-root default pattern,
+which `ensureDefaultPattern` exists to compile exactly once. Each of those
+compiles is synchronous, so it wedges the worker's event loop and stalls
+unrelated IPC — the "second-boot slow window" the lunch-poll vote test describes.
+With the controller uninstrumented, that test ran for 16 minutes and never
+rendered its UI. Once it instruments, the test passes in 7 seconds.
 
-4. It would distort the gate's numbers through the accounting artifact described
-   above. Crediting integration runs would flip many pattern files from the
-   full-file denominator to the narrower instrumented-statement denominator, so
-   reported debt would drop for reasons unrelated to new testing.
+A new browser-driven suite that creates its pieces some other way should expect
+the same trap.
 
-The net effect on metric quality is that crediting integration runs would trade
-a smaller, bounded source of false negatives for a larger source of false
-positives and a less faithful, more gameable gate.
+Getting the hits back out crosses two boundaries: the worker's and the browser's.
+`PatternCoverageCollector.toData()` and `ingest()` give the spans and hit counts a
+plain-JSON form. The worker exposes them over the RuntimeClient IPC
+(`GetPatternCoverage`), and the harness pulls them with `page.evaluate` at
+teardown — one batched dump per page, not a per-hit round trip. Every realm runs
+the same instrumented bytes, so the fileName-plus-span-id keys line up: a realm
+that only warm-loaded already-instrumented bytes reports hits that merge cleanly
+against the realm that compiled them and holds the spans. The harness merges the
+realms' hits and writes one `*.pattern-coverage.lcov` tagged
+`TN:pattern-runtime-integration`, which the job uploads in its
+`coverage-profile-*` artifact.
+
+Integration coverage counts toward the gated `coverage-debt: packages/patterns`
+metric exactly like unit coverage, which means a broad end-to-end flow that runs a
+line without asserting on it lowers the debt. That trade is deliberate. Crediting
+integration coverage only in a separate, never-gated number would score whatever
+an end-to-end flow reaches — a piece assembled across several patterns, a path
+through the shell no unit test drives — as uncovered however well it is
+exercised. Coverage does not measure verification either way (see the properties
+under "Authored pattern code is measured by transformer instrumentation"), so a
+unit test that asserts on what it ran remains the better test; the gate just does
+not treat what an integration test covers as worthless.
+
+A span's file name is whatever the realm that compiled it called the module, and
+that arrives in two shapes. A pattern the controller resolved off disk is named
+relative to the patterns root (`/lunch-poll/main.tsx`), because that is the root
+the resolver was given. A pattern the worker fetched over HTTP is named by its URL
+pathname (`/api/patterns/system/default-app.tsx`), because Toolshed's pattern
+identity is computed over pathname-prefixed names. Stripping the route prefix maps
+the second shape onto the first, and both then resolve against the patterns root.
+
+That rename runs when the report is written rather than as each realm reports,
+because the realms do not all arrive the same way: the browser dumps are ingested,
+but a runtime this process runs registers its spans into the shared collector
+directly, as it compiles. Renaming on the way in silently covers only the first
+kind. A record naming a file that is not in the checkout is the failure mode to
+watch for — the gate matches records against the files it walked, so such a record
+matches nothing and drops its coverage without complaining, which looks exactly
+like a pattern nobody tested. Writing one warns.
 
 ## Known limitations and possible future work
 
-- False negatives exist today. A pattern line that only an integration test
-  exercises is counted as uncovered, because no integration job collects pattern
-  coverage. This understates true coverage for the patterns that are reachable
-  only through end-to-end flows. The trade is deliberate: the alternative above
-  inflates the numbers more than this understates them.
+- Only the browser-driven suites contribute. A pattern exercised solely through
+  the headless multi-runtime harness (`multi-runtime-harness.ts`), whose sessions
+  are Deno workers rather than pages, has nowhere for the teardown dump to run and
+  contributes nothing. Those sessions could write their own LCOV directly — they
+  are Deno realms with a filesystem — which is the natural way to extend this.
 
-- The record-versus-no-record denominator difference is a pre-existing property
-  of the gate, not specific to integration jobs. If pattern coverage is ever
-  expanded, normalizing the denominator (always scoring a pattern file against
-  the same line set whether or not it has a record) would make the numbers
-  easier to trust.
+- Integration coverage is not a reason to skip a unit test. A unit test can cover
+  a handler body too (see the handler bullet above) and can assert on what the
+  handler did, which coverage never checks. Integration coverage only removes the
+  case where a line no unit test happens to drive would otherwise read as
+  untested.
 
 ## Related documentation
 
@@ -200,4 +266,4 @@ positives and a less faithful, more gameable gate.
   request on the metrics described here.
 - [../common/workflows/pattern-testing.md](../common/workflows/pattern-testing.md)
   — writing the pattern unit tests that the `pattern-unit-test` job runs through
-  `cf test`, which is the only source of authored-pattern coverage.
+  `cf test`, the source of the gated authored-pattern coverage.

--- a/packages/integration/deno.jsonc
+++ b/packages/integration/deno.jsonc
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./index.ts",
     "./shell-utils": "./shell-utils.ts",
+    "./pattern-coverage": "./pattern-coverage.ts",
     "./temp-identity": "./temp-identity.ts",
     "./wait-for-cell-value": "./wait-for-cell-value.ts"
   }

--- a/packages/integration/pattern-coverage.test.ts
+++ b/packages/integration/pattern-coverage.test.ts
@@ -1,0 +1,69 @@
+import { assert, assertEquals } from "@std/assert";
+import { resolve } from "@std/path";
+import type { PatternCoverageSpan } from "@commonfabric/runner";
+import { PATTERNS_ROOT, withRepositoryFileNames } from "./pattern-coverage.ts";
+
+const span = (fileName: string): PatternCoverageSpan => ({
+  fileName,
+  id: 1,
+  kind: "runtime",
+  startLine: 1,
+  endLine: 1,
+  startColumn: 1,
+  endColumn: 2,
+});
+
+// A worker reports two shapes of file name, depending on how the pattern reached
+// it, and the gate only credits a line if its `SF:` path matches the file the
+// source walk found. So resolve each shape the way the LCOV writer will and
+// check it lands on a file that actually exists — a mapping that is merely
+// plausible produces a path nothing matches, and the coverage silently
+// evaporates rather than failing anything.
+Deno.test("worker span file names resolve onto real pattern files", async () => {
+  const cases = [
+    {
+      label: "fetched over HTTP, named by URL pathname",
+      reported: "/api/patterns/system/default-app.tsx",
+      expected: "/system/default-app.tsx",
+      file: "system/default-app.tsx",
+    },
+    {
+      label: "resolved from disk, named relative to the patterns root",
+      reported: "/lunch-poll/main.tsx",
+      expected: "/lunch-poll/main.tsx",
+      file: "lunch-poll/main.tsx",
+    },
+  ];
+
+  for (const { label, reported, expected, file } of cases) {
+    const mapped = withRepositoryFileNames({
+      spans: [span(reported)],
+      hits: [{ fileName: reported, id: 1, count: 1 }],
+    });
+    assertEquals(mapped.spans[0].fileName, expected, label);
+    // The hits must be renamed with the spans; a hit left under the old name
+    // would key against nothing and report the line uncovered.
+    assertEquals(mapped.hits[0].fileName, expected, label);
+
+    // This is what `writePatternCoverageLcov({ root: PATTERNS_ROOT })` emits.
+    const sourcePath = resolve(
+      PATTERNS_ROOT,
+      mapped.spans[0].fileName.slice(1),
+    );
+    assertEquals(sourcePath, resolve(PATTERNS_ROOT, file), label);
+    assert(
+      (await Deno.stat(sourcePath)).isFile,
+      `${label}: ${sourcePath} is not a file in this checkout`,
+    );
+  }
+});
+
+Deno.test("a name that is not under the patterns route is left alone", () => {
+  // Fabric mounts carry their own identity-based path and are reported as-is.
+  const mounted = "/~cf/abc123/main.tsx";
+  const mapped = withRepositoryFileNames({
+    spans: [span(mounted)],
+    hits: [{ fileName: mounted, id: 1, count: 1 }],
+  });
+  assertEquals(mapped.spans[0].fileName, mounted);
+});

--- a/packages/integration/pattern-coverage.ts
+++ b/packages/integration/pattern-coverage.ts
@@ -1,0 +1,197 @@
+/**
+ * Authored-pattern coverage for the browser-driven integration suites.
+ *
+ * The pattern's statements execute in the shell's runtime Web Worker, which has
+ * no filesystem, so the hits have to come back across two boundaries before this
+ * process can write LCOV: the worker's (a `GetPatternCoverage` request) and the
+ * browser's (a `page.evaluate`). Both are crossed once per page at teardown —
+ * the worker accumulates hits locally and hands over the whole report, rather
+ * than reporting each hit as it happens.
+ *
+ * See docs/development/COVERAGE.md.
+ */
+import { fromFileUrl, join, resolve } from "@std/path";
+import {
+  PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
+  PatternCoverageCollector,
+  type PatternCoverageData,
+  writePatternCoverageLcov,
+} from "@commonfabric/runner";
+import type { Page } from "./page.ts";
+// Declares the `commonfabric` page global the dump below reads.
+import "../shell/src/globals.ts";
+
+/**
+ * The authored patterns' root. Span file names are relative to it, so it is what
+ * turns them back into repository paths the coverage gate can match against its
+ * source walk. Resolved from this module rather than the working directory,
+ * which differs between the two integration jobs.
+ */
+export const PATTERNS_ROOT: string = fromFileUrl(
+  new URL("../patterns", import.meta.url),
+);
+
+/**
+ * The URL prefix Toolshed serves patterns under (PATTERNS_ROUTE_PREFIX in
+ * packages/toolshed/routes/patterns/patterns-server.ts). A pattern the worker
+ * fetched over HTTP is named by its URL pathname, so its spans carry this
+ * prefix; a pattern resolved from disk by the test process is named relative to
+ * the patterns root already. Stripping the prefix maps the first shape onto the
+ * second, and both then resolve against PATTERNS_ROOT.
+ */
+const PATTERNS_ROUTE_PREFIX = "/api/patterns/";
+
+/**
+ * Every page's hits merge here. Realms share one span-id keyspace — they run the
+ * same instrumented bytes, which carry the file name and span id of whichever
+ * realm compiled them — so a page that only warm-loaded bytes still reports hits
+ * that land on another page's spans.
+ */
+const collector = new PatternCoverageCollector();
+
+/** Where to write the LCOV, or undefined when this run collects no coverage. */
+export function patternCoverageDir(): string | undefined {
+  const dir = Deno.env.get("CF_PATTERN_COVERAGE_DIR");
+  return dir ? resolve(Deno.cwd(), dir) : undefined;
+}
+
+/**
+ * The collector for a runtime this test process runs itself, or undefined when
+ * the run collects no coverage. It is the same collector the browser dumps merge
+ * into, so both realms' hits reach one report.
+ *
+ * Handing this to a pieces controller matters for more than its own coverage:
+ * the pieces it creates are stored under the instrumented cached variant, so a
+ * browser collecting coverage against that space warm-loads them. Without it
+ * every browser misses the ordinary variant and cold-compiles each pattern —
+ * including the space-root default pattern that `ensureDefaultPattern` exists to
+ * compile once — which wedges each worker's event loop for seconds.
+ */
+export function patternCoverageCollector():
+  | PatternCoverageCollector
+  | undefined {
+  return patternCoverageDir() === undefined ? undefined : collector;
+}
+
+/** One file per test process; `deno test` runs a shard's files in one process. */
+function outputPath(dir: string): string {
+  return join(dir, `pattern-integration-${Deno.pid}.pattern-coverage.lcov`);
+}
+
+export function withRepositoryFileNames(
+  data: PatternCoverageData,
+): PatternCoverageData {
+  const rename = (fileName: string) =>
+    fileName.startsWith(PATTERNS_ROUTE_PREFIX)
+      ? `/${fileName.slice(PATTERNS_ROUTE_PREFIX.length)}`
+      : fileName;
+  return {
+    spans: data.spans.map((span) => ({
+      ...span,
+      fileName: rename(span.fileName),
+    })),
+    hits: data.hits.map((hit) => ({ ...hit, fileName: rename(hit.fileName) })),
+  };
+}
+
+/**
+ * Turn on worker pattern coverage for this page. Read before the worker runtime
+ * is constructed (at login), so this must run after navigation and before the
+ * page logs in. A no-op unless the run collects coverage.
+ */
+export async function enablePatternCoverage(page: Page): Promise<void> {
+  if (patternCoverageDir() === undefined) return;
+  await page.evaluate(() => {
+    globalThis.localStorage.setItem("patternCoverage", "true");
+  });
+}
+
+/**
+ * Pull one page's accumulated hits and rewrite the merged LCOV. Must run before
+ * the page's runtime is disposed, which takes the worker's collector with it.
+ *
+ * Best-effort: a page that never booted a runtime, or whose worker is already
+ * gone, contributes nothing rather than failing the test it is tearing down.
+ * Rewriting the whole merged report on every dump keeps the file complete
+ * without needing a process-exit hook.
+ */
+export async function collectPatternCoverage(page: Page): Promise<void> {
+  const dir = patternCoverageDir();
+  if (dir === undefined) return;
+
+  // `noRuntime` and a null report are different failures: the first is a page
+  // that never booted a runtime (nothing to collect, and normal), the second is
+  // a worker built without a collector — i.e. the flag above never reached it,
+  // which would otherwise look exactly like a pattern that ran no lines.
+  let result: { noRuntime: true } | { data: PatternCoverageData | null };
+  try {
+    result = await page.evaluate(async () => {
+      const rt = globalThis.commonfabric?.rt;
+      if (!rt?.getPatternCoverage) return { noRuntime: true as const };
+      return { data: await rt.getPatternCoverage() };
+    }) as { noRuntime: true } | { data: PatternCoverageData | null };
+  } catch {
+    return;
+  }
+  if ("noRuntime" in result) return;
+
+  const data = result.data;
+  if (data === null) {
+    console.warn(
+      "[pattern-coverage] CF_PATTERN_COVERAGE_DIR is set but this page's " +
+        "worker was built without a collector, so its pattern coverage is " +
+        "lost. The host flag did not reach the worker's InitializationData.",
+    );
+    return;
+  }
+  if (data.spans.length === 0) return;
+
+  collector.ingest(data);
+  await writeMergedPatternCoverage(dir);
+}
+
+/**
+ * Write every realm's hits as one LCOV.
+ *
+ * The rename happens here rather than as each realm reports, because the realms
+ * do not all arrive through `ingest`: a runtime this process runs registers its
+ * spans into the shared collector directly, as it compiles. Renaming on the way
+ * in would cover the browser dumps and miss those.
+ */
+async function writeMergedPatternCoverage(dir: string): Promise<void> {
+  const renamed = new PatternCoverageCollector();
+  renamed.ingest(withRepositoryFileNames(collector.toData()));
+  await writePatternCoverageLcov(renamed, outputPath(dir), {
+    root: PATTERNS_ROOT,
+    testName: PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
+  });
+  await warnOnUnmappedRecords(outputPath(dir));
+}
+
+/**
+ * Report any record whose source path does not exist in the checkout. The gate
+ * matches records to files it walked, so such a record is not wrong-looking —
+ * it simply matches nothing, and the coverage it carries is dropped silently.
+ * Synthetic `cf-mount/` paths name a mounted module by identity and have no
+ * file to find, so they are not checked.
+ */
+async function warnOnUnmappedRecords(lcovPath: string): Promise<void> {
+  const paths = (await Deno.readTextFile(lcovPath))
+    .split("\n")
+    .filter((line) => line.startsWith("SF:"))
+    .map((line) => line.slice(3))
+    .filter((path) => path.startsWith("/"));
+
+  const missing: string[] = [];
+  for (const path of paths) {
+    if (!await Deno.stat(path).then((s) => s.isFile).catch(() => false)) {
+      missing.push(path);
+    }
+  }
+  if (missing.length === 0) return;
+  console.warn(
+    `[pattern-coverage] ${missing.length} record(s) name a file that is not ` +
+      `in this checkout, so the gate will not credit their coverage:\n` +
+      missing.map((path) => `  ${path}`).join("\n"),
+  );
+}

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -22,6 +22,10 @@ import {
   isAppViewEqual,
 } from "@commonfabric/shell/shared";
 import { waitFor } from "./utils.ts";
+import {
+  collectPatternCoverage,
+  enablePatternCoverage,
+} from "./pattern-coverage.ts";
 import { ConsoleEvent, PageErrorEvent } from "@astral/astral";
 
 import "../shell/src/globals.ts";
@@ -257,6 +261,10 @@ export class ShellIntegration {
     const page = this.page();
     await page.goto(url);
     await page.applyConsoleFormatter();
+    // The worker runtime reads this when it is constructed, at login, so it has
+    // to be set after the page has an origin to store it against and before the
+    // login below.
+    await enablePatternCoverage(page);
     await this.waitForState({ view });
     if (identity) {
       await this.login(identity);
@@ -312,6 +320,9 @@ export class ShellIntegration {
   #afterAll = async () => {
     if (this.#page) {
       await getPresentationSession()?.close(this.#page);
+      // Before disposing: the worker owns the collector, and disposing the
+      // runtime takes it with it.
+      await collectPatternCoverage(this.#page);
     }
     await this.#disposePageRuntime();
     await this.#page?.close();

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -159,6 +159,12 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    */
   forwardWorkerConsole?: boolean;
   /**
+   * When true, the worker runtime instruments pattern compiles for statement
+   * coverage; the integration harness pulls the accumulated hits at teardown.
+   * Test/CI only, off by default. See docs/development/COVERAGE.md.
+   */
+  patternCoverage?: boolean;
+  /**
    * Override the runtime worker URL. By default, deployed builds use the
    * immutable `/builds/<clientVersion>/` asset namespace while local builds
    * fall back to `/scripts/worker-runtime.js`.
@@ -246,6 +252,7 @@ export function createRuntimeClientOptions({
   trustSnapshot,
   clientVersion,
   forwardWorkerConsole,
+  patternCoverage,
 }: {
   session: Session;
   apiUrl: URL;
@@ -257,6 +264,7 @@ export function createRuntimeClientOptions({
   trustSnapshot?: RuntimeTrustSnapshot | null;
   clientVersion?: string;
   forwardWorkerConsole?: boolean;
+  patternCoverage?: boolean;
 }) {
   const resolvedTrustSnapshot = trustSnapshot === undefined
     ? {
@@ -286,6 +294,7 @@ export function createRuntimeClientOptions({
     trustSnapshot: resolvedTrustSnapshot,
     clientVersion,
     forwardWorkerConsole,
+    patternCoverage,
   };
 }
 
@@ -656,6 +665,7 @@ export class RuntimeInternals extends EventTarget {
     trustSnapshot,
     clientVersion,
     forwardWorkerConsole,
+    patternCoverage,
     getBuildHash = fetchBuildHash,
     workerUrl,
     navigate,
@@ -714,6 +724,7 @@ export class RuntimeInternals extends EventTarget {
         trustSnapshot,
         clientVersion,
         forwardWorkerConsole,
+        patternCoverage,
       }),
     );
 

--- a/packages/patterns/integration/pieces-controller.ts
+++ b/packages/patterns/integration/pieces-controller.ts
@@ -1,5 +1,6 @@
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { createCompileByteCache } from "@commonfabric/test-support/compile-byte-cache";
+import { patternCoverageCollector } from "@commonfabric/integration/pattern-coverage";
 
 export { PieceController, PiecesController };
 
@@ -10,10 +11,18 @@ type InitializePiecesControllerOptions = Parameters<
 export const moduleByteCache = createCompileByteCache();
 
 export function initializePiecesController(
-  options: Omit<InitializePiecesControllerOptions, "moduleByteCache">,
+  options: Omit<
+    InitializePiecesControllerOptions,
+    "moduleByteCache" | "patternCoverage"
+  >,
 ): Promise<PiecesController> {
   return PiecesController.initialize({
     ...options,
     moduleByteCache,
+    // Off unless the run collects coverage. When it does, this controller must
+    // collect too: it authors the space's pieces, and a browser that collects
+    // coverage reads a different cached variant than an uninstrumented
+    // controller writes, so it would recompile every pattern for itself.
+    patternCoverage: patternCoverageCollector(),
   });
 }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -9,6 +9,7 @@ import {
   type JSONSchema,
   type MemorySpace,
   type ModuleByteCache,
+  type PatternCoverageCollector,
   Runtime,
   runtimePresets,
   RuntimeProgram,
@@ -204,15 +205,23 @@ export class PiecesController<T = unknown> {
     }
   }
 
-  static async initialize({ apiUrl, identity, spaceName, moduleByteCache }: {
-    apiUrl: URL;
-    identity: Identity;
-    spaceName: string;
-    // Optional compiled-module-byte cache to share across controllers. Supplied
-    // only by test code (see the integration suite's compile-byte-cache helper);
-    // unset in production, so no cache is installed.
-    moduleByteCache?: ModuleByteCache;
-  }): Promise<PiecesController> {
+  static async initialize(
+    { apiUrl, identity, spaceName, moduleByteCache, patternCoverage }: {
+      apiUrl: URL;
+      identity: Identity;
+      spaceName: string;
+      // Optional compiled-module-byte cache to share across controllers. Supplied
+      // only by test code (see the integration suite's compile-byte-cache helper);
+      // unset in production, so no cache is installed.
+      moduleByteCache?: ModuleByteCache;
+      // Collect statement coverage for the patterns this controller compiles.
+      // Test/CI only. Beyond the coverage itself, this decides which cached
+      // variant the pieces it creates are stored under, so a browser collecting
+      // coverage against the same space warm-loads them instead of recompiling
+      // every pattern for itself.
+      patternCoverage?: PatternCoverageCollector;
+    },
+  ): Promise<PiecesController> {
     const session = await createSession({ identity, spaceName });
     // Shared first-party posture for client runtimes against a deployed API
     // (CT-1814); the CFC pin this site previously restated lives in the
@@ -226,6 +235,7 @@ export class PiecesController<T = unknown> {
       }),
       experimental: experimentalOptionsFromEnv(readEnv),
       moduleByteCache,
+      patternCoverage,
       trustSnapshotProvider: () => ({
         id: `principal:${session.as.did()}`,
         actingPrincipal: session.as.did(),

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import { CFC_COMPILED_BY_ATOM } from "@commonfabric/api/cfc";
+import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 import { computeModuleHashes } from "../harness/module-identity.ts";
 import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
 import { deriveModuleRecordFields } from "../sandbox/module-record-compiler.ts";
@@ -89,6 +90,15 @@ export interface CompiledDoc extends ModuleDocBase {
   readonly starTargetSpecs?: readonly string[];
   readonly importSpecs?: readonly string[];
   readonly policyManifests?: readonly unknown[];
+  /**
+   * Authored-line spans for the coverage probes the transformer baked into
+   * `code`, keyed by `(fileName, id)`. Present only on documents written by a
+   * coverage-instrumented compile, which store under their own runtime-version
+   * variant (`<runtimeVersion>/pattern-coverage`), so an ordinary document never
+   * carries them. A collector maps a probe's `(fileName, id)` back to source
+   * lines through these spans; a warm load that registers none reports nothing.
+   */
+  readonly patternCoverageSpans?: readonly PatternCoverageSpan[];
 }
 
 /**
@@ -711,6 +721,27 @@ export async function loadVerifiedSourceClosure(
  */
 export const COMPILED_INTEGRITY_ATOM: string = CFC_COMPILED_BY_ATOM;
 
+/**
+ * Schema for one {@link PatternCoverageSpan} on a compiled document. Shared by
+ * the write and read schemas so a span field can never be written under one
+ * shape and filtered out under the other.
+ */
+const patternCoverageSpansSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      fileName: { type: "string" },
+      id: { type: "number" },
+      kind: { type: "string" },
+      startLine: { type: "number" },
+      endLine: { type: "number" },
+      startColumn: { type: "number" },
+      endColumn: { type: "number" },
+    },
+  },
+} as const;
+
 const compiledDocProperties = {
   kind: { type: "string" },
   identity: { type: "string" },
@@ -720,6 +751,7 @@ const compiledDocProperties = {
   exportNames: { type: "array", items: { type: "string" } },
   starTargetSpecs: { type: "array", items: { type: "string" } },
   importSpecs: { type: "array", items: { type: "string" } },
+  patternCoverageSpans: patternCoverageSpansSchema,
   policyManifests: {
     type: "array",
     items: { type: "object", additionalProperties: true },
@@ -755,6 +787,7 @@ export const COMPILED_DOC_SCHEMA = {
         exportNames: { type: "array", items: { type: "string" } },
         starTargetSpecs: { type: "array", items: { type: "string" } },
         importSpecs: { type: "array", items: { type: "string" } },
+        patternCoverageSpans: patternCoverageSpansSchema,
         policyManifests: {
           type: "array",
           items: { type: "object", additionalProperties: true },
@@ -796,8 +829,50 @@ interface StoredCompiledDoc {
   exportNames?: readonly string[];
   starTargetSpecs?: readonly string[];
   importSpecs?: readonly string[];
+  patternCoverageSpans?: readonly PatternCoverageSpan[];
   policyManifests?: readonly unknown[];
   imports: { specifier: string; link: unknown }[];
+}
+
+/**
+ * The coverage spans stored on a compiled document, snapshotted off the
+ * transaction and shape-checked. Yields `undefined` for a document written
+ * without spans, and for a stored value that does not match the span shape —
+ * the load then carries no spans for that module, and the collector reports no
+ * lines for it rather than reporting against malformed coordinates. Spans are
+ * a reporting aid, never an execution input, so a rejection here cannot affect
+ * what the module does.
+ */
+function storedCoverageSpans(
+  stored: unknown,
+): readonly PatternCoverageSpan[] | undefined {
+  if (stored === undefined) return undefined;
+  const spans = snapshotQueryResult(stored);
+  if (!Array.isArray(spans)) return undefined;
+  const out: PatternCoverageSpan[] = [];
+  for (const span of spans) {
+    if (!isRecord(span)) return undefined;
+    const { fileName, id, kind, startLine, endLine, startColumn, endColumn } =
+      span;
+    if (
+      typeof fileName !== "string" || typeof id !== "number" ||
+      kind !== "runtime" || typeof startLine !== "number" ||
+      typeof endLine !== "number" || typeof startColumn !== "number" ||
+      typeof endColumn !== "number"
+    ) {
+      return undefined;
+    }
+    out.push({
+      fileName,
+      id,
+      kind,
+      startLine,
+      endLine,
+      startColumn,
+      endColumn,
+    });
+  }
+  return out;
 }
 
 /** Whether a cell's persisted CFC label carries `atom` at its root path. */
@@ -882,6 +957,9 @@ export function writeCompiledDocs(
         ...(module.sourceMap !== undefined
           ? { sourceMap: module.sourceMap }
           : {}),
+        ...(module.patternCoverageSpans === undefined
+          ? {}
+          : { patternCoverageSpans: module.patternCoverageSpans }),
         ...(policyManifests === undefined ? {} : { policyManifests }),
         imports: storedImportRefs(module, entryIdentity, extraRoots, {
           includeFabricEdges: true,
@@ -974,6 +1052,11 @@ export async function loadCompiledClosure(
     if (visited.has(doc.identity)) continue;
     visited.add(doc.identity);
 
+    // Detach the spans from the transaction: the callers abort their read tx
+    // before the closure is consumed, and a collector holds registered spans for
+    // the life of the process.
+    const coverageSpans = storedCoverageSpans(doc.patternCoverageSpans);
+
     const imports: ModuleImportRef[] = [];
     for (const imp of doc.imports ?? []) {
       if (!isCell(imp.link)) continue;
@@ -1001,6 +1084,9 @@ export async function loadCompiledClosure(
       ...(doc.importSpecs !== undefined
         ? { importSpecs: doc.importSpecs }
         : {}),
+      ...(coverageSpans === undefined
+        ? {}
+        : { patternCoverageSpans: coverageSpans }),
       ...(doc.policyManifests !== undefined
         ? { policyManifests: doc.policyManifests }
         : {}),

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -94,9 +94,10 @@ export interface CompiledDoc extends ModuleDocBase {
    * Authored-line spans for the coverage probes the transformer baked into
    * `code`, keyed by `(fileName, id)`. Present only on documents written by a
    * coverage-instrumented compile, which store under their own runtime-version
-   * variant (`<runtimeVersion>/pattern-coverage`), so an ordinary document never
-   * carries them. A collector maps a probe's `(fileName, id)` back to source
-   * lines through these spans; a warm load that registers none reports nothing.
+   * variant (`<runtimeVersion>/pattern-coverage`), so an ordinary
+   * document never carries them. A collector maps a probe's `(fileName, id)`
+   * back to source lines through these spans; a warm load that registers none
+   * reports nothing.
    */
   readonly patternCoverageSpans?: readonly PatternCoverageSpan[];
 }
@@ -721,27 +722,6 @@ export async function loadVerifiedSourceClosure(
  */
 export const COMPILED_INTEGRITY_ATOM: string = CFC_COMPILED_BY_ATOM;
 
-/**
- * Schema for one {@link PatternCoverageSpan} on a compiled document. Shared by
- * the write and read schemas so a span field can never be written under one
- * shape and filtered out under the other.
- */
-const patternCoverageSpansSchema = {
-  type: "array",
-  items: {
-    type: "object",
-    properties: {
-      fileName: { type: "string" },
-      id: { type: "number" },
-      kind: { type: "string" },
-      startLine: { type: "number" },
-      endLine: { type: "number" },
-      startColumn: { type: "number" },
-      endColumn: { type: "number" },
-    },
-  },
-} as const;
-
 const compiledDocProperties = {
   kind: { type: "string" },
   identity: { type: "string" },
@@ -751,7 +731,7 @@ const compiledDocProperties = {
   exportNames: { type: "array", items: { type: "string" } },
   starTargetSpecs: { type: "array", items: { type: "string" } },
   importSpecs: { type: "array", items: { type: "string" } },
-  patternCoverageSpans: patternCoverageSpansSchema,
+  patternCoverageSpansJson: { type: "string" },
   policyManifests: {
     type: "array",
     items: { type: "object", additionalProperties: true },
@@ -787,7 +767,7 @@ export const COMPILED_DOC_SCHEMA = {
         exportNames: { type: "array", items: { type: "string" } },
         starTargetSpecs: { type: "array", items: { type: "string" } },
         importSpecs: { type: "array", items: { type: "string" } },
-        patternCoverageSpans: patternCoverageSpansSchema,
+        patternCoverageSpansJson: { type: "string" },
         policyManifests: {
           type: "array",
           items: { type: "object", additionalProperties: true },
@@ -829,25 +809,30 @@ interface StoredCompiledDoc {
   exportNames?: readonly string[];
   starTargetSpecs?: readonly string[];
   importSpecs?: readonly string[];
-  patternCoverageSpans?: readonly PatternCoverageSpan[];
+  patternCoverageSpansJson?: string;
   policyManifests?: readonly unknown[];
   imports: { specifier: string; link: unknown }[];
 }
 
 /**
- * The coverage spans stored on a compiled document, snapshotted off the
- * transaction and shape-checked. Yields `undefined` for a document written
- * without spans, and for a stored value that does not match the span shape —
- * the load then carries no spans for that module, and the collector reports no
- * lines for it rather than reporting against malformed coordinates. Spans are
- * a reporting aid, never an execution input, so a rejection here cannot affect
- * what the module does.
+ * The coverage spans stored as scalar JSON on a compiled document, parsed and
+ * shape-checked. Yields `undefined` for a document written without spans, and
+ * for a stored value that does not match the span shape. The load then carries
+ * no spans for that module, and the collector reports no lines for it rather
+ * than reporting against malformed coordinates. Spans are a reporting aid,
+ * never an execution input, so a rejection here cannot affect what the module
+ * does.
  */
 function storedCoverageSpans(
   stored: unknown,
 ): readonly PatternCoverageSpan[] | undefined {
-  if (stored === undefined) return undefined;
-  const spans = snapshotQueryResult(stored);
+  if (typeof stored !== "string") return undefined;
+  let spans: unknown;
+  try {
+    spans = JSON.parse(stored);
+  } catch {
+    return undefined;
+  }
   if (!Array.isArray(spans)) return undefined;
   const out: PatternCoverageSpan[] = [];
   for (const span of spans) {
@@ -957,9 +942,11 @@ export function writeCompiledDocs(
         ...(module.sourceMap !== undefined
           ? { sourceMap: module.sourceMap }
           : {}),
-        ...(module.patternCoverageSpans === undefined
-          ? {}
-          : { patternCoverageSpans: module.patternCoverageSpans }),
+        ...(module.patternCoverageSpans === undefined ? {} : {
+          patternCoverageSpansJson: JSON.stringify(
+            module.patternCoverageSpans,
+          ),
+        }),
         ...(policyManifests === undefined ? {} : { policyManifests }),
         imports: storedImportRefs(module, entryIdentity, extraRoots, {
           includeFabricEdges: true,
@@ -1055,7 +1042,9 @@ export async function loadCompiledClosure(
     // Detach the spans from the transaction: the callers abort their read tx
     // before the closure is consumed, and a collector holds registered spans for
     // the life of the process.
-    const coverageSpans = storedCoverageSpans(doc.patternCoverageSpans);
+    const coverageSpans = storedCoverageSpans(
+      doc.patternCoverageSpansJson,
+    );
 
     const imports: ModuleImportRef[] = [];
     for (const imp of doc.imports ?? []) {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -21,6 +21,7 @@ import type {
 import { InMemoryProgram } from "@commonfabric/js-compiler/program";
 import type { PatternCoverageOptions } from "@commonfabric/ts-transformers";
 import {
+  findFirstContentLineIndex,
   PATTERN_COVERAGE_GLOBAL,
   sourceDisablesCfTransform,
 } from "@commonfabric/ts-transformers/runtime-contract";
@@ -721,6 +722,7 @@ export class Engine extends EventTarget implements Harness {
     entryFilename: string,
     options: {
       fabricImports?: TypeScriptHarnessProcessOptions["fabricImports"];
+      patternCoverage?: PatternCoverageCollector;
     } = {},
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }> {
     const { compiler } = await this.getCompilerInternals();
@@ -787,12 +789,25 @@ export class Engine extends EventTarget implements Harness {
       mounts,
     );
 
+    // Instrumenting does not disturb the identity check below: identity hashes
+    // the authored source, not the emitted JS. The paths here are prefix-free,
+    // so coverage names them without an `/<id>` prefix to strip.
+    const patternCoverage = patternCoverageOptionsForCompile(
+      options.patternCoverage,
+      {
+        id: undefined,
+        mounts,
+        sourceFiles: pristineModuleFiles,
+      },
+    );
+
     const emitted = compiler.compileToModules(resolvedForCompile, {
       runtimeModules: Engine.runtimeModuleNames(),
       specifierAliases,
       beforeTransformers: (program) => {
         const pipeline = new (compilerStack()
           .CommonFabricTransformerPipeline)({
+          patternCoverage,
           moduleIdentities: identityByPath,
         });
         return {
@@ -817,6 +832,11 @@ export class Engine extends EventTarget implements Harness {
     const modules: CacheableModule[] = pristineModuleFiles.map((file) => {
       const out = emitted.get(file.name)!;
       const identity = identityByPath.get(file.name)!;
+      const patternCoverageSpans = patternCoverage === undefined
+        ? undefined
+        : options.patternCoverage?.spansForFile(
+          coverageFilenameFor(file.name, undefined, mounts),
+        );
       const imports = cacheableImportsFor(
         file.name,
         importEdges,
@@ -833,6 +853,7 @@ export class Engine extends EventTarget implements Harness {
         source: file.contents,
         js: out.js,
         ...(out.sourceMap === undefined ? {} : { sourceMap: out.sourceMap }),
+        ...(patternCoverageSpans === undefined ? {} : { patternCoverageSpans }),
         ...(policyManifests === undefined ? {} : { policyManifests }),
         imports,
       };
@@ -1235,7 +1256,11 @@ export class Engine extends EventTarget implements Harness {
   async evaluateCachedModules(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
-    options: { sourceFiles?: Source[]; trustedBodies?: boolean } = {},
+    options: {
+      sourceFiles?: Source[];
+      trustedBodies?: boolean;
+      patternCoverage?: PatternCoverageCollector;
+    } = {},
   ): Promise<EvaluateResult> {
     await this.getRuntimeInternals();
     const { runtimeExports } = await this.getRuntimeInternals();
@@ -1265,6 +1290,21 @@ export class Engine extends EventTarget implements Harness {
     const graph = buildRecordsFromCompiled(modules, {
       runtimeModules: runtimeModulesOption,
     });
+
+    // The cached bodies carry the coverage probes from the compile that emitted
+    // them, and the spans that name the lines those probes stand for. Register
+    // both against this graph so `evaluateGraph` installs the collector as the
+    // sandbox global. The spans are what map a probe's `(fileName, id)` back to
+    // source lines; a graph registered without them reports nothing for its
+    // hits.
+    if (options.patternCoverage !== undefined) {
+      for (const module of modules) {
+        options.patternCoverage.registerSpans(
+          module.patternCoverageSpans ?? [],
+        );
+      }
+      this.patternCoverageByGraph.set(graph, options.patternCoverage);
+    }
 
     // Register runtime-module records so cf:runtime/* imports resolve.
     const runtimeRecordExports: Record<string, Record<string, unknown>> = {};
@@ -1619,15 +1659,33 @@ function injectMountSources(files: readonly Source[]): Source[] {
   });
 }
 
+// The line shift `transformInjectHelperModule` applies to a file's authored
+// content, mirroring its decision order. Injection puts the one-line helper
+// import ahead of the first content line and appends an `h` shim after the last
+// (packages/ts-transformers/src/core/cf-helpers.ts); only the leading import
+// moves the authored lines, so an injected file shifts by exactly one line.
+// Three kinds of file reach the compiler unchanged and keep their authored
+// lines: a stored legacy envelope, whose authored bytes already carry the
+// helper import (tolerated only on the storage-fed paths — `checkCFHelperVar`
+// rejects those bytes on every authoring path); a file with no content line to
+// inject ahead of; and a file that disables the transform, whose directive line
+// is blanked in place rather than removed.
+export function helperInjectionLineOffset(contents: string): number {
+  const { isLegacyInjectedEnvelope } = compilerStack();
+  if (isLegacyInjectedEnvelope(contents)) return 0;
+  if (findFirstContentLineIndex(contents.split("\n")) === null) return 0;
+  if (sourceDisablesCfTransform(contents)) return 0;
+  return -1;
+}
+
 // Pattern coverage runs after helper injection. This maps spans back to the
 // authored file and skips spans from helper code added around the source.
-// The normal line offset depends on the one-line helper import from
-// packages/ts-transformers/src/core/cf-helpers.ts.
 function patternCoverageOptionsForCompile(
   collector: PatternCoverageCollector | undefined,
   params: {
-    id: string;
+    id: string | undefined;
     mounts: readonly FabricMount[];
+    // The AUTHORED bytes per file — what the offsets are measured against.
     sourceFiles: readonly Source[];
   },
 ): PatternCoverageOptions | undefined {
@@ -1637,8 +1695,8 @@ function patternCoverageOptionsForCompile(
     params.sourceFiles.map((file) => [
       coverageFilenameFor(file.name, params.id, params.mounts),
       {
-        lineOffset: sourceDisablesCfTransform(file.contents) ? 0 : -1,
-        lineCount: file.contents.split(/\r\n|\r|\n/).length,
+        lineOffset: helperInjectionLineOffset(file.contents),
+        lineCount: lineCountOf(file.contents),
       },
     ]),
   );
@@ -1675,9 +1733,13 @@ function cachedArtifactsIncludePatternCoverage(
   return true;
 }
 
+function lineCountOf(source: string): number {
+  return source.split(/\r\n|\r|\n/).length;
+}
+
 function coverageFilenameFor(
   name: string,
-  id: string,
+  id: string | undefined,
   mounts: readonly FabricMount[],
 ): string {
   // Mount paths carry the imported module identity. The coverage collector keys

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -4,6 +4,7 @@ import type {
   Source,
 } from "@commonfabric/js-compiler";
 import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
+import type { PatternCoverageCollector } from "../pattern-coverage.ts";
 import type { MemorySpace } from "../runtime.ts";
 import type {
   CachedCompiledModule,
@@ -173,7 +174,11 @@ export interface Harness extends EventTarget {
   evaluateCachedModules(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
-    options?: { sourceFiles?: Source[]; trustedBodies?: boolean },
+    options?: {
+      sourceFiles?: Source[];
+      trustedBodies?: boolean;
+      patternCoverage?: PatternCoverageCollector;
+    },
   ): Promise<EvaluateResult>;
 
   // Cold recovery: recompile cacheable modules from the stored (already-resolved,
@@ -181,7 +186,10 @@ export interface Harness extends EventTarget {
   compileResolvedToRecordGraph(
     resolvedFiles: Source[],
     entryFilename: string,
-    options?: { fabricImports?: FabricImportOptions },
+    options?: {
+      fabricImports?: FabricImportOptions;
+      patternCoverage?: PatternCoverageCollector;
+    },
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }>;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -79,7 +79,10 @@ export {
   type TypeScriptHarnessProcessOptions,
 } from "./harness/index.ts";
 export {
+  PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
+  PATTERN_COVERAGE_TEST_NAME,
   PatternCoverageCollector,
+  type PatternCoverageData,
   type PatternCoverageFileReport,
   type PatternCoverageKind,
   patternCoverageOutputPath,

--- a/packages/runner/src/pattern-coverage.ts
+++ b/packages/runner/src/pattern-coverage.ts
@@ -38,6 +38,26 @@ export interface PatternCoverageReportOptions {
   includeTestFiles?: boolean;
 }
 
+/**
+ * A collector's raw spans and per-span hit counts in a plain-JSON shape that
+ * survives serialization across a process, worker, or browser boundary. It
+ * carries the unnormalized `fileName`s the transformer baked into the compiled
+ * bytes, so a report produced in one realm (a browser worker) can be
+ * {@link PatternCoverageCollector.ingest}ed into a collector in another (the
+ * test process) with matching `(fileName, id)` keys.
+ */
+export interface PatternCoverageData {
+  spans: PatternCoverageSpan[];
+  hits: { fileName: string; id: number; count: number }[];
+}
+
+/** Default LCOV test name for pattern-coverage records (see {@link isPatternRuntimeTestName} in the gate). */
+export const PATTERN_COVERAGE_TEST_NAME = "pattern-runtime";
+
+/** LCOV test name for pattern coverage collected through the integration jobs. */
+export const PATTERN_COVERAGE_INTEGRATION_TEST_NAME =
+  "pattern-runtime-integration";
+
 export class PatternCoverageCollector {
   #spans = new Map<string, PatternCoverageSpan>();
   #hits = new Map<string, number>();
@@ -65,6 +85,39 @@ export class PatternCoverageCollector {
     return {
       hit: (fileName: string, id: number) => this.hit(fileName, id),
     };
+  }
+
+  /**
+   * Export this collector's spans and per-span hit counts as plain JSON, so a
+   * collector filled in another realm can be moved across a boundary and merged
+   * into a collector here with {@link ingest}. `fileName`s are the raw values
+   * the transformer baked into the compiled bytes — no path normalization —
+   * which is what keeps `(fileName, id)` keys aligned across realms that ran the
+   * same bytes.
+   */
+  toData(): PatternCoverageData {
+    const hits: PatternCoverageData["hits"] = [];
+    for (const [key, count] of this.#hits) {
+      const { fileName, id } = splitSpanKey(key);
+      hits.push({ fileName, id, count });
+    }
+    return { spans: [...this.#spans.values()], hits };
+  }
+
+  /**
+   * Merge another realm's {@link toData} export into this collector: register
+   * its spans (idempotent by `(fileName, id)`) and add its hit counts. A realm
+   * that only warm-loaded already-instrumented bytes reports hits with no spans
+   * of its own; the spans come from whichever realm compiled the bytes, so the
+   * union across realms carries both.
+   */
+  ingest(data: PatternCoverageData): void {
+    this.registerSpans(data.spans);
+    for (const { fileName, id, count } of data.hits) {
+      if (count === 0) continue;
+      const key = spanKey(fileName, id);
+      this.#hits.set(key, (this.#hits.get(key) ?? 0) + count);
+    }
   }
 
   report(options: PatternCoverageReportOptions = {}): PatternCoverageReport {
@@ -120,21 +173,22 @@ declare module "./harness/types.ts" {
 export async function writePatternCoverageLcov(
   collector: PatternCoverageCollector,
   outputPath: string,
-  options: PatternCoverageReportOptions = {},
+  options: PatternCoverageReportOptions & { testName?: string } = {},
 ): Promise<void> {
   await Deno.mkdir(dirname(outputPath), { recursive: true });
   await Deno.writeTextFile(
     outputPath,
-    patternCoverageReportToLcov(collector.report(options)),
+    patternCoverageReportToLcov(collector.report(options), options.testName),
   );
 }
 
 export function patternCoverageReportToLcov(
   report: PatternCoverageReport,
+  testName: string = PATTERN_COVERAGE_TEST_NAME,
 ): string {
   const lines: string[] = [];
   for (const file of report.files) {
-    lines.push("TN:pattern-runtime");
+    lines.push(`TN:${testName}`);
     lines.push(`SF:${normalizeLcovPath(file.path)}`);
 
     const hitsByLine = hitsByRuntimeLine(file.spans);
@@ -228,6 +282,14 @@ function sortedLines(lines: Set<number>): number[] {
 
 function spanKey(fileName: string, id: number): string {
   return `${fileName}\0${id}`;
+}
+
+function splitSpanKey(key: string): { fileName: string; id: number } {
+  const separator = key.lastIndexOf("\0");
+  return {
+    fileName: key.slice(0, separator),
+    id: Number(key.slice(separator + 1)),
+  };
 }
 
 function normalizeReportPath(fileName: string, root?: string): string {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -13,6 +13,7 @@ import {
   setPatternProgram,
 } from "./builder/pattern-metadata.ts";
 import type { MemorySpace, Runtime } from "./runtime.ts";
+import type { PatternCoverageCollector } from "./pattern-coverage.ts";
 import { createRef } from "./create-ref.ts";
 import type {
   CacheableModule,
@@ -357,7 +358,13 @@ export class PatternManager {
     // write-backs first. (Their own set, not flushCompileCacheWrites: this
     // replication promise is tracked there and would await itself.)
     await Promise.allSettled([...this.pendingCacheWriteBacks]);
-    const runtimeVersion = await getCompileCacheRuntimeVersion();
+    // Replicate the same cached variant the compile path uses — the coverage
+    // suffix keeps an instrumented closure from being served under an ordinary
+    // key (and vice versa).
+    const runtimeVersion = moduleByteCacheRuntimeVersion(
+      await getCompileCacheRuntimeVersion(),
+      { patternCoverage: this.runtime.patternCoverage !== undefined },
+    );
     const readTx = this.runtime.edit();
     let sourceDocs;
     let compiledDocs;
@@ -479,10 +486,14 @@ export class PatternManager {
     if (cacheCtx && this.runtime.cfcEnforcementMode !== "disabled") {
       return await this.compileViaCellCache(program, cacheCtx);
     }
+    const patternCoverage = this.patternCoverageFor();
     const { id, graph, mainSpecifier, entryIdentity } = await this.runtime
       .harness.compileToRecordGraph(
         program,
-        cacheCtx ? { fabricImports: { space: cacheCtx.space } } : {},
+        {
+          ...(cacheCtx ? { fabricImports: { space: cacheCtx.space } } : {}),
+          ...(patternCoverage ? { patternCoverage } : {}),
+        },
       );
     cacheCtx?.onEntryIdentity?.(entryIdentity);
     // evaluateRecordGraph is a single synchronous SES stretch; in the browser
@@ -517,21 +528,37 @@ export class PatternManager {
    * `Engine.compileAndEvaluateModules` only to inspect serialized/verified output
    * *without running* (engine unit tests), where stamping entry refs is unwanted.
    */
+  /**
+   * The pattern-coverage collector to instrument a compile with: a per-call
+   * option wins, else the runtime-level default (`RuntimeOptions.patternCoverage`).
+   * Undefined leaves the compile uninstrumented.
+   */
+  private patternCoverageFor(
+    options?: TypeScriptHarnessProcessOptions,
+  ): PatternCoverageCollector | undefined {
+    return options?.patternCoverage ?? this.runtime.patternCoverage;
+  }
+
   async compileAndRegisterModules(
     program: RuntimeProgram,
     options?: TypeScriptHarnessProcessOptions,
   ): Promise<EvaluateResult> {
+    const patternCoverage = this.patternCoverageFor(options);
+    const effectiveOptions: TypeScriptHarnessProcessOptions = {
+      ...options,
+      patternCoverage,
+    };
     const byteCache = this.runtime.moduleByteCache;
     const runtimeVersion = byteCache === undefined
       ? undefined
       : moduleByteCacheRuntimeVersion(
         await getCompileCacheRuntimeVersion(),
-        { patternCoverage: options?.patternCoverage !== undefined },
+        { patternCoverage: patternCoverage !== undefined },
       );
     if (byteCache === undefined || runtimeVersion === undefined) {
       const result = await this.runtime.harness.compileAndEvaluateModules(
         program,
-        options,
+        effectiveOptions,
       );
       this.registerEvaluatedModules(result);
       return result;
@@ -539,7 +566,7 @@ export class PatternManager {
 
     const { id, graph, mainSpecifier, modules } = await this.runtime.harness
       .compileToRecordGraph(program, {
-        ...options,
+        ...effectiveOptions,
         precompiledModulesFor: ({ identities }) =>
           Promise.resolve(byteCache.getCompleteSet(runtimeVersion, identities)),
       });
@@ -574,12 +601,25 @@ export class PatternManager {
   ): Promise<Pattern> {
     const harness = this.runtime.harness;
     const { space } = cacheCtx;
-    const runtimeVersion = await getCompileCacheRuntimeVersion();
+    const patternCoverage = this.patternCoverageFor();
+    // The instrumented compile is a distinct cached variant: the coverage suffix
+    // keeps its compiled bytes from colliding with an ordinary compile of the
+    // same source under one key, and makes a coverage-on runtime miss (and
+    // recompile-with-coverage) rather than reuse uninstrumented bytes. Source
+    // docs are keyed by content identity, not by this version, so they stay
+    // shared — a coverage run reuses the persisted source and only recompiles.
+    const runtimeVersion = moduleByteCacheRuntimeVersion(
+      await getCompileCacheRuntimeVersion(),
+      { patternCoverage: patternCoverage !== undefined },
+    );
     if (runtimeVersion === undefined) {
       const { id, graph, mainSpecifier, entryIdentity, modules } = await harness
         .compileToRecordGraph(
           program,
-          { fabricImports: { space } },
+          {
+            fabricImports: { space },
+            ...(patternCoverage ? { patternCoverage } : {}),
+          },
         );
       await this.persistSourceCacheTracked(space, modules, entryIdentity);
       cacheCtx.onEntryIdentity?.(entryIdentity);
@@ -636,6 +676,11 @@ export class PatternManager {
     try {
       compiled = await harness.compileToRecordGraph(program, {
         fabricImports: { space },
+        // A miss below falls through to a fresh compile; instrument it when
+        // coverage is on so the recompiled bytes carry the hit calls. A warm hit
+        // reuses bytes a prior coverage compile already instrumented (the coverage
+        // suffix on `runtimeVersion` keeps the two variants apart).
+        ...(patternCoverage ? { patternCoverage } : {}),
         // The bodies returned below come either from the process byte cache or
         // from `loadCompiledClosure`, an integrity-gated (`requiredIntegrity`,
         // fail-closed) read of the compiled set. On a full hit the byte cache's
@@ -762,6 +807,9 @@ export class PatternManager {
     program: RuntimeProgram,
   ): Promise<Pattern | undefined> {
     const harness = this.runtime.harness;
+    // `cacheOpts.runtimeVersion` already selects the coverage variant, so the
+    // bodies read below carry probes exactly when this is set.
+    const patternCoverage = this.patternCoverageFor();
     const readTx = this.runtime.edit();
     let closure;
     try {
@@ -798,6 +846,10 @@ export class PatternManager {
         ...(doc.importSpecs !== undefined
           ? { importSpecs: doc.importSpecs }
           : {}),
+        // The spans naming the lines this body's coverage probes stand for.
+        ...(doc.patternCoverageSpans !== undefined
+          ? { patternCoverageSpans: doc.patternCoverageSpans }
+          : {}),
         // Drop the synthetic entry→root links (cfc.ts etc.); only real
         // require/export-* edges resolve module records.
         imports: doc.imports
@@ -813,7 +865,11 @@ export class PatternManager {
         // Bodies came from the integrity-gated compiled-set read
         // (`loadCompiledClosure`, `requiredIntegrity`), so the CFC label is the
         // security boundary — skip redundant SES body re-verification.
-        { sourceFiles: program.files, trustedBodies: true },
+        {
+          sourceFiles: program.files,
+          trustedBodies: true,
+          ...(patternCoverage ? { patternCoverage } : {}),
+        },
       );
       return this.patternFromEvaluation(result, program, entryIdentity);
     } catch (error) {
@@ -903,7 +959,14 @@ export class PatternManager {
     space: MemorySpace,
   ): Promise<Pattern | undefined> {
     const harness = this.runtime.harness;
-    const runtimeVersion = await getCompileCacheRuntimeVersion();
+    const patternCoverage = this.patternCoverageFor();
+    // Select the same cached variant the compile path wrote. A coverage-on
+    // runtime resumes from the instrumented closure; reading the ordinary key
+    // here would serve uninstrumented bodies for an instrumented run.
+    const runtimeVersion = moduleByteCacheRuntimeVersion(
+      await getCompileCacheRuntimeVersion(),
+      { patternCoverage: patternCoverage !== undefined },
+    );
     if (runtimeVersion === undefined) {
       return await this.tryColdLoadByIdentity(entryIdentity, symbol, space);
     }
@@ -951,6 +1014,10 @@ export class PatternManager {
         ...(doc.importSpecs !== undefined
           ? { importSpecs: doc.importSpecs }
           : {}),
+        // The spans naming the lines this body's coverage probes stand for.
+        ...(doc.patternCoverageSpans !== undefined
+          ? { patternCoverageSpans: doc.patternCoverageSpans }
+          : {}),
         imports: doc.imports
           .filter((i) => !i.specifier.startsWith(ROOT_LINK_SPECIFIER))
           .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
@@ -965,7 +1032,10 @@ export class PatternManager {
       const result = await harness.evaluateCachedModules(
         cachedModules,
         entryIdentity,
-        { trustedBodies: true },
+        {
+          trustedBodies: true,
+          ...(patternCoverage ? { patternCoverage } : {}),
+        },
       );
       const pattern = this.patternFromMain(result, symbol, entryIdentity);
       this.esmCacheStats.byIdentityHits++;
@@ -1018,11 +1088,15 @@ export class PatternManager {
       contents: doc.code,
     }));
 
+    const patternCoverage = this.patternCoverageFor();
     try {
       const compiled = await harness.compileResolvedToRecordGraph(
         sourceFiles,
         entry.filename,
-        { fabricImports: { space } },
+        {
+          fabricImports: { space },
+          ...(patternCoverage ? { patternCoverage } : {}),
+        },
       );
       if (compiled.entryIdentity !== entryIdentity) {
         throw new Error(
@@ -1037,13 +1111,20 @@ export class PatternManager {
           ...(module.sourceMap !== undefined
             ? { sourceMap: module.sourceMap as never }
             : {}),
+          // The spans naming the lines this body's coverage probes stand for.
+          ...(module.patternCoverageSpans !== undefined
+            ? { patternCoverageSpans: module.patternCoverageSpans }
+            : {}),
           imports: module.imports,
         }),
       );
       const result = await harness.evaluateCachedModules(
         cachedModules,
         entryIdentity,
-        { sourceFiles },
+        {
+          sourceFiles,
+          ...(patternCoverage ? { patternCoverage } : {}),
+        },
       );
       const pattern = this.patternFromMain(result, symbol, entryIdentity);
       if (cacheOpts !== undefined) {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -29,6 +29,7 @@ import type {
   IExtendedStorageTransaction,
 } from "./storage/interface.ts";
 import {
+  buildSourceDocs,
   compiledDocKey,
   getCompileCacheRuntimeVersion,
   loadCompiledClosure,
@@ -56,6 +57,7 @@ const logger = getLogger("pattern-manager");
 // bundle is ~10 modules), and entries are cheap (a reference to an already-live
 // namespace).
 const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
+const PATTERN_COVERAGE_CACHE_VARIANT = "pattern-coverage";
 
 function throwableStorageError(error: CommitError): Error {
   if (error instanceof Error) return error;
@@ -71,8 +73,60 @@ function moduleByteCacheRuntimeVersion(
 ): string | undefined {
   if (runtimeVersion === undefined) return undefined;
   return options.patternCoverage
-    ? `${runtimeVersion}/pattern-coverage`
+    ? `${runtimeVersion}/${PATTERN_COVERAGE_CACHE_VARIANT}`
     : runtimeVersion;
+}
+
+function isPatternCoverageCacheRuntimeVersion(runtimeVersion: string): boolean {
+  return runtimeVersion.endsWith(`/${PATTERN_COVERAGE_CACHE_VARIANT}`);
+}
+
+function compileCachePersistenceSlotKey(
+  space: MemorySpace,
+  entryIdentity: string,
+  opts: { runtimeVersion: string },
+): string {
+  return JSON.stringify([space, opts.runtimeVersion, entryIdentity]);
+}
+
+function compileCacheClosureSignature(
+  moduleIdentities: readonly string[],
+): string {
+  return JSON.stringify([...new Set(moduleIdentities)].sort());
+}
+
+function expectedSourceClosureIdentities(
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
+): Set<string> {
+  const docs = buildSourceDocs(modules, entryIdentity);
+  const reachable = new Set<string>();
+  const pending = [entryIdentity];
+  while (pending.length > 0) {
+    const identity = pending.pop()!;
+    if (reachable.has(identity)) continue;
+    reachable.add(identity);
+    for (const imp of docs.get(identity)?.imports ?? []) {
+      pending.push(imp.identity);
+    }
+  }
+  return reachable;
+}
+
+function compileCacheRecoveryKey(
+  space: MemorySpace,
+  entryIdentity: string,
+): string {
+  return JSON.stringify([space, entryIdentity]);
+}
+
+function cacheEntriesIncludePatternCoverage(
+  entries: Iterable<{ readonly patternCoverageSpans?: unknown }>,
+): boolean {
+  for (const entry of entries) {
+    if (!Array.isArray(entry.patternCoverageSpans)) return false;
+  }
+  return true;
 }
 
 /**
@@ -189,15 +243,22 @@ export class PatternManager {
   // awaited by compilePattern; recovery/replication paths may still run in the
   // background.
   private compileCacheWrites = new Set<Promise<unknown>>();
-  // The subset of `compileCacheWrites` that are cold-compile closure
-  // write-backs. Tracked separately so `replicateClosures` can await them
-  // before reading the origin space — its own promise lives in
-  // `compileCacheWrites`, so awaiting that whole set would deadlock on itself.
+  // Closure write-backs that replication must observe before reading its
+  // origin space. Tracked separately because the replication promise also
+  // lives in `compileCacheWrites` and cannot await itself.
   private pendingCacheWriteBacks = new Set<Promise<unknown>>();
-  // `${entryIdentity}\0${space}` closure replications already kicked off this
-  // session (see `replicatePatternToSpace`). An entry is removed on failure so
-  // the next child creation retries.
-  private replicatedClosures = new Set<string>();
+  // Maps each storage slot written during this PatternManager session to its
+  // complete module set. One slot can hold only one closure shape at a time.
+  private persistedCompileCacheClosures = new Map<string, string>();
+  // Writes to one storage slot are serialized. Requests for the same closure
+  // share the write that is already running.
+  private inProgressCompileCacheWrites = new Map<
+    string,
+    { closureSignature: string; persistence: Promise<void> }
+  >();
+  // A best-effort identity recovery that failed to persist skips the in-memory
+  // artifact shortcuts on the next load so storage recovery runs again.
+  private failedCompileCacheRecoveries = new Set<string>();
 
   constructor(readonly runtime: Runtime) {}
 
@@ -312,16 +373,11 @@ export class PatternManager {
 
     const entryRef = this.getArtifactEntryRef(pattern);
     if (!entryRef) return;
-    const dedupeKey = `${entryRef.identity}\0${toSpace}`;
-    if (this.replicatedClosures.has(dedupeKey)) return;
-    this.replicatedClosures.add(dedupeKey);
     const replication = this.replicateClosures(
       entryRef.identity,
       fromSpace,
       toSpace,
     ).catch((error) => {
-      // Release the claim so a later child creation retries.
-      this.replicatedClosures.delete(dedupeKey);
       logger.error("closure-replication-failed", () => [
         `entry=${entryRef.identity}`,
         `from=${fromSpace}`,
@@ -350,13 +406,11 @@ export class PatternManager {
     if (visited.has(visitKey)) return;
     visited.add(visitKey);
 
-    // The origin-space closure may have been produced by THIS session's cold
-    // compile, whose write-back is itself fire-and-forget and may not have
-    // committed yet. A lost race would throw here — and for a handler-created
-    // child (one space per profile) nothing re-fires the released dedupe key,
-    // leaving that child permanently unloadable. Await the in-flight
-    // write-backs first. (Their own set, not flushCompileCacheWrites: this
-    // replication promise is tracked there and would await itself.)
+    // The origin-space closure may still have an in-flight cache write. Reading
+    // before it commits would make this replication fail even though the source
+    // is about to become available. Await write-backs first. Use their own set,
+    // not flushCompileCacheWrites: this replication promise is tracked there and
+    // would await itself.
     await Promise.allSettled([...this.pendingCacheWriteBacks]);
     // Replicate the same cached variant the compile path uses — the coverage
     // suffix keeps an instrumented closure from being served under an ordinary
@@ -398,6 +452,14 @@ export class PatternManager {
     if (!sourceDocs?.has(entryIdentity)) {
       throw new Error("source closure unavailable in origin space");
     }
+    if (
+      runtimeVersion !== undefined &&
+      isPatternCoverageCacheRuntimeVersion(runtimeVersion) &&
+      (compiledDocs === undefined ||
+        !cacheEntriesIncludePatternCoverage(compiledDocs.values()))
+    ) {
+      throw new Error("coverage spans unavailable in origin space");
+    }
     const modules: CacheableModule[] = [];
     const fabricDependencies = new Set<string>();
     for (const [identity, doc] of sourceDocs) {
@@ -417,6 +479,12 @@ export class PatternManager {
         ...(compiled?.sourceMap !== undefined
           ? { sourceMap: compiled.sourceMap }
           : {}),
+        ...(compiled?.patternCoverageSpans !== undefined
+          ? { patternCoverageSpans: [...compiled.patternCoverageSpans] }
+          : {}),
+        ...(compiled?.policyManifests !== undefined
+          ? { policyManifests: compiled.policyManifests }
+          : {}),
         // The write functions re-derive the entry's root links; keep only the
         // real import edges.
         imports: uniqueCacheableImports([
@@ -430,20 +498,16 @@ export class PatternManager {
         ]),
       });
     }
-    const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(this.runtime, toSpace, modules, entryIdentity, tx);
-      if (runtimeVersion !== undefined) {
-        writeCompiledDocs(
-          this.runtime,
-          toSpace,
-          modules,
-          entryIdentity,
-          { runtimeVersion },
-          tx,
-        );
-      }
-    });
-    if (error) throw error;
+    if (runtimeVersion === undefined) {
+      await this.persistSourceCacheTracked(toSpace, modules, entryIdentity);
+    } else {
+      await this.persistCompileCacheTracked(
+        toSpace,
+        modules,
+        entryIdentity,
+        { runtimeVersion },
+      );
+    }
 
     for (const dependencyIdentity of fabricDependencies) {
       await this.replicateClosures(
@@ -666,12 +730,11 @@ export class PatternManager {
     // The per-space storage closure served the full module set (already durable
     // in this space, so no write-back needed).
     let warmHit = false;
-    // The process-level byte cache served the full module set, skipping the
-    // transform-and-emit step (the TypeScript program build, type-check, the
-    // type-driven CF transformer, and the emit — `compileToModules`). The bytes
-    // are durable in the byte cache but NOT necessarily in this space's persisted
-    // cache, so this still triggers a write-back.
-    let processServed = false;
+    // Cached compiled bodies served the full module set. They can come from the
+    // process byte cache or from compiled storage whose source closure needs
+    // repair. Either skips the transform-and-emit step but still triggers a
+    // write-back.
+    let compiledBodiesServed = false;
     let compiled;
     try {
       compiled = await harness.compileToRecordGraph(program, {
@@ -690,24 +753,6 @@ export class PatternManager {
         // undefined below → fresh compile → bodies are SES-verified as usual.
         trustedBodies: true,
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
-          // Process byte cache first (cross-runtime, cross-space): a full hit
-          // skips BOTH the transform-and-emit step (`compileToModules`: TS
-          // program build, type-check, CF transform, emit) and the per-space
-          // storage read. Trust by provenance: bytes this process compiled were
-          // SES-verified then; bytes a test seeded from a CI disk file were not —
-          // those are trusted via the workflow's cache key, which fingerprints
-          // every compile input. Either path is test/CI-only: nothing in
-          // production installs a byte cache.
-          if (byteCache) {
-            const bodies = byteCache.getCompleteSet(
-              cacheOpts.runtimeVersion,
-              identities,
-            );
-            if (bodies) {
-              processServed = true;
-              return bodies;
-            }
-          }
           // Concurrency-safe timing: explicit start (no shared timer key, which
           // parallel compiles would clobber). Same for the others below.
           const readStart = performance.now();
@@ -722,23 +767,76 @@ export class PatternManager {
           // Full hit only: every emitted module must be present (and
           // integrity-valid). A partial set cannot be trusted (transitively
           // sensitive identities), so fall back to a full recompile.
-          if (!identities.every((identity) => closure.has(identity))) {
-            return undefined;
+          const storageIsComplete = identities.every((identity) =>
+            closure.has(identity)
+          );
+          let storageBodiesNeedingRepair:
+            | Map<string, CompiledModuleArtifact>
+            | undefined;
+          if (storageIsComplete) {
+            const bodies = new Map<string, CompiledModuleArtifact>();
+            for (const [identity, doc] of closure) {
+              bodies.set(identity, {
+                js: doc.code,
+                ...(doc.sourceMap === undefined
+                  ? {}
+                  : { sourceMap: doc.sourceMap }),
+                ...(doc.patternCoverageSpans === undefined
+                  ? {}
+                  : { patternCoverageSpans: [...doc.patternCoverageSpans] }),
+                ...(doc.policyManifests === undefined
+                  ? {}
+                  : { policyManifests: doc.policyManifests }),
+              });
+            }
+            if (
+              !patternCoverage ||
+              cacheEntriesIncludePatternCoverage(bodies.values())
+            ) {
+              const sourceClosure = await loadVerifiedSourceClosure(
+                this.runtime,
+                space,
+                entryIdentity,
+                readTx,
+              );
+              if (sourceClosure?.has(entryIdentity)) {
+                warmHit = true;
+                return bodies;
+              }
+              storageBodiesNeedingRepair = bodies;
+            }
           }
-          const bodies = new Map<string, CompiledModuleArtifact>();
-          for (const [identity, doc] of closure) {
-            bodies.set(identity, {
-              js: doc.code,
-              ...(doc.sourceMap === undefined
-                ? {}
-                : { sourceMap: doc.sourceMap }),
-              ...(doc.policyManifests === undefined
-                ? {}
-                : { policyManifests: doc.policyManifests }),
-            });
+
+          // A storage miss makes any remembered success for this slot stale.
+          // The process cache can still skip compilation, but the resulting
+          // closure must be written back into the space again.
+          this.persistedCompileCacheClosures.delete(
+            compileCachePersistenceSlotKey(space, entryIdentity, cacheOpts),
+          );
+          if (storageBodiesNeedingRepair !== undefined) {
+            compiledBodiesServed = true;
+            return storageBodiesNeedingRepair;
           }
-          warmHit = true;
-          return bodies;
+          // Process byte cache (cross-runtime, cross-space): a full hit skips
+          // the transform-and-emit step (`compileToModules`: TS program build,
+          // type-check, CF transform, emit). Trust by provenance: bytes this
+          // process compiled were SES-verified then; bytes a test seeded from a
+          // CI disk file are trusted via the workflow cache key, which
+          // fingerprints every compile input. Nothing in production installs a
+          // byte cache.
+          const processBodies = byteCache?.getCompleteSet(
+            cacheOpts.runtimeVersion,
+            identities,
+          );
+          if (
+            processBodies &&
+            (!patternCoverage ||
+              cacheEntriesIncludePatternCoverage(processBodies.values()))
+          ) {
+            compiledBodiesServed = true;
+            return processBodies;
+          }
+          return undefined;
         },
       });
     } finally {
@@ -771,7 +869,7 @@ export class PatternManager {
       // already durable here — no write-back.
       this.esmCacheStats.hits++;
     } else {
-      this.esmCacheStats[processServed ? "hits" : "misses"]++;
+      this.esmCacheStats[compiledBodiesServed ? "hits" : "misses"]++;
       // Persist the module set into this space. AWAITED (identity E4): refs-only
       // pattern JSON makes artifact persistence part of the compilation
       // contract — a cell can only carry a `$patternRef` after compilePattern
@@ -812,6 +910,7 @@ export class PatternManager {
     const patternCoverage = this.patternCoverageFor();
     const readTx = this.runtime.edit();
     let closure;
+    let sourceClosure;
     try {
       const readStart = performance.now();
       closure = await loadCompiledClosure(
@@ -821,11 +920,28 @@ export class PatternManager {
         cacheOpts,
         readTx,
       );
+      if (closure.has(entryIdentity)) {
+        sourceClosure = await loadVerifiedSourceClosure(
+          this.runtime,
+          space,
+          entryIdentity,
+          readTx,
+        );
+      }
       logger.time(readStart, "compile-cache", "read-by-identity");
     } finally {
       readTx.abort?.("compile-cache by-identity read complete");
     }
-    if (!closure.has(entryIdentity)) return undefined;
+    if (
+      !closure.has(entryIdentity) || !sourceClosure?.has(entryIdentity) ||
+      (patternCoverage !== undefined &&
+        !cacheEntriesIncludePatternCoverage(closure.values()))
+    ) {
+      this.persistedCompileCacheClosures.delete(
+        compileCachePersistenceSlotKey(space, entryIdentity, cacheOpts),
+      );
+      return undefined;
+    }
 
     const cachedModules: CachedCompiledModule[] = [...closure].map(
       ([identity, doc]) => ({
@@ -901,13 +1017,19 @@ export class PatternManager {
     symbol: string,
     space: MemorySpace,
   ): Promise<Pattern | undefined> {
+    const recoveryKey = compileCacheRecoveryKey(space, entryIdentity);
+    const retryFailedRecovery = this.failedCompileCacheRecoveries.has(
+      recoveryKey,
+    );
     // In-memory artifact index: the pattern may already be live this session —
     // an evaluated ESM artifact, or a hand-built pattern given a synthetic
     // pointer via `associatePatternIdentity`. This path is independent of the
     // compiled cache (and of CFC enforcement), so it serves the same artifact
     // `artifactFromIdentitySync` would return.
     const indexed = this.addressableByIdentity.get(entryIdentity)?.get(symbol);
-    if (indexed !== undefined && isTrustedPattern(indexed)) {
+    if (
+      !retryFailedRecovery && indexed !== undefined && isTrustedPattern(indexed)
+    ) {
       this.esmCacheStats.byIdentityHits++;
       return indexed;
     }
@@ -917,7 +1039,9 @@ export class PatternManager {
     // In-memory fast path (CT-1623): the module may already be live from a
     // parent bundle's evaluation (e.g. a sub-pattern of the just-loaded
     // space root). Reuse it directly — no storage closure read, no SES re-eval.
-    const live = this.patternFromEvaluatedModule(entryIdentity, symbol);
+    const live = retryFailedRecovery
+      ? undefined
+      : this.patternFromEvaluatedModule(entryIdentity, symbol);
     if (live) {
       this.esmCacheStats.byIdentityHits++;
       return live;
@@ -987,7 +1111,14 @@ export class PatternManager {
     } finally {
       readTx.abort?.("load-pattern-by-identity read complete");
     }
-    if (!closure.has(entryIdentity)) {
+    if (
+      !closure.has(entryIdentity) ||
+      (patternCoverage !== undefined &&
+        !cacheEntriesIncludePatternCoverage(closure.values()))
+    ) {
+      this.persistedCompileCacheClosures.delete(
+        compileCachePersistenceSlotKey(space, entryIdentity, cacheOpts),
+      );
       return await this.tryColdLoadByIdentity(
         entryIdentity,
         symbol,
@@ -1038,6 +1169,9 @@ export class PatternManager {
         },
       );
       const pattern = this.patternFromMain(result, symbol, entryIdentity);
+      this.failedCompileCacheRecoveries.delete(
+        compileCacheRecoveryKey(space, entryIdentity),
+      );
       this.esmCacheStats.byIdentityHits++;
       return pattern;
     } catch (error) {
@@ -1128,24 +1262,24 @@ export class PatternManager {
       );
       const pattern = this.patternFromMain(result, symbol, entryIdentity);
       if (cacheOpts !== undefined) {
-        const writeBack = this.writeBackCompileCache(
+        const recoveryKey = compileCacheRecoveryKey(space, entryIdentity);
+        const repair = this.persistCompileCacheTracked(
           space,
           compiled.modules,
           entryIdentity,
           cacheOpts,
-        ).catch((error) => {
+        ).then(() => {
+          this.failedCompileCacheRecoveries.delete(recoveryKey);
+        }).catch((error) => {
+          this.failedCompileCacheRecoveries.add(recoveryKey);
           logger.warn("load-pattern-by-identity-writeback-failed", () => [
             `entry=${entryIdentity}`,
             `symbol=${symbol}`,
             String(error),
           ]);
         });
-        this.compileCacheWrites.add(writeBack);
-        this.pendingCacheWriteBacks.add(writeBack);
-        writeBack.finally(() => {
-          this.compileCacheWrites.delete(writeBack);
-          this.pendingCacheWriteBacks.delete(writeBack);
-        });
+        this.compileCacheWrites.add(repair);
+        repair.finally(() => this.compileCacheWrites.delete(repair));
       }
       return pattern;
     } catch (error) {
@@ -1385,19 +1519,122 @@ export class PatternManager {
     entryIdentity: string,
     opts: { runtimeVersion: string },
   ): Promise<void> {
-    const writeBack = this.writeBackCompileCache(
+    const persistenceSlotKey = compileCachePersistenceSlotKey(
       space,
-      modules,
       entryIdentity,
       opts,
     );
-    this.compileCacheWrites.add(writeBack);
-    this.pendingCacheWriteBacks.add(writeBack);
+    const closureSignature = compileCacheClosureSignature(
+      modules.map((module) => module.identity),
+    );
+    const predecessor = this.inProgressCompileCacheWrites.get(
+      persistenceSlotKey,
+    );
+    if (predecessor?.closureSignature === closureSignature) {
+      await predecessor.persistence;
+      return;
+    }
+
+    // Install the successor as the slot's tail before waiting for its
+    // predecessor. Replication snapshots `pendingCacheWriteBacks`, so every
+    // write already requested when that snapshot is taken must be represented.
+    const persistence = (async () => {
+      await predecessor?.persistence.catch(() => {});
+
+      if (
+        predecessor === undefined &&
+        this.persistedCompileCacheClosures.get(persistenceSlotKey) ===
+          closureSignature
+      ) {
+        const stored = await this.hasStoredCompileCacheClosure(
+          space,
+          modules,
+          entryIdentity,
+          opts,
+        ).catch(() => false);
+        if (stored) {
+          this.failedCompileCacheRecoveries.delete(
+            compileCacheRecoveryKey(space, entryIdentity),
+          );
+          return;
+        }
+        this.persistedCompileCacheClosures.delete(persistenceSlotKey);
+      }
+
+      await this.writeBackCompileCache(
+        space,
+        modules,
+        entryIdentity,
+        opts,
+      );
+      this.persistedCompileCacheClosures.set(
+        persistenceSlotKey,
+        closureSignature,
+      );
+      this.failedCompileCacheRecoveries.delete(
+        compileCacheRecoveryKey(space, entryIdentity),
+      );
+    })();
+    this.inProgressCompileCacheWrites.set(persistenceSlotKey, {
+      closureSignature,
+      persistence,
+    });
+    this.compileCacheWrites.add(persistence);
+    this.pendingCacheWriteBacks.add(persistence);
     try {
-      await writeBack;
+      await persistence;
     } finally {
-      this.compileCacheWrites.delete(writeBack);
-      this.pendingCacheWriteBacks.delete(writeBack);
+      const current = this.inProgressCompileCacheWrites.get(
+        persistenceSlotKey,
+      );
+      if (current?.persistence === persistence) {
+        this.inProgressCompileCacheWrites.delete(persistenceSlotKey);
+      }
+      this.compileCacheWrites.delete(persistence);
+      this.pendingCacheWriteBacks.delete(persistence);
+    }
+  }
+
+  private async hasStoredCompileCacheClosure(
+    space: MemorySpace,
+    modules: readonly CacheableModule[],
+    entryIdentity: string,
+    opts: { runtimeVersion: string },
+  ): Promise<boolean> {
+    const readTx = this.runtime.edit();
+    try {
+      const source = await loadVerifiedSourceClosure(
+        this.runtime,
+        space,
+        entryIdentity,
+        readTx,
+      );
+      if (source === undefined) return false;
+      for (
+        const identity of expectedSourceClosureIdentities(
+          modules,
+          entryIdentity,
+        )
+      ) {
+        if (!source.has(identity)) return false;
+      }
+
+      const compiled = await loadCompiledClosure(
+        this.runtime,
+        space,
+        entryIdentity,
+        opts,
+        readTx,
+      );
+      if (
+        isPatternCoverageCacheRuntimeVersion(opts.runtimeVersion) &&
+        !cacheEntriesIncludePatternCoverage(compiled.values())
+      ) {
+        return false;
+      }
+      return modules.every((module) => compiled.has(module.identity));
+    } finally {
+      readTx.abort?.("compile-cache persistence check complete");
     }
   }
 
@@ -1616,7 +1853,7 @@ export class PatternManager {
       // { identity, symbol } in a fresh runtime (the meta-cell fallback is
       // gone). When this hit serves a different space than the one we first
       // compiled into, replicate the closure there — cheap (no TS recompile),
-      // deduped, and fire-and-forget (tracked in compileCacheWrites).
+      // with persistence writes deduplicated and tracked in compileCacheWrites.
       if (space && cached.space && space !== cached.space) {
         this.replicatePatternToSpace(cached.pattern, space, cached.space);
       }

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -74,6 +74,9 @@
  * | pieceCreatedCallback       | delta (browserWorker only)                       |
  * | telemetry                  | delta (productionServer, browserWorker)          |
  * | moduleByteCache            | delta (patternTest, remoteClient, unitTest)      |
+ * | patternCoverage            | delta (patternTest, remoteClient, browserWorker) |
+ * |                            | — test/CI statement-coverage collection, unset   |
+ * |                            | elsewhere                                        |
  * | trustSnapshotProvider      | delta (remoteClient, browserWorker)              |
  * | spaceHostMap               | delta (browserWorker only — federation routing   |
  * |                            | is decided by the shell host)                    |
@@ -89,6 +92,7 @@ import type {
   TrustSnapshot,
 } from "./cfc/mod.ts";
 import type { CommitBackpressurePolicy } from "./scheduler/backpressure.ts";
+import type { PatternCoverageCollector } from "./pattern-coverage.ts";
 import type { IStorageManager } from "./storage/interface.ts";
 import type { RuntimeTelemetry } from "./telemetry.ts";
 import type {
@@ -144,6 +148,7 @@ export const RUNTIME_OPTION_KEYS = [
   "hideInternalStackFrames",
   "commitBackpressure",
   "moduleByteCache",
+  "patternCoverage",
   "fetch",
 ] as const satisfies readonly (keyof RuntimeOptions)[];
 
@@ -285,6 +290,8 @@ export interface RemoteClientPresetParams extends CoreParams {
   moduleByteCache?: ModuleByteCache;
   /** Trust provenance for CFC-relevant writes (pieces controller). */
   trustSnapshotProvider?: () => TrustSnapshot | undefined;
+  /** Statement-coverage collector for the pattern integration harness. */
+  patternCoverage?: PatternCoverageCollector;
 }
 
 export interface PatternTestPresetParams extends CoreParams {
@@ -295,6 +302,8 @@ export interface PatternTestPresetParams extends CoreParams {
   moduleByteCache?: ModuleByteCache;
   /** Per-test laxer mode; defaults to the shared core pin. */
   cfcEnforcementMode?: CfcEnforcementMode;
+  /** Statement-coverage collector for `cf test` and the pattern harnesses. */
+  patternCoverage?: PatternCoverageCollector;
 }
 
 export interface BrowserWorkerPresetParams extends CoreParams {
@@ -313,6 +322,8 @@ export interface BrowserWorkerPresetParams extends CoreParams {
   pieceCreatedCallback?: PieceCreatedCallback;
   /** System-pattern update version-skew signal → shell IPC. */
   onVersionSkew?: VersionSkewHandler;
+  /** Statement-coverage collector, set only on the coverage-collecting shell build. */
+  patternCoverage?: PatternCoverageCollector;
 }
 
 export interface UnitTestPresetParams extends Omit<CoreParams, "experimental"> {
@@ -369,6 +380,9 @@ export const runtimePresets = {
       ...(params.trustSnapshotProvider !== undefined
         ? { trustSnapshotProvider: params.trustSnapshotProvider }
         : {}),
+      ...(params.patternCoverage !== undefined
+        ? { patternCoverage: params.patternCoverage }
+        : {}),
     };
   },
 
@@ -394,6 +408,9 @@ export const runtimePresets = {
         : {}),
       ...(params.moduleByteCache !== undefined
         ? { moduleByteCache: params.moduleByteCache }
+        : {}),
+      ...(params.patternCoverage !== undefined
+        ? { patternCoverage: params.patternCoverage }
         : {}),
     };
   },
@@ -445,6 +462,9 @@ export const runtimePresets = {
         : {}),
       ...(params.onVersionSkew !== undefined
         ? { onVersionSkew: params.onVersionSkew }
+        : {}),
+      ...(params.patternCoverage !== undefined
+        ? { patternCoverage: params.patternCoverage }
         : {}),
     };
   },

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -33,6 +33,7 @@ import {
   setEagerSourceAnnotation,
 } from "./builder/module.ts";
 import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
+import type { PatternCoverageCollector } from "./pattern-coverage.ts";
 import type {
   ChangeGroup,
   CommitError,
@@ -439,6 +440,19 @@ export interface RuntimeOptions {
    */
   moduleByteCache?: ModuleByteCache;
   /**
+   * Statement-coverage collector for authored patterns. When set, every compile
+   * this runtime performs is instrumented — the transformer injects a hit call
+   * in front of each authored statement — and the collector receives the hits.
+   * The compiled-byte caches (the process byte cache and the per-space durable
+   * cell cache) key the instrumented variant separately from the ordinary one,
+   * so an instrumented and an uninstrumented compile of the same source never
+   * collide, and a runtime with coverage on never serves or stores uninstrumented
+   * bytes. A per-compile `patternCoverage` option still overrides this default.
+   * Test-and-CI only; production runtimes leave it unset. See
+   * packages/runner/src/pattern-coverage.ts and docs/development/COVERAGE.md.
+   */
+  patternCoverage?: PatternCoverageCollector;
+  /**
    * Override for the outbound `fetch` used by network builtins (`fetchJson` et al).
    * Defaults to the host `globalThis.fetch`. Scoped to this runtime instance, so
    * a test harness can inject a deterministic mock without mutating process
@@ -599,6 +613,8 @@ export class Runtime {
   readonly storageManager: IStorageManager;
   /** Optional process-level compiled-module-byte cache; see RuntimeOptions. */
   readonly moduleByteCache?: ModuleByteCache;
+  /** Optional pattern statement-coverage collector; see RuntimeOptions. */
+  readonly patternCoverage?: PatternCoverageCollector;
   readonly trustSnapshotProvider: () => TrustSnapshot | undefined;
   readonly telemetry: RuntimeTelemetry;
   /** Resolved experimental flags (all properties present with built-in defaults). */
@@ -935,6 +951,7 @@ export class Runtime {
       setTelemetry?: (telemetry: RuntimeTelemetry) => void;
     }).setTelemetry?.(this.telemetry);
     this.moduleByteCache = options.moduleByteCache;
+    this.patternCoverage = options.patternCoverage;
     // Validated + digested + frozen before the trust-snapshot provider
     // default below, whose `revision` covers the config digest (a trust
     // config change must invalidate prepared digests like any other

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,6 +1,7 @@
 import type ts from "typescript";
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Source, SourceMap } from "@commonfabric/js-compiler";
+import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 import { resolveImportSpecifier } from "@commonfabric/js-compiler/specifier";
 import { compilerStack } from "../harness/deferred-compiler-stack.ts";
 import {
@@ -834,6 +835,13 @@ export interface CachedCompiledModule {
   exportNames?: readonly string[];
   starTargetSpecs?: readonly string[];
   importSpecs?: readonly string[];
+  /**
+   * Authored-line spans for the coverage probes baked into `code`, carried from
+   * the cached document. The engine registers them with the collector it
+   * installs for the evaluation, which is what lets a probe's `(fileName, id)`
+   * resolve to source lines. Absent whenever `code` is uninstrumented.
+   */
+  patternCoverageSpans?: readonly PatternCoverageSpan[];
 }
 
 /**

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -64,3 +64,10 @@ export type {
   WriteStackTraceMatcher,
   WriteStackTraceMatchMode,
 } from "./storage/write-stack-trace.ts";
+// Type-only: the plain-JSON shape the worker returns for a pattern-coverage
+// dump. No runtime import (the module's value exports never load here).
+export type {
+  PatternCoverageData,
+  PatternCoverageKind,
+  PatternCoverageSpan,
+} from "./pattern-coverage.ts";

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -703,7 +703,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     );
   });
 
-  it("round-trips pattern coverage spans and rejects malformed stored spans", async () => {
+  it("round-trips JSON coverage spans and rejects unsupported stored spans", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
     const spans = [{
       fileName: "/main.tsx",
@@ -719,6 +719,17 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     writeCompiledDocs(runtime, spaceA, modules, entryIdentity, opts(), wtx);
     wtx.prepareCfc();
     await wtx.commit();
+
+    const inspectTx = runtime.edit();
+    const storedDoc = runtime.getCell(
+      spaceA,
+      compiledDocKey(RTVER, entryIdentity),
+      compiledDocWriteSchema(),
+      inspectTx,
+    ).get() as Record<string, unknown>;
+    expect(typeof storedDoc.patternCoverageSpansJson).toBe("string");
+    expect(storedDoc.patternCoverageSpans).toBeUndefined();
+    inspectTx.abort?.();
 
     const coldLoad = async () => {
       const rtx = runtime.edit();
@@ -739,7 +750,12 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
 
     // Overwrite the stored doc's spans with malformed values, bypassing the
     // write path's integrity via the compile-cache implementation identity.
-    const replaceSpans = async (value: unknown) => {
+    const replaceSpans = async (
+      value: {
+        patternCoverageSpansJson?: unknown;
+        patternCoverageSpans?: unknown;
+      },
+    ) => {
       const tx = runtime.edit();
       const previousIdentity = tx.getCfcState().implementationIdentity;
       tx.setCfcImplementationIdentity({
@@ -753,10 +769,10 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
           compiledDocWriteSchema(),
           tx,
         );
-        cell.set({
-          ...(cell.get() as Record<string, unknown>),
-          patternCoverageSpans: value,
-        });
+        const next = { ...(cell.get() as Record<string, unknown>) };
+        delete next.patternCoverageSpansJson;
+        delete next.patternCoverageSpans;
+        cell.set({ ...next, ...value });
       } finally {
         tx.setCfcImplementationIdentity(previousIdentity);
       }
@@ -766,12 +782,22 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
 
     // A span whose id is the wrong type is dropped rather than reported against
     // malformed coordinates.
-    await replaceSpans([{ ...spans[0], id: "not-a-number" }]);
+    await replaceSpans({
+      patternCoverageSpansJson: JSON.stringify([{
+        ...spans[0],
+        id: "not-a-number",
+      }]),
+    });
     expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
       .toBeUndefined();
 
-    // A non-array spans value is dropped too.
-    await replaceSpans("not-an-array");
+    // Malformed JSON is dropped too.
+    await replaceSpans({ patternCoverageSpansJson: "not-json" });
+    expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
+      .toBeUndefined();
+
+    // The durable format accepts only the scalar JSON field.
+    await replaceSpans({ patternCoverageSpans: spans });
     expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
       .toBeUndefined();
   });
@@ -1226,6 +1252,31 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
   it("replicates fabric dependencies even though source closures exclude them", async () => {
     const spaceB = "did:key:z6MkCellCacheFabricReplicationTarget";
     const { modules, importerIdentity, depIdentity } = fabricLinkedModules();
+    const coverageSpans = [{
+      fileName: "/main.tsx",
+      id: 1,
+      kind: "runtime" as const,
+      startLine: 1,
+      endLine: 1,
+      startColumn: 1,
+      endColumn: 20,
+    }];
+    const policyManifest = buildCfcPolicyArtifactManifest({
+      formatVersion: 1,
+      moduleIdentity: importerIdentity,
+      symbol: "rules",
+      template: {
+        templateVersion: 1,
+        exchangeRules: [],
+        dependencies: { authorityOnly: [], dataBearing: [] },
+        integrityRequirements: {},
+      },
+    });
+    modules[0] = {
+      ...modules[0]!,
+      patternCoverageSpans: coverageSpans,
+      policyManifests: [policyManifest],
+    };
     const replicationOpts = {
       runtimeVersion,
     };
@@ -1277,7 +1328,269 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     expect(depSource?.has(depIdentity)).toBe(true);
     expect(compiled.has(importerIdentity)).toBe(true);
     expect(compiled.has(depIdentity)).toBe(true);
+    expect(compiled.get(importerIdentity)?.patternCoverageSpans).toEqual(
+      coverageSpans,
+    );
+    expect(compiled.get(importerIdentity)?.policyManifests).toEqual([
+      policyManifest,
+    ]);
+
+    const damageTx = runtime.edit();
+    const previousIdentity = damageTx.getCfcState().implementationIdentity;
+    damageTx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: "compile-cache",
+    });
+    try {
+      runtime.getCell(
+        spaceB,
+        sourceDocKey(importerIdentity),
+        undefined,
+        damageTx,
+      ).set({ damaged: true });
+      runtime.getCell(
+        spaceB,
+        compiledDocKey(runtimeVersion, importerIdentity),
+        undefined,
+        damageTx,
+      ).set({ damaged: true });
+    } finally {
+      damageTx.setCfcImplementationIdentity(previousIdentity);
+    }
+    damageTx.prepareCfc();
+    expect((await damageTx.commit()).error).toBeUndefined();
+
+    await manager.replicateClosures(importerIdentity, spaceA, spaceB);
+    const repairedTx = runtime.edit();
+    const repairedSource = await loadVerifiedSourceClosure(
+      runtime,
+      spaceB,
+      importerIdentity,
+      repairedTx,
+    );
+    const repairedCompiled = await loadCompiledClosure(
+      runtime,
+      spaceB,
+      importerIdentity,
+      replicationOpts,
+      repairedTx,
+    );
+    repairedTx.abort?.();
+    expect(repairedSource?.has(importerIdentity)).toBe(true);
+    expect(repairedCompiled.has(importerIdentity)).toBe(true);
   });
+
+  it("distinguishes persisted closures that share an entry module", async () => {
+    const targetSpace = "did:key:z6MkCellCacheSharedEntryTarget";
+    const main = {
+      name: "/main.ts",
+      contents: "export const main = 1;",
+    };
+    const first = toModules({
+      main: main.name,
+      files: [
+        main,
+        { name: "/first.ts", contents: "export const first = 1;" },
+      ],
+    });
+    const second = toModules({
+      main: main.name,
+      files: [
+        main,
+        { name: "/second.ts", contents: "export const second = 2;" },
+      ],
+    });
+    expect(second.entryIdentity).toBe(first.entryIdentity);
+
+    const manager = runtime.patternManager as unknown as {
+      persistCompileCacheTracked(
+        space: string,
+        modules: CacheableModule[],
+        entryIdentity: string,
+        opts: { runtimeVersion: string },
+      ): Promise<void>;
+    };
+    await manager.persistCompileCacheTracked(
+      targetSpace,
+      first.modules,
+      first.entryIdentity,
+      { runtimeVersion },
+    );
+    await manager.persistCompileCacheTracked(
+      targetSpace,
+      second.modules,
+      second.entryIdentity,
+      { runtimeVersion },
+    );
+
+    const firstExtraIdentity =
+      first.modules.find((module) => module.filename === "/first.ts")!.identity;
+    const secondExtraIdentity =
+      second.modules.find((module) => module.filename === "/second.ts")!
+        .identity;
+    const readTx = runtime.edit();
+    const loaded = await loadCompiledClosure(
+      runtime,
+      targetSpace,
+      second.entryIdentity,
+      { runtimeVersion },
+      readTx,
+    );
+    readTx.abort?.();
+
+    expect(loaded.has(secondExtraIdentity)).toBe(true);
+    expect(loaded.has(firstExtraIdentity)).toBe(false);
+
+    await manager.persistCompileCacheTracked(
+      targetSpace,
+      first.modules,
+      first.entryIdentity,
+      { runtimeVersion },
+    );
+    const replayTx = runtime.edit();
+    const replayed = await loadCompiledClosure(
+      runtime,
+      targetSpace,
+      first.entryIdentity,
+      { runtimeVersion },
+      replayTx,
+    );
+    replayTx.abort?.();
+    expect(replayed.has(firstExtraIdentity)).toBe(true);
+    expect(replayed.has(secondExtraIdentity)).toBe(false);
+  });
+
+  it("tracks a queued replacement write before its predecessor completes", async () => {
+    const targetSpace = "did:key:z6MkCellCacheQueuedWriteTarget";
+    const main = {
+      name: "/main.ts",
+      contents: "export const main = 1;",
+    };
+    const first = toModules({
+      main: main.name,
+      files: [
+        main,
+        { name: "/first.ts", contents: "export const first = 1;" },
+      ],
+    });
+    const second = toModules({
+      main: main.name,
+      files: [
+        main,
+        { name: "/second.ts", contents: "export const second = 2;" },
+      ],
+    });
+    const manager = runtime.patternManager as unknown as {
+      persistCompileCacheTracked(
+        space: string,
+        modules: CacheableModule[],
+        entryIdentity: string,
+        opts: { runtimeVersion: string },
+      ): Promise<void>;
+      writeBackCompileCache(
+        space: string,
+        modules: CacheableModule[],
+        entryIdentity: string,
+        opts: { runtimeVersion: string },
+      ): Promise<void>;
+      pendingCacheWriteBacks: Set<Promise<unknown>>;
+    };
+    const originalWriteBack = manager.writeBackCompileCache;
+    const firstStarted = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+    const secondStarted = Promise.withResolvers<void>();
+    const releaseSecond = Promise.withResolvers<void>();
+    let writeCount = 0;
+    let firstWrite: Promise<void> | undefined;
+    let secondWrite: Promise<void> | undefined;
+    manager.writeBackCompileCache = async () => {
+      writeCount++;
+      if (writeCount === 1) {
+        firstStarted.resolve();
+        await releaseFirst.promise;
+      } else {
+        secondStarted.resolve();
+        await releaseSecond.promise;
+      }
+    };
+
+    try {
+      firstWrite = manager.persistCompileCacheTracked(
+        targetSpace,
+        first.modules,
+        first.entryIdentity,
+        { runtimeVersion },
+      );
+      await firstStarted.promise;
+      secondWrite = manager.persistCompileCacheTracked(
+        targetSpace,
+        second.modules,
+        second.entryIdentity,
+        { runtimeVersion },
+      );
+
+      expect(manager.pendingCacheWriteBacks.size).toBe(2);
+      releaseFirst.resolve();
+      await secondStarted.promise;
+      releaseSecond.resolve();
+      await Promise.all([firstWrite, secondWrite]);
+      expect(writeCount).toBe(2);
+    } finally {
+      releaseFirst.resolve();
+      releaseSecond.resolve();
+      await Promise.allSettled(
+        [firstWrite, secondWrite].filter(
+          (write): write is Promise<void> => write !== undefined,
+        ),
+      );
+      manager.writeBackCompileCache = originalWriteBack;
+    }
+  });
+
+  it("retains persistence entries for the runner session", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const manager = runtime.patternManager as unknown as {
+      persistCompileCacheTracked(
+        space: string,
+        modules: CacheableModule[],
+        entryIdentity: string,
+        opts: { runtimeVersion: string },
+      ): Promise<void>;
+      writeBackCompileCache(
+        space: string,
+        modules: CacheableModule[],
+        entryIdentity: string,
+        opts: { runtimeVersion: string },
+      ): Promise<void>;
+      persistedCompileCacheClosures: Map<string, string>;
+    };
+    const originalWriteBack = manager.writeBackCompileCache;
+    manager.writeBackCompileCache = () => Promise.resolve();
+    try {
+      for (let index = 0; index <= 1000; index++) {
+        await manager.persistCompileCacheTracked(
+          `did:key:z6MkPersistenceSlot${index}`,
+          modules,
+          entryIdentity,
+          { runtimeVersion },
+        );
+      }
+    } finally {
+      manager.writeBackCompileCache = originalWriteBack;
+    }
+
+    expect(manager.persistedCompileCacheClosures.size).toBe(1001);
+    expect(
+      manager.persistedCompileCacheClosures.has(
+        JSON.stringify([
+          "did:key:z6MkPersistenceSlot0",
+          runtimeVersion,
+          entryIdentity,
+        ]),
+      ),
+    ).toBe(true);
+  });
+
   // Regression: before bd98e01a4, compiled docs were stamped with a per-user
   // `cf-compiled-by:<did>` atom. A second user's cold-compile writeback of the
   // SAME content into the same space was rejected by the CFC label merge

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -703,6 +703,79 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     );
   });
 
+  it("round-trips pattern coverage spans and rejects malformed stored spans", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const spans = [{
+      fileName: "/main.tsx",
+      id: 1,
+      kind: "runtime" as const,
+      startLine: 3,
+      endLine: 3,
+      startColumn: 1,
+      endColumn: 20,
+    }];
+    modules[0] = { ...modules[0]!, patternCoverageSpans: spans };
+    const wtx = runtime.edit();
+    writeCompiledDocs(runtime, spaceA, modules, entryIdentity, opts(), wtx);
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    const coldLoad = async () => {
+      const rtx = runtime.edit();
+      const loaded = await loadCompiledClosure(
+        runtime,
+        spaceA,
+        entryIdentity,
+        opts(),
+        rtx,
+      );
+      rtx.abort?.();
+      return loaded;
+    };
+
+    // Valid spans survive the round trip.
+    expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
+      .toEqual(spans);
+
+    // Overwrite the stored doc's spans with malformed values, bypassing the
+    // write path's integrity via the compile-cache implementation identity.
+    const replaceSpans = async (value: unknown) => {
+      const tx = runtime.edit();
+      const previousIdentity = tx.getCfcState().implementationIdentity;
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "compile-cache",
+      });
+      try {
+        const cell = runtime.getCell(
+          spaceA,
+          compiledDocKey(RTVER, entryIdentity),
+          compiledDocWriteSchema(),
+          tx,
+        );
+        cell.set({
+          ...(cell.get() as Record<string, unknown>),
+          patternCoverageSpans: value,
+        });
+      } finally {
+        tx.setCfcImplementationIdentity(previousIdentity);
+      }
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+    };
+
+    // A span whose id is the wrong type is dropped rather than reported against
+    // malformed coordinates.
+    await replaceSpans([{ ...spans[0], id: "not-a-number" }]);
+    expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
+      .toBeUndefined();
+
+    // A non-array spans value is dropped too.
+    await replaceSpans("not-an-array");
+    expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
+      .toBeUndefined();
+  });
+
   it("persists and cold-loads verified policy manifests without module evaluation", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
     const artifact = buildCfcPolicyArtifactManifest({

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -4,6 +4,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
+import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import type { Engine } from "../src/harness/engine.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import type {
@@ -11,10 +12,13 @@ import type {
   IExtendedStorageTransaction,
 } from "../src/storage/interface.ts";
 import {
+  compiledDocKey,
+  compiledDocWriteSchema,
   getCompileCacheRuntimeVersion,
   loadCompiledClosure,
   loadVerifiedSourceClosure,
   setCompileCacheRuntimeVersionForTesting,
+  sourceDocKey,
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 
@@ -25,6 +29,7 @@ if (resolvedRuntimeVersion === undefined) {
   throw new Error("compile-cache runtime version unavailable in Deno test");
 }
 const runtimeVersion = resolvedRuntimeVersion;
+const coverageRuntimeVersion = `${runtimeVersion}/pattern-coverage`;
 
 // Step 5: PatternManager drives the content-addressed cell cache on the ESM
 // path — cold compiles write the module set back (CFC-stamped), warm compiles
@@ -52,10 +57,11 @@ describe("ESM compile via content-addressed cell cache", () => {
     ],
   };
 
-  const newRuntime = () =>
+  const newRuntime = (patternCoverage?: PatternCoverageCollector) =>
     new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      ...(patternCoverage === undefined ? {} : { patternCoverage }),
     });
 
   beforeEach(() => {
@@ -168,6 +174,123 @@ describe("ESM compile via content-addressed cell cache", () => {
     expect(await run(warm, 6)).toEqual({ result: 12 });
   });
 
+  it("recompiles coverage documents without JSON spans before loading by identity", async () => {
+    const firstCoverage = new PatternCoverageCollector();
+    const firstRuntime = newRuntime(firstCoverage);
+    const firstTx = firstRuntime.edit();
+    try {
+      const compiled = await firstRuntime.patternManager.compilePattern(
+        PROGRAM,
+        { space, tx: firstTx },
+      );
+      const entryIdentity = firstRuntime.patternManager.getArtifactEntryRef(
+        compiled,
+      )!.identity;
+
+      const readTx = firstRuntime.edit();
+      const closure = await loadCompiledClosure(
+        firstRuntime,
+        space,
+        entryIdentity,
+        { runtimeVersion: coverageRuntimeVersion },
+        readTx,
+      );
+      readTx.abort?.("coverage closure read complete");
+      expect(closure.size).toBeGreaterThan(0);
+      for (const doc of closure.values()) {
+        expect(Array.isArray(doc.patternCoverageSpans)).toBe(true);
+      }
+
+      const legacyTx = firstRuntime.edit();
+      const previousIdentity = legacyTx.getCfcState().implementationIdentity;
+      legacyTx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "compile-cache",
+      });
+      try {
+        for (const identity of closure.keys()) {
+          const cell = firstRuntime.getCell(
+            space,
+            compiledDocKey(coverageRuntimeVersion, identity),
+            compiledDocWriteSchema(),
+            legacyTx,
+          );
+          const stored = { ...(cell.get() as Record<string, unknown>) };
+          delete stored.patternCoverageSpansJson;
+          cell.set(stored);
+        }
+      } finally {
+        legacyTx.setCfcImplementationIdentity(previousIdentity);
+      }
+      legacyTx.prepareCfc();
+      expect((await legacyTx.commit()).error).toBeUndefined();
+
+      const restoredCoverage = new PatternCoverageCollector();
+      const restoredRuntime = newRuntime(restoredCoverage);
+      try {
+        const restored = await restoredRuntime.patternManager
+          .loadPatternByIdentity(entryIdentity, "default", space);
+        expect(typeof restored).toBe("function");
+        await restoredRuntime.patternManager.flushCompileCacheWrites();
+        expect(restoredCoverage.report().files.length).toBeGreaterThan(0);
+
+        const inspectTx = restoredRuntime.edit();
+        for (const identity of closure.keys()) {
+          const stored = restoredRuntime.getCell(
+            space,
+            compiledDocKey(coverageRuntimeVersion, identity),
+            compiledDocWriteSchema(),
+            inspectTx,
+          ).get() as Record<string, unknown>;
+          expect(typeof stored.patternCoverageSpansJson).toBe("string");
+        }
+        inspectTx.abort?.("repaired coverage closure inspection complete");
+      } finally {
+        await restoredRuntime.dispose();
+      }
+    } finally {
+      firstTx.abort?.("coverage format recovery test complete");
+      await firstRuntime.dispose();
+    }
+  });
+
+  it("repairs missing source data before a known-identity warm load", async () => {
+    const pm = runtime.patternManager;
+    const cold = await pm.compilePattern(PROGRAM, { space, tx });
+    const entryIdentity = pm.getArtifactEntryRef(cold)!.identity;
+
+    const damageTx = runtime.edit();
+    runtime.getCell(
+      space,
+      sourceDocKey(entryIdentity),
+      undefined,
+      damageTx,
+    ).set({ damaged: true });
+    expect((await damageTx.commit()).error).toBeUndefined();
+
+    const repaired = await pm.compilePattern(PROGRAM, {
+      space,
+      tx,
+      knownEntryIdentity: entryIdentity,
+    });
+    expect(pm.getCompileCacheStats()).toEqual({
+      hits: 1,
+      misses: 1,
+      byIdentityHits: 0,
+    });
+    expect(await run(repaired, 4)).toEqual({ result: 8 });
+
+    const readTx = runtime.edit();
+    const source = await loadVerifiedSourceClosure(
+      runtime,
+      space,
+      entryIdentity,
+      readTx,
+    );
+    readTx.abort?.("known-identity source repair probe complete");
+    expect(source?.has(entryIdentity)).toBe(true);
+  });
+
   it("persists the derived record surface and reads it back (Fix B round-trip)", async () => {
     // Guards the Fix B perf win against a SILENT regression: because the parse
     // fallback yields byte-identical records, a pattern still loads + runs
@@ -241,7 +364,7 @@ describe("ESM compile via content-addressed cell cache", () => {
     }
   });
 
-  it("keeps source-free identity recovery best-effort when writeback fails", async () => {
+  it("retries a best-effort identity recovery writeback on the next load", async () => {
     const compiled = await (runtime.harness as Engine).compileToRecordGraph(
       PROGRAM,
     );
@@ -275,6 +398,26 @@ describe("ESM compile via content-addressed cell cache", () => {
       );
       expect(typeof loaded).toBe("function");
       await runtime2.patternManager.flushCompileCacheWrites();
+
+      runtime2.editWithRetry = originalEditWithRetry;
+      const retried = await runtime2.patternManager.loadPatternByIdentity(
+        compiled.entryIdentity,
+        "default",
+        space,
+      );
+      expect(typeof retried).toBe("function");
+      await runtime2.patternManager.flushCompileCacheWrites();
+
+      const readTx = runtime2.edit();
+      const recovered = await loadCompiledClosure(
+        runtime2,
+        space,
+        compiled.entryIdentity,
+        { runtimeVersion },
+        readTx,
+      );
+      readTx.abort?.();
+      expect(recovered.has(compiled.entryIdentity)).toBe(true);
     } finally {
       runtime2.editWithRetry = originalEditWithRetry;
       await runtime2.dispose();

--- a/packages/runner/test/module-byte-cache.test.ts
+++ b/packages/runner/test/module-byte-cache.test.ts
@@ -9,10 +9,14 @@ import type {
   CompiledModuleArtifact,
   RuntimeProgram,
 } from "../src/harness/types.ts";
+import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import {
+  compiledDocKey,
   getCompileCacheRuntimeVersion,
   loadCompiledClosure,
+  loadVerifiedSourceClosure,
   setCompileCacheRuntimeVersionForTesting,
+  sourceDocKey,
 } from "../src/compilation-cache/cell-cache.ts";
 
 const signer = await Identity.fromPassphrase("module byte cache test");
@@ -45,16 +49,20 @@ class FakeByteCache implements ModuleByteCache {
   }
   putAll(
     rt: string,
-    mods: readonly { identity: string; js: string; sourceMap?: unknown }[],
+    mods: readonly ({ identity: string } & CompiledModuleArtifact)[],
   ): void {
     this.puts++;
     for (const x of mods) {
-      this.m.set(
-        `${rt}\0${x.identity}`,
-        x.sourceMap === undefined
-          ? { js: x.js }
-          : { js: x.js, sourceMap: x.sourceMap },
-      );
+      this.m.set(`${rt}\0${x.identity}`, {
+        js: x.js,
+        ...(x.sourceMap === undefined ? {} : { sourceMap: x.sourceMap }),
+        ...(x.patternCoverageSpans === undefined
+          ? {}
+          : { patternCoverageSpans: x.patternCoverageSpans }),
+        ...(x.policyManifests === undefined
+          ? {}
+          : { policyManifests: x.policyManifests }),
+      });
     }
   }
 }
@@ -195,6 +203,146 @@ describe("ModuleByteCache cross-runtime reuse", () => {
       expect(result.getAsQueryResult()).toEqual({ result: 49 });
     } finally {
       await rtB.dispose();
+    }
+  });
+
+  it("repairs a remembered closure after its stored documents are damaged", async () => {
+    const byteCache = new FakeByteCache();
+    const rt = runtimeIn(byteCache);
+    const space = (await Identity.fromPassphrase(
+      "damaged byte-cache space",
+    )).did();
+    const originalEditWithRetry = rt.editWithRetry.bind(rt);
+    let persistenceWrites = 0;
+    rt.editWithRetry = ((fn, maxRetries) => {
+      persistenceWrites++;
+      return originalEditWithRetry(fn, maxRetries);
+    }) as typeof rt.editWithRetry;
+
+    const compile = async (): Promise<string> => {
+      const tx = rt.edit();
+      try {
+        const pattern = await rt.patternManager.compilePattern(PROGRAM, {
+          space,
+          tx,
+        });
+        await tx.commit();
+        return rt.patternManager.getArtifactEntryRef(pattern)!.identity;
+      } catch (error) {
+        tx.abort?.(error);
+        throw error;
+      }
+    };
+
+    try {
+      const entryIdentity = await compile();
+      expect(persistenceWrites).toBe(1);
+
+      const damageTx = rt.edit();
+      const previousIdentity = damageTx.getCfcState().implementationIdentity;
+      damageTx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "compile-cache",
+      });
+      try {
+        rt.getCell(
+          space,
+          sourceDocKey(entryIdentity),
+          undefined,
+          damageTx,
+        ).set({ damaged: true });
+        rt.getCell(
+          space,
+          compiledDocKey(runtimeVersion, entryIdentity),
+          undefined,
+          damageTx,
+        ).set({ damaged: true });
+      } finally {
+        damageTx.setCfcImplementationIdentity(previousIdentity);
+      }
+      damageTx.prepareCfc();
+      expect((await damageTx.commit()).error).toBeUndefined();
+
+      const repairedIdentity = await compile();
+      expect(repairedIdentity).toBe(entryIdentity);
+      expect(persistenceWrites).toBe(2);
+      expect(rt.patternManager.getCompileCacheStats()).toEqual({
+        hits: 1,
+        misses: 1,
+        byIdentityHits: 0,
+      });
+
+      const readTx = rt.edit();
+      const source = await loadVerifiedSourceClosure(
+        rt,
+        space,
+        entryIdentity,
+        readTx,
+      );
+      const compiled = await loadCompiledClosure(
+        rt,
+        space,
+        entryIdentity,
+        { runtimeVersion },
+        readTx,
+      );
+      readTx.abort?.();
+      expect(source?.has(entryIdentity)).toBe(true);
+      expect(compiled.has(entryIdentity)).toBe(true);
+    } finally {
+      rt.editWithRetry = originalEditWithRetry;
+      await rt.dispose();
+    }
+  });
+
+  it("persists covered process-cache hits once per space", async () => {
+    const byteCache = new FakeByteCache();
+    const coverage = new PatternCoverageCollector();
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      moduleByteCache: byteCache,
+      patternCoverage: coverage,
+    });
+    const spaceA = (await Identity.fromPassphrase(
+      "covered byte-cache space A",
+    )).did();
+    const spaceB = (await Identity.fromPassphrase(
+      "covered byte-cache space B",
+    )).did();
+    const originalEditWithRetry = rt.editWithRetry.bind(rt);
+    let persistenceWrites = 0;
+    rt.editWithRetry = ((fn, maxRetries) => {
+      persistenceWrites++;
+      return originalEditWithRetry(fn, maxRetries);
+    }) as typeof rt.editWithRetry;
+
+    const compileIn = async (space: typeof spaceA) => {
+      const tx = rt.edit();
+      try {
+        await rt.patternManager.compilePattern(PROGRAM, { space, tx });
+        await tx.commit();
+      } catch (error) {
+        tx.abort?.(error);
+        throw error;
+      }
+    };
+
+    try {
+      await compileIn(spaceA);
+      await compileIn(spaceA);
+      await Promise.all([compileIn(spaceB), compileIn(spaceB)]);
+
+      expect(persistenceWrites).toBe(2);
+      expect(rt.patternManager.getCompileCacheStats()).toEqual({
+        hits: 3,
+        misses: 1,
+        byIdentityHits: 0,
+      });
+      expect(coverage.report().files.length).toBeGreaterThan(0);
+    } finally {
+      rt.editWithRetry = originalEditWithRetry;
+      await rt.dispose();
     }
   });
 

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals, assertObjectMatch } from "@std/assert";
+import { join } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import {
   PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
@@ -7,6 +8,7 @@ import {
   patternCoverageReportToLcov,
   Runtime,
   type RuntimeProgram,
+  writePatternCoverageLcov,
 } from "../src/index.ts";
 
 function lineContaining(source: string, text: string): number {
@@ -721,6 +723,71 @@ Deno.test("runtime-level coverage instruments the cell-cache compile path", asyn
   }
 });
 
+Deno.test("runtime-level coverage instruments the direct (no-space) compile path", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("direct compile coverage");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const coverage = new PatternCoverageCollector();
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+    patternCoverage: coverage,
+  });
+  try {
+    const source = [
+      'import { pattern } from "commonfabric";',
+      'const greeting = "hi";',
+      "export default pattern(() => {",
+      "  return { greeting };",
+      "});",
+    ].join("\n");
+    // No target space → compilePattern takes the direct compileToRecordGraph
+    // path rather than compileViaCellCache.
+    await runtime.patternManager.compilePattern(source);
+    assert(coverage.report().totals.coveredRuntimeLines > 0);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("runtime-level coverage instruments the cell-cache path with no resolved compile version", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const { setCompileCacheRuntimeVersionForTesting } = await import(
+    "../src/compilation-cache/cell-cache.ts"
+  );
+  const identity = await Identity.fromPassphrase(
+    "no-version cell-cache coverage",
+  );
+  const storageManager = StorageManager.emulate({ as: identity });
+  const coverage = new PatternCoverageCollector();
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+    patternCoverage: coverage,
+  });
+  // Force getCompileCacheRuntimeVersion() to resolve undefined, which routes
+  // compileViaCellCache through its no-cache-version branch.
+  const restore = setCompileCacheRuntimeVersionForTesting(undefined);
+  try {
+    const source = [
+      'import { pattern } from "commonfabric";',
+      'const greeting = "hi";',
+      "export default pattern(() => {",
+      "  return { greeting };",
+      "});",
+    ].join("\n");
+    await runtime.patternManager.compilePattern(source, {
+      space: identity.did(),
+    });
+    assert(coverage.report().totals.coveredRuntimeLines > 0);
+  } finally {
+    restore();
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("toData/ingest round-trips spans and hit counts", () => {
   const source = new PatternCoverageCollector();
   const span = {
@@ -781,6 +848,61 @@ Deno.test("ingest merges hit-only data against another realm's spans", () => {
       "",
     ].join("\n"),
   );
+});
+
+Deno.test("ingest ignores zero-count hits", () => {
+  // A realm that ran the instrumented bytes but never reached a statement
+  // reports it with count 0; merging that must not mark the line covered.
+  const collector = new PatternCoverageCollector();
+  collector.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  collector.ingest({
+    spans: [],
+    hits: [{ fileName: "/subject.tsx", id: 1, count: 0 }],
+  });
+  assertEquals(collector.report().totals.coveredRuntimeLines, 0);
+});
+
+Deno.test("writePatternCoverageLcov writes the tagged report to a file", async () => {
+  const collector = new PatternCoverageCollector();
+  collector.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  collector.hit("/subject.tsx", 1);
+
+  const dir = await Deno.makeTempDir({ prefix: "write-pattern-lcov-" });
+  try {
+    // A nested path exercises the mkdir the writer does before writing.
+    const outputPath = join(dir, "nested", "coverage.lcov");
+    await writePatternCoverageLcov(collector, outputPath, {
+      testName: PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
+    });
+
+    const written = await Deno.readTextFile(outputPath);
+    assertEquals(
+      written,
+      patternCoverageReportToLcov(
+        collector.report(),
+        PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
+      ),
+    );
+    assert(written.includes("TN:pattern-runtime-integration"));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("patternCoverageReportToLcov tags the integration stream", () => {

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals, assertObjectMatch } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import {
+  PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
   PatternCoverageCollector,
   patternCoverageOutputPath,
   patternCoverageReportToLcov,
@@ -672,6 +673,136 @@ Deno.test("pattern coverage excludes test files by default", () => {
   );
 });
 
+Deno.test("runtime-level coverage instruments the cell-cache compile path", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("cell-cache coverage test");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const coverage = new PatternCoverageCollector();
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+    patternCoverage: coverage,
+  });
+  try {
+    const source = [
+      'import { pattern } from "commonfabric";',
+      'const greeting = "hi";',
+      "export default pattern(() => {",
+      "  return { greeting };",
+      "});",
+    ].join("\n");
+    // compilePattern with a target space takes the content-addressed cell-cache
+    // path (compileViaCellCache) — the same path a piece creation and a browser
+    // pattern load take — rather than the direct compile the other tests use.
+    await runtime.patternManager.compilePattern(source, {
+      space: identity.did(),
+    });
+
+    // Prove the cell-cache path actually ran, and cold-compiled. Only
+    // compileViaCellCache touches these counters, so the direct compile — which
+    // instruments too, and would satisfy the coverage assertions below on its
+    // own — leaves them at zero and fails here instead of passing quietly.
+    assertEquals(runtime.patternManager.getCompileCacheStats(), {
+      hits: 0,
+      misses: 1,
+      byIdentityHits: 0,
+    });
+
+    const report = coverage.report();
+    assert(report.files.length > 0, "cell-cache compile registered no spans");
+    // The top-level statements run at module evaluation, so they record hits.
+    assert(
+      report.totals.coveredRuntimeLines > 0,
+      "cell-cache compile recorded no covered lines",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("toData/ingest round-trips spans and hit counts", () => {
+  const source = new PatternCoverageCollector();
+  const span = {
+    fileName: "/subject.tsx",
+    kind: "runtime" as const,
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  };
+  source.registerSpan({ ...span, id: 1 });
+  source.registerSpan({ ...span, id: 2, startLine: 2, endLine: 2 });
+  source.hit("/subject.tsx", 1);
+  source.hit("/subject.tsx", 1);
+
+  // A JSON round-trip stands in for the process/worker boundary the data crosses.
+  const data = JSON.parse(JSON.stringify(source.toData()));
+  const sink = new PatternCoverageCollector();
+  sink.ingest(data);
+
+  assertEquals(
+    patternCoverageReportToLcov(sink.report()),
+    patternCoverageReportToLcov(source.report()),
+  );
+});
+
+Deno.test("ingest merges hit-only data against another realm's spans", () => {
+  // The realm that compiled the pattern owns the spans; a realm that only
+  // warm-loaded the already-instrumented bytes reports hits with no spans. The
+  // union carries both, keyed by the fileName the transformer baked in.
+  const compiler = new PatternCoverageCollector();
+  compiler.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+
+  const merged = new PatternCoverageCollector();
+  merged.ingest(compiler.toData()); // spans, no hits (compiler never ran)
+  merged.ingest({
+    spans: [],
+    hits: [{ fileName: "/subject.tsx", id: 1, count: 3 }],
+  });
+
+  assertEquals(
+    patternCoverageReportToLcov(merged.report()),
+    [
+      "TN:pattern-runtime",
+      "SF:/subject.tsx",
+      "DA:1,3",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("patternCoverageReportToLcov tags the integration stream", () => {
+  const coverage = new PatternCoverageCollector();
+  coverage.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  coverage.hit("/subject.tsx", 1);
+
+  const lcov = patternCoverageReportToLcov(
+    coverage.report(),
+    PATTERN_COVERAGE_INTEGRATION_TEST_NAME,
+  );
+  assertEquals(lcov.split("\n")[0], "TN:pattern-runtime-integration");
+});
+
 Deno.test("pattern coverage output paths distinguish separators from underscores", () => {
   const coverageDir = "/tmp/coverage";
   const cwd = Deno.cwd();
@@ -687,4 +818,275 @@ Deno.test("pattern coverage output paths distinguish separators from underscores
   assert(withSeparator.includes("fixtures%2Fa%2Fb.test.tsx"));
   assert(withUnderscores.includes("fixtures%2Fa__b.test.tsx"));
   assert(withSeparator !== withUnderscores);
+});
+
+// A piece created in one realm and resumed in another loads source-free BY
+// IDENTITY: the resuming runtime holds only the entry's content identity, so it
+// reads the compiled closure from storage and evaluates it without a compile.
+// That path has to carry coverage on its own — it never runs the transformer, so
+// the spans naming the instrumented lines can only come from the stored
+// document, and the collector only observes probes if it is installed as the
+// sandbox global for the evaluation. This is where authored event-handler bodies
+// actually execute in the browser.
+const RESUME_COVERAGE_SOURCE = [
+  `import { handler, pattern, schema, type Stream } from "commonfabric";`,
+  `import "commonfabric/schema";`,
+  ``,
+  `interface Input {`,
+  `  messageCount: number;`,
+  `}`,
+  ``,
+  `interface Output {`,
+  `  messageCount: number;`,
+  `  recordMessage: Stream<{ message: string }>;`,
+  `}`,
+  ``,
+  `const model = schema({`,
+  `  type: "object",`,
+  `  properties: {`,
+  `    messageCount: { type: "number", default: 0, asCell: ["cell"] },`,
+  `  },`,
+  `  default: { messageCount: 0 },`,
+  `});`,
+  ``,
+  `const recordMessage = handler(`,
+  `  {`,
+  `    type: "object",`,
+  `    properties: { message: { type: "string" } },`,
+  `    required: ["message"],`,
+  `  },`,
+  `  model,`,
+  `  (_event, state) => {`,
+  `    const next = state.messageCount.get() + 1;`,
+  `    state.messageCount.set(next);`,
+  `  },`,
+  `);`,
+  ``,
+  `export const coveragePattern = pattern<Input, Output>(`,
+  `  (cell) => {`,
+  `    return {`,
+  `      messageCount: cell.messageCount,`,
+  `      recordMessage: recordMessage(cell),`,
+  `    };`,
+  `  },`,
+  `  model,`,
+  `);`,
+].join("\n");
+
+Deno.test("pattern coverage records a piece resumed by identity", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const signer = await Identity.fromPassphrase("by-identity pattern coverage");
+  const space = signer.did();
+  const storageManager = StorageManager.emulate({ as: signer });
+
+  const program: RuntimeProgram = {
+    main: "/main.tsx",
+    mainExport: "coveragePattern",
+    files: [{ name: "/main.tsx", contents: RESUME_COVERAGE_SOURCE }],
+  };
+  const resultCause = "by-identity pattern coverage resume";
+
+  const authorCoverage = new PatternCoverageCollector();
+  const resumeCoverage = new PatternCoverageCollector();
+  const newRuntime = (patternCoverage: PatternCoverageCollector) =>
+    new Runtime({
+      storageManager,
+      apiUrl: new URL(import.meta.url),
+      patternCoverage,
+    });
+  const rt1 = newRuntime(authorCoverage);
+  const rt2 = newRuntime(resumeCoverage);
+  try {
+    // Session 1: compile + run the piece, then flush its compiled closure to
+    // storage so a second runtime can resume it.
+    const pm1 = rt1.patternManager;
+    const tx1 = rt1.edit();
+    const cold = await pm1.compilePattern(program, { space, tx: tx1 });
+    const resultCell1 = rt1.getCell<Record<string, unknown>>(
+      space,
+      resultCause,
+      undefined,
+      tx1,
+    );
+    const r1 = rt1.run(tx1, cold, {}, resultCell1);
+    await tx1.commit();
+    await r1.pull();
+    await pm1.flushCompileCacheWrites();
+    await rt1.storageManager.synced();
+
+    // Session 2: a fresh runtime resumes the SAME piece from storage. Its nodes
+    // come from the persisted graph, so resolution runs purely by identity.
+    const pm2 = rt2.patternManager;
+    const tx2 = rt2.edit();
+    const resultCell2 = rt2.getCell<Record<string, unknown>>(
+      space,
+      resultCause,
+      undefined,
+      tx2,
+    );
+    await tx2.commit();
+    await resultCell2.sync();
+    const started = await rt2.start(resultCell2);
+    assertEquals(started, true);
+    // Pins the path under test: a cold compile in session 2 would report
+    // coverage for its own reasons and let everything below pass vacuously.
+    assertEquals(pm2.getCompileCacheStats().byIdentityHits, 1);
+
+    // Drive the handler in the RESUMED runtime — its body runs only on invoke,
+    // so the lines asserted below can only be covered by this send.
+    await resultCell2.pull();
+    resultCell2.key("recordMessage").send({ message: "world" });
+    await resultCell2.pull();
+    assertEquals(
+      (resultCell2.getAsQueryResult() as { messageCount: number }).messageCount,
+      1,
+    );
+
+    const report = resumeCoverage.report();
+    assert(report.files.length > 0);
+    assert(report.totals.coveredRuntimeLines > 0);
+    const lcov = patternCoverageReportToLcov(report);
+    assertLineHit(
+      RESUME_COVERAGE_SOURCE,
+      lcov,
+      "/main.tsx",
+      "state.messageCount.set(next);",
+    );
+  } finally {
+    await rt2.dispose();
+    await rt1.dispose();
+    await storageManager.close();
+  }
+});
+
+// The integration scenario: a non-coverage realm authored the piece, so the
+// coverage-keyed compiled closure the resuming runtime looks for does not exist.
+// The resume then falls back to cold recovery — a recompile from the stored
+// source closure — which is the only place the instrumentation can come from.
+Deno.test("pattern coverage records a piece authored without coverage and resumed with it", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const signer = await Identity.fromPassphrase(
+    "cold-recovery pattern coverage",
+  );
+  const space = signer.did();
+  const storageManager = StorageManager.emulate({ as: signer });
+
+  const program: RuntimeProgram = {
+    main: "/main.tsx",
+    mainExport: "coveragePattern",
+    files: [{ name: "/main.tsx", contents: RESUME_COVERAGE_SOURCE }],
+  };
+  const resultCause = "cold-recovery pattern coverage resume";
+
+  const resumeCoverage = new PatternCoverageCollector();
+  const healedCoverage = new PatternCoverageCollector();
+  const newRuntime = (patternCoverage?: PatternCoverageCollector) =>
+    new Runtime({
+      storageManager,
+      apiUrl: new URL(import.meta.url),
+      ...(patternCoverage ? { patternCoverage } : {}),
+    });
+  // Session 1 has coverage OFF, so it writes only the ordinary compiled variant.
+  const rt1 = newRuntime();
+  const rt2 = newRuntime(resumeCoverage);
+  const rt3 = newRuntime(healedCoverage);
+  try {
+    const pm1 = rt1.patternManager;
+    const tx1 = rt1.edit();
+    const cold = await pm1.compilePattern(program, { space, tx: tx1 });
+    const resultCell1 = rt1.getCell<Record<string, unknown>>(
+      space,
+      resultCause,
+      undefined,
+      tx1,
+    );
+    const r1 = rt1.run(tx1, cold, {}, resultCell1);
+    await tx1.commit();
+    await r1.pull();
+    await pm1.flushCompileCacheWrites();
+    await rt1.storageManager.synced();
+
+    // Session 2: coverage ON. Its closure read is keyed by the coverage variant,
+    // which session 1 never wrote, so this resume can only be served by the
+    // cold-recovery recompile.
+    const pm2 = rt2.patternManager;
+    const tx2 = rt2.edit();
+    const resultCell2 = rt2.getCell<Record<string, unknown>>(
+      space,
+      resultCause,
+      undefined,
+      tx2,
+    );
+    await tx2.commit();
+    await resultCell2.sync();
+    assertEquals(await rt2.start(resultCell2), true);
+    // Pins the path under test. `tryColdLoadByIdentity` is the one load path
+    // that touches no counter: a warm by-identity hit (session 1's variant
+    // reused, uninstrumented) or a compile through `compilePattern` (which
+    // instruments for its own reasons) would each satisfy the coverage
+    // assertions below without proving anything about cold recovery.
+    assertEquals(pm2.getCompileCacheStats(), {
+      hits: 0,
+      misses: 0,
+      byIdentityHits: 0,
+    });
+
+    // Drive the handler in the RESUMED runtime — its body runs only on invoke,
+    // so the lines asserted below can only be covered by this send.
+    await resultCell2.pull();
+    resultCell2.key("recordMessage").send({ message: "world" });
+    await resultCell2.pull();
+    assertEquals(
+      (resultCell2.getAsQueryResult() as { messageCount: number }).messageCount,
+      1,
+    );
+
+    const report = resumeCoverage.report();
+    assert(report.files.length > 0, "cold recovery registered no spans");
+    assert(report.totals.coveredRuntimeLines > 0);
+    assertLineHit(
+      RESUME_COVERAGE_SOURCE,
+      patternCoverageReportToLcov(report),
+      "/main.tsx",
+      "state.messageCount.set(next);",
+    );
+
+    // Session 2's recovery wrote its instrumented bodies back under the
+    // coverage variant, so a third coverage-on session warm-loads them instead
+    // of recompiling, and still reports coverage — the recovery heals the
+    // coverage key rather than repeating per session.
+    await pm2.flushCompileCacheWrites();
+    await rt2.storageManager.synced();
+
+    const pm3 = rt3.patternManager;
+    const tx3 = rt3.edit();
+    const resultCell3 = rt3.getCell<Record<string, unknown>>(
+      space,
+      resultCause,
+      undefined,
+      tx3,
+    );
+    await tx3.commit();
+    await resultCell3.sync();
+    assertEquals(await rt3.start(resultCell3), true);
+    assertEquals(pm3.getCompileCacheStats().byIdentityHits, 1);
+
+    await resultCell3.pull();
+    resultCell3.key("recordMessage").send({ message: "again" });
+    await resultCell3.pull();
+
+    const healedReport = healedCoverage.report();
+    assert(healedReport.totals.coveredRuntimeLines > 0);
+    assertLineHit(
+      RESUME_COVERAGE_SOURCE,
+      patternCoverageReportToLcov(healedReport),
+      "/main.tsx",
+      "state.messageCount.set(next);",
+    );
+  } finally {
+    await rt3.dispose();
+    await rt2.dispose();
+    await rt1.dispose();
+    await storageManager.close();
+  }
 });

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -717,6 +717,35 @@ Deno.test("runtime-level coverage instruments the cell-cache compile path", asyn
       report.totals.coveredRuntimeLines > 0,
       "cell-cache compile recorded no covered lines",
     );
+
+    // A stored coverage closure must carry its span metadata back into the
+    // engine. Without those spans the engine rejects the cached bodies and
+    // recompiles them.
+    const { compiler } = await runtime.harness.initialize();
+    const originalCompileToModules = compiler.compileToModules;
+    const originalCompileToModulesInterleaved =
+      compiler.compileToModulesInterleaved;
+    const failWarmCompile = () => {
+      throw new Error("warm coverage cache recompiled");
+    };
+    compiler.compileToModules =
+      failWarmCompile as typeof compiler.compileToModules;
+    compiler.compileToModulesInterleaved =
+      failWarmCompile as typeof compiler.compileToModulesInterleaved;
+    try {
+      await runtime.patternManager.compilePattern(source, {
+        space: identity.did(),
+      });
+    } finally {
+      compiler.compileToModules = originalCompileToModules;
+      compiler.compileToModulesInterleaved =
+        originalCompileToModulesInterleaved;
+    }
+    assertEquals(runtime.patternManager.getCompileCacheStats(), {
+      hits: 1,
+      misses: 1,
+      byIdentityHits: 0,
+    });
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -8,6 +8,8 @@ import {
   preserveLineCount,
   transformInjectHelperModule,
 } from "../src/harness/pretransform.ts";
+import { helperInjectionLineOffset } from "../src/harness/engine.ts";
+import { injectCfHelpers } from "@commonfabric/ts-transformers";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
@@ -214,4 +216,68 @@ Deno.test("preserveLineCount rejects expanding rewrites", () => {
     Error,
     "Import rewrite expanded from 1 to 2 lines",
   );
+});
+
+// The coverage span mapper subtracts `helperInjectionLineOffset` from every span
+// line to recover the authored line, so it has to predict exactly how far
+// `transformInjectHelperModule` moved that file's content. The two live in
+// different modules and the prediction is a re-implementation of the injector's
+// branches, so pin them against each other rather than against a hand-written
+// number: only the leading helper import shifts lines, and the trailing `h` shim
+// the injector also appends must not count.
+Deno.test("helperInjectionLineOffset matches what the injector actually shifts", async () => {
+  await ensureCompilerStack();
+  const MARKER = "const marker = 1;";
+
+  // Every shape that reaches the mapper, and what the injector does with it.
+  const cases: { label: string; source: string }[] = [
+    { label: "plain authored source", source: `const top = 0;\n${MARKER}\n` },
+    {
+      label: "disable-transform directive (blanked in place)",
+      source: `/// <cf-disable-transform />\nconst top = 0;\n${MARKER}\n`,
+    },
+    {
+      label: "stored legacy envelope (passes through untouched)",
+      source: injectCfHelpers(`const top = 0;\n${MARKER}\n`),
+    },
+  ];
+
+  for (const { label, source } of cases) {
+    const injected = transformInjectHelperModule(
+      { main: "/main.tsx", files: [{ name: "/main.tsx", contents: source }] },
+      // Mounts and the stored-source recompile both tolerate the legacy
+      // envelope; this is the path whose offsets the mapper has to predict.
+      { tolerateStoredLegacyEnvelope: true },
+    ).files[0].contents;
+
+    const lineOf = (text: string, needle: string) =>
+      text.split("\n").findIndex((line) => line.includes(needle)) + 1;
+    const authoredLine = lineOf(source, MARKER);
+    const injectedLine = lineOf(injected, MARKER);
+    assertEquals(authoredLine > 0 && injectedLine > 0, true, label);
+
+    // A span is measured over the injected text; adding the offset must land on
+    // the authored line.
+    assertEquals(
+      injectedLine + helperInjectionLineOffset(source),
+      authoredLine,
+      `${label}: offset does not recover the authored line`,
+    );
+  }
+});
+
+Deno.test("helperInjectionLineOffset leaves a blank file alone", async () => {
+  await ensureCompilerStack();
+  // "Content" here means any non-blank line, comments included — a
+  // comment-only file is injected like any other, so only a wholly blank file
+  // takes this branch. Assert against what the injector did rather than a bare
+  // number, so the two cannot drift apart.
+  for (const source of ["", "\n\n"]) {
+    const injected = transformInjectHelperModule(
+      { main: "/main.tsx", files: [{ name: "/main.tsx", contents: source }] },
+      { tolerateStoredLegacyEnvelope: true },
+    ).files[0].contents;
+    assertEquals(injected, source, "the injector touched a blank file");
+    assertEquals(helperInjectionLineOffset(source), 0);
+  }
 });

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -106,6 +106,7 @@ const MINIMAL_TREATMENT: Record<RuntimeOptionKey, MinimalTreatment> = {
   hideInternalStackFrames: { treat: "absent" },
   commitBackpressure: { treat: "absent" },
   moduleByteCache: { treat: "absent" },
+  patternCoverage: { treat: "absent" },
   fetch: { treat: "absent" },
 };
 
@@ -182,6 +183,9 @@ describe("runtimePresets conformance (CT-1814)", () => {
       get: () => undefined,
       set: () => {},
     } as unknown as NonNullable<RuntimeOptions["moduleByteCache"]>;
+    const patternCoverage = {
+      registerSpan: () => {},
+    } as unknown as NonNullable<RuntimeOptions["patternCoverage"]>;
     const trustSnapshotProvider = () => undefined;
     const telemetry = {
       dispatchEvent: () => true,
@@ -215,12 +219,14 @@ describe("runtimePresets conformance (CT-1814)", () => {
         navigateCallback,
         moduleByteCache,
         trustSnapshotProvider,
+        patternCoverage,
       })).toEqual({
         ...minimalOutputs.remoteClient,
         errorHandlers,
         navigateCallback,
         moduleByteCache,
         trustSnapshotProvider,
+        patternCoverage,
       });
     });
 
@@ -232,6 +238,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         navigateCallback,
         moduleByteCache,
         cfcEnforcementMode: "observe",
+        patternCoverage,
       })).toEqual({
         ...minimalOutputs.patternTest,
         fetch: fetchSentinel,
@@ -239,6 +246,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         navigateCallback,
         moduleByteCache,
         cfcEnforcementMode: "observe",
+        patternCoverage,
       });
     });
 
@@ -256,6 +264,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         navigateCallback,
         pieceCreatedCallback,
         onVersionSkew,
+        patternCoverage,
       })).toEqual({
         ...minimalOutputs.browserWorker,
         spaceHostMap,
@@ -269,6 +278,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         navigateCallback,
         pieceCreatedCallback,
         onVersionSkew,
+        patternCoverage,
       });
     });
 

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -2378,6 +2378,55 @@ describe("RuntimeProcessor VDom event label-view ingress", () => {
   });
 });
 
+describe("RuntimeProcessor pattern coverage IPC", () => {
+  const report = {
+    spans: [{
+      fileName: "/main.tsx",
+      id: 1,
+      kind: "runtime" as const,
+      startLine: 1,
+      endLine: 1,
+      startColumn: 1,
+      endColumn: 2,
+    }],
+    hits: [{ fileName: "/main.tsx", id: 1, count: 3 }],
+  };
+
+  it("returns the worker collector's report", () => {
+    const processor = {
+      runtime: { patternCoverage: { toData: () => report } },
+    } as unknown as RuntimeProcessor;
+    expect(
+      RuntimeProcessor.prototype.getPatternCoverage.call(processor, {
+        type: RequestType.GetPatternCoverage,
+      }),
+    ).toEqual({ data: report });
+  });
+
+  it("reports null when the worker was built without a collector", () => {
+    const processor = { runtime: {} } as unknown as RuntimeProcessor;
+    expect(
+      RuntimeProcessor.prototype.getPatternCoverage.call(processor, {
+        type: RequestType.GetPatternCoverage,
+      }),
+    ).toEqual({ data: null });
+  });
+
+  it("routes a GetPatternCoverage request through the dispatcher", async () => {
+    const processor = {
+      runtime: { patternCoverage: { toData: () => report } },
+      // handleRequest dispatches to this.getPatternCoverage; the stub carries
+      // the real method so the routing case executes it.
+      getPatternCoverage: RuntimeProcessor.prototype.getPatternCoverage,
+    } as unknown as RuntimeProcessor;
+    expect(
+      await RuntimeProcessor.prototype.handleRequest.call(processor, {
+        type: RequestType.GetPatternCoverage,
+      }),
+    ).toEqual({ data: report });
+  });
+});
+
 describe("browserWorkerParamsFromInitializationData", () => {
   it("threads CFC initialization settings through the preset into runtime options", () => {
     const telemetry = { marker() {} } as unknown as Parameters<
@@ -2496,6 +2545,39 @@ describe("browserWorkerParamsFromInitializationData", () => {
     expect(options.spaceHostMap).toEqual({
       "did:key:federated": "http://other-host.test/",
     });
+  });
+
+  it("builds a fresh collector only when the host asks for coverage", () => {
+    const storageManager = {
+      as: { did: () => "did:key:worker" },
+    } as unknown as Parameters<
+      typeof browserWorkerParamsFromInitializationData
+    >[1];
+    const telemetry = { marker() {} } as unknown as Parameters<
+      typeof browserWorkerParamsFromInitializationData
+    >[2];
+    const params = (patternCoverage: boolean | undefined) =>
+      browserWorkerParamsFromInitializationData(
+        {
+          apiUrl: "http://worker.test/",
+          identity: {} as never,
+          spaceDid: "did:key:space",
+          ...(patternCoverage === undefined ? {} : { patternCoverage }),
+        },
+        storageManager,
+        telemetry,
+      );
+
+    // On → a real collector the GetPatternCoverage handler can read back.
+    const on = runtimePresets.browserWorker(params(true));
+    expect(on.patternCoverage).toBeDefined();
+    expect(typeof on.patternCoverage?.toData).toBe("function");
+
+    // Off / absent → omitted, so the worker runs uninstrumented.
+    expect(runtimePresets.browserWorker(params(false)).patternCoverage)
+      .toBeUndefined();
+    expect(runtimePresets.browserWorker(params(undefined)).patternCoverage)
+      .toBeUndefined();
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -25,6 +25,7 @@ import {
   isCellResult,
   markRendererInputTx,
   markUiInputBlindWriteTx,
+  PatternCoverageCollector,
   Runtime,
   runtimePresets,
   RuntimeTelemetry,
@@ -77,6 +78,7 @@ import {
   GetGraphSnapshotRequest,
   type GetHomeSpaceCellRequest,
   type GetLoggerCountsRequest,
+  type GetPatternCoverageRequest,
   type GetPatternSourcesRequest,
   type GetSettleStatsHistoryRequest,
   type GetSettleStatsRequest,
@@ -100,6 +102,7 @@ import {
   type PageStartRequest,
   type PageStopRequest,
   type PageSyncedRequest,
+  type PatternCoverageResponse,
   type PatternSourcesResponse,
   type RecreateSpaceRootPatternRequest,
   type RegisterSpaceHostRequest,
@@ -248,6 +251,11 @@ export function browserWorkerParamsFromInitializationData(
       : {}),
     ...(data.trustSnapshot
       ? { trustSnapshotProvider: () => data.trustSnapshot }
+      : {}),
+    // The worker owns its collector so the GetPatternCoverage handler can read
+    // it back through `runtime.patternCoverage`; the harness pulls it at teardown.
+    ...(data.patternCoverage
+      ? { patternCoverage: new PatternCoverageCollector() }
       : {}),
   };
 }
@@ -1329,6 +1337,10 @@ export class RuntimeProcessor {
     return { counts, metadata, timing, flags };
   }
 
+  getPatternCoverage(_: GetPatternCoverageRequest): PatternCoverageResponse {
+    return { data: this.runtime.patternCoverage?.toData() ?? null };
+  }
+
   #getLoggerMetadata(): LoggerMetadata {
     const global = globalThis as unknown as {
       commonfabric?: { logger?: Record<string, Logger> };
@@ -1611,6 +1623,8 @@ export class RuntimeProcessor {
         return this.getGraphSnapshot(request);
       case RequestType.GetLoggerCounts:
         return this.getLoggerCounts(request);
+      case RequestType.GetPatternCoverage:
+        return this.getPatternCoverage(request);
       case RequestType.SetLoggerLevel:
         return this.setLoggerLevel(request);
       case RequestType.SetLoggerEnabled:

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1337,10 +1337,6 @@ export class RuntimeProcessor {
     return { counts, metadata, timing, flags };
   }
 
-  getPatternCoverage(_: GetPatternCoverageRequest): PatternCoverageResponse {
-    return { data: this.runtime.patternCoverage?.toData() ?? null };
-  }
-
   #getLoggerMetadata(): LoggerMetadata {
     const global = globalThis as unknown as {
       commonfabric?: { logger?: Record<string, Logger> };
@@ -1489,6 +1485,10 @@ export class RuntimeProcessor {
       request.durationMs,
     );
     return { result };
+  }
+
+  getPatternCoverage(_: GetPatternCoverageRequest): PatternCoverageResponse {
+    return { data: this.runtime.patternCoverage?.toData() ?? null };
   }
 
   getSettleStats(

--- a/packages/runtime-client/client/initialize-init-data.test.ts
+++ b/packages/runtime-client/client/initialize-init-data.test.ts
@@ -60,6 +60,32 @@ describe("RuntimeClient.initialize InitializationData wiring", () => {
     expect(data.clientVersion).toBe("client-sha-xyz");
   });
 
+  it("forwards patternCoverage into the worker InitializationData", async () => {
+    // The same drop-on-the-wire failure as clientVersion above: the flag is set
+    // on RuntimeClientOptions but the hand-built InitializationData literal must
+    // copy it, or the worker is built without a coverage collector and the
+    // integration jobs collect nothing.
+    const identity = await Identity.fromPassphrase("init-data coverage test");
+    const transport = new CapturingTransport();
+
+    await RuntimeClient.initialize(transport, {
+      apiUrl: new URL("http://toolshed.test"),
+      identity,
+      spaceDid: identity.did(),
+      experimental: {},
+      patternCoverage: true,
+    });
+
+    const init = transport.sent.find(
+      (m): m is IPCClientMessage =>
+        "msgId" in m && m.data?.type === RequestType.Initialize,
+    );
+    expect(init).toBeDefined();
+    const data = (init as { data: { data: { patternCoverage?: boolean } } })
+      .data.data;
+    expect(data.patternCoverage).toBe(true);
+  });
+
   it("re-emits a worker versionSkew notification as a client event", async () => {
     const identity = await Identity.fromPassphrase("skew forward test");
     const transport = new CapturingTransport();

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -3,6 +3,7 @@ import type {
   JSONSchema,
   JSONValue,
   NormalizedFullLink,
+  PatternCoverageData,
   SchedulerDiagnosisResult,
   SchedulerGraphSnapshot,
   SettleStats,
@@ -57,6 +58,7 @@ export enum RequestType {
   FlushCompileCacheWrites = "runtime:flushCompileCacheWrites",
   GetGraphSnapshot = "runtime:getGraphSnapshot",
   GetLoggerCounts = "runtime:getLoggerCounts",
+  GetPatternCoverage = "runtime:getPatternCoverage",
   SetLoggerLevel = "runtime:setLoggerLevel",
   SetLoggerEnabled = "runtime:setLoggerEnabled",
   SetTelemetryEnabled = "runtime:setTelemetryEnabled",
@@ -210,6 +212,11 @@ export interface InitializationData {
   // integration-test console capture. Off by default: each forwarded call
   // costs one postMessage, so it is enabled only for diagnostic runs.
   forwardWorkerConsole?: boolean;
+  // When true, the worker runtime instruments every pattern compile for
+  // statement coverage and accumulates hits, which the integration harness
+  // pulls at teardown via GetPatternCoverage. Test/CI only (the coverage shell
+  // build sets it); off by default. See docs/development/COVERAGE.md.
+  patternCoverage?: boolean;
 }
 
 export interface InitializeRequest extends BaseRequest {
@@ -350,6 +357,10 @@ export interface GetGraphSnapshotRequest extends BaseRequest {
 
 export interface GetLoggerCountsRequest extends BaseRequest {
   type: RequestType.GetLoggerCounts;
+}
+
+export interface GetPatternCoverageRequest extends BaseRequest {
+  type: RequestType.GetPatternCoverage;
 }
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -739,6 +750,7 @@ export type IPCClientRequest =
   | EnsureHomePatternRunningRequest
   | GetGraphSnapshotRequest
   | GetLoggerCountsRequest
+  | GetPatternCoverageRequest
   | SetLoggerLevelRequest
   | SetLoggerEnabledRequest
   | SetTelemetryEnabledRequest
@@ -822,6 +834,17 @@ export interface LoggerCountsResponse {
   metadata: LoggerMetadata;
   timing: LoggerTimingData;
   flags: LoggerFlagsData;
+}
+
+export interface PatternCoverageResponse {
+  /**
+   * The worker collector's spans and hit counts, or `null` when this worker was
+   * built without a collector. Null and empty are kept apart on purpose: a
+   * worker that never had coverage on and one that had it on but ran nothing
+   * instrumented are different failures, and reporting both as an empty report
+   * makes the first invisible.
+   */
+  data: PatternCoverageData | null;
 }
 
 export interface CellUpdateNotification {
@@ -939,6 +962,7 @@ export type RemoteResponse =
   | CfcLabelViewResponse
   | GraphSnapshotResponse
   | LoggerCountsResponse
+  | PatternCoverageResponse
   | SettleStatsResponse
   | SettleStatsHistoryResponse
   | ActionRunTraceResponse
@@ -998,6 +1022,10 @@ export type Commands = {
   [RequestType.GetLoggerCounts]: {
     request: GetLoggerCountsRequest;
     response: LoggerCountsResponse;
+  };
+  [RequestType.GetPatternCoverage]: {
+    request: GetPatternCoverageRequest;
+    response: PatternCoverageResponse;
   };
   [RequestType.SetLoggerLevel]: {
     request: SetLoggerLevelRequest;

--- a/packages/runtime-client/runtime-client.test.ts
+++ b/packages/runtime-client/runtime-client.test.ts
@@ -149,6 +149,43 @@ describe("RuntimeClient.hasPendingWrites", () => {
   });
 });
 
+describe("RuntimeClient.getPatternCoverage", () => {
+  // Same connection stub as above: the method is a single request whose response
+  // `data` it returns verbatim (null included), so a stub that records the
+  // request and replies with a fixed response pins the wiring.
+  function clientWithResponse(
+    response: unknown,
+  ): { client: RuntimeClient; requests: unknown[] } {
+    const requests: unknown[] = [];
+    const conn = {
+      on: () => {},
+      request: (message: unknown) => {
+        requests.push(message);
+        return Promise.resolve(response);
+      },
+    } as unknown as never;
+    const client = new (RuntimeClient as unknown as {
+      new (conn: never, options: unknown): RuntimeClient;
+    })(conn, {});
+    return { client, requests };
+  }
+
+  it("returns the worker's coverage report", async () => {
+    const data = {
+      spans: [],
+      hits: [{ fileName: "/main.tsx", id: 1, count: 2 }],
+    };
+    const { client, requests } = clientWithResponse({ data });
+    expect(await client.getPatternCoverage()).toEqual(data);
+    expect(requests).toEqual([{ type: RequestType.GetPatternCoverage }]);
+  });
+
+  it("returns null when the worker has no collector", async () => {
+    const { client } = clientWithResponse({ data: null });
+    expect(await client.getPatternCoverage()).toBeNull();
+  });
+});
+
 describe("RuntimeClient boot-window diagnostics", () => {
   // Both getters are main-thread snapshots forwarded straight from the
   // connection (no worker round-trip), so a connection stub pins the wiring.

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -9,6 +9,7 @@ import type { DID, Identity } from "@commonfabric/identity";
 import type {
   ActionRunTraceEntry,
   JSONSchema,
+  PatternCoverageData,
   RuntimeTelemetryMarkerResult,
   SchedulerDiagnosisResult,
   SchedulerGraphSnapshot,
@@ -145,6 +146,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       renderConfidentialityCeiling: options.renderConfidentialityCeiling,
       trustSnapshot: options.trustSnapshot,
       forwardWorkerConsole: options.forwardWorkerConsole,
+      patternCoverage: options.patternCoverage,
     });
     return new RuntimeClient(initialized, options);
   }
@@ -424,6 +426,19 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       timing: res.timing,
       flags: res.flags,
     };
+  }
+
+  /**
+   * Pull the worker runtime's accumulated pattern-coverage spans and hit counts,
+   * or `null` when this worker was not started with coverage on. The integration
+   * harness calls this once at teardown (through `commonfabric.rt`) and merges
+   * the result with the other realms' coverage. See docs/development/COVERAGE.md.
+   */
+  async getPatternCoverage(): Promise<PatternCoverageData | null> {
+    const res = await this.#conn.request<RequestType.GetPatternCoverage>({
+      type: RequestType.GetPatternCoverage,
+    });
+    return res.data;
   }
 
   /**

--- a/packages/shell/src/lib/host-toggles.ts
+++ b/packages/shell/src/lib/host-toggles.ts
@@ -27,6 +27,20 @@ export function setupHostToggles(): void {
 }
 
 /**
+ * Read the pattern-coverage host flag. Unlike the other toggles this carries no
+ * `commonfabric.*` console command: it is set by the integration harness via
+ * localStorage before login (gated by CF_PATTERN_COVERAGE_DIR on the test
+ * process), never by a dogfooding user. See docs/development/COVERAGE.md.
+ */
+export function isPatternCoverageEnabled(): boolean {
+  try {
+    return globalThis.localStorage?.getItem("patternCoverage") === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * The host-toggle flags read at runtime creation and passed to
  * RuntimeInternals.create. Read fresh per creation: a re-created runtime
  * (identity or host change) picks up the current persisted state.
@@ -34,9 +48,11 @@ export function setupHostToggles(): void {
 export function runtimeHostFlags(): {
   forwardWorkerConsole: boolean;
   cfcRenderCeiling: boolean;
+  patternCoverage: boolean;
 } {
   return {
     forwardWorkerConsole: isWorkerConsoleForwardingEnabled(),
     cfcRenderCeiling: isCfcRenderCeilingEnabled(),
+    patternCoverage: isPatternCoverageEnabled(),
   };
 }

--- a/packages/shell/test/host-toggles.test.ts
+++ b/packages/shell/test/host-toggles.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { runtimeHostFlags, setupHostToggles } from "../src/lib/host-toggles.ts";
+import {
+  isPatternCoverageEnabled,
+  runtimeHostFlags,
+  setupHostToggles,
+} from "../src/lib/host-toggles.ts";
 
 class FakeStorage {
   map = new Map<string, string>();
@@ -69,6 +73,33 @@ describe("setupHostToggles", () => {
       expect(typeof cf?.cfcRenderCeiling).toBe("function");
     } finally {
       h.restore();
+    }
+  });
+});
+
+describe("isPatternCoverageEnabled", () => {
+  it("defaults to false when reading localStorage throws", () => {
+    // Accessing localStorage throws in some environments (disabled storage,
+    // sandboxed frames). The toggle must swallow that and default off rather
+    // than break runtime construction at login.
+    const descriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "localStorage",
+    );
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage is blocked");
+      },
+    });
+    try {
+      expect(isPatternCoverageEnabled()).toBe(false);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, "localStorage", descriptor);
+      } else {
+        delete (globalThis as { localStorage?: unknown }).localStorage;
+      }
     }
   });
 });

--- a/packages/shell/test/host-toggles.test.ts
+++ b/packages/shell/test/host-toggles.test.ts
@@ -80,6 +80,7 @@ describe("runtimeHostFlags", () => {
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: false,
         cfcRenderCeiling: false,
+        patternCoverage: false,
       });
     } finally {
       h.restore();
@@ -93,11 +94,19 @@ describe("runtimeHostFlags", () => {
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: true,
         cfcRenderCeiling: false,
+        patternCoverage: false,
       });
       h.storage.map.set("cfcRenderCeiling", "true");
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: true,
         cfcRenderCeiling: true,
+        patternCoverage: false,
+      });
+      h.storage.map.set("patternCoverage", "true");
+      expect(runtimeHostFlags()).toEqual({
+        forwardWorkerConsole: true,
+        cfcRenderCeiling: true,
+        patternCoverage: true,
       });
     } finally {
       h.restore();

--- a/packages/ts-transformers/src/transformers/pattern-coverage.ts
+++ b/packages/ts-transformers/src/transformers/pattern-coverage.ts
@@ -26,14 +26,21 @@ export class PatternCoverageTransformer extends Transformer {
         PATTERN_COVERAGE_GLOBAL,
       );
 
+    // `createCallChain`, not `createCallExpression`: the call has to be part of
+    // the optional chain. A plain call wrapping a chained callee prints as
+    // `(globalThis.__cfPatternCoverage?.hit)(...)`, whose parentheses end the
+    // chain — the short-circuit yields `undefined` and the call then throws. As a
+    // chain it prints `globalThis.__cfPatternCoverage?.hit(...)` and a body with
+    // no collector installed skips the probe instead of throwing.
     const makeHitStatement = (spanId: number): ts.Statement => {
       return context.factory.createExpressionStatement(
-        context.factory.createCallExpression(
+        context.factory.createCallChain(
           context.factory.createPropertyAccessChain(
             coverageGlobal(),
             context.factory.createToken(ts.SyntaxKind.QuestionDotToken),
             "hit",
           ),
+          undefined,
           undefined,
           [
             context.factory.createStringLiteral(fileName),

--- a/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
+++ b/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
@@ -105,10 +105,11 @@ function transformWithDirectCall(source: string): string {
   return printResult(result);
 }
 
-// Every emitted `(globalThis.__cfPatternCoverage?.hit)(file, id)` call, with its
-// arguments evaluated to their JS values. The callee is a parenthesized
-// optional-chain member access, so it is matched by unwrapping the parens and
-// checking the `.hit` member name rather than by a simple call-name lookup.
+// Every emitted `globalThis.__cfPatternCoverage?.hit(file, id)` call, with its
+// arguments evaluated to their JS values. The callee is an optional-chain member
+// access, so it is matched by checking the `.hit` member name rather than by a
+// simple call-name lookup. Parens are unwrapped first so a callee printed in
+// either form is matched.
 function hitCallArgs(root: ts.Node): unknown[][] {
   return collect(root, ts.isCallExpression)
     .filter((call) => {
@@ -145,6 +146,39 @@ function expectNoSpanContaining(
     false,
   );
 }
+
+Deno.test("instrumented code runs without a collector installed", () => {
+  // The probe has to be part of the optional chain. Emitted as a plain call
+  // around a chained callee it prints `(globalThis.__cfPatternCoverage?.hit)(…)`,
+  // whose parens end the chain: the short-circuit yields `undefined` and calling
+  // it throws. Every runtime that evaluates an instrumented body without
+  // installing the collector would then fail, so this pins the behavior rather
+  // than the printed shape — a regex on the emit cannot tell the two apart at a
+  // glance, and the throwing form looks correct.
+  const { output: emitted } = transformWithCoverage(
+    ["const top = 1;", "function run() {", "  return top + 1;", "}"].join("\n"),
+  );
+  assert(emitted.includes("__cfPatternCoverage?.hit"));
+
+  const globals = globalThis as Record<string, unknown>;
+  assertEquals(globals.__cfPatternCoverage, undefined);
+  // Runs the module body's probes, then the function body's via run().
+  const run = new Function(`${emitted}\nreturn run;`)();
+  run();
+
+  // With a collector installed the same code reports its hits.
+  const hits: [string, number][] = [];
+  globals.__cfPatternCoverage = {
+    hit: (file: string, id: number) => hits.push([file, id]),
+  };
+  try {
+    new Function(`${emitted}\nreturn run;`)()();
+    assert(hits.length > 0);
+    assert(hits.every(([file]) => file === "/pattern.tsx"));
+  } finally {
+    delete globals.__cfPatternCoverage;
+  }
+});
 
 Deno.test("PatternCoverageTransformer skips files when coverage is disabled", () => {
   const source = "const value = 1;";
@@ -317,27 +351,27 @@ export {};
   assertEquals(flag.type?.kind, ts.SyntaxKind.BooleanKeyword);
   assertMatch(
     output,
-    /function declaredFunction\(flag: boolean\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+    /function declaredFunction\(flag: boolean\) \{\s+globalThis\.__cfPatternCoverage\?\.hit/,
   );
   assertMatch(
     output,
-    /const arrowExpression = \(value: number\) => \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+return value \+ topLevel;/,
+    /const arrowExpression = \(value: number\) => \{\s+globalThis\.__cfPatternCoverage\?\.hit[\s\S]+return value \+ topLevel;/,
   );
   assertMatch(
     output,
-    /constructor\(\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+    /constructor\(\) \{\s+globalThis\.__cfPatternCoverage\?\.hit/,
   );
   assertMatch(
     output,
-    /get count\(\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+    /get count\(\) \{\s+globalThis\.__cfPatternCoverage\?\.hit/,
   );
   assertMatch(
     output,
-    /set count\(value: number\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+    /set count\(value: number\) \{\s+globalThis\.__cfPatternCoverage\?\.hit/,
   );
   assertMatch(
     output,
-    /method\(\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+    /method\(\) \{\s+globalThis\.__cfPatternCoverage\?\.hit/,
   );
 });
 
@@ -404,11 +438,11 @@ function run() {
   expectSpanContaining(spans, source, "const value = 1;");
   assertMatch(
     output,
-    /^"use strict";\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+const top = 1;/,
+    /^"use strict";\s+globalThis\.__cfPatternCoverage\?\.hit[\s\S]+const top = 1;/,
   );
   assertMatch(
     output,
-    /function run\(\) \{\s+"use strict";\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+    /function run\(\) \{\s+"use strict";\s+globalThis\.__cfPatternCoverage\?\.hit/,
   );
 });
 
@@ -538,10 +572,10 @@ for (let i = 0; i < 0; i++) doFor();
   // The bare statements are lifted into blocks carrying a hit call.
   assertMatch(
     output,
-    /if \(flag > 0\)\s*\{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+doThen\(\);/,
+    /if \(flag > 0\)\s*\{\s+globalThis\.__cfPatternCoverage\?\.hit[\s\S]+doThen\(\);/,
   );
   assertMatch(
     output,
-    /while \(flag < 0\)\s*\{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+doWhile\(\);/,
+    /while \(flag < 0\)\s*\{\s+globalThis\.__cfPatternCoverage\?\.hit[\s\S]+doWhile\(\);/,
   );
 });

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -179,6 +179,48 @@ Deno.test("collectCoverageDebtMetricsFromLcov computes debt from compact reports
   }
 });
 
+Deno.test("integration pattern coverage feeds the debt metric", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-fold-test-" });
+  try {
+    const sourcePath = path.join(rootDir, "packages/patterns/main.tsx");
+    await Deno.mkdir(path.dirname(sourcePath), { recursive: true });
+    await Deno.writeTextFile(
+      sourcePath,
+      [
+        "export const a = 1;",
+        "export const b = 2;",
+        "export const c = 3;",
+      ].join("\n"),
+    );
+
+    const metricFor = async (lcov: string) =>
+      (await collectCoverageDebtMetricsFromLcov({ rootDir, lcov })).find(
+        (metric) =>
+          metric.name === "coverage-debt: packages/patterns uncovered lines",
+      )?.uncoveredLines;
+
+    // No record: every tracked line is uncovered.
+    assertEquals(await metricFor(""), 3);
+
+    // A record from the integration stream is scored like any other: its
+    // covered lines leave the debt and its unhit lines stay in it. Nothing
+    // discriminates on the test name, so a line only an end-to-end flow
+    // exercises lowers the gated number.
+    assertEquals(
+      await metricFor([
+        "TN:pattern-runtime-integration",
+        `SF:${sourcePath}`,
+        "DA:1,1",
+        "DA:2,0",
+        "end_of_record",
+      ].join("\n")),
+      1,
+    );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
 Deno.test("collectUncoveredLinesForFiles resolves lines only for requested files", async () => {
   const rootDir = await Deno.makeTempDir({ prefix: "coverage-lines-test-" });
   try {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -1101,6 +1101,11 @@ async function extractCoverageDebtSamples(
       ? await readCombinedLcov(lcovDir)
       : await lcovFromCoverageProfile(profileDir);
 
+    // Every coverage stream feeds the gate: V8 runtime coverage, unit pattern
+    // coverage (TN:pattern-runtime), and integration pattern coverage
+    // (TN:pattern-runtime-integration) all join here, and a line covered by any
+    // of them counts covered. So a pattern line an end-to-end flow exercises
+    // that the unit suite does not lowers the gated debt.
     const coverageMetrics = await collectCoverageDebtMetricsFromLcov({
       rootDir: Deno.cwd(),
       lcov,


### PR DESCRIPTION
A pattern line that only an end-to-end flow exercises is scored as uncovered. The two pattern-integration jobs collect V8 runtime coverage but no authored-pattern coverage, so anything a unit test cannot reach — every event-handler body, since the runner materializes onClick as an opaque handler ref and `cf test` has no DOM to fire it — counts as debt however well an integration test drives it.

Collecting it means crossing a process boundary. In an integration test the pattern executes in two realms: the test process that creates the piece, and the browser's runtime Web Worker, which is where a real click actually runs the handler. The transformer's `globalThis.__cfPatternCoverage?.hit(...)` probes fire in whichever realm evaluates the module, and only `cf test` ever built a collector, so in the browser the probes hit an undefined global and the counts never reach a process that can write LCOV.

The approach, and why each piece is needed:

- Pattern coverage becomes a runtime-level capability (`RuntimeOptions.patternCoverage`) rather than a `cf test` one, so any realm can be constructed to collect it. The presets classify it, and the browser-worker preset takes it from host data.

- The instrumented compile is keyed apart from the ordinary one in the content-addressed cell cache. Without this a coverage-enabled realm warm-loads the uninstrumented bytes an earlier realm persisted and silently reports nothing: the probes are simply not in the code it runs.

- The collector gains a serializable form (`toData`/`ingest`). Every realm runs the same instrumented bytes, so fileName-plus-span-id keys agree across realms, and a realm that only warm-loaded bytes can report bare hit counts that merge against the realm that compiled them and holds the spans.

- The worker exposes its report over the RuntimeClient IPC (`GetPatternCoverage`), which the harness pulls with `page.evaluate` at teardown: one batched dump per page, not a per-hit round trip.

Coverage from every source feeds the gated `coverage-debt: packages/patterns` metric. This needs no accounting change: the gate already joins all LCOV fragments, sums hits across duplicate records, and never reads the LCOV test name. The unit and integration streams carry distinct test names purely so a reader of the combined report can tell what covered a line. Counting integration coverage does let a broad flow that asserts little lower the debt; that trade is taken deliberately, because the alternative scores handler bodies as uncovered no matter how well they are exercised.

Two pieces of wiring remain before the false negative is actually closed: the harness teardown dump, and the two jobs' coverage output and artifact upload. One design point needs settling with them — a worker runs many patterns through one collector and statement fileNames are program-relative (`/main.tsx`), so the harness must map each back to its `packages/patterns/<name>/...` path without the per-invocation `--root` that disambiguates this for `cf test`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collect authored-pattern coverage during browser-driven integration runs by enabling a worker-side collector and writing LCOV at teardown. Integration coverage now joins unit and V8 coverage in the gated coverage-debt metric (TN:pattern-runtime-integration).

- **New Features**
  - Public API: worker IPC `GetPatternCoverage` and `RuntimeClient.getPatternCoverage()` return `PatternCoverageData | null`; `RuntimeClient.initialize` forwards the `patternCoverage` flag in `InitializationData`.
  - Host toggle: `localStorage.patternCoverage` read by `@commonfabric/shell` and forwarded via `createRuntimeClientOptions`; runtime presets and `@commonfabric/lib-shell` add `RuntimeOptions.patternCoverage`.
  - Integration harness (`@commonfabric/integration/pattern-coverage`): `enablePatternCoverage(page)` and `collectPatternCoverage(page, dir)` pull one batched report via `page.evaluate`, map worker file names (relative or `/api/patterns/...`) to `packages/patterns/...`, and write `*.pattern-coverage.lcov` with `PATTERN_COVERAGE_INTEGRATION_TEST_NAME`.
  - Compile cache: instrumented compiles persist spans and use a distinct cache key; cold recovery recompiles with instrumentation. The browser-driven pieces controller collects coverage too to avoid variant mismatches and slow cold compiles.
  - CI: `.github/workflows/deno.yml` sets `DENO_COVERAGE_DIR` and absolute `CF_PATTERN_COVERAGE_DIR` so integration jobs emit both V8 and authored-pattern LCOV; `perf-check` folds integration LCOV into the debt metric. Docs updated in `docs/development/COVERAGE.md`.

- **Bug Fixes**
  - Transformer emits a true optional-chain call (`globalThis.__cfPatternCoverage?.hit(...)`) so instrumented code does not throw without a collector.
  - `GetPatternCoverage` returns `null` when the worker has no collector, distinguishing “no coverage enabled” from “no hits.”
  - Reduced compile-cache persistence load for coverage spans: store spans as scalar JSON under the pattern-coverage cache variant, dedupe and serialize writes, validate/repair incomplete state, and preserve coverage/policy metadata across warm loads and replication.

<sup>Written for commit 076d4edf6c705867003a1c560ca7bb92ba0c6203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_COVERAGE_BASELINE