### PR TITLE
fix(iframe-sandbox): unsubscribe a guest subscription whose receipt i…

### DIFF
--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -251,10 +251,12 @@ export class CommonIframeSandboxElement extends LitElement {
           : message.data;
 
         for (const key of keys) {
-          const receipt = this.subscriptions.get(key);
-          if (!receipt) {
+          // A receipt is opaque and may be any value the handler returns,
+          // including falsy ones like `0`. Test for the entry, not the value.
+          if (!this.subscriptions.has(key)) {
             continue;
           }
+          const receipt = this.subscriptions.get(key);
           IframeHandler.unsubscribe(this, this.context, receipt);
           this.subscriptions.delete(key);
         }

--- a/packages/iframe-sandbox/test/iframe.test.ts
+++ b/packages/iframe-sandbox/test/iframe.test.ts
@@ -1,19 +1,16 @@
 import { CommonIframeSandboxElement as _ } from "../src/common-iframe-sandbox.ts";
 import {
+  assertDeepEquals,
   assertEquals,
   cleanupFixtures,
   ContextShim,
+  deepEquals,
   render,
   setIframeTestHandler,
-  waitForCondition,
+  waitForContextValue,
 } from "./utils.ts";
-import { sleep } from "@commonfabric/utils/sleep";
 
 setIframeTestHandler();
-
-function compareDeepEquals(a: unknown, b: unknown) {
-  return JSON.stringify(a) !== JSON.stringify(b);
-}
 
 const API_SHIM = `<script>
 window.onUpdate = function(key, value){};
@@ -66,7 +63,7 @@ read('a');
 </script>`;
     const iframe = await render(body, context);
 
-    await waitForCondition(() => context.get(iframe, "a") === 2);
+    await waitForContextValue(context, iframe, "a", (value) => value === 2);
   } finally {
     cleanupFixtures();
   }
@@ -77,37 +74,68 @@ Deno.test("subscribes", async () => {
   try {
     const context = new ContextShim({ a: 1 });
 
+    // "barrier" stays subscribed after "a" is unsubscribed, so a write to it
+    // can be used to mark a point in the update stream. It reports arrivals
+    // under its own key to leave `updates` holding only what the test asserts
+    // on.
     const body = `
 ${API_SHIM}
 <script>
 const updates = [];
 onUpdate = (key, value) => {
+  if (key === "barrier") {
+    write("barrier-seen", value);
+    return;
+  }
   updates.push([key, value]);
   write("updates", updates);
   if (key === "a" && value === 3) {
     unsubscribe("a");
-    write("unsubscribed", true); 
+    write("unsubscribed", true);
   }
 };
 subscribe("a");
+subscribe("barrier");
 write("ready", true);
 </script>`;
     const iframe = await render(body, context);
-    await waitForCondition(() => context.get(iframe, "ready") === true);
+    await waitForContextValue(
+      context,
+      iframe,
+      "ready",
+      (value) => value === true,
+    );
     context.set(iframe, "b", 1);
     context.set(iframe, "a", 2);
     context.set(iframe, "a", 3);
     context.set(iframe, "b", 2);
-    await waitForCondition(() =>
-      compareDeepEquals(context.get(iframe, "updates"), [["a", 2], ["a", 3]])
+    await waitForContextValue(
+      context,
+      iframe,
+      "updates",
+      (value) => deepEquals(value, [["a", 2], ["a", 3]]),
     );
-    await waitForCondition(() => context.get(iframe, "unsubscribed") === true);
+    await waitForContextValue(
+      context,
+      iframe,
+      "unsubscribed",
+      (value) => value === true,
+    );
+
+    // Writes to "a" after the unsubscribe must not reach the guest. Write to
+    // the still-subscribed "barrier" afterwards and wait for the guest to
+    // report it: messages are delivered in order, so once the barrier has been
+    // seen, an "a" update would already have arrived had one been sent.
     context.set(iframe, "a", 4);
     context.set(iframe, "a", 5);
-    await sleep(100);
-    await waitForCondition(() =>
-      compareDeepEquals(context.get(iframe, "updates"), [["a", 2], ["a", 3]])
+    context.set(iframe, "barrier", 1);
+    await waitForContextValue(
+      context,
+      iframe,
+      "barrier-seen",
+      (value) => value === 1,
     );
+    assertDeepEquals(context.get(iframe, "updates"), [["a", 2], ["a", 3]]);
   } finally {
     cleanupFixtures();
   }
@@ -137,12 +165,15 @@ read("b");
 </script>`;
     const iframe1 = await render(body1, context1);
     const iframe2 = await render(body2, context2);
-    await waitForCondition(() =>
-      context1.get(iframe1, "a") === 1 && context1.get(iframe1, "b") === 1
-    );
-    await waitForCondition(() =>
-      context2.get(iframe2, "a") === 200 && context2.get(iframe2, "b") === 100
-    );
+    // Each frame writes one key: iframe1 writes "b" into context1, and iframe2
+    // answers its read of "b" by writing "a" into context2. Waiting for both
+    // writes puts each frame past the point where a write to the wrong context
+    // would have happened, so the untouched keys can then be checked for the
+    // value they started with.
+    await waitForContextValue(context1, iframe1, "b", (value) => value === 1);
+    await waitForContextValue(context2, iframe2, "a", (value) => value === 200);
+    assertEquals(context1.get(iframe1, "a"), 1);
+    assertEquals(context2.get(iframe2, "b"), 100);
   } finally {
     cleanupFixtures();
   }
@@ -164,10 +195,10 @@ ${API_SHIM}
 write("c", 1);
 </script>`;
     const iframe = await render(body1, context);
-    await waitForCondition(() => context.get(iframe, "b") === 1);
+    await waitForContextValue(context, iframe, "b", (value) => value === 1);
     // @ts-ignore This is a lit property.
     iframe.src = body2;
-    await waitForCondition(() => context.get(iframe, "c") === 1);
+    await waitForContextValue(context, iframe, "c", (value) => value === 1);
   } finally {
     cleanupFixtures();
   }
@@ -199,13 +230,31 @@ subscribe("b");
 write("ready2", true);
 </script>`;
     const iframe = await render(body1, context);
-    await waitForCondition(() => context.get(iframe, "ready1") === true);
+    await waitForContextValue(
+      context,
+      iframe,
+      "ready1",
+      (value) => value === true,
+    );
     // @ts-ignore This is a lit property.
     iframe.src = body2;
-    await waitForCondition(() => context.get(iframe, "ready2") === true);
+    await waitForContextValue(
+      context,
+      iframe,
+      "ready2",
+      (value) => value === true,
+    );
+    // "a" is written first, so by the time the guest reports the "b" update it
+    // subscribed to, an "a" update from the previous document's subscription
+    // would already have arrived had it survived the load.
     context.set(iframe, "a", 1000);
     context.set(iframe, "b", 1000);
-    await waitForCondition(() => context.get(iframe, "got-b-update") === true);
+    await waitForContextValue(
+      context,
+      iframe,
+      "got-b-update",
+      (value) => value === true,
+    );
     assertEquals(context.get(iframe, "got-a-update"), undefined);
   } finally {
     cleanupFixtures();

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -1,6 +1,6 @@
 import { CommonIframeSandboxElement } from "../src/common-iframe-sandbox.ts";
 import { setIframeContextHandler } from "../src/index.ts";
-import { sleep } from "@commonfabric/utils/sleep";
+import { defer } from "@commonfabric/utils/defer";
 
 type Callback = (key: string, value: unknown) => void;
 interface Context {
@@ -11,11 +11,13 @@ export class ContextShim {
   data: Context;
   callbacks: [number, string, Callback][];
   receiptIds: number;
+  observers: [string, Callback][];
 
   constructor(object = {}) {
     this.data = object;
     this.callbacks = [];
     this.receiptIds = 0;
+    this.observers = [];
   }
   set(_element: CommonIframeSandboxElement, key: string, value: unknown) {
     this.data[key] = value;
@@ -25,6 +27,25 @@ export class ContextShim {
         callback(key, value);
       }
     }
+    for (const [observer_key, observer] of [...this.observers]) {
+      if (key === observer_key) {
+        observer(key, value);
+      }
+    }
+  }
+
+  // Watch writes to `key`. Observers are held apart from `subscribe`'s
+  // callbacks so that a test watching a key does not consume a receipt id,
+  // which would change the ids the guest's own subscriptions are given.
+  observe(key: string, callback: Callback): () => void {
+    const entry: [string, Callback] = [key, callback];
+    this.observers.push(entry);
+    return () => {
+      const index = this.observers.indexOf(entry);
+      if (index !== -1) {
+        this.observers.splice(index, 1);
+      }
+    };
   }
 
   get(_element: CommonIframeSandboxElement, key: string): unknown {
@@ -92,6 +113,18 @@ export function assertEquals(a: unknown, b: unknown) {
   }
 }
 
+export function deepEquals(a: unknown, b: unknown) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function assertDeepEquals(a: unknown, b: unknown) {
+  if (!deepEquals(a, b)) {
+    throw new Error(
+      `${JSON.stringify(a)} does not deep equal ${JSON.stringify(b)}.`,
+    );
+  }
+}
+
 const FIXTURE_ID = "common-iframe-csp-fixture-container";
 export function cleanupFixtures() {
   for (const fixture of document.querySelectorAll(`[id^="${FIXTURE_ID}-"]`)) {
@@ -143,16 +176,25 @@ export function waitForEvent(
   });
 }
 
-export async function waitForCondition(
-  condition: () => boolean,
-  tries = 10,
-  timeout = 100,
-) {
-  while (tries-- > 0) {
-    if (condition()) {
-      return;
-    }
-    await sleep(timeout);
+// Resolves once `key`'s value in `context` satisfies `predicate`. A guest's
+// write reaches the context through the handler, so observing the context
+// settles the wait when the write arrives. The current value is checked first,
+// for a write that already landed before the wait began.
+export function waitForContextValue(
+  context: ContextShim,
+  element: CommonIframeSandboxElement,
+  key: string,
+  predicate: (value: unknown) => boolean,
+): Promise<void> {
+  if (predicate(context.get(element, key))) {
+    return Promise.resolve();
   }
-  throw new Error("waitForCondition tries exhausted");
+  const deferred = defer();
+  const stop = context.observe(key, (_key, value) => {
+    if (predicate(value)) {
+      stop();
+      deferred.resolve();
+    }
+  });
+  return deferred.promise;
 }


### PR DESCRIPTION
…s falsy

When a guest asks to unsubscribe from a key, the sandbox looks the key's receipt up in its subscriptions map and skips the unsubscribe when the receipt is falsy. A receipt is whatever the registered `IframeContextHandler` returned from `subscribe`; the type is `unknown`, so it is an opaque token the sandbox is only meant to hand back. A handler that numbers its receipts from zero therefore has its very first subscription pinned forever: the receipt is `0`, the truthiness test reads that as "no such subscription", and the guest keeps receiving updates for a key it unsubscribed from. The key is also never removed from the map, so a later re-subscribe is refused as a duplicate and that key stays wedged. The same goes for a handler returning any other falsy receipt.

Test for the map entry instead of the receipt's truthiness. The map only holds keys the guest is subscribed to, so its own membership is the question being asked, and the receipt's value stops mattering. The unsubscribe-everything path in `loadInnerDoc` already iterates the map directly and was never affected.

The tests did not catch this because the comparison helper backing the assertion was inverted. `compareDeepEquals` returned true when its two arguments *differed*, so the "subscribes" test's final wait — meant to confirm that updates stop arriving after unsubscribe — was satisfied precisely when they kept arriving. The bug it was written to catch was the reason it passed. The helper now has the polarity its name implies, and lives with the other assertion helpers so that the predicate and the assertion built on it are defined once.

The rest of this change replaces how those tests wait. Every wait was a bounded poll: `waitForCondition` re-ran a predicate ten times at 100 millisecond intervals and threw once it ran out of tries, which put a one second ceiling on success, since a write that took longer could never be observed however correct it was. What the predicates were watching for is a write arriving from the guest. A guest's write travels to the host as a message, and the host hands it to the registered `IframeContextHandler`, which in these tests is `ContextShim`. The shim is owned by the tests, so it can say when a write lands rather than being asked ten times whether one has. `waitForContextValue` resolves a deferred from a shim callback, and checks the current value first so that a write that already landed resolves the wait immediately. This is the shape
`docs/development/waiting-in-tests.md` prescribes for waits with no page to observe.

The existing `waitForEvent` could not serve here. It waits on a DOM event, and the element dispatches only `load` and `common-iframe-error`; nothing is dispatched when a read, write or subscribe message arrives. Making it fit would have meant adding an event to the element for the tests' benefit alone.

Observers are held apart from the shim's `subscribe` callbacks. Sharing them would let a test's wait take a receipt id, shifting the ids handed to the guest's own subscriptions — and receipt `0` is exactly the case that hid the unsubscribe bug, so a shared list would hide it again.

Two of the waits were watching a value that no message would ever change, so no wait could have expressed them. The pair in "handles multiple iframes" checked that neither frame's write landed in the other frame's context, against keys each context was constructed with. They are now assertions, made once both frames are known to be past the point where a stray write would have happened. The negative in "subscribes" needed the same treatment but had no later message to sequence against, which is what the `sleep(100)` stood in for: it waited a fixed interval and took the absence of an update as proof that unsubscribe held. The guest now also subscribes to a second key. Writing to that key after the unsubscribed writes, and waiting for the guest to report it, orders the check behind anything the unsubscribed key could have delivered, because messages arrive in the order they were sent. Absence is now established by a message that must overtake, rather than by a duration.

With the polarity corrected and the sandbox left unfixed, the test fails and names the leak. The five tests in this file drop from 1112ms to 113ms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unsubscribe bug in `iframe-sandbox` where subscriptions with falsy receipts (e.g., 0) were never removed, causing leaked updates and blocking re-subscribe. Also makes tests reliable and faster by removing flaky polling and fixing a broken equality helper.

- **Bug Fixes**
  - Unsubscribe now checks `subscriptions.has(key)` instead of receipt truthiness, so falsy receipts are handled correctly and keys are removed.

- **Refactors**
  - Replaced polling (`waitForCondition`) with `waitForContextValue` using `ContextShim.observe` and `defer` for event-driven waits.
  - Fixed inverted deep-equality helper; added `deepEquals`/`assertDeepEquals`; reworked tests to assert absence via a barrier key and ensure iframe isolation.
  - Test file runtime drops from ~1112ms to ~113ms.

<sup>Written for commit 3fdcd68001c2f48981ba56319bb853cf949f111d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

