### PR TITLE
fix(data-model): `FabricHash.fromString()` splits at the first colon again

### DIFF
--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -109,14 +109,18 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 
   /**
    * Parses an instance from its string representation
-   * (`<tag>:<base64urlHash>`). Splits at the LAST colon: the hash segment is
-   * base64url and never contains one, while the tag segment may in principle.
-   * Entity kinds do NOT ride the tag — they ride the URI scheme OUTSIDE the
-   * tagged-hash string (`computed:fid1:<hash>`; see `entity-kind.ts`), so a
-   * kinded id's hash portion parses here as a plain `fid1` hash.
+   * (`<tag>:<base64urlHash>`), which contains exactly one colon: a tag has
+   * none, and neither does base64url. Splitting at the first colon therefore
+   * rejects any source bearing a second one, since the colon then falls in the
+   * hash segment, where it is not valid base64url.
+   *
+   * That rejection is a feature. A string with an extra colon is not a tagged
+   * hash, and the only alternative to refusing it is to guess which colon was
+   * meant -- silently returning a `FabricHash` with a tag its author never
+   * wrote, which renders back as the string it came from and so looks correct.
    */
   static fromString(source: string): FabricHash {
-    const colonIndex = source.lastIndexOf(":");
+    const colonIndex = source.indexOf(":");
     if (colonIndex === -1) {
       throw new ReferenceError(`Invalid content hash string: ${source}`);
     }

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -116,6 +116,24 @@ describe("FabricHash", () => {
           "Invalid content hash string",
         );
       });
+
+      it("throws on a source with more than one colon", () => {
+        // A tagged hash has exactly one colon, so a second one lands in the
+        // hash segment, where base64url rejects it. No message is asserted:
+        // the contract is the rejection, not which layer voices it.
+        //
+        // Each tail below is itself valid base64url, so these fail only
+        // because of WHERE the split happens. That is deliberate: a tail like
+        // `c` throws under any split (as an invalid base64 length), and so
+        // would pass whether or not the parser is correct.
+        expect(() => FabricHash.fromString("a:b:AAAA")).toThrow();
+        expect(() => FabricHash.fromString("x::AAAA")).toThrow();
+
+        // A well-formed tagged hash with anything prefixed onto it is, of
+        // course, not a tagged hash.
+        const tagged = new FabricHash(SAMPLE_HASH, "fid1").toString();
+        expect(() => FabricHash.fromString(`extra:${tagged}`)).toThrow();
+      });
     });
 
     describe("[CODEC]", () => {


### PR DESCRIPTION
## Why

A tagged hash (`<tag>:<base64urlHash>`) contains exactly one colon: a tag has
none, and neither does base64url. `fromString()` currently splits at the LAST
colon, so it accepts a source bearing a second one and silently returns a
`FabricHash` whose tag is not one its author ever wrote — and which renders
back as the string it came from, so it looks correct.

The last-colon split arrived with the `fid2:computed:<hash>` tag format, whose
whole point was a colon-bearing tag:

> `fromString` now splits at the last colon … so fid1 ids parse unchanged and
> kinded ids parse with tag `"fid2:computed"`

That format was retired later in the same PR (#4659), in favor of carrying the
kind on the URI scheme:

> The FabricHash tag stays fid1; the fid2 tag machinery is retired with no
> back-compat readers (the flag never shipped).

The split outlived its reason. No tag anywhere in the repo contains a colon —
`fid1` is the only one — so it buys nothing today.

## It is not free

From #4659's own history:

> `entityIdFrom` silently parsed `"of:fid1:H"` as a hash whose TAG is
> `"of:fid1"` — addressing the nonexistent `of:of:fid1:H` with no error, so
> every post-create navigation (new note → navigateTo) hung until the
> integration tests timed out.

Splitting at the first colon rejects that at the intake, where it is one
error instead of a debugging session.

## Testing

- `data-model`: 52 passed, 0 failed.
- `runner`: 943 passed, 0 failed.
- Whole workspace green.

Nothing depends on the last-colon behavior. #4659's own one-way test
(`runner/test/uri-utils.test.ts`) feeds `fromString` the *bare* `fid1:<hash>`,
so it is indifferent to the split point.

The added test's inputs each end in valid base64url, so they fail only on
WHERE the split happens. That is deliberate: a tail like `c` throws under
either parser (as an invalid base64 length) and so would pass regardless —
a test that cannot fail against the bug it names is worse than none. Verified
by running it both ways: it passes on this change and fails on `lastIndexOf`.

## Not in scope

The companion cleanups this turned up are deliberately left out, to keep the
revert reviewable on its own:

- `entityIdFrom()` (`runner/src/create-ref.ts:36`) still accepts schemed ids
  silently; it already imports `hasEntityUriScheme`.
- `runner/test/uri-utils.test.ts:131` says "the salted preimage keeps the
  BYTES distinct" — the kind-salt was dropped in #4659, and the bytes are now
  identical by design (`entity-kind.ts:5-8` says so).
- `uri-utils.ts:20-23` warns that a `fromURI` round-trip "silently renames"; it
  actually throws. The silent rename happens via the `EntityId` branch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxmQgELnDx4NJQWPqTVMZe


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `FabricHash.fromString()` to split at the first colon. This restores the `<tag>:<base64urlHash>` contract and prevents silent mis-tagging when extra colons are present.

- **Bug Fixes**
  - Rejects inputs with multiple colons instead of guessing the tag.
  - Adds tests for multi-colon and prefixed-string cases.

<sup>Written for commit 3cae9f0fc9dd1f3d5cde6c30cb310137d30d9670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

