### PR TITLE
test(runner): wait on sink events instead of polling in the sqlite tests

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -59,11 +59,63 @@ click.
 (from `packages/utils/src/defer.ts`) inside a callback the test already registers
 — a cell `sink`/`subscribe`, a storage subscription's `next`, a scheduler
 `onError`, a telemetry listener, or a counter incremented inside a test-owned
-transport. A read of a cell that a sink already observes belongs here too: record
-the latest value in the sink callback and resolve the waiter when it reaches the
-target. Because the sink fires once on registration and then on every committed
-change, the waiter can resolve immediately when the value is already there and
-otherwise on the next change the sink reports.
+transport. A read of a cell that a sink already observes belongs here too: the
+sink wakes the waiter, and the waiter compares the cell against the target.
+Because the sink fires once on registration and then on every committed change,
+the waiter can resolve immediately when the value is already there and otherwise
+on the next change the sink reports.
+
+The runner's in-process tests have that last shape packaged as
+`waitForCellValue` in `packages/runner/test/support/wait-for-cell-value.ts`. It
+sleeps on the sink and applies its predicate to the cell only after
+`runtime.idle()`, so the wait has neither a poll interval under it nor an
+iteration cap over it. Its predicate takes `T | undefined`, since a cell holds
+no value until its piece writes one.
+
+Some traps are worth knowing before you hand-roll one of these against a
+runtime. They cost real debugging to find, and they are why the helper takes a
+runtime.
+
+Where a runtime is in reach, test the value the cell holds once the scheduler
+is quiescent, not the one the sink handed the callback. A cell passes through
+states that exist only until the scheduler drains, and a predicate can accept
+one that is about to be superseded — a query that has not yet re-run against
+new inputs still holds its previous settled result, so "settled and without
+error" matches the stale value. Waking on the sink but reading after
+`runtime.idle()` keeps those states away from the predicate. The waits above
+that have no runtime to idle, such as the shell's result-cell reads, do compare
+the callback's value, and have to keep their predicates specific enough that no
+passing state is a stale one.
+
+A cell's value is a live view either way, so whatever a wait returns can still
+move afterwards, and a test that accepts a value and then awaits something else
+before reading it can assert against a state the predicate never approved.
+Reading at quiescence narrows that window rather than closing it: there is no
+pending reactive work left to drive the value on, but `runtime.idle()` settles
+reactivity only, not storage sync, so a value arriving from another runtime can
+still land late. Read what a wait hands back before awaiting anything else.
+
+Cancelling the sink is a trap of its own. Resolving from inside the callback
+wakes the waiting code while the action that reported the value is still
+finishing, and finalizing an action resubscribes it, so a cancel issued from
+that continuation is undone and the sink goes on firing afterwards. Await
+`runtime.idle()` before cancelling.
+
+An in-process wait like this needs no timeout backstop. When the value never
+arrives and the runtime goes quiet, Deno's test runner reports `Promise
+resolution is still pending but the event loop has already resolved` and fails
+the test at once, rather than hanging. The message names the test, not the wait
+inside it, so a test holding several waits needs the last step printed without
+an `ok` to place the failure. It still beats a deadline, which reports only that
+time ran out, and reports it later.
+
+That argument covers the in-process waits in this section and nothing else. It
+holds because nothing in these tests keeps the event loop alive by itself: the
+runner's one repeating timer is unref'd and gated behind `CF_TRAVERSE_CAPTURE`,
+and an unsatisfiable wait still fails in seconds in the heaviest setup we have,
+two runtimes over an in-process memory server. It does not carry over to the
+browser waits above, where a live DevTools Protocol connection holds the loop
+open and a waiter that never fires would hang instead.
 
 ## Guard against new usage
 

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -7,9 +7,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { defer } from "@commonfabric/utils/defer";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { waitForCellValue } from "./support/wait-for-cell-value.ts";
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -73,10 +75,10 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
     const result = runtime.run(tx, queryPattern, {}, resultCell);
     tx.commit();
 
-    const q = await waitUntil<QueryState>(
+    const q = await waitForCellValue<QueryState>(
       runtime,
       result,
-      (v) => v.pending === false,
+      (v) => v?.pending === false,
     );
     expect(q.error).toBeUndefined();
     expect(q.result).toEqual([]);
@@ -165,8 +167,10 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
     };
     const original = provider.sqliteQuery.bind(provider);
     let seenScope: unknown = "<<unset>>";
+    const issued = defer<void>();
     provider.sqliteQuery = (db, ...rest) => {
       seenScope = db?.scope;
+      issued.resolve();
       return original(db, ...rest);
     };
     try {
@@ -184,13 +188,12 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
         queryPattern.resultSchema,
         tx,
       );
-      const result = runtime.run(tx, queryPattern, {}, resultCell);
+      runtime.run(tx, queryPattern, {}, resultCell);
       tx.commit();
-      await waitUntil<QueryState>(
-        runtime,
-        result,
-        () => seenScope !== "<<unset>>",
-      );
+      // The wire call is the event here, not a result value: the spy above
+      // resolves `issued` when `db.query` reaches the provider, which the
+      // post-commit flush drives without the result being observed.
+      await issued.promise;
       return seenScope;
     } finally {
       provider.sqliteQuery = original;
@@ -398,28 +401,3 @@ type QueryState = {
   error?: unknown;
   requestHash?: string;
 };
-
-// Wait until `pred(cell value)` holds. A `sink` keeps the effect chain live so
-// reactOn re-runs are driven (pull-mode runs effects only while observed); the
-// loop is fully awaited and the sink is cancelled in `finally`, so nothing runs
-// after the test disposes the engine (avoids an FFI-after-dispose segfault).
-// deno-lint-ignore no-explicit-any
-async function waitUntil<T>(
-  runtime: Runtime,
-  cell: any,
-  pred: (v: T) => boolean,
-  iterations = 400,
-): Promise<T> {
-  const cancel = cell.sink(() => {}) as () => void;
-  try {
-    for (let i = 0; i < iterations; i++) {
-      await runtime.idle();
-      const v = cell.get() as T;
-      if (pred(v)) return v;
-      await new Promise((r) => setTimeout(r, 15));
-    }
-    throw new Error("timeout waiting for sqlite result");
-  } finally {
-    cancel?.();
-  }
-}

--- a/packages/runner/test/sqlite-db-owner.test.ts
+++ b/packages/runner/test/sqlite-db-owner.test.ts
@@ -15,6 +15,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { SqliteDbRef } from "@commonfabric/memory/v2";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { waitForCellValue } from "./support/wait-for-cell-value.ts";
 import { Runtime } from "../src/runtime.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -67,7 +68,7 @@ describe("sqliteDatabase handle owner", () => {
     const result = runtime.run(tx, dbPattern, {}, resultCell);
     await tx.commit();
 
-    const minted = await waitUntil<SqliteDbRef>(
+    const minted = await waitForCellValue<SqliteDbRef>(
       runtime,
       result,
       (v) => v?.owner !== undefined,
@@ -85,7 +86,7 @@ describe("sqliteDatabase handle owner", () => {
     await tx2.commit();
 
     // A correct re-initialization leaves the handle value UNCHANGED, so there
-    // is no value transition to wait for — a `waitUntil(owner defined)` here
+    // is no value transition to wait for — a `waitForCellValue(owner defined)`
     // would be satisfied by the pre-restart state before the re-run executes.
     // Instead drive the fresh builtin action under observation (pull-mode
     // runs effects only while observed) and wait for full quiescence
@@ -101,28 +102,3 @@ describe("sqliteDatabase handle owner", () => {
     expect((result.get() as SqliteDbRef).owner).toBe("did:test:alice");
   });
 });
-
-// Wait until `pred(cell value)` holds. A `sink` keeps the effect chain live
-// (pull-mode runs effects only while observed); the loop is fully awaited and
-// the sink is cancelled in `finally`, so nothing runs after the test disposes
-// the engine (same idiom as sqlite-builtins.test.ts).
-async function waitUntil<T>(
-  runtime: Runtime,
-  // deno-lint-ignore no-explicit-any
-  cell: any,
-  pred: (v: T) => boolean,
-  iterations = 400,
-): Promise<T> {
-  const cancel = cell.sink(() => {}) as () => void;
-  try {
-    for (let i = 0; i < iterations; i++) {
-      await runtime.idle();
-      const v = cell.get() as T;
-      if (pred(v)) return v;
-      await new Promise((r) => setTimeout(r, 15));
-    }
-    throw new Error("timeout waiting for sqlite db handle");
-  } finally {
-    cancel?.();
-  }
-}

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -32,6 +32,7 @@ import {
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { waitForCellValue } from "./support/wait-for-cell-value.ts";
 import { isSigilLink } from "../src/link-utils.ts";
 
 // Fresh identity per RUN: the server derives the on-disk cell-db file from the
@@ -187,26 +188,6 @@ function runPattern(runtime: Runtime) {
   return { resultCell, commit };
 }
 
-async function waitUntil<T>(
-  runtime: Runtime,
-  cell: { sink: (f: () => void) => () => void; get: () => unknown },
-  pred: (v: T) => boolean,
-  iterations = 400,
-): Promise<T> {
-  const cancel = cell.sink(() => {});
-  try {
-    for (let i = 0; i < iterations; i++) {
-      await runtime.idle();
-      const v = cell.get() as T;
-      if (pred(v)) return v;
-      await new Promise((r) => setTimeout(r, 15));
-    }
-    throw new Error("timeout waiting for sqlite result");
-  } finally {
-    cancel?.();
-  }
-}
-
 /** All sigil links reachable in a RAW stored value (never descends into one). */
 function collectSigilLinks(value: unknown, out: unknown[] = []): unknown[] {
   if (isSigilLink(value)) {
@@ -296,7 +277,7 @@ describe("sqlite handle across runtimes (rule term lists)", () => {
     await runtimeA.idle();
     await seedDbFile(runtimeA, a.resultCell);
     const qCellA = a.resultCell.key("q").resolveAsCell();
-    const qA = await waitUntil<QueryState>(
+    const qA = await waitForCellValue<QueryState>(
       runtimeA,
       qCellA,
       (v) => v?.pending === false && v?.error === undefined,
@@ -339,7 +320,7 @@ describe("sqlite handle across runtimes (rule term lists)", () => {
       qCellA.getAsNormalizedFullLink().id,
     );
 
-    const qB = await waitUntil<QueryState>(
+    const qB = await waitForCellValue<QueryState>(
       runtimeB!,
       qCellB,
       (v) => v?.pending === false && v?.requestHash === hashA,

--- a/packages/runner/test/sqlite-query-rowschema-decode.test.ts
+++ b/packages/runner/test/sqlite-query-rowschema-decode.test.ts
@@ -22,27 +22,7 @@ import { isCell } from "../src/cell.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { encodeCfLinkValue } from "../src/builtins/sqlite/cf-link.ts";
-
-// deno-lint-ignore no-explicit-any
-async function waitUntil<T>(
-  runtime: Runtime,
-  cell: any,
-  pred: (v: T) => boolean,
-  iterations = 400,
-): Promise<T> {
-  const cancel = cell.sink(() => {}) as () => void;
-  try {
-    for (let i = 0; i < iterations; i++) {
-      await runtime.idle();
-      const v = cell.get() as T;
-      if (pred(v)) return v;
-      await new Promise((r) => setTimeout(r, 15));
-    }
-    throw new Error("timeout waiting for sqlite result");
-  } finally {
-    cancel?.();
-  }
-}
+import { waitForCellValue } from "./support/wait-for-cell-value.ts";
 
 type QueryState = {
   pending: boolean;
@@ -142,11 +122,12 @@ describe("sqliteQuery rowSchema-driven _cf_link decode (Piece A runtime)", () =>
     const result = runtime.run(tx2, p, {}, resultCell);
     await tx2.commit();
 
-    const v = await waitUntil<QueryState>(
+    const v = await waitForCellValue<QueryState>(
       runtime,
       result,
       (s) =>
-        s.pending === false && Array.isArray(s.result) && s.result.length === 1,
+        s?.pending === false && Array.isArray(s.result) &&
+        s.result.length === 1,
     );
     expect(v.error).toBeUndefined();
 

--- a/packages/runner/test/support/wait-for-cell-value.ts
+++ b/packages/runner/test/support/wait-for-cell-value.ts
@@ -1,0 +1,48 @@
+import { defer } from "@commonfabric/utils/defer";
+import type { Cell } from "../../src/cell.ts";
+import type { Runtime } from "../../src/runtime.ts";
+
+/**
+ * Resolve with `cell`'s value once `predicate` accepts it at a quiescent
+ * moment.
+ *
+ * The predicate is only ever applied to a value read after `runtime.idle()`,
+ * never to one the sink reports mid-flight. A cell passes through states that
+ * exist only until the scheduler drains — a query that has not yet re-run
+ * against new inputs still holds its previous settled result, and a predicate
+ * such as "settled and without error" accepts that superseded value. Reading
+ * only at quiescence steps over those states.
+ *
+ * Between attempts the wait sleeps on the sink rather than on a timer: the
+ * callback wakes it on every committed change, so there is no poll interval
+ * under the latency and no iteration cap over it. `predicate` takes
+ * `T | undefined` because a cell holds no value until its piece writes one.
+ */
+export async function waitForCellValue<T>(
+  runtime: Runtime,
+  // deno-lint-ignore no-explicit-any
+  cell: Cell<any>,
+  predicate: (value: T | undefined) => boolean,
+): Promise<T> {
+  let changed = defer<void>();
+  const cancel = cell.sink(() => {
+    changed.resolve();
+    changed = defer<void>();
+  });
+  try {
+    while (true) {
+      await runtime.idle();
+      // Captured before the read, so a change racing the predicate wakes the
+      // next attempt instead of being missed.
+      const next = changed.promise;
+      const value = cell.get() as T;
+      if (predicate(value)) return value;
+      await next;
+    }
+  } finally {
+    // Cancelling while the action that reported a value is still finalizing
+    // does not stick, because finalizing an action resubscribes it.
+    await runtime.idle();
+    cancel();
+  }
+}


### PR DESCRIPTION
Four sqlite tests in packages/runner/test each defined their own identical `waitUntil` helper: a loop that ran up to 400 times, awaiting `runtime.idle()` and then sleeping 15 milliseconds between probes of a result cell. Each one registered a sink purely to keep the cell observed, threw the callback away, and polled `cell.get()` alongside it. That put a 6-second ceiling on success — anything slower could never be observed, however close it was to finishing — and a 15-millisecond floor under every probe. The repository's guard against new polling waits, tasks/check-no-waitfor.ts, only sees named imports of the shared `waitFor` from the integration package, so four locally defined copies of the same loop were invisible to it.

The callback these loops discarded is the event they were missing. A sink runs its callback once at registration and again on every committed change, so the cell itself can say when to look again, and nothing has to guess an interval. Collapse the four copies into one `waitForCellValue` in packages/runner/test/support/, alongside the existing shared test helpers. `docs/development/waiting-in-tests.md` already prescribed this shape for an off-page wait; it now names the helper, so the next author does not rediscover it.

The helper keeps the old loop's contract and changes only how it waits. It reads the cell after `runtime.idle()` and applies the predicate to that value, exactly as the loop did; when the predicate fails it sleeps on the sink rather than on a timer. So the 15-millisecond floor and the 400-iteration ceiling both go, and nothing else moves. The loop that remains carries no delay, no retry and no bound: each turn is woken by a real committed change.

Reading at quiescence is the part worth keeping, and it is subtle enough to be worth stating. A cell passes through states that exist only until the scheduler drains, and a predicate can accept one that is about to be superseded — a query that has not yet re-run against new inputs still holds its previous settled result, so "settled and without error" matches the stale value. The multi-runtime test is reachable proof: it seeds a db file, which makes the query re-run under a new request hash, then latches the hash it finds. Testing the value the sink hands the callback latches the pre-seed hash whenever that result lands first, and because the value is a live view the cell then moves on and the assertion passes on a hash the wait never approved. Awaiting `runtime.idle()` before each read keeps those states away from the predicate.

Cancelling the sink needs the same quiescence. Finalizing an action resubscribes it, so a cancel issued while the action that reported a value is still finishing is silently undone and the subscription outlives the wait. The old loops did not have this problem because they only ever cancelled after `await runtime.idle()`. Both reasons are why the helper takes a runtime.

The predicate takes `T | undefined`, because a cell holds no value until its piece writes one. Three of the five call sites already guarded with `?.`; the other two now do too.

No bound replaces the iteration cap. In an in-process test none is needed: when a value never arrives and the runtime goes quiet, Deno reports a promise that can no longer settle and fails immediately, which is both faster than a deadline and more honest about the cause.

One call site does not convert to a cell-value wait. `capturedQueryScope` in sqlite-builtins.test.ts asserts on the db scope forwarded to the wire, and its predicate ignored the cell entirely, reading a variable set by a spy wrapped around the storage provider's `sqliteQuery`. The event it waits for is the spy call, so it resolves a `defer()` there instead. Its sink is gone rather than kept: the query is issued by the flush that follows the commit, which runs whether or not anything observes the result, so the sink it inherited from the shared poll helper drove nothing.

Each converted wait was checked in both directions: the tests pass, and each one fails rather than passing when its predicate is made unsatisfiable, so no wait has become a no-op.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced polling loops in sqlite tests with an event-driven `waitForCellValue` helper to remove fixed delays and iteration caps, making waits faster and more reliable.

- **Refactors**
  - Added `waitForCellValue` in `packages/runner/test/support/`, which waits on cell `sink` events and reads after `runtime.idle()`.
  - Updated four sqlite tests to use it; predicates now accept `T | undefined` and use `?.` where needed.
  - Switched one case to a `defer()` resolved by the `sqliteQuery` spy since the wire call is the event.
  - Expanded `docs/development/waiting-in-tests.md` to name the helper and cover traps: read at quiescence, cancel after `runtime.idle()`, and no timeout needed in in-process tests.

<sup>Written for commit b54c41e29bc59bbbf2f983081304bdfc6222fc23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

