### PR TITLE
fuse: resolve names for detached subtrees so stale-inode writes don't…

### DIFF
--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -23,9 +23,14 @@ Every path must resolve to a valid `stat` result:
 as fallback). `ctime` = `mtime`. `atime` = current time or mount time (atime
 tracking is expensive and not useful here).
 
-**Inode assignment**: Inodes are assigned from a counter, keyed by
-`(entity_id, path)`. The same logical cell always gets the same inode within
-a mount session.
+**Inode assignment**: Inodes are assigned from a counter that only ever counts
+up (`FsTree.allocInode` in `packages/fuse/tree.ts`). Nothing keys them by cell
+identity or by path, so a path keeps its inode only for as long as the subtree
+holding it survives. Rebuilding a piece property replaces that subtree and
+allocates fresh inodes, so the same logical cell presents a new inode after
+each rebuild. A rebuild detaches the old subtree rather than dropping it
+immediately, which keeps the old inodes resolvable for a short window so that
+file handles opened before the rebuild continue to reach the same cell.
 
 ### `readdir`
 

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1738,6 +1738,31 @@ Deno.test("CellBridge decodes encoded space directory names for write paths", ()
   assertEquals(writePath?.jsonPath, ["title"]);
 });
 
+Deno.test("CellBridge resolves write paths through a detached prop subtree", () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "did:key:zSpace", []);
+  const piece = { id: "of:detached-piece", name: () => "Detached Piece" };
+  state.pieceControllers.set("notes", piece as never);
+
+  const pieceIno = tree.addDir(state.piecesIno, "notes");
+  const inputIno = tree.addDir(pieceIno, "input");
+  const lastMessageIno = tree.addFile(inputIno, "lastMessage", "hi", "string");
+
+  // A prop rebuild detaches the old `input` subtree, retains it so open handles
+  // keep working, and builds a replacement under the same name.
+  (bridge as unknown as { retainDetachedSubtree: (ino: bigint) => void })
+    .retainDetachedSubtree(inputIno);
+  const rebuiltInputIno = tree.addDir(pieceIno, "input");
+  tree.addFile(rebuiltInputIno, "lastMessage", "hi", "string");
+
+  const writePath = bridge.resolveWritePath(lastMessageIno);
+  assertEquals(writePath?.spaceName, "did:key:zSpace");
+  assertEquals(writePath?.pieceName, "notes");
+  assertEquals(writePath?.cell, "input");
+  assertEquals(writePath?.jsonPath, ["lastMessage"]);
+});
+
 Deno.test("CellBridge decodes encoded space directory names for source write paths", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");

--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -142,10 +142,29 @@ Deno.test("detached subtrees stay readable by inode until cleared", () => {
   assertEquals(tree.getPath(dir), "/dir");
   assertEquals(tree.getPath(file), "/dir/nested.txt");
 
+  assertEquals(tree.getNameForIno(dir), "dir");
+  assertEquals(tree.getNameForIno(file), "nested.txt");
+
   tree.clear(dir);
 
   assertEquals(tree.inodes.has(dir), false);
   assertEquals(tree.inodes.has(file), false);
+  assertEquals(tree.getNameForIno(dir), undefined);
+  assertEquals(tree.getNameForIno(file), undefined);
+});
+
+Deno.test("a detached subtree keeps its name after a replacement takes the path", () => {
+  const tree = new FsTree();
+  const oldDir = tree.addDir(tree.rootIno, "dir");
+  const oldFile = tree.addFile(oldDir, "nested.txt", "old", "string");
+
+  tree.detach(oldDir);
+
+  const newDir = tree.addDir(tree.rootIno, "dir");
+  tree.addFile(newDir, "nested.txt", "new", "string");
+
+  assertEquals(tree.getNameForIno(oldDir), "dir");
+  assertEquals(tree.getNameForIno(oldFile), "nested.txt");
 });
 
 Deno.test("clearing a detached subtree does not remove a replacement path mapping", () => {

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -1,4 +1,16 @@
 // tree.ts — In-memory filesystem tree with inode management
+//
+// Reference documentation:
+// - docs/specs/fuse-filesystem/README.md — index of the filesystem spec
+// - docs/specs/fuse-filesystem/4-read-write.md — stat, read and write
+//   semantics, inode assignment, and the cell-error-to-errno mapping
+// - docs/specs/fuse-filesystem/6-reactivity.md — how a cell change rebuilds a
+//   subtree and invalidates kernel caches, and the kernel cache timeouts that
+//   bound how long a client can hold a stale entry
+// - docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md — the errno
+//   decision table
+// - RELIABILITY_DESIGN.md — which module owns which state
+// - README.md — mount options and client-side cache tuning
 
 import type { CallableKind } from "./callables.ts";
 import {
@@ -259,7 +271,16 @@ export class FsTree {
     return childIno;
   }
 
-  /** Unlink a subtree from its parent while keeping its inodes temporarily live. */
+  /**
+   * Unlink a subtree from its parent while keeping its inodes temporarily live.
+   *
+   * A piece-prop rebuild detaches the old subtree and builds a replacement with
+   * fresh inodes. A client can still hold the old inode for as long as its
+   * kernel caches allow, so the detached inodes stay resolvable until they are
+   * cleared: `getNode`, `getPath` and `getNameForIno` all keep answering for
+   * them, which lets a write that arrives on a detached inode resolve to the
+   * same cell as the path it was opened on.
+   */
   detach(ino: bigint): void {
     if (!this.inodes.has(ino)) return;
     this.unlinkFromParent(ino);
@@ -356,7 +377,13 @@ export class FsTree {
     for (const [name, childIno] of parent.children) {
       if (childIno === ino) return name;
     }
-    return undefined;
+    // A detached subtree keeps its inodes and its recorded path until it is
+    // cleared. The parent no longer lists it, so recover the name from the
+    // recorded path.
+    const path = this.inoPaths.get(ino);
+    if (path === undefined) return undefined;
+    const name = path.slice(path.lastIndexOf("/") + 1);
+    return name === "" ? undefined : name;
   }
 
   /** Remove a subtree rooted at `ino`, including the node itself. */


### PR DESCRIPTION
… fail with EACCES

The FUSE CLI integration suite failed intermittently when truncating a mounted value file shortly after writing to it through an open file descriptor:

  integration/fuse-exec.sh: .../pieces/<piece>/input/lastMessage: Permission denied

Writing through the open descriptor flushes to the backing cell, which triggers a reactive rebuild of the piece's `input` prop. That rebuild calls retainDetachedSubtree on the old `input` directory: the directory is unlinked from its parent's children map but its inodes, parent links and recorded path are deliberately kept alive so open handles keep working, while a replacement directory is built with fresh inodes.

The kernel can still have the value file's dentry cached against the old inode. A subsequent open of that path lands on the retained inode, and CellBridge.resolveWritePath walks from the inode up to the root calling FsTree.getNameForIno at each level to rebuild the write path. That walk reached the detached `input` directory, whose parent no longer lists it as a child, so getNameForIno returned undefined, resolveWritePath returned null, and open replied EACCES.

getNameForIno now falls back to the basename of the node's recorded path, which detach leaves intact. This restores the invariant the tree already holds for detached subtrees — getPath resolves them, and their inodes stay readable until they are cleared — so a write that arrives on a retained inode resolves to the same cell as the path it was opened on.

The truncate has to land on the old inode rather than be rejected. The open path calls handles.truncateByIno after resolving the write path, and that call matches open handles by inode and empties their buffers. It is what stops the stale descriptor from writing its contents back when it is closed. Replying with a stale-handle error instead of resolving the write would skip that step and leave the stale descriptor armed. The CFC errno table agrees the permission error was the wrong answer: it prefers a stale-handle error over a generic EACCES when a stale reference forces a denial, and this goes further by resolving the write instead of denying it.

This widens retained detached subtrees from read-only to writable. A write that arrives on a stale inode for a path the rebuilt tree no longer has now resolves against the recorded path instead of failing. An example is a stale entry for an array index that the rebuilt array has dropped. That is accepted here: it follows from retaining the subtree at all, it needs a stale kernel cache entry and a shape change inside the retention window, and the alternative is the spurious permission error being fixed.

The window is bounded by the retention TTL, which is why the failure was rare in CI. The added tests cover the bug directly rather than through the timing-dependent path: one asserts getNameForIno keeps working across a detach and a replacement that takes over the same path, the other asserts resolveWritePath still resolves a value file inside a detached prop subtree.

Alongside the fix, record what this depends on. FsTree.detach now states the contract that retained inodes stay resolvable, which was load-bearing and existed only as an implicit property of the code. The top of tree.ts lists the FUSE filesystem specs, which nothing in the tree or bridge source pointed at, leaving the specs on inode assignment, rebuild and cache invalidation, and the errno table hard to find from the code they describe.

The spec's inode assignment paragraph claimed inodes are keyed by `(entity_id, path)` and that the same logical cell always keeps one inode for the life of a mount. Both halves are wrong. FsTree.allocInode is a counter that only ever counts up and is keyed by nothing, and every rebuild of a piece property allocates fresh inodes for the subtree it replaces. The rest of the spec set already assumed the correct model: the CFC annotation spec calls inodes transient and refuses to build refs on them. The claim is worth correcting rather than leaving because it denies the premise of this bug. A reader who believes a path keeps one inode per mount concludes that a write cannot arrive on a stale inode, which is exactly the case that failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale-inode writes in the FUSE layer by resolving names for detached subtrees, so truncation/open on cached dentries no longer returns EACCES. Writes via retained inodes now map back to the correct cell using the recorded path.

- **Bug Fixes**
  - `FsTree.getNameForIno` now falls back to the basename of the recorded path for detached nodes.
  - `CellBridge.resolveWritePath` resolves value files inside a detached prop subtree, ensuring truncate hits the old inode and `handles.truncateByIno` clears buffers.
  - Added tests in `packages/fuse/tree.test.ts` and `packages/fuse/cell-bridge.test.ts` to cover name resolution after detach and write-path resolution.

- **Refactors**
  - Documented the retained-inode contract in `FsTree.detach` and added spec references in `packages/fuse/tree.ts`.
  - Corrected inode assignment in `docs/specs/fuse-filesystem/4-read-write.md` (inodes are allocated monotonically; not keyed by `(entity_id, path)`).

<sup>Written for commit f7b9386c19f529b28dc7c3c976cf6cd158c3976c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

