### PR TITLE
test(runner): pin transformer sandbox helper equivalence

### DIFF
--- a/packages/runner/test/sandbox-contract-helper-equivalence.test.ts
+++ b/packages/runner/test/sandbox-contract-helper-equivalence.test.ts
@@ -1,0 +1,76 @@
+import { assertEquals } from "@std/assert";
+import ts from "typescript";
+import {
+  BINDING_IDENTITY_HELPER_NAME,
+  createBindingIdentityHelperSource,
+  createFunctionHardeningHelperSource,
+  FUNCTION_HARDENING_HELPER_NAME,
+} from "@commonfabric/utils/sandbox-contract";
+import { stripJsTrivia } from "../src/sandbox/compiled-js-parser.ts";
+import { COMMONFABRIC_TYPES } from "../../ts-transformers/test/commonfabric-test-types.ts";
+import { transformSource } from "../../ts-transformers/test/utils.ts";
+
+function emittedFunction(
+  source: string,
+  sourceFile: ts.SourceFile,
+  name: string,
+): string {
+  const matches = sourceFile.statements.filter((statement) =>
+    ts.isFunctionDeclaration(statement) && statement.name?.text === name
+  );
+  assertEquals(
+    matches.length,
+    1,
+    `expected exactly one emitted ${name} declaration`,
+  );
+  const match = matches[0]!;
+  return stripJsTrivia(source, match.getStart(sourceFile), match.getEnd());
+}
+
+Deno.test("transformer hardening helpers match the sandbox verifier contract", async () => {
+  const output = await transformSource(
+    `/// <cts-enable />
+      import { pattern, WriteAuthorizedBy } from "commonfabric";
+
+      function saveTitle(): string {
+        return "saved";
+      }
+
+      interface Output {
+        savedTitle: WriteAuthorizedBy<string, typeof saveTitle>;
+      }
+
+      export default pattern<{}, Output>(() => ({
+        savedTitle: "saved",
+      }));
+    `,
+    { types: COMMONFABRIC_TYPES },
+  );
+  const sourceFile = ts.createSourceFile(
+    "/test.tsx",
+    output,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  assertEquals(
+    emittedFunction(output, sourceFile, FUNCTION_HARDENING_HELPER_NAME),
+    stripJsTrivia(
+      createFunctionHardeningHelperSource(
+        FUNCTION_HARDENING_HELPER_NAME,
+        { typedParameter: true },
+      ),
+    ),
+  );
+  assertEquals(
+    emittedFunction(output, sourceFile, BINDING_IDENTITY_HELPER_NAME),
+    stripJsTrivia(
+      createBindingIdentityHelperSource(
+        BINDING_IDENTITY_HELPER_NAME,
+        undefined,
+        { typedParameter: true },
+      ),
+    ),
+  );
+});


### PR DESCRIPTION
## What

- add a cross-package regression test that compiles a representative pattern
- extract the transformer-emitted function-hardening and binding-identity helpers
- compare both helpers, after trivia normalization, with the canonical sandbox-contract generators

## Why

These helpers sit on the compiler/verifier trust boundary. The transformer and runner sandbox must agree on their exact executable structure; otherwise a harmless refactor can create a compiler/verifier mismatch. This test makes that equivalence an explicit, executable contract.

This is an independent follow-up identified during the comprehensive review of #4694.

## Impact

Test-only. Runtime and emitted output are unchanged.

## Validation

Post-rebase verification:

- `ENV=test deno test --allow-all --unstable-sloppy-imports test/sandbox-contract-helper-equivalence.test.ts` — `1 passed`, `0 failed`
- `git diff --check` — clean

## Provenance

Rebased directly onto `main` at `b5caa856c`; current branch head is `235d8e10a`. The one-commit, test-only change applied without conflict.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test in `packages/runner` that compiles a sample pattern and asserts the transformer-emitted function-hardening and binding-identity helpers exactly match the canonical sources from `@commonfabric/utils/sandbox-contract` (trivia-insensitive). This pins the compiler–runner sandbox contract; test-only with no runtime or emitted output changes.

<sup>Written for commit 235d8e10acdc3d0946771d9150bc3ac6c9ad674e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

