### PR TITLE
Document several latent issues in `data-model` and `runner`

### DIFF
--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -48,10 +48,27 @@ function isInDeepFrozenCache(obj: object): boolean {
 
 /**
  * Indicates whether or not a value is "necessarily frozen." As of this writing,
- * this is the same as asking if it's a primitive value, but with an emphasis on
- * the point. However, at some point we'll end up with special knowledge about
- * objects which are also "necessarily frozen" by construction, and this is the
- * place where we'll get to expand the logic accordingly.
+ * this is _intended_ to be the same as asking if it's a primitive value, but
+ * with an emphasis on the point. However, at some point we'll end up with
+ * special knowledge about objects which are also "necessarily frozen" by
+ * construction, and this is the place where we'll get to expand the logic
+ * accordingly.
+ *
+ * TODO(danfuzz): This produces an incorrect result for values of type
+ * `function`, which are neither primitives nor necessarily frozen: a function
+ * is an ordinary mutable object, but `typeof fn !== "object"` lets it pass here
+ * as "necessarily frozen." Two consequences, both live: `isDeepFrozen()`
+ * reports `true` for any graph that reaches a function, and `deepFreeze()`
+ * silently declines to freeze one -- so a graph both of them call deep-frozen
+ * can still be mutated through it.
+ *
+ * The deeper trouble is that this file isn't consistent about which of its
+ * functions answer a question about arbitrary JavaScript values and which
+ * answer one about `FabricValue`s. For a function the two answers legitimately
+ * differ -- it's a mutable JS object, and it isn't a `FabricValue` at all --
+ * and only the `FabricValue`-shaped one (`isDeepFrozenFabricValue()`) is
+ * currently right. Sorting out that distinction is the actual fix; patching
+ * `typeof` tests one at a time is not.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
   return (value === null) || (typeof value !== "object");
@@ -256,6 +273,12 @@ export function deepFreeze<T>(value: T): T {
  * Indicates whether the value is a deep-frozen `FabricValue`. Returns `true` if
  * the value is a primitive, or a frozen object/array whose children are all
  * also deep-frozen `FabricValue`s.
+ *
+ * A value of type `function` is not a `FabricValue`, and so yields `false`,
+ * whether it is the value itself or reached anywhere within it. Note that this
+ * differs from `isDeepFrozen()`, which asks the JavaScript-level question and
+ * (incorrectly) admits functions; see the `TODO` on
+ * `isNecessarilyFrozenValue()`.
  */
 export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // TODO(@danfuzz): A function `isFabricValue()` should ultimately get

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -19,6 +19,15 @@ const deepFrozenCache = new WeakSet<object>();
  * and valid Fabric values. Accessors and FabricInstance protocol values are
  * deliberately excluded: Object.freeze() does not freeze their closed-over or
  * private logical state, so their proof is not stable by root identity.
+ *
+ * TODO(danfuzz): Evaluate the above reasoning as to why `FabricInstance` is
+ * excluded. Though it's certainly true that `#private` members mean that
+ * something which is deep-frozen per the JavaScript contract might not _really_
+ * be deep frozen, the data model's contract for the `IS_DEEP_FROZEN` protocol
+ * should make it so that clients can in fact rely on `FabricInstance`s' reports
+ * about their deep-frozenness. To the extent that a `FabricInstance` class is
+ * "lying" about its effective frozenness, it probably shouldn't be up to _this_
+ * code to paper over that fact.
  */
 const deepFrozenFabricValueCache = new WeakSet<object>();
 

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -100,16 +100,35 @@ hashToRef.set(primInterns.undefined.taggedHashString, undefined);
  * matching its already-canonical hash, so every path/runtime converges.
  *
  * - Array order is preserved (arrays are ordered).
- * - Already-interned sub-schemas are returned by reference: they are already
- *   canonical and shared, so the freshly-spread owned top is the only part
- *   rebuilt (see `traverse.ts`'s `schemaAtPathCanonical`).
+ * - Already-interned sub-schemas are returned by reference, so that a freshly
+ *   spread owned top is the only part rebuilt (see `traverse.ts`'s
+ *   `schemaAtPathCanonical`). Note that this is _not_ sound as a
+ *   canonicalization step: `internSchemaReturningSchemaAndHash()` registers the
+ *   non-canonical input object along with the canonical one, so
+ *   `isInternedSchema()` also answers `true` for objects which are not in
+ *   canonical order, and this skip then preserves whatever order they had. The
+ *   stored form is correspondingly not reliably canonical.
  * - An object already in canonical order with unchanged children is returned
  *   unchanged, preserving identity (and `internSchema`'s same-reference contract)
  *   for the common already-canonical case.
+ *
+ * TODO(danfuzz): This entire function is a workaround for a defect elsewhere:
+ * `link-utils.ts`'s `createDataCellURI()` mints ids with a plain
+ * `JSON.stringify()` instead of the standard `data-model` value encoding, which
+ * canonicalizes key order as a matter of spec (see
+ * `docs/specs/space-model-formal-spec/3-json-encoding.md` section 10, and the
+ * `TODO` in that function). Because the id-minting encoder does not
+ * canonicalize, the in-memory key order of every interned schema was made to
+ * carry that weight instead -- which is an invariant this file cannot actually
+ * maintain, per the by-reference note above. Once the ids are minted through a
+ * conforming encoder, in-memory key order stops mattering, and this function
+ * along with its call site should be removed rather than repaired.
  */
 function canonicalizeSchemaKeyOrder(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value;
-  // Already-interned sub-schemas are canonical (and shared); keep them as-is.
+  // Already-interned sub-schemas are kept as-is. Note that this is unsound as
+  // canonicalization -- "interned" does not imply "canonical" -- per the
+  // by-reference note in the doc comment above.
   if (isInternedSchema(value as JSONSchema)) return value;
   if (Array.isArray(value)) {
     let changed = false;

--- a/packages/data-model/src/schema-tags.ts
+++ b/packages/data-model/src/schema-tags.ts
@@ -21,6 +21,9 @@ const HASHTAG_PATTERN = /#([\p{L}\p{M}\p{N}_]+)/gu;
  * Unicode letters, combining marks, numbers, and underscores; a hyphen, space,
  * or other punctuation ends it. Returns the tokens lowercased, without the
  * leading `#`, deduplicated, in order of first appearance.
+ *
+ * TODO(danfuzz): This function doesn't really have anything to do with the
+ * data model and should probably move to the `utils` package.
  */
 export function extractHashtags(text: string): string[] {
   const tags: string[] = [];

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -362,7 +362,39 @@ export function findAndInlineDataURILinks(value: any): any {
   }
 }
 
-// Helper to create data URIs for testing
+/**
+ * Makes a `data:` URI that names a cell whose content is carried in the id
+ * itself. Reading such a cell means decoding its own id; there is no document
+ * in a space to fetch.
+ *
+ * The encoded payload is a storage document of the conventional shape
+ * `{"value": <data>}`, with readers unwrapping `value` before walking a link's
+ * path.
+ *
+ * This is the encode half of a matched set: {@link getJSONFromDataURI} (in
+ * `uri-utils.ts`) is what reads back what this writes. The two are a pair by
+ * construction -- the encoding chosen here dictates what is decodable there --
+ * but nothing mechanically holds them in agreement, so a change to either has
+ * to move the other with it; see the `TODO`s in both bodies.
+ *
+ * Each primitive cell link within `data` is rewritten to a full sigil link,
+ * with relative links resolved against `base`. That rewriting is what makes
+ * the result self-contained: the ids it embeds don't depend on where it was
+ * minted, so the URI denotes the same value wherever it later gets read.
+ *
+ * **Note:** This does not use the standard `data-model` value encoding, and
+ * callers are exposed to two consequences. A `FabricSpecialObject` within
+ * `data` is not represented correctly, and plain-object keys are not
+ * canonicalized -- so two runtimes holding the same value can mint two
+ * different ids for it, which is to say that the content addressing here is
+ * not reliably addressing content. See the `TODO`s in the body.
+ *
+ * @param data The value to encode. Must be acyclic.
+ * @param base Optional base link; relative links within `data` are resolved
+ *   against it.
+ * @returns A `data:application/json` URI naming a cell whose content is `data`.
+ * @throws If `data` contains a reference cycle.
+ */
 export function createDataCellURI(
   data: any,
   base?: Cell | NormalizedLink,
@@ -404,6 +436,12 @@ export function createDataCellURI(
       seen.delete(value);
     }
   }
+  // TODO(danfuzz): This `JSON.stringify()` should be changed to use the
+  // standard `data-model` value encoding, both so that `FabricSpecialObject`s
+  // can be properly represented and so that plain objects get properly
+  // canonicalized. Once this is done, the changes to `schema-hash.ts` made in
+  // PR #4360 should be able to be reverted, as those changes amount to a
+  // workaround for the plain object canonicalization issue.
   const json = JSON.stringify({
     value: traverseAndAddBaseIdToRelativeLinks(data, new Set()),
   });

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -57,18 +57,33 @@ export function fromURI(uri: URI | string): string {
 }
 
 /**
- * Extract the JSON object from a data URI
+ * Extracts and parses the JSON payload of a `data:` URI, which is required to
+ * have the media type `application/json`. The payload is everything past the
+ * first comma, and how it is spelled is dictated by the parameters in the
+ * header before that comma:
  *
- * Data URIs are a way to embed JSON in a URI. They are a base64 encoded string
- * that is prefixed with "data:application/json". The string is then encoded in
- * base64.
+ * - `;base64` selects Base64. Without it, the payload is percent-encoded.
+ * - `;charset=` is honored only as `utf-8` (or `utf8`), and any other value is
+ *   rejected. It is UTF-8 either way; the parameter only gets to agree.
  *
- * The data URI is a string that looks like this:
+ * An empty payload yields `undefined`, rather than being a parse error.
  *
- * data:application/json;charset=utf-8;base64,
- * @param uri - The data URI to extract the JSON from
- * @returns The JSON object
- * @throws If the URI is invalid or the JSON is invalid
+ * This reads a strict superset of what gets written by `link-utils.ts`'s
+ * `createDataCellURI()`, which only ever emits the percent-encoded form with no
+ * header parameters (`data:application/json,...`). The Base64 and `charset`
+ * spellings are for `data:` URIs originating anywhere else.
+ *
+ * **Note:** This is the decode half of a matched set: it reads what
+ * `createDataCellURI()` writes. The two are a pair by construction -- the
+ * encoding chosen there dictates what is decodable here -- but the dependency
+ * between the files only runs one way (`link-utils.ts` imports this module,
+ * not the reverse), so nothing mechanically holds them in agreement. Change
+ * one and the other has to move with it; see the `TODO`s in both bodies.
+ *
+ * @param uri The `data:` URI to read.
+ * @returns The parsed payload, or `undefined` if the payload is empty.
+ * @throws If `uri` is not an `application/json` `data:` URI, if it declares a
+ *   charset other than UTF-8, or if its payload is not valid JSON.
  */
 export function getJSONFromDataURI(uri: URI | string): any {
   if (!uri.startsWith("data:application/json")) {
@@ -114,5 +129,21 @@ export function getJSONFromDataURI(uri: URI | string): any {
     decodedData = decodeURIComponent(data);
   }
 
+  // TODO(danfuzz): This `JSON.parse()` is the decode half of the `data:` URI
+  // boundary, and has to change in lockstep with the `JSON.stringify()` in
+  // `link-utils.ts`'s `createDataCellURI()`: whatever encodes the payload
+  // determines what can decode it. The `data-model` counterpart is
+  // `valueFromJson()`, given a `ReconstructionContext`;
+  // `memory/v2.ts`'s `encodeMemoryBoundary()`/`decodeMemoryBoundary()` pair is
+  // a worked example of the same boundary, and uses an
+  // `EmptyReconstructionContext` because links at that boundary are sigil
+  // (plain) data rather than `FabricInstance`s, which is true here too.
+  //
+  // Note that this decode cannot simply switch over: a `data:` URI _is_ its
+  // own content, and such URIs are embedded in persisted documents, so ids in
+  // the current (bare JSON) form survive indefinitely. This side will have to
+  // accept both forms for as long as any of them remain. The encoded form is
+  // self-identifying -- `data-model` tags it `fvj1:` -- and
+  // `seemsLikeJsonEncodedFabricValue()` exists to make that distinction.
   return decodedData.length > 0 ? JSON.parse(decodedData) : undefined;
 }

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -75,6 +75,18 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * numeric indices (that is, it has no named properties). Returns `true` for
  * sparse arrays.
  *
+ * **Note:** This function relies on `Object.keys()` on arrays producing output
+ * which agrees with the JavaScript spec with regards to the ordering of index
+ * vs. non-index keys. Built-in arrays of course do this, but it's possible for
+ * a `Proxy` to (a) effectively purport to be an array, and yet (b) have an
+ * `ownKeys()` trap that diverges from the behavior of built-in arrays. In such
+ * cases, this function can incorrectly return `true`, exactly because it
+ * depends on the spec-defined ordering. The rationale for this implementation
+ * is that it's reasonable to expect proxied arrays to implement `ownKeys()` in
+ * agreement with the standard array order (even though the spec _does_ allow
+ * leeway with regards to what `Proxy`s actually do), _and_ by making this
+ * assumpion, this function avoids having to iterate over _all_ keys.
+ *
  * @param array The array to check.
  * @returns `true` if the array has only numeric properties, `false` otherwise.
  */
@@ -84,9 +96,9 @@ export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
   // `Object.keys()` on an (ordinary) array yields all array-index keys first,
   // followed by any non-index keys. So if an array has _any_ non-index keys,
   // then _one_ of them is always the final key. This means the array is
-  // index-only exactly when it has no keys or its last key is an index. (This
-  // relies on ordinary-array key ordering; the input is always a real array,
-  // never a `Proxy` with a reordering `ownKeys` trap.)
+  // index-only exactly when it has no keys or its last key is an index. (But
+  // see the doc comment above for potential `Proxy` troubles that this
+  // implementation _intentionally_ does not try to handle.)
   const lastKey = keys.at(-1);
   return lastKey === undefined || isArrayIndexPropertyName(lastKey);
 }


### PR DESCRIPTION
## Why

I was away from mid-June to mid-July. This records what turned up in a review of
changes made to `data-model` (and the parts of `utils` I maintain) in that
window, plus a few pre-existing issues found along the way.

**Every change here is a comment.** No code changes, no behavior changes. The
point is to stop rediscovering these, and to put the findings where the next
person to touch the code will actually meet them.

## What

### `deep-freeze.ts`

- **`deepFrozenFabricValueCache`** (added by #4693). A `TODO` questioning the
  reasoning for excluding `FabricInstance`s: the data model's `IS_DEEP_FROZEN`
  contract ought to make an instance's own report authoritative, and a class
  that "lies" about its frozenness shouldn't be this code's problem to paper
  over. Worth noting the exclusion sets `cacheableByIdentity = false` for the
  *entire* root graph, so any value reaching a `FabricLink` -- the modern link
  form -- is uncacheable.
- **Values of type `function`.** `isNecessarilyFrozenValue()` tests `typeof
  value !== "object"`, which admits functions -- neither primitives nor
  necessarily frozen. So `isDeepFrozen()` reports `true` for any graph reaching
  a function, and `deepFreeze()` silently declines to freeze one; a graph both
  call deep-frozen remains mutable through it. The root is that the file isn't
  consistent about which of its functions ask a JavaScript-level question and
  which ask a `FabricValue` one.

### `schema-hash.ts`

- Two comments asserted that already-interned sub-schemas are already canonical.
  They aren't: `internSchemaReturningSchemaAndHash()` registers the
  non-canonical input alongside the canonical one, so `isInternedSchema()`
  answers `true` for objects not in canonical order, and
  `canonicalizeSchemaKeyOrder()`'s by-reference skip preserves whatever order
  they had. (Instrumenting the invariant and running the `runner` suite turns up
  208 violations across 123 distinct sites -- `$defs`, `anyOf`, `items`,
  `properties`.)
- A `TODO` noting that the function is a workaround for the item below, and
  should be removed rather than repaired once that lands.

### `link-utils.ts` / `uri-utils.ts`

- `createDataCellURI()` mints content-addressed cell ids with a plain
  `JSON.stringify()`, rather than the standard `data-model` value encoding --
  which canonicalizes plain-object key order as a matter of spec
  (`docs/specs/space-model-formal-spec/3-json-encoding.md` section 10). That is
  the actual defect the `schema-hash.ts` canonicalization exists to work around.
  It also can't represent `FabricSpecialObject`s correctly.
- It had no doc comment, only a stale `// Helper to create data URIs for
  testing` -- accurate when written (`03b3a1078`, Oct 2025), but it has three
  production callers now (`cell.ts`, `link-resolution.ts`, `traverse.ts`).
- `getJSONFromDataURI()`'s doc described Base64 as *the* payload format (it's one
  of two branches, and the one the paired encoder never emits), implied `charset`
  was part of the form rather than validated, and promised "the JSON object" from
  a function that returns any JSON value -- and `undefined`, not a throw, for an
  empty payload.
- Both now state that they are a matched set, with a `TODO` on each. Nothing
  mechanically holds them in agreement: the import runs one way only, so no
  compiler ever gets the chance to notice a disagreement. That the decoder's own
  docs described a format its matched encoder does not write is the case in
  point.

### `utils/arrays.ts`

`isArrayWithOnlyIndexProperties()` asserted its input is never a `Proxy` with a
reordering `ownKeys` trap. It can be: `Array.isArray()` reports on the proxy's
target, and the proxy invariants constrain *which* keys `ownKeys()` reports, not
their order -- so a reordering trap is fully conformant, and the engine accepts
it. Now documented as a caveat, with the rationale for not handling it.

### `schema-tags.ts`

A `TODO` noting `extractHashtags()` has nothing to do with the data model and
should probably live in `utils`.

## Testing

Comments only. Full workspace suite green regardless (37/37 packages), and
`deno fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxmQgELnDx4NJQWPqTVMZe


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents latent issues and caveats across `data-model`, `runner`, and `utils`, and fully documents the `data:` URI encode/decode pair. No behavior changes.

- **Notes**
  - `deep-freeze.ts`: Added TODO on excluding `FabricInstance`; documented that `function` values are wrongly treated as necessarily frozen, affecting `isDeepFrozen()`/`deepFreeze()`; clarified JS vs `FabricValue` scope.
  - `schema-hash.ts`: Corrected claim that interned schemas are canonical; noted by-ref skip is unsound; added TODO to drop this workaround once `createDataCellURI()` uses canonical `data-model` encoding.
  - `link-utils.ts` / `uri-utils.ts`: Added docs that they are a matched pair; clarified percent-encoding vs `;base64`, UTF-8 validation, and empty-payload behavior; noted encoder uses `JSON.stringify` (no `FabricSpecialObject`, non-canonical keys) with TODO to switch; decoder stays bi-modal for persisted URIs.
  - `utils/arrays.ts`: Documented `Proxy` caveat for `isArrayWithOnlyIndexProperties()` and why we rely on spec key order.
  - `schema-tags.ts`: Added TODO to move `extractHashtags()` to `utils`.

<sup>Written for commit e45e638541d15ff29261d00ccfa45fe65825300b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

