### PR TITLE
docs(lunch-poll): refresh deploy/practices/roadmap for the July changes

### DIFF
--- a/packages/patterns/lunch-poll/BEST-PRACTICES.md
+++ b/packages/patterns/lunch-poll/BEST-PRACTICES.md
@@ -66,11 +66,11 @@ shared pattern documentation.
 - Multi-user tests are required when identity, `PerUser`, host/admin state, or
   cross-viewer behavior moves across a composition boundary.
 - Validate against populated existing state before deploying over a live piece.
-  Fresh local state can miss regressions involving stored images, existing
-  votes, joined identities, and SQLite-backed history.
-- After `setsrc`, verify both normal cell-backed state and non-cell-backed
-  capabilities such as SQLite query outputs. Browser console probes are useful
-  when CLI reads do not subscribe or a remote websocket is unreliable.
+  Fresh local state can miss regressions involving existing votes, joined
+  identities, and stored history.
+- After `setsrc`, verify the piece's state reads back as expected. Browser
+  console probes are useful when CLI reads do not subscribe or a remote
+  websocket is unreliable.
 
 ## Documentation
 

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -82,16 +82,19 @@ SPACE=team-lunch
 
 ## Option A — update the existing piece in place (recommended)
 
-> **⚠️ Currently blocked on runtimes built from `main` (2026-07-15+).** #4717
-> ("validate schema-compatible setsrc updates") added a `setsrc`-time gate that
-> rejects any input link whose source lacks a durable schema contract, and this
-> pattern's `myName` (`PerUser<string>`) trips it:
-> `input link at myName schema is not compatible: source has no durable schema
+> **⚠️ Blocked on runtimes built from `main` between 2026-07-15 and the merge of
+> [#4785](https://github.com/commontoolsinc/labs/pull/4785).** #4717 ("validate
+> schema-compatible setsrc updates") added a `setsrc`-time gate whose
+> contract-recovery could not prove scoped inputs (this pattern's `myName`, a
+> `PerUser`) or mergeable-pushed list elements (`options.0` etc.), rejecting
+> even an identical-source update with
+> `input link at <path> schema is not compatible: source has no durable schema
 > contract`.
-> Until that's resolved, deploy on a current-`main` runtime via **Option B** (or
-> a fresh `cf piece new`), neither of which routes through `setsrc`. Prod
-> (`rapids`) may still run an older runtime where `setsrc` works. This gate is
-> being investigated (it rejects even an identical-source update).
+> [#4785](https://github.com/commontoolsinc/labs/pull/4785) fixes the recovery
+> (gate intact). On an affected runtime, deploy via **Option B** (or a fresh
+> `cf piece new`), neither of which routes through `setsrc`; prod (`rapids`) may
+> predate #4717 entirely and be unaffected. Delete this caveat once #4785 is
+> merged and deployed.
 
 To push code changes **and keep all accumulated state**, update the source of
 the existing piece. Do **not** run `cf piece new` — that mints a fresh, empty

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -5,12 +5,12 @@ verify it actually worked, and recover it when it breaks. Written for someone
 (human or agent) operating the poll for the first time — read top to bottom
 once.
 
-> **Status (2026-06-22): live-deployable.** The visit history + per-visit vote
-> snapshots live in a plain **`PerSpace<HistoryEntry[]>` array** (`visits`),
-> each entry embedding its own vote snapshot. (History was briefly on the SQLite
-> builtin, #4144/#4145; that's been reverted — see `LUNCH-COORDINATOR-TODO.md`
-> for the history. There is no longer any `sqliteDatabase`, `db.exec`, or
-> `sqliteRev`.)
+> **Status (2026-07-17): live-deployable** (re-verified via a fresh local
+> deploy). The visit history + per-visit vote snapshots live in a plain
+> **`PerSpace<HistoryEntry[]>` array** (`visits`), each entry embedding its own
+> vote snapshot. (History was briefly on the SQLite builtin, #4144/#4145; that's
+> been reverted — see `LUNCH-COORDINATOR-TODO.md` for the history. There is no
+> longer any `sqliteDatabase`, `db.exec`, or `sqliteRev`.)
 
 ## Where the data lives (mental model)
 
@@ -18,10 +18,10 @@ A poll's durable state belongs to **one deployed piece instance in one space**,
 addressed by `(space, causal-cell-id)` — not to "the pattern" in the abstract.
 So "share the state" = "everyone points at the same piece"; "copy the state" =
 "move that piece's values into a new piece." It all lives in **`PerSpace` input
-cells**, shared by everyone in the space: `question`, `city`, `options`,
-`votes`, `users`, `adminName`, `webSearchUrl`, and **`visits`** (the "Recently
-eaten" log + embedded vote snapshots that feed "Lunch stats"). Plus
-**`myName`**, which is **`PerUser`** (keyed by your DID).
+cells**, shared by everyone in the space: `question`, `options`, `votes`,
+`users`, `adminName`, and **`visits`** (the "Recently eaten" log + embedded vote
+snapshots that feed "Lunch stats"). Plus **`myName`**, which is **`PerUser`**
+(keyed by your DID).
 
 All of these survive an in-place `setsrc` (Option A) and — because `visits` is
 now an ordinary `PerSpace` cell — can all be copied to another piece via the CLI
@@ -82,6 +82,17 @@ SPACE=team-lunch
 
 ## Option A — update the existing piece in place (recommended)
 
+> **⚠️ Currently blocked on runtimes built from `main` (2026-07-15+).** #4717
+> ("validate schema-compatible setsrc updates") added a `setsrc`-time gate that
+> rejects any input link whose source lacks a durable schema contract, and this
+> pattern's `myName` (`PerUser<string>`) trips it:
+> `input link at myName schema is not compatible: source has no durable schema
+> contract`.
+> Until that's resolved, deploy on a current-`main` runtime via **Option B** (or
+> a fresh `cf piece new`), neither of which routes through `setsrc`. Prod
+> (`rapids`) may still run an older runtime where `setsrc` works. This gate is
+> being investigated (it rejects even an identical-source update).
+
 To push code changes **and keep all accumulated state**, update the source of
 the existing piece. Do **not** run `cf piece new` — that mints a fresh, empty
 instance.
@@ -116,7 +127,7 @@ MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
 
 # 2. Copy each PerSpace field from the canonical piece into yours.
 #    `--input` reads/writes the input cell where these live.
-for field in question city users options votes adminName webSearchUrl visits; do
+for field in question users options votes adminName visits; do
   deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
     | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
 done
@@ -166,12 +177,13 @@ deno task cf piece get --piece "$PIECE" -s "$SPACE" visits --input -q
 `myName` is `PerUser` (keyed by your authenticated DID); `adminName` (host) and
 the `users` directory are `PerSpace`. Consequences that bite:
 
-1. **This build joins by free-text name.** Type a name in the join field and
-   click Join — no profile needed; the **first person to join becomes host**.
-   (On `main`, joining instead goes through the shared-profile `wish` flow,
-   which requires a profile in your home space. This `freetext-join` variant
-   removes that gate. The `joinAs` handler still honors an explicit `name`, so
-   CLI/headless joins work either way.)
+1. **Joining is profile-first, with a free-text fallback.** When your shared
+   profile resolves (`#profileName`), the card offers a one-click **Join as
+   \<name\>** — carrying your profile name and avatar — plus a **Use a different
+   name** escape hatch. When no profile resolves, it falls back to a **Your
+   name…** field: type a name and click **Join**. Either way the **first person
+   to join becomes host**. The `joinAs` handler honors an explicit `name`, so
+   CLI/headless joins work regardless of the UI path.
 
 2. **CLI and browser are different identities unless you make them the same.**
    If you join/seed from the `cf` CLI (one DID) then open the piece in a browser
@@ -255,18 +267,21 @@ overwritten`, the space's
 **stored** root pattern is a stale compiled artifact. Fix: open the header menu
 → **Toggle debug mode** (🐛) → click the red **Recreate Root Pattern** button in
 the debugger drawer, then reload. (Console fallback:
-`localStorage.setItem("showDebuggerView","true")` then reload.) The
-free-text-join build of this poll sidesteps the profile requirement entirely.
+`localStorage.setItem("showDebuggerView","true")` then reload.) The poll's
+free-text join fallback lets you in even when your profile / home space won't
+load — you just don't get your profile name and avatar pre-filled.
 
 ## Performance notes
 
-Cold loads of a poll with many options can take **minutes** — this is **not**
-graph/runtime cost (instantiation measures ~linear, ~12ms/option), it's the
-**per-option AI work done host-side on load**: each option triggers an image
-generation, a web search, and a `generateText` homepage-verification call,
-serialized behind a 30s mutex. Results are cached (`option.imageUrl` etc.), so
-warm loads are cheaper; the pain is the first host load of un-cached options.
-See willkelly's perf investigation in
+The poll no longer does any per-option AI work. The generated cuisine-image
+(#4325) and web-search homepage-enrichment (#4326) features were removed on
+2026-06-23, and with them the per-option image generation, web search, and
+`generateText` homepage-verification call — plus the 30s mutex that serialized
+them. That work, not graph/runtime cost, was what made cold loads of a
+many-option poll take **minutes**. What remains is graph/runtime cost, which
+instantiation measured at ~linear, ~12ms/option.
+
+For the deeper aggregate + write-conflict findings that still apply to a poll
+with many options and voters, see willkelly's perf investigation in
 [labs#4141](https://github.com/commontoolsinc/labs/pull/4141) (keyed-collection
-/ runtime-aggregate direction) for the deeper aggregate + write-conflict
-findings.
+/ runtime-aggregate direction).

--- a/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
@@ -88,6 +88,33 @@ poll picking a place that's closed when you walk over.
 Completed entries are ordered newest first. Dates use the local merge/commit
 date for the completed work.
 
+### 2026-07-12 — Day-scoped votes (#4661)
+
+Votes now carry a `castAt` stamp; tallies, swatches, top choice, the header
+count, and `logVisit` snapshots show only votes cast on the viewing session's
+current local day. Older votes stay stored but hidden, and a same-color click on
+a stale vote re-casts it rather than toggling off an invisible one. "Today" is
+the pattern-body clock read, refreshed by a `PerSession` cell so a tab that
+crosses midnight snaps forward on the next interaction.
+
+### 2026-07-08 — Profile-first join with free-text fallback (#4597)
+
+The join surface now leads with the viewer's shared profile: when `#profileName`
+resolves it offers a one-click "Join as \<name\>" (carrying the profile name and
+avatar), with "Use a different name" as an escape hatch. The manual "Your name…"
+input is the fallback, shown only when no profile resolves. No change to the
+`joinAs` handler or the pattern's inputs/outputs — purely which control the join
+card offers first.
+
+### 2026-06-23 — Removed generated cuisine-image and web-search homepage (#4325/#4326)
+
+Dropped the per-option generated food thumbnail (`generated-art.tsx`, since
+deleted) and the web-search homepage enrichment, along with the per-option AI
+work they drove: image generation, web search, `generateText` homepage
+verification, and the 30s mutex that serialized them. Cold-load cost of a
+many-option poll is now graph/runtime only. This is why `city` and
+`webSearchUrl` are no longer pattern inputs.
+
 ### 2026-06-16 — Pattern composition refactor and sub-pattern standards
 
 The lunch poll now exercises pattern-to-pattern composition by factoring the

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1569,8 +1569,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       // indistinguishable from "not yet computed" for cross-runtime readers —
       // so every snapshot yields a real, stable value (the shared EMPTY
       // constants keep the fallback idempotent across recomputes). The visit
-      // history is no longer a PerSpace input — it lives in SQLite now and is
-      // surfaced via `recentVisits`/`mostRecentTitle` below.
+      // history lives in the `visits` PerSpace input and is surfaced here via
+      // the derived `recentVisits`/`mostRecentTitle` below, not as a raw cell.
       options: computed(() => options ?? EMPTY_OPTIONS),
       votes: computed(() => votes ?? EMPTY_VOTES),
       users: computed(() => users ?? EMPTY_USERS),


### PR DESCRIPTION
Reconciles the lunch-poll operating docs with everything that landed after DEPLOY-AND-SHARE's 2026-06-22 status stamp, verified by a fresh local deploy (start-local-dev → `cf piece new` → `step` → `inspect`, all per the doc's own instructions).

## Staleness fixed

- **`city` and `webSearchUrl` are gone** (removed with the cuisine-image / web-search-homepage features, #4325/#4326): dropped from the data-model field list and — the one that would actually bite an operator — from the **Option B copy loop**, which would have tried to copy two nonexistent fields.
- **Join flow**: the deployed build is now profile-first with a manual-name fallback (#4597). The old framing ("this build joins by free-text" vs "`main`'s wish flow" vs a "`freetext-join` variant") described two builds that no longer exist as separate things; there is one build. The home-space-recovery note updated to match.
- **Performance notes**: rewritten — the per-option AI work the section described (image generation, web search, `generateText` homepage verification, 30s mutex) was all removed on 2026-06-23, so the minutes-long cold loads it explained are gone with it. What remains is graph/runtime cost (~linear, ~12ms/option).
- **BEST-PRACTICES**: dropped "stored images" / "SQLite-backed history" / "SQLite query outputs" from the testing guidance.
- **LUNCH-COORDINATOR-TODO**: added newest-first Completed entries for #4325/#4326 (feature removals), #4597 (profile-first join), and #4661 (day-scoped votes).
- **`main.tsx`**: fixed a stale comment claiming visit history "lives in SQLite now" — it's back on the `visits` `PerSpace` input since #4303.

## New caveat

Option A (in-place `setsrc`, the doc's recommended path) is currently rejected on post-2026-07-15 runtimes by #4717's link-contract validation — found during this session's verification, root-caused, and fixed in **#4785**. The caveat names both failing shapes (scoped inputs, mergeable-pushed elements), points at the fix, and is marked for deletion once #4785 is merged and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hzxBndZknq9pfGWmTKAh5

## Performance Baseline

This PR is doc-only, so the following accounts for spurious perf check failures:


NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/lunch-stats.test.tsx = 14s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/multi-user.test.tsx = 42s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/poll-option-card.test.tsx = 12s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/participant-identity-card.test.tsx = 12s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes lunch‑poll docs to match July changes: removes `city`/`webSearchUrl`, reflects the profile‑first join flow, and updates performance guidance. Also adds a temporary `setsrc` caveat and fixes a stale comment in `main.tsx`.

- **Migration**
  - Runtimes built from `main` between 2026-07-15 and the merge of #4785 reject Option A `setsrc` due to #4717. Use Option B (copy inputs) or `cf piece new` until #4785 is deployed.

<sup>Written for commit 7257d6afbf00a484502d53e198c6122efcb5f503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

