### PR TITLE
docs: wait on real signals in the FUSE skills; link the waiting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,33 @@ rules are in `docs/README.md`; the short version:
 - When a live plan or design reaches "done" or is abandoned — for example, your
   change lands its last phase — archive it to `docs/history/` following the
   procedure in `docs/README.md`.
+- TypeScript and TSX code blocks under `docs/` are type-checked in CI by
+  `deno task check-docs`. A block selects the scaffold it compiles inside with
+  an opening context comment; `docs/check.md` defines that vocabulary, which is
+  not derivable from the source.
 
-## Pattern Development
+## Engineering principles and coding style
+
+### Avoid timeouts, retry loops, and sleeps
+
+Timeouts cause flakiness because they put an upper bound on success: anything
+that would have eventually completed cannot complete once it hits the timeout.
+
+Retry loops mask errors: anything that should have succeeded first time now gets
+missed because if it succeeds sometimes.
+
+Sleeps are flaky and expensive: they increase the floor on the amount of time
+operations take, and they rely on unpredictable timings to align for success.
+
+Avoid all three; when you see them in existing code, point them out and suggest
+starting an agent to remove them.
+
+For tests, `docs/development/waiting-in-tests.md` is the canonical guidance. It
+names the event-driven primitives to reach for instead of a poll, and the
+specific cases where a bounded poll is the honest tool — read it before removing
+one, so you don't strip a wait the repo keeps on purpose.
+
+### Pattern Development
 
 If you are developing patterns, use the repo-local `pattern-dev` skill at
 `skills/pattern-dev/SKILL.md`. `skills/` is the canonical authored source. Codex
@@ -57,9 +82,11 @@ compatibility continues to use `.claude/skills/`.
 When authoring or reviewing a skill itself, read
 `docs/development/skill-authoring.md` — what belongs in a skill (non-derivable
 map & values) versus what just constrains the agent (procedure a capable model
-already does).
+already does). `docs/development/skill-audit.md` covers what keeps those facts
+honest, including the `deno task check-skill-facts` tripwire that fails CI when
+a path or import a skill cites stops resolving.
 
-### Useful Pattern documentation
+#### Useful Pattern documentation
 
 **Start here:**
 
@@ -95,7 +122,7 @@ already does).
 
 **Important:** Ignore the `packages/patterns/deprecated` folder - it is defunct.
 
-## Runtime Development
+### Runtime Development
 
 If you are developing runtime code, read the following documentation:
 
@@ -105,6 +132,8 @@ If you are developing runtime code, read the following documentation:
   servers correctly (use `dev-local` for shell, not `dev`)
 - `docs/development/TESTING.md` - Running the test suites and the general unit
   and integration test structure; hub that links the other testing docs
+- `docs/development/waiting-in-tests.md` - Waiting on a real event instead of
+  polling: the primitives to use.
 - `docs/development/CI_PERFORMANCE.md` - When to stop or revisit CI wall-time
   splitting/rebalancing work
 - `docs/development/COVERAGE.md` - The two coverage mechanisms (V8 runtime
@@ -139,16 +168,7 @@ before inferring from source code alone:
 deno task cf check <pattern-or-fixture>.tsx --show-transformed --no-run
 ```
 
-The transformed output is dense. Pipe it into `cf view` for an interactive,
-syntax-aware pager (less-like) that colours builders, schemas, closures and type
-positions, and lets you navigate the structure tree (`wasd`), search (`/`) and
-peek definitions. The text shown is verbatim — colour only:
-
-```bash
-deno task cf check <pattern>.tsx --show-transformed --no-run | deno task cf view
-```
-
-### Adding New Packages
+#### Adding New Packages
 
 When adding a new workspace package:
 

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -85,10 +85,26 @@ load. Reads stall during the window.
 ls /tmp/cf-mount/
 
 # Remount:
-cf fuse mount /tmp/cf-mount --background && sleep 3
+cf fuse mount /tmp/cf-mount --background
 ```
 
-Add `sleep 2` before verification reads if you see repeated stalls.
+`--background` waits until the daemon reports it has mounted, so no delay is
+needed after it. It exits non-zero if the child dies during startup, or if the
+child does not report readiness within about 20 seconds.
+
+If reads still stall, read the mount status rather than waiting:
+
+```bash
+cat /tmp/cf-mount/.status
+```
+
+- `connection.disconnected` — the transport is dead. Remount; waiting does not
+  recover it.
+- `rebuilds.pending` — a subtree is still rebuilding. Those reads settle on
+  their own.
+- On macOS/FUSE-T, staleness beyond about a second suggests the mount was
+  created with `--attrcache-timeout 0` or `--noattrcache`; remount with the
+  default of 1. Neither option applies on Linux or macFUSE.
 
 ### Transport disconnection (silent write failures)
 
@@ -315,7 +331,7 @@ AGENT_NAME=$(resolve_agent)
 # Or on error:
 AGENT_NAME=$(resolve_agent)
 "MOUNT/SPACE/pieces/$AGENT_NAME/result/markError.handler" \
-  --summary "FUSE mount unresponsive after 3 retries"
+  --summary "FUSE mount unresponsive: .status reports transport disconnected"
 ```
 
 `markRunning`, `markIdle`, and `markError` automatically log to the Activity Log

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -53,7 +53,7 @@ deno task cf fuse unmount /tmp/cf
   <space>/                        # connected on first access
     pieces/
       <piece-name>/
-        meta.json                 # read-only: id, entityId, name, patternName
+        meta.json                 # read-only: id, entityId, name
         input.json                # full input cell as JSON
         input/                    # exploded input — each key is a file or dir
           title                   # raw text (no quotes): "My Title"
@@ -156,9 +156,12 @@ cat /tmp/cf/my-space/pieces/assistant/result.json | jq '.messages'
 echo '{"message":"Hello from agent"}' > \
   /tmp/cf/my-space/pieces/assistant/result/sendMessage.handler
 
-# Agent waits for a piece to reach a state. Address it by entity ID, not name:
-# a piece's name gains a count suffix on every state change, so a
-# pieces/<name>/... path goes stale on the very change being waited for.
+# Agent waits for a piece to reach a state. Resolve the entity ID once, then
+# address the piece by it: a name gains a count suffix on every state change, so
+# a pieces/<name>/... path goes stale on the very change being waited for. The
+# entity ID is the piece ID, and it never changes.
+ENTITY_ID=$(jq -r .entityId /tmp/cf/my-space/pieces/task/meta.json)
+
 until [ "$(cat /tmp/cf/my-space/entities/$ENTITY_ID/result/status)" = "done" ]; do
   sleep 1
 done

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -156,9 +156,24 @@ cat /tmp/cf/my-space/pieces/assistant/result.json | jq '.messages'
 echo '{"message":"Hello from agent"}' > \
   /tmp/cf/my-space/pieces/assistant/result/sendMessage.handler
 
-# Agent monitors for changes (polling — fswatch may not work with FUSE-T)
-while true; do cat /tmp/cf/my-space/pieces/task/result/status; sleep 2; done
+# Agent waits for a piece to reach a state. Address it by entity ID, not name:
+# a piece's name gains a count suffix on every state change, so a
+# pieces/<name>/... path goes stale on the very change being waited for.
+until [ "$(cat /tmp/cf/my-space/entities/$ENTITY_ID/result/status)" = "done" ]; do
+  sleep 1
+done
 ```
+
+Wait on the condition and let the loop end when it holds, rather than printing
+on a `while true` loop. This polls because no change-notification surface
+through the mount is known to work — `fswatch` and `watchman` are untested
+against FUSE-T. The loop cannot detect a dead transport, which stalls it
+indefinitely; `.status` at the mount root reports `connection.disconnected`.
+
+For a subscription rather than a poll, go through the runtime instead of the
+filesystem: `cf piece render --piece <id> --watch` subscribes to the cell and
+re-renders on each change. That surface renders UI, so it fits watching a piece
+render rather than reading a single scalar.
 
 ### Pattern Development Loop
 


### PR DESCRIPTION
The fuse-agent and fuse-workflow skills told agents to sleep after mounting, to sleep before verification reads when the mount stalled, and to watch a piece's state with an unbounded print loop. None of the three waited on anything real.

The sleep after `cf fuse mount --background` was waiting for something that had already happened. The command blocks until the background daemon reports it has mounted and confirms the child is still alive, and exits non-zero if startup fails or readiness is never reported. The sleep is removed and the guarantee stated in its place.

The sleep before verification reads was aimed at a failure it cannot fix. A stalled read is either a dead transport, which needs a remount and never recovers by waiting, or a subtree still rebuilding, which settles on its own. The .status file at the mount root distinguishes the two through connection.disconnected and rebuilds.pending, so the guidance now reads that file and names those fields. The note on cache staleness is scoped to macOS/FUSE-T, where the attribute-cache flags it mentions actually apply.

The change-monitoring example was an unbounded loop that reprinted a piece's status every two seconds and never terminated. It now waits for the condition it cares about and ends once the condition holds. It also addresses the piece by entity ID rather than by name: a piece's name gains a count suffix on every state change, so a pieces/<name>/... path goes stale on the very change being waited for, and the previous shape would have missed the completion it was watching for. This case stays a poll because no change-notification surface through the mount is known to work, which the comment now says without asserting a mechanism the code does not support. For callers that want a subscription, the note points at `cf piece render --watch`, which sinks the cell and re-renders on each change.

AGENTS.md gains the engineering principle these skills were violating, and pointers to the documentation that explains how to satisfy it. The section on avoiding timeouts, retry loops, and sleeps states the rule; the canonical guidance in docs/development/waiting-in-tests.md names the event-driven primitives to reach for instead of a poll and enumerates the cases where a bounded poll is the honest tool, so an agent following the rule literally does not strip out waits the repository keeps on purpose. That document was also missing from the testing list, which had enumerated four of the six documents the TESTING.md hub links.

Two further sections directed agents at work a CI check gates without naming the check. The documentation lifecycle section requires updating live documentation in the same change, but code blocks under docs/ are type-checked by `check-docs`, and a block selects its compilation scaffold with an opening context comment whose vocabulary is defined only in docs/check.md and cannot be derived from the source. The skill-authoring paragraph directs agents to author skills, but `check-skill-facts` fails when a path or import specifier a skill cites stops resolving; docs/development/skill-audit.md describes that tripwire and was reachable from neither AGENTS.md nor skill-authoring.md.

Adding New Packages is nested back under Runtime Development, having become its sibling when the surrounding sections were demoted. AGENTS.md also failed `deno fmt --check`, which CI runs against the repository root and which does not exclude it: several paragraphs carried trailing whitespace and one line exceeded the wrap width.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces sleeps and infinite loops in FUSE skill docs with event-driven waits and real status checks. Clarifies mount readiness, stalled-read diagnosis, entity-based waiting, fixes the filesystem docs, and adds engineering guidance and CI guardrails in `AGENTS.md`.

- **FUSE skills**
  - Remove `sleep` after `cf fuse mount --background`; it blocks until mounted and exits non-zero on failure.
  - For stalls, read `/.status`: remount on `connection.disconnected`; let `rebuilds.pending` settle; macOS/FUSE‑T attr‑cache note only; update the error example to reference `.status` in `markError`.
  - Wait for piece state by polling the entity path, not the name; resolve `ENTITY_ID` via `pieces/<name>/meta.json` (`.entityId`); note unreliable FS notifications and point to `cf piece render --watch`.
  - Fix layout docs: `meta.json` lists `id`, `entityId`, `name` (no `patternName`).

- **AGENTS.md**
  - Add principle: avoid timeouts, retry loops, and sleeps; link `docs/development/waiting-in-tests.md`.
  - Document `deno task check-docs` and context comments (`docs/check.md`); link `docs/development/skill-audit.md` and `deno task check-skill-facts`.
  - Nest “Adding New Packages” under Runtime Development; add the missing testing doc and fix formatting.

<sup>Written for commit 59556526f4bf7c893aab5f59a872a2a1c438c188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

