### PR TITLE
docs: add Topics Estuary skill

### DIFF
--- a/.agents/skills/topics
+++ b/.agents/skills/topics
@@ -1,0 +1,1 @@
+../../skills/topics

--- a/.claude/skills/topics
+++ b/.claude/skills/topics
@@ -1,0 +1,1 @@
+../../skills/topics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ already does). `docs/development/skill-audit.md` covers what keeps those facts
 honest, including the `deno task check-skill-facts` tripwire that fails CI when
 a path or import a skill cites stops resolving.
 
-For Topics on Estuary, use the repo-local skill at `skills/topics/SKILL.md`.
+For reading or changing Topics on Estuary, use `skills/topics/SKILL.md`.
 
 #### Useful Pattern documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ already does). `docs/development/skill-audit.md` covers what keeps those facts
 honest, including the `deno task check-skill-facts` tripwire that fails CI when
 a path or import a skill cites stops resolving.
 
+For Topics on Estuary, use the repo-local skill at `skills/topics/SKILL.md`.
+
 #### Useful Pattern documentation
 
 **Start here:**

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -68,9 +68,12 @@ cf piece step --piece <topic>                      # refresh computed fields
 ```
 
 Handler source writes commit before `piece step`, so `--input` reads can verify
-bodies, comments, links, and the board's topics list immediately. A step is
-still needed before relying on computed result fields such as `topicCount`,
-`crossrefs`, `commentCount`, or `lastActivityAt`. Fresh CLI replicas converge
-the board's linked topic inputs before recomputing; there is no Topics-specific
-exception to the normal step workflow. Prefer the canonical topic fids exported
-by `crossrefs` over intermediate wrapper links in the board's input array.
+bodies, comments, links, and the board's topics list immediately. A step
+requests recomputation of result fields such as `topicCount`, `crossrefs`,
+`commentCount`, or `lastActivityAt`, but callers must re-read the fields they
+need: a successful step message alone does not prove the result materialized.
+The fresh-replica regression covers convergence of linked input reads, not full
+pattern result recomputation. Prefer canonical topic fids exported by
+`crossrefs` over intermediate wrapper links in the board's input array, and
+never interpret a default empty `crossrefs` as an empty board without comparing
+`topics --input`.

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -61,19 +61,16 @@ Agents are first-class participants. Against a deployed board piece:
 ```bash
 cf piece call --piece <board> setMyName '{"name":"Fable"}'
 cf piece call --piece <board> addTopic '{"title":"..."}'
-cf piece step --piece <board>                      # materialize computed rows
-cf piece get  --piece <board> crossrefs            # canonical topic fids
+cf piece get  --piece <board> crossrefs --step     # recompute + canonical fids
 cf piece call --piece <topic> addComment '{"body":"..."}'
-cf piece step --piece <topic>                      # refresh computed fields
+cf piece get  --piece <topic> commentCount --step  # recompute + verify
 ```
 
-Handler source writes commit before `piece step`, so `--input` reads can verify
-bodies, comments, links, and the board's topics list immediately. A step
-requests recomputation of result fields such as `topicCount`, `crossrefs`,
-`commentCount`, or `lastActivityAt`, but callers must re-read the fields they
-need: a successful step message alone does not prove the result materialized.
-The fresh-replica regression covers convergence of linked input reads, not full
-pattern result recomputation. Prefer canonical topic fids exported by
-`crossrefs` over intermediate wrapper links in the board's input array, and
-never interpret a default empty `crossrefs` as an empty board without comparing
-`topics --input`.
+Handler source writes commit before result recomputation, so `--input` reads can
+verify bodies, comments, links, and the board's topics list immediately. For
+computed result fields such as `topicCount`, `crossrefs`, `commentCount`, or
+`lastActivityAt`, use `piece get --step`: start, recomputation, and the read
+must share one CLI runtime when derived cells are session-scoped. Prefer the
+canonical topic fids exported by `crossrefs` over intermediate wrapper links in
+the board's input array. Never interpret an empty `crossrefs` as an empty board
+without comparing `topics --input`; a failed result projection is not absence.

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -56,29 +56,16 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 
 ## Headless / agent use
 
-Agents are first-class participants. For now, an agent uses the exact same
-Estuary identity key as its human user rather than minting an agent-specific
-key. Because that transport identity is shared, set `myName` immediately before
-each mutation and sign the mutation's text with `— <agent name> (agent)`. Use a
-final signature line for bodies and comments, and an inline suffix for titles
-and link labels.
-
-Against a deployed board piece:
+Agents are first-class participants. Against a deployed board piece:
 
 ```bash
 cf piece call --piece <board> setMyName '{"name":"Fable"}'
-cf piece call --piece <board> addTopic '{"title":"... — Fable (agent)"}'
-cf piece get  --piece <board> crossrefs --step     # recompute + canonical fids
-cf piece call --piece <board> setMyName '{"name":"Fable"}'
-cf piece call --piece <topic> addComment '{"body":"...\n\n— Fable (agent)"}'
-cf piece get  --piece <topic> commentCount --step  # recompute + verify
+cf piece call --piece <board> addTopic '{"title":"..."}'
+cf piece get  --piece <board> topics --input      # then address a topic piece
+cf piece call --piece <topic> addComment '{"body":"..."}'
 ```
 
-Handler source writes commit before result recomputation, so `--input` reads can
-verify bodies, comments, links, and the board's topics list immediately. For
-computed result fields such as `topicCount`, `crossrefs`, `commentCount`, or
-`lastActivityAt`, use `piece get --step`: start, recomputation, and the read
-must share one CLI runtime when derived cells are session-scoped. Prefer the
-canonical topic fids exported by `crossrefs` over intermediate wrapper links in
-the board's input array. Never interpret an empty `crossrefs` as an empty board
-without comparing `topics --input`; a failed result projection is not absence.
+Do **not** run `cf piece step` from a fresh CLI replica: a replica with a
+partial view persists deriveds computed from that partial view. Writes commit
+fine on their own; renderers derive for themselves. Verify writes via a renderer
+or post-materialization fid reads.

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -56,13 +56,21 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 
 ## Headless / agent use
 
-Agents are first-class participants. Against a deployed board piece:
+Agents are first-class participants. For now, an agent uses the exact same
+Estuary identity key as its human user rather than minting an agent-specific
+key. Because that transport identity is shared, set `myName` immediately before
+each mutation and sign the mutation's text with `— <agent name> (agent)`. Use a
+final signature line for bodies and comments, and an inline suffix for titles
+and link labels.
+
+Against a deployed board piece:
 
 ```bash
 cf piece call --piece <board> setMyName '{"name":"Fable"}'
-cf piece call --piece <board> addTopic '{"title":"..."}'
+cf piece call --piece <board> addTopic '{"title":"... — Fable (agent)"}'
 cf piece get  --piece <board> crossrefs --step     # recompute + canonical fids
-cf piece call --piece <topic> addComment '{"body":"..."}'
+cf piece call --piece <board> setMyName '{"name":"Fable"}'
+cf piece call --piece <topic> addComment '{"body":"...\n\n— Fable (agent)"}'
 cf piece get  --piece <topic> commentCount --step  # recompute + verify
 ```
 

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -61,11 +61,16 @@ Agents are first-class participants. Against a deployed board piece:
 ```bash
 cf piece call --piece <board> setMyName '{"name":"Fable"}'
 cf piece call --piece <board> addTopic '{"title":"..."}'
-cf piece get  --piece <board> topics --input      # then address a topic piece
+cf piece step --piece <board>                      # materialize computed rows
+cf piece get  --piece <board> crossrefs            # canonical topic fids
 cf piece call --piece <topic> addComment '{"body":"..."}'
+cf piece step --piece <topic>                      # refresh computed fields
 ```
 
-Do **not** run `cf piece step` from a fresh CLI replica: a replica with a
-partial view persists deriveds computed from that partial view. Writes commit
-fine on their own; renderers derive for themselves. Verify writes via a renderer
-or post-materialization fid reads.
+Handler source writes commit before `piece step`, so `--input` reads can verify
+bodies, comments, links, and the board's topics list immediately. A step is
+still needed before relying on computed result fields such as `topicCount`,
+`crossrefs`, `commentCount`, or `lastActivityAt`. Fresh CLI replicas converge
+the board's linked topic inputs before recomputing; there is no Topics-specific
+exception to the normal step workflow. Prefer the canonical topic fids exported
+by `crossrefs` over intermediate wrapper links in the board's input array.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: topics
+description: Interact with the Common Fabric team's Topics board on Estuary through
+  the Labs cf CLI. Use when reading, creating, or updating Topics; posting Topic
+  progress comments; or attaching pull request links to Topics.
+---
+
+# Topics on Estuary
+
+Topics is the team's minimal issue tracker. This skill names the deployed board,
+its CLI surface, and the team's authorship and editorial conventions. For the
+general CLI map, use `skills/cf/SKILL.md`; for Topics semantics, the canonical
+source is `packages/patterns/topics/README.md` and the handlers in
+`packages/patterns/topics/main.tsx` and `packages/patterns/topics/topic.tsx`.
+
+## Deployment
+
+Run commands from the Labs repository root. This skill is intentionally specific
+to the current Estuary dogfood deployment:
+
+```bash
+export TOPICS_BOARD_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
+export CF_IDENTITY="$HOME/.config/commonfabric/<agent-slug>-agent.key"
+```
+
+The board space is `topics-dev-476ea34f`. A topic URL has the same host and
+space, with the topic's `fid1:...` in place of the board fid.
+
+## Identity and authorship
+
+Every agent acts under its own unique identity. Use `CF_IDENTITY` only when it
+is known to represent you. Otherwise look for the exact agent-specific path
+under `~/.config/commonfabric/`; never pick the first key returned by a
+wildcard, borrow a human's or another agent's key, or use the publicly derivable
+`implicit trust` identity against Estuary. If your stable display name is not
+clear from context, ask the user before writing.
+
+When Topics onboarding has been authorized and no key exists for you, create a
+new one without overwriting any existing file:
+
+```bash
+mkdir -p "$HOME/.config/commonfabric"
+deno run -A packages/cli/mod.ts id new > "$HOME/.config/commonfabric/<agent-slug>-agent.key"
+chmod 600 "$HOME/.config/commonfabric/<agent-slug>-agent.key"
+deno run -A packages/cli/mod.ts id did "$HOME/.config/commonfabric/<agent-slug>-agent.key"
+```
+
+Do not use `deno task cf id new` when redirecting: the task wrapper writes a
+preamble to stdout and corrupts the key file.
+
+Immediately before every `addTopic`, `setBody`, `addComment`, or `addLink` call,
+set the board's per-user author name to your own stable display name:
+
+```bash
+deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<your name>"}'
+```
+
+Do this even when the board already appears to show the right name; never leave
+a change attributed to the previous actor.
+
+## Reading Topics
+
+Read the board's topic references from its input cell, then address a topic by
+its direct URL:
+
+```bash
+deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input
+export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
+deno task cf piece get --url "$TOPIC_URL"
+```
+
+Read the existing topic before changing it, especially its full body, comments,
+and links.
+
+## Creating and updating
+
+Create a topic through the board rather than deploying the Topic pattern
+directly:
+
+```bash
+# First setMyName on the board as shown above.
+deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic '{"title":"<title>"}'
+```
+
+Find the new topic in the board input before applying further changes. All
+handler arguments are JSON; encode multiline Markdown rather than passing an
+unescaped string.
+
+```bash
+# Set your name on the board immediately before each command below.
+deno task cf piece call --url "$TOPIC_URL" setBody '{"body":"<complete revised body>"}'
+deno task cf piece call --url "$TOPIC_URL" addComment '{"body":"<point-in-time update>"}'
+deno task cf piece call --url "$TOPIC_URL" addLink '{"kind":"pr","url":"<PR URL>","label":"<PR label>"}'
+```
+
+The body is the living big-picture document. Replace it in place with the full
+revised body so a reader sees the current state without replaying the thread,
+while retaining the Topic's meaningful history and decisions. A compact
+current-state section followed by historical context is often useful.
+
+Comments are append-only, point-in-time progress records. Add one after a
+meaningful work increment to explain what changed, what was learned or decided,
+and what comes next; use the body for the synthesized narrative rather than
+trying to revise earlier comments.
+
+Add every relevant pull request explicitly with `addLink` and `kind: "pr"`;
+mentioning it only in prose is not enough. Topic-to-topic connections are
+derived automatically from topic fids or page URLs mentioned in bodies,
+comments, and link URLs, so do not add manual `kind: "topic"` links.
+
+## Estuary persistence exception
+
+Do **not** run `cf piece step` against Topics from a fresh CLI replica. Writes
+commit without it; stepping a partial-view replica can persist derived values
+computed from incomplete state. This Topics-specific rule overrides the generic
+CLI workflow in `skills/cf/SKILL.md`. Verify a write by reading the direct topic
+URL or opening it in a materialized renderer, not by stepping it.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -39,14 +39,15 @@ When Topics onboarding has been authorized and no key exists for you, create a
 new one without overwriting any existing file:
 
 ```bash
-mkdir -p "$HOME/.config/commonfabric"
-deno run -A packages/cli/mod.ts id new > "$HOME/.config/commonfabric/<agent-slug>-agent.key"
-chmod 600 "$HOME/.config/commonfabric/<agent-slug>-agent.key"
-deno run -A packages/cli/mod.ts id did "$HOME/.config/commonfabric/<agent-slug>-agent.key"
+mkdir -p "$(dirname "$CF_IDENTITY")"
+(set -o noclobber; umask 077; deno run -A packages/cli/mod.ts id new > "$CF_IDENTITY")
+chmod 600 "$CF_IDENTITY"
+deno run -A packages/cli/mod.ts id did "$CF_IDENTITY"
 ```
 
-Do not use `deno task cf id new` when redirecting: the task wrapper writes a
-preamble to stdout and corrupts the key file.
+The `noclobber` subshell makes an existing identity a loud error instead of
+overwriting it. Do not use `deno task cf id new` when redirecting: the task
+wrapper writes a preamble to stdout and corrupts the key file.
 
 Immediately before every `addTopic`, `setBody`, `addComment`, or `addLink` call,
 set the board's per-user author name to your own stable display name:
@@ -67,13 +68,17 @@ the canonical fid published in the board's `crossrefs` result:
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input
 deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs
 export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
-deno task cf piece get --url "$TOPIC_URL"
+deno task cf piece get --url "$TOPIC_URL" title --input
+deno task cf piece get --url "$TOPIC_URL" body --input
+deno task cf piece get --url "$TOPIC_URL" comments --input
+deno task cf piece get --url "$TOPIC_URL" links --input
 ```
 
 Each crossref row's `fid` is the canonical address for its `topic`. Prefer it to
 the intermediate wrapper link stored in the board's topics array. Read the
-existing topic before changing it, especially its full body, comments, and
-links.
+existing topic's input before changing it, especially its full body, comments,
+and links. If `topics --input` is non-empty but `crossrefs` is empty or absent,
+do not infer that the board is empty; see the Estuary caveat below.
 
 ## Creating and updating
 
@@ -123,8 +128,24 @@ them. After changing a topic, step that topic before relying on `commentCount`,
 `lastActivityAt`, or its derived connections. After creating a topic, step the
 board before relying on `topicCount` or `crossrefs`.
 
-There is no Topics-specific prohibition on stepping a fresh CLI replica. The
-current CLI converges the board's linked topic inputs before recomputing its
-results, so use the normal step workflow from `skills/cf/SKILL.md` whenever
-fresh computed values are needed. The linked-input convergence regression lives
-in `packages/runner/test/fresh-replica-read-asymmetry.test.ts`.
+There is no Topics-specific prohibition on requesting a step from a fresh CLI
+replica, but a successful `piece step` message is not proof that the expected
+result materialized. Re-read the result fields you need. The linked-input
+regression at `packages/runner/test/fresh-replica-read-asymmetry.test.ts` pins
+input-read convergence; it does not cover pattern result recomputation.
+
+## Current Estuary caveat
+
+Re-verified on 2026-07-21 after the #4768 Topics deployment: a fresh current-
+`main` CLI could read all durable board inputs and direct topic inputs, but both
+board and topic results were `undefined`. Board and topic steps reported success
+without materializing those results, and `crossrefs` read as its default empty
+list despite non-empty `topics --input`.
+
+In that state, a known topic URL remains readable through the input-only
+commands above, but board-to-topic fid discovery and verification of
+result-dependent operations are blocked. Do not substitute `piece ls` as an
+authoritative topic list; it can omit pieces created inside handlers. Report the
+deployment/runtime blocker instead of claiming a read or mutation succeeded.
+Remove this caveat only after the live board and a regression test both
+demonstrate fresh-CLI result materialization.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -20,7 +20,7 @@ to the current Estuary dogfood deployment:
 
 ```bash
 export TOPICS_BOARD_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
-export CF_IDENTITY="$HOME/.config/commonfabric/<agent-slug>-agent.key"
+export CF_IDENTITY="<exact path to the key your human user uses>"
 ```
 
 The board space is `topics-dev-476ea34f`. A topic URL has the same host and
@@ -28,36 +28,28 @@ space, with the topic's `fid1:...` in place of the board fid.
 
 ## Identity and authorship
 
-Every agent acts under its own unique identity. Use `CF_IDENTITY` only when it
-is known to represent you. Otherwise look for the exact agent-specific path
-under `~/.config/commonfabric/`; never pick the first key returned by a
-wildcard, borrow a human's or another agent's key, or use the publicly derivable
-`implicit trust` identity against Estuary. If your stable display name is not
-clear from context, ask the user before writing.
+For now, use the same Estuary identity key as your human user. Do not mint a
+separate agent key, guess a key from a wildcard, use another human's key, or use
+the publicly derivable `implicit trust` identity against Estuary. If the exact
+key path is not already explicit, ask your human user; if the key is unavailable
+locally, stop rather than creating one.
 
-When Topics onboarding has been authorized and no key exists for you, create a
-new one without overwriting any existing file:
-
-```bash
-mkdir -p "$(dirname "$CF_IDENTITY")"
-(set -o noclobber; umask 077; deno run -A packages/cli/mod.ts id new > "$CF_IDENTITY")
-chmod 600 "$CF_IDENTITY"
-deno run -A packages/cli/mod.ts id did "$CF_IDENTITY"
-```
-
-The `noclobber` subshell makes an existing identity a loud error instead of
-overwriting it. Do not use `deno task cf id new` when redirecting: the task
-wrapper writes a preamble to stdout and corrupts the key file.
+The transport identity is shared, so textual signatures provide agent-level
+attribution. Sign every content mutation with `— <agent name> (agent)`: use a
+final signature line for bodies and comments, and an inline suffix for titles
+and link labels. Preserve existing signed history when replacing a body. If your
+stable agent name is unclear, ask before writing.
 
 Immediately before every `addTopic`, `setBody`, `addComment`, or `addLink` call,
-set the board's per-user author name to your own stable display name:
+set the board's per-user author name to that same stable agent name:
 
 ```bash
-deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<your name>"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
 ```
 
 Do this even when the board already appears to show the right name; never leave
-a change attributed to the previous actor.
+a change attributed to the previous actor. `setMyName` is self-identifying; the
+content mutation that follows still needs its textual signature.
 
 ## Reading Topics
 
@@ -87,8 +79,8 @@ Create a topic through the board rather than deploying the Topic pattern
 directly:
 
 ```bash
-# First setMyName on the board as shown above.
-deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic '{"title":"<title>"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic '{"title":"<title> — <agent name> (agent)"}'
 deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step
 ```
 
@@ -97,10 +89,12 @@ changes. All handler arguments are JSON; encode multiline Markdown rather than
 passing an unescaped string.
 
 ```bash
-# Set your name on the board immediately before each command below.
-deno task cf piece call --url "$TOPIC_URL" setBody '{"body":"<complete revised body>"}'
-deno task cf piece call --url "$TOPIC_URL" addComment '{"body":"<point-in-time update>"}'
-deno task cf piece call --url "$TOPIC_URL" addLink '{"kind":"pr","url":"<PR URL>","label":"<PR label>"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
+deno task cf piece call --url "$TOPIC_URL" setBody '{"body":"<complete revised body, retaining signed history>\n\n— <agent name> (agent)"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
+deno task cf piece call --url "$TOPIC_URL" addComment '{"body":"<point-in-time update>\n\n— <agent name> (agent)"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
+deno task cf piece call --url "$TOPIC_URL" addLink '{"kind":"pr","url":"<PR URL>","label":"<PR label> — <agent name> (agent)"}'
 deno task cf piece get --url "$TOPIC_URL" commentCount --step
 ```
 

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -66,7 +66,7 @@ the canonical fid published in the board's `crossrefs` result:
 
 ```bash
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step
 export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
 deno task cf piece get --url "$TOPIC_URL" title --input
 deno task cf piece get --url "$TOPIC_URL" body --input
@@ -77,8 +77,9 @@ deno task cf piece get --url "$TOPIC_URL" links --input
 Each crossref row's `fid` is the canonical address for its `topic`. Prefer it to
 the intermediate wrapper link stored in the board's topics array. Read the
 existing topic's input before changing it, especially its full body, comments,
-and links. If `topics --input` is non-empty but `crossrefs` is empty or absent,
-do not infer that the board is empty; see the Estuary caveat below.
+and links. Input reads are durable and do not need `--step`; use `--step` on
+result reads that must be current. If `topics --input` is non-empty but
+`crossrefs --step` is empty or fails, do not infer that the board is empty.
 
 ## Creating and updating
 
@@ -88,8 +89,7 @@ directly:
 ```bash
 # First setMyName on the board as shown above.
 deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic '{"title":"<title>"}'
-deno task cf piece step --url "$TOPICS_BOARD_URL"
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step
 ```
 
 Find the new topic's canonical fid in `crossrefs` before applying further
@@ -101,7 +101,7 @@ passing an unescaped string.
 deno task cf piece call --url "$TOPIC_URL" setBody '{"body":"<complete revised body>"}'
 deno task cf piece call --url "$TOPIC_URL" addComment '{"body":"<point-in-time update>"}'
 deno task cf piece call --url "$TOPIC_URL" addLink '{"kind":"pr","url":"<PR URL>","label":"<PR label>"}'
-deno task cf piece step --url "$TOPIC_URL"
+deno task cf piece get --url "$TOPIC_URL" commentCount --step
 ```
 
 The body is the living big-picture document. Replace it in place with the full
@@ -121,31 +121,27 @@ comments, and link URLs, so do not add manual `kind: "topic"` links.
 
 ## Persistence and computed results
 
-Topics handler writes commit durably before `piece step`: verify source fields
-such as bodies, comments, and links with `piece get ... --input`. Do not expect
-computed result fields to refresh without a step or renderer materialization.
-After changing a topic, request a topic step before checking `commentCount`,
-`lastActivityAt`, or derived connections. After creating a topic, request a
-board step before checking `topicCount` or `crossrefs`.
+Topics handlers commit source writes before result recomputation. Verify bodies,
+comments, links, titles, and the board's topic list with
+`piece get ... --input`. To read `topicCount`, `crossrefs`, `commentCount`,
+`lastActivityAt`, or other computed results, use `piece get ... --step`. This
+keeps start, pull, recomputation, synchronization, read, and stop in one CLI
+runtime; a separate `piece step` process cannot carry session-scoped
+materialization into a later `piece get` process.
 
-There is no Topics-specific prohibition on requesting a step from a fresh CLI
-replica, but a successful `piece step` message is not proof that the expected
-result materialized. Re-read the result fields you need. The linked-input
-regression at `packages/runner/test/fresh-replica-read-asymmetry.test.ts` pins
-input-read convergence; it does not cover pattern result recomputation.
+An unstepped result read with stored raw data but unresolved required values
+exits nonzero and points to `--step`; it is not an empty or absent result. If
+`--step` itself reports that a required value did not materialize, use input
+reads to establish what committed, but do not claim result-dependent
+verification succeeded.
 
-## Current Estuary caveat
+## Troubleshooting
 
-Re-verified on 2026-07-21 after the #4768 Topics deployment: a fresh current-
-`main` CLI could read all durable board inputs and direct topic inputs, but both
-board and topic results were `undefined`. Board and topic steps reported success
-without materializing those results, and `crossrefs` read as its default empty
-list despite non-empty `topics --input`.
-
-In that state, a known topic URL remains readable through the input-only
-commands above, but board-to-topic fid discovery and verification of
-result-dependent operations are blocked. Do not substitute `piece ls` as an
-authoritative topic list; it can omit pieces created inside handlers. Report the
-deployment/runtime blocker instead of claiming a read or mutation succeeded.
-Remove this caveat only after the live board and a regression test both
-demonstrate fresh-CLI result materialization.
+- If initial CLI synchronization times out, no piece read or mutation ran. Retry
+  once; if it repeats, report the deployment or authorization blocker.
+- If `topics --input` is non-empty while `crossrefs --step` is empty or fails,
+  do not call the board empty. Preserve the input evidence and report the
+  result-materialization failure.
+- Do not substitute `piece ls` for the board's topic list. Pieces created inside
+  handlers can be absent from that listing; `crossrefs --step` is the canonical
+  fid index, with `topics --input` as the durable fallback.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -34,22 +34,16 @@ the publicly derivable `implicit trust` identity against Estuary. If the exact
 key path is not already explicit, ask your human user; if the key is unavailable
 locally, stop rather than creating one.
 
-The transport identity is shared, so textual signatures provide agent-level
-attribution. Sign every content mutation with `— <agent name> (agent)`: use a
-final signature line for bodies and comments, and an inline suffix for titles
-and link labels. Preserve existing signed history when replacing a body. If your
-stable agent name is unclear, ask before writing.
+The transport identity is shared, so every content mutation must carry
+`"agentName":"<stable agent name>"` in the same JSON payload. The pattern stores
+that as structured authorship and renders it as `<agent name> (agent)`, while
+Fabric retains the human principal behind the key. Do not call `setMyName`,
+decorate titles or link labels, or add manual signature lines to bodies and
+comments. If your stable agent name is unclear, ask before writing.
 
-Immediately before every `addTopic`, `setBody`, `addComment`, or `addLink` call,
-set the board's per-user author name to that same stable agent name:
-
-```bash
-deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
-```
-
-Do this even when the board already appears to show the right name; never leave
-a change attributed to the previous actor. `setMyName` is self-identifying; the
-content mutation that follows still needs its textual signature.
+Legacy boards and topics may still contain `myName`, `createdByName`, or
+`authorName`. Treat them as read-only compatibility fields: never set or copy
+them into new mutations.
 
 ## Reading Topics
 
@@ -79,8 +73,8 @@ Create a topic through the board rather than deploying the Topic pattern
 directly:
 
 ```bash
-deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
-deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic '{"title":"<title> — <agent name> (agent)"}'
+deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic \
+  '{"title":"<title>","agentName":"<agent name>"}'
 deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step
 ```
 
@@ -89,19 +83,21 @@ changes. All handler arguments are JSON; encode multiline Markdown rather than
 passing an unescaped string.
 
 ```bash
-deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
-deno task cf piece call --url "$TOPIC_URL" setBody '{"body":"<complete revised body, retaining signed history>\n\n— <agent name> (agent)"}'
-deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
-deno task cf piece call --url "$TOPIC_URL" addComment '{"body":"<point-in-time update>\n\n— <agent name> (agent)"}'
-deno task cf piece call --url "$TOPICS_BOARD_URL" setMyName '{"name":"<agent name>"}'
-deno task cf piece call --url "$TOPIC_URL" addLink '{"kind":"pr","url":"<PR URL>","label":"<PR label> — <agent name> (agent)"}'
+deno task cf piece call --url "$TOPIC_URL" setBody \
+  '{"body":"<complete revised body>","agentName":"<agent name>"}'
+deno task cf piece call --url "$TOPIC_URL" addComment \
+  '{"body":"<point-in-time update>","agentName":"<agent name>"}'
+deno task cf piece call --url "$TOPIC_URL" addLink \
+  '{"kind":"pr","url":"<PR URL>","label":"<PR label>","agentName":"<agent name>"}'
 deno task cf piece get --url "$TOPIC_URL" commentCount --step
 ```
 
 The body is the living big-picture document. Replace it in place with the full
 revised body so a reader sees the current state without replaying the thread,
-while retaining the Topic's meaningful history and decisions. A compact
-current-state section followed by historical context is often useful.
+while retaining the Topic's meaningful narrative and decisions. A compact
+current-state section followed by historical context is often useful. Fabric
+owns the revision history; do not reproduce it as a separate activity ledger
+inside the body.
 
 Comments are append-only, point-in-time progress records. Add one after a
 meaningful work increment to explain what changed, what was learned or decided,

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -122,11 +122,11 @@ comments, and link URLs, so do not add manual `kind: "topic"` links.
 ## Persistence and computed results
 
 Topics handler writes commit durably before `piece step`: verify source fields
-such as bodies, comments, and links with `piece get ... --input`. Computed
-result fields remain stale until the piece is stepped or a renderer materializes
-them. After changing a topic, step that topic before relying on `commentCount`,
-`lastActivityAt`, or its derived connections. After creating a topic, step the
-board before relying on `topicCount` or `crossrefs`.
+such as bodies, comments, and links with `piece get ... --input`. Do not expect
+computed result fields to refresh without a step or renderer materialization.
+After changing a topic, request a topic step before checking `commentCount`,
+`lastActivityAt`, or derived connections. After creating a topic, request a
+board step before checking `topicCount` or `crossrefs`.
 
 There is no Topics-specific prohibition on requesting a step from a fresh CLI
 replica, but a successful `piece step` message is not proof that the expected

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -61,16 +61,19 @@ a change attributed to the previous actor.
 ## Reading Topics
 
 Read the board's topic references from its input cell, then address a topic by
-its direct URL:
+the canonical fid published in the board's `crossrefs` result:
 
 ```bash
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs
 export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
 deno task cf piece get --url "$TOPIC_URL"
 ```
 
-Read the existing topic before changing it, especially its full body, comments,
-and links.
+Each crossref row's `fid` is the canonical address for its `topic`. Prefer it to
+the intermediate wrapper link stored in the board's topics array. Read the
+existing topic before changing it, especially its full body, comments, and
+links.
 
 ## Creating and updating
 
@@ -80,17 +83,20 @@ directly:
 ```bash
 # First setMyName on the board as shown above.
 deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic '{"title":"<title>"}'
+deno task cf piece step --url "$TOPICS_BOARD_URL"
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs
 ```
 
-Find the new topic in the board input before applying further changes. All
-handler arguments are JSON; encode multiline Markdown rather than passing an
-unescaped string.
+Find the new topic's canonical fid in `crossrefs` before applying further
+changes. All handler arguments are JSON; encode multiline Markdown rather than
+passing an unescaped string.
 
 ```bash
 # Set your name on the board immediately before each command below.
 deno task cf piece call --url "$TOPIC_URL" setBody '{"body":"<complete revised body>"}'
 deno task cf piece call --url "$TOPIC_URL" addComment '{"body":"<point-in-time update>"}'
 deno task cf piece call --url "$TOPIC_URL" addLink '{"kind":"pr","url":"<PR URL>","label":"<PR label>"}'
+deno task cf piece step --url "$TOPIC_URL"
 ```
 
 The body is the living big-picture document. Replace it in place with the full
@@ -108,10 +114,17 @@ mentioning it only in prose is not enough. Topic-to-topic connections are
 derived automatically from topic fids or page URLs mentioned in bodies,
 comments, and link URLs, so do not add manual `kind: "topic"` links.
 
-## Estuary persistence exception
+## Persistence and computed results
 
-Do **not** run `cf piece step` against Topics from a fresh CLI replica. Writes
-commit without it; stepping a partial-view replica can persist derived values
-computed from incomplete state. This Topics-specific rule overrides the generic
-CLI workflow in `skills/cf/SKILL.md`. Verify a write by reading the direct topic
-URL or opening it in a materialized renderer, not by stepping it.
+Topics handler writes commit durably before `piece step`: verify source fields
+such as bodies, comments, and links with `piece get ... --input`. Computed
+result fields remain stale until the piece is stepped or a renderer materializes
+them. After changing a topic, step that topic before relying on `commentCount`,
+`lastActivityAt`, or its derived connections. After creating a topic, step the
+board before relying on `topicCount` or `crossrefs`.
+
+There is no Topics-specific prohibition on stepping a fresh CLI replica. The
+current CLI converges the board's linked topic inputs before recomputing its
+results, so use the normal step workflow from `skills/cf/SKILL.md` whenever
+fresh computed values are needed. The linked-input convergence regression lives
+in `packages/runner/test/fresh-replica-read-asymmetry.test.ts`.


### PR DESCRIPTION
## Summary

- add a repo-local `topics` skill for the hard-coded Estuary dogfood board
- document the temporary human-shared key policy and require `agentName` atomically in every agent mutation payload
- document the living-body, append-only comment, explicit PR-link, and derived topic-link conventions
- make durable `--input` reads authoritative and use atomic `piece get --step` for current computed results
- treat unresolved result projection and initial synchronization failures as blockers rather than empty Topics state
- wire the skill into `AGENTS.md` and both skill-discovery mirrors

## Dependency

This documentation assumes [#4917](https://github.com/commontoolsinc/labs/pull/4917) lands and the Topics board is updated to that pattern revision. That PR removes the mutable `setMyName` flow, adds Profile-native browser authorship, and makes agent attribution part of each mutation.

[#4874](https://github.com/commontoolsinc/labs/pull/4874), which provides `piece get --step` and loud unresolved-result diagnostics, has merged.

## Operational contract

- agents use the exact same Estuary key as their human user rather than minting an agent key
- every `addTopic`, `setBody`, `addComment`, and `addLink` payload includes the agent's stable `agentName`
- agents do not call `setMyName` or add manual prose/title/label signatures; the pattern stores and renders structured agent attribution while Fabric retains the authenticated human principal
- legacy `myName`, `createdByName`, and `authorName` fields are read-only compatibility data
- source fields such as titles, bodies, comments, links, and the board's topic list are read through `--input`
- computed fields such as `crossrefs`, `topicCount`, `commentCount`, and `lastActivityAt` are read with `get --step`
- canonical topic discovery comes from `crossrefs --step`; `topics --input` is the durable fallback and `piece ls` is not authoritative for handler-created topics

## Validation

- `deno task check-skill-facts`
- `deno task check-docs` (518 code blocks)
- `deno fmt --check AGENTS.md skills/topics/SKILL.md`
- both `.agents/skills/topics` and `.claude/skills/topics` resolve to the skill
- `git diff --check origin/main...HEAD`

The generic skill-creator `quick_validate.py` could not run in this checkout because its Python environment lacks PyYAML; the repository-native skill/docs validators above pass.