### PR TITLE
fix(check-no-waitfor): ignore commented-out imports and catch relativ…

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -293,9 +293,10 @@ never poll-and-pray, and never re-click.
 
 A CI check enforces this for the polling `waitFor`: `deno task check-no-waitfor`
 fails when an integration test imports `waitFor` from
-`@commonfabric/integration`. See
-[`waiting-in-tests.md`](./waiting-in-tests.md) for the rationale, the full
-event-driven toolkit, and the allowlist of intentional exceptions.
+`@commonfabric/integration`, whether through the bare specifier or a relative
+path to the package. See [`waiting-in-tests.md`](./waiting-in-tests.md) for the
+rationale, the full event-driven toolkit, and the allowlist of intentional
+exceptions.
 
 ## Best Practices
 

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -122,11 +122,22 @@ open and a waiter that never fires would hang instead.
 A check prevents new integration tests from importing the polling `waitFor`.
 `tasks/check-no-waitfor.ts` scans the `.ts` files under any `integration/`
 directory beneath `packages/` (excluding the `@commonfabric/integration` package,
-which defines `waitFor`) and fails when one names `waitFor` in an import from
-`@commonfabric/integration` and is not on the check's allowlist. Run it with
-`deno task check-no-waitfor`; the CI "Check" job runs it on every pull request.
-The error names the offending file and points at `waitForCondition`,
-`awaitViewSettled`, the in-process `defer()` replacement, and this report.
+which defines `waitFor`) and fails when one names `waitFor` in an import of that
+package and is not on the check's allowlist. Two spellings reach it and both
+count: the bare `@commonfabric/integration` specifier, and a relative path ending
+at the package's `utils.ts` or `index.ts`. Commenting the import out clears the
+check, so it stays out of the way while a test is being migrated — text inside a
+comment or a string is not an import. Run it with `deno task check-no-waitfor`;
+the CI "Check" job runs it on every pull request. The error names the offending
+file and points at `waitForCondition`, `awaitViewSettled`, the in-process
+`defer()` replacement, and this report.
+
+The check is a speed bump against reaching for `waitFor` out of habit, not a seal
+against a determined evasion. It reads the import statement and nothing else, so
+a namespace import — `import * as I from "@commonfabric/integration"` followed by
+`I.waitFor(...)` — passes it. Every import of the package in the repository uses
+the named form. Treat a green check as "no new polling `waitFor` was imported the
+usual way", not as proof that a suite polls nowhere.
 
 The allowlist inside `tasks/check-no-waitfor.ts` covers only the exceptions the
 check can see: the integration-test files that import the shared `waitFor` from

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -105,6 +105,126 @@ Deno.test("importsPollingWaitFor ignores a commented-out member", () => {
   assertEquals(importsPollingWaitFor(source), false);
 });
 
+// Commenting the import out is the first step of migrating a test off the
+// polling waitFor, so none of these shapes may be flagged.
+
+Deno.test("importsPollingWaitFor ignores an import in a line comment", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      '// import { waitFor } from "@commonfabric/integration";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores an import in a block comment", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      '/* import { waitFor } from "@commonfabric/integration"; */',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores an import quoted in JSDoc prose", () => {
+  const source = [
+    "/**",
+    ' * Do not: import { waitFor } from "@commonfabric/integration"',
+    " */",
+    "export const helper = () => {};",
+  ].join("\n");
+  assertEquals(importsPollingWaitFor(source), false);
+});
+
+Deno.test("importsPollingWaitFor ignores an import inside a string", () => {
+  const source =
+    `const banned = 'import { waitFor } from "@commonfabric/integration";';`;
+  assertEquals(importsPollingWaitFor(source), false);
+});
+
+Deno.test("importsPollingWaitFor ignores an import inside a template literal", () => {
+  const source = [
+    "const sample = `",
+    'import { waitFor } from "@commonfabric/integration";',
+    "`;",
+  ].join("\n");
+  assertEquals(importsPollingWaitFor(source), false);
+});
+
+// The blanking of comments and strings must not swallow the code around them.
+
+Deno.test("importsPollingWaitFor detects an import after a comment holding an apostrophe and a brace", () => {
+  const source = [
+    "// Don't use this: it polls { every 50ms }.",
+    'import { waitFor } from "@commonfabric/integration";',
+  ].join("\n");
+  assert(importsPollingWaitFor(source));
+});
+
+Deno.test("importsPollingWaitFor detects an import after a template literal", () => {
+  const source = [
+    "const selector = `#${id} > .row`;",
+    'import { waitFor } from "@commonfabric/integration";',
+  ].join("\n");
+  assert(importsPollingWaitFor(source));
+});
+
+// A template literal ends at its own closing backtick even when it holds a
+// nested one, so what follows is read as code again.
+Deno.test("importsPollingWaitFor detects an import after a nested template literal", () => {
+  const source = [
+    "const label = `a ${`b ${c}`} d`;",
+    'import { waitFor } from "@commonfabric/integration";',
+  ].join("\n");
+  assert(importsPollingWaitFor(source));
+});
+
+// A string may carry a newline through a trailing backslash, so the scan cannot
+// simply stop looking at the end of the line.
+Deno.test("importsPollingWaitFor ignores an import in a line-continued string", () => {
+  const source = 'const sample = "\\\n' +
+    "import { waitFor } from '@commonfabric/integration';\\\n" +
+    '";';
+  assertEquals(importsPollingWaitFor(source), false);
+});
+
+// A relative path reaches the same waitFor without naming the package.
+
+Deno.test("importsPollingWaitFor detects a relative import of the package's utils.ts", () => {
+  assert(
+    importsPollingWaitFor(
+      'import { waitFor } from "../../integration/utils.ts";',
+    ),
+  );
+});
+
+Deno.test("importsPollingWaitFor detects a relative import of the package's index.ts", () => {
+  assert(
+    importsPollingWaitFor(
+      'import { env, waitFor } from "../../../../integration/index.ts";',
+    ),
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores a relative import of a module that lacks waitFor", () => {
+  // shell-utils.ts imports waitFor for its own use but does not re-export it,
+  // so naming waitFor in an import of it would not resolve. The clause has to
+  // name waitFor for this to test the specifier rather than the clause.
+  assertEquals(
+    importsPollingWaitFor(
+      'import { waitFor } from "../../integration/shell-utils.ts";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores a sibling utils.ts outside the package", () => {
+  assertEquals(
+    importsPollingWaitFor('import { waitFor } from "./utils.ts";'),
+    false,
+  );
+});
+
 Deno.test("isIntegrationTestFile scopes to integration test files", () => {
   assert(isIntegrationTestFile("packages/shell/integration/piece.test.ts"));
   assert(

--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -13,8 +13,10 @@
 // A file is in scope when it lives under an `integration/` directory somewhere
 // beneath `packages/`, excluding the `@commonfabric/integration` package itself,
 // which defines and re-exports `waitFor`. An in-scope file fails the check when
-// it names `waitFor` in an import from "@commonfabric/integration" and is not on
-// the ALLOWLIST below.
+// it names `waitFor` in an import of that package — either through the bare
+// specifier or through a relative path to the package's `utils.ts` or `index.ts`
+// — and is not on the ALLOWLIST below. Text inside a comment or a string is not
+// an import, so commenting the import out clears the check.
 //
 // The ALLOWLIST holds the files that are exempt from this check; the reason for
 // each is recorded in the "Where the polling `waitFor` stays" section of
@@ -56,17 +58,56 @@ export const ALLOWLIST: ReadonlySet<string> = new Set([
   "packages/patterns/integration/cf-render.test.disabled.ts",
 ]);
 
-// Matches an import from exactly "@commonfabric/integration" and captures the
+// Matches an import of the `@commonfabric/integration` package and captures the
 // named-imports clause between the braces. A leading default import and a
-// `type` modifier are tolerated. The closing quote right after `integration`
-// keeps subpath specifiers (".../shell-utils") from matching, and `[^}]*` keeps
-// the capture from bleeding past the end of the clause.
-const NAMED_IMPORT_RE =
-  /import\s+(?:[\w$]+\s*,\s*)?(?:type\s+)?\{([^}]*)\}\s*from\s*["']@commonfabric\/integration["']/g;
+// `type` modifier are tolerated, and `[^}]*` keeps the capture from bleeding
+// past the end of the clause.
+//
+// Two spellings reach the package. The bare specifier names it directly; the
+// closing quote right after `integration` excludes its subpath exports
+// (".../shell-utils", which does not re-export `waitFor`). A relative path
+// reaches the same code without naming the package: `utils.ts` defines
+// `waitFor` and `index.ts` re-exports it, so a specifier that starts with a `.`
+// and ends at either file counts. Under `packages/`, only the package itself
+// holds an `integration/utils.ts` or an `integration/index.ts`.
+//
+// Namespace imports are out of scope: `import * as I from
+// "@commonfabric/integration"` with a later `I.waitFor(...)` passes the check.
+// Every import of this package in the repository uses the named form.
+const PACKAGE_IMPORT =
+  /import\s+(?:[\w$]+\s*,\s*)?(?:type\s+)?\{(?<clause>[^}]*)\}\s*from\s*["'](?:@commonfabric\/integration|\.[^"']*\/integration\/(?:utils|index)\.ts)["']/;
 
-// Removes `//` and `/* */` comments from a named-imports clause. Such a clause
-// holds only identifiers, `as`, `type`, and commas, so a `waitFor` inside a
-// comment is a commented-out member rather than a real import.
+// The comment and literal forms that can hold import-shaped text. A `'` or `"`
+// opens a string only when its closing quote lands on the same line; a template
+// literal may span lines, and its `${...}` is swallowed as part of the literal,
+// which holds here because an import statement cannot sit inside one.
+//
+// Regular-expression literals are not modelled. A `/\//` reads as a line
+// comment and a quote inside a regex reads as a string opening, so both blind
+// the scan to the rest of that line. Imports sit at the top of a file, above any
+// regex literal.
+const LINE_COMMENT = /\/\/[^\n]*/;
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//;
+const TEMPLATE = /`(?:[^`\\]|\\[\s\S])*`/;
+const STRING = /"(?:[^"\\\n]|\\[\s\S])*"|'(?:[^'\\\n]|\\[\s\S])*'/;
+
+// One match per comment, literal, or package import, whichever starts first.
+// Each match consumes its own text, so a comment or a literal that opens before
+// an import carries the import-shaped text inside it away with it and
+// `PACKAGE_IMPORT` never matches there. Only a `PACKAGE_IMPORT` match sets the
+// `clause` group.
+const TOKEN_RE = new RegExp(
+  [LINE_COMMENT, BLOCK_COMMENT, TEMPLATE, STRING, PACKAGE_IMPORT]
+    .map((part) => part.source)
+    .join("|"),
+  "g",
+);
+
+// Removes `//` and `/* */` comments from a named-imports clause. A
+// `PACKAGE_IMPORT` match consumes its own braces, so a comment between them
+// arrives intact. Such a clause holds only identifiers, `as`, `type`, and
+// commas, so a `waitFor` inside a comment is a commented-out member rather than
+// a real import.
 function stripComments(clause: string): string {
   return clause
     .replace(/\/\*[\s\S]*?\*\//g, " ")
@@ -74,14 +115,17 @@ function stripComments(clause: string): string {
 }
 
 /**
- * Returns true when `source` imports the polling `waitFor` as a named import
- * from "@commonfabric/integration". `waitForCondition`, `waitForText`, and other
- * `waitFor`-prefixed names do not count; a `waitFor` on a subpath specifier or a
- * `harness.waitFor(...)` member call does not count either.
+ * Returns true when `source` imports the polling `waitFor` as a named import of
+ * the `@commonfabric/integration` package. `waitForCondition`, `waitForText`,
+ * and other `waitFor`-prefixed names do not count; neither does a `waitFor` on a
+ * subpath specifier, a `harness.waitFor(...)` member call, or an import that is
+ * commented out or quoted inside a string.
  */
 export function importsPollingWaitFor(source: string): boolean {
-  for (const match of source.matchAll(NAMED_IMPORT_RE)) {
-    if (/\bwaitFor\b/.test(stripComments(match[1]))) return true;
+  for (const match of source.matchAll(TOKEN_RE)) {
+    const clause = match.groups?.clause;
+    if (clause === undefined) continue;
+    if (/\bwaitFor\b/.test(stripComments(clause))) return true;
   }
   return false;
 }


### PR DESCRIPTION
…e ones

The guard that keeps new integration tests from importing the polling `waitFor` matched its import regex against the raw file text. Only the named-imports clause captured between the braces had comments stripped from it, and nothing at all looked at the text around the import statement. Anything shaped like the import was therefore a hit, whether or not it was code.

That flagged four shapes that are not imports: an import commented out with `//`, one commented out with `/* */`, prose in a JSDoc block that mentions the import, and the import text sitting inside a string literal. Commenting an import out is the ordinary first step of taking a test off `waitFor`, so the guard fired on the migration it exists to encourage, and its error message gave no hint that the offending line was a comment.

Separately, detection keyed on the bare `@commonfabric/integration` specifier, so a relative path into the package slipped through. `import { waitFor } from "../../integration/utils.ts"` reaches the same function and was missed. No file does this today, but importing the package by relative path is already established style elsewhere in the integration suites, so a contributor copying it and reaching for `waitFor` would have sailed past the guard.

Read the source as tokens instead. One alternation, matched globally over the file, covers a line comment, a block comment, a template literal, a string, and a package import, whichever starts first. Each match consumes its own text, so a comment or a literal that opens before an import carries the import-shaped text inside it away with it, and the import alternative never matches there. Only the import alternative captures a named group, which is how a real import is told from a token that merely contained one. The clause keeps its own comment strip: an import match consumes its own braces, so a member commented out between them arrives intact.

The alternation leaves some detail out on purpose. A template literal's `${...}` is swallowed whole, which holds because an import statement cannot sit inside one. Regular-expression literals are not modelled at all: a `/\//` reads as a line comment, and a quote inside a regex reads as a string opening, so each blinds the scan to the rest of its line. Imports sit at the top of a file, above any regex literal. The comments say as much rather than implying a bound that is not there.

Extend the specifier match to cover a relative path ending at the package's `utils.ts`, which defines `waitFor`, or its `index.ts`, which re-exports it. Under `packages/`, only the package itself holds a file at either path, so this adds no false-positive surface. The bare specifier's subpath exports still do not match.

A namespace import followed by a member call on the binding stays undetected, deliberately. Catching it means pairing an `import * as` with a later `I.waitFor(...)`, which a text scan gets wrong in both directions, and every import of the package in the repository uses the named form. The guard is a speed bump against habit, not a seal. Record that as a comment on the regex and a note in the document so it reads as a choice rather than an oversight.

Bring `UI_TESTING.md`, which described only the bare specifier, in step.

The scan stays static and single-pass, it decides all 357 files it scans exactly as before, and the allowlist is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `check-no-waitfor` guard to only flag real imports and to catch relative paths that reach `waitFor`. This removes false positives during migrations and closes a gap for `@commonfabric/integration`.

- **Bug Fixes**
  - Parse source as tokens to skip line/block comments, strings, and template literals.
  - Detect named imports from `@commonfabric/integration` and relative paths ending in `integration/utils.ts` or `integration/index.ts`.
  - Leave `import * as …; I.waitFor()` out of scope by design.
  - Keep the allowlist unchanged and behavior fast; add targeted tests for comments, strings/templates, and relative paths.

- **Docs**
  - Update `UI_TESTING.md` and `waiting-in-tests.md` to note relative-path detection and clarify the check’s scope during migrations.

<sup>Written for commit 2a38dde9f2da22eadfb64249611eb22995236394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

