### PR TITLE
feat(ts-transformers): preserve optional call semantics

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -2808,6 +2808,17 @@ pipeline. Current built-in behavior:
    schema generation resolves the resulting exact manifest marker. The
    `WriteAuthorizedBy` validation remains a separate transformer rather than a
    schema-generator responsibility.
+6. Invoking a function value that flows through reactive pattern data (for
+   example a function-typed input property called as `input.fn(...)` or
+   `input.fn?.(...)`) produces no diagnostic at any expression site. Function
+   values are not schema-representable, so synthesized lift input schemas
+   silently drop function-typed captures; the lowered closure then reads an
+   absent property at runtime, making the call dead code (`undefined` under
+   optional invocation, a runtime `TypeError` when a plain invocation is
+   reached). The target language classifies such callable roots as
+   unsupported — the problem is the unstorable function value, not the call
+   syntax — but that classification is not yet surfaced as an authoring-time
+   diagnostic. The open follow-up is recorded in the design-deltas addendum.
 
 ## 20. Test Coverage Snapshot
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -471,18 +471,14 @@ Diagnostics emitted in all modes:
   - message instructs the author to move the use into a nested
     `computed(() => ...)` or module-scope `lift()`
 - **Error** `pattern-context:optional-chaining`
-  - optional calls in restricted reactive context **outside JSX and outside
-    explicit compute callbacks** — top-level (`input?.foo()`), statement
-    position, and collection callbacks (`items.map((item) =>
-    item?.toUpperCase())`) all error (`test/validation.test.ts:546,567,1509`)
-  - inside JSX expressions (`{maybeFn?.(1)}`, `{text?.trim()}`) and inside
-    `computed(...)` bodies the same shapes are accepted and lowered intact —
-    an unratified delta from the target-language matrix's unconditional
-    "Unsupported" (see the design-deltas 2026-07-10 record; note the
-    lowering drops function-typed captures from the lift input schema, so an
-    accepted reactive optional-call is dead code at runtime)
   - optional property / element access that appears outside a supported
     lowerable expression site
+  - optional calls do not receive this diagnostic merely because they are
+    optional: their underlying call root is classified by the same policy as a
+    non-optional call
+  - at supported expression sites, receiver optionality (`value?.method()`),
+    invocation optionality (`value.method?.()`), and combined chains lower as
+    whole calls with JavaScript short-circuit and receiver semantics intact
 - **Error** `pattern-context:computation`
   - binary/unary/conditional computations using opaque dependencies outside
     wrappers
@@ -926,8 +922,10 @@ Primary behaviors:
   access in pattern contexts
 - preserves terminal path methods (`get`, `set`, `update`, etc.) and rewrites
   only the receiver path portion when needed
-- treats dynamic key access, spread, and optional-call forms as non-lowerable in
-  pattern context with diagnostics
+- treats dynamic key access and spread as non-lowerable in unsupported pattern
+  contexts with diagnostics
+- classifies optional calls by their underlying call kind and expression site;
+  optionality itself neither admits nor rejects a call
 - treats wildcard traversals (`Object.keys/values/entries`, `JSON.stringify`) as
   broad/full-shape access for capability analysis, but allows whole-call
   lowering when they appear in supported expression-root positions
@@ -1111,6 +1109,10 @@ adjustments:
 - capability analysis resolves member access through `.get()` when the member
   access itself is observed (`notes.get().length` records `["length"]` rather
   than a blanket root read) and suppresses the redundant blanket `.get()` read
+- optional `.get()` chains retain an explicit readonly read of the receiver
+  Cell even when a projected result member is observed; this preserves the
+  nested Cell in synthesized closure schemas without widening the enclosing
+  root to wildcard
 - array-like roots whose observed paths only touch non-item properties
   (`length`, `get`, `set`, `key`, `update`) keep array shape but shrink their
   item type to `unknown`
@@ -2787,21 +2789,14 @@ pipeline. Current built-in behavior:
    intentionally omitted).
 2. Action and JSX inline handler callback extraction currently unwraps arrow
    functions only.
-3. Optional-call forms on opaque pattern roots report
-   `pattern-context:optional-chaining` at top level, statement position, and
-   inside collection callbacks — but are accepted and lowered inside JSX
-   expressions and `computed(...)` bodies (see §6.5; unratified language
-   delta). Optional property/element access is supported only in explicit
-   lowerable expression sites; statement-position optional access still
-   errors.
-4. Non-static destructuring defaults, rest destructuring, and unsupported
+3. Non-static destructuring defaults, rest destructuring, and unsupported
    computed destructuring keys in pattern callbacks remain non-lowerable and
    produce pattern-context diagnostics.
-5. Interprocedural capability propagation applies only when a resolved callee
+4. Interprocedural capability propagation applies only when a resolved callee
    declaration is analyzable in-proc (arrow/function
    expression/declaration/method); external/unresolved calls remain
    conservative.
-6. The CFC authoring contract under `docs/specs/ts-transformer/cfc_*.md` is
+5. The CFC authoring contract under `docs/specs/ts-transformer/cfc_*.md` is
    implemented for the canonical alias set: the schema-generator's
    common-fabric formatter lowers `Cfc` payloads, the wrapper aliases, the
    projection helpers, and the `WriteAuthorizedBy` writer-identity marker into

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -88,9 +88,9 @@ landed after the snapshot above:
 
 ### Addendum 2 (2026-07-10 phase-4 verification findings)
 
-Unratified language deltas found by adversarial verification of the
-target-language matrix (implementation vs normative spec; each needs a
-ratify-or-revert decision):
+Language deltas found by adversarial verification of the target-language
+matrix (implementation vs normative spec). Resolution status is recorded on
+each finding:
 
 - **Top-level eager-read carve-out (#3725, 2026-05-28).** Validation accepts
   computation-feeding top-level `.get()` reads and auto-wraps the containing
@@ -99,13 +99,16 @@ ratify-or-revert decision):
   `test/validation.test.ts:3179`). Matrix row still says Unsupported
   unconditionally. Decision open: ratify a terminal-vs-computation-feeding
   split in the matrix, or revert (breaks two goldens + one test).
-- **Optional-call accepted in JSX and compute callbacks.** `{maybeFn?.(1)}`
-  and `computed(() => maybeFn?.(1))` lower intact while the same shapes error
-  at top level, statement position, and in collection callbacks. Rider: the
-  lowering drops function-typed captures from the lift input schema (function
-  values are not schema-representable or cell-storable), so the accepted form
-  is dead code at runtime — which argues for rejecting it and keeping the
-  matrix row unqualified. Decision open.
+- **Optional-call accepted in JSX and compute callbacks — resolved 2026-07-23
+  by making optionality orthogonal to call support.** The earlier location
+  split was an implementation leak, and the proposed blanket rejection would
+  have removed valid authoring forms. Optional receiver and invocation forms
+  now follow the same expression-site and call-root policy as the corresponding
+  non-optional call. Supported sites lower the whole call and preserve
+  receiver binding, nullish short-circuiting, and lazy argument evaluation;
+  unsupported call roots remain unsupported for their existing reason.
+  Function-valued reactive data remains outside the storable data model whether
+  invoked with `()` or `?.()`.
 - **Residual pass-through emits runnable-looking output alongside errors.**
   Both documented bucket-4 forms are alive: `forEach`-in-JSX survives
   verbatim as plain JS and promise-`.then` gets compute-island-wrapped, in
@@ -280,8 +283,9 @@ contract support).
    the analyzed function scope.
 5. Opaque path navigation lowering (`prop` / optional-chain navigation ->
    `key(...)`) is deterministic and semantics-preserving.
-6. Optional-call forms (for example `foo?.bar()`) are explicitly out of scope
-   for key-lowering until modeled separately.
+6. Optional receiver and invocation forms (for example `foo?.bar()` and
+   `foo.bar?.()`) follow the underlying call-root policy; supported forms lower
+   as whole calls rather than extracting a function-valued member.
 7. ~~A feature gate exists for rollout and A/B fixture validation.~~
    (Completed: `useLegacyReactiveSemantics` gate has been removed; the single
    transform pipeline is the only path.)
@@ -638,7 +642,7 @@ emitters and contextual checks.
 
 **Recommendation:** add a targeted lowering step (or utility used by emitters)
 that converts property navigation on capability-proven `OpaqueCell` receivers to
-`key(...)` chains, with explicit exclusions for optional-call.
+`key(...)` chains while routing an enclosing optional call as one semantic unit.
 
 ## S-010 Add A Shared Parameter Canonicalization Pass
 
@@ -852,12 +856,14 @@ independently.
 1. Lower `foo.bar.baz` and optional-chain path navigation to `foo.key(...)` when
    receiver summary is `OpaqueCell`.
 2. Ensure optional-chain navigation lowering preserves no-throw behavior.
-3. Keep optional-call excluded and diagnosed if needed.
+3. Classify optional calls by the same call-root and expression-site policy as
+   non-optional calls, lowering supported forms as whole calls.
 4. Ensure destructured parameter lowering composes with path-navigation lowering
    without duplicate or conflicting rewrites.
 
-**Exit criteria:** snapshot parity for supported forms and explicit handling of
-unsupported optional-call cases.
+**Exit criteria:** snapshot parity for supported forms, including receiver and
+invocation optionality, and explicit diagnostics for underlying call roots that
+remain unsupported.
 
 ## Phase D7: Interprocedural Summaries (Compute Context Focus)
 

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -109,6 +109,28 @@ each finding:
   unsupported call roots remain unsupported for their existing reason.
   Function-valued reactive data remains outside the storable data model whether
   invoked with `()` or `?.()`.
+  - **Carried-forward open sub-finding: no diagnostic enforces the
+    function-valued-data boundary.** The earlier revision of this finding
+    recorded that lift lowering drops function-typed captures from input
+    schemas, so an invocation of a function value from reactive data compiles
+    without diagnostics and is dead code at runtime (current-behavior spec
+    §19.6). That behavior predates the orthogonality change for plain `()`
+    calls and now uniformly covers `?.()` forms, which previously errored at
+    top-level, statement, and collection-callback sites — as an accident of
+    the removed optional-call bucket, not as a considered rejection of the
+    callable-root family. The open decision is where enforcement belongs:
+    a call-site diagnostic for callable roots that resolve to reactive-data
+    function values (ts-transformers scope, diagnoses the symptom), a
+    declaration-site diagnostic where schema generation drops a function-typed
+    property (schema-generator scope, diagnoses the root cause and also
+    catches stored-but-never-called function values), or both. Any
+    enforcement must not fire for legal callable families: pattern factories,
+    cell/stream-branded values, registered runtime exports, and module-scope
+    captures. Decided 2026-07-23: the call-site diagnostic proceeds as
+    CT-1905 (a corpus sweep found zero authored occurrences of the family,
+    so error severity is safe); the declaration-site option stays open as a
+    schema-generator design question (no diagnostics channel exists there
+    today).
 - **Residual pass-through emits runnable-looking output alongside errors.**
   Both documented bucket-4 forms are alive: `forEach`-in-JSX survives
   verbatim as plain JS and promise-`.then` gets compute-island-wrapped, in

--- a/docs/specs/ts-transformer/ts_transformers_goals.md
+++ b/docs/specs/ts-transformer/ts_transformers_goals.md
@@ -296,11 +296,14 @@ When capability/path analysis is uncertain, behavior must degrade safely toward
 broader types and fewer aggressive rewrites rather than risking unsound
 narrowing.
 
-## C-008 Optional-Chain Navigation Semantics
+## C-008 Optional-Chain Navigation And Call Semantics
 
 If property-navigation optional chains are lowered to `key(...)` on opaque
-receivers, lowering must preserve no-throw navigation semantics. Optional-call
-forms remain explicitly out of scope until modeled.
+receivers, lowering must preserve no-throw navigation semantics. Optional
+receiver and invocation forms follow the same support policy as their
+non-optional call root. Whole-call lowering must preserve receiver binding,
+single evaluation, authored nullish short-circuit points, and skipped argument
+evaluation.
 
 ## C-009 Destructuring Lowering Semantics
 

--- a/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
+++ b/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
@@ -109,6 +109,25 @@ combined chain, the lowered form must preserve:
 The compiler should lower the whole call rather than extract a function-valued
 member into reactive data.
 
+Two boundaries of that obligation are deliberate:
+
+- The four properties govern value evaluation inside the lowered computation.
+  Reactive dependency subscription stays eager: capability analysis captures
+  every dependency mentioned in the authored expression regardless of control
+  flow, so a dependency that appears only after a short-circuit point (for
+  example `state.suffix` in `value.replace?.("x", state.suffix)`) is still
+  subscribed, and a change to it re-runs the computation even while the chain
+  short-circuits. Short-circuiting constrains evaluation of the authored
+  expression, not the dependency set — the same rule as the untaken branches
+  of conditional and logical expressions.
+- On total navigation into cell space, authored `?.` may be absorbed rather
+  than preserved verbatim: `key(...)` navigation cannot throw on missing
+  values, so an optional navigation step lowered to `key(...)` (for example
+  `state.items?.[0]`, or the receiver path of `value.auth?.get?.()`) carries
+  no residual short-circuit point, and reads of absent members yield
+  `undefined` through the read itself. Value-space chains inside lowered
+  closures keep their authored `?.` tokens verbatim.
+
 ## 3.5 Collection Operator Ownership Must Stay Coherent
 
 For collection operators:

--- a/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
+++ b/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
@@ -32,6 +32,7 @@ especially:
 - reactive control flow
 - reactive collection operators
 - property/element access over reactive values
+- receiver-method and other supported call expressions
 - wrapper introduction (`computed`, helper control-flow forms)
 - callback capture and ownership lowering
 
@@ -96,6 +97,18 @@ unless that new shape is explicitly proven equivalent.
 
 Whole-call wrapping is acceptable when it preserves authored callee semantics.
 
+Optionality is part of that same obligation, not a separate call family. When
+lowering a supported form such as `obj?.method(arg)`, `obj.method?.(arg)`, or a
+combined chain, the lowered form must preserve:
+
+1. single evaluation of the receiver and callee
+2. the original receiver as `this`
+3. the authored nullish short-circuit points
+4. non-evaluation of call arguments when optional invocation short-circuits
+
+The compiler should lower the whole call rather than extract a function-valued
+member into reactive data.
+
 ## 3.5 Collection Operator Ownership Must Stay Coherent
 
 For collection operators:
@@ -157,7 +170,6 @@ over:
 
 This is especially important for:
 
-- optional-call
 - wildcard traversal outside supported whole-call expression-root positions
 - foreign callback-container roots in pattern-facing contexts
 - direct top-level eager `.get()` reads on reactive or cell-like values

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -75,7 +75,7 @@ Each construct family is classified as one of:
 | Cell-style `.get()` reads on explicitly cell-like values inside JSX expressions, authored helper control flow, or explicit computation callbacks | Supported | Eager cell reads remain valid when authored in JSX interpolation, helper control flow such as `ifElse` / `when` / `unless`, and explicit computation callbacks such as `computed`, `action`, `lift`, and `handler` |
 | Foreign callback / imperative container roots in JSX | Unsupported | Shapes like `[0, 1].forEach(() => list.map(...))` are not part of the intended reactive language core and should move into supported value expressions, wrappers, or helpers |
 | Residual callback-container pass-through behavior for invalid programs | Compatibility-only | Some invalid callback-container shapes may still survive as plain JS in current emitted output, but that is residual implementation behavior rather than supported language policy |
-| Optional-call on reactive receivers | Unsupported | Optional-call forms are outside the intended language because they are difficult to lower without semantic ambiguity |
+| Optional receiver navigation and optional invocation on otherwise-supported call roots | Supported | Optionality does not define a separate call family: `value?.method()`, `value.method?.()`, and combined chains lower wherever the corresponding non-optional call is supported, with receiver binding, evaluation order, nullish short-circuiting, and skipped argument evaluation preserved |
 | Direct non-JSX receiver-method calls on reactive values in top-level pattern-body expression sites | Supported | Value-like receiver-method roots at top-level object-property, call-argument, variable-initializer, array-element, or return-expression sites lower to derived local value expressions |
 | Direct receiver-method roots inside supported collection callbacks | Supported | Callback-local value-like receiver-method roots lower to callback-local lift-applied computations instead of remaining raw or requiring manual wrapper calls |
 | Direct top-level `.get()` reads in pattern-owned reactive context | Unsupported | Even on true cell-like values, eager `.get()` reads should move into JSX or an explicit computation callback such as `computed`, `action`, `lift`, or `handler` rather than living directly in the top-level declarative pattern body |
@@ -124,7 +124,7 @@ The top-level pattern body should stay declarative.
 ```ts
 // Shown for illustration only.
 pattern(({ items, show }) => ({
-  upper: items[0].name.toUpperCase(),
+  upper: items[0]?.name?.toUpperCase?.(),
   title: show ? "Visible" : "Hidden",
   visibleCount: ifElse(show, items.length, 0),
   [UI]: <div>{items.map((item) => item.name)}</div>,
@@ -160,6 +160,7 @@ JSX is the main local reactive expression context.
 // Shown as JSX element children.
 <div>
   {user.name.toUpperCase()}
+  {user.name?.toUpperCase?.()}
   {selectedScopes[key]}
   {ifElse(show, count.get(), 0)}
   {items.filter((item) => item.visible).join(", ")}
@@ -190,6 +191,7 @@ imperative/value-computation boundaries.
 // Shown inside a pattern body.
 computed(() => input[key])
 computed(() => count.get())
+computed(() => input.name?.trim?.())
 action(() => state.name.trim())
 ```
 
@@ -235,6 +237,7 @@ expression context.
 // Shown inside a pattern body.
 items.map((item) => item.name)
 items.map((item) => item.toUpperCase())
+items.map((item) => item?.toUpperCase?.())
 items.map((item) => identity(item.toUpperCase()))
 items.map((item) => ifElse(item.active, item.name, "hidden"))
 items.map((item) => <span>{item.name.toUpperCase()}</span>)
@@ -331,25 +334,24 @@ pattern(({ selectedScopes, key }) =>
 or move the imperative container entirely outside the pattern-facing expression
 site into a named helper or handler.
 
-### Optional-Call -> Explicit Nullish Control Flow
+### Optional Calls Follow The Underlying Call Policy
 
-**Avoid**
-
-```ts
-// Shown for illustration only.
-pattern(({ maybeFn, value }) => ({
-  result: maybeFn?.(value),
-}));
-```
-
-**Prefer**
+Optionality does not make an otherwise unsupported call legal, and it does not
+make an otherwise supported call ambiguous.
 
 ```ts
 // Shown for illustration only.
-pattern(({ maybeFn, value }) => ({
-  result: computed(() => maybeFn == null ? undefined : maybeFn(value)),
+pattern(({ maybeName }) => ({
+  result: maybeName?.trim?.(),
 }));
 ```
+
+The compiler lowers the whole call expression and preserves JavaScript's
+receiver binding and short-circuit behavior. A function-valued pattern input is
+still outside the reactive data model whether invoked as `fn()` or `fn?.()`:
+the problem in that case is the unstorable function value, not optional-call
+syntax. Put behavior in a module-scope helper, `lift`, or `handler` instead of
+placing a function in reactive data.
 
 ## 5. Construct Notes
 
@@ -487,19 +489,33 @@ The intended split is:
      - `ifElse(show, state.name.trim(), "fallback")`
      - `items.map((item) => item.toUpperCase())`
      - `items.map((item) => identity(item.toUpperCase()))`
-3. **optional-call / ambiguous receiver-call forms**
-   - still outside the target language
+3. **optional receiver and invocation forms of supported calls**
+   - part of the same target-language call family
    - examples:
-     - `input?.foo()`
-     - `items.map((item) => item?.toUpperCase())`
+     - `{ upper: input.name?.trim?.() }`
+     - JSX expression sites like `{input.name?.trim?.()}`
+     - `computed(() => input.name?.trim?.())`
+     - `items.map((item) => item?.toUpperCase?.())`
+   - lowering preserves:
+     - single evaluation of the receiver and callee
+     - the original `this` binding
+     - nullish short-circuiting
+     - non-evaluation of arguments when invocation short-circuits
+4. **calls that are already outside the language**
+   - remain unsupported with or without `?.`
+   - examples:
+     - a statement-position receiver call in the top-level declarative pattern
+       body
+     - invocation of a function value supplied through reactive pattern data
 
 So the language should not be read as “receiver methods are unsupported.” The
 real rule is that **receiver methods are supported in explicit local expression
 contexts, inside supported collection callbacks, and at lowerable top-level
-non-JSX pattern sites, but optional-call receiver forms remain unsupported**.
-Optional property / element access follows the ordinary lowerable
-expression-site rules; only optional-call forms remain outside the target
-language.
+non-JSX pattern sites, and optionality does not change that classification**.
+Optional property / element access and optional invocation follow the ordinary
+lowerable expression-site and call-root rules. Standalone functions and
+execution callbacks such as `action`, `lift`, and `handler` retain ordinary
+JavaScript behavior as before.
 
 ## 5.7 `.key(...)` And `.get()` Are Cell-Semantics-Split
 
@@ -563,8 +579,9 @@ questions:
    would be a later language revision rather than an unresolved v1 semantic
 3. preserve typed-input/schema continuity tests around explicit cell-like
    inputs without promoting direct top-level `.get()` reads into the language
-4. keep optional-call on reactive receivers unsupported in v1 unless a future
-   language revision defines an explicit evaluation model
+4. preserve the optional-call evaluation model with golden coverage for
+   receiver optionality, invocation optionality, combined chains, receiver
+   binding, and lazy argument evaluation
 
 ## 7. Use This Spec
 

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -124,7 +124,8 @@ The top-level pattern body should stay declarative.
 ```ts
 // Shown for illustration only.
 pattern(({ items, show }) => ({
-  upper: items[0]?.name?.toUpperCase?.(),
+  upper: items[0].name.toUpperCase(),
+  maybeUpper: items[0]?.name?.toUpperCase?.(),
   title: show ? "Visible" : "Hidden",
   visibleCount: ifElse(show, items.length, 0),
   [UI]: <div>{items.map((item) => item.name)}</div>,

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -3055,14 +3055,6 @@ export function analyzeFunctionCapabilities(
           }
         }
 
-        // Optional-call forms are non-lowerable; treat as wildcard usage.
-        if (node.questionDotToken && ts.isExpression(node.expression)) {
-          const source = resolveSourceRef(node.expression);
-          if (source) {
-            markWildcard(source.root, source.path);
-          }
-        }
-
         if (
           ts.isPropertyAccessExpression(node.expression) ||
           ts.isElementAccessExpression(node.expression)
@@ -3171,8 +3163,12 @@ export function analyzeFunctionCapabilities(
             } else if (READER_METHODS.has(methodName)) {
               // If the .get() result was already resolved with a more specific
               // path by the member-access handler (e.g. notes.get().length →
-              // ["notes", "length"]), skip the blanket read.
-              if (!resolvedGetCalls.has(node)) {
+              // ["notes", "length"]), skip the blanket read. Optional chains
+              // are the exception: their projected result path does not by
+              // itself retain the receiver Cell in every synthesized closure
+              // shape, so record the receiver read explicitly without
+              // widening the root to wildcard.
+              if (ts.isCallChain(node) || !resolvedGetCalls.has(node)) {
                 trackReadRef(receiver);
                 recordMergeableReadSite(receiver, node);
               }

--- a/packages/ts-transformers/src/transformers/call-root-support.ts
+++ b/packages/ts-transformers/src/transformers/call-root-support.ts
@@ -12,7 +12,6 @@ export type SupportedCallRootKind =
 
 export type UnsupportedCallRootKind =
   | "restricted-get-call"
-  | "optional-call"
   | "unsupported-receiver-method";
 
 export type CallRootPolicyDecision =
@@ -38,7 +37,6 @@ export type ExpressionSiteCallRootKind =
   | "ordinary-call"
   | "parameterized-inline-call"
   | "receiver-method"
-  | "optional-call"
   | "other";
 
 type CallRootPolicySiteInfo = {
@@ -47,15 +45,6 @@ type CallRootPolicySiteInfo = {
   readonly helperBoundaryKind?: ExpressionSiteHelperBoundaryKind;
   readonly callRootKind?: ExpressionSiteCallRootKind;
 };
-
-function hasOptionalChainedCallee(
-  callee: ts.LeftHandSideExpression,
-): boolean {
-  return (
-    ts.isPropertyAccessExpression(callee) ||
-    ts.isElementAccessExpression(callee)
-  ) && !!callee.questionDotToken;
-}
 
 function hasOpaquePathTerminalReceiverChain(
   callee: ts.LeftHandSideExpression,
@@ -112,16 +101,6 @@ export function classifyCallRootPolicy(
     siteInfo.reactiveContext.kind !== "pattern"
   ) {
     return { kind: "none" };
-  }
-
-  if (
-    siteInfo.callRootKind === "optional-call" ||
-    hasOptionalChainedCallee(expression.expression)
-  ) {
-    return {
-      kind: "unsupported",
-      unsupportedKind: "optional-call",
-    };
   }
 
   if (siteInfo.callRootKind !== "receiver-method") {

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -235,10 +235,6 @@ function classifyCallExpressionRoot(
   context: TransformationContext,
   analyze: AnalyzeFn,
 ): ExpressionSiteCallRootKind {
-  if (expression.questionDotToken) {
-    return "optional-call";
-  }
-
   const callKind = detectCallKind(expression, context.checker);
   switch (callKind?.kind) {
     case "ifElse":

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -841,10 +841,6 @@ function rewriteTrackedOpaquePatternBody(
         if (
           KNOWN_PATH_TERMINAL_METHODS.has(visited.name.text) && parentCall
         ) {
-          if (unsupportedCallRoot === "optional-call") {
-            return visited;
-          }
-
           if (info.path.length <= 1) {
             return visited;
           }
@@ -866,7 +862,6 @@ function rewriteTrackedOpaquePatternBody(
 
         if (parentCall) {
           if (
-            unsupportedCallRoot === "optional-call" ||
             unsupportedCallRoot === "unsupported-receiver-method"
           ) {
             return visited;

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -27,7 +27,7 @@
  * - Optional chaining:
  *   - optional property/element access is allowed in supported lowerable
  *     expression sites
- *   - optional calls and non-lowerable optional access still error
+ *   - non-lowerable optional access still errors
  * - Calling .get() on cells: ERROR (must wrap in computed())
  * - Function creation in pattern context: ERROR (move to module scope)
  * - lift()/handler() inside pattern: ERROR (move to module scope)
@@ -93,6 +93,30 @@ type ObjectMemberKind =
   | "method"
   | "setter"
   | "function-property";
+
+function isPartOfOptionalChainCallee(
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+): boolean {
+  let current: ts.Expression = node;
+  let parent = current.parent;
+
+  while (
+    parent &&
+    (
+      ts.isPropertyAccessExpression(parent) ||
+      ts.isElementAccessExpression(parent)
+    ) &&
+    parent.expression === current
+  ) {
+    current = parent;
+    parent = current.parent;
+  }
+
+  return !!parent &&
+    ts.isCallExpression(parent) &&
+    parent.expression === current &&
+    ts.isCallChain(parent);
+}
 
 // A getter and a `toJSON()` member run when the pattern result is stored;
 // a method, setter, or function-valued property is a function value the data
@@ -198,9 +222,11 @@ export class PatternContextValidationTransformer
         this.validateObjectMemberCreation(node, context, checker);
       }
 
-      // Check for optional chaining in reactive context
-      // Note: isInRestrictedReactiveContext returns false for JSX expressions,
-      // so this won't flag optional chaining inside JSX like <div>{user?.name}</div>
+      // Check for optional navigation in reactive context. Optional property /
+      // element access remains valid at lowerable expression sites (including
+      // JSX). When the chain is a call callee, the call-root policy decides
+      // whether the underlying call kind is lowerable; optionality itself does
+      // not change that decision.
       if (
         (
           ts.isPropertyAccessExpression(node) ||
@@ -209,15 +235,7 @@ export class PatternContextValidationTransformer
         node.questionDotToken
       ) {
         const optionalCallTargetHandledByCallRootPolicy =
-          !!node.questionDotToken &&
-          !!node.parent &&
-          ts.isCallExpression(node.parent) &&
-          node.parent.expression === node &&
-          classifyUnsupportedExpressionSiteCallRoot(
-              node.parent,
-              context,
-              analyze,
-            ) === "optional-call";
+          isPartOfOptionalChainCallee(node);
         if (
           !optionalCallTargetHandledByCallRootPolicy &&
           isInRestrictedReactiveContext(node, checker, context) &&
@@ -247,16 +265,7 @@ export class PatternContextValidationTransformer
           context,
           analyze,
         );
-        if (unsupportedCallRoot === "optional-call") {
-          context.reportDiagnostic({
-            severity: "error",
-            type: "pattern-context:optional-chaining",
-            message:
-              `Optional chaining '?.' is not allowed in reactive context. ` +
-              `Use ifElse() or wrap in computed() for conditional access.`,
-            node,
-          });
-        } else if (
+        if (
           unsupportedCallRoot === "restricted-get-call" &&
           !findLowerableExpressionSite(node, context, analyze)
         ) {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.expected.jsx
@@ -1,0 +1,215 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+function format(value: string): string {
+    return value.toUpperCase();
+}
+__cfHardenFn(format);
+interface State {
+    maybeText?: string;
+    suffix: string;
+    items: Array<string | undefined>;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    state: {
+        maybeText?: string | undefined;
+    };
+}, string | undefined>(({ state }) => state.maybeText?.trim(), {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                maybeText: {
+                    type: "string"
+                }
+            }
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: ["string", "undefined"]
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    state: {
+        maybeText?: string | undefined;
+    };
+}, string>(({ state }) => format?.(state.maybeText ?? ""), {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                maybeText: {
+                    type: "string"
+                }
+            }
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    state: {
+        maybeText?: string | undefined;
+        suffix: string;
+    };
+}, string | undefined>(({ state }) => state.maybeText?.replace?.("x", state.suffix), {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                maybeText: {
+                    type: "string"
+                },
+                suffix: {
+                    type: "string"
+                }
+            },
+            required: ["suffix"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: ["string", "undefined"]
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_4 = __cfHelpers.lift<{
+    item: string | undefined;
+}, string | undefined>(({ item }) => item?.trim?.(), {
+    type: "object",
+    properties: {
+        item: {
+            type: "string"
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: ["string", "undefined"]
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span>{__cfLift_4({ item: item })}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: optional-method-calls
+// Verifies: receiver and invocation optionality lower as whole computations
+//   state.maybeText?.trim()                     → lift preserving receiver ?.
+//   state.maybeText?.replace?.("x", state.suffix) → lift preserving both ?.
+//   item?.trim?.()                              → callback lift preserving both ?.
+//   format?.(state.maybeText ?? "")              → lift preserving lazy args
+// Context: Optionality modifies an otherwise supported call;
+//          the underlying call's provenance and lowering route stay unchanged.
+export default pattern((state) => ({
+    normalized: __cfLift_1({ state: {
+            maybeText: state.key("maybeText")
+        } }).for(["__patternResult", "normalized"], true),
+    selected: __cfLift_2({ state: {
+            maybeText: state.key("maybeText")
+        } }).for(["__patternResult", "selected"], true),
+    [UI]: (<div>
+      <p>{__cfLift_3({ state: {
+            maybeText: state.key("maybeText"),
+            suffix: state.key("suffix")
+        } })}</p>
+      {state.key("items").mapWithPattern(__cfPattern_1, {})}
+    </div>)
+}), {
+    type: "object",
+    properties: {
+        maybeText: {
+            type: "string"
+        },
+        suffix: {
+            type: "string"
+        },
+        items: {
+            type: "array",
+            items: {
+                type: ["string", "undefined"]
+            }
+        }
+    },
+    required: ["suffix", "items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        normalized: {
+            type: ["string", "undefined"]
+        },
+        selected: {
+            type: "string"
+        },
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["normalized", "selected", "$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.input.tsx
@@ -1,0 +1,30 @@
+import { pattern, UI } from "commonfabric";
+
+function format(value: string): string {
+  return value.toUpperCase();
+}
+
+interface State {
+  maybeText?: string;
+  suffix: string;
+  items: Array<string | undefined>;
+}
+
+// FIXTURE: optional-method-calls
+// Verifies: receiver and invocation optionality lower as whole computations
+//   state.maybeText?.trim()                     → lift preserving receiver ?.
+//   state.maybeText?.replace?.("x", state.suffix) → lift preserving both ?.
+//   item?.trim?.()                              → callback lift preserving both ?.
+//   format?.(state.maybeText ?? "")              → lift preserving lazy args
+// Context: Optionality modifies an otherwise supported call;
+//          the underlying call's provenance and lowering route stay unchanged.
+export default pattern<State>((state) => ({
+  normalized: state.maybeText?.trim(),
+  selected: format?.(state.maybeText ?? ""),
+  [UI]: (
+    <div>
+      <p>{state.maybeText?.replace?.("x", state.suffix)}</p>
+      {state.items.map((item) => <span>{item?.trim?.()}</span>)}
+    </div>
+  ),
+}));

--- a/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
@@ -150,10 +150,10 @@ Deno.test(
 );
 
 Deno.test(
-  "optional call form over a tracked argument widens the argument to wildcard",
+  "unknown optional callback use still widens its tracked argument",
   () => {
-    // `cb?.(input)` is a non-lowerable optional call, so the argument is
-    // treated conservatively as a whole-root use.
+    // Optionality does not change the call policy. The unresolved callback
+    // itself requires conservative whole-root treatment of its argument.
     const input = getPaths(
       analyze(`${CELL}
         const fn = (input: { thing: number }, cb?: (x: unknown) => void) => {
@@ -164,6 +164,46 @@ Deno.test(
 
     assertEquals(input.wildcard, true);
     assertEquals(input.passthrough, true);
+  },
+);
+
+Deno.test(
+  "optional invocation does not wildcard a supported receiver-method path",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        const fn = (input: { name?: string }) => {
+          return input.name?.trim?.();
+        };`),
+      "input",
+    );
+
+    assertEquals(input.capability, "readonly");
+    assertEquals(input.wildcard, false);
+    assert(input.readPaths.includes("name"));
+  },
+);
+
+Deno.test(
+  "optional get chains retain the nested cell read path",
+  () => {
+    const input = getPaths(
+      analyze(`${CELL}
+        type ReadCell<T> = Cell<T> & { get(): T };
+        const fn = (
+          input: {
+            state: string;
+            auth?: ReadCell<{ token: string; refreshToken: string }>;
+          },
+        ) => input.state === "ready" &&
+          input.auth?.get?.()?.token === "initial";`),
+      "input",
+    );
+
+    assertEquals(input.capability, "readonly");
+    assertEquals(input.wildcard, false);
+    assert(input.readPaths.includes("state"));
+    assert(input.readPaths.includes("auth"));
   },
 );
 

--- a/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
+++ b/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
@@ -381,6 +381,46 @@ Deno.test(
 );
 
 Deno.test(
+  "Expression site policy: optionality preserves receiver-method call-root ownership",
+  () => {
+    const { sourceFile, checker, context } = createProgramAndContext(`
+      declare function pattern<T>(fn: (state: any) => T): T;
+
+      const view = pattern((state: any) => ({
+        receiverOptional: state.name?.toUpperCase(),
+        invocationOptional: state.name.toUpperCase?.(),
+        bothOptional: state.name?.toUpperCase?.(),
+      }));
+    `);
+
+    const calls = findAllNodes(
+      sourceFile,
+      (node): node is ts.CallExpression =>
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "toUpperCase",
+    );
+    const analyze = createDataFlowAnalyzer(checker);
+
+    assertEquals(calls.length, 3);
+    for (const call of calls) {
+      assertEquals(
+        classifyExpressionSiteHandling(
+          call,
+          "object-property",
+          context,
+          analyze,
+        ),
+        {
+          kind: "shared",
+          lowerable: true,
+        },
+      );
+    }
+  },
+);
+
+Deno.test(
   "Expression site policy: aliased reactive array callbacks keep receiver-method ownership",
   () => {
     const { sourceFile, checker, context } = createProgramAndContext(`

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3510,6 +3510,84 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
+    "errors on optional-receiver .get() for the get-call reason, not optionality",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      export default pattern<{ items: string[] }>(({ items }) => {
+        items?.get();
+        return {};
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:get-call");
+      assertEquals(
+        errors.some((error) =>
+          error.type === "pattern-context:optional-chaining"
+        ),
+        false,
+        "Optionality should not be the reason the .get() is rejected",
+      );
+    },
+  );
+
+  await t.step(
+    "errors on optional-invocation .get?.() for the get-call reason, not optionality",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      export default pattern<{ items: string[] }>(({ items }) => {
+        items.get?.();
+        return {};
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:get-call");
+      assertEquals(
+        errors.some((error) =>
+          error.type === "pattern-context:optional-chaining"
+        ),
+        false,
+        "Optionality should not be the reason the .get() is rejected",
+      );
+    },
+  );
+
+  await t.step(
+    "errors on combined optional .get() chain for the get-call reason, not optionality",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      export default pattern<{ items: string[] }>(({ items }) => {
+        items?.get?.();
+        return {};
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:get-call");
+      assertEquals(
+        errors.some((error) =>
+          error.type === "pattern-context:optional-chaining"
+        ),
+        false,
+        "Optionality should not be the reason the .get() is rejected",
+      );
+    },
+  );
+
+  await t.step(
     "allows direct access on computed result (correct usage)",
     async () => {
       const source = `      import { pattern, computed } from "commonfabric";

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -543,33 +543,178 @@ Deno.test("Pattern Context Validation - Restricted Contexts", async (t) => {
   );
 
   await t.step(
-    "errors on top-level optional call in pattern body",
+    "allows optional receiver calls inside JSX expressions",
     async () => {
-      const source = `      import { pattern } from "commonfabric";
+      const source = `      import { pattern, h } from "commonfabric";
 
-      export default pattern((input) => input?.foo());
+      interface Item { name?: string; }
+
+      export default pattern<{ item: Item }>(({ item }) => {
+        return <div>{item.name?.trim()}</div>;
+      });
     `;
       const { diagnostics } = await validateSource(source, {
         types: COMMONFABRIC_TYPES,
       });
       const errors = getErrors(diagnostics);
-      assertGreater(errors.length, 0, "Expected at least one error");
-      assertHasErrorType(errors, "pattern-context:optional-chaining");
       assertEquals(
-        errors.some((error) => error.message.includes("Optional chaining")),
-        true,
-        "Optional call diagnostics should explain the optional chaining restriction",
+        errors.length,
+        0,
+        "JSX lowering should preserve optional receiver-call semantics",
       );
     },
   );
 
   await t.step(
-    "errors on statement-position optional call in pattern body",
+    "allows optional callable invocation inside JSX expressions",
+    async () => {
+      const source = `      import { pattern, h } from "commonfabric";
+
+      interface Item { name?: string; }
+
+      export default pattern<{ item: Item }>(({ item }) => {
+        return <div>{item.name?.toUpperCase?.()}</div>;
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "JSX lowering should preserve optional callable-invocation semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "allows optional receiver calls inside computed callbacks",
+    async () => {
+      const source = `      import { computed, pattern } from "commonfabric";
+
+      interface Item { name?: string; }
+
+      export default pattern<{ item: Item }>(({ item }) => ({
+        normalized: computed(() => item.name?.trim()),
+      }));
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "computed() lowering should preserve optional receiver-call semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "allows optional callable invocation inside computed callbacks",
+    async () => {
+      const source = `      import { computed, pattern } from "commonfabric";
+
+      interface Item { name?: string; }
+
+      export default pattern<{ item: Item }>(({ item }) => ({
+        normalized: computed(() => item.name?.toUpperCase?.()),
+      }));
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "computed() lowering should preserve optional callable-invocation semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "allows optional calls in ordinary module-scope JavaScript",
+    async () => {
+      const source = `      export function normalize(
+        value?: string,
+        callback?: (value: string) => string,
+      ) {
+        return callback?.(value?.trim() ?? "");
+      }
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "Ordinary JavaScript execution should retain optional-call semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "allows top-level optional receiver call in pattern body",
     async () => {
       const source = `      import { pattern } from "commonfabric";
 
-      export default pattern((input) => {
-        input?.foo();
+      interface Input {
+        name?: string;
+      }
+
+      export default pattern<Input>((input) => input.name?.trim());
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "Pattern lowering should preserve optional receiver-call semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "allows top-level optional callable invocation in pattern body",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      interface Input {
+        name?: string;
+      }
+
+      export default pattern<Input>((input) =>
+        input.name?.toUpperCase?.()
+      );
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "Pattern lowering should preserve optional callable-invocation semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "optional invocation does not make an unsupported call position lowerable",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      interface Input {
+        name?: string;
+      }
+
+      export default pattern<Input>((input) => {
+        input.name?.toUpperCase?.();
         return {};
       });
     `;
@@ -577,8 +722,15 @@ Deno.test("Pattern Context Validation - Restricted Contexts", async (t) => {
         types: COMMONFABRIC_TYPES,
       });
       const errors = getErrors(diagnostics);
-      assertGreater(errors.length, 0, "Expected at least one error");
-      assertHasErrorType(errors, "pattern-context:optional-chaining");
+      assertGreater(errors.length, 0, "Expected the statement-position error");
+      assertHasErrorType(errors, "pattern-context:computation");
+      assertEquals(
+        errors.some((error) =>
+          error.type === "pattern-context:optional-chaining"
+        ),
+        false,
+        "Optionality should not be the reason the call is rejected",
+      );
     },
   );
 
@@ -1506,7 +1658,7 @@ Deno.test("Pattern Context Validation - Receiver Method Calls", async (t) => {
   );
 
   await t.step(
-    "still errors on optional receiver-call root inside pattern-owned array-method callbacks",
+    "allows optional receiver-call roots inside pattern-owned array-method callbacks",
     async () => {
       const source = `      import { pattern } from "commonfabric";
 
@@ -1518,8 +1670,32 @@ Deno.test("Pattern Context Validation - Receiver Method Calls", async (t) => {
         types: COMMONFABRIC_TYPES,
       });
       const errors = getErrors(diagnostics);
-      assertGreater(errors.length, 0, "Expected at least one error");
-      assertHasErrorType(errors, "pattern-context:optional-chaining");
+      assertEquals(
+        errors.length,
+        0,
+        "Collection callback lowering should preserve optional receiver-call semantics",
+      );
+    },
+  );
+
+  await t.step(
+    "allows optional callable invocation inside pattern-owned array-method callbacks",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      export default pattern<{ items: Array<string | undefined> }>(({ items }) => {
+        return items.map((item) => item?.toUpperCase?.());
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "Collection callback lowering should preserve optional callable-invocation semantics",
+      );
     },
   );
 
@@ -1636,6 +1812,32 @@ Deno.test("Pattern Context Validation - Safe Wrappers", async (t) => {
       "Reading opaques inside action() should be allowed",
     );
   });
+
+  await t.step(
+    "allows optional calls inside execution callbacks",
+    async () => {
+      const source =
+        `      import { action, handler, lift } from "commonfabric";
+
+      export const normalize = lift((value: string | undefined) => value?.trim());
+      export const logAction = action((event: { value?: string }) => {
+        console.log(event.value?.trim());
+      });
+      export const logHandler = handler((event: { value?: string }, _state: {}) => {
+        console.log(event.value?.trim());
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "action(), lift(), and handler() should retain JavaScript optional-call semantics",
+      );
+    },
+  );
 
   await t.step("allows reading opaques inside computed()", async () => {
     const source =


### PR DESCRIPTION
## What

- Treat optionality as orthogonal to call legality: optional receiver, optional invocation, and combined optional chains now follow the same call-root and expression-site policy as their nonoptional counterparts.
- Lower every supported form as one complete call expression so receiver binding, single evaluation, authored short-circuit points, and skipped argument evaluation are preserved.
- Remove the standalone `optional-call` rejection category and its blanket capability wildcarding; unsupported calls remain unsupported for the underlying call-root or expression-site reason.
- Retain concrete readonly receiver capabilities for optional Cell reader chains such as `value.auth?.get?.()`, so nested Cells remain present in synthesized closure schemas without widening the enclosing root to wildcard.
- Align the target-language spec, lowering contract, goals, current-behavior spec, and design-delta record with that model.
- Add policy, capability, validation-matrix, and golden-fixture coverage across JSX, computed/module expressions, pattern returns, collection callbacks, and execution callbacks.
- Keep the authored pattern corpus unchanged. The previous 70-site source migration and its coverage-debt override are no longer needed.

## Semantic model

| Authored form | Rule |
| --- | --- |
| `value?.method(args)` | Uses the same eligibility as `value.method(args)` and preserves receiver short-circuiting. |
| `value.method?.(args)` | Uses the same eligibility as `value.method(args)` and preserves callable short-circuiting. |
| `value?.method?.(args)` | Uses the same eligibility and preserves both authored short-circuit points. |
| `fn?.(args)` | Uses the same site/root policy as `fn(args)`; optional syntax does not make an otherwise unsupported callable root legal. |
| Optional call with an unsupported underlying root/site | Remains unsupported for that underlying reason, not because it is optional. |

Function-valued reactive data remains outside the storable/schema-representable pattern-language model. This change preserves optional-call syntax where the corresponding call is already legal; it does not introduce function serialization or use optionality to bypass that boundary.

## Why

This resolves the optional-call follow-up identified during the #4694 transformer/spec review and consolidated in the [follow-up decisions topic](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:O4Cm5vLYtmX-xpNJae9s5z35O6aOYyKp_7-Hv-9jxMs).

The previous revision treated optional calls as a distinct unsupported construct and rewrote 70 authored sites. That conflated two independent questions:

1. whether a call root is legal at a lowering boundary; and
2. whether JavaScript should short-circuit before receiver/member invocation.

Making optionality orthogonal gives the pattern language the more compositional abstraction: supported calls retain JavaScript's optional-chain semantics, while unsupported calls remain governed by the existing root/site and storage constraints.

## Implementation notes

- Call-root classification no longer diverts `CallChain` nodes into an `optional-call` bucket.
- Pattern-body and expression-site lowering own the complete optional call when the underlying call root is supported.
- Pattern-context validation defers optional-chain callees to call-root policy while continuing to diagnose non-lowerable optional navigation.
- Capability analysis no longer widens every optional callee to wildcard solely because it is optional.
- Optional Cell `.get()` chains explicitly retain the readonly receiver path; this preserves the Cell wrapper in the closure schema while remaining non-wildcard.
- The golden output demonstrates that optional receiver/invocation chains stay intact inside a single lowered callback, including argument short-circuit behavior.

## Verification

Post-rebase verification on the exact pushed head:

- `deno task test` in `packages/ts-transformers` — 1,108 passed (748 fixture steps), 0 failed
- `deno task integration pattern-tests 1/5` — all 21 tests in the formerly failing CI shard pass, including `auth/ready-auth.test.tsx` (8/8)
- `deno task cfcheck` — all 423 current pattern files pass with their original authored optional calls
- `deno task check` — all 400 workspace paths type-check
- focused policy/capability/validation regressions and emitted-output inspection — pass
- `deno fmt --check` for all 209 transformer-package files and `git diff --check` — clean

## Coverage

No performance or coverage-debt override is requested. The branch no longer changes `packages/patterns`; removing the blanket source migration eliminates the previously reported six-line uncovered-code increase.

## Provenance

Focused follow-up to #4694. Rebased directly onto `main` at `0f9150b4b` on 2026-07-23; pushed branch head is `d4db1584c`. The base includes the merged Toolshed readiness fix from #4935. The final diff is limited to transformer policy/implementation, normative and descriptive specs, and regression fixtures/tests.

## Amendment (2026-07-23 review follow-through)

Pushed as `8f9b1da65` on the same branch:

- The validation matrix now pins rejection-side parity for restricted reads: `items?.get()`, `items.get?.()`, and `items?.get?.()` report the same `pattern-context:get-call` as the non-optional form — never `pattern-context:optional-chaining`.
- The current-behavior spec (§19.6) documents the residual this PR's resolution had left undocumented: invoking a function value that flows through reactive data compiles without diagnostics (function-typed captures are dropped from lift input schemas) and is dead code at runtime. The design-deltas addendum carries this forward as an explicit open sub-finding; call-site enforcement is filed as [CT-1905](https://linear.app/common-tools/issue/CT-1905/diagnose-invocation-of-function-values-from-reactive-data-call-site), and the declaration-site alternative stays open as a schema-generator design question.
- The lowering contract (§3.4) states the two deliberate boundaries of whole-call preservation: dependency subscription stays eager while short-circuiting governs value evaluation, and authored `?.` on total cell-space navigation is absorbed by `key(...)` lowering while value-space chains keep it verbatim.
- The target-language §4 example shows the plain and optional call forms side by side.

Amendment verification: `deno fmt --check` and `deno lint` clean, `deno task check` (400 workspace paths), `deno task check-docs` (518 blocks), full `packages/ts-transformers` suite — 1,108 passed (751 steps), 0 failed.
