### PR TITLE
Harden lunch poll deployments and stale-root recovery

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -20,7 +20,7 @@ in the same change.
 > flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
 > record, so the history stays discoverable.
 
-**Last reviewed:** 2026-07-09. Each flag's section carries the date its status
+**Last reviewed:** 2026-07-14. Each flag's section carries the date its status
 was last checked against the code.
 
 ## Summary table
@@ -226,6 +226,12 @@ propagate](#how-flags-propagate).
   IPC signal — which raises the shell's reload banner — fires only on a proven
   mismatch (both shas known and different). See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).
+  If an existing root fails its first start, the open path runs this same gated
+  check synchronously once and retries only after an in-place update. Legacy
+  roots without `patternSource` enroll only when their verified authored entry
+  path identifies the official system pattern appropriate to that space type;
+  custom roots stay pinned. Manual system-root recreation now stamps provenance
+  too.
 - **Current default and planned end state.** The runner built-in default is off
   like every flag in this category; the shell build injects `true` unless the
   define is set to `"false"`, so the deployed product (and local shell dev
@@ -233,8 +239,9 @@ propagate](#how-flags-propagate).
   background piece service) leave it off unless the env var is set. End state:
   graduate to always-on for system roots once golden-replay coverage has soaked
   and the home audit lands, then delete both auto-update flags.
-- **Status on 2026-07-09.** Implemented; on in the shell for non-home roots,
-  off elsewhere.
+- **Status on 2026-07-14.** Implemented; on in the shell for non-home roots,
+  off elsewhere. Failed-start recovery, verified legacy provenance repair, and
+  provenance stamping on system-root recreation are covered by focused tests.
 - **Path to removal.** Graduate the home root (below), make the check
   unconditional, and remove both flags together.
 

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -17,18 +17,17 @@ Home root and published-pattern updates remain design (Phases 2–4).
 
 ## Last Updated
 
-2026-07-08
+2026-07-14
 
 ## Motivation
 
 - **System patterns must self-heal and roll forward.** `home.tsx` /
-  `default-app.tsx` are the most critical patterns to keep current, but today
-  they are **lazy-pinned at creation**: `ensureDefaultPattern`'s fast path
-  returns the existing root piece forever and never re-checks source
-  (`packages/piece/src/ops/pieces-controller.ts:342`). The only roll-forward is
-  a **manual** `recreateDefaultPattern` (shell Debugger button / CLI), which is
-  **not state-preserving** — it mints a new piece (`cause:
-  home-pattern-${Date.now()}`) and relinks (`pieces-controller.ts:222`).
+  `default-app.tsx` are the most critical patterns to keep current. Before
+  Phase 1 they were lazy-pinned at creation and the only roll-forward was a
+  **manual** `recreateDefaultPattern`, which is **not state-preserving** because
+  it mints and links a new root piece. Phase 1 adds the state-preserving update
+  path, including recovery when the stored root cannot start under the current
+  runtime.
 - **Two hazard cases to handle explicitly.** (1) We shipped a broken system
   pattern — once a fix ships, recovery must be automatic. (2) An
   schema-incompatible update slips through — the damage must be *bounded*
@@ -61,7 +60,7 @@ Home root and published-pattern updates remain design (Phases 2–4).
 | Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | write `runner.ts:1012`, read `getPatternIdentityRef` `runner.ts:4441` | The thing an update rewrites |
 | **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts:1246` (enabled unless `doNotUpdateOnPatternChange`, `runner.ts:1341`) | **The apply mechanism — already built.** An update is a meta write; the watcher does the rest |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/manager.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
-| `ensureDefaultPattern` (lazy, pinned-at-creation) / `recreateDefaultPattern` (manual, **not** state-preserving) | `pieces-controller.ts:342` / `:222` | The hook (ensure) and the escape hatch (recreate) |
+| `ensureDefaultPattern` (starts existing roots and retries once after a gated update) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The open/recovery hook (ensure) and the last-resort escape hatch (recreate) |
 | System patterns = **raw TSX served by path**, bundled via `deno compile --include`; **no name→identity manifest** | `packages/toolshed/routes/patterns/patterns-server.ts`, `patterns.routes.ts` | Where the current system source + its identity come from |
 | Per-space host resolution: `mappedHostFor(space)` / `registerSpaceHost` (3-tier: seed `spaceHostMap` → learned site-table → default) | `runtime.ts:1423` / `:1444`, `storage/v2-remote-session.ts` | Which toolshed a space's source is fetched from |
 | Build identity: `/api/meta` → `{ did, gitSha }` | `packages/toolshed/routes/meta/` | The version-skew signal |
@@ -186,7 +185,15 @@ and `home.tsx`:
 
 **Runtime side (at space open, in the per-space worker).**
 
-1. `url` = home space → `home.tsx`; else the root piece's `patternSource`.
+0. A system root created by `ensureDefaultPattern` or recreated by the manual
+   escape hatch stores `patternSource` in the same transaction as its
+   `patternIdentity`. A supplied `customProgram` remains deliberately
+   untracked. For a legacy root without provenance, a source is inferred only
+   when the verified authored entry path is the official API or local system
+   path appropriate to that space type (home or default-app); an unknown,
+   custom, or mismatched entry is pinned.
+1. `url` = home space → `home.tsx`; else the root piece's stored or safely
+   inferred `patternSource`.
    `host` = `mappedHostFor(space) ?? apiUrl`. *(Change from today:
    `ensureDefaultPattern` builds the URL from the global `apiUrl`,
    `pieces-controller.ts:274` — it must resolve against the space's host, which
@@ -202,6 +209,16 @@ and `home.tsx`:
 5. else → fetch `{host}{url}` source, `compilePattern(program, { space })`,
    write `patternIdentity = { identity: currentId, symbol }`. The watcher
    re-instantiates in place.
+
+The normal space-open path starts the stored root and launches this check in
+the background. If that first start throws (for example because the stored
+artifact predates a transformer/runtime change), `ensureDefaultPattern`
+synchronously runs the same gated update once. It retries the start only after
+an `updated` outcome; disabled, skewed, unknown, or custom roots rethrow the
+original start error instead of masking it or being recreated destructively.
+When an inferred legacy source already resolves to the running identity, the
+check writes only `patternSource` (`repaired-provenance`) so later opens use the
+normal tracked path.
 
 ## Version-skew gate
 
@@ -241,11 +258,13 @@ so no build-dependence and no gate.
   shipping — the primary defense (feasible precisely because the list is short
   and we own the source).
 - **Self-heal from a borked ship**: fix source → new identity → next space open
-  swaps it in place → recovered, automatically.
+  swaps it in place → recovered automatically, even when the old root fails its
+  initial start under the new runtime.
 - **Rollback = redeploy**: ship the prior source → toolshed serves the prior
   identity → the same swap rolls back. No per-piece rollback state needed.
 - **Escape hatch**: manual `recreateDefaultPattern` remains (state-losing; last
-  resort).
+  resort). System recreates stamp provenance so the replacement rejoins future
+  auto-updates; explicit custom-program recreates remain pinned.
 - **Residual**: schema-valid-but-semantically-wrong is not reliably detectable;
   it is *bounded* by fast rollback + golden replay, not gated on.
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -162,6 +162,7 @@ ${pieceEnvStatus()}
 TIPS:
   • Use 'setsrc' for iteration, not repeated 'new' (avoids clutter)
   • After 'set', run 'step' to trigger computed value updates
+  • Each CLI invocation has a fresh session; @session cannot read browser or prior-command state
   • Path format: forward slashes only (items/0/name, not items[0].name)
   • JSON values: strings need quotes: echo '"hello"' | cf piece set ...`);
 
@@ -465,7 +466,9 @@ Name: ${pieceData.name || "<no name>"}
         output += `\n  - ${ref.id}${ref.name ? ` (${ref.name})` : ""}`;
       });
     } else {
-      output += "\n  (none)";
+      output += pieceData.connectionErrors?.readingFrom
+        ? "\n  (unavailable)"
+        : "\n  (none)";
     }
 
     output += "\n\n--- Read By ---";
@@ -474,7 +477,20 @@ Name: ${pieceData.name || "<no name>"}
         output += `\n  - ${ref.id}${ref.name ? ` (${ref.name})` : ""}`;
       });
     } else {
-      output += "\n  (none)";
+      output += pieceData.connectionErrors?.readBy
+        ? "\n  (unavailable)"
+        : "\n  (none)";
+    }
+
+    if (pieceData.connectionErrors) {
+      output += "\n\n--- Connection Analysis ---";
+      for (
+        const [direction, message] of Object.entries(
+          pieceData.connectionErrors,
+        )
+      ) {
+        output += `\n  ${direction}: <unavailable: ${message}>`;
+      }
     }
 
     render(output);
@@ -703,7 +719,11 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
     `Get a value from a piece at a specific path. Omit path to return the full result.
 
 PATH FORMAT: Use forward slashes and numeric indices for arrays.
-  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name`,
+  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
+
+SESSION SCOPE: Every CLI invocation creates a fresh runtime session. An
+  @session address sees only this invocation, not a browser tab or an earlier
+  CLI command. Verify browser session state in that browser session.`,
   )
   .usage(pieceUsage)
   .example(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1000,6 +1000,28 @@ export interface PieceConnection {
   readBy: string[];
 }
 
+export interface PieceInspection {
+  id: string;
+  name?: string;
+  source?: Readonly<unknown>;
+  result: Readonly<unknown>;
+  readingFrom: Array<{ id: string; name?: string }>;
+  readBy: Array<{ id: string; name?: string }>;
+  connectionErrors?: {
+    readingFrom?: string;
+    readBy?: string;
+  };
+}
+
+export interface InspectablePiece {
+  readonly id: string;
+  name(): string | undefined;
+  input: { get(): Promise<unknown> };
+  result: { get(): Promise<unknown> };
+  readingFrom(): Promise<Array<{ id: string; name(): string | undefined }>>;
+  readBy(): Promise<Array<{ id: string; name(): string | undefined }>>;
+}
+
 export type PieceConnectionMap = Map<string, PieceConnection>;
 
 // Helper functions for piece mapping
@@ -1037,6 +1059,15 @@ async function buildConnectionMap(
     const pieceConfig: PieceConfig = { ...config, piece: piece.id };
     try {
       const details = await inspectPiece(pieceConfig);
+      if (details.connectionErrors) {
+        const errors = Object.entries(details.connectionErrors)
+          .map(([direction, message]) => `${direction}: ${message}`)
+          .join("; ");
+        console.error(
+          `Warning: Could not inspect connections for piece ${piece.id}: ` +
+            errors,
+        );
+      }
       connections.set(piece.id, createPieceConnection(piece, details));
     } catch (error) {
       // Skip pieces that can't be inspected, but include them with no connections
@@ -1149,14 +1180,9 @@ export async function generateSpaceMap(
   return formatSpaceMap(connections, format);
 }
 
-export async function inspectPiece(config: PieceConfig): Promise<{
-  id: string;
-  name?: string;
-  source?: Readonly<unknown>;
-  result: Readonly<unknown>;
-  readingFrom: Array<{ id: string; name?: string }>;
-  readBy: Array<{ id: string; name?: string }>;
-}> {
+export async function inspectPiece(
+  config: PieceConfig,
+): Promise<PieceInspection> {
   const manager = await loadManager(config);
   let resolvedConfig: PieceConfig;
   try {
@@ -1178,18 +1204,46 @@ export async function inspectPiece(config: PieceConfig): Promise<{
     resolvedConfig.pieceScope,
   );
 
+  return await inspectLoadedPiece(piece);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Inspect an already-resolved piece. Core state is authoritative; connection
+ * analysis is best-effort because it walks the space piece list and may need to
+ * start an unrelated (including the root) piece.
+ */
+export async function inspectLoadedPiece(
+  piece: InspectablePiece,
+): Promise<PieceInspection> {
   const id = piece.id;
   const name = piece.name();
   const source = (await piece.input.get()) as Readonly<unknown>;
   const result = (await piece.result.get()) as Readonly<unknown>;
-  const readingFrom = (await piece.readingFrom()).map((piece) => ({
-    id: piece.id,
-    name: piece.name(),
-  }));
-  const readBy = (await piece.readBy()).map((piece) => ({
-    id: piece.id,
-    name: piece.name(),
-  }));
+  let readingFrom: PieceInspection["readingFrom"] = [];
+  let readBy: PieceInspection["readBy"] = [];
+  const connectionErrors: NonNullable<PieceInspection["connectionErrors"]> = {};
+
+  try {
+    readingFrom = (await piece.readingFrom()).map((piece) => ({
+      id: piece.id,
+      name: piece.name(),
+    }));
+  } catch (error) {
+    connectionErrors.readingFrom = errorMessage(error);
+  }
+
+  try {
+    readBy = (await piece.readBy()).map((piece) => ({
+      id: piece.id,
+      name: piece.name(),
+    }));
+  } catch (error) {
+    connectionErrors.readBy = errorMessage(error);
+  }
 
   return {
     id,
@@ -1198,20 +1252,14 @@ export async function inspectPiece(config: PieceConfig): Promise<{
     result,
     readingFrom,
     readBy,
+    ...(Object.keys(connectionErrors).length > 0 ? { connectionErrors } : {}),
   };
 }
 
 async function inspectSlugTargetCell(
   manager: PieceManager,
   slug: string,
-): Promise<{
-  id: string;
-  name?: string;
-  source?: Readonly<unknown>;
-  result: Readonly<unknown>;
-  readingFrom: Array<{ id: string; name?: string }>;
-  readBy: Array<{ id: string; name?: string }>;
-}> {
+): Promise<PieceInspection> {
   const target = await resolveSlugTargetCell(manager, slug);
   await target.pull();
   const result = target.get() as Readonly<unknown>;
@@ -1229,8 +1277,37 @@ async function inspectSlugTargetCell(
 }
 
 export async function getPieceView(config: PieceConfig): Promise<unknown> {
-  const data = (await inspectPiece(config)) as any;
-  return data.result?.[UI] as VNode;
+  const manager = await loadManager(config);
+  let resolvedConfig: PieceConfig;
+  try {
+    resolvedConfig = await resolvePieceConfigWithManager(config, manager);
+  } catch (error) {
+    if (error instanceof SlugResolutionError && error.code === "not-piece") {
+      const target = await resolveSlugTargetCell(manager, config.piece);
+      await target.pull();
+      return viewFromResult(target.get());
+    }
+    throw error;
+  }
+  const pieces = new PiecesController(manager);
+  const piece = await pieces.get(
+    resolvedConfig.piece,
+    false,
+    undefined,
+    resolvedConfig.pieceScope,
+  );
+  return await getLoadedPieceView(piece);
+}
+
+export async function getLoadedPieceView(
+  piece: Pick<InspectablePiece, "result">,
+): Promise<unknown> {
+  return viewFromResult(await piece.result.get());
+}
+
+function viewFromResult(result: unknown): VNode | undefined {
+  if (typeof result !== "object" || result === null) return undefined;
+  return (result as Record<PropertyKey, unknown>)[UI] as VNode | undefined;
 }
 
 export function formatViewTree(view: unknown): string {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
+  getLoadedPieceView,
+  inspectLoadedPiece,
   recreateSpaceRootPattern,
   resolveLinkEndpointAddress,
   resolvePieceConfig,
@@ -9,6 +11,7 @@ import {
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
 import { SlugResolutionError } from "@commonfabric/piece";
+import { UI } from "@commonfabric/runner";
 import {
   normalizeApiUrl,
   parseLink,
@@ -24,6 +27,43 @@ const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
 describe("cli piece parsing", () => {
+  it("returns piece state when connection analysis fails", async () => {
+    const inspected = await inspectLoadedPiece({
+      id: "fid1:target",
+      name: () => "Lunch Poll",
+      input: { get: () => Promise.resolve({ question: "Lunch?" }) },
+      result: { get: () => Promise.resolve({ votes: 3 }) },
+      readingFrom: () => Promise.reject(new Error("space root failed")),
+      readBy: () =>
+        Promise.resolve([{
+          id: "fid1:reader",
+          name: () => "Dashboard",
+        }]),
+    });
+
+    expect(inspected.source).toEqual({ question: "Lunch?" });
+    expect(inspected.result).toEqual({ votes: 3 });
+    expect(inspected.readingFrom).toEqual([]);
+    expect(inspected.readBy).toEqual([{
+      id: "fid1:reader",
+      name: "Dashboard",
+    }]);
+    expect(inspected.connectionErrors).toEqual({
+      readingFrom: "space root failed",
+    });
+  });
+
+  it("reads a piece view without walking its connection graph", async () => {
+    const view = { name: "cf-screen", props: {}, children: [] };
+    const result = { [UI]: view };
+
+    expect(
+      await getLoadedPieceView({
+        result: { get: () => Promise.resolve(result) },
+      }),
+    ).toBe(view);
+  });
+
   it("normalizes API URLs for app route hints", () => {
     expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net/",

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -1,272 +1,265 @@
-# Deploying, updating & sharing lunch-poll state
+# Lunch poll deployment and recovery
 
-How to deploy the lunch poll, update it in place without losing data, share it,
-verify it actually worked, and recover it when it breaks. Written for someone
-(human or agent) operating the poll for the first time — read top to bottom
-once.
+This is the operator runbook for deploying the lunch poll without losing its
+shared state. The safe default is: update the existing piece through its stable
+slug, verify that its durable inputs did not change, and do mutation testing on
+a disposable canary.
 
-> **Status (2026-06-22): live-deployable.** The visit history + per-visit vote
-> snapshots live in a plain **`PerSpace<HistoryEntry[]>` array** (`visits`),
-> each entry embedding its own vote snapshot. (History was briefly on the SQLite
-> builtin, #4144/#4145; that's been reverted — see `LUNCH-COORDINATOR-TODO.md`
-> for the history. There is no longer any `sqliteDatabase`, `db.exec`, or
-> `sqliteRev`.)
+> **Status (2026-07-14): live-deployable.** Visit history and vote snapshots
+> are stored in the ordinary `PerSpace` input `visits`. There is no SQLite
+> database or separate process state to migrate.
 
-## Where the data lives (mental model)
+## Production address and state contract
 
-A poll's durable state belongs to **one deployed piece instance in one space**,
-addressed by `(space, causal-cell-id)` — not to "the pattern" in the abstract.
-So "share the state" = "everyone points at the same piece"; "copy the state" =
-"move that piece's values into a new piece." It all lives in **`PerSpace` input
-cells**, shared by everyone in the space: `question`, `city`, `options`,
-`votes`, `users`, `adminName`, `webSearchUrl`, and **`visits`** (the "Recently
-eaten" log + embedded vote snapshots that feed "Lunch stats"). Plus
-**`myName`**, which is **`PerUser`** (keyed by your DID).
+The public address is the stable slug, not the current causal piece id:
 
-All of these survive an in-place `setsrc` (Option A) and — because `visits` is
-now an ordinary `PerSpace` cell — can all be copied to another piece via the CLI
-(Option B).
-
-## The canonical piece
-
-One shared instance everyone iterates on. **This is a deployment pointer, not a
-stable identifier — current as of 2026-06-22.** A piece is tied to one
-space/server and can be reset, wedged, or lost; if it 404s, `inspect` fails, or
-it stops responding, re-establish it (see "Recovering" below) and update this
-block.
-
-The poll lives on **`rapids`** (`rapids.saga-castor.ts.net`), the intended
-successor to `toolshed`.
-
-```
-space:  team-lunch
-piece:  fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
-url:    https://rapids.saga-castor.ts.net/team-lunch/fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
+```text
+host:      https://rapids.saga-castor.ts.net
+space:     team-lunch
+slug:      lunch-poll
+public:    https://rapids.saga-castor.ts.net/team-lunch/lunch-poll
+piece id:  fid1:uC_TJ5p2vRMf9sDtci7pPKG7GThHYY7GFPbRJVSE71g
 ```
 
-### Historical: the `toolshed` piece
+The piece id is recorded only for recovery. Normal deploys and links should use
+`lunch-poll`; if a migration ever creates a replacement piece, repoint the slug
+only after the replacement has passed verification.
 
-Before `rapids`, the canonical poll ran on `toolshed`
-(`toolshed.saga-castor.ts.net`). Retained here for reference, and in case the
-`rapids` migration is rolled back:
+Durable shared inputs are:
 
-```
-space:  team-lunch
-piece:  fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg
-url:    https://toolshed.saga-castor.ts.net/team-lunch/fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg
+```text
+question options votes users adminName visits
 ```
 
-## Environment setup
+`myName` is `PerUser`. Do not copy it during a migration. Form drafts, the
+current-day override, and confirmation state are `PerSession` internals and are
+intentionally fresh in each browser/runtime session.
+
+## One-time operator setup
+
+Run commands from the repository root:
 
 ```bash
-export CF_API_URL=https://rapids.saga-castor.ts.net/   # current prod; toolshed.saga-castor.ts.net is the predecessor; http://localhost:8000 for local dev
-export CF_IDENTITY=./your-identity.key
-PIECE=fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0    # rapids; current as of 2026-06-22
+set -euo pipefail
+export CF_API_URL=https://rapids.saga-castor.ts.net
+export CF_IDENTITY="${CF_IDENTITY:-$HOME/.config/commonfabric/identity.key}"
 SPACE=team-lunch
+POLL=lunch-poll
+PATTERN=packages/patterns/lunch-poll/main.tsx
+
+test -r "$CF_IDENTITY"
+deno run -A packages/cli/mod.ts id did "$CF_IDENTITY"
 ```
 
-**Identity key:**
+The DID printed by the final command should be the intended deployer. Import
+the same key in the browser when the browser and CLI must act as the same user;
+see
+[`SHARED_IDENTITY.md`](../../../docs/development/SHARED_IDENTITY.md).
 
-- **Local dev** — the local toolshed trusts the identity derived from the
-  passphrase `"implicit trust"`. Mint a matching key (use `deno run`, **not**
-  `deno task`, when redirecting — the task wrapper prints ANSI preamble that
-  pollutes the file):
-  ```bash
-  deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
-  chmod 600 cf.key
-  ```
-- **Prod** — deploy with your own identity, or mint a fresh one
-  (`deno run -A packages/cli/mod.ts id new > prod.key`) and share that key with
-  whoever should be able to update the piece. Whoever deployed owns it; the
-  **host** is a separate, in-poll role (first joiner — see Identity below).
-
-## Option A — update the existing piece in place (recommended)
-
-To push code changes **and keep all accumulated state**, update the source of
-the existing piece. Do **not** run `cf piece new` — that mints a fresh, empty
-instance.
+For local development, derive the trusted local identity with `deno run` so
+shell redirection contains only the key:
 
 ```bash
-deno task cf piece setsrc --piece "$PIECE" -s "$SPACE" \
-  packages/patterns/lunch-poll/main.tsx
-deno task cf piece step --piece "$PIECE" -s "$SPACE"
+deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+chmod 600 cf.key
 ```
 
-**What survives `setsrc` (verified):** all the `PerSpace` cells
-(`users`/`votes`/`options`/`visits`/…). Cell ids derive from the causal
-generation chain (not contents, scope excluded), so `setsrc` keeps the same
-result cell and its populated inputs. **Adding a new `PerSpace` field is safe**
-— on an existing piece it hydrates to its `Default<>` while populated fields
-keep their data.
+### Bootstrap the stable slug
 
-**Caveat:** this holds only while each input's identity in the recipe stays
-stable. Adding fields is safe; heavily **reordering or renaming** pattern inputs
-can shift the causal chain and orphan old data. Don't refactor the input
-interface casually against a piece you care about.
-
-## Option B — copy the state into your own piece
-
-To get your **own** instance seeded with the current data (e.g. to experiment
-without touching the shared poll):
+A first deployment can create the slug atomically:
 
 ```bash
-# 1. Create your own empty piece (note the new ID it prints).
-MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
-  -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+deno task cf piece new "$PATTERN" -s "$SPACE" --slug "$POLL"
+```
 
-# 2. Copy each PerSpace field from the canonical piece into yours.
-#    `--input` reads/writes the input cell where these live.
-for field in question city users options votes adminName webSearchUrl visits; do
-  deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
-    | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
+For the existing production piece, or after recovering an old deployment that
+predates slugs, bind it once:
+
+```bash
+RAW_PIECE=fid1:uC_TJ5p2vRMf9sDtci7pPKG7GThHYY7GFPbRJVSE71g
+deno task cf piece set-slug -s "$SPACE" "$POLL" "$RAW_PIECE"
+```
+
+## Normal deployment: update in place
+
+Start from the intended revision and run the focused tests before touching
+production:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+deno task cf test --timeout 180000 --root packages/patterns \
+  packages/patterns/lunch-poll/main.test.tsx
+deno task cf test --timeout 180000 --root packages/patterns \
+  packages/patterns/lunch-poll/multi-user.test.tsx
+```
+
+Snapshot every durable input, update the source in place, then prove those
+inputs are byte-for-byte unchanged:
+
+```bash
+SNAPSHOT_DIR=$(mktemp -d)
+STATE_FIELDS=(question options votes users adminName visits)
+
+for field in "${STATE_FIELDS[@]}"; do
+  deno task cf piece get -s "$SPACE" --piece "$POLL" \
+    "$field" --input > "$SNAPSHOT_DIR/$field.before.json"
 done
 
-# 3. Recompute so derived values (counts, ranking) refresh.
-deno task cf piece step --piece "$MINE" -s "$SPACE"
-deno task cf piece inspect --piece "$MINE" -s "$SPACE" --summary
+deno task cf piece setsrc -s "$SPACE" --piece "$POLL" "$PATTERN"
+deno task cf piece step -s "$SPACE" --piece "$POLL"
+
+for field in "${STATE_FIELDS[@]}"; do
+  deno task cf piece get -s "$SPACE" --piece "$POLL" \
+    "$field" --input > "$SNAPSHOT_DIR/$field.after.json"
+  cmp "$SNAPSHOT_DIR/$field.before.json" "$SNAPSHOT_DIR/$field.after.json"
+done
+
+deno task cf piece inspect -s "$SPACE" --piece "$POLL" --summary --json
 ```
 
-This is a **one-time snapshot copy**, not a live link — the pieces diverge
-after. Because the copy loop includes `visits`, the "Recently eaten" log and
-"Lunch stats" come across too. (This is a change from the SQLite era, when the
-history lived in a per-piece, cell-derived db the CLI couldn't copy or repoint;
-the fabric-array model restores CLI portability — history copies like any other
-`PerSpace` cell.)
+`setsrc` retains the piece/result identity and its populated input cells. Adding
+a new defaulted input is safe. Renaming or heavily reordering inputs can change
+their causal identities, so treat that as a migration and test it against a
+copy first.
 
-## Verifying a deploy actually worked
+Open the stable URL after the CLI checks:
 
-History is now a plain `PerSpace` cell with computeds over it, so it reads back
-over the CLI like the rest of the poll's state — no subscription/`{ pending }`
-gotcha and no SQLite files to inspect.
+```text
+https://rapids.saga-castor.ts.net/team-lunch/lunch-poll
+```
 
-- **Read the `visits` input directly** to confirm a write landed (no browser
-  needed):
-  ```bash
-  deno task cf piece get --piece "$PIECE" -s "$SPACE" visits --input -q
-  ```
-  The derived outputs (`recentVisits`, `placeStats`, `historyCount`,
-  `mostRecentTitle`, `voteHistoryCount`) recompute on `step` and read back the
-  same way.
+Verify that the poll renders, existing options/history are present, joining
+works, and `todayDate` reflects the browser's local date. Session-scoped values
+must be checked in that browser tab: every `cf` invocation creates a fresh
+runtime session, so `piece@session` in a later CLI command cannot observe a
+browser tab or a previous CLI invocation.
 
-**Smoke test after deploy** (host-gated handlers need a join first):
+## Mutation smoke test: use a disposable canary
+
+Do not add test restaurants, votes, users, or visits to production. Exercise
+handlers on a newly created canary and remove it afterward:
 
 ```bash
-deno task cf piece call --piece "$PIECE" -s "$SPACE" joinAs '{"name":"Host"}'
-deno task cf piece step --piece "$PIECE" -s "$SPACE"
-deno task cf piece call --piece "$PIECE" -s "$SPACE" addOption '{"title":"Test Cafe"}'
-deno task cf piece step --piece "$PIECE" -s "$SPACE"
-deno task cf piece call --piece "$PIECE" -s "$SPACE" logVisit '{"title":"Test Cafe"}'
-deno task cf piece step --piece "$PIECE" -s "$SPACE"
-# Confirm the entry landed (no browser needed):
-deno task cf piece get --piece "$PIECE" -s "$SPACE" visits --input -q
+CF=(deno run -A packages/cli/mod.ts)
+CANARY=$("${CF[@]}" piece new -s "$SPACE" "$PATTERN" --quiet)
+cleanup() { "${CF[@]}" piece rm -s "$SPACE" --piece "$CANARY" || true; }
+trap cleanup EXIT
+
+"${CF[@]}" piece call -s "$SPACE" --piece "$CANARY" joinAs \
+  '{"name":"Deploy Canary"}'
+"${CF[@]}" piece call -s "$SPACE" --piece "$CANARY" addOption \
+  '{"title":"Canary Cafe"}'
+"${CF[@]}" piece call -s "$SPACE" --piece "$CANARY" logVisit \
+  '{"title":"Canary Cafe"}'
+"${CF[@]}" piece step -s "$SPACE" --piece "$CANARY"
+
+"${CF[@]}" piece get -s "$SPACE" --piece "$CANARY" optionCount
+"${CF[@]}" piece get -s "$SPACE" --piece "$CANARY" historyCount
+"${CF[@]}" piece get -s "$SPACE" --piece "$CANARY" mostRecentTitle
 ```
 
-## Identity & joining
+The expected values are `1`, `1`, and `"Canary Cafe"`. The canary has a raw id
+and never owns the production slug.
 
-`myName` is `PerUser` (keyed by your authenticated DID); `adminName` (host) and
-the `users` directory are `PerSpace`. Consequences that bite:
+## Copy or replace a deployment
 
-1. **This build joins by free-text name.** Type a name in the join field and
-   click Join — no profile needed; the **first person to join becomes host**.
-   (On `main`, joining instead goes through the shared-profile `wish` flow,
-   which requires a profile in your home space. This `freetext-join` variant
-   removes that gate. The `joinAs` handler still honors an explicit `name`, so
-   CLI/headless joins work either way.)
-
-2. **CLI and browser are different identities unless you make them the same.**
-   If you join/seed from the `cf` CLI (one DID) then open the piece in a browser
-   (a different DID), the browser's `myName` is empty and it won't treat you as
-   host. To act as the same person in both, import your CLI key in the browser
-   via **Import CLI Key**; see
-   [`docs/development/SHARED_IDENTITY.md`](../../../docs/development/SHARED_IDENTITY.md).
-   Verify with `cf id did "$CF_IDENTITY"`.
-
-3. **Names are unique.** `joinAs` rejects a name already in `users`. If a
-   test/seed claimed your name, pick another or clear the stale entry.
-
-4. **Host role is claimable.** Any joined participant can take the host seat
-   with **Become host** (`claimHost`). A squatted/stale host seat doesn't need
-   an operator reset — just join and click Become host. (You can also reset
-   `adminName` to `""` directly when no one is joined.)
-
-## Resetting / re-seeding state (host or operator)
-
-**Coordinate before running this against the shared piece — it mutates state
-everyone sees, and direct `set` races anyone's live browser session.**
-
-- **Votes:** use the in-app `resetVotes` (host) — or call it via CLI.
-- **History:** use the **`clearHistory` handler** (host-gated) — it empties the
-  `visits` log (and its embedded vote snapshots):
-  ```bash
-  deno task cf piece call --piece "$PIECE" -s "$SPACE" clearHistory '{}'
-  deno task cf piece step --piece "$PIECE" -s "$SPACE"
-  ```
-  Or, since `visits` is an ordinary `PerSpace` cell, write it directly (below).
-- **PerSpace cells:** write the input cells directly:
-  ```bash
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" users     --input -q
-  echo '""' | deno task cf piece set --piece "$PIECE" -s "$SPACE" adminName --input -q
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" options   --input -q
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" votes     --input -q
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" visits    --input -q
-  deno task cf piece step --piece "$PIECE" -s "$SPACE"
-  ```
-  After this, the first person to join in the browser becomes host as their own
-  browser identity.
-
-## Recovering the piece
-
-### Re-establishing (if it's lost / 404s)
+Use this only for a canary seeded with production data, a causal-input
+migration, or a genuinely unrecoverable piece. It copies a point-in-time
+snapshot; the two pieces diverge afterward.
 
 ```bash
-deno task cf piece new packages/patterns/lunch-poll/main.tsx -s "$SPACE"
-# → prints a new fid1:… — update the "canonical piece" block above.
+OLD=$POLL
+NEW=$(deno run -A packages/cli/mod.ts piece new -s "$SPACE" "$PATTERN" --quiet)
+STATE_FIELDS=(question options votes users adminName visits)
+MIGRATION_DIR=$(mktemp -d)
+
+for field in "${STATE_FIELDS[@]}"; do
+  deno task cf piece get -s "$SPACE" --piece "$OLD" \
+    "$field" --input > "$MIGRATION_DIR/$field.json"
+  deno task cf piece set -s "$SPACE" --piece "$NEW" \
+    "$field" --input < "$MIGRATION_DIR/$field.json"
+done
+
+deno task cf piece step -s "$SPACE" --piece "$NEW"
+
+for field in "${STATE_FIELDS[@]}"; do
+  deno task cf piece get -s "$SPACE" --piece "$NEW" \
+    "$field" --input > "$MIGRATION_DIR/$field.new.json"
+  cmp "$MIGRATION_DIR/$field.json" "$MIGRATION_DIR/$field.new.json"
+done
+
+# Browser-test /team-lunch/$NEW before changing the public pointer.
+deno task cf piece set-slug -s "$SPACE" "$POLL" "$NEW"
 ```
 
-You need `WRITE`/`OWNER` on the space (ACL-gated); a denied write changes
-nothing.
+Keep the old piece until the new public URL has been verified. Do not copy
+`myName`; each user rejoins or retains their own per-user state only when the
+same piece is updated in place.
 
-### Recovering a wedged piece
+## Reading and resetting state
 
-A piece can get into a bad **process** state — UI renders but **clicks do
-nothing**, no console errors (a settle loop flickers / logs warnings). Observed
-once when a "reset votes" click wedged the running instance. `setsrc` does
-**not** fix this (it reuses the same process cell); the cure is a fresh process:
+For reliable automation, read the specific input or scalar output you need:
 
 ```bash
-# 1. Confirm it's instance-specific: deploy the same code to a NEW piece. If the
-#    fresh piece works, the old one's process is wedged.
-NEW=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
-  -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
-
-# 2. Copy the PerSpace state across with the Option B loop (history carries too,
-#    since `visits` is now a PerSpace cell). Tip: leave users/adminName empty so
-#    the first joiner becomes host, or copy them and use Become host.
-
-# 3. Make the fresh piece canonical: update the "canonical piece" block above.
+deno task cf piece get -s "$SPACE" --piece "$POLL" visits --input
+deno task cf piece get -s "$SPACE" --piece "$POLL" historyCount
+deno task cf piece get -s "$SPACE" --piece "$POLL" todayVoteCount
 ```
 
-### Home space won't load (profile setup, `main`-style builds)
+`piece inspect` also reports source/result state. Connection analysis is
+best-effort because it walks other pieces in the space; a connection warning
+does not mean the target piece's state was unavailable.
 
-Unrelated to the poll itself, but bites colleagues setting up a profile: if a
-home space fails to load with
-`Handler used as lift, because $stream: true was
-overwritten`, the space's
-**stored** root pattern is a stale compiled artifact. Fix: open the header menu
-→ **Toggle debug mode** (🐛) → click the red **Recreate Root Pattern** button in
-the debugger drawer, then reload. (Console fallback:
-`localStorage.setItem("showDebuggerView","true")` then reload.) The
-free-text-join build of this poll sidesteps the profile requirement entirely.
+Reset commands mutate the shared poll and require coordination. Prefer the
+host-gated UI/handlers (`resetVotes`, `clearHistory`). An operator can directly
+replace the `votes` or `visits` input only when an intentional emergency reset
+has been agreed.
 
-## Performance notes
+## Identity and host behavior
 
-Cold loads of a poll with many options can take **minutes** — this is **not**
-graph/runtime cost (instantiation measures ~linear, ~12ms/option), it's the
-**per-option AI work done host-side on load**: each option triggers an image
-generation, a web search, and a `generateText` homepage-verification call,
-serialized behind a 30s mutex. Results are cached (`option.imageUrl` etc.), so
-warm loads are cheaper; the pain is the first host load of un-cached options.
-See willkelly's perf investigation in
-[labs#4141](https://github.com/commontoolsinc/labs/pull/4141) (keyed-collection
-/ runtime-aggregate direction) for the deeper aggregate + write-conflict
-findings.
+- Joining is profile-first when `#profileName` resolves, with manual entry as a
+  fallback. Programmatic callers may pass `{"name":"..."}` to `joinAs`.
+- `users` and `adminName` are shared; `myName` is per-user. The first joiner
+  becomes host.
+- Names are unique. A joined participant can use **Become host** (`claimHost`)
+  if the recorded host is stale.
+- The browser and CLI are different users unless they use the same imported
+  identity key.
+
+## Recovery and diagnosis
+
+### A root-pattern failure blocks unrelated CLI work
+
+Connection discovery and piece-list operations may traverse the space root. A
+stale root can therefore make an otherwise healthy poll look broken. Current
+runtimes attempt the system-pattern update before retrying a failed root start,
+and back-fill provenance for legacy roots whose verified authored entry is an
+official system pattern. Recreated system roots also retain provenance for the
+next update.
+
+Upgrade the shell/CLI to a build containing that recovery before taking a
+destructive action. Custom roots remain pinned and are never inferred as system
+roots.
+
+As a final, state-losing repair for the **space root** (not the poll piece):
+
+```bash
+deno task cf piece recreate-root -s "$SPACE"
+```
+
+Use this only after the automatic recovery fails. It recreates the space's
+navigation/root pattern; it is not a remedy for session-scoped browser state.
+
+### The source updated but a CLI session value did not
+
+This is usually scope, not a wedged deployment. `PerSession` state belongs to a
+single browser/runtime session, and each CLI command starts another one. Check
+durable `PerSpace` inputs with `piece get --input`, per-user state with the same
+identity, and UI/session state in the browser tab that owns it.
+
+### The piece is genuinely missing
+
+Create a replacement without changing the production slug, follow the copy and
+verification procedure above, and repoint `lunch-poll` only at the end. This
+keeps the shared URL stable and gives rollback a concrete old piece id.

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1568,9 +1568,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       // didn't write them, and a computed that RETURNS undefined is
       // indistinguishable from "not yet computed" for cross-runtime readers —
       // so every snapshot yields a real, stable value (the shared EMPTY
-      // constants keep the fallback idempotent across recomputes). The visit
-      // history is no longer a PerSpace input — it lives in SQLite now and is
-      // surfaced via `recentVisits`/`mostRecentTitle` below.
+      // constants keep the fallback idempotent across recomputes). Visit
+      // history remains the ordinary PerSpace `visits` input and is surfaced
+      // through the derived summaries below.
       options: computed(() => options ?? EMPTY_OPTIONS),
       votes: computed(() => votes ?? EMPTY_VOTES),
       users: computed(() => users ?? EMPTY_USERS),

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -33,18 +33,17 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 // System space-root patterns, served as raw TSX by the toolshed patterns route.
 export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
 export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
+const LOCAL_HOME_PATTERN_PATH = "/system/home.tsx";
+const LOCAL_DEFAULT_APP_PATTERN_PATH = "/system/default-app.tsx";
 
 /**
  * The system space-root pattern URL a space of this type is created with — the
  * home DID gets home.tsx, every other space the default app. Used to back-fill
  * `patternSource` for spaces created before provenance stamping.
  *
- * Known v1 limitation: an existing *custom-app* space (whose root was seeded
- * from home's `defaultAppUrl`) that carries no stored `patternSource` derives to
- * default-app.tsx here. The auto-update check must therefore only act when a
- * stored `patternSource` is present (or the running identity matches a known
- * system identity) — otherwise it would roll a custom app to the default. See
- * docs/specs/pattern-imports/pattern-updates.md risk list.
+ * This is safe for a newly created system root. Existing roots without stored
+ * provenance must additionally prove that their verified authored entry path
+ * is a known system pattern; see {@link inferLegacySystemPatternSource}.
  */
 export function deriveSystemPatternUrl(
   space: MemorySpace,
@@ -53,6 +52,30 @@ export function deriveSystemPatternUrl(
   return space === runtime.userIdentityDID
     ? HOME_PATTERN_URL
     : DEFAULT_APP_PATTERN_URL;
+}
+
+async function inferLegacySystemPatternSource(
+  root: Cell<unknown>,
+  runtime: Runtime,
+  space: MemorySpace,
+): Promise<string | undefined> {
+  const ref = getPatternIdentityRef(root);
+  if (!ref) return undefined;
+  const program = await runtime.patternManager
+    .getPatternSourceProgramByIdentity(ref.identity, space);
+  const expected = deriveSystemPatternUrl(space, runtime);
+  switch (program?.main) {
+    case HOME_PATTERN_URL:
+    case LOCAL_HOME_PATTERN_PATH:
+      return expected === HOME_PATTERN_URL ? HOME_PATTERN_URL : undefined;
+    case DEFAULT_APP_PATTERN_URL:
+    case LOCAL_DEFAULT_APP_PATTERN_PATH:
+      return expected === DEFAULT_APP_PATTERN_URL
+        ? DEFAULT_APP_PATTERN_URL
+        : undefined;
+    default:
+      return undefined;
+  }
 }
 
 // Same logger as manager.ts's timePiecePhase: timing stats record even while
@@ -67,6 +90,7 @@ const pieceUpdateLogger = getLogger("piece.update", {
 /** The result of a system-pattern update check. */
 export type UpdateOutcome =
   | "updated"
+  | "repaired-provenance"
   | "current"
   | "skipped-skew"
   | "skipped-unknown-build"
@@ -354,6 +378,13 @@ export class PiecesController<T = unknown> {
       // Run pattern setup within same transaction
       this.#manager.runtime.run(tx, pattern, {}, pieceCell);
 
+      // System roots created through the recovery escape hatch must rejoin the
+      // normal auto-update path. Custom programs have no resolvable source
+      // pointer, so deliberately leave those untracked.
+      if (!options?.customProgram) {
+        setPatternSource(pieceCell, tx, patternConfig.urlPath);
+      }
+
       // Link as default pattern within same transaction
       const spaceCellWithTx = spaceCellContents.withTx(tx);
       const defaultPatternCell = spaceCellWithTx.key("defaultPattern");
@@ -395,8 +426,20 @@ export class PiecesController<T = unknown> {
   async ensureDefaultPattern(): Promise<PieceController<NameSchema>> {
     this.disposeCheck();
 
-    // Fast path: check if pattern already exists (outside transaction)
-    const existingPattern = await this.#manager.getDefaultPattern();
+    // Fast path: check if the pattern already exists (outside transaction).
+    // A stored system root can become unstartable after the transformer or
+    // runtime advances. Give the auto-update path one chance to swap its
+    // identity in place before surfacing the original start failure.
+    let existingPattern: Cell<NameSchema> | undefined;
+    try {
+      existingPattern = await this.#manager.getDefaultPattern();
+    } catch (startError) {
+      const outcome = await this.checkAndUpdateDefaultPattern();
+      if (outcome !== "updated") {
+        throw startError;
+      }
+      existingPattern = await this.#manager.getDefaultPattern();
+    }
     if (existingPattern) {
       return new PieceController<NameSchema>(this.#manager, existingPattern);
     }
@@ -531,8 +574,10 @@ export class PiecesController<T = unknown> {
    * new pattern onto the SAME result cell (no new piece, state preserved by
    * stable key). Never calls run()/stop()/recreateDefaultPattern.
    *
-   * Call it AFTER {@link ensureDefaultPattern} has resolved (the root must be
-   * running for the watcher to be live).
+   * Usually called after {@link ensureDefaultPattern} has resolved, while the
+   * pattern watcher is live. It may also be called by `ensureDefaultPattern`
+   * after a stored root fails to start; in that recovery path the identity is
+   * swapped first and the following start instantiates the new pattern.
    */
   async checkAndUpdateDefaultPattern(): Promise<UpdateOutcome> {
     const runtime = this.#manager.runtime;
@@ -555,17 +600,18 @@ export class PiecesController<T = unknown> {
 
       // 3. Provenance + per-space host (NOT the global apiUrl — a foreign-homed
       //    space must resolve against its own toolshed). A non-home root
-      //    created before provenance stamping has no patternSource; we must NOT
-      //    derive default-app.tsx for it — a custom-app space (seeded from
-      //    home's defaultAppUrl) would be silently rolled to the default app.
-      //    Deriving is only safe for the home root (definitionally home.tsx).
-      //    Legacy non-home roots stay pinned until re-created stamps them; a
-      //    known-system-identity match could relax this later (spec M2.3).
+      //    created before provenance stamping has no patternSource. Recover it
+      //    only when its verified authored entry path identifies a known system
+      //    pattern; blindly deriving default-app.tsx could roll a custom-app
+      //    space to the wrong root.
       const storedSource = getPatternSource(root);
-      if (storedSource === undefined && !isHomeSpace) {
+      const inferredSource = storedSource === undefined
+        ? await inferLegacySystemPatternSource(root, runtime, space)
+        : undefined;
+      if (storedSource === undefined && inferredSource === undefined) {
         return "current";
       }
-      const url = storedSource ?? deriveSystemPatternUrl(space, runtime);
+      const url = storedSource ?? inferredSource!;
       const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
 
       // The version gate (step 4) validates `host`'s build, and the light
@@ -605,7 +651,24 @@ export class PiecesController<T = unknown> {
 
       // 6. Compare to the running identity.
       const running = getPatternIdentityRef(root)?.identity;
-      if (currentId === running) return "current";
+      if (currentId === running) {
+        if (storedSource !== undefined) return "current";
+        const { error } = await runtime.editWithRetry((tx) => {
+          setPatternSource(root, tx, url);
+        });
+        if (error) {
+          pieceUpdateLogger.warn(
+            "provenance-repair-failed",
+            () => [
+              "checkAndUpdateDefaultPattern: provenance repair failed",
+              space,
+              error,
+            ],
+          );
+          return "current";
+        }
+        return "repaired-provenance";
+      }
 
       // 7. Apply: compile the new source, then swap patternIdentity in place.
       const program = await runtime.harness.resolve(

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -256,12 +256,64 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(getPatternIdentityRef(piece.getCell())?.identity).toBe(before);
   });
 
-  it("skips a legacy non-home root with no patternSource (custom-app safety)", async () => {
+  it("repairs an existing system root after its first start fails", async () => {
     await setup({ systemPatternAutoUpdate: true });
-    // recreateDefaultPattern does NOT stamp patternSource — it stands in for a
-    // legacy root created before provenance existed (which might be a custom app
-    // seeded from home's defaultAppUrl, NOT the default app).
-    await controller.recreateDefaultPattern();
+    const piece = await controller.ensureDefaultPattern();
+    const firstRef = getPatternIdentityRef(piece.getCell());
+    await manager.stopPiece(piece.getCell());
+
+    stub.setSource(SOURCE_V2);
+    const originalGetDefaultPattern = manager.getDefaultPattern.bind(manager);
+    let failStartOnce = true;
+    manager.getDefaultPattern = ((runIt = true) => {
+      if (runIt && failStartOnce) {
+        failStartOnce = false;
+        return Promise.reject(new Error("stored root no longer compiles"));
+      }
+      return originalGetDefaultPattern(runIt);
+    }) as typeof manager.getDefaultPattern;
+
+    const recovered = await controller.ensureDefaultPattern();
+
+    const recoveredRef = getPatternIdentityRef(recovered.getCell());
+    expect(recovered.id).toBe(piece.id);
+    expect(recoveredRef).toBeDefined();
+    expect(recoveredRef!.identity).not.toBe(firstRef!.identity);
+    expect(recoveredRef!.identity).toBe(await identityForSource(SOURCE_V2));
+  });
+
+  it("back-fills a legacy default-app root from verified source", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    // Simulate a pre-provenance system root: the authored entry identifies the
+    // official pattern, but the root cell itself has no patternSource metadata.
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: DEFAULT_APP_PATTERN_URL,
+        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+      },
+    });
+    const root = piece.getCell();
+    expect(getPatternSource(root)).toBeUndefined();
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+      "repaired-provenance",
+    );
+    await runtime.idle();
+    const repairedRoot = (await manager.getDefaultPattern(false))!;
+    expect(getPatternSource(repairedRoot)).toBe(DEFAULT_APP_PATTERN_URL);
+  });
+
+  it("skips a custom root with no patternSource", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    // A custom root has no resolvable patternSource. It also stands in for a
+    // legacy root created before provenance existed, which might have been
+    // seeded from home's custom defaultAppUrl rather than default-app.tsx.
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-root.tsx",
+        files: [{ name: "/custom-root.tsx", contents: SOURCE_V1 }],
+      },
+    });
     const root = (await manager.getDefaultPattern(false))!;
     expect(getPatternSource(root)).toBeUndefined();
     const before = getPatternIdentityRef(root)?.identity;
@@ -298,6 +350,40 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(await controller.checkAndUpdateDefaultPattern()).toBe(
       "skipped-disabled",
     );
+    expect(stub.identityFetches()).toBe(0);
+  });
+
+  it("does not infer provenance for a custom home root", async () => {
+    versionSkews = [];
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      clientVersion: BUILD_SHA,
+      experimental: {
+        systemPatternAutoUpdate: true,
+        systemPatternAutoUpdateHome: true,
+      },
+    });
+    const homeSession = await createSession({
+      identity: signer,
+      spaceDid: signer.did(),
+    });
+    manager = new PieceManager(homeSession, runtime);
+    await manager.synced();
+    controller = new PiecesController(manager);
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const before = getPatternIdentityRef(root)?.identity;
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(root)?.identity).toBe(before);
+    expect(getPatternSource(root)).toBeUndefined();
     expect(stub.identityFetches()).toBe(0);
   });
 });

--- a/packages/piece/test/pattern-source-provenance.test.ts
+++ b/packages/piece/test/pattern-source-provenance.test.ts
@@ -104,4 +104,28 @@ describe("ensureDefaultPattern stamps patternSource", () => {
     const source = getPatternSource(piece.getCell());
     expect(source).toBe(DEFAULT_APP_PATTERN_URL);
   });
+
+  it("stamps provenance when recreating a system root", async () => {
+    await controller.ensureDefaultPattern();
+
+    const piece = await controller.recreateDefaultPattern();
+
+    expect(getPatternSource(piece.getCell())).toBe(DEFAULT_APP_PATTERN_URL);
+  });
+
+  it("leaves recreated custom roots untracked", async () => {
+    await controller.ensureDefaultPattern();
+
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-root.tsx",
+        files: [{
+          name: "/custom-root.tsx",
+          contents: DEFAULT_APP_SOURCE,
+        }],
+      },
+    });
+
+    expect(getPatternSource(piece.getCell())).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Why

Launching the lunch poll exposed three failures that made a healthy piece look broken or encouraged risky recovery: a transformer-incompatible space root failed before auto-update could repair it, `piece inspect` coupled target-state reads to space-wide connection analysis, and the deployment guide used rotating raw IDs plus mutating smoke tests against production.

## What Changed

- recover a stored system root in place when its initial start fails, with verified legacy provenance backfill and custom-root safety
- stamp provenance when the system-root recreation escape hatch is used
- make CLI piece state and view reads independent of best-effort connection graph traversal, and document fresh `@session` semantics
- replace the lunch-poll runbook with a stable-slug, snapshot-before-update, state-preserving migration, and disposable-canary workflow
- update the system-pattern spec and experimental flag registry

## Test plan

- `deno task --cwd packages/piece test` (67 steps)
- `deno task --cwd packages/cli test` (915 tests / 342 steps; 1 ignored)
- `deno test -A packages/cli/test/piece.test.ts` (30 steps)
- `deno task cf test --timeout 180000 --root packages/patterns packages/patterns/lunch-poll/main.test.tsx` (26 assertions)
- `deno task cf test --timeout 180000 --root packages/patterns packages/patterns/lunch-poll/multi-user.test.tsx` (11 assertions)
- `deno task cf check packages/patterns/lunch-poll/main.tsx --no-run`
- production read-only inspect through `team-lunch/lunch-poll` confirmed the slug resolves to the existing piece and its durable state is preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened system-root recovery and made lunch-poll deployments safer with a slug-based, state-preserving workflow. Also made CLI inspection/view reads resilient and clarified `@session` scope.

- **Bug Fixes**
  - Recover stored system roots that fail their first start by running one version-gated in-place update; legacy roots back-fill provenance when their authored entry matches official system patterns; custom roots remain pinned; system-root recreation now stamps provenance.
  - `cf piece inspect` returns source/result even if connection discovery fails, and reports `connectionErrors`; piece view reads no longer walk the space graph; CLI help documents fresh `@session` scope per invocation.

- **Migration**
  - Updated the lunch-poll runbook to use the stable slug `lunch-poll`, snapshot-before-update verification of durable `PerSpace` inputs, and a disposable canary for mutation smoke tests.
  - Added guidance for copying/replacing a deployment and space-root recovery, plus identity/host behavior notes and commands.

<sup>Written for commit 2a9575604aa3abbc715b4cb1cb52a4341e286ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

