### PR TITLE
fix(cli): wait for background FUSE mount readiness on events, not a poll

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -422,9 +422,15 @@ mount that was about to work. In a test or CI lane the ambient limit is the
 backstop, in place of a per-command ceiling that fails healthy mounts.
 
 Each status write lands by rename, so a read woken by a write sees a complete
-document rather than a half-written one. Unreadable or foreign content reads as
-"not yet reported" rather than as a verdict; the daemon rewrites the file on
-every state change and on its heartbeat.
+document rather than a half-written one. The writes are also serialized, so the
+file settles on the state of the most recent call. The calls come from four
+places that do not coordinate — the startup path, the readiness report, the
+heartbeat and the signal handler — and two renames issued concurrently can
+complete in either order, so without that a heartbeat still in flight could
+replace a terminal state and leave the file reporting a mount that had already
+gone. Unreadable or foreign content reads as "not yet reported" rather than as
+a verdict; the daemon rewrites the file on every state change and on its
+heartbeat.
 
 One bound remains on this path, in a different process. `recordFuseChildPid`
 in `packages/cli/lib/fuse-supervisor.ts` is how the supervisor writes the child

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -395,16 +395,44 @@ Two waits in this script are not polls, and should not become polls.
 
 Mount readiness needs no timing loop. `cf fuse mount --background` calls
 `awaitBackgroundMountStartup`, which waits for the daemon to report the
-`mounted` supervisor state and confirms both the supervisor and the child are
-alive before the command prints the PID. Every other exit from that function
-throws, and a throw kills the child and fails the command, so a script that has
-parsed a PID has a daemon that reported mounted.
+`mounted` supervisor state and confirms the child is alive before the command
+prints the PID. Every other exit from that function throws, and a throw kills
+the child and fails the command, so a script that has parsed a PID has a daemon
+that reported mounted.
 
-The daemon reports that state just before it enters its FUSE session loop, so it
-means the kernel mount exists rather than that any request has been served, and
-mounted paths hydrate lazily besides. Both gaps belong to `wait_for_path`, whose
-probe carries its own kill-timeout and retries for twenty seconds. What is left
-for the script is one check that the daemon survived the handshake.
+That wait is a race between two real events, with no poll and no deadline under
+it. The supervisor is spawned through `Deno.Command`, so its `status` promise
+reports the exit that means the startup failed. The daemon publishes its state
+to a file beside the mount state file, so a `Deno.watchFs` watch over the
+directory holding both reports every write to either. The directory is the unit
+watched rather than the status file, because neither file need exist when the
+wait starts, and because the wait also depends on the supervisor recording the
+child PID into the mount state file — until it does, no status can be tied to
+this mount. The wait reads once after installing the watch, so a daemon that
+reports before the watch began is still seen, and reads again on every event
+after that.
+
+There is deliberately no deadline on readiness. A deadline can only convert a
+slow startup — a cold cache, a large space, a loaded machine — into a reported
+failure, and startup carries no liveness signal finer than the process itself:
+the daemon's heartbeat only begins once it is already mounted, so nothing
+distinguishes a slow child from a stuck one. A child that never reports leaves
+the command waiting, which is interruptible and visible, rather than killing a
+mount that was about to work. In a test or CI lane the ambient limit is the
+backstop, in place of a per-command ceiling that fails healthy mounts.
+
+Each status write lands by rename, so a read woken by a write sees a complete
+document rather than a half-written one. Unreadable or foreign content reads as
+"not yet reported" rather than as a verdict; the daemon rewrites the file on
+every state change and on its heartbeat.
+
+The daemon reports `mounted` once it has dispatched its FUSE session loop and
+installed the signal handlers that unmount cleanly, so the state means the
+kernel mount exists and a SIGTERM will be handled, rather than that any request
+has been served. Requests that arrive first queue rather than fail. That gap,
+and lazy hydration of mounted paths, belong to `wait_for_path`, whose probe
+carries its own kill-timeout and retries for twenty seconds. What is left for
+the script is one check that the daemon survived the handshake.
 
 The stale-descriptor assertion — that truncating a path does not let an already
 open descriptor write its old buffer back — waits on `wait_for_piece_value`

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -412,7 +412,7 @@ this mount. The wait reads once after installing the watch, so a daemon that
 reports before the watch began is still seen, and reads again on every event
 after that.
 
-There is deliberately no deadline on readiness. A deadline can only convert a
+The wait itself sets no deadline, deliberately. A deadline can only convert a
 slow startup — a cold cache, a large space, a loaded machine — into a reported
 failure, and startup carries no liveness signal finer than the process itself:
 the daemon's heartbeat only begins once it is already mounted, so nothing
@@ -425,6 +425,21 @@ Each status write lands by rename, so a read woken by a write sees a complete
 document rather than a half-written one. Unreadable or foreign content reads as
 "not yet reported" rather than as a verdict; the daemon rewrites the file on
 every state change and on its heartbeat.
+
+One bound remains on this path, in a different process. `recordFuseChildPid`
+in `packages/cli/lib/fuse-supervisor.ts` is how the supervisor writes the child
+PID into the mount state file, and the wait above cannot tie any status to this
+mount until it does. It waits for the file by retrying twenty times at fifty
+milliseconds, then gives up, and giving up exits the supervisor, which the wait
+reports as a mount that died during startup. So a machine loaded enough to
+delay the CLI's own state-file write by a second still turns a healthy mount
+into a reported failure — the same shape as the ceiling removed from the wait
+itself, one layer down. Unlike that ceiling, this bound does some real work: it
+is also what stops a supervisor from waiting forever, holding a mount, when the
+CLI dies before writing the file at all. Removing it honestly means giving the
+supervisor an event for the CLI's death rather than a deadline, which changes
+what the CLI hands the supervisor when it spawns it. Until then this is a known
+bound, recorded here rather than left as a bare constant.
 
 The daemon reports `mounted` once it has dispatched its FUSE session loop and
 installed the signal handlers that unmount cleanly, so the state means the

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -136,11 +136,11 @@ async function removeMountStateAndChildStatus(
 }
 
 /**
- * The spawned supervisor, as this wait needs to see it: an identifier for the
- * error message, and the exit that ends the startup race.
+ * The spawned supervisor, as this wait needs to see it: the exit that ends the
+ * startup race. The daemon's own liveness is read from the status file, which
+ * carries its PID.
  */
 export interface BackgroundMountProcess {
-  pid: number;
   status: Promise<Deno.CommandStatus>;
 }
 

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command";
-import { basename, resolve } from "@std/path";
+import { basename, dirname, resolve } from "@std/path";
 import ports from "@commonfabric/ports" with { type: "json" };
+import { defer } from "@commonfabric/utils/defer";
 import {
   buildBackgroundSupervisorDenoArgs,
   buildDenoArgs,
@@ -44,11 +45,6 @@ interface FuseChildSupervisorStatus {
   error?: string;
   exitCode?: number;
 }
-
-const BACKGROUND_STARTUP_ATTEMPTS = 20;
-const CHILD_STATUS_STARTUP_ATTEMPTS = 200;
-const BACKGROUND_STARTUP_DELAY_MS = 50;
-const CHILD_STATUS_STARTUP_DELAY_MS = 100;
 
 export function childStatusPathForStatePath(statePath: string): string {
   return `${statePath}.child-status`;
@@ -139,146 +135,185 @@ async function removeMountStateAndChildStatus(
   await removeStateFile(childStatusPath).catch(() => undefined);
 }
 
+/**
+ * The spawned supervisor, as this wait needs to see it: an identifier for the
+ * error message, and the exit that ends the startup race.
+ */
+export interface BackgroundMountProcess {
+  pid: number;
+  status: Promise<Deno.CommandStatus>;
+}
+
+/** A source of "the state directory changed" wake-ups. */
+export interface ChildStatusWatcher extends AsyncIterable<unknown> {
+  close(): void;
+}
+
+export interface AwaitBackgroundMountStartupDeps {
+  childStatusPath: string;
+  childStatusToken?: string;
+  mountpoint?: string;
+  isAlive?: (pid: number) => boolean;
+  removeStateFile?: (path: string) => Promise<void>;
+  readTextFile?: (path: string) => Promise<string>;
+  readMountStateFile?: (path: string) => Promise<string>;
+  watchStatus?: (childStatusPath: string) => ChildStatusWatcher;
+}
+
+/** A startup that ended badly, and how much of the mount's state to clear. */
+interface FailedStartup {
+  message: string;
+  removeChildStatus: boolean;
+}
+
+/**
+ * The status file lives alongside the mount state file, and neither is
+ * guaranteed to exist when the wait starts, so the watch covers the directory
+ * holding both. Writes to the mount state file matter too: the supervisor
+ * records the child PID there, and the status file cannot be tied to this
+ * mount until it does.
+ */
+function watchChildStatusDirectory(
+  childStatusPath: string,
+): ChildStatusWatcher {
+  return Deno.watchFs([dirname(childStatusPath)]);
+}
+
+/**
+ * Wait until the background FUSE daemon reports that it has mounted.
+ *
+ * Two real events end the wait: the supervisor exiting, which is a failure,
+ * and the child reporting a terminal supervisor state, which is a success when
+ * that state is `mounted`. Nothing else does. There is deliberately no
+ * deadline — a deadline could only turn a slow startup into a reported failure,
+ * and startup carries no liveness signal that would tell a slow child from a
+ * stuck one. A child that never reports leaves the command waiting, which is
+ * interruptible and honest, rather than killing a mount that was about to work.
+ */
 export async function awaitBackgroundMountStartup(
-  pid: number,
+  supervisor: BackgroundMountProcess,
   statePath: string,
-  deps: {
-    attempts?: number;
-    delayMs?: number;
-    isAlive?: (pid: number) => boolean;
-    removeStateFile?: (path: string) => Promise<void>;
-    readTextFile?: (path: string) => Promise<string>;
-    readMountStateFile?: (path: string) => Promise<string>;
-    childStatusPath?: string;
-    childStatusToken?: string;
-    mountpoint?: string;
-    sleep?: (ms: number) => Promise<void>;
-  } = {},
+  deps: AwaitBackgroundMountStartupDeps,
 ): Promise<void> {
-  const attempts = deps.attempts ??
-    (deps.childStatusPath
-      ? CHILD_STATUS_STARTUP_ATTEMPTS
-      : BACKGROUND_STARTUP_ATTEMPTS);
-  const delayMs = deps.delayMs ??
-    (deps.childStatusPath
-      ? CHILD_STATUS_STARTUP_DELAY_MS
-      : BACKGROUND_STARTUP_DELAY_MS);
   const isAliveFn = deps.isAlive ?? isAlive;
   const removeStateFileFn = deps.removeStateFile ?? removeMountStateFile;
   const readTextFile = deps.readTextFile ?? Deno.readTextFile;
   const readMountStateFile = deps.readMountStateFile ?? Deno.readTextFile;
-  const sleep = deps.sleep ??
-    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  let invalidChildStatusSeen = false;
+  const watchStatus = deps.watchStatus ?? watchChildStatusDirectory;
+  const childStatusPath = deps.childStatusPath;
 
-  for (let i = 0; i < attempts; i++) {
-    if (!isAliveFn(pid)) {
-      await removeStateFileFn(statePath);
-      throw new Error(
-        "Background FUSE process exited during startup. Re-run without --background to inspect startup errors.",
-      );
+  // Classify the status file as it stands. `null` means the child has not
+  // reported an outcome for this mount yet, so the wait continues. A status
+  // file that is missing, half-written or from another mount reads as "not
+  // yet" — the child rewrites it on every state change and on its heartbeat.
+  const readOutcome = async (): Promise<"mounted" | FailedStartup | null> => {
+    let status: FuseChildSupervisorStatus | null = null;
+    try {
+      status = parseChildSupervisorStatus(await readTextFile(childStatusPath));
+    } catch {
+      return null;
     }
-    if (deps.childStatusPath) {
-      let status: FuseChildSupervisorStatus | null = null;
-      try {
-        status = parseChildSupervisorStatus(
-          await readTextFile(deps.childStatusPath),
-        );
-        if (!status) invalidChildStatusSeen = true;
-      } catch {
-        status = null;
-      }
-      const belongsToThisMount = await childStatusBelongsToMount(
-        status,
-        statePath,
-        {
-          token: deps.childStatusToken,
-          mountpoint: deps.mountpoint,
-          readMountStateFile,
-        },
-      );
-      if (status?.state === "mounted" && belongsToThisMount) {
-        if (!isAliveFn(status.pid!)) {
-          await removeMountStateAndChildStatus(
-            statePath,
-            deps.childStatusPath,
-            removeStateFileFn,
-          );
-          throw new Error(
+    const belongsToThisMount = await childStatusBelongsToMount(
+      status,
+      statePath,
+      {
+        token: deps.childStatusToken,
+        mountpoint: deps.mountpoint,
+        readMountStateFile,
+      },
+    );
+    if (!status || !belongsToThisMount) return null;
+    switch (status.state) {
+      case "mounted":
+        if (isAliveFn(status.pid!)) return "mounted";
+        return {
+          message:
             "Background FUSE mount failed during startup: child exited after reporting mounted.",
-          );
-        }
-
-        await sleep(delayMs);
-        let confirmedStatus: FuseChildSupervisorStatus | null = null;
-        try {
-          confirmedStatus = parseChildSupervisorStatus(
-            await readTextFile(deps.childStatusPath),
-          );
-        } catch {
-          confirmedStatus = null;
-        }
-        const confirmedBelongsToThisMount = await childStatusBelongsToMount(
-          confirmedStatus,
-          statePath,
-          {
-            token: deps.childStatusToken,
-            mountpoint: deps.mountpoint,
-            readMountStateFile,
-          },
-        );
-        if (
-          confirmedStatus?.state === "mounted" &&
-          confirmedBelongsToThisMount &&
-          isAliveFn(pid) &&
-          isAliveFn(confirmedStatus.pid!)
-        ) {
-          return;
-        }
-        await removeMountStateAndChildStatus(
-          statePath,
-          deps.childStatusPath,
-          removeStateFileFn,
-        );
-        const reason = confirmedBelongsToThisMount && confirmedStatus
-          ? `child reported ${confirmedStatus.state}`
-          : "child did not remain mounted";
-        throw new Error(
-          `Background FUSE mount failed during startup: ${reason}`,
-        );
-      }
-      if (
-        belongsToThisMount &&
-        (status?.state === "failed" || status?.state === "exiting" ||
-          status?.state === "exited")
-      ) {
-        await removeStateFileFn(statePath);
-        throw new Error(
-          `Background FUSE mount failed during startup: ${
+          removeChildStatus: true,
+        };
+      case "failed":
+      case "exiting":
+      case "exited":
+        return {
+          message: `Background FUSE mount failed during startup: ${
             status.error ?? `child reported ${status.state}`
           }`,
-        );
+          removeChildStatus: false,
+        };
+      default:
+        return null;
+    }
+  };
+
+  // Watch before the first read, so a report that lands between the two is
+  // still delivered as an event rather than missed.
+  const watcher = watchStatus(childStatusPath);
+  const settled = defer<"mounted" | FailedStartup>();
+  let done = false;
+  const settle = (outcome: "mounted" | FailedStartup) => {
+    if (done) return;
+    done = true;
+    settled.resolve(outcome);
+  };
+
+  supervisor.status.then(
+    () =>
+      settle({
+        message:
+          "Background FUSE process exited during startup. Re-run without --background to inspect startup errors.",
+        removeChildStatus: false,
+      }),
+    () => {
+      // The supervisor handle can only fail to report an exit if the process
+      // was never ours to wait on; the status file still decides.
+    },
+  );
+
+  (async () => {
+    const initial = await readOutcome();
+    if (initial) {
+      settle(initial);
+      return;
+    }
+    for await (const _event of watcher) {
+      if (done) return;
+      const outcome = await readOutcome();
+      if (outcome) {
+        settle(outcome);
+        return;
       }
     }
-    if (i < attempts - 1) {
-      await sleep(delayMs);
-    }
-  }
+  })().catch((error) =>
+    settle({
+      message: `Background FUSE mount failed during startup: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      removeChildStatus: false,
+    })
+  );
 
-  if (deps.childStatusPath) {
-    if (invalidChildStatusSeen) {
-      await removeMountStateAndChildStatus(
-        statePath,
-        deps.childStatusPath,
-        removeStateFileFn,
-      );
-    } else {
-      await removeStateFileFn(statePath);
-    }
-    throw new Error(
-      "Background FUSE process did not report mount readiness before startup timeout.",
-    );
+  const outcome = await settled.promise;
+  // Leaving the event loop closes the watcher, so this close is what stops a
+  // loop still waiting on events — the supervisor-exit path. When the status
+  // file decided instead, the loop has already closed it and closing again
+  // reports a bad resource.
+  try {
+    watcher.close();
+  } catch {
+    // Already closed by the iterator.
   }
+  if (outcome === "mounted") return;
+
+  if (outcome.removeChildStatus) {
+    await removeMountStateAndChildStatus(
+      statePath,
+      childStatusPath,
+      removeStateFileFn,
+    );
+  } else {
+    await removeStateFileFn(statePath);
+  }
+  throw new Error(outcome.message);
 }
 
 async function childStatusBelongsToMount(
@@ -511,7 +546,7 @@ export const fuse = new Command()
           logFile,
           childStatusPath,
         });
-        await awaitBackgroundMountStartup(pid, statePath, {
+        await awaitBackgroundMountStartup(child, statePath, {
           childStatusPath,
           childStatusToken,
           mountpoint: absMountpoint,

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -109,6 +109,33 @@ wait_for_path() {
   error "Timed out waiting for path: $path"
 }
 
+# A mounted JSON document answers lookups from a stub while the daemon hydrates
+# the piece behind it, and rebuilds land on a debounce after that, so the path
+# existing says nothing about the content being final. Poll the document until
+# it renders what is expected, the same way the path probes poll for lookups.
+wait_for_json() {
+  local path="$1"
+  local filter="$2"
+  local message="$3"
+  local timeout_seconds="${4:-20}"
+  local started_at
+  started_at=$(date +%s)
+
+  while true; do
+    if jq -e "$filter" "$path" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  local actual
+  actual=$(head -c 400 "$path" 2>/dev/null || true)
+  error "$message. Last content of $(basename "$path"): $actual"
+}
+
 fuse_encode_component() {
   local value="$1"
   value="${value//%/%25}"
@@ -330,12 +357,12 @@ success "Mounted callable entries exist"
 success "Entities namespace exposes matching entry for mounted piece"
 
 assert_not_exists "$RESULT_DIR/search" "Pattern tool internals should not be exposed as a directory."
-jq -e '.recordMessage == {"/handler":"recordMessage"}' "$RESULT_JSON" >/dev/null ||
-  error "result.json should render recordMessage as a handler sigil."
-jq -e '.legacyWrite == {"/handler":"legacyWrite"}' "$RESULT_JSON" >/dev/null ||
-  error "result.json should render legacyWrite as a handler sigil."
-jq -e '.search == {"/tool":"search"}' "$RESULT_JSON" >/dev/null ||
-  error "result.json should render search as a tool sigil."
+wait_for_json "$RESULT_JSON" '.recordMessage == {"/handler":"recordMessage"}' \
+  "result.json should render recordMessage as a handler sigil"
+wait_for_json "$RESULT_JSON" '.legacyWrite == {"/handler":"legacyWrite"}' \
+  "result.json should render legacyWrite as a handler sigil"
+wait_for_json "$RESULT_JSON" '.search == {"/tool":"search"}' \
+  "result.json should render search as a tool sigil"
 success "Mounted JSON surface hides callable internals"
 
 HANDLER_FIRST_LINE=$(head -n 1 "$HANDLER_FILE")

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
 import { basename, join, resolve, toFileUrl } from "@std/path";
 import {
   awaitBackgroundMountStartup,
@@ -40,14 +41,16 @@ import { withEnv } from "./utils.ts";
 
 /**
  * A stand-in for the spawned supervisor whose exit the test decides.
- * `awaitBackgroundMountStartup` only ever reads `pid` and `status`.
+ * `awaitBackgroundMountStartup` reads nothing from it but `status`.
  */
-function fakeSupervisor(pid: number = Deno.pid) {
+function fakeSupervisor() {
   const exited = defer<Deno.CommandStatus>();
   return {
-    process: { pid, status: exited.promise },
+    process: { status: exited.promise },
     exit: (code = 1) =>
       exited.resolve({ success: code === 0, code, signal: null }),
+    /** Report the exit as unobservable rather than as a process exit. */
+    fail: (error: Error) => exited.reject(error),
   };
 }
 
@@ -502,7 +505,7 @@ describe("mount state operations", () => {
       startedAt: "2026-03-17T00:00:00.000Z",
     });
     const childStatusPath = childStatusPathForStatePath(statePath);
-    const supervisor = fakeSupervisor(1073741824);
+    const supervisor = fakeSupervisor();
     const watcher = fakeStatusWatcher();
     const removed: string[] = [];
 
@@ -625,6 +628,62 @@ describe("mount state operations", () => {
     expect(reads).toBe(heartbeatsBeforeMounted + 1);
     expect(watcher.closed).toBe(true);
     await expect(Deno.stat(statePath)).resolves.toBeDefined();
+  });
+
+  it("puts no deadline on readiness, however much time passes", async () => {
+    // The attempt-driven test above cannot see a wall-clock deadline, because
+    // its heartbeats all land within a few real milliseconds. Virtual time is
+    // what makes the absence of a deadline observable: an hour passes while
+    // the child is still starting, and the wait must survive it.
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const watcher = fakeStatusWatcher();
+    let state = "starting";
+    const time = new FakeTime();
+
+    try {
+      const startup = awaitBackgroundMountStartup(
+        fakeSupervisor().process,
+        statePath,
+        {
+          childStatusPath,
+          childStatusToken: "token-1",
+          mountpoint: "/tmp/test-mount",
+          isAlive: () => true,
+          readTextFile: () =>
+            Promise.resolve(JSON.stringify({
+              state,
+              pid: 321,
+              mountpoint: "/tmp/test-mount",
+              token: "token-1",
+              updatedAt: "2026-03-17T00:00:00.000Z",
+            })),
+          // Kept off real disk so no timer-independent I/O has to progress
+          // while the clock is faked.
+          readMountStateFile: () =>
+            Promise.resolve(JSON.stringify({ childPid: 321 })),
+          watchStatus: () => watcher,
+        },
+      );
+      let ended = false;
+      startup.then(() => ended = true, () => ended = true);
+
+      await time.tickAsync(60 * 60 * 1000);
+      expect(ended).toBe(false);
+
+      state = "mounted";
+      watcher.emit();
+      await expect(startup).resolves.toBeUndefined();
+    } finally {
+      time.restore();
+    }
   });
 
   it("reports readiness from a mounted status already written before the wait began", async () => {
@@ -766,6 +825,144 @@ describe("mount state operations", () => {
     const supervisor = fakeSupervisor();
     const watcher = fakeStatusWatcher();
     const removed: string[] = [];
+    let reads = 0;
+
+    // A leftover mount at this mountpoint reports mounted under its own token.
+    // The wait has to read it and hold, so the reads are driven one at a time
+    // and the exit only fires once several have been rejected — otherwise the
+    // exit would settle the wait before the status was ever consulted, and the
+    // test would pass without exercising the token check at all.
+    const startup = awaitBackgroundMountStartup(supervisor.process, statePath, {
+      childStatusPath,
+      childStatusToken: "token-1",
+      mountpoint: "/tmp/test-mount",
+      isAlive: () => true,
+      readTextFile: () => {
+        reads++;
+        if (reads < 3) queueMicrotask(() => watcher.emit());
+        else supervisor.exit(1);
+        return Promise.resolve(JSON.stringify({
+          state: "mounted",
+          pid: 321,
+          mountpoint: "/tmp/test-mount",
+          token: "stale-token",
+          updatedAt: "2026-03-17T00:00:00.000Z",
+        }));
+      },
+      watchStatus: () => watcher,
+      removeStateFile: async (path: string) => {
+        removed.push(path);
+        await Deno.remove(path);
+      },
+    });
+
+    await expect(startup).rejects.toThrow(
+      /Background FUSE process exited during startup/i,
+    );
+    expect(reads).toBe(3);
+    expect(removed).toEqual([statePath]);
+  });
+
+  it("never reports readiness from a status whose pid is not this mount's child", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 999,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const supervisor = fakeSupervisor();
+    const watcher = fakeStatusWatcher();
+    let reads = 0;
+    let stateReads = 0;
+
+    // Token and mountpoint match, but the PID belongs to a different child, so
+    // the mount state file is what rejects this status.
+    const startup = awaitBackgroundMountStartup(supervisor.process, statePath, {
+      childStatusPath,
+      childStatusToken: "token-1",
+      mountpoint: "/tmp/test-mount",
+      isAlive: () => true,
+      readTextFile: () => {
+        reads++;
+        if (reads < 3) queueMicrotask(() => watcher.emit());
+        else supervisor.exit(1);
+        return Promise.resolve(JSON.stringify({
+          state: "mounted",
+          pid: 321,
+          mountpoint: "/tmp/test-mount",
+          token: "token-1",
+          updatedAt: "2026-03-17T00:00:00.000Z",
+        }));
+      },
+      readMountStateFile: () => {
+        stateReads++;
+        return Promise.resolve(JSON.stringify({ childPid: 999 }));
+      },
+      watchStatus: () => watcher,
+    });
+
+    await expect(startup).rejects.toThrow(
+      /Background FUSE process exited during startup/i,
+    );
+    expect(reads).toBe(3);
+    expect(stateReads).toBeGreaterThan(0);
+  });
+
+  it("reports a failure when the watch itself fails", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    // A watch that cannot be iterated leaves no way for readiness to arrive,
+    // so it has to be reported rather than waited on forever.
+    const brokenWatcher: ChildStatusWatcher = {
+      close() {},
+      async *[Symbol.asyncIterator]() {
+        throw new Error("watch failed: too many open files");
+      },
+    };
+
+    await expect(
+      awaitBackgroundMountStartup(fakeSupervisor().process, statePath, {
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () => Promise.reject(new Deno.errors.NotFound()),
+        watchStatus: () => brokenWatcher,
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path);
+        },
+      }),
+    ).rejects.toThrow(/watch failed: too many open files/);
+
+    expect(removed).toEqual([statePath]);
+  });
+
+  it("lets the status file decide when the supervisor exit is unobservable", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const supervisor = fakeSupervisor();
+    const watcher = fakeStatusWatcher();
+    let state = "starting";
 
     const startup = awaitBackgroundMountStartup(supervisor.process, statePath, {
       childStatusPath,
@@ -774,25 +971,21 @@ describe("mount state operations", () => {
       isAlive: () => true,
       readTextFile: () =>
         Promise.resolve(JSON.stringify({
-          state: "mounted",
+          state,
           pid: 321,
           mountpoint: "/tmp/test-mount",
-          token: "stale-token",
+          token: "token-1",
           updatedAt: "2026-03-17T00:00:00.000Z",
         })),
       watchStatus: () => watcher,
-      removeStateFile: async (path: string) => {
-        removed.push(path);
-        await Deno.remove(path);
-      },
     });
-    watcher.emit();
-    supervisor.exit(1);
 
-    await expect(startup).rejects.toThrow(
-      /Background FUSE process exited during startup/i,
-    );
-    expect(removed).toEqual([statePath]);
+    // A handle that cannot report the exit must not fail the mount by itself.
+    supervisor.fail(new Error("not our process to wait on"));
+    state = "mounted";
+    watcher.emit();
+
+    await expect(startup).resolves.toBeUndefined();
   });
 
   it("keeps waiting through a half-written child status file", async () => {

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -6,6 +6,7 @@ import {
   awaitForegroundMountExit,
   buildMountStatusRows,
   childStatusPathForStatePath,
+  type ChildStatusWatcher,
   formatMountStatusTable,
   fuse,
   isFuseProcessCommand,
@@ -34,7 +35,63 @@ import {
   supervisorHelp,
 } from "../lib/fuse-supervisor.ts";
 import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
+import { defer, type Deferred } from "@commonfabric/utils/defer";
 import { withEnv } from "./utils.ts";
+
+/**
+ * A stand-in for the spawned supervisor whose exit the test decides.
+ * `awaitBackgroundMountStartup` only ever reads `pid` and `status`.
+ */
+function fakeSupervisor(pid: number = Deno.pid) {
+  const exited = defer<Deno.CommandStatus>();
+  return {
+    process: { pid, status: exited.promise },
+    exit: (code = 1) =>
+      exited.resolve({ success: code === 0, code, signal: null }),
+  };
+}
+
+/**
+ * A stand-in for the state-directory watcher, matching the parts of
+ * `Deno.watchFs` this wait depends on: events are buffered from creation, so a
+ * test can queue one before the wait starts iterating; leaving the event loop
+ * closes the watcher; and closing an already-closed watcher reports a bad
+ * resource.
+ */
+function fakeStatusWatcher(): ChildStatusWatcher & {
+  emit(): void;
+  closed: boolean;
+} {
+  const buffered: unknown[] = [];
+  let wake: Deferred<void> | null = null;
+  const watcher = {
+    closed: false,
+    emit() {
+      buffered.push({ kind: "modify" });
+      wake?.resolve();
+      wake = null;
+    },
+    close() {
+      if (watcher.closed) throw new Deno.errors.BadResource("Bad resource ID");
+      watcher.closed = true;
+      wake?.resolve();
+      wake = null;
+    },
+    async *[Symbol.asyncIterator]() {
+      try {
+        while (true) {
+          while (buffered.length > 0) yield buffered.shift();
+          if (watcher.closed) return;
+          wake = defer<void>();
+          await wake.promise;
+        }
+      } finally {
+        watcher.closed = true;
+      }
+    },
+  };
+  return watcher;
+}
 
 describe("mountpointHash", () => {
   it("returns a 16-char hex string", async () => {
@@ -444,59 +501,38 @@ describe("mount state operations", () => {
       identity: "/tmp/test-identity.pem",
       startedAt: "2026-03-17T00:00:00.000Z",
     });
-
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const supervisor = fakeSupervisor(1073741824);
+    const watcher = fakeStatusWatcher();
     const removed: string[] = [];
-    await expect(
-      awaitBackgroundMountStartup(
-        1073741824,
-        statePath,
-        {
-          attempts: 1,
-          isAlive: () => false,
-          removeStateFile: async (path: string) => {
-            removed.push(path);
-            await Deno.remove(path);
-          },
-          sleep: () => Promise.resolve(),
-        },
-      ),
-    ).rejects.toThrow(/Background FUSE process exited during startup/i);
 
+    const startup = awaitBackgroundMountStartup(
+      supervisor.process,
+      statePath,
+      {
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => false,
+        readTextFile: () => Promise.reject(new Deno.errors.NotFound()),
+        watchStatus: () => watcher,
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path);
+        },
+      },
+    );
+    supervisor.exit(1);
+
+    await expect(startup).rejects.toThrow(
+      /Background FUSE process exited during startup/i,
+    );
     expect(removed).toEqual([statePath]);
+    expect(watcher.closed).toBe(true);
     await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
-  it("allows background mounts that stay alive through the startup window", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-
-    let checks = 0;
-    await expect(
-      awaitBackgroundMountStartup(
-        Deno.pid,
-        statePath,
-        {
-          attempts: 3,
-          isAlive: () => {
-            checks++;
-            return true;
-          },
-          sleep: () => Promise.resolve(),
-        },
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(checks).toBe(3);
-    await expect(Deno.stat(statePath)).resolves.toBeDefined();
-  });
-
-  it("waits for explicit child mounted status when available", async () => {
+  it("does not report readiness for a child that stays alive without reporting mounted", async () => {
     const statePath = await writeMountState(tmpDir, {
       pid: Deno.pid,
       childPid: 321,
@@ -506,31 +542,177 @@ describe("mount state operations", () => {
       startedAt: "2026-03-17T00:00:00.000Z",
     });
     const childStatusPath = childStatusPathForStatePath(statePath);
+    const supervisor = fakeSupervisor();
+    const watcher = fakeStatusWatcher();
+    const removed: string[] = [];
     let reads = 0;
 
+    // The child is alive and reporting, but never reports mounted. Liveness
+    // alone must not be read as readiness, so the process exiting is the only
+    // way out. Each read arms the next wake-up, so the wait is observed
+    // staying open across several of them before the exit ends it.
+    const startup = awaitBackgroundMountStartup(supervisor.process, statePath, {
+      childStatusPath,
+      childStatusToken: "token-1",
+      mountpoint: "/tmp/test-mount",
+      isAlive: () => true,
+      readTextFile: () => {
+        reads++;
+        if (reads < 3) queueMicrotask(() => watcher.emit());
+        else supervisor.exit(1);
+        return Promise.resolve(JSON.stringify({
+          state: "starting",
+          pid: 321,
+          mountpoint: "/tmp/test-mount",
+          token: "token-1",
+          updatedAt: "2026-03-17T00:00:00.000Z",
+        }));
+      },
+      watchStatus: () => watcher,
+      removeStateFile: async (path: string) => {
+        removed.push(path);
+        await Deno.remove(path);
+      },
+    });
+
+    await expect(startup).rejects.toThrow(
+      /Background FUSE process exited during startup/i,
+    );
+    expect(reads).toBe(3);
+    expect(removed).toEqual([statePath]);
+  });
+
+  it("waits for the child to report mounted, however long that takes", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const supervisor = fakeSupervisor();
+    const watcher = fakeStatusWatcher();
+    // A slow startup: the child heartbeats far more times than any past
+    // attempt ceiling allowed before it finally reports mounted. Each read
+    // arms the next wake-up, so these are consumed one at a time rather than
+    // collapsing into a single buffered batch.
+    const heartbeatsBeforeMounted = 500;
+    let reads = 0;
+
+    const startup = awaitBackgroundMountStartup(supervisor.process, statePath, {
+      childStatusPath,
+      childStatusToken: "token-1",
+      mountpoint: "/tmp/test-mount",
+      isAlive: () => true,
+      readTextFile: () => {
+        reads++;
+        const ready = reads > heartbeatsBeforeMounted;
+        if (!ready) queueMicrotask(() => watcher.emit());
+        return Promise.resolve(JSON.stringify({
+          state: ready ? "mounted" : "starting",
+          pid: 321,
+          mountpoint: "/tmp/test-mount",
+          token: "token-1",
+          updatedAt: "2026-03-17T00:00:00.000Z",
+        }));
+      },
+      watchStatus: () => watcher,
+    });
+
+    await expect(startup).resolves.toBeUndefined();
+    expect(reads).toBe(heartbeatsBeforeMounted + 1);
+    expect(watcher.closed).toBe(true);
+    await expect(Deno.stat(statePath)).resolves.toBeDefined();
+  });
+
+  it("reports readiness from a mounted status already written before the wait began", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const watcher = fakeStatusWatcher();
+
+    // The child can win the race and report mounted before the CLI starts
+    // watching; the read that follows the watch has to catch that.
     await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 3,
+      awaitBackgroundMountStartup(fakeSupervisor().process, statePath, {
         childStatusPath,
         childStatusToken: "token-1",
         mountpoint: "/tmp/test-mount",
         isAlive: () => true,
-        readTextFile: () => {
-          reads++;
-          return Promise.resolve(JSON.stringify({
-            state: reads === 1 ? "starting" : "mounted",
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            state: "mounted",
             pid: 321,
             mountpoint: "/tmp/test-mount",
             token: "token-1",
             updatedAt: "2026-03-17T00:00:00.000Z",
-          }));
-        },
-        sleep: () => Promise.resolve(),
+          })),
+        watchStatus: () => watcher,
       }),
     ).resolves.toBeUndefined();
 
-    expect(reads).toBe(3);
+    expect(watcher.closed).toBe(true);
     await expect(Deno.stat(statePath)).resolves.toBeDefined();
+  });
+
+  it("reports readiness from a real filesystem watch of the state directory", async () => {
+    // A fake watcher cannot stand in for `Deno.watchFs` here. The real one
+    // closes itself when the wait leaves its event loop, so this is the only
+    // test that covers what the background mount command actually wires up.
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: Deno.pid,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const firstReadSettled = defer<void>();
+    let reads = 0;
+
+    const startup = awaitBackgroundMountStartup(
+      fakeSupervisor().process,
+      statePath,
+      {
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        readTextFile: async (path: string) => {
+          reads++;
+          try {
+            return await Deno.readTextFile(path);
+          } finally {
+            if (reads === 1) firstReadSettled.resolve();
+          }
+        },
+      },
+    );
+
+    // Let the read that follows the watch miss the file, so readiness can only
+    // arrive as a real filesystem event rather than from that first read.
+    await firstReadSettled.promise;
+    await Deno.writeTextFile(
+      childStatusPath,
+      JSON.stringify({
+        state: "mounted",
+        pid: Deno.pid,
+        mountpoint: "/tmp/test-mount",
+        token: "token-1",
+        updatedAt: "2026-03-17T00:00:00.000Z",
+      }),
+    );
+
+    await expect(startup).resolves.toBeUndefined();
+    expect(reads).toBeGreaterThan(1);
   });
 
   it("rejects background mounts when child exits after reporting mounted", async () => {
@@ -546,8 +728,7 @@ describe("mount state operations", () => {
     const removed: string[] = [];
 
     await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 2,
+      awaitBackgroundMountStartup(fakeSupervisor().process, statePath, {
         childStatusPath,
         childStatusToken: "token-1",
         mountpoint: "/tmp/test-mount",
@@ -560,11 +741,11 @@ describe("mount state operations", () => {
             token: "token-1",
             updatedAt: "2026-03-17T00:00:00.000Z",
           })),
+        watchStatus: () => fakeStatusWatcher(),
         removeStateFile: async (path: string) => {
           removed.push(path);
           await Deno.remove(path).catch(() => undefined);
         },
-        sleep: () => Promise.resolve(),
       }),
     ).rejects.toThrow(/child exited after reporting mounted/i);
 
@@ -572,7 +753,7 @@ describe("mount state operations", () => {
     await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
-  it("rejects background mounts when mounted status is followed by exiting", async () => {
+  it("never reports readiness from a mounted status belonging to another startup attempt", async () => {
     const statePath = await writeMountState(tmpDir, {
       pid: Deno.pid,
       childPid: 321,
@@ -582,78 +763,39 @@ describe("mount state operations", () => {
       startedAt: "2026-03-17T00:00:00.000Z",
     });
     const childStatusPath = childStatusPathForStatePath(statePath);
+    const supervisor = fakeSupervisor();
+    const watcher = fakeStatusWatcher();
     const removed: string[] = [];
-    let reads = 0;
 
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 2,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () => {
-          reads++;
-          return Promise.resolve(JSON.stringify({
-            state: reads === 1 ? "mounted" : "exiting",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          }));
-        },
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path).catch(() => undefined);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/child reported exiting/i);
-
-    expect(reads).toBe(2);
-    expect(removed).toEqual([statePath, childStatusPath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
-  });
-
-  it("ignores mounted child status from a different startup attempt", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
+    const startup = awaitBackgroundMountStartup(supervisor.process, statePath, {
+      childStatusPath,
+      childStatusToken: "token-1",
       mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
+      isAlive: () => true,
+      readTextFile: () =>
+        Promise.resolve(JSON.stringify({
+          state: "mounted",
+          pid: 321,
+          mountpoint: "/tmp/test-mount",
+          token: "stale-token",
+          updatedAt: "2026-03-17T00:00:00.000Z",
+        })),
+      watchStatus: () => watcher,
+      removeStateFile: async (path: string) => {
+        removed.push(path);
+        await Deno.remove(path);
+      },
     });
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
+    watcher.emit();
+    supervisor.exit(1);
 
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "mounted",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "stale-token",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/did not report mount readiness/i);
-
+    await expect(startup).rejects.toThrow(
+      /Background FUSE process exited during startup/i,
+    );
     expect(removed).toEqual([statePath]);
   });
 
-  it("cleans up malformed child status sidecars after readiness timeout", async () => {
+  it("keeps waiting through a half-written child status file", async () => {
     const statePath = await writeMountState(tmpDir, {
       pid: Deno.pid,
       childPid: 321,
@@ -663,25 +805,34 @@ describe("mount state operations", () => {
       startedAt: "2026-03-17T00:00:00.000Z",
     });
     const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
+    const watcher = fakeStatusWatcher();
+    let text = "{not-json";
 
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
+    const startup = awaitBackgroundMountStartup(
+      fakeSupervisor().process,
+      statePath,
+      {
         childStatusPath,
         childStatusToken: "token-1",
         mountpoint: "/tmp/test-mount",
         isAlive: () => true,
-        readTextFile: () => Promise.resolve("{not-json"),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path).catch(() => undefined);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/did not report mount readiness/i);
+        readTextFile: () => Promise.resolve(text),
+        watchStatus: () => watcher,
+      },
+    );
 
-    expect(removed).toEqual([statePath, childStatusPath]);
+    // Unreadable content is "not yet", not a verdict: the next write decides.
+    watcher.emit();
+    text = JSON.stringify({
+      state: "mounted",
+      pid: 321,
+      mountpoint: "/tmp/test-mount",
+      token: "token-1",
+      updatedAt: "2026-03-17T00:00:00.000Z",
+    });
+    watcher.emit();
+
+    await expect(startup).resolves.toBeUndefined();
   });
 
   it("does not read child status sidecars as mount state entries", async () => {
@@ -795,8 +946,7 @@ describe("mount state operations", () => {
     const removed: string[] = [];
 
     await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
+      awaitBackgroundMountStartup(fakeSupervisor().process, statePath, {
         childStatusPath,
         childStatusToken: "token-1",
         mountpoint: "/tmp/test-mount",
@@ -810,11 +960,11 @@ describe("mount state operations", () => {
             updatedAt: "2026-03-17T00:00:00.000Z",
             error: "fuse_session_mount failed",
           })),
+        watchStatus: () => fakeStatusWatcher(),
         removeStateFile: async (path: string) => {
           removed.push(path);
           await Deno.remove(path);
         },
-        sleep: () => Promise.resolve(),
       }),
     ).rejects.toThrow(/fuse_session_mount failed/);
 
@@ -835,8 +985,7 @@ describe("mount state operations", () => {
     const removed: string[] = [];
 
     await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
+      awaitBackgroundMountStartup(fakeSupervisor().process, statePath, {
         childStatusPath,
         childStatusToken: "token-1",
         mountpoint: "/tmp/test-mount",
@@ -849,52 +998,13 @@ describe("mount state operations", () => {
             token: "token-1",
             updatedAt: "2026-03-17T00:00:00.000Z",
           })),
+        watchStatus: () => fakeStatusWatcher(),
         removeStateFile: async (path: string) => {
           removed.push(path);
           await Deno.remove(path);
         },
-        sleep: () => Promise.resolve(),
       }),
     ).rejects.toThrow(/child reported exiting/);
-
-    expect(removed).toEqual([statePath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
-  });
-
-  it("rejects background mounts when child readiness times out", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
-
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "starting",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/did not report mount readiness/i);
 
     expect(removed).toEqual([statePath]);
     await expect(Deno.stat(statePath)).rejects.toThrow();

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -1,8 +1,9 @@
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
   appendDecodedJsonPath,
   bufferForNoHandleTruncate,
   cfcWritebackXattrResultErrno,
+  createSupervisorStatusWriter,
   decodeFuseNamespaceName,
   DEFAULT_CFC_XATTR_NAMESPACE,
   defaultCfcWritebackStatePath,
@@ -577,5 +578,153 @@ Deno.test("platform provider reports the implementation openFuse loaded", () => 
       noattrcache: false,
     }),
     ["fuse_ct"],
+  );
+});
+
+/**
+ * A filesystem whose write latency the test decides, so the ordering of two
+ * status writes is chosen rather than raced.
+ *
+ * Held writes complete newest first. That is the ordering the real filesystem
+ * is free to choose and the one that breaks an unserialized writer: the write
+ * issued first is the one that lands last, so it is the one that wins the
+ * file. A writer that lets only one write be in flight never has a second held
+ * write to reorder against.
+ */
+function fakeStatusFilesystem() {
+  const files = new Map<string, string>();
+  const pending: Array<() => void> = [];
+  let holdWrites = false;
+  return {
+    holdNextWrites: () => holdWrites = true,
+    releaseHeldWrites: () => {
+      holdWrites = false;
+      while (pending.length > 0) pending.pop()!();
+    },
+    published: () => files.get("/state/status"),
+    scratchFilesLeft: () =>
+      [...files.keys()].filter((path) => path.endsWith(".tmp")),
+    writeTextFile: (path: string, data: string) => {
+      if (!holdWrites) {
+        files.set(path, data);
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) =>
+        pending.push(() => {
+          files.set(path, data);
+          resolve();
+        })
+      );
+    },
+    rename: (from: string, to: string) => {
+      files.set(to, files.get(from)!);
+      files.delete(from);
+      return Promise.resolve();
+    },
+    remove: (path: string) => {
+      files.delete(path);
+      return Promise.resolve();
+    },
+  };
+}
+
+function statusWriterOver(fs: ReturnType<typeof fakeStatusFilesystem>) {
+  return createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    token: "token-1",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    now: () => "2026-03-17T00:00:01.000Z",
+    writeTextFile: fs.writeTextFile,
+    rename: fs.rename,
+    remove: fs.remove,
+  });
+}
+
+Deno.test("supervisor status does not regress when a slow write is still in flight", async () => {
+  const fs = fakeStatusFilesystem();
+  const write = statusWriterOver(fs);
+
+  // The heartbeat announces `mounted` and its write stalls. The session loop
+  // then ends and announces `exited`. The file must settle on the later call,
+  // not on whichever write the filesystem happens to finish last.
+  fs.holdNextWrites();
+  const heartbeat = write("mounted");
+  const exited = write("exited", { exitCode: 0 });
+  fs.releaseHeldWrites();
+  await Promise.all([heartbeat, exited]);
+
+  assertEquals(JSON.parse(fs.published()!).state, "exited");
+});
+
+Deno.test("supervisor status settles on exiting when it follows a stalled mounted", async () => {
+  const fs = fakeStatusFilesystem();
+  const write = statusWriterOver(fs);
+
+  // The readiness report stalls and a signal arrives while it is in flight.
+  fs.holdNextWrites();
+  const mounted = write("mounted");
+  const exiting = write("exiting");
+  fs.releaseHeldWrites();
+  await Promise.all([mounted, exiting]);
+
+  assertEquals(JSON.parse(fs.published()!).state, "exiting");
+});
+
+Deno.test("supervisor status keeps publishing after a write fails", async () => {
+  const fs = fakeStatusFilesystem();
+  let failNext = true;
+  const write = createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    writeTextFile: (path, data) => {
+      if (failNext) {
+        failNext = false;
+        return Promise.reject(new Error("disk full"));
+      }
+      return fs.writeTextFile(path, data);
+    },
+    rename: fs.rename,
+    remove: fs.remove,
+  });
+
+  // A failed write is reported to its caller and leaves no scratch file, and
+  // the states after it still reach the file.
+  await assertRejects(() => write("mounted"), Error, "disk full");
+  await write("exited", { exitCode: 0 });
+
+  assertEquals(JSON.parse(fs.published()!).state, "exited");
+  assertEquals(fs.scratchFilesLeft(), []);
+});
+
+Deno.test("supervisor status records when a state was reached, not when it drained", async () => {
+  const fs = fakeStatusFilesystem();
+  let clock = "2026-03-17T00:00:01.000Z";
+  const write = createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    now: () => clock,
+    writeTextFile: fs.writeTextFile,
+    rename: fs.rename,
+    remove: fs.remove,
+  });
+
+  // Serializing writes means a state can reach the file well after it was
+  // reached. The stamp has to come from the call, so time moves on while the
+  // write is stalled.
+  fs.holdNextWrites();
+  const mounted = write("mounted");
+  clock = "2026-03-17T00:00:09.000Z";
+  fs.releaseHeldWrites();
+  await mounted;
+
+  assertEquals(
+    JSON.parse(fs.published()!).updatedAt,
+    "2026-03-17T00:00:01.000Z",
   );
 });

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -243,6 +243,83 @@ type SupervisorStatusState =
   | "exiting"
   | "exited";
 
+export interface SupervisorStatusWriterOptions {
+  statusPath: string;
+  pid: number;
+  mountpoint: string;
+  token?: string;
+  startedAt: string;
+  now?: () => string;
+  writeTextFile?: (path: string, data: string) => Promise<void>;
+  rename?: (from: string, to: string) => Promise<void>;
+  remove?: (path: string) => Promise<void>;
+}
+
+export type SupervisorStatusWriter = (
+  state: SupervisorStatusState,
+  extra?: Record<string, unknown>,
+) => Promise<void>;
+
+/**
+ * Build the function that publishes the daemon's supervisor state.
+ *
+ * The states form a lifecycle, and the calls announcing them come from four
+ * places that do not coordinate: the startup path, the readiness report, the
+ * heartbeat and the signal handler. Writes are therefore serialized, so the
+ * file ends on the state of the most recent call. Each write also replaces the
+ * file by rename, so a reader woken by the write sees a complete document.
+ * Renames issued concurrently can complete in either order, which would let a
+ * heartbeat still in flight replace a terminal state and leave the file
+ * claiming a mount that has already gone.
+ */
+export function createSupervisorStatusWriter(
+  options: SupervisorStatusWriterOptions,
+): SupervisorStatusWriter {
+  const writeTextFile = options.writeTextFile ?? Deno.writeTextFile;
+  const rename = options.rename ?? Deno.rename;
+  const remove = options.remove ?? Deno.remove;
+  const now = options.now ?? (() => new Date().toISOString());
+  let queue: Promise<void> = Promise.resolve();
+  let writes = 0;
+
+  const publish = async (document: string): Promise<void> => {
+    // The scratch name carries the PID and a counter, so a daemon left over
+    // from an earlier mount at this path cannot share it.
+    const pendingPath = `${options.statusPath}.${options.pid}.${writes++}.tmp`;
+    try {
+      await writeTextFile(pendingPath, document);
+      await rename(pendingPath, options.statusPath);
+    } catch (error) {
+      await remove(pendingPath).catch(() => undefined);
+      throw error;
+    }
+  };
+
+  return (state, extra = {}) => {
+    // Built at call time, so `updatedAt` records when the state was reached
+    // rather than when its turn in the queue came up.
+    const document = JSON.stringify(
+      {
+        state,
+        pid: options.pid,
+        mountpoint: options.mountpoint,
+        token: options.token || undefined,
+        startedAt: options.startedAt,
+        updatedAt: now(),
+        ...extra,
+      },
+      null,
+      2,
+    );
+    const write = queue.then(() => publish(document));
+    // A failed write must neither stop later states from being published nor
+    // surface through the queue as an unhandled rejection. Callers still see
+    // the failure through the promise returned here.
+    queue = write.catch(() => undefined);
+    return write;
+  };
+}
+
 export async function writeFailedSupervisorStartupStatus(
   error: unknown,
   writeSupervisorStatus: (
@@ -392,42 +469,15 @@ export async function main(argv: string[] = Deno.args) {
   const supervisorStatusPath = String(args["supervisor-status"] ?? "");
   const supervisorToken = String(args["supervisor-token"] ?? "");
   const supervisorStatusStartedAt = new Date().toISOString();
-  let supervisorStatusWrites = 0;
-  // Each write replaces the file by rename, so a reader woken by the write
-  // sees either the previous status or the new one, never a half-written one.
-  // The temp name carries a per-write counter, so overlapping writes — a
-  // heartbeat and a state change in the same tick — cannot share a scratch
-  // file.
-  async function writeSupervisorStatus(
-    state: SupervisorStatusState,
-    extra: Record<string, unknown> = {},
-  ): Promise<void> {
-    if (!supervisorStatusPath) return;
-    const pendingPath =
-      `${supervisorStatusPath}.${Deno.pid}.${supervisorStatusWrites++}.tmp`;
-    try {
-      await Deno.writeTextFile(
-        pendingPath,
-        JSON.stringify(
-          {
-            state,
-            pid: Deno.pid,
-            mountpoint,
-            token: supervisorToken || undefined,
-            startedAt: supervisorStatusStartedAt,
-            updatedAt: new Date().toISOString(),
-            ...extra,
-          },
-          null,
-          2,
-        ),
-      );
-      await Deno.rename(pendingPath, supervisorStatusPath);
-    } catch (error) {
-      await Deno.remove(pendingPath).catch(() => undefined);
-      throw error;
-    }
-  }
+  const writeSupervisorStatus: SupervisorStatusWriter = supervisorStatusPath
+    ? createSupervisorStatusWriter({
+      statusPath: supervisorStatusPath,
+      pid: Deno.pid,
+      mountpoint,
+      token: supervisorToken || undefined,
+      startedAt: supervisorStatusStartedAt,
+    })
+    : () => Promise.resolve();
   try {
     await writeSupervisorStatus("starting");
   } catch (error) {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -392,27 +392,41 @@ export async function main(argv: string[] = Deno.args) {
   const supervisorStatusPath = String(args["supervisor-status"] ?? "");
   const supervisorToken = String(args["supervisor-token"] ?? "");
   const supervisorStatusStartedAt = new Date().toISOString();
+  let supervisorStatusWrites = 0;
+  // Each write replaces the file by rename, so a reader woken by the write
+  // sees either the previous status or the new one, never a half-written one.
+  // The temp name carries a per-write counter, so overlapping writes — a
+  // heartbeat and a state change in the same tick — cannot share a scratch
+  // file.
   async function writeSupervisorStatus(
     state: SupervisorStatusState,
     extra: Record<string, unknown> = {},
   ): Promise<void> {
     if (!supervisorStatusPath) return;
-    await Deno.writeTextFile(
-      supervisorStatusPath,
-      JSON.stringify(
-        {
-          state,
-          pid: Deno.pid,
-          mountpoint,
-          token: supervisorToken || undefined,
-          startedAt: supervisorStatusStartedAt,
-          updatedAt: new Date().toISOString(),
-          ...extra,
-        },
-        null,
-        2,
-      ),
-    );
+    const pendingPath =
+      `${supervisorStatusPath}.${Deno.pid}.${supervisorStatusWrites++}.tmp`;
+    try {
+      await Deno.writeTextFile(
+        pendingPath,
+        JSON.stringify(
+          {
+            state,
+            pid: Deno.pid,
+            mountpoint,
+            token: supervisorToken || undefined,
+            startedAt: supervisorStatusStartedAt,
+            updatedAt: new Date().toISOString(),
+            ...extra,
+          },
+          null,
+          2,
+        ),
+      );
+      await Deno.rename(pendingPath, supervisorStatusPath);
+    } catch (error) {
+      await Deno.remove(pendingPath).catch(() => undefined);
+      throw error;
+    }
   }
   try {
     await writeSupervisorStatus("starting");
@@ -3368,19 +3382,6 @@ export async function main(argv: string[] = Deno.args) {
     };
   }
 
-  await writeSupervisorStatus("mounted").catch((error) => {
-    console.warn(`[FUSE] Unable to write mounted supervisor status: ${error}`);
-  });
-  const supervisorHeartbeat = supervisorStatusPath
-    ? setInterval(() => {
-      if (unmounting) return;
-      writeSupervisorStatus("mounted").catch(() => undefined);
-    }, 1_000)
-    : undefined;
-
-  console.log(`Mounted at ${mountpoint}`);
-  console.log("Press Ctrl+C to unmount");
-
   // Cleanup on signal
   function unmount() {
     if (unmounting) return;
@@ -3398,7 +3399,32 @@ export async function main(argv: string[] = Deno.args) {
   });
 
   // Run FUSE event loop (nonblocking: true → returns Promise)
-  const result = await fuse.symbols.fuse_session_loop(handle.session);
+  const sessionLoop = fuse.symbols.fuse_session_loop(handle.session);
+
+  // Readiness is reported here rather than earlier: the session loop is
+  // dispatched and the signal handlers are installed, so a caller that has
+  // seen `mounted` has a mount that serves requests and unmounts cleanly on
+  // SIGTERM. The heartbeat republishes the state so a reader that missed the
+  // first write, or read the file before the child PID was recorded, still
+  // converges.
+  if (!unmounting) {
+    await writeSupervisorStatus("mounted").catch((error) => {
+      console.warn(
+        `[FUSE] Unable to write mounted supervisor status: ${error}`,
+      );
+    });
+  }
+  const supervisorHeartbeat = supervisorStatusPath
+    ? setInterval(() => {
+      if (unmounting) return;
+      writeSupervisorStatus("mounted").catch(() => undefined);
+    }, 1_000)
+    : undefined;
+
+  console.log(`Mounted at ${mountpoint}`);
+  console.log("Press Ctrl+C to unmount");
+
+  const result = await sessionLoop;
   console.log(`FUSE loop exited (code ${result})`);
   if (supervisorHeartbeat !== undefined) clearInterval(supervisorHeartbeat);
   await writeSupervisorStatus("exited", { exitCode: result }).catch(() => {


### PR DESCRIPTION
## The problem

`cf fuse mount --background` decided whether the daemon had come up by polling a
status file two hundred times at a hundred milliseconds apart. That put a twenty
second ceiling on success. A mount that was healthy but slow to start — a cold
cache, a large space, a loaded machine — was killed on exhaustion and reported to
the user as a failure, so a non-zero exit meant "failed, or merely slow".

Three smaller faults sat alongside it. The poll used a fixed delay as a
synchronization primitive: on first seeing the `mounted` state it slept and
re-read the file to confirm, which moved the window in which a dying child went
unnoticed rather than closing it. It polled even though the daemon already
publishes a real signal. And called without a status file path, the function
checked only that the process was alive and then returned success, having
confirmed nothing about the mount — production always passed the path, so the CLI
never reached it, but the exported function would have lied to any future caller.

All four are what the repository policy on timeouts, retry loops and sleeps
forbids, and all four were unnecessary, because two real events were already
available.

## The approach

The wait is now a race between those two events, with no deadline. The supervisor
is spawned through `Deno.Command`, so its `status` promise reports the exit that
means startup failed. The daemon publishes its state to a file beside the mount
state file, so a `Deno.watchFs` watch reports every write.

The watch covers the directory holding both files rather than the status file
alone. Neither file need exist when the wait starts, and readiness also depends on
the supervisor recording the child PID into the mount state file, since until it
does no status can be tied to this mount. The wait reads once after installing the
watch, so a daemon that reports before the watch began is still seen, and reads
again on each event after that.

Readiness has no deadline by design. A deadline can only turn a slow startup into
a reported failure, and startup carries no liveness signal finer than the process
itself, because the daemon's heartbeat begins only once it is already mounted.
Nothing distinguishes a slow child from a stuck one, so a child that never reports
now leaves the command waiting — interruptible and visible — rather than killing a
mount that was about to work. In tests and CI the ambient limit is the backstop.

The status file path is now a required parameter, so the shape that returned
success without checking anything cannot be expressed.

## Daemon-side changes

Status writes now land by rename, so a reader woken by a write sees a complete
document rather than a half-written one. A torn read mattered little when reads
happened on an unrelated tick, but the reader now reads at the moment of the
write.

`mounted` is published after the FUSE session loop is dispatched and the signal
handlers are installed, rather than before both. Previously the CLI could be told
a mount was ready while a SIGTERM would still have killed the daemon outright
instead of unmounting it cleanly.

## Verification

Driving the real flow end to end proved the headline fix and caught a bug the unit
tests could not see. A startup taking twenty-five seconds — past the old ceiling —
now succeeds cleanly, and the failure path still rejects the moment the process
exits. The bug: leaving a `for await` over a real `Deno.FsWatcher` closes it, so
the explicit close afterwards reported a bad resource, which would have crashed the
command right after a *successful* mount. One test now uses a real watch, because
a fake cannot stand in for that.

Each property was checked by breaking the implementation and confirming the test
failed for the expected reason. That exposed two tests of my own that passed for
the wrong reason: one buffered all its events before the wait began iterating, so
it never exercised a long wait, and one let the supervisor's exit win the
microtask race so the status file was never consulted. Both are rewritten to drive
wake-ups one at a time. A separate test fakes the clock and advances an hour while
the child is still starting, because an attempt-driven test cannot see a wall-clock
deadline — five hundred heartbeats complete in a few milliseconds, so a twenty
second timer could otherwise have been reintroduced with the suite still green.

`deno fmt --check` and `deno lint` are clean repo-wide; the CLI and FUSE suites
pass.

## Known bound left behind

`recordFuseChildPid` still retries twenty times at fifty milliseconds before
giving up, and giving up exits the supervisor, which the wait reports as a mount
that died during startup. Since no status can be tied to a mount until that PID is
recorded, it is a ceiling on readiness of the same shape, one layer down. It is
left in place because, unlike the ceiling removed here, it does real work: it also
stops a supervisor from waiting forever, holding a mount, when the CLI dies before
writing the state file. Removing it honestly means giving the supervisor an event
for the CLI's death rather than a deadline, which changes what the CLI hands it at
spawn time, so it belongs in its own change. It is recorded in
`docs/development/waiting-in-tests.md` rather than left as a bare constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `cf fuse mount --background` startup detection from polling to an event-driven wait with no fixed timeout. Slow-but-healthy mounts no longer fail on a deadline, and real startup failures are reported promptly; supervisor status writes are now serialized to prevent state regressions.

- **Bug Fixes**
  - Wait on real events: supervisor exit (`Deno.Command.status`) or daemon status writes via `Deno.watchFs` on the status directory.
  - Read once after installing the watch and again on each event; remove sleeps, attempt limits, and the “sleep-then-reconfirm” race.
  - Require `childStatusPath`; liveness alone is never treated as readiness.
  - Classify status by token/mountpoint and child PID; reject foreign or unreadable content as “not yet,” not a verdict.
  - Cleanup on failure is precise: remove only mount state or both state and child-status as appropriate.
  - Integration script now polls `result.json` content with `jq` until sigils render to avoid reading mid-rebuild.

- **Refactors**
  - Supervisor status writer moved to `createSupervisorStatusWriter`; writes are serialized and land via temp-file+rename, with `updatedAt` stamped at call time. Prevents a late heartbeat from overwriting `exiting/exited`.
  - Publish `mounted` after the FUSE session loop is dispatched and signal handlers are installed; continue 1s heartbeat.
  - Tests use a watcher seam and a fake supervisor to drive events; add a real `Deno.watchFs` test for close semantics and a fake-clock test to prove there’s no time-based deadline.
  - Document the remaining startup bound: `recordFuseChildPid`’s retry ceiling, recorded in `docs/development/waiting-in-tests.md`.

<sup>Written for commit 9df16b97dc8943fce774a51d9f190d33cb8b84e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

