### PR TITLE
test(cli): wait on real signals in the FUSE exec suite instead of sle…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -309,6 +309,100 @@ express. They stay a poll for the same reason as the disabled tests below:
 nothing automated exercises this file, so converting it churns code that no run
 covers.
 
+### A shell script observing another process through a kernel mount
+
+`packages/cli/integration/fuse-exec.sh` drives the FUSE daemon as a separate
+process through a real mount, and observes it from bash. Its three poll loops —
+`wait_for_path`, `resolve_entity_dir`, and `wait_for_piece_value` — stay polls.
+
+There is no event channel to convert them to. The state each loop waits on lives
+in another process: the daemon's tree for the two path loops, and the server's
+cell for the value loop. Bash has no callback to resolve a `defer()` from.
+
+Watching the filesystem does not substitute for one. A mounted path appears
+because the daemon added a node to its own tree, and that is not a filesystem
+operation passing through the mount, which is what the kernel raises inotify
+events for. The daemon's two notification calls, `notify_inval_entry` and
+`notify_inval_inode`, tell the kernel to drop cache entries; they do not announce
+new state to a watcher.
+
+The two path loops also drive the work they wait for, which is the same shape as
+the pattern harness's `pull()` above. The lookup behind a `test -e` is what makes
+the daemon fetch: for the space root it runs `connectSpace`, and for the piece
+paths beneath it `CellBridge.prepareLookup`, which hydrates the piece property.
+Polling the probe until it converges is the honest wait.
+
+Two waits in this script are not polls, and should not become polls.
+
+Mount readiness needs no timing loop. `cf fuse mount --background` calls
+`awaitBackgroundMountStartup`, which waits for the daemon to report the
+`mounted` supervisor state and confirms both the supervisor and the child are
+alive before the command prints the PID. Every other exit from that function
+throws, and a throw kills the child and fails the command, so a script that has
+parsed a PID has a daemon that reported mounted.
+
+The daemon reports that state just before it enters its FUSE session loop, so it
+means the kernel mount exists rather than that any request has been served, and
+mounted paths hydrate lazily besides. Both gaps belong to `wait_for_path`, whose
+probe carries its own kill-timeout and retries for twenty seconds. What is left
+for the script is one check that the daemon survived the handshake.
+
+The stale-descriptor assertion — that truncating a path does not let an already
+open descriptor write its old buffer back — waits on `wait_for_piece_value`
+alone. This looks like it needs a delay, because it asserts that something does
+not happen. It does not, because a descriptor that could write late is a
+descriptor that has already written.
+
+Both truncate paths — `open` with `O_TRUNC` on Linux, and the handle-less
+`setattr` that FUSE-T issues on macOS — reach `handles.truncateByIno`, which
+empties the buffer of every handle on the inode and clears both `dirty` and
+`truncatePending` on the one that is not the truncating handle. `flushHandle`,
+`flushCb` and `releaseCb` all gate on that pair, so the disarmed descriptor is
+inert. A descriptor that stayed armed instead flushes from the callback the
+kernel sends on `close()`, which the flush callback issues in the same tick when
+the handle is dirty. Its write targets the same cell as the truncate's own write
+and is issued after it, so it lands last and the value settles on the stale
+content rather than `""`.
+
+The deferred flush that every write arms, `scheduleFlush(handle, 500)`, is the
+one path that could fire after the wait, and it cannot resurrect anything.
+`truncateByIno` does not cancel it, so it does fire around half a second later —
+into `flushHandle`'s guard, which the disarm has already closed. In the armed
+case it never gets that far, because the flush callback calls
+`clearScheduledFlush` before flushing.
+
+#### The daemon's `.status` file is not a wait signal
+
+The FUSE daemon keeps write statistics (`writeStats` in `packages/fuse/mod.ts`)
+and publishes them through the `.status` file at the mount root. That file looks
+like a way to wait for the daemon to report a write-path event. It is not. The
+counters it carries lag the events they describe, and reading it around a write
+shows them frozen across the open, the write, the truncate and the release, then
+jumping several counts at once.
+
+The content is a snapshot rather than a live view. `CellBridge.initStatus` bakes
+JSON into a tree node and the read callback serves that node's stored bytes, so
+the numbers a reader sees are the ones the last `updateStatus` call baked.
+
+Refreshes do reach `.status` from the write path, but never carrying the counter
+a waiter wants. A successful flush calls `markExistingFinalized`, which reaches
+`updateStatus` through `CfcWritebackStore.deletePrepared`, `persist` and the
+store's `onChange` hook. That chain runs before `writeStats.flushed++` on every
+flush branch, so the snapshot a flush triggers always reports the count from
+before that flush. Opening and writing move their own counters with no refresh
+attached at all.
+
+Attribute caching sits on top. `.status` is a static inode, so `replyEntry` gives
+it a one-second entry and attribute timeout on Linux, and a macOS mount bounds
+staleness through an NFS attribute-cache option instead, because FUSE-T ignores
+the timeouts a reply carries. `updateStatus` assigns `node.content` and changes
+no size or mtime, so nothing invalidates a cached reader either way.
+
+Waiting on `.status` therefore means waiting for a refresh that reports the state
+before the event, through a cache with no invalidation, at a granularity coarser
+than the wait itself. Making it a real signal means ordering the refresh after
+the counters, regenerating on read, and giving a reader something to notice.
+
 ### Disabled tests
 
 `cf-code-editor.test.disabled.ts`, `cf-render.test.disabled.ts`, and

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -279,14 +279,13 @@ case "$MOUNT_PID" in
     ;;
 esac
 
-for _ in $(seq 1 30); do
-  if ! kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
-    error "Fuse daemon exited before mount became ready."
-  fi
-  sleep 0.1
-done
-
-sleep 1
+# 'cf fuse mount --background' returns only after the daemon has reported the
+# 'mounted' supervisor state and been confirmed alive. The daemon reports that
+# just before it enters its FUSE session loop, and mounted paths hydrate lazily,
+# so the wait_for_path calls below cover the rest.
+if ! kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+  error "Fuse daemon exited immediately after reporting mount readiness."
+fi
 
 wait_for_path "$MOUNTPOINT/$SPACE/pieces"
 
@@ -480,12 +479,13 @@ exec 9<> "$INPUT_LAST_MESSAGE"
 printf 'open-stale' >&9
 : > "$INPUT_LAST_MESSAGE"
 exec 9>&-
+# The truncate empties the buffer of every descriptor open on this inode, which
+# disarms the one opened above. A descriptor that stayed armed is left dirty, and
+# a dirty handle flushes in the same tick as the callback the kernel sends on
+# close(), so its write is issued before the close returns. That write reaches the
+# cell after the truncate's own write, so lastMessage settles on 'open-stale' and
+# this wait reports it rather than reaching "".
 wait_for_piece_value "lastMessage" '""'
-sleep 0.5
-LAST_MESSAGE_AFTER_TRUNCATE=$(cf piece get $SPACE_ARGS --piece "$PIECE_ID" "lastMessage" 2>/dev/null || true)
-if [ "$LAST_MESSAGE_AFTER_TRUNCATE" != '""' ]; then
-  error "Path truncate should not be undone by a stale open file handle. Got: $LAST_MESSAGE_AFTER_TRUNCATE"
-fi
 success "Path truncate clears stale open write handles"
 
 echo "FUSE exec integration passed."


### PR DESCRIPTION
…eping

The FUSE exec integration suite carried six sleeps. Each put a floor under the suite's runtime and made its result depend on unpredictable timing lining up. Three of them are removable, because something else in the script already waits for the thing they stand in for. The other three are honest polls and stay.

Mount readiness cost about four seconds of dead time on every run. A loop of thirty tenth-of-a-second sleeps checked only that the daemon had not exited, so it had no success condition and always burned the full three seconds, and an unconditional one-second sleep followed it. Neither established anything. Mounting in the background does not return until awaitBackgroundMountStartup has seen the daemon report the `mounted` supervisor state and confirmed that both the supervisor and the child are alive, and every other exit from that function throws, which kills the child and fails the command. A script that has parsed a PID therefore already has a daemon that reported mounted. The daemon reports that state just before it enters its FUSE session loop, so it means the kernel mount exists rather than that a request has been served, and mounted paths hydrate lazily besides. Both gaps already belong to the wait_for_path calls that follow, whose probe carries its own kill-timeout and retries for twenty seconds. What is left is a single check that the daemon survived the handshake, which replaces the timing loop rather than being dropped with it.

The half-second sleep in the stale-descriptor assertion guarded an assertion about something not happening: that closing a descriptor left open across a truncate does not write its old buffer back. Nothing can wait for an event that should never occur, but nothing needs to, because a descriptor that could write late is a descriptor that has already written. Both truncate paths — open with O_TRUNC on Linux, and the handle-less setattr that FUSE-T issues on macOS — reach handles.truncateByIno, which empties the buffer of every handle on the inode and clears both dirty and truncatePending on the ones that are not truncating. flushHandle, flushCb and releaseCb all gate on that pair, so a disarmed descriptor is inert. A descriptor that stayed armed is left dirty, and a dirty handle flushes in the same tick as the callback the kernel sends on close(), so its write is issued before close returns, lands after the truncate's own write, and leaves the value on the stale content. The existing wait for the value to read back as "" already catches that. The deferred flush that every write arms survives the truncate and does fire around half a second later, and still cannot resurrect anything, because it fires into the guard the disarm has closed.

The three remaining tenth-of-a-second sleeps sit inside poll loops and stay. The state each waits on lives in another process, and bash has no callback to resolve a promise from. Watching the filesystem does not substitute for one, because a mounted path appears when the daemon adds a node to its own tree, which is not an operation passing through the mount. The two path loops also drive the hydration they wait for, so polling until the probe converges is the honest wait.

docs/development/waiting-in-tests.md gains a section recording all of that, so the next reader does not re-derive it. It also records why the daemon's .status file is not the signal it appears to be: refreshes reach it from the write path, but the chain runs before the flush counter increments, so the snapshot a flush triggers reports the count from before that flush, and updateStatus rewrites the node's content without changing size or mtime, so a cached reader has nothing to notice.

The suite drops from about twenty-five and a half seconds to about eighteen and a half, and the spread across runs narrows from about four seconds to about a fifth of a second. The stale-descriptor assertion was checked against a deliberately broken disarm and still fails, for the reason it is meant to catch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace arbitrary sleeps in the FUSE exec integration tests with real readiness checks to make the suite faster and more reliable. Runtime drops by ~7s (≈25.5s → ≈18.5s) and jitter shrinks (~4s → ~0.2s).

- **Refactors**
  - In `packages/cli/integration/fuse-exec.sh`, remove the 3s+1s mount-readiness sleeps; after `cf fuse mount --background` (which waits via `awaitBackgroundMountStartup`), use a single `kill -0` liveness check and rely on existing `wait_for_path` probes.
  - Remove the 0.5s delay after truncate; rely on `wait_for_piece_value` and the fact that `truncateByIno` disarms open handles. Added inline comments for clarity.
  - Retain the three 100ms sleeps inside polling loops (`wait_for_path`, `resolve_entity_dir`, `wait_for_piece_value`) since they observe state in another process and drive hydration.
  - Add guidance in `docs/development/waiting-in-tests.md` on waiting strategies and why the daemon `.status` file is not a reliable signal.

<sup>Written for commit 39e1543821b3556fe31fe63520db8b666b868553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

