### PR TITLE
fix(runner): factory re-entry with a hardened implementation must not fork its verified identity

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -23,7 +23,11 @@ import {
 } from "./node-utils.ts";
 import { assertNotInActionExecution } from "./action-context.ts";
 import { moduleToJSON } from "./json-utils.ts";
-import { brandTrustedBuilderArtifact } from "./pattern-metadata.ts";
+import {
+  brandTrustedBuilderArtifact,
+  getArtifactEntryRef,
+} from "./pattern-metadata.ts";
+import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
 import { getTopFrame } from "./pattern.ts";
 import { generateHandlerSchema } from "../schema.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -654,6 +658,22 @@ function prepareInspectableImplementation<
   implementation: T,
 ): T {
   if (Object.isExtensible(implementation)) {
+    return implementation;
+  }
+
+  // A hardened implementation that already carries verified identity must be
+  // returned as-is. Provenance and artifact entry refs are keyed on the
+  // function OBJECT (WeakMaps, the anti-spoof design), so the wrapper below is
+  // a fresh identity-less function: it serializes body-only with no `$implRef`
+  // and re-evaluates bare-SES — module scope gone — on reload (the silent
+  // "helper is not a function" unlink; see the helper-unlink investigation
+  // record). A registered implementation already passed through a factory
+  // once — that is how it was registered — so it already carries its
+  // inspectable metadata and loses nothing by skipping the wrap.
+  if (
+    getVerifiedProvenance(implementation) !== undefined ||
+    getArtifactEntryRef(implementation) !== undefined
+  ) {
     return implementation;
   }
 

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -5,6 +5,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
 import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import { lift } from "../src/builder/module.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
 import { trustModule } from "./support/trusted-builder.ts";
@@ -95,6 +96,33 @@ describe("content-addressed action identity", () => {
     // (`fn.src` is no longer asserted here: it is lazy/debug-only and off by
     // default, and identity no longer depends on it — provenance is the source
     // of truth above.)
+  });
+
+  it("re-lifting a hardened registered implementation keeps its identity (no wrapper fork)", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const impl = module.implementation as HarnessedFunction;
+    // Its own factory pass hardened it, and registration keyed provenance on
+    // the function OBJECT.
+    expect(Object.isExtensible(impl)).toBe(false);
+    expect(getVerifiedProvenance(impl)).toBeDefined();
+
+    // Factory re-entry with the already-built implementation (the shape the
+    // runtime list-op factories produce): the factory must reuse the object.
+    // A fresh wrapper carries no WeakMap provenance, so it would serialize
+    // body-only with no `$implRef` and re-evaluate bare-SES — module scope
+    // gone — on reload (the silent helper-unlink failure; see the
+    // helper-unlink investigation record).
+    const refactory = lift(impl as (...args: unknown[]) => unknown);
+    const reimpl = (refactory as unknown as { implementation: unknown })
+      .implementation;
+    expect(reimpl).toBe(impl);
+
+    const json =
+      (refactory as unknown as { toJSON: () => Record<string, unknown> })
+        .toJSON();
+    expect(json.$implRef).toBeDefined();
+    expect("implementation" in json).toBe(false);
   });
 
   it("serializes javascript modules with $implRef only (no legacy fields)", async () => {

--- a/packages/runner/test/twin-lineage-provenance.test.ts
+++ b/packages/runner/test/twin-lineage-provenance.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+/**
+ * Twin-lineage provenance regression (the "helper is not a function" /
+ * helper-unlink family — see the investigation record topic on topics-dev,
+ * 2026-07).
+ *
+ * The failing wild topology: a program carries BOTH an evaluated module
+ * lineage and a never-imported-at-runtime "ghost" lineage (dragged in by a
+ * type-only import) whose computed-lambda source text is byte-identical to
+ * the evaluated one's, plus sub-patterns instantiated per list element. In
+ * the wild this combination lost action provenance in long-lived workers:
+ * generic action ids at creation, module nodes serialized body-only with no
+ * `$implRef`, and silent bare-SES re-evaluation on reload — where every
+ * module-scope helper reference breaks.
+ *
+ * These tests pin the invariants that make that failure impossible to
+ * reintroduce quietly:
+ *  1. every javascript module node in the compiled twin program carries
+ *     object-keyed verified provenance, and
+ *  2. every one of them serializes ref-carrying (never body-only), and
+ *  3. the program runs healthy end-to-end including the dynamic list-op
+ *     (.map row) path with the UI pulled — the surface prior headless
+ *     probes never exercised.
+ *
+ * The ghost here differs from the entry by ONE comment line (and its card
+ * import), the sharpest variant from the investigation's factorial: module
+ * identities differ while every lambda's source text is byte-identical.
+ */
+
+const signer = await Identity.fromPassphrase("twin-lineage-provenance");
+const space = signer.did();
+
+// ── The twin topology, inlined (mirrors the investigation's twin3e probe) ──
+
+const ENTRY_BODY = `
+import {
+  computed,
+  Default,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+import TwinCard from "./twin-card.tsx";
+import TwinRow from "./twin-row.tsx";
+
+export interface JoinEvent {
+  name?: string;
+}
+
+// Module-scope arrow helpers — byte-identical across entry and ghost.
+const shout = (s: string | undefined) => \`\${s ?? ""}\`.toUpperCase() + "!";
+const countNonEmpty = (xs: readonly string[]) =>
+  xs.filter((x) => x.trim() !== "").length;
+
+interface MainInput {
+  title?: Writable<string | Default<"twin probe">>;
+  myName?: Writable<string | Default<"">>;
+  joinName?: Writable<string | Default<"">>;
+  items?: Writable<string[] | Default<["alpha", "beta"]>>;
+}
+
+interface MainOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  loud: string;
+  itemCount: number;
+  me: string;
+  isJoined: boolean;
+}
+
+export default pattern<MainInput, MainOutput>(
+  ({ title, myName, joinName, items }) => {
+    const loud = computed(() => shout(title.get()));
+    const itemCount = computed(() => countNonEmpty(items.get()));
+    const card = TwinCard({ myName, joinName });
+    return {
+      [NAME]: "TwinMain",
+      [UI]: (
+        <div>
+          <h3>{loud}</h3>
+          <p>items: {itemCount}</p>
+          {card[UI]}
+          <ul>{items.map((label) => <TwinRow label={label} />)}</ul>
+        </div>
+      ),
+      loud,
+      itemCount,
+      me: card.me,
+      isJoined: card.isJoined,
+    };
+  },
+);
+`;
+
+// The ghost: byte-identical to the entry except its card import line and one
+// extra comment — module identity differs, every lambda text coincides.
+const GHOST_BODY = ENTRY_BODY.replace(
+  `import TwinCard from "./twin-card.tsx";`,
+  `import TwinCard from "./twin-card-ghost.tsx";`,
+).replace(
+  "// Module-scope arrow helpers — byte-identical across entry and ghost.",
+  "// Module-scope arrow helpers — byte-identical across entry and ghost.\n// (ghost lineage copy)",
+);
+
+const CARD_BODY = (ghostSuffix: string) => `
+import {
+  computed,
+  Default,
+  handler,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+import type { JoinEvent } from "./twin-ghost.tsx";
+${ghostSuffix}
+// Module-scope arrow helper — byte-identical across both cards.
+const trimmedName = (n: string | undefined) => (n ?? "").trim();
+
+// Module-scope handler (the factorial's proven topology): registers via the
+// transformer's __cfReg hoist under the module's identity.
+const joinAs = handler<JoinEvent, { myName: Writable<string>; joinName: Writable<string> }>(
+  (event, { myName, joinName }) => {
+    const trimmed = (event.name ?? joinName.get() ?? "").trim();
+    if (trimmed !== "") myName.set(trimmed);
+  },
+);
+
+interface CardInput {
+  myName?: Writable<string | Default<"">>;
+  joinName?: Writable<string | Default<"">>;
+}
+
+interface CardOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  me: string;
+  isJoined: boolean;
+}
+
+export default pattern<CardInput, CardOutput>(({ myName, joinName }) => {
+  const me = computed(() => trimmedName(myName.get()));
+  const isJoined = computed(() => trimmedName(myName.get()) !== "");
+  return {
+    [NAME]: "TwinCard",
+    [UI]: (
+      <div>
+        <input value={joinName} placeholder="Your name..." />
+        <button onClick={joinAs({ myName, joinName })}>Join</button>
+      </div>
+    ),
+    me,
+    isJoined,
+  };
+});
+`;
+
+const ROW_BODY = `
+import {
+  computed,
+  Default,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+// Module-scope arrow helper — the per-row derive the wild failures hit.
+const decorate = (s: string | undefined) => \`• \${(s ?? "").trim()} •\`;
+
+interface RowInput {
+  label: Writable<string | Default<"">>;
+}
+
+interface RowOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  pretty: string;
+}
+
+export default pattern<RowInput, RowOutput>(({ label }) => {
+  const pretty = computed(() => decorate(label.get()));
+  return {
+    [NAME]: "TwinRow",
+    [UI]: <li>{pretty}</li>,
+    pretty,
+  };
+});
+`;
+
+const TWIN_PROGRAM = {
+  main: "/twin-main.tsx",
+  files: [
+    { name: "/twin-main.tsx", contents: ENTRY_BODY },
+    { name: "/twin-ghost.tsx", contents: GHOST_BODY },
+    { name: "/twin-card.tsx", contents: CARD_BODY("") },
+    { name: "/twin-card-ghost.tsx", contents: CARD_BODY("// (ghost card)\n") },
+    { name: "/twin-row.tsx", contents: ROW_BODY },
+  ],
+};
+
+// Recursively collect every javascript module node, descending into
+// sub-pattern module implementations.
+function collectJavaScriptModules(
+  pattern: Pattern,
+  out: Module[] = [],
+  depth = 0,
+): Module[] {
+  if (depth > 3 || !pattern?.nodes) return out;
+  for (const node of pattern.nodes) {
+    const module = node.module as Module;
+    if (!module || typeof module !== "object") continue;
+    if (module.type === "pattern") {
+      const inner = (module as { implementation?: unknown }).implementation;
+      if (inner && typeof inner === "object") {
+        collectJavaScriptModules(inner as Pattern, out, depth + 1);
+      }
+      continue;
+    }
+    if (module.type === "javascript") out.push(module);
+  }
+  return out;
+}
+
+describe("twin-lineage provenance (helper-unlink regression)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+  let tx: IExtendedStorageTransaction | undefined;
+
+  afterEach(async () => {
+    await tx?.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+    tx = undefined;
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const setup = async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const compiled = await runtime.patternManager.compilePattern(TWIN_PROGRAM);
+    await runtime.idle();
+    return compiled as Pattern;
+  };
+
+  it("every module node keeps provenance and serializes ref-carrying despite the byte-identical ghost lineage", async () => {
+    const compiled = await setup();
+    const modules = collectJavaScriptModules(compiled);
+    // Entry lifts + card lifts/handler ride the compiled graph; the exact
+    // count is allowed to evolve, but an empty walk means the collector broke.
+    expect(modules.length).toBeGreaterThanOrEqual(6);
+
+    for (const module of modules) {
+      const impl = (module as { implementation?: unknown }).implementation;
+      expect(typeof impl).toBe("function");
+      // Object-keyed verified provenance survived compilation with the ghost
+      // lineage present.
+      expect(getVerifiedProvenance(impl)).toBeDefined();
+
+      // And the wire shape is ref-carrying — never the silent body-only form
+      // that bare-SES re-evaluates outside module scope on reload.
+      const json = (module as Module & { toJSON?: () => unknown }).toJSON
+        ? (module as Module & { toJSON: () => unknown }).toJSON() as Record<
+          string,
+          unknown
+        >
+        : JSON.parse(JSON.stringify(module));
+      expect(json.$implRef).toBeDefined();
+      expect(typeof json.implementation).not.toBe("string");
+    }
+  });
+
+  it("runs healthy end-to-end with the dynamic .map row path materialized", async () => {
+    const compiled = await setup();
+    tx = runtime!.edit();
+    const resultCell = runtime!.getCell<Record<string, unknown>>(
+      space,
+      "twin-lineage run",
+      undefined,
+      tx,
+    );
+    const result = runtime!.run(tx, compiled, {}, resultCell);
+    await tx.commit();
+    tx = runtime!.edit();
+
+    await result.pull();
+    const value = result.getAsQueryResult() as Record<string, unknown>;
+    // The module-scope helpers executed in module scope: the derives computed.
+    expect(value.loud).toBe("TWIN PROBE!");
+    expect(value.itemCount).toBe(2);
+
+    // Pull the UI so the list-op instantiates the per-row sub-patterns — the
+    // dynamic path the wild failures fired on (and the one headless probes
+    // historically skipped).
+    const ui = result.key("$UI");
+    await ui.pull();
+    expect(ui.getAsQueryResult()).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Why

The helper-unlink investigation (record topic on topics-dev, board index 4; closed 2026-07-14) root-caused the wild "helper is not a function" share-mount failures to module nodes that reach resolution with a stringified body and no `$implRef` — which the runner silently re-evaluates in a bare SES compartment, outside module scope, so every module-scope reference breaks.

The one proven producer of that shape on main today: re-entering `createNodeFactory` with an implementation that is already hardened. `prepareInspectableImplementation` wraps non-extensible implementations to give debug metadata somewhere to live — but provenance and artifact entry refs are keyed on the function **object** (WeakMaps, deliberately, as the anti-spoof design), so the wrapper is a fresh identity-less function. Downstream: generic action ids at creation, body-only wire shape, silent bare-SES on reload. The fork is silent and CFC-relevant.

## What changed

- `prepareInspectableImplementation` returns a hardened implementation **as-is** when it already carries verified provenance or an artifact entry ref. A registered implementation already passed through a factory once (that is how it got registered), so it already carries its inspectable metadata — nothing is lost by skipping the wrap. Truly-anonymous frozen functions (test-built exotica) keep the existing wrap behavior.
- Unit regression (`content-addressed-identity.test.ts`): re-lifting a hardened registered implementation keeps object identity and serializes `$implRef`-carrying with the body omitted. **Red-checked**: fails on main without the fix (wrapper fork), passes with it.
- Twin-lineage regression (`twin-lineage-provenance.test.ts`, new): pins the investigation's wild topology — byte-identical computed-lambda source text across an evaluated module and a never-runtime-imported ghost (dragged by a type-only import), plus sub-patterns instantiated via the dynamic `.map` row path with the UI pulled — asserting every module node keeps provenance, serializes ref-carrying, and the program runs healthy end-to-end.

## Test plan

- `packages/runner`: full suite — **938 passed (4977 steps), 0 failed**
- repo `deno task check` clean; `deno lint` / `deno fmt` clean on touched files
- Red-check evidence for the unit regression (fails without the src change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid wrapping already-hardened factory implementations so re-entry doesn’t change the function identity. This keeps provenance and `$implRef` serialization and prevents the “helper is not a function” unlink on reload.

- **Bug Fixes**
  - In `packages/runner/src/builder/module.ts`, `prepareInspectableImplementation` now returns the function as-is when `getVerifiedProvenance` or `getArtifactEntryRef` is present.
  - Preserves object identity across factory re-entry, keeps content-addressed IDs and `$implRef`, and avoids body-only serialization and bare-SES re-evaluation that loses module scope.
  - Added regressions in `packages/runner/test`: `content-addressed-identity.test.ts` (re-lift retains identity and serializes via `$implRef`) and `twin-lineage-provenance.test.ts` (twin lineage with a ghost module and dynamic `.map` rows remains healthy with provenance intact).

<sup>Written for commit aa442f46277f2a3e730708ee5366a813035f6103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

