### PR TITLE
fix(perf): keep GitHub error logs body-free

### DIFF
--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -616,7 +616,7 @@ Deno.test("fetchPRForCommitWithError captures lookup errors", async () => {
   );
 
   assertEquals(result.pr, null);
-  assertStringIncludes(String(result.error), "GitHub API 404");
+  assertStringIncludes(String(result.error), "GitHub API GET 404");
 });
 
 Deno.test("newestArtifactNamed filters expired artifacts and keeps newest id", () => {

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertExists,
   assertFalse,
+  assertRejects,
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
@@ -31,6 +32,8 @@ import {
   formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
+  githubPatch,
+  githubPost,
   type Job,
   latestNonColdSample,
   newestArtifactsByName,
@@ -1391,7 +1394,7 @@ Deno.test("fetchCurrentPRBody falls back to the event body if the live request f
     assertEquals(result.body, "EVENT BODY");
     assertEquals(result.source, "event-fallback");
     assertEquals(
-      result.errorMessage?.includes("GitHub API 429:"),
+      result.errorMessage?.includes("GitHub API GET 429:"),
       true,
     );
   } finally {
@@ -1451,6 +1454,100 @@ Deno.test("githubGet does not retry non-transient GitHub responses", async () =>
 
     assertEquals(rejected, true);
     assertEquals(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("GitHub REST errors include status text and omit response bodies", async (t) => {
+  const responseBody =
+    "upstream request: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB";
+  const cases: {
+    name: string;
+    status: number;
+    statusText: string;
+    expectedMessage: string;
+    request: () => Promise<unknown>;
+  }[] = [
+    {
+      name: "GET 503",
+      status: 503,
+      statusText: "Service Unavailable",
+      expectedMessage:
+        "GitHub API GET 503 Service Unavailable: /repos/commontoolsinc/labs/actions/runs/123/jobs",
+      request: () =>
+        githubGet("/repos/commontoolsinc/labs/actions/runs/123/jobs"),
+    },
+    {
+      name: "POST 422",
+      status: 422,
+      statusText: "Unprocessable Content",
+      expectedMessage:
+        "GitHub API POST 422 Unprocessable Content: /repos/commontoolsinc/labs/issues/123/comments",
+      request: () =>
+        githubPost("/repos/commontoolsinc/labs/issues/123/comments", {
+          body: "comment",
+        }),
+    },
+    {
+      name: "PATCH 500",
+      status: 500,
+      statusText: "Internal Server Error",
+      expectedMessage:
+        "GitHub API PATCH 500 Internal Server Error: /repos/commontoolsinc/labs/issues/comments/456",
+      request: () =>
+        githubPatch("/repos/commontoolsinc/labs/issues/comments/456", {
+          body: "updated comment",
+        }),
+    },
+  ];
+
+  for (const testCase of cases) {
+    await t.step(testCase.name, async () => {
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = ((_input, _init) =>
+          Promise.resolve(
+            new Response(responseBody, {
+              status: testCase.status,
+              statusText: testCase.statusText,
+              headers: { "retry-after": "0" },
+            }),
+          )) as typeof fetch;
+
+        const error = await assertRejects(testCase.request, Error);
+        assertEquals(error.message, testCase.expectedMessage);
+        assertFalse(error.message.includes(responseBody));
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+});
+
+Deno.test("GitHub REST errors survive response cancellation failures", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = ((_input, _init) =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            cancel() {
+              throw new Error("response cancellation failed");
+            },
+          }),
+          { status: 404, statusText: "Not Found" },
+        ),
+      )) as typeof fetch;
+
+    const error = await assertRejects(
+      () => githubGet("/repos/commontoolsinc/labs/missing"),
+      Error,
+    );
+    assertEquals(
+      error.message,
+      "GitHub API GET 404 Not Found: /repos/commontoolsinc/labs/missing",
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1567,6 +1664,13 @@ Deno.test("downloadAndExtractArtifact retries transient artifact downloads", asy
         warning.includes("attempt 4: GitHub artifact download 410")
       ),
       true,
+    );
+    assertEquals(
+      warnings.some((warning) =>
+        warning.includes("temporary artifact backend error") ||
+        warning.includes("gone")
+      ),
+      false,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -330,12 +330,22 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function responseBodySnippet(resp: Response): Promise<string> {
+function githubApiError(
+  resp: Response,
+  path: string,
+  method: "GET" | "POST" | "PATCH",
+): Error {
+  const statusText = resp.statusText ? ` ${resp.statusText}` : "";
+  return new Error(
+    `GitHub API ${method} ${resp.status}${statusText}: ${path}`,
+  );
+}
+
+async function cancelResponseBody(resp: Response): Promise<void> {
   try {
-    const body = await resp.text();
-    return body.length > 1_000 ? `${body.slice(0, 1_000)}...` : body;
-  } catch (error) {
-    return `Could not read response body: ${error}`;
+    await resp.body?.cancel();
+  } catch {
+    // The GitHub status error remains the reported failure.
   }
 }
 
@@ -366,11 +376,11 @@ export async function githubGet<T>(path: string): Promise<T> {
       !RETRYABLE_GITHUB_STATUSES.has(resp.status) ||
       attempt === GITHUB_GET_MAX_ATTEMPTS
     ) {
-      const body = await resp.text();
-      throw new Error(`GitHub API ${resp.status}: ${path}\n${body}`);
+      await cancelResponseBody(resp);
+      throw githubApiError(resp, path, "GET");
     }
 
-    await resp.body?.cancel();
+    await cancelResponseBody(resp);
     await sleep(githubRetryDelayMs(resp, attempt));
   }
 
@@ -387,8 +397,8 @@ export async function githubPost<T>(
     body: JSON.stringify(body),
   });
   if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`GitHub API POST ${resp.status}: ${path}\n${text}`);
+    await cancelResponseBody(resp);
+    throw githubApiError(resp, path, "POST");
   }
   return resp.json();
 }
@@ -403,8 +413,8 @@ export async function githubPatch<T>(
     body: JSON.stringify(body),
   });
   if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`GitHub API PATCH ${resp.status}: ${path}\n${text}`);
+    await cancelResponseBody(resp);
+    throw githubApiError(resp, path, "PATCH");
   }
   return resp.json();
 }
@@ -708,10 +718,11 @@ export async function downloadAndExtractArtifact(
     }
 
     if (!resp.ok) {
-      const body = await responseBodySnippet(resp);
+      const statusText = resp.statusText ? ` ${resp.statusText}` : "";
       lastError =
-        `GitHub artifact download ${resp.status} ${resp.statusText}: ${body}`;
+        `GitHub artifact download ${resp.status}${statusText}: ${artifactPath}`;
       attemptErrors.push(`attempt ${attempt}: ${lastError}`);
+      await cancelResponseBody(resp);
       if (
         attempt < GITHUB_GET_MAX_ATTEMPTS &&
         RETRYABLE_ARTIFACT_DOWNLOAD_STATUSES.has(resp.status)


### PR DESCRIPTION
GitHub REST failure responses can echo request payloads. The performance gate appended those response bodies to errors, which could flood CI logs with encoded assets and other request data.

Build GitHub API errors from the method, status code, optional status text, and endpoint only. Cancel failed response streams without allowing cancellation errors to hide the HTTP failure, and apply the same body-free behavior to artifact downloads.

Cover GET, POST, PATCH, artifact download, response-cancellation failure, and status-text formatting paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop including GitHub response bodies in error messages to keep CI logs small and avoid leaking payloads. Errors now show only the HTTP method, status (and text), and endpoint; the same applies to artifact downloads.

- **Bug Fixes**
  - `githubGet`, `githubPost`, `githubPatch`: throw errors like "GitHub API GET 503 Service Unavailable: /path" with no response body, and cancel failed response streams.
  - Preserve the HTTP error even if response cancellation throws.
  - `downloadAndExtractArtifact`: remove body snippets from errors and include only status (and text) plus the artifact path; retry logic unchanged.

<sup>Written for commit 4348e6fefbc41e6c47d7c35e5143fc5484cbf354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
NEW_PERF_BASELINE: job: Runner Tests (1/5) = 269s

