### PR TITLE
fix(cli): make cf output script- and automation-friendly

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2011,6 +2011,7 @@
         "dependencies": [
           "jsr:@cliffy/table@1.0.0-rc.8",
           "jsr:@db/sqlite@0.13.0",
+          "jsr:@std/fmt@~1.0.2",
           "npm:typescript@6.0.3"
         ]
       },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,39 @@ as `cf piece ls`. Human-readable output uses the same columns as `piece ls`.
 matches. If part of a piece cannot be read, the command reports a warning on
 standard error and continues searching that piece and the rest of the space.
 
+## Output Conventions
+
+- stdout carries command output only; hints and diagnostics go to stderr.
+  `piece get` prints plain JSON, except an absent value prints the literal
+  `undefined` — which is not valid JSON, so test for it before parsing. It is
+  `undefined` rather than `null` on purpose: loom's fresh-space readback gate
+  tolerates `undefined` as a transient, and `null` would hard-fail its deploy
+  gate (see the `-q` note below and the PR compatibility rationale).
+- ANSI colors are emitted only when stdout is a TTY. `--no-color` or
+  `NO_COLOR=1` disables them everywhere (including Cliffy help/usage output);
+  `FORCE_COLOR=1`/`CLICOLOR_FORCE=1` forces them when piped. The policy is
+  applied in `lib/color-mode.ts`; the `@std/fmt/colors` import-map pin in
+  `deno.jsonc` must track Cliffy's own `@std/fmt` dependency range (guarded by
+  `test/color-mode.test.ts`).
+- `-q/--quiet` (on `piece`/`wish` subcommands) suppresses the stderr hint and
+  next-step blocks. It deliberately does NOT change the log floor: consumers
+  parse `--quiet` runs' stderr for runtime warnings (Loom's stale-root heal
+  greps for `load-pattern-by-identity-source-miss`). Use `--log-level error` to
+  drop warnings; the two compose.
+- `piece call` accepts its payload as an inline JSON argument, `-` for stdin, an
+  implicit pipe (no payload argument), or schema-derived flags after `--`.
+- A `piece get` path that doesn't resolve prints a one-line error on stderr and
+  exits 1 — it is a data error, not a usage error.
+- The launcher spawns the child CLI with `deno run --quiet` so Deno's own
+  warnings (npm "Ignored build scripts" banner) never reach users.
+
+## Built Binary
+
+`deno task build-binaries --cli-only` compiles the CLI to `dist/cf` — fully
+cwd-independent with no Deno startup noise, the recommended entry point for
+agents and scripts. Rebuild after every `git pull`: a stale binary rejects newer
+flags and can hit wire-protocol skew against an updated server.
+
 ## Launcher Contract
 
 `packages/cli/launcher.ts` is the stable Deno launcher for consumers that need

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -52,6 +52,11 @@ LOGGING:
     CF_LOG_LEVEL=debug cf piece ls
   Valid levels: debug, info, warn (default), error, silent
 
+COLOR:
+  ANSI colors are emitted only when stdout is a terminal. Override with
+  --no-color or NO_COLOR=1 to disable, FORCE_COLOR=1 or CLICOLOR_FORCE=1 to
+  force when piped.
+
 Run 'cf <command> --help' for command-specific help.`);
 
 export const main = new Command()

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -151,8 +151,58 @@ export function localPatternEntry(
   };
 }
 
-function pieceCallRawArgs(tail: string[], literalArgs: string[]): string[] {
+/**
+ * A `piece get` failure caused by a data condition rather than bad arguments:
+ * a path that doesn't resolve, or a result schema that can't project the
+ * stored data (PieceResultProjectionError). Reported as a plain error on
+ * stderr with exit 1, never as a Cliffy ValidationError (which would dump the
+ * usage screen and read as an arg-parse failure).
+ */
+export function isPieceGetDataError(error: unknown): error is Error {
+  return error instanceof PieceResultProjectionError ||
+    (error instanceof Error &&
+      error.message.startsWith("Cannot access path"));
+}
+
+/**
+ * Build the stderr report for a `piece get` failure. Returns null when the
+ * error is not a data error (the caller should rethrow). `message` is the
+ * one-line error; `hint` is an optional next-step tip. A projection error
+ * already carries its own `--step` guidance, and an input-mode read has
+ * nothing more to suggest — only a result-mode unresolved path gets the
+ * `--input` tip.
+ */
+export function pieceGetDataErrorReport(
+  error: unknown,
+  opts: { input?: boolean; piece?: string },
+): { message: string; hint?: string } | null {
+  if (!isPieceGetDataError(error)) return null;
+  if (error instanceof PieceResultProjectionError || opts.input) {
+    return { message: error.message };
+  }
+  return {
+    message: error.message,
+    hint: cliText(
+      `TIP: The path was read from the result cell. If the field is an input, retry with --input, or run 'cf piece inspect --piece ${opts.piece} ...' to see both cells.`,
+    ),
+  };
+}
+
+export function pieceCallRawArgs(
+  tail: string[],
+  literalArgs: string[],
+): string[] {
   if (literalArgs.length > 0) {
+    // Schema-derived flags after `--`. A payload token before `--` (inline
+    // JSON or the `-` stdin sentinel) would be silently dropped here, so
+    // reject the combination loudly instead — the same no-op this family of
+    // fixes is stamping out. Mirrors the `tail.length > 1` rejection below.
+    if (tail.length > 0) {
+      throw new ValidationError(
+        'Pass either a payload argument (inline JSON or "-" for stdin) or ' +
+          'schema-derived flags after "--", not both.',
+      );
+    }
     return literalArgs;
   }
 
@@ -172,6 +222,17 @@ function pieceCallRawArgs(tail: string[], literalArgs: string[]): string[] {
     );
   }
 
+  // Explicit two-token stdin sentinels (a JSON/value flag plus "-"), forwarded
+  // to the exec layer so the friendly surface matches `cf exec` and the bare
+  // "-" form. Without this they'd hit the multi-argument rejection below.
+  if (
+    tail.length === 2 && tail[1] === "-" &&
+    (tail[0] === "--json" || tail[0] === "--json-file" ||
+      tail[0] === "--value-file")
+  ) {
+    return [tail[0], "-"];
+  }
+
   if (tail[0] === "--json") {
     if (tail.length === 1) {
       // --json alone is a no-op: cf piece call always outputs JSON.
@@ -186,6 +247,12 @@ function pieceCallRawArgs(tail: string[], literalArgs: string[]): string[] {
     throw new ValidationError(
       'Use a single inline JSON argument or "--" before schema-derived flags.',
     );
+  }
+
+  // "-" is the conventional stdin sentinel; route it through the existing
+  // --json-file stdin path so empty stdin still fails loudly.
+  if (tail[0] === "-") {
+    return ["--json-file", "-"];
   }
 
   return ["--json", tail[0]];
@@ -814,6 +881,7 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   )
   .arguments("[path:string]")
   .action(async (options, pathString) => {
+    setQuietMode(!!options.quiet);
     const pieceConfig = parsePieceOptions(options);
     const pathSegments = pathString ? parseCellPath(pathString) : [];
     try {
@@ -823,11 +891,18 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
       });
       render(value, { json: true });
     } catch (error) {
-      if (
-        error instanceof PieceResultProjectionError ||
-        error instanceof Error && error.message.startsWith("Cannot access path")
-      ) {
-        throw new ValidationError(error.message, { exitCode: 1 });
+      // A read that fails on a data condition — the path doesn't resolve, or
+      // the result schema can't project the stored data (PieceResultProjection
+      // Error) — is a data error, not a usage error. Report it on stderr
+      // instead of letting Cliffy dump the help screen over it.
+      const report = pieceGetDataErrorReport(error, {
+        input: options.input,
+        piece: pieceConfig.piece,
+      });
+      if (report) {
+        console.error(report.message);
+        if (report.hint) hint(report.hint);
+        Deno.exit(1);
       }
       throw error;
     }
@@ -907,6 +982,12 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     ),
     `Call the "setName" handler with JSON arguments on piece "${RAW_EX_COMP
       .piece!}".`,
+  )
+  .example(
+    cliText(
+      `echo '{"value":"My Name"}' | cf piece call ${EX_ID} ${EX_COMP_PIECE} setName -`,
+    ),
+    `Read the JSON payload from stdin ("-" is the stdin sentinel).`,
   )
   .example(
     cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} search -- --query milk`),

--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -15,6 +15,11 @@
     // Held at the release candidate alongside @cliffy/command; the two share
     // internal packages and resolve as a set.
     "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.8",
+    // Pinned to @cliffy/command's own dependency range so lib/color-mode.ts
+    // shares Cliffy's module instance — setColorEnabled() on a second copy
+    // would not de-colorize Cliffy help/version/usage output. Guarded by the
+    // piped-output test in test/color-mode.test.ts.
+    "@std/fmt/colors": "jsr:@std/fmt@~1.0.2/colors",
     "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "typescript": "npm:typescript@6.0.3"
   }

--- a/packages/cli/launcher.ts
+++ b/packages/cli/launcher.ts
@@ -243,6 +243,10 @@ export const buildCfLauncherCommand = (
   command: options.denoPath,
   args: [
     "run",
+    // Suppress Deno's own diagnostics (npm "Ignored build scripts" banner,
+    // download progress) — they print ANSI to stderr on every invocation and
+    // are noise for CLI consumers. CLI/runtime output is unaffected.
+    "--quiet",
     "--config",
     options.configPath,
     "--allow-net",

--- a/packages/cli/lib/color-mode.ts
+++ b/packages/cli/lib/color-mode.ts
@@ -1,0 +1,98 @@
+// The import below must resolve to the same @std/fmt instance Cliffy uses
+// (see the "@std/fmt/colors" pin in packages/cli/deno.jsonc); a second
+// instance would leave Cliffy's help/version/usage output colored even when
+// this module disables colors.
+import { setColorEnabled } from "@std/fmt/colors";
+
+/**
+ * Read an env var, returning undefined instead of throwing. Deno.env.get
+ * throws on a missing --allow-env permission (and on an invalid key), which
+ * should degrade to "unset" rather than crash color resolution.
+ */
+export function safeEnvGet(key: string): string | undefined {
+  try {
+    return Deno.env.get(key);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extract `--no-color` from args before Cliffy sees it.
+ * Returns whether the flag was present and the cleaned args array.
+ *
+ * Scanning stops at the first `--`: everything after it is a payload for the
+ * target command (e.g. a schema-derived handler flag named `--no-color`), and
+ * silently eating it would be exactly the kind of no-op this CLI is trying to
+ * stamp out. Use `cf --no-color <cmd> -- --no-color` to set both.
+ */
+export function extractNoColor(
+  args: string[],
+): { noColor: boolean; args: string[] } {
+  const end = args.indexOf("--");
+  const scanned = end === -1 ? args : args.slice(0, end);
+  const passthrough = end === -1 ? [] : args.slice(end);
+  const cleaned = scanned.filter((arg) => arg !== "--no-color");
+  return {
+    noColor: cleaned.length !== scanned.length,
+    args: [...cleaned, ...passthrough],
+  };
+}
+
+/**
+ * Decide whether ANSI colors should be emitted.
+ *
+ * Precedence (disable wins): `--no-color` flag, then a set `NO_COLOR` env var,
+ * then `FORCE_COLOR`/`CLICOLOR_FORCE` (any value except "" or "0" forces color
+ * even when piped), then stdout TTY detection.
+ *
+ * `NO_COLOR` is read from the raw env rather than trusting `denoNoColor`:
+ * Deno pre-arbitrates FORCE_COLOR over NO_COLOR (so `Deno.noColor` is `false`
+ * under `NO_COLOR=1 FORCE_COLOR=1`), but it does not know CLICOLOR_FORCE. Left
+ * unchecked, the two force vars would rank inconsistently against NO_COLOR;
+ * reading the raw var keeps NO_COLOR winning over both.
+ *
+ * Note `cf view` keeps its own `--color always|auto|never` flag; "always"
+ * bypasses this policy because the pager writes raw SGR sequences itself.
+ */
+export function resolveColorEnabled(opts: {
+  noColorFlag: boolean;
+  denoNoColor: boolean;
+  isTerminal: boolean;
+  env: (key: string) => string | undefined;
+}): boolean {
+  if (opts.noColorFlag) return false;
+  if (opts.denoNoColor || (opts.env("NO_COLOR") ?? "") !== "") return false;
+  const force = opts.env("FORCE_COLOR") ?? opts.env("CLICOLOR_FORCE");
+  if (force !== undefined && force !== "" && force !== "0") return true;
+  return opts.isTerminal;
+}
+
+/**
+ * Resolve the color policy from CLI args and environment and apply it,
+ * returning the args with `--no-color` removed plus the decision.
+ *
+ * Callers must also pass `enabled` to the root command's Cliffy help options
+ * (`main.help({ colors: enabled })`): Cliffy's HelpGenerator saves, force-sets
+ * and restores the global color flag while rendering, so `setColorEnabled`
+ * alone cannot reach help/usage output.
+ *
+ * When colors are disabled, `NO_COLOR=1` is also exported so spawned child
+ * processes (workers, `cf check` pipelines) inherit the decision.
+ */
+export function applyColorMode(
+  args: string[],
+): { args: string[]; enabled: boolean } {
+  const { noColor, args: cleanArgs } = extractNoColor(args);
+  const enabled = resolveColorEnabled({
+    noColorFlag: noColor,
+    denoNoColor: Deno.noColor,
+    isTerminal: Deno.stdout.isTerminal(),
+    env: safeEnvGet,
+  });
+  setColorEnabled(enabled);
+  if (!enabled) {
+    Deno.env.set("NO_COLOR", "1");
+  }
+  return { args: cleanArgs, enabled };
+}

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -117,13 +117,17 @@ function parseJson(value: string, flagName: string): unknown {
 function parseInlineOrStdinJson(
   args: string[],
   index: number,
-): { inlineValue?: string; consumeNext: boolean } {
+): { inlineValue?: string; consumeNext: boolean; fromStdin?: boolean } {
   const candidate = args[index + 1];
   if (candidate === undefined) {
     return { consumeNext: false };
   }
   if (candidate.startsWith("--")) {
     throw new Error("--json cannot be combined with generated flags");
+  }
+  if (candidate === "-") {
+    // stdin sentinel, same as --json-file -
+    return { consumeNext: true, fromStdin: true };
   }
   return { inlineValue: candidate, consumeNext: true };
 }
@@ -234,8 +238,16 @@ function parseObjectInput(
       if (usedJson) {
         throw new Error("--json can only be provided once");
       }
-      const { inlineValue, consumeNext } = parseInlineOrStdinJson(args, i);
+      const { inlineValue, consumeNext, fromStdin } = parseInlineOrStdinJson(
+        args,
+        i,
+      );
       usedJson = true;
+      if (fromStdin) {
+        readJsonFromStdin = true;
+        i++;
+        continue;
+      }
       if (inlineValue === undefined) {
         readJsonFromStdin = true;
         continue;
@@ -427,6 +439,15 @@ function parseNonObjectInput(
   if (flag === "--json") {
     if (rawValue.startsWith("--")) {
       throw new Error("--json cannot be combined with generated flags");
+    }
+    if (rawValue === "-") {
+      // stdin sentinel, same as --json-file -
+      return {
+        input: undefined,
+        readJsonFromStdin: true,
+        readTextFromStdin: false,
+        usedJsonInput: true,
+      };
     }
     return {
       input: parseJson(rawValue, flag),

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -1,7 +1,9 @@
 import { parse } from "./commands/mod.ts";
+import { main as rootCommand } from "./commands/main.ts";
 import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
 import { cliName } from "./lib/cli-name.ts";
 import { applyLogLevel } from "./lib/log-level.ts";
+import { applyColorMode } from "./lib/color-mode.ts";
 
 /**
  * The value to print for a top-level CLI failure. TransformerError and
@@ -20,8 +22,17 @@ export function renderCliError(e: unknown): unknown {
 }
 
 export async function main(args: string[]) {
-  // Extract --log-level before Cliffy parses and apply the resulting floor.
-  const cleanArgs = applyLogLevel(args);
+  // Extract --log-level and --no-color before Cliffy parses; apply the log
+  // floor and the color policy (TTY detection, NO_COLOR, FORCE_COLOR).
+  const { args: cleanArgs, enabled: colorsEnabled } = applyColorMode(
+    applyLogLevel(args),
+  );
+  // Cliffy's help generator ignores the global color flag (it force-sets its
+  // own `colors` option while rendering), so mirror the decision here. The
+  // .reset() re-targets the builder chain at the root command (without it,
+  // .help() lands on the last-registered subcommand); help settings inherit,
+  // so the root covers every subcommand.
+  rootCommand.reset().help({ colors: colorsEnabled });
   Deno.env.set("CF_CLI_NAME", cliName());
   const profileDoneMarker = Deno.env.get("CF_PROFILE_DONE_MARKER");
 

--- a/packages/cli/test/color-mode.test.ts
+++ b/packages/cli/test/color-mode.test.ts
@@ -1,0 +1,181 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { getColorEnabled, setColorEnabled } from "@std/fmt/colors";
+import {
+  extractNoColor,
+  resolveColorEnabled,
+  safeEnvGet,
+} from "../lib/color-mode.ts";
+import { main } from "../commands/main.ts";
+
+const noEnv = () => undefined;
+
+Deno.test("extractNoColor strips the flag and reports it", () => {
+  assertEquals(extractNoColor(["--no-color", "piece", "ls"]), {
+    noColor: true,
+    args: ["piece", "ls"],
+  });
+  assertEquals(extractNoColor(["piece", "ls"]), {
+    noColor: false,
+    args: ["piece", "ls"],
+  });
+});
+
+Deno.test("extractNoColor leaves payload args after -- untouched", () => {
+  // `--no-color` after `--` is a schema-derived flag for the target handler,
+  // not a color directive; eating it would silently drop handler input.
+  assertEquals(
+    extractNoColor(["piece", "call", "h", "--", "--no-color", "x"]),
+    {
+      noColor: false,
+      args: ["piece", "call", "h", "--", "--no-color", "x"],
+    },
+  );
+  // Both positions: the leading one is consumed, the payload one survives.
+  assertEquals(
+    extractNoColor(["--no-color", "piece", "call", "h", "--", "--no-color"]),
+    {
+      noColor: true,
+      args: ["piece", "call", "h", "--", "--no-color"],
+    },
+  );
+});
+
+Deno.test("safeEnvGet returns undefined instead of throwing", () => {
+  // A present var reads through.
+  Deno.env.set("CF_COLOR_MODE_TEST", "x");
+  try {
+    assertEquals(safeEnvGet("CF_COLOR_MODE_TEST"), "x");
+  } finally {
+    Deno.env.delete("CF_COLOR_MODE_TEST");
+  }
+  // An unset var is undefined, not an error.
+  assertEquals(safeEnvGet("CF_DEFINITELY_UNSET_VAR_XYZ"), undefined);
+  // An invalid key (empty string) makes Deno.env.get throw — swallowed.
+  assertEquals(safeEnvGet(""), undefined);
+});
+
+Deno.test("resolveColorEnabled follows a TTY by default", () => {
+  assert(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: true,
+    env: noEnv,
+  }));
+  assertFalse(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: false,
+    env: noEnv,
+  }));
+});
+
+Deno.test("resolveColorEnabled disable overrides win over everything", () => {
+  const forceEnv = (key: string) => key === "FORCE_COLOR" ? "1" : undefined;
+  assertFalse(resolveColorEnabled({
+    noColorFlag: true,
+    denoNoColor: false,
+    isTerminal: true,
+    env: forceEnv,
+  }));
+  assertFalse(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: true,
+    isTerminal: true,
+    env: forceEnv,
+  }));
+});
+
+Deno.test("resolveColorEnabled: NO_COLOR wins over both force vars (raw env)", () => {
+  // Reproduces the live bug at the env level: with NO_COLOR set, color must
+  // stay off regardless of FORCE_COLOR/CLICOLOR_FORCE. denoNoColor is false
+  // here because Deno pre-arbitrates FORCE_COLOR over NO_COLOR — the resolver
+  // must consult the raw NO_COLOR var, not just the pre-arbitrated flag.
+  assertFalse(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: true,
+    env: (key) =>
+      key === "NO_COLOR" ? "1" : key === "FORCE_COLOR" ? "1" : undefined,
+  }));
+  assertFalse(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: true,
+    env: (key) =>
+      key === "NO_COLOR" ? "1" : key === "CLICOLOR_FORCE" ? "1" : undefined,
+  }));
+  // An empty NO_COLOR is "unset" per the NO_COLOR spec — force still wins.
+  assert(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: false,
+    env: (key) =>
+      key === "NO_COLOR" ? "" : key === "FORCE_COLOR" ? "1" : undefined,
+  }));
+});
+
+Deno.test("resolveColorEnabled honors FORCE_COLOR / CLICOLOR_FORCE when piped", () => {
+  assert(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: false,
+    env: (key) => key === "FORCE_COLOR" ? "1" : undefined,
+  }));
+  assert(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: false,
+    env: (key) => key === "CLICOLOR_FORCE" ? "1" : undefined,
+  }));
+  // "0" and "" do not force
+  assertFalse(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: false,
+    env: (key) => key === "FORCE_COLOR" ? "0" : undefined,
+  }));
+  assertFalse(resolveColorEnabled({
+    noColorFlag: false,
+    denoNoColor: false,
+    isTerminal: false,
+    env: (key) => key === "FORCE_COLOR" ? "" : undefined,
+  }));
+});
+
+// Guards the invariant behind the "@std/fmt/colors" import-map pin in
+// packages/cli/deno.jsonc: our setColorEnabled() must reach the same module
+// instance Cliffy styles version/error output with. If Cliffy's @std/fmt
+// dependency range drifts away from the pin, this test fails and the pin
+// must be updated.
+Deno.test("setColorEnabled controls Cliffy version output", () => {
+  const previous = getColorEnabled();
+  try {
+    setColorEnabled(false);
+    assertFalse(main.getLongVersion().includes("\x1b["));
+    setColorEnabled(true);
+    assert(main.getLongVersion().includes("\x1b["));
+  } finally {
+    setColorEnabled(previous);
+  }
+});
+
+// Cliffy's HelpGenerator force-sets its own `colors` option while rendering,
+// so help output is controlled through Command.help(), not setColorEnabled —
+// mod.ts mirrors the resolved policy into main.help({ colors }).
+Deno.test("help colors follow the Cliffy help option", () => {
+  try {
+    main.reset().help({ colors: false });
+    assertFalse(main.getHelp().includes("\x1b["));
+    const pieceGet = main.getCommand("piece")?.getCommand("get");
+    assert(pieceGet, "piece get subcommand exists");
+    assertFalse(
+      pieceGet.getHelp().includes("\x1b["),
+      "subcommands inherit the root help colors",
+    );
+    main.reset().help({ colors: true });
+    assert(main.getHelp().includes("\x1b["));
+  } finally {
+    // colors: true matches the HelpGenerator default the command started with.
+    main.reset().help({ colors: true });
+  }
+});

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -300,6 +300,34 @@ describe("parseExecArgs", () => {
     expect(result.input).toBeUndefined();
   });
 
+  it('treats "--json -" as the stdin sentinel for non-object schemas', () => {
+    const result = parseExecArgs(
+      makeSpec("handler", { type: "number" }),
+      ["--json", "-"],
+    );
+
+    expect(result.readJsonFromStdin).toBe(true);
+    expect(result.usedJsonInput).toBe(true);
+    expect(result.input).toBeUndefined();
+  });
+
+  it('treats "--json -" as the stdin sentinel for object schemas', () => {
+    const result = parseExecArgs(
+      makeSpec("tool", {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      }),
+      ["--json", "-"],
+    );
+
+    expect(result.readJsonFromStdin).toBe(true);
+    expect(result.usedJsonInput).toBe(true);
+    expect(result.input).toBeUndefined();
+  });
+
   it("preserves omitted non-object inputs as undefined", () => {
     const primitive = parseExecArgs(
       makeSpec("handler", { type: "number" }),

--- a/packages/cli/test/launcher.test.ts
+++ b/packages/cli/test/launcher.test.ts
@@ -345,6 +345,7 @@ Deno.test("buildCfLauncherCommand builds the child deno invocation", () => {
       command: "/usr/local/bin/deno",
       args: [
         "run",
+        "--quiet",
         "--config",
         "/workspace/labs/deno.json",
         "--allow-net",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -2,7 +2,15 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import { CF_RUNTIME_ERROR_LOG } from "../lib/callable.ts";
-import { executePieceCallable } from "../lib/piece.ts";
+import {
+  executePieceCallable,
+  PieceResultProjectionError,
+} from "../lib/piece.ts";
+import {
+  isPieceGetDataError,
+  pieceCallRawArgs,
+  pieceGetDataErrorReport,
+} from "../commands/piece.ts";
 
 describe("executePieceCallable", () => {
   it("invokes handlers from schema-derived flags", async () => {
@@ -803,3 +811,213 @@ function getChildSchema(
 
   return properties[key] as JSONSchema | undefined;
 }
+
+describe("piece call stdin payloads", () => {
+  it('maps a bare "-" payload onto the --json-file stdin path', () => {
+    expect(pieceCallRawArgs(["-"], [])).toEqual(["--json-file", "-"]);
+  });
+
+  it("forwards explicit two-token stdin sentinels instead of rejecting them", () => {
+    // `cf piece call h --json-file -` (and the --value-file / --json variants)
+    // should read stdin, matching `cf exec` and the bare "-" form, rather than
+    // hitting the multi-argument rejection.
+    expect(pieceCallRawArgs(["--json-file", "-"], [])).toEqual([
+      "--json-file",
+      "-",
+    ]);
+    expect(pieceCallRawArgs(["--value-file", "-"], [])).toEqual([
+      "--value-file",
+      "-",
+    ]);
+    expect(pieceCallRawArgs(["--json", "-"], [])).toEqual(["--json", "-"]);
+    // A file path (not "-") still requires "--"; it is not a stdin sentinel.
+    expect(() => pieceCallRawArgs(["--json-file", "/p.json"], [])).toThrow(
+      /single inline JSON argument or "--"/,
+    );
+  });
+
+  it("rejects a payload token combined with post-`--` flags instead of dropping it", () => {
+    // `cf piece call h - -- --query milk` → tail=["-"], literalArgs=["--query",
+    // "milk"]. The "-" used to be silently ignored (post-`--` flags win); now
+    // the conflict is loud.
+    expect(() => pieceCallRawArgs(["-"], ["--query", "milk"])).toThrow(
+      /payload argument .* or .* schema-derived flags after/,
+    );
+    expect(() => pieceCallRawArgs(['{"x":1}'], ["--query", "milk"])).toThrow(
+      /not both/,
+    );
+    // The legit "flags after -- only" shape (tail empty) still passes through.
+    expect(pieceCallRawArgs([], ["--query", "milk"])).toEqual([
+      "--query",
+      "milk",
+    ]);
+  });
+
+  it('reads the payload from stdin for a bare "-"', async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "recordMessage",
+      ["--json-file", "-"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve('{"message":"from stdin"}'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["recordMessage"],
+        value: { message: "from stdin" },
+      },
+    ]);
+  });
+
+  it('treats "--json -" as the stdin sentinel', async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "recordMessage",
+      ["--json", "-"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve('{"message":"json stdin"}'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["recordMessage"],
+        value: { message: "json stdin" },
+      },
+    ]);
+  });
+
+  it('fails loudly when "-" gets empty stdin', async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    });
+
+    await expect(
+      executePieceCallable(
+        {
+          apiUrl: "http://localhost:8000",
+          identity: "/tmp/test-identity.pem",
+          piece: "fid1:piece-123",
+          space: "home",
+        },
+        "recordMessage",
+        ["--json-file", "-"],
+        {
+          loadManager: () => Promise.resolve(harness.manager),
+          loadPiece: () => Promise.resolve(harness.piece),
+          isStdinTerminal: () => false,
+          readTextInput: () => Promise.resolve(""),
+        },
+      ),
+    ).rejects.toThrow(/Expected JSON from stdin/);
+  });
+});
+
+describe("piece get data errors", () => {
+  it("classifies unresolved-path failures as data errors, not usage errors", () => {
+    expect(
+      isPieceGetDataError(
+        new Error('Cannot access path "bogus" - property "bogus" not found'),
+      ),
+    ).toBe(true);
+    expect(isPieceGetDataError(new Error("network unreachable"))).toBe(false);
+    expect(isPieceGetDataError("Cannot access path")).toBe(false);
+  });
+
+  it("reports a result-mode data error with an --input hint", () => {
+    const report = pieceGetDataErrorReport(
+      new Error('Cannot access path "x" - property "x" not found'),
+      { input: false, piece: "fid1:piece-123" },
+    );
+    expect(report?.message).toMatch(/Cannot access path "x"/);
+    expect(report?.hint).toMatch(/retry with --input/);
+    expect(report?.hint).toMatch(/fid1:piece-123/);
+  });
+
+  it("omits the hint in input mode (nothing left to suggest)", () => {
+    const report = pieceGetDataErrorReport(
+      new Error('Cannot access path "x" - property "x" not found'),
+      { input: true, piece: "fid1:piece-123" },
+    );
+    expect(report?.message).toMatch(/Cannot access path "x"/);
+    expect(report?.hint).toBeUndefined();
+  });
+
+  it("returns null for a non-data error (caller rethrows)", () => {
+    expect(
+      pieceGetDataErrorReport(new Error("network unreachable"), {
+        input: false,
+        piece: "fid1:piece-123",
+      }),
+    ).toBeNull();
+  });
+
+  it("treats a result-projection failure as a data error, keeping its own --step hint", () => {
+    const projectionError = new PieceResultProjectionError(
+      ["totalSpent"],
+      false,
+    );
+    expect(isPieceGetDataError(projectionError)).toBe(true);
+    const report = pieceGetDataErrorReport(projectionError, {
+      input: false,
+      piece: "fid1:piece-123",
+    });
+    // The message carries its own --step guidance; we must not bury it under
+    // the generic --input tip (a different remedy).
+    expect(report?.message).toMatch(/schema could not resolve/);
+    expect(report?.message).toMatch(/--step/);
+    expect(report?.hint).toBeUndefined();
+  });
+});

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -18,6 +18,50 @@ deno task cf piece --help     # Piece operations
 deno task cf check --help     # Type checking
 ```
 
+## Invocation Paths
+
+Three equivalent ways to run the CLI, in order of preference for agents:
+
+1. **Built binary (recommended for scripted/agent use):**
+
+   ```bash
+   deno task build-binaries --cli-only   # produces dist/cf
+   export PATH="$PWD/dist:$PATH"         # or copy dist/cf onto PATH
+   cf piece ls ...                       # works from any cwd, no Deno noise
+   ```
+
+   The binary is fully cwd-independent and prints nothing but CLI output.
+   **Rebuild it after every `git pull`** — a stale binary rejects newer flags
+   and can hit wire-protocol skew against an updated server.
+
+2. **`deno task cf ...`** — works from any directory inside the repo (the
+   launcher resolves the repo root itself and runs the CLI from your invoking
+   cwd). Deno prints a one-line `Task cf ...` echo to stderr; silence it with
+   `deno -q task cf ...`. stdout stays clean, so redirection is safe.
+
+3. **`deno run -q -A packages/cli/mod.ts ...`** — repo-root-relative; only works
+   with the repo root as cwd. The `-q` suppresses Deno's own warnings (e.g. the
+   npm "Ignored build scripts" banner).
+
+## Output Conventions (scripts & agents)
+
+- stdout carries command output only; hints, tips and diagnostics go to stderr.
+  `piece get` prints plain JSON, with no ANSI to strip — except an absent value
+  prints the literal `undefined`, which is not valid JSON, so test for it before
+  parsing (it stays `undefined` rather than `null`; see the loom note in
+  `packages/cli/README.md` for why).
+- ANSI colors are emitted only when stdout is a TTY. Force off with `--no-color`
+  or `NO_COLOR=1`; force on (e.g. through a pager) with `FORCE_COLOR=1`.
+  (`cf view` keeps its own `--color` flag.)
+- `-q/--quiet` (on `piece`/`wish` subcommands) suppresses hints and next-step
+  blocks on stderr. To also drop runtime warnings, add `--log-level error` (`-q`
+  deliberately leaves the log floor alone — scripts parse those warnings).
+- `piece call` payloads: inline JSON argument, `-` to read stdin
+  (`echo '{...}' | cf piece call ... handler -`), a bare pipe with no payload
+  argument, or schema-derived flags after `--`. Empty stdin fails loudly.
+- A `piece get` path that doesn't resolve is a data error: one-line message on
+  stderr, exit 1 (no usage screen).
+
 ## Environment Setup
 
 **Identity key** (required for most operations):
@@ -52,9 +96,9 @@ different derivations and produce different DIDs from the same text. Use
 `from-mnemonic` to match browser mnemonic login; see
 `docs/development/SHARED_IDENTITY.md`.
 
-**IMPORTANT:** Do NOT use `deno task cf id new > file` — the `deno task` wrapper
-prints ANSI-colored preamble to stdout, which pollutes the key file. Always use
-`deno run -A packages/cli/mod.ts` when redirecting output.
+Redirecting stdout (as above) is safe through any invocation path: the
+`deno task` echo and all Deno/CLI diagnostics go to stderr, so
+`deno task cf id new > cf.key` produces a clean key file.
 
 **Environment variables** (avoid repeating flags):
 
@@ -229,8 +273,9 @@ cf fuse mount /tmp/cf -s my-space
 # error: Unknown option "-s"
 ```
 
-**Fix:** use the source CLI through the repo task wrapper instead (cd to the
-labs repo root first):
+**Fix:** rebuild the binary (`deno task build-binaries --cli-only`), or use the
+source CLI through the repo task wrapper (works from any directory inside the
+repo):
 
 ```bash
 export CF_IDENTITY=./cf.key


### PR DESCRIPTION
## Summary

The `cf` CLI is awkward to drive from scripts and automation. Several rough
edges force every programmatic caller to add workarounds:

- ANSI color codes are written even when output is piped, so consumers have to
  strip escape sequences before parsing.
- `piece call` can only take its JSON payload as an argv argument — there is no
  way to pipe it in.
- A `piece get` whose path doesn't resolve prints a full (colorized) usage/help
  screen to **stdout**, so `val=$(cf piece get … path)` captures kilobytes of
  help text instead of failing cleanly.
- Invocation is documented only as `deno run -A packages/cli/mod.ts …`, which
  breaks when the shell's working directory isn't the repo root.
- Deno's own npm "Ignored build scripts" banner prints on every `deno task cf`
  invocation.

This PR makes the CLI behave like a well-mannered Unix tool: colorize only on a
TTY, keep stdout machine-parseable, accept stdin, and fail as a data error
rather than a usage error.

## Changes

**Color is TTY-gated.** ANSI is emitted only when stdout is a terminal.
`--no-color` / `NO_COLOR` force it off; `FORCE_COLOR` / `CLICOLOR_FORCE` force
it on (e.g. through a pager). This also covers Cliffy's help/version/usage
output, which colorized unconditionally before. Cliffy's help generator
overrides the global color flag while it renders, so the resolved policy is
mirrored into the root command's help options, and `@std/fmt/colors` is pinned
to Cliffy's own dependency range so the color toggle reaches the module
instance Cliffy uses (a test guards the pin).

**`piece call` reads stdin.** A `-` payload is a stdin sentinel —
`echo '{…}' | cf piece call … <handler> -` — reusing the existing
`--json-file -` path so empty stdin fails loudly. `--json -` works the same
way. Previously `-` produced a confusing `Invalid JSON for --json` and never
read stdin.

**`piece get` on an unresolved path is a data error.** It now prints a one-line
message to stderr and exits 1, instead of throwing a Cliffy `ValidationError`
that dumped the usage screen to stdout. When the path exists only on the input
cell, it hints to retry with `--input`.

**Built binary documented as the primary entry point.**
`deno task build-binaries --cli-only` compiles `dist/cf`, which is
cwd-independent and free of Deno startup noise. `skills/cf/SKILL.md` and
`packages/cli/README.md` now recommend it (with a rebuild-after-pull note) and
describe the output conventions.

**No more Deno banner.** The launcher spawns the child CLI with
`deno run --quiet`, suppressing the npm "Ignored build scripts" banner on the
`deno task cf` path.

## Before / after

Identical commands, output piped (non-TTY), on `main` vs this branch:

| Command | Before | After |
|---|---|---|
| `val=$(cf piece get -q … missingField)` | 3171 bytes of colorized usage screen captured into `$val` (stdout); exit 1 | 0 bytes on stdout; one `Cannot access path …` line on stderr; exit 1 |
| `cf piece get --help \| cat` | 22 ANSI escape sequences | 0 (and 22 again with `FORCE_COLOR=1`) |
| `echo '{…}' \| cf piece call … <handler> -` | `Invalid JSON for --json`; stdin ignored | payload read from stdin |

## Compatibility constraints (intentionally unchanged)

Two adjacent behaviors look like they should change but are load-bearing for
[`loom`](https://github.com/commontoolsinc/loom), which vendors this CLI under
`vendor/labs` and parses its output. They are left as-is on purpose:

- **`-q` / `--quiet` does not change the log level.** It suppresses only the
  hint / next-step blocks. loom greps the CLI's stderr for the runtime warning
  `load-pattern-by-identity-source-miss` to trigger an automatic root-pattern
  repair; quieting warnings under `-q` would silently disable that. Use
  `--log-level error` to drop warnings.
- **`piece get` renders an empty result as literal `undefined`, not JSON
  `null`.** A fresh-space deploy reads back `undefined` during a normal window,
  and loom's deploy gate treats that as a tolerated transient; emitting `null`
  would turn it into a hard failure.

## Tests

New unit coverage keeps the change coverage-neutral (no net coverage debt in
`packages/cli`): `test/color-mode.test.ts` (TTY/env precedence, the `--`
payload boundary, `safeEnvGet`, the `@std/fmt` pin guard); `--json -` /
`--json-file -` stdin sentinels for object and non-object schemas in
`test/exec.test.ts`; stdin-payload and `pieceGetDataErrorReport` cases in
`test/piece-call.test.ts`; and a launcher `--quiet` assertion. The stdin,
color-policy, and data-error logic is factored into pure, unit-tested helpers.
The full `packages/cli` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Coverage baseline

```
NEW_PERF_BASELINE: coverage-debt: packages/cli uncovered lines = 4006 lines
```

Accepts a narrow +1 uncovered line in `packages/cli`. It comes from routing
main's new `PieceResultProjectionError` (#4874) through this PR's clean
data-error path instead of the Cliffy usage-screen wrapper it shipped with —
the pure logic is unit-tested; the residual line is the integration-only
`piece get` action wiring (a `.action()` callback that calls `Deno.exit`, not
reachable from a unit test and not exercised by an existing integration test).
