### PR TITLE
docs: fold the live-connection caveat into the paragraph that scopes it

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -104,11 +104,7 @@ that continuation is undone and the sink goes on firing afterwards. Await
 An in-process wait like this needs no timeout backstop. When the value never
 arrives and the runtime goes quiet, Deno's test runner reports `Promise
 resolution is still pending but the event loop has already resolved` and fails
-the test at once, rather than hanging. That fail-fast report depends on the
-event loop draining: a wait whose runtime holds a live server connection keeps
-the loop alive, so a never-arriving value there runs to the ambient test or CI
-limit instead. Dispose such a probe runtime once the wait returns, so a
-completed wait does not hold the loop open for the rest of the suite. The message names the test, not the wait
+the test at once, rather than hanging. The message names the test, not the wait
 inside it, so a test holding several waits needs the last step printed without
 an `ok` to place the failure. It still beats a deadline, which reports only that
 time ran out, and reports it later.
@@ -119,7 +115,12 @@ runner's one repeating timer is unref'd and gated behind `CF_TRAVERSE_CAPTURE`,
 and an unsatisfiable wait still fails in seconds in the heaviest setup we have,
 two runtimes over an in-process memory server. It does not carry over to the
 browser waits above, where a live DevTools Protocol connection holds the loop
-open and a waiter that never fires would hang instead.
+open and a waiter that never fires would hang instead. A client talking to a
+live server holds the loop open the same way. A wait against one runs to the
+ambient test or CI limit rather than failing fast. The CLI suite's readiness
+probe is such a client. It disposes its controller once the wait returns, which
+also keeps a finished wait from holding the loop open for the rest of the
+suite.
 
 ## Guard against new usage
 


### PR DESCRIPTION
The note on why an in-process cell wait needs no timeout backstop gained a caveat about waits whose runtime holds a live server connection, inserted into the middle of the paragraph that describes Deno's fail-fast report. The paragraph immediately below it already scoped that same argument, naming the browser waits and their live DevTools Protocol connection as the case it does not cover. The insertion therefore said a second time what the next paragraph said, and split "the message names the test" from the report it refers to, leaving that reference three sentences from its antecedent.

Restore the first paragraph and extend the scoping paragraph instead: a client talking to a live server holds the loop open the way a DevTools connection does, so a wait against one runs to the ambient test or CI limit rather than failing fast. Keep the one piece of guidance the insertion added that is not stated elsewhere — the CLI suite's readiness probe disposes its controller once the wait returns.

`deno fmt` excludes `docs/`, so nothing reflowed the over-long line the insertion left behind; this rewraps it to match the file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the “waiting in tests” doc by removing a duplicated caveat, restoring the fail-fast explanation, and moving the live-connection note into the scoping paragraph (covers browser DevTools and live server clients). Kept the CLI readiness probe guidance (dispose its controller after the wait) and rewrapped an overlong line.

<sup>Written for commit eb41f5a2816420eb6ec64f7406270565a11d6782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

