### PR TITLE
fix(piece): canonicalize value-link slot in manager.get (cf piece step on a slot fid)

### DIFF
--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -317,7 +317,7 @@ export class PieceManager {
     scope?: CellScope,
   ): Promise<Cell<T>> {
     // Get the piece cell
-    const piece: Cell<unknown> = isCell(id)
+    const addressed: Cell<unknown> = isCell(id)
       ? id
       : this.runtime.getCellFromEntityId(
         this.space,
@@ -328,19 +328,29 @@ export class PieceManager {
         scope,
       );
 
+    // Load persisted result/metadata before start() decides whether this is a
+    // resumed piece that needs dependency sync before scheduler wiring — and so
+    // the addressed cell's value link is local for the canonicalization below.
+    await timePiecePhase("get.piece.sync", () => addressed.sync());
+
+    // Canonicalize a value-link "slot" address to the piece's canonical result
+    // cell. A piece created inside a handler and stored into a list/object (e.g.
+    // the topics board's `addTopic` doing `topics.push(Topic({...}))`) is
+    // addressed by a plain value-link that redirects to the result cell, where
+    // setup wrote `patternIdentity` and the `argument` meta-link. start() needs
+    // that identity and reads need that metadata, so resolving here makes
+    // start / read / stop all operate on the real piece rather than the wrapper.
+    // Idempotent for a normal top-level piece.
+    const piece = addressed.resolveAsCell();
+    await timePiecePhase("get.canonical.sync", () => piece.sync());
+
     if (runIt) {
-      // Load persisted result/metadata before start() decides whether this is a
-      // resumed piece that needs dependency sync before scheduler wiring.
-      await timePiecePhase("get.piece.sync", () => piece.sync());
       // start() handles pattern loading and running. It's idempotent - no
       // effect if already running.
       await timePiecePhase(
         "get.runtime.start",
         () => this.runtime.start(piece),
       );
-    } else {
-      // Just sync the cell if not running
-      await timePiecePhase("get.piece.sync", () => piece.sync());
     }
 
     // If caller provided a schema, use it

--- a/packages/piece/test/piece-step-slot.test.ts
+++ b/packages/piece/test/piece-step-slot.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { getPatternIdentityRef, Pattern, Runtime } from "@commonfabric/runner";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PieceManager } from "../src/manager.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece step slot");
+
+function doublePattern(): Pattern {
+  return {
+    argumentSchema: {
+      type: "object",
+      properties: { input: { type: "number" } },
+    },
+    resultSchema: {
+      type: "object",
+      properties: { output: { type: "number" } },
+    },
+    derivedInternalCells: [{ partialCause: "output" }],
+    result: { output: { $alias: { partialCause: "output", path: [] } } },
+    nodes: [
+      {
+        module: {
+          type: "javascript",
+          implementation: (input: number) => input * 2,
+        },
+        inputs: { $alias: { cell: "argument", path: ["input"] } },
+        outputs: { $alias: { partialCause: "output", path: [] } },
+      },
+    ],
+  };
+}
+
+describe("piece run/step through a value-link slot", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "piece-step-slot-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("starts a piece addressed through a value-link slot (the cf piece step path)", async () => {
+    // Canonical piece K carries patternIdentity; the value-link slot R -> K (the
+    // shape a piece pushed into a list/object gets addressed by) carries none.
+    const k = await manager.runPersistent(
+      runtime.unsafeTrustPattern(doublePattern(), {
+        reason: "piece step slot test fixture",
+      }),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const r = runtime.getCell(
+      manager.getSpace(),
+      "step-slot-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      r.withTx(tx).set(k.getAsLink());
+    });
+    await manager.synced();
+    const slotId = entityRefToString(r.entityId);
+
+    // Before this fix, `get(slotId, runIt=true)` -> `runtime.start(R)` threw
+    // "Cannot start: no pattern identity" (R has none). `manager.get` now
+    // canonicalizes R -> K, so start / read / stop operate on the real piece.
+    const pieces = new PiecesController(manager);
+    const started = await pieces.get(slotId, true);
+    expect(getPatternIdentityRef(started.getCell())).toBeDefined();
+    expect(await started.result.get(["output"])).toBe(10);
+  });
+});

--- a/packages/piece/test/test.ts
+++ b/packages/piece/test/test.ts
@@ -16,6 +16,9 @@ describe("PieceManager.get", () => {
         pieceSynced = true;
         return Promise.resolve();
       },
+      // A non-wrapper piece resolves to itself; get() canonicalizes the address
+      // (value-link slot -> result cell) before syncing + starting.
+      resolveAsCell: () => piece,
       asSchema: () => piece,
     };
     const runtime = {


### PR DESCRIPTION
## Summary

Follow-up to #4758, same "value-link slot" addressing gap but on the **run** path: `cf piece step <slot-fid>` (and `apply`, and any `get(id, runIt=true)`) threw `Cannot start: no pattern identity`. `manager.get` resolved the fid straight to the slot cell **R** and called `runtime.start(R)` — but `patternIdentity` lives on the canonical result cell **K** that R redirects to.

## Fix

`PieceManager.get` now canonicalizes the addressed cell (`resolveAsCell` on the value link) after syncing and before start/return, so `start`, `read`, and `stop` all operate on the real piece K. Idempotent for a normal top-level piece (resolves to itself), so non-slot pieces are unaffected.

This is the run-path counterpart to #4758's read-path canonicalization in `PiecePropIo.#getTargetCell`, and it also covers direct `PiecesController.get` callers. One source file: `packages/piece/src/manager.ts`.

## Tests

- `packages/piece/test/piece-step-slot.test.ts` — creates a value-link slot R→K, then `get(slotId, runIt=true)`; asserts it returns the canonical cell (`patternIdentity` defined) and reads its result. Gates the fix: without it, `runtime.start(R)` throws `Cannot start: no pattern identity`.
- Updated the lightweight `PieceManager.get` mock in `test/test.ts` to implement `resolveAsCell` (the tested flow now canonicalizes before syncing + starting; the sync-before-start invariant it guards is preserved).

## Verification

- `packages/piece` suite (203 steps) + CLI consumer tests (`piece.test.ts`, `piece-cell-operations.test.ts`, `inspect-remote.test.ts`): green
- `deno fmt` / `deno lint` / `deno check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes value-link slot IDs in `PieceManager.get` so start/step/apply run the canonical result cell, fixing "Cannot start: no pattern identity." Ensures run, read, and stop operate on the real piece when addressed through a slot.

- **Bug Fixes**
  - Resolves the addressed cell via `resolveAsCell` after initial sync and before start/return; idempotent for top‑level pieces.
  - Covers `cf piece step`, `apply`, and `get(id, runIt=true)`; also supports direct `PiecesController.get` callers.

<sup>Written for commit 4810b2b9fc9094194d8e1b0b3d016eea4cccf012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

