### PR TITLE
fix(schema-generator): keep enum-member schemas inline

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -159,7 +159,7 @@ by any repo test.
 | `Record<K,V>` with finite literal-union `K` | expands to concrete `properties` (checker-driven property enumeration) | via `ObjectFormatter`; fixture `record-union-keys` | record-mapped-types.test.ts |
 | Functions / callables / constructables | property skipped entirely (not in `properties`, not in `required`) — **except** callable properties whose call signature returns `Stream`/`Cell`/`SqliteDb` (ModuleFactory/HandlerFactory shapes): kept as `{ asCell: ["stream"/"cell"/"sqlite"] }` and they participate in `required` | skip: `type-utils.ts:558-575`, `object-formatter.ts:233-238,259,269-287`; exception: `object-formatter.ts:44-67` (only those three kinds; capability cells like `ReadonlyCell` returns are *not* kept) | pattern-with-types fixtures |
 | TS `enum` declaration | hoisted under the enum name with **no `type` key** (all-literal union path, §8): numeric → `$defs: { Color: { enum: [0,1,2] } }` + `$ref`; string → `$defs: { Mode: { enum: ["on","off"] } }` | union path `union-formatter.ts:176-214`; hoisting §5 | `test/enum-schema-rows.test.ts` |
-| Single enum member type (`Mode.On`) | hoisted under the **bare member name**: `$defs: { On: { type: "string", enum: ["on"] } }` — two enums sharing a member name **collide** on the `$defs` key (first wins: the second property `$ref`s the wrong value set), and an enum member colliding with an interface name steals its `$ref` (order-dependent). KNOWN BUG | pinned: `test/enum-member-hoisting.test.ts` | — |
+| Single enum member type (`Mode.On`) | inline literal schema, e.g. `{ type: "string", enum: ["on"] }`; enum-member symbols are excluded from named-type hoisting so same-named members and unrelated named types cannot collide in `$defs` | `getNamedTypeKey`, `type-utils.ts`; pinned by `test/enum-member-hoisting.test.ts` | — |
 | `Date` / `URL` / typed arrays / etc. | native table, §5.2 | `native-type-formatter.ts:5-28` | date-types fixture, native-type tests |
 | `Map`/`WeakMap`/`Set`/`WeakSet` | **throws** (§13) | `type-utils.ts:400-411` | schema-generator.test.ts:643-682 |
 | `Reactive<T>` | erases to `<T>`'s schema, **no marker** (§6.4) | — | capability-wrapper-types.test.ts:118-132 |
@@ -195,7 +195,8 @@ these holds:
   aliasSymbol fallback (`:472-477`), so **non-generic aliases to type literals
   hoist under the alias name** (fixture `shared-type`: `type Shared = {…}` →
   `$defs.Shared` + two `$ref`s);
-- the symbol is property/method/signature/function/type-parameter-like
+- the symbol is property/method/signature/function/type-parameter-like or an
+  enum member
   (`:483-501`);
 - the name is `Array`/`ReadonlyArray` (`:503`), a wrapper name by symbol
   (`:504-509`), or in the `NativeTypeFormatter` table (`:511-514`, §5.2);
@@ -205,11 +206,11 @@ these holds:
 - the type is a **generic interface/class instantiation** without an alias name
   (`typeParameters` + `typeArguments` on the reference target) (`:537-550`).
 
-Everything else — interfaces, classes, named aliases, and (observed) TS enums
-and even enum members — hoists under its bare symbol name. There is no
-source-file qualification and no collision disambiguation on the `$defs` key:
-the first definition stored under a name wins; later same-named types emit
-`$ref`s to it (`:397-407`).
+Everything else — interfaces, classes, named aliases, and TS enum declarations
+— hoists under its bare symbol name. Enum members stay inline. There is no
+source-file qualification and no collision disambiguation for other named
+types on the `$defs` key: the first definition stored under a name wins; later
+same-named types emit `$ref`s to it (`:397-407`).
 
 ### 5.2 Native leaf table
 
@@ -703,11 +704,9 @@ synthetic node resolution failure → `any` → `true`
    (`cfc.ts:528-536`, traversal in `cfc/schema-refs.ts:81` /
    `schema-merge.ts:272`) and the api dialect declares it — emission here is
    the missing half, gated on the pruning-safety argument above.
-2. **TS enums** — hoisted `{ enum: […] }` defs with no `type` key; enum
-   members hoist under the bare member name with a **confirmed** cross-enum
-   `$defs` collision (first wins, silent wrong-value schemas; cross-kind
-   collision with same-named interfaces confirmed order-dependent). KNOWN
-   BUG. Pinned by `test/enum-member-hoisting.test.ts` +
+2. **TS enums** — whole enum declarations hoist `{ enum: […] }` defs with no
+   `type` key; individual enum-member types stay inline to avoid `$defs` name
+   collisions. Pinned by `test/enum-member-hoisting.test.ts` +
    `test/enum-schema-rows.test.ts`.
 3. **`widenLiterals` is incoherent at the literal-union boundary** (§14;
    pinned by `test/widen-literals.test.ts`): all-literal unions stay enums

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -486,7 +486,8 @@ export function getNamedTypeKey(
     (symFlags & ts.SymbolFlags.Method) !== 0 ||
     (symFlags & ts.SymbolFlags.Signature) !== 0 ||
     (symFlags & ts.SymbolFlags.Function) !== 0 ||
-    (symFlags & ts.SymbolFlags.TypeParameter) !== 0
+    (symFlags & ts.SymbolFlags.TypeParameter) !== 0 ||
+    (symFlags & ts.SymbolFlags.EnumMember) !== 0
   ) {
     return undefined;
   }
@@ -494,7 +495,8 @@ export function getNamedTypeKey(
   if (
     decls.some((d) =>
       ts.isPropertySignature(d) || ts.isMethodSignature(d) ||
-      ts.isPropertyDeclaration(d) || ts.isMethodDeclaration(d)
+      ts.isPropertyDeclaration(d) || ts.isMethodDeclaration(d) ||
+      ts.isEnumMember(d)
     )
   ) {
     return undefined;

--- a/packages/schema-generator/test/enum-member-hoisting.test.ts
+++ b/packages/schema-generator/test/enum-member-hoisting.test.ts
@@ -1,13 +1,8 @@
-// Pins TS enum handling (mapping spec §4) and the KNOWN BUG in spec §16.2:
-// single enum-member types hoist into $defs under the BARE member name with
-// no disambiguation, so two enums sharing a member name — or an enum member
-// sharing a name with any other named type — collide on the $defs key.
-// First definition wins; later occurrences emit a $ref to the WRONG schema
-// (silently wrong values, or even a wrong shape), order-dependently.
-//
-// The collision expectations below pin today's corrupted output ON PURPOSE
-// so a fix (e.g. qualifying member defs as `<Enum>.<Member>` or inlining
-// member literals) flips them consciously.
+// Pins TS enum-member handling (mapping spec §4/§16.2). Enum members are scalar
+// literal types, not reusable named definitions: keeping them inline prevents
+// their short member names from colliding with members of another enum or with
+// an unrelated named type in $defs. Whole enum declarations remain hoisted and
+// are covered separately by enum-schema-rows.test.ts.
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { SchemaGenerator } from "../src/schema-generator.ts";
@@ -19,8 +14,8 @@ async function generate(code: string, typeName: string) {
   return generator.generateSchema(type, checker, typeNode);
 }
 
-describe("TS enum member hoisting collisions", () => {
-  it("hoists a single enum-member type under the bare member name", async () => {
+describe("TS enum member schemas", () => {
+  it("keeps a single enum-member type inline", async () => {
     const schema = await generate(
       `enum Mode { On = "on", Off = "off" }
        interface S { m: Mode.On; }`,
@@ -28,50 +23,49 @@ describe("TS enum member hoisting collisions", () => {
     );
     expect(schema).toEqual({
       type: "object",
-      properties: { m: { $ref: "#/$defs/On" } },
+      properties: { m: { type: "string", enum: ["on"] } },
       required: ["m"],
-      $defs: { On: { type: "string", enum: ["on"] } },
     });
   });
 
-  it("KNOWN BUG §16.2: members of two enums sharing a name collide, first wins", async () => {
+  it("keeps same-named members of different enums distinct", async () => {
     const schema = await generate(
       `enum AlphaMode { On = "alpha-on", Off = "alpha-off" }
        enum BetaMode { On = "beta-on", Off = "beta-off" }
        interface State { a: AlphaMode.On; b: BetaMode.On; }`,
       "State",
     );
-    // BUG pinned: property `b` (BetaMode.On, value "beta-on") $refs the
-    // AlphaMode.On definition and would validate "alpha-on" instead.
     expect(schema).toEqual({
       type: "object",
       properties: {
-        a: { $ref: "#/$defs/On" },
-        b: { $ref: "#/$defs/On" },
+        a: { type: "string", enum: ["alpha-on"] },
+        b: { type: "string", enum: ["beta-on"] },
       },
       required: ["a", "b"],
-      $defs: { On: { type: "string", enum: ["alpha-on"] } },
     });
   });
 
-  it("KNOWN BUG §16.2: an enum member colliding with an interface name steals its $ref", async () => {
+  it("does not collide with a same-named interface", async () => {
     const schema = await generate(
       `enum E { Config = "e-config" }
        interface Config { url: string; }
        interface App { mode: E.Config; settings: Config; }`,
       "App",
     );
-    // BUG pinned: `settings` (an object type) $refs the enum-member string
-    // schema because the member was formatted first. Reversing property
-    // order reverses the winner (order-dependent corruption).
     expect(schema).toEqual({
       type: "object",
       properties: {
-        mode: { $ref: "#/$defs/Config" },
+        mode: { type: "string", enum: ["e-config"] },
         settings: { $ref: "#/$defs/Config" },
       },
       required: ["mode", "settings"],
-      $defs: { Config: { type: "string", enum: ["e-config"] } },
+      $defs: {
+        Config: {
+          type: "object",
+          properties: { url: { type: "string" } },
+          required: ["url"],
+        },
+      },
     });
   });
 });

--- a/packages/ts-transformers/test/schema-generator-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-generator-coverage.test.ts
@@ -97,8 +97,10 @@ export { s };
   assertEquals(enumText(props, "small"), ["-Infinity"]);
   assertEquals(enumText(props, "neg"), ["-7"]);
 
-  const defs = propInitializer(schema, "$defs") as ts.ObjectLiteralExpression;
-  assertEquals(enumText(defs, "NaNValue"), ["NaN"]);
+  // Enum-member types stay inline so their short names cannot collide in
+  // $defs with another enum member or named type.
+  assertEquals(enumText(props, "tag"), ["NaN"]);
+  assertEquals(propInitializer(schema, "$defs"), undefined);
 
   assertEquals(propInitializer(schema, "maximum")!.getText(root), "NaN");
 });


### PR DESCRIPTION
## What

- keep TypeScript enum-member literal types inline instead of hoisting them into `$defs`
- prevent bare enum-member names from colliding with members of another enum or unrelated named types
- update the schema mapping spec and regression/coverage tests to describe the corrected behavior

## Why

Enum members were treated as reusable named types and hoisted under their short member name. Two enums with the same member name—or an enum member and an interface with the same name—could therefore share one `$defs` key, making output order-dependent and silently incorrect. Enum members are scalar literal types, so inlining them removes the collision while leaving whole enum declarations hoisted.

This is an independent follow-up identified during the comprehensive review of #4694.

## Impact

Generated schemas for single enum-member types now contain the literal schema at the use site. Whole enums and ordinary named object types keep their existing `$defs` behavior.

## Validation

Post-rebase verification:

- `deno task test` in `packages/schema-generator` — `36 passed (282 steps)`, `0 failed` (including type-checking)
- `git diff --check` — clean

## Provenance

Rebased directly onto `main` at `b5caa856c`; current branch head is `17e059f9f`. The one-commit change applied without conflict.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline TypeScript enum-member schemas at the use site to eliminate `$defs` name collisions and order-dependent output. Whole enums continue to hoist unchanged.

- **Bug Fixes**
  - Exclude enum members from named-type hoisting in `getNamedTypeKey`; emit inline literal schemas for types like `Mode.On`.
  - Prevent `$defs` collisions between same-named members and with unrelated named types.
  - Update the mapping spec and tests (including coverage) to reflect and pin the corrected behavior.

<sup>Written for commit 17e059f9f66213cabd42345a921dbde8072feaee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

