### PR TITLE
fix(memory): harden sync schema table validation

### DIFF
--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -47,10 +47,11 @@ The client MUST declare its protocol version in the first WebSocket message:
 ```json
 {
   "type": "hello",
-  "protocol": "memory/v2",
+  "protocol": "memory",
   "flags": {
     "modernCellRep": true,
-    "persistentSchedulerState": true
+    "persistentSchedulerState": true,
+    "syncSchemaTableV2": true
   }
 }
 ```
@@ -60,10 +61,11 @@ If the server accepts the protocol, it returns:
 ```json
 {
   "type": "hello.ok",
-  "protocol": "memory/v2",
+  "protocol": "memory",
   "flags": {
     "modernCellRep": true,
-    "persistentSchedulerState": true
+    "persistentSchedulerState": true,
+    "syncSchemaTableV2": true
   },
   "sessionOpen": {
     "audience": "did:key:z6Mk...",
@@ -128,6 +130,13 @@ a client and server may connect when their scheduler-state flags differ, and
 the server's flag controls the scheduler-observation data plane for that
 connection.
 
+`syncSchemaTableV2` advertises support for the hash-keyed schema table described
+in [Session Sync Payload](#423-session-sync-payload). It defaults to `false`
+when absent. The server sends compact sync payloads only when both peers
+advertise the capability; otherwise it sends the historical fully expanded
+shape. The older `syncSchemaTable` flag names an incompatible, index-keyed draft
+and does not enable the v2 encoding.
+
 ### 4.1.2 Logical Sessions and Resume
 
 Pending-read resolution, idempotent replay, and live sync are scoped to a
@@ -159,7 +168,7 @@ interface SessionOpenInvocation {
   sub: SpaceId;
   aud: DID;
   args: {
-    protocol: "memory/v2";
+    protocol: "memory";
     session: {
       sessionId?: SessionId;
       seenSeq?: number;
@@ -229,10 +238,11 @@ semantic commit body. Per-commit signed UCAN envelopes remain deferred.
 // Shown at module scope.
 interface HelloMessage {
   type: "hello";
-  protocol: "memory/v2";
+  protocol: "memory";
   flags: {
     modernCellRep: boolean;
     persistentSchedulerState?: boolean;
+    syncSchemaTableV2?: boolean;
   };
 }
 
@@ -315,6 +325,64 @@ Semantics:
 - `deleted: true` means the entity is currently tombstoned
 - `removes` are not deletions in storage; they mean the entity is no longer in
   the session's relevant watch-set result
+
+#### Negotiated schema-table encoding
+
+When both peers advertise `syncSchemaTableV2`, the server MAY compact a
+server-to-client `SessionSync` carried by `response.ok.sync` or
+`session/effect.effect`. For each JSON Schema attached to a modern `link@1`
+payload or legacy `$alias` payload, it:
+
+1. computes the canonical tagged schema hash
+2. replaces the inline schema with `schema-ref@2:<tagged-hash>`
+3. adds the canonical schema to a frame-local `schemaTable` keyed by that hash
+
+For example, the compact wire form can contain:
+
+```json
+{
+  "type": "sync",
+  "fromSeq": 10,
+  "toSeq": 11,
+  "upserts": [{
+    "branch": "",
+    "id": "of:example",
+    "seq": 11,
+    "doc": {
+      "value": {
+        "contact": {
+          "/": {
+            "link@1": {
+              "id": "of:contact",
+              "path": [],
+              "schema": "schema-ref@2:fid1:..."
+            }
+          }
+        }
+      }
+    }
+  }],
+  "removes": [],
+  "schemaTable": {
+    "fid1:...": {
+      "type": "object",
+      "properties": { "name": { "type": "string" } }
+    }
+  }
+}
+```
+
+The table is scoped to one sync payload, not to a connection or logical
+session. A client MUST resolve every `schema-ref@2:` before exposing the sync to
+the session cache. It MUST reject a reference when the table is missing the key
+or when hashing the referenced table value does not reproduce the key. After
+expansion, downstream consumers observe the historical `SessionSync` shape with
+inline schemas and no `schemaTable` field.
+
+The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
+legacy `$alias` payloads. Memory servers MUST reject set or patch operations
+whose resulting stored document uses that prefix as an opaque schema string;
+ordinary strings in other document positions are unaffected.
 
 ### 4.2.4 Batching
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -335,7 +335,9 @@ payload or legacy `$alias` payload, it:
 
 1. computes the canonical tagged schema hash
 2. replaces the inline schema with `schema-ref@2:<tagged-hash>`
-3. adds the canonical schema to a frame-local `schemaTable` keyed by that hash
+3. adds the interned schema to a frame-local `schemaTable` keyed by that
+   hash (structurally equal to the inline schema; its serialized key order is
+   not guaranteed canonical — only the hash is)
 
 For example, the compact wire form can contain:
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -331,7 +331,7 @@ Semantics:
 When both peers advertise `syncSchemaTableV2`, the server MAY compact a
 server-to-client `SessionSync` carried by `response.ok.sync` or
 `session/effect.effect`. For each JSON Schema attached to a modern `link@1`
-payload or legacy `$alias` payload, it:
+payload, it:
 
 1. computes the canonical tagged schema hash
 2. replaces the inline schema with `schema-ref@2:<tagged-hash>`
@@ -377,9 +377,19 @@ For example, the compact wire form can contain:
 The table is scoped to one sync payload, not to a connection or logical
 session. A client MUST resolve every `schema-ref@2:` before exposing the sync to
 the session cache. It MUST reject a reference when the table is missing the key
-or when hashing the referenced table value does not reproduce the key. After
-expansion, downstream consumers observe the historical `SessionSync` shape with
-inline schemas and no `schemaTable` field.
+or when hashing the referenced table value does not reproduce the key. It MUST
+also reject a sync whose documents still carry a reserved reference at a
+recognized schema position after expansion — a reference the client does not
+interpret must fail the frame rather than reach the session cache as data.
+After expansion, downstream consumers observe the historical `SessionSync`
+shape with inline schemas and no `schemaTable` field.
+
+Earlier revisions of this encoding also interned the `schema` field of legacy
+`$alias` bindings still present in stored documents. Current servers leave
+alias schemas inline (the runner is retiring `$alias` from persisted data),
+but clients deployed against the earlier revision continue to expand
+references at alias schema positions, so those positions remain covered by
+the reservation rule below.
 
 The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
 legacy `$alias` payloads. Link recognition follows the canonical cell-rep

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -384,12 +384,12 @@ interpret must fail the frame rather than reach the session cache as data.
 After expansion, downstream consumers observe the historical `SessionSync`
 shape with inline schemas and no `schemaTable` field.
 
-Earlier revisions of this encoding also interned the `schema` field of legacy
-`$alias` bindings still present in stored documents. Current servers leave
-alias schemas inline (the runner is retiring `$alias` from persisted data),
-but clients deployed against the earlier revision continue to expand
-references at alias schema positions, so those positions remain covered by
-the reservation rule below.
+Earlier revisions of this encoding also interned the `schema` field of
+`$alias` records. Those records are Pattern-binding vocabulary, not links —
+their `schema` field is binding metadata — and saved patterns continue to
+carry them, so current servers leave alias schemas inline. Clients deployed
+against the earlier revision continue to expand references at alias schema
+positions, so those positions remain covered by the reservation rule below.
 
 The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
 legacy `$alias` payloads. Link recognition follows the canonical cell-rep

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -380,9 +380,13 @@ expansion, downstream consumers observe the historical `SessionSync` shape with
 inline schemas and no `schemaTable` field.
 
 The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
-legacy `$alias` payloads. Memory servers MUST reject set or patch operations
-whose resulting stored document uses that prefix as an opaque schema string;
-ordinary strings in other document positions are unaffected.
+legacy `$alias` payloads. Link recognition follows the canonical cell-rep
+form — in the legacy representation, the single-key `{ "/": { "link@1": … } }`
+envelope — so an envelope carrying sibling keys is not a link and its contents
+are ordinary data. Memory servers MUST reject set or patch operations
+whose resulting stored document uses that prefix as an opaque schema string in
+a recognized schema position; ordinary strings in other document positions are
+unaffected.
 
 ### 4.2.4 Batching
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -331,6 +331,175 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
   }
 });
 
+Deno.test("memory v2 engine replays stateful entities across set and delete revisions", async () => {
+  const { engine, path } = await createEngine();
+  const reservedRef = "schema-ref@2:sha256:harmless-position";
+  const id = "entity:stateful-replay";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:stateful-replay",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: toEntityDocument({ base: true }),
+        }],
+      },
+    });
+
+    // One commit whose replay walks every stateful branch without throwing:
+    // a candidate patch placing a reserved string in a harmless position,
+    // a wholesale set, a follow-up patch, and a tombstoning delete.
+    applyCommit(engine, {
+      sessionId: "session:stateful-replay",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "add",
+            path: "/value/harmless",
+            value: reservedRef,
+          }],
+        }, {
+          op: "set",
+          id,
+          value: toEntityDocument({ replaced: true }),
+        }, {
+          op: "patch",
+          id,
+          patches: [{
+            op: "add",
+            path: "/value/afterSet",
+            value: "clean",
+          }],
+        }, {
+          op: "delete",
+          id,
+        }],
+      },
+    });
+
+    assertEquals(read(engine, { id }), null);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine validates clean moves against snapshot-backed pre-state", async () => {
+  const { engine, path } = await createEngineWithOptions({
+    snapshotInterval: 1,
+  });
+  const reservedRef = "schema-ref@2:sha256:snapshot-resident";
+  const id = "entity:snapshot-move";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:snapshot-move",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: toEntityDocument({
+            harmless: reservedRef,
+            ref: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:target",
+                  path: [],
+                  schema: "opaque-schema-name",
+                },
+              },
+            },
+          }),
+        }],
+      },
+    });
+    // Force a snapshot so the clean-move probe reads the snapshot row rather
+    // than the base set revision.
+    applyCommit(engine, {
+      sessionId: "session:snapshot-move",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{ op: "add", path: "/value/padding", value: "clean" }],
+        }],
+      },
+    });
+
+    // The move commit's own serialization is clean; only the snapshot-backed
+    // pre-state carries the reserved string, and relocating it into a schema
+    // position must still be rejected.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:snapshot-move",
+          invocation: invocationFor(3),
+          authorization,
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id,
+              patches: [{
+                op: "move",
+                from: "/value/harmless",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+              }],
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+
+    // A clean move between harmless positions over the same snapshot-backed
+    // pre-state is allowed.
+    applyCommit(engine, {
+      sessionId: "session:snapshot-move",
+      invocation: invocationFor(3),
+      authorization,
+      commit: {
+        localSeq: 3,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "move",
+            from: "/value/harmless",
+            path: "/value/relocated",
+          }],
+        }],
+      },
+    });
+    const document = read(engine, { id });
+    assertEquals(
+      (document?.value as Record<string, unknown>).relocated,
+      reservedRef,
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine reserves request CAS schema reference strings", async () => {
   const { engine, path } = await createEngine();
   const reservedRef = "schema-cas@1:sha256:user-controlled";

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -8,6 +8,7 @@ import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   type EntityRef,
   entityRefFromString,
+  LINK_V1_TAG,
 } from "@commonfabric/data-model/cell-rep";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
@@ -85,6 +86,254 @@ const toEntityDocument = (
   }
   return document as EntityDocument;
 };
+
+Deno.test("memory v2 engine reserves sync schema reference strings", async () => {
+  const { engine, path } = await createEngine();
+  const id = "entity:reserved-sync-schema-ref";
+  const reservedRef = "schema-ref@2:sha256:user-controlled";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:reserved-sync-schema-ref",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: toEntityDocument({
+            harmless: reservedRef,
+            ref: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:target",
+                  path: [],
+                  schema: "opaque-schema-name",
+                },
+              },
+            },
+            $alias: {
+              id: "of:legacy-target",
+              path: [],
+              schema: "opaque-legacy-schema-name",
+            },
+          }),
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:reserved-sync-schema-ref-set",
+              value: toEntityDocument({
+                $alias: {
+                  id: "of:target",
+                  path: [],
+                  schema: reservedRef,
+                },
+              }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+
+    applyCommit(engine, {
+      sessionId: "session:reserved-sync-schema-ref",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "add",
+            path: "/value/harmlessPatch",
+            value: reservedRef,
+          }],
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id,
+              patches: [{
+                op: "replace",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+                value: reservedRef,
+              }],
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+
+    for (
+      const path of [
+        `/value/ref/~1/${LINK_V1_TAG}/schema`,
+        "/value/$alias/schema",
+      ]
+    ) {
+      assertThrows(
+        () =>
+          applyCommit(engine, {
+            sessionId: "session:reserved-sync-schema-ref",
+            commit: {
+              localSeq: 3,
+              reads: { confirmed: [], pending: [] },
+              operations: [{
+                op: "patch",
+                id,
+                patches: [{
+                  op: "move",
+                  from: "/value/harmless",
+                  path,
+                }],
+              }],
+            },
+          }),
+        ProtocolError,
+        "reserved wire schema reference",
+      );
+    }
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:reserved-sync-schema-ref-hidden-by-set",
+              value: toEntityDocument({
+                $alias: {
+                  id: "of:target",
+                  path: [],
+                  schema: reservedRef,
+                },
+              }),
+            }, {
+              op: "set",
+              id: "entity:reserved-sync-schema-ref-hidden-by-set",
+              value: toEntityDocument({ safe: true }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+    assertEquals(
+      read(engine, { id: "entity:reserved-sync-schema-ref-hidden-by-set" }),
+      null,
+    );
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id,
+              patches: [{
+                op: "replace",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+                value: reservedRef,
+              }],
+            }, {
+              op: "delete",
+              id,
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+
+    assertEquals(
+      read(engine, { id }),
+      toEntityDocument({
+        harmless: reservedRef,
+        harmlessPatch: reservedRef,
+        ref: {
+          "/": {
+            [LINK_V1_TAG]: {
+              id: "of:target",
+              path: [],
+              schema: "opaque-schema-name",
+            },
+          },
+        },
+        $alias: {
+          id: "of:legacy-target",
+          path: [],
+          schema: "opaque-legacy-schema-name",
+        },
+      }),
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine reserves request CAS schema reference strings", async () => {
+  const { engine, path } = await createEngine();
+  const reservedRef = "schema-cas@1:sha256:user-controlled";
+  try {
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-request-schema-ref",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:reserved-request-schema-ref",
+              value: toEntityDocument({
+                $alias: {
+                  id: "of:target",
+                  path: [],
+                  schema: reservedRef,
+                },
+              }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+    assertEquals(
+      read(engine, { id: "entity:reserved-request-schema-ref" }),
+      null,
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
 
 Deno.test("memory v2 engine stores independent scoped instances for the same id", async () => {
   const { engine, path } = await createEngine();

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -271,6 +271,39 @@ Deno.test("memory v2 engine reserves sync schema reference strings", async () =>
       "reserved wire schema reference",
     );
 
+    // A reserved reference that exists only in a mid-commit state — placed by
+    // one patch and cleaned by the next in the same commit — is still stored
+    // history (readable at its seq) and must be rejected.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:reserved-sync-schema-ref",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id,
+              patches: [{
+                op: "replace",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+                value: reservedRef,
+              }],
+            }, {
+              op: "patch",
+              id,
+              patches: [{
+                op: "replace",
+                path: `/value/ref/~1/${LINK_V1_TAG}/schema`,
+                value: "opaque-schema-name",
+              }],
+            }],
+          },
+        }),
+      ProtocolError,
+      "reserved wire schema reference",
+    );
+
     assertEquals(
       read(engine, { id }),
       toEntityDocument({

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -214,10 +214,10 @@ Deno.test("sync schema table preserves own __proto__ fields", () => {
 });
 
 Deno.test("sync schema table leaves legacy alias schemas inline", () => {
-  // The mapper no longer treats `$alias.schema` as a schema position: the
-  // runner is retiring `$alias` from persisted data, and docs that still
-  // carry it travel with their alias schemas inline. The alias record IS
-  // ordinary data, though — a link nested inside its schema value is a
+  // The mapper no longer treats `$alias.schema` as a schema position:
+  // `$alias` records are Pattern-binding vocabulary, not links, and their
+  // schema field is binding metadata that travels inline. The alias record
+  // IS ordinary data, though — a link nested inside its schema value is a
   // live position and interns normally.
   const aliasSchema: JSONSchema = {
     type: "object",

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -29,6 +29,7 @@ import {
   expandSessionSyncSchemas,
   type SchemaTableSessionSync,
 } from "../v2/sync-schema-table.ts";
+import { findSyncSchemaRef } from "../v2/sync-schema-ref.ts";
 import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 
 const textEncoder = new TextEncoder();
@@ -155,6 +156,50 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
   );
 });
 
+Deno.test("sync schema table reports each repeated schema once", () => {
+  const observed: JSONSchema[] = [];
+
+  compressSessionSyncSchemas(repeatedSchemaSync(2), (schema) => {
+    observed.push(schema);
+  });
+
+  assertEquals(observed, [internSchema(largeSchema(), true).schema]);
+});
+
+Deno.test("sync schema table preserves own __proto__ fields", () => {
+  const value = JSON.parse('{"__proto__":{"safe":true}}') as Record<
+    string,
+    unknown
+  >;
+  value.ref = linkRefFrom({
+    id: "of:target",
+    path: [],
+    schema: { type: "string" },
+  });
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:proto-source",
+      scope: "space",
+      seq: 1,
+      doc: { value },
+    }],
+    removes: [],
+  };
+
+  const compressed = compressSessionSyncSchemas(sync);
+  const compressedValue = compressed.upserts[0].doc?.value as Record<
+    string,
+    unknown
+  >;
+
+  assert(Object.hasOwn(compressedValue, "__proto__"));
+  assertEquals(compressedValue.__proto__, { safe: true });
+});
+
 Deno.test("sync schema table round-trips legacy aliases nested in arrays", () => {
   const schema: JSONSchema = {
     type: "object",
@@ -227,7 +272,14 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
     ).schema,
     undefined,
   );
-  assertEquals(expandSessionSyncSchemas(compressed), sync);
+  const expandedSchemas: JSONSchema[] = [];
+  assertEquals(
+    expandSessionSyncSchemas(compressed, (expanded) => {
+      expandedSchemas.push(expanded);
+    }),
+    sync,
+  );
+  assertEquals(expandedSchemas, [internSchema(schema, true).schema]);
 });
 
 Deno.test("sync schema table continues through sibling fields after link payloads", () => {
@@ -293,6 +345,20 @@ Deno.test("sync schema table continues through sibling fields after link payload
   assertEquals(compressedPayload.schema, `schema-ref@2:${primaryHash}`);
   assertEquals(compressedSiblingPayload.schema, `schema-ref@2:${siblingHash}`);
   assertEquals(expandSessionSyncSchemas(compressed), sync);
+});
+
+Deno.test("sync schema table ignores inherited fields while finding schema refs", () => {
+  const inherited = {
+    hidden: {
+      $alias: {
+        schema: "schema-ref@2:inherited",
+      },
+    },
+  };
+  const payload = Object.create(inherited) as Record<string, unknown>;
+  payload.visible = { value: "ordinary data" };
+
+  assertEquals(findSyncSchemaRef(payload), undefined);
 });
 
 Deno.test("sync schema table leaves syncs without compressible schemas unchanged", () => {
@@ -448,6 +514,63 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
       }),
     Error,
     "Invalid sync schema table content",
+  );
+});
+
+Deno.test("sync schema table rejects refs without a populated table", () => {
+  const compressed = compressSessionSyncSchemas(
+    repeatedSchemaSync(1),
+  ) as SchemaTableSessionSync;
+  const { schemaTable: _schemaTable, ...withoutTable } = compressed;
+
+  assertThrows(
+    () => expandSessionSyncSchemas(withoutTable),
+    Error,
+    "Invalid sync schema table reference",
+  );
+  assertThrows(
+    () => expandSessionSyncSchemas({ ...withoutTable, schemaTable: {} }),
+    Error,
+    "Invalid sync schema table reference",
+  );
+});
+
+Deno.test("sync schema table validates dangling refs without recursive traversal", () => {
+  const danglingRef = "schema-ref@2:sha256:missing";
+  let deeplyNested: unknown = {
+    $alias: {
+      id: "of:deep-target",
+      path: [],
+      schema: danglingRef,
+    },
+  };
+  for (let index = 0; index < 20_000; index += 1) {
+    deeplyNested = { next: deeplyNested };
+  }
+
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:deep-dangling-ref",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          harmless: danglingRef,
+          nested: deeplyNested,
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  assertThrows(
+    () => expandSessionSyncSchemas(sync),
+    Error,
+    "Invalid sync schema table reference",
   );
 });
 

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -30,7 +30,10 @@ import {
   expandSessionSyncSchemas,
   type SchemaTableSessionSync,
 } from "../v2/sync-schema-table.ts";
-import { findSyncSchemaRef } from "../v2/sync-schema-ref.ts";
+import {
+  containsSyncSchemaRefString,
+  findSyncSchemaRef,
+} from "../v2/sync-schema-ref.ts";
 import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 
 const textEncoder = new TextEncoder();
@@ -804,5 +807,38 @@ Deno.test("sync schema table compression preserves own __proto__ keys", () => {
   assertEquals(
     relocated[LINK_V1_TAG].schema,
     `schema-ref@2:${canonical.taggedHashString}`,
+  );
+});
+
+Deno.test("findSyncSchemaRef traverses arrays and containsSyncSchemaRefString scans leaves", () => {
+  assertEquals(
+    findSyncSchemaRef([
+      "plain",
+      [{
+        "/": {
+          [LINK_V1_TAG]: {
+            id: "of:in-array",
+            path: [],
+            schema: "schema-ref@2:fid1:inside-array",
+          },
+        },
+      }],
+    ]),
+    "schema-ref@2:fid1:inside-array",
+  );
+
+  assertEquals(
+    containsSyncSchemaRefString({
+      a: 1,
+      b: [null, true, { c: "schema-cas@1:fid1:leaf" }],
+    }),
+    true,
+  );
+  assertEquals(
+    containsSyncSchemaRefString({
+      a: 1,
+      b: [null, true, { c: "an ordinary string" }],
+    }),
+    false,
   );
 });

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -42,6 +42,7 @@ import {
   containsSyncSchemaRefString,
   findSyncSchemaRef,
 } from "../v2/sync-schema-ref.ts";
+import { mapLinkSchemas } from "../v2/schema-table-links.ts";
 import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 
 const textEncoder = new TextEncoder();
@@ -933,4 +934,168 @@ Deno.test("schema table and reserved-ref detection handle modern cell-rep links"
     setModernCellRepConfig(false);
     resetModernCellRepConfig();
   }
+});
+
+Deno.test("schema subtrees are opaque: nested link shapes inside schemas are data", () => {
+  // A schema whose `default` embeds a link-shaped structure with a reserved
+  // ref string: the whole schema is one position. Compression swallows it
+  // wholesale, expansion restores it byte-identically without interpreting
+  // the nested shape, and the validator does not flag it.
+  const schemaWithNestedLink: JSONSchema = {
+    type: "object",
+    default: {
+      "/": {
+        [LINK_V1_TAG]: {
+          id: "of:inner",
+          path: [],
+          schema: "schema-ref@2:fid1:nested-as-data",
+        },
+      },
+    },
+  } as unknown as JSONSchema;
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:opaque-schema",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          ref: linkRefFrom({
+            id: "of:target",
+            path: [],
+            schema: schemaWithNestedLink,
+          }),
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  assertEquals(findSyncSchemaRef(sync.upserts[0].doc), undefined);
+
+  const compressed = compressSessionSyncSchemas(sync) as SchemaTableSessionSync;
+  assertExists(compressed.schemaTable);
+  const canonical = internSchema(schemaWithNestedLink, true);
+  assertEquals(
+    compressed.schemaTable![canonical.taggedHashString],
+    canonical.schema,
+  );
+  const expanded = expandSessionSyncSchemas(compressed);
+  assertEquals(expanded, sync);
+});
+
+Deno.test("validator and mapper agree on schema positions across shapes", () => {
+  // Drift guard: findSyncSchemaRef is iterative (stack-safe) while
+  // mapLinkSchemas is recursive; this corpus mechanically enforces that
+  // both walkers see exactly the same schema positions. If either learns a
+  // new position or prunes one, this fails until the other is taught.
+  const planted = "schema-ref@2:fid1:planted";
+  const probe = (value: unknown): string | undefined => {
+    let found: string | undefined;
+    mapLinkSchemas(value as never, (schema) => {
+      if (
+        found === undefined && typeof schema === "string" &&
+        schema.startsWith("schema-ref@2:")
+      ) {
+        found = schema;
+      }
+      return schema;
+    });
+    return found;
+  };
+
+  const corpus: Array<{ label: string; value: unknown }> = [
+    {
+      label: "legacy link payload",
+      value: {
+        "/": { [LINK_V1_TAG]: { id: "of:a", path: [], schema: planted } },
+      },
+    },
+    {
+      label: "alias payload",
+      value: { $alias: { id: "of:b", path: [], schema: planted } },
+    },
+    {
+      label: "nested in array",
+      value: [1, [{ $alias: { id: "of:c", path: [], schema: planted } }]],
+    },
+    {
+      label: "sibling'd envelope is not a link",
+      value: {
+        "/": { [LINK_V1_TAG]: { id: "of:d", path: [], schema: planted } },
+        sibling: true,
+      },
+    },
+    {
+      label: "inside a schema subtree is data",
+      value: {
+        $alias: {
+          id: "of:e",
+          path: [],
+          schema: { type: "object", default: { deep: planted } },
+        },
+      },
+    },
+    {
+      label: "harmless string position",
+      value: { note: planted },
+    },
+    {
+      label: "alias sibling fields still walked",
+      value: {
+        $alias: {
+          id: "of:f",
+          path: [],
+          extra: { $alias: { id: "of:g", path: [], schema: planted } },
+        },
+      },
+    },
+  ];
+
+  for (const { label, value } of corpus) {
+    assertEquals(
+      findSyncSchemaRef(value),
+      probe(value),
+      `walker disagreement on: ${label}`,
+    );
+  }
+
+  // Modern regime: same agreement through FabricLink instances.
+  setModernCellRepConfig(true);
+  try {
+    const modern = {
+      wrapped: linkRefFrom({ id: "of:m", path: [], schema: planted }),
+    };
+    assertEquals(findSyncSchemaRef(modern), probe(modern));
+    assertEquals(findSyncSchemaRef(modern), planted);
+  } finally {
+    setModernCellRepConfig(false);
+    resetModernCellRepConfig();
+  }
+});
+
+Deno.test("encodeMemoryBoundary embeds reserved prefixes verbatim", () => {
+  // Pins the property the substring gates depend on (see the note on
+  // encodeMemoryBoundary): strings serialize byte-verbatim, so a payload's
+  // text contains a reserved prefix iff some string value carries it.
+  const withRefs = encodeMemoryBoundary({
+    doc: {
+      value: {
+        a: "schema-ref@2:fid1:x",
+        b: { nested: ["schema-cas@1:fid1:y"] },
+      },
+    },
+  });
+  assert(withRefs.includes("schema-ref@2:"));
+  assert(withRefs.includes("schema-cas@1:"));
+
+  const withoutRefs = encodeMemoryBoundary({
+    doc: { value: { a: "plain", b: { nested: [1, true, null] } } },
+  });
+  assert(!withoutRefs.includes("schema-ref@2:"));
+  assert(!withoutRefs.includes("schema-cas@1:"));
 });

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -213,13 +213,19 @@ Deno.test("sync schema table preserves own __proto__ fields", () => {
   assertEquals(compressedValue.__proto__, { safe: true });
 });
 
-Deno.test("sync schema table round-trips legacy aliases nested in arrays", () => {
-  const schema: JSONSchema = {
+Deno.test("sync schema table leaves legacy alias schemas inline", () => {
+  // The mapper no longer treats `$alias.schema` as a schema position: the
+  // runner is retiring `$alias` from persisted data, and docs that still
+  // carry it travel with their alias schemas inline. The alias record IS
+  // ordinary data, though — a link nested inside its schema value is a
+  // live position and interns normally.
+  const aliasSchema: JSONSchema = {
     type: "object",
     properties: {
       title: { type: "string" },
     },
   };
+  const nestedLinkSchema: JSONSchema = { type: "string" };
   const sync: SessionSync = {
     type: "sync",
     fromSeq: 0,
@@ -236,7 +242,7 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
               $alias: {
                 id: "of:legacy-target",
                 path: [],
-                schema,
+                schema: aliasSchema,
               },
             },
             {
@@ -247,10 +253,20 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
               },
             },
             {
-              "/": {
-                [LINK_V1_TAG]: {
-                  id: "of:no-schema-target",
-                  path: [],
+              $alias: {
+                id: "of:alias-with-nested-link",
+                path: [],
+                schema: {
+                  type: "object",
+                  default: {
+                    "/": {
+                      [LINK_V1_TAG]: {
+                        id: "of:inside-alias-schema",
+                        path: [],
+                        schema: nestedLinkSchema,
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -262,29 +278,31 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
   };
 
   const compressed = compressSessionSyncSchemas(sync) as SchemaTableSessionSync;
+  const nestedHash = internSchema(nestedLinkSchema, true).taggedHashString;
+
+  assertExists(compressed.schemaTable);
+  assertEquals(Object.keys(compressed.schemaTable), [nestedHash]);
+
   const compressedAliases =
     (compressed.upserts[0].doc?.value as Record<string, unknown>)
       .aliases as Record<string, unknown>[];
-  const schemaHash = internSchema(schema, true).taggedHashString;
-
-  assertExists(compressed.schemaTable);
-  assertEquals(Object.keys(compressed.schemaTable), [schemaHash]);
   assertEquals(
     (compressedAliases[0].$alias as Record<string, unknown>).schema,
-    `schema-ref@2:${schemaHash}`,
+    aliasSchema,
   );
   assertEquals(
     (compressedAliases[1].$alias as Record<string, unknown>).schema,
     "opaque-schema-name",
   );
+  const nestedEnvelope = ((
+    (compressedAliases[2].$alias as Record<string, unknown>)
+      .schema as Record<string, unknown>
+  ).default as Record<string, unknown>)["/"] as Record<string, unknown>;
   assertEquals(
-    (
-      (compressedAliases[2]["/"] as Record<string, unknown>)[
-        LINK_V1_TAG
-      ] as Record<string, unknown>
-    ).schema,
-    undefined,
+    (nestedEnvelope[LINK_V1_TAG] as Record<string, unknown>).schema,
+    `schema-ref@2:${nestedHash}`,
   );
+
   const expandedSchemas: JSONSchema[] = [];
   assertEquals(
     expandSessionSyncSchemas(compressed, (expanded) => {
@@ -292,11 +310,52 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
     }),
     sync,
   );
-  assertEquals(expandedSchemas, [internSchema(schema, true).schema]);
+  assertEquals(expandedSchemas, [
+    internSchema(nestedLinkSchema, true).schema,
+  ]);
+});
+
+Deno.test("sync schema table expansion rejects refs at uninterpreted positions", () => {
+  // An older server may still intern legacy `$alias` schema positions.
+  // This expander no longer interprets them; delivering the surviving ref
+  // string as data would silently corrupt the doc, so expansion fails
+  // loudly even when the table carries the referenced schema.
+  const schema: JSONSchema = { type: "object" };
+  const interned = internSchema(schema, true);
+  const sync: SchemaTableSessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:old-server-alias",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          bound: {
+            $alias: {
+              id: "of:target",
+              path: [],
+              schema: `schema-ref@2:${interned.taggedHashString}`,
+            },
+          },
+        },
+      },
+    }],
+    removes: [],
+    schemaTable: { [interned.taggedHashString]: interned.schema },
+  };
+
+  assertThrows(
+    () => expandSessionSyncSchemas(sync),
+    Error,
+    "Unexpanded sync schema table reference",
+  );
 });
 
 Deno.test("sync schema table interns only strict link envelopes", () => {
-  // Link recognition goes through the cell-rep chokepoint, which defines a
+  // Link recognition goes through the cell-rep link API, which defines a
   // legacy link as the single-key `{ "/": { "link@1": ... } }` envelope. An
   // envelope with sibling keys is NOT a link: its inner "schema" is inert
   // user data — uniformly for compression, expansion, and the reserved-ref
@@ -988,11 +1047,15 @@ Deno.test("schema subtrees are opaque: nested link shapes inside schemas are dat
   assertEquals(expanded, sync);
 });
 
-Deno.test("validator and mapper agree on schema positions across shapes", () => {
+Deno.test("validator covers mapper schema positions plus legacy aliases", () => {
   // Drift guard: findSyncSchemaRef is iterative (stack-safe) while
-  // mapLinkSchemas is recursive; this corpus mechanically enforces that
-  // both walkers see exactly the same schema positions. If either learns a
-  // new position or prunes one, this fails until the other is taught.
+  // mapLinkSchemas is recursive. The validator must see every position the
+  // mapper interprets — equal on link positions — plus exactly one extra
+  // family: legacy `$alias` schema positions, which clients shipped before
+  // the mapper stopped interpreting them still expand (see
+  // sync-schema-ref.ts). If either walker learns or prunes a position,
+  // this corpus fails until the other (and its expectation here) is
+  // updated.
   const planted = "schema-ref@2:fid1:planted";
   const probe = (value: unknown): string | undefined => {
     let found: string | undefined;
@@ -1008,20 +1071,31 @@ Deno.test("validator and mapper agree on schema positions across shapes", () => 
     return found;
   };
 
-  const corpus: Array<{ label: string; value: unknown }> = [
+  const corpus: Array<{
+    label: string;
+    value: unknown;
+    validator: string | undefined;
+    mapper: string | undefined;
+  }> = [
     {
       label: "legacy link payload",
       value: {
         "/": { [LINK_V1_TAG]: { id: "of:a", path: [], schema: planted } },
       },
+      validator: planted,
+      mapper: planted,
     },
     {
-      label: "alias payload",
+      label: "alias payload is validator-only",
       value: { $alias: { id: "of:b", path: [], schema: planted } },
+      validator: planted,
+      mapper: undefined,
     },
     {
       label: "nested in array",
       value: [1, [{ $alias: { id: "of:c", path: [], schema: planted } }]],
+      validator: planted,
+      mapper: undefined,
     },
     {
       label: "sibling'd envelope is not a link",
@@ -1029,9 +1103,11 @@ Deno.test("validator and mapper agree on schema positions across shapes", () => 
         "/": { [LINK_V1_TAG]: { id: "of:d", path: [], schema: planted } },
         sibling: true,
       },
+      validator: undefined,
+      mapper: undefined,
     },
     {
-      label: "inside a schema subtree is data",
+      label: "plain strings inside an alias schema value are data",
       value: {
         $alias: {
           id: "of:e",
@@ -1039,10 +1115,45 @@ Deno.test("validator and mapper agree on schema positions across shapes", () => 
           schema: { type: "object", default: { deep: planted } },
         },
       },
+      validator: undefined,
+      mapper: undefined,
+    },
+    {
+      label: "link nested in an alias schema value is live for both",
+      value: {
+        $alias: {
+          id: "of:h",
+          path: [],
+          schema: {
+            type: "object",
+            default: {
+              "/": { [LINK_V1_TAG]: { id: "of:i", path: [], schema: planted } },
+            },
+          },
+        },
+      },
+      validator: planted,
+      mapper: planted,
+    },
+    {
+      label: "link schema subtree stays opaque",
+      value: {
+        "/": {
+          [LINK_V1_TAG]: {
+            id: "of:j",
+            path: [],
+            schema: { type: "object", default: { deep: planted } },
+          },
+        },
+      },
+      validator: undefined,
+      mapper: undefined,
     },
     {
       label: "harmless string position",
       value: { note: planted },
+      validator: undefined,
+      mapper: undefined,
     },
     {
       label: "alias sibling fields still walked",
@@ -1053,15 +1164,14 @@ Deno.test("validator and mapper agree on schema positions across shapes", () => 
           extra: { $alias: { id: "of:g", path: [], schema: planted } },
         },
       },
+      validator: planted,
+      mapper: undefined,
     },
   ];
 
-  for (const { label, value } of corpus) {
-    assertEquals(
-      findSyncSchemaRef(value),
-      probe(value),
-      `walker disagreement on: ${label}`,
-    );
+  for (const { label, value, validator, mapper } of corpus) {
+    assertEquals(findSyncSchemaRef(value), validator, `validator on: ${label}`);
+    assertEquals(probe(value), mapper, `mapper on: ${label}`);
   }
 
   // Modern regime: same agreement through FabricLink instances.

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -315,6 +315,63 @@ Deno.test("sync schema table leaves legacy alias schemas inline", () => {
   ]);
 });
 
+Deno.test("sync schema table survives malformed link envelope payloads", () => {
+  // Stored data can carry an envelope-shaped record whose payload is not a
+  // record at all — cell-rep recognizes the envelope shape only. Compression
+  // and expansion must treat these as ordinary data, not throw mid-sync (a
+  // throw here breaks the space's sync stream for every watcher). The walk
+  // still descends into them, so a valid link nested inside one interns.
+  const nestedSchema: JSONSchema = { type: "number" };
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:malformed-envelopes",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          nullPayload: { "/": { [LINK_V1_TAG]: null } },
+          stringPayload: { "/": { [LINK_V1_TAG]: "not a payload" } },
+          arrayPayload: {
+            "/": {
+              [LINK_V1_TAG]: [{
+                "/": {
+                  [LINK_V1_TAG]: {
+                    id: "of:nested",
+                    path: [],
+                    schema: nestedSchema,
+                  },
+                },
+              }],
+            },
+          },
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  const compressed = compressSessionSyncSchemas(sync) as SchemaTableSessionSync;
+  const nestedHash = internSchema(nestedSchema, true).taggedHashString;
+  assertExists(compressed.schemaTable);
+  assertEquals(Object.keys(compressed.schemaTable), [nestedHash]);
+  assertEquals(expandSessionSyncSchemas(compressed), sync);
+
+  // The string scanner takes the same ordinary walk: no throw on the
+  // malformed payloads, and a reserved string sitting AS the payload is
+  // still found.
+  assertEquals(containsSyncSchemaRefString(sync), false);
+  assertEquals(
+    containsSyncSchemaRefString({
+      "/": { [LINK_V1_TAG]: "schema-ref@2:fid1:planted" },
+    }),
+    true,
+  );
+});
+
 Deno.test("sync schema table expansion rejects refs at uninterpreted positions", () => {
   // An older server may still intern legacy `$alias` schema positions.
   // This expander no longer interprets them; delivering the surviving ref
@@ -1148,6 +1205,24 @@ Deno.test("validator covers mapper schema positions plus legacy aliases", () => 
       },
       validator: undefined,
       mapper: undefined,
+    },
+    {
+      label: "malformed envelope payload is not a link",
+      value: { "/": { [LINK_V1_TAG]: null } },
+      validator: undefined,
+      mapper: undefined,
+    },
+    {
+      label: "malformed envelope contents are walked as data",
+      value: {
+        "/": {
+          [LINK_V1_TAG]: [{
+            "/": { [LINK_V1_TAG]: { id: "of:k", path: [], schema: planted } },
+          }],
+        },
+      },
+      validator: planted,
+      mapper: planted,
     },
     {
       label: "harmless string position",

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -5,7 +5,15 @@ import {
   assertStrictEquals,
   assertThrows,
 } from "@std/assert";
-import { LINK_V1_TAG, linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import {
+  isLinkRef,
+  LINK_V1_TAG,
+  linkRefFrom,
+  linkRefPayload,
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
 import {
@@ -286,7 +294,12 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
   assertEquals(expandedSchemas, [internSchema(schema, true).schema]);
 });
 
-Deno.test("sync schema table continues through sibling fields after link payloads", () => {
+Deno.test("sync schema table interns only strict link envelopes", () => {
+  // Link recognition goes through the cell-rep chokepoint, which defines a
+  // legacy link as the single-key `{ "/": { "link@1": ... } }` envelope. An
+  // envelope with sibling keys is NOT a link: its inner "schema" is inert
+  // user data — uniformly for compression, expansion, and the reserved-ref
+  // hardening — while a strict sibling link in the same record is interned.
   const primarySchema: JSONSchema = {
     type: "object",
     properties: { title: { type: "string" } },
@@ -338,17 +351,26 @@ Deno.test("sync schema table continues through sibling fields after link payload
     ((compressedCompound.sibling as Record<string, unknown>)[
       "/"
     ] as Record<string, unknown>)[LINK_V1_TAG] as Record<string, unknown>;
-  const primaryHash = internSchema(primarySchema, true).taggedHashString;
   const siblingHash = internSchema(siblingSchema, true).taggedHashString;
 
   assertExists(compressed.schemaTable);
-  assertEquals(
-    Object.keys(compressed.schemaTable).sort(),
-    [primaryHash, siblingHash].sort(),
-  );
-  assertEquals(compressedPayload.schema, `schema-ref@2:${primaryHash}`);
+  assertEquals(Object.keys(compressed.schemaTable), [siblingHash]);
+  // The sibling'd envelope is not a link: its schema stays inline.
+  assertEquals(compressedPayload.schema, primarySchema);
   assertEquals(compressedSiblingPayload.schema, `schema-ref@2:${siblingHash}`);
   assertEquals(expandSessionSyncSchemas(compressed), sync);
+
+  // The hardening applies the same strictness: a reserved string inside a
+  // sibling'd envelope's payload is ordinary data, not a schema position.
+  assertEquals(
+    findSyncSchemaRef({
+      "/": {
+        [LINK_V1_TAG]: { id: "of:x", path: [], schema: "schema-ref@2:z" },
+      },
+      sibling: true,
+    }),
+    undefined,
+  );
 });
 
 Deno.test("sync schema table ignores inherited fields while finding schema refs", () => {
@@ -738,23 +760,24 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
 });
 
 Deno.test("findSyncSchemaRef ignores inherited object properties", () => {
-  // The traversal must only follow own properties: an enumerable prototype
-  // pollution carrying a link-payload shape must not surface as a reserved
-  // reference in an unrelated document.
-  const polluted = {
-    $alias: { id: "of:polluted", path: [], schema: "schema-ref@2:fid1:evil" },
+  // The traversal must only follow own properties: an enumerable INHERITED
+  // key carrying a link-payload shape must not surface as a reserved
+  // reference. Built on a custom prototype so the test never touches
+  // Object.prototype.
+  const pollutedProto = {
+    polluted: {
+      $alias: { id: "of:polluted", path: [], schema: "schema-ref@2:fid1:evil" },
+    },
   };
-  Object.defineProperty(Object.prototype, "polluted", {
-    value: polluted,
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  });
-  try {
-    assertEquals(findSyncSchemaRef({ value: { plain: "doc" } }), undefined);
-  } finally {
-    delete (Object.prototype as Record<string, unknown>).polluted;
-  }
+  const doc = Object.assign(Object.create(pollutedProto), {
+    value: { plain: "doc" },
+  }) as Record<string, unknown>;
+  assertEquals(findSyncSchemaRef(doc), undefined);
+  // Sanity: the same shape as an OWN property is found.
+  assertEquals(
+    findSyncSchemaRef({ nested: pollutedProto.polluted }),
+    "schema-ref@2:fid1:evil",
+  );
 });
 
 Deno.test("sync schema table compression preserves own __proto__ keys", () => {
@@ -841,4 +864,73 @@ Deno.test("findSyncSchemaRef traverses arrays and containsSyncSchemaRefString sc
     }),
     false,
   );
+});
+
+Deno.test("schema table and reserved-ref detection handle modern cell-rep links", () => {
+  // Under modernCellRep, links are FabricLink instances rather than plain
+  // envelopes; recognition must go through the cell-rep chokepoint or every
+  // link becomes an opaque leaf and both interning and hardening no-op.
+  setModernCellRepConfig(true);
+  try {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    const canonical = internSchema(schema, true);
+    const sync: SessionSync = {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 1,
+      upserts: [{
+        branch: "",
+        id: "of:modern",
+        scope: "space",
+        seq: 1,
+        doc: {
+          value: {
+            contact: linkRefFrom({
+              id: "of:contact",
+              path: [],
+              schema,
+            }) as unknown as FabricValue,
+          },
+        } as unknown as EntityDocument,
+      }],
+      removes: [],
+    };
+
+    const compressed = compressSessionSyncSchemas(
+      sync,
+    ) as SchemaTableSessionSync;
+    assertExists(compressed.schemaTable, "modern links must be interned");
+    const compressedLink =
+      (compressed.upserts[0].doc?.value as Record<string, unknown>).contact;
+    assert(isLinkRef(compressedLink), "rewrite must preserve the link form");
+    assertEquals(
+      (linkRefPayload(compressedLink) as Record<string, unknown>).schema,
+      `schema-ref@2:${canonical.taggedHashString}`,
+    );
+
+    // Hardening detection sees inside FabricLink payloads too.
+    assertEquals(
+      findSyncSchemaRef(compressed.upserts[0].doc),
+      `schema-ref@2:${canonical.taggedHashString}`,
+    );
+    assertEquals(
+      containsSyncSchemaRefString(compressed.upserts[0].doc),
+      true,
+    );
+
+    const expanded = expandSessionSyncSchemas(compressed);
+    const expandedLink =
+      (expanded.upserts[0].doc?.value as Record<string, unknown>).contact;
+    assert(isLinkRef(expandedLink));
+    assertEquals(
+      (linkRefPayload(expandedLink) as Record<string, unknown>).schema,
+      canonical.schema,
+    );
+  } finally {
+    setModernCellRepConfig(false);
+    resetModernCellRepConfig();
+  }
 });

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -10,6 +10,7 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
 import {
   encodeMemoryBoundary,
+  type EntityDocument,
   getMemoryProtocolFlags,
   type HelloOkMessage,
   MEMORY_PROTOCOL,
@@ -731,4 +732,77 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
   assertExists(await run("v2"));
   assertEquals(await run("legacy"), undefined);
   assertEquals(await run("off"), undefined);
+});
+
+Deno.test("findSyncSchemaRef ignores inherited object properties", () => {
+  // The traversal must only follow own properties: an enumerable prototype
+  // pollution carrying a link-payload shape must not surface as a reserved
+  // reference in an unrelated document.
+  const polluted = {
+    $alias: { id: "of:polluted", path: [], schema: "schema-ref@2:fid1:evil" },
+  };
+  Object.defineProperty(Object.prototype, "polluted", {
+    value: polluted,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    assertEquals(findSyncSchemaRef({ value: { plain: "doc" } }), undefined);
+  } finally {
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  }
+});
+
+Deno.test("sync schema table compression preserves own __proto__ keys", () => {
+  const schema: JSONSchema = { type: "object" };
+  const canonical = internSchema(schema, true);
+  const linkWithSchema = {
+    "/": {
+      [LINK_V1_TAG]: { id: "of:target", path: [], schema },
+    },
+  };
+  // An own "__proto__" data property (constructible via defineProperty or a
+  // hostile codec) must survive the rewrite as an own property — plain
+  // assignment would silently hit the prototype accessor instead.
+  const doc: Record<string, unknown> = { value: { nested: linkWithSchema } };
+  Object.defineProperty(doc.value as object, "__proto__", {
+    value: { alsoHere: linkWithSchema },
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+
+  const sync = {
+    type: "sync" as const,
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:example",
+      seq: 1,
+      doc: doc as unknown as EntityDocument,
+    }],
+    removes: [],
+  };
+  const compressed = compressSessionSyncSchemas(sync) as SessionSync & {
+    schemaTable?: Record<string, JSONSchema>;
+  };
+  assertExists(compressed.schemaTable);
+  assertEquals(
+    compressed.schemaTable![canonical.taggedHashString],
+    canonical.schema,
+  );
+
+  const value = compressed.upserts[0].doc?.value as Record<string, unknown>;
+  const protoEntry = Object.getOwnPropertyDescriptor(value, "__proto__");
+  assertExists(protoEntry, "own __proto__ key must remain an own property");
+  assertEquals(Object.getPrototypeOf(value), Object.prototype);
+  const relocated =
+    (protoEntry!.value as Record<string, Record<string, unknown>>)
+      .alsoHere["/"] as Record<string, Record<string, unknown>>;
+  assertEquals(
+    relocated[LINK_V1_TAG].schema,
+    `schema-ref@2:${canonical.taggedHashString}`,
+  );
 });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -839,6 +839,18 @@ export const wireMemoryProtocolFlags = (
   sqliteCommitRowLabelEval: flags.sqliteCommitRowLabelEval,
 });
 
+/**
+ * Encodes a wire payload. The encoding embeds every string value
+ * byte-verbatim (`fvj1:` tag + canonical JSON; strings self-represent, and
+ * neither reserved schema-reference prefix contains a JSON-escapable
+ * character). Three consumers depend on that property as a cheap substring
+ * gate and must move in lockstep with any codec change (fvj2, escaping of
+ * tag-like strings): the client receive-path expansion gate (v2/client.ts),
+ * `containsReservedSchemaRefSubstring` (v2/sync-schema-ref.ts), and the
+ * engine's commit/stored-row probes (v2/engine.ts). A pinning test in
+ * test/v2-sync-schema-table-test.ts fails loudly if verbatim embedding ever
+ * stops holding.
+ */
 export const encodeMemoryBoundary = (value: FabricValue): string =>
   jsonFromValue(value);
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -32,7 +32,7 @@ import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
-import { SYNC_SCHEMA_REF_PREFIX } from "./sync-schema-ref.ts";
+import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
 
 export interface Transport {
   send(payload: string): Promise<void>;
@@ -253,10 +253,11 @@ export class Client {
     let message: unknown;
     try {
       message = decodeMemoryBoundary(payload);
-      // A frame whose raw text lacks the reference prefix cannot carry any
-      // schema reference (every string appears verbatim in the payload), so
-      // the expansion walk over its upserts is skipped entirely.
-      if (payload.includes(SYNC_SCHEMA_REF_PREFIX)) {
+      // A frame whose raw text lacks every reserved reference prefix cannot
+      // carry a schema reference (strings serialize verbatim — see the note
+      // on encodeMemoryBoundary), so the expansion walk over its upserts is
+      // skipped entirely.
+      if (containsReservedSchemaRefSubstring(payload)) {
         message = expandServerMessageSchemas(message);
       }
     } catch (cause) {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -32,6 +32,7 @@ import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
+import { SYNC_SCHEMA_REF_PREFIX } from "./sync-schema-ref.ts";
 
 export interface Transport {
   send(payload: string): Promise<void>;
@@ -252,7 +253,12 @@ export class Client {
     let message: unknown;
     try {
       message = decodeMemoryBoundary(payload);
-      message = expandServerMessageSchemas(message);
+      // A frame whose raw text lacks the reference prefix cannot carry any
+      // schema reference (every string appears verbatim in the payload), so
+      // the expansion walk over its upserts is skipped entirely.
+      if (payload.includes(SYNC_SCHEMA_REF_PREFIX)) {
+        message = expandServerMessageSchemas(message);
+      }
     } catch (cause) {
       const error = new Error("Unable to parse memory server message", {
         cause,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -8,6 +8,7 @@ import {
 } from "./patch.ts";
 import { isPrefixPath, parentPath, pathsOverlap } from "./path.ts";
 import {
+  containsReservedSchemaRefSubstring,
   containsSyncSchemaRefString,
   findSyncSchemaRef,
 } from "./sync-schema-ref.ts";
@@ -5064,7 +5065,7 @@ const applyCommitTransaction = (
     revisions.push(revision);
   }
 
-  validateStoredSyncSchemaRefs(engine, branch, revisions);
+  validateStoredSyncSchemaRefs(engine, branch, revisions, original);
 
   engine.statements.updateBranchHead.run({ branch, seq });
   materializeSnapshots(engine, branch, revisions);
@@ -5961,46 +5962,188 @@ const materializeSnapshots = (
   }
 };
 
+const rejectStoredSyncSchemaRef = (
+  document: EntityDocument | undefined,
+): void => {
+  const ref = findSyncSchemaRef(document);
+  if (ref !== undefined) {
+    throw new ProtocolError(
+      `memory v2 documents may not persist reserved wire schema reference: ${ref}`,
+    );
+  }
+};
+
 const validateStoredSyncSchemaRefs = (
   engine: Engine,
   branch: BranchName,
   revisions: readonly AppliedRevision[],
+  serializedCommit: string,
 ): void => {
-  const candidates: AppliedRevision[] = [];
+  // Every string a set document or patch operation carries appears verbatim
+  // in the commit's serialization (already computed for the commit log), so
+  // a commit whose serialization lacks both reserved prefixes can only put a
+  // reference into a schema position via a JSON Patch move relocating a
+  // string that already exists in the stored pre-state.
+  const commitMayIntroduceRef = containsReservedSchemaRefSubstring(
+    serializedCommit,
+  );
+
+  // Entities whose patches need post-state validation, keyed by revision key,
+  // preserving this commit's revision order per entity.
+  const statefulEntities = new Map<string, AppliedRevision[]>();
 
   for (const revision of revisions) {
+    if (revision.op === "set" && commitMayIntroduceRef) {
+      rejectStoredSyncSchemaRef(revision.document);
+    }
     if (
-      (revision.op === "set" &&
-        findSyncSchemaRef(revision.document) !== undefined) ||
-      (revision.op === "patch" &&
-        (containsSyncSchemaRefString(revision.patches) ||
-          revision.patches?.some((patch) => patch.op === "move") === true))
+      revision.op !== "set" && revision.op !== "patch" &&
+      revision.op !== "delete"
     ) {
-      candidates.push(revision);
+      continue;
+    }
+    const key = revisionKey(
+      branch,
+      revision.id,
+      revision.scopeKey ?? DEFAULT_SCOPE_KEY,
+    );
+    const isCandidatePatch = revision.op === "patch" &&
+      (revision.patches?.some((patch) => patch.op === "move") === true ||
+        (commitMayIntroduceRef &&
+          containsSyncSchemaRefString(revision.patches)));
+    const group = statefulEntities.get(key);
+    if (group !== undefined) {
+      // Once an entity is stateful, every later revision participates in the
+      // replay so each intermediate stored state is validated.
+      group.push(revision);
+      continue;
+    }
+    if (isCandidatePatch) {
+      // Earlier same-commit revisions of this entity are irrelevant history:
+      // a set baseline is re-established by the replay's reconstruction.
+      statefulEntities.set(key, [revision]);
     }
   }
 
-  for (const revision of candidates) {
-    const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
-    let document: EntityDocument | undefined;
+  for (const group of statefulEntities.values()) {
+    validateStatefulEntityRevisions(
+      engine,
+      branch,
+      group,
+      commitMayIntroduceRef,
+    );
+  }
+};
+
+/** Replays one entity's in-commit revisions, validating each stored state.
+ *  Reconstructs the pre-state at most once per entity (and not at all when
+ *  neither the commit nor any stored source row can contain a reserved
+ *  reference), keeping validation linear in this commit's patch count. */
+const validateStatefulEntityRevisions = (
+  engine: Engine,
+  branch: BranchName,
+  entityRevisions: readonly AppliedRevision[],
+  commitMayIntroduceRef: boolean,
+): void => {
+  const first = entityRevisions[0];
+  const scopeKey = first.scopeKey ?? DEFAULT_SCOPE_KEY;
+  if (
+    !commitMayIntroduceRef &&
+    !storedEntitySourcesMayContainRef(engine, {
+      id: first.id,
+      scopeKey,
+      branch,
+      seq: first.seq,
+      opIndex: first.opIndex,
+    })
+  ) {
+    // A move can only relocate an existing string, and every string in the
+    // stored pre-state appears verbatim in some stored source row.
+    return;
+  }
+
+  let document: EntityDocument | undefined;
+  for (const revision of entityRevisions) {
     if (revision.op === "set") {
       document = revision.document;
-    } else if (revision.op === "patch") {
-      document = reconstructPatchedDocument(engine, {
+      // Already validated by the set path when the commit can introduce a
+      // reference; a clean commit's set document cannot contain one.
+      continue;
+    }
+    if (revision.op !== "patch") {
+      // A delete tombstones the entity: later in-commit patches start empty.
+      document = emptyEntityDocument();
+      continue;
+    }
+    document = document === undefined
+      ? reconstructPatchedDocument(engine, {
         id: revision.id,
         scopeKey,
         branch,
         seq: revision.seq,
         opIndex: revision.opIndex,
-      });
-    }
-    const ref = findSyncSchemaRef(document);
-    if (ref !== undefined) {
-      throw new ProtocolError(
-        `memory v2 documents may not persist reserved wire schema reference: ${ref}`,
-      );
-    }
+      })
+      : applyPatchDocument(document, revision.patches ?? []);
+    rejectStoredSyncSchemaRef(document);
   }
+};
+
+/** Substring probe over the serialized rows reconstruction would read — the
+ *  latest set/snapshot base and the patch span — without decoding any of
+ *  them. A negative answer proves the reconstructed pre-state cannot contain
+ *  a reserved reference. */
+const storedEntitySourcesMayContainRef = (
+  engine: Engine,
+  options: {
+    id: EntityId;
+    scopeKey: string;
+    branch: BranchName;
+    seq: number;
+    opIndex: number;
+  },
+): boolean => {
+  const { id, scopeKey, branch, seq, opIndex } = options;
+  const baseRow = engine.statements.selectLatestBase.get({
+    branch,
+    id,
+    scope_key: scopeKey,
+    seq,
+    op_index: opIndex,
+  }) as ReadRow | undefined;
+  const snapshotRow = engine.statements.selectLatestSnapshot.get({
+    branch,
+    id,
+    scope_key: scopeKey,
+    seq,
+  }) as SnapshotRow | undefined;
+
+  let baseSeq = 0;
+  let baseOpIndex = -1;
+  let baseMayContain = false;
+  if (snapshotRow && (!baseRow || snapshotRow.seq >= baseRow.seq)) {
+    baseSeq = snapshotRow.seq;
+    baseOpIndex = Number.MAX_SAFE_INTEGER;
+    baseMayContain = containsReservedSchemaRefSubstring(snapshotRow.value);
+  } else if (baseRow) {
+    baseSeq = baseRow.seq;
+    baseOpIndex = baseRow.op_index;
+    baseMayContain = baseRow.op === "set" && baseRow.data !== null &&
+      containsReservedSchemaRefSubstring(baseRow.data);
+  }
+  if (baseMayContain) return true;
+
+  const patches = engine.statements.selectPatches.all({
+    branch,
+    id,
+    scope_key: scopeKey,
+    base_seq: baseSeq,
+    base_op_index: baseOpIndex,
+    seq,
+    op_index: opIndex,
+  }) as Array<{ data: string }>;
+  return patches.some((patch) =>
+    containsReservedSchemaRefSubstring(patch.data)
+  );
 };
 
 const maybeMaterializeSnapshot = (

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5996,12 +5996,8 @@ const validateStoredSyncSchemaRefs = (
     if (revision.op === "set" && commitMayIntroduceRef) {
       rejectStoredSyncSchemaRef(revision.document);
     }
-    if (
-      revision.op !== "set" && revision.op !== "patch" &&
-      revision.op !== "delete"
-    ) {
-      continue;
-    }
+    // Every revision here is set/patch/delete: sqlite operations never enter
+    // the revisions list (see applyCommitTransaction).
     const key = revisionKey(
       branch,
       revision.id,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -8,6 +8,10 @@ import {
 } from "./patch.ts";
 import { isPrefixPath, parentPath, pathsOverlap } from "./path.ts";
 import {
+  containsSyncSchemaRefString,
+  findSyncSchemaRef,
+} from "./sync-schema-ref.ts";
+import {
   type BranchName,
   type CellScope,
   type ClientCommit,
@@ -5060,6 +5064,8 @@ const applyCommitTransaction = (
     revisions.push(revision);
   }
 
+  validateStoredSyncSchemaRefs(engine, branch, revisions);
+
   engine.statements.updateBranchHead.run({ branch, seq });
   materializeSnapshots(engine, branch, revisions);
 
@@ -5952,6 +5958,48 @@ const materializeSnapshots = (
     }
     seen.add(key);
     maybeMaterializeSnapshot(engine, branch, revision.id, revisionScopeKey);
+  }
+};
+
+const validateStoredSyncSchemaRefs = (
+  engine: Engine,
+  branch: BranchName,
+  revisions: readonly AppliedRevision[],
+): void => {
+  const candidates: AppliedRevision[] = [];
+
+  for (const revision of revisions) {
+    if (
+      (revision.op === "set" &&
+        findSyncSchemaRef(revision.document) !== undefined) ||
+      (revision.op === "patch" &&
+        (containsSyncSchemaRefString(revision.patches) ||
+          revision.patches?.some((patch) => patch.op === "move") === true))
+    ) {
+      candidates.push(revision);
+    }
+  }
+
+  for (const revision of candidates) {
+    const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
+    let document: EntityDocument | undefined;
+    if (revision.op === "set") {
+      document = revision.document;
+    } else if (revision.op === "patch") {
+      document = reconstructPatchedDocument(engine, {
+        id: revision.id,
+        scopeKey,
+        branch,
+        seq: revision.seq,
+        opIndex: revision.opIndex,
+      });
+    }
+    const ref = findSyncSchemaRef(document);
+    if (ref !== undefined) {
+      throw new ProtocolError(
+        `memory v2 documents may not persist reserved wire schema reference: ${ref}`,
+      );
+    }
   }
 };
 

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -18,16 +18,22 @@ const isPlainRecord = (value: FabricValue): value is FabricPlainObject =>
   isPlainObject(value);
 
 /**
- * Maps schemas only in link-payload and legacy `$alias` schema positions.
+ * Maps schemas only in link-payload schema positions.
  *
  * Link recognition and reconstruction use the cell-rep link API
  * ({@link isLinkRef} / {@link linkRefPayload} / {@link linkRefFrom}), so both
  * `modernCellRep` regimes are handled transparently — legacy envelope or
- * `FabricLink` instance alike. The `$alias` form is recognized locally here:
- * cell-rep doesn't know it, and it can't be dropped — saved patterns still
- * persist binding aliases whose optional `schema` field the runner fills in
- * (see `LegacyAlias` in packages/runner/src/sigil-types.ts), so sync frames
- * carry them. It stays until the runner stops persisting alias schemas.
+ * `FabricLink` instance alike.
+ *
+ * Legacy `$alias` bindings are ordinary data to this walk: their `schema`
+ * field is not a position, so it is never interned and never expanded. The
+ * runner is retiring `$alias` from persisted data, and stored docs that
+ * still carry it just travel with their alias schemas inline (transport
+ * compression absorbs most of the byte cost). Clients shipped BEFORE this
+ * change do interpret alias schema positions, so the reserved-ref validator
+ * keeps refusing refs there — see {@link findSyncSchemaRef} in
+ * sync-schema-ref.ts, which deliberately checks a superset of this walk's
+ * positions.
  *
  * Schema VALUES are opaque to this walk: after a schema position is mapped,
  * the traversal does not descend into the schema (or its mapped
@@ -77,29 +83,10 @@ export const mapLinkSchemas = (
 
   if (!isPlainRecord(value)) return value;
 
-  let mappedValue = value;
-  const alias = value.$alias;
-  const hasAlias = isPlainRecord(alias);
-  if (hasAlias) {
-    const mappedAlias = mapPayloadSchemas(alias, mapSchema, traversal, depth);
-    if (mappedAlias !== alias) {
-      mappedValue = { ...mappedValue, $alias: mappedAlias };
-    }
-  }
-
-  // The alias payload was walked above; do not descend into it again.
-  const walked = mapRecordChildren(
-    mappedValue,
-    mapSchema,
-    traversal,
-    depth,
-    hasAlias ? "$alias" : undefined,
-  );
-  if (walked !== mappedValue) return walked;
-  return mappedValue === value ? value : mappedValue;
+  return mapRecordChildren(value, mapSchema, traversal, depth);
 };
 
-/** Maps the `schema` position of one link/alias payload — without descending
+/** Maps the `schema` position of one link payload — without descending
  *  into the schema value — and walks the payload's other entries. */
 const mapPayloadSchemas = (
   payload: FabricPlainObject,

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -60,16 +60,36 @@ export const mapLinkSchemas = (
     }
   }
 
-  const mapped: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(mappedValue)) {
+  // Read via entries (own properties only) and defer allocating the copy
+  // until a child actually changes: unchanged records — the overwhelmingly
+  // common case — cost no object build. Plain assignment is safe for every
+  // key except "__proto__", whose assignment would hit the prototype
+  // accessor instead of creating an own property.
+  const entries = Object.entries(mappedValue);
+  const mappedChildren: unknown[] = new Array(entries.length);
+  let childChanged = false;
+  for (let index = 0; index < entries.length; index += 1) {
+    const child = entries[index][1];
     const next = mapLinkSchemas(child, mapSchema, traversal, depth + 1);
-    changed ||= next !== child;
-    Object.defineProperty(mapped, key, {
-      value: next,
-      enumerable: true,
-      configurable: true,
-      writable: true,
-    });
+    mappedChildren[index] = next;
+    childChanged ||= next !== child;
   }
-  return changed ? mapped : value;
+  if (!childChanged) return changed ? mappedValue : value;
+
+  const mapped: Record<string, unknown> = {};
+  for (let index = 0; index < entries.length; index += 1) {
+    const key = entries[index][0];
+    const next = mappedChildren[index];
+    if (key === "__proto__") {
+      Object.defineProperty(mapped, key, {
+        value: next,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      mapped[key] = next;
+    }
+  }
+  return mapped;
 };

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -20,7 +20,7 @@ const isPlainRecord = (value: FabricValue): value is FabricPlainObject =>
 /**
  * Maps schemas only in link-payload and legacy `$alias` schema positions.
  *
- * Link recognition and reconstruction go through the `cell-rep` chokepoint
+ * Link recognition and reconstruction use the cell-rep link API
  * ({@link isLinkRef} / {@link linkRefPayload} / {@link linkRefFrom}), so both
  * `modernCellRep` regimes are handled transparently — legacy envelope or
  * `FabricLink` instance alike. The `$alias` form is recognized locally here:

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -37,15 +37,15 @@ const isPlainRecord = (value: FabricValue): value is FabricPlainObject =>
  * verification is never rewritten afterwards.
  *
  * Non-link `FabricInstance`s are not walked: their contents live in private
- * slots, not enumerable own-properties. That blindness is sound because
- * every consumer of these positions — the compressor, the expander, and the
- * reserved-ref validator (a probe over this same walk) — shares it, so a
- * reference inside an instance can be neither produced nor interpreted; the
- * engine's serialized substring gate still sees instance contents verbatim.
- * INVARIANT: any instance type this walk learns to descend into is
- * inherited by the probe-based validator automatically, but the string
- * scanner `containsSyncSchemaRefString` in sync-schema-ref.ts must be
- * taught in the same change.
+ * slots, not enumerable own-properties. That is safe because every consumer
+ * of these positions — the compressor, the expander, and the reserved-ref
+ * validator in sync-schema-ref.ts — skips them the same way, so a reference
+ * inside an instance can be neither produced nor interpreted, and the
+ * engine's serialized substring check still sees instance contents
+ * verbatim. If this walk ever learns to descend into an instance type, the
+ * validator and `containsSyncSchemaRefString` must learn it in the same
+ * change — the walker-agreement test in v2-sync-schema-table-test.ts fails
+ * until they do.
  */
 export const mapLinkSchemas = (
   value: FabricValue,

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -23,8 +23,11 @@ const isPlainRecord = (value: FabricValue): value is FabricPlainObject =>
  * Link recognition and reconstruction go through the `cell-rep` chokepoint
  * ({@link isLinkRef} / {@link linkRefPayload} / {@link linkRefFrom}), so both
  * `modernCellRep` regimes are handled transparently — legacy envelope or
- * `FabricLink` instance alike. The `$alias` form predates the chokepoint and
- * is never regime-dispatched, so it is recognized locally here.
+ * `FabricLink` instance alike. The `$alias` form is recognized locally here:
+ * cell-rep doesn't know it, and it can't be dropped — saved patterns still
+ * persist binding aliases whose optional `schema` field the runner fills in
+ * (see `LegacyAlias` in packages/runner/src/sigil-types.ts), so sync frames
+ * carry them. It stays until the runner stops persisting alias schemas.
  *
  * Schema VALUES are opaque to this walk: after a schema position is mapped,
  * the traversal does not descend into the schema (or its mapped

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -72,13 +72,20 @@ export const mapLinkSchemas = (
 
   if (isLinkRef(value)) {
     const payload = linkRefPayload(value);
-    const mappedPayload = mapPayloadSchemas(
-      payload,
-      mapSchema,
-      traversal,
-      depth,
-    );
-    return mappedPayload === payload ? value : linkRefFrom(mappedPayload);
+    if (isPlainRecord(payload)) {
+      const mappedPayload = mapPayloadSchemas(
+        payload,
+        mapSchema,
+        traversal,
+        depth,
+      );
+      return mappedPayload === payload ? value : linkRefFrom(mappedPayload);
+    }
+    // Envelope-shaped but the payload is not a record: cell-rep recognizes
+    // the envelope shape only, so stored data can put null, a primitive, or
+    // an array here. That is not a usable link — fall through and walk it
+    // as ordinary data (the pre-cell-rep walker did the same) instead of
+    // throwing mid-sync on the malformed payload.
   }
 
   if (!isPlainRecord(value)) return value;

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -1,4 +1,9 @@
-import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import {
+  isLinkRef,
+  linkRefFrom,
+  linkRefPayload,
+} from "@commonfabric/data-model/cell-rep";
+import type { FabricPlainObject } from "@commonfabric/api";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
@@ -12,7 +17,15 @@ export interface LinkSchemaTraversal {
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   isPlainObject(value);
 
-/** Maps schemas only in modern and legacy link payload positions. */
+/**
+ * Maps schemas only in link-payload and legacy `$alias` schema positions.
+ *
+ * Link recognition and reconstruction go through the `cell-rep` chokepoint
+ * ({@link isLinkRef} / {@link linkRefPayload} / {@link linkRefFrom}), so both
+ * `modernCellRep` regimes are handled transparently — legacy envelope or
+ * `FabricLink` instance alike. The `$alias` form predates the chokepoint and
+ * is never regime-dispatched, so it is recognized locally here.
+ */
 export const mapLinkSchemas = (
   value: unknown,
   mapSchema: (schema: unknown) => unknown,
@@ -30,26 +43,35 @@ export const mapLinkSchemas = (
     return changed ? mapped : value;
   }
 
+  if (isLinkRef(value)) {
+    const payload = linkRefPayload(value);
+    let mappedPayload: FabricPlainObject = payload;
+    let changed = false;
+    if (Object.hasOwn(payload, "schema")) {
+      traversal?.visitSchemaPosition();
+      const schema = mapSchema(payload.schema);
+      if (schema !== payload.schema) {
+        mappedPayload = { ...payload, schema } as FabricPlainObject;
+        changed = true;
+      }
+    }
+    const walked = mapRecordChildren(
+      mappedPayload as Record<string, unknown>,
+      mapSchema,
+      traversal,
+      depth,
+    );
+    if (walked !== mappedPayload) {
+      mappedPayload = walked as FabricPlainObject;
+      changed = true;
+    }
+    return changed ? linkRefFrom(mappedPayload) : value;
+  }
+
   if (!isPlainRecord(value)) return value;
 
   let mappedValue = value;
   let changed = false;
-  const linkEnvelope = value["/"];
-  if (isPlainRecord(linkEnvelope)) {
-    const payload = linkEnvelope[LINK_V1_TAG];
-    if (isPlainRecord(payload) && Object.hasOwn(payload, "schema")) {
-      traversal?.visitSchemaPosition();
-      const schema = mapSchema(payload.schema);
-      if (schema !== payload.schema) {
-        mappedValue = {
-          ...mappedValue,
-          "/": { ...linkEnvelope, [LINK_V1_TAG]: { ...payload, schema } },
-        };
-        changed = true;
-      }
-    }
-  }
-
   const alias = value.$alias;
   if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
     traversal?.visitSchemaPosition();
@@ -60,12 +82,22 @@ export const mapLinkSchemas = (
     }
   }
 
-  // Read via entries (own properties only) and defer allocating the copy
-  // until a child actually changes: unchanged records — the overwhelmingly
-  // common case — cost no object build. Plain assignment is safe for every
-  // key except "__proto__", whose assignment would hit the prototype
-  // accessor instead of creating an own property.
-  const entries = Object.entries(mappedValue);
+  const walked = mapRecordChildren(mappedValue, mapSchema, traversal, depth);
+  if (walked !== mappedValue) return walked;
+  return changed ? mappedValue : value;
+};
+
+/** Walks every own entry of a record, allocating a copy only on change.
+ *  Plain assignment is safe for every key except "__proto__", whose
+ *  assignment would hit the prototype accessor instead of creating an own
+ *  property. */
+const mapRecordChildren = (
+  record: Record<string, unknown>,
+  mapSchema: (schema: unknown) => unknown,
+  traversal: LinkSchemaTraversal | undefined,
+  depth: number,
+): Record<string, unknown> => {
+  const entries = Object.entries(record);
   const mappedChildren: unknown[] = new Array(entries.length);
   let childChanged = false;
   for (let index = 0; index < entries.length; index += 1) {
@@ -74,7 +106,7 @@ export const mapLinkSchemas = (
     mappedChildren[index] = next;
     childChanged ||= next !== child;
   }
-  if (!childChanged) return changed ? mappedValue : value;
+  if (!childChanged) return record;
 
   const mapped: Record<string, unknown> = {};
   for (let index = 0; index < entries.length; index += 1) {

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -1,0 +1,75 @@
+import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { isPlainObject } from "@commonfabric/utils/types";
+
+export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
+
+/** Optional request-local accounting for recursive schema-bearing values. */
+export interface LinkSchemaTraversal {
+  visitNode(depth: number): void;
+  visitSchemaPosition(): void;
+}
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);
+
+/** Maps schemas only in modern and legacy link payload positions. */
+export const mapLinkSchemas = (
+  value: unknown,
+  mapSchema: (schema: unknown) => unknown,
+  traversal?: LinkSchemaTraversal,
+  depth = 0,
+): unknown => {
+  traversal?.visitNode(depth);
+  if (Array.isArray(value)) {
+    let changed = false;
+    const mapped = value.map((item) => {
+      const next = mapLinkSchemas(item, mapSchema, traversal, depth + 1);
+      changed ||= next !== item;
+      return next;
+    });
+    return changed ? mapped : value;
+  }
+
+  if (!isPlainRecord(value)) return value;
+
+  let mappedValue = value;
+  let changed = false;
+  const linkEnvelope = value["/"];
+  if (isPlainRecord(linkEnvelope)) {
+    const payload = linkEnvelope[LINK_V1_TAG];
+    if (isPlainRecord(payload) && Object.hasOwn(payload, "schema")) {
+      traversal?.visitSchemaPosition();
+      const schema = mapSchema(payload.schema);
+      if (schema !== payload.schema) {
+        mappedValue = {
+          ...mappedValue,
+          "/": { ...linkEnvelope, [LINK_V1_TAG]: { ...payload, schema } },
+        };
+        changed = true;
+      }
+    }
+  }
+
+  const alias = value.$alias;
+  if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
+    traversal?.visitSchemaPosition();
+    const schema = mapSchema(alias.schema);
+    if (schema !== alias.schema) {
+      mappedValue = { ...mappedValue, $alias: { ...alias, schema } };
+      changed = true;
+    }
+  }
+
+  const mapped: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(mappedValue)) {
+    const next = mapLinkSchemas(child, mapSchema, traversal, depth + 1);
+    changed ||= next !== child;
+    Object.defineProperty(mapped, key, {
+      value: next,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return changed ? mapped : value;
+};

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -25,15 +25,15 @@ const isPlainRecord = (value: FabricValue): value is FabricPlainObject =>
  * `modernCellRep` regimes are handled transparently — legacy envelope or
  * `FabricLink` instance alike.
  *
- * Legacy `$alias` bindings are ordinary data to this walk: their `schema`
- * field is not a position, so it is never interned and never expanded. The
- * runner is retiring `$alias` from persisted data, and stored docs that
- * still carry it just travel with their alias schemas inline (transport
- * compression absorbs most of the byte cost). Clients shipped BEFORE this
- * change do interpret alias schema positions, so the reserved-ref validator
- * keeps refusing refs there — see {@link findSyncSchemaRef} in
- * sync-schema-ref.ts, which deliberately checks a superset of this walk's
- * positions.
+ * `$alias` records are Pattern-binding vocabulary, not links (#4895):
+ * their `schema` field is binding metadata, not a link-schema position, so
+ * this walk never interns or expands it. Saved patterns keep emitting
+ * alias bindings until a sigil binding encoding replaces them, so those
+ * schemas travel inline indefinitely (transport compression absorbs most
+ * of the byte cost). Clients shipped BEFORE this change do interpret alias
+ * schema positions, so the reserved-ref validator keeps refusing refs
+ * there — see {@link findSyncSchemaRef} in sync-schema-ref.ts, which
+ * deliberately checks a superset of this walk's positions.
  *
  * Schema VALUES are opaque to this walk: after a schema position is mapped,
  * the traversal does not descend into the schema (or its mapped

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -3,7 +3,7 @@ import {
   linkRefFrom,
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
-import type { FabricPlainObject } from "@commonfabric/api";
+import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
@@ -14,7 +14,7 @@ export interface LinkSchemaTraversal {
   visitSchemaPosition(): void;
 }
 
-const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+const isPlainRecord = (value: FabricValue): value is FabricPlainObject =>
   isPlainObject(value);
 
 /**
@@ -25,19 +25,37 @@ const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
  * `modernCellRep` regimes are handled transparently — legacy envelope or
  * `FabricLink` instance alike. The `$alias` form predates the chokepoint and
  * is never regime-dispatched, so it is recognized locally here.
+ *
+ * Schema VALUES are opaque to this walk: after a schema position is mapped,
+ * the traversal does not descend into the schema (or its mapped
+ * replacement), so link-shaped structures inside a schema — for example in a
+ * `default` — are data, never positions. This keeps compression and
+ * expansion inverse, and means a table entry delivered under hash
+ * verification is never rewritten afterwards.
+ *
+ * Non-link `FabricInstance`s are not walked: their contents live in private
+ * slots, not enumerable own-properties. That blindness is sound because
+ * every consumer of these positions — the compressor, the expander, and the
+ * reserved-ref validator (a probe over this same walk) — shares it, so a
+ * reference inside an instance can be neither produced nor interpreted; the
+ * engine's serialized substring gate still sees instance contents verbatim.
+ * INVARIANT: any instance type this walk learns to descend into is
+ * inherited by the probe-based validator automatically, but the string
+ * scanner `containsSyncSchemaRefString` in sync-schema-ref.ts must be
+ * taught in the same change.
  */
 export const mapLinkSchemas = (
-  value: unknown,
-  mapSchema: (schema: unknown) => unknown,
+  value: FabricValue,
+  mapSchema: (schema: FabricValue) => FabricValue,
   traversal?: LinkSchemaTraversal,
   depth = 0,
-): unknown => {
+): FabricValue => {
   traversal?.visitNode(depth);
   if (Array.isArray(value)) {
     let changed = false;
     const mapped = value.map((item) => {
       const next = mapLinkSchemas(item, mapSchema, traversal, depth + 1);
-      changed ||= next !== item;
+      changed ||= !Object.is(next, item);
       return next;
     });
     return changed ? mapped : value;
@@ -45,70 +63,93 @@ export const mapLinkSchemas = (
 
   if (isLinkRef(value)) {
     const payload = linkRefPayload(value);
-    let mappedPayload: FabricPlainObject = payload;
-    let changed = false;
-    if (Object.hasOwn(payload, "schema")) {
-      traversal?.visitSchemaPosition();
-      const schema = mapSchema(payload.schema);
-      if (schema !== payload.schema) {
-        mappedPayload = { ...payload, schema } as FabricPlainObject;
-        changed = true;
-      }
-    }
-    const walked = mapRecordChildren(
-      mappedPayload as Record<string, unknown>,
+    const mappedPayload = mapPayloadSchemas(
+      payload,
       mapSchema,
       traversal,
       depth,
     );
-    if (walked !== mappedPayload) {
-      mappedPayload = walked as FabricPlainObject;
-      changed = true;
-    }
-    return changed ? linkRefFrom(mappedPayload) : value;
+    return mappedPayload === payload ? value : linkRefFrom(mappedPayload);
   }
 
   if (!isPlainRecord(value)) return value;
 
   let mappedValue = value;
-  let changed = false;
   const alias = value.$alias;
-  if (isPlainRecord(alias) && Object.hasOwn(alias, "schema")) {
-    traversal?.visitSchemaPosition();
-    const schema = mapSchema(alias.schema);
-    if (schema !== alias.schema) {
-      mappedValue = { ...mappedValue, $alias: { ...alias, schema } };
-      changed = true;
+  const hasAlias = isPlainRecord(alias);
+  if (hasAlias) {
+    const mappedAlias = mapPayloadSchemas(alias, mapSchema, traversal, depth);
+    if (mappedAlias !== alias) {
+      mappedValue = { ...mappedValue, $alias: mappedAlias };
     }
   }
 
-  const walked = mapRecordChildren(mappedValue, mapSchema, traversal, depth);
+  // The alias payload was walked above; do not descend into it again.
+  const walked = mapRecordChildren(
+    mappedValue,
+    mapSchema,
+    traversal,
+    depth,
+    hasAlias ? "$alias" : undefined,
+  );
   if (walked !== mappedValue) return walked;
-  return changed ? mappedValue : value;
+  return mappedValue === value ? value : mappedValue;
 };
 
-/** Walks every own entry of a record, allocating a copy only on change.
- *  Plain assignment is safe for every key except "__proto__", whose
- *  assignment would hit the prototype accessor instead of creating an own
- *  property. */
-const mapRecordChildren = (
-  record: Record<string, unknown>,
-  mapSchema: (schema: unknown) => unknown,
+/** Maps the `schema` position of one link/alias payload — without descending
+ *  into the schema value — and walks the payload's other entries. */
+const mapPayloadSchemas = (
+  payload: FabricPlainObject,
+  mapSchema: (schema: FabricValue) => FabricValue,
   traversal: LinkSchemaTraversal | undefined,
   depth: number,
-): Record<string, unknown> => {
+): FabricPlainObject => {
+  let mappedPayload = payload;
+  if (Object.hasOwn(payload, "schema")) {
+    traversal?.visitSchemaPosition();
+    const schema = mapSchema(payload.schema);
+    // Object.is: a NaN-valued leaf returned unchanged must not count as a
+    // change (see the data-model Object.is sweep).
+    if (!Object.is(schema, payload.schema)) {
+      mappedPayload = { ...payload, schema };
+    }
+  }
+  return mapRecordChildren(
+    mappedPayload,
+    mapSchema,
+    traversal,
+    depth,
+    "schema",
+  );
+};
+
+/** Walks every own entry of a record except `skippedKey`, allocating a copy
+ *  only on change. Plain assignment is safe for every key except
+ *  "__proto__", whose assignment would hit the prototype accessor instead of
+ *  creating an own property. */
+const mapRecordChildren = (
+  record: FabricPlainObject,
+  mapSchema: (schema: FabricValue) => FabricValue,
+  traversal: LinkSchemaTraversal | undefined,
+  depth: number,
+  skippedKey?: string,
+): FabricPlainObject => {
   const entries = Object.entries(record);
-  const mappedChildren: unknown[] = new Array(entries.length);
+  const mappedChildren: FabricValue[] = new Array(entries.length);
   let childChanged = false;
   for (let index = 0; index < entries.length; index += 1) {
-    const child = entries[index][1];
+    const [key, child] = entries[index];
+    if (key === skippedKey) {
+      mappedChildren[index] = child;
+      continue;
+    }
     const next = mapLinkSchemas(child, mapSchema, traversal, depth + 1);
     mappedChildren[index] = next;
-    childChanged ||= next !== child;
+    childChanged ||= !Object.is(next, child);
   }
   if (!childChanged) return record;
 
-  const mapped: Record<string, unknown> = {};
+  const mapped: FabricPlainObject = {};
   for (let index = 0; index < entries.length; index += 1) {
     const key = entries[index][0];
     const next = mappedChildren[index];

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -36,8 +36,9 @@ const payloadSchemaRef = (
  * Finds a reserved wire reference in a schema position, or undefined.
  *
  * Visits exactly the schema positions {@link mapLinkSchemas} interprets —
- * link payloads (via the cell-rep chokepoint, both `modernCellRep` regimes)
- * and legacy `$alias` payloads — with the same blindness: schema subtrees
+ * link payloads (via cell-rep, both `modernCellRep` regimes) and `$alias`
+ * payloads (still persisted with schemas in saved patterns — see
+ * schema-table-links.ts) — with the same blindness: schema subtrees
  * are opaque, and non-link `FabricInstance` contents are not walked. The
  * traversal engine is deliberately ITERATIVE (explicit stack) so
  * adversarially deep documents cannot overflow the call stack; position

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -14,15 +14,16 @@ const isReservedSchemaRef = (value: string): boolean =>
 /**
  * Whether serialized text contains a reserved reference prefix anywhere.
  * Serializations of documents and patches embed every string value they
- * carry verbatim, so a negative answer proves the serialized value cannot
- * introduce a reserved reference — the cheap gate in front of the deep
- * walks below.
+ * carry verbatim — see the note on `encodeMemoryBoundary` in ../v2.ts, which
+ * names this gate as a dependent — so a negative answer proves the
+ * serialized value cannot introduce a reserved reference. This is the cheap
+ * gate in front of the deep walks below.
  */
 export const containsReservedSchemaRefSubstring = (value: string): boolean =>
   value.includes(SYNC_SCHEMA_REF_PREFIX) ||
   value.includes(REQUEST_SCHEMA_CAS_REF_PREFIX);
 
-const schemaRefIn = (
+const payloadSchemaRef = (
   payload: Record<string, unknown>,
 ): string | undefined => {
   const schema = payload.schema;
@@ -32,13 +33,18 @@ const schemaRefIn = (
 };
 
 /**
- * Finds reserved wire references only in link-payload and legacy `$alias`
- * schema positions.
+ * Finds a reserved wire reference in a schema position, or undefined.
  *
- * Link recognition goes through the `cell-rep` chokepoint ({@link isLinkRef}
- * / {@link linkRefPayload}), covering both `modernCellRep` regimes — legacy
- * envelope or `FabricLink` instance. The `$alias` form predates the
- * chokepoint and is never regime-dispatched, so it is recognized locally.
+ * Visits exactly the schema positions {@link mapLinkSchemas} interprets —
+ * link payloads (via the cell-rep chokepoint, both `modernCellRep` regimes)
+ * and legacy `$alias` payloads — with the same blindness: schema subtrees
+ * are opaque, and non-link `FabricInstance` contents are not walked. The
+ * traversal engine is deliberately ITERATIVE (explicit stack) so
+ * adversarially deep documents cannot overflow the call stack; position
+ * parity with the recursive mapper is enforced mechanically by the
+ * walker-agreement test in test/v2-sync-schema-table-test.ts — teach both
+ * (and `containsSyncSchemaRefString`) in the same change or that test
+ * fails.
  */
 export const findSyncSchemaRef = (value: unknown): string | undefined => {
   const pending: unknown[] = [value];
@@ -53,8 +59,8 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
     }
 
     if (isLinkRef(current)) {
-      const payload = linkRefPayload(current) as Record<string, unknown>;
-      const ref = schemaRefIn(payload);
+      const payload = linkRefPayload(current);
+      const ref = payloadSchemaRef(payload);
       if (ref !== undefined) {
         return ref;
       }
@@ -73,7 +79,7 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
     const legacyAlias = current.$alias;
     const hasLegacyAlias = isPlainRecord(legacyAlias);
     if (hasLegacyAlias) {
-      const ref = schemaRefIn(legacyAlias);
+      const ref = payloadSchemaRef(legacyAlias);
       if (ref !== undefined) {
         return ref;
       }
@@ -98,7 +104,17 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
   return undefined;
 };
 
-/** Checks arbitrary input for a string that could introduce a wire reference. */
+/**
+ * Checks plain containers (arrays, plain records) and link payloads for a
+ * string that could introduce a wire reference. The logical contents of
+ * non-link `FabricInstance`s are NOT walked — they live in private slots,
+ * not enumerable own-properties. That blindness is sound because the
+ * compressor, expander, and {@link findSyncSchemaRef} share it (a reference
+ * inside an instance can be neither produced nor interpreted), and the
+ * engine's serialized substring gate sees instance contents verbatim. If
+ * {@link mapLinkSchemas} ever learns to descend into an instance type, this
+ * scanner must be taught in the same change.
+ */
 export const containsSyncSchemaRefString = (value: unknown): boolean => {
   const pending: unknown[] = [value];
 

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -71,16 +71,20 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
 
     if (isLinkRef(current)) {
       const payload = linkRefPayload(current);
-      const ref = payloadSchemaRef(payload);
-      if (ref !== undefined) {
-        return ref;
-      }
-      for (const key in payload) {
-        if (key !== "schema" && Object.hasOwn(payload, key)) {
-          pending.push(payload[key]);
+      if (isPlainRecord(payload)) {
+        const ref = payloadSchemaRef(payload);
+        if (ref !== undefined) {
+          return ref;
         }
+        for (const key in payload) {
+          if (key !== "schema" && Object.hasOwn(payload, key)) {
+            pending.push(payload[key]);
+          }
+        }
+        continue;
       }
-      continue;
+      // Envelope-shaped but the payload is not a record: not a usable link.
+      // Fall through to the ordinary record walk, mirroring the mapper.
     }
 
     if (!isPlainRecord(current)) {
@@ -145,8 +149,11 @@ export const containsSyncSchemaRefString = (value: unknown): boolean => {
       }
       continue;
     }
-    if (isLinkRef(current)) {
+    if (isLinkRef(current) && !isPlainRecord(current)) {
       // A FabricLink's payload is not reachable by plain-record iteration.
+      // The legacy envelope IS a plain record and takes the ordinary walk
+      // below, which reaches its payload — malformed or not — and any
+      // sibling entries without trusting the payload extraction.
       pending.push(linkRefPayload(current));
       continue;
     }

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -35,17 +35,27 @@ const payloadSchemaRef = (
 /**
  * Finds a reserved wire reference in a schema position, or undefined.
  *
- * Visits exactly the schema positions {@link mapLinkSchemas} interprets —
- * link payloads (via cell-rep, both `modernCellRep` regimes) and `$alias`
- * payloads (still persisted with schemas in saved patterns — see
- * schema-table-links.ts) — with the same blindness: schema subtrees
- * are opaque, and non-link `FabricInstance` contents are not walked. The
- * traversal engine is deliberately ITERATIVE (explicit stack) so
- * adversarially deep documents cannot overflow the call stack; position
- * parity with the recursive mapper is enforced mechanically by the
- * walker-agreement test in test/v2-sync-schema-table-test.ts — teach both
- * (and `containsSyncSchemaRefString`) in the same change or that test
- * fails.
+ * Visits a SUPERSET of the schema positions {@link mapLinkSchemas}
+ * interprets:
+ *
+ * - Link payloads (via cell-rep, both `modernCellRep` regimes), with the
+ *   mapper's blindness — link schema subtrees are opaque, and non-link
+ *   `FabricInstance` contents are not walked.
+ * - Legacy `$alias` schema positions, which the mapper no longer
+ *   interprets. Clients shipped before that removal still expand refs
+ *   there, so stored data must not be able to deliver one to them; this
+ *   stays until pre-removal clients are out of circulation. Unlike a link
+ *   payload's, an alias's `schema` value is also walked as ordinary data,
+ *   because that is how the mapper now sees it — link positions inside it
+ *   are live.
+ *
+ * The traversal engine is deliberately ITERATIVE (explicit stack) so
+ * adversarially deep documents cannot overflow the call stack. The
+ * superset relationship with the recursive mapper — equal on link
+ * positions, wider by exactly the legacy alias positions — is enforced
+ * mechanically by the walker-agreement test in
+ * test/v2-sync-schema-table-test.ts; teach both (and
+ * `containsSyncSchemaRefString`) in the same change or that test fails.
  */
 export const findSyncSchemaRef = (value: unknown): string | undefined => {
   const pending: unknown[] = [value];
@@ -84,8 +94,10 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
       if (ref !== undefined) {
         return ref;
       }
+      // Every alias child — the schema value included — is walked as data,
+      // mirroring the mapper's view of the alias record.
       for (const key in legacyAlias) {
-        if (key !== "schema" && Object.hasOwn(legacyAlias, key)) {
+        if (Object.hasOwn(legacyAlias, key)) {
           pending.push(legacyAlias[key]);
         }
       }

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -1,4 +1,4 @@
-import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { isPlainObject } from "@commonfabric/utils/types";
 import { REQUEST_SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
 
@@ -22,7 +22,7 @@ export const containsReservedSchemaRefSubstring = (value: string): boolean =>
   value.includes(SYNC_SCHEMA_REF_PREFIX) ||
   value.includes(REQUEST_SCHEMA_CAS_REF_PREFIX);
 
-const schemaRefInPayload = (
+const schemaRefIn = (
   payload: Record<string, unknown>,
 ): string | undefined => {
   const schema = payload.schema;
@@ -31,19 +31,15 @@ const schemaRefInPayload = (
     : undefined;
 };
 
-const pushOwnValuesExcept = (
-  pending: unknown[],
-  record: Record<string, unknown>,
-  skippedKey: string,
-): void => {
-  for (const key in record) {
-    if (key !== skippedKey && Object.hasOwn(record, key)) {
-      pending.push(record[key]);
-    }
-  }
-};
-
-/** Finds reserved wire references only in link-payload schema positions. */
+/**
+ * Finds reserved wire references only in link-payload and legacy `$alias`
+ * schema positions.
+ *
+ * Link recognition goes through the `cell-rep` chokepoint ({@link isLinkRef}
+ * / {@link linkRefPayload}), covering both `modernCellRep` regimes — legacy
+ * envelope or `FabricLink` instance. The `$alias` form predates the
+ * chokepoint and is never regime-dispatched, so it is recognized locally.
+ */
 export const findSyncSchemaRef = (value: unknown): string | undefined => {
   const pending: unknown[] = [value];
 
@@ -55,43 +51,44 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
       }
       continue;
     }
-    if (!isPlainRecord(current)) {
-      continue;
-    }
 
-    const linkEnvelope = current["/"];
-    const linkPayload = isPlainRecord(linkEnvelope)
-      ? linkEnvelope[LINK_V1_TAG]
-      : undefined;
-    const hasLinkPayload = isPlainRecord(linkEnvelope) &&
-      isPlainRecord(linkPayload);
-    if (hasLinkPayload) {
-      const ref = schemaRefInPayload(linkPayload);
+    if (isLinkRef(current)) {
+      const payload = linkRefPayload(current) as Record<string, unknown>;
+      const ref = schemaRefIn(payload);
       if (ref !== undefined) {
         return ref;
       }
-      pushOwnValuesExcept(pending, linkPayload, "schema");
-      pushOwnValuesExcept(pending, linkEnvelope, LINK_V1_TAG);
+      for (const key in payload) {
+        if (key !== "schema" && Object.hasOwn(payload, key)) {
+          pending.push(payload[key]);
+        }
+      }
+      continue;
+    }
+
+    if (!isPlainRecord(current)) {
+      continue;
     }
 
     const legacyAlias = current.$alias;
     const hasLegacyAlias = isPlainRecord(legacyAlias);
     if (hasLegacyAlias) {
-      const ref = schemaRefInPayload(legacyAlias);
+      const ref = schemaRefIn(legacyAlias);
       if (ref !== undefined) {
         return ref;
       }
-      pushOwnValuesExcept(pending, legacyAlias, "schema");
+      for (const key in legacyAlias) {
+        if (key !== "schema" && Object.hasOwn(legacyAlias, key)) {
+          pending.push(legacyAlias[key]);
+        }
+      }
     }
 
     for (const key in current) {
       if (!Object.hasOwn(current, key)) {
         continue;
       }
-      if (
-        (key === "/" && hasLinkPayload) ||
-        (key === "$alias" && hasLegacyAlias)
-      ) {
+      if (key === "$alias" && hasLegacyAlias) {
         continue;
       }
       pending.push(current[key]);
@@ -117,6 +114,11 @@ export const containsSyncSchemaRefString = (value: unknown): boolean => {
       for (let index = 0; index < current.length; index += 1) {
         pending.push(current[index]);
       }
+      continue;
+    }
+    if (isLinkRef(current)) {
+      // A FabricLink's payload is not reachable by plain-record iteration.
+      pending.push(linkRefPayload(current));
       continue;
     }
     if (!isPlainRecord(current)) {

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -1,0 +1,122 @@
+import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { isPlainObject } from "@commonfabric/utils/types";
+import { REQUEST_SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
+
+export const SYNC_SCHEMA_REF_PREFIX = "schema-ref@2:";
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);
+
+const isReservedSchemaRef = (value: string): boolean =>
+  value.startsWith(SYNC_SCHEMA_REF_PREFIX) ||
+  value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
+
+const schemaRefInPayload = (
+  payload: Record<string, unknown>,
+): string | undefined => {
+  const schema = payload.schema;
+  return typeof schema === "string" && isReservedSchemaRef(schema)
+    ? schema
+    : undefined;
+};
+
+const pushOwnValuesExcept = (
+  pending: unknown[],
+  record: Record<string, unknown>,
+  skippedKey: string,
+): void => {
+  for (const key in record) {
+    if (key !== skippedKey && Object.hasOwn(record, key)) {
+      pending.push(record[key]);
+    }
+  }
+};
+
+/** Finds reserved wire references only in link-payload schema positions. */
+export const findSyncSchemaRef = (value: unknown): string | undefined => {
+  const pending: unknown[] = [value];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      for (let index = 0; index < current.length; index += 1) {
+        pending.push(current[index]);
+      }
+      continue;
+    }
+    if (!isPlainRecord(current)) {
+      continue;
+    }
+
+    const linkEnvelope = current["/"];
+    const linkPayload = isPlainRecord(linkEnvelope)
+      ? linkEnvelope[LINK_V1_TAG]
+      : undefined;
+    const hasLinkPayload = isPlainRecord(linkEnvelope) &&
+      isPlainRecord(linkPayload);
+    if (hasLinkPayload) {
+      const ref = schemaRefInPayload(linkPayload);
+      if (ref !== undefined) {
+        return ref;
+      }
+      pushOwnValuesExcept(pending, linkPayload, "schema");
+      pushOwnValuesExcept(pending, linkEnvelope, LINK_V1_TAG);
+    }
+
+    const legacyAlias = current.$alias;
+    const hasLegacyAlias = isPlainRecord(legacyAlias);
+    if (hasLegacyAlias) {
+      const ref = schemaRefInPayload(legacyAlias);
+      if (ref !== undefined) {
+        return ref;
+      }
+      pushOwnValuesExcept(pending, legacyAlias, "schema");
+    }
+
+    for (const key in current) {
+      if (!Object.hasOwn(current, key)) {
+        continue;
+      }
+      if (
+        (key === "/" && hasLinkPayload) ||
+        (key === "$alias" && hasLegacyAlias)
+      ) {
+        continue;
+      }
+      pending.push(current[key]);
+    }
+  }
+
+  return undefined;
+};
+
+/** Checks arbitrary input for a string that could introduce a wire reference. */
+export const containsSyncSchemaRefString = (value: unknown): boolean => {
+  const pending: unknown[] = [value];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === "string") {
+      if (isReservedSchemaRef(current)) {
+        return true;
+      }
+      continue;
+    }
+    if (Array.isArray(current)) {
+      for (let index = 0; index < current.length; index += 1) {
+        pending.push(current[index]);
+      }
+      continue;
+    }
+    if (!isPlainRecord(current)) {
+      continue;
+    }
+    for (const key in current) {
+      if (Object.hasOwn(current, key)) {
+        pending.push(current[key]);
+      }
+    }
+  }
+
+  return false;
+};

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -11,6 +11,17 @@ const isReservedSchemaRef = (value: string): boolean =>
   value.startsWith(SYNC_SCHEMA_REF_PREFIX) ||
   value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
 
+/**
+ * Whether serialized text contains a reserved reference prefix anywhere.
+ * Serializations of documents and patches embed every string value they
+ * carry verbatim, so a negative answer proves the serialized value cannot
+ * introduce a reserved reference — the cheap gate in front of the deep
+ * walks below.
+ */
+export const containsReservedSchemaRefSubstring = (value: string): boolean =>
+  value.includes(SYNC_SCHEMA_REF_PREFIX) ||
+  value.includes(REQUEST_SCHEMA_CAS_REF_PREFIX);
+
 const schemaRefInPayload = (
   payload: Record<string, unknown>,
 ): string | undefined => {

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema } from "@commonfabric/api";
+import type { FabricValue, JSONSchema } from "@commonfabric/api";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type {
@@ -74,9 +74,9 @@ const expandSchemaRef = (
 };
 
 const rewriteSchemaValue = (
-  value: unknown,
+  value: FabricValue,
   state: RewriteState,
-): unknown => {
+): FabricValue => {
   if (isCompressibleSchema(value)) {
     state.changed = true;
     return schemaRefFor(value, state);
@@ -85,19 +85,19 @@ const rewriteSchemaValue = (
 };
 
 const expandSchemaValue = (
-  value: unknown,
+  value: FabricValue,
   schemas: SchemaTable | undefined,
   onSchema?: (schema: JSONSchema) => void,
-): unknown => expandSchemaRef(value, schemas, onSchema) ?? value;
+): FabricValue => expandSchemaRef(value, schemas, onSchema) ?? value;
 
-const rewriteValue = (value: unknown, state: RewriteState): unknown =>
+const rewriteValue = (value: FabricValue, state: RewriteState): FabricValue =>
   mapLinkSchemas(value, (schema) => rewriteSchemaValue(schema, state));
 
 const expandValue = (
-  value: unknown,
+  value: FabricValue,
   schemas: SchemaTable | undefined,
   onSchema?: (schema: JSONSchema) => void,
-): unknown =>
+): FabricValue =>
   mapLinkSchemas(
     value,
     (schema) => expandSchemaValue(schema, schemas, onSchema),

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -154,6 +154,14 @@ export const expandSessionSyncSchemas = (
       return upsert;
     }
     const doc = expandValue(upsert.doc, schemas, onSchema);
+    // A ref surviving expansion sits at a position this expander does not
+    // interpret — e.g. a legacy `$alias` schema position interned by an
+    // older server. Delivering it would hand the session cache a ref
+    // string as data; fail loudly instead.
+    const leftover = findSyncSchemaRef(doc);
+    if (leftover !== undefined) {
+      throw new Error(`Unexpanded sync schema table reference: ${leftover}`);
+    }
     return doc === upsert.doc ? upsert : {
       ...upsert,
       doc: doc as typeof upsert.doc,

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -1,5 +1,4 @@
 import type { JSONSchema } from "@commonfabric/api";
-import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type {
@@ -8,8 +7,11 @@ import type {
   SessionSync,
 } from "../v2.ts";
 import { isPlainObject } from "@commonfabric/utils/types";
-
-const SCHEMA_REF_PREFIX = "schema-ref@2:";
+import {
+  findSyncSchemaRef,
+  SYNC_SCHEMA_REF_PREFIX,
+} from "./sync-schema-ref.ts";
+import { mapLinkSchemas } from "./schema-table-links.ts";
 
 type SchemaTable = Record<string, JSONSchema>;
 
@@ -20,6 +22,7 @@ export type SchemaTableSessionSync = SessionSync & {
 type RewriteState = {
   schemas: Map<string, JSONSchema>;
   changed: boolean;
+  onSchema?: (schema: JSONSchema) => void;
 };
 
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
@@ -36,18 +39,23 @@ const schemaRefFor = (
   const hash = schemaAndHash.taggedHashString;
   if (!state.schemas.has(hash)) {
     state.schemas.set(hash, schemaAndHash.schema);
+    state.onSchema?.(schemaAndHash.schema);
   }
-  return `${SCHEMA_REF_PREFIX}${hash}`;
+  return `${SYNC_SCHEMA_REF_PREFIX}${hash}`;
 };
 
 const expandSchemaRef = (
   value: unknown,
   schemas: SchemaTable | undefined,
+  onSchema?: (schema: JSONSchema) => void,
 ): JSONSchema | undefined => {
-  if (typeof value !== "string" || !value.startsWith(SCHEMA_REF_PREFIX)) {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith(SYNC_SCHEMA_REF_PREFIX)
+  ) {
     return undefined;
   }
-  const hash = value.slice(SCHEMA_REF_PREFIX.length);
+  const hash = value.slice(SYNC_SCHEMA_REF_PREFIX.length);
   if (
     hash.length === 0 || schemas === undefined ||
     !Object.hasOwn(schemas, hash)
@@ -61,6 +69,7 @@ const expandSchemaRef = (
       `Invalid sync schema table content for reference: ${value}`,
     );
   }
+  onSchema?.(schemaAndHash.schema);
   return schemaAndHash.schema;
 };
 
@@ -78,145 +87,30 @@ const rewriteSchemaValue = (
 const expandSchemaValue = (
   value: unknown,
   schemas: SchemaTable | undefined,
-): unknown => expandSchemaRef(value, schemas) ?? value;
+  onSchema?: (schema: JSONSchema) => void,
+): unknown => expandSchemaRef(value, schemas, onSchema) ?? value;
 
-const rewriteLinkPayload = (
-  payload: Record<string, unknown>,
-  state: RewriteState,
-): Record<string, unknown> => {
-  if (!Object.hasOwn(payload, "schema")) {
-    return payload;
-  }
-  const schema = rewriteSchemaValue(payload.schema, state);
-  return schema === payload.schema ? payload : { ...payload, schema };
-};
-
-const expandLinkPayload = (
-  payload: Record<string, unknown>,
-  schemas: SchemaTable | undefined,
-): Record<string, unknown> => {
-  if (!Object.hasOwn(payload, "schema")) {
-    return payload;
-  }
-  const schema = expandSchemaValue(payload.schema, schemas);
-  return schema === payload.schema ? payload : { ...payload, schema };
-};
-
-const rewriteValue = (value: unknown, state: RewriteState): unknown => {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const rewritten = value.map((item) => {
-      const next = rewriteValue(item, state);
-      changed ||= next !== item;
-      return next;
-    });
-    return changed ? rewritten : value;
-  }
-
-  if (!isPlainRecord(value)) {
-    return value;
-  }
-
-  const linkEnvelope = value["/"];
-  let rewrittenValue = value;
-  let changed = false;
-  if (isPlainRecord(linkEnvelope)) {
-    const payload = linkEnvelope[LINK_V1_TAG];
-    if (isPlainRecord(payload)) {
-      const nextPayload = rewriteLinkPayload(payload, state);
-      if (nextPayload !== payload) {
-        rewrittenValue = {
-          ...rewrittenValue,
-          "/": {
-            ...linkEnvelope,
-            [LINK_V1_TAG]: nextPayload,
-          },
-        };
-        changed = true;
-      }
-    }
-  }
-
-  const legacyAlias = value.$alias;
-  if (isPlainRecord(legacyAlias)) {
-    const nextAlias = rewriteLinkPayload(legacyAlias, state);
-    if (nextAlias !== legacyAlias) {
-      rewrittenValue = { ...rewrittenValue, $alias: nextAlias };
-      changed = true;
-    }
-  }
-
-  const rewritten: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(rewrittenValue)) {
-    const next = rewriteValue(child, state);
-    changed ||= next !== child;
-    rewritten[key] = next;
-  }
-  return changed ? rewritten : value;
-};
+const rewriteValue = (value: unknown, state: RewriteState): unknown =>
+  mapLinkSchemas(value, (schema) => rewriteSchemaValue(schema, state));
 
 const expandValue = (
   value: unknown,
   schemas: SchemaTable | undefined,
-): unknown => {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const expanded = value.map((item) => {
-      const next = expandValue(item, schemas);
-      changed ||= next !== item;
-      return next;
-    });
-    return changed ? expanded : value;
-  }
-
-  if (!isPlainRecord(value)) {
-    return value;
-  }
-
-  const linkEnvelope = value["/"];
-  let expandedValue = value;
-  let changed = false;
-  if (isPlainRecord(linkEnvelope)) {
-    const payload = linkEnvelope[LINK_V1_TAG];
-    if (isPlainRecord(payload)) {
-      const nextPayload = expandLinkPayload(payload, schemas);
-      if (nextPayload !== payload) {
-        expandedValue = {
-          ...expandedValue,
-          "/": {
-            ...linkEnvelope,
-            [LINK_V1_TAG]: nextPayload,
-          },
-        };
-        changed = true;
-      }
-    }
-  }
-
-  const legacyAlias = value.$alias;
-  if (isPlainRecord(legacyAlias)) {
-    const nextAlias = expandLinkPayload(legacyAlias, schemas);
-    if (nextAlias !== legacyAlias) {
-      expandedValue = { ...expandedValue, $alias: nextAlias };
-      changed = true;
-    }
-  }
-
-  const expanded: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(expandedValue)) {
-    const next = expandValue(child, schemas);
-    changed ||= next !== child;
-    expanded[key] = next;
-  }
-  return changed ? expanded : value;
-};
+  onSchema?: (schema: JSONSchema) => void,
+): unknown =>
+  mapLinkSchemas(
+    value,
+    (schema) => expandSchemaValue(schema, schemas, onSchema),
+  );
 
 export const compressSessionSyncSchemas = (
   sync: SessionSync,
+  onSchema?: (schema: JSONSchema) => void,
 ): SessionSync | SchemaTableSessionSync => {
   const state: RewriteState = {
     schemas: new Map(),
     changed: false,
+    onSchema,
   };
   const upserts = sync.upserts.map((upsert) => {
     if (upsert.doc === undefined) {
@@ -242,9 +136,16 @@ export const compressSessionSyncSchemas = (
 
 export const expandSessionSyncSchemas = (
   sync: SessionSync | SchemaTableSessionSync,
+  onSchema?: (schema: JSONSchema) => void,
 ): SessionSync => {
   const schemas = (sync as SchemaTableSessionSync).schemaTable;
   if (schemas === undefined || Object.keys(schemas).length === 0) {
+    for (const upsert of sync.upserts) {
+      const ref = findSyncSchemaRef(upsert.doc);
+      if (ref !== undefined) {
+        expandSchemaRef(ref, schemas, onSchema);
+      }
+    }
     return sync;
   }
 
@@ -252,7 +153,7 @@ export const expandSessionSyncSchemas = (
     if (upsert.doc === undefined) {
       return upsert;
     }
-    const doc = expandValue(upsert.doc, schemas);
+    const doc = expandValue(upsert.doc, schemas, onSchema);
     return doc === upsert.doc ? upsert : {
       ...upsert,
       doc: doc as typeof upsert.doc,
@@ -267,7 +168,10 @@ export const expandSessionSyncSchemas = (
   return deepFreeze(expanded as SessionSync);
 };
 
-const compressResponseSync = (message: ServerMessage): ServerMessage => {
+const compressResponseSync = (
+  message: ServerMessage,
+  onSchema?: (schema: JSONSchema) => void,
+): ServerMessage => {
   if (message.type !== "response" || message.ok === undefined) {
     return message;
   }
@@ -283,12 +187,18 @@ const compressResponseSync = (message: ServerMessage): ServerMessage => {
     ...message,
     ok: {
       ...message.ok,
-      sync: compressSessionSyncSchemas(sync as unknown as SessionSync),
+      sync: compressSessionSyncSchemas(
+        sync as unknown as SessionSync,
+        onSchema,
+      ),
     },
   };
 };
 
-const expandResponseSync = (message: unknown): unknown => {
+const expandResponseSync = (
+  message: unknown,
+  onSchema?: (schema: JSONSchema) => void,
+): unknown => {
   if (!isPlainRecord(message) || message.type !== "response") {
     return message;
   }
@@ -306,6 +216,7 @@ const expandResponseSync = (message: unknown): unknown => {
       ...message.ok,
       sync: expandSessionSyncSchemas(
         sync as unknown as SchemaTableSessionSync,
+        onSchema,
       ),
     },
   };
@@ -313,24 +224,29 @@ const expandResponseSync = (message: unknown): unknown => {
 
 export const compressServerMessageSchemas = (
   message: ServerMessage,
+  onSchema?: (schema: JSONSchema) => void,
 ): ServerMessage => {
   if (message.type === "session/effect") {
     return {
       ...message,
-      effect: compressSessionSyncSchemas(message.effect),
+      effect: compressSessionSyncSchemas(message.effect, onSchema),
     } as SessionEffectMessage;
   }
-  return compressResponseSync(message);
+  return compressResponseSync(message, onSchema);
 };
 
-export const expandServerMessageSchemas = (message: unknown): unknown => {
+export const expandServerMessageSchemas = (
+  message: unknown,
+  onSchema?: (schema: JSONSchema) => void,
+): unknown => {
   if (isPlainRecord(message) && message.type === "session/effect") {
     return {
       ...message,
       effect: expandSessionSyncSchemas(
         message.effect as SchemaTableSessionSync,
+        onSchema,
       ),
     };
   }
-  return expandResponseSync(message);
+  return expandResponseSync(message, onSchema);
 };

--- a/packages/toolshed/middlewares/pino-logger.test.ts
+++ b/packages/toolshed/middlewares/pino-logger.test.ts
@@ -1,0 +1,64 @@
+import { assertEquals } from "@std/assert";
+import { redactHeaders, serializeResponse } from "./pino-logger.ts";
+
+Deno.test("redactHeaders removes sensitive Headers values", () => {
+  assertEquals(
+    redactHeaders(
+      new Headers({
+        authorization: "Bearer secret",
+        cookie: "session=secret",
+        "set-cookie": "session=response-secret",
+        "user-agent": "diagnostic-browser",
+      }),
+    ),
+    {
+      authorization: "[redacted]",
+      cookie: "[redacted]",
+      "set-cookie": "[redacted]",
+      "user-agent": "diagnostic-browser",
+    },
+  );
+});
+
+Deno.test("redactHeaders handles plain objects case-insensitively", () => {
+  assertEquals(
+    redactHeaders({
+      Authorization: "Bearer secret",
+      "Proxy-Authorization": "Basic secret",
+      "Set-Cookie": "session=secret",
+      accept: "application/json",
+    }),
+    {
+      Authorization: "[redacted]",
+      "Proxy-Authorization": "[redacted]",
+      "Set-Cookie": "[redacted]",
+      accept: "application/json",
+    },
+  );
+});
+
+Deno.test("redactHeaders preserves non-header values", () => {
+  assertEquals(redactHeaders(undefined), undefined);
+  assertEquals(redactHeaders(null), null);
+  assertEquals(redactHeaders("headers unavailable"), "headers unavailable");
+  assertEquals(redactHeaders([]), []);
+});
+
+Deno.test("response serializer redacts sensitive headers", () => {
+  assertEquals(
+    serializeResponse({
+      statusCode: 200,
+      headers: new Headers({
+        "content-type": "application/json",
+        "set-cookie": "session=response-secret",
+      }),
+    }),
+    {
+      status: 200,
+      headers: JSON.stringify({
+        "content-type": "application/json",
+        "set-cookie": "[redacted]",
+      }),
+    },
+  );
+});

--- a/packages/toolshed/middlewares/pino-logger.ts
+++ b/packages/toolshed/middlewares/pino-logger.ts
@@ -4,20 +4,54 @@ import pretty from "pino-pretty";
 
 import env from "@/env.ts";
 
+const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "set-cookie",
+]);
+
+export function redactHeaders(headers: unknown): unknown {
+  if (headers instanceof Headers) {
+    return Object.fromEntries(
+      [...headers.entries()].map(([name, value]) => [
+        name,
+        SENSITIVE_HEADERS.has(name.toLowerCase()) ? "[redacted]" : value,
+      ]),
+    );
+  }
+  if (
+    headers === null || typeof headers !== "object" || Array.isArray(headers)
+  ) {
+    return headers;
+  }
+  return Object.fromEntries(
+    Object.entries(headers as Record<string, unknown>).map(([name, value]) => [
+      name,
+      SENSITIVE_HEADERS.has(name.toLowerCase()) ? "[redacted]" : value,
+    ]),
+  );
+}
+
+export function serializeResponse(response: {
+  statusCode: number;
+  headers: unknown;
+}): { status: number; headers: string } | undefined {
+  if (env.DISABLE_LOG_REQ_RES) {
+    return undefined;
+  }
+  return {
+    status: response.statusCode,
+    headers: JSON.stringify(redactHeaders(response.headers)),
+  };
+}
+
 export function pinoLogger() {
   return logger({
     pino: pino({
       level: env.LOG_LEVEL || "info",
       serializers: {
-        res: (res) => {
-          if (env.DISABLE_LOG_REQ_RES) {
-            return undefined;
-          }
-          return {
-            status: res.statusCode,
-            headers: JSON.stringify(res.headers),
-          };
-        },
+        res: serializeResponse,
         req: (req) => {
           if (env.DISABLE_LOG_REQ_RES) {
             return undefined;
@@ -26,8 +60,8 @@ export function pinoLogger() {
             method: req.method,
             url: req.url,
             headers: env.ENV === "production"
-              ? req.headers
-              : JSON.stringify(req.headers),
+              ? redactHeaders(req.headers)
+              : JSON.stringify(redactHeaders(req.headers)),
           };
         },
       },


### PR DESCRIPTION
## Summary

Hardening for the **frame-local sync schema table** that shipped in #4292 (`syncSchemaTableV2`) — extracted from #4712, the original PR, which bundled this hardening together with the durable request-schema CAS and its measurement diagnostics. This PR carries only the hardening; the CAS feature and its ACL-race repairs stay in #4712, and the wire-accounting diagnostics are not included.

## What it protects, and why that matters

#4292's interning is **on by default and serving production traffic today**: every negotiated connection receives sync frames whose repeated JSON schemas are replaced by `schema-ref@2:<hash>` references into a frame-local table. Measured on the real two-user Lunch Poll browser flow with same-run paired wire accounting, that interning saves **≈14.6–14.7% of total browser memory-websocket payload** — sync-bearing responses specifically shrink ~23.5% (`session.watch.add` syncs) and ~14–15% (`session/effect` syncs). Those savings ride on trusting hash-keyed references, which before this PR were unverified.

## How it helps

- **Closes a writer-reachable, per-space denial of service.** On main, any WRITE-authorized user can persist a literal `schema-ref@2:` string into a `link@1`/`$alias` schema slot (directly, or by relocating an innocent string with JSON-Patch `move`). When the server later compacts a sync frame containing that document, every watching client's expansion throws on the dangling reference — the space's sync stream breaks for all watchers. This PR rejects such commits at storage time, including the `move` case, with transactional rollback preserved. Both reserved prefixes (`schema-ref@2:`, `schema-cas@1:`) are covered so a future request-side encoding needs no further engine changes.
- **Prevents schema substitution via a poisoned table.** Expansion now re-hashes every `schemaTable` entry against its key, so a corrupted or malicious table cannot silently hand a client a different schema than the hash promises.
- **Rejects dangling references at the boundary** instead of leaking reserved strings into the session cache.
- **Costs ~nothing at runtime.** Validation gates on a substring check of the commit serialization the engine already computes; the deep walks run only when a reserved prefix is actually present (essentially never in legitimate traffic). Move-op commits probe serialized source rows before reconstructing, and per-entity validation replays linearly (each intermediate stored state checked once). A/B on the full runner CI shard measured +0.5%, within noise.

Also included: the protocol spec now documents the `syncSchemaTableV2` negotiation, compact wire form, client MUST-reject obligations, and the reserved-prefix storage rule (and corrects the stale `memory/v2` protocol string); toolshed's pino logger redacts `authorization`/`cookie` headers in both directions.

## `$alias` schema positions: no longer interned, still validated

#4895 reclassifies `$alias` as a Pattern-binding form, not a link, and flags this package's `$alias` payload rewriting as the memory-side follow-up — this PR is that follow-up. The mapper no longer treats `$alias.schema` as a schema position: it is binding metadata, not a link schema. Saved patterns keep emitting alias bindings (schema field included) until a sigil binding encoding replaces them, so those schemas now travel inline on every pattern-document sync; #4770's transport compression absorbs most of that byte cost. One honesty note on the headline figure above: the ≈14.6–14.7% was measured with alias interning still on, and the alias share of interned bytes was not broken out — a re-measurement on this branch will read somewhat lower until deflate lands. Two things deliberately stay:

- **The storage-time validator keeps recognizing `$alias` schema positions.** Every client deployed today expands refs there; until those clients age out, stored data must not be able to deliver a ref they would resolve against an unrelated frame table. The walker corpus test now pins the validator as a documented superset of the mapper: equal on link positions, wider by exactly the legacy alias positions.
- **Expansion fails loudly on refs it does not interpret.** If an older server interns an alias schema position, the updated client rejects the frame ("Unexpanded sync schema table reference") instead of silently handing the session cache a ref string as data. Practical skew note: servers normally deploy ahead of clients here, and the only degraded window is a newer client against a not-yet-deployed server — which now fails closed.

## Relationship to #4770 and the flag's future

If the websocket deflate transport (#4770) lands and `syncSchemaTableV2` is subsequently retired (deflate subsumes most of interning's byte savings), this hardening is deleted together with the encoder and expander it guards — merging this does not commit to keeping interning. Until that retirement actually happens, this PR is what stands between deployed production traffic and the holes above.

## Verification

- Memory package: 413 tests pass (new engine reserved-ref suites incl. snapshot-backed move validation and mid-commit transient states; expanded sync-schema-table suite incl. prototype-pollution and own-`__proto__` traversal cases)
- Toolshed memory route + pino-logger tests: 24 pass
- `deno task check-docs`: 510 code blocks pass
- `deno check` / `deno fmt --check` / `deno lint` clean on touched packages
- Performance Check: green (validation gating verified by A/B: all five runner shards 200.34s vs 200.41s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

