### PR TITLE
test(cli): run piece-get integration test in CI with an event-driven wait

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -505,6 +505,20 @@ jobs:
           : > "$CF_CLI_INTEGRATION_TIMINGS_FILE"
           API_URL="http://localhost:${TOOLSHED_PORT}" ./integration/${{ matrix.script }}
 
+      # Deno-based integration tests against the same toolshed. Type checking
+      # of the CLI package is done by `deno task check`, so this run skips it.
+      # The prebuilt `cf` binary is on PATH, so the tests exercise it rather
+      # than the source-tree CLI task.
+      - name: 🧪 Run CLI deno integration tests
+        if: ${{ matrix.suite_name == 'core-piece-values' }}
+        working-directory: packages/cli
+        env:
+          TOOLSHED_PORT: ${{ matrix.toolshed_port }}
+        run: |
+          API_URL="http://localhost:${TOOLSHED_PORT}" deno test --no-check \
+            --allow-net --allow-ffi --allow-read --allow-write --allow-env \
+            --allow-run test/piece-integration.test.ts
+
       - name: 🧪 Run CLI FUSE integration suite
         if: ${{ matrix.suite_name == 'fuse' }}
         working-directory: packages/cli

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -65,9 +65,9 @@ Because the sink fires once on registration and then on every committed change,
 the waiter can resolve immediately when the value is already there and otherwise
 on the next change the sink reports.
 
-The runner's in-process tests have that last shape packaged as
-`waitForCellValue` in `packages/runner/test/support/wait-for-cell-value.ts`. It
-sleeps on the sink and applies its predicate to the cell only after
+That last shape is packaged as `waitForCellValue` in
+`@commonfabric/integration/wait-for-cell-value`, usable from any package's
+tests. It sleeps on the sink and applies its predicate to the cell only after
 `runtime.idle()`, so the wait has neither a poll interval under it nor an
 iteration cap over it. Its predicate takes `T | undefined`, since a cell holds
 no value until its piece writes one.
@@ -104,7 +104,11 @@ that continuation is undone and the sink goes on firing afterwards. Await
 An in-process wait like this needs no timeout backstop. When the value never
 arrives and the runtime goes quiet, Deno's test runner reports `Promise
 resolution is still pending but the event loop has already resolved` and fails
-the test at once, rather than hanging. The message names the test, not the wait
+the test at once, rather than hanging. That fail-fast report depends on the
+event loop draining: a wait whose runtime holds a live server connection keeps
+the loop alive, so a never-arriving value there runs to the ambient test or CI
+limit instead. Dispose such a probe runtime once the wait returns, so a
+completed wait does not hold the loop open for the rest of the suite. The message names the test, not the wait
 inside it, so a test holding several waits needs the last step printed without
 an `ok` to place the failure. It still beats a deadline, which reports only that
 time ran out, and reports it later.

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -1,24 +1,31 @@
+// Integration tests for `cf piece get` against a live toolshed. The suite
+// runs when API_URL names a running toolshed (as in the CI cli-integration
+// jobs) and is skipped otherwise. A throwaway identity keyfile and space are
+// created per run. Run locally with:
+//   API_URL=http://localhost:8000 deno test --allow-net --allow-ffi \
+//     --allow-read --allow-write --allow-env --allow-run \
+//     test/piece-integration.test.ts
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
+import type { Identity } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import {
   callPieceHandler,
   type EntryConfig,
   newPiece,
   type SpaceConfig,
 } from "../lib/piece.ts";
-import { cf } from "./utils.ts";
+import { integrationCf } from "./utils.ts";
 
-const INTEGRATION = Deno.env.get("CF_INTEGRATION") === "1";
+const API_URL = Deno.env.get("API_URL");
 
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
 const NOTE_PATTERN = `${REPO_ROOT}/packages/patterns/notes/note.tsx`;
 
-const spaceConfig: SpaceConfig = {
-  apiUrl: "http://localhost:8000",
-  space: `cf-1406-test-${Date.now()}`,
-  identity: "/tmp/bench.key",
-};
+const NOTE_CONTENT = "Hello world";
 
 const noteEntry: EntryConfig = {
   mainPath: NOTE_PATTERN,
@@ -27,18 +34,48 @@ const noteEntry: EntryConfig = {
 
 let pieceId = "";
 let flags = "";
+let identityPath = "";
 
-async function waitForContent(waitFlags: string): Promise<void> {
-  for (let i = 0; i < 20; i++) {
-    const { code } = await cf(`piece get ${waitFlags} result/content`);
-    if (code === 0) return;
-    await new Promise((r) => setTimeout(r, 500));
+// Resolves once the piece's result/content cell holds `expected`. Uses its
+// own controller, so readiness is judged from a fresh client's view of the
+// server.
+async function waitForContent(
+  identity: Identity,
+  spaceName: string,
+  piece: string,
+  expected: string,
+): Promise<void> {
+  const pieces = await PiecesController.initialize({
+    apiUrl: new URL(API_URL!),
+    identity,
+    spaceName,
+  });
+  try {
+    const controller = await pieces.get(piece);
+    const contentCell = (await controller.result.getCell())
+      .asSchema<{ content?: string }>()
+      .key("content");
+    await contentCell.pull();
+    await waitForCellValue<string>(
+      pieces.manager().runtime,
+      contentCell,
+      (value) => value === expected,
+    );
+  } finally {
+    await pieces.dispose();
   }
-  throw new Error("Piece never became ready");
 }
 
-describe("cf piece get (integration)", { ignore: !INTEGRATION }, () => {
+describe("cf piece get (integration)", { ignore: !API_URL }, () => {
   beforeAll(async () => {
+    const { identity, path } = await writeTempIdentity();
+    identityPath = path;
+    const spaceName = `cf-piece-get-test-${Date.now()}`;
+    const spaceConfig: SpaceConfig = {
+      apiUrl: API_URL!,
+      space: spaceName,
+      identity: identityPath,
+    };
     pieceId = await newPiece(spaceConfig, noteEntry);
     await callPieceHandler(
       { ...spaceConfig, piece: pieceId },
@@ -48,34 +85,37 @@ describe("cf piece get (integration)", { ignore: !INTEGRATION }, () => {
     await callPieceHandler(
       { ...spaceConfig, piece: pieceId },
       "editContent",
-      { detail: { value: "Hello world" } },
+      { detail: { value: NOTE_CONTENT } },
     );
     flags =
-      `--api-url http://localhost:8000 --identity /tmp/bench.key --space ${spaceConfig.space} --piece ${pieceId}`;
-    await waitForContent(flags);
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceName} --piece ${pieceId}`;
+    await waitForContent(identity, spaceName, pieceId, NOTE_CONTENT);
   });
 
   afterAll(async () => {
-    // No cleanup required — ephemeral space names ensure isolation.
-    await Promise.resolve();
+    // Ephemeral space names ensure isolation; only the throwaway identity
+    // keyfile needs removing.
+    if (identityPath) {
+      await Deno.remove(identityPath);
+    }
   });
 
   it("bad path exits 1 with Available keys: in output", async () => {
-    const { code, stdout } = await cf(
-      `piece get ${flags} result/nonexistent`,
+    const { code, stderr } = await integrationCf(
+      `piece get ${flags} nonexistent`,
     );
     expect(code).toBe(1);
-    expect(stdout.join("\n")).toContain("Available keys:");
+    expect(stderr.join("\n")).toContain("Available keys:");
   });
 
   it("good path exits 0 with valid output", async () => {
-    const { code, stdout } = await cf(`piece get ${flags} result/content`);
+    const { code, stdout } = await integrationCf(`piece get ${flags} content`);
     expect(code).toBe(0);
     expect(stdout.length).toBeGreaterThan(0);
   });
 
   it("no path returns full result JSON", async () => {
-    const { code, stdout } = await cf(`piece get ${flags}`);
+    const { code, stdout } = await integrationCf(`piece get ${flags}`);
     expect(code).toBe(0);
     const json = JSON.parse(stdout.join(""));
     expect(typeof json).toBe("object");

--- a/packages/cli/test/run-tests.ts
+++ b/packages/cli/test/run-tests.ts
@@ -47,6 +47,14 @@ const SERIAL_TESTS = [
   "test/view-pager-pty.test.ts",
 ];
 
+// Tests that need a live toolshed named by API_URL. This runner excludes
+// them: its --allow-net=127.0.0.1 grant cannot reach an arbitrary API_URL.
+// The CI cli-integration-test job runs them against its toolshed; each
+// file's header documents the direct local invocation.
+const INTEGRATION_TESTS = [
+  "test/piece-integration.test.ts",
+];
+
 function slashPath(path: string): string {
   return path.replaceAll("\\", "/");
 }
@@ -99,8 +107,22 @@ if (missingSerialTests.length > 0) {
   Deno.exit(1);
 }
 
+const integration = new Set(INTEGRATION_TESTS);
+const missingIntegrationTests = INTEGRATION_TESTS.filter((test) =>
+  !allTests.includes(test)
+);
+if (missingIntegrationTests.length > 0) {
+  console.error(
+    `Integration CLI test file(s) not found: ${
+      missingIntegrationTests.join(", ")
+    }`,
+  );
+  Deno.exit(1);
+}
+const unitTests = allTests.filter((test) => !integration.has(test));
+
 const shard = parseCliTestShard();
-const tests = allTests.filter((_, i) => i % shard.count === shard.index);
+const tests = unitTests.filter((_, i) => i % shard.count === shard.index);
 
 const parallelTests = tests.filter((test) => !serial.has(test));
 const serialTests = tests.filter((test) => serial.has(test));

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -36,31 +36,30 @@ export function checkStderr(stderr: string[]) {
   expect(relevant[0]).toMatch(/deno run /);
 }
 
-async function runCliTask(
-  task: "cli-no-pwd-override",
-  command: string,
-  stdin?: string,
-): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
-  // Use a regex to split up spaces outside of quotes.
+export interface CliResult {
+  code: number;
+  stdout: string[];
+  stderr: string[];
+}
+
+// Splits a command string into arguments on spaces outside of double quotes,
+// then strips the quotes.
+function parseCliCommand(command: string): string[] {
   const match = command.match(/(?:[^\s"]+|"[^"]*")+/g);
   if (!match || match.length === 0) {
     throw new Error(`Could not parse command: ${command}.`);
   }
-  // Filter out quotes that are in strings
-  const args = match.map((arg) => arg.replace(/"/g, ""));
+  return match.map((arg) => arg.replace(/"/g, ""));
+}
 
-  const child = new Deno.Command(Deno.execPath(), {
+async function spawnCli(
+  executable: string,
+  args: string[],
+  stdin?: string,
+): Promise<CliResult> {
+  const child = new Deno.Command(executable, {
     cwd: join(import.meta.dirname!, ".."),
-    args: [
-      "task",
-      // Deno tasks run with PWD set to wherever the deno.jsonc manifest is.
-      // The `cli` task in this package overrides that to use the shell's PWD.
-      // As these tests run within a test task, we can't override that PWD.
-      // For tests, use a version of the cli task that does *not* override
-      // user/deno's PWD.
-      task,
-      ...args,
-    ],
+    args,
     // `.output()` requires stdout/stderr to be piped; `.spawn()` would
     // otherwise default them to "inherit".
     stdout: "piped",
@@ -82,14 +81,75 @@ async function runCliTask(
   };
 }
 
+async function runCliTask(
+  task: "cli-no-pwd-override",
+  command: string,
+  stdin?: string,
+): Promise<CliResult> {
+  return await spawnCli(
+    Deno.execPath(),
+    [
+      "task",
+      // Deno tasks run with PWD set to wherever the deno.jsonc manifest is.
+      // The `cli` task in this package overrides that to use the shell's PWD.
+      // As these tests run within a test task, we can't override that PWD.
+      // For tests, use a version of the cli task that does *not* override
+      // user/deno's PWD.
+      task,
+      ...parseCliCommand(command),
+    ],
+    stdin,
+  );
+}
+
 // Executes the `cf` command via CLI
 // `const { stdout, stderr, code } = cf("dev --no-run ./pattern.tsx")`
 // Pass `stdin` to feed the command's standard input.
 export async function cf(
   command: string,
   stdin?: string,
-): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
+): Promise<CliResult> {
   return await runCliTask("cli-no-pwd-override", command, stdin);
+}
+
+let cfBinaryProbe: Promise<boolean> | undefined;
+
+// True when integration tests should run the prebuilt `cf` binary from PATH:
+// CF_CLI_INTEGRATION_USE_LOCAL is unset (the same override integration.sh
+// honors) and a `cf` on PATH answers `id --help`, a subcommand other tools
+// that install a `cf` binary reject. Probed once per process.
+function cfBinaryAvailable(): Promise<boolean> {
+  cfBinaryProbe ??= (async () => {
+    if (Deno.env.get("CF_CLI_INTEGRATION_USE_LOCAL")) {
+      return false;
+    }
+    try {
+      const { success } = await new Deno.Command("cf", {
+        args: ["id", "--help"],
+        stdout: "null",
+        stderr: "null",
+        stdin: "null",
+      }).output();
+      return success;
+    } catch {
+      return false;
+    }
+  })();
+  return cfBinaryProbe;
+}
+
+// Executes the `cf` command for integration tests: the prebuilt `cf` binary
+// from PATH when one is available (as in the CI integration jobs, which put
+// the built binaries on PATH), the source-tree CLI task otherwise. Set
+// CF_CLI_INTEGRATION_USE_LOCAL=1 to force the source-tree CLI.
+export async function integrationCf(
+  command: string,
+  stdin?: string,
+): Promise<CliResult> {
+  if (await cfBinaryAvailable()) {
+    return await spawnCli("cf", parseCliCommand(command), stdin);
+  }
+  return await cf(command, stdin);
 }
 
 export async function withEnv(

--- a/packages/integration/deno.jsonc
+++ b/packages/integration/deno.jsonc
@@ -5,6 +5,8 @@
   },
   "exports": {
     ".": "./index.ts",
-    "./shell-utils": "./shell-utils.ts"
+    "./shell-utils": "./shell-utils.ts",
+    "./temp-identity": "./temp-identity.ts",
+    "./wait-for-cell-value": "./wait-for-cell-value.ts"
   }
 }

--- a/packages/integration/temp-identity.ts
+++ b/packages/integration/temp-identity.ts
@@ -1,0 +1,26 @@
+import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
+
+export interface TempIdentity {
+  /** The identity, for in-process use. */
+  identity: Identity;
+  /** Path to the PKCS8 keyfile, for a spawned CLI's `--identity` flag. */
+  path: string;
+}
+
+/**
+ * Generates a fresh identity and writes its PKCS8 keyfile to a temporary
+ * file, giving a test both the in-process identity and a keyfile path that a
+ * spawned CLI can load. The keyfile parses through the same
+ * `Identity.fromPkcs8` path the CLI's `--identity` loading uses. The caller
+ * owns the file and removes it when done. Callers that serialize the
+ * identity (for example shell login) need `{ implementation: "noble" }`.
+ */
+export async function writeTempIdentity(
+  config: IdentityCreateConfig = {},
+): Promise<TempIdentity> {
+  const pkcs8 = await Identity.generatePkcs8();
+  const identity = await Identity.fromPkcs8(pkcs8, config);
+  const path = await Deno.makeTempFile({ prefix: "cf-test-identity-" });
+  await Deno.writeFile(path, pkcs8);
+  return { identity, path };
+}

--- a/packages/integration/wait-for-cell-value.ts
+++ b/packages/integration/wait-for-cell-value.ts
@@ -1,6 +1,5 @@
 import { defer } from "@commonfabric/utils/defer";
-import type { Cell } from "../../src/cell.ts";
-import type { Runtime } from "../../src/runtime.ts";
+import type { Cell, Runtime } from "@commonfabric/runner";
 
 /**
  * Resolve with `cell`'s value once `predicate` accepts it at a quiescent

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -11,7 +11,7 @@ import { defer } from "@commonfabric/utils/defer";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForCellValue } from "./support/wait-for-cell-value.ts";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/sqlite-db-owner.test.ts
+++ b/packages/runner/test/sqlite-db-owner.test.ts
@@ -15,7 +15,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { SqliteDbRef } from "@commonfabric/memory/v2";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForCellValue } from "./support/wait-for-cell-value.ts";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { Runtime } from "../src/runtime.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -32,7 +32,7 @@ import {
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForCellValue } from "./support/wait-for-cell-value.ts";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { isSigilLink } from "../src/link-utils.ts";
 
 // Fresh identity per RUN: the server derives the on-disk cell-db file from the

--- a/packages/runner/test/sqlite-query-rowschema-decode.test.ts
+++ b/packages/runner/test/sqlite-query-rowschema-decode.test.ts
@@ -22,7 +22,7 @@ import { isCell } from "../src/cell.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { encodeCfLinkValue } from "../src/builtins/sqlite/cf-link.ts";
-import { waitForCellValue } from "./support/wait-for-cell-value.ts";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 
 type QueryState = {
   pending: boolean;


### PR DESCRIPTION
## What

The `cf piece get` integration test (`packages/cli/test/piece-integration.test.ts`)
was manually-run-only and had silently rotted. This PR makes it correct,
event-driven, and part of CI.

## Why

The test gated on a bespoke `CF_INTEGRATION=1` flag that nothing in CI ever set,
so it never ran automatically — and had drifted out of sync with the CLI:

- Its readiness check ran `cf piece get result/content` in a child process up to
  20 times with 500ms sleeps, then threw a generic "Piece never became ready".
- `cf piece get` resolves paths against the piece's **result cell**, so the
  `result/` prefix never resolves. Every attempt failed deterministically, the
  loop swallowed the real error, and the suite spent ~19s failing with the
  generic message.

Run-by-hand tests that CI doesn't exercise are false assurance; this one proved it.

## Changes

**Event-driven wait.** `waitForContent` now loads a fresh piece manager
in-process and subscribes to the result `content` cell with `sink`, resolving
the moment the `editContent` handler's write is observed. No cap on success, no
sleeps, no child-process spawns — matching the repo's move off polling waits
(see `tasks/check-no-waitfor.ts` and `docs/development/waiting-in-tests.md`).

**Assertions fixed to match the CLI.** Result-cell-relative paths (`content`,
`nonexistent`); the "Available keys:" hint asserted on stderr, where the
cliffy `ValidationError` actually prints it.

**Wired into CI, following existing idioms.**
- Dropped the `CF_INTEGRATION` flag; the test now gates on `API_URL`, the
  repo-standard integration variable (`packages/integration/env.ts`,
  `docs/development/LOCAL_DEV_SERVERS.md`) that the `cli-integration-test` job
  already exports.
- Self-provisions its identity with `Deno.makeTempFile()` + `pkcs8FromEntropy()`
  (mirroring `integration.sh`'s `setup_space`) instead of a hardcoded
  `/tmp/bench.key`, and removes it in `afterAll`.
- Added a step to the `core-piece-values` matrix entry of `cli-integration-test`
  that runs the file against that job's toolshed.
- The `cf()` test helper now prefers the prebuilt `cf` binary from PATH (probing
  with `cf id --help`, a distinctive subcommand) and falls back to the source
  task, honoring `CF_CLI_INTEGRATION_USE_LOCAL` like `integration.sh` — so CI
  exercises the shipped binary.
- Excluded the file from `test/run-tests.ts` (the unit runner's
  `--allow-net=127.0.0.1` can't reach an arbitrary `API_URL`), so exporting
  `API_URL` no longer perturbs `deno task test`. A header comment documents the
  direct local invocation.

## Testing

- `deno fmt` / `lint` / `check` clean on all touched files.
- All three steps pass in ~3s against a live toolshed, in both source and
  prebuilt-binary modes.
- Full `deno task test` with `API_URL` exported passes and skips the
  integration file.
- Reviewed with adversarial forward/reverse subagents in isolated worktrees;
  their findings (unit-runner net-permission exposure, binary-probe
  specificity, temp-key cleanup) are addressed above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `cf piece get` integration test event-driven and run it in CI. Also add shared helpers for cell-value waits and temp identities, and update tests to use them.

- New Features
  - Event-driven wait: use `@commonfabric/integration/wait-for-cell-value` with a fresh controller; no sleeps or polling.
  - CI: added a `cli-integration-test` step to run the Deno test against the toolshed; tests prefer the prebuilt `cf` via `integrationCf` (override with `CF_CLI_INTEGRATION_USE_LOCAL`).
  - Shared helpers: moved `waitForCellValue` and added `writeTempIdentity` in `@commonfabric/integration`; exported in `deno.jsonc`, updated runner sqlite tests, and documented disposal of probe runtimes.

- Bug Fixes
  - Correct path handling (use result-cell-relative `content`/`nonexistent`) and assert the "Available keys:" hint on stderr.
  - Gate on `API_URL`, generate and clean a temp identity per run, and exclude the file from the unit test runner.

<sup>Written for commit 9a0dae36c7246bb508c8c2f2c7f3409e93e669d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

