### PR TITLE
fix(runner): report ref-less module resolution as an error

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import { getLogger } from "@commonfabric/utils/logger";
 import {
   emptySchemaObject,
   schemaForValueType,
@@ -30,6 +31,15 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { isCell } from "../cell.ts";
+
+// Ledger-visible counter for the silent sick-write shape (see moduleToJSON):
+// counts increment even while the logger is disabled, so a worker's logger
+// ledger exposes how many function implementations serialized with neither
+// provenance nor an entry ref without turning any logging on.
+const serializeShapeLogger = getLogger("builder.serialize-shape", {
+  enabled: false,
+  logCountEvery: 0,
+});
 
 export type CellAliasResolver = (
   cell: Reactive<any>,
@@ -408,6 +418,25 @@ export function moduleToJSON(module: Module) {
     const implRefValue = (provenance?.symbol
       ? { identity: provenance.identity, symbol: provenance.symbol }
       : undefined) ?? entryRefValue;
+    if (module.type === "javascript" && implRefValue === undefined) {
+      // This module will serialize body-only with no `$implRef` — the shape a
+      // reader can only resolve through the silent bare-SES stringified-source
+      // fallback, where module-scope references break (the helper-unlink
+      // failure family; topics-dev record, 2026-07). Legitimate for test-built
+      // / never-verified modules, so this stays at debug — but the ledger
+      // count fires even when disabled, so the sick-write volume is always
+      // observable from the logger ledger.
+      serializeShapeLogger.debug("noref-body-write", () => [
+        "Serializing a function implementation with neither provenance nor a" +
+        " verified entry ref (body-only, no $implRef)",
+        {
+          preview: Function.prototype.toString.call(implementation).slice(
+            0,
+            80,
+          ),
+        },
+      ]);
+    }
     const implRef = implRefValue ? { $implRef: implRefValue } : {};
     const preview = (implementation as { preview?: string }).preview ??
       implementation.toString().slice(0, 200);

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -1,4 +1,5 @@
 import { isObjectOrArray } from "@commonfabric/utils/types";
+import { getLogger } from "@commonfabric/utils/logger";
 import { isInertArray } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
 import {
@@ -43,6 +44,15 @@ export type CellAliasResolver = (
   path: readonly PropertyKey[],
   ignoreSelfAliases: boolean,
 ) => AliasBinding | null | undefined;
+
+// Ledger-visible counter for the body-only module write (see
+// `moduleToEncodableForm`): counts increment even while the logger is
+// disabled, so the volume of function implementations serialized with neither
+// provenance nor an entry ref is always observable from the logger ledger.
+const serializeShapeLogger = getLogger("builder.serialize-shape", {
+  enabled: false,
+  logCountEvery: 0,
+});
 
 /**
  * The refusal a `FabricInstance` gets from the binding walks. Nothing reaches
@@ -326,6 +336,24 @@ export function moduleToEncodableForm(module: Module): FabricExecPlainObject {
     const implRefValue = (provenance?.symbol
       ? { identity: provenance.identity, symbol: provenance.symbol }
       : undefined) ?? entryRefValue;
+    if (module.type === "javascript" && implRefValue === undefined) {
+      // This module serializes body-only with no `$implRef` — a shape a
+      // reader can resolve only through the bare-SES stringified-source
+      // fallback, where module-scope references do not exist. Test-built and
+      // never-verified modules produce it legitimately, so this stays at
+      // debug; the ledger count still fires while the logger is disabled, so
+      // the write volume is always observable.
+      serializeShapeLogger.debug("noref-body-write", () => [
+        "Serializing a function implementation with neither provenance nor a" +
+        " verified entry ref (body-only, no $implRef)",
+        {
+          preview: Function.prototype.toString.call(implementation).slice(
+            0,
+            80,
+          ),
+        },
+      ]);
+    }
     const implRef = implRefValue ? { $implRef: implRefValue } : {};
     const preview = (implementation as { preview?: string }).preview ??
       implementation.toString().slice(0, 200);

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -45,12 +45,10 @@ export type CellAliasResolver = (
   ignoreSelfAliases: boolean,
 ) => AliasBinding | null | undefined;
 
-// Ledger-visible counter for the body-only module write (see
-// `moduleToEncodableForm`): counts increment even while the logger is
-// disabled, so the volume of function implementations serialized with neither
-// provenance nor an entry ref is always observable from the logger ledger.
+// Surfaces the body-only module write (see `moduleToEncodableForm`). It has
+// its own name so write-time diagnostics can be silenced or raised without
+// touching everything the `runner` logger carries.
 const serializeShapeLogger = getLogger("builder.serialize-shape", {
-  enabled: false,
   logCountEvery: 0,
 });
 
@@ -339,11 +337,10 @@ export function moduleToEncodableForm(module: Module): FabricExecPlainObject {
     if (module.type === "javascript" && implRefValue === undefined) {
       // This module serializes body-only with no `$implRef` — a shape a
       // reader can resolve only through the bare-SES stringified-source
-      // fallback, where module-scope references do not exist. Test-built and
-      // never-verified modules produce it legitimately, so this stays at
-      // debug; the ledger count still fires while the logger is disabled, so
-      // the write volume is always observable.
-      serializeShapeLogger.debug("noref-body-write", () => [
+      // fallback, where module-scope references do not exist. Surfacing it
+      // here catches the shape as it is written, which is the only signal for
+      // graphs serialized inline rather than persisted by pattern reference.
+      serializeShapeLogger.warn("noref-body-write", () => [
         "Serializing a function implementation with neither provenance nor a" +
         " verified entry ref (body-only, no $implRef)",
         {

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -340,7 +340,7 @@ export function moduleToEncodableForm(module: Module): FabricExecPlainObject {
       // fallback, where module-scope references do not exist. Surfacing it
       // here catches the shape as it is written, which is the only signal for
       // graphs serialized inline rather than persisted by pattern reference.
-      serializeShapeLogger.warn("noref-body-write", () => [
+      serializeShapeLogger.error("noref-body-write", () => [
         "Serializing a function implementation with neither provenance nor a" +
         " verified entry ref (body-only, no $implRef)",
         {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3216,11 +3216,15 @@ export class Runner {
         return implementation as (...args: any[]) => any;
       }
     }
-    // Eviction insurance: the artifact index is FIFO-bounded and can roll a
-    // running pattern's module out mid-session, and a post-flip graph has no
-    // legacy ref (and no body when the writer proved resolvability). The
-    // engine's content-addressed implementation index is strong for the
-    // session, so the `$implRef` keeps resolving.
+    // Second-chance resolution through the engine's content-addressed
+    // implementation index (strong and session-unbounded). Note the artifact
+    // index above (`addressableByIdentity`) is ALSO session-lifetime and never
+    // evicted — the bounded FIFO in the pattern manager covers only the
+    // module-NAMESPACE reuse cache (`modulesByIdentity`), not artifact
+    // resolution. This arm covers the cases where the two indexes genuinely
+    // diverge: a module verified-evaluated by the engine without passing
+    // through the PatternManager's registration (e.g. a standalone-Engine
+    // compile), and a post-flip graph that carries no legacy ref and no body.
     return this.runtime.harness.getVerifiedImplementation?.(
       ref.identity,
       ref.symbol,
@@ -4472,6 +4476,25 @@ export class Runner {
         "Verified function resolution missed; running SES-recompiled," +
         " CFC-unverified fallback",
         { $implRef: implRef },
+      ]);
+    } else {
+      // No `$implRef` at all: the writer serialized this module with neither
+      // provenance nor an entry ref, so it re-evaluates bare-SES with NO
+      // breadcrumb anywhere upstream. This branch being fully silent cost the
+      // helper-unlink investigation (topics-dev record, 2026-07) weeks: keep a
+      // ledger-visible counter here even when the logger is disabled (counts
+      // increment before the level/disabled gates).
+      logger.debug("unverified-source-fallback", () => [
+        "Module reached resolution with no $implRef; running SES-recompiled," +
+        " CFC-unverified fallback from stringified source",
+        {
+          preview: typeof module.implementation === "function"
+            ? Function.prototype.toString.call(module.implementation).slice(
+              0,
+              80,
+            )
+            : String(module.implementation).slice(0, 80),
+        },
       ]);
     }
     if (typeof module.implementation === "function") {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5128,21 +5128,34 @@ export class Runner {
   }
 
   /**
+   * The module's content-addressed `$implRef` — the defining module's content
+   * identity plus the registered artifact's export/`__cfReg` symbol — when it
+   * is structurally whole. A ref missing either half addresses nothing, so it
+   * reads the same as no ref at all, and every caller treats it that way.
+   */
+  private contentAddressedImplRef(
+    module: Module,
+  ): { identity: string; symbol: string } | undefined {
+    const ref = (module as { $implRef?: { identity: string; symbol: string } })
+      .$implRef;
+    return ref && typeof ref.identity === "string" &&
+        typeof ref.symbol === "string"
+      ? ref
+      : undefined;
+  }
+
+  /**
    * Resolve a module's implementation through its content-addressed
-   * `$implRef` (the defining module's content identity + the registered
-   * artifact's export/`__cfReg` symbol). Returns undefined on a miss (no ref,
-   * never registered, or rolled out of the bounded index) — callers fall back
-   * to the legacy ref or the stringified source.
+   * `$implRef`. Returns undefined when the module carries no usable ref or the
+   * ref names an implementation this runtime never registered; the caller then
+   * falls through to the module's live implementation, and failing that to the
+   * stringified source.
    */
   private resolveByImplRef(
     module: Module,
   ): ((...args: any[]) => any) | undefined {
-    const ref = (module as { $implRef?: { identity: string; symbol: string } })
-      .$implRef;
-    if (
-      !ref || typeof ref.identity !== "string" ||
-      typeof ref.symbol !== "string"
-    ) {
+    const ref = this.contentAddressedImplRef(module);
+    if (!ref) {
       return undefined;
     }
     const artifact = this.runtime.patternManager.artifactFromIdentitySync(
@@ -6561,8 +6574,7 @@ export class Runner {
   private getFallbackJavaScriptImplementation(
     module: Module,
   ): (...args: any[]) => any {
-    const implRef =
-      (module as { $implRef?: { identity: string; symbol: string } }).$implRef;
+    const implRef = this.contentAddressedImplRef(module);
     if (implRef) {
       // The module carries a content-addressed `$implRef` — it was expected to
       // resolve through the verified registry — yet resolution fell through to

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -6583,7 +6583,7 @@ export class Runner {
       // Counts increment even while the logger is disabled, so a live
       // worker's logger ledger always exposes how often unverified source is
       // executing.
-      logger.debug("unverified-source-fallback", () => [
+      logger.warn("unverified-source-fallback", () => [
         "Module reached resolution with no $implRef; running SES-recompiled," +
         " CFC-unverified fallback from stringified source",
         {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -6583,7 +6583,7 @@ export class Runner {
       // Counts increment even while the logger is disabled, so a live
       // worker's logger ledger always exposes how often unverified source is
       // executing.
-      logger.warn("unverified-source-fallback", () => [
+      logger.error("unverified-source-fallback", () => [
         "Module reached resolution with no $implRef; running SES-recompiled," +
         " CFC-unverified fallback from stringified source",
         {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5156,11 +5156,15 @@ export class Runner {
         return implementation as (...args: any[]) => any;
       }
     }
-    // Eviction insurance: the artifact index is FIFO-bounded and can roll a
-    // running pattern's module out mid-session, and a post-flip graph has no
-    // legacy ref (and no body when the writer proved resolvability). The
-    // engine's content-addressed implementation index is strong for the
-    // session, so the `$implRef` keeps resolving.
+    // Second-chance resolution through the engine's content-addressed
+    // implementation index, which is strong for the whole session. The
+    // artifact index consulted above is also session-lifetime and never
+    // evicted — the pattern manager's bounded FIFO covers only the
+    // module-namespace reuse cache — so this arm exists for the cases where
+    // the two indexes genuinely diverge: a module verified-evaluated by the
+    // engine without passing through the pattern manager's registration
+    // (a standalone-Engine compile), and a post-flip graph that carries no
+    // legacy ref and no body.
     return this.runtime.harness.getVerifiedImplementation?.(
       ref.identity,
       ref.symbol,
@@ -6569,6 +6573,27 @@ export class Runner {
         "Verified function resolution missed; running SES-recompiled," +
         " CFC-unverified fallback",
         { $implRef: implRef },
+      ]);
+    } else {
+      // No `$implRef` at all: the module carries neither provenance nor a
+      // verified entry ref, so the bare-SES re-evaluation below is the only
+      // resolution left. Module-scope references do not exist under that
+      // evaluator, so when a module that needs them lands here, helpers fail
+      // at call time with no upstream signal — this counter is the tell.
+      // Counts increment even while the logger is disabled, so a live
+      // worker's logger ledger always exposes how often unverified source is
+      // executing.
+      logger.debug("unverified-source-fallback", () => [
+        "Module reached resolution with no $implRef; running SES-recompiled," +
+        " CFC-unverified fallback from stringified source",
+        {
+          preview: typeof module.implementation === "function"
+            ? Function.prototype.toString.call(module.implementation).slice(
+              0,
+              80,
+            )
+            : String(module.implementation).slice(0, 80),
+        },
       ]);
     }
     if (typeof module.implementation === "function") {

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -213,13 +213,16 @@ describe("content-addressed action identity", () => {
     expect(r.key("name").get()).toBe("resolved-after-eviction");
   });
 
-  const ledgerCount = (loggerName: string, messageKey: string): number =>
+  // Reads the ERROR tally rather than the level-blind total: the severity is
+  // the behavior under test, since the pattern-test harness fails on error
+  // output and not on debug or warn.
+  const errorCount = (loggerName: string, messageKey: string): number =>
     (getLoggerCountsBreakdown()[loggerName]?.[messageKey] as
-      | { total?: number }
-      | undefined)?.total ?? 0;
+      | { error?: number }
+      | undefined)?.error ?? 0;
 
   it("counts serializing a function implementation that carries neither provenance nor an entry ref", () => {
-    const before = ledgerCount("builder.serialize-shape", "noref-body-write");
+    const before = errorCount("builder.serialize-shape", "noref-body-write");
     const anonymous = (x: number) => x + 1;
     const encodable = moduleToEncodableForm(
       { type: "javascript", implementation: anonymous } as Module,
@@ -227,7 +230,7 @@ describe("content-addressed action identity", () => {
     // The body-only wire shape: stringified implementation, no `$implRef`.
     expect(typeof encodable.implementation).toBe("string");
     expect("$implRef" in encodable).toBe(false);
-    expect(ledgerCount("builder.serialize-shape", "noref-body-write")).toBe(
+    expect(errorCount("builder.serialize-shape", "noref-body-write")).toBe(
       before + 1,
     );
   });
@@ -251,7 +254,7 @@ describe("content-addressed action identity", () => {
         : node
     );
     const rehydrated = { ...pattern, nodes } as unknown as Pattern;
-    const before = ledgerCount("runner", "unverified-source-fallback");
+    const before = errorCount("runner", "unverified-source-fallback");
     const tx = runtime!.edit();
     const resultCell = runtime!.getCell<{ name: string }>(
       signer.did(),
@@ -266,8 +269,48 @@ describe("content-addressed action identity", () => {
     r.key("setName").send({ name: "resolved-through-fallback" });
     await runtime!.idle();
     expect(r.key("name").get()).toBe("resolved-through-fallback");
-    expect(ledgerCount("runner", "unverified-source-fallback"))
-      .toBeGreaterThan(before);
+    expect(errorCount("runner", "unverified-source-fallback")).toBe(
+      before + 1,
+    );
+  });
+
+  it("counts a module whose $implRef is missing its parts as ref-less", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const source = Function.prototype.toString.call(module.implementation);
+    const encodable = (module as Module & { toEncodableForm: () => unknown })
+      .toEncodableForm() as Record<string, unknown>;
+    // A ref carrying neither identity nor symbol addresses nothing, so it has
+    // to read as ref-less rather than as a resolution that merely missed.
+    const malformed = {
+      ...encodable,
+      $implRef: {},
+      implementation: source,
+    };
+
+    const nodes = pattern.nodes.map((node) =>
+      (node.module as Module).type === "javascript" &&
+        (node.module as Module).wrapper === "handler"
+        ? { ...node, module: malformed as unknown as Module }
+        : node
+    );
+    const rehydrated = { ...pattern, nodes } as unknown as Pattern;
+    const before = errorCount("runner", "unverified-source-fallback");
+    const tx = runtime!.edit();
+    const resultCell = runtime!.getCell<{ name: string }>(
+      signer.did(),
+      "malformed-implref-resolution",
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r = runtime!.run(tx, rehydrated, {}, resultCell) as any;
+    await tx.commit();
+    await r.pull();
+    r.key("setName").send({ name: "resolved-through-fallback" });
+    await runtime!.idle();
+    expect(r.key("name").get()).toBe("resolved-through-fallback");
+    expect(errorCount("runner", "unverified-source-fallback")).toBe(before + 1);
   });
 
   it("minting a builder artifact inside a running action fails loudly", async () => {

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -4,8 +4,10 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
 import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
 import { lift } from "../src/builder/module.ts";
+import { moduleToEncodableForm } from "../src/builder/to-encodable-form.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
 import { trustModule } from "./support/trusted-builder.ts";
@@ -209,6 +211,63 @@ describe("content-addressed action identity", () => {
     r.key("setName").send({ name: "resolved-after-eviction" });
     await runtime!.idle();
     expect(r.key("name").get()).toBe("resolved-after-eviction");
+  });
+
+  const ledgerCount = (loggerName: string, messageKey: string): number =>
+    (getLoggerCountsBreakdown()[loggerName]?.[messageKey] as
+      | { total?: number }
+      | undefined)?.total ?? 0;
+
+  it("counts serializing a function implementation that carries neither provenance nor an entry ref", () => {
+    const before = ledgerCount("builder.serialize-shape", "noref-body-write");
+    const anonymous = (x: number) => x + 1;
+    const encodable = moduleToEncodableForm(
+      { type: "javascript", implementation: anonymous } as Module,
+    ) as Record<string, unknown>;
+    // The body-only wire shape: stringified implementation, no `$implRef`.
+    expect(typeof encodable.implementation).toBe("string");
+    expect("$implRef" in encodable).toBe(false);
+    expect(ledgerCount("builder.serialize-shape", "noref-body-write")).toBe(
+      before + 1,
+    );
+  });
+
+  it("counts and still executes a module that reaches the fallback with no $implRef", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    // Rebuild the handler module as the body-only wire shape: stringified
+    // source, no `$implRef`. The handler body only touches its parameters, so
+    // the bare-SES stringified-source fallback can execute it.
+    const source = Function.prototype.toString.call(module.implementation);
+    const encodable = (module as Module & { toEncodableForm: () => unknown })
+      .toEncodableForm() as Record<string, unknown>;
+    const { $implRef: _dropped, ...rest } = encodable;
+    const refless = { ...rest, implementation: source };
+
+    const nodes = pattern.nodes.map((node) =>
+      (node.module as Module).type === "javascript" &&
+        (node.module as Module).wrapper === "handler"
+        ? { ...node, module: refless as unknown as Module }
+        : node
+    );
+    const rehydrated = { ...pattern, nodes } as unknown as Pattern;
+    const before = ledgerCount("runner", "unverified-source-fallback");
+    const tx = runtime!.edit();
+    const resultCell = runtime!.getCell<{ name: string }>(
+      signer.did(),
+      "refless-fallback-resolution",
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r = runtime!.run(tx, rehydrated, {}, resultCell) as any;
+    await tx.commit();
+    await r.pull();
+    r.key("setName").send({ name: "resolved-through-fallback" });
+    await runtime!.idle();
+    expect(r.key("name").get()).toBe("resolved-through-fallback");
+    expect(ledgerCount("runner", "unverified-source-fallback"))
+      .toBeGreaterThan(before);
   });
 
   it("minting a builder artifact inside a running action fails loudly", async () => {


### PR DESCRIPTION
## Why

A javascript module that reaches resolution with **no `$implRef`** runs SES-recompiled and CFC-unverified with no trace: the existing `verified-fallback-downgrade` breadcrumb fires only when a ref *is* present. Module-scope references do not exist under that evaluator, so a module that needs them fails at call time with nothing upstream to point at. The matching writer moment — serializing a function implementation with neither provenance nor a verified entry ref — was equally silent.

Nothing in the runtime produces that shape any more. #6071 made `str` a builtin, which was the last producer reachable from a pattern. So this reports the shape at **error** on both sides rather than merely counting it.

## What changed

- **Reader**: `getFallbackJavaScriptImplementation` reports `unverified-source-fallback` when a module arrives with no `$implRef`, with an implementation preview.
- **Writer**: `moduleToEncodableForm` reports `builder.serialize-shape` / `noref-body-write` when a function implementation serializes body-only — the moment the shape is written. It carries its own logger name so write-time diagnostics stay separable from everything the shared `runner` logger reports.
- Both are covered by tests that assert the ledger counts, and the ref-less fallback still executes a self-contained lambda so the reader test drives the real path.
- **Comment fix** in `resolveByImplRef`: the previous text attributed eviction to the artifact index. `addressableByIdentity` is session-lifetime and never evicted; the bounded FIFO covers only the module-namespace reuse cache. The comment now describes the cases where the two indexes genuinely diverge.

## Why error is safe, and what it buys

The pattern-test harness fails a test on error output (`allowConsoleErrors` is the per-test opt-in). Measured on this branch: **all 142 pattern tests pass** at error, and `packages/runner` is **1246 passed / 0 failed**. So the absence of ref-less modules stops being a property that happens to hold and becomes a standing guarantee for patterns — a stronger guard than the log level itself.

Two limits worth stating plainly:

- The guarantee is enforced for **patterns**, not unit tests, which have no console gate. Tests that produce a ref-less module deliberately — `security.test.ts` verifying that untrusted self-contained callbacks run through the SES fallback, and the adversarial suite asserting a dynamic symbol-less artifact never gets a resolvable ref — will now print errors without failing. Those want count-assertions rather than blanket opt-ins; that is follow-up work alongside removing `cf-disable-transform`, which is where the remaining unit-test producers come from.
- One question this instrumentation is partly there to answer: a compiled pattern's compile → run → persist → reload lifecycle serializes *zero* javascript modules through the writer, because compiled patterns persist by pattern reference and source docs, yet body-only module nodes have been observed on the wire in stored graphs. Some path inline-serializes them and it is not one reachable from a test here. If the write-side error ever fires somewhere real, that is the answer.

## Test plan

- `packages/runner` full suite: **1246 passed / 0 failed**
- `deno task integration pattern-tests` (whole suite): **all 142 pattern tests pass**
- repo `deno task check`, `deno fmt --check`, `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
