### PR TITLE
test(html): wait for the reconciler's op flush instead of sleeping 10ms

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -1,9 +1,10 @@
 # Test waits: prefer events over polling `waitFor`
 
-A test wait should resolve on a real event, not a poll loop. This note explains
-why, which primitives to reach for instead, the check that keeps new polling
-`waitFor` out of the integration suites, and the specific places where a bounded
-`waitFor` poll is still the right tool.
+A test wait should resolve on a real event, not a poll loop or a fixed delay.
+This note explains why, which primitives to reach for instead, how to wait on
+the two pieces of machinery whose timing is easy to guess wrong, the check that
+keeps new polling `waitFor` out of the integration suites, and the specific
+places where a bounded `waitFor` poll is still the right tool.
 
 ## Why avoid `waitFor`
 
@@ -121,6 +122,45 @@ ambient test or CI limit rather than failing fast. The CLI suite's readiness
 probe is such a client. It disposes its controller once the wait returns, which
 also keeps a finished wait from holding the loop open for the rest of the
 suite.
+
+## Waiting for the scheduler and for the worker reconciler
+
+Two pieces of machinery come up often enough in unit tests, and dispatch
+differently enough from each other, that guessing at their timing is where fixed
+delays tend to creep back in.
+
+The **scheduler** delivers a runtime-backed cell's updates through `queueTask`
+(`packages/runner/src/scheduler/diagnostics.ts`), which is `setTimeout(fn, 0)`.
+That is a macrotask, so yielding to the microtask queue never reaches a change
+made through a real cell, however many times the test yields. Wait for these
+with `runtime.idle()`, which resolves once the scheduler has settled.
+
+The **worker reconciler** (`packages/html/src/worker/reconciler.ts`) is
+synchronous apart from one line. It queues its VDOM ops as it renders and
+flushes them from a `queueMicrotask` callback, which hands the batch to the
+`onOps` callback the test registered. So once the change itself has landed, the
+ops are one microtask away, and a microtask the test queues afterwards runs
+after the flush, because microtasks run in the order they were queued.
+
+The reconciler tests in `packages/html/test/` wait through a local helper that
+covers both, because their trees mix synchronous mock cells with runtime-backed
+ones:
+
+```ts
+function opsFlushed(runtime: Runtime): Promise<void> {
+  return runtime.idle().then(() =>
+    new Promise<void>((resolve) => queueMicrotask(resolve))
+  );
+}
+```
+
+This shape is an ordering guarantee rather than a deadline, so it cannot lose a
+race under load. It also holds for a test asserting that an op is *absent*:
+once it returns, every op the change was going to produce has been delivered, so
+no later batch can falsify the absence. Those tests need it. A wait on the
+`onOps` callback would never return for them, since a change that emits no ops
+produces no batch, and they pass vacuously when nothing has flushed at all —
+their teeth come from the wait being long enough to have seen an unwanted op.
 
 ## Guard against new usage
 

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -142,12 +142,13 @@ flushes them from a `queueMicrotask` callback, which hands the batch to the
 ops are one microtask away, and a microtask the test queues afterwards runs
 after the flush, because microtasks run in the order they were queued.
 
-The reconciler tests in `packages/html/test/` wait through a local helper that
-covers both, because their trees mix synchronous mock cells with runtime-backed
-ones:
+The reconciler tests in `packages/html/test/` wait through `opsFlushed` in
+`packages/html/test/reconciler-support.ts`, which covers both, because their
+trees mix synchronous mock cells with runtime-backed ones:
 
 ```ts
-function opsFlushed(runtime: Runtime): Promise<void> {
+// Shown at module scope.
+export function opsFlushed(runtime: Runtime): Promise<void> {
   return runtime.idle().then(() =>
     new Promise<void>((resolve) => queueMicrotask(resolve))
   );

--- a/packages/html/test/reconciler-support.ts
+++ b/packages/html/test/reconciler-support.ts
@@ -1,0 +1,20 @@
+import type { Runtime } from "@commonfabric/runner";
+
+/**
+ * Resolve once the reconciler has flushed the ops a change produced.
+ *
+ * Cells backed by the runtime deliver their updates through the scheduler,
+ * which dispatches with `setTimeout(fn, 0)`, so `runtime.idle()` is the wait
+ * that covers them. The reconciler queues its ops synchronously and flushes
+ * them from a microtask, so a microtask queued afterwards runs after that
+ * flush.
+ *
+ * Both waits are needed: the reconciler tests mix synchronous mock cells, which
+ * never reach the scheduler, with runtime-backed cells, which are unreachable
+ * by yielding to the microtask queue.
+ */
+export function opsFlushed(runtime: Runtime): Promise<void> {
+  return runtime.idle().then(() =>
+    new Promise<void>((resolve) => queueMicrotask(resolve))
+  );
+}

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -7,6 +7,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime, UI } from "@commonfabric/runner";
 import type { Cell } from "@commonfabric/runner";
+import { opsFlushed } from "./reconciler-support.ts";
 
 /**
  * Helper to collect ops emitted by the reconciler.
@@ -153,7 +154,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
 
       // Mount
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const createOps = collector.getOpsOfType("create-element");
       const spanCreate = createOps.find((op: any) => op.tagName === "span");
@@ -172,7 +173,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { id: "child-span-updated" },
         children: ["Updated"],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       // VNode in-place update: span element should NOT be removed/recreated
       const removeOps = collector.getOpsOfType("remove-node");
@@ -228,7 +229,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       // Re-set the reused child VNode with IDENTICAL props but changed children,
@@ -241,7 +242,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { id: "tab", "data-role": "tab" },
         children: ["B"],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const unchangedPropOps = collector.getOpsOfType("set-prop").filter((op) =>
         "key" in op && (op.key === "id" || op.key === "data-role")
@@ -267,7 +268,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { id: "tab-2", "data-role": "tab" },
         children: ["B"],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const idOps = collector.getOpsOfType("set-prop").filter((op) =>
         "key" in op && op.key === "id"
@@ -317,7 +318,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       // Reuse the same input VNode with IDENTICAL props. The worker can't see
@@ -330,7 +331,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { ...liveProps },
         children: [],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const keys = collector.getOpsOfType("set-prop")
         .filter((op) => "key" in op)
@@ -373,7 +374,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       // Same object reference, changed child to force the reconcile. Object
@@ -384,7 +385,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { id: "s", style: styleObj },
         children: ["B"],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const keys = collector.getOpsOfType("set-prop")
         .filter((op) => "key" in op)
@@ -424,7 +425,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       // Text-integrity sink props have policy-dependent transforms and must
@@ -435,7 +436,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { id: "m1", name: "Alice", content: "hi" },
         children: [],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const keys = collector.getOpsOfType("set-prop")
         .filter((op) => "key" in op)
@@ -476,7 +477,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       rootCell.set({
@@ -485,7 +486,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: {},
         children: [secondChild as unknown as Cell<WorkerRenderNode>],
       } as WorkerVNode);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       assertEquals(
         collector.getOpsOfType("remove-node").length > 0,
@@ -521,7 +522,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       rootCell.set(
@@ -532,7 +533,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           children: ["literal text"],
         } satisfies WorkerVNode,
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       assertEquals(
         collector.getOpsOfType("remove-node").length > 0,
@@ -549,7 +550,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
 
       collector.clear();
       oldChild.set("stale cell update");
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       assertEquals(
         collector.getOps().length,
@@ -605,13 +606,13 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       firstChildren.set([voteSpan("Alice")]);
       middleChildren.set([null, voteSpan("Alice")]);
       lastChildren.set([null, null, voteSpan("Alice")]);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const spanCreates = collector.getOpsOfType("create-element").filter(
         (op) => "tagName" in op && op.tagName === "span",
@@ -663,7 +664,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       mappedChildren.set([
@@ -671,13 +672,13 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         middleMappedResult,
         lastMappedResult,
       ]);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       firstMappedResult.set(voteSpan("Alice"));
       middleMappedResult.set(voteSpan("Alice"));
       lastMappedResult.set(voteSpan("Alice"));
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const spanCreates = collector.getOpsOfType("create-element").filter(
         (op) => "tagName" in op && op.tagName === "span",
@@ -725,7 +726,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     });
 
     reconciler.mount(rootCell as any);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await opsFlushed(runtime);
 
     const createSpanOp = collector.getOpsOfType("create-element").find(
       (op: any) => op.tagName === "span",
@@ -741,7 +742,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       children: ["Button"],
     };
     childCell.set(buttonVNode);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await opsFlushed(runtime);
 
     const removeOps = collector.getOpsOfType("remove-node");
     const spanRemoved = removeOps.some((op: any) => op.nodeId === spanNodeId);
@@ -769,12 +770,12 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     });
 
     reconciler.mount(rootCell as any);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await opsFlushed(runtime);
     collector.clear();
 
     // Update text
     childCell.set("World");
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await opsFlushed(runtime);
 
     const removeOps = collector.getOpsOfType("remove-node");
     assertEquals(removeOps.length, 0, "Should not remove text node");
@@ -816,7 +817,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
 
       reconciler.mount(rootCell as unknown as Cell<unknown>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       const screenCreate = collector.getOpsOfType("create-element").find(
         (op) => "tagName" in op && op.tagName === "cf-screen",
       );
@@ -839,7 +840,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           }],
         } satisfies WorkerVNode,
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const textOps = collector.getOps().filter((op) =>
         (op.op === "update-text" || op.op === "create-text") &&
@@ -897,7 +898,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
 
       reconciler.mount(rootCell as unknown as Cell<unknown>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       summary.set(
@@ -915,7 +916,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           ],
         } satisfies WorkerVNode,
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const textOps = collector.getOpsOfType("update-text");
       assertEquals(
@@ -969,7 +970,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
 
       reconciler.mount(rootCell as unknown as Cell<unknown>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const spanCreate = collector.getOpsOfType("create-element").find(
         (op) => "tagName" in op && op.tagName === "span",
@@ -988,7 +989,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           children: [afterChild],
         } satisfies WorkerVNode,
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       assertEquals(
         collector.getOpsOfType("remove-node").some((op) =>
@@ -1031,7 +1032,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const setEventOps = collector.getOpsOfType("set-event");
       assertEquals(setEventOps.length, 1, "Should emit initial set-event");
@@ -1049,7 +1050,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           children: ["Click me"],
         }],
       });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const newSetEventOps = collector.getOpsOfType("set-event");
       assertEquals(
@@ -1076,7 +1077,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       rootCell.set({
@@ -1085,7 +1086,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: {},
         children: ["Click me"],
       });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const removeEventOps = collector.getOpsOfType("remove-event");
       assertEquals(removeEventOps.length, 1, "Should emit remove-event");
@@ -1123,7 +1124,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       rootCell.set({
@@ -1132,7 +1133,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { onClick: undefined },
         children: ["Click me"],
       });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const removeEventOps = collector.getOpsOfType("remove-event");
       assertEquals(removeEventOps.length, 1, "Should emit remove-event");
@@ -1163,11 +1164,11 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       handlerCell.set(undefined);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const removeEventOps = collector.getOpsOfType("remove-event");
       assertEquals(removeEventOps.length, 1, "Should emit remove-event");
@@ -1198,7 +1199,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const initialTextOps = collector.getOpsOfType("create-text");
       assertEquals(
@@ -1213,7 +1214,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
 
       collector.clear();
       childrenCell.set("");
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const emptyStringTextOps = collector.getOpsOfType("create-text");
       assertEquals(
@@ -1252,7 +1253,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       rootCell.set({
@@ -1261,7 +1262,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: {},
         children: [],
       });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const removePropOps = collector.getOpsOfType("remove-prop");
       const hasValueRemove = removePropOps.some((op) =>
@@ -1297,19 +1298,19 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       // Emit exact SAME value
       childCell.set("Hello");
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const ops = collector.getOps();
       assertEquals(ops.length, 0, "Should emit NO ops for identical value");
 
       // Emit DIFFERENT value
       childCell.set("World");
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const updateOps = collector.getOpsOfType("update-text");
       assertEquals(
@@ -1354,7 +1355,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       const rootCell = new MockCell(rootVNode);
 
       reconciler.mount(rootCell as any);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       collector.clear();
 
       // Update parent with SAME children order
@@ -1365,7 +1366,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         children: [child1, child2], // Same objects, same keys
       };
       rootCell.set(rootVNodeUpdated);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const insertOps = collector.getOpsOfType("insert-child");
       assertEquals(insertOps.length, 0, "Should skip inserts if order is same");
@@ -1378,7 +1379,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         children: [child2, child1], // Swap
       };
       rootCell.set(rootVNodeSwapped);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       const swapInserts = collector.getOpsOfType("insert-child");
       // Naive reorder: remove/insert or move.
@@ -1417,7 +1418,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
 
       reconciler.mount(rootCell as unknown as Cell<unknown>);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
       const spanCreate = collector.getOps().find((op) =>
         op.op === "create-element" && "tagName" in op &&
         op.tagName === "span"
@@ -1443,7 +1444,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           ],
         } satisfies WorkerVNode,
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await opsFlushed(runtime);
 
       assertEquals(
         collector.getOpsOfType("create-element").some((op) =>
@@ -1499,7 +1500,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     );
 
     reconciler.mount(rootCell as unknown as Cell<unknown>);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await opsFlushed(runtime);
     const spanCreate = collector.getOpsOfType("create-element").find((op) =>
       "tagName" in op && op.tagName === "span"
     );
@@ -1522,7 +1523,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         }],
       } satisfies WorkerVNode,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await opsFlushed(runtime);
 
     assertEquals(
       collector.getOpsOfType("remove-node").some((op) =>

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -8,6 +8,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { KeepAsCell, Runtime } from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
+import { opsFlushed } from "./reconciler-support.ts";
 
 /**
  * Helper to collect ops emitted by the reconciler.
@@ -228,7 +229,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setPropOps = collector.getOpsOfType("set-prop");
         const classOp = setPropOps.find((op: any) => op.key === "className");
@@ -267,12 +268,12 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
         collector.clear();
 
         // Update primitive prop
         propsCell.set({ className: "bar" });
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setPropOps = collector.getOpsOfType("set-prop");
         const classOp = setPropOps.find((op: any) => op.key === "className");
@@ -303,12 +304,12 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
         collector.clear();
 
         // Add a new prop
         propsCell.set({ className: "foo", title: "new" });
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setPropOps = collector.getOpsOfType("set-prop");
         const titleOp = setPropOps.find((op: any) => op.key === "title");
@@ -342,12 +343,12 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
         collector.clear();
 
         // Remove title prop
         propsCell.set({ className: "foo" });
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const removePropOps = collector.getOpsOfType("remove-prop");
         const titleRemoved = removePropOps.some((op: any) =>
@@ -377,7 +378,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setPropOps = collector.getOpsOfType("set-prop");
         const styleOp = setPropOps.find((op: any) => op.key === "style");
@@ -413,11 +414,11 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           propsCell.set({ style: undefined });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -451,7 +452,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setPropOps = collector.getOpsOfType("set-prop");
         const itemsOp = setPropOps.find((op: any) => op.key === "items");
@@ -484,7 +485,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setEventOps = collector.getOpsOfType("set-event");
         assertEquals(setEventOps.length >= 1, true, "Should emit set-event");
@@ -515,7 +516,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setEventOps = collector.getOpsOfType("set-event");
           const eventOp = setEventOps[0] as Extract<
@@ -557,7 +558,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const firstEventOps = collector.getOpsOfType("set-event");
           const firstEventOp = firstEventOps[0] as Extract<
@@ -567,7 +568,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
           collector.clear();
 
           propsCell.set({ onclick: secondStream });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const secondEventOps = collector.getOpsOfType("set-event");
           const secondEventOp = secondEventOps[0] as Extract<
@@ -642,7 +643,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const eventOps = collector.getOpsOfType("set-event");
           const eventOp = eventOps[0] as Extract<
@@ -652,7 +653,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
           collector.clear();
 
           rootCell.set("Replaced");
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           assertEquals(
             reconciler.dispatchEvent(
@@ -703,7 +704,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const eventOp = collector.getOpsOfType("set-event")[0] as Extract<
             VDomOp,
@@ -717,7 +718,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
             props: secondPropsCell,
             children: ["Click"],
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           assertEquals(
             collector.getOpsOfType("remove-event").some((op: any) =>
@@ -770,7 +771,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const eventOp = collector.getOpsOfType("set-event")[0] as Extract<
             VDomOp,
@@ -832,7 +833,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         const setBindingOps = collector.getOpsOfType("set-binding");
         assertEquals(
@@ -876,7 +877,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setBindingOps = collector.getOpsOfType("set-binding");
           assertEquals(
@@ -931,7 +932,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setBindingOps = collector.getOpsOfType("set-binding");
           assertEquals(
@@ -1006,7 +1007,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
         ).asSchema(rendererVDOMSchema);
         const cancel = reconciler.mount(rootVDOMCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setBindingOps = collector.getOpsOfType("set-binding");
           assertEquals(
@@ -1086,7 +1087,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
         ).asSchema(rendererVDOMSchema);
         const cancel = reconciler.mount(rootVDOMCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const createdTags = collector.getOpsOfType("create-element").map(
             (op) => (op as Extract<VDomOp, { op: "create-element" }>).tagName,
@@ -1154,7 +1155,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
         ).asSchema(rendererVDOMSchema);
         const cancel = reconciler.mount(rootVDOMCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const createdTags = collector.getOpsOfType("create-element").map(
             (op) => (op as Extract<VDomOp, { op: "create-element" }>).tagName,
@@ -1188,7 +1189,16 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
+          // Pins the absence below to the same-cell check rather than to the
+          // props never having been rendered at all.
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op: any) =>
+              op.key === "className"
+            ),
+            true,
+            "mount should emit set-prop for className",
+          );
           collector.clear();
 
           // Update root but keep same propsCell reference
@@ -1198,7 +1208,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
             props: propsCell as any,
             children: [],
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           // Same Cell<Props> → updatePropsInPlace should detect same cell and skip
           const setPropOps = collector.getOpsOfType("set-prop");
@@ -1235,7 +1245,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const initialEvents = collector.getOpsOfType("set-event");
           assertEquals(initialEvents.length >= 1, true, "Initial set-event");
@@ -1249,7 +1259,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
           // Clear all props
           propsCell.set(null);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const removeOps = collector.getOps();
           assertEquals(removeOps.length > 0, true, "Should emit removal ops");
@@ -1257,7 +1267,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
           // Re-emit the same props — handlers must be re-registered
           propsCell.set({ className: "foo", onclick: mockStream });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const reEvents = collector.getOpsOfType("set-event");
           assertEquals(
@@ -1299,12 +1309,12 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           // Re-emit identical values
           propsCell.set({ className: "foo", title: "bar" });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -1317,7 +1327,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
           // Change only one value
           propsCell.set({ className: "foo", title: "baz" });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const updatedOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -1358,14 +1368,14 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           // Re-emit identical values. The worker can't see live DOM drift, so
           // the DOM-live `value` must re-emit to let setPropDefault repair it;
           // the inert className stays quiet (parity with the inline static path).
           propsCell.set({ className: "foo", value: "hello" });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const keys = collector.getOpsOfType("set-prop")
             .map((op: any) => op.key);
@@ -1407,13 +1417,13 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
         const cancel = mountReconciler(reconciler, rootCell);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           // Text-integrity sinks have policy-dependent transforms and must
           // re-run; only the inert id may be skipped.
           propsCell.set({ id: "m1", name: "Alice", content: "hi" });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const keys = collector.getOpsOfType("set-prop")
             .map((op: any) => op.key);
@@ -1468,7 +1478,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       const cancel = mountReconciler(reconciler, rootCell);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await opsFlushed(runtime);
 
         // Verify primitive prop
         const setPropOps = collector.getOpsOfType("set-prop");

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -16,6 +16,7 @@ import type { WorkerVNode } from "../src/worker/types.ts";
 import { normalizeRenderDeclassificationPolicy } from "../src/worker/types.ts";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { VDomOp } from "../src/vdom-ops.ts";
+import { opsFlushed } from "./reconciler-support.ts";
 
 function createOpsCollector() {
   const allOps: VDomOp[] = [];
@@ -373,7 +374,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -407,7 +408,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -447,7 +448,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -486,7 +487,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -524,7 +525,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -587,7 +588,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -634,7 +635,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           rootCell.set(
             {
@@ -653,7 +654,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
               }],
             } satisfies WorkerVNode,
           );
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -698,14 +699,14 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           propsCell.set({
             maxConfidentiality: [],
             declassifyConfidentiality: [healthRecordAtom],
             $value: confidential,
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -738,7 +739,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -771,7 +772,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -807,7 +808,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -861,7 +862,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -916,7 +917,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -955,7 +956,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -996,7 +997,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           rootCell.set(
@@ -1016,7 +1017,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
               }],
             } satisfies WorkerVNode,
           );
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1052,7 +1053,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           let renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -1069,7 +1070,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
               children: [confidential as never],
             } satisfies WorkerVNode,
           );
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1109,7 +1110,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           propsCell.set({
@@ -1117,7 +1118,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             declassifyConfidentiality: [healthRecordAtom],
             $value: confidential,
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1160,11 +1161,11 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           propsCell.flushInitial();
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1199,7 +1200,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1233,7 +1234,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1273,7 +1274,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1308,7 +1309,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1367,7 +1368,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1401,7 +1402,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1436,7 +1437,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1495,7 +1496,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           // Authorship boundaries emit create-element in document order, so the
           // first is the outer (enclosing) boundary and the second is the inner.
@@ -1566,7 +1567,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const authorshipIds = collector.getOpsOfType("create-element")
             .filter((op) => op.tagName === "cf-cfc-authorship")
@@ -1642,12 +1643,12 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         const rootCell = new MockCell(nestedAuthorshipTree(verifiedText));
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           // Reactively swap to content that fails the requirement.
           rootCell.set(nestedAuthorshipTree(unsignedReleaseText));
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           // The failing text is hidden behind the integrity placeholder.
           const renderedText = collector.getOpsOfType("create-text")
@@ -1684,7 +1685,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         );
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
               op.key === "textIntegrityState" && op.value === "blocked"
@@ -1695,7 +1696,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
           // Reactively swap to content that satisfies the requirement.
           rootCell.set(nestedAuthorshipTree(verifiedText));
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           // The verified text renders and no enclosing boundary is left blocked.
           const renderedText = collector.getOpsOfType("create-text")
@@ -1764,7 +1765,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         const rootCell = new MockCell(tree(true));
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
               op.key === "textIntegrityState" && op.value === "blocked"
@@ -1777,7 +1778,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           // (its enclosing-boundary set shrinks {outer,inner} -> {outer}). The
           // outer still gates the failing text, so it stays hidden.
           rootCell.set(tree(false));
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -1819,7 +1820,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -1874,7 +1875,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -1931,7 +1932,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -2042,7 +2043,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootVDOMCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -2162,7 +2163,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootVDOMCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -2272,7 +2273,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootVDOMCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -2329,7 +2330,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           collector.clear();
 
           const updateTx = runtime.edit();
@@ -2337,7 +2338,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           runtime.prepareTxForCommit(updateTx);
           const updateResult = await updateTx.commit();
           assertEquals(updateResult.ok !== undefined, true);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -2358,7 +2359,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           runtime.prepareTxForCommit(relaxTx);
           const relaxResult = await relaxTx.commit();
           assertEquals(relaxResult.ok !== undefined, true);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const relaxedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -2395,7 +2396,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
               op.key === "textIntegrityState" && op.value === "blocked"
@@ -2414,7 +2415,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             },
             children: [verifiedText as never],
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
@@ -2447,7 +2448,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
               op.key === "textIntegrityState" && op.value === "blocked"
@@ -2465,7 +2466,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             },
             children: [verifiedText as never, "sibling-after"],
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
@@ -2504,7 +2505,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
               op.key === "textIntegrityState" && op.value === "blocked"
@@ -2519,7 +2520,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             props: {},
             children: [verifiedText as never],
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
@@ -2561,7 +2562,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(rootCell as never);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
               op.key === "textIntegrityState" && op.value === "blocked"
@@ -2585,7 +2586,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
               children: [verifiedText as never],
             }],
           });
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           assertEquals(
             collector.getOpsOfType("set-prop").some((op) =>
@@ -2629,7 +2630,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
 
           const setPropOps = collector.getOpsOfType("set-prop");
           assertEquals(
@@ -2710,7 +2711,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancel = reconciler.mount(plainRoot(confidential));
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -2737,7 +2738,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancel = reconciler.mount(plainRoot(confidential));
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -2763,7 +2764,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancelAllowed = allowedReconciler.mount(plainRoot(influenced));
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = allowed.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(renderedText.includes("Influenced draft text"), true);
@@ -2778,7 +2779,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancelBlocked = blockedReconciler.mount(plainRoot(influenced));
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = blocked.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(renderedText.includes("Influenced draft text"), false);
@@ -2808,7 +2809,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         };
         const cancel = reconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -2834,7 +2835,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancelBlocked = blockedReconciler.mount(confidential);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = blocked.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -2856,7 +2857,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancelAdmitted = admittedReconciler.mount(confidential);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = admitted.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -2876,7 +2877,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         const reconciler = new WorkerReconciler({ onOps: collector.onOps });
         const cancel = reconciler.mount(confidential);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -2963,7 +2964,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           children: [ownContent as never, otherContent as never],
         });
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(renderedText.includes("Acting user's own note"), true);
@@ -3060,7 +3061,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           ],
         });
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(renderedText.includes("User-scoped note"), true);
@@ -3166,7 +3167,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           children: [markerCell as never, caveatCell as never],
         });
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const text = rootCollector.getOpsOfType("create-text").map((op) =>
             op.text
           );
@@ -3198,7 +3199,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           children: [declassCell as never],
         });
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const text = declassCollector.getOpsOfType("create-text").map((op) =>
             op.text
           );
@@ -3228,7 +3229,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           children: [declassOrCell as never],
         });
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const text = orCollector.getOpsOfType("create-text").map((op) =>
             op.text
           );
@@ -3290,7 +3291,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancelCeiling = ceilingReconciler.mount(markerLabeled);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = ceiling.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -3317,7 +3318,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         };
         const cancelDeclassify = declassifyReconciler.mount(root);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = declassify.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -3347,7 +3348,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         });
         const cancel = reconciler.mount(confidential);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(
@@ -3461,7 +3462,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           children: [teamLabeled as never, plainCell as never],
         });
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           // Before the ACL grants READ, the Space(team) label fails closed.
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
@@ -3488,7 +3489,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           granted = true;
           collector.clear();
           fireAcl(teamSpace);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
               .includes("Team note"),
@@ -3503,7 +3504,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           granted = false;
           collector.clear();
           fireAcl(teamSpace);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
               .includes("Team note"),
@@ -3599,7 +3600,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         // Mount the labeled cell AS the root.
         const cancel = reconciler.mount(teamLabeled);
         try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
               .includes("Root team note"),
@@ -3613,7 +3614,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           granted = true;
           collector.clear();
           fireAcl(teamSpace);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
               .includes("Root team note"),
@@ -3624,7 +3625,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           granted = false;
           collector.clear();
           fireAcl(teamSpace);
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await opsFlushed(runtime);
           assertEquals(
             collector.getOpsOfType("create-text").map((op) => op.text)
               .includes("Root team note"),


### PR DESCRIPTION
The three worker-reconciler test files below waited for the reconciler to deliver its VDOM ops by sleeping for a fixed ten milliseconds and then reading the ops the collector had gathered:

  await new Promise((resolve) => setTimeout(resolve, 10));

There were 171 such sleeps across the three files, which is the largest single cluster of fixed delays in the repository. Together they put roughly 1.7 seconds of floor under the package's test suite: time every run had to spend waiting whether or not the work had already finished.

The delay was also standing in for a wait the tests can express directly. The reconciler is synchronous apart from one line: it queues its ops as it renders and flushes them from a `queueMicrotask` callback, which hands the batch to the `onOps` callback the tests already register. Nothing else in the file awaits, and the confidentiality label lookups the render-policy tests exercise are synchronous reads. So for a change delivered by a synchronous cell, the ops are one microtask away, and a microtask queued after that change always runs after the flush, because microtasks run in the order they were queued.

Cells backed by the runtime are the exception. Their updates travel through the scheduler, which dispatches with `setTimeout(fn, 0)` rather than a microtask, so no amount of microtask draining reaches them; those changes need `runtime.idle()`, which resolves once the scheduler has settled. That is the wait `worker-reconciler-diffing.test.ts` already uses for the same reconciler and the same collector. For those sites the ten-millisecond sleep was a genuine race rather than merely a slow one, since it capped how long the scheduler had to converge: delaying the scheduler past ten milliseconds fails them, while the replacement still passes.

The three files now wait through one shared helper covering both paths:

  export function opsFlushed(runtime: Runtime): Promise<void> {
    return runtime.idle().then(() =>
      new Promise<void>((resolve) => queueMicrotask(resolve))
    );
  }

`runtime.idle()` settles any scheduler-delivered change, and the queued microtask resolves after the reconciler's flush. Both halves are needed: the render-policy tests commit through real cells, and the rest drive synchronous mock cells that never reach the scheduler. `runtime.idle()` alone happens to work for the mock-driven sites, but only because awaiting it costs a tick, which says nothing about the flush it is standing in for.

The helper lives in `test/reconciler-support.ts` rather than being copied into each file. `test/assert.ts` is the existing shared module in that directory, but it holds an assertion library and a wait is not an assertion. Being outside the `*.test.ts` pattern the runner matches, the new module is not collected as a test file. The neighbouring `createOpsCollector` stays duplicated, since those copies have each grown their own additions.

The wait is an ordering guarantee rather than a deadline, so it cannot lose a race under load, and it holds for the tests that assert an op is absent as much as for those that assert one is present. Once it returns, every op the change was going to produce has been delivered, so there is no later batch that could falsify the absence. Those tests need that property: an event-driven wait for the next batch would never return for them, because a change that emits no ops produces no batch.

Absence assertions pass vacuously when nothing has flushed at all, so their teeth come from the wait being long enough to have seen an unwanted op. One of them had no teeth of its own to begin with. "Cell<Props> same cell on update → no re-bind" asserts that re-emitting a root VNode carrying the same props cell emits no set-prop op, which also holds when the props were never rendered: a reconciler stubbed to emit nothing at all satisfied it, alone among the steps here that exercise the reconciler. It now asserts that the mount emitted the className set-prop before clearing the collector, so the absence afterwards means the reconciler skipped the re-bind rather than never having rendered. The other absence assertions already carry a positive check in the same step.

The note on test waits gains the timing facts behind all of this, since guessing either dispatch wrong is what a fixed delay usually papers over.

The package's suite drops from about 5.5 seconds to about 2.7, with the same 38 tests and 283 steps passing.

Two `setTimeout(resolve, 0)` waits in worker-reconciler-space-stamp.test.ts are left alone. They are the same shape but impose no floor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced 10ms sleeps in HTML worker‑reconciler tests with a deterministic wait for VDOM op flush using a shared `opsFlushed(runtime)` helper. This removes race conditions and cuts ~1.7s of wasted wait, dropping the suite from ~5.5s to ~2.7s.

- **Refactors**
  - Added `packages/html/test/reconciler-support.ts` with `opsFlushed(runtime)` that awaits `runtime.idle()` then a microtask to ensure scheduler updates and the reconciler’s flush are done.
  - Replaced sleeps with `await opsFlushed(runtime)` in `worker-reconciler-cell-child.test.ts`, `worker-reconciler-cell-props.test.ts`, and `worker-reconciler-cfc-render-policy.test.ts`; left two zero‑delay waits in `worker-reconciler-space-stamp.test.ts`.
  - Strengthened the “Cell<Props> same cell on update → no re-bind” test by first asserting the mount emitted `className` set‑prop; updated `docs/development/waiting-in-tests.md` with scheduler/reconciler wait guidance and a type-checked op-flush snippet (marked “shown at module scope”) that matches `packages/html/test/reconciler-support.ts`.

<sup>Written for commit 9317d79550a663f22ae966e14c6aeead27eab2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

