### PR TITLE
test: make the suite ready for a Deno 2.9 roll

### DIFF
--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -22,6 +22,10 @@ export function isIgnorableDenoWarningLine(line: string): boolean {
     trimmed.startsWith("╭ Warning") ||
     trimmed.startsWith("╰─") ||
     trimmed.startsWith("│") ||
+    // Deno prints one of these per module it fetches whenever the module cache
+    // is cold, which happens on a fresh machine and after any change that
+    // invalidates the cache, such as a Deno version bump.
+    trimmed.startsWith("Download ") ||
     /^[└├]/u.test(trimmed);
 }
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -139,7 +139,7 @@ describe("FabricError", () => {
           string,
           FabricValue
         >;
-        expect("__proto__" in state).toBe(false);
+        expect(Object.hasOwn(state, "__proto__")).toBe(false);
       });
 
       it("does not let custom props override built-in fields", () => {

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -365,5 +365,27 @@ describe("types", () => {
       expect(isUnsafeObjectKey("toString")).toBe(false);
       expect(isUnsafeObjectKey("hasOwnProperty")).toBe(false);
     });
+
+    it("is backstopped by the runtime keeping `__proto__` inert", () => {
+      // Deno neutralises `__proto__`: assigning it lands a plain own property
+      // and leaves the prototype alone. That is the layer beneath
+      // isUnsafeObjectKey(), which filters the key at trust boundaries.
+      const target: Record<string, unknown> = {};
+      const untrustedKey = "__proto__";
+      try {
+        target[untrustedKey] = { polluted: true };
+        expect(Object.hasOwn(target, untrustedKey)).toBe(true);
+        expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+      } catch (e) {
+        console.error(
+          "This runtime lets a `__proto__` assignment reach the prototype " +
+            "chain. Whoever rolled the Deno version that changed this must " +
+            "investigate the security implications: every place that copies " +
+            "untrusted keys onto an object without filtering them through " +
+            "isUnsafeObjectKey() is now open to prototype pollution.",
+        );
+        throw e;
+      }
+    });
   });
 });


### PR DESCRIPTION
Rolling the pinned Deno toolchain from 2.8 to 2.9 turns three tests red. None of them indicates a fault in the code being tested; each is a test that measured something other than what it meant to measure. This fixes all three, on the current 2.8 pin, so that the eventual version roll is left with nothing but the version bump itself.

FabricError's "does not copy __proto__ or constructor keys" test asked whether `"__proto__" in state` was false. The `in` operator searches the prototype chain, so that question is only equivalent to "was the key copied onto state" while nothing in the chain offers a `__proto__` property. Deno 2.8 removes the accessor from Object.prototype outright, which is why the test passed. Deno 2.9 keeps the accessor but neuters it, so the search now finds it and the test fails even though encode() still filters the key correctly. Ask about the own property instead, which is what the test is really about and which holds on both versions.

The cli tests assert that the command wrote exactly one line to standard error. Deno also writes one "Download" line per module it fetches, so those tests only pass while the module cache is warm. Continuous integration keys its Deno cache on the version, so bumping the version empties the cache and the downloads appear. The version bump only exposed this; the same failure follows any cold cache. Ignore Download lines alongside the peer-dependency warnings the helper already ignores. Lines the command itself writes, including the "deno run" line the tests match on, are untouched.

Finally, add a test next to isUnsafeObjectKey() recording the runtime behavior that sits underneath it: assigning `__proto__` must land a plain own property and leave the prototype alone. Both 2.8 and 2.9 behave this way, so the guard's callers are equally safe on either. If a future Deno restores a live `__proto__`, that assumption breaks everywhere untrusted keys are copied without the guard, so the test fails with a message telling whoever rolled the version to weigh the security consequences. Verified against `deno test --unsafe-proto`, which restores the live accessor: the test fails and prints the message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Get the test suite ready for Deno 2.9 by fixing three tests that failed due to runtime changes, not product bugs. No runtime code changes; this makes the future version bump a clean diff.

- **Bug Fixes**
  - FabricError test: use `Object.hasOwn(state, "__proto__")` instead of `"__proto__" in state` to avoid prototype-chain lookup across Deno 2.8/2.9.
  - CLI stderr checks: ignore Deno “Download ” lines when the module cache is cold; our command’s stderr output checks remain unchanged.
  - Add a backstop test next to `isUnsafeObjectKey()`: assigning `__proto__` creates an own property and leaves the prototype intact; fails with guidance if a future runtime reactivates `__proto__`.

<sup>Written for commit e753da97baab55359049f96711884e35b8fccc61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

