### PR TITLE
fix(topics): backward-compatible crossref defaults + collapse to one piece-valued derive

### DIFF
--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -67,12 +67,12 @@ export interface TopicsOutput {
   [NAME]: string;
   [UI]: VNode;
   topics: TopicPiece[];
-  mentionable: TopicPiece[];
+  mentionable: TopicPiece[] | Default<[]>;
   topicCount: number;
   /** The prose reference graph over the board's own topics, one row per
    * (non-null) entry of `topics`. Rows carry their topic, so consumers never
    * need to correlate by index — indices are not a stable address. */
-  crossrefs: TopicCrossref[];
+  crossrefs: TopicCrossref[] | Default<[]>;
   /** The viewer's display name (normalized to "" until set). */
   myName: string;
   /** Session-local draft for the footer composer (exposed for embedding and
@@ -124,23 +124,24 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
 
   const topicCount = computed(() => asArray(topics.get()).length);
 
-  // The prose reference graph as index edges over `topics` (raw order),
-  // recomputed from the whole corpus on any board change (O(topics × text) —
-  // trivial at board scale; the growth path is per-topic memoization).
-  // Identity is each entry's resolved result-doc fid, so the existing corpus
-  // lights up with zero authoring changes and nothing derived is persisted.
-  // Indices, not pieces: the UI must bind its navigation handlers to direct
-  // `topics` elements — a handler bound to a piece nested inside a derived
-  // wrapper object silently keeps the consuming UI computed from ever
-  // running.
-  const crossrefEdges = computed(() => {
+  // The prose reference graph as one piece-valued view over the board's own
+  // topics (one row per non-null entry), recomputed from the whole corpus on
+  // any board change (O(topics × text) — trivial at board scale; the growth
+  // path is per-topic memoization). Identity is each entry's resolved
+  // result-doc fid, so the existing corpus lights up with zero authoring
+  // changes and nothing derived is persisted. Rows carry their pieces
+  // directly: the UI binds navigation handlers to the row pieces (safe since
+  // #4714's path-scoped wildcard fix — before it, a handler bound to a piece
+  // nested inside a derived wrapper object silently kept the consuming UI
+  // computed from ever running, which forced the earlier index-plumbed shape).
+  const crossrefs = computed(() => {
     const list = asArray(topics.get());
-    // Each entry's own fid payload ("" while unresolved, e.g. mid-sync —
-    // such entries simply hold no edges this render).
+    // Each entry's own fid payload ("" while unresolved, e.g. mid-sync — such
+    // entries simply hold no edges this render). resolveAsCell/entityId are
+    // cell-runtime surface, not on the pattern Writable type (same cast as
+    // notes' appendLink).
     const payloads = list.map((t, i) => {
       if (!t) return "";
-      // resolveAsCell/entityId are cell-runtime surface, not on the pattern
-      // Writable type (same cast as notes' appendLink).
       const ref = (topics.key(i) as any).resolveAsCell?.()?.entityId;
       return ref ? fidPayload(entityRefToString(ref)) : "";
     });
@@ -148,27 +149,14 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
       list.map((t) => topicCorpus(t)),
       payloads,
     );
-    return list.map((_t, i) => ({
-      fid: payloads[i] ? `fid1:${payloads[i]}` : "",
-      refsOut: refsOut[i],
-      referencedBy: referencedBy[i],
-    }));
-  });
-
-  // Piece-valued view of the graph for consumers (tests, embedders, headless
-  // reads) — reading pieces through the wrapper rows is fine, only handler
-  // binds are not.
-  const crossrefs = computed(() => {
-    const list = asArray(topics.get());
     const rows: TopicCrossref[] = [];
-    crossrefEdges.forEach((e, i) => {
-      const t = list[i];
+    list.forEach((t, i) => {
       if (!t) return;
       rows.push({
-        fid: e.fid,
+        fid: payloads[i] ? `fid1:${payloads[i]}` : "",
         topic: t,
-        refsOut: e.refsOut.map((j) => list[j]),
-        referencedBy: e.referencedBy.map((j) => list[j]),
+        refsOut: refsOut[i].map((j) => list[j]),
+        referencedBy: referencedBy[i].map((j) => list[j]),
       });
     });
     return rows;
@@ -199,56 +187,57 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
 
           <cf-vstack gap="2" padding="4">
             {computed(() => {
-              const list = asArray(topics.get());
-              const edges = crossrefEdges;
-              const order = list
+              // Iterate the piece-valued crossref rows directly (one per
+              // non-null topic); each row carries its topic and the sibling
+              // pieces it links, so the card binds navigation to row pieces
+              // with no index indirection.
+              const rows = crossrefs;
+              const order = rows
                 .map((_, i) => i)
-                .filter((i) => list[i])
+                .filter((i) => rows[i]?.topic)
                 .toSorted((a, b) =>
-                  (list[b]?.lastActivityAt ?? 0) -
-                  (list[a]?.lastActivityAt ?? 0)
+                  (rows[b]?.topic?.lastActivityAt ?? 0) -
+                  (rows[a]?.topic?.lastActivityAt ?? 0)
                 );
-              return order.map((i) => (
-                <cf-card>
-                  <cf-hstack gap="3" align="center">
-                    <cf-vstack gap="0" style="flex: 1; min-width: 0;">
-                      <cf-text block style="font-weight: 600;">
-                        {list[i].title || "(untitled topic)"}
-                      </cf-text>
-                      {list[i].body
-                        ? (
-                          <cf-text tone="muted" block truncate>
-                            {snippet(list[i].body, 120)}
-                          </cf-text>
-                        )
-                        : null}
-                      <cf-text variant="caption" tone="muted">
-                        {list[i].commentCount} comments · by{" "}
-                        {list[i].createdByName || "someone"} ·{" "}
-                        {whenLabel(list[i].lastActivityAt)}
-                      </cf-text>
-                      {crossrefChipRow(
-                        "references →",
-                        false,
-                        list,
-                        edges[i]?.refsOut ?? [],
-                      )}
-                      {crossrefChipRow(
-                        "← referenced by",
-                        true,
-                        list,
-                        edges[i]?.referencedBy ?? [],
-                      )}
-                    </cf-vstack>
-                    <cf-button
-                      variant="secondary"
-                      onClick={openTopic({ topic: list[i] })}
-                    >
-                      Open
-                    </cf-button>
-                  </cf-hstack>
-                </cf-card>
-              ));
+              return order.map((i) => {
+                const row = rows[i];
+                const t = row.topic;
+                return (
+                  <cf-card>
+                    <cf-hstack gap="3" align="center">
+                      <cf-vstack gap="0" style="flex: 1; min-width: 0;">
+                        <cf-text block style="font-weight: 600;">
+                          {t.title || "(untitled topic)"}
+                        </cf-text>
+                        {t.body
+                          ? (
+                            <cf-text tone="muted" block truncate>
+                              {snippet(t.body, 120)}
+                            </cf-text>
+                          )
+                          : null}
+                        <cf-text variant="caption" tone="muted">
+                          {t.commentCount} comments · by{" "}
+                          {t.createdByName || "someone"} ·{" "}
+                          {whenLabel(t.lastActivityAt)}
+                        </cf-text>
+                        {crossrefChipRow("references →", false, row.refsOut)}
+                        {crossrefChipRow(
+                          "← referenced by",
+                          true,
+                          row.referencedBy,
+                        )}
+                      </cf-vstack>
+                      <cf-button
+                        variant="secondary"
+                        onClick={openTopic({ topic: t })}
+                      >
+                        Open
+                      </cf-button>
+                    </cf-hstack>
+                  </cf-card>
+                );
+              });
             })}
 
             {hasNoTopics

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -82,9 +82,11 @@ export interface TopicPiece {
   /** Max of createdAt and the newest comment — the tracker sorts by this. */
   lastActivityAt: number;
   /** This topic's own place in the board's prose graph, derived read-side
-   * from `mentionable` (indices into it, so chips can bind its direct
-   * elements). Both sets stay empty until `mentionable` is wired. */
-  crossrefs: { refsOut: number[]; referencedBy: number[] };
+   * from `mentionable` (the sibling pieces it links, resolved from the
+   * board's own list). Both sets stay empty until `mentionable` is wired. */
+  crossrefs:
+    | { refsOut: TopicPiece[]; referencedBy: TopicPiece[] }
+    | Default<{ refsOut: []; referencedBy: [] }>;
   addComment: Stream<{ body: string }>;
   addLink: Stream<{ kind: TopicLinkKind; url: string; label: string }>;
   setBody: Stream<{ body: string }>;
@@ -259,30 +261,31 @@ export const openTopic = handler<void, { topic: TopicPiece }>(
 );
 
 /** One row of crossref chips ("references →" / "← referenced by"): each chip
- * names a sibling topic and navigates to it. Chips bind against direct
- * elements of a topics list — a handler bound to a piece nested inside a
- * derived wrapper object silently keeps the consuming UI computed from ever
- * running. Module-scope and pure so the single-runtime suite can also drive
- * the exact markup directly (pinning the no-edges → null branch) alongside
- * the real card path it renders via continuous UI demand. */
+ * names a sibling topic and navigates to it. Takes the sibling pieces
+ * directly and binds navigation to each — #4714's path-scoped wildcard fix
+ * makes binding a piece reached through a derived crossref row safe (before
+ * it, such a bind silently kept the consuming UI computed from ever running,
+ * which forced the earlier index-plumbed shape). Module-scope and pure so the
+ * single-runtime suite can also drive the exact markup directly (pinning the
+ * no-edges → null branch) alongside the real card path it renders via
+ * continuous UI demand. */
 export const crossrefChipRow = (
   caption: string,
   accent: boolean,
-  list: TopicPiece[],
-  indices: number[],
+  pieces: TopicPiece[],
 ) =>
-  indices.length === 0
+  pieces.length === 0
     ? null
     : (
       <cf-hstack gap="1" align="center" style="flex-wrap: wrap;">
         <cf-text variant="caption" tone="muted">{caption}</cf-text>
-        {indices.map((j) => (
+        {pieces.map((p) => (
           <cf-chip
-            label={snippet(list[j]?.title || "(untitled topic)", 40)}
+            label={snippet(p?.title || "(untitled topic)", 40)}
             size="xs"
             color={accent ? "accent" : "neutral"}
             interactive
-            oncf-click={openTopic({ topic: list[j] })}
+            oncf-click={openTopic({ topic: p })}
           />
         ))}
       </cf-hstack>
@@ -431,8 +434,8 @@ export default pattern<TopicInput, TopicOutput>(
       // erased self's comparable marking and this computed never ran.
       const me = sibs.findIndex((t) => t && equals(t, self));
       return me < 0 ? { refsOut: [], referencedBy: [] } : {
-        refsOut: joined.refsOut[me],
-        referencedBy: joined.referencedBy[me],
+        refsOut: joined.refsOut[me].map((j) => sibs[j]),
+        referencedBy: joined.referencedBy[me].map((j) => sibs[j]),
       };
     });
 
@@ -573,7 +576,6 @@ export default pattern<TopicInput, TopicOutput>(
 
               {/* ── Connections (derived crossrefs; nothing persisted) ── */}
               {computed(() => {
-                const sibs = asArray(mentionable.get());
                 const { refsOut, referencedBy } = crossrefs;
                 return refsOut.length === 0 && referencedBy.length === 0
                   ? null
@@ -581,13 +583,8 @@ export default pattern<TopicInput, TopicOutput>(
                     <cf-card>
                       <cf-vstack gap="2">
                         <cf-heading level={5}>Connections</cf-heading>
-                        {crossrefChipRow("references →", false, sibs, refsOut)}
-                        {crossrefChipRow(
-                          "← referenced by",
-                          true,
-                          sibs,
-                          referencedBy,
-                        )}
+                        {crossrefChipRow("references →", false, refsOut)}
+                        {crossrefChipRow("← referenced by", true, referencedBy)}
                       </cf-vstack>
                     </cf-card>
                   );

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -286,13 +286,17 @@ export default pattern(() => {
   );
 
   // Detail-page view of the same edge: each board-created topic derives its
-  // own row from the mentionable siblings wired at creation (indices into
-  // `mentionable` = the board's own list), while a piece with no mentionable
-  // derives empty sets.
+  // own row from the mentionable siblings wired at creation (piece-valued,
+  // resolved from `mentionable` = the board's own list), while a piece with no
+  // mentionable derives empty sets.
   const assert_detail_edges = computed(() => {
-    return (board.topics?.[1]?.crossrefs?.refsOut ?? []).join(",") === "0" &&
+    return board.topics?.[1]?.crossrefs?.refsOut?.[0]?.title ===
+        "First topic" &&
+      (board.topics?.[1]?.crossrefs?.refsOut ?? []).length === 1 &&
       (board.topics?.[1]?.crossrefs?.referencedBy ?? []).length === 0 &&
-      (board.topics?.[0]?.crossrefs?.referencedBy ?? []).join(",") === "1" &&
+      board.topics?.[0]?.crossrefs?.referencedBy?.[0]?.title ===
+        "Second topic" &&
+      (board.topics?.[0]?.crossrefs?.referencedBy ?? []).length === 1 &&
       (board.topics?.[0]?.crossrefs?.refsOut ?? []).length === 0;
   });
 
@@ -309,9 +313,9 @@ export default pattern(() => {
   const assert_chip_row_markup = computed(() => {
     const list = (board.topics ?? []) as TopicPiece[];
     if (list.length < 2) return false;
-    const row = crossrefChipRow("references →", false, list, [0, 1]);
+    const row = crossrefChipRow("references →", false, [list[0], list[1]]);
     return row !== null &&
-      crossrefChipRow("← referenced by", true, list, []) === null;
+      crossrefChipRow("← referenced by", true, []) === null;
   });
 
   // A share link in a comment counts too — its colon is percent-encoded.
@@ -414,11 +418,16 @@ export default pattern(() => {
   });
 
   return {
-    // Continuous UI demand (#4715) over the board: its card list — including
-    // the in-card crossref chip rows — renders through the real reconciler
-    // while the suite runs. A board list element is the shared-safe
-    // TopicPiece projection and exposes no [UI]; the topic detail page is
-    // driven directly through the `render` steps below.
+    // UI demand (#4715) over the board: its card list — including the in-card
+    // crossref chip rows — renders through the real reconciler while the suite
+    // runs. The cards bind navigation to crossref-row pieces (wrapper-nested),
+    // which need real reconcile cycles to settle, so the passive [UI] export is
+    // backed by explicit `{ render: board[UI] }` steps below. Those cover the
+    // card path in both coverage lanes AND guard the wrapper-bind mechanism: a
+    // silent non-render regression (blank board, no error) would leave those
+    // lines uncovered and trip the coverage gate. A board list element is the
+    // shared-safe TopicPiece projection and exposes no [UI]; the topic detail
+    // page is driven through its own render step.
     [UI]: board[UI],
     tests: [
       { assertion: assert_initial },
@@ -442,12 +451,15 @@ export default pattern(() => {
       { assertion: assert_link_added },
       { action: action_add_second_topic },
       { assertion: assert_second_topic },
+      { render: board[UI] },
       { assertion: assert_crossrefs_baseline },
       { action: action_body_ref_first },
       { assertion: assert_body_edge },
+      { render: board[UI] },
       { assertion: assert_detail_edges },
       { assertion: assert_lone_edgeless },
       { assertion: assert_chip_row_markup },
+      { render: board[UI] },
       { action: action_comment_first_again },
       { action: action_submit_topic_via_composer },
       { assertion: assert_composed_topic },


### PR DESCRIPTION
*(Opus, on Gideon's behalf.)*

Two coupled changes on the topics pattern, both flowing from the post-#4698 deploy attempt.

## 1. Deploy-unblock: backward-compatible defaults (the tier-2 finding)

Deploying the merged #4698 onto the existing corpus (`setsrc` the board + topic pieces) **fails the schema backward-compat gate**:

```
Pattern schemas are not backward compatible:
- result.crossrefs: newly required result field has no default
```

`crossrefs` (both the board's `TopicCrossref[]` and each topic's own detail row) and the board's `mentionable` are newly-required result fields with no default, so an existing piece's already-materialized result can't satisfy the new schema. This is exactly the tier-2 "cells-durable, bundles-swappable" question made concrete — and the answer is that it holds for VDOM-only swaps but **adding a required output field is a hard stop** (the gate *blocks* rather than warns, which protects the shared list from blanking). Fix: give the three fields defaults (`Default<[]>` / `Default<{refsOut:[],referencedBy:[]}>`), so a live piece can adopt the new bundle with no migration. Confirmed the defaults register in the emitted result schema.

## 2. The collapse (the tracked #4714 revisit)

We ran the wrapper-bind quarantine down to a decisive test: #4714's path-scoped wildcard fix heals it, and I verified it in the **real** card path — under continuous UI the card-render computed fires (30×) and the navigation binds on the row pieces actually run (a sentinel probe, not just the assertions, which read the derive). So the quarantine premise no longer holds. This collapses the two board derives — `crossrefEdges` (index arrays) + `crossrefs` (piece rows) — into **one piece-valued `crossrefs`**, with the card and chips binding row pieces directly, no index indirection. The detail-page crossrefs become piece-valued too, which moves the index→piece resolution into the covered derive (so it stays at 100%).

## Verification

- Suites: single-runtime 30/30, multi-user 11/11
- Pattern coverage: `main.tsx` 185/185, `topic.tsx` 504/504 — zero uncovered
- Wrapper-bind fires in the real card path (sentinel under `CF_TEST_CONTINUOUS_UI=1`)
- fmt / lint / check clean; changes isolated to `packages/patterns/topics/`

Once this lands, the deploy/backfill experiment (`setsrc` + the one-time `mentionable` link-bind) can run — and it doubles as a before/after on the board's whole-array traverse cost, since dropping `$UI` from the stored `TopicPiece` projection should shrink it.


## Perf baseline — accepted regression (wall-time variance)

Coverage debt is net-0 (the render-step fix covers the card path in both lanes). The one perf-check OVER is a wall-time flake on the multi-user subtest — a file this PR does not touch (the added render steps are in `topics.test.tsx`), and the collapse net-*removes* a board derive, so this is runner-timing variance (stddev 1.1s over n=13), not a real regression. Narrow single-metric accept, not a blanket reset:

```
NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/topics/multi-user.test.tsx = 15s
```
