### PR TITLE
feat(tools): expose running pattern provenance

### DIFF
--- a/docs/specs/fuse-filesystem/2-path-scheme.md
+++ b/docs/specs/fuse-filesystem/2-path-scheme.md
@@ -260,6 +260,7 @@ pieces/.index.json    # {"todo-app": "of:ba4jcbvpq3k5soo...", ...}
   "symbol": "default",
   "source": {
     "ref": "cf:pattern:<content-hash>",
+    "repository": "https://github.com/commontoolsinc/labs",
     "entry": "/packages/patterns/todo-app.tsx"
   }
 }
@@ -268,12 +269,13 @@ pieces/.index.json    # {"todo-app": "of:ba4jcbvpq3k5soo...", ...}
 The prefix-free identity and symbol are the authoritative pointer to the
 running artifact (`cf:module/<identity>#<symbol>` in display form).
 `source.ref` is the immutable in-fabric source reference from the pattern-import
-grammar. `source.entry` is the optional authored path inside the verified source
-closure; `source.origin` is the optional `patternSource` update provenance.
-For local deployments, `--root` defines the path namespace, so passing a
-repository root preserves a repository-relative entry path without persisting
-an absolute machine path. Pattern references update in place when the piece
-rolls forward; they do not participate in directory-name selection. See
+grammar. `source.repository` is optional, explicitly supplied repository
+discovery metadata. `source.entry` is the optional authored path inside the
+verified source closure; `source.origin` is the optional `patternSource` update
+provenance. For local deployments, `--root` defines the path namespace, while
+`--repository` records which repository that path belongs to without inspecting
+Git configuration. Pattern references update in place when the piece rolls
+forward; they do not participate in directory-name selection. See
 `docs/specs/pattern-imports/README.md` for the canonical field semantics.
 
 ## Entity Directory

--- a/docs/specs/fuse-filesystem/2-path-scheme.md
+++ b/docs/specs/fuse-filesystem/2-path-scheme.md
@@ -258,17 +258,23 @@ pieces/.index.json    # {"todo-app": "of:ba4jcbvpq3k5soo...", ...}
 {
   "identity": "<content-hash>",
   "symbol": "default",
-  "source": "/todo-app.tsx"
+  "source": {
+    "ref": "cf:pattern:<content-hash>",
+    "entry": "/packages/patterns/todo-app.tsx"
+  }
 }
 ```
 
 The prefix-free identity and symbol are the authoritative pointer to the
 running artifact (`cf:module/<identity>#<symbol>` in display form).
-`source` is a best-effort discovery locator: explicit `patternSource`
-provenance when present, otherwise the authored entry filename recovered from
-the current pattern's verified source closure. Pattern references update in
-place when the piece rolls forward; they do not participate in directory-name
-selection.
+`source.ref` is the immutable in-fabric source reference from the pattern-import
+grammar. `source.entry` is the optional authored path inside the verified source
+closure; `source.origin` is the optional `patternSource` update provenance.
+For local deployments, `--root` defines the path namespace, so passing a
+repository root preserves a repository-relative entry path without persisting
+an absolute machine path. Pattern references update in place when the piece
+rolls forward; they do not participate in directory-name selection. See
+`docs/specs/pattern-imports/README.md` for the canonical field semantics.
 
 ## Entity Directory
 

--- a/docs/specs/fuse-filesystem/2-path-scheme.md
+++ b/docs/specs/fuse-filesystem/2-path-scheme.md
@@ -38,6 +38,7 @@ The mount root contains spaces. Each space contains pieces and entities.
         result/*.handler             # Top-level mounted handlers
         result/*.tool                # Top-level mounted pattern tools
         meta.json                     # Read-only piece metadata
+      pieces.json                     # Discovery manifest incl. pattern refs
     entities/                         # Raw entity view (advanced)
       <entity-id>/
         .json                         # Full entity value
@@ -141,7 +142,7 @@ home/pieces/todo-app/
     addItem.handler   # executable: invoke via cf exec or write JSON
     search.tool       # executable: run via cf exec
     $UI.json          # serialized VNode tree (not exploded)
-  meta.json           # {"id":"of:ba4j...","patternName":"todo-app",...}
+  meta.json           # {"id":"of:ba4j...","patternRef":{...},...}
   .handlers           # hidden summary: one line per callable with type info
 ```
 
@@ -235,20 +236,39 @@ a stable `cf exec` shebang, and the same paths are valid under both
 Piece names are derived from:
 
 1. `piece.name()` if set (the user-visible display name)
-2. Pattern name from metadata
-3. Shortened entity ID (first 12 chars) as fallback
+2. The entity ID as fallback
 
 Names are sanitized for filesystem safety:
-- Replace `/` with `_`
-- Replace null bytes
-- Trim to 255 bytes (filesystem limit)
-- Ensure uniqueness within the directory
+
+- Normalize Unicode and remove combining marks and emoji
+- Collapse non-alphanumeric runs to `-`
+- Trim/collapse `-` runs
+- Ensure uniqueness within the directory with numeric suffixes
 
 A symlink or index file maps human names back to canonical entity IDs:
 
 ```
 pieces/.index.json    # {"todo-app": "of:ba4jcbvpq3k5soo...", ...}
 ```
+
+`meta.json` and `pieces/pieces.json` carry the same optional structured
+`patternRef`:
+
+```json
+{
+  "identity": "<content-hash>",
+  "symbol": "default",
+  "source": "/todo-app.tsx"
+}
+```
+
+The prefix-free identity and symbol are the authoritative pointer to the
+running artifact (`cf:module/<identity>#<symbol>` in display form).
+`source` is a best-effort discovery locator: explicit `patternSource`
+provenance when present, otherwise the authored entry filename recovered from
+the current pattern's verified source closure. Pattern references update in
+place when the piece rolls forward; they do not participate in directory-name
+selection.
 
 ## Entity Directory
 

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -37,7 +37,7 @@ is a companion: `pattern-updates.md`.
 
 ## Last Updated
 
-2026-07-08
+2026-07-17
 
 ## Motivation
 
@@ -106,6 +106,46 @@ Because both come up, and only one is the pin:
   (`cf:module/<hash>`, compile cache, `$patternRef`,
   `meta("patternIdentity")`). **This is the pin**, and `cf:pattern:<identity>`
   is its reference spelling.
+
+### Tooling reference for a running piece
+
+Piece tooling exposes the running pattern and its source as three deliberately
+separate facts:
+
+```json
+{
+  "identity": "<prefix-free-entry-module-hash>",
+  "symbol": "default",
+  "source": {
+    "ref": "cf:pattern:<prefix-free-entry-module-hash>",
+    "entry": "/packages/patterns/annotation.tsx",
+    "origin": "cf:/did:key:z6Mk.../annotation"
+  }
+}
+```
+
+- `identity` + `symbol` is the authoritative reference to the executable
+  export (`cf:module/<identity>#<symbol>` in display form).
+- `source.ref` is the immutable, in-fabric reference to the verified source
+  closure that produced the running identity. It uses the same
+  `cf:pattern:<hash>` grammar as imports and is derived from `identity`; it does
+  not depend on how or where the pattern was authored.
+- `source.entry` is the optional authored entry filename recovered from that
+  verified closure. Authored filenames are relative to the compilation root.
+  For a local deployment, passing the repository root as `cf piece new
+  --root` / `cf piece setsrc --root` therefore preserves a path inside that
+  repository rather than only a basename. Absolute paths from the author's
+  machine are never persisted.
+- `source.origin` is the optional `patternSource` update provenance carried by
+  the piece (a `cf:` publication ref or a toolshed system-pattern path). It
+  answers "where should updates be checked?", not "which exact bytes are
+  running?"; `source.ref` answers the latter.
+
+No Git remote or revision is inferred automatically. A checkout may be dirty,
+have several remotes, or contain credentials in a remote URL, so inferred VCS
+metadata would be both non-authoritative and potentially sensitive. A future
+explicit repository annotation can add discovery links without changing the
+content-addressed `source.ref` contract.
 
 ## Specifier syntax
 

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -109,8 +109,8 @@ Because both come up, and only one is the pin:
 
 ### Tooling reference for a running piece
 
-Piece tooling exposes the running pattern and its source as three deliberately
-separate facts:
+Piece tooling exposes the running pattern and its source as deliberately
+separate fields:
 
 ```json
 {
@@ -118,6 +118,7 @@ separate facts:
   "symbol": "default",
   "source": {
     "ref": "cf:pattern:<prefix-free-entry-module-hash>",
+    "repository": "https://github.com/commontoolsinc/labs",
     "entry": "/packages/patterns/annotation.tsx",
     "origin": "cf:/did:key:z6Mk.../annotation"
   }
@@ -130,22 +131,26 @@ separate facts:
   closure that produced the running identity. It uses the same
   `cf:pattern:<hash>` grammar as imports and is derived from `identity`; it does
   not depend on how or where the pattern was authored.
+- `source.repository` is the optional repository locator supplied explicitly at
+  deployment. It is descriptive discovery metadata, not proof of which bytes
+  are running; `source.ref` remains authoritative for that. The CLI stores the
+  value exactly as supplied and never derives it from local Git configuration.
 - `source.entry` is the optional authored entry filename recovered from that
   verified closure. Authored filenames are relative to the compilation root.
-  For a local deployment, passing the repository root as `cf piece new
-  --root` / `cf piece setsrc --root` therefore preserves a path inside that
-  repository rather than only a basename. Absolute paths from the author's
-  machine are never persisted.
+  For a local deployment, passing the repository root as `--root` therefore
+  preserves a path inside that repository rather than only a basename.
+  Absolute paths from the author's machine are never persisted.
 - `source.origin` is the optional `patternSource` update provenance carried by
   the piece (a `cf:` publication ref or a toolshed system-pattern path). It
   answers "where should updates be checked?", not "which exact bytes are
   running?"; `source.ref` answers the latter.
 
-No Git remote or revision is inferred automatically. A checkout may be dirty,
-have several remotes, or contain credentials in a remote URL, so inferred VCS
-metadata would be both non-authoritative and potentially sensitive. A future
-explicit repository annotation can add discovery links without changing the
-content-addressed `source.ref` contract.
+`cf piece new`, `cf piece setsrc`, and custom `cf piece set-home` accept
+`--repository <locator>` alongside `--root`. `new` and custom `set-home` stamp
+the locator on the new piece. `setsrc` replaces it when the flag is present and
+preserves the existing locator when the flag is omitted. `set-home --reset`
+rejects the flag because the system pattern was not deployed from the caller's
+repository. No Git remote or revision is inferred automatically.
 
 ## Specifier syntax
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -370,6 +370,7 @@ export type MetaField =
   | "patternIdentity" // content-addressed {identity, symbol} pattern reference
   | "patternSource" // provenance: the source a piece tracks for updates (a
   // toolshed pattern path, or later a `cf:` fabric ref)
+  | "patternRepository" // optional caller-supplied repository locator
   | "internal"
   | "schema"
   | "slug";

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -96,8 +96,9 @@ FILESYSTEM LAYOUT:
           input/*.handler
           input/*.tool
           input.json
-          meta.json             # piece ID, entity, pattern name
+          meta.json             # piece ID, entity, running pattern ref
         .index.json             # name-to-entity-ID mapping
+        pieces.json             # discovery manifest with pattern refs
       entities/                 # access cells by entity ID
       space.json                # { did, name }
     .spaces.json                # known space-name -> DID mapping

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -36,6 +36,7 @@ import type { CellScope } from "@commonfabric/api";
 import { parseCellPath } from "@commonfabric/runner";
 import { UI } from "@commonfabric/runner";
 import ports from "@commonfabric/ports" with { type: "json" };
+import type { PiecePatternRef } from "@commonfabric/piece/ops";
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;
@@ -76,6 +77,21 @@ function summarizeForDisplay(value: unknown): unknown {
     else out[k] = "[Object]";
   }
   return out;
+}
+
+export function formatPatternRef(
+  patternRef: PiecePatternRef | undefined,
+): string {
+  if (patternRef === undefined) return "<unknown>";
+  return patternRef.source ?? formatPatternIdentity(patternRef);
+}
+
+export function formatPatternIdentity(
+  patternRef: PiecePatternRef | undefined,
+): string {
+  return patternRef === undefined
+    ? "<unknown>"
+    : `cf:module/${patternRef.identity}#${patternRef.symbol}`;
 }
 
 function pieceCallRawArgs(tail: string[], literalArgs: string[]): string[] {
@@ -202,17 +218,19 @@ export const piece = new Command()
         pieces.map((p) => ({
           id: p.id,
           name: p.name ?? null,
+          patternRef: p.patternRef ?? null,
         })),
         { json: true },
       );
       return;
     }
     const piecesData = [
-      ["ID", "NAME"],
+      ["ID", "NAME", "PATTERN"],
       ...(pieces.map(
         (data) => [
           data.id,
           data.error ? `<error: ${data.error}>` : (data.name ?? "<unnamed>"),
+          data.error ? "" : formatPatternRef(data.patternRef),
         ],
       )),
     ];
@@ -430,6 +448,8 @@ export const piece = new Command()
     let output = `
 === Piece: ${pieceData.id} ===
 Name: ${pieceData.name || "<no name>"}
+Pattern: ${formatPatternRef(pieceData.patternRef)}
+Pattern Ref: ${formatPatternIdentity(pieceData.patternRef)}
 
 --- Source (Inputs) ---`;
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -83,6 +83,11 @@ export function formatPatternRef(
   patternRef: PiecePatternRef | undefined,
 ): string {
   if (patternRef === undefined) return "<unknown>";
+  if (patternRef.source.repository !== undefined) {
+    return patternRef.source.entry === undefined
+      ? patternRef.source.repository
+      : `${patternRef.source.repository}#${patternRef.source.entry}`;
+  }
   return patternRef.source.origin ?? patternRef.source.entry ??
     patternRef.source.ref;
 }
@@ -270,6 +275,10 @@ export const piece = new Command()
     "--root <path:string>",
     "Root directory for imports and authored source paths. Use a repository root to preserve repository-relative paths.",
   )
+  .option(
+    "--repository <repository:string>",
+    "Repository locator associated with the authored source (stored exactly as supplied).",
+  )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
   .action(async (options, main) => {
     setQuietMode(!!options.quiet);
@@ -279,6 +288,7 @@ export const piece = new Command()
       {
         mainPath: absPath(main),
         mainExport: options.mainExport,
+        repository: options.repository,
         rootPath: options.root ? absPath(options.root) : undefined,
       },
       { start: options.start, slug: options.slug },
@@ -394,6 +404,10 @@ export const piece = new Command()
     "--root <path:string>",
     "Root directory for imports and authored source paths. Use a repository root to preserve repository-relative paths.",
   )
+  .option(
+    "--repository <repository:string>",
+    "Repository locator associated with the authored source (stored exactly as supplied).",
+  )
   .arguments("<main:string>")
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
@@ -401,6 +415,7 @@ export const piece = new Command()
     await setPiecePattern(pieceConfig, {
       mainPath: absPath(mainPath),
       mainExport: options.mainExport,
+      repository: options.repository,
       rootPath: options.root ? absPath(options.root) : undefined,
     });
     render(`Updated source for piece ${pieceConfig.piece}`);
@@ -452,6 +467,9 @@ Name: ${pieceData.name || "<no name>"}
 Pattern: ${formatPatternRef(pieceData.patternRef)}
 Pattern Ref: ${formatPatternIdentity(pieceData.patternRef)}
 Source Ref: ${pieceData.patternRef?.source.ref ?? "<unknown>"}
+Repository: ${pieceData.patternRef?.source.repository ?? "<unknown>"}
+Source Entry: ${pieceData.patternRef?.source.entry ?? "<unknown>"}
+Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
 
 --- Source (Inputs) ---`;
 
@@ -949,7 +967,11 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
   )
   .option(
     "--root <path:string>",
-    "Root directory for resolving imports.",
+    "Root directory for imports and authored source paths. Use a repository root to preserve repository-relative paths.",
+  )
+  .option(
+    "--repository <repository:string>",
+    "Repository locator associated with the authored source (stored exactly as supplied).",
   )
   .arguments("[main:string]")
   .action(async (options, main?: string) => {
@@ -967,6 +989,12 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
         { exitCode: 1 },
       );
     }
+    if (options.reset && options.repository !== undefined) {
+      throw new ValidationError(
+        "Cannot use --repository with --reset.",
+        { exitCode: 1 },
+      );
+    }
 
     const baseConfig = parseSetHomeOptions(options);
 
@@ -977,6 +1005,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
       await setHomePattern(baseConfig, {
         mainPath: absPath(main!),
         mainExport: options.mainExport,
+        repository: options.repository,
         rootPath: options.root ? absPath(options.root) : undefined,
       });
       render("Deployed custom home pattern.");

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2,6 +2,7 @@ import { Table } from "@cliffy/table";
 import { Command, ValidationError } from "@cliffy/command";
 import {
   applyPieceInput,
+  type EntryConfig,
   executePieceCallable,
   formatViewTree,
   generateSpaceMap,
@@ -98,6 +99,22 @@ export function formatPatternIdentity(
   return patternRef === undefined
     ? "<unknown>"
     : `cf:module/${patternRef.identity}#${patternRef.symbol}`;
+}
+
+export function localPatternEntry(
+  mainPath: string,
+  options: {
+    mainExport?: string;
+    repository?: string;
+    root?: string;
+  },
+): EntryConfig {
+  return {
+    mainPath: absPath(mainPath),
+    mainExport: options.mainExport,
+    repository: options.repository,
+    rootPath: options.root ? absPath(options.root) : undefined,
+  };
 }
 
 function pieceCallRawArgs(tail: string[], literalArgs: string[]): string[] {
@@ -285,12 +302,7 @@ export const piece = new Command()
     const spaceConfig = parseSpaceOptions(options);
     const pieceId = await newPiece(
       spaceConfig,
-      {
-        mainPath: absPath(main),
-        mainExport: options.mainExport,
-        repository: options.repository,
-        rootPath: options.root ? absPath(options.root) : undefined,
-      },
+      localPatternEntry(main, options),
       { start: options.start, slug: options.slug },
     );
     render(pieceId);
@@ -412,12 +424,7 @@ export const piece = new Command()
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
     const pieceConfig = parsePieceOptions(options);
-    await setPiecePattern(pieceConfig, {
-      mainPath: absPath(mainPath),
-      mainExport: options.mainExport,
-      repository: options.repository,
-      rootPath: options.root ? absPath(options.root) : undefined,
-    });
+    await setPiecePattern(pieceConfig, localPatternEntry(mainPath, options));
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
   → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
@@ -1002,12 +1009,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
       await resetHomePattern(baseConfig);
       render("Reset home pattern to system default.");
     } else {
-      await setHomePattern(baseConfig, {
-        mainPath: absPath(main!),
-        mainExport: options.mainExport,
-        repository: options.repository,
-        rootPath: options.root ? absPath(options.root) : undefined,
-      });
+      await setHomePattern(baseConfig, localPatternEntry(main!, options));
       render("Deployed custom home pattern.");
     }
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -83,7 +83,8 @@ export function formatPatternRef(
   patternRef: PiecePatternRef | undefined,
 ): string {
   if (patternRef === undefined) return "<unknown>";
-  return patternRef.source ?? formatPatternIdentity(patternRef);
+  return patternRef.source.origin ?? patternRef.source.entry ??
+    patternRef.source.ref;
 }
 
 export function formatPatternIdentity(
@@ -267,7 +268,7 @@ export const piece = new Command()
   )
   .option(
     "--root <path:string>",
-    "Root directory for resolving imports. Allows imports from parent directories within this root.",
+    "Root directory for imports and authored source paths. Use a repository root to preserve repository-relative paths.",
   )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
   .action(async (options, main) => {
@@ -391,7 +392,7 @@ export const piece = new Command()
   )
   .option(
     "--root <path:string>",
-    "Root directory for resolving imports. Allows imports from parent directories within this root.",
+    "Root directory for imports and authored source paths. Use a repository root to preserve repository-relative paths.",
   )
   .arguments("<main:string>")
   .action(async (options, mainPath) => {
@@ -450,6 +451,7 @@ export const piece = new Command()
 Name: ${pieceData.name || "<no name>"}
 Pattern: ${formatPatternRef(pieceData.patternRef)}
 Pattern Ref: ${formatPatternIdentity(pieceData.patternRef)}
+Source Ref: ${pieceData.patternRef?.source.ref ?? "<unknown>"}
 
 --- Source (Inputs) ---`;
 

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -1,5 +1,8 @@
 import type { PieceManager } from "@commonfabric/piece";
-import { PiecesController } from "@commonfabric/piece/ops";
+import {
+  type PiecePatternRef,
+  PiecesController,
+} from "@commonfabric/piece/ops";
 import { basename, dirname, join, relative, resolve } from "@std/path";
 import {
   type MountedCallablePath,
@@ -30,6 +33,7 @@ export interface MountedPieceMeta {
   id: string;
   entityId?: string;
   name?: string;
+  patternRef?: PiecePatternRef;
 }
 
 export interface ResolvedMountedCallableFile {
@@ -110,10 +114,27 @@ async function readMountedPieceMeta(
     throw new Error(`Mounted piece metadata missing id for ${absFilePath}`);
   }
 
+  const rawPatternRef = meta.patternRef;
+  const patternRef = typeof rawPatternRef === "object" &&
+      rawPatternRef !== null && !Array.isArray(rawPatternRef) &&
+      typeof (rawPatternRef as Record<string, unknown>).identity === "string" &&
+      typeof (rawPatternRef as Record<string, unknown>).symbol === "string"
+    ? {
+      identity: (rawPatternRef as Record<string, unknown>).identity as string,
+      symbol: (rawPatternRef as Record<string, unknown>).symbol as string,
+      ...(typeof (rawPatternRef as Record<string, unknown>).source === "string"
+        ? {
+          source: (rawPatternRef as Record<string, unknown>).source as string,
+        }
+        : {}),
+    }
+    : undefined;
+
   return {
     id: meta.id,
     entityId: typeof meta.entityId === "string" ? meta.entityId : undefined,
     name: typeof meta.name === "string" ? meta.name : undefined,
+    patternRef,
   };
 }
 

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -115,18 +115,39 @@ async function readMountedPieceMeta(
   }
 
   const rawPatternRef = meta.patternRef;
+  const rawPatternSource = typeof rawPatternRef === "object" &&
+      rawPatternRef !== null && !Array.isArray(rawPatternRef)
+    ? (rawPatternRef as Record<string, unknown>).source
+    : undefined;
+  const patternSource = typeof rawPatternSource === "object" &&
+      rawPatternSource !== null && !Array.isArray(rawPatternSource) &&
+      typeof (rawPatternSource as Record<string, unknown>).ref === "string"
+    ? {
+      ref: (rawPatternSource as Record<string, unknown>).ref as string,
+      ...(typeof (rawPatternSource as Record<string, unknown>).entry ===
+          "string"
+        ? {
+          entry: (rawPatternSource as Record<string, unknown>).entry as string,
+        }
+        : {}),
+      ...(typeof (rawPatternSource as Record<string, unknown>).origin ===
+          "string"
+        ? {
+          origin: (rawPatternSource as Record<string, unknown>)
+            .origin as string,
+        }
+        : {}),
+    }
+    : undefined;
   const patternRef = typeof rawPatternRef === "object" &&
       rawPatternRef !== null && !Array.isArray(rawPatternRef) &&
       typeof (rawPatternRef as Record<string, unknown>).identity === "string" &&
-      typeof (rawPatternRef as Record<string, unknown>).symbol === "string"
+      typeof (rawPatternRef as Record<string, unknown>).symbol === "string" &&
+      patternSource !== undefined
     ? {
       identity: (rawPatternRef as Record<string, unknown>).identity as string,
       symbol: (rawPatternRef as Record<string, unknown>).symbol as string,
-      ...(typeof (rawPatternRef as Record<string, unknown>).source === "string"
-        ? {
-          source: (rawPatternRef as Record<string, unknown>).source as string,
-        }
-        : {}),
+      source: patternSource,
     }
     : undefined;
 

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -124,6 +124,13 @@ async function readMountedPieceMeta(
       typeof (rawPatternSource as Record<string, unknown>).ref === "string"
     ? {
       ref: (rawPatternSource as Record<string, unknown>).ref as string,
+      ...(typeof (rawPatternSource as Record<string, unknown>).repository ===
+          "string"
+        ? {
+          repository: (rawPatternSource as Record<string, unknown>)
+            .repository as string,
+        }
+        : {}),
       ...(typeof (rawPatternSource as Record<string, unknown>).entry ===
           "string"
         ? {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -5,6 +5,7 @@ import {
   Cell,
   entityIdFrom,
   experimentalOptionsFromEnv,
+  formatFabricRef,
   getPatternIdentityRef,
   isSlugAddress,
   NAME,
@@ -1227,7 +1228,21 @@ async function inspectSlugTargetCell(
   const name = isRecord(result) && typeof result[NAME] === "string"
     ? result[NAME]
     : undefined;
-  const patternRef = getPatternIdentityRef(target);
+  const identityRef = getPatternIdentityRef(target);
+  const patternRef: PiecePatternRef | undefined = identityRef === undefined
+    ? undefined
+    : {
+      ...identityRef,
+      source: {
+        ref: formatFabricRef({
+          ref: {
+            kind: "uri",
+            scheme: "pattern",
+            hash: identityRef.identity,
+          },
+        }),
+      },
+    };
 
   return {
     id: slug,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -107,6 +107,13 @@ export interface PieceResolutionDeps {
   ) => Promise<string>;
 }
 
+interface PieceOperationDependencies extends PieceResolutionDeps {
+  loadIdentity?: typeof loadIdentity;
+  getProgramFromFile?: typeof getProgramFromFile;
+  getPinnedProgramFromFile?: typeof getPinnedProgramFromFile;
+  createController?: (manager: PieceManager) => PiecesController;
+}
+
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
 
 interface DisposableRuntime {
@@ -316,11 +323,13 @@ async function getPinnedProgramFromFile(
 // Returns an array of metadata about pieces to display.
 export async function listPieces(
   config: SpaceConfig,
+  deps: PieceOperationDependencies = {},
 ): Promise<
   { id: string; name?: string; patternRef?: PiecePatternRef; error?: string }[]
 > {
-  const manager = await loadManager(config);
-  const pieces = new PiecesController(manager);
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
   const allPieces = await pieces.getAllPieces();
   return Promise.all(
     allPieces.map(async (piece) => {
@@ -400,12 +409,14 @@ export async function newPiece(
   config: SpaceConfig,
   entry: EntryConfig,
   options?: { start?: boolean; slug?: string },
+  deps: PieceOperationDependencies = {},
 ): Promise<string> {
   const manager = await timeCliPhase(
     "newPiece.loadManager",
-    () => loadManager(config),
+    () => (deps.loadManager ?? loadManager)(config),
   );
-  const pieces = new PiecesController(manager);
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
 
   // The default pattern is a hard requirement for this command: even when the
   // user's pattern doesn't use it, registration below (manager.add) sends an
@@ -431,7 +442,11 @@ export async function newPiece(
 
   const program = await timeCliPhase(
     "newPiece.getProgramFromFile",
-    () => getPinnedProgramFromFile(manager, entry),
+    () =>
+      (deps.getPinnedProgramFromFile ?? getPinnedProgramFromFile)(
+        manager,
+        entry,
+      ),
   );
   const PIECE_START_TIMEOUT_MS = 60_000;
   const piece = await timeCliPhase("newPiece.create", () => {
@@ -525,19 +540,29 @@ export async function setPieceSlug(
 export async function setPiecePattern(
   config: PieceConfig,
   entry: EntryConfig,
+  deps: PieceOperationDependencies = {},
 ): Promise<void> {
-  const manager = await loadManager(config);
-  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
-  const pieces = new PiecesController(manager);
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(
+    config,
+    manager,
+    deps.resolvePieceAddress,
+  );
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
   const piece = await pieces.get(
     resolvedConfig.piece,
     false,
     undefined,
     resolvedConfig.pieceScope,
   );
-  await piece.setPattern(await getPinnedProgramFromFile(manager, entry), {
-    repository: entry.repository,
-  });
+  await piece.setPattern(
+    await (deps.getPinnedProgramFromFile ?? getPinnedProgramFromFile)(
+      manager,
+      entry,
+    ),
+    { repository: entry.repository },
+  );
 }
 
 export async function savePiecePattern(
@@ -1161,7 +1186,10 @@ export async function generateSpaceMap(
   return formatSpaceMap(connections, format);
 }
 
-export async function inspectPiece(config: PieceConfig): Promise<{
+export async function inspectPiece(
+  config: PieceConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<{
   id: string;
   name?: string;
   patternRef?: PiecePatternRef;
@@ -1170,10 +1198,14 @@ export async function inspectPiece(config: PieceConfig): Promise<{
   readingFrom: Array<{ id: string; name?: string }>;
   readBy: Array<{ id: string; name?: string }>;
 }> {
-  const manager = await loadManager(config);
+  const manager = await (deps.loadManager ?? loadManager)(config);
   let resolvedConfig: PieceConfig;
   try {
-    resolvedConfig = await resolvePieceConfigWithManager(config, manager);
+    resolvedConfig = await resolvePieceConfigWithManager(
+      config,
+      manager,
+      deps.resolvePieceAddress,
+    );
   } catch (error) {
     if (
       error instanceof SlugResolutionError &&
@@ -1183,7 +1215,8 @@ export async function inspectPiece(config: PieceConfig): Promise<{
     }
     throw error;
   }
-  const pieces = new PiecesController(manager);
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
   const piece = await pieces.get(
     resolvedConfig.piece,
     false,
@@ -1426,12 +1459,17 @@ function isVNodeLike(value: unknown): value is VNode {
 export async function setHomePattern(
   config: Omit<SpaceConfig, "space">,
   entry: EntryConfig,
+  deps: PieceOperationDependencies = {},
 ): Promise<void> {
-  const identity = await loadIdentity(config.identity);
+  const identity = await (deps.loadIdentity ?? loadIdentity)(config.identity);
   const homeConfig: SpaceConfig = { ...config, space: identity.did() };
-  const manager = await loadManager(homeConfig);
-  const program = await getProgramFromFile(manager, entry);
-  const pieces = new PiecesController(manager);
+  const manager = await (deps.loadManager ?? loadManager)(homeConfig);
+  const program = await (deps.getProgramFromFile ?? getProgramFromFile)(
+    manager,
+    entry,
+  );
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
   await pieces.recreateDefaultPattern({
     customProgram: program,
     repository: entry.repository,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -25,7 +25,10 @@ import {
   setSlugLink,
   SlugResolutionError,
 } from "@commonfabric/piece";
-import { PiecesController } from "@commonfabric/piece/ops";
+import {
+  type PiecePatternRef,
+  PiecesController,
+} from "@commonfabric/piece/ops";
 import { dirname, join } from "@std/path";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
@@ -312,7 +315,7 @@ async function getPinnedProgramFromFile(
 export async function listPieces(
   config: SpaceConfig,
 ): Promise<
-  { id: string; name?: string; error?: string }[]
+  { id: string; name?: string; patternRef?: PiecePatternRef; error?: string }[]
 > {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
@@ -324,9 +327,11 @@ export async function listPieces(
         const name = (await (
           livePiece.getCell().key(NAME) as Cell<unknown>
         ).pull()) as string | undefined;
+        const patternRef = await livePiece.getPatternRef();
         return {
           id: piece.id,
           name,
+          patternRef,
         };
       } catch (err) {
         return {
@@ -1152,6 +1157,7 @@ export async function generateSpaceMap(
 export async function inspectPiece(config: PieceConfig): Promise<{
   id: string;
   name?: string;
+  patternRef?: PiecePatternRef;
   source?: Readonly<unknown>;
   result: Readonly<unknown>;
   readingFrom: Array<{ id: string; name?: string }>;
@@ -1180,6 +1186,7 @@ export async function inspectPiece(config: PieceConfig): Promise<{
 
   const id = piece.id;
   const name = piece.name();
+  const patternRef = await piece.getPatternRef();
   const source = (await piece.input.get()) as Readonly<unknown>;
   const result = (await piece.result.get()) as Readonly<unknown>;
   const readingFrom = (await piece.readingFrom()).map((piece) => ({
@@ -1194,6 +1201,7 @@ export async function inspectPiece(config: PieceConfig): Promise<{
   return {
     id,
     name,
+    patternRef,
     source,
     result,
     readingFrom,
@@ -1207,6 +1215,7 @@ async function inspectSlugTargetCell(
 ): Promise<{
   id: string;
   name?: string;
+  patternRef?: PiecePatternRef;
   source?: Readonly<unknown>;
   result: Readonly<unknown>;
   readingFrom: Array<{ id: string; name?: string }>;
@@ -1218,10 +1227,12 @@ async function inspectSlugTargetCell(
   const name = isRecord(result) && typeof result[NAME] === "string"
     ? result[NAME]
     : undefined;
+  const patternRef = getPatternIdentityRef(target);
 
   return {
     id: slug,
     name,
+    patternRef,
     result,
     readingFrom: [],
     readBy: [],

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -59,6 +59,7 @@ import { deriveDiskHandleId } from "./sqlite-source.ts";
 export interface EntryConfig {
   mainPath: string;
   mainExport?: string;
+  repository?: string;
   rootPath?: string;
 }
 
@@ -434,7 +435,10 @@ export async function newPiece(
   );
   const PIECE_START_TIMEOUT_MS = 60_000;
   const piece = await timeCliPhase("newPiece.create", () => {
-    const createPromise = pieces.create(program, { start: options?.start });
+    const createPromise = pieces.create(program, {
+      repository: entry.repository,
+      start: options?.start,
+    });
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
@@ -531,7 +535,9 @@ export async function setPiecePattern(
     undefined,
     resolvedConfig.pieceScope,
   );
-  await piece.setPattern(await getPinnedProgramFromFile(manager, entry));
+  await piece.setPattern(await getPinnedProgramFromFile(manager, entry), {
+    repository: entry.repository,
+  });
 }
 
 export async function savePiecePattern(
@@ -1426,7 +1432,10 @@ export async function setHomePattern(
   const manager = await loadManager(homeConfig);
   const program = await getProgramFromFile(manager, entry);
   const pieces = new PiecesController(manager);
-  await pieces.recreateDefaultPattern({ customProgram: program });
+  await pieces.recreateDefaultPattern({
+    customProgram: program,
+    repository: entry.repository,
+  });
 }
 
 /**

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1032,6 +1032,7 @@ describe("mounted callable resolution and execution", () => {
         symbol: "default",
         source: {
           ref: `cf:pattern:${"A".repeat(43)}`,
+          repository: "https://github.com/commontoolsinc/labs",
           entry: "/notes/note.tsx",
         },
       },
@@ -1072,6 +1073,7 @@ describe("mounted callable resolution and execution", () => {
       symbol: "default",
       source: {
         ref: `cf:pattern:${"A".repeat(43)}`,
+        repository: "https://github.com/commontoolsinc/labs",
         entry: "/notes/note.tsx",
       },
     });
@@ -2191,6 +2193,7 @@ async function createMountedFile(
       symbol: string;
       source: {
         ref: string;
+        repository?: string;
         entry?: string;
         origin?: string;
       };

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1027,6 +1027,11 @@ describe("mounted callable resolution and execution", () => {
     const filePath = await createMountedFile(mountpoint, {
       relativePath: "home/pieces/notes-2/result/search.tool",
       pieceId: "of:canonical-piece",
+      patternRef: {
+        identity: "A".repeat(43),
+        symbol: "default",
+        source: "/notes/note.tsx",
+      },
     });
     const harness = createExecHarness({
       callableKind: "tool",
@@ -1059,6 +1064,11 @@ describe("mounted callable resolution and execution", () => {
     });
 
     expect(resolved.pieceId).toBe("of:canonical-piece");
+    expect(resolved.pieceMeta.patternRef).toEqual({
+      identity: "A".repeat(43),
+      symbol: "default",
+      source: "/notes/note.tsx",
+    });
   });
 
   it("resolves callable paths under both pieces and entities", async () => {
@@ -2167,7 +2177,15 @@ async function writeLiveMountState(
 
 async function createMountedFile(
   mountpoint: string,
-  options: { relativePath: string; pieceId: string },
+  options: {
+    relativePath: string;
+    pieceId: string;
+    patternRef?: {
+      identity: string;
+      symbol: string;
+      source?: string;
+    };
+  },
 ): Promise<string> {
   const absPath = join(mountpoint, options.relativePath);
   await Deno.mkdir(dirname(absPath), { recursive: true });
@@ -2180,6 +2198,9 @@ async function createMountedFile(
       id: options.pieceId,
       entityId: options.pieceId,
       name: "Fixture Piece",
+      ...(options.patternRef === undefined
+        ? {}
+        : { patternRef: options.patternRef }),
     }),
   );
 

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1030,7 +1030,10 @@ describe("mounted callable resolution and execution", () => {
       patternRef: {
         identity: "A".repeat(43),
         symbol: "default",
-        source: "/notes/note.tsx",
+        source: {
+          ref: `cf:pattern:${"A".repeat(43)}`,
+          entry: "/notes/note.tsx",
+        },
       },
     });
     const harness = createExecHarness({
@@ -1067,7 +1070,10 @@ describe("mounted callable resolution and execution", () => {
     expect(resolved.pieceMeta.patternRef).toEqual({
       identity: "A".repeat(43),
       symbol: "default",
-      source: "/notes/note.tsx",
+      source: {
+        ref: `cf:pattern:${"A".repeat(43)}`,
+        entry: "/notes/note.tsx",
+      },
     });
   });
 
@@ -2183,7 +2189,11 @@ async function createMountedFile(
     patternRef?: {
       identity: string;
       symbol: string;
-      source?: string;
+      source: {
+        ref: string;
+        entry?: string;
+        origin?: string;
+      };
     };
   },
 ): Promise<string> {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1034,6 +1034,7 @@ describe("mounted callable resolution and execution", () => {
           ref: `cf:pattern:${"A".repeat(43)}`,
           repository: "https://github.com/commontoolsinc/labs",
           entry: "/notes/note.tsx",
+          origin: "file:///repo/notes/note.tsx",
         },
       },
     });
@@ -1075,6 +1076,7 @@ describe("mounted callable resolution and execution", () => {
         ref: `cf:pattern:${"A".repeat(43)}`,
         repository: "https://github.com/commontoolsinc/labs",
         entry: "/notes/note.tsx",
+        origin: "file:///repo/notes/note.tsx",
       },
     });
   });

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -28,10 +28,12 @@ const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
 const NOTE_PATTERN = `${REPO_ROOT}/packages/patterns/notes/note.tsx`;
 
 const NOTE_CONTENT = "Hello world";
+const REPOSITORY = "https://github.com/commontoolsinc/labs";
 
 const noteEntry: EntryConfig = {
   mainPath: NOTE_PATTERN,
   rootPath: REPO_ROOT,
+  repository: REPOSITORY,
 };
 
 let pieceId = "";
@@ -131,6 +133,7 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
     expect(identity).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(listedPiece?.patternRef?.source).toEqual({
       ref: `cf:pattern:${identity}`,
+      repository: REPOSITORY,
       entry: "/packages/patterns/notes/note.tsx",
     });
 

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -15,6 +15,8 @@ import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value"
 import {
   callPieceHandler,
   type EntryConfig,
+  inspectPiece,
+  listPieces,
   newPiece,
   type SpaceConfig,
 } from "../lib/piece.ts";
@@ -35,6 +37,7 @@ const noteEntry: EntryConfig = {
 let pieceId = "";
 let flags = "";
 let identityPath = "";
+let spaceConfig: SpaceConfig;
 
 // Resolves once the piece's result/content cell holds `expected`. Uses its
 // own controller, so readiness is judged from a fresh client's view of the
@@ -71,7 +74,7 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
     const { identity, path } = await writeTempIdentity();
     identityPath = path;
     const spaceName = `cf-piece-get-test-${Date.now()}`;
-    const spaceConfig: SpaceConfig = {
+    spaceConfig = {
       apiUrl: API_URL!,
       space: spaceName,
       identity: identityPath,
@@ -119,5 +122,16 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
     expect(code).toBe(0);
     const json = JSON.parse(stdout.join(""));
     expect(typeof json).toBe("object");
+  });
+
+  it("list and inspect expose the running pattern reference", async () => {
+    const listed = await listPieces(spaceConfig);
+    const listedPiece = listed.find((piece) => piece.id === pieceId);
+    expect(listedPiece?.patternRef?.source).toBe("/notes/note.tsx");
+
+    const inspected = await inspectPiece({ ...spaceConfig, piece: pieceId });
+    expect(inspected.patternRef).toEqual(listedPiece?.patternRef);
+    expect(inspected.patternRef?.identity).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(inspected.patternRef?.symbol).toBe("default");
   });
 });

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -31,7 +31,7 @@ const NOTE_CONTENT = "Hello world";
 
 const noteEntry: EntryConfig = {
   mainPath: NOTE_PATTERN,
-  rootPath: `${REPO_ROOT}/packages/patterns`,
+  rootPath: REPO_ROOT,
 };
 
 let pieceId = "";
@@ -127,11 +127,15 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
   it("list and inspect expose the running pattern reference", async () => {
     const listed = await listPieces(spaceConfig);
     const listedPiece = listed.find((piece) => piece.id === pieceId);
-    expect(listedPiece?.patternRef?.source).toBe("/notes/note.tsx");
+    const identity = listedPiece?.patternRef?.identity;
+    expect(identity).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(listedPiece?.patternRef?.source).toEqual({
+      ref: `cf:pattern:${identity}`,
+      entry: "/packages/patterns/notes/note.tsx",
+    });
 
     const inspected = await inspectPiece({ ...spaceConfig, piece: pieceId });
     expect(inspected.patternRef).toEqual(listedPiece?.patternRef);
-    expect(inspected.patternRef?.identity).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(inspected.patternRef?.symbol).toBe("default");
   });
 });

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -2,9 +2,14 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
+  inspectPiece,
+  listPieces,
+  newPiece,
   recreateSpaceRootPattern,
   resolveLinkEndpointAddress,
   resolvePieceConfig,
+  setHomePattern,
+  setPiecePattern,
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
@@ -12,10 +17,12 @@ import { SlugResolutionError } from "@commonfabric/piece";
 import {
   formatPatternIdentity,
   formatPatternRef,
+  localPatternEntry,
   normalizeApiUrl,
   parseLink,
   parsePieceOptions,
   parseSpaceOptions,
+  piece,
 } from "../commands/piece.ts";
 
 const API_URL = "https://cf.dev";
@@ -440,33 +447,195 @@ describe("cli piece parsing", () => {
     });
   });
 
-  it("shows source-location options for every local deployment command", async () => {
-    const { code, stdout, stderr } = await cf("piece new --help");
-    checkStderr(stderr);
-    expect(code).toBe(0);
-    const newHelp = stripAnsi(stdout.join("\n"));
-    expect(newHelp).toContain("--slug");
-    expect(newHelp).toContain("--root");
-    expect(newHelp).toContain("--repository");
+  it("shows source-location options for every local deployment command", () => {
+    const optionFlags = (command: string) =>
+      piece.getCommand(command)!.getOptions().flatMap((option) => option.flags);
+    const newFlags = optionFlags("new");
+    expect(newFlags).toContain("--slug");
+    expect(newFlags).toContain("--root");
+    expect(newFlags).toContain("--repository");
 
     for (const command of ["setsrc", "set-home"]) {
-      const help = await cf(`piece ${command} --help`);
-      checkStderr(help.stderr);
-      expect(help.code).toBe(0);
-      const output = stripAnsi(help.stdout.join("\n"));
-      expect(output).toContain("--root");
-      expect(output).toContain("--repository");
+      const flags = optionFlags(command);
+      expect(flags).toContain("--root");
+      expect(flags).toContain("--repository");
     }
   });
 
   it("rejects repository metadata when resetting the home pattern", async () => {
-    const { code, stderr } = await cf(
-      "piece set-home --reset --repository https://github.com/commontoolsinc/labs",
+    const { piece: command } = await import(
+      "../commands/piece.ts?repository-reset-test"
     );
-    expect(code).toBe(1);
-    expect(stripAnsi(stderr.join("\n"))).toContain(
-      "Cannot use --repository with --reset",
+    command.throwErrors();
+    await expect(command.parse([
+      "set-home",
+      "--reset",
+      "--repository",
+      "https://github.com/commontoolsinc/labs",
+    ])).rejects.toThrow("Cannot use --repository with --reset");
+  });
+
+  it("builds repository-aware entries from deployment flags", () => {
+    expect(localPatternEntry("/repo/pattern.tsx", {
+      mainExport: "named",
+      repository: "https://github.com/commontoolsinc/labs",
+      root: "/repo",
+    })).toEqual({
+      mainPath: "/repo/pattern.tsx",
+      mainExport: "named",
+      repository: "https://github.com/commontoolsinc/labs",
+      rootPath: "/repo",
+    });
+  });
+
+  it("lists pattern provenance and isolates unreadable pieces", async () => {
+    const patternRef = {
+      identity: "A".repeat(43),
+      symbol: "default",
+      source: {
+        ref: `cf:pattern:${"A".repeat(43)}`,
+        repository: "https://github.com/commontoolsinc/labs",
+        entry: "/notes/note.tsx",
+      },
+    };
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([
+          { id: "of:readable" },
+          { id: "of:unreadable" },
+        ]),
+      get: (id: string) =>
+        id === "of:unreadable"
+          ? Promise.reject(new Error("not readable"))
+          : Promise.resolve({
+            getCell: () => ({
+              key: () => ({ pull: () => Promise.resolve("Readable") }),
+            }),
+            getPatternRef: () => Promise.resolve(patternRef),
+          }),
+    };
+
+    const listed = await listPieces({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+    }, {
+      loadManager: () => Promise.resolve({} as any),
+      createController: () => controller as any,
+    });
+
+    expect(listed).toEqual([
+      { id: "of:readable", name: "Readable", patternRef },
+      { id: "of:unreadable", error: "not readable" },
+    ]);
+  });
+
+  it("forwards repository metadata through piece creation and updates", async () => {
+    const repository = "https://github.com/commontoolsinc/labs";
+    const entry = { mainPath: "/repo/main.tsx", repository };
+    const program = {} as any;
+    const manager = {
+      add: () => Promise.resolve(),
+    };
+    let createOptions: unknown;
+    let setPatternOptions: unknown;
+    const createdPiece = { id: PIECE, getCell: () => ({} as any) };
+
+    const createdId = await newPiece(
+      { apiUrl: API_URL, space: SPACE, identity: ID },
+      entry,
+      { start: false },
+      {
+        loadManager: () => Promise.resolve(manager as any),
+        createController: () => ({
+          ensureDefaultPattern: () => Promise.resolve({}),
+          create: (_program: unknown, options: unknown) => {
+            createOptions = options;
+            return Promise.resolve(createdPiece);
+          },
+        } as any),
+        getPinnedProgramFromFile: () => Promise.resolve(program),
+      },
     );
+    expect(createdId).toBe(PIECE);
+    expect(createOptions).toEqual({ repository, start: false });
+
+    await setPiecePattern(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: "notes" },
+      entry,
+      {
+        loadManager: () => Promise.resolve(manager as any),
+        resolvePieceAddress: () => Promise.resolve(PIECE),
+        createController: () => ({
+          get: () =>
+            Promise.resolve({
+              setPattern: (_program: unknown, options: unknown) => {
+                setPatternOptions = options;
+                return Promise.resolve();
+              },
+            }),
+        } as any),
+        getPinnedProgramFromFile: () => Promise.resolve(program),
+      },
+    );
+    expect(setPatternOptions).toEqual({ repository });
+  });
+
+  it("returns pattern provenance from piece inspection", async () => {
+    const patternRef = {
+      identity: "B".repeat(43),
+      symbol: "default",
+      source: { ref: `cf:pattern:${"B".repeat(43)}` },
+    };
+    const inspected = await inspectPiece(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: "notes" },
+      {
+        loadManager: () => Promise.resolve({} as any),
+        resolvePieceAddress: () => Promise.resolve(PIECE),
+        createController: () => ({
+          get: () =>
+            Promise.resolve({
+              id: PIECE,
+              name: () => "Notes",
+              getPatternRef: () => Promise.resolve(patternRef),
+              input: { get: () => Promise.resolve({ title: "Input" }) },
+              result: { get: () => Promise.resolve({ title: "Result" }) },
+              readingFrom: () => Promise.resolve([]),
+              readBy: () => Promise.resolve([]),
+            }),
+        } as any),
+      },
+    );
+
+    expect(inspected.patternRef).toEqual(patternRef);
+    expect(inspected.id).toBe(PIECE);
+  });
+
+  it("forwards repository metadata when deploying a home pattern", async () => {
+    const repository = "https://github.com/commontoolsinc/labs";
+    let recreateOptions: unknown;
+
+    await setHomePattern(
+      { apiUrl: API_URL, identity: ID },
+      { mainPath: "/repo/home.tsx", repository },
+      {
+        loadIdentity: () =>
+          Promise.resolve({ did: () => "did:key:home" } as any),
+        loadManager: () => Promise.resolve({} as any),
+        getProgramFromFile: () => Promise.resolve({} as any),
+        createController: () => ({
+          recreateDefaultPattern: (options: unknown) => {
+            recreateOptions = options;
+            return Promise.resolve({ id: PIECE });
+          },
+        } as any),
+      },
+    );
+
+    expect(recreateOptions).toEqual({
+      customProgram: {},
+      repository,
+    });
   });
 
   it("shows set-slug command options", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -10,6 +10,8 @@ import {
 } from "../lib/piece.ts";
 import { SlugResolutionError } from "@commonfabric/piece";
 import {
+  formatPatternIdentity,
+  formatPatternRef,
   normalizeApiUrl,
   parseLink,
   parsePieceOptions,
@@ -24,6 +26,24 @@ const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
 describe("cli piece parsing", () => {
+  it("formats structured pattern references for human output", () => {
+    const identity = "A".repeat(43);
+    const patternRef = {
+      identity,
+      symbol: "default",
+      source: "/notes/note.tsx",
+    };
+    expect(formatPatternRef(patternRef)).toBe("/notes/note.tsx");
+    expect(formatPatternIdentity(patternRef)).toBe(
+      `cf:module/${identity}#default`,
+    );
+    expect(formatPatternRef({
+      identity,
+      symbol: "named",
+    })).toBe(`cf:module/${identity}#named`);
+    expect(formatPatternRef(undefined)).toBe("<unknown>");
+  });
+
   it("normalizes API URLs for app route hints", () => {
     expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net/",

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -31,7 +31,10 @@ describe("cli piece parsing", () => {
     const patternRef = {
       identity,
       symbol: "default",
-      source: "/notes/note.tsx",
+      source: {
+        ref: `cf:pattern:${identity}`,
+        entry: "/notes/note.tsx",
+      },
     };
     expect(formatPatternRef(patternRef)).toBe("/notes/note.tsx");
     expect(formatPatternIdentity(patternRef)).toBe(
@@ -40,7 +43,16 @@ describe("cli piece parsing", () => {
     expect(formatPatternRef({
       identity,
       symbol: "named",
-    })).toBe(`cf:module/${identity}#named`);
+      source: { ref: `cf:pattern:${identity}` },
+    })).toBe(`cf:pattern:${identity}`);
+    expect(formatPatternRef({
+      identity,
+      symbol: "named",
+      source: {
+        ref: `cf:pattern:${identity}`,
+        origin: "cf:/did:key:z6Mk/example",
+      },
+    })).toBe("cf:/did:key:z6Mk/example");
     expect(formatPatternRef(undefined)).toBe("<unknown>");
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -50,6 +50,17 @@ describe("cli piece parsing", () => {
       symbol: "named",
       source: {
         ref: `cf:pattern:${identity}`,
+        repository: "https://github.com/commontoolsinc/labs",
+        entry: "/packages/patterns/notes/note.tsx",
+      },
+    })).toBe(
+      "https://github.com/commontoolsinc/labs#/packages/patterns/notes/note.tsx",
+    );
+    expect(formatPatternRef({
+      identity,
+      symbol: "named",
+      source: {
+        ref: `cf:pattern:${identity}`,
         origin: "cf:/did:key:z6Mk/example",
       },
     })).toBe("cf:/did:key:z6Mk/example");
@@ -429,11 +440,33 @@ describe("cli piece parsing", () => {
     });
   });
 
-  it("shows slug option for piece new", async () => {
+  it("shows source-location options for every local deployment command", async () => {
     const { code, stdout, stderr } = await cf("piece new --help");
     checkStderr(stderr);
     expect(code).toBe(0);
-    expect(stripAnsi(stdout.join("\n"))).toContain("--slug");
+    const newHelp = stripAnsi(stdout.join("\n"));
+    expect(newHelp).toContain("--slug");
+    expect(newHelp).toContain("--root");
+    expect(newHelp).toContain("--repository");
+
+    for (const command of ["setsrc", "set-home"]) {
+      const help = await cf(`piece ${command} --help`);
+      checkStderr(help.stderr);
+      expect(help.code).toBe(0);
+      const output = stripAnsi(help.stdout.join("\n"));
+      expect(output).toContain("--root");
+      expect(output).toContain("--repository");
+    }
+  });
+
+  it("rejects repository metadata when resetting the home pattern", async () => {
+    const { code, stderr } = await cf(
+      "piece set-home --reset --repository https://github.com/commontoolsinc/labs",
+    );
+    expect(code).toBe(1);
+    expect(stripAnsi(stderr.join("\n"))).toContain(
+      "Cannot use --repository with --reset",
+    );
   });
 
   it("shows set-slug command options", async () => {

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -110,7 +110,7 @@ xattr -p user.json.type home/pieces/todo-app/result/count
 
 # View piece metadata
 cat home/pieces/todo-app/meta.json
-# => {"id":"of:ba4j...","entityId":"ba4j...","name":"todo-app","patternRef":{"identity":"<hash>","symbol":"default","source":{"ref":"cf:pattern:<hash>","entry":"/packages/patterns/todo-app.tsx"}}}
+# => {"id":"of:ba4j...","entityId":"ba4j...","name":"todo-app","patternRef":{"identity":"<hash>","symbol":"default","source":{"ref":"cf:pattern:<hash>","repository":"https://github.com/commontoolsinc/labs","entry":"/packages/patterns/todo-app.tsx"}}}
 
 # Mounted callables are executable and start with a cf exec shebang
 head -n1 home/pieces/todo-app/result/addItem.handler
@@ -125,8 +125,9 @@ cat home/pieces/todo-app/result.json | jq '.addItem, .search'
 The prefix-free `patternRef.identity` + `patternRef.symbol` are the
 authoritative reference to the artifact currently running the piece
 (`cf:module/<identity>#<symbol>` in display form). `patternRef.source.ref` is
-the immutable in-fabric source reference. Optional `source.entry` preserves the
-authored path within the compilation root, while `source.origin` carries the
+the immutable in-fabric source reference. Optional `source.repository` records
+the explicitly supplied repository locator, `source.entry` preserves the
+authored path within the compilation root, and `source.origin` carries the
 piece's update provenance. The same object appears in `pieces/pieces.json` for
 bulk discovery.
 

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -110,7 +110,7 @@ xattr -p user.json.type home/pieces/todo-app/result/count
 
 # View piece metadata
 cat home/pieces/todo-app/meta.json
-# => {"id":"of:ba4j...","entityId":"ba4j...","name":"todo-app","patternRef":{"identity":"<hash>","symbol":"default","source":"/todo-app.tsx"}}
+# => {"id":"of:ba4j...","entityId":"ba4j...","name":"todo-app","patternRef":{"identity":"<hash>","symbol":"default","source":{"ref":"cf:pattern:<hash>","entry":"/packages/patterns/todo-app.tsx"}}}
 
 # Mounted callables are executable and start with a cf exec shebang
 head -n1 home/pieces/todo-app/result/addItem.handler
@@ -124,11 +124,11 @@ cat home/pieces/todo-app/result.json | jq '.addItem, .search'
 
 The prefix-free `patternRef.identity` + `patternRef.symbol` are the
 authoritative reference to the artifact currently running the piece
-(`cf:module/<identity>#<symbol>` in display form). `patternRef.source` is
-best-effort: it is the tracked `patternSource` provenance when present,
-otherwise the authored entry filename recovered from the artifact's verified
-source closure. The same object appears in `pieces/pieces.json` for bulk
-discovery.
+(`cf:module/<identity>#<symbol>` in display form). `patternRef.source.ref` is
+the immutable in-fabric source reference. Optional `source.entry` preserves the
+authored path within the compilation root, while `source.origin` carries the
+piece's update provenance. The same object appears in `pieces/pieces.json` for
+bulk discovery.
 
 ### Writing
 

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -58,8 +58,9 @@ cf fuse unmount /tmp/cf
         input/                        # exploded input tree
           submit.handler              # handlers/tools can exist under input too
           search.tool
-        meta.json                     # piece ID, entity, pattern name
+        meta.json                     # piece ID, entity, running pattern ref
       .index.json                     # piece name → entity ID mapping
+      pieces.json                     # discovery manifest with pattern refs
     entities/                         # access cells by entity ID
     space.json                        # { did, name }
   .spaces.json                        # known space name → DID mapping
@@ -109,7 +110,7 @@ xattr -p user.json.type home/pieces/todo-app/result/count
 
 # View piece metadata
 cat home/pieces/todo-app/meta.json
-# => {"id":"of:ba4j...","entityId":"ba4j...","name":"todo-app"}
+# => {"id":"of:ba4j...","entityId":"ba4j...","name":"todo-app","patternRef":{"identity":"<hash>","symbol":"default","source":"/todo-app.tsx"}}
 
 # Mounted callables are executable and start with a cf exec shebang
 head -n1 home/pieces/todo-app/result/addItem.handler
@@ -120,6 +121,14 @@ cat home/pieces/todo-app/result.json | jq '.addItem, .search'
 # => {"/handler":"addItem"}
 # => {"/tool":"search"}
 ```
+
+The prefix-free `patternRef.identity` + `patternRef.symbol` are the
+authoritative reference to the artifact currently running the piece
+(`cf:module/<identity>#<symbol>` in display form). `patternRef.source` is
+best-effort: it is the tracked `patternSource` provenance when present,
+otherwise the authored entry filename recovered from the artifact's verified
+source closure. The same object appears in `pieces/pieces.json` for bulk
+discovery.
 
 ### Writing
 

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -117,22 +117,21 @@ class SinkableCell {
 }
 
 class PatternIdentityCell {
-  #sink: (() => void) | undefined;
+  #sinks = new Map<string, () => void>();
 
   asSchema() {
     return { sync: () => Promise.resolve() };
   }
 
   sinkMeta(key: string, sink: () => void): () => void {
-    assertEquals(key, "patternIdentity");
-    this.#sink = sink;
+    this.#sinks.set(key, sink);
     return () => {
-      if (this.#sink === sink) this.#sink = undefined;
+      if (this.#sinks.get(key) === sink) this.#sinks.delete(key);
     };
   }
 
-  emit(): void {
-    this.#sink?.();
+  emit(key = "patternIdentity"): void {
+    this.#sinks.get(key)?.();
   }
 }
 
@@ -261,6 +260,7 @@ Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference",
         symbol: "default",
         source: {
           ref: `cf:pattern:${"A".repeat(43)}`,
+          repository: "https://github.com/commontoolsinc/labs",
           entry: "/notes/note.tsx",
         },
       }),
@@ -288,6 +288,7 @@ Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference",
     symbol: "default",
     source: {
       ref: `cf:pattern:${"A".repeat(43)}`,
+      repository: "https://github.com/commontoolsinc/labs",
       entry: "/notes/note.tsx",
     },
   });
@@ -1636,6 +1637,7 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
     symbol: "default",
     source: {
       ref: `cf:pattern:${"A".repeat(43)}`,
+      repository: "https://github.com/commontoolsinc/labs",
       entry: "/notes/note.tsx",
     },
   };
@@ -1667,6 +1669,7 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
     symbol: "default",
     source: {
       ref: `cf:pattern:${"B".repeat(43)}`,
+      repository: "https://github.com/commontoolsinc/labs",
       entry: "/notes/note.tsx",
     },
   };
@@ -1696,6 +1699,26 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
     getFileContent(tree, state.piecesIno, "pieces.json"),
   );
   assertEquals(piecesJson[0].patternRef, patternRef);
+
+  patternRef = {
+    ...patternRef,
+    source: {
+      ...patternRef.source,
+      repository: "https://github.com/commontoolsinc/another-repo",
+    },
+  };
+  const repositoryRefreshed = defer();
+  bridge.onInvalidate = (parentIno, names) => {
+    if (parentIno === pieceIno && names.includes("meta.json")) {
+      repositoryRefreshed.resolve();
+    }
+  };
+  rootCell.emit("patternRepository");
+  await repositoryRefreshed.promise;
+  assertEquals(
+    JSON.parse(getFileContent(tree, pieceIno, "meta.json")).patternRef,
+    patternRef,
+  );
 
   const subs = state.pieceSubs.get(projectedName);
   if (subs) { for (const cancel of subs) cancel(); }

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1,5 +1,6 @@
 // cell-bridge.test.ts — Integration tests for CellBridge using fake piece objects
 import { assertEquals, assertNotEquals } from "@std/assert";
+import { defer } from "@commonfabric/utils/defer";
 import { FsTree } from "./tree.ts";
 import {
   CellBridge,
@@ -115,6 +116,26 @@ class SinkableCell {
   }
 }
 
+class PatternIdentityCell {
+  #sink: (() => void) | undefined;
+
+  asSchema() {
+    return { sync: () => Promise.resolve() };
+  }
+
+  sinkMeta(key: string, sink: () => void): () => void {
+    assertEquals(key, "patternIdentity");
+    this.#sink = sink;
+    return () => {
+      if (this.#sink === sink) this.#sink = undefined;
+    };
+  }
+
+  emit(): void {
+    this.#sink?.();
+  }
+}
+
 function getFileContent(tree: FsTree, parentIno: bigint, name: string): string {
   const ino = tree.lookup(parentIno, name);
   if (ino === undefined) throw new Error(`File "${name}" not found`);
@@ -227,14 +248,19 @@ type WriteFsFile = (
 // Group 1: loadPieceTree — initial tree structure
 // ---------------------------------------------------------------------------
 
-Deno.test("CellBridge.loadPieceTree creates meta.json with id, name", async () => {
+Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
 
   const piece = {
     id: "of:entity-123",
     name: () => "My Note",
-    getPatternMeta: () => Promise.resolve({}),
+    getPatternRef: () =>
+      Promise.resolve({
+        identity: "A".repeat(43),
+        symbol: "default",
+        source: "/notes/note.tsx",
+      }),
     input: {
       getCell: () => Promise.resolve(makeCell({}, undefined)),
       get: () => Promise.resolve({}),
@@ -254,6 +280,11 @@ Deno.test("CellBridge.loadPieceTree creates meta.json with id, name", async () =
   const meta = JSON.parse(getFileContent(tree, pieceIno, "meta.json"));
   assertEquals(meta.id, "of:entity-123");
   assertEquals(meta.name, "My Note");
+  assertEquals(meta.patternRef, {
+    identity: "A".repeat(43),
+    symbol: "default",
+    source: "/notes/note.tsx",
+  });
 });
 
 Deno.test("CellBridge.loadPieceTree creates stable input/result stubs without eager hydration", async () => {
@@ -1503,6 +1534,11 @@ Deno.test("CellBridge.updatePiecesJson writes cached manifest data without piece
   state.pieceMap.set("Beta", "of:beta");
   state.pieceManifest.set("of:alpha", {
     summary: "alpha summary",
+    patternRef: {
+      identity: "A".repeat(43),
+      symbol: "default",
+      source: "/alpha.tsx",
+    },
   });
   state.pieceManifest.set("of:beta", {
     summary: "beta summary",
@@ -1520,6 +1556,11 @@ Deno.test("CellBridge.updatePiecesJson writes cached manifest data without piece
       name: "Alpha",
       summary: "alpha summary",
       entityPath: "entities/of%3Aalpha",
+      patternRef: {
+        identity: "A".repeat(43),
+        symbol: "default",
+        source: "/alpha.tsx",
+      },
     },
     {
       id: "of:beta",
@@ -1570,6 +1611,75 @@ Deno.test("CellBridge result hydration updates pieces.json summary from current 
 
   // Cancel subscriptions to avoid timer leaks
   const subs = state.pieceSubs.get("Summary-Piece");
+  if (subs) { for (const cancel of subs) cancel(); }
+});
+
+Deno.test("CellBridge refreshes pattern references after an in-place swap", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const rootCell = new PatternIdentityCell();
+  let patternRef = {
+    identity: "A".repeat(43),
+    symbol: "default",
+    source: "/notes/note.tsx",
+  };
+  const piece = {
+    id: "of:swapped-piece",
+    name: () => "Swapped Piece",
+    getCell: () => rootCell,
+    getPatternRef: () => Promise.resolve(patternRef),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({ summary: "current" }),
+    },
+  };
+
+  const projectedName = await (bridge as unknown as {
+    addPieceToSpace: AddPieceToSpace;
+  }).addPieceToSpace(state, piece, "home");
+  (bridge as unknown as { updatePiecesJson: UpdatePiecesJson })
+    .updatePiecesJson(
+      state,
+    );
+
+  patternRef = {
+    identity: "B".repeat(43),
+    symbol: "default",
+    source: "/notes/note.tsx",
+  };
+  const pieceIno = state.pieceInos.get(projectedName)!;
+  const refreshed = defer();
+  bridge.onInvalidate = (parentIno, names) => {
+    if (parentIno === pieceIno && names.includes("meta.json")) {
+      refreshed.resolve();
+    }
+  };
+  rootCell.emit();
+  await refreshed.promise;
+
+  assertEquals(
+    JSON.parse(getFileContent(tree, pieceIno, "meta.json")).patternRef,
+    patternRef,
+  );
+  const entityIno = tree.lookup(
+    state.entitiesIno,
+    encodeFuseComponent(piece.id),
+  )!;
+  assertEquals(
+    JSON.parse(getFileContent(tree, entityIno, "meta.json")).patternRef,
+    patternRef,
+  );
+  const piecesJson = JSON.parse(
+    getFileContent(tree, state.piecesIno, "pieces.json"),
+  );
+  assertEquals(piecesJson[0].patternRef, patternRef);
+
+  const subs = state.pieceSubs.get(projectedName);
   if (subs) { for (const cancel of subs) cancel(); }
 });
 

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -259,7 +259,10 @@ Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference",
       Promise.resolve({
         identity: "A".repeat(43),
         symbol: "default",
-        source: "/notes/note.tsx",
+        source: {
+          ref: `cf:pattern:${"A".repeat(43)}`,
+          entry: "/notes/note.tsx",
+        },
       }),
     input: {
       getCell: () => Promise.resolve(makeCell({}, undefined)),
@@ -283,7 +286,10 @@ Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference",
   assertEquals(meta.patternRef, {
     identity: "A".repeat(43),
     symbol: "default",
-    source: "/notes/note.tsx",
+    source: {
+      ref: `cf:pattern:${"A".repeat(43)}`,
+      entry: "/notes/note.tsx",
+    },
   });
 });
 
@@ -1537,7 +1543,10 @@ Deno.test("CellBridge.updatePiecesJson writes cached manifest data without piece
     patternRef: {
       identity: "A".repeat(43),
       symbol: "default",
-      source: "/alpha.tsx",
+      source: {
+        ref: `cf:pattern:${"A".repeat(43)}`,
+        entry: "/alpha.tsx",
+      },
     },
   });
   state.pieceManifest.set("of:beta", {
@@ -1559,7 +1568,10 @@ Deno.test("CellBridge.updatePiecesJson writes cached manifest data without piece
       patternRef: {
         identity: "A".repeat(43),
         symbol: "default",
-        source: "/alpha.tsx",
+        source: {
+          ref: `cf:pattern:${"A".repeat(43)}`,
+          entry: "/alpha.tsx",
+        },
       },
     },
     {
@@ -1622,7 +1634,10 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
   let patternRef = {
     identity: "A".repeat(43),
     symbol: "default",
-    source: "/notes/note.tsx",
+    source: {
+      ref: `cf:pattern:${"A".repeat(43)}`,
+      entry: "/notes/note.tsx",
+    },
   };
   const piece = {
     id: "of:swapped-piece",
@@ -1650,7 +1665,10 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
   patternRef = {
     identity: "B".repeat(43),
     symbol: "default",
-    source: "/notes/note.tsx",
+    source: {
+      ref: `cf:pattern:${"B".repeat(43)}`,
+      entry: "/notes/note.tsx",
+    },
   };
   const pieceIno = state.pieceInos.get(projectedName)!;
   const refreshed = defer();

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -238,6 +238,12 @@ type BuildSourceTree = (
   pieceName: string,
 ) => Promise<void>;
 
+type RefreshPiecePatternMetadata = (
+  state: SpaceState,
+  piece: unknown,
+  pieceIno: bigint,
+) => Promise<void>;
+
 type WriteFsFile = (
   writePath: unknown,
   text: string,
@@ -1724,6 +1730,118 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
   if (subs) { for (const cancel of subs) cancel(); }
 });
 
+Deno.test("CellBridge pattern reference refresh fails closed", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const pieceIno = tree.addDir(state.piecesIno, "notes");
+  let shouldReject = true;
+  const piece = {
+    id: "of:pattern-ref-failure",
+    getPatternRef: () =>
+      shouldReject
+        ? Promise.reject(new Error("unavailable"))
+        : Promise.resolve(undefined),
+  };
+  const refresh = (bridge as unknown as {
+    refreshPiecePatternMetadata: RefreshPiecePatternMetadata;
+  }).refreshPiecePatternMetadata.bind(bridge);
+
+  await refresh(state, piece, pieceIno);
+  shouldReject = false;
+  await refresh(state, piece, pieceIno);
+
+  assertEquals(state.pieceManifest.size, 0);
+});
+
+Deno.test("CellBridge reports pattern metadata subscription failures", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+  const immediateRootCell = {
+    asSchema: () => ({ sync: () => Promise.resolve() }),
+    sinkMeta: (_key: string, sink: () => void) => {
+      sink();
+      return () => {};
+    },
+  };
+  const piece = {
+    id: "of:pattern-subscription-failure",
+    name: () => "Pattern Subscription Failure",
+    getCell: () => immediateRootCell,
+    getPatternRef: () => Promise.resolve(undefined),
+    getPatternMeta: () => Promise.resolve({}),
+    getPatternSourceFiles: () => Promise.resolve([]),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+  };
+  (bridge as unknown as {
+    refreshPiecePatternMetadata: RefreshPiecePatternMetadata;
+  }).refreshPiecePatternMetadata = () =>
+    Promise.reject(new Error("refresh failed"));
+
+  try {
+    await (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+      .addPieceToSpace(state, piece, "home");
+    await Promise.resolve();
+  } finally {
+    console.error = originalError;
+  }
+
+  assertEquals(errors.some((line) => line.includes("refresh failed")), true);
+});
+
+Deno.test("CellBridge reports pattern metadata setup failures", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+  const piece = {
+    id: "of:pattern-setup-failure",
+    name: () => "Pattern Setup Failure",
+    getCell: () => {
+      throw new Error("root unavailable");
+    },
+    getPatternRef: () => Promise.resolve(undefined),
+    getPatternMeta: () => Promise.resolve({}),
+    getPatternSourceFiles: () => Promise.resolve([]),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+  };
+
+  try {
+    await (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+      .addPieceToSpace(state, piece, "home");
+  } finally {
+    console.error = originalError;
+  }
+
+  assertEquals(
+    errors.some((line) =>
+      line.includes("Could not subscribe") && line.includes("root unavailable")
+    ),
+    true,
+  );
+});
+
 Deno.test("CellBridge.writeFsFile writes markdown frontmatter and body to FS paths", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
@@ -1919,14 +2037,24 @@ Deno.test("CellBridge decodes encoded space directory names for source write pat
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "did:key:zSource", []);
   const pieceIno = tree.addDir(state.piecesIno, "notes");
+  let patternRefReads = 0;
   const piece = {
     id: "of:encoded-source-piece",
+    getPatternRef: () => {
+      patternRefReads++;
+      return Promise.resolve({
+        identity: "C".repeat(43),
+        symbol: "default",
+        source: { ref: `cf:pattern:${"C".repeat(43)}` },
+      });
+    },
     getPatternSourceFiles: () =>
       Promise.resolve([
         { name: "/src/main.ts", contents: "export default 1;" },
       ]),
   };
   state.pieceControllers.set("notes", piece as never);
+  state.pieceInos.set("notes", pieceIno);
   state.srcInos.set("notes", pieceIno);
 
   await (bridge as unknown as { buildSourceTree: BuildSourceTree })
@@ -1940,6 +2068,9 @@ Deno.test("CellBridge decodes encoded space directory names for source write pat
   assertEquals(sourcePath?.spaceName, "did:key:zSource");
   assertEquals(sourcePath?.pieceName, "notes");
   assertEquals(sourcePath?.relPath, "src/main.ts");
+
+  await bridge.finalizeSourceWritePath(sourcePath!);
+  assertEquals(patternRefReads, 1);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -669,7 +669,9 @@ export class CellBridge {
     const changed = next.summary !== current.summary ||
       next.patternRef?.identity !== current.patternRef?.identity ||
       next.patternRef?.symbol !== current.patternRef?.symbol ||
-      next.patternRef?.source !== current.patternRef?.source;
+      next.patternRef?.source.ref !== current.patternRef?.source.ref ||
+      next.patternRef?.source.entry !== current.patternRef?.source.entry ||
+      next.patternRef?.source.origin !== current.patternRef?.source.origin;
     state.pieceManifest.set(pieceId, next);
     return changed;
   }

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -45,6 +45,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import type { PieceManager } from "@commonfabric/piece";
 import type {
   PieceController,
+  PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
 
@@ -213,7 +214,10 @@ export interface SpaceState {
   pieceMap: Map<string, string>; // name → entity ID
   pieceInos: Map<string, bigint>; // name → root inode
   pieceControllers: Map<string, PieceController>; // name → controller
-  pieceManifest: Map<string, { summary: string }>;
+  pieceManifest: Map<
+    string,
+    { summary: string; patternRef?: PiecePatternRef }
+  >;
   /** Per-piece subscription cancellers, keyed by piece name. */
   pieceSubs: Map<string, Cancel[]>;
   did: string;
@@ -593,6 +597,7 @@ export class CellBridge {
     piece: PieceController,
   ): Promise<void> {
     let summary = "";
+    let patternRef: PiecePatternRef | undefined;
 
     try {
       const result = await piece.result.get();
@@ -601,19 +606,70 @@ export class CellBridge {
       // Summary is best-effort only.
     }
 
-    this.updatePieceManifest(state, piece.id, { summary });
+    try {
+      patternRef = await piece.getPatternRef();
+    } catch {
+      // Pattern source is best-effort; identity-less pieces remain listable.
+    }
+
+    this.updatePieceManifest(state, piece.id, { summary, patternRef });
+  }
+
+  /** Refresh synthetic pattern metadata after an in-place pattern swap. */
+  private async refreshPiecePatternMetadata(
+    state: SpaceState,
+    piece: PieceController,
+    pieceIno: bigint,
+  ): Promise<void> {
+    let patternRef: PiecePatternRef | undefined;
+    try {
+      patternRef = await piece.getPatternRef();
+    } catch {
+      return;
+    }
+    if (patternRef === undefined) return;
+
+    const manifestChanged = this.updatePieceManifest(state, piece.id, {
+      patternRef,
+    });
+    this.updatePieceMetaPatternRef(pieceIno, patternRef);
+
+    const entityIno = this.tree.lookup(
+      state.entitiesIno,
+      encodeFuseComponent(piece.id),
+    );
+    if (entityIno !== undefined) {
+      this.updatePieceMetaPatternRef(entityIno, patternRef);
+    }
+
+    if (manifestChanged) {
+      this.updatePiecesJson(state);
+    }
+    if (this.onInvalidate) {
+      this.onInvalidate(pieceIno, ["meta.json"]);
+      if (entityIno !== undefined) {
+        this.onInvalidate(entityIno, ["meta.json"]);
+      }
+      if (manifestChanged) {
+        this.onInvalidate(state.piecesIno, ["pieces.json"]);
+      }
+    }
   }
 
   private updatePieceManifest(
     state: SpaceState,
     pieceId: string,
-    updates: Partial<{ summary: string }>,
+    updates: Partial<{ summary: string; patternRef: PiecePatternRef }>,
   ): boolean {
     const current = state.pieceManifest.get(pieceId) ?? { summary: "" };
     const next = {
       summary: updates.summary ?? current.summary,
+      patternRef: updates.patternRef ?? current.patternRef,
     };
-    const changed = next.summary !== current.summary;
+    const changed = next.summary !== current.summary ||
+      next.patternRef?.identity !== current.patternRef?.identity ||
+      next.patternRef?.symbol !== current.patternRef?.symbol ||
+      next.patternRef?.source !== current.patternRef?.source;
     state.pieceManifest.set(pieceId, next);
     return changed;
   }
@@ -623,12 +679,14 @@ export class CellBridge {
     name: string;
     summary: string;
     entityPath: string;
+    patternRef?: PiecePatternRef;
   }> {
     const entries: Array<{
       id: string;
       name: string;
       summary: string;
       entityPath: string;
+      patternRef?: PiecePatternRef;
     }> = [];
 
     for (const [name, id] of state.pieceMap) {
@@ -638,6 +696,9 @@ export class CellBridge {
         name,
         summary: manifest.summary,
         entityPath: `entities/${encodeFuseComponent(id)}`,
+        ...(manifest.patternRef === undefined
+          ? {}
+          : { patternRef: manifest.patternRef }),
       });
     }
 
@@ -1599,6 +1660,11 @@ export class CellBridge {
       state,
       writePath.pieceName,
     );
+    await this.refreshPiecePatternMetadata(
+      state,
+      writePath.piece,
+      pieceIno,
+    );
   }
 
   invalidateHandlerTarget(target: HandlerTarget): void {
@@ -2055,10 +2121,12 @@ export class CellBridge {
     // first access, avoiding doubled subscriptions and startup cost.
     const entityName = encodeFuseComponent(piece.id);
     const entityStubIno = this.tree.addDir(state.entitiesIno, entityName);
+    const patternRef = state.pieceManifest.get(piece.id)?.patternRef;
     const entityMetaObject = {
       id: piece.id,
       entityId: piece.id,
       name: piece.name() || "",
+      ...(patternRef === undefined ? {} : { patternRef }),
     };
     const entityAnnotator = this.makeCfcAnnotator({
       spaceName,
@@ -2308,6 +2376,20 @@ export class CellBridge {
   }
 
   private updatePieceMetaName(parentIno: bigint, name: string): void {
+    this.updatePieceMeta(parentIno, { name });
+  }
+
+  private updatePieceMetaPatternRef(
+    parentIno: bigint,
+    patternRef: PiecePatternRef,
+  ): void {
+    this.updatePieceMeta(parentIno, { patternRef });
+  }
+
+  private updatePieceMeta(
+    parentIno: bigint,
+    updates: Record<string, unknown>,
+  ): void {
     const metaIno = this.tree.lookup(parentIno, "meta.json");
     if (metaIno === undefined) return;
 
@@ -2323,7 +2405,7 @@ export class CellBridge {
       }
       this.tree.updateFile(
         metaIno,
-        JSON.stringify({ ...parsed, name }, null, 2),
+        JSON.stringify({ ...parsed, ...updates }, null, 2),
         "object",
       );
     } catch {
@@ -2868,6 +2950,41 @@ export class CellBridge {
       }
     }
 
+    // Pattern hot-swaps (system roll-forward, CLI setsrc, or FUSE source
+    // edits) retain the same piece entity. Keep the synthetic reference in
+    // meta.json and pieces.json aligned with the currently running artifact.
+    const getRootCell = (piece as unknown as {
+      getCell?: () => Cell<unknown>;
+    }).getCell;
+    if (typeof getRootCell === "function") {
+      try {
+        const rootCell = getRootCell.call(piece) as Cell<unknown> & {
+          sinkMeta?: Cell<unknown>["sinkMeta"];
+        };
+        if (typeof rootCell.sinkMeta === "function") {
+          const cancelPatternRef = rootCell.sinkMeta(
+            "patternIdentity",
+            () => {
+              void this.refreshPiecePatternMetadata(
+                state,
+                piece,
+                pieceIno,
+              ).catch((e) => {
+                console.error(
+                  `[${spaceName}] Could not refresh ${pieceName} pattern reference: ${e}`,
+                );
+              });
+            },
+          );
+          cancels.push(cancelPatternRef);
+        }
+      } catch (e) {
+        console.error(
+          `[${spaceName}] Could not subscribe to ${pieceName} pattern reference: ${e}`,
+        );
+      }
+    }
+
     // Subscribe to the result cell to detect [NAME] changes and rename the
     // piece directory in the FUSE tree accordingly.
     // We use the result cell (not the root entity cell) because [NAME] is part
@@ -3107,7 +3224,6 @@ export class CellBridge {
     };
   }
 
-  // deno-lint-ignore require-await
   private async loadPieceTree(
     piece: PieceController,
     parentIno: bigint,
@@ -3119,10 +3235,17 @@ export class CellBridge {
     const pieceIno = existingIno ?? this.tree.addDir(parentIno, name);
 
     // Create meta.json first so it's always present
+    let patternRef: PiecePatternRef | undefined;
+    try {
+      patternRef = await piece.getPatternRef();
+    } catch {
+      // Pattern metadata is best-effort; keep the piece mount available.
+    }
     const metaObject = {
       id: piece.id,
       entityId: piece.id,
       name: piece.name() || "",
+      ...(patternRef === undefined ? {} : { patternRef }),
     };
     const pieceAnnotator = this.makeCfcAnnotator({
       spaceName,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -670,6 +670,8 @@ export class CellBridge {
       next.patternRef?.identity !== current.patternRef?.identity ||
       next.patternRef?.symbol !== current.patternRef?.symbol ||
       next.patternRef?.source.ref !== current.patternRef?.source.ref ||
+      next.patternRef?.source.repository !==
+        current.patternRef?.source.repository ||
       next.patternRef?.source.entry !== current.patternRef?.source.entry ||
       next.patternRef?.source.origin !== current.patternRef?.source.origin;
     state.pieceManifest.set(pieceId, next);
@@ -2953,8 +2955,9 @@ export class CellBridge {
     }
 
     // Pattern hot-swaps (system roll-forward, CLI setsrc, or FUSE source
-    // edits) retain the same piece entity. Keep the synthetic reference in
-    // meta.json and pieces.json aligned with the currently running artifact.
+    // edits) and repository annotation changes retain the same piece entity.
+    // Keep the synthetic reference in meta.json and pieces.json aligned with
+    // the currently running artifact and its source locator.
     const getRootCell = (piece as unknown as {
       getCell?: () => Cell<unknown>;
     }).getCell;
@@ -2964,21 +2967,25 @@ export class CellBridge {
           sinkMeta?: Cell<unknown>["sinkMeta"];
         };
         if (typeof rootCell.sinkMeta === "function") {
-          const cancelPatternRef = rootCell.sinkMeta(
-            "patternIdentity",
-            () => {
-              void this.refreshPiecePatternMetadata(
-                state,
-                piece,
-                pieceIno,
-              ).catch((e) => {
-                console.error(
-                  `[${spaceName}] Could not refresh ${pieceName} pattern reference: ${e}`,
-                );
-              });
-            },
-          );
-          cancels.push(cancelPatternRef);
+          for (
+            const key of ["patternIdentity", "patternRepository"] as const
+          ) {
+            const cancelPatternRef = rootCell.sinkMeta(
+              key,
+              () => {
+                void this.refreshPiecePatternMetadata(
+                  state,
+                  piece,
+                  pieceIno,
+                ).catch((e) => {
+                  console.error(
+                    `[${spaceName}] Could not refresh ${pieceName} pattern reference: ${e}`,
+                  );
+                });
+              },
+            );
+            cancels.push(cancelPatternRef);
+          }
         }
       } catch (e) {
         console.error(

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -756,13 +756,14 @@ export class PieceManager {
     pattern: Pattern | Module,
     inputs?: unknown,
     cause?: unknown,
-    options?: { start?: boolean },
+    options?: { start?: boolean; repository?: string },
   ): Promise<Cell<T>> {
     const start = options?.start ?? true;
     const piece = await this.setupPersistent<T>(
       pattern,
       inputs,
       cause,
+      { repository: options?.repository },
     );
     if (start) {
       await this.startPiece(piece);
@@ -785,6 +786,7 @@ export class PieceManager {
         argumentCell: Cell<unknown>,
         argumentSchema: JSONSchema,
       ) => void;
+      repository?: string;
     },
   ): Promise<Cell<unknown>> {
     const piece = this.runtime.getCellFromEntityId(
@@ -797,6 +799,7 @@ export class PieceManager {
     if (start) {
       currentPiece = await this.runtime.runSynced(piece, pattern, inputs, {
         expectedPatternIdentity: options?.expectedPatternIdentity,
+        patternRepository: options?.repository,
         validateArgumentLinks: options?.validateArgumentLinks,
       });
     } else {
@@ -821,6 +824,7 @@ export class PieceManager {
     pattern: Pattern | Module,
     inputs?: unknown,
     cause?: unknown,
+    options?: { repository?: string },
   ): Promise<Cell<T>> {
     await timePiecePhase(
       "setupPersistent.runtime.idle",
@@ -839,7 +843,10 @@ export class PieceManager {
     );
     await timePiecePhase(
       "setupPersistent.runtime.setup",
-      () => this.runtime.setup(undefined, pattern, inputs ?? {}, piece),
+      () =>
+        this.runtime.setup(undefined, pattern, inputs ?? {}, piece, {
+          patternRepository: options?.repository,
+        }),
     );
     await timePiecePhase(
       "setupPersistent.syncPattern",

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -806,7 +806,9 @@ export class PieceManager {
       if (options?.expectedPatternIdentity) {
         throw new Error("atomic pattern updates require starting the piece");
       }
-      await this.runtime.setup(undefined, pattern, inputs ?? {}, piece);
+      await this.runtime.setup(undefined, pattern, inputs ?? {}, piece, {
+        patternRepository: options?.repository,
+      });
     }
     await this.syncPattern(currentPiece);
     if (start) {

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -1,3 +1,7 @@
 export { PiecesController } from "./pieces-controller.ts";
 export { ACLManager } from "./acl-manager.ts";
-export { PieceController, type PiecePatternRef } from "./piece-controller.ts";
+export {
+  PieceController,
+  type PiecePatternRef,
+  type PiecePatternSourceRef,
+} from "./piece-controller.ts";

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -1,3 +1,3 @@
 export { PiecesController } from "./pieces-controller.ts";
 export { ACLManager } from "./acl-manager.ts";
-export { PieceController } from "./piece-controller.ts";
+export { PieceController, type PiecePatternRef } from "./piece-controller.ts";

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -6,6 +6,7 @@ import {
   formatFabricRef,
   getMetaLink,
   getPatternIdentityRef,
+  getPatternRepository,
   getPatternSource,
   getValueAtPath,
   isCell,
@@ -173,6 +174,8 @@ interface StoredCellTopology {
 export interface PiecePatternSourceRef {
   /** Immutable in-fabric reference to the verified source closure. */
   ref: string;
+  /** Optional caller-supplied repository associated with the source tree. */
+  repository?: string;
   /** Authored entry path within the program's compilation root. */
   entry?: string;
   /** Optional mutable/update provenance carried by `patternSource`. */
@@ -184,8 +187,8 @@ export interface PiecePatternSourceRef {
  *
  * `identity` is the prefix-free module hash stored in `patternIdentity`;
  * `identity` + `symbol` are the authoritative executable pointer. `source.ref`
- * names the immutable source closure; optional entry and origin fields aid
- * discovery without changing that identity.
+ * names the immutable source closure; optional repository, entry, and origin
+ * fields aid discovery without changing that identity.
  */
 export interface PiecePatternRef {
   identity: string;
@@ -2465,6 +2468,8 @@ export class PieceController<T = unknown> {
         ref: { kind: "uri", scheme: "pattern", hash: ref.identity },
       }),
     };
+    const repository = getPatternRepository(this.#cell);
+    if (repository !== undefined) source.repository = repository;
     const trackedSource = getPatternSource(this.#cell);
     if (trackedSource !== undefined) {
       return { ...ref, source: { ...source, origin: trackedSource } };
@@ -2627,7 +2632,10 @@ export class PieceController<T = unknown> {
     return (await this.getPatternSourceProgram())?.files;
   }
 
-  async setPattern(program: RuntimeProgram): Promise<void> {
+  async setPattern(
+    program: RuntimeProgram,
+    options?: { repository?: string },
+  ): Promise<void> {
     const mutationVersion = ++this.#mutationVersion;
     await this.#runMutation(mutationVersion, async () => {
       const { pattern: previousPattern, ref: previousRef } = await this
@@ -2644,6 +2652,7 @@ export class PieceController<T = unknown> {
             argumentCell,
             this.#manager,
           ),
+        repository: options?.repository,
       }) as Cell<T>;
     });
   }
@@ -2739,6 +2748,7 @@ async function execute(
       argumentCell: Cell<unknown>,
       argumentSchema: JSONSchema,
     ) => void;
+    repository?: string;
   },
 ): Promise<Cell<unknown>> {
   return await manager.runWithPattern(pattern, pieceId, input, options);

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2471,9 +2471,7 @@ export class PieceController<T = unknown> {
     const repository = getPatternRepository(this.#cell);
     if (repository !== undefined) source.repository = repository;
     const trackedSource = getPatternSource(this.#cell);
-    if (trackedSource !== undefined) {
-      return { ...ref, source: { ...source, origin: trackedSource } };
-    }
+    if (trackedSource !== undefined) source.origin = trackedSource;
 
     try {
       const program = await this.#manager.runtime.patternManager

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -5,6 +5,7 @@ import {
   extractDefaultValues,
   getMetaLink,
   getPatternIdentityRef,
+  getPatternSource,
   getValueAtPath,
   isCell,
   isLink,
@@ -165,6 +166,21 @@ interface OuterCellLocalization {
 interface StoredCellTopology {
   value: unknown;
   opaqueHandle: boolean;
+}
+
+/**
+ * Tooling-facing reference to the pattern currently running a piece.
+ *
+ * `identity` is the prefix-free module hash stored in `patternIdentity`;
+ * `identity` + `symbol` are the authoritative content-addressed pointer.
+ * `source` is a best-effort human/discovery locator: explicit `patternSource`
+ * provenance when the piece tracks one, otherwise the authored entry filename
+ * recovered from the current pattern's verified source closure.
+ */
+export interface PiecePatternRef {
+  identity: string;
+  symbol: string;
+  source?: string;
 }
 
 function storedCellTopology(
@@ -2427,6 +2443,32 @@ export class PieceController<T = unknown> {
 
   getCell(): Cell<T> {
     return this.#cell;
+  }
+
+  /** Return a stable reference to the pattern currently running this piece. */
+  async getPatternRef(): Promise<PiecePatternRef | undefined> {
+    const ref = getPatternIdentityRef(this.#cell);
+    if (!ref) return undefined;
+
+    const trackedSource = getPatternSource(this.#cell);
+    if (trackedSource !== undefined) {
+      return { ...ref, source: trackedSource };
+    }
+
+    try {
+      const program = await this.#manager.runtime.patternManager
+        .getPatternSourceProgramByIdentity(
+          ref.identity,
+          this.#manager.getSpace(),
+        );
+      return program?.main === undefined
+        ? ref
+        : { ...ref, source: program.main };
+    } catch {
+      // The content pointer remains useful even if the source closure is
+      // unavailable or unreadable in this space.
+      return ref;
+    }
   }
 
   async setInput(input: object): Promise<void> {

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3,6 +3,7 @@ import {
   type CellPath,
   ContextualFlowControl,
   extractDefaultValues,
+  formatFabricRef,
   getMetaLink,
   getPatternIdentityRef,
   getPatternSource,
@@ -168,19 +169,28 @@ interface StoredCellTopology {
   opaqueHandle: boolean;
 }
 
+/** Tooling-facing source locator for a running pattern. */
+export interface PiecePatternSourceRef {
+  /** Immutable in-fabric reference to the verified source closure. */
+  ref: string;
+  /** Authored entry path within the program's compilation root. */
+  entry?: string;
+  /** Optional mutable/update provenance carried by `patternSource`. */
+  origin?: string;
+}
+
 /**
  * Tooling-facing reference to the pattern currently running a piece.
  *
  * `identity` is the prefix-free module hash stored in `patternIdentity`;
- * `identity` + `symbol` are the authoritative content-addressed pointer.
- * `source` is a best-effort human/discovery locator: explicit `patternSource`
- * provenance when the piece tracks one, otherwise the authored entry filename
- * recovered from the current pattern's verified source closure.
+ * `identity` + `symbol` are the authoritative executable pointer. `source.ref`
+ * names the immutable source closure; optional entry and origin fields aid
+ * discovery without changing that identity.
  */
 export interface PiecePatternRef {
   identity: string;
   symbol: string;
-  source?: string;
+  source: PiecePatternSourceRef;
 }
 
 function storedCellTopology(
@@ -2450,9 +2460,14 @@ export class PieceController<T = unknown> {
     const ref = getPatternIdentityRef(this.#cell);
     if (!ref) return undefined;
 
+    const source: PiecePatternSourceRef = {
+      ref: formatFabricRef({
+        ref: { kind: "uri", scheme: "pattern", hash: ref.identity },
+      }),
+    };
     const trackedSource = getPatternSource(this.#cell);
     if (trackedSource !== undefined) {
-      return { ...ref, source: trackedSource };
+      return { ...ref, source: { ...source, origin: trackedSource } };
     }
 
     try {
@@ -2462,12 +2477,12 @@ export class PieceController<T = unknown> {
           this.#manager.getSpace(),
         );
       return program?.main === undefined
-        ? ref
-        : { ...ref, source: program.main };
+        ? { ...ref, source }
+        : { ...ref, source: { ...source, entry: program.main } };
     } catch {
       // The content pointer remains useful even if the source closure is
       // unavailable or unreadable in this space.
-      return ref;
+      return { ...ref, source };
     }
   }
 

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -13,6 +13,7 @@ import {
   runtimePresets,
   RuntimeProgram,
   type Schema,
+  setPatternRepository,
   setPatternSource,
 } from "@commonfabric/runner";
 import type { CellScope } from "@commonfabric/api";
@@ -95,6 +96,7 @@ async function timePiecesPhase<T>(
 
 export interface CreatePieceOptions {
   input?: object;
+  repository?: string;
   start?: boolean;
 }
 
@@ -123,7 +125,7 @@ export class PiecesController<T = unknown> {
       pattern,
       options.input,
       cause,
-      { start },
+      { repository: options.repository, start },
     );
     if (!start) {
       await this.#manager.runtime.idle();
@@ -273,9 +275,16 @@ export class PiecesController<T = unknown> {
    * @returns The newly created default pattern piece
    */
   async recreateDefaultPattern(
-    options?: { customProgram?: RuntimeProgram },
+    options?: { customProgram?: RuntimeProgram; repository?: string },
   ): Promise<PieceController<NameSchema>> {
     this.disposeCheck();
+    if (
+      options?.repository !== undefined && options.customProgram === undefined
+    ) {
+      throw new Error(
+        "A repository locator can only be supplied with a custom program",
+      );
+    }
 
     // Stop and unlink the existing default pattern first (before any operations that might fail)
     // We need to stop it to prevent resource leaks or duplicate behavior from the old pattern
@@ -353,6 +362,10 @@ export class PiecesController<T = unknown> {
 
       // Run pattern setup within same transaction
       this.#manager.runtime.run(tx, pattern, {}, pieceCell);
+
+      if (options?.repository !== undefined) {
+        setPatternRepository(pieceCell, tx, options.repository);
+      }
 
       // Link as default pattern within same transaction
       const spaceCellWithTx = spaceCellContents.withTx(tx);

--- a/packages/piece/test/ensure-default-pattern.test.ts
+++ b/packages/piece/test/ensure-default-pattern.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { NAME, Runtime } from "@commonfabric/runner";
+import { getPatternRepository, NAME, Runtime } from "@commonfabric/runner";
 import type { RuntimeProgram } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
@@ -337,5 +337,22 @@ describe("PiecesController.recreateDefaultPattern", () => {
     } finally {
       runtime.editWithRetry = originalEditWithRetry;
     }
+  });
+
+  it("stores an explicitly supplied repository for a custom root", async () => {
+    const repository = "https://github.com/commontoolsinc/labs";
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: defaultPatternProgram,
+      repository,
+    });
+
+    expect(getPatternRepository(piece.getCell())).toBe(repository);
+    expect((await piece.getPatternRef())?.source.repository).toBe(repository);
+  });
+
+  it("rejects a repository locator without a custom root program", async () => {
+    await expect(controller.recreateDefaultPattern({
+      repository: "https://github.com/commontoolsinc/labs",
+    })).rejects.toThrow(/only be supplied with a custom program/);
   });
 });

--- a/packages/piece/test/pattern-source-provenance.test.ts
+++ b/packages/piece/test/pattern-source-provenance.test.ts
@@ -112,6 +112,7 @@ describe("ensureDefaultPattern stamps patternSource", () => {
       ...identityRef,
       source: {
         ref: `cf:pattern:${identityRef.identity}`,
+        entry: DEFAULT_APP_PATTERN_URL,
         origin: DEFAULT_APP_PATTERN_URL,
       },
     });

--- a/packages/piece/test/pattern-source-provenance.test.ts
+++ b/packages/piece/test/pattern-source-provenance.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { getPatternSource, Runtime } from "@commonfabric/runner";
+import {
+  getPatternIdentityRef,
+  getPatternSource,
+  Runtime,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
@@ -103,5 +107,9 @@ describe("ensureDefaultPattern stamps patternSource", () => {
     const piece = await controller.ensureDefaultPattern();
     const source = getPatternSource(piece.getCell());
     expect(source).toBe(DEFAULT_APP_PATTERN_URL);
+    expect(await piece.getPatternRef()).toEqual({
+      ...getPatternIdentityRef(piece.getCell()),
+      source: DEFAULT_APP_PATTERN_URL,
+    });
   });
 });

--- a/packages/piece/test/pattern-source-provenance.test.ts
+++ b/packages/piece/test/pattern-source-provenance.test.ts
@@ -107,9 +107,13 @@ describe("ensureDefaultPattern stamps patternSource", () => {
     const piece = await controller.ensureDefaultPattern();
     const source = getPatternSource(piece.getCell());
     expect(source).toBe(DEFAULT_APP_PATTERN_URL);
+    const identityRef = getPatternIdentityRef(piece.getCell())!;
     expect(await piece.getPatternRef()).toEqual({
-      ...getPatternIdentityRef(piece.getCell()),
-      source: DEFAULT_APP_PATTERN_URL,
+      ...identityRef,
+      source: {
+        ref: `cf:pattern:${identityRef.identity}`,
+        origin: DEFAULT_APP_PATTERN_URL,
+      },
     });
   });
 });

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -147,12 +147,13 @@ function namedPattern(name: string, multiplier: number): Pattern {
 function compiledMultiplierProgram(
   version: string,
   multiplier: number,
+  main = "/main.tsx",
 ): RuntimeProgram {
   return {
-    main: "/main.tsx",
+    main,
     files: [
       {
-        name: "/main.tsx",
+        name: main,
         contents: [
           "import { pattern, lift } from 'commonfabric';",
           `const multiply = lift((input: number) => input * ${multiplier});`,
@@ -4753,7 +4754,11 @@ describe("piece pull materialization", () => {
       output: 10,
     });
 
-    await controller.setPattern(compiledMultiplierProgram("v2", 10));
+    await controller.setPattern(compiledMultiplierProgram(
+      "v2",
+      10,
+      "/packages/patterns/examples/multiplier.tsx",
+    ));
     await manager.runtime.idle();
     await manager.synced();
 
@@ -4793,7 +4798,10 @@ describe("piece pull materialization", () => {
       );
       expect(await freshPiece.getPatternRef()).toEqual({
         ...freshRef,
-        source: "/main.tsx",
+        source: {
+          ref: `cf:pattern:${freshRef!.identity}`,
+          entry: "/packages/patterns/examples/multiplier.tsx",
+        },
       });
     } finally {
       await freshRuntime.dispose();

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1305,6 +1305,80 @@ describe("piece pull materialization", () => {
     }
   });
 
+  it("keeps pattern content refs useful when source programs are unavailable", async () => {
+    const identityless = runtime.getCell(
+      manager.getSpace(),
+      "identityless-piece-" + crypto.randomUUID(),
+      { type: "object", properties: {} },
+    );
+    expect(await new PieceController(manager, identityless).getPatternRef())
+      .toBeUndefined();
+
+    const program = compiledMultiplierProgram("unavailable-source", 2);
+    const piece = await manager.runPersistent(
+      await runtime.patternManager.compilePattern(program, {
+        space: manager.getSpace(),
+      }),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+    const identityRef = getPatternIdentityRef(piece)!;
+    const contentOnlyRef = {
+      ...identityRef,
+      source: { ref: `cf:pattern:${identityRef.identity}` },
+    };
+    const originalLookup = runtime.patternManager
+      .getPatternSourceProgramByIdentity.bind(runtime.patternManager);
+
+    try {
+      runtime.patternManager.getPatternSourceProgramByIdentity = () =>
+        Promise.resolve(undefined);
+      expect(await controller.getPatternRef()).toEqual(contentOnlyRef);
+
+      runtime.patternManager.getPatternSourceProgramByIdentity = () =>
+        Promise.reject(new Error("source unavailable"));
+      expect(await controller.getPatternRef()).toEqual(contentOnlyRef);
+    } finally {
+      runtime.patternManager.getPatternSourceProgramByIdentity = originalLookup;
+    }
+  });
+
+  it("distinguishes absent setup patterns from unknown stored identities", async () => {
+    const emptyPiece = runtime.getCell(
+      manager.getSpace(),
+      "missing-setup-pattern-" + crypto.randomUUID(),
+      { type: "object", properties: {} },
+    );
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      await runtime.setup(undefined, undefined, {}, emptyPiece);
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings).toEqual([
+      "No pattern provided and no pattern found in result metadata. Not running.",
+    ]);
+
+    const unknownPiece = runtime.getCell(
+      manager.getSpace(),
+      "unknown-setup-pattern-" + crypto.randomUUID(),
+      { type: "object", properties: {} },
+    );
+    await runtime.editWithRetry((tx) => {
+      unknownPiece.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: "Z".repeat(43),
+        symbol: "default",
+      });
+    });
+
+    await expect(runtime.setup(undefined, undefined, {}, unknownPiece))
+      .rejects.toThrow(`Unknown pattern: ${"Z".repeat(43)}#default`);
+  });
+
   it("pulls before reading result values", async () => {
     const piece = await manager.runPersistent(
       trustPattern(runtime, doublePattern()),
@@ -4732,6 +4806,25 @@ describe("piece pull materialization", () => {
     );
 
     expect(manager.getResult(piece).get()).toEqual({ output: 50 });
+  });
+
+  it("stores repository metadata when preparing without starting", async () => {
+    const repository = "https://github.com/commontoolsinc/labs";
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, doublePattern()),
+      { input: 5 },
+      undefined,
+      { start: false },
+    );
+
+    await manager.runWithPattern(
+      trustPattern(runtime, tenfoldPattern()),
+      entityRefToString(piece.entityId),
+      { input: 5 },
+      { start: false, repository },
+    );
+
+    expect(getPatternRepository(piece)).toBe(repository);
   });
 
   it("persists setPattern replacement by identity for fresh runtime reloads", async () => {

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -4791,6 +4791,10 @@ describe("piece pull materialization", () => {
       expect(source?.files.some((file) => file.contents.includes("v2"))).toBe(
         true,
       );
+      expect(await freshPiece.getPatternRef()).toEqual({
+        ...freshRef,
+        source: "/main.tsx",
+      });
     } finally {
       await freshRuntime.dispose();
     }

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   getPatternIdentityRef,
+  getPatternRepository,
   type JSONSchema,
   KeepAsCell,
   NAME,
@@ -4734,6 +4735,7 @@ describe("piece pull materialization", () => {
   });
 
   it("persists setPattern replacement by identity for fresh runtime reloads", async () => {
+    const repository = "https://github.com/commontoolsinc/labs";
     const firstPattern = await runtime.patternManager.compilePattern(
       compiledMultiplierProgram("v1", 2),
       { space: manager.getSpace() },
@@ -4742,7 +4744,7 @@ describe("piece pull materialization", () => {
       firstPattern,
       { input: 5 },
       "compiled-set-pattern-" + crypto.randomUUID(),
-      { start: true },
+      { start: true, repository },
     );
     const id = entityRefToString(piece.entityId);
     const controller = new PieceController(manager, piece);
@@ -4754,11 +4756,14 @@ describe("piece pull materialization", () => {
       output: 10,
     });
 
-    await controller.setPattern(compiledMultiplierProgram(
-      "v2",
-      10,
-      "/packages/patterns/examples/multiplier.tsx",
-    ));
+    await controller.setPattern(
+      compiledMultiplierProgram(
+        "v2",
+        10,
+        "/packages/patterns/examples/multiplier.tsx",
+      ),
+      { repository },
+    );
     await manager.runtime.idle();
     await manager.synced();
 
@@ -4800,12 +4805,41 @@ describe("piece pull materialization", () => {
         ...freshRef,
         source: {
           ref: `cf:pattern:${freshRef!.identity}`,
+          repository,
           entry: "/packages/patterns/examples/multiplier.tsx",
         },
       });
+      expect(getPatternRepository(freshCell)).toBe(repository);
     } finally {
       await freshRuntime.dispose();
     }
+  });
+
+  it("preserves a repository until a source update explicitly replaces it", async () => {
+    const originalRepository = "https://github.com/commontoolsinc/labs";
+    const replacementRepository = "https://github.com/commontoolsinc/patterns";
+    const firstPattern = await runtime.patternManager.compilePattern(
+      compiledMultiplierProgram("v1", 2),
+      { space: manager.getSpace() },
+    );
+    const piece = await manager.runPersistent(
+      firstPattern,
+      { input: 5 },
+      "repository-update-" + crypto.randomUUID(),
+      { start: true, repository: originalRepository },
+    );
+    const controller = new PieceController(manager, piece);
+
+    await controller.setPattern(compiledMultiplierProgram("v2", 3));
+    expect(getPatternRepository(piece)).toBe(originalRepository);
+
+    await controller.setPattern(compiledMultiplierProgram("v3", 4), {
+      repository: replacementRepository,
+    });
+    expect(getPatternRepository(piece)).toBe(replacementRepository);
+    expect((await controller.getPatternRef())?.source.repository).toBe(
+      replacementRepository,
+    );
   });
 
   it("updates a piece across backward-compatible schema additions", async () => {
@@ -5097,6 +5131,7 @@ describe("piece pull materialization", () => {
   });
 
   it("preserves conflicting defined values while merging object defaults", async () => {
+    const originalRepository = "https://github.com/commontoolsinc/labs";
     const firstPattern = await runtime.patternManager.compilePattern(
       compiledDefaultedOptionsProgram(1),
       { space: manager.getSpace() },
@@ -5105,7 +5140,7 @@ describe("piece pull materialization", () => {
       firstPattern,
       { value: 4 },
       "defined-object-default-conflict-" + crypto.randomUUID(),
-      { start: true },
+      { start: true, repository: originalRepository },
     );
     const controller = new PieceController(manager, piece);
     const inputCell = await controller.input.getCell();
@@ -5118,10 +5153,13 @@ describe("piece pull materialization", () => {
     const previousRef = getPatternIdentityRef(piece);
 
     await expect(
-      controller.setPattern(compiledDefaultedOptionsProgram(2)),
+      controller.setPattern(compiledDefaultedOptionsProgram(2), {
+        repository: "https://github.com/commontoolsinc/other",
+      }),
     ).rejects.toThrow(/updated arguments do not match the candidate schema/);
 
     expect(getPatternIdentityRef(piece)).toEqual(previousRef);
+    expect(getPatternRepository(piece)).toBe(originalRepository);
     expect(inputCell.getRaw()).toEqual({ value: 4, options: "legacy" });
   });
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -112,11 +112,13 @@ export {
   asPatternIdentityRef,
   extractDefaultValues,
   getPatternIdentityRef,
+  getPatternRepository,
   getPatternSource,
   mergeSchemaDefaults,
   patternIdentityKey,
   schemaAcceptsOpaqueCellValue,
   schemaHasDefaultValue,
+  setPatternRepository,
   setPatternSource,
 } from "./runner.ts";
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -247,6 +247,7 @@ export {
 export {
   type FabricRef,
   FabricRefError,
+  formatFabricRef,
   isFabricImportSpecifier,
   parseFabricRef,
 } from "./sandbox/fabric-import-specifier.ts";

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -553,6 +553,8 @@ type SetupValidationOptions = {
     argumentCell: Cell<unknown>,
     argumentSchema: JSONSchema,
   ) => void;
+  /** Optional repository locator written atomically with pattern setup. */
+  patternRepository?: string;
 };
 
 type RunResult<R> = {
@@ -778,21 +780,30 @@ export class Runner {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
+    options?: SetupValidationOptions,
   ): Promise<Cell<R>>;
   setup<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
+    options?: SetupValidationOptions,
   ): Promise<Cell<R>>;
   setup<T, R = any>(
     providedTx: IExtendedStorageTransaction | undefined,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
+    options: SetupValidationOptions = {},
   ): Promise<Cell<R>> {
     if (providedTx) {
-      this.setupInternal(providedTx, patternOrModule, argument, resultCell);
+      this.setupInternal(
+        providedTx,
+        patternOrModule,
+        argument,
+        resultCell,
+        options,
+      );
       return Promise.resolve(resultCell);
     } else {
       // Ignore retry/commit errors after retrying for now, as outside the tx,
@@ -802,7 +813,7 @@ export class Runner {
       // overwritten. Still surface real callback failures from setupInternal so
       // callers don't silently continue after a broken setup.
       return this.runtime.editWithRetry((tx) => {
-        this.setupInternal(tx, patternOrModule, argument, resultCell);
+        this.setupInternal(tx, patternOrModule, argument, resultCell, options);
       }).then(({ error }) => {
         if (error) {
           if (
@@ -1346,6 +1357,14 @@ export class Runner {
     }
 
     this.updateResultSchemaMeta(tx, resultCell, pattern.resultSchema);
+
+    if (validationOptions.patternRepository !== undefined) {
+      setPatternRepository(
+        resultCell,
+        tx,
+        validationOptions.patternRepository,
+      );
+    }
 
     const runningSetup = this.maybeReuseRunningSetup(
       tx,
@@ -2188,6 +2207,7 @@ export class Runner {
     options?: {
       expectedPatternIdentity?: { identity: string; symbol: string };
       validateArgumentLinks?: SetupValidationOptions["validateArgumentLinks"];
+      patternRepository?: string;
     },
   ) {
     await resultCell.sync();
@@ -2232,7 +2252,10 @@ export class Runner {
         pattern,
         inputs,
         resultCell.withTx(givenTx),
-        { validateArgumentLinks: options?.validateArgumentLinks },
+        {
+          patternRepository: options?.patternRepository,
+          validateArgumentLinks: options?.validateArgumentLinks,
+        },
       );
     } else {
       const { error } = await this.runtime.editWithRetry((tx) => {
@@ -2242,7 +2265,10 @@ export class Runner {
           pattern,
           inputs,
           resultCell.withTx(tx),
-          { validateArgumentLinks: options?.validateArgumentLinks },
+          {
+            patternRepository: options?.patternRepository,
+            validateArgumentLinks: options?.validateArgumentLinks,
+          },
         );
       });
       if (error) {
@@ -5416,6 +5442,25 @@ export function setPatternSource(
   url: string,
 ): void {
   resultCell.withTx(tx).setMetaRaw("patternSource", url);
+}
+
+/** Read an explicitly supplied repository locator for a piece's source. */
+export function getPatternRepository(
+  resultCell: Cell<unknown>,
+): string | undefined {
+  const raw = resultCell.getMetaRaw("patternRepository", {
+    meta: ignoreReadForScheduling,
+  });
+  return typeof raw === "string" ? raw : undefined;
+}
+
+/** Stamp an explicitly supplied repository locator with pattern setup. */
+export function setPatternRepository(
+  resultCell: Cell<unknown>,
+  tx: IExtendedStorageTransaction,
+  repository: string,
+): void {
+  resultCell.withTx(tx).setMetaRaw("patternRepository", repository);
 }
 
 /** Narrow a raw meta value to a `{ identity, symbol }` pattern ref, or undefined. */

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1802,20 +1802,29 @@ export class Runtime {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
+    options?: { patternRepository?: string },
   ): Promise<Cell<R>>;
   setup<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
+    options?: { patternRepository?: string },
   ): Promise<Cell<R>>;
   setup<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
+    options?: { patternRepository?: string },
   ): Promise<Cell<R>> {
-    return this.runner.setup<T, R>(tx, patternOrModule, argument, resultCell);
+    return this.runner.setup<T, R>(
+      tx,
+      patternOrModule,
+      argument,
+      resultCell,
+      options,
+    );
   }
   run<T, R>(
     tx: IExtendedStorageTransaction | undefined,
@@ -1848,6 +1857,7 @@ export class Runtime {
         argumentCell: Cell<unknown>,
         argumentSchema: JSONSchema,
       ) => void;
+      patternRepository?: string;
     },
   ) {
     return this.runner.runSynced(resultCell, pattern, inputs, options);

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -77,18 +77,18 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 
 ## Quick Command Reference
 
-| Operation         | Command                                                                   |
-| ----------------- | ------------------------------------------------------------------------- |
-| Type check        | `deno task cf check pattern.tsx --no-run`                                 |
-| Deploy new        | `deno task cf piece new pattern.tsx -i key -a url -s space`               |
-| Update existing   | `deno task cf piece setsrc pattern.tsx --piece ID -i key -a url -s space` |
-| Inspect state     | `deno task cf piece inspect --piece ID ...`                               |
-| Get field         | `deno task cf piece get --piece ID fieldPath ...`                         |
-| Set field         | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`       |
-| Call handler      | `deno task cf piece call --piece ID handlerName ...`                      |
-| Trigger recompute | `deno task cf piece step --piece ID ...`                                  |
-| List pieces       | `deno task cf piece ls -i key -a url -s space`                            |
-| Visualize         | `deno task cf piece map ...`                                              |
+| Operation         | Command                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| Type check        | `deno task cf check pattern.tsx --no-run`                                                            |
+| Deploy new        | `deno task cf piece new pattern.tsx --root . --repository REPO -i key -a url -s space`               |
+| Update existing   | `deno task cf piece setsrc pattern.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
+| Inspect state     | `deno task cf piece inspect --piece ID ...`                                                          |
+| Get field         | `deno task cf piece get --piece ID fieldPath ...`                                                    |
+| Set field         | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
+| Call handler      | `deno task cf piece call --piece ID handlerName ...`                                                 |
+| Trigger recompute | `deno task cf piece step --piece ID ...`                                                             |
+| List pieces       | `deno task cf piece ls -i key -a url -s space`                                                       |
+| Visualize         | `deno task cf piece map ...`                                                                         |
 
 ## Check Command Flags
 
@@ -129,6 +129,17 @@ deno task cf piece setsrc pattern.tsx --piece bafyreia... ...
 ```
 
 **Why:** `new` creates duplicate pieces. `setsrc` updates in-place.
+
+### Source location metadata
+
+The local-source deployment commands `piece new`, `piece setsrc`, and custom
+`piece set-home` accept `--root` plus `--repository`. Use the repository
+checkout root for `--root`; this preserves `source.entry` as a path inside the
+repository. `--repository` is stored exactly as supplied in `source.repository`
+and is never inferred from Git configuration. On `setsrc`, omitting
+`--repository` preserves the existing value; supplying it replaces the value.
+`piece inspect --json` and `piece ls --json` expose the resulting structured
+source locator.
 
 ## JSON Input Format
 

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -53,16 +53,19 @@ cat "MOUNT/SPACE/pieces/pieces.json"
 {
   "identity": "<content-hash>",
   "symbol": "default",
-  "source": "/annotation.tsx"
+  "source": {
+    "ref": "cf:pattern:<content-hash>",
+    "entry": "/packages/patterns/annotation.tsx"
+  }
 }
 ```
 
 The prefix-free `identity` + `symbol` are the authoritative reference to the
-running artifact (`cf:module/<identity>#<symbol>` in display form). `source` is
-a best-effort discovery locator: tracked `patternSource` provenance when
-present, otherwise the authored entry filename recovered from the current
-artifact. Match the entry filename for pattern-kind discovery; do not infer it
-from the piece's mutable display name.
+running artifact (`cf:module/<identity>#<symbol>` in display form). `source.ref`
+addresses the immutable source closure; `source.entry` is its optional authored
+entry path, and `source.origin` is optional update provenance. For pattern-kind
+discovery, match the entry filename and fall back to the origin path when the
+entry is absent; do not infer it from the piece's mutable display name.
 
 ---
 
@@ -280,8 +283,9 @@ import json, sys
 p = json.load(sys.stdin)
 for x in p:
     ref = x.get('patternRef', {})
-    source = ref.get('source', '') if isinstance(ref, dict) else ''
-    if source.rsplit('/', 1)[-1] == 'annotation.tsx':
+    source = ref.get('source', {}) if isinstance(ref, dict) else {}
+    locator = (source.get('entry') or source.get('origin', '')) if isinstance(source, dict) else ''
+    if locator.rsplit('/', 1)[-1] == 'annotation.tsx':
         print(x['name'], '—', x.get('summary','')[:60])
 "
 ```
@@ -367,8 +371,9 @@ import json, sys
 p = json.load(sys.stdin)
 for x in p:
     ref = x.get('patternRef', {})
-    source = ref.get('source', '') if isinstance(ref, dict) else ''
-    if source.rsplit('/', 1)[-1] == 'agent.tsx':
+    source = ref.get('source', {}) if isinstance(ref, dict) else {}
+    locator = (source.get('entry') or source.get('origin', '')) if isinstance(source, dict) else ''
+    if locator.rsplit('/', 1)[-1] == 'agent.tsx':
         print(x['name'], '—', x.get('summary','')[:60])
 "
 ```

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -55,6 +55,7 @@ cat "MOUNT/SPACE/pieces/pieces.json"
   "symbol": "default",
   "source": {
     "ref": "cf:pattern:<content-hash>",
+    "repository": "https://github.com/commontoolsinc/labs",
     "entry": "/packages/patterns/annotation.tsx"
   }
 }
@@ -62,8 +63,9 @@ cat "MOUNT/SPACE/pieces/pieces.json"
 
 The prefix-free `identity` + `symbol` are the authoritative reference to the
 running artifact (`cf:module/<identity>#<symbol>` in display form). `source.ref`
-addresses the immutable source closure; `source.entry` is its optional authored
-entry path, and `source.origin` is optional update provenance. For pattern-kind
+addresses the immutable source closure; `source.repository` is an optional,
+explicitly supplied repository locator; `source.entry` is its optional authored
+entry path; and `source.origin` is optional update provenance. For pattern-kind
 discovery, match the entry filename and fall back to the origin path when the
 entry is absent; do not infer it from the piece's mutable display name.
 

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -45,6 +45,25 @@ cat "MOUNT/SPACE/pieces/pieces.json"
 4. Verify via `result/summary`
 5. Append wikilink to any source note that motivated the deploy
 
+### Identifying the running pattern
+
+`pieces/pieces.json` and each piece's `meta.json` expose `patternRef`:
+
+```json
+{
+  "identity": "<content-hash>",
+  "symbol": "default",
+  "source": "/annotation.tsx"
+}
+```
+
+The prefix-free `identity` + `symbol` are the authoritative reference to the
+running artifact (`cf:module/<identity>#<symbol>` in display form). `source` is
+a best-effort discovery locator: tracked `patternSource` provenance when
+present, otherwise the authored entry filename recovered from the current
+artifact. Match the entry filename for pattern-kind discovery; do not infer it
+from the piece's mutable display name.
+
 ---
 
 ## Lifecycle Gotchas
@@ -260,7 +279,9 @@ cat "MOUNT/SPACE/pieces/pieces.json" | python3 -c "
 import json, sys
 p = json.load(sys.stdin)
 for x in p:
-    if x.get('patternName','') == 'annotation':
+    ref = x.get('patternRef', {})
+    source = ref.get('source', '') if isinstance(ref, dict) else ''
+    if source.rsplit('/', 1)[-1] == 'annotation.tsx':
         print(x['name'], '—', x.get('summary','')[:60])
 "
 ```
@@ -345,7 +366,9 @@ cat "MOUNT/SPACE/pieces/pieces.json" | python3 -c "
 import json, sys
 p = json.load(sys.stdin)
 for x in p:
-    if x.get('patternName','') == 'agent':
+    ref = x.get('patternRef', {})
+    source = ref.get('source', '') if isinstance(ref, dict) else ''
+    if source.rsplit('/', 1)[-1] == 'agent.tsx':
         print(x['name'], '—', x.get('summary','')[:60])
 "
 ```


### PR DESCRIPTION
## Summary

- restore a durable reference to the pattern currently running each piece
- expose the pattern identity and structured source locator through `cf piece ls`, `cf piece inspect`, FUSE `meta.json`, and `pieces.json`
- refresh mounted metadata when a piece is updated in place
- add explicit `--repository` support to `cf piece new`, `cf piece setsrc`, and custom `cf piece set-home`
- document the source contract and update the CF/FUSE workflow skills

## Why

This restores the discoverability called out in [the earlier FUSE review](https://github.com/commontoolsinc/labs/pull/4156#issuecomment-5000302986) without bringing back the mutable `patternName` field.

The running executable remains content-addressed by `identity + symbol`. Tooling now also reports:

- `source.ref`: immutable `cf:pattern:<identity>` source reference
- `source.repository`: optional repository locator supplied explicitly at deployment
- `source.entry`: authored path within the deployment `--root`
- `source.origin`: optional update provenance carried by `patternSource`

Repository metadata is never inferred from Git configuration. A `setsrc` call preserves the existing repository when the flag is omitted and atomically replaces it when supplied.

## Validation

- Piece tests: 7 passed, 127 steps
- CLI tests: 8 passed, 95 steps
- FUSE tests: 44 passed
- `deno task check`
- `deno lint` on changed TypeScript
- `deno fmt --check`
- `deno task check-docs specs`
- `deno task check-skill-facts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a structured pattern reference for each running piece across the CLI and FUSE, with repository-aware provenance that stays correct through swaps, updates, and offline-source cases.

- **New Features**
  - Adds `patternRef` to piece metadata: `{ identity, symbol, source: { ref, repository?, entry?, origin? } }`.
  - Shown in `cf piece ls` (new PATTERN column and `--json`), `cf piece inspect`/`--json`, FUSE `meta.json`, and `pieces/pieces.json`.
  - Pattern refs auto-refresh in FUSE when a piece updates in place (identity swap or repository change).
  - New `--repository` flag for `cf piece new`, `cf piece setsrc`, and custom `cf piece set-home`; `--root` preserves repository-relative paths.
  - Runtime stores `patternRepository` and exposes `getPatternRef()` via `PieceController` in `@commonfabric/piece/ops`; end-to-end support in `@commonfabric/runner` (`setPatternRepository`, `getPatternRepository`, `formatFabricRef`).
  - `getPatternRef()` returns a stable content pointer when source programs are unavailable and includes `source.entry` when present.

- **Migration**
  - For discovery, read `patternRef.source.entry` first; fall back to `patternRef.source.origin`. Do not infer from Git or piece display names.
  - Display the running artifact as `cf:module/<identity>#<symbol>`; treat `patternRef.source.ref` as the immutable source pointer.
  - When deploying from a repo, pass `--root <repo-root>` and optionally `--repository <locator>`; omitting `--repository` on `setsrc` preserves the current value.
  - `set-home --reset` rejects `--repository`; supplying a repository is only valid when providing a custom home program.
  - Prefer `patternRef` over any legacy name fields in tools and scripts.

<sup>Written for commit d4bd229466442583ee41a72ac392cca13f5278da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

