### PR TITLE
fix(patterns): require a control to be rendered before tagging it for…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -55,6 +55,27 @@ target to be rendered — laid out, and not `display:none` or `visibility:hidden
 clickable rather than tagged while it has no layout box and then failing to
 click.
 
+Ask `probe.isRendered` for that check rather than hand-rolling it, and note that
+it is deliberately not `probe.isVisible`, which additionally requires the
+element to be on-screen. A click scrolls its element into view before it
+dispatches, so where the element sits at tagging time does not decide whether
+the click lands. Requiring it on-screen only adds ways to wait forever: the
+shell sets `html { scroll-behavior: smooth }`, so a `scrollIntoView()` a
+predicate issues animates over several hundred milliseconds, and a viewport
+check within the same predicate reads a position the scroll has not reached yet.
+
+Check the element the click is dispatched on, not the host that matched the
+selector. Hiding the host or any ancestor reaches the inner control either way:
+`display:none` zeroes the control's layout box, and `visibility:hidden` inherits
+into its computed visibility. So the click target's own check covers the whole
+chain, and checking the host as well buys nothing.
+
+Being rendered is a question about whether a click can be delivered, which is
+why it belongs in the predicate that tags the control. Whether the control is
+`disabled` is a separate question — a disabled control still takes the click and
+declines it. A test that needs a control enabled before clicking says so with
+`waitForDisabled(page, selector, false)`.
+
 **Non-browser and off-page waits** have no page to observe. Resolve a `defer()`
 (from `packages/utils/src/defer.ts`) inside a callback the test already registers
 — a cell `sink`/`subscribe`, a storage subscription's `next`, a scheduler

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -81,7 +81,15 @@ export const awaitViewSettled = async (page: Page): Promise<boolean> => {
 export interface ProbeApi {
   /** Every element matching `selector`, descending through shadow roots. */
   collect(selector: string): Element[];
-  /** Whether `element` is on-screen and not display/visibility hidden. */
+  /**
+   * Whether `element` is rendered: it has a non-empty layout box and is not
+   * `display:none` or `visibility:hidden`. Viewport-independent, so an element
+   * below the fold is rendered. This is the "is this control laid out yet"
+   * question a predicate asks before tagging a control it is about to click —
+   * a click scrolls the element into view itself.
+   */
+  isRendered(element: Element): boolean;
+  /** Whether `element` is rendered and also on-screen. */
   isVisible(element: Element): boolean;
   /** Visible text of `root` plus its shadow and slotted descendants. */
   deepText(root: ParentNode): string;
@@ -118,13 +126,18 @@ function installWaiter(
   predicateSource: string,
   predicateArgs: unknown[],
 ): void {
-  type Probe = {
-    collect: (selector: string) => Element[];
-    isVisible: (element: Element) => boolean;
-    deepText: (root: ParentNode) => string;
+  const isRendered = (element: Element): boolean => {
+    const style = globalThis.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
   };
 
-  const probe: Probe = {
+  // Typed as the ProbeApi the predicates are handed, so a method added to that
+  // interface has to be implemented here too. The annotation is erased before
+  // this function is serialized into the page, so it adds no runtime reference
+  // to module scope.
+  const probe: ProbeApi = {
     collect(selector) {
       const out: Element[] = [];
       const walk = (root: Document | ShadowRoot) => {
@@ -140,14 +153,13 @@ function installWaiter(
       walk(document);
       return out;
     },
+    isRendered,
     isVisible(element) {
+      if (!isRendered(element)) return false;
       const rect = element.getBoundingClientRect();
-      const style = globalThis.getComputedStyle(element);
-      return rect.width > 0 && rect.height > 0 &&
-        rect.bottom >= 0 && rect.right >= 0 &&
+      return rect.bottom >= 0 && rect.right >= 0 &&
         rect.top <= globalThis.innerHeight &&
-        rect.left <= globalThis.innerWidth &&
-        style.visibility !== "hidden" && style.display !== "none";
+        rect.left <= globalThis.innerWidth;
     },
     deepText(root) {
       const parts: string[] = [];
@@ -184,7 +196,7 @@ function installWaiter(
   };
 
   const predicate = new Function("return (" + predicateSource + ")")() as (
-    probe: Probe,
+    probe: ProbeApi,
     ...args: unknown[]
   ) => unknown;
 

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -209,7 +209,14 @@ const fillAndVerify = async (
 };
 
 // Scroll the cf-button behind `selector` into view and tag its inner click
-// target so the test can resolve and click exactly that element.
+// target so the test can resolve and click exactly that element. A click target
+// that is still detached, or not rendered — laid out, and not display:none or
+// visibility:hidden — is left untagged, so a re-check on the next DOM mutation
+// retries the mark once the control renders. The check is viewport-independent:
+// the click scrolls the element into view itself, so a control below the fold
+// is markable. It reads the click target alone because hiding the host or any
+// ancestor reaches the inner button either way: display:none zeroes its box,
+// and visibility:hidden inherits into its computed visibility.
 const markForClick = async (
   probe: ProbeApi,
   selector: string,
@@ -225,6 +232,7 @@ const markForClick = async (
   const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
     | HTMLElement
     | null) ?? target;
+  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
   clickTarget.setAttribute(attr, token);
   return true;
 };
@@ -606,15 +614,24 @@ export async function clickCfButton(
 ) {
   const token = `cf-button-${crypto.randomUUID()}`;
   try {
-    // Wait until the button exists, then mark its inner click target exactly
-    // once; the mark is the predicate, so the re-check on each DOM mutation
-    // retries finding the button without re-clicking anything.
+    // Wait until the button is rendered, then mark its inner click target
+    // exactly once; the mark is the predicate, so the re-check on each DOM
+    // mutation retries finding the button without re-clicking anything.
     await waitForCondition(page, markForClick, {
       timeout,
       args: [selector, token, CLICK_TARGET_ATTR],
     });
   } catch (cause) {
-    throw new Error(`Unable to mark ${selector} for click`, { cause });
+    // The probe's per-match `rect` and `visible` report whether the control was
+    // absent or present without a layout box.
+    const probe = await readTextProbe(page, selector).catch(() => undefined);
+    // Indented for readable test-log output
+    throw new Error(
+      `Unable to mark ${selector} for click. Last probe: ${
+        toIndentedDebugString(probe)
+      }`,
+      { cause },
+    );
   }
   try {
     const clickTarget = await page.waitForSelector(

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -3211,14 +3211,8 @@ const markNoteButton = async (
   token: string,
   attr: string,
 ): Promise<boolean> => {
-  const isRendered = (element: Element): boolean => {
-    const style = globalThis.getComputedStyle(element);
-    if (style.display === "none" || style.visibility === "hidden") return false;
-    const rect = element.getBoundingClientRect();
-    return rect.width > 0 && rect.height > 0;
-  };
   const target = probe.collect(selector).find((element) => {
-    if (!isRendered(element)) return false;
+    if (!probe.isRendered(element)) return false;
     if (match === "title") return element.getAttribute("title") === needle;
     const text = (element.textContent ?? "").trim();
     return match === "exact" ? text === needle : text.includes(needle);
@@ -3231,7 +3225,7 @@ const markNoteButton = async (
   const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
     | HTMLElement
     | null) ?? target;
-  if (!clickTarget.isConnected || !isRendered(clickTarget)) return false;
+  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
   clickTarget.setAttribute(attr, token);
   return true;
 };

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -438,14 +438,8 @@ const markNoteButton = async (
   token: string,
   attr: string,
 ): Promise<boolean> => {
-  const isRendered = (element: Element): boolean => {
-    const style = globalThis.getComputedStyle(element);
-    if (style.display === "none" || style.visibility === "hidden") return false;
-    const rect = element.getBoundingClientRect();
-    return rect.width > 0 && rect.height > 0;
-  };
   const target = probe.collect(selector).find((element) => {
-    if (!isRendered(element)) return false;
+    if (!probe.isRendered(element)) return false;
     if (match === "title") return element.getAttribute("title") === needle;
     const text = (element.textContent ?? "").trim();
     return match === "exact" ? text === needle : text.includes(needle);
@@ -458,7 +452,7 @@ const markNoteButton = async (
   const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
     | HTMLElement
     | null) ?? target;
-  if (!clickTarget.isConnected || !isRendered(clickTarget)) return false;
+  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
   clickTarget.setAttribute(attr, token);
   return true;
 };

--- a/packages/shell/integration/shadow-dom.ts
+++ b/packages/shell/integration/shadow-dom.ts
@@ -12,31 +12,20 @@ export async function clickPierce(
   page: Page,
   selector: string,
 ): Promise<void> {
-  // Wait until a visible, enabled click target for `selector` exists, then
-  // click it once. The last visible match across shadow roots wins; if that
+  // Wait until a rendered, enabled click target for `selector` exists, then
+  // click it once. The last rendered match across shadow roots wins; if that
   // host wraps a shadow <button> the button is the target and must be enabled.
   // The waiter re-evaluates on DOM mutations and resolves the moment a target
   // is ready, rather than re-running the scan from the test process on a fixed
   // interval.
-  await waitForCondition(page, (_probe, targetSelector) => {
-    function isVisible(el: HTMLElement): boolean {
-      const rect = el.getBoundingClientRect();
-      const style = globalThis.getComputedStyle(el);
-      return (
-        rect.width > 0 &&
-        rect.height > 0 &&
-        style.display !== "none" &&
-        style.visibility !== "hidden"
-      );
-    }
-
+  await waitForCondition(page, (probe, targetSelector) => {
     function findClickableHost(
       root: Document | ShadowRoot,
     ): HTMLElement | null {
       const matches: HTMLElement[] = [];
 
       for (const match of root.querySelectorAll(targetSelector)) {
-        if (match instanceof HTMLElement && isVisible(match)) {
+        if (match instanceof HTMLElement && probe.isRendered(match)) {
           matches.push(match);
         }
       }
@@ -60,14 +49,14 @@ export async function clickPierce(
 
     const button = host.shadowRoot?.querySelector("button");
     if (button instanceof HTMLButtonElement) {
-      if (button.disabled || !isVisible(button)) {
+      if (button.disabled || !probe.isRendered(button)) {
         return false;
       }
       button.click();
       return true;
     }
 
-    if (!isVisible(host)) {
+    if (!probe.isRendered(host)) {
       return false;
     }
 


### PR DESCRIPTION
… click

`markForClick`, the in-page predicate behind `clickCfButton` and `clickCfButtonAndWaitForText`, tagged its click target unconditionally. It took the first element matching the selector, scrolled it into view, waited two animation frames, resolved the click target, and tagged it whether or not the control was laid out. The predicate then reported success and the test dispatched its one click, which either failed outright or landed on whatever those coordinates happened to point at. Both outcomes surface as a confusing click failure rather than as the wait continuing until the control renders, which is the honest one.

Requiring the control to be rendered is the rule `waiting-in-tests.md` already states, and the one the neighbouring predicates already follow: `markTrustedAction` gates on the control being visible, and the `markNoteButton` predicates in the default-app tests gate on it being rendered. `clickCfButton` — the helper that document names as the shape to copy — was the only one that did not.

The check reads the resolved click target rather than the element that matched the selector. `display:none` or `visibility:hidden` on the host or any ancestor already zeroes the inner control's layout box and inherits into its computed visibility, so a single check on the click target covers the whole chain, and that is the element the click is dispatched on.

The check is viewport-independent, so it asks `probe.isRendered` rather than `probe.isVisible`. A click scrolls its own element into view before dispatching, so where the element sits at tagging time does not decide whether the click lands, and requiring it on-screen only adds ways to wait forever. The shell sets `html { scroll-behavior: smooth }`, which makes the predicate's own `scrollIntoView()` animate over several hundred milliseconds; a viewport check in the same predicate would read a position the scroll has not reached yet and fall back on the waiter's coarse backstop to recover.

`probe.isRendered` is new. The probe already offered `isVisible`, which asks the same question plus on-screen, and two test files hand-rolled the viewport-independent variant because no shared one existed. Adding it gives those predicates one definition to share, and `isVisible` is now expressed in terms of it so the two cannot drift apart.

The in-page probe object was typed by a structural copy of `ProbeApi` declared alongside it, which nothing tied to the interface. That duplication only became load-bearing with a second method to keep in step: adding one to `ProbeApi` and forgetting the object would still typecheck, then fail in the page with an opaque `waitForCondition` timeout, because a predicate's error is swallowed. The object is now annotated with `ProbeApi` so the compiler enforces the contract. The annotation is erased before the installer is serialized into the page, so it adds no runtime reference to module scope.

There is deliberately no `disabled` check here. Being rendered decides whether a click can be delivered at all, which is why it belongs in the predicate that tags the control. Being disabled decides whether the delivered click does anything — a user can click a disabled control, and the handler declines it. A test that needs a control enabled before clicking says so with `waitForDisabled`, and every current caller of a control with a disabled state already does.

A control that never renders now times out in the wait rather than at the click, so `clickCfButton` reports the element probe on that failure, naming whether the control was absent or present without a layout box.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make click helpers wait for controls to be rendered before tagging and clicking, preventing premature clicks and clearer wait failures. Adds `probe.isRendered` and updates docs.

- **Bug Fixes**
  - `markForClick` now requires the resolved click target to be connected and `probe.isRendered` before tagging; retries until it renders.
  - The check runs on the inner click target (covers ancestor `display:none`/`visibility:hidden`) and does not require it on-screen.
  - On timeout, `clickCfButton` includes the last probe snapshot in the error message.

- **New Features**
  - Added `probe.isRendered`; `isVisible` now builds on it for consistency.
  - Annotated the in-page probe with `ProbeApi` to enforce the API at compile time, with no runtime cost.
  - Expanded `waiting-in-tests.md` with guidance on rendered vs visible and `disabled` handling.

<sup>Written for commit d67fba6275be31cba16e32858ba53a7f7c233f99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

