### PR TITLE
refactor(ts-transformers): remove dormant __cfDataHelper wiring

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1983,25 +1983,27 @@ argument (`__cf_data((exports.x = evil, 1))`), and pipeline-compiled bodies are
 required precisely because bare `ts.transpileModule` cannot produce the
 `__cf_data` wrapping (`packages/runner/src/sandbox/module-record-compiler.ts`).
 
-### 15.6 Dormant alternate wiring (`__cfDataHelper`), historical
+### 15.6 Alternate wiring (`__cfDataHelper`), removed — historical
 
-The transformer and `CFHelpers` retain a second, data-helper-only emission
-path: when `__cfHelpers` is absent, `wrapWithCfData` falls back to a named
-`__cfDataHelper` import binding (`CFHelpers.getDataHelperExpr`) or a bare
-`__cfDataHelper` identifier plus a prepended
-`import { __cf_data as __cfDataHelper } from "commonfabric"`
-(`createCfDataHelperImport`, `CF_DATA_HELPER_IDENTIFIER`), and
-`shouldWrapTopLevelExpression` narrows to primitive-snapshot calls only. All
-of that is unreachable in the current pipeline: the `HelpersOnlyTransformer`
-filter guarantees `sourceHasHelpers()` at every wrap site. It is a remnant of
-the opt-in era (#3168), when modules without a `/// <cts-enable />` directive
-received only the data-helper import via `injectCfDataHelper`
-(`src/core/cf-helpers.ts`) from the runner's pretransform; that call site was
-removed when transforms became default-on (#3254,
-`packages/runner/src/harness/pretransform.ts`). The orphaned
-`injectCfDataHelper` helper itself was removed after the 2026-07 docs audit
-confirmed it had no callers; `test/transform.test.ts` asserts `__cfDataHelper`
-does not appear in opted-out output.
+Until the 2026-07 docs audit the transformer and `CFHelpers` retained a
+second, data-helper-only emission path from the opt-in era (#3168), when
+modules without a `/// <cts-enable />` directive received only a
+`__cf_data as __cfDataHelper` import from the runner's pretransform (via a
+string-pass `injectCfDataHelper` helper): with `__cfHelpers` absent,
+`wrapWithCfData` fell back to that import binding or a bare `__cfDataHelper`
+identifier plus a prepended import, and `shouldWrapTopLevelExpression`
+narrowed to primitive-snapshot calls only. The wiring became unreachable when
+transforms went default-on (#3254 removed the pretransform call site; the
+`HelpersOnlyTransformer` filter guarantees `sourceHasHelpers()` at every wrap
+site) and its output had drifted out of contract — `__cfDataHelper(...)` is
+not in `TRUSTED_DATA_HELPERS`, so the sandbox verifier would not classify the
+fallback's wraps. The audit removed the whole path: `injectCfDataHelper`, the
+fallback emission arms, `createCfDataHelperImport`, and the
+`getDataHelperExpr` / `sourceHasDataHelper` recognizer surface.
+`wrapWithCfData` now has the single §15.2 emission form, and `getHelperExpr`
+throws if the filter invariant is ever violated (pinned in
+`test/module-scope-cf-data-coverage.test.ts`); `test/transform.test.ts` still
+asserts `__cfDataHelper` does not appear in opted-out output.
 
 
 ## 16. Pattern Runtime Coverage Instrumentation

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -2,7 +2,6 @@ import ts from "typescript";
 import { TransformationContext } from "./mod.ts";
 
 export const CF_HELPERS_IDENTIFIER = "__cfHelpers";
-export const CF_DATA_HELPER_IDENTIFIER = "__cfDataHelper";
 
 const CF_HELPERS_SPECIFIER = "commonfabric";
 
@@ -27,7 +26,6 @@ export class CFHelpers {
   #sourceFile: ts.SourceFile;
   #factory: ts.NodeFactory;
   #helperIdent?: ts.Identifier;
-  #dataHelperIdent?: ts.Identifier;
 
   constructor(params: Pick<TransformationContext, "sourceFile" | "factory">) {
     this.#sourceFile = params.sourceFile;
@@ -38,20 +36,11 @@ export class CFHelpers {
       if (helperSymbol) {
         this.#helperIdent = helperSymbol;
       }
-
-      const dataHelperSymbol = getCFDataHelperIdentifier(stmt);
-      if (dataHelperSymbol) {
-        this.#dataHelperIdent = dataHelperSymbol;
-      }
     }
   }
 
   sourceHasHelpers(): boolean {
     return !!this.#helperIdent;
-  }
-
-  sourceHasDataHelper(): boolean {
-    return !!this.#dataHelperIdent;
   }
 
   // Returns an PropertyAccessExpression of the requested
@@ -128,22 +117,6 @@ export class CFHelpers {
     return this.#factory.createQualifiedName(
       this.#helperIdent!,
       name,
-    );
-  }
-
-  getDataHelperExpr(originalNode?: ts.Node): ts.Identifier {
-    if (!this.sourceHasDataHelper()) {
-      throw new Error("Source file does not contain __cfDataHelper.");
-    }
-
-    if (!originalNode) {
-      return this.#factory.createIdentifier(this.#dataHelperIdent!.text);
-    }
-
-    return this.preserveNodeSourceMap(
-      this.#factory.createIdentifier(this.#dataHelperIdent!.text),
-      originalNode,
-      this.#dataHelperIdent!,
     );
   }
 }
@@ -305,30 +278,6 @@ function getCFHelpersIdentifier(
     if (bindingName.text === CF_HELPERS_IDENTIFIER) {
       return element.name;
     }
-  }
-  return;
-}
-
-function getCFDataHelperIdentifier(
-  statement: ts.Statement,
-): ts.Identifier | undefined {
-  if (!ts.isImportDeclaration(statement)) return;
-  const { importClause, moduleSpecifier } = statement;
-
-  if (!ts.isStringLiteral(moduleSpecifier)) return;
-  if (moduleSpecifier.text !== CF_HELPERS_SPECIFIER) return;
-
-  if (!importClause || !ts.isImportClause(importClause)) return;
-  const { namedBindings } = importClause;
-  if (!namedBindings || !ts.isNamedImports(namedBindings)) return;
-  for (const element of namedBindings.elements) {
-    if (element.name.text !== CF_DATA_HELPER_IDENTIFIER) {
-      continue;
-    }
-    if ((element.propertyName ?? element.name).text !== "__cf_data") {
-      continue;
-    }
-    return element.name;
   }
   return;
 }

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -226,7 +226,6 @@ export {
 } from "./transformers.ts";
 export * from "./common-fabric-symbols.ts";
 export {
-  CF_DATA_HELPER_IDENTIFIER,
   CF_HELPERS_IDENTIFIER,
   CFHelpers,
   injectCfHelpers,

--- a/packages/ts-transformers/src/transformers/module-scope-cf-data.ts
+++ b/packages/ts-transformers/src/transformers/module-scope-cf-data.ts
@@ -3,11 +3,7 @@ import {
   isTrustedBuilder,
   isTrustedDataHelper,
 } from "@commonfabric/utils/sandbox-contract";
-import {
-  CF_DATA_HELPER_IDENTIFIER,
-  HelpersOnlyTransformer,
-  TransformationContext,
-} from "../core/mod.ts";
+import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
 
 const CF_DATA_CONSTRUCTOR_NAMES = new Set(["Map", "Set"]);
@@ -36,13 +32,7 @@ export class ModuleScopeCfDataTransformer extends HelpersOnlyTransformer {
       return sourceFile;
     }
 
-    const statements = (
-        context.cfHelpers.sourceHasHelpers() ||
-        context.cfHelpers.sourceHasDataHelper()
-      )
-      ? transformedStatements
-      : [createCfDataHelperImport(factory), ...transformedStatements];
-    return factory.updateSourceFile(sourceFile, statements);
+    return factory.updateSourceFile(sourceFile, transformedStatements);
   }
 }
 
@@ -130,13 +120,10 @@ function wrapWithCfData(
   expression: ts.Expression,
   context: TransformationContext,
 ): ts.CallExpression {
-  const helperExpr = context.cfHelpers.sourceHasHelpers()
-    ? context.cfHelpers.getHelperExpr("__cf_data")
-    : context.cfHelpers.sourceHasDataHelper()
-    ? context.cfHelpers.getDataHelperExpr(expression)
-    : context.factory.createIdentifier(CF_DATA_HELPER_IDENTIFIER);
+  // The HelpersOnlyTransformer filter guarantees the helpers import is
+  // present; getHelperExpr throws if that invariant is ever violated.
   return context.factory.createCallExpression(
-    helperExpr,
+    context.cfHelpers.getHelperExpr("__cf_data"),
     undefined,
     [expression],
   );
@@ -152,7 +139,6 @@ function shouldWrapTopLevelExpression(
   }
 
   const expr = unwrapExpression(expression);
-  const helpersPresent = context.cfHelpers.sourceHasHelpers();
 
   if (
     ts.isArrowFunction(expr) ||
@@ -160,10 +146,6 @@ function shouldWrapTopLevelExpression(
     ts.isClassExpression(expr)
   ) {
     return false;
-  }
-
-  if (!helpersPresent) {
-    return ts.isCallExpression(expr) && isPrimitiveSnapshotCall(expr, context);
   }
 
   if (ts.isCallExpression(expr)) {
@@ -189,27 +171,6 @@ function shouldWrapTopLevelExpression(
   }
 
   return false;
-}
-
-function createCfDataHelperImport(
-  factory: ts.NodeFactory,
-): ts.ImportDeclaration {
-  return factory.createImportDeclaration(
-    undefined,
-    factory.createImportClause(
-      false,
-      undefined,
-      factory.createNamedImports([
-        factory.createImportSpecifier(
-          false,
-          factory.createIdentifier("__cf_data"),
-          factory.createIdentifier(CF_DATA_HELPER_IDENTIFIER),
-        ),
-      ]),
-    ),
-    factory.createStringLiteral("commonfabric"),
-    undefined,
-  );
 }
 
 function isTrustedBuilderCall(expression: ts.CallExpression): boolean {

--- a/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
+++ b/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
@@ -3,19 +3,17 @@
  *
  * These tests exercise the CFHelpers class's import-scanning constructor and its
  * expression/qualified-name factory methods, plus the module-level import-shape
- * recognizers `getCFHelpersIdentifier` / `getCFDataHelperIdentifier` (reached
- * indirectly through the constructor and `sourceHasHelpers` /
- * `sourceHasDataHelper`).
+ * recognizer `getCFHelpersIdentifier` (reached indirectly through the
+ * constructor and `sourceHasHelpers`).
  *
- * The recognizers accept only a named import of `__cfHelpers` (or `__cf_data`
- * aliased to `__cfDataHelper`) from the "commonfabric" module specifier. Each
- * test pins one gate of that shape by feeding a source whose import differs in
- * exactly one respect and asserting whether the helper is detected.
+ * The recognizer accepts only a named import of `__cfHelpers` from the
+ * "commonfabric" module specifier. Each test pins one gate of that shape by
+ * feeding a source whose import differs in exactly one respect and asserting
+ * whether the helper is detected.
  */
 import ts from "typescript";
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import {
-  CF_DATA_HELPER_IDENTIFIER,
   CF_HELPERS_IDENTIFIER,
   CFHelpers,
   injectCfHelpers,
@@ -49,7 +47,7 @@ function printExpr(node: ts.Node, sourceFile: ts.SourceFile): string {
 }
 
 // ---------------------------------------------------------------------------
-// Constructor scanning: getCFHelpersIdentifier / getCFDataHelperIdentifier
+// Constructor scanning: getCFHelpersIdentifier
 // ---------------------------------------------------------------------------
 
 Deno.test("CFHelpers detects the __cfHelpers named import from commonfabric", () => {
@@ -57,7 +55,6 @@ Deno.test("CFHelpers detects the __cfHelpers named import from commonfabric", ()
     `import { __cfHelpers } from "commonfabric";`,
   );
   assert(helpers.sourceHasHelpers());
-  assertFalse(helpers.sourceHasDataHelper());
 });
 
 Deno.test("CFHelpers detects a renamed __cfHelpers import via its property name", () => {
@@ -121,52 +118,10 @@ Deno.test("CFHelpers ignores a bare import declaration with no import clause", (
   // `import "commonfabric"` has `importClause === undefined`.
   const helpers = helpersFor(`import "commonfabric";`);
   assertFalse(helpers.sourceHasHelpers());
-  assertFalse(helpers.sourceHasDataHelper());
-});
-
-Deno.test("CFHelpers detects the __cf_data data helper import aliased to __cfDataHelper", () => {
-  // The data helper is only recognized as `__cf_data as __cfDataHelper`.
-  const helpers = helpersFor(
-    `import { __cf_data as __cfDataHelper } from "commonfabric";`,
-  );
-  assert(helpers.sourceHasDataHelper());
-  assertFalse(helpers.sourceHasHelpers());
-});
-
-Deno.test("CFHelpers rejects a data helper import whose local name is not __cfDataHelper", () => {
-  // `element.name.text` must equal `__cfDataHelper`; here it is `other`.
-  const helpers = helpersFor(
-    `import { __cf_data as other } from "commonfabric";`,
-  );
-  assertFalse(helpers.sourceHasDataHelper());
-});
-
-Deno.test("CFHelpers rejects a data helper import whose imported name is not __cf_data", () => {
-  // Local name matches `__cfDataHelper`, but the imported (property) name is
-  // `wrong`, not `__cf_data`, so the second gate rejects it.
-  const helpers = helpersFor(
-    `import { wrong as __cfDataHelper } from "commonfabric";`,
-  );
-  assertFalse(helpers.sourceHasDataHelper());
-});
-
-Deno.test("CFHelpers ignores a data-helper-shaped import from a foreign module", () => {
-  const helpers = helpersFor(
-    `import { __cf_data as __cfDataHelper } from "other-module";`,
-  );
-  assertFalse(helpers.sourceHasDataHelper());
-});
-
-Deno.test("CFHelpers ignores a data helper default import from commonfabric", () => {
-  // Import clause present but no NamedImports binding.
-  const helpers = helpersFor(
-    `import __cfDataHelper from "commonfabric";`,
-  );
-  assertFalse(helpers.sourceHasDataHelper());
 });
 
 // ---------------------------------------------------------------------------
-// getHelperExpr / getHelperQualified / getDataHelperExpr
+// getHelperExpr / getHelperQualified
 // ---------------------------------------------------------------------------
 
 Deno.test("getHelperExpr throws when the source has no helpers import", () => {
@@ -227,44 +182,6 @@ Deno.test("getHelperQualified builds a qualified name against the helper identif
   assert(ts.isQualifiedName(qualified));
   assertEquals(qualified.right.text, "JSONSchema");
   assertEquals((qualified.left as ts.Identifier).text, CF_HELPERS_IDENTIFIER);
-});
-
-Deno.test("getDataHelperExpr throws when the source has no data helper import", () => {
-  const helpers = helpersFor(`const x = 1;`);
-  assertThrows(
-    () => helpers.getDataHelperExpr(),
-    Error,
-    "Source file does not contain __cfDataHelper.",
-  );
-});
-
-Deno.test("getDataHelperExpr without an original node returns a bare data-helper identifier", () => {
-  const source = `import { __cf_data as __cfDataHelper } from "commonfabric";`;
-  const sf = sourceFileFor(source);
-  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
-  const ident = helpers.getDataHelperExpr();
-  assert(ts.isIdentifier(ident));
-  assertEquals(ident.text, CF_DATA_HELPER_IDENTIFIER);
-});
-
-Deno.test("getDataHelperExpr with an original node preserves its source map range", () => {
-  const source =
-    `import { __cf_data as __cfDataHelper } from "commonfabric";\nconst marker = 2;`;
-  const sf = sourceFileFor(source);
-  const helpers = new CFHelpers({ sourceFile: sf, factory: ts.factory });
-
-  let original: ts.Node | undefined;
-  const visit = (node: ts.Node): void => {
-    if (!original && ts.isNumericLiteral(node)) original = node;
-    ts.forEachChild(node, visit);
-  };
-  visit(sf);
-  assert(original);
-
-  const ident = helpers.getDataHelperExpr(original);
-  assert(ts.isIdentifier(ident));
-  assertEquals(ident.text, CF_DATA_HELPER_IDENTIFIER);
-  assertEquals(ts.getSourceMapRange(ident).pos, original.pos);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ts-transformers/test/module-scope-cf-data-coverage.test.ts
+++ b/packages/ts-transformers/test/module-scope-cf-data-coverage.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import ts from "typescript";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
@@ -12,36 +12,11 @@ import {
 } from "./transformed-ast.ts";
 
 /**
- * True when the module imports `{ <imported> as <local> }` from `<module>`.
- */
-function hasNamedImport(
-  root: ts.SourceFile,
-  imported: string,
-  local: string,
-  moduleSpecifier: string,
-): boolean {
-  return collect(root, ts.isImportDeclaration).some((decl) => {
-    if (
-      !ts.isStringLiteral(decl.moduleSpecifier) ||
-      decl.moduleSpecifier.text !== moduleSpecifier
-    ) {
-      return false;
-    }
-    const bindings = decl.importClause?.namedBindings;
-    if (!bindings || !ts.isNamedImports(bindings)) return false;
-    return bindings.elements.some((element) =>
-      element.name.text === local &&
-      (element.propertyName?.text ?? element.name.text) === imported
-    );
-  });
-}
-
-/**
- * The bare-identifier argument of the sole `__cfDataHelper(...)` wrap call, or
+ * The argument text of the sole `__cfHelpers.__cf_data(...)` wrap call, or
  * undefined if there is no such call. Asserts there is at most one.
  */
-function cfDataHelperArgText(root: ts.SourceFile): string | undefined {
-  const calls = callsNamed(root, "__cfDataHelper");
+function cfDataArgText(root: ts.SourceFile): string | undefined {
+  const calls = callsNamed(root, "__cf_data");
   assert(
     calls.length <= 1,
     `expected at most one wrap call, got ${calls.length}`,
@@ -62,14 +37,17 @@ function defaultExportExpression(
 
 // The module-scope cf-data transformer wraps top-level data expressions with a
 // `__cf_data` helper call. The existing `module-scope-cf-data.test.ts` drives
-// the full pipeline, where the `__cfHelpers` import is always injected, so
-// `context.cfHelpers.sourceHasHelpers()` is always true. These tests target the
-// branches that only run when the source has NO helper import: the primitive
-// snapshot classification path (`shouldWrapTopLevelExpression` line 165-167),
-// the helper-import injection (`createCfDataHelperImport`), and the union /
-// intersection primitive-type analysis. To reach that state the transformer is
-// driven directly through `ts.transform`, bypassing the `HelpersOnlyTransformer`
-// filter that would otherwise skip a source without helpers.
+// the full pipeline; these tests drive the transformer directly through
+// `ts.transform` with a bare single-file program so the checker-dependent
+// classification arms (`isPrimitiveSnapshotCall`'s union / intersection
+// analysis) and the callable-classification walks can be pinned against
+// minimal sources. The callees are `declare const` bindings on purpose: a
+// top-level function declaration or const arrow/function-expression would
+// match `isTopLevelLocalHelperCall` first and short-circuit past the
+// primitive-snapshot arm. Driving directly also bypasses the
+// `HelpersOnlyTransformer` filter, which lets the final test pin the loud
+// invariant: wrap emission on a helpers-less source throws rather than
+// silently emitting a form the sandbox verifier does not recognize.
 
 function createProgram(source: string): {
   program: ts.Program;
@@ -102,10 +80,10 @@ function createProgram(source: string): {
   return { program, sourceFile: program.getSourceFile("/test.ts")! };
 }
 
-// Runs the cf-data transformer directly against a helper-free source. The
-// direct call bypasses the `sourceHasHelpers()` filter so the no-helpers
-// branches execute.
-function transformWithoutHelpers(source: string): string {
+// Runs the cf-data transformer directly, bypassing the pipeline (and with it
+// the `sourceHasHelpers()` filter — sources here carry their own helpers
+// import, except where the filter invariant itself is under test).
+function transformDirect(source: string): string {
   const { program, sourceFile } = createProgram(source);
   const transformer = new ModuleScopeCfDataTransformer({ mode: "transform" });
   const result = ts.transform(sourceFile, [
@@ -122,55 +100,59 @@ function transformWithoutHelpers(source: string): string {
 }
 
 Deno.test(
-  "cf-data without helpers wraps a primitive-typed call and injects the __cf_data import",
+  "cf-data wraps a bare-identifier call whose result type is primitive",
   () => {
-    const output = transformWithoutHelpers(
-      `declare function n(): number;\nconst z = n();\n`,
+    const output = transformDirect(
+      `import { __cfHelpers } from "commonfabric";\n` +
+        `declare const n: () => number;\n` +
+        `const z = n();\n`,
     );
-    // With no `__cfHelpers` import present the transformer prepends its own
-    // named import and wraps the snapshot call with the bare identifier form.
-    const root = parseModule(output);
-    assert(
-      hasNamedImport(root, "__cf_data", "__cfDataHelper", "commonfabric"),
-      "expected the injected __cf_data import",
-    );
-    assertEquals(cfDataHelperArgText(root), "n()");
+    // `n` is neither a local callable binding nor a member call, so only the
+    // checker-resolved primitive result type qualifies the call as a snapshot.
+    assertEquals(cfDataArgText(parseModule(output)), "n()");
   },
 );
 
 Deno.test(
-  "cf-data without helpers wraps a call whose type is a union of primitives",
+  "cf-data wraps a call whose type is a union of primitives",
   () => {
-    const output = transformWithoutHelpers(
-      `declare function u(): string | number;\nconst z = u();\n`,
+    const output = transformDirect(
+      `import { __cfHelpers } from "commonfabric";\n` +
+        `declare const u: () => string | number;\n` +
+        `const z = u();\n`,
     );
     // A union return type is classified as primitive-like when every member is
     // primitive-like, so the snapshot call is wrapped.
-    assertEquals(cfDataHelperArgText(parseModule(output)), "u()");
+    assertEquals(cfDataArgText(parseModule(output)), "u()");
   },
 );
 
 Deno.test(
-  "cf-data without helpers wraps a call whose type is an intersection of primitives",
+  "cf-data wraps a call whose type is an intersection of primitives",
   () => {
-    const output = transformWithoutHelpers(
-      `type A = string;\ntype B = string;\ndeclare function u(): A & B;\nconst z = u();\n`,
+    const output = transformDirect(
+      `import { __cfHelpers } from "commonfabric";\n` +
+        `type A = string;\ntype B = string;\n` +
+        `declare const u: () => A & B;\n` +
+        `const z = u();\n`,
     );
     // An intersection is primitive-like when every member is primitive-like.
-    assertEquals(cfDataHelperArgText(parseModule(output)), "u()");
+    assertEquals(cfDataArgText(parseModule(output)), "u()");
   },
 );
 
 Deno.test(
-  "cf-data without helpers leaves a call whose intersection has a non-primitive member unwrapped",
+  "cf-data leaves a call whose intersection has a non-primitive member unwrapped",
   () => {
-    const output = transformWithoutHelpers(
-      `declare function u(): string & { b: string };\nconst z = u();\n`,
+    const output = transformDirect(
+      `import { __cfHelpers } from "commonfabric";\n` +
+        `declare const u: () => string & { b: string };\n` +
+        `const z = u();\n`,
     );
     // The object member is not primitive-like, so the intersection fails the
     // `every` check and the call is not treated as a snapshot.
     assertEquals(
-      callsNamed(parseModule(output), "__cfDataHelper").length,
+      callsNamed(parseModule(output), "__cf_data").length,
       0,
       "expected the non-primitive intersection to be left unwrapped",
     );
@@ -180,15 +162,16 @@ Deno.test(
 Deno.test(
   "cf-data leaves a declared callable with no body unwrapped on default export",
   () => {
-    const output = transformWithoutHelpers(
-      `declare function helper(): number;\nexport default helper;\n`,
+    const output = transformDirect(
+      `import { __cfHelpers } from "commonfabric";\n` +
+        `declare function helper(): number;\nexport default helper;\n`,
     );
     // `callableMayReturnCallResult` returns false for a declaration without a
     // body, so the ambient callable is not classified as a default-exported
     // data callable.
     const root = parseModule(output);
     assertEquals(
-      callsNamed(root, "__cfDataHelper").length,
+      callsNamed(root, "__cf_data").length,
       0,
       "expected the body-less declared callable to be left unwrapped",
     );
@@ -201,8 +184,9 @@ Deno.test(
 Deno.test(
   "cf-data wraps a callable that returns a call-on-call result past a nested class boundary and trailing members",
   () => {
-    const output = transformWithoutHelpers(
-      `declare function factory(): () => number;\n` +
+    const output = transformDirect(
+      `import { __cfHelpers } from "commonfabric";\n` +
+        `declare function factory(): () => number;\n` +
         `const nested = () => ({ make: class {}, a: factory()(), b: 1 });\n` +
         `export default nested;\n`,
     );
@@ -212,8 +196,23 @@ Deno.test(
     const root = parseModule(output);
     const exported = defaultExportExpression(root);
     assert(exported && ts.isCallExpression(exported), "expected a wrap call");
-    assertEquals(calleeName(exported), "__cfDataHelper");
+    assertEquals(calleeName(exported), "__cf_data");
     assertEquals(exported.arguments[0]?.getText(root), "nested");
+  },
+);
+
+Deno.test(
+  "cf-data wrap emission on a helpers-less source throws (filter invariant)",
+  () => {
+    // The HelpersOnlyTransformer filter guarantees every source reaching
+    // transform() carries the helpers import. Bypassing it with a wrappable
+    // statement must fail loudly via getHelperExpr, not fall back to an
+    // alternate emission the sandbox verifier does not recognize.
+    assertThrows(
+      () => transformDirect(`const z = { a: 1 };\n`),
+      Error,
+      "does not contain helpers",
+    );
   },
 );
 


### PR DESCRIPTION
**Stacked on #4767** (base is its branch; will rebase onto main and mark ready once #4767 merges). Completes what #4767's second commit started: #4767 removed the orphaned string-pass `injectCfDataHelper` entry point; this removes the rest of the dormant `__cfDataHelper` wiring that spec §15.6 documented.

## What the wiring was

Opt-in-era (#3168) remnant: when `__cfHelpers` was absent, `wrapWithCfData` fell back to a `__cfDataHelper` import binding or a bare identifier plus a prepended `import { __cf_data as __cfDataHelper }` (`createCfDataHelperImport`), and `shouldWrapTopLevelExpression` narrowed to primitive-snapshot calls only.

## Why it can go

- **Unreachable, structurally**: `ModuleScopeCfDataTransformer extends HelpersOnlyTransformer`, whose `filter` is literally `sourceHasHelpers()` — every dormant fork sat behind an always-true first arm. Empirically: zero fixture goldens contain `__cfDataHelper`.
- **Out of contract if ever reached**: `__cfDataHelper` is not in the sandbox verifier's `TRUSTED_DATA_HELPERS` (`schema`, `__cf_data`, `nonPrivateRandom`, `safeDateNow`), so the fallback's wraps would not classify. The dormancy was not belt-and-braces — it was a silent semantic downgrade to an unverifiable form.
- **The loud invariant is free**: `getHelperExpr` already throws on a helpers-less source, so removal converts "silent fallback" into "loud failure" with no new code. A new test pins this.

## What was removed / kept

Removed: both fallback arms in `wrapWithCfData`, the helpers-less narrowing in `shouldWrapTopLevelExpression`, the import-prepend + `createCfDataHelperImport`, and `CFHelpers`' `getDataHelperExpr` / `sourceHasDataHelper` / `getCFDataHelperIdentifier` recognizer surface + `CF_DATA_HELPER_IDENTIFIER` (no external importers; the `cf view` pager re-declares its own copy). Net −173 lines.

Kept deliberately: `isTrustedDataHelper` / `TRUSTED_DATA_HELPERS` (a different, live "data helper" concept), the `cf view` vocab entry (a viewer's vocabulary legitimately covers historical tokens in old stored output), and `test/transform.test.ts`'s assertion that `__cfDataHelper` never appears in opted-out output.

Tests: the checker-dependent classification tests (primitive/union/intersection snapshots, callable walks) are **rewritten to the helpers-present form**, not deleted — using `declare const` callees so the primitive-snapshot arm isn't short-circuited by the local-callable arm. Their live-code coverage is preserved and improved: `module-scope-cf-data.ts` is now **100% branch/function/line** (cf-helpers.ts 97.3/99.4). Spec §15.6 rewritten as a removal record.

## Verification

- Package gate clean: fmt/lint/check, tests **1079/0** (count reconciles exactly: −8 dead-branch tests, +1 invariant test vs #4767's 1086).
- **Zero fixture-golden diffs** — live-path emission is byte-identical, so the runner's sandbox-verifier contract (`sandbox-contract.ts` pattern-matching) is provably untouched.
- All 11 external importer files of the package `deno check` clean; runner `esm-engine` + `load-by-identity` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)