### PR TITLE
fix(piece): let setsrc validation prove scoped inputs and mergeable elements

### DIFF
--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -82,19 +82,14 @@ SPACE=team-lunch
 
 ## Option A — update the existing piece in place (recommended)
 
-> **⚠️ Blocked on runtimes built from `main` between 2026-07-15 and the merge of
-> [#4785](https://github.com/commontoolsinc/labs/pull/4785).** #4717 ("validate
-> schema-compatible setsrc updates") added a `setsrc`-time gate whose
-> contract-recovery could not prove scoped inputs (this pattern's `myName`, a
-> `PerUser`) or mergeable-pushed list elements (`options.0` etc.), rejecting
-> even an identical-source update with
-> `input link at <path> schema is not compatible: source has no durable schema
-> contract`.
-> [#4785](https://github.com/commontoolsinc/labs/pull/4785) fixes the recovery
-> (gate intact). On an affected runtime, deploy via **Option B** (or a fresh
-> `cf piece new`), neither of which routes through `setsrc`; prod (`rapids`) may
-> predate #4717 entirely and be unaffected. Delete this caveat once #4785 is
-> merged and deployed.
+> **Note:** servers built from `main` between #4717 (2026-07-15) and #4785
+> reject `setsrc` on any piece with a scoped input (this pattern's `myName`) or
+> a pushed list element, with
+> `input link at <path> schema is not compatible:
+> source has no durable schema contract`.
+> If the server you're deploying to is on such a build, upgrade it or use
+> **Option B** (or a fresh `cf piece new`), neither of which routes through
+> `setsrc`.
 
 To push code changes **and keep all accumulated state**, update the source of
 the existing piece. Do **not** run `cf piece new` — that mints a fresh, empty

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1131,7 +1131,7 @@ export function durableSourceContract(
   // even an identical-source `setsrc`; reading only base would strip a scoped
   // result cell of its legitimate contract.
   const metaScope = ((): LinkScope | undefined => {
-    if (rawSourceLink.scope === undefined) return undefined;
+    if (rawSourceLink.scope === "space") return rawSourceLink.scope;
     const scopedRoot = manager.runtime.getCellFromLink(
       { ...rawSourceLink, path: [], schema: undefined },
       undefined,
@@ -1362,16 +1362,21 @@ function assertContractSubset(
   for (const target of targets) {
     let lastError: unknown;
     const proved = sources.some((source) => {
-      // A source that may hold no value (its schema carries an explicit
-      // `undefined` alternative, added by `includePossibleMissingValue`) is
-      // acceptable to a destination slot that is itself optional: absence is a
-      // state the destination schema already tolerates. Discharge that
-      // alternative here, structurally, rather than injecting an `undefined`
-      // union into the target — a union-with-default target is not stable
-      // under default insertion and would fail closed. A required destination
-      // keeps the alternative, so a possibly-absent source still fails there.
-      const sourceSchema = target.mayBeMissing === true
-        ? withoutUndefinedAlternative(source.schema)
+      // A source that may hold no value must prove absence acceptable. When
+      // the destination slot is itself optional, absence is a state the
+      // destination already tolerates, so the value schemas are compared
+      // directly. When the destination is required, absence must be provable
+      // against the destination's value schema, so an explicit `undefined`
+      // alternative is injected into the source side of the proof. Absence is
+      // discharged at the flag level — never by rewriting the source schema —
+      // so a producer schema that itself admits a *present* `undefined` value
+      // keeps that alternative and the destination value schema must accept
+      // it, optional slot or not. (Injecting `undefined` into the target
+      // instead would trip the union-with-default "not stable under default
+      // insertion" fail-close.)
+      const sourceSchema: JSONSchema = source.mayBeMissing === true &&
+          target.mayBeMissing !== true
+        ? { anyOf: [source.schema, { type: "undefined" }] }
         : source.schema;
       try {
         assertSchemaSubset(
@@ -1390,36 +1395,11 @@ function assertContractSubset(
   }
 }
 
-/**
- * Remove a top-level `{ type: "undefined" }` alternative from a schema union,
- * collapsing a resulting singleton wrapper to its sole branch. Used when the
- * destination contract tolerates absence, so the possible-missing alternative
- * need not be proven against the destination's value schema.
- */
-function withoutUndefinedAlternative(schema: JSONSchema): JSONSchema {
-  if (typeof schema !== "object" || schema === null) return schema;
-  const alternatives = schema.anyOf;
-  if (!Array.isArray(alternatives)) return schema;
-  const remaining = alternatives.filter((alternative) =>
-    !(typeof alternative === "object" && alternative !== null &&
-      alternative.type === "undefined" &&
-      Object.keys(alternative).length === 1)
-  );
-  if (remaining.length === alternatives.length) return schema;
-  if (remaining.length === 1 && Object.keys(schema).length === 1) {
-    return remaining[0]!;
-  }
-  return { ...schema, anyOf: remaining };
-}
-
-function includePossibleMissingValue(
-  contract: PathSchemaContract,
+/** Drop the `mayBeMissing` flag for proofs where absence cannot occur. */
+function withoutMissingFlag(
+  { mayBeMissing: _, ...contract }: PathSchemaContract,
 ): PathSchemaContract {
-  if (contract.mayBeMissing !== true) return contract;
-  return {
-    schema: { anyOf: [contract.schema, { type: "undefined" }] },
-    root: contract.root,
-  };
+  return contract;
 }
 
 /** @internal Exported for focused durable-link contract tests. */
@@ -1679,11 +1659,12 @@ export function assertSuppliedLinkSchemasCompatible(
       sourceContracts = localizedSources.map((entry) => entry.contract);
       targetContracts = localizedTargets.map((entry) => entry.contract);
     }
-    sourceContracts = sourceContracts.map(includePossibleMissingValue);
 
     // The source and target contracts are conjunctions. Proving any source
     // conjunct implies each target conjunct is a conservative proof that the
     // complete source intersection is accepted by the target intersection.
+    // Possible absence of a source value rides the contracts' `mayBeMissing`
+    // flags and is resolved per source/target pair inside the proof.
     const label = `input link at ${displayPath}`;
     if (
       !preservesDirectHandle || targetOuter.kind !== "writeonly" &&
@@ -1694,7 +1675,14 @@ export function assertSuppliedLinkSchemasCompatible(
     if (preservesDirectHandle && cellKindCanWrite(targetOuter.kind)) {
       // A writable handle can send values back to the producer, so the
       // destination payload contract must also fit the source payload.
-      assertContractSubset(targetContracts, sourceContracts, label);
+      // Absence never flows through a write-back — the handle writes concrete
+      // values — so slot optionality on either side is irrelevant here and
+      // the `mayBeMissing` flags are dropped from both.
+      assertContractSubset(
+        targetContracts.map(withoutMissingFlag),
+        sourceContracts.map(withoutMissingFlag),
+        label,
+      );
     }
   }
   return preservedDirectHandles;

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -21,7 +21,7 @@ import {
   sanitizeSchemaForLinks,
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
-import type { CellKind } from "@commonfabric/api";
+import type { CellKind, LinkScope } from "@commonfabric/api";
 import {
   cfcSchemaChildRoot,
   resolveCfcSchemaRefRoot,
@@ -1119,7 +1119,29 @@ export function durableSourceContract(
   linkedCell: Cell<unknown>,
   manager: PieceManager,
 ): DurableSourceContract | undefined {
-  const sourceLink = linkedCell.getAsNormalizedFullLink();
+  const rawSourceLink = linkedCell.getAsNormalizedFullLink();
+  // Producer-owned metadata (`schema`, and the `result` backlink) is
+  // scope-partitioned. A scoped *result* cell carries its own metadata in its
+  // scope partition, but a scoped *input* redirect (a `PerUser`/`PerSession`
+  // input) points at a base-scoped producer document whose metadata lives only
+  // in the base ("space") partition — the redirect's own partition holds just
+  // the scoped value. Recover at whichever partition actually holds the
+  // metadata: prefer the link's own scope, then fall back to base. Reading only
+  // the redirect's scope makes a scoped input look contract-less, which rejects
+  // even an identical-source `setsrc`; reading only base would strip a scoped
+  // result cell of its legitimate contract.
+  const metaScope = ((): LinkScope | undefined => {
+    if (rawSourceLink.scope === undefined) return undefined;
+    const scopedRoot = manager.runtime.getCellFromLink(
+      { ...rawSourceLink, path: [], schema: undefined },
+      undefined,
+      linkedCell.tx,
+    );
+    const hasScopedMeta = scopedRoot.getMetaRaw("schema") !== undefined ||
+      scopedRoot.getMetaRaw("result") !== undefined;
+    return hasScopedMeta ? rawSourceLink.scope : undefined;
+  })();
+  const sourceLink = { ...rawSourceLink, scope: metaScope };
   const sourceRoot = manager.runtime.getCellFromLink(
     { ...sourceLink, path: [], schema: undefined },
     undefined,
@@ -1159,7 +1181,7 @@ export function durableSourceContract(
     if (
       producerLink.space !== sourceLink.space ||
       producerLink.id !== sourceLink.id ||
-      producerLink.scope !== sourceLink.scope ||
+      (producerLink.scope ?? "space") !== (sourceLink.scope ?? "space") ||
       producerLink.path.length > sourceLink.path.length ||
       producerLink.path.some((segment, index) =>
         segment !== sourceLink.path[index]
@@ -1340,9 +1362,20 @@ function assertContractSubset(
   for (const target of targets) {
     let lastError: unknown;
     const proved = sources.some((source) => {
+      // A source that may hold no value (its schema carries an explicit
+      // `undefined` alternative, added by `includePossibleMissingValue`) is
+      // acceptable to a destination slot that is itself optional: absence is a
+      // state the destination schema already tolerates. Discharge that
+      // alternative here, structurally, rather than injecting an `undefined`
+      // union into the target — a union-with-default target is not stable
+      // under default insertion and would fail closed. A required destination
+      // keeps the alternative, so a possibly-absent source still fails there.
+      const sourceSchema = target.mayBeMissing === true
+        ? withoutUndefinedAlternative(source.schema)
+        : source.schema;
       try {
         assertSchemaSubset(
-          withoutTopLevelScope(source.schema),
+          withoutTopLevelScope(sourceSchema),
           withoutTopLevelScope(target.schema),
           label,
           { sourceRoot: source.root, targetRoot: target.root },
@@ -1355,6 +1388,28 @@ function assertContractSubset(
     });
     if (!proved) throw lastError;
   }
+}
+
+/**
+ * Remove a top-level `{ type: "undefined" }` alternative from a schema union,
+ * collapsing a resulting singleton wrapper to its sole branch. Used when the
+ * destination contract tolerates absence, so the possible-missing alternative
+ * need not be proven against the destination's value schema.
+ */
+function withoutUndefinedAlternative(schema: JSONSchema): JSONSchema {
+  if (typeof schema !== "object" || schema === null) return schema;
+  const alternatives = schema.anyOf;
+  if (!Array.isArray(alternatives)) return schema;
+  const remaining = alternatives.filter((alternative) =>
+    !(typeof alternative === "object" && alternative !== null &&
+      alternative.type === "undefined" &&
+      Object.keys(alternative).length === 1)
+  );
+  if (remaining.length === alternatives.length) return schema;
+  if (remaining.length === 1 && Object.keys(schema).length === 1) {
+    return remaining[0]!;
+  }
+  return { ...schema, anyOf: remaining };
 }
 
 function includePossibleMissingValue(
@@ -1377,6 +1432,18 @@ export function assertSuppliedLinkSchemasCompatible(
     basePath?: readonly (string | number)[];
     destinationIsStream?: boolean;
     destinationRoot?: JSONSchema;
+    /**
+     * The prior pattern's argument schema, supplied only on a pattern update
+     * over existing state. A linked document with no producer-owned metadata —
+     * e.g. a mergeable-push element doc, which is created under the piece's
+     * own write authority and never carries any — is then held to the prior
+     * contract at the link's own path instead of failing closed outright: the
+     * proof becomes prior-contract ⊆ candidate, so a candidate that narrows
+     * away values the piece may already hold is still rejected. Absent this
+     * option (every non-update flow), an unprovable source stays a hard error,
+     * so a fresh link to an arbitrary contract-less document is still refused.
+     */
+    priorArgumentSchema?: JSONSchema;
   } = {},
 ): Set<SuppliedLink> {
   const preservedDirectHandles = new Set<SuppliedLink>();
@@ -1401,9 +1468,14 @@ export function assertSuppliedLinkSchemasCompatible(
           suppliedLink.path,
         );
       } else {
+        // Track destination presence so an optional destination slot records
+        // `mayBeMissing`, mirroring the source-side tracking below: a source
+        // that may hold no value must only be provable against a destination
+        // that also tolerates absence.
         targetContracts = linkPathContracts(
           [{ schema: destinationSchema, root: destinationRoot }],
           fullPath,
+          { trackSourcePresence: true, preserveMissingFlag: true },
         );
       }
     } catch (error) {
@@ -1422,7 +1494,23 @@ export function assertSuppliedLinkSchemasCompatible(
     // A direct Cell view can be narrowed with asSchema() just as easily as a
     // serialized alias can carry a narrowed schema. Neither is a future-value
     // invariant, so every durable link needs producer-owned Piece metadata.
-    const durableSource = durableSourceContract(linkedCell, manager);
+    let durableSource = durableSourceContract(linkedCell, manager);
+    if (
+      durableSource === undefined && options.priorArgumentSchema !== undefined
+    ) {
+      // Pattern update over existing state: hold a metadata-less linked doc to
+      // the prior argument contract at this path (see the option's doc).
+      durableSource = {
+        schemas: [{
+          root: options.priorArgumentSchema,
+          path: [...fullPath],
+          rawBasePath: [],
+          schemaBaseDepth: 0,
+          validationCell: baseCell,
+          validationPath: [...fullPath],
+        }],
+      };
+    }
     if (durableSource === undefined) {
       throw new Error(
         `input link at ${displayPath} schema is not compatible: source has no durable schema contract`,
@@ -2586,6 +2674,7 @@ export class PieceController<T = unknown> {
             argumentSchema,
             argumentCell,
             this.#manager,
+            { priorArgumentSchema: previousPattern.argumentSchema },
           ),
       }) as Cell<T>;
     });

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -4903,6 +4903,88 @@ describe("piece pull materialization", () => {
     });
   });
 
+  it("rejects a producer-declared undefined alternative at an optional destination", async () => {
+    // Destination optionality permits *omission*, not a present `undefined`
+    // value: a producer whose contract admits `undefined` as a value must
+    // still be rejected when the destination value schema does not accept it,
+    // even at an optional slot.
+    const sourcePiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            value: { anyOf: [{ type: "string" }, { type: "undefined" }] },
+          },
+          required: ["value"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { value: "present" },
+      undefined,
+      { start: true },
+    );
+    const targetPiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: { slot: { type: "string" } },
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    await expect(
+      new PieceController(manager, targetPiece).input.set(
+        manager.getArgument(sourcePiece).key("value"),
+        ["slot"],
+      ),
+    ).rejects.toThrow(/not accepted by the candidate/);
+  });
+
+  it("rejects a possibly-missing source at a required destination", async () => {
+    const sourcePiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: { maybe: { type: "string" } },
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { maybe: "present" },
+      undefined,
+      { start: true },
+    );
+    const targetPiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: { slot: { type: "string" } },
+          required: ["slot"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { slot: "seed" },
+      undefined,
+      { start: true },
+    );
+    await expect(
+      new PieceController(manager, targetPiece).input.set(
+        manager.getArgument(sourcePiece).key("maybe"),
+        ["slot"],
+      ),
+    ).rejects.toThrow(/not accepted by the candidate/);
+  });
+
   it("updates a piece across backward-compatible schema additions", async () => {
     const firstPattern = await runtime.patternManager.compilePattern(
       compiledSchemaEvolutionProgram(1),

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   getPatternIdentityRef,
+  isLink,
   type JSONSchema,
   KeepAsCell,
   NAME,
@@ -159,6 +160,32 @@ function compiledMultiplierProgram(
           "export default pattern<{ input: number }>(({ input }) => ({",
           `  version: ${JSON.stringify(version)},`,
           "  output: multiply(input),",
+          "}));",
+        ].join("\n"),
+      },
+    ],
+  };
+}
+
+function compiledScopedInputProgram(version: string): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { Default, NAME, pattern, type PerSpace, type PerUser, UI, type VNode } from 'commonfabric';",
+          "interface Item { title: string; }",
+          "interface In {",
+          '  who?: PerUser<string | Default<"">>;',
+          "  options?: PerSpace<Item[] | Default<[]>>;",
+          "}",
+          "interface Out { [NAME]: string; [UI]: VNode; who: string; count: number; }",
+          "export default pattern<In, Out>(({ who, options }) => ({",
+          `  [NAME]: ${JSON.stringify("probe-" + version)},`,
+          "  [UI]: <div>{who}</div>,",
+          "  who,",
+          "  count: options.length,",
           "}));",
         ].join("\n"),
       },
@@ -4794,6 +4821,86 @@ describe("piece pull materialization", () => {
     } finally {
       await freshRuntime.dispose();
     }
+  });
+
+  it("recovers a durable contract through a scoped redirect link", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, doublePattern()),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const argument = manager.getArgument(piece);
+    // Baseline: the producer-owned argument doc has a durable contract at its
+    // own (base) scope.
+    expect(durableSourceContract(argument, manager)?.schemas.length)
+      .toBeGreaterThan(0);
+
+    // A PerUser/PerSession input is a redirect to that same producer-owned
+    // doc, but tagged with a non-base scope. Producer-owned metadata lives
+    // only in the base ("space") partition, so recovery must read there — not
+    // the redirect link's own "user"/"session" partition, which holds only the
+    // scoped value. Regression guard for #4717: reading scope-locally makes
+    // every scoped input permanently reject an in-place setsrc with
+    // "source has no durable schema contract".
+    for (const scope of ["user", "session"] as const) {
+      const scopedSource = runtime.getCellFromLink({
+        ...argument.getAsNormalizedFullLink(),
+        scope,
+      });
+      const contract = durableSourceContract(scopedSource, manager);
+      expect(contract?.schemas.length, `scope=${scope}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("updates a piece whose argument holds scoped and mergeable-element links", async () => {
+    // Mirrors a deployed piece: a `PerUser` input is stored as a scoped
+    // redirect link, and a mergeable push stores the array element as its own
+    // metadata-less document linked from the array. Neither link's contract is
+    // provable from the linked document alone; the first recovers through the
+    // base-scope producer metadata, the second through the prior pattern's
+    // argument contract. Regression guard for the #4717 validation rejecting
+    // both shapes ("source has no durable schema contract") and the optional
+    // destination slot ("a schema alternative accepted previously...").
+    const compiled = await runtime.patternManager.compilePattern(
+      compiledScopedInputProgram("v1"),
+      { space: manager.getSpace() },
+    );
+    const piece = await manager.runPersistent(
+      compiled,
+      {},
+      "scoped-mergeable-update-" + crypto.randomUUID(),
+      { start: true },
+    );
+    await runtime.idle();
+    const controller = new PieceController(manager, piece);
+    const argument = manager.getArgument(piece);
+    const rawWho =
+      (argument.getRawUntyped({ lastNode: "top" }) as Record<string, unknown>)
+        .who;
+    expect(isLink(rawWho)).toBe(true);
+
+    // A version bump forces the full validation path (an identical pattern
+    // identity short-circuits before link validation).
+    await controller.setPattern(compiledScopedInputProgram("v2"));
+    expect(await controller.result.get()).toMatchObject({ count: 0 });
+
+    await runtime.editWithRetry((tx) => {
+      (argument.withTx(tx).key("options") as unknown as {
+        push: (value: unknown) => void;
+      }).push({ title: "Test Cafe" });
+    });
+    await runtime.idle();
+    const rawOptions =
+      (argument.getRawUntyped({ lastNode: "top" }) as Record<string, unknown>)
+        .options;
+    expect(isLink((rawOptions as unknown[])[0])).toBe(true);
+
+    await controller.setPattern(compiledScopedInputProgram("v3"));
+    expect(await controller.result.get()).toMatchObject({ count: 1 });
+    expect(await controller.input.get()).toMatchObject({
+      options: [{ title: "Test Cafe" }],
+    });
   });
 
   it("updates a piece across backward-compatible schema additions", async () => {


### PR DESCRIPTION
## Problem

Since #4717, `cf piece setsrc` fails on any piece whose argument holds a `PerUser`/`PerSession` input or a mergeable-pushed collection element — including a **byte-identical re-setsrc** with no schema change at all:

```
input link at myName schema is not compatible: source has no durable schema contract
input link at options.0 schema is not compatible: source has no durable schema contract
```

Concretely: the deployed lunch-poll (a `PerUser` `myName` plus pushed `options`/`votes`/`users`/`visits` lists) can no longer be updated in place on a post-#4717 runtime, and any real piece with a scoped input or a handler-pushed list is in the same boat — scoped inputs and mergeable elements were permanently un-upgradeable.

The gate itself (validate schema-compatible setsrc updates, protect stored data from incompatible upgrades) is sound and stays intact; the gaps are all in how the validator **proves** a supplied link's contract. cc @seefeldb — this touches your #4717 machinery, and each relaxation is deliberately narrower than the gate's design; review very welcome.

## Three gaps, three fixes

**1. Scope-partitioned metadata reads** (`durableSourceContract`). A scoped input is stored as a scope-redirect link; the source root was resolved at the redirect's own scope, but producer-owned metadata (`schema`, the `result` backlink) for a scoped input's target lives only in the base ("space") partition — the scoped partition holds just the scoped value. Recovery always came back empty. Now: probe the link's own scope first (a scoped *result* cell legitimately keeps its metadata there — pinned by the existing "follow cap" test), then fall back to base. `relativePath` compares scopes under the `?? "space"` default for the same reason.

**2. One-sided absence tracking.** Source contracts record `mayBeMissing` (an optional argument property may hold no value) and get an explicit `{type:"undefined"}` alternative — but destination contracts were built without presence tracking, so an *equally optional* destination slot could never accept that alternative. This only ever fired for scoped self-links (ordinary cross-piece links source from required result fields), which is why #4717's tests never saw it. Now: track presence on the (non-stream) destination side and discharge the source's undefined alternative structurally in `assertContractSubset` when the destination slot is optional. (Injecting an `undefined` union into the target instead trips the union-with-default "not stable under default insertion" fail-close — tried and rejected.) A required destination still rejects a possibly-absent source, and the write-back direction is untouched.

**3. Metadata-less mergeable element docs.** A mergeable push stores the array element as its own document, created under the piece's own write authority and carrying no producer metadata at all (`schema`/`result`/`argument`/`internal` all absent) — so its contract is unprovable from the document alone, and every piece with a pushed list fails at `<list>.<index>`. Now, on a pattern update only, `setPattern` passes the new `priorArgumentSchema` option and such a link is held to the **prior pattern's argument contract at the link's own path**. Soundness: this accepts nothing `assertPatternSchemasBackwardCompatible` hasn't already vouched for — the proof is prior-contract-at-path ⊆ candidate-at-path, so a narrowing candidate still fails at the pattern-level check first. Non-update flows pass no prior schema, so `input.set` of a link to an arbitrary contract-less document stays a hard error (pinned by the existing orphan test in `pull-materialization.test.ts`).

## Verification

- **End-to-end** against a local toolshed running this branch: `cf piece new` + populate (join → `PerUser` `myName`, `addOption` → mergeable element) + `cf piece setsrc lunch-poll/main.tsx` succeeds and **preserves all state** (`myName`, `users`, `options`). Pre-fix the same sequence failed at `myName`, and after fix 1+2 alone at `options.0`.
- **New regression tests**, both verified to fail against the unpatched validator:
  - unit: scoped-redirect recovery through `durableSourceContract` (`user` + `session` scopes);
  - integration: compiled `PerUser` + `PerSpace` list program → `setPattern` bump → mergeable push → `setPattern` again, asserting state and count.
- Full `packages/piece` suite: 20 files, 207 steps, 0 failed. `deno check` / `fmt` / `lint` clean.

## Context

Found while updating the lunch-poll deploy docs: `DEPLOY-AND-SHARE.md`'s recommended in-place-update path failed on a current-`main` runtime. A doc-side caveat pointing at #4717 exists on a separate branch (`danfuzz/lunch-poll-doc-refresh`) and can be retired if this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hzxBndZknq9pfGWmTKAh5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cf piece setsrc` so pieces with scoped inputs and mergeable list elements can be updated in place without breaking the compatibility gate. Also updates the lunch-poll deploy note to limit the `setsrc` caveat to the builds between #4717 and #4785.

- **Bug Fixes**
  - Scoped inputs: recover producer metadata by probing the link’s scope first, then base; base scope short-circuits; scope comparisons default missing scopes to "space".
  - Presence-aware proofs: track `mayBeMissing` on both sides; inject `undefined` only when the source may be absent and the destination is required; producer-declared `undefined` is preserved; write-back drops presence flags.
  - Mergeable elements: on pattern updates only, validate metadata-less element links against the prior argument contract at the link path via `priorArgumentSchema`; non-update flows remain strict.

<sup>Written for commit e02f2eb3a7502d6c3addb416ac2b119b180abb59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

