### PR TITLE
fix(piece): resolve value-link slot to canonical piece before reading input/result

### DIFF
--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -328,21 +328,23 @@ export class PieceManager {
         scope,
       );
 
-    // Load persisted result/metadata before start() decides whether this is a
-    // resumed piece that needs dependency sync before scheduler wiring — and so
-    // the addressed cell's value link is local for the canonicalization below.
+    // Load the addressed cell. Syncing a value-link "slot" address also loads
+    // its link target — the piece's canonical result cell — together with that
+    // cell's `argument`/`patternIdentity` meta, because the query follows the
+    // top-of-doc value link and returns the target's meta docs. So this one sync
+    // makes both the slot and the canonical cell (with its metadata) local.
     await timePiecePhase("get.piece.sync", () => addressed.sync());
 
-    // Canonicalize a value-link "slot" address to the piece's canonical result
-    // cell. A piece created inside a handler and stored into a list/object (e.g.
-    // the topics board's `addTopic` doing `topics.push(Topic({...}))`) is
-    // addressed by a plain value-link that redirects to the result cell, where
-    // setup wrote `patternIdentity` and the `argument` meta-link. start() needs
-    // that identity and reads need that metadata, so resolving here makes
-    // start / read / stop all operate on the real piece rather than the wrapper.
-    // Idempotent for a normal top-level piece.
+    // Canonicalize the value-link "slot" to the piece's canonical result cell.
+    // A piece created inside a handler and stored into a list/object (e.g. the
+    // topics board's `addTopic` doing `topics.push(Topic({...}))`) is addressed
+    // by a plain value-link that redirects to the result cell, where setup wrote
+    // `patternIdentity` and the `argument` meta-link. start() needs that identity
+    // and reads need that metadata, so resolving here makes start / read / stop
+    // operate on the real piece rather than the wrapper. The sync above already
+    // made the canonical cell local, so this resolves over local links with no
+    // further sync. Idempotent for a normal top-level piece.
     const piece = addressed.resolveAsCell();
-    await timePiecePhase("get.canonical.sync", () => piece.sync());
 
     if (runIt) {
       // start() handles pattern loading and running. It's idempotent - no

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -317,7 +317,7 @@ export class PieceManager {
     scope?: CellScope,
   ): Promise<Cell<T>> {
     // Get the piece cell
-    const piece: Cell<unknown> = isCell(id)
+    const addressed: Cell<unknown> = isCell(id)
       ? id
       : this.runtime.getCellFromEntityId(
         this.space,
@@ -328,19 +328,29 @@ export class PieceManager {
         scope,
       );
 
+    // Load persisted result/metadata before start() decides whether this is a
+    // resumed piece that needs dependency sync before scheduler wiring — and so
+    // the addressed cell's value link is local for the canonicalization below.
+    await timePiecePhase("get.piece.sync", () => addressed.sync());
+
+    // Canonicalize a value-link "slot" address to the piece's canonical result
+    // cell. A piece created inside a handler and stored into a list/object (e.g.
+    // the topics board's `addTopic` doing `topics.push(Topic({...}))`) is
+    // addressed by a plain value-link that redirects to the result cell, where
+    // setup wrote `patternIdentity` and the `argument` meta-link. start() needs
+    // that identity and reads need that metadata, so resolving here makes
+    // start / read / stop all operate on the real piece rather than the wrapper.
+    // Idempotent for a normal top-level piece.
+    const piece = addressed.resolveAsCell();
+    await timePiecePhase("get.canonical.sync", () => piece.sync());
+
     if (runIt) {
-      // Load persisted result/metadata before start() decides whether this is a
-      // resumed piece that needs dependency sync before scheduler wiring.
-      await timePiecePhase("get.piece.sync", () => piece.sync());
       // start() handles pattern loading and running. It's idempotent - no
       // effect if already running.
       await timePiecePhase(
         "get.runtime.start",
         () => this.runtime.start(piece),
       );
-    } else {
-      // Just sync the cell if not running
-      await timePiecePhase("get.piece.sync", () => piece.sync());
     }
 
     // If caller provided a schema, use it

--- a/packages/piece/test/piece-step-slot.test.ts
+++ b/packages/piece/test/piece-step-slot.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { getPatternIdentityRef, Pattern, Runtime } from "@commonfabric/runner";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PieceManager } from "../src/manager.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece step slot");
+
+function doublePattern(): Pattern {
+  return {
+    argumentSchema: {
+      type: "object",
+      properties: { input: { type: "number" } },
+    },
+    resultSchema: {
+      type: "object",
+      properties: { output: { type: "number" } },
+    },
+    derivedInternalCells: [{ partialCause: "output" }],
+    result: { output: { $alias: { partialCause: "output", path: [] } } },
+    nodes: [
+      {
+        module: {
+          type: "javascript",
+          implementation: (input: number) => input * 2,
+        },
+        inputs: { $alias: { cell: "argument", path: ["input"] } },
+        outputs: { $alias: { partialCause: "output", path: [] } },
+      },
+    ],
+  };
+}
+
+describe("piece run/step through a value-link slot", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "piece-step-slot-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("starts a piece addressed through a value-link slot (the cf piece step path)", async () => {
+    // Canonical piece K carries patternIdentity; the value-link slot R -> K (the
+    // shape a piece pushed into a list/object gets addressed by) carries none.
+    const k = await manager.runPersistent(
+      runtime.unsafeTrustPattern(doublePattern(), {
+        reason: "piece step slot test fixture",
+      }),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const r = runtime.getCell(
+      manager.getSpace(),
+      "step-slot-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      r.withTx(tx).set(k.getAsLink());
+    });
+    await manager.synced();
+    const slotId = entityRefToString(r.entityId);
+
+    // Before this fix, `get(slotId, runIt=true)` -> `runtime.start(R)` threw
+    // "Cannot start: no pattern identity" (R has none). `manager.get` now
+    // canonicalizes R -> K, so start / read / stop operate on the real piece.
+    const pieces = new PiecesController(manager);
+    const started = await pieces.get(slotId, true);
+    expect(getPatternIdentityRef(started.getCell())).toBeDefined();
+    expect(await started.result.get(["output"])).toBe(10);
+  });
+});

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -15,7 +15,11 @@ import {
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
 import { defer } from "@commonfabric/utils/defer";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  EmulatedStorageManager,
+  StorageManager,
+} from "@commonfabric/runner/storage/cache.deno";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   validateAgainstSchema,
   validateSchemaValue,
@@ -371,6 +375,43 @@ function trustPattern(runtime: Runtime, pattern: Pattern): Pattern {
   return runtime.unsafeTrustPattern(pattern, {
     reason: "piece pull materialization test fixture",
   });
+}
+
+// Two-replica harness: a server that several emulated replicas can share, so a
+// fresh reader must fetch cross-replica rather than read its own warm cache.
+// Mirrors newSharedServer/SharedServerStorageManager in
+// fresh-replica-read-asymmetry.test.ts; the auth matches the server
+// EmulatedStorageManager.emulate builds for itself (v2-emulate.ts).
+const EMULATED_AUDIENCE = "did:key:z6Mk-runner-emulated-memory";
+
+function newSharedServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: { audience: EMULATED_AUDIENCE },
+  });
+}
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: { as: typeof signer },
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      // deno-lint-ignore no-explicit-any
+      { ...options, memoryHost: new URL("memory://") } as any,
+      () => server,
+    );
+    manager.#sharedServer = server;
+    return manager;
+  }
+  #sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this.#sharedServer;
+  }
 }
 
 describe("piece link contract localization", () => {
@@ -6032,5 +6073,120 @@ describe("piece pull materialization", () => {
       [NAME]: "tenfold",
       output: 50,
     });
+  });
+
+  it("reads a piece addressed through a value-link wrapper (headless sub-piece slot)", async () => {
+    // The canonical piece K — setup writes patternIdentity + the argument link.
+    const k = await manager.runPersistent(
+      trustPattern(runtime, doublePattern()),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    expect(manager.getResult(k).get()).toEqual({ output: 10 });
+
+    // A value-link "slot" cell R that redirects to K — the exact shape a piece
+    // pushed into a list/object gets addressed by (the array/object element,
+    // written as the child result cell's getAsLink()). Reproduces the topics
+    // board's `addTopic`, whose array element is a plain value-link to the topic
+    // piece; the slot itself carries no piece metadata.
+    const r = runtime.getCell(
+      manager.getSpace(),
+      "wrapper-slot-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      r.withTx(tx).set(k.getAsLink());
+    });
+    await manager.synced();
+
+    // Reading the argument directly off the slot fails exactly as
+    // `cf piece inspect <slot-fid>` did before this fix:
+    expect(() => manager.getArgument(r)).toThrow("piece missing argument cell");
+
+    // Addressing the slot by its fid (the path `cf piece inspect`/`get` take)
+    // canonicalizes R -> its result cell K (a VALUE link) in manager.get, so
+    // input/result reads land on the real piece, not the un-materialized wrapper.
+    const pieces = new PiecesController(manager);
+    const piece = await pieces.get(entityRefToString(r.entityId), false);
+    expect(await piece.result.get(["output"])).toBe(10);
+    expect(await piece.input.get(["input"])).toBe(5);
+  });
+});
+
+describe("piece cold-replica slot read (two replicas, one server)", () => {
+  let server: MemoryV2Server.Server;
+  let writerStorage: SharedServerStorageManager;
+  let writerRuntime: Runtime;
+  let writerManager: PieceManager;
+  let spaceName: string;
+
+  beforeEach(async () => {
+    server = newSharedServer();
+    writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    writerRuntime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager: writerStorage,
+    });
+    spaceName = "cold-slot-" + crypto.randomUUID();
+    const session = await createSession({ identity: signer, spaceName });
+    writerManager = new PieceManager(session, writerRuntime);
+    await writerManager.synced();
+  });
+
+  afterEach(async () => {
+    await writerRuntime?.dispose();
+    await writerStorage?.close();
+    await server?.close();
+  });
+
+  it("a fresh replica reads a piece addressed through a value-link slot (cold fetch)", async () => {
+    // Writer replica: create the canonical piece K (setup writes patternIdentity
+    // + the argument link), then a value-link slot R -> K — the exact shape the
+    // topics board's addTopic produces — and sync both to the shared server.
+    const k = await writerManager.runPersistent(
+      trustPattern(writerRuntime, doublePattern()),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const r = writerRuntime.getCell(
+      writerManager.getSpace(),
+      "wrapper-slot-" + crypto.randomUUID(),
+    );
+    await writerRuntime.editWithRetry((tx) => {
+      r.withTx(tx).set(k.getAsLink());
+    });
+    await writerManager.synced();
+    const slotId = entityRefToString(r.entityId);
+
+    // Fresh reader replica: a NEW storage manager on the SAME server, so it has
+    // never pulled K. Reading the slot by its fid must canonicalize R -> K (a
+    // VALUE link) AND cold-fetch K's docs from the server — the end-to-end
+    // behavior the local-toolshed run confirmed, now repeatable in-process.
+    const readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRuntime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager: readerStorage,
+    });
+    const readerSession = await createSession({ identity: signer, spaceName });
+    const readerManager = new PieceManager(readerSession, readerRuntime);
+    try {
+      await readerManager.synced();
+      const readerPieces = new PiecesController(readerManager);
+      const piece = await readerPieces.get(slotId, false);
+
+      // Both reads canonicalize the slot R -> its result cell K (a value link)
+      // and cold-fetch K from the shared server. The argument read is the path
+      // that threw "piece missing argument cell" pre-fix, so exercise it first.
+      expect(await piece.input.get(["input"])).toBe(5);
+      expect(await piece.result.get(["output"])).toBe(10);
+    } finally {
+      await readerRuntime.dispose();
+      await readerStorage.close();
+    }
   });
 });

--- a/packages/piece/test/test.ts
+++ b/packages/piece/test/test.ts
@@ -16,6 +16,9 @@ describe("PieceManager.get", () => {
         pieceSynced = true;
         return Promise.resolve();
       },
+      // A non-wrapper piece resolves to itself; get() canonicalizes the address
+      // (value-link slot -> result cell) before syncing + starting.
+      resolveAsCell: () => piece,
       asSchema: () => piece,
     };
     const runtime = {


### PR DESCRIPTION
## Summary

Fixes the "headless sub-piece" addressing gap: a piece created inside a handler and stored into a list/object — e.g. the topics board's `addTopic` doing `topics.push(Topic({...}))` — was unaddressable by its own fid via the CLI until a renderer opened it. Reads (`cf piece inspect`/`get`) failed with `piece missing argument cell` / `undefined`, and runs (`cf piece step`/`apply`) failed with `Cannot start: no pattern identity`.

## Root cause — an addressing gap, not a materialization gap

The child piece **is** fully set up at create time, synchronously in the handler's transaction: `instantiatePatternNode` mints its canonical result cell **K** (`getCell({resultFor: <slot coords>})`) and runs setup on K, writing `patternIdentity` (`runner.ts:1130`) and the `argument` meta-link (`runner.ts:1102`). The array/object element the list stores — call it **R** — is only a **plain value-link** to K (`childResultCell.getAsLink()`, `runner.ts:5076`, `overwrite:"this"`), carrying no piece metadata.

The board hands out R's fid, and `PieceManager.get` resolved that fid straight to R, so:
- **reads** (`getArgument`/`getResult` off R) found no meta → `piece missing argument cell` / undefined;
- **runs** (`runtime.start(R)`) threw `Cannot start: no pattern identity` — `patternIdentity` lives on K.

The only path that reached K was the renderer's `navigateTo`, which resolves via `resolveAsCell` — hence "unaddressable until a renderer opens it."

(Empirically confirmed create-time, not idle-gated: after a single `dispatchQueuedEvent` with no `synced()` / no scheduler idle, K already carries `patternIdentity` + the argument link; R never does.)

## Fix

Canonicalize the exposed address at the one choke point every get-based caller flows through — **`PieceManager.get`**: after syncing the addressed cell, `resolveAsCell` its **value** link to the canonical result cell K, then start / read / return operate on K. So reads (via `PiecesController.get`), runs (`step` / `apply`), and `stop` all reach the real piece.

- The redirect is a **value** link → resolved via `resolveAsCell` / `resolveLink`, **not** the `result`-meta follower `followCellToResult` (which would not bridge it).
- The addressed cell is `sync()`'d before resolving, since `resolveAsCell` resolves over locally-present links only — this also covers the cold-replica case (see the two-replica test).
- Idempotent for a normal top-level piece (resolves to itself), so non-slot pieces are unaffected. `readingFrom` / `readBy` already canonicalize via `followCellToResult`.

One source file: `packages/piece/src/manager.ts`.

## Tests (`packages/piece/test`)

- `pull-materialization.test.ts` — reads a value-link slot by fid (regression; raw `getArgument(slot)` still throws, but reads via `pieces.get` succeed), plus a **two-replica cold-fetch** (a fresh reader replica reads the slot fid and must both canonicalize R→K and cold-fetch K's docs from the shared server).
- `piece-step-slot.test.ts` — starts a piece via a slot fid (the `cf piece step` path); asserts it reaches the canonical cell and its result. Gates the run-path fix.
- `test.ts` — the `PieceManager.get` mock now implements `resolveAsCell`.

## Verification

- **Live cold read (local toolshed):** deployed the real topics board, headlessly `addTopic`'d, then cold-read the topic by its slot fid from a fresh CLI replica — `inspect` / `get --input title` / `get title` all succeed with the fix, and reproduce `piece missing argument cell` without it.
- `packages/piece` suite (205 steps) + CLI consumer tests (`piece.test.ts`, `piece-cell-operations.test.ts`, `inspect-remote.test.ts`): green. `deno fmt` / `deno lint` / `deno check`: clean.

Context: reframed from "materialization" to "addressing" via the Discord thread with @seefeld and a multi-facet + adversarial analysis — the piece is materialized; the exposed fid was just a wrapper the read/run paths didn't follow. This PR also carries the run-path fix originally split into #4761, consolidated here because `manager.get` is the single canonicalization point that covers both read and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
