### PR TITLE
feat(memory): per-message deflate for the memory websocket

### DIFF
--- a/SPIKE-NOTES.md
+++ b/SPIKE-NOTES.md
@@ -79,10 +79,15 @@ so the −78.8% is measured on top of already-interned payloads.
   Order is fixed at enqueue time, and the CLOSE notification queues behind
   pending inflates so every frame that arrived before a close is delivered
   before the close is signaled — the exact contract of the synchronous
-  pre-spike path. (An adversarial review round found and we fixed: stale
+  pre-spike path. (Two adversarial review rounds found and we fixed: stale
   frames after close on the client, dropped pre-close frames on the server,
-  and a swallowed error in the server's settle→handoff window.) Covered by
-  unit tests on both ends.
+  swallowed errors in the server's settle→handoff window, a client inflate
+  failure that let later frames deliver past the gap — which the session
+  would then ack and resume beyond, silently losing the missing update — and
+  a missing closed-latch that let an `open()` parked on the drain dial and
+  leak a fresh socket after `close()` returned. A failed inflate now poisons
+  that socket's inbound queue, and the transport refuses to dial once
+  closed.) Covered by unit tests on both ends.
 - **Capability probe**: clients offer the subprotocol only if the runtime can
   construct `deflate-raw` streams (pre-2023 browsers would otherwise
   negotiate and then brick in a reconnect loop).
@@ -113,6 +118,15 @@ so the −78.8% is measured on top of already-interned payloads.
 5. No end-to-end test drives `WebSocketTransport` against a server in pure
    text mode (all real-socket pairings in-repo now negotiate); covered at
    the unit level only.
+6. Known self-healing race: a request issued in the window between a socket
+   drop and the drained close notification can dial the next socket and go
+   out ahead of the reconnect `hello`; the server rejects it and the
+   handshake retry succeeds. One wasted reconnect attempt — fix belongs in
+   the client's hello sequencing if it matters in practice.
+7. Compression side channels (CRIME-class): compressed frame sizes leak
+   payload structure to a network observer under TLS, exactly as
+   permessage-deflate would. Needs a deliberate sign-off before production
+   exposure to hostile networks.
 
 ## Reproducing the measurements
 

--- a/SPIKE-NOTES.md
+++ b/SPIKE-NOTES.md
@@ -1,0 +1,130 @@
+# Spike: websocket compression for the memory v2 transport
+
+Branch `spike/ws-compression`, based on main @ `f4faf22f1`. Status: **spike**
+— measured and reviewed, not productionized. Do not merge as-is; see the
+hardening list at the bottom.
+
+## What it is
+
+Per-message raw-deflate (RFC 1951) compression of memory v2 websocket
+payloads, negotiated per connection via the websocket subprotocol
+`fvj1.deflate`. Compressed payloads ride binary frames; payloads under 192
+UTF-8 bytes stay text; non-negotiated connections are byte-identical to
+before. The memory protocol itself (hello flags, message shapes, ordering
+semantics) is untouched — the layer sits strictly below
+`encodeMemoryBoundary`.
+
+This substitutes for permessage-deflate, which `Deno.upgradeWebSocket` does
+not negotiate (verified: the browser offers it, toolshed's 101 response omits
+`sec-websocket-extensions`).
+
+Files:
+
+- `packages/memory/v2/transport-deflate.ts` — codec, subprotocol constant,
+  threshold, inflate cap, `SerialTaskQueue` (new)
+- `packages/toolshed/routes/storage/memory/memory.handlers.ts` — negotiation
+  at upgrade, ordered inbound inflate, ordered outbound deflate
+- `packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts` —
+  env-gated per-connection byte accounting (diagnostic, new)
+- `packages/memory/v2/standalone.ts` — same support for the harness server
+- `packages/runner/src/storage/v2-remote-session.ts` — client offer, ordered
+  send/receive hops
+- Tests: `packages/memory/test/v2-transport-deflate-test.ts`,
+  `packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts`,
+  `packages/runner/test/memory-v2-ws-deflate.test.ts`
+- Flag registered in `docs/development/EXPERIMENTAL_OPTIONS.md`
+  (`memoryWsDeflate`).
+
+## Measured results (Lunch Poll two-browser flow, 2026-07-16)
+
+Same-run paired accounting: logical = UTF-8 bytes of the uncompressed text
+payload (identical to the metric PR #4712 uses), wire = bytes actually sent.
+
+| Run | Result | Scenario wall | Bytes |
+| --- | --- | ---: | --- |
+| main baseline (unmodified) | PASS | 2,760 ms | — |
+| spike, deflate on | PASS | 3,019 ms | browser: 3,960,389 → 837,854 B (**−78.8%**); all conns: 9,090,619 → 1,583,657 B (**−82.6%**) |
+| spike, `CF_MEMORY_WS_DEFLATE=0` | PASS | 3,114 ms | server outbound wire == logical exactly; browsers still negotiate |
+| spike, post-review fixes | PASS | — | browser −78.5%, all conns −81.7% (consistent re-measurement) |
+
+Browser detail (deflate on): inbound 1,188,630 → 369,316 B (−68.9%),
+outbound 2,771,759 → 468,538 B (−83.1%). Frame counts unchanged — no added
+round trips, no retry protocol. Wall times are localhost and within run
+noise; the win is bandwidth, not latency, at this scale. Time spent inside
+compression hops totaled ~1.7 s across all 12 connections per run
+(wall-in-hop, overstates pure CPU under event-loop contention; a
+microbenchmark of the codec is ~0.06 ms per 5 KB message).
+
+For calibration against the schema-machinery approach measured on PR #4712
+(same flow, same metric): frame-local schema interning + durable request
+schema CAS achieves −14.6% to −20.1%; this spike achieves −78.8% on browser
+connections with roughly 250 lines of transport code and no protocol-level
+state. Note main already includes #4292's frame-local sync-schema interning,
+so the −78.8% is measured on top of already-interned payloads.
+
+## Design notes
+
+- **Negotiation**: websocket subprotocol, not a hello flag — the transport
+  layer never parses memory messages, and the first frame can already be
+  compressed. RFC 6455 §4.1 means a client that offers and is refused fails
+  the connection (verified empirically: a server that refuses breaks the
+  browser flow), therefore:
+  - servers ALWAYS select the subprotocol when offered;
+  - `CF_MEMORY_WS_DEFLATE=0` only stops a process from *spending*: Deno
+    clients stop offering, servers stop compressing outbound. Inbound
+    decompression stays unconditional.
+  - **Rollout order**: server support must deploy before clients offer.
+- **Ordering**: websocket delivery is ordered but deflate/inflate are async;
+  each direction of each connection funnels through a `SerialTaskQueue`.
+  Order is fixed at enqueue time, and the CLOSE notification queues behind
+  pending inflates so every frame that arrived before a close is delivered
+  before the close is signaled — the exact contract of the synchronous
+  pre-spike path. (An adversarial review round found and we fixed: stale
+  frames after close on the client, dropped pre-close frames on the server,
+  and a swallowed error in the server's settle→handoff window.) Covered by
+  unit tests on both ends.
+- **Capability probe**: clients offer the subprotocol only if the runtime can
+  construct `deflate-raw` streams (pre-2023 browsers would otherwise
+  negotiate and then brick in a reconnect loop).
+- **Close codes**: 1003 wrong frame type, 1007 undecodable compressed data,
+  1009 inflate backlog exceeded, 1011 other.
+- **Statelessness**: no shared sliding window (unlike permessage-deflate
+  context takeover), so reconnects and replays need no transport state, and
+  a corrupted frame cannot poison later frames. Context takeover would buy
+  roughly a further 8 points (measured offline: −89% vs −81%) at the cost of
+  per-connection window state; not worth it for a first pass.
+- **Zip-bomb guard**: streaming inflate with a 64 MiB cap per frame; the
+  server's 1 MiB pre-handshake negotiation buffer counts inflated bytes.
+
+## Hardening before productionizing
+
+1. Sync zlib (`node:zlib` `deflateRawSync`) or a pooled compressor on the
+   server instead of per-message `CompressionStream` — cuts stream-setup
+   overhead and the wall-in-hop cost.
+2. Decide browser-client failure UX for old servers (currently: connection
+   fails, reconnect loops). Requires server-first rollout, or an
+   offer-then-fallback dial in the client.
+3. Threshold (192 B), inflate cap (64 MiB), and inbound backlog bound
+   (16 MiB, server-side) were chosen by eyeball; tune with the stats
+   diagnostic. The client side has no backlog bound (it trusts the server).
+4. The stats recorder writes synchronously on connection close and its flush
+   can slightly undercount frames still in the inflate queue at close; fine
+   as a dev diagnostic, keep it env-gated or remove before merge.
+5. No end-to-end test drives `WebSocketTransport` against a server in pure
+   text mode (all real-socket pairings in-repo now negotiate); covered at
+   the unit level only.
+
+## Reproducing the measurements
+
+```bash
+# byte accounting (server side, per closed connection):
+CF_MEMORY_WS_DEFLATE_STATS_FILE=/tmp/ws-deflate-stats.jsonl \
+  deno task integration patterns lunch-poll-vote
+
+# kill switch (server sends text, Deno clients do not offer):
+CF_MEMORY_WS_DEFLATE=0 deno task integration patterns lunch-poll-vote
+```
+
+Unit suites: memory package (`deno task test`), toolshed
+`routes/storage/memory/memory-ws-deflate.test.ts`, runner
+`test/memory-v2-ws-deflate.test.ts`.

--- a/SPIKE-NOTES.md
+++ b/SPIKE-NOTES.md
@@ -1,29 +1,28 @@
 # Spike: websocket compression for the memory v2 transport
 
-Branch `spike/ws-compression`, based on main @ `f4faf22f1`. Status: **spike**
-— measured and reviewed, not productionized. Do not merge as-is; see the
-hardening list at the bottom.
+Branch `spike/ws-compression`, based on main @ `f4faf22f1`. Status: **spike** —
+measured and reviewed, not productionized. Do not merge as-is; see the hardening
+list at the bottom.
 
 ## What it is
 
-Per-message raw-deflate (RFC 1951) compression of memory v2 websocket
-payloads, negotiated per connection via the websocket subprotocol
-`fvj1.deflate`. Compressed payloads ride binary frames; payloads under 192
-UTF-8 bytes stay text; non-negotiated connections are byte-identical to
-before. The memory protocol itself (hello flags, message shapes, ordering
-semantics) is untouched — the layer sits strictly below
-`encodeMemoryBoundary`.
+Per-message raw-deflate (RFC 1951) compression of memory v2 websocket payloads,
+negotiated per connection via the websocket subprotocol `fvj1.deflate`.
+Compressed payloads ride binary frames; payloads under 192 UTF-8 bytes stay
+text; non-negotiated connections are byte-identical to before. The memory
+protocol itself (hello flags, message shapes, ordering semantics) is untouched —
+the layer sits strictly below `encodeMemoryBoundary`.
 
-This substitutes for permessage-deflate, which `Deno.upgradeWebSocket` does
-not negotiate (verified: the browser offers it, toolshed's 101 response omits
+This substitutes for permessage-deflate, which `Deno.upgradeWebSocket` does not
+negotiate (verified: the browser offers it, toolshed's 101 response omits
 `sec-websocket-extensions`).
 
 Files:
 
 - `packages/memory/v2/transport-deflate.ts` — codec, subprotocol constant,
   threshold, inflate cap, `SerialTaskQueue` (new)
-- `packages/toolshed/routes/storage/memory/memory.handlers.ts` — negotiation
-  at upgrade, ordered inbound inflate, ordered outbound deflate
+- `packages/toolshed/routes/storage/memory/memory.handlers.ts` — negotiation at
+  upgrade, ordered inbound inflate, ordered outbound deflate
 - `packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts` —
   env-gated per-connection byte accounting (diagnostic, new)
 - `packages/memory/v2/standalone.ts` — same support for the harness server
@@ -40,93 +39,92 @@ Files:
 Same-run paired accounting: logical = UTF-8 bytes of the uncompressed text
 payload (identical to the metric PR #4712 uses), wire = bytes actually sent.
 
-| Run | Result | Scenario wall | Bytes |
-| --- | --- | ---: | --- |
-| main baseline (unmodified) | PASS | 2,760 ms | — |
-| spike, deflate on | PASS | 3,019 ms | browser: 3,960,389 → 837,854 B (**−78.8%**); all conns: 9,090,619 → 1,583,657 B (**−82.6%**) |
-| spike, `CF_MEMORY_WS_DEFLATE=0` | PASS | 3,114 ms | server outbound wire == logical exactly; browsers still negotiate |
-| spike, post-review fixes | PASS | — | browser −78.5%, all conns −81.7% (consistent re-measurement) |
+| Run                             | Result | Scenario wall | Bytes                                                                                        |
+| ------------------------------- | ------ | ------------: | -------------------------------------------------------------------------------------------- |
+| main baseline (unmodified)      | PASS   |      2,760 ms | —                                                                                            |
+| spike, deflate on               | PASS   |      3,019 ms | browser: 3,960,389 → 837,854 B (**−78.8%**); all conns: 9,090,619 → 1,583,657 B (**−82.6%**) |
+| spike, `CF_MEMORY_WS_DEFLATE=0` | PASS   |      3,114 ms | server outbound wire == logical exactly; browsers still negotiate                            |
+| spike, post-review fixes        | PASS   |             — | browser −78.5%, all conns −81.7% (consistent re-measurement)                                 |
 
-Browser detail (deflate on): inbound 1,188,630 → 369,316 B (−68.9%),
-outbound 2,771,759 → 468,538 B (−83.1%). Frame counts unchanged — no added
-round trips, no retry protocol. Wall times are localhost and within run
-noise; the win is bandwidth, not latency, at this scale. Time spent inside
-compression hops totaled ~1.7 s across all 12 connections per run
-(wall-in-hop, overstates pure CPU under event-loop contention; a
-microbenchmark of the codec is ~0.06 ms per 5 KB message).
+Browser detail (deflate on): inbound 1,188,630 → 369,316 B (−68.9%), outbound
+2,771,759 → 468,538 B (−83.1%). Frame counts unchanged — no added round trips,
+no retry protocol. Wall times are localhost and within run noise; the win is
+bandwidth, not latency, at this scale. Time spent inside compression hops
+totaled ~1.7 s across all 12 connections per run (wall-in-hop, overstates pure
+CPU under event-loop contention; a microbenchmark of the codec is ~0.06 ms per 5
+KB message).
 
-For calibration against the schema-machinery approach measured on PR #4712
-(same flow, same metric): frame-local schema interning + durable request
-schema CAS achieves −14.6% to −20.1%; this spike achieves −78.8% on browser
-connections with roughly 250 lines of transport code and no protocol-level
-state. Note main already includes #4292's frame-local sync-schema interning,
-so the −78.8% is measured on top of already-interned payloads.
+For calibration against the schema-machinery approach measured on PR #4712 (same
+flow, same metric): frame-local schema interning + durable request schema CAS
+achieves −14.6% to −20.1%; this spike achieves −78.8% on browser connections
+with roughly 250 lines of transport code and no protocol-level state. Note main
+already includes #4292's frame-local sync-schema interning, so the −78.8% is
+measured on top of already-interned payloads.
 
 ## Design notes
 
-- **Negotiation**: websocket subprotocol, not a hello flag — the transport
-  layer never parses memory messages, and the first frame can already be
-  compressed. RFC 6455 §4.1 means a client that offers and is refused fails
-  the connection (verified empirically: a server that refuses breaks the
-  browser flow), therefore:
+- **Negotiation**: websocket subprotocol, not a hello flag — the transport layer
+  never parses memory messages, and the first frame can already be compressed.
+  RFC 6455 §4.1 means a client that offers and is refused fails the connection
+  (verified empirically: a server that refuses breaks the browser flow),
+  therefore:
   - servers ALWAYS select the subprotocol when offered;
-  - `CF_MEMORY_WS_DEFLATE=0` only stops a process from *spending*: Deno
-    clients stop offering, servers stop compressing outbound. Inbound
-    decompression stays unconditional.
+  - `CF_MEMORY_WS_DEFLATE=0` only stops a process from _spending_: Deno clients
+    stop offering, servers stop compressing outbound. Inbound decompression
+    stays unconditional.
   - **Rollout order**: server support must deploy before clients offer.
 - **Ordering**: websocket delivery is ordered but deflate/inflate are async;
-  each direction of each connection funnels through a `SerialTaskQueue`.
-  Order is fixed at enqueue time, and the CLOSE notification queues behind
-  pending inflates so every frame that arrived before a close is delivered
-  before the close is signaled — the exact contract of the synchronous
-  pre-spike path. (Two adversarial review rounds found and we fixed: stale
-  frames after close on the client, dropped pre-close frames on the server,
-  swallowed errors in the server's settle→handoff window, a client inflate
-  failure that let later frames deliver past the gap — which the session
-  would then ack and resume beyond, silently losing the missing update — and
-  a missing closed-latch that let an `open()` parked on the drain dial and
-  leak a fresh socket after `close()` returned. A failed inflate now poisons
-  that socket's inbound queue, and the transport refuses to dial once
-  closed.) Covered by unit tests on both ends.
+  each direction of each connection funnels through a `SerialTaskQueue`. Order
+  is fixed at enqueue time, and the CLOSE notification queues behind pending
+  inflates so every frame that arrived before a close is delivered before the
+  close is signaled — the exact contract of the synchronous pre-spike path. (Two
+  adversarial review rounds found and we fixed: stale frames after close on the
+  client, dropped pre-close frames on the server, swallowed errors in the
+  server's settle→handoff window, a client inflate failure that let later frames
+  deliver past the gap — which the session would then ack and resume beyond,
+  silently losing the missing update — and a missing closed-latch that let an
+  `open()` parked on the drain dial and leak a fresh socket after `close()`
+  returned. A failed inflate now poisons that socket's inbound queue, and the
+  transport refuses to dial once closed.) Covered by unit tests on both ends.
 - **Capability probe**: clients offer the subprotocol only if the runtime can
-  construct `deflate-raw` streams (pre-2023 browsers would otherwise
-  negotiate and then brick in a reconnect loop).
-- **Close codes**: 1003 wrong frame type, 1007 undecodable compressed data,
-  1009 inflate backlog exceeded, 1011 other.
-- **Statelessness**: no shared sliding window (unlike permessage-deflate
-  context takeover), so reconnects and replays need no transport state, and
-  a corrupted frame cannot poison later frames. Context takeover would buy
-  roughly a further 8 points (measured offline: −89% vs −81%) at the cost of
-  per-connection window state; not worth it for a first pass.
+  construct `deflate-raw` streams (pre-2023 browsers would otherwise negotiate
+  and then brick in a reconnect loop).
+- **Close codes**: 1003 wrong frame type, 1007 undecodable compressed data, 1009
+  inflate backlog exceeded, 1011 other.
+- **Statelessness**: no shared sliding window (unlike permessage-deflate context
+  takeover), so reconnects and replays need no transport state, and a corrupted
+  frame cannot poison later frames. Context takeover would buy roughly a further
+  8 points (measured offline: −89% vs −81%) at the cost of per-connection window
+  state; not worth it for a first pass.
 - **Zip-bomb guard**: streaming inflate with a 64 MiB cap per frame; the
   server's 1 MiB pre-handshake negotiation buffer counts inflated bytes.
 
 ## Hardening before productionizing
 
-1. Sync zlib (`node:zlib` `deflateRawSync`) or a pooled compressor on the
-   server instead of per-message `CompressionStream` — cuts stream-setup
-   overhead and the wall-in-hop cost.
+1. Sync zlib (`node:zlib` `deflateRawSync`) or a pooled compressor on the server
+   instead of per-message `CompressionStream` — cuts stream-setup overhead and
+   the wall-in-hop cost.
 2. Decide browser-client failure UX for old servers (currently: connection
    fails, reconnect loops). Requires server-first rollout, or an
    offer-then-fallback dial in the client.
-3. Threshold (192 B), inflate cap (64 MiB), and inbound backlog bound
-   (16 MiB, server-side) were chosen by eyeball; tune with the stats
-   diagnostic. The client side has no backlog bound (it trusts the server).
-4. The stats recorder writes synchronously on connection close and its flush
-   can slightly undercount frames still in the inflate queue at close; fine
-   as a dev diagnostic, keep it env-gated or remove before merge.
-5. No end-to-end test drives `WebSocketTransport` against a server in pure
-   text mode (all real-socket pairings in-repo now negotiate); covered at
-   the unit level only.
-6. Known self-healing race: a request issued in the window between a socket
-   drop and the drained close notification can dial the next socket and go
-   out ahead of the reconnect `hello`; the server rejects it and the
-   handshake retry succeeds. One wasted reconnect attempt — fix belongs in
-   the client's hello sequencing if it matters in practice.
-7. Compression side channels (CRIME-class): compressed frame sizes leak
-   payload structure to a network observer under TLS, exactly as
-   permessage-deflate would. Needs a deliberate sign-off before production
-   exposure to hostile networks.
+3. Threshold (192 B), inflate cap (64 MiB), and inbound backlog bound (16 MiB,
+   server-side) were chosen by eyeball; tune with the stats diagnostic. The
+   client side has no backlog bound (it trusts the server).
+4. The stats recorder writes synchronously on connection close and its flush can
+   slightly undercount frames still in the inflate queue at close; fine as a dev
+   diagnostic, keep it env-gated or remove before merge.
+5. No end-to-end test drives `WebSocketTransport` against a server in pure text
+   mode (all real-socket pairings in-repo now negotiate); covered at the unit
+   level only.
+6. Known self-healing race: a request issued in the window between a socket drop
+   and the drained close notification can dial the next socket and go out ahead
+   of the reconnect `hello`; the server rejects it and the handshake retry
+   succeeds. One wasted reconnect attempt — fix belongs in the client's hello
+   sequencing if it matters in practice.
+7. Compression side channels (CRIME-class): compressed frame sizes leak payload
+   structure to a network observer under TLS, exactly as permessage-deflate
+   would. Needs a deliberate sign-off before production exposure to hostile
+   networks.
 
 ## Reproducing the measurements
 

--- a/SPIKE-NOTES.md
+++ b/SPIKE-NOTES.md
@@ -1,8 +1,15 @@
 # Spike: websocket compression for the memory v2 transport
 
-Branch `spike/ws-compression`, based on main @ `f4faf22f1`. Status: **spike** —
-measured and reviewed, not productionized. Do not merge as-is; see the hardening
-list at the bottom.
+Branch `spike/ws-compression`, based on main @ `f4faf22f1`. Status:
+**productionizing** — the hardening list at the bottom tracks what has landed
+versus what remains. Key production decisions now implemented: servers use the
+synchronous `node:zlib` codec (dispatch stays synchronous, so the server-side
+ordering machinery is gone), auth-bearing frames (`hello`, `hello.ok`,
+`session.open`, and the session.open response carrying the bearer session token)
+are never compressed by either peer (compression-size side-channel mitigation),
+servers cap synchronous inbound inflation at 8 MiB, the client bounds its
+inflate backlog, and sends issued inside a reconnect's drain window are rejected
+retryably instead of racing the fresh handshake.
 
 ## What it is
 
@@ -101,27 +108,28 @@ measured on top of already-interned payloads.
 
 ## Hardening before productionizing
 
-1. Sync zlib (`node:zlib` `deflateRawSync`) or a pooled compressor on the server
-   instead of per-message `CompressionStream` — cuts stream-setup overhead and
-   the wall-in-hop cost.
+1. ~~Sync zlib on the server~~ **Done**: `transport-deflate-sync.ts`; server
+   dispatch is synchronous again and the per-message stream-setup overhead is
+   gone (measured 2–3.8× cheaper per frame).
 2. Decide browser-client failure UX for old servers (currently: connection
    fails, reconnect loops). Requires server-first rollout, or an
    offer-then-fallback dial in the client.
-3. Threshold (192 B), inflate cap (64 MiB), and inbound backlog bound (16 MiB,
-   server-side) were chosen by eyeball; tune with the stats diagnostic. The
-   client side has no backlog bound (it trusts the server).
+3. Threshold (192 B) and inflate cap (64 MiB) were chosen by eyeball; tune with
+   the stats diagnostic. ~~Client backlog bound~~ **Done**: the client bounds
+   queued compressed bytes at 16 MiB (the server inflates synchronously and
+   needs no bound).
 4. The stats recorder writes synchronously on connection close and its flush can
    slightly undercount frames still in the inflate queue at close; fine as a dev
    diagnostic, keep it env-gated or remove before merge.
 5. No end-to-end test drives `WebSocketTransport` against a server in pure text
    mode (all real-socket pairings in-repo now negotiate); covered at the unit
    level only.
-6. Known self-healing race: a request issued in the window between a socket drop
-   and the drained close notification can dial the next socket and go out ahead
-   of the reconnect `hello`; the server rejects it and the handshake retry
-   succeeds. One wasted reconnect attempt — fix belongs in the client's hello
-   sequencing if it matters in practice.
-7. Compression side channels (CRIME-class): compressed frame sizes leak payload
+6. ~~Drain-window hello race~~ **Done**: sends issued while the close
+   notification is still draining are rejected retryably; the reconnect path
+   (which runs after the notification) dials normally.
+7. Compression side channels (CRIME-class) — **mitigated for credentials**:
+   auth-bearing frames (`hello`, `hello.ok`, `session.open`) are never
+   compressed by either peer. Residual: compressed frame sizes leak payload
    structure to a network observer under TLS, exactly as permessage-deflate
    would. Needs a deliberate sign-off before production exposure to hostile
    networks.

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -170,6 +170,8 @@ The toolshed-embedded memory service has two modes:
 | `MEMORY_URL` | `http://localhost:8000` | Where other components reach the memory service. |
 | `MEMORY_ACL_MODE` | `enforce` | Space ACL policy: `off`, `observe`, or `enforce`. `observe` logs ordinary access shortfalls, while malformed ACLs and fresh-space genesis violations still fail closed. |
 | `MEMORY_SERVICE_DIDS` | _(empty)_ | Comma-separated DIDs with implicit OWNER on every space. These identities may initialize ACLs but still cannot make an ordinary first write before genesis. |
+| `CF_MEMORY_WS_DEFLATE` | _(unset — enabled)_ | `0`/`false` stops this process compressing outbound memory-websocket frames (and Deno clients offering the subprotocol); servers always select an offered subprotocol regardless. See [`memoryWsDeflate`](EXPERIMENTAL_OPTIONS.md#memorywsdeflate). |
+| `CF_MEMORY_WS_DEFLATE_STATS_FILE` | _(unset — disabled)_ | Diagnostic: append one JSON line of per-connection deflate byte accounting (no payload contents) on each memory websocket close. |
 
 With ACL policy active, a fresh space is read-only until its space identity or a
 configured service DID writes a valid ACL with a concrete OWNER. A populated

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -590,18 +590,30 @@ the per-epic implementation notes).
   [`packages/memory/v2/transport-deflate.ts`](../../packages/memory/v2/transport-deflate.ts).
 - **Added by.** William Kelly, websocket compression spike (no PR yet).
 - **Purpose.** Transport-level wire-size reduction: on a negotiated connection
-  either peer may send any memory wire payload as a binary frame holding the
+  either peer may send a memory wire payload as a binary frame holding the
   raw-deflate compression of its UTF-8 bytes. Payloads under 192 bytes stay as
-  text frames. The memory protocol itself (hello flags, message shapes,
-  ordering) is untouched — this substitutes for the permessage-deflate
-  extension that `Deno.upgradeWebSocket` does not support.
+  text frames, and auth-bearing frames (`hello`, `hello.ok`, `session.open`,
+  and the session.open response carrying the bearer session token) are never
+  compressed by either peer so credential material stays out of
+  compression-size side channels (CRIME-class); receivers accept any frame
+  either way. Servers use the synchronous `node:zlib` codec
+  (`transport-deflate-sync.ts`) so websocket dispatch stays synchronous;
+  browser clients use the async streaming codec with ordered queues. The
+  memory protocol itself (hello flags, message shapes, ordering) is
+  untouched — this substitutes for the permessage-deflate extension that
+  `Deno.upgradeWebSocket` does not support.
 - **Current default and planned end state.** On by default in the spike
   branch. RFC 6455 requires a client that offers a subprotocol to fail the
   connection if the server selects none, so server-side support must deploy
   before clients offer it. End state: graduate to always-on (and eventually
   drop the text fallback), or delete the branch if the spike is not adopted.
-- **Status on 2026-07-16.** Spike implementation; measured on the Lunch Poll
-  two-browser flow.
+- **Status on 2026-07-17.** Productionizing: synchronous server codec,
+  auth-frame exemption, client inbound backlog bound, and reconnect-window
+  send guard are implemented with test coverage. Measured on the Lunch Poll
+  two-browser flow (−78–79% browser payload bytes; ~+150 ms localhost CPU
+  cost in the A/B, roughly halved by the sync server codec). Rollout: deploy
+  server support fleet-wide first (a normal rolling restart), then let
+  clients offer.
 - **Path to removal.** Adopt: keep the subprotocol negotiation until every
   client offers it, then require it. Reject: revert the spike branch; the
   subprotocol was never shipped so no peer depends on it.

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -44,7 +44,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
-| [`memoryWsDeflate`](#memorywsdeflate) | `CF_MEMORY_WS_DEFLATE` env (negotiated per connection via websocket subprotocol) | on | William Kelly (spike) | graduate or delete after spike evaluation | SPIKE, on by default in the spike branch |
+| [`memoryWsDeflate`](#memorywsdeflate) | `CF_MEMORY_WS_DEFLATE` env (negotiated per connection via websocket subprotocol) | on | William Kelly (#4770) | graduate to always-on after fleet rollout | implemented, on by default |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
@@ -580,7 +580,9 @@ the per-epic implementation notes).
 ### `memoryWsDeflate`
 
 - **Toggle via.** `CF_MEMORY_WS_DEFLATE` env var (`0`/`false` disables;
-  anything else, including unset, enables). The switch gates only what a
+  anything else, including unset, enables). A Deno process whose env access is
+  permission-restricted cannot express an opt-out, so it defaults to NOT
+  offering (fail-safe); browsers have no env and default on. The switch gates only what a
   process SPENDS: Deno clients stop offering the subprotocol, and servers
   stop compressing their outbound. Servers always select an offered
   subprotocol and always accept compressed inbound — refusing an offer fails
@@ -588,7 +590,7 @@ the per-epic implementation notes).
   read env. Negotiated per connection via the `fvj1.deflate` websocket
   subprotocol declared in
   [`packages/memory/v2/transport-deflate.ts`](../../packages/memory/v2/transport-deflate.ts).
-- **Added by.** William Kelly, websocket compression spike (no PR yet).
+- **Added by.** William Kelly (#4770).
 - **Purpose.** Transport-level wire-size reduction: on a negotiated connection
   either peer may send a memory wire payload as a binary frame holding the
   raw-deflate compression of its UTF-8 bytes. Payloads under 192 bytes stay as

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -587,7 +587,7 @@ the per-epic implementation notes).
   stop compressing their outbound. Servers always select an offered
   subprotocol and always accept compressed inbound — refusing an offer fails
   the whole connection per RFC 6455 for clients (like browsers) that cannot
-  read env. Negotiated per connection via the `fvj1.deflate` websocket
+  read env. Negotiated per connection via the `cf-memory.deflate.v1` websocket
   subprotocol declared in
   [`packages/memory/v2/transport-deflate.ts`](../../packages/memory/v2/transport-deflate.ts).
 - **Added by.** William Kelly (#4770).

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -604,21 +604,24 @@ the per-epic implementation notes).
   memory protocol itself (hello flags, message shapes, ordering) is
   untouched — this substitutes for the permessage-deflate extension that
   `Deno.upgradeWebSocket` does not support.
-- **Current default and planned end state.** On by default in the spike
-  branch. RFC 6455 requires a client that offers a subprotocol to fail the
-  connection if the server selects none, so server-side support must deploy
-  before clients offer it. End state: graduate to always-on (and eventually
-  drop the text fallback), or delete the branch if the spike is not adopted.
-- **Status on 2026-07-17.** Productionizing: synchronous server codec,
+- **Current default and planned end state.** On by default. RFC 6455
+  requires a client that offers a subprotocol to fail the connection if the
+  server selects none — browsers enforce this, Deno clients tolerate it and
+  continue uncompressed — so server-side support must be deployed fleet-wide
+  before browser clients offer. End state: graduate to always-on and
+  eventually drop the text fallback for negotiated connections.
+- **Status on 2026-07-21.** Implemented (#4770): synchronous server codec,
   auth-frame exemption, client inbound backlog bound, and reconnect-window
-  send guard are implemented with test coverage. Measured on the Lunch Poll
-  two-browser flow (−78–79% browser payload bytes; ~+150 ms localhost CPU
-  cost in the A/B, roughly halved by the sync server codec). Rollout: deploy
-  server support fleet-wide first (a normal rolling restart), then let
+  send guard, all with test coverage. Measured on the Lunch Poll two-browser
+  flow: −78–79% browser payload bytes; ~+150 ms localhost CPU cost in the
+  A/B, roughly halved by the sync server codec. Rollout: deploy server
+  support fleet-wide first (a normal rolling restart), then let browser
   clients offer.
-- **Path to removal.** Adopt: keep the subprotocol negotiation until every
-  client offers it, then require it. Reject: revert the spike branch; the
-  subprotocol was never shipped so no peer depends on it.
+- **Path to removal.** Keep the subprotocol negotiation until every client
+  offers it, then require it and delete the text fallback. If the transport
+  layer ever gains native permessage-deflate (upstream fastwebsockets),
+  clients stop offering the subprotocol when `socket.extensions` shows it
+  and this feature deletes entirely.
 - **Companion diagnostic.** `CF_MEMORY_WS_DEFLATE_STATS_FILE=<path>` makes
   toolshed append one JSON line per closed memory websocket connection with
   logical-versus-wire byte totals per direction (no payload contents). Unset

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -44,6 +44,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
+| [`memoryWsDeflate`](#memorywsdeflate) | `CF_MEMORY_WS_DEFLATE` env (negotiated per connection via websocket subprotocol) | on | William Kelly (spike) | graduate or delete after spike evaluation | SPIKE, on by default in the spike branch |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
@@ -575,6 +576,39 @@ the per-epic implementation notes).
 - **Path to removal.** Confirm no peer still needs the expanded payload, then
   delete the negotiation and the expanded-form encoder and always send the
   compact form.
+
+### `memoryWsDeflate`
+
+- **Toggle via.** `CF_MEMORY_WS_DEFLATE` env var (`0`/`false` disables;
+  anything else, including unset, enables). The switch gates only what a
+  process SPENDS: Deno clients stop offering the subprotocol, and servers
+  stop compressing their outbound. Servers always select an offered
+  subprotocol and always accept compressed inbound — refusing an offer fails
+  the whole connection per RFC 6455 for clients (like browsers) that cannot
+  read env. Negotiated per connection via the `fvj1.deflate` websocket
+  subprotocol declared in
+  [`packages/memory/v2/transport-deflate.ts`](../../packages/memory/v2/transport-deflate.ts).
+- **Added by.** William Kelly, websocket compression spike (no PR yet).
+- **Purpose.** Transport-level wire-size reduction: on a negotiated connection
+  either peer may send any memory wire payload as a binary frame holding the
+  raw-deflate compression of its UTF-8 bytes. Payloads under 192 bytes stay as
+  text frames. The memory protocol itself (hello flags, message shapes,
+  ordering) is untouched — this substitutes for the permessage-deflate
+  extension that `Deno.upgradeWebSocket` does not support.
+- **Current default and planned end state.** On by default in the spike
+  branch. RFC 6455 requires a client that offers a subprotocol to fail the
+  connection if the server selects none, so server-side support must deploy
+  before clients offer it. End state: graduate to always-on (and eventually
+  drop the text fallback), or delete the branch if the spike is not adopted.
+- **Status on 2026-07-16.** Spike implementation; measured on the Lunch Poll
+  two-browser flow.
+- **Path to removal.** Adopt: keep the subprotocol negotiation until every
+  client offers it, then require it. Reject: revert the spike branch; the
+  subprotocol was never shipped so no peer depends on it.
+- **Companion diagnostic.** `CF_MEMORY_WS_DEFLATE_STATS_FILE=<path>` makes
+  toolshed append one JSON line per closed memory websocket connection with
+  logical-versus-wire byte totals per direction (no payload contents). Unset
+  disables it entirely.
 
 > Two neighbours in the same handshake are related but are not runtime-toggleable
 > experimental flags:

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -214,6 +214,10 @@ One line per archived document; each document's header carries the fuller
   and
   [pattern-integration-compile-bound.md](development/performance/pattern-integration-compile-bound.md)
   — June 2026 profiling snapshots.
+- [memory-ws-deflate-spike-2026-07-16.md](development/performance/memory-ws-deflate-spike-2026-07-16.md)
+  — spike record for the memory websocket per-message deflate transport
+  (design decisions, Lunch Poll measurements, hardening ledger); the feature
+  productionized in PR #4770.
 - [2026-07-pattern-capability-ci-duration-increase.md](development/performance/2026-07-pattern-capability-ci-duration-increase.md)
   — root cause of the July 2026 labs CI duration increase: two unsharded
   pattern time-capability sweeps, especially the 56-pattern sweep on shard 3.

--- a/docs/history/development/performance/memory-ws-deflate-spike-2026-07-16.md
+++ b/docs/history/development/performance/memory-ws-deflate-spike-2026-07-16.md
@@ -1,3 +1,10 @@
+---
+status: historical
+created: 2026-07-16
+archived: 2026-07-21
+reason: "Spike record for the memory websocket deflate transport; the feature productionized in PR #4770 and live guidance moved to the memoryWsDeflate registry entry."
+---
+
 # Spike: websocket compression for the memory v2 transport
 
 Branch `spike/ws-compression`, based on main @ `f4faf22f1`. Status:
@@ -44,7 +51,9 @@ Files:
 ## Measured results (Lunch Poll two-browser flow, 2026-07-16)
 
 Same-run paired accounting: logical = UTF-8 bytes of the uncompressed text
-payload (identical to the metric PR #4712 uses), wire = bytes actually sent.
+payload (identical to the metric PR #4712 uses), wire = websocket payload
+bytes as sent (excludes frame headers, masking, and TLS — not an end-to-end
+bandwidth measurement).
 
 | Run                             | Result | Scenario wall | Bytes                                                                                        |
 | ------------------------------- | ------ | ------------: | -------------------------------------------------------------------------------------------- |
@@ -80,8 +89,10 @@ measured on top of already-interned payloads.
     stop offering, servers stop compressing outbound. Inbound decompression
     stays unconditional.
   - **Rollout order**: server support must deploy before clients offer.
-- **Ordering**: websocket delivery is ordered but deflate/inflate are async;
-  each direction of each connection funnels through a `SerialTaskQueue`. Order
+- **Ordering (client-side)**: the server codec is synchronous, so server
+  dispatch order is an event-loop property with no queues. Browsers only have
+  the async streaming codec, so on the CLIENT each direction funnels through a
+  `SerialTaskQueue`. Order
   is fixed at enqueue time, and the CLOSE notification queues behind pending
   inflates so every frame that arrived before a close is delivered before the
   close is signaled — the exact contract of the synchronous pre-spike path. (Two
@@ -103,8 +114,10 @@ measured on top of already-interned payloads.
   frame cannot poison later frames. Context takeover would buy roughly a further
   8 points (measured offline: −89% vs −81%) at the cost of per-connection window
   state; not worth it for a first pass.
-- **Zip-bomb guard**: streaming inflate with a 64 MiB cap per frame; the
-  server's 1 MiB pre-handshake negotiation buffer counts inflated bytes.
+- **Zip-bomb guard**: the client's streaming inflate caps a frame at 64 MiB;
+  the server's synchronous inflate caps inbound frames at 8 MiB (bounding
+  pre-authorization event-loop blocking); the server's 1 MiB pre-handshake
+  negotiation buffer counts queued (inflated) text bytes.
 
 ## Hardening before productionizing
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -128,6 +128,39 @@ a client and server may connect when their scheduler-state flags differ, and
 the server's flag controls the scheduler-observation data plane for that
 connection.
 
+#### Transport compression (`fvj1.deflate`)
+
+The connection MAY negotiate per-message compression at the websocket layer,
+below the message protocol: the client offers the `fvj1.deflate` subprotocol
+in its upgrade request, and a supporting server always selects an offered
+subprotocol (refusing one fails the connection for RFC 6455-conforming
+clients such as browsers). Nothing in the hello handshake changes.
+
+On a negotiated connection, either peer MAY send any wire payload as a
+binary frame containing the raw-deflate (RFC 1951) compression of the
+payload's UTF-8 bytes. Text frames remain valid and are processed
+unchanged. Compression is stateless per message: no sliding window is
+shared between frames, so reconnects and replays carry no compression
+state. Senders SHOULD leave payloads under 192 UTF-8 bytes as text.
+
+Auth-bearing frames — `hello`, `hello.ok`, `session.open`, and any response
+whose body carries the session bearer token or the next session-open
+challenge — MUST NOT be compressed by the sender, keeping credential
+material out of compression-size side channels. Receivers accept any frame
+in either framing; the exemption is sender policy.
+
+Receivers bound inflation (servers reject frames that inflate past their
+cap by closing with code 1007; an undecodable compressed frame also closes
+1007) and non-negotiated connections keep the historical text-only framing:
+binary frames on them remain a protocol error (1003).
+
+Clients MUST NOT offer the subprotocol unless they can inflate `deflate-raw`
+streams. Deno-based clients tolerate a server that selects no subprotocol
+and simply continue uncompressed; browser clients fail such connections per
+RFC 6455, so server-side support MUST be deployed before browser clients
+offer. The `memoryWsDeflate` entry in the experimental-options registry
+records the rollout state and the `CF_MEMORY_WS_DEFLATE` kill switch.
+
 ### 4.1.2 Logical Sessions and Resume
 
 Pending-read resolution, idempotent replay, and live sync are scoped to a

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -128,10 +128,10 @@ a client and server may connect when their scheduler-state flags differ, and
 the server's flag controls the scheduler-observation data plane for that
 connection.
 
-#### Transport compression (`fvj1.deflate`)
+#### Transport compression (`cf-memory.deflate.v1`)
 
 The connection MAY negotiate per-message compression at the websocket layer,
-below the message protocol: the client offers the `fvj1.deflate` subprotocol
+below the message protocol: the client offers the `cf-memory.deflate.v1` subprotocol
 in its upgrade request, and a supporting server always selects an offered
 subprotocol (refusing one fails the connection for RFC 6455-conforming
 clients such as browsers). Nothing in the hello handshake changes.

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -34,6 +34,7 @@
     "./v2/engine": "./v2/engine.ts",
     "./v2/server": "./v2/server.ts",
     "./v2/standalone": "./v2/standalone.ts",
+    "./v2/transport-deflate": "./v2/transport-deflate.ts",
     "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
     "./v2/dump": "./v2/dump.ts",

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -35,6 +35,7 @@
     "./v2/server": "./v2/server.ts",
     "./v2/standalone": "./v2/standalone.ts",
     "./v2/transport-deflate": "./v2/transport-deflate.ts",
+    "./v2/transport-deflate-sync": "./v2/transport-deflate-sync.ts",
     "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
     "./v2/dump": "./v2/dump.ts",

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -49,6 +49,7 @@
   },
   "imports": {
     "@db/sqlite": "jsr:@db/sqlite@0.13.0",
+    "builtin-zlib": "node:zlib",
     "@denosaurs/plug": "jsr:@denosaurs/plug@^1.1.0",
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.1"
   }

--- a/packages/memory/test/v2-client-send-failure-test.ts
+++ b/packages/memory/test/v2-client-send-failure-test.ts
@@ -9,6 +9,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { assertEquals, assertRejects } from "@std/assert";
 import {
+  decodeMemoryBoundary,
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
@@ -41,9 +42,7 @@ describe("memory v2 client transport send failures", () => {
     const transport: Transport = {
       send(payload: string): Promise<void> {
         if (failSends) return Promise.reject(connectionError());
-        const message = JSON.parse(payload.slice("fvj1:".length)) as {
-          type?: string;
-        };
+        const message = decodeMemoryBoundary(payload) as { type?: string };
         if (message.type === "hello") {
           queueMicrotask(() => receiver(encodeMemoryBoundary(HELLO_OK)));
         }

--- a/packages/memory/test/v2-client-send-failure-test.ts
+++ b/packages/memory/test/v2-client-send-failure-test.ts
@@ -1,0 +1,107 @@
+/**
+ * A transport send that fails after the connection turned over (the deflate
+ * transport's drain-window guard, a dial failure) must not leave orphaned
+ * pending state behind: a later connection-close sweep rejecting a promise
+ * nobody observes is a fatal unhandled rejection in Deno processes. These
+ * tests fail via Deno's unhandled-rejection detection if the cleanup
+ * regresses.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+} from "../v2.ts";
+import { Client, type Transport } from "../v2/client.ts";
+
+const HELLO_OK = {
+  type: "hello.ok",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+  sessionOpen: {
+    audience: "did:key:z6Mk-send-failure-audience",
+    challenge: { value: "challenge:send-failure", expiresAt: 1_000_000 },
+  },
+} as const;
+
+const connectionError = (): Error => {
+  const error = new Error(
+    "memory websocket transport reconnected during send",
+  );
+  error.name = "ConnectionError";
+  return error;
+};
+
+describe("memory v2 client transport send failures", () => {
+  it("withdraws the pending request when send fails, so the close sweep cannot reject an unobserved promise", async () => {
+    let receiver = (_payload: string) => {};
+    let closeReceiver: (error?: Error) => void = () => {};
+    let failSends = false;
+    const transport: Transport = {
+      send(payload: string): Promise<void> {
+        if (failSends) return Promise.reject(connectionError());
+        const message = JSON.parse(payload.slice("fvj1:".length)) as {
+          type?: string;
+        };
+        if (message.type === "hello") {
+          queueMicrotask(() => receiver(encodeMemoryBoundary(HELLO_OK)));
+        }
+        return Promise.resolve();
+      },
+      close: () => Promise.resolve(),
+      setReceiver(next) {
+        receiver = next;
+      },
+      setCloseReceiver(next) {
+        closeReceiver = next;
+      },
+    };
+
+    const client = await Client.connect({ transport });
+    assertEquals(client.isConnected(), true);
+
+    // The connection is now "turning over": sends fail with a retryable
+    // connection error while the close notification has not yet landed.
+    failSends = true;
+    await assertRejects(
+      () =>
+        client.request({
+          type: "graph.query",
+          requestId: crypto.randomUUID(),
+          space: "did:key:z6Mk-send-failure",
+          sessionId: "session:none",
+          query: { roots: [] },
+        }),
+      Error,
+      "reconnected during send",
+    );
+
+    // The close notification sweeps pending requests. If the failed request
+    // above left its entry behind, this rejects a promise with no handlers
+    // and Deno's unhandled-rejection tracking fails this test.
+    closeReceiver(connectionError());
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await client.close();
+  });
+
+  it("clears the pending hello when the handshake send fails", async () => {
+    let closeReceiver: (error?: Error) => void = () => {};
+    const transport: Transport = {
+      send: () => Promise.reject(connectionError()),
+      close: () => Promise.resolve(),
+      setReceiver() {},
+      setCloseReceiver(next) {
+        closeReceiver = next;
+      },
+    };
+
+    await assertRejects(
+      () => Client.connect({ transport }),
+      Error,
+      "reconnected during send",
+    );
+    closeReceiver(connectionError());
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+});

--- a/packages/memory/test/v2-client-send-failure-test.ts
+++ b/packages/memory/test/v2-client-send-failure-test.ts
@@ -84,6 +84,84 @@ describe("memory v2 client transport send failures", () => {
     await client.close();
   });
 
+  it("stops rescheduling the ack flush when the connection is turning over", async () => {
+    const sends: string[] = [];
+    let receiver = (_payload: string) => {};
+    let closeReceiver: (error?: Error) => void = () => {};
+    let failSends = false;
+    const transport: Transport = {
+      send(payload: string): Promise<void> {
+        const message = decodeMemoryBoundary(payload) as {
+          type?: string;
+          requestId?: string;
+        };
+        if (message.type) sends.push(message.type);
+        if (failSends) return Promise.reject(connectionError());
+        if (message.type === "hello") {
+          queueMicrotask(() => receiver(encodeMemoryBoundary(HELLO_OK)));
+        }
+        if (message.type === "session.open") {
+          queueMicrotask(() =>
+            receiver(encodeMemoryBoundary({
+              type: "response",
+              requestId: message.requestId!,
+              ok: {
+                sessionId: "session:ack-flush",
+                sessionToken: "token:ack-flush",
+                serverSeq: 0,
+                sessionOpen: HELLO_OK.sessionOpen,
+              },
+            }))
+          );
+        }
+        return Promise.resolve();
+      },
+      close: () => Promise.resolve(),
+      setReceiver(next) {
+        receiver = next;
+      },
+      setCloseReceiver(next) {
+        closeReceiver = next;
+      },
+    };
+
+    const client = await Client.connect({ transport });
+    const session = await client.mount("did:key:z6Mk-ack-flush");
+
+    // Deliver an effect the session must ack while sends already fail with a
+    // retryable connection error: the scheduled flush runs against a
+    // connection that is turning over but still reads as connected.
+    failSends = true;
+    receiver(encodeMemoryBoundary({
+      type: "session/effect",
+      space: "did:key:z6Mk-ack-flush",
+      sessionId: "session:ack-flush",
+      effect: {
+        type: "sync",
+        fromSeq: 0,
+        toSeq: 1,
+        upserts: [],
+        removes: [],
+      },
+    }));
+
+    // The flush is scheduled on a 0ms timer; a regression that reschedules
+    // after the connection error would attempt its second ack on the next
+    // timer turn, so draining three turns makes a respin observable.
+    for (let turn = 0; turn < 3; turn += 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    assertEquals(
+      sends.filter((type) => type === "session.ack").length,
+      1,
+      "a turning-over connection must get exactly one ack attempt",
+    );
+
+    closeReceiver(connectionError());
+    await session.close();
+    await client.close();
+  });
+
   it("clears the pending hello when the handshake send fails", async () => {
     let closeReceiver: (error?: Error) => void = () => {};
     const transport: Transport = {

--- a/packages/memory/test/v2-standalone-deflate-test.ts
+++ b/packages/memory/test/v2-standalone-deflate-test.ts
@@ -1,0 +1,231 @@
+/**
+ * Real-socket coverage for the standalone harness server's `fvj1.deflate`
+ * support: negotiation, synchronous inflate/deflate both directions, the
+ * auth-frame exemption, and frame-error close codes — mirroring toolshed's
+ * behavior so `cf test` multi-user harnesses exercise the same transport.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { assert, assertEquals } from "@std/assert";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type SessionOpenChallenge,
+} from "../v2.ts";
+import { StandaloneMemoryServer } from "../v2/standalone.ts";
+import {
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_DEFLATE_SUBPROTOCOL,
+} from "../v2/transport-deflate.ts";
+import {
+  deflateWirePayloadSync,
+  inflateWirePayloadSync,
+} from "../v2/transport-deflate-sync.ts";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { Identity } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+type HelloOk = {
+  type: "hello.ok";
+  sessionOpen: { audience: string; challenge: SessionOpenChallenge };
+};
+
+const openSocket = async (
+  url: URL,
+  protocols?: string[],
+): Promise<WebSocket> => {
+  const address = new URL(url);
+  address.protocol = "ws:";
+  const socket = new WebSocket(address, protocols);
+  socket.binaryType = "arraybuffer";
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", (event) => reject(event), { once: true });
+  });
+  return socket;
+};
+
+const readWireMessage = async <Message extends FabricValue>(
+  socket: WebSocket,
+): Promise<{ message: Message; wasBinary: boolean }> => {
+  const data = await new Promise<string | ArrayBuffer>((resolve, reject) => {
+    socket.addEventListener("message", (event) => {
+      if (typeof event.data === "string" || event.data instanceof ArrayBuffer) {
+        resolve(event.data);
+        return;
+      }
+      reject(new Error("Unexpected websocket frame type"));
+    }, { once: true });
+    socket.addEventListener(
+      "error",
+      () => reject(new Error("WebSocket error before message")),
+      { once: true },
+    );
+  });
+  if (typeof data === "string") {
+    return { message: decodeMemoryBoundary<Message>(data), wasBinary: false };
+  }
+  return {
+    message: decodeMemoryBoundary<Message>(inflateWirePayloadSync(data)),
+    wasBinary: true,
+  };
+};
+
+const closeSocket = async (socket: WebSocket): Promise<void> => {
+  const closed = new Promise<void>((resolve) => {
+    socket.addEventListener("close", () => resolve(), { once: true });
+  });
+  socket.close();
+  await closed;
+};
+
+describe("standalone memory server deflate transport", () => {
+  it("negotiates and compresses non-auth frames in both directions", async () => {
+    const identity = await Identity.fromPassphrase("standalone-deflate");
+    const server = StandaloneMemoryServer.start();
+    const space = identity.did();
+
+    try {
+      const socket = await openSocket(server.url, [
+        MEMORY_WS_DEFLATE_SUBPROTOCOL,
+      ]);
+      assertEquals(socket.protocol, MEMORY_WS_DEFLATE_SUBPROTOCOL);
+
+      // Compressed hello: the server must inflate a binary first frame.
+      socket.send(deflateWirePayloadSync(encodeMemoryBoundary(HELLO)));
+      const hello = await readWireMessage<HelloOk>(socket);
+      assertEquals(hello.message.type, "hello.ok");
+      // hello.ok exceeds the threshold but carries the challenge: exempt.
+      assertEquals(hello.wasBinary, false);
+
+      const iat = Math.floor(Date.now() / 1000);
+      const invocation = {
+        iss: identity.did(),
+        cmd: "session.open",
+        sub: space,
+        aud: hello.message.sessionOpen.audience,
+        args: { protocol: MEMORY_PROTOCOL, session: {} },
+        challenge: hello.message.sessionOpen.challenge.value,
+        iat,
+        exp: iat + 300,
+      };
+      const signature = await identity.sign(hashOf(invocation).bytes);
+      if (signature.error) throw signature.error;
+      socket.send(encodeMemoryBoundary({
+        type: "session.open",
+        requestId: "open-1",
+        space,
+        session: {},
+        invocation,
+        authorization: { signature: new FabricBytes(signature.ok) },
+      }));
+      const opened = await readWireMessage<{
+        type: "response";
+        ok: { sessionId: string };
+      }>(socket);
+      assertEquals(opened.message.type, "response");
+      // The session.open response carries the bearer token: exempt.
+      assertEquals(opened.wasBinary, false);
+
+      // A large transact goes up compressed; its watch response comes back
+      // compressed (the standalone server has no ACL genesis requirement).
+      const fatValue = "standalone-".repeat(120);
+      socket.send(deflateWirePayloadSync(encodeMemoryBoundary({
+        type: "transact",
+        requestId: "tx-1",
+        space,
+        sessionId: opened.message.ok.sessionId,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:fat",
+            value: { value: { fat: fatValue } },
+          }],
+        },
+      })));
+      const committed = await readWireMessage<{
+        type: "response";
+        error?: { name: string };
+      }>(socket);
+      assertEquals(committed.message.error, undefined);
+
+      socket.send(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch-1",
+        space,
+        sessionId: opened.message.ok.sessionId,
+        watches: [{
+          id: "fat",
+          kind: "graph",
+          query: {
+            roots: [{
+              id: "of:doc:fat",
+              selector: { path: [], schema: false },
+            }],
+          },
+        }],
+      }));
+      const watched = await readWireMessage<{
+        type: "response";
+        ok?: {
+          sync?: { upserts?: Array<{ doc?: { value?: { fat?: string } } }> };
+        };
+      }>(socket);
+      assertEquals(
+        watched.message.ok?.sync?.upserts?.[0]?.doc?.value?.fat,
+        fatValue,
+      );
+      assert(
+        encodeMemoryBoundary(watched.message).length >=
+          MEMORY_WS_DEFLATE_MIN_BYTES,
+      );
+      assertEquals(
+        watched.wasBinary,
+        true,
+        "large non-auth standalone frames must be compressed",
+      );
+
+      await closeSocket(socket);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("closes 1007 on malformed compressed frames and 1003 on unexpected binary", async () => {
+    const server = StandaloneMemoryServer.start();
+    try {
+      const negotiated = await openSocket(server.url, [
+        MEMORY_WS_DEFLATE_SUBPROTOCOL,
+      ]);
+      const closed1007 = new Promise<CloseEvent>((resolve) => {
+        negotiated.addEventListener("close", (event) => resolve(event), {
+          once: true,
+        });
+      });
+      negotiated.send(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+      assertEquals((await closed1007).code, 1007);
+
+      const plain = await openSocket(server.url);
+      assertEquals(plain.protocol, "");
+      const closed1003 = new Promise<CloseEvent>((resolve) => {
+        plain.addEventListener("close", (event) => resolve(event), {
+          once: true,
+        });
+      });
+      plain.send(new Uint8Array([1, 2, 3]));
+      assertEquals((await closed1003).code, 1003);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/memory/test/v2-standalone-deflate-test.ts
+++ b/packages/memory/test/v2-standalone-deflate-test.ts
@@ -1,5 +1,5 @@
 /**
- * Real-socket coverage for the standalone harness server's `fvj1.deflate`
+ * Real-socket coverage for the standalone harness server's `cf-memory.deflate.v1`
  * support: negotiation, synchronous inflate/deflate both directions, the
  * auth-frame exemption, and frame-error close codes — mirroring toolshed's
  * behavior so `cf test` multi-user harnesses exercise the same transport.

--- a/packages/memory/test/v2-standalone-server-test.ts
+++ b/packages/memory/test/v2-standalone-server-test.ts
@@ -1,0 +1,213 @@
+/**
+ * Real-socket coverage for the standalone harness server's non-transport
+ * behavior: the plain-HTTP response for non-websocket requests, and the
+ * CF_DEBUG_MEMORY_WRITES commit tracing — one stderr line per operation with
+ * op/id/scope — including that tracing never interferes with message
+ * handling, even for frames the server cannot parse.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type SessionOpenChallenge,
+} from "../v2.ts";
+import { StandaloneMemoryServer } from "../v2/standalone.ts";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { Identity } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+type HelloOk = {
+  type: "hello.ok";
+  sessionOpen: { audience: string; challenge: SessionOpenChallenge };
+};
+
+const openSocket = async (url: URL): Promise<WebSocket> => {
+  const address = new URL(url);
+  address.protocol = "ws:";
+  const socket = new WebSocket(address);
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", (event) => reject(event), { once: true });
+  });
+  return socket;
+};
+
+const readWireMessage = async <Message extends FabricValue>(
+  socket: WebSocket,
+): Promise<Message> => {
+  const data = await new Promise<string>((resolve, reject) => {
+    socket.addEventListener("message", (event) => {
+      if (typeof event.data === "string") {
+        resolve(event.data);
+        return;
+      }
+      reject(new Error("Unexpected binary websocket frame"));
+    }, { once: true });
+    socket.addEventListener(
+      "error",
+      () => reject(new Error("WebSocket error before message")),
+      { once: true },
+    );
+  });
+  return decodeMemoryBoundary<Message>(data);
+};
+
+const closeSocket = async (socket: WebSocket): Promise<void> => {
+  const closed = new Promise<void>((resolve) => {
+    socket.addEventListener("close", () => resolve(), { once: true });
+  });
+  socket.close();
+  await closed;
+};
+
+const openSession = async (
+  socket: WebSocket,
+  identity: Identity,
+): Promise<string> => {
+  socket.send(encodeMemoryBoundary(HELLO));
+  const hello = await readWireMessage<HelloOk>(socket);
+  assertEquals(hello.type, "hello.ok");
+
+  const space = identity.did();
+  const iat = Math.floor(Date.now() / 1000);
+  const invocation = {
+    iss: identity.did(),
+    cmd: "session.open",
+    sub: space,
+    aud: hello.sessionOpen.audience,
+    args: { protocol: MEMORY_PROTOCOL, session: {} },
+    challenge: hello.sessionOpen.challenge.value,
+    iat,
+    exp: iat + 300,
+  };
+  const signature = await identity.sign(hashOf(invocation).bytes);
+  if (signature.error) throw signature.error;
+  socket.send(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open-1",
+    space,
+    session: {},
+    invocation,
+    authorization: { signature: new FabricBytes(signature.ok) },
+  }));
+  const opened = await readWireMessage<{
+    type: "response";
+    ok: { sessionId: string };
+  }>(socket);
+  assertEquals(opened.type, "response");
+  return opened.ok.sessionId;
+};
+
+describe("standalone memory server", () => {
+  it("answers non-websocket requests with a plain identification page", async () => {
+    const server = StandaloneMemoryServer.start();
+    try {
+      const response = await fetch(server.url);
+      assertEquals(response.status, 200);
+      assertEquals(await response.text(), "memory websocket endpoint");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("traces one line per commit operation under CF_DEBUG_MEMORY_WRITES", async () => {
+    const previousEnv = Deno.env.get("CF_DEBUG_MEMORY_WRITES");
+    const originalError = console.error;
+    const stderrLines: string[] = [];
+    Deno.env.set("CF_DEBUG_MEMORY_WRITES", "1");
+    console.error = (...args: unknown[]) => {
+      stderrLines.push(args.map(String).join(" "));
+    };
+
+    const identity = await Identity.fromPassphrase("standalone-tracing");
+    const server = StandaloneMemoryServer.start();
+    try {
+      const socket = await openSocket(server.url);
+      const space = identity.did();
+      const sessionId = await openSession(socket, identity);
+
+      socket.send(encodeMemoryBoundary({
+        type: "transact",
+        requestId: "tx-set",
+        space,
+        sessionId,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:trace",
+            value: { value: { fat: "initial" } },
+          }],
+        },
+      }));
+      const setResponse = await readWireMessage<{
+        type: "response";
+        error?: { name: string };
+      }>(socket);
+      assertEquals(setResponse.error, undefined);
+
+      socket.send(encodeMemoryBoundary({
+        type: "transact",
+        requestId: "tx-patch",
+        space,
+        sessionId,
+        commit: {
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "patch",
+            id: "of:doc:trace",
+            patches: [{ op: "replace", path: "/value/fat", value: "patched" }],
+          }],
+        },
+      }));
+      const patchResponse = await readWireMessage<{
+        type: "response";
+        error?: { name: string };
+      }>(socket);
+      assertEquals(patchResponse.error, undefined);
+
+      // Tracing inspects every inbound text frame before the server parses
+      // it, so an unparseable frame must still get the server's normal
+      // invalid-message response — tracing never breaks handling.
+      socket.send("this is not a memory frame");
+      const invalid = await readWireMessage<{
+        type: "response";
+        requestId: string;
+        error?: { name: string };
+      }>(socket);
+      assertEquals(invalid.requestId, "invalid");
+      assertEquals(invalid.error?.name, "InvalidMessageError");
+
+      await closeSocket(socket);
+    } finally {
+      await server.close();
+      console.error = originalError;
+      if (previousEnv === undefined) {
+        Deno.env.delete("CF_DEBUG_MEMORY_WRITES");
+      } else {
+        Deno.env.set("CF_DEBUG_MEMORY_WRITES", previousEnv);
+      }
+    }
+
+    const traces = stderrLines.filter((line) => line.includes("[memwrite"));
+    assertEquals(traces.length, 2, traces.join("\n"));
+    assertStringIncludes(traces[0], "op=set");
+    assertStringIncludes(traces[0], "id=of:doc:trace");
+    assertStringIncludes(traces[0], 'keys=["fat"]');
+    assertStringIncludes(traces[0], "scope=(space)");
+    assertStringIncludes(traces[1], "op=patch");
+    assertStringIncludes(traces[1], 'paths=["/value/fat"]');
+  });
+});

--- a/packages/memory/test/v2-transport-deflate-sync-test.ts
+++ b/packages/memory/test/v2-transport-deflate-sync-test.ts
@@ -105,4 +105,16 @@ describe("auth-bearing wire message detection", () => {
     assertEquals(isAuthBearingWireMessage("fvj1:{}" as never), true);
     assertEquals(isAuthBearingWireMessage(null as never), true);
   });
+
+  it("fails closed on frame types the unions do not know", () => {
+    // Unlike the non-object garbage above (caught by the early guard), an
+    // object with an unrecognized `type` reaches the exhaustive switch's
+    // default arm — e.g. a frame from a newer server this client build has
+    // no case for. It must classify as auth-bearing so it is never
+    // compressed.
+    assertEquals(
+      isAuthBearingWireMessage({ type: "session.telemetry" } as never),
+      true,
+    );
+  });
 });

--- a/packages/memory/test/v2-transport-deflate-sync-test.ts
+++ b/packages/memory/test/v2-transport-deflate-sync-test.ts
@@ -4,13 +4,13 @@ import {
   deflateWirePayload,
   inflateWirePayload,
 } from "../v2/transport-deflate.ts";
-import { isAuthBearingWireMessage } from "../v2.ts";
+import { encodeMemoryBoundary, isAuthBearingWireMessage } from "../v2.ts";
 import {
   deflateWirePayloadSync,
   inflateWirePayloadSync,
 } from "../v2/transport-deflate-sync.ts";
 
-const PAYLOAD = "fvj1:" + JSON.stringify({
+const PAYLOAD = encodeMemoryBoundary({
   upserts: Array.from({ length: 64 }, (_, index) => ({
     id: `of:entity-${index}`,
     doc: { value: { text: "x".repeat(120), index } },

--- a/packages/memory/test/v2-transport-deflate-sync-test.ts
+++ b/packages/memory/test/v2-transport-deflate-sync-test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "@std/testing/bdd";
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  isAuthBearingWireMessage,
+} from "../v2/transport-deflate.ts";
+import {
+  deflateWirePayloadSync,
+  inflateWirePayloadSync,
+} from "../v2/transport-deflate-sync.ts";
+
+const PAYLOAD = "fvj1:" + JSON.stringify({
+  upserts: Array.from({ length: 64 }, (_, index) => ({
+    id: `of:entity-${index}`,
+    doc: { value: { text: "x".repeat(120), index } },
+  })),
+});
+
+describe("memory ws sync codec", () => {
+  it("roundtrips synchronously", () => {
+    assertEquals(
+      inflateWirePayloadSync(deflateWirePayloadSync(PAYLOAD)),
+      PAYLOAD,
+    );
+  });
+
+  it("interoperates with the async codec in both directions", async () => {
+    // Server compresses sync, client inflates async — and vice versa. Both
+    // speak identical raw-deflate bytes.
+    assertEquals(
+      await inflateWirePayload(deflateWirePayloadSync(PAYLOAD)),
+      PAYLOAD,
+    );
+    assertEquals(
+      inflateWirePayloadSync(await deflateWirePayload(PAYLOAD)),
+      PAYLOAD,
+    );
+  });
+
+  it("accepts typed-array views and pre-encoded bytes", () => {
+    const compressed = deflateWirePayloadSync(
+      new TextEncoder().encode(PAYLOAD),
+    );
+    const padded = new Uint8Array(compressed.byteLength + 8);
+    padded.set(compressed, 4);
+    const view = new Uint8Array(padded.buffer, 4, compressed.byteLength);
+    assertEquals(inflateWirePayloadSync(view), PAYLOAD);
+  });
+
+  it("enforces the inflate cap", () => {
+    const bomb = deflateWirePayloadSync("z".repeat(1024 * 1024));
+    assertThrows(() => inflateWirePayloadSync(bomb, 64 * 1024));
+  });
+
+  it("rejects malformed deflate data", () => {
+    assertThrows(() =>
+      inflateWirePayloadSync(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+    );
+  });
+});
+
+describe("auth-bearing wire message detection", () => {
+  it("classifies handshake and credential frames", () => {
+    assertEquals(isAuthBearingWireMessage({ type: "hello" }), true);
+    assertEquals(isAuthBearingWireMessage({ type: "hello.ok" }), true);
+    assertEquals(isAuthBearingWireMessage({ type: "session.open" }), true);
+    assertEquals(
+      isAuthBearingWireMessage({
+        type: "response",
+        requestId: "open-1",
+        ok: { sessionId: "s", sessionToken: "secret", serverSeq: 0 },
+      }),
+      true,
+    );
+    assertEquals(
+      isAuthBearingWireMessage({
+        type: "response",
+        requestId: "open-1",
+        ok: { sessionId: "s", sessionOpen: { audience: "did:key:z" } },
+      }),
+      true,
+    );
+  });
+
+  it("leaves ordinary traffic compressible", () => {
+    assertEquals(
+      isAuthBearingWireMessage({
+        type: "response",
+        requestId: "tx-1",
+        ok: { seq: 4 },
+      }),
+      false,
+    );
+    assertEquals(isAuthBearingWireMessage({ type: "session/effect" }), false);
+    assertEquals(isAuthBearingWireMessage("fvj1:{}"), false);
+    assertEquals(isAuthBearingWireMessage(null), false);
+  });
+});

--- a/packages/memory/test/v2-transport-deflate-sync-test.ts
+++ b/packages/memory/test/v2-transport-deflate-sync-test.ts
@@ -3,8 +3,8 @@ import { assertEquals, assertThrows } from "@std/assert";
 import {
   deflateWirePayload,
   inflateWirePayload,
-  isAuthBearingWireMessage,
 } from "../v2/transport-deflate.ts";
+import { isAuthBearingWireMessage } from "../v2.ts";
 import {
   deflateWirePayloadSync,
   inflateWirePayloadSync,
@@ -62,9 +62,12 @@ describe("memory ws sync codec", () => {
 
 describe("auth-bearing wire message detection", () => {
   it("classifies handshake and credential frames", () => {
-    assertEquals(isAuthBearingWireMessage({ type: "hello" }), true);
-    assertEquals(isAuthBearingWireMessage({ type: "hello.ok" }), true);
-    assertEquals(isAuthBearingWireMessage({ type: "session.open" }), true);
+    assertEquals(isAuthBearingWireMessage({ type: "hello" } as never), true);
+    assertEquals(isAuthBearingWireMessage({ type: "hello.ok" } as never), true);
+    assertEquals(
+      isAuthBearingWireMessage({ type: "session.open" } as never),
+      true,
+    );
     assertEquals(
       isAuthBearingWireMessage({
         type: "response",
@@ -92,8 +95,14 @@ describe("auth-bearing wire message detection", () => {
       }),
       false,
     );
-    assertEquals(isAuthBearingWireMessage({ type: "session/effect" }), false);
-    assertEquals(isAuthBearingWireMessage("fvj1:{}"), false);
-    assertEquals(isAuthBearingWireMessage(null), false);
+    assertEquals(
+      isAuthBearingWireMessage({ type: "session/effect" } as never),
+      false,
+    );
+    // Values outside the message unions fail CLOSED (never compressed):
+    // the classifier's default arm is unreachable for typed callers, and
+    // never-compressing is always safe for untyped embedders.
+    assertEquals(isAuthBearingWireMessage("fvj1:{}" as never), true);
+    assertEquals(isAuthBearingWireMessage(null as never), true);
   });
 });

--- a/packages/memory/test/v2-transport-deflate-test.ts
+++ b/packages/memory/test/v2-transport-deflate-test.ts
@@ -4,6 +4,9 @@ import {
   deflateWirePayload,
   inflateWirePayload,
   MEMORY_WS_DEFLATE_SUBPROTOCOL,
+  memoryWsDeflateEnabled,
+  memoryWsDeflateSupported,
+  resetMemoryWsDeflateSupport,
   selectMemoryWsDeflateProtocol,
   SerialTaskQueue,
 } from "../v2/transport-deflate.ts";
@@ -138,5 +141,37 @@ describe("memory ws deflate serial queue", () => {
     await assertRejects(() => failing, Error, "boom");
     assertEquals(await after, "ok");
     assertEquals(order, ["after"]);
+  });
+});
+
+describe("memory ws deflate environment probes", () => {
+  it("fails safe when env access throws in a Deno process", () => {
+    assertEquals(
+      memoryWsDeflateEnabled(() => {
+        throw new Error("env permission denied");
+      }),
+      // Deno global present: an unexpressable opt-out defaults to off.
+      false,
+    );
+    assertEquals(memoryWsDeflateEnabled(() => "0"), false);
+    assertEquals(memoryWsDeflateEnabled(() => "false"), false);
+    assertEquals(memoryWsDeflateEnabled(() => undefined), true);
+  });
+
+  it("caches a failed deflate-raw capability probe as unsupported", () => {
+    resetMemoryWsDeflateSupport();
+    try {
+      assertEquals(
+        memoryWsDeflateSupported(() => {
+          throw new Error("no deflate-raw");
+        }),
+        false,
+      );
+      // Cached: a later working probe is not consulted.
+      assertEquals(memoryWsDeflateSupported(() => {}), false);
+    } finally {
+      resetMemoryWsDeflateSupport();
+    }
+    assertEquals(memoryWsDeflateSupported(), true);
   });
 });

--- a/packages/memory/test/v2-transport-deflate-test.ts
+++ b/packages/memory/test/v2-transport-deflate-test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertRejects } from "@std/assert";
+import { encodeMemoryBoundary } from "../v2.ts";
 import {
   deflateWirePayload,
   inflateWirePayload,
@@ -13,16 +14,20 @@ import {
 
 describe("memory ws deflate codec", () => {
   it("roundtrips wire payloads through raw deflate", async () => {
+    // The deflate layer treats payload content as opaque text; real wire
+    // frames come from the codec, and the remaining cases are arbitrary
+    // text (unicode, empty) with no reason to imitate frame shape.
     const payloads = [
-      "fvj1:{}",
-      "fvj1:" + JSON.stringify({
+      encodeMemoryBoundary({ type: "hello", flags: {} }),
+      encodeMemoryBoundary({
         type: "sync",
         upserts: Array.from({ length: 64 }, (_, i) => ({
           id: `of:entity-${i}`,
           doc: { value: { n: i, text: "x".repeat(200) } },
         })),
       }),
-      "fvj1:" + JSON.stringify({ unicode: "snowman ☃ και ελληνικά 🎿" }),
+      "snowman ☃ και ελληνικά 🎿",
+      "",
     ];
     for (const payload of payloads) {
       const compressed = await deflateWirePayload(payload);
@@ -31,7 +36,7 @@ describe("memory ws deflate codec", () => {
   });
 
   it("compresses repetitive protocol payloads well", async () => {
-    const payload = "fvj1:" + JSON.stringify({
+    const payload = encodeMemoryBoundary({
       upserts: Array.from({ length: 100 }, (_, i) => ({
         id: "of:did:key:z6MkjJcyGFU2QkPjvzuWUHr59i112SkPBkXQo2TVdWLPUdKB",
         seq: i,
@@ -47,7 +52,7 @@ describe("memory ws deflate codec", () => {
   });
 
   it("accepts typed-array views over the compressed bytes", async () => {
-    const payload = "fvj1:" + JSON.stringify({ hello: "world".repeat(50) });
+    const payload = "compressible ".repeat(40);
     const compressed = await deflateWirePayload(payload);
     const padded = new Uint8Array(compressed.byteLength + 8);
     padded.set(compressed, 4);

--- a/packages/memory/test/v2-transport-deflate-test.ts
+++ b/packages/memory/test/v2-transport-deflate-test.ts
@@ -1,0 +1,142 @@
+import { describe, it } from "@std/testing/bdd";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  MEMORY_WS_DEFLATE_SUBPROTOCOL,
+  selectMemoryWsDeflateProtocol,
+  SerialTaskQueue,
+} from "../v2/transport-deflate.ts";
+
+describe("memory ws deflate codec", () => {
+  it("roundtrips wire payloads through raw deflate", async () => {
+    const payloads = [
+      "fvj1:{}",
+      "fvj1:" + JSON.stringify({
+        type: "sync",
+        upserts: Array.from({ length: 64 }, (_, i) => ({
+          id: `of:entity-${i}`,
+          doc: { value: { n: i, text: "x".repeat(200) } },
+        })),
+      }),
+      "fvj1:" + JSON.stringify({ unicode: "snowman ☃ και ελληνικά 🎿" }),
+    ];
+    for (const payload of payloads) {
+      const compressed = await deflateWirePayload(payload);
+      assertEquals(await inflateWirePayload(compressed), payload);
+    }
+  });
+
+  it("compresses repetitive protocol payloads well", async () => {
+    const payload = "fvj1:" + JSON.stringify({
+      upserts: Array.from({ length: 100 }, (_, i) => ({
+        id: "of:did:key:z6MkjJcyGFU2QkPjvzuWUHr59i112SkPBkXQo2TVdWLPUdKB",
+        seq: i,
+        doc: { value: { schema: { type: "object" } } },
+      })),
+    });
+    const originalBytes = new TextEncoder().encode(payload).byteLength;
+    const compressed = await deflateWirePayload(payload);
+    assert(
+      compressed.byteLength < originalBytes / 4,
+      `expected >4x compression, got ${originalBytes} -> ${compressed.byteLength}`,
+    );
+  });
+
+  it("accepts typed-array views over the compressed bytes", async () => {
+    const payload = "fvj1:" + JSON.stringify({ hello: "world".repeat(50) });
+    const compressed = await deflateWirePayload(payload);
+    const padded = new Uint8Array(compressed.byteLength + 8);
+    padded.set(compressed, 4);
+    const view = new Uint8Array(padded.buffer, 4, compressed.byteLength);
+    assertEquals(await inflateWirePayload(view), payload);
+  });
+
+  it("rejects malformed deflate data", async () => {
+    await assertRejects(() =>
+      inflateWirePayload(new Uint8Array([1, 2, 3, 4, 5]))
+    );
+  });
+
+  it("rejects payloads that inflate past the cap", async () => {
+    const bomb = await deflateWirePayload("z".repeat(1024 * 1024));
+    await assertRejects(
+      () => inflateWirePayload(bomb, 64 * 1024),
+      Error,
+      "inflates past",
+    );
+  });
+
+  it("rejects compressed frames that decode to invalid UTF-8", async () => {
+    // Compress raw bytes that are not valid UTF-8 (lone continuation bytes).
+    const invalid = new Uint8Array(1024).fill(0x80);
+    const stream = new Blob([invalid]).stream()
+      .pipeThrough(new CompressionStream("deflate-raw"));
+    const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+    await assertRejects(() => inflateWirePayload(compressed));
+  });
+});
+
+describe("memory ws deflate subprotocol selection", () => {
+  it("selects the subprotocol whenever it is offered", () => {
+    assertEquals(
+      selectMemoryWsDeflateProtocol(MEMORY_WS_DEFLATE_SUBPROTOCOL),
+      MEMORY_WS_DEFLATE_SUBPROTOCOL,
+    );
+    assertEquals(
+      selectMemoryWsDeflateProtocol(
+        `other.protocol, ${MEMORY_WS_DEFLATE_SUBPROTOCOL}`,
+      ),
+      MEMORY_WS_DEFLATE_SUBPROTOCOL,
+    );
+    assertEquals(selectMemoryWsDeflateProtocol(null), undefined);
+    assertEquals(selectMemoryWsDeflateProtocol(undefined), undefined);
+    assertEquals(selectMemoryWsDeflateProtocol("other.protocol"), undefined);
+  });
+
+  it("does not match substrings of other offered protocols", () => {
+    assertEquals(
+      selectMemoryWsDeflateProtocol(
+        `${MEMORY_WS_DEFLATE_SUBPROTOCOL}-extended`,
+      ),
+      undefined,
+    );
+  });
+});
+
+describe("memory ws deflate serial queue", () => {
+  it("runs tasks in enqueue order despite varying latency", async () => {
+    const queue = new SerialTaskQueue();
+    const order: number[] = [];
+    const tasks = [
+      queue.enqueue(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        order.push(1);
+      }),
+      queue.enqueue(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        order.push(2);
+      }),
+      queue.enqueue(() => {
+        order.push(3);
+      }),
+    ];
+    await Promise.all(tasks);
+    assertEquals(order, [1, 2, 3]);
+  });
+
+  it("propagates a task failure to its caller without poisoning the chain", async () => {
+    const queue = new SerialTaskQueue();
+    const order: string[] = [];
+    const failing = queue.enqueue(() => {
+      throw new Error("boom");
+    });
+    const after = queue.enqueue(() => {
+      order.push("after");
+      return "ok";
+    });
+    await assertRejects(() => failing, Error, "boom");
+    assertEquals(await after, "ok");
+    assertEquals(order, ["after"]);
+  });
+});

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -667,6 +667,54 @@ export type ServerMessage =
   | SessionEffectMessage
   | SessionRevokedMessage;
 
+const SESSION_TOKEN_KEY = "sessionToken" satisfies keyof SessionOpenResult;
+const SESSION_OPEN_KEY = "sessionOpen" satisfies keyof SessionOpenResult;
+
+/**
+ * Whether a wire message carries authentication material and must therefore
+ * never be COMPRESSED by a sender (the deflate transport's auth exemption —
+ * receivers accept any framing; this is sender policy). Lives beside the
+ * message unions so the exhaustive switch makes every new wire message type
+ * a compile error until classified, and the `satisfies keyof` tethers make
+ * a credential-field rename a compile error. The runtime default fails
+ * closed: never-compressing is always safe, since text frames stay valid on
+ * a negotiated connection.
+ */
+export const isAuthBearingWireMessage = (
+  message: ClientMessage | ServerMessage,
+): boolean => {
+  if (typeof message !== "object" || message === null) {
+    // Unreachable for typed callers; untyped embedders fail closed.
+    return true;
+  }
+  switch (message.type) {
+    case "hello":
+    case "hello.ok":
+    case "session.open":
+      return true;
+    case "response": {
+      const ok: unknown = message.ok;
+      return typeof ok === "object" && ok !== null &&
+        (SESSION_TOKEN_KEY in ok || SESSION_OPEN_KEY in ok);
+    }
+    case "transact":
+    case "graph.query":
+    case "sqlite.query":
+    case "sqlite.register-disk-source":
+    case "session.watch.set":
+    case "session.watch.add":
+    case "scheduler.snapshot.list":
+    case "session.ack":
+    case "session/effect":
+    case "session/revoked":
+      return false;
+    default: {
+      message satisfies never;
+      return true;
+    }
+  }
+};
+
 const memoryReconstructionContext = new EmptyReconstructionContext(
   true,
   "no cell reconstruction at the memory boundary",

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -33,8 +33,17 @@ import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 
+/** Per-send transport hints. Optional for implementations: a transport that
+ * ignores them (every scripted test transport) remains correct, just less
+ * conservative about what it compresses. */
+export interface TransportSendHints {
+  /** Never compress this payload — set for auth-bearing frames so credential
+   * material stays out of compression-size side channels (CRIME-class). */
+  noCompress?: boolean;
+}
+
 export interface Transport {
-  send(payload: string): Promise<void>;
+  send(payload: string, hints?: TransportSendHints): Promise<void>;
   close(): Promise<void>;
   setReceiver(receiver: (payload: string) => void): void;
   setCloseReceiver?(receiver: (error?: Error) => void): void;
@@ -175,7 +184,20 @@ export class Client {
     const requestId = message.requestId as string;
     const pending = Promise.withResolvers<unknown>();
     this.#pending.set(requestId, pending);
-    await this.transport.send(encodeMemoryBoundary(message));
+    try {
+      // session.open carries the signed invocation and challenge response:
+      // auth-bearing frames are never compressed.
+      await this.transport.send(
+        encodeMemoryBoundary(message),
+        message.type === "session.open" ? { noCompress: true } : undefined,
+      );
+    } catch (error) {
+      // The request never reached the wire: withdraw the pending entry so a
+      // later connection-close rejection cannot fire on a promise nobody
+      // observes (an unhandled rejection is fatal in Deno processes).
+      this.#pending.delete(requestId);
+      throw error;
+    }
     const result = await pending.promise as ResponseMessage<Result>;
     if (result.error) {
       const error = new Error(result.error.message);
@@ -235,14 +257,24 @@ export class Client {
   private async hello(): Promise<void> {
     const ack = Promise.withResolvers<void>();
     this.#helloPending = ack;
-    await this.transport.send(encodeMemoryBoundary({
-      type: "hello",
-      protocol: MEMORY_PROTOCOL,
-      flags: getMemoryProtocolFlags(),
-    }));
     try {
+      await this.transport.send(
+        encodeMemoryBoundary({
+          type: "hello",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+        }),
+        // The handshake frame stays uncompressed alongside the other
+        // auth-bearing frames.
+        { noCompress: true },
+      );
       await ack.promise;
       this.#connected = true;
+    } catch (error) {
+      // If the send failed, a concurrent close may still reject the pending
+      // ack; observe it so the rejection cannot become unhandled.
+      ack.promise.catch(() => {});
+      throw error;
     } finally {
       this.#helloPending = null;
     }
@@ -859,11 +891,21 @@ export class SpaceSession {
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
         this.#ackScheduled = false;
         this.#ackFlushing = true;
+        let reschedule = true;
         try {
           await this.flushScheduledAcks();
+        } catch (error) {
+          if (!isConnectionError(error) && !isSessionRevokedError(error)) {
+            throw error;
+          }
+          // The connection is turning over: session restore re-acks after
+          // reconnect, so retrying now would only spin against the closed
+          // transport while isConnected() is still stale.
+          reschedule = false;
         } finally {
           this.#ackFlushing = false;
           if (
+            reschedule &&
             this.#pendingAckSeq > this.#ackedSeq &&
             !this.#closed &&
             this.client.isConnected()

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -1,5 +1,6 @@
 import {
   type ClientCommit,
+  type ClientMessage,
   compatibleMemoryProtocolFlags,
   decodeMemoryBoundary,
   encodeMemoryBoundary,
@@ -8,6 +9,7 @@ import {
   getPersistentSchedulerStateConfig,
   type GraphQuery,
   type GraphQueryResult,
+  isAuthBearingWireMessage,
   MEMORY_PROTOCOL,
   type MemoryProtocolFlags,
   parseMemoryProtocolFlags,
@@ -185,11 +187,13 @@ export class Client {
     const pending = Promise.withResolvers<unknown>();
     this.#pending.set(requestId, pending);
     try {
-      // session.open carries the signed invocation and challenge response:
-      // auth-bearing frames are never compressed.
+      // Auth-bearing frames (per the shared classifier beside the message
+      // unions) are never compressed.
       await this.transport.send(
         encodeMemoryBoundary(message),
-        message.type === "session.open" ? { noCompress: true } : undefined,
+        isAuthBearingWireMessage(message as unknown as ClientMessage)
+          ? { noCompress: true }
+          : undefined,
       );
     } catch (error) {
       // The request never reached the wire: withdraw the pending entry so a

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -15,7 +15,17 @@
 import { encodeMemoryBoundary } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
 import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  memoryWsDeflateEnabled,
+  selectMemoryWsDeflateProtocol,
+  SerialTaskQueue,
+} from "./transport-deflate.ts";
 import { Identity } from "@commonfabric/identity";
+
+const standaloneTextEncoder = new TextEncoder();
 
 const standaloneMemoryAudience = (await Identity.fromPassphrase(
   "common tools standalone memory audience",
@@ -68,32 +78,100 @@ export class StandaloneMemoryServer {
       if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
         return new Response("memory websocket endpoint", { status: 200 });
       }
-      const { socket, response } = Deno.upgradeWebSocket(request);
+      // SPIKE: mirror toolshed's deflate subprotocol so in-repo clients that
+      // offer it keep working against the standalone harness server. The
+      // offer is always selected (refusal fails the connection per RFC 6455);
+      // the env switch only gates this server's outbound compression.
+      const deflateProtocol = selectMemoryWsDeflateProtocol(
+        request.headers.get("sec-websocket-protocol"),
+      );
+      const { socket, response } = Deno.upgradeWebSocket(
+        request,
+        deflateProtocol !== undefined ? { protocol: deflateProtocol } : {},
+      );
+      socket.binaryType = "arraybuffer";
       const connectionTag = nextConnectionTag++;
+      const sendQueue =
+        deflateProtocol !== undefined && memoryWsDeflateEnabled()
+          ? new SerialTaskQueue()
+          : null;
       const connection = memory.connect((message) => {
-        if (socket.readyState === WebSocket.OPEN) {
-          socket.send(encodeMemoryBoundary(message));
-        }
-      });
-      const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
-      socket.addEventListener("message", (event) => {
-        if (typeof event.data !== "string") {
-          socket.close(1003, "memory websocket expects text frames");
-          connection.close();
+        const payload = encodeMemoryBoundary(message);
+        if (sendQueue === null) {
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.send(payload);
+          }
           return;
         }
+        void sendQueue.enqueue(async () => {
+          if (
+            standaloneTextEncoder.encode(payload).byteLength <
+              MEMORY_WS_DEFLATE_MIN_BYTES
+          ) {
+            if (socket.readyState === WebSocket.OPEN) socket.send(payload);
+            return;
+          }
+          const compressed = await deflateWirePayload(payload);
+          if (socket.readyState === WebSocket.OPEN) socket.send(compressed);
+        }).catch(() => {
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.close(1011, "memory websocket send failure");
+          }
+          connection.close();
+        });
+      });
+      const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
+      const receiveQueue = deflateProtocol !== undefined
+        ? new SerialTaskQueue()
+        : null;
+      const handleText = (text: string) => {
         if (debugWrites) {
-          logCommitOperations(connectionTag, event.data);
+          logCommitOperations(connectionTag, text);
         }
-        connection.receive(event.data).catch(() => {
+        connection.receive(text).catch(() => {
           if (socket.readyState === WebSocket.OPEN) {
             socket.close(1011, "memory websocket receive failure");
           }
           connection.close();
         });
+      };
+      socket.addEventListener("message", (event) => {
+        const data: unknown = event.data;
+        if (typeof data === "string") {
+          if (receiveQueue === null) {
+            handleText(data);
+            return;
+          }
+          void receiveQueue.enqueue(() => handleText(data)).catch(() => {});
+          return;
+        }
+        if (
+          receiveQueue !== null &&
+          (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
+        ) {
+          void receiveQueue.enqueue(async () => {
+            handleText(await inflateWirePayload(data));
+          }).catch(() => {
+            if (socket.readyState === WebSocket.OPEN) {
+              socket.close(1007, "memory websocket inflate failure");
+            }
+            connection.close();
+          });
+          return;
+        }
+        socket.close(1003, "memory websocket expects text frames");
+        connection.close();
       });
-      socket.addEventListener("close", () => connection.close());
-      socket.addEventListener("error", () => connection.close());
+      const closeAfterPendingFrames = () => {
+        if (receiveQueue === null) {
+          connection.close();
+          return;
+        }
+        // Frames that arrived before the close still deliver first.
+        void receiveQueue.enqueue(() => connection.close());
+      };
+      socket.addEventListener("close", closeAfterPendingFrames);
+      socket.addEventListener("error", closeAfterPendingFrames);
       return response;
     });
     return new StandaloneMemoryServer(memory, http);

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -81,7 +81,7 @@ export class StandaloneMemoryServer {
       if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
         return new Response("memory websocket endpoint", { status: 200 });
       }
-      // SPIKE: mirror toolshed's deflate subprotocol so in-repo clients that
+      // mirror toolshed's deflate subprotocol so in-repo clients that
       // offer it keep working against the standalone harness server. The
       // offer is always selected (refusal fails the connection per RFC 6455);
       // the env switch only gates this server's outbound compression.

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -168,7 +168,7 @@ export class StandaloneMemoryServer {
           return;
         }
         // Frames that arrived before the close still deliver first.
-        void receiveQueue.enqueue(() => connection.close());
+        void receiveQueue.enqueue(() => connection.close()).catch(() => {});
       };
       socket.addEventListener("close", closeAfterPendingFrames);
       socket.addEventListener("error", closeAfterPendingFrames);

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -120,15 +120,25 @@ export class StandaloneMemoryServer {
         }
       });
       const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
+      // Closing drops chained-but-unstarted receives; frames already handed
+      // to receive() must settle before the connection closes.
+      let lastReceive: Promise<unknown> = Promise.resolve();
+      const closeConnection = () => {
+        void lastReceive.catch(() => undefined).finally(() =>
+          connection.close()
+        );
+      };
       const handleText = (text: string) => {
         if (debugWrites) {
           logCommitOperations(connectionTag, text);
         }
-        connection.receive(text).catch(() => {
+        const received = connection.receive(text);
+        lastReceive = received;
+        received.catch(() => {
           if (socket.readyState === WebSocket.OPEN) {
             socket.close(1011, "memory websocket receive failure");
           }
-          connection.close();
+          closeConnection();
         });
       };
       socket.addEventListener("message", (event) => {
@@ -149,17 +159,17 @@ export class StandaloneMemoryServer {
             );
           } catch {
             socket.close(1007, "memory websocket inflate failure");
-            connection.close();
+            closeConnection();
             return;
           }
           handleText(text);
           return;
         }
         socket.close(1003, "memory websocket expects text frames");
-        connection.close();
+        closeConnection();
       });
-      socket.addEventListener("close", () => connection.close());
-      socket.addEventListener("error", () => connection.close());
+      socket.addEventListener("close", () => closeConnection());
+      socket.addEventListener("error", () => closeConnection());
       return response;
     });
     return new StandaloneMemoryServer(memory, http);

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -12,23 +12,18 @@
  * bundles.
  */
 
-import { encodeMemoryBoundary } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
 import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
 import {
-  isAuthBearingWireMessage,
-  MEMORY_WS_DEFLATE_MIN_BYTES,
   MEMORY_WS_SERVER_INFLATE_MAX_BYTES,
   memoryWsDeflateEnabled,
   selectMemoryWsDeflateProtocol,
 } from "./transport-deflate.ts";
 import {
-  deflateWirePayloadSync,
+  encodeMemoryWireFrameSync,
   inflateWirePayloadSync,
 } from "./transport-deflate-sync.ts";
 import { Identity } from "@commonfabric/identity";
-
-const standaloneTextEncoder = new TextEncoder();
 
 const standaloneMemoryAudience = (await Identity.fromPassphrase(
   "common tools standalone memory audience",
@@ -100,20 +95,10 @@ export class StandaloneMemoryServer {
         if (socket.readyState !== WebSocket.OPEN) {
           return;
         }
-        const payload = encodeMemoryBoundary(message);
-        // Auth-bearing frames stay uncompressed (see toolshed's
-        // memory.handlers.ts for the side-channel rationale).
-        if (
-          !deflateOutbound ||
-          isAuthBearingWireMessage(message) ||
-          standaloneTextEncoder.encode(payload).byteLength <
-            MEMORY_WS_DEFLATE_MIN_BYTES
-        ) {
-          socket.send(payload);
-          return;
-        }
+        // Shared sender policy (auth exemption, threshold) lives in
+        // encodeMemoryWireFrameSync; teardown stays per-site.
         try {
-          socket.send(deflateWirePayloadSync(payload));
+          socket.send(encodeMemoryWireFrameSync(message, deflateOutbound));
         } catch {
           socket.close(1011, "memory websocket send failure");
           connection.close();

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -16,13 +16,16 @@ import { encodeMemoryBoundary } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
 import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
 import {
-  deflateWirePayload,
-  inflateWirePayload,
+  isAuthBearingWireMessage,
   MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_SERVER_INFLATE_MAX_BYTES,
   memoryWsDeflateEnabled,
   selectMemoryWsDeflateProtocol,
-  SerialTaskQueue,
 } from "./transport-deflate.ts";
+import {
+  deflateWirePayloadSync,
+  inflateWirePayloadSync,
+} from "./transport-deflate-sync.ts";
 import { Identity } from "@commonfabric/identity";
 
 const standaloneTextEncoder = new TextEncoder();
@@ -91,39 +94,32 @@ export class StandaloneMemoryServer {
       );
       socket.binaryType = "arraybuffer";
       const connectionTag = nextConnectionTag++;
-      const sendQueue =
-        deflateProtocol !== undefined && memoryWsDeflateEnabled()
-          ? new SerialTaskQueue()
-          : null;
+      const deflateOutbound = deflateProtocol !== undefined &&
+        memoryWsDeflateEnabled();
       const connection = memory.connect((message) => {
-        const payload = encodeMemoryBoundary(message);
-        if (sendQueue === null) {
-          if (socket.readyState === WebSocket.OPEN) {
-            socket.send(payload);
-          }
+        if (socket.readyState !== WebSocket.OPEN) {
           return;
         }
-        void sendQueue.enqueue(async () => {
-          if (
-            standaloneTextEncoder.encode(payload).byteLength <
-              MEMORY_WS_DEFLATE_MIN_BYTES
-          ) {
-            if (socket.readyState === WebSocket.OPEN) socket.send(payload);
-            return;
-          }
-          const compressed = await deflateWirePayload(payload);
-          if (socket.readyState === WebSocket.OPEN) socket.send(compressed);
-        }).catch(() => {
-          if (socket.readyState === WebSocket.OPEN) {
-            socket.close(1011, "memory websocket send failure");
-          }
+        const payload = encodeMemoryBoundary(message);
+        // Auth-bearing frames stay uncompressed (see toolshed's
+        // memory.handlers.ts for the side-channel rationale).
+        if (
+          !deflateOutbound ||
+          isAuthBearingWireMessage(message) ||
+          standaloneTextEncoder.encode(payload).byteLength <
+            MEMORY_WS_DEFLATE_MIN_BYTES
+        ) {
+          socket.send(payload);
+          return;
+        }
+        try {
+          socket.send(deflateWirePayloadSync(payload));
+        } catch {
+          socket.close(1011, "memory websocket send failure");
           connection.close();
-        });
+        }
       });
       const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
-      const receiveQueue = deflateProtocol !== undefined
-        ? new SerialTaskQueue()
-        : null;
       const handleText = (text: string) => {
         if (debugWrites) {
           logCommitOperations(connectionTag, text);
@@ -138,40 +134,32 @@ export class StandaloneMemoryServer {
       socket.addEventListener("message", (event) => {
         const data: unknown = event.data;
         if (typeof data === "string") {
-          if (receiveQueue === null) {
-            handleText(data);
-            return;
-          }
-          void receiveQueue.enqueue(() => handleText(data)).catch(() => {});
+          handleText(data);
           return;
         }
         if (
-          receiveQueue !== null &&
+          deflateProtocol !== undefined &&
           (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
         ) {
-          void receiveQueue.enqueue(async () => {
-            handleText(await inflateWirePayload(data));
-          }).catch(() => {
-            if (socket.readyState === WebSocket.OPEN) {
-              socket.close(1007, "memory websocket inflate failure");
-            }
+          let text: string;
+          try {
+            text = inflateWirePayloadSync(
+              data,
+              MEMORY_WS_SERVER_INFLATE_MAX_BYTES,
+            );
+          } catch {
+            socket.close(1007, "memory websocket inflate failure");
             connection.close();
-          });
+            return;
+          }
+          handleText(text);
           return;
         }
         socket.close(1003, "memory websocket expects text frames");
         connection.close();
       });
-      const closeAfterPendingFrames = () => {
-        if (receiveQueue === null) {
-          connection.close();
-          return;
-        }
-        // Frames that arrived before the close still deliver first.
-        void receiveQueue.enqueue(() => connection.close()).catch(() => {});
-      };
-      socket.addEventListener("close", closeAfterPendingFrames);
-      socket.addEventListener("error", closeAfterPendingFrames);
+      socket.addEventListener("close", () => connection.close());
+      socket.addEventListener("error", () => connection.close());
       return response;
     });
     return new StandaloneMemoryServer(memory, http);

--- a/packages/memory/v2/transport-deflate-sync.ts
+++ b/packages/memory/v2/transport-deflate-sync.ts
@@ -1,5 +1,5 @@
 /**
- * Synchronous server-side codec for the `fvj1.deflate` memory websocket
+ * Synchronous server-side codec for the `cf-memory.deflate.v1` memory websocket
  * transport (see transport-deflate.ts for the negotiation contract).
  *
  * Servers use the synchronous zlib codec instead of the streaming one for a
@@ -14,7 +14,15 @@
  */
 
 import { deflateRawSync, inflateRawSync } from "builtin-zlib";
-import { MEMORY_WS_INFLATE_MAX_BYTES } from "./transport-deflate.ts";
+import {
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_INFLATE_MAX_BYTES,
+} from "./transport-deflate.ts";
+import {
+  encodeMemoryBoundary,
+  isAuthBearingWireMessage,
+  type ServerMessage,
+} from "../v2.ts";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder("utf-8", { fatal: true });
@@ -50,4 +58,49 @@ export const inflateWirePayloadSync = (
     : new Uint8Array(data);
   const inflated = inflateRawSync(bytes, { maxOutputLength: maxBytes });
   return textDecoder.decode(inflated);
+};
+
+/** Per-frame accounting hook for {@link encodeMemoryWireFrameSync}. */
+export type OutboundFrameHook = (
+  wireBytes: number,
+  logicalBytes: number,
+  compressed: boolean,
+  cpuMs?: number,
+) => void;
+
+/**
+ * Encodes one outbound server frame, owning the shared sender policy: text
+ * when compression is off for this connection, for auth-bearing messages
+ * (see `isAuthBearingWireMessage` in ../v2.ts), or below the size
+ * threshold; compressed otherwise. Both memory websocket servers (toolshed
+ * and the standalone harness) route sends through this single decision
+ * tree; error handling and socket teardown stay per-site.
+ */
+export const encodeMemoryWireFrameSync = (
+  message: ServerMessage,
+  deflateOutbound: boolean,
+  onFrame?: OutboundFrameHook,
+): string | Uint8Array<ArrayBuffer> => {
+  const payload = encodeMemoryBoundary(message);
+  if (!deflateOutbound || isAuthBearingWireMessage(message)) {
+    if (onFrame !== undefined) {
+      const bytes = textEncoder.encode(payload).byteLength;
+      onFrame(bytes, bytes, false);
+    }
+    return payload;
+  }
+  const payloadBytes = textEncoder.encode(payload);
+  if (payloadBytes.byteLength < MEMORY_WS_DEFLATE_MIN_BYTES) {
+    onFrame?.(payloadBytes.byteLength, payloadBytes.byteLength, false);
+    return payload;
+  }
+  const started = performance.now();
+  const compressed = deflateWirePayloadSync(payloadBytes);
+  onFrame?.(
+    compressed.byteLength,
+    payloadBytes.byteLength,
+    true,
+    performance.now() - started,
+  );
+  return compressed;
 };

--- a/packages/memory/v2/transport-deflate-sync.ts
+++ b/packages/memory/v2/transport-deflate-sync.ts
@@ -1,0 +1,54 @@
+/**
+ * Synchronous server-side codec for the `fvj1.deflate` memory websocket
+ * transport (see transport-deflate.ts for the negotiation contract).
+ *
+ * Servers use the synchronous zlib codec instead of the streaming one for a
+ * structural reason beyond speed: a synchronous codec keeps websocket
+ * dispatch synchronous inside the message event handler, so frame ordering,
+ * pre-close delivery, and nothing-after-close remain properties of the event
+ * loop itself rather than of hand-maintained queues. Browsers have no
+ * synchronous codec, so the client side keeps the async machinery; both
+ * codecs speak identical raw-deflate (RFC 1951) bytes.
+ *
+ * Deno/Node only — this module must never be imported into browser bundles.
+ */
+
+import { deflateRawSync, inflateRawSync } from "node:zlib";
+import { Buffer } from "node:buffer";
+import { MEMORY_WS_INFLATE_MAX_BYTES } from "./transport-deflate.ts";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+/** Raw-deflate compression of a wire payload's UTF-8 bytes, synchronously.
+ *  Accepts pre-encoded bytes so hot paths that already measured the payload
+ *  do not encode twice. */
+export const deflateWirePayloadSync = (
+  payload: string | Uint8Array,
+): Uint8Array<ArrayBuffer> => {
+  const compressed = deflateRawSync(
+    typeof payload === "string" ? textEncoder.encode(payload) : payload,
+  );
+  return new Uint8Array(
+    compressed.buffer,
+    compressed.byteOffset,
+    compressed.byteLength,
+  ) as Uint8Array<ArrayBuffer>;
+};
+
+/**
+ * Inflates a binary frame back into a wire payload string, synchronously.
+ * `maxBytes` bounds the inflated size (zlib aborts past it — zip-bomb
+ * guard). Throws on malformed deflate data, invalid UTF-8, or an over-limit
+ * payload.
+ */
+export const inflateWirePayloadSync = (
+  data: ArrayBuffer | ArrayBufferView,
+  maxBytes: number = MEMORY_WS_INFLATE_MAX_BYTES,
+): string => {
+  const bytes = ArrayBuffer.isView(data)
+    ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+    : Buffer.from(data);
+  const inflated = inflateRawSync(bytes, { maxOutputLength: maxBytes });
+  return textDecoder.decode(inflated);
+};

--- a/packages/memory/v2/transport-deflate-sync.ts
+++ b/packages/memory/v2/transport-deflate-sync.ts
@@ -13,8 +13,7 @@
  * Deno/Node only — this module must never be imported into browser bundles.
  */
 
-import { deflateRawSync, inflateRawSync } from "node:zlib";
-import { Buffer } from "node:buffer";
+import { deflateRawSync, inflateRawSync } from "builtin-zlib";
 import { MEMORY_WS_INFLATE_MAX_BYTES } from "./transport-deflate.ts";
 
 const textEncoder = new TextEncoder();
@@ -47,8 +46,8 @@ export const inflateWirePayloadSync = (
   maxBytes: number = MEMORY_WS_INFLATE_MAX_BYTES,
 ): string => {
   const bytes = ArrayBuffer.isView(data)
-    ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
-    : Buffer.from(data);
+    ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    : new Uint8Array(data);
   const inflated = inflateRawSync(bytes, { maxOutputLength: maxBytes });
   return textDecoder.decode(inflated);
 };

--- a/packages/memory/v2/transport-deflate.ts
+++ b/packages/memory/v2/transport-deflate.ts
@@ -56,11 +56,16 @@ export const MEMORY_WS_INFLATE_MAX_BYTES = 64 * 1024 * 1024;
  * whole connection per RFC 6455 §4.1, and browsers cannot read env — so the
  * kill switch only stops this process from spending compression CPU.
  */
-export const memoryWsDeflateEnabled = (): boolean => {
+const defaultEnvReader = (): string | undefined =>
+  (globalThis as { Deno?: typeof Deno }).Deno?.env?.get(
+    "CF_MEMORY_WS_DEFLATE",
+  );
+
+export const memoryWsDeflateEnabled = (
+  readEnv: () => string | undefined = defaultEnvReader,
+): boolean => {
   try {
-    const value = (globalThis as { Deno?: typeof Deno }).Deno?.env?.get(
-      "CF_MEMORY_WS_DEFLATE",
-    );
+    const value = readEnv();
     return value !== "0" && value !== "false";
   } catch {
     // Browsers (no Deno global) default on; a Deno process whose env is
@@ -71,16 +76,27 @@ export const memoryWsDeflateEnabled = (): boolean => {
 
 let deflateRawSupport: boolean | null = null;
 
+const defaultDeflateRawProbe = (): void => {
+  new CompressionStream("deflate-raw");
+  new DecompressionStream("deflate-raw");
+};
+
+/** Test seam: forget the cached probe result. */
+export const resetMemoryWsDeflateSupport = (): void => {
+  deflateRawSupport = null;
+};
+
 /**
  * Whether this runtime can construct `deflate-raw` compression streams.
  * Clients must not offer the subprotocol without this: an offer is a
  * commitment to inflate whatever the server compresses.
  */
-export const memoryWsDeflateSupported = (): boolean => {
+export const memoryWsDeflateSupported = (
+  probe: () => void = defaultDeflateRawProbe,
+): boolean => {
   if (deflateRawSupport !== null) return deflateRawSupport;
   try {
-    new CompressionStream("deflate-raw");
-    new DecompressionStream("deflate-raw");
+    probe();
     deflateRawSupport = true;
   } catch {
     deflateRawSupport = false;

--- a/packages/memory/v2/transport-deflate.ts
+++ b/packages/memory/v2/transport-deflate.ts
@@ -1,7 +1,7 @@
 /**
  * transport-level per-message compression for the memory v2 websocket.
  *
- * Negotiated via the websocket subprotocol `fvj1.deflate`: the client offers
+ * Negotiated via the websocket subprotocol `cf-memory.deflate.v1`: the client offers
  * it in the upgrade request, and the server always selects an offer. Once
  * negotiated, either peer MAY send any memory wire payload as a binary frame
  * containing the raw-deflate (RFC 1951) compression of the payload's UTF-8
@@ -32,7 +32,7 @@
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder("utf-8", { fatal: true });
 
-export const MEMORY_WS_DEFLATE_SUBPROTOCOL = "fvj1.deflate";
+export const MEMORY_WS_DEFLATE_SUBPROTOCOL = "cf-memory.deflate.v1";
 
 /**
  * Payloads whose UTF-8 encoding is below this size are sent as plain text
@@ -121,29 +121,6 @@ export const MEMORY_WS_MAX_PENDING_INFLATE_BYTES = 16 * 1024 * 1024;
  * frames may be larger, so clients keep the wider cap above.
  */
 export const MEMORY_WS_SERVER_INFLATE_MAX_BYTES = 8 * 1024 * 1024;
-
-/**
- * Whether a wire message carries authentication material and must therefore
- * never be compressed by the sender (see the module doc): `hello`,
- * `hello.ok`, `session.open`, and any response whose body carries the
- * session bearer token or the next session-open challenge (the session.open
- * response). Structural, so both servers and any host embedding the codec
- * apply the same policy.
- */
-export const isAuthBearingWireMessage = (message: unknown): boolean => {
-  if (typeof message !== "object" || message === null) return false;
-  const record = message as Record<string, unknown>;
-  if (
-    record.type === "hello" || record.type === "hello.ok" ||
-    record.type === "session.open"
-  ) {
-    return true;
-  }
-  if (record.type !== "response") return false;
-  const ok = record.ok;
-  return typeof ok === "object" && ok !== null &&
-    ("sessionToken" in ok || "sessionOpen" in ok);
-};
 
 /**
  * Picks the deflate subprotocol out of a `Sec-WebSocket-Protocol` offer

--- a/packages/memory/v2/transport-deflate.ts
+++ b/packages/memory/v2/transport-deflate.ts
@@ -1,0 +1,177 @@
+/**
+ * SPIKE: transport-level per-message compression for the memory v2 websocket.
+ *
+ * Negotiated via the websocket subprotocol `fvj1.deflate`: the client offers
+ * it in the upgrade request, and the server always selects an offer. Once
+ * negotiated, either peer MAY send any memory wire payload as a binary frame
+ * containing the raw-deflate (RFC 1951) compression of the payload's UTF-8
+ * bytes. Text frames remain valid after negotiation and are processed
+ * unchanged, so senders skip compression for small payloads. Peers that do
+ * not negotiate the subprotocol keep the historical text-only framing byte
+ * for byte, and the memory protocol itself (hello/flags, message shapes) is
+ * untouched — this layer sits strictly below `encodeMemoryBoundary`.
+ *
+ * Compression is stateless per message (no shared sliding window), so
+ * reconnects and replays need no transport state. The one obligation this
+ * layer adds is ordering: websocket delivery is ordered, but inflate/deflate
+ * are async, so each direction of each connection must funnel through a
+ * `SerialTaskQueue` to keep dispatch order identical to arrival order.
+ *
+ * Rollout caveat (per RFC 6455 §4.1): a client that offers a subprotocol
+ * MUST fail the connection when the server selects none, so servers must
+ * support (or at least select) the subprotocol before clients start offering
+ * it. Deno clients can disable the offer with `CF_MEMORY_WS_DEFLATE=0`.
+ */
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+export const MEMORY_WS_DEFLATE_SUBPROTOCOL = "fvj1.deflate";
+
+/**
+ * Payloads whose UTF-8 encoding is below this size are sent as plain text
+ * frames even on a negotiated connection: raw deflate saves little below a
+ * couple hundred bytes and every frame pays the async hop.
+ */
+export const MEMORY_WS_DEFLATE_MIN_BYTES = 192;
+
+/**
+ * Hard cap on a single inflated payload. Nothing legitimate approaches this
+ * today (large sync frames are a few MB); the cap exists so a hostile peer
+ * cannot expand a tiny binary frame into unbounded memory (zip bomb).
+ */
+export const MEMORY_WS_INFLATE_MAX_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Whether this process should OFFER the subprotocol (clients) and COMPRESS
+ * its outbound payloads (either peer). Deliberately NOT consulted for
+ * selection or inbound decompression: a server must select the subprotocol
+ * whenever it is offered — a client that offers and is refused fails the
+ * whole connection per RFC 6455 §4.1, and browsers cannot read env — so the
+ * kill switch only stops this process from spending compression CPU.
+ */
+export const memoryWsDeflateEnabled = (): boolean => {
+  try {
+    const value = (globalThis as { Deno?: typeof Deno }).Deno?.env?.get(
+      "CF_MEMORY_WS_DEFLATE",
+    );
+    return value !== "0" && value !== "false";
+  } catch {
+    // Browsers (no Deno global) default on; a Deno process whose env is
+    // permission-restricted cannot express an opt-out, so default off there.
+    return typeof (globalThis as { Deno?: unknown }).Deno === "undefined";
+  }
+};
+
+let deflateRawSupport: boolean | null = null;
+
+/**
+ * Whether this runtime can construct `deflate-raw` compression streams.
+ * Clients must not offer the subprotocol without this: an offer is a
+ * commitment to inflate whatever the server compresses.
+ */
+export const memoryWsDeflateSupported = (): boolean => {
+  if (deflateRawSupport !== null) return deflateRawSupport;
+  try {
+    new CompressionStream("deflate-raw");
+    new DecompressionStream("deflate-raw");
+    deflateRawSupport = true;
+  } catch {
+    deflateRawSupport = false;
+  }
+  return deflateRawSupport;
+};
+
+/**
+ * Cap on compressed bytes a connection may have queued behind the serial
+ * inflate hop. Inflation normally drains faster than frames arrive; the cap
+ * exists so a peer cannot grow the queue without bound while the event loop
+ * is busy.
+ */
+export const MEMORY_WS_MAX_PENDING_INFLATE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Picks the deflate subprotocol out of a `Sec-WebSocket-Protocol` offer
+ * header, or undefined when it is absent or malformed. Selection is pure
+ * compatibility (see `memoryWsDeflateEnabled`) — servers pass the result
+ * straight to `Deno.upgradeWebSocket`'s `protocol` whenever it is defined.
+ */
+export const selectMemoryWsDeflateProtocol = (
+  offerHeader: string | null | undefined,
+): string | undefined => {
+  if (typeof offerHeader !== "string") return undefined;
+  const offered = offerHeader.split(",").map((token) => token.trim());
+  return offered.includes(MEMORY_WS_DEFLATE_SUBPROTOCOL)
+    ? MEMORY_WS_DEFLATE_SUBPROTOCOL
+    : undefined;
+};
+
+/** Raw-deflate compression of a wire payload's UTF-8 bytes. */
+export const deflateWirePayload = async (
+  payload: string,
+): Promise<Uint8Array<ArrayBuffer>> => {
+  const stream = new Blob([textEncoder.encode(payload)]).stream()
+    .pipeThrough(new CompressionStream("deflate-raw"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+/**
+ * Inflates a binary frame back into a wire payload string, enforcing
+ * `maxBytes` on the inflated size while streaming so an over-limit payload
+ * aborts before it is fully materialized. Throws on malformed deflate data,
+ * invalid UTF-8, or an over-limit payload.
+ */
+export const inflateWirePayload = async (
+  data: ArrayBuffer | ArrayBufferView,
+  maxBytes: number = MEMORY_WS_INFLATE_MAX_BYTES,
+): Promise<string> => {
+  // Websocket frames are never SharedArrayBuffer-backed; the assertion keeps
+  // the view zero-copy under TypeScript's ArrayBufferLike-generic typed arrays.
+  const bytes =
+    (ArrayBuffer.isView(data)
+      ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      : new Uint8Array(data)) as Uint8Array<ArrayBuffer>;
+  const stream = new Blob([bytes]).stream()
+    .pipeThrough(new DecompressionStream("deflate-raw"));
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new Error(
+          `Memory websocket payload inflates past ${maxBytes} bytes`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+    await stream.cancel().catch(() => {});
+  }
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return textDecoder.decode(joined);
+};
+
+/**
+ * FIFO chain for the async compression hops. Order is fixed at `enqueue`
+ * call time; a task's failure rejects that task's caller without poisoning
+ * later tasks.
+ */
+export class SerialTaskQueue {
+  #chain: Promise<void> = Promise.resolve();
+
+  enqueue<T>(task: () => T | Promise<T>): Promise<T> {
+    const result = this.#chain.then(task);
+    this.#chain = result.then(() => {}, () => {});
+    return result;
+  }
+}

--- a/packages/memory/v2/transport-deflate.ts
+++ b/packages/memory/v2/transport-deflate.ts
@@ -12,10 +12,16 @@
  * untouched — this layer sits strictly below `encodeMemoryBoundary`.
  *
  * Compression is stateless per message (no shared sliding window), so
- * reconnects and replays need no transport state. The one obligation this
- * layer adds is ordering: websocket delivery is ordered, but inflate/deflate
- * are async, so each direction of each connection must funnel through a
- * `SerialTaskQueue` to keep dispatch order identical to arrival order.
+ * reconnects and replays need no transport state. Auth-bearing frames
+ * (`hello`, `hello.ok`, `session.open`) are never compressed by either
+ * peer, keeping credential material out of compression-size side channels;
+ * receivers accept any frame either way — the exemption is sender policy.
+ *
+ * Servers use the synchronous codec (transport-deflate-sync.ts) so dispatch
+ * stays inside the message event handler. Browser clients have only the
+ * async streaming codec below, which detaches dispatch from event delivery —
+ * so the client side funnels each direction through a `SerialTaskQueue` to
+ * keep dispatch order identical to arrival order.
  *
  * Rollout caveat (per RFC 6455 §4.1): a client that offers a subprotocol
  * MUST fail the connection when the server selects none, so servers must
@@ -83,12 +89,45 @@ export const memoryWsDeflateSupported = (): boolean => {
 };
 
 /**
- * Cap on compressed bytes a connection may have queued behind the serial
+ * Cap on compressed bytes a client may have queued behind its serial
  * inflate hop. Inflation normally drains faster than frames arrive; the cap
  * exists so a peer cannot grow the queue without bound while the event loop
- * is busy.
+ * is busy. (Servers inflate synchronously and need no such bound.)
  */
 export const MEMORY_WS_MAX_PENDING_INFLATE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Tighter inflate cap for server-side (inbound) frames. A server inflates
+ * synchronously on the shared event loop, before any session authorization,
+ * so the cap bounds how long one unauthenticated frame can block every
+ * connection on the process. 8 MiB is a few milliseconds of inflation while
+ * comfortably exceeding any legitimate client frame; server-to-client sync
+ * frames may be larger, so clients keep the wider cap above.
+ */
+export const MEMORY_WS_SERVER_INFLATE_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Whether a wire message carries authentication material and must therefore
+ * never be compressed by the sender (see the module doc): `hello`,
+ * `hello.ok`, `session.open`, and any response whose body carries the
+ * session bearer token or the next session-open challenge (the session.open
+ * response). Structural, so both servers and any host embedding the codec
+ * apply the same policy.
+ */
+export const isAuthBearingWireMessage = (message: unknown): boolean => {
+  if (typeof message !== "object" || message === null) return false;
+  const record = message as Record<string, unknown>;
+  if (
+    record.type === "hello" || record.type === "hello.ok" ||
+    record.type === "session.open"
+  ) {
+    return true;
+  }
+  if (record.type !== "response") return false;
+  const ok = record.ok;
+  return typeof ok === "object" && ok !== null &&
+    ("sessionToken" in ok || "sessionOpen" in ok);
+};
 
 /**
  * Picks the deflate subprotocol out of a `Sec-WebSocket-Protocol` offer

--- a/packages/memory/v2/transport-deflate.ts
+++ b/packages/memory/v2/transport-deflate.ts
@@ -1,5 +1,5 @@
 /**
- * SPIKE: transport-level per-message compression for the memory v2 websocket.
+ * transport-level per-message compression for the memory v2 websocket.
  *
  * Negotiated via the websocket subprotocol `fvj1.deflate`: the client offers
  * it in the upgrade request, and the server always selects an offer. Once

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -123,8 +123,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
   #outbound = new SerialTaskQueue();
   // While a closed socket's queued frames drain toward the close
   // notification, a re-dial must wait — otherwise a send() could open a new
-  // socket before the consumer learns the old one closed, a window the
-  // historical synchronous path never had.
+  // socket before the consumer learns the old one closed.
   #draining: Promise<void> | null = null;
   // Once close() is called nothing may dial again: a late send must not
   // leak a brand-new live socket that nothing owns.
@@ -310,7 +309,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
           });
           return;
         }
-        // Non-negotiated binary frames stay ignored (historical behavior).
+        // Binary frames on a non-negotiated socket are ignored.
       });
       socket.addEventListener("close", () => {
         if (this.#socket === socket) {

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -108,16 +108,16 @@ export class WebSocketTransport implements MemoryClient.Transport {
   #closeReceiver: (error?: Error) => void = () => {};
   #socket: WebSocket | null = null;
   #opening: Promise<WebSocket> | null = null;
-  // SPIKE: outbound ordering queue for the async deflate hop on a negotiated
+  // outbound ordering queue for the async deflate hop on a negotiated
   // connection. One queue per transport is safe across reconnects because
   // each task captures its own socket and no-ops once that socket closes.
   #outbound = new SerialTaskQueue();
-  // SPIKE: while a closed socket's queued frames drain toward the close
+  // While a closed socket's queued frames drain toward the close
   // notification, a re-dial must wait — otherwise a send() could open a new
   // socket before the consumer learns the old one closed, a window the
-  // synchronous pre-spike path never had.
+  // historical synchronous path never had.
   #draining: Promise<void> | null = null;
-  // SPIKE: once close() is called nothing may dial again. Without this latch
+  // once close() is called nothing may dial again. Without this latch
   // an open() parked on #draining could resume after close() returned and
   // leak a brand-new live socket.
   #closed = false;
@@ -219,7 +219,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
     }
     const address = toWebSocketAddress(this.address);
     const opening = new Promise<WebSocket>((resolve, reject) => {
-      // SPIKE: offer the deflate subprotocol when this runtime can actually
+      // offer the deflate subprotocol when this runtime can actually
       // inflate (offering is a commitment) and it is not opted out via
       // CF_MEMORY_WS_DEFLATE=0. Servers that predate the subprotocol will
       // fail this connection per RFC 6455, so server support deploys first.
@@ -232,7 +232,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
       socket.binaryType = "arraybuffer";
       this.#socket = socket;
       let opened = false;
-      // SPIKE: inbound ordering queue, per socket — async inflation must not
+      // inbound ordering queue, per socket — async inflation must not
       // let a later text frame overtake an earlier compressed frame. A failed
       // inflate poisons the queue: delivering frames past a transport-level
       // gap would let the session ack and resume beyond messages it never
@@ -329,7 +329,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
         if (this.#opening === opening) {
           this.#opening = null;
         }
-        // SPIKE: the close notification queues behind pending inflates so
+        // the close notification queues behind pending inflates so
         // every frame that arrived before the close is delivered first —
         // the client's reconnect must not race a stale frame (and nothing
         // may be delivered after the close notification).

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -245,9 +245,20 @@ export class WebSocketTransport implements MemoryClient.Transport {
         try {
           this.#receiver(payload);
         } catch (error) {
-          // Receiver failures are the consumer's problem, not a transport
-          // gap: log and keep delivering (same as the non-negotiated path).
-          console.error("memory websocket receiver failed", error);
+          // A frame the consumer failed to apply is a gap: continuing would
+          // let the session ack past it from inconsistent state. Poison this
+          // socket and close so the client's reconnect machinery restores a
+          // consistent view from the server.
+          console.error(
+            "memory websocket receiver failed; reconnecting",
+            error,
+          );
+          poisoned = true;
+          try {
+            socket.close();
+          } catch {
+            // Ignore close races with the peer.
+          }
         }
       };
       socket.addEventListener("open", () => {

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -16,6 +16,15 @@ import {
 
 const TEXT_ENCODER = new TextEncoder();
 
+/** Close, tolerating a socket already racing the peer's close. */
+const safeClose = (socket: WebSocket): void => {
+  try {
+    socket.close();
+  } catch {
+    // Ignore close races with the peer.
+  }
+};
+
 export interface SessionFactory {
   /** Opt in to StorageManager's ACL genesis handshake. Scripted factories used
    *  by lower-level replica tests omit this because they intentionally model
@@ -117,9 +126,8 @@ export class WebSocketTransport implements MemoryClient.Transport {
   // socket before the consumer learns the old one closed, a window the
   // historical synchronous path never had.
   #draining: Promise<void> | null = null;
-  // once close() is called nothing may dial again. Without this latch
-  // an open() parked on #draining could resume after close() returned and
-  // leak a brand-new live socket.
+  // Once close() is called nothing may dial again: a late send must not
+  // leak a brand-new live socket that nothing owns.
   #closed = false;
 
   constructor(private readonly address: URL) {}
@@ -211,12 +219,6 @@ export class WebSocketTransport implements MemoryClient.Transport {
     if (this.#opening) {
       return await this.#opening;
     }
-    if (this.#draining !== null) {
-      await this.#draining;
-      // Drain completion may have raced another open() or a close(); re-enter
-      // to observe the current state (including the closed latch).
-      return await this.open();
-    }
     const address = toWebSocketAddress(this.address);
     const opening = new Promise<WebSocket>((resolve, reject) => {
       // offer the deflate subprotocol when this runtime can actually
@@ -254,11 +256,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
             error,
           );
           poisoned = true;
-          try {
-            socket.close();
-          } catch {
-            // Ignore close races with the peer.
-          }
+          safeClose(socket);
         }
       };
       socket.addEventListener("open", () => {
@@ -287,11 +285,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
             // treat it as a transport failure rather than buffering without
             // bound.
             poisoned = true;
-            try {
-              socket.close();
-            } catch {
-              // Ignore close races with the peer.
-            }
+            safeClose(socket);
             return;
           }
           pendingInflateBytes += data.byteLength;
@@ -312,11 +306,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
           }).catch(() => {
             // A malformed compressed frame is a transport failure: close so
             // the client's reconnect machinery takes over and replays.
-            try {
-              socket.close();
-            } catch {
-              // Ignore close races with the peer.
-            }
+            safeClose(socket);
           });
           return;
         }
@@ -339,11 +329,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
           // notification is not rejected by the draining guard.
           if (this.#draining === drained) this.#draining = null;
           this.#closeReceiver();
-        })
-          .catch(() => {})
-          .finally(() => {
-            if (this.#draining === drained) this.#draining = null;
-          });
+        }).catch(() => {});
         this.#draining = drained;
         if (!opened) {
           reject(new Error("memory websocket transport closed before opening"));
@@ -363,11 +349,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
         const drained = inbound.enqueue(() => {
           if (this.#draining === drained) this.#draining = null;
           this.#closeReceiver(error);
-        })
-          .catch(() => {})
-          .finally(() => {
-            if (this.#draining === drained) this.#draining = null;
-          });
+        }).catch(() => {});
         this.#draining = drained;
         reject(event);
       }, { once: true });

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -8,6 +8,7 @@ import {
   inflateWirePayload,
   MEMORY_WS_DEFLATE_MIN_BYTES,
   MEMORY_WS_DEFLATE_SUBPROTOCOL,
+  MEMORY_WS_MAX_PENDING_INFLATE_BYTES,
   memoryWsDeflateEnabled,
   memoryWsDeflateSupported,
   SerialTaskQueue,
@@ -131,17 +132,38 @@ export class WebSocketTransport implements MemoryClient.Transport {
     this.#closeReceiver = receiver;
   }
 
-  async send(payload: string): Promise<void> {
+  async send(
+    payload: string,
+    hints?: MemoryClient.TransportSendHints,
+  ): Promise<void> {
+    if (this.#draining !== null) {
+      // The connection is turning over: its close notification is still
+      // queued behind pending inflates, so the caller does not yet know the
+      // socket dropped. Sending now would dial the next socket and put a
+      // stale payload ahead of the client's fresh handshake. Callers treat
+      // this like any other transport failure and replay via the reconnect
+      // machinery (which only runs after the close notification lands, when
+      // the drain is already cleared).
+      const error = new Error(
+        "memory websocket transport reconnected during send",
+      );
+      error.name = "ConnectionError";
+      throw error;
+    }
     const socket = await this.open();
     if (socket.protocol !== MEMORY_WS_DEFLATE_SUBPROTOCOL) {
       socket.send(payload);
       return;
     }
     // Negotiated: every send funnels through the queue — a small text frame
-    // must not overtake an earlier payload still being compressed.
+    // must not overtake an earlier payload still being compressed. Frames
+    // with the noCompress hint (auth-bearing) stay text but keep their
+    // position in the same order.
     await this.#outbound.enqueue(async () => {
       const bytes = TEXT_ENCODER.encode(payload).byteLength;
-      if (bytes < MEMORY_WS_DEFLATE_MIN_BYTES) {
+      if (
+        hints?.noCompress === true || bytes < MEMORY_WS_DEFLATE_MIN_BYTES
+      ) {
         if (socket.readyState === WebSocket.OPEN) socket.send(payload);
         return;
       }
@@ -179,7 +201,9 @@ export class WebSocketTransport implements MemoryClient.Transport {
 
   private async open(): Promise<WebSocket> {
     if (this.#closed) {
-      throw new Error("memory websocket transport is closed");
+      const error = new Error("memory websocket transport is closed");
+      error.name = "ConnectionError";
+      throw error;
     }
     if (this.#socket?.readyState === WebSocket.OPEN) {
       return this.#socket;
@@ -215,6 +239,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
       // saw. Only the close notification may follow a poisoned frame.
       const inbound = new SerialTaskQueue();
       let poisoned = false;
+      let pendingInflateBytes = 0;
       const deliver = (payload: string) => {
         if (poisoned) return;
         try {
@@ -243,16 +268,36 @@ export class WebSocketTransport implements MemoryClient.Transport {
           socket.protocol === MEMORY_WS_DEFLATE_SUBPROTOCOL &&
           (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
         ) {
-          void inbound.enqueue(async () => {
-            if (poisoned) return;
-            let payload: string;
+          if (
+            pendingInflateBytes + data.byteLength >
+              MEMORY_WS_MAX_PENDING_INFLATE_BYTES
+          ) {
+            // The server outpaced local inflation past any legitimate burst:
+            // treat it as a transport failure rather than buffering without
+            // bound.
+            poisoned = true;
             try {
-              payload = await inflateWirePayload(data);
-            } catch (error) {
-              poisoned = true;
-              throw error;
+              socket.close();
+            } catch {
+              // Ignore close races with the peer.
             }
-            deliver(payload);
+            return;
+          }
+          pendingInflateBytes += data.byteLength;
+          void inbound.enqueue(async () => {
+            try {
+              if (poisoned) return;
+              let payload: string;
+              try {
+                payload = await inflateWirePayload(data);
+              } catch (error) {
+                poisoned = true;
+                throw error;
+              }
+              deliver(payload);
+            } finally {
+              pendingInflateBytes -= data.byteLength;
+            }
           }).catch(() => {
             // A malformed compressed frame is a transport failure: close so
             // the client's reconnect machinery takes over and replays.
@@ -277,7 +322,13 @@ export class WebSocketTransport implements MemoryClient.Transport {
         // every frame that arrived before the close is delivered first —
         // the client's reconnect must not race a stale frame (and nothing
         // may be delivered after the close notification).
-        const drained = inbound.enqueue(() => this.#closeReceiver())
+        const drained = inbound.enqueue(() => {
+          // Dial-able again the instant the consumer learns of the close:
+          // clear before notifying so a reconnect issued inside the
+          // notification is not rejected by the draining guard.
+          if (this.#draining === drained) this.#draining = null;
+          this.#closeReceiver();
+        })
           .catch(() => {})
           .finally(() => {
             if (this.#draining === drained) this.#draining = null;
@@ -298,7 +349,10 @@ export class WebSocketTransport implements MemoryClient.Transport {
           event instanceof ErrorEvent && event.error instanceof Error
             ? event.error
             : new Error("memory websocket transport error");
-        const drained = inbound.enqueue(() => this.#closeReceiver(error))
+        const drained = inbound.enqueue(() => {
+          if (this.#draining === drained) this.#draining = null;
+          this.#closeReceiver(error);
+        })
           .catch(() => {})
           .finally(() => {
             if (this.#draining === drained) this.#draining = null;

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -116,6 +116,10 @@ export class WebSocketTransport implements MemoryClient.Transport {
   // socket before the consumer learns the old one closed, a window the
   // synchronous pre-spike path never had.
   #draining: Promise<void> | null = null;
+  // SPIKE: once close() is called nothing may dial again. Without this latch
+  // an open() parked on #draining could resume after close() returned and
+  // leak a brand-new live socket.
+  #closed = false;
 
   constructor(private readonly address: URL) {}
 
@@ -149,10 +153,14 @@ export class WebSocketTransport implements MemoryClient.Transport {
   }
 
   async close(): Promise<void> {
+    this.#closed = true;
     const socket = this.#socket;
     this.#socket = null;
     this.#opening = null;
     if (!socket || socket.readyState === WebSocket.CLOSED) {
+      // A drain may still be delivering frames from an already-closed socket;
+      // close() returning must mean nothing fires afterwards.
+      if (this.#draining !== null) await this.#draining;
       return;
     }
     const closed = new Promise<void>((resolve) => {
@@ -166,9 +174,13 @@ export class WebSocketTransport implements MemoryClient.Transport {
       socket.close();
     }
     await closed;
+    if (this.#draining !== null) await this.#draining;
   }
 
   private async open(): Promise<WebSocket> {
+    if (this.#closed) {
+      throw new Error("memory websocket transport is closed");
+    }
     if (this.#socket?.readyState === WebSocket.OPEN) {
       return this.#socket;
     }
@@ -177,8 +189,8 @@ export class WebSocketTransport implements MemoryClient.Transport {
     }
     if (this.#draining !== null) {
       await this.#draining;
-      // Drain completion may have raced another open(); re-enter to observe
-      // the current socket state.
+      // Drain completion may have raced another open() or a close(); re-enter
+      // to observe the current state (including the closed latch).
       return await this.open();
     }
     const address = toWebSocketAddress(this.address);
@@ -197,8 +209,22 @@ export class WebSocketTransport implements MemoryClient.Transport {
       this.#socket = socket;
       let opened = false;
       // SPIKE: inbound ordering queue, per socket — async inflation must not
-      // let a later text frame overtake an earlier compressed frame.
+      // let a later text frame overtake an earlier compressed frame. A failed
+      // inflate poisons the queue: delivering frames past a transport-level
+      // gap would let the session ack and resume beyond messages it never
+      // saw. Only the close notification may follow a poisoned frame.
       const inbound = new SerialTaskQueue();
+      let poisoned = false;
+      const deliver = (payload: string) => {
+        if (poisoned) return;
+        try {
+          this.#receiver(payload);
+        } catch (error) {
+          // Receiver failures are the consumer's problem, not a transport
+          // gap: log and keep delivering (same as the non-negotiated path).
+          console.error("memory websocket receiver failed", error);
+        }
+      };
       socket.addEventListener("open", () => {
         opened = true;
         resolve(socket);
@@ -207,12 +233,10 @@ export class WebSocketTransport implements MemoryClient.Transport {
         const data: unknown = event.data;
         if (typeof data === "string") {
           if (socket.protocol !== MEMORY_WS_DEFLATE_SUBPROTOCOL) {
-            this.#receiver(data);
+            deliver(data);
             return;
           }
-          void inbound.enqueue(() => this.#receiver(data)).catch((error) => {
-            console.error("memory websocket receiver failed", error);
-          });
+          void inbound.enqueue(() => deliver(data));
           return;
         }
         if (
@@ -220,10 +244,18 @@ export class WebSocketTransport implements MemoryClient.Transport {
           (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
         ) {
           void inbound.enqueue(async () => {
-            this.#receiver(await inflateWirePayload(data));
+            if (poisoned) return;
+            let payload: string;
+            try {
+              payload = await inflateWirePayload(data);
+            } catch (error) {
+              poisoned = true;
+              throw error;
+            }
+            deliver(payload);
           }).catch(() => {
             // A malformed compressed frame is a transport failure: close so
-            // the client's reconnect machinery takes over.
+            // the client's reconnect machinery takes over and replays.
             try {
               socket.close();
             } catch {

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -3,6 +3,17 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type MemorySpace, type Signer } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_DEFLATE_SUBPROTOCOL,
+  memoryWsDeflateEnabled,
+  memoryWsDeflateSupported,
+  SerialTaskQueue,
+} from "@commonfabric/memory/v2/transport-deflate";
+
+const TEXT_ENCODER = new TextEncoder();
 
 export interface SessionFactory {
   /** Opt in to StorageManager's ACL genesis handshake. Scripted factories used
@@ -96,6 +107,15 @@ export class WebSocketTransport implements MemoryClient.Transport {
   #closeReceiver: (error?: Error) => void = () => {};
   #socket: WebSocket | null = null;
   #opening: Promise<WebSocket> | null = null;
+  // SPIKE: outbound ordering queue for the async deflate hop on a negotiated
+  // connection. One queue per transport is safe across reconnects because
+  // each task captures its own socket and no-ops once that socket closes.
+  #outbound = new SerialTaskQueue();
+  // SPIKE: while a closed socket's queued frames drain toward the close
+  // notification, a re-dial must wait — otherwise a send() could open a new
+  // socket before the consumer learns the old one closed, a window the
+  // synchronous pre-spike path never had.
+  #draining: Promise<void> | null = null;
 
   constructor(private readonly address: URL) {}
 
@@ -109,7 +129,23 @@ export class WebSocketTransport implements MemoryClient.Transport {
 
   async send(payload: string): Promise<void> {
     const socket = await this.open();
-    socket.send(payload);
+    if (socket.protocol !== MEMORY_WS_DEFLATE_SUBPROTOCOL) {
+      socket.send(payload);
+      return;
+    }
+    // Negotiated: every send funnels through the queue — a small text frame
+    // must not overtake an earlier payload still being compressed.
+    await this.#outbound.enqueue(async () => {
+      const bytes = TEXT_ENCODER.encode(payload).byteLength;
+      if (bytes < MEMORY_WS_DEFLATE_MIN_BYTES) {
+        if (socket.readyState === WebSocket.OPEN) socket.send(payload);
+        return;
+      }
+      const compressed = await deflateWirePayload(payload);
+      // Mirrors the uncompressed path: sending on a socket that closed
+      // after open() resolved is a silent drop, recovered by reconnect.
+      if (socket.readyState === WebSocket.OPEN) socket.send(compressed);
+    });
   }
 
   async close(): Promise<void> {
@@ -139,19 +175,64 @@ export class WebSocketTransport implements MemoryClient.Transport {
     if (this.#opening) {
       return await this.#opening;
     }
+    if (this.#draining !== null) {
+      await this.#draining;
+      // Drain completion may have raced another open(); re-enter to observe
+      // the current socket state.
+      return await this.open();
+    }
     const address = toWebSocketAddress(this.address);
     const opening = new Promise<WebSocket>((resolve, reject) => {
-      const socket = new WebSocket(address);
+      // SPIKE: offer the deflate subprotocol when this runtime can actually
+      // inflate (offering is a commitment) and it is not opted out via
+      // CF_MEMORY_WS_DEFLATE=0. Servers that predate the subprotocol will
+      // fail this connection per RFC 6455, so server support deploys first.
+      const socket = new WebSocket(
+        address,
+        memoryWsDeflateEnabled() && memoryWsDeflateSupported()
+          ? [MEMORY_WS_DEFLATE_SUBPROTOCOL]
+          : [],
+      );
+      socket.binaryType = "arraybuffer";
       this.#socket = socket;
       let opened = false;
+      // SPIKE: inbound ordering queue, per socket — async inflation must not
+      // let a later text frame overtake an earlier compressed frame.
+      const inbound = new SerialTaskQueue();
       socket.addEventListener("open", () => {
         opened = true;
         resolve(socket);
       }, { once: true });
       socket.addEventListener("message", (event) => {
-        if (typeof event.data === "string") {
-          this.#receiver(event.data);
+        const data: unknown = event.data;
+        if (typeof data === "string") {
+          if (socket.protocol !== MEMORY_WS_DEFLATE_SUBPROTOCOL) {
+            this.#receiver(data);
+            return;
+          }
+          void inbound.enqueue(() => this.#receiver(data)).catch((error) => {
+            console.error("memory websocket receiver failed", error);
+          });
+          return;
         }
+        if (
+          socket.protocol === MEMORY_WS_DEFLATE_SUBPROTOCOL &&
+          (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
+        ) {
+          void inbound.enqueue(async () => {
+            this.#receiver(await inflateWirePayload(data));
+          }).catch(() => {
+            // A malformed compressed frame is a transport failure: close so
+            // the client's reconnect machinery takes over.
+            try {
+              socket.close();
+            } catch {
+              // Ignore close races with the peer.
+            }
+          });
+          return;
+        }
+        // Non-negotiated binary frames stay ignored (historical behavior).
       });
       socket.addEventListener("close", () => {
         if (this.#socket === socket) {
@@ -160,7 +241,16 @@ export class WebSocketTransport implements MemoryClient.Transport {
         if (this.#opening === opening) {
           this.#opening = null;
         }
-        this.#closeReceiver();
+        // SPIKE: the close notification queues behind pending inflates so
+        // every frame that arrived before the close is delivered first —
+        // the client's reconnect must not race a stale frame (and nothing
+        // may be delivered after the close notification).
+        const drained = inbound.enqueue(() => this.#closeReceiver())
+          .catch(() => {})
+          .finally(() => {
+            if (this.#draining === drained) this.#draining = null;
+          });
+        this.#draining = drained;
         if (!opened) {
           reject(new Error("memory websocket transport closed before opening"));
         }
@@ -172,11 +262,16 @@ export class WebSocketTransport implements MemoryClient.Transport {
         if (this.#opening === opening) {
           this.#opening = null;
         }
-        this.#closeReceiver(
+        const error =
           event instanceof ErrorEvent && event.error instanceof Error
             ? event.error
-            : new Error("memory websocket transport error"),
-        );
+            : new Error("memory websocket transport error");
+        const drained = inbound.enqueue(() => this.#closeReceiver(error))
+          .catch(() => {})
+          .finally(() => {
+            if (this.#draining === drained) this.#draining = null;
+          });
+        this.#draining = drained;
         reject(event);
       }, { once: true });
     });

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -213,8 +213,9 @@ describe("WebSocketTransport deflate framing", () => {
       await send;
 
       // Drop the socket with a compressed frame still inflating, then close
-      // the transport while the drain is pending. A send parked behind the
-      // drain must reject — never dial a fresh socket that nothing owns.
+      // the transport while the drain is pending. A send in that window must
+      // reject — never dial a fresh socket that nothing owns — and a send
+      // after close() must reject with the closed error.
       socket().dispatchEvent(
         new MessageEvent("message", {
           data: (await deflateWirePayload(LARGE)).buffer,
@@ -223,8 +224,11 @@ describe("WebSocketTransport deflate framing", () => {
       const socketCount = DeflatingWebSocket.instances.length;
       socket().close();
       const parked = transport.send(SMALL);
-      await transport.close();
       await expect(parked).rejects.toThrow(
+        "memory websocket transport reconnected during send",
+      );
+      await transport.close();
+      await expect(transport.send(SMALL)).rejects.toThrow(
         "memory websocket transport is closed",
       );
       expect(DeflatingWebSocket.instances.length).toBe(socketCount);
@@ -250,6 +254,83 @@ describe("WebSocketTransport deflate framing", () => {
       // Give any stray async work a tick before asserting.
       await new Promise((resolve) => setTimeout(resolve, 10));
       expect(received).toEqual([SMALL]);
+    });
+  });
+
+  it("keeps noCompress frames as text in outbound order", async () => {
+    await withTransport(async (transport, socket) => {
+      const warmup = transport.send(SMALL);
+      openSocket(socket());
+      await warmup;
+
+      // A large compressed frame followed by a large auth frame: the auth
+      // frame must stay text AND must not overtake the compressed frame
+      // still in the async deflate hop.
+      const large = transport.send(LARGE);
+      const auth = transport.send(LARGE, { noCompress: true });
+      await Promise.all([large, auth]);
+
+      expect(socket().sent.length).toBe(3);
+      expect(typeof socket().sent[1]).not.toBe("string");
+      expect(socket().sent[2]).toBe(LARGE);
+    });
+  });
+
+  it("rejects a send parked across a reconnect instead of leaking it", async () => {
+    await withTransport(async (transport, socket) => {
+      const warmup = transport.send(SMALL);
+      openSocket(socket());
+      await warmup;
+
+      // Drop the socket with an inflate pending so the drain window is open,
+      // then issue a send inside that window. The payload must not ride the
+      // next socket ahead of the client's fresh handshake — and once the
+      // drain completes, a new send may dial again normally.
+      socket().dispatchEvent(
+        new MessageEvent("message", {
+          data: (await deflateWirePayload(LARGE)).buffer,
+        }),
+      );
+      const socketCount = DeflatingWebSocket.instances.length;
+      const drained = new Promise<void>((resolve) => {
+        transport.setCloseReceiver(() => resolve());
+      });
+      socket().close();
+      const parked = transport.send(SMALL);
+      await expect(parked).rejects.toThrow(
+        "memory websocket transport reconnected during send",
+      );
+      expect(DeflatingWebSocket.instances.length).toBe(socketCount);
+
+      // After the close notification lands (drain cleared), sends dial
+      // fresh — the reconnect path is not blocked.
+      await drained;
+      const redial = transport.send(SMALL);
+      openSocket(socket());
+      await redial;
+      expect(DeflatingWebSocket.instances.length).toBe(socketCount + 1);
+    });
+  });
+
+  it("closes the socket when the inflate backlog exceeds its bound", async () => {
+    await withTransport(async (transport, socket) => {
+      const received: string[] = [];
+      transport.setReceiver((payload) => received.push(payload));
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      const closed = new Promise<void>((resolve) => {
+        socket().addEventListener("close", () => resolve(), { once: true });
+      });
+      // Two 9 MiB frames dispatched back-to-back breach the 16 MiB pending
+      // bound before the first inflate task can run.
+      const nineMiB = new ArrayBuffer(9 * 1024 * 1024);
+      socket().dispatchEvent(new MessageEvent("message", { data: nineMiB }));
+      socket().dispatchEvent(new MessageEvent("message", { data: nineMiB }));
+
+      await closed;
+      expect(received).toEqual([]);
     });
   });
 

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -1,5 +1,5 @@
 /**
- * SPIKE: WebSocketTransport behavior on a connection that negotiated the
+ * WebSocketTransport behavior on a connection that negotiated the
  * `fvj1.deflate` subprotocol — threshold framing, strict ordering across the
  * async compression hops, and unchanged behavior when not negotiated.
  */

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -174,6 +174,63 @@ describe("WebSocketTransport deflate framing", () => {
     });
   });
 
+  it("stops delivering after a failed inflate so a gap cannot be acked past", async () => {
+    await withTransport(async (transport, socket) => {
+      const received: string[] = [];
+      transport.setReceiver((payload) => received.push(payload));
+      let closed = false;
+      const sawClose = new Promise<void>((resolve) => {
+        transport.setCloseReceiver(() => {
+          closed = true;
+          resolve();
+        });
+      });
+
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      // A corrupt compressed frame followed by a valid text frame: the valid
+      // frame arrived AFTER the gap, so it must NOT be delivered — otherwise
+      // the session would ack past the missing message and resume beyond it.
+      socket().dispatchEvent(
+        new MessageEvent("message", {
+          data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer,
+        }),
+      );
+      socket().dispatchEvent(new MessageEvent("message", { data: SMALL }));
+
+      await sawClose;
+      expect(received).toEqual([]);
+      expect(closed).toBe(true);
+    });
+  });
+
+  it("refuses to dial again after close() resolves", async () => {
+    await withTransport(async (transport, socket) => {
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      // Drop the socket with a compressed frame still inflating, then close
+      // the transport while the drain is pending. A send parked behind the
+      // drain must reject — never dial a fresh socket that nothing owns.
+      socket().dispatchEvent(
+        new MessageEvent("message", {
+          data: (await deflateWirePayload(LARGE)).buffer,
+        }),
+      );
+      const socketCount = DeflatingWebSocket.instances.length;
+      socket().close();
+      const parked = transport.send(SMALL);
+      await transport.close();
+      await expect(parked).rejects.toThrow(
+        "memory websocket transport is closed",
+      );
+      expect(DeflatingWebSocket.instances.length).toBe(socketCount);
+    });
+  });
+
   it("ignores binary frames when the socket did not negotiate deflate", async () => {
     await withTransport(async (transport, socket) => {
       const received: string[] = [];

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -1,0 +1,209 @@
+/**
+ * SPIKE: WebSocketTransport behavior on a connection that negotiated the
+ * `fvj1.deflate` subprotocol — threshold framing, strict ordering across the
+ * async compression hops, and unchanged behavior when not negotiated.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_DEFLATE_SUBPROTOCOL,
+} from "@commonfabric/memory/v2/transport-deflate";
+import { WebSocketTransport } from "../src/storage/v2-remote-session.ts";
+
+class DeflatingWebSocket extends EventTarget {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: DeflatingWebSocket[] = [];
+  readyState = DeflatingWebSocket.OPEN;
+  binaryType = "blob";
+  protocol: string;
+  sent: (string | Uint8Array)[] = [];
+  constructor(readonly url: string | URL, protocols?: string[]) {
+    super();
+    this.protocol = protocols?.[0] ?? "";
+    DeflatingWebSocket.instances.push(this);
+  }
+  send(payload: string | Uint8Array): void {
+    this.sent.push(payload);
+  }
+  close(): void {
+    this.readyState = DeflatingWebSocket.CLOSED;
+    this.dispatchEvent(new CloseEvent("close"));
+  }
+}
+
+function withTransport(
+  body: (
+    transport: WebSocketTransport,
+    socket: () => DeflatingWebSocket,
+  ) => Promise<void>,
+): Promise<void> {
+  const realWebSocket = globalThis.WebSocket;
+  DeflatingWebSocket.instances.length = 0;
+  (globalThis as { WebSocket: unknown }).WebSocket = DeflatingWebSocket;
+  const transport = new WebSocketTransport(
+    new URL("wss://memory.test/api/storage/memory"),
+  );
+  return body(transport, () => DeflatingWebSocket.instances.at(-1)!)
+    .finally(() => {
+      (globalThis as { WebSocket: unknown }).WebSocket = realWebSocket;
+    });
+}
+
+const openSocket = (socket: DeflatingWebSocket) => {
+  socket.readyState = DeflatingWebSocket.OPEN;
+  socket.dispatchEvent(new Event("open"));
+};
+
+const SMALL = "fvj1:{}";
+const LARGE = "fvj1:" + JSON.stringify({
+  padding: "x".repeat(MEMORY_WS_DEFLATE_MIN_BYTES * 4),
+});
+
+describe("WebSocketTransport deflate framing", () => {
+  it("offers the deflate subprotocol when opening", async () => {
+    await withTransport(async (transport, socket) => {
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+      expect(socket().protocol).toBe(MEMORY_WS_DEFLATE_SUBPROTOCOL);
+      expect(socket().binaryType).toBe("arraybuffer");
+    });
+  });
+
+  it("sends small payloads as text and large payloads compressed", async () => {
+    await withTransport(async (transport, socket) => {
+      const first = transport.send(SMALL);
+      openSocket(socket());
+      await first;
+      await transport.send(LARGE);
+
+      expect(socket().sent.length).toBe(2);
+      expect(socket().sent[0]).toBe(SMALL);
+      const compressed = socket().sent[1];
+      expect(typeof compressed).not.toBe("string");
+      expect(await inflateWirePayload(compressed as Uint8Array)).toBe(LARGE);
+    });
+  });
+
+  it("keeps outbound order when a small send follows a large one", async () => {
+    await withTransport(async (transport, socket) => {
+      const warmup = transport.send(SMALL);
+      openSocket(socket());
+      await warmup;
+
+      // Issue both without awaiting: the small text frame must not overtake
+      // the large frame that is still inside the async deflate hop.
+      const large = transport.send(LARGE);
+      const small = transport.send(SMALL);
+      await Promise.all([large, small]);
+
+      expect(socket().sent.length).toBe(3);
+      expect(typeof socket().sent[1]).not.toBe("string");
+      expect(await inflateWirePayload(socket().sent[1] as Uint8Array))
+        .toBe(LARGE);
+      expect(socket().sent[2]).toBe(SMALL);
+    });
+  });
+
+  it("keeps inbound order when text arrives behind a compressed frame", async () => {
+    await withTransport(async (transport, socket) => {
+      const received: string[] = [];
+      let sawBoth: () => void = () => {};
+      const done = new Promise<void>((resolve) => {
+        sawBoth = () => {
+          if (received.length === 2) resolve();
+        };
+      });
+      transport.setReceiver((payload) => {
+        received.push(payload);
+        sawBoth();
+      });
+
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      const compressed = await deflateWirePayload(LARGE);
+      // Dispatch a binary frame immediately followed by a text frame; the
+      // text frame must wait for the inflate ahead of it.
+      socket().dispatchEvent(
+        new MessageEvent("message", { data: compressed.buffer }),
+      );
+      socket().dispatchEvent(new MessageEvent("message", { data: SMALL }));
+
+      await done;
+      expect(received).toEqual([LARGE, SMALL]);
+    });
+  });
+
+  it("delivers frames that arrived before close ahead of the close signal", async () => {
+    await withTransport(async (transport, socket) => {
+      const events: string[] = [];
+      let done: () => void = () => {};
+      const closed = new Promise<void>((resolve) => {
+        done = resolve;
+      });
+      transport.setReceiver((payload) => events.push(`msg:${payload}`));
+      transport.setCloseReceiver(() => {
+        events.push("close");
+        done();
+      });
+
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      // A compressed frame arrives, then the socket drops while the inflate
+      // is still in flight. The frame must be delivered BEFORE the close
+      // notification — never after it, and never dropped.
+      socket().dispatchEvent(
+        new MessageEvent("message", {
+          data: (await deflateWirePayload(LARGE)).buffer,
+        }),
+      );
+      socket().dispatchEvent(new CloseEvent("close"));
+
+      await closed;
+      expect(events).toEqual([`msg:${LARGE}`, "close"]);
+    });
+  });
+
+  it("ignores binary frames when the socket did not negotiate deflate", async () => {
+    await withTransport(async (transport, socket) => {
+      const received: string[] = [];
+      transport.setReceiver((payload) => received.push(payload));
+
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+      socket().protocol = "";
+
+      const compressed = await deflateWirePayload(LARGE);
+      socket().dispatchEvent(
+        new MessageEvent("message", { data: compressed.buffer }),
+      );
+      socket().dispatchEvent(new MessageEvent("message", { data: SMALL }));
+
+      // Give any stray async work a tick before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(received).toEqual([SMALL]);
+    });
+  });
+
+  it("sends everything as plain text when the server declined the offer", async () => {
+    await withTransport(async (transport, socket) => {
+      const first = transport.send(SMALL);
+      openSocket(socket());
+      socket().protocol = "";
+      await first;
+      await transport.send(LARGE);
+      expect(socket().sent).toEqual([SMALL, LARGE]);
+    });
+  });
+});

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -1,6 +1,6 @@
 /**
  * WebSocketTransport behavior on a connection that negotiated the
- * `fvj1.deflate` subprotocol — threshold framing, strict ordering across the
+ * `cf-memory.deflate.v1` subprotocol — threshold framing, strict ordering across the
  * async compression hops, and unchanged behavior when not negotiated.
  */
 import { describe, it } from "@std/testing/bdd";

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -60,10 +60,10 @@ const openSocket = (socket: DeflatingWebSocket) => {
   socket.dispatchEvent(new Event("open"));
 };
 
-const SMALL = "fvj1:{}";
-const LARGE = "fvj1:" + JSON.stringify({
-  padding: "x".repeat(MEMORY_WS_DEFLATE_MIN_BYTES * 4),
-});
+const SMALL = "small";
+// The transport treats payloads as opaque text; this only needs to be
+// compressible and above the threshold.
+const LARGE = "large-payload ".repeat(MEMORY_WS_DEFLATE_MIN_BYTES / 2);
 
 describe("WebSocketTransport deflate framing", () => {
   it("offers the deflate subprotocol when opening", async () => {

--- a/packages/runner/test/memory-v2-ws-deflate.test.ts
+++ b/packages/runner/test/memory-v2-ws-deflate.test.ts
@@ -235,6 +235,63 @@ describe("WebSocketTransport deflate framing", () => {
     });
   });
 
+  it("closes the socket when the receiver fails to apply a frame", async () => {
+    await withTransport(async (transport, socket) => {
+      const received: string[] = [];
+      transport.setReceiver((payload) => {
+        received.push(payload);
+        if (received.length === 1) {
+          throw new Error("consumer failed to apply this frame");
+        }
+      });
+
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      const closed = new Promise<void>((resolve) => {
+        socket().addEventListener("close", () => resolve(), { once: true });
+      });
+      // First frame throws in the receiver: the transport must treat the
+      // unapplied frame as a gap and close rather than deliver frame two
+      // (which the session would ack from inconsistent state).
+      socket().dispatchEvent(
+        new MessageEvent("message", {
+          data: (await deflateWirePayload(LARGE)).buffer,
+        }),
+      );
+      socket().dispatchEvent(new MessageEvent("message", { data: SMALL }));
+
+      await closed;
+      expect(received).toEqual([LARGE]);
+    });
+  });
+
+  it("tolerates a close() that throws while poisoning", async () => {
+    await withTransport(async (transport, socket) => {
+      const received: string[] = [];
+      transport.setReceiver((payload) => received.push(payload));
+      const send = transport.send(SMALL);
+      openSocket(socket());
+      await send;
+
+      // Force the poison path's socket.close() to throw: the failure must
+      // stay contained (no unhandled rejection, no delivery past the gap).
+      socket().close = () => {
+        throw new Error("close raced the peer");
+      };
+      socket().dispatchEvent(
+        new MessageEvent("message", {
+          data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer,
+        }),
+      );
+      socket().dispatchEvent(new MessageEvent("message", { data: SMALL }));
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(received).toEqual([]);
+    });
+  });
+
   it("ignores binary frames when the socket did not negotiate deflate", async () => {
     await withTransport(async (transport, socket) => {
       const received: string[] = [];

--- a/packages/toolshed/.env.example
+++ b/packages/toolshed/.env.example
@@ -88,3 +88,13 @@ OTEL_TRACES_SAMPLER_ARG=1.0
 ## Strava OAuth
 # STRAVA_CLIENT_ID=
 # STRAVA_CLIENT_SECRET=
+
+# Memory websocket per-message deflate (fvj1.deflate subprotocol). "0"/"false"
+# stops this process from compressing outbound (and Deno clients from
+# offering); servers always select an offered subprotocol regardless. See
+# docs/development/EXPERIMENTAL_OPTIONS.md#memorywsdeflate.
+# CF_MEMORY_WS_DEFLATE=0
+
+# Diagnostic: append per-connection deflate byte accounting (JSON lines,
+# no payload contents) to this file on connection close. Unset disables.
+# CF_MEMORY_WS_DEFLATE_STATS_FILE=/tmp/memory-ws-deflate-stats.jsonl

--- a/packages/toolshed/.env.example
+++ b/packages/toolshed/.env.example
@@ -89,7 +89,7 @@ OTEL_TRACES_SAMPLER_ARG=1.0
 # STRAVA_CLIENT_ID=
 # STRAVA_CLIENT_SECRET=
 
-# Memory websocket per-message deflate (fvj1.deflate subprotocol). "0"/"false"
+# Memory websocket per-message deflate (cf-memory.deflate.v1 subprotocol). "0"/"false"
 # stops this process from compressing outbound (and Deno clients from
 # offering); servers always select an offered subprotocol regardless. See
 # docs/development/EXPERIMENTAL_OPTIONS.md#memorywsdeflate.

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.test.ts
@@ -1,0 +1,49 @@
+import { assert, assertEquals } from "@std/assert";
+import { createMemoryWsDeflateStatsRecorder } from "./memory-ws-deflate-stats.ts";
+
+Deno.test("deflate stats recorder flushes once and classifies browsers", async () => {
+  const statsFile = await Deno.makeTempFile({ suffix: ".jsonl" });
+  Deno.env.set("CF_MEMORY_WS_DEFLATE_STATS_FILE", statsFile);
+  try {
+    const recorder = createMemoryWsDeflateStatsRecorder(
+      "Mozilla/5.0 (X11; Linux x86_64)",
+      true,
+    );
+    assert(recorder !== undefined);
+    recorder!.recordInbound(50, 100, true, 0.5);
+    recorder!.recordOutbound(80, 80, false);
+    recorder!.flush();
+    // A second flush (close and error events can both fire) must not append
+    // a duplicate line.
+    recorder!.flush();
+
+    const lines = (await Deno.readTextFile(statsFile)).trim().split("\n");
+    assertEquals(lines.length, 1);
+    const record = JSON.parse(lines[0]);
+    assertEquals(record.kind, "browser");
+    assertEquals(record.negotiated, true);
+    assertEquals(record.inbound.compressedFrames, 1);
+    assertEquals(record.outbound.compressedFrames, 0);
+    assertEquals(record.cpuMs, 0.5);
+  } finally {
+    Deno.env.delete("CF_MEMORY_WS_DEFLATE_STATS_FILE");
+    await Deno.remove(statsFile).catch(() => {});
+  }
+});
+
+Deno.test("deflate stats recorder swallows write failures on flush", () => {
+  Deno.env.set(
+    "CF_MEMORY_WS_DEFLATE_STATS_FILE",
+    "/nonexistent-dir/never/stats.jsonl",
+  );
+  try {
+    const recorder = createMemoryWsDeflateStatsRecorder(undefined, false);
+    assert(recorder !== undefined);
+    recorder!.recordOutbound(10, 10, false);
+    // The append target is unwritable: flush must not throw — diagnostics
+    // never disturb the connection.
+    recorder!.flush();
+  } finally {
+    Deno.env.delete("CF_MEMORY_WS_DEFLATE_STATS_FILE");
+  }
+});

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts
@@ -74,6 +74,10 @@ export const createMemoryWsDeflateStatsRecorder = (
       if (flushed) return;
       flushed = true;
       try {
+        // Plain JSON.stringify on purpose: this is a diagnostic JSONL line
+        // of scalar counters, not wire data — the memory codec
+        // (encodeMemoryBoundary) is for protocol payloads and would be the
+        // wrong tool here.
         Deno.writeTextFileSync(
           file,
           JSON.stringify({

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts
@@ -1,0 +1,93 @@
+/**
+ * SPIKE diagnostic: per-connection byte accounting for the memory websocket
+ * deflate transport. When `CF_MEMORY_WS_DEFLATE_STATS_FILE` names a file,
+ * every memory websocket connection appends one JSON line on close with its
+ * logical (uncompressed text) versus wire (post-compression) byte totals per
+ * direction, frame counts, and compression CPU time. Payload contents are
+ * never recorded. With the env var unset this module is inert.
+ */
+
+export interface MemoryWsDeflateStatsRecorder {
+  recordInbound(
+    wireBytes: number,
+    logicalBytes: number,
+    compressed: boolean,
+    cpuMs?: number,
+  ): void;
+  recordOutbound(
+    wireBytes: number,
+    logicalBytes: number,
+    compressed: boolean,
+    cpuMs?: number,
+  ): void;
+  flush(): void;
+}
+
+const statsFile = (): string | undefined => {
+  const value = Deno.env.get("CF_MEMORY_WS_DEFLATE_STATS_FILE");
+  return value === undefined || value === "" ? undefined : value;
+};
+
+const connectionKind = (userAgent: string | undefined): string =>
+  userAgent !== undefined && userAgent.includes("Mozilla")
+    ? "browser"
+    : "runtime";
+
+let connectionSeq = 0;
+
+export const createMemoryWsDeflateStatsRecorder = (
+  userAgent: string | undefined,
+  negotiated: boolean,
+): MemoryWsDeflateStatsRecorder | undefined => {
+  const file = statsFile();
+  if (file === undefined) return undefined;
+
+  const connectionId = ++connectionSeq;
+  const totals = {
+    inbound: { wireBytes: 0, logicalBytes: 0, frames: 0, compressedFrames: 0 },
+    outbound: { wireBytes: 0, logicalBytes: 0, frames: 0, compressedFrames: 0 },
+  };
+  let cpuMs = 0;
+  let flushed = false;
+
+  const record = (
+    direction: "inbound" | "outbound",
+    wireBytes: number,
+    logicalBytes: number,
+    compressed: boolean,
+    frameCpuMs?: number,
+  ) => {
+    const bucket = totals[direction];
+    bucket.wireBytes += wireBytes;
+    bucket.logicalBytes += logicalBytes;
+    bucket.frames += 1;
+    if (compressed) bucket.compressedFrames += 1;
+    if (frameCpuMs !== undefined) cpuMs += frameCpuMs;
+  };
+
+  return {
+    recordInbound: (wireBytes, logicalBytes, compressed, frameCpuMs) =>
+      record("inbound", wireBytes, logicalBytes, compressed, frameCpuMs),
+    recordOutbound: (wireBytes, logicalBytes, compressed, frameCpuMs) =>
+      record("outbound", wireBytes, logicalBytes, compressed, frameCpuMs),
+    flush: () => {
+      if (flushed) return;
+      flushed = true;
+      try {
+        Deno.writeTextFileSync(
+          file,
+          JSON.stringify({
+            connectionId,
+            kind: connectionKind(userAgent),
+            negotiated,
+            cpuMs: Math.round(cpuMs * 1000) / 1000,
+            ...totals,
+          }) + "\n",
+          { append: true },
+        );
+      } catch {
+        // Diagnostics never disturb the connection.
+      }
+    },
+  };
+};

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate-stats.ts
@@ -1,5 +1,5 @@
 /**
- * SPIKE diagnostic: per-connection byte accounting for the memory websocket
+ * Diagnostic: per-connection byte accounting for the memory websocket
  * deflate transport. When `CF_MEMORY_WS_DEFLATE_STATS_FILE` names a file,
  * every memory websocket connection appends one JSON line on close with its
  * logical (uncompressed text) versus wire (post-compression) byte totals per

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
@@ -1,5 +1,5 @@
 /**
- * Real-websocket coverage for the negotiated `fvj1.deflate` memory
+ * Real-websocket coverage for the negotiated `cf-memory.deflate.v1` memory
  * transport: negotiation via subprotocol, synchronous server codec both
  * directions, the auth-frame compression exemption, the env kill switch,
  * and byte-identical behavior for clients that do not offer the

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
@@ -1,8 +1,9 @@
 /**
- * SPIKE: real-websocket coverage for the negotiated `fvj1.deflate` memory
- * transport — negotiation via subprotocol, compressed frames both directions,
- * mixed text/binary on one connection, and byte-identical behavior for
- * clients that do not offer the subprotocol.
+ * Real-websocket coverage for the negotiated `fvj1.deflate` memory
+ * transport: negotiation via subprotocol, synchronous server codec both
+ * directions, the auth-frame compression exemption, the env kill switch,
+ * and byte-identical behavior for clients that do not offer the
+ * subprotocol.
  */
 import { assert, assertEquals } from "@std/assert";
 import app from "../../../app.ts";
@@ -15,11 +16,13 @@ import {
   type SessionOpenChallenge,
 } from "@commonfabric/memory/v2";
 import {
-  deflateWirePayload,
-  inflateWirePayload,
   MEMORY_WS_DEFLATE_MIN_BYTES,
   MEMORY_WS_DEFLATE_SUBPROTOCOL,
 } from "@commonfabric/memory/v2/transport-deflate";
+import {
+  deflateWirePayloadSync,
+  inflateWirePayloadSync,
+} from "@commonfabric/memory/v2/transport-deflate-sync";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
@@ -74,7 +77,7 @@ const readWireMessage = async <Message extends FabricValue>(
     return { message: decodeMemoryBoundary<Message>(data), wasBinary: false };
   }
   return {
-    message: decodeMemoryBoundary<Message>(await inflateWirePayload(data)),
+    message: decodeMemoryBoundary<Message>(inflateWirePayloadSync(data)),
     wasBinary: true,
   };
 };
@@ -107,7 +110,149 @@ const createSessionOpenAuth = async (
   };
 };
 
-Deno.test("memory websocket negotiates deflate and speaks compressed frames both directions", async () => {
+/** hello (compressed — servers must accept any framing) → hello.ok →
+ *  session.open (text, matching the real client's auth exemption). */
+const negotiateSession = async (
+  socket: WebSocket,
+  identity: Identity,
+  space: string,
+): Promise<{ sessionId: string; helloWasBinary: boolean }> => {
+  socket.send(deflateWirePayloadSync(encodeMemoryBoundary(HELLO)));
+  const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
+  assertEquals(hello.message.type, "hello.ok");
+  assertEquals(hello.message.protocol, MEMORY_PROTOCOL);
+
+  const auth = await createSessionOpenAuth(
+    identity,
+    space,
+    hello.message.sessionOpen,
+  );
+  socket.send(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open-1",
+    space,
+    session: {},
+    ...auth,
+  }));
+  const opened = await readWireMessage<{
+    type: "response";
+    requestId: string;
+    ok: { sessionId: string };
+  }>(socket);
+  assertEquals(opened.message.type, "response");
+  assert(opened.message.ok.sessionId.length > 0);
+  // The session.open response carries the bearer session token and the next
+  // challenge: auth-bearing frames are never compressed, regardless of size.
+  assertEquals(
+    opened.wasBinary,
+    false,
+    "session.open response must never be compressed (auth exemption)",
+  );
+  return {
+    sessionId: opened.message.ok.sessionId,
+    helloWasBinary: hello.wasBinary,
+  };
+};
+
+/** Writes a document large enough that its watch.add sync response crosses
+ *  the compression threshold, then watches it. Returns the response frame's
+ *  framing plus decoded response. The transact itself is sent COMPRESSED to
+ *  exercise synchronous server-side inflation of a large frame. */
+const transactAndWatchFatDoc = async (
+  socket: WebSocket,
+  space: string,
+  sessionId: string,
+  ownerDid: string,
+): Promise<{ watchWasBinary: boolean; fatValue: string }> => {
+  // Fresh spaces demand an ACL-only genesis commit before ordinary writes.
+  socket.send(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "tx-genesis",
+    space,
+    sessionId,
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: `of:${space}`,
+        value: { value: { [ownerDid]: "OWNER" } },
+      }],
+    },
+  }));
+  const genesis = await readWireMessage<{
+    type: "response";
+    requestId: string;
+    error?: { name: string; message: string };
+  }>(socket);
+  assertEquals(genesis.message.requestId, "tx-genesis");
+  assertEquals(genesis.message.error, undefined);
+
+  const fatValue = "lunch-".repeat(200);
+  socket.send(deflateWirePayloadSync(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "tx-1",
+    space,
+    sessionId,
+    commit: {
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:doc:fat",
+        value: { value: { fat: fatValue } },
+      }],
+    },
+  })));
+  const committed = await readWireMessage<{
+    type: "response";
+    requestId: string;
+    ok?: Record<string, unknown>;
+    error?: { name: string; message: string };
+  }>(socket);
+  assertEquals(committed.message.requestId, "tx-1");
+  assertEquals(committed.message.error, undefined);
+
+  socket.send(encodeMemoryBoundary({
+    type: "session.watch.add",
+    requestId: "watch-1",
+    space,
+    sessionId,
+    watches: [{
+      id: "fat-doc",
+      kind: "graph",
+      query: {
+        roots: [{ id: "of:doc:fat", selector: { path: [], schema: false } }],
+      },
+    }],
+  }));
+  const watched = await readWireMessage<{
+    type: "response";
+    requestId: string;
+    ok?: { sync?: { upserts?: Array<{ doc?: { value?: { fat?: string } } }> } };
+    error?: { name: string; message: string };
+  }>(socket);
+  assertEquals(watched.message.requestId, "watch-1");
+  assertEquals(watched.message.error, undefined);
+  const roundtripped = watched.message.ok?.sync?.upserts?.[0]?.doc?.value?.fat;
+  assertEquals(roundtripped, fatValue);
+  assert(
+    encodeMemoryBoundary(watched.message).length >=
+      MEMORY_WS_DEFLATE_MIN_BYTES,
+    "watch response must cross the compression threshold for this test",
+  );
+  return { watchWasBinary: watched.wasBinary, fatValue };
+};
+
+const closeSocket = async (socket: WebSocket): Promise<void> => {
+  const closed = new Promise<void>((resolve) => {
+    socket.addEventListener("close", () => resolve(), { once: true });
+  });
+  socket.close();
+  await closed;
+};
+
+Deno.test("memory websocket compresses large frames both ways but never auth frames", async () => {
   const identity = await Identity.fromPassphrase("memory-ws-deflate-test");
   const server = Deno.serve({ port: 0 }, app.fetch);
   const address = new URL(
@@ -119,57 +264,34 @@ Deno.test("memory websocket negotiates deflate and speaks compressed frames both
     const socket = await openSocket(address, [MEMORY_WS_DEFLATE_SUBPROTOCOL]);
     assertEquals(socket.protocol, MEMORY_WS_DEFLATE_SUBPROTOCOL);
 
-    // Send the hello COMPRESSED even though it is small: the server must
-    // inflate a binary first frame before protocol sniffing.
-    socket.send(await deflateWirePayload(encodeMemoryBoundary(HELLO)));
-
-    const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
-    assertEquals(hello.message.type, "hello.ok");
-    assertEquals(hello.message.protocol, MEMORY_PROTOCOL);
-    assertEquals(hello.message.flags, getMemoryProtocolFlags());
-    // hello.ok (flags + audience + challenge) is above the compression
-    // threshold, so a negotiated server ships it as a binary frame.
-    assert(hello.wasBinary, "expected hello.ok as a compressed binary frame");
-
-    // Mixed framing: a plain-text frame is still valid after negotiation.
-    const auth = await createSessionOpenAuth(
+    const { sessionId, helloWasBinary } = await negotiateSession(
+      socket,
       identity,
       space,
-      hello.message.sessionOpen,
     );
-    socket.send(encodeMemoryBoundary({
-      type: "session.open",
-      requestId: "open-1",
-      space,
-      session: {},
-      ...auth,
-    }));
-
-    const opened = await readWireMessage<{
-      type: "response";
-      requestId: string;
-      ok: { sessionId: string; serverSeq: number };
-    }>(socket);
-    assertEquals(opened.message.type, "response");
-    assertEquals(opened.message.requestId, "open-1");
-    assertEquals(opened.message.ok.serverSeq, 0);
-    assert(opened.message.ok.sessionId.length > 0);
-    // Framing must follow the threshold: payloads at or above the minimum
-    // ship compressed, smaller ones stay text.
-    const encodedBytes = new TextEncoder().encode(
-      encodeMemoryBoundary(opened.message),
-    ).byteLength;
+    // hello.ok carries the session-open challenge: auth frames are exempt
+    // from compression even though hello.ok exceeds the size threshold.
     assertEquals(
-      opened.wasBinary,
-      encodedBytes >= MEMORY_WS_DEFLATE_MIN_BYTES,
-      `framing must match threshold for a ${encodedBytes}-byte payload`,
+      helloWasBinary,
+      false,
+      "hello.ok must never be compressed (auth exemption)",
     );
 
-    const closed = new Promise<void>((resolve) => {
-      socket.addEventListener("close", () => resolve(), { once: true });
-    });
-    socket.close();
-    await closed;
+    // Large non-auth traffic compresses in both directions: the transact
+    // goes up compressed, and the watch response comes down compressed.
+    const { watchWasBinary } = await transactAndWatchFatDoc(
+      socket,
+      space,
+      sessionId,
+      identity.did(),
+    );
+    assertEquals(
+      watchWasBinary,
+      true,
+      "large non-auth server frames must be compressed",
+    );
+
+    await closeSocket(socket);
   } finally {
     await server.shutdown();
   }
@@ -194,21 +316,19 @@ Deno.test("memory websocket without the subprotocol stays text-only", async () =
       "non-negotiated connections must never receive binary frames",
     );
 
-    const closed = new Promise<void>((resolve) => {
-      socket.addEventListener("close", () => resolve(), { once: true });
-    });
-    socket.close();
-    await closed;
+    await closeSocket(socket);
   } finally {
     await server.shutdown();
   }
 });
 
 Deno.test("env kill switch keeps negotiation but stops outbound compression", async () => {
+  const identity = await Identity.fromPassphrase("memory-ws-deflate-kill");
   const server = Deno.serve({ port: 0 }, app.fetch);
   const address = new URL(
     `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
   );
+  const space = identity.did();
 
   Deno.env.set("CF_MEMORY_WS_DEFLATE", "0");
   try {
@@ -218,17 +338,21 @@ Deno.test("env kill switch keeps negotiation but stops outbound compression", as
     assertEquals(socket.protocol, MEMORY_WS_DEFLATE_SUBPROTOCOL);
 
     // Compressed inbound frames are still accepted...
-    socket.send(await deflateWirePayload(encodeMemoryBoundary(HELLO)));
-    const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
-    assertEquals(hello.message.type, "hello.ok");
-    // ...but the server's outbound stays text.
-    assertEquals(hello.wasBinary, false);
+    const { sessionId } = await negotiateSession(socket, identity, space);
+    // ...but even large non-auth outbound stays text.
+    const { watchWasBinary } = await transactAndWatchFatDoc(
+      socket,
+      space,
+      sessionId,
+      identity.did(),
+    );
+    assertEquals(
+      watchWasBinary,
+      false,
+      "kill switch must stop outbound compression",
+    );
 
-    const closed = new Promise<void>((resolve) => {
-      socket.addEventListener("close", () => resolve(), { once: true });
-    });
-    socket.close();
-    await closed;
+    await closeSocket(socket);
   } finally {
     Deno.env.delete("CF_MEMORY_WS_DEFLATE");
     await server.shutdown();
@@ -243,7 +367,7 @@ Deno.test("memory websocket closes on a malformed compressed frame", async () =>
 
   try {
     const socket = await openSocket(address, [MEMORY_WS_DEFLATE_SUBPROTOCOL]);
-    socket.send(await deflateWirePayload(encodeMemoryBoundary(HELLO)));
+    socket.send(deflateWirePayloadSync(encodeMemoryBoundary(HELLO)));
     const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
     assertEquals(hello.message.type, "hello.ok");
 

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
@@ -383,3 +383,62 @@ Deno.test("memory websocket closes on a malformed compressed frame", async () =>
     await server.shutdown();
   }
 });
+
+Deno.test("stats recorder captures negotiated compression per connection", async () => {
+  const identity = await Identity.fromPassphrase("memory-ws-deflate-stats");
+  const statsFile = await Deno.makeTempFile({ suffix: ".jsonl" });
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  const space = identity.did();
+
+  Deno.env.set("CF_MEMORY_WS_DEFLATE_STATS_FILE", statsFile);
+  try {
+    const socket = await openSocket(address, [MEMORY_WS_DEFLATE_SUBPROTOCOL]);
+    const { sessionId } = await negotiateSession(socket, identity, space);
+    await transactAndWatchFatDoc(socket, space, sessionId, identity.did());
+    await closeSocket(socket);
+
+    // The recorder appends on the server's close event; poll briefly.
+    let lines: string[] = [];
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const content = await Deno.readTextFile(statsFile).catch(() => "");
+      lines = content.split("\n").filter((line) => line.length > 0);
+      if (lines.length > 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assertEquals(lines.length, 1, "one closed connection, one stats line");
+    const record = JSON.parse(lines[0]) as {
+      negotiated: boolean;
+      kind: string;
+      cpuMs: number;
+      inbound: {
+        wireBytes: number;
+        logicalBytes: number;
+        frames: number;
+        compressedFrames: number;
+      };
+      outbound: {
+        wireBytes: number;
+        logicalBytes: number;
+        frames: number;
+        compressedFrames: number;
+      };
+    };
+    assertEquals(record.negotiated, true);
+    assertEquals(record.kind, "runtime");
+    // The fat transact went up compressed and the fat watch response came
+    // down compressed, so both directions must show savings.
+    assert(record.inbound.compressedFrames >= 1);
+    assert(record.outbound.compressedFrames >= 1);
+    assert(record.inbound.wireBytes < record.inbound.logicalBytes);
+    assert(record.outbound.wireBytes < record.outbound.logicalBytes);
+    assert(record.inbound.frames > record.inbound.compressedFrames);
+    assert(record.cpuMs >= 0);
+  } finally {
+    Deno.env.delete("CF_MEMORY_WS_DEFLATE_STATS_FILE");
+    await server.shutdown();
+    await Deno.remove(statsFile).catch(() => {});
+  }
+});

--- a/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-ws-deflate.test.ts
@@ -1,0 +1,261 @@
+/**
+ * SPIKE: real-websocket coverage for the negotiated `fvj1.deflate` memory
+ * transport — negotiation via subprotocol, compressed frames both directions,
+ * mixed text/binary on one connection, and byte-identical behavior for
+ * clients that do not offer the subprotocol.
+ */
+import { assert, assertEquals } from "@std/assert";
+import app from "../../../app.ts";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type SessionOpenChallenge,
+} from "@commonfabric/memory/v2";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_DEFLATE_SUBPROTOCOL,
+} from "@commonfabric/memory/v2/transport-deflate";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { Identity } from "@commonfabric/identity";
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+type HelloOkWithSessionOpen = {
+  type: "hello.ok";
+  protocol: string;
+  flags: ReturnType<typeof getMemoryProtocolFlags>;
+  sessionOpen: {
+    audience: string;
+    challenge: SessionOpenChallenge;
+  };
+};
+
+const openSocket = async (
+  url: URL,
+  protocols?: string[],
+): Promise<WebSocket> => {
+  const socket = new WebSocket(url, protocols);
+  socket.binaryType = "arraybuffer";
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", (event) => reject(event), { once: true });
+  });
+  return socket;
+};
+
+const readWireMessage = async <Message extends FabricValue>(
+  socket: WebSocket,
+): Promise<{ message: Message; wasBinary: boolean }> => {
+  const data = await new Promise<string | ArrayBuffer>((resolve, reject) => {
+    socket.addEventListener("message", (event) => {
+      if (typeof event.data === "string" || event.data instanceof ArrayBuffer) {
+        resolve(event.data);
+        return;
+      }
+      reject(new Error("Unexpected websocket frame type"));
+    }, { once: true });
+    socket.addEventListener(
+      "error",
+      () => reject(new Error("WebSocket error before message")),
+      { once: true },
+    );
+  });
+  if (typeof data === "string") {
+    return { message: decodeMemoryBoundary<Message>(data), wasBinary: false };
+  }
+  return {
+    message: decodeMemoryBoundary<Message>(await inflateWirePayload(data)),
+    wasBinary: true,
+  };
+};
+
+const createSessionOpenAuth = async (
+  identity: Identity,
+  space: string,
+  sessionOpen: { audience: string; challenge: SessionOpenChallenge },
+) => {
+  const iat = Math.floor(Date.now() / 1000);
+  const invocation = {
+    iss: identity.did(),
+    cmd: "session.open",
+    sub: space,
+    aud: sessionOpen.audience,
+    args: { protocol: MEMORY_PROTOCOL, session: {} },
+    challenge: sessionOpen.challenge.value,
+    iat,
+    exp: iat + 300,
+  };
+  const signature = await identity.sign(hashOf(invocation).bytes);
+  if (signature.error) {
+    throw signature.error;
+  }
+  return {
+    invocation,
+    // Mirror the production producer (`v2-remote-session.ts`): send the
+    // signature as a `FabricBytes`.
+    authorization: { signature: new FabricBytes(signature.ok) },
+  };
+};
+
+Deno.test("memory websocket negotiates deflate and speaks compressed frames both directions", async () => {
+  const identity = await Identity.fromPassphrase("memory-ws-deflate-test");
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  const space = identity.did();
+
+  try {
+    const socket = await openSocket(address, [MEMORY_WS_DEFLATE_SUBPROTOCOL]);
+    assertEquals(socket.protocol, MEMORY_WS_DEFLATE_SUBPROTOCOL);
+
+    // Send the hello COMPRESSED even though it is small: the server must
+    // inflate a binary first frame before protocol sniffing.
+    socket.send(await deflateWirePayload(encodeMemoryBoundary(HELLO)));
+
+    const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
+    assertEquals(hello.message.type, "hello.ok");
+    assertEquals(hello.message.protocol, MEMORY_PROTOCOL);
+    assertEquals(hello.message.flags, getMemoryProtocolFlags());
+    // hello.ok (flags + audience + challenge) is above the compression
+    // threshold, so a negotiated server ships it as a binary frame.
+    assert(hello.wasBinary, "expected hello.ok as a compressed binary frame");
+
+    // Mixed framing: a plain-text frame is still valid after negotiation.
+    const auth = await createSessionOpenAuth(
+      identity,
+      space,
+      hello.message.sessionOpen,
+    );
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space,
+      session: {},
+      ...auth,
+    }));
+
+    const opened = await readWireMessage<{
+      type: "response";
+      requestId: string;
+      ok: { sessionId: string; serverSeq: number };
+    }>(socket);
+    assertEquals(opened.message.type, "response");
+    assertEquals(opened.message.requestId, "open-1");
+    assertEquals(opened.message.ok.serverSeq, 0);
+    assert(opened.message.ok.sessionId.length > 0);
+    // Framing must follow the threshold: payloads at or above the minimum
+    // ship compressed, smaller ones stay text.
+    const encodedBytes = new TextEncoder().encode(
+      encodeMemoryBoundary(opened.message),
+    ).byteLength;
+    assertEquals(
+      opened.wasBinary,
+      encodedBytes >= MEMORY_WS_DEFLATE_MIN_BYTES,
+      `framing must match threshold for a ${encodedBytes}-byte payload`,
+    );
+
+    const closed = new Promise<void>((resolve) => {
+      socket.addEventListener("close", () => resolve(), { once: true });
+    });
+    socket.close();
+    await closed;
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("memory websocket without the subprotocol stays text-only", async () => {
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+
+  try {
+    const socket = await openSocket(address);
+    assertEquals(socket.protocol, "");
+
+    socket.send(encodeMemoryBoundary(HELLO));
+    const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
+    assertEquals(hello.message.type, "hello.ok");
+    assertEquals(
+      hello.wasBinary,
+      false,
+      "non-negotiated connections must never receive binary frames",
+    );
+
+    const closed = new Promise<void>((resolve) => {
+      socket.addEventListener("close", () => resolve(), { once: true });
+    });
+    socket.close();
+    await closed;
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("env kill switch keeps negotiation but stops outbound compression", async () => {
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+
+  Deno.env.set("CF_MEMORY_WS_DEFLATE", "0");
+  try {
+    const socket = await openSocket(address, [MEMORY_WS_DEFLATE_SUBPROTOCOL]);
+    // The subprotocol is still selected — refusing an offer would fail the
+    // connection for clients (like browsers) that cannot read the env.
+    assertEquals(socket.protocol, MEMORY_WS_DEFLATE_SUBPROTOCOL);
+
+    // Compressed inbound frames are still accepted...
+    socket.send(await deflateWirePayload(encodeMemoryBoundary(HELLO)));
+    const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
+    assertEquals(hello.message.type, "hello.ok");
+    // ...but the server's outbound stays text.
+    assertEquals(hello.wasBinary, false);
+
+    const closed = new Promise<void>((resolve) => {
+      socket.addEventListener("close", () => resolve(), { once: true });
+    });
+    socket.close();
+    await closed;
+  } finally {
+    Deno.env.delete("CF_MEMORY_WS_DEFLATE");
+    await server.shutdown();
+  }
+});
+
+Deno.test("memory websocket closes on a malformed compressed frame", async () => {
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+
+  try {
+    const socket = await openSocket(address, [MEMORY_WS_DEFLATE_SUBPROTOCOL]);
+    socket.send(await deflateWirePayload(encodeMemoryBoundary(HELLO)));
+    const hello = await readWireMessage<HelloOkWithSessionOpen>(socket);
+    assertEquals(hello.message.type, "hello.ok");
+
+    const closed = new Promise<CloseEvent>((resolve) => {
+      socket.addEventListener("close", (event) => resolve(event), {
+        once: true,
+      });
+    });
+    socket.send(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+    const event = await closed;
+    assertEquals(event.code, 1007);
+  } finally {
+    await server.shutdown();
+  }
+});

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -2,14 +2,16 @@ import type { AppRouteHandler } from "@/lib/types.ts";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import {
-  deflateWirePayload,
-  inflateWirePayload,
+  isAuthBearingWireMessage,
   MEMORY_WS_DEFLATE_MIN_BYTES,
-  MEMORY_WS_MAX_PENDING_INFLATE_BYTES,
+  MEMORY_WS_SERVER_INFLATE_MAX_BYTES,
   memoryWsDeflateEnabled,
   selectMemoryWsDeflateProtocol,
-  SerialTaskQueue,
 } from "@commonfabric/memory/v2/transport-deflate";
+import {
+  deflateWirePayloadSync,
+  inflateWirePayloadSync,
+} from "@commonfabric/memory/v2/transport-deflate-sync";
 import type * as Routes from "./memory.routes.ts";
 import { memoryServer } from "../memory.ts";
 import { createSpan } from "@/middlewares/opentelemetry.ts";
@@ -28,14 +30,14 @@ type NegotiatedSocketHandlers = {
 type NegotiationOptions = {
   maxBufferedBytes?: number;
   /**
-   * SPIKE: present only when the connection negotiated `fvj1.deflate`.
-   * Binary frames are inflated with this and every frame (text included)
-   * then flows through one ordered async chain so dispatch order matches
-   * arrival order. Absent, the historical synchronous text-only path is
-   * used unchanged and binary frames stay fatal.
+   * Present only when the connection negotiated `fvj1.deflate`. The codec is
+   * deliberately SYNCHRONOUS: dispatch stays inside the message event
+   * handler, so frame ordering, pre-close delivery, and nothing-after-close
+   * remain event-loop properties rather than queue invariants. Absent, the
+   * historical text-only path is unchanged and binary frames stay fatal.
    */
-  inflateBinary?: (data: ArrayBuffer | ArrayBufferView) => Promise<string>;
-  /** SPIKE diagnostic: per-frame inbound byte accounting. */
+  inflateBinarySync?: (data: ArrayBuffer | ArrayBufferView) => string;
+  /** Diagnostic: per-frame inbound byte accounting. */
   onFrame?: (
     wireBytes: number,
     logicalBytes: number,
@@ -48,15 +50,13 @@ const NEGOTIATION_BUFFER_MAX_BYTES = 1_048_576;
 const TEXT_ENCODER = new TextEncoder();
 
 /** Close codes for transport-level frame errors: 1003 for a frame type the
- * connection does not accept, 1007 for undecodable compressed data, 1009 for
- * an inflate backlog past its bound, 1011 otherwise. */
+ * connection does not accept, 1007 for undecodable compressed data, 1011
+ * otherwise. */
 const closeCodeForSocketError = (error: Error): number =>
   error.message === "Memory websocket expects text frames"
     ? 1003
     : error.message === "Memory websocket inflate failure"
     ? 1007
-    : error.message === "Memory websocket inflate backlog exceeded"
-    ? 1009
     : 1011;
 
 export const bufferTextMessagesUntilNegotiated = (
@@ -133,15 +133,6 @@ export const bufferTextMessagesUntilNegotiated = (
       forwardMessage(text);
     };
 
-    // SPIKE: when the deflate subprotocol is negotiated, every frame goes
-    // through this chain so async inflation cannot reorder dispatch, and the
-    // close notification queues behind it so frames that arrived before the
-    // close are still delivered — matching the synchronous path's semantics.
-    const inflateQueue = options.inflateBinary !== undefined
-      ? new SerialTaskQueue()
-      : null;
-    let pendingInflateBytes = 0;
-
     const onMessage = (event: MessageEvent) => {
       const data: unknown = event.data;
       if (typeof data === "string") {
@@ -149,52 +140,37 @@ export const bufferTextMessagesUntilNegotiated = (
           const bytes = TEXT_ENCODER.encode(data).byteLength;
           options.onFrame(bytes, bytes, false);
         }
-        if (inflateQueue === null) {
-          dispatchText(data);
-          return;
-        }
-        void inflateQueue.enqueue(() => dispatchText(data)).catch(() =>
-          failFrame(new Error("Memory websocket dispatch failure"))
-        );
+        dispatchText(data);
         return;
       }
 
       if (
-        inflateQueue !== null &&
+        options.inflateBinarySync !== undefined &&
         (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
       ) {
-        if (
-          pendingInflateBytes + data.byteLength >
-            MEMORY_WS_MAX_PENDING_INFLATE_BYTES
-        ) {
-          failFrame(new Error("Memory websocket inflate backlog exceeded"));
+        let text: string;
+        try {
+          const started = performance.now();
+          text = options.inflateBinarySync(data);
+          options.onFrame?.(
+            data.byteLength,
+            TEXT_ENCODER.encode(text).byteLength,
+            true,
+            performance.now() - started,
+          );
+        } catch {
+          failFrame(new Error("Memory websocket inflate failure"));
           return;
         }
-        pendingInflateBytes += data.byteLength;
-        void inflateQueue.enqueue(async () => {
-          try {
-            const started = performance.now();
-            const text = await options.inflateBinary!(data);
-            options.onFrame?.(
-              data.byteLength,
-              TEXT_ENCODER.encode(text).byteLength,
-              true,
-              performance.now() - started,
-            );
-            dispatchText(text);
-          } finally {
-            pendingInflateBytes -= data.byteLength;
-          }
-        }).catch(() =>
-          failFrame(new Error("Memory websocket inflate failure"))
-        );
+        dispatchText(text);
         return;
       }
 
       failFrame(new Error("Memory websocket expects text frames"));
     };
 
-    const notifyClose = () => {
+    const onClose = () => {
+      cleanup();
       if (!settled) {
         settled = true;
         resolve(undefined);
@@ -209,16 +185,8 @@ export const bufferTextMessagesUntilNegotiated = (
       closePending = true;
     };
 
-    const onClose = () => {
+    const onError = () => {
       cleanup();
-      if (inflateQueue === null) {
-        notifyClose();
-        return;
-      }
-      void inflateQueue.enqueue(notifyClose).catch(() => {});
-    };
-
-    const notifyError = () => {
       if (!settled) {
         reject(new Error("Memory websocket failed before negotiation"));
         return;
@@ -230,17 +198,6 @@ export const bufferTextMessagesUntilNegotiated = (
       // Settled but not handed off: surface the failure at handoff so the
       // memory connection is still torn down instead of leaking.
       negotiationError = new Error("Memory websocket receive failure");
-    };
-
-    const onError = () => {
-      cleanup();
-      // Abnormal closures fire error-then-close; queue the notification like
-      // onClose so frames already inflating still deliver first.
-      if (inflateQueue === null) {
-        notifyError();
-        return;
-      }
-      void inflateQueue.enqueue(notifyError).catch(() => {});
     };
 
     cleanup = () => {
@@ -309,17 +266,19 @@ const attachMemorySocketPipeline = (
       // Ignore close races with the peer.
     }
   };
-  // SPIKE: on a negotiated connection, sends funnel through a serial queue
-  // because deflate is async and outbound order must match message order.
-  const sendQueue = options.deflateOutbound === true
-    ? new SerialTaskQueue()
-    : null;
   const connection = memoryServer.connect((message) => {
+    if (socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
     const payload = encodeMemoryBoundary(message);
-    if (sendQueue === null) {
-      if (socket.readyState !== WebSocket.OPEN) {
-        return;
-      }
+    // Auth-bearing frames (hello.ok's challenge, the session.open response's
+    // bearer token) are never compressed: credential material stays out of
+    // compression-size side channels (CRIME-class). The codec is
+    // synchronous, so ordering needs no queue.
+    if (
+      options.deflateOutbound !== true ||
+      isAuthBearingWireMessage(message)
+    ) {
       if (options.stats !== undefined) {
         const bytes = TEXT_ENCODER.encode(payload).byteLength;
         options.stats.recordOutbound(bytes, bytes, false);
@@ -327,28 +286,30 @@ const attachMemorySocketPipeline = (
       socket.send(payload);
       return;
     }
-    void sendQueue.enqueue(async () => {
-      const logicalBytes = TEXT_ENCODER.encode(payload).byteLength;
-      if (logicalBytes < MEMORY_WS_DEFLATE_MIN_BYTES) {
-        if (socket.readyState !== WebSocket.OPEN) return;
-        options.stats?.recordOutbound(logicalBytes, logicalBytes, false);
-        socket.send(payload);
-        return;
-      }
+    const payloadBytes = TEXT_ENCODER.encode(payload);
+    if (payloadBytes.byteLength < MEMORY_WS_DEFLATE_MIN_BYTES) {
+      options.stats?.recordOutbound(
+        payloadBytes.byteLength,
+        payloadBytes.byteLength,
+        false,
+      );
+      socket.send(payload);
+      return;
+    }
+    try {
       const started = performance.now();
-      const compressed = await deflateWirePayload(payload);
-      if (socket.readyState !== WebSocket.OPEN) return;
+      const compressed = deflateWirePayloadSync(payloadBytes);
       options.stats?.recordOutbound(
         compressed.byteLength,
-        logicalBytes,
+        payloadBytes.byteLength,
         true,
         performance.now() - started,
       );
       socket.send(compressed);
-    }).catch(() => {
+    } catch {
       safeSocketClose(1011, "Memory websocket send failure");
       connection.close();
-    });
+    }
   });
   const closeConnection = () => {
     connection.close();
@@ -443,7 +404,15 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
       void createSpan("memory.socket.setup", async (setupSpan) => {
         const negotiation = bufferTextMessagesUntilNegotiated(socket, {
           ...(deflateProtocol !== undefined
-            ? { inflateBinary: inflateWirePayload }
+            ? {
+              // The tighter server cap bounds pre-authorization synchronous
+              // inflation on the shared event loop.
+              inflateBinarySync: (data) =>
+                inflateWirePayloadSync(
+                  data,
+                  MEMORY_WS_SERVER_INFLATE_MAX_BYTES,
+                ),
+            }
             : {}),
           ...(stats !== undefined
             ? {

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -311,8 +311,13 @@ const attachMemorySocketPipeline = (
       connection.close();
     }
   });
+  // The connection processes receives through an ordered chain, and closing
+  // drops chained-but-unstarted receives. Frames already handed to receive()
+  // — including the handoff's buffered flush — must settle before the close,
+  // or messages that arrived before the close event are silently discarded.
+  let lastReceive: Promise<unknown> = Promise.resolve();
   const closeConnection = () => {
-    connection.close();
+    void lastReceive.catch(() => undefined).finally(() => connection.close());
   };
 
   // Gated diagnostic write trace (off by default). `CF_DEBUG_MEMORY_WRITES=1`
@@ -348,7 +353,9 @@ const attachMemorySocketPipeline = (
         onMessage(message) {
           // Trace only after the receive resolves, so a message whose receive
           // fails (the fatal-error path below) is not logged as a write.
-          void connection.receive(message).then(
+          const received = connection.receive(message);
+          lastReceive = received;
+          void received.then(
             () => logMemWrites(message),
             () => {
               safeSocketClose(1011, "Memory websocket receive failure");

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -215,16 +215,32 @@ export const bufferTextMessagesUntilNegotiated = (
         notifyClose();
         return;
       }
-      void inflateQueue.enqueue(notifyClose);
+      void inflateQueue.enqueue(notifyClose).catch(() => {});
     };
 
-    const onError = () => {
-      cleanup();
+    const notifyError = () => {
       if (!settled) {
         reject(new Error("Memory websocket failed before negotiation"));
         return;
       }
-      handlers?.onError?.(new Error("Memory websocket receive failure"));
+      if (handlers !== null) {
+        handlers.onError?.(new Error("Memory websocket receive failure"));
+        return;
+      }
+      // Settled but not handed off: surface the failure at handoff so the
+      // memory connection is still torn down instead of leaking.
+      negotiationError = new Error("Memory websocket receive failure");
+    };
+
+    const onError = () => {
+      cleanup();
+      // Abnormal closures fire error-then-close; queue the notification like
+      // onClose so frames already inflating still deliver first.
+      if (inflateQueue === null) {
+        notifyError();
+        return;
+      }
+      void inflateQueue.enqueue(notifyError).catch(() => {});
     };
 
     cleanup = () => {

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -244,7 +244,7 @@ const attachMemorySocketPipeline = (
   negotiation: ReturnType<typeof bufferTextMessagesUntilNegotiated>,
   firstMessage: string,
   options: {
-    /** SPIKE: compress outbound payloads (deflate subprotocol negotiated). */
+    /** compress outbound payloads (deflate subprotocol negotiated). */
     deflateOutbound?: boolean;
     stats?: MemoryWsDeflateStatsRecorder;
   } = {},
@@ -383,7 +383,7 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
     try {
       span.setAttribute("memory.operation", "subscribe");
 
-      // SPIKE: transport-level compression rides the websocket subprotocol.
+      // transport-level compression rides the websocket subprotocol.
       // Selection is unconditional on the offer — refusing an offered
       // subprotocol fails the connection per RFC 6455 — while the env kill
       // switch only stops this server from compressing its own outbound.

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -1,10 +1,23 @@
 import type { AppRouteHandler } from "@/lib/types.ts";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
+import {
+  deflateWirePayload,
+  inflateWirePayload,
+  MEMORY_WS_DEFLATE_MIN_BYTES,
+  MEMORY_WS_MAX_PENDING_INFLATE_BYTES,
+  memoryWsDeflateEnabled,
+  selectMemoryWsDeflateProtocol,
+  SerialTaskQueue,
+} from "@commonfabric/memory/v2/transport-deflate";
 import type * as Routes from "./memory.routes.ts";
 import { memoryServer } from "../memory.ts";
 import { createSpan } from "@/middlewares/opentelemetry.ts";
 import { formatMemWriteTrace, type MemWriteOp } from "./memwrite-trace.ts";
+import {
+  createMemoryWsDeflateStatsRecorder,
+  type MemoryWsDeflateStatsRecorder,
+} from "./memory-ws-deflate-stats.ts";
 
 type NegotiatedSocketHandlers = {
   onMessage: (message: string) => void;
@@ -14,10 +27,37 @@ type NegotiatedSocketHandlers = {
 
 type NegotiationOptions = {
   maxBufferedBytes?: number;
+  /**
+   * SPIKE: present only when the connection negotiated `fvj1.deflate`.
+   * Binary frames are inflated with this and every frame (text included)
+   * then flows through one ordered async chain so dispatch order matches
+   * arrival order. Absent, the historical synchronous text-only path is
+   * used unchanged and binary frames stay fatal.
+   */
+  inflateBinary?: (data: ArrayBuffer | ArrayBufferView) => Promise<string>;
+  /** SPIKE diagnostic: per-frame inbound byte accounting. */
+  onFrame?: (
+    wireBytes: number,
+    logicalBytes: number,
+    compressed: boolean,
+    cpuMs?: number,
+  ) => void;
 };
 
 const NEGOTIATION_BUFFER_MAX_BYTES = 1_048_576;
 const TEXT_ENCODER = new TextEncoder();
+
+/** Close codes for transport-level frame errors: 1003 for a frame type the
+ * connection does not accept, 1007 for undecodable compressed data, 1009 for
+ * an inflate backlog past its bound, 1011 otherwise. */
+const closeCodeForSocketError = (error: Error): number =>
+  error.message === "Memory websocket expects text frames"
+    ? 1003
+    : error.message === "Memory websocket inflate failure"
+    ? 1007
+    : error.message === "Memory websocket inflate backlog exceeded"
+    ? 1009
+    : 1011;
 
 export const bufferTextMessagesUntilNegotiated = (
   socket: WebSocket,
@@ -35,6 +75,7 @@ export const bufferTextMessagesUntilNegotiated = (
   let cleanup = () => {};
   let handlers: NegotiatedSocketHandlers | null = null;
   let negotiationError: Error | null = null;
+  let closePending = false;
 
   const forwardMessage = (message: string) => {
     if (handlers === null) {
@@ -63,36 +104,118 @@ export const bufferTextMessagesUntilNegotiated = (
   };
 
   const firstMessage = new Promise<string | undefined>((resolve, reject) => {
-    const onMessage = (event: MessageEvent) => {
-      if (typeof event.data !== "string") {
-        if (!settled) {
-          cleanup();
-          reject(new Error("Memory websocket expects text frames"));
-        } else {
-          handlers?.onError?.(
-            new Error("Memory websocket expects text frames"),
-          );
-        }
-        return;
-      }
-
+    const failFrame = (error: Error) => {
       if (!settled) {
-        settled = true;
-        resolve(event.data);
+        cleanup();
+        reject(error);
         return;
       }
-
-      forwardMessage(event.data);
+      if (handlers !== null) {
+        handlers.onError?.(error);
+        return;
+      }
+      // Settled but not handed off: fail the socket now and let handoff
+      // deliver the error, instead of silently swallowing the frame.
+      negotiationError = error;
+      try {
+        socket.close(closeCodeForSocketError(error), error.message);
+      } catch {
+        // Ignore close races with the peer.
+      }
     };
 
-    const onClose = () => {
-      cleanup();
+    const dispatchText = (text: string) => {
+      if (!settled) {
+        settled = true;
+        resolve(text);
+        return;
+      }
+      forwardMessage(text);
+    };
+
+    // SPIKE: when the deflate subprotocol is negotiated, every frame goes
+    // through this chain so async inflation cannot reorder dispatch, and the
+    // close notification queues behind it so frames that arrived before the
+    // close are still delivered — matching the synchronous path's semantics.
+    const inflateQueue = options.inflateBinary !== undefined
+      ? new SerialTaskQueue()
+      : null;
+    let pendingInflateBytes = 0;
+
+    const onMessage = (event: MessageEvent) => {
+      const data: unknown = event.data;
+      if (typeof data === "string") {
+        if (options.onFrame !== undefined) {
+          const bytes = TEXT_ENCODER.encode(data).byteLength;
+          options.onFrame(bytes, bytes, false);
+        }
+        if (inflateQueue === null) {
+          dispatchText(data);
+          return;
+        }
+        void inflateQueue.enqueue(() => dispatchText(data)).catch(() =>
+          failFrame(new Error("Memory websocket dispatch failure"))
+        );
+        return;
+      }
+
+      if (
+        inflateQueue !== null &&
+        (data instanceof ArrayBuffer || ArrayBuffer.isView(data))
+      ) {
+        if (
+          pendingInflateBytes + data.byteLength >
+            MEMORY_WS_MAX_PENDING_INFLATE_BYTES
+        ) {
+          failFrame(new Error("Memory websocket inflate backlog exceeded"));
+          return;
+        }
+        pendingInflateBytes += data.byteLength;
+        void inflateQueue.enqueue(async () => {
+          try {
+            const started = performance.now();
+            const text = await options.inflateBinary!(data);
+            options.onFrame?.(
+              data.byteLength,
+              TEXT_ENCODER.encode(text).byteLength,
+              true,
+              performance.now() - started,
+            );
+            dispatchText(text);
+          } finally {
+            pendingInflateBytes -= data.byteLength;
+          }
+        }).catch(() =>
+          failFrame(new Error("Memory websocket inflate failure"))
+        );
+        return;
+      }
+
+      failFrame(new Error("Memory websocket expects text frames"));
+    };
+
+    const notifyClose = () => {
       if (!settled) {
         settled = true;
         resolve(undefined);
         return;
       }
-      handlers?.onClose?.();
+      if (handlers !== null) {
+        handlers.onClose?.();
+        return;
+      }
+      // Between settle and handoff: remember the close so handoff can
+      // deliver it after flushing buffered messages.
+      closePending = true;
+    };
+
+    const onClose = () => {
+      cleanup();
+      if (inflateQueue === null) {
+        notifyClose();
+        return;
+      }
+      void inflateQueue.enqueue(notifyClose);
     };
 
     const onError = () => {
@@ -129,6 +252,9 @@ export const bufferTextMessagesUntilNegotiated = (
       for (const message of queued) {
         nextHandlers.onMessage(message);
       }
+      if (closePending) {
+        nextHandlers.onClose?.();
+      }
     },
     dispose: cleanup,
   };
@@ -144,6 +270,11 @@ const attachMemorySocketPipeline = (
   socket: WebSocket,
   negotiation: ReturnType<typeof bufferTextMessagesUntilNegotiated>,
   firstMessage: string,
+  options: {
+    /** SPIKE: compress outbound payloads (deflate subprotocol negotiated). */
+    deflateOutbound?: boolean;
+    stats?: MemoryWsDeflateStatsRecorder;
+  } = {},
 ): boolean => {
   if (MemoryServer.parseClientMessage(firstMessage) === null) {
     return false;
@@ -162,11 +293,46 @@ const attachMemorySocketPipeline = (
       // Ignore close races with the peer.
     }
   };
+  // SPIKE: on a negotiated connection, sends funnel through a serial queue
+  // because deflate is async and outbound order must match message order.
+  const sendQueue = options.deflateOutbound === true
+    ? new SerialTaskQueue()
+    : null;
   const connection = memoryServer.connect((message) => {
-    if (socket.readyState !== WebSocket.OPEN) {
+    const payload = encodeMemoryBoundary(message);
+    if (sendQueue === null) {
+      if (socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      if (options.stats !== undefined) {
+        const bytes = TEXT_ENCODER.encode(payload).byteLength;
+        options.stats.recordOutbound(bytes, bytes, false);
+      }
+      socket.send(payload);
       return;
     }
-    socket.send(encodeMemoryBoundary(message));
+    void sendQueue.enqueue(async () => {
+      const logicalBytes = TEXT_ENCODER.encode(payload).byteLength;
+      if (logicalBytes < MEMORY_WS_DEFLATE_MIN_BYTES) {
+        if (socket.readyState !== WebSocket.OPEN) return;
+        options.stats?.recordOutbound(logicalBytes, logicalBytes, false);
+        socket.send(payload);
+        return;
+      }
+      const started = performance.now();
+      const compressed = await deflateWirePayload(payload);
+      if (socket.readyState !== WebSocket.OPEN) return;
+      options.stats?.recordOutbound(
+        compressed.byteLength,
+        logicalBytes,
+        true,
+        performance.now() - started,
+      );
+      socket.send(compressed);
+    }).catch(() => {
+      safeSocketClose(1011, "Memory websocket send failure");
+      connection.close();
+    });
   });
   const closeConnection = () => {
     connection.close();
@@ -215,12 +381,7 @@ const attachMemorySocketPipeline = (
         },
         onClose: closeConnection,
         onError(error) {
-          safeSocketClose(
-            error.message === "Memory websocket expects text frames"
-              ? 1003
-              : 1011,
-            error.message,
-          );
+          safeSocketClose(closeCodeForSocketError(error), error.message);
           closeConnection();
         },
       });
@@ -238,11 +399,43 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
     try {
       span.setAttribute("memory.operation", "subscribe");
 
-      const { socket, response } = Deno.upgradeWebSocket(c.req.raw);
+      // SPIKE: transport-level compression rides the websocket subprotocol.
+      // Selection is unconditional on the offer — refusing an offered
+      // subprotocol fails the connection per RFC 6455 — while the env kill
+      // switch only stops this server from compressing its own outbound.
+      const deflateProtocol = selectMemoryWsDeflateProtocol(
+        c.req.header("sec-websocket-protocol"),
+      );
+      const deflateOutbound = deflateProtocol !== undefined &&
+        memoryWsDeflateEnabled();
+      const { socket, response } = Deno.upgradeWebSocket(
+        c.req.raw,
+        deflateProtocol !== undefined ? { protocol: deflateProtocol } : {},
+      );
+      socket.binaryType = "arraybuffer";
       span.setAttribute("websocket.upgrade", "success");
+      span.setAttribute("websocket.deflate", deflateProtocol !== undefined);
+
+      const stats = createMemoryWsDeflateStatsRecorder(
+        c.req.header("user-agent"),
+        deflateProtocol !== undefined,
+      );
+      if (stats !== undefined) {
+        socket.addEventListener("close", () => stats.flush(), { once: true });
+      }
 
       void createSpan("memory.socket.setup", async (setupSpan) => {
-        const negotiation = bufferTextMessagesUntilNegotiated(socket);
+        const negotiation = bufferTextMessagesUntilNegotiated(socket, {
+          ...(deflateProtocol !== undefined
+            ? { inflateBinary: inflateWirePayload }
+            : {}),
+          ...(stats !== undefined
+            ? {
+              onFrame: (wireBytes, logicalBytes, compressed, cpuMs) =>
+                stats.recordInbound(wireBytes, logicalBytes, compressed, cpuMs),
+            }
+            : {}),
+        });
         const firstMessage = await negotiation.firstMessage;
         if (firstMessage === undefined) {
           negotiation.dispose();
@@ -250,7 +443,12 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
           return;
         }
 
-        if (attachMemorySocketPipeline(socket, negotiation, firstMessage)) {
+        if (
+          attachMemorySocketPipeline(socket, negotiation, firstMessage, {
+            deflateOutbound,
+            ...(stats !== undefined ? { stats } : {}),
+          })
+        ) {
           setupSpan.setAttribute("socket.setup", "memory");
           return;
         }

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -1,15 +1,12 @@
 import type { AppRouteHandler } from "@/lib/types.ts";
-import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import {
-  isAuthBearingWireMessage,
-  MEMORY_WS_DEFLATE_MIN_BYTES,
   MEMORY_WS_SERVER_INFLATE_MAX_BYTES,
   memoryWsDeflateEnabled,
   selectMemoryWsDeflateProtocol,
 } from "@commonfabric/memory/v2/transport-deflate";
 import {
-  deflateWirePayloadSync,
+  encodeMemoryWireFrameSync,
   inflateWirePayloadSync,
 } from "@commonfabric/memory/v2/transport-deflate-sync";
 import type * as Routes from "./memory.routes.ts";
@@ -30,11 +27,11 @@ type NegotiatedSocketHandlers = {
 type NegotiationOptions = {
   maxBufferedBytes?: number;
   /**
-   * Present only when the connection negotiated `fvj1.deflate`. The codec is
+   * Present only when the connection negotiated `cf-memory.deflate.v1`. The codec is
    * deliberately SYNCHRONOUS: dispatch stays inside the message event
    * handler, so frame ordering, pre-close delivery, and nothing-after-close
    * remain event-loop properties rather than queue invariants. Absent, the
-   * historical text-only path is unchanged and binary frames stay fatal.
+   * connection is text-only and binary frames are fatal.
    */
   inflateBinarySync?: (data: ArrayBuffer | ArrayBufferView) => string;
   /** Diagnostic: per-frame inbound byte accounting. */
@@ -270,42 +267,24 @@ const attachMemorySocketPipeline = (
     if (socket.readyState !== WebSocket.OPEN) {
       return;
     }
-    const payload = encodeMemoryBoundary(message);
-    // Auth-bearing frames (hello.ok's challenge, the session.open response's
-    // bearer token) are never compressed: credential material stays out of
-    // compression-size side channels (CRIME-class). The codec is
-    // synchronous, so ordering needs no queue.
-    if (
-      options.deflateOutbound !== true ||
-      isAuthBearingWireMessage(message)
-    ) {
-      if (options.stats !== undefined) {
-        const bytes = TEXT_ENCODER.encode(payload).byteLength;
-        options.stats.recordOutbound(bytes, bytes, false);
-      }
-      socket.send(payload);
-      return;
-    }
-    const payloadBytes = TEXT_ENCODER.encode(payload);
-    if (payloadBytes.byteLength < MEMORY_WS_DEFLATE_MIN_BYTES) {
-      options.stats?.recordOutbound(
-        payloadBytes.byteLength,
-        payloadBytes.byteLength,
-        false,
-      );
-      socket.send(payload);
-      return;
-    }
+    // The shared frame encoder owns the sender policy (compression off,
+    // auth-bearing exemption, size threshold); teardown stays here, tied to
+    // this server's close machinery. The codec is synchronous, so ordering
+    // needs no queue.
     try {
-      const started = performance.now();
-      const compressed = deflateWirePayloadSync(payloadBytes);
-      options.stats?.recordOutbound(
-        compressed.byteLength,
-        payloadBytes.byteLength,
-        true,
-        performance.now() - started,
-      );
-      socket.send(compressed);
+      socket.send(encodeMemoryWireFrameSync(
+        message,
+        options.deflateOutbound === true,
+        options.stats === undefined
+          ? undefined
+          : (wireBytes, logicalBytes, compressed, cpuMs) =>
+            options.stats!.recordOutbound(
+              wireBytes,
+              logicalBytes,
+              compressed,
+              cpuMs,
+            ),
+      ));
     } catch {
       safeSocketClose(1011, "Memory websocket send failure");
       connection.close();


### PR DESCRIPTION
## Summary

Transport-level per-message raw-deflate compression for the memory v2 websocket, negotiated per connection via the `cf-memory.deflate.v1` subprotocol. Compressed payloads ride binary frames; payloads under 192 UTF-8 bytes stay text; **auth-bearing frames are never compressed**; non-negotiated connections stay byte-identical to today. The memory protocol itself (hello flags, message shapes, ordering semantics) is untouched.

Started as a measurement spike, now productionized. Motivation and calibration: the memory websocket carries uncompressed JSON (browsers offer `permessage-deflate`; `Deno.upgradeWebSocket` — via fastwebsockets — cannot negotiate it, and the fleet's nginx cannot terminate it either). On the identical flow and metric, the schema-machinery approach (#4292 + #4712) measures −14.6% to −20.1%; this measures **−78.7% browser payload bytes**, on top of main's already-interned sync frames.

## Results (Lunch Poll two-browser flow, real websockets)

| Metric | Value |
| --- | --- |
| Browser payload bytes | 3,915,887 → 834,252 (**−78.7%**) |
| All connections | ~−82% |
| Frame count / round trips | unchanged |
| Wall time (localhost A/B, 3×/side) | +~150 ms (~5%) with the async codec; server share since cut ~24× by the sync codec (~1,650 ms → ~70 ms accounted codec time per run) |
| Kill-switch control | server outbound wire bytes == logical bytes exactly |

## Design

- **Synchronous server codec** (`transport-deflate-sync.ts`, `node:zlib`): dispatch stays inside the websocket message event handler, so frame ordering, pre-close delivery, and nothing-after-close are event-loop properties on the server — no queues to get wrong. Server inbound inflation is capped at 8 MiB, bounding how long one unauthenticated frame can block the shared event loop. Browsers have no sync codec, so the client keeps the async `CompressionStream` path with per-direction serial queues, a 16 MiB inbound backlog bound, a poison latch on inflate failure, and drain-gated redial. Both codecs emit identical raw-deflate bytes.
- **Auth-frame exemption** (compression-size side-channel mitigation, CRIME-class): `hello` and `session.open` via a `noCompress` transport hint; `hello.ok` (session challenge) and the `session.open` response (bearer session token) via a structural `isAuthBearingWireMessage` check shared by both servers. Receivers accept any framing — the exemption is sender policy. Residual side-channel exposure for document traffic is documented in the spike record (docs/history/development/performance/memory-ws-deflate-spike-2026-07-16.md) and matches what permessage-deflate would have.
- **Negotiation**: websocket subprotocol, offered only when the runtime supports `deflate-raw` (capability probe — pre-2023 browsers never offer). Per RFC 6455 a refused offer fails the connection, so **servers must deploy before clients offer**; on the current fleet that's a normal rolling restart, and `CF_MEMORY_WS_DEFLATE=0` in the shared env is the fleet-wide kill switch (stops offering/compressing without breaking negotiation — worth setting for on-host runtime clients like bg-piece-service, where localhost compression is pure CPU waste).

## Review process

Three adversarial multi-agent review rounds ran against this branch; all confirmed findings are fixed and regression-tested, including two majors from round two (stale frame delivery after close; a socket leak via a send parked across a drain) and a **critical** from round three, reproduced end-to-end: a send failing during a reconnect's drain window orphaned its pending-request entry, and the subsequent close sweep raised an unhandled rejection that exits Deno processes (cf CLI, background-piece-service). Requests now withdraw pending state when a send fails, transport turnover errors are classified as retryable `ConnectionError`s so in-flight commits replay through the existing reconnect machinery, and the round-three review also caught the `session.open` response shipping compressed with the bearer token — closed by the structural exemption.

## Verification

- Full suites: memory 402, toolshed memory routes 31, runner transport/reconnect 13 — all green
- `deno task integration patterns lunch-poll-vote`: passes repeatedly (deflate on, kill switch, post-fix re-measurements)
- New tests cover: codec roundtrip + cross-codec interop, inflate caps, auth-frame classification + real-socket framing assertions, send-failure pending cleanup (fails on unhandled rejection if it regresses), ordering across the async hops, close-ordering, backlog bounds, drain-window rejection + redial
- `deno fmt` / `deno lint` / `deno check` clean

## Compatibility verification (cf CLI, live)

Hands-on skew verification with the real `cf` CLI from this branch:

- **New cf → old toolshed (production Estuary, `rapids.saga-castor.ts.net`, running main):** `cf piece ls --space team-lunch` returns the full piece listing, exit 0. The new client offers `cf-memory.deflate.v1`; the old server ignores it; Deno's WebSocket client (unlike browsers) tolerates the unselected subprotocol (`socket.protocol === ""`), and the transport degrades to plain text. **No version-skew breakage for Deno-side clients in either deploy order.**
- **New cf → new toolshed (local, this branch):** `cf piece ls` works and the server-side stats recorder shows the connection negotiated and compressed, e.g.:

  ```
  kind=runtime negotiated=True
    inbound:  3,503B logical -> 2,515B wire (3/5 frames compressed)
    outbound: 1,542B logical -> 1,407B wire (2/5 frames compressed)
  ```

  The uncompressed frames are exactly the auth exemption (hello / hello.ok / session.open and its response) plus sub-threshold frames.

Browsers do enforce RFC 6455's fail-on-unselected-subprotocol, so the server-first rollout note below still applies to the shell — but since Deno clients degrade gracefully, only the browser leg cares about ordering at all.

## Rollout

1. Land; deploy toolshed fleet-wide (servers select the subprotocol whenever offered; nothing offers yet from Deno clients — browsers only after the shell picks up the new transport build).
2. Soak with `CF_MEMORY_WS_DEFLATE_STATS_FILE` on a staging instance; watch close codes 1007/1009 and realized savings.
3. Optional follow-ups tracked in the spike record: threshold/cap tuning from soak data, text-mode e2e pairing test, context-takeover variant (+~8 points) if ever warranted.



## Coverage baseline acceptance

The coverage ratchet initially flagged +63 uncovered lines; targeted tests reclaimed the substantial majority (real-socket standalone-server suite, stats-recorder end-to-end and edge tests, injectable env/capability probes, receiver-failure tests) and unreachable defensive code was deleted rather than tested. The remaining deltas were decomposed by per-file comparison of main's own CI coverage artifacts against this branch's:

- **`packages/runner`**: the entire delta sits in `scheduler/execution.ts` (+16) and `scheduler/facade.ts` (+6) — timing-dependent scheduler coverage in files this PR does not touch — while this PR's own `v2-remote-session.ts` is **3 lines better covered than main**. Branch-side coverage is stable run-to-run (±1 line); the wobble is race-dependent coverage outside the diff, so the ceiling below carries headroom for it.
- **`packages/memory`**: no override needed. A later main baseline improvement put the ratchet 8 lines over; per-file comparison traced all 8 to reachable code in this diff, and real tests now cover it (the classifier's fail-closed default arm for unknown frame types, the ack-flush stop-rescheduling guard on connection turnover, and the standalone server's plain-HTTP response plus the whole CF_DEBUG_MEMORY_WRITES commit tracer, which previously had zero coverage). The package now measures ~19 lines **better** than main's baseline.
- **`packages/toolshed`**: a handful of defensive branches (close-race guards, settle-window error paths, the sync-codec catch), several of them pre-existing main debt relocated by the diff; deterministic tests for them would be contrived scaffolding around event races.

The ceilings accept that residue; the fresh (lower) measured values become the post-merge baseline:

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7215 lines

NEW_PERF_BASELINE: coverage-debt: packages/toolshed uncovered lines = 4744 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)






