### PR TITLE
fix(cli,fuse): wake the FUSE mount handshake on events, not on a timer

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -398,12 +398,14 @@ converting it churns code that no run covers.
 ### A shell script observing another process through a kernel mount
 
 `packages/cli/integration/fuse-exec.sh` drives the FUSE daemon as a separate
-process through a real mount, and observes it from bash. Its three poll loops —
-`wait_for_path`, `resolve_entity_dir`, and `wait_for_piece_value` — stay polls.
+process through a real mount, and observes it from bash. Its poll loops —
+`wait_for_path`, `wait_for_json`, `resolve_entity_dir`, and
+`wait_for_piece_value` — stay polls.
 
 There is no event channel to convert them to. The state each loop waits on lives
-in another process: the daemon's tree for the two path loops, and the server's
-cell for the value loop. Bash has no callback to resolve a `defer()` from.
+in another process: the daemon's tree for the path and JSON loops, and the
+server's cell for the value loop. Bash has no callback to resolve a `defer()`
+from.
 
 Watching the filesystem does not substitute for one. A mounted path appears
 because the daemon added a node to its own tree, and that is not a filesystem
@@ -429,11 +431,13 @@ parsed a PID has a daemon that reported mounted. That wait is itself
 event-driven, carried by the pipe that [The FUSE mount
 handshake](#the-fuse-mount-handshake) describes.
 
-The daemon reports that state just before it enters its FUSE session loop, so it
-means the kernel mount exists rather than that any request has been served, and
-mounted paths hydrate lazily besides. Both gaps belong to `wait_for_path`, whose
-probe carries its own kill-timeout and retries for twenty seconds. What is left
-for the script is one check that the daemon survived the handshake.
+The daemon reports that state once its session loop is dispatched, so the mount
+serves requests, but the paths under it still hydrate lazily and the documents at
+those paths settle on a debounce after the path first answers a lookup. A path
+existing is not the same as its content being final. Those gaps belong to
+`wait_for_path` and `wait_for_json`, which poll a lookup and a rendered document
+until each converges, each carrying its own timeout. What is left for the script
+directly is one check that the daemon survived the handshake.
 
 The stale-descriptor assertion — that truncating a path does not let an already
 open descriptor write its old buffer back — waits on `wait_for_piece_value`
@@ -597,36 +601,31 @@ the daemon and so the only one that knows both pids; it writes the file once and
 completely. The command prepares the containing directory and the path, and the
 supervisor holds write access to that one file and no read access.
 
-Two things here are deliberately not events.
+What lets the readiness read stay pure-event is where the daemon announces
+`mounted`. It announces only after it has dispatched its FUSE session loop and
+installed its signal handlers, so a command that has read `mounted` has a mount
+that serves requests and tears down cleanly on a signal. The announcement
+carries that guarantee, so the command trusts it on arrival: it confirms the
+child and the supervisor are alive at that instant — a point-in-time probe, not a
+wait — and returns. An announcement made earlier, before the loop was dispatched,
+would report a mount that might still fail in the loop, and to catch that the
+command would have to wait out a fixed confirmation window on every successful
+mount, a genuine timing bet because nothing announces that a process intends to
+keep running. Moving the announcement behind the loop dispatch retires that wait
+rather than tuning it.
 
-The confirmation that the mount stayed up keeps a window, and the reason is worth
-understanding before anyone tries to collapse it to a point check. The daemon
-reports `mounted` just before entering its FUSE session loop, so a mount that
-fails in the loop reports mounted and then exits. At the instant the report
-arrives the daemon is genuinely still running, and a pid probe says so — the probe
-is not wrong, it is early. A liveness check at that instant therefore reports a
-healthy mount for a daemon already on its way out, and reliably so rather than
-occasionally, because the event-driven read hands control back the moment the
-report lands, ahead of the exit that would reveal the failure.
+The status file the daemon also writes, the record `cf fuse status` reads, is
+written to survive a concurrent reader, because its startup, readiness, heartbeat
+and signal paths all write it without coordinating. Each write lands under a
+scratch name and is renamed into place, so a reader woken mid-write sees a whole
+document rather than a truncated one. And the writes are serialized through a
+queue, so the file ends on the state of the most recent call: without that, two
+renames could complete in either order and let a heartbeat still in flight
+replace a terminal state, leaving the file claiming a mount that has already
+gone.
 
-What distinguishes the two cases is that a dying daemon takes the supervisor down
-with it, and the supervisor's exit is an event. So the confirmation waits for
-that exit to either arrive or not: it fails the moment the supervisor goes, and
-otherwise costs a fixed grace period. The grace is the one duration in this
-handshake, and it is a genuine timing bet, because nothing announces that a
-process intends to keep running. It is not a deadline — a slow mount is not
-capped by it — and it reads no file.
-
-That last point matters more than it sounds. The heartbeat rewrites the status
-file every second through a plain `Deno.writeTextFile`, which truncates and then
-writes rather than replacing the file atomically, so a concurrent reader can
-catch it half-written — looping a reader against such a writer turns up
-unparseable reads at a low but real rate (33 in 4000 measured). The confirmation
-waits on the supervisor's exit rather than on the file, so it is immune to that.
-The one reader that does read the file, `cf fuse status`, degrades to reporting
-`unknown` for a single tick when it loses that race.
-
-`cleanupFuseChild`'s shutdown escalation keeps a timeout. It sends SIGTERM,
+One wait in the handshake keeps a real duration:
+`cleanupFuseChild`'s shutdown escalation. It sends SIGTERM,
 allows the child five seconds to exit, then sends SIGKILL. The wait for the
 child's exit is event-driven — it races the real status promise — and the timeout
 is the escalation policy, not a stand-in for a missing signal. A process ignoring

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -6,6 +6,12 @@ the two pieces of machinery whose timing is easy to guess wrong, the check that
 keeps new polling `waitFor` out of the integration suites, and the specific
 places where a bounded `waitFor` poll is still the right tool.
 
+The same principle applies to production code, and the last two sections cover
+it there: [Production reconnect backoff](#production-reconnect-backoff), a
+deliberate exception because nothing announces that a downed server is back, and
+[The FUSE mount handshake](#the-fuse-mount-handshake), a cross-process readiness
+signal carried by a pipe.
+
 ## Why avoid `waitFor`
 
 `waitFor(predicate, { timeout, delay })` (in `packages/integration/utils.ts`)
@@ -419,7 +425,9 @@ Mount readiness needs no timing loop. `cf fuse mount --background` calls
 `mounted` supervisor state and confirms both the supervisor and the child are
 alive before the command prints the PID. Every other exit from that function
 throws, and a throw kills the child and fails the command, so a script that has
-parsed a PID has a daemon that reported mounted.
+parsed a PID has a daemon that reported mounted. That wait is itself
+event-driven, carried by the pipe that [The FUSE mount
+handshake](#the-fuse-mount-handshake) describes.
 
 The daemon reports that state just before it enters its FUSE session loop, so it
 means the kernel mount exists rather than that any request has been served, and
@@ -519,3 +527,114 @@ Cancelling an in-progress backoff stays event-driven: the pause between attempts
 is a single timer that `close()` cancels directly, so a client closed mid-backoff
 settles at once and nothing wakes on an interval. The backoff delay between
 attempts stays; its cancellation carries no poll.
+
+## The FUSE mount handshake
+
+`cf fuse mount --background` has to find out whether a daemon it did not spawn
+directly came up. It spawns a supervisor, the supervisor spawns the FUSE daemon,
+and the daemon is therefore a grandchild the command holds no handle to. Both
+halves of the handshake wake on an event rather than a poll. The shape is worth
+knowing, because "the processes are detached" reads like an argument that no
+channel is available, and it is not one.
+
+The daemon publishes readiness states — starting, mounted, failed, exiting,
+exited — through a child-status file next to the mount state, refreshed by a
+one-second heartbeat. Those states are the signal `cf fuse status` reads. A file
+cannot wake a reader, though, so readiness for the handshake itself travels over
+a pipe. The command spawns the supervisor with a piped stdout and blocks reading
+it; the supervisor passes that descriptor down to the daemon, so the daemon's
+readiness line arrives at the command directly and the read wakes on the write.
+The status file serves `cf fuse status`, and the heartbeat keeps it fresh; only
+the one-shot startup transitions go through the pipe, so the heartbeat does not
+flood a channel nobody reads once the command has returned.
+
+Detachment does not rule the pipe out, and the reasons are worth stating because
+each one looks like a blocker.
+
+The daemon must outlive the command. It does: the descriptor is inherited at
+spawn, and closing the read end has no effect on the processes holding the write
+end. The command reads one line, cancels the reader and exits, and the mount
+stays up.
+
+A daemon whose parent has gone must not die. It does not. Deno ignores SIGPIPE
+and surfaces a write to a readerless pipe as a catchable `BrokenPipe`, so the
+readiness write catches and the mount continues unobserved. Nothing else reaches
+that descriptor: a background daemon redirects `console.log` and friends into its
+log file, and only tees to stderr when stderr is a terminal, which for a
+background mount it is not.
+
+The supervisor is unreferenced only after the handshake. `unref` keeps the child
+from holding the command's event loop open, which is what the command wants once
+the mount is up and outlives it. Unreferencing before the read would stop the
+readiness read from holding the loop open too, and the command would exit
+mid-handshake with a zero status and no output.
+
+Failure is an event as well, and this is the part a poll cannot match. Two things
+end the read besides a report. End of stream means every process holding the
+write end has exited. The supervisor's exit — which the command already holds,
+because the supervisor is the child it spawned — means no report is coming from a
+daemon that cannot send one. Both fire the moment they happen rather than on the
+next liveness tick, and a daemon that fails during startup publishes its own
+error first, so the command reports the cause rather than only that the process
+went away.
+
+Watching the supervisor's exit is not belt-and-braces on top of end of stream;
+without it the command can hang. The daemon inherits the write end, so a daemon
+orphaned by a dead supervisor holds the stream open on its own and end of stream
+never arrives. A supervisor killed while its daemon sits there silently would
+otherwise leave the read outstanding forever.
+
+The pipe is private to one invocation, which is why the handshake carries no
+correlation. The status file is a shared namespace — a stale file from an earlier
+mount at the same mountpoint sits at the same path — so a reader of that file
+would need a correlation token, a mountpoint check and a cross-check against the
+mount state to tell its own child's report from a leftover. A line on the pipe
+came from this invocation's daemon and nothing else, so the handshake needs none
+of that.
+
+The supervisor owns the mount state file, because it is the process that spawns
+the daemon and so the only one that knows both pids; it writes the file once and
+completely. The command prepares the containing directory and the path, and the
+supervisor holds write access to that one file and no read access.
+
+Two things here are deliberately not events.
+
+The confirmation that the mount stayed up keeps a window, and the reason is worth
+understanding before anyone tries to collapse it to a point check. The daemon
+reports `mounted` just before entering its FUSE session loop, so a mount that
+fails in the loop reports mounted and then exits. At the instant the report
+arrives the daemon is genuinely still running, and a pid probe says so — the probe
+is not wrong, it is early. A liveness check at that instant therefore reports a
+healthy mount for a daemon already on its way out, and reliably so rather than
+occasionally, because the event-driven read hands control back the moment the
+report lands, ahead of the exit that would reveal the failure.
+
+What distinguishes the two cases is that a dying daemon takes the supervisor down
+with it, and the supervisor's exit is an event. So the confirmation waits for
+that exit to either arrive or not: it fails the moment the supervisor goes, and
+otherwise costs a fixed grace period. The grace is the one duration in this
+handshake, and it is a genuine timing bet, because nothing announces that a
+process intends to keep running. It is not a deadline — a slow mount is not
+capped by it — and it reads no file.
+
+That last point matters more than it sounds. The heartbeat rewrites the status
+file every second through a plain `Deno.writeTextFile`, which truncates and then
+writes rather than replacing the file atomically, so a concurrent reader can
+catch it half-written — looping a reader against such a writer turns up
+unparseable reads at a low but real rate (33 in 4000 measured). The confirmation
+waits on the supervisor's exit rather than on the file, so it is immune to that.
+The one reader that does read the file, `cf fuse status`, degrades to reporting
+`unknown` for a single tick when it loses that race.
+
+`cleanupFuseChild`'s shutdown escalation keeps a timeout. It sends SIGTERM,
+allows the child five seconds to exit, then sends SIGKILL. The wait for the
+child's exit is event-driven — it races the real status promise — and the timeout
+is the escalation policy, not a stand-in for a missing signal. A process ignoring
+SIGTERM never announces that it intends to keep ignoring it.
+
+There is no deadline on the readiness read. A daemon that neither mounts nor
+exits, under a supervisor that is also still there, blocks the command
+indefinitely — which is what a foreground mount does too, and the user interrupts
+it or a CI job limit catches it. Every way the pair can actually fail ends the
+read instead. A ceiling over the read would instead fail a mount that would have
+succeeded on a loaded machine, the ceiling this note warns about throughout.

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -136,8 +136,6 @@ async function removeMountStateAndChildStatus(
   }
 }
 
-const CHILD_CONFIRM_MS = 100;
-
 /**
  * Reads readiness lines until the child settles on a state, and returns null
  * once no report can arrive any more.
@@ -180,17 +178,6 @@ async function readSettledChildStatus(
   }
 }
 
-/** Whether `exit` settles within `ms`. */
-function exitsWithin(exit: Promise<unknown>, ms: number): Promise<boolean> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const elapsed = new Promise<boolean>((resolve) => {
-    timer = setTimeout(() => resolve(false), ms);
-  });
-  return Promise.race([exit.then(() => true), elapsed]).finally(() => {
-    if (timer !== undefined) clearTimeout(timer);
-  });
-}
-
 /**
  * Waits for a background mount to report that it is up.
  *
@@ -201,7 +188,10 @@ function exitsWithin(exit: Promise<unknown>, ms: number): Promise<boolean> {
  * the mount state.
  *
  * Returns only once the child has reported `mounted` and both the supervisor and
- * the child are alive. Every other outcome removes the mount state and throws.
+ * the child are alive. There is no deadline: a child that never reports leaves
+ * the command waiting, which is interruptible and honest, rather than turning a
+ * slow startup into a reported failure. Every other outcome removes the mount
+ * state and throws.
  */
 export async function awaitBackgroundMountStartup(
   pid: number,
@@ -212,12 +202,10 @@ export async function awaitBackgroundMountStartup(
     isAlive?: (pid: number) => boolean;
     removeStateFile?: (path: string) => Promise<void>;
     childStatusPath?: string;
-    confirmMs?: number;
   },
 ): Promise<void> {
   const isAliveFn = deps.isAlive ?? isAlive;
   const removeStateFileFn = deps.removeStateFile ?? removeMountStateFile;
-  const confirmMs = deps.confirmMs ?? CHILD_CONFIRM_MS;
   const exitedDuringStartup =
     "Background FUSE process exited during startup. Re-run without --background to inspect startup errors.";
   const fail = async (message: string): Promise<never> => {
@@ -243,19 +231,13 @@ export async function awaitBackgroundMountStartup(
     );
   }
 
-  // The child reports `mounted` just before entering its FUSE session loop, so a
-  // mount that fails in the loop reports mounted and then exits. At the instant
-  // the report arrives the child is still running, and a pid probe says so; what
-  // distinguishes the two is that a dying child takes the supervisor down with
-  // it. Wait for that exit to either arrive or not. This is the one wait here
-  // with a duration in it, because nothing announces that a process intends to
-  // keep running.
-  if (await exitsWithin(deps.supervisorExit, confirmMs)) {
-    return await fail(
-      "Background FUSE mount failed during startup: child exited after reporting mounted.",
-    );
-  }
-
+  // The child announces `mounted` only after its FUSE session loop is dispatched
+  // and its signal handlers are installed, so the report means the kernel mount
+  // exists and a signal will unmount it cleanly. A point-in-time probe rejects a
+  // child or supervisor that has already exited by the time the report is read.
+  // It does not wait to see whether one exits shortly after: that wait was a
+  // fixed grace period paid on every successful mount, and while it ran a slow
+  // but healthy mount was indistinguishable from a stuck one.
   if (typeof status.pid !== "number" || !isAliveFn(status.pid)) {
     return await fail(
       "Background FUSE mount failed during startup: child exited after reporting mounted.",

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -11,8 +11,8 @@ import {
   fuseSupervisorMod,
   isAlive,
   isMountStateAlive,
-  mountpointHash,
   type MountStateEntry,
+  prepareMountStatePath,
   readAllMountStates,
   readMountState,
   removeMountStateFile,
@@ -40,15 +40,9 @@ interface FuseChildSupervisorStatus {
   pid?: number;
   mountpoint?: string;
   updatedAt?: string;
-  token?: string;
   error?: string;
   exitCode?: number;
 }
-
-const BACKGROUND_STARTUP_ATTEMPTS = 20;
-const CHILD_STATUS_STARTUP_ATTEMPTS = 200;
-const BACKGROUND_STARTUP_DELAY_MS = 50;
-const CHILD_STATUS_STARTUP_DELAY_MS = 100;
 
 export function childStatusPathForStatePath(statePath: string): string {
   return `${statePath}.child-status`;
@@ -133,177 +127,141 @@ export async function awaitForegroundMountExit(
 
 async function removeMountStateAndChildStatus(
   statePath: string,
-  childStatusPath: string,
+  childStatusPath: string | undefined,
   removeStateFile: (path: string) => Promise<void>,
 ): Promise<void> {
   await removeStateFile(statePath);
-  await removeStateFile(childStatusPath).catch(() => undefined);
+  if (childStatusPath) {
+    await removeStateFile(childStatusPath).catch(() => undefined);
+  }
 }
 
+const CHILD_CONFIRM_MS = 100;
+
+/**
+ * Reads readiness lines until the child settles on a state, and returns null
+ * once no report can arrive any more.
+ *
+ * Two things end the read besides a report. End of stream means every process
+ * holding the write end has exited. The supervisor exiting means the same thing
+ * for a child that cannot report on its own: the FUSE child inherits the write
+ * end, so an orphaned child holds the stream open and end of stream never comes.
+ */
+async function readSettledChildStatus(
+  readiness: ReadableStream<Uint8Array>,
+  supervisorExit: Promise<unknown>,
+): Promise<FuseChildSupervisorStatus | null> {
+  const reader = readiness.getReader();
+  const decoder = new TextDecoder();
+  const supervisorGone = Symbol("supervisorGone");
+  let buffered = "";
+  try {
+    while (true) {
+      const next = await Promise.race<
+        ReadableStreamReadResult<Uint8Array> | typeof supervisorGone
+      >([
+        reader.read(),
+        supervisorExit.then(() => supervisorGone),
+      ]);
+      if (next === supervisorGone) return null;
+      const { value, done } = next;
+      if (done) return null;
+      buffered += decoder.decode(value, { stream: true });
+      let newline = buffered.indexOf("\n");
+      while (newline !== -1) {
+        const status = parseChildSupervisorStatus(buffered.slice(0, newline));
+        buffered = buffered.slice(newline + 1);
+        if (status && status.state !== "starting") return status;
+        newline = buffered.indexOf("\n");
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+}
+
+/** Whether `exit` settles within `ms`. */
+function exitsWithin(exit: Promise<unknown>, ms: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const elapsed = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), ms);
+  });
+  return Promise.race([exit.then(() => true), elapsed]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+/**
+ * Waits for a background mount to report that it is up.
+ *
+ * The supervisor and its FUSE child write readiness to `deps.readiness`, a pipe
+ * this command holds the read end of, so the read wakes on the child's own
+ * announcement rather than on a clock. The channel is private to this mount, so
+ * a line arriving on it came from this child and needs no correlation against
+ * the mount state.
+ *
+ * Returns only once the child has reported `mounted` and both the supervisor and
+ * the child are alive. Every other outcome removes the mount state and throws.
+ */
 export async function awaitBackgroundMountStartup(
   pid: number,
   statePath: string,
   deps: {
-    attempts?: number;
-    delayMs?: number;
+    readiness: ReadableStream<Uint8Array>;
+    supervisorExit: Promise<unknown>;
     isAlive?: (pid: number) => boolean;
     removeStateFile?: (path: string) => Promise<void>;
-    readTextFile?: (path: string) => Promise<string>;
-    readMountStateFile?: (path: string) => Promise<string>;
     childStatusPath?: string;
-    childStatusToken?: string;
-    mountpoint?: string;
-    sleep?: (ms: number) => Promise<void>;
-  } = {},
+    confirmMs?: number;
+  },
 ): Promise<void> {
-  const attempts = deps.attempts ??
-    (deps.childStatusPath
-      ? CHILD_STATUS_STARTUP_ATTEMPTS
-      : BACKGROUND_STARTUP_ATTEMPTS);
-  const delayMs = deps.delayMs ??
-    (deps.childStatusPath
-      ? CHILD_STATUS_STARTUP_DELAY_MS
-      : BACKGROUND_STARTUP_DELAY_MS);
   const isAliveFn = deps.isAlive ?? isAlive;
   const removeStateFileFn = deps.removeStateFile ?? removeMountStateFile;
-  const readTextFile = deps.readTextFile ?? Deno.readTextFile;
-  const readMountStateFile = deps.readMountStateFile ?? Deno.readTextFile;
-  const sleep = deps.sleep ??
-    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  let invalidChildStatusSeen = false;
+  const confirmMs = deps.confirmMs ?? CHILD_CONFIRM_MS;
+  const exitedDuringStartup =
+    "Background FUSE process exited during startup. Re-run without --background to inspect startup errors.";
+  const fail = async (message: string): Promise<never> => {
+    await removeMountStateAndChildStatus(
+      statePath,
+      deps.childStatusPath,
+      removeStateFileFn,
+    );
+    throw new Error(message);
+  };
 
-  for (let i = 0; i < attempts; i++) {
-    if (!isAliveFn(pid)) {
-      await removeStateFileFn(statePath);
-      throw new Error(
-        "Background FUSE process exited during startup. Re-run without --background to inspect startup errors.",
-      );
-    }
-    if (deps.childStatusPath) {
-      let status: FuseChildSupervisorStatus | null = null;
-      try {
-        status = parseChildSupervisorStatus(
-          await readTextFile(deps.childStatusPath),
-        );
-        if (!status) invalidChildStatusSeen = true;
-      } catch {
-        status = null;
-      }
-      const belongsToThisMount = await childStatusBelongsToMount(
-        status,
-        statePath,
-        {
-          token: deps.childStatusToken,
-          mountpoint: deps.mountpoint,
-          readMountStateFile,
-        },
-      );
-      if (status?.state === "mounted" && belongsToThisMount) {
-        if (!isAliveFn(status.pid!)) {
-          await removeMountStateAndChildStatus(
-            statePath,
-            deps.childStatusPath,
-            removeStateFileFn,
-          );
-          throw new Error(
-            "Background FUSE mount failed during startup: child exited after reporting mounted.",
-          );
-        }
+  const status = await readSettledChildStatus(
+    deps.readiness,
+    deps.supervisorExit,
+  );
 
-        await sleep(delayMs);
-        let confirmedStatus: FuseChildSupervisorStatus | null = null;
-        try {
-          confirmedStatus = parseChildSupervisorStatus(
-            await readTextFile(deps.childStatusPath),
-          );
-        } catch {
-          confirmedStatus = null;
-        }
-        const confirmedBelongsToThisMount = await childStatusBelongsToMount(
-          confirmedStatus,
-          statePath,
-          {
-            token: deps.childStatusToken,
-            mountpoint: deps.mountpoint,
-            readMountStateFile,
-          },
-        );
-        if (
-          confirmedStatus?.state === "mounted" &&
-          confirmedBelongsToThisMount &&
-          isAliveFn(pid) &&
-          isAliveFn(confirmedStatus.pid!)
-        ) {
-          return;
-        }
-        await removeMountStateAndChildStatus(
-          statePath,
-          deps.childStatusPath,
-          removeStateFileFn,
-        );
-        const reason = confirmedBelongsToThisMount && confirmedStatus
-          ? `child reported ${confirmedStatus.state}`
-          : "child did not remain mounted";
-        throw new Error(
-          `Background FUSE mount failed during startup: ${reason}`,
-        );
-      }
-      if (
-        belongsToThisMount &&
-        (status?.state === "failed" || status?.state === "exiting" ||
-          status?.state === "exited")
-      ) {
-        await removeStateFileFn(statePath);
-        throw new Error(
-          `Background FUSE mount failed during startup: ${
-            status.error ?? `child reported ${status.state}`
-          }`,
-        );
-      }
-    }
-    if (i < attempts - 1) {
-      await sleep(delayMs);
-    }
-  }
-
-  if (deps.childStatusPath) {
-    if (invalidChildStatusSeen) {
-      await removeMountStateAndChildStatus(
-        statePath,
-        deps.childStatusPath,
-        removeStateFileFn,
-      );
-    } else {
-      await removeStateFileFn(statePath);
-    }
-    throw new Error(
-      "Background FUSE process did not report mount readiness before startup timeout.",
+  if (!status) return await fail(exitedDuringStartup);
+  if (status.state !== "mounted") {
+    return await fail(
+      `Background FUSE mount failed during startup: ${
+        status.error ?? `child reported ${status.state}`
+      }`,
     );
   }
-}
 
-async function childStatusBelongsToMount(
-  status: FuseChildSupervisorStatus | null,
-  statePath: string,
-  deps: {
-    token?: string;
-    mountpoint?: string;
-    readMountStateFile: (path: string) => Promise<string>;
-  },
-): Promise<boolean> {
-  if (!status) return false;
-  if (deps.token && status.token !== deps.token) return false;
-  if (deps.mountpoint && status.mountpoint !== deps.mountpoint) return false;
-  if (typeof status.pid !== "number") return false;
-
-  try {
-    const state = JSON.parse(await deps.readMountStateFile(statePath)) as {
-      childPid?: unknown;
-    };
-    return state.childPid === status.pid;
-  } catch {
-    return false;
+  // The child reports `mounted` just before entering its FUSE session loop, so a
+  // mount that fails in the loop reports mounted and then exits. At the instant
+  // the report arrives the child is still running, and a pid probe says so; what
+  // distinguishes the two is that a dying child takes the supervisor down with
+  // it. Wait for that exit to either arrive or not. This is the one wait here
+  // with a duration in it, because nothing announces that a process intends to
+  // keep running.
+  if (await exitsWithin(deps.supervisorExit, confirmMs)) {
+    return await fail(
+      "Background FUSE mount failed during startup: child exited after reporting mounted.",
+    );
   }
+
+  if (typeof status.pid !== "number" || !isAliveFn(status.pid)) {
+    return await fail(
+      "Background FUSE mount failed during startup: child exited after reporting mounted.",
+    );
+  }
+  if (!isAliveFn(pid)) return await fail(exitedDuringStartup);
 }
 
 export const fuse = new Command()
@@ -461,12 +419,11 @@ export const fuse = new Command()
       // Derive log file path: /tmp/cf-fuse-<mountname>.log
       const logFile = `/tmp/cf-fuse-${basename(absMountpoint)}.log`;
 
-      const statePath = resolve(
-        stateDir,
-        `${await mountpointHash(absMountpoint)}.json`,
-      );
+      // The supervisor writes the mount state, because it is the process that
+      // spawns the FUSE child and so the only one that knows both PIDs. It holds
+      // write access to that one file, so the directory is prepared here.
+      const statePath = await prepareMountStatePath(stateDir, absMountpoint);
       const childStatusPath = childStatusPathForStatePath(statePath);
-      const childStatusToken = crypto.randomUUID();
       try {
         await Deno.remove(childStatusPath);
       } catch (error) {
@@ -478,7 +435,6 @@ export const fuse = new Command()
         logFile,
         statePath,
         supervisorStatusPath: childStatusPath,
-        supervisorToken: childStatusToken,
       };
       spawnCmd = execPath;
       spawnArgs = isCompiledBinary
@@ -491,32 +447,27 @@ export const fuse = new Command()
           ...supervisorFlags,
         });
 
-      // Detached background process
+      // Detached background process. Its stdout is a pipe the supervisor passes
+      // down to the FUSE child, which writes its readiness into it.
       const cmd = new Deno.Command(spawnCmd, {
         args: spawnArgs,
         stdin: "null",
-        stdout: "null",
+        stdout: "piped",
         stderr: "null",
       });
       const child = cmd.spawn();
-      child.unref();
 
       const pid = child.pid;
       try {
-        await writeMountState(stateDir, {
-          pid,
-          mountpoint: absMountpoint,
-          apiUrl,
-          identity,
-          startedAt: new Date().toISOString(),
-          logFile,
-          childStatusPath,
-        });
         await awaitBackgroundMountStartup(pid, statePath, {
+          readiness: child.stdout,
+          supervisorExit: child.status,
           childStatusPath,
-          childStatusToken,
-          mountpoint: absMountpoint,
         });
+        // The mount is up and outlives this command, so stop holding the process
+        // open for it. Unreferencing any earlier would also stop the readiness
+        // read from holding it, and the command would exit mid-handshake.
+        child.unref();
       } catch (error) {
         try {
           Deno.kill(pid, "SIGTERM");

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -130,10 +130,6 @@ export const main = new Command()
         "--supervisor-status <path:string>",
         "Child readiness and heartbeat status file.",
       )
-      .option(
-        "--supervisor-token <token:string>",
-        "Child readiness status correlation token.",
-      )
       .option("-s, --space <name:string>", "Space(s) to connect.", {
         collect: true,
       })
@@ -156,7 +152,6 @@ export const main = new Command()
           cfcWritebackState: options.cfcWritebackState,
           statePath: options.statePath,
           supervisorStatusPath: options.supervisorStatus,
-          supervisorToken: options.supervisorToken,
         });
       }),
   )

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -109,6 +109,33 @@ wait_for_path() {
   error "Timed out waiting for path: $path"
 }
 
+# A mounted JSON document answers lookups from a stub while the daemon hydrates
+# the piece behind it, and rebuilds land on a debounce after that, so the path
+# existing says nothing about the content being final. Poll the document until
+# it renders what is expected, the same way the path probes poll for lookups.
+wait_for_json() {
+  local path="$1"
+  local filter="$2"
+  local message="$3"
+  local timeout_seconds="${4:-20}"
+  local started_at
+  started_at=$(date +%s)
+
+  while true; do
+    if jq -e "$filter" "$path" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  local actual
+  actual=$(head -c 400 "$path" 2>/dev/null || true)
+  error "$message. Last content of $(basename "$path"): $actual"
+}
+
 fuse_encode_component() {
   local value="$1"
   value="${value//%/%25}"
@@ -330,12 +357,12 @@ success "Mounted callable entries exist"
 success "Entities namespace exposes matching entry for mounted piece"
 
 assert_not_exists "$RESULT_DIR/search" "Pattern tool internals should not be exposed as a directory."
-jq -e '.recordMessage == {"/handler":"recordMessage"}' "$RESULT_JSON" >/dev/null ||
-  error "result.json should render recordMessage as a handler sigil."
-jq -e '.legacyWrite == {"/handler":"legacyWrite"}' "$RESULT_JSON" >/dev/null ||
-  error "result.json should render legacyWrite as a handler sigil."
-jq -e '.search == {"/tool":"search"}' "$RESULT_JSON" >/dev/null ||
-  error "result.json should render search as a tool sigil."
+wait_for_json "$RESULT_JSON" '.recordMessage == {"/handler":"recordMessage"}' \
+  "result.json should render recordMessage as a handler sigil"
+wait_for_json "$RESULT_JSON" '.legacyWrite == {"/handler":"legacyWrite"}' \
+  "result.json should render legacyWrite as a handler sigil"
+wait_for_json "$RESULT_JSON" '.search == {"/tool":"search"}' \
+  "result.json should render search as a tool sigil"
 success "Mounted JSON surface hides callable internals"
 
 HANDLER_FIRST_LINE=$(head -n 1 "$HANDLER_FILE")

--- a/packages/cli/lib/fuse-supervisor.ts
+++ b/packages/cli/lib/fuse-supervisor.ts
@@ -1,5 +1,10 @@
 import { basename } from "@std/path";
-import { buildFuseChildDenoArgs, fuseMod } from "./fuse.ts";
+import {
+  buildFuseChildDenoArgs,
+  fuseMod,
+  type MountStateEntry,
+  writeMountStateFile,
+} from "./fuse.ts";
 
 export interface FuseSupervisorOptions {
   mountpoint: string;
@@ -18,12 +23,14 @@ export interface FuseSupervisorOptions {
   cfcWritebackState?: string;
   statePath?: string;
   supervisorStatusPath?: string;
-  supervisorToken?: string;
   importMetaUrl?: string;
   command?: FuseCommandConstructor;
   execPath?: string;
   childShutdownTimeoutMs?: number;
-  sleep?: (ms: number) => Promise<void>;
+  writeMountStateFile?: (
+    path: string,
+    entry: MountStateEntry,
+  ) => Promise<void>;
   exit?: (code: number) => never | void;
   addSignalListener?: (signal: Deno.Signal, handler: () => void) => void;
   removeSignalListener?: (signal: Deno.Signal, handler: () => void) => void;
@@ -78,9 +85,6 @@ export function buildFuseChildCommand(
     if (options.supervisorStatusPath) {
       args.push("--supervisor-status", options.supervisorStatusPath);
     }
-    if (options.supervisorToken) {
-      args.push("--supervisor-token", options.supervisorToken);
-    }
     for (const space of options.spaces) args.push("--space", space);
     return { command: execPath, args };
   }
@@ -104,7 +108,6 @@ export function buildFuseChildCommand(
       cfcWritebackXattrs: options.cfcWritebackXattrs,
       cfcWritebackState: options.cfcWritebackState,
       supervisorStatusPath: options.supervisorStatusPath,
-      supervisorToken: options.supervisorToken,
     }),
   };
 }
@@ -115,10 +118,13 @@ export async function runFuseSupervisor(
   const childCommand = buildFuseChildCommand(options);
   const CommandCtor = options.command ?? Deno.Command;
   const exit = options.exit ?? Deno.exit;
+  // The child inherits this process's stdout. For a background mount that is the
+  // pipe `cf fuse mount` blocks on, so the child's readiness line reaches the
+  // command directly.
   const child = new CommandCtor(childCommand.command, {
     args: childCommand.args,
     stdin: "null",
-    stdout: "null",
+    stdout: "inherit",
     stderr: "null",
   }).spawn();
 
@@ -152,15 +158,7 @@ export async function runFuseSupervisor(
 
   try {
     if (options.statePath) {
-      const recorded = await recordFuseChildPid({
-        statePath: options.statePath,
-        childPid: child.pid,
-        supervisorPid: options.supervisorPid ?? Deno.pid,
-        sleep: options.sleep,
-      });
-      if (!recorded) {
-        throw new Error("Unable to record FUSE child PID in mount state.");
-      }
+      await recordFuseMountState(options, child.pid);
     }
     const status = await child.status;
     childExited = true;
@@ -292,9 +290,6 @@ export function parseSupervisorArgs(
       case "--supervisor-status":
         options.supervisorStatusPath = requireValue(rawArgs, ++i, arg);
         break;
-      case "--supervisor-token":
-        options.supervisorToken = requireValue(rawArgs, ++i, arg);
-        break;
       case "--space":
       case "-s":
         options.spaces.push(requireValue(rawArgs, ++i, arg));
@@ -341,42 +336,39 @@ Options:
   --cfc-writeback-state <path>    CFC writeback state path
   --state-path <path>             Mount state file to update with child PID
   --supervisor-status <path>      Child readiness and heartbeat status file
-  --supervisor-token <token>      Child readiness status correlation token
   -s, --space <name>              Space(s) to connect
   -h, --help                      Show this help
 `;
 }
 
-export async function recordFuseChildPid(
-  options: {
-    statePath: string;
-    childPid: number;
-    supervisorPid: number;
-    sleep?: (ms: number) => Promise<void>;
-  },
-): Promise<boolean> {
-  const sleep = options.sleep ??
-    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  for (let attempt = 0; attempt < 20; attempt++) {
-    try {
-      const state = JSON.parse(
-        await Deno.readTextFile(options.statePath),
-      ) as Record<string, unknown>;
-      if (state.pid !== options.supervisorPid) {
-        await sleep(50);
-        continue;
-      }
-      state.childPid = options.childPid;
-      await Deno.writeTextFile(
-        options.statePath,
-        JSON.stringify(state, null, 2),
-      );
-      return true;
-    } catch {
-      await sleep(50);
-    }
+/**
+ * Writes the mount state file. This process spawned the FUSE child, so it is the
+ * only one that knows both PIDs, and it writes the file once and completely.
+ * `cf fuse mount` prepares the containing directory and the path, then leaves the
+ * contents to this process.
+ */
+export async function recordFuseMountState(
+  options: FuseSupervisorOptions,
+  childPid: number,
+): Promise<void> {
+  const statePath = options.statePath;
+  if (!statePath) return;
+  const write = options.writeMountStateFile ?? writeMountStateFile;
+  const entry: MountStateEntry = {
+    pid: options.supervisorPid ?? Deno.pid,
+    childPid,
+    mountpoint: options.mountpoint,
+    apiUrl: options.apiUrl,
+    identity: options.identity,
+    startedAt: new Date().toISOString(),
+    childStatusPath: options.supervisorStatusPath,
+    logFile: options.logFile || undefined,
+  };
+  try {
+    await write(statePath, entry);
+  } catch (error) {
+    throw new Error(`Unable to record FUSE mount state: ${error}`);
   }
-  return false;
 }
 
 if (import.meta.main) {

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -38,7 +38,6 @@ export interface FuseChildDenoArgsOptions {
   cfcWritebackXattrs?: boolean;
   cfcWritebackState?: string;
   supervisorStatusPath?: string;
-  supervisorToken?: string;
 }
 
 export interface BackgroundSupervisorDenoArgsOptions
@@ -141,21 +140,45 @@ export async function mountpointHash(mountpoint: string): Promise<string> {
   );
 }
 
-export async function writeMountState(
+/**
+ * Creates the state directory, drops any state file left at the mountpoint's
+ * previous hash, and returns the path this mountpoint's state file belongs at.
+ * Callers that hold write access to the directory run this before a writer that
+ * only holds write access to the single file.
+ */
+export async function prepareMountStatePath(
   stateDir: string,
-  entry: MountStateEntry,
+  mountpoint: string,
 ): Promise<string> {
   await Deno.mkdir(stateDir, { recursive: true });
-  const normalized = normalizeMountStateEntry(entry);
-  const hash = await mountpointHash(normalized.mountpoint);
-  const path = resolve(stateDir, `${hash}.json`);
-  await Deno.writeTextFile(path, JSON.stringify(normalized, null, 2));
-  const legacyHash = await legacyMountpointHash(normalized.mountpoint);
+  const hash = await mountpointHash(mountpoint);
+  const legacyHash = await legacyMountpointHash(mountpoint);
   if (legacyHash !== hash) {
     await Deno.remove(resolve(stateDir, `${legacyHash}.json`)).catch(() =>
       undefined
     );
   }
+  return resolve(stateDir, `${hash}.json`);
+}
+
+/** Writes an entry to an already-prepared state file path. */
+export async function writeMountStateFile(
+  path: string,
+  entry: MountStateEntry,
+): Promise<void> {
+  await Deno.writeTextFile(
+    path,
+    JSON.stringify(normalizeMountStateEntry(entry), null, 2),
+  );
+}
+
+export async function writeMountState(
+  stateDir: string,
+  entry: MountStateEntry,
+): Promise<string> {
+  const normalized = normalizeMountStateEntry(entry);
+  const path = await prepareMountStatePath(stateDir, normalized.mountpoint);
+  await writeMountStateFile(path, normalized);
   return path;
 }
 
@@ -385,9 +408,6 @@ export function buildFuseChildDenoArgs(
   if (opts.supervisorStatusPath) {
     args.push("--supervisor-status", opts.supervisorStatusPath);
   }
-  if (opts.supervisorToken) {
-    args.push("--supervisor-token", opts.supervisorToken);
-  }
   for (const space of opts.spaces ?? []) args.push("--space", space);
 
   return args;
@@ -423,9 +443,6 @@ export function buildFuseBinaryArgs(opts: FuseBinaryArgsOptions): string[] {
   if (opts.supervisorStatusPath) {
     args.push("--supervisor-status", opts.supervisorStatusPath);
   }
-  if (opts.supervisorToken) {
-    args.push("--supervisor-token", opts.supervisorToken);
-  }
   for (const space of opts.spaces ?? []) args.push("--space", space);
 
   return args;
@@ -443,8 +460,7 @@ export function buildBackgroundSupervisorDenoArgs(
   ];
 
   if (opts.statePath) {
-    args.splice(2, 0, `--allow-read=${opts.statePath}`);
-    args.splice(3, 0, `--allow-write=${opts.statePath}`);
+    args.splice(2, 0, `--allow-write=${opts.statePath}`);
     args.push("--state-path", opts.statePath);
   }
 
@@ -468,9 +484,6 @@ export function buildBackgroundSupervisorDenoArgs(
   }
   if (opts.supervisorStatusPath) {
     args.push("--supervisor-status", opts.supervisorStatusPath);
-  }
-  if (opts.supervisorToken) {
-    args.push("--supervisor-token", opts.supervisorToken);
   }
   for (const space of opts.spaces ?? []) args.push("--space", space);
 

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
 import { basename, join, resolve, toFileUrl } from "@std/path";
 import {
   awaitBackgroundMountStartup,
@@ -90,16 +91,27 @@ function openReadinessStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
+/** An open channel the test pushes readiness lines into on its own schedule. */
+function controllableReadinessStream(): {
+  stream: ReadableStream<Uint8Array>;
+  push: (line: string) => void;
+} {
+  const encoder = new TextEncoder();
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    stream,
+    push: (line: string) => controller.enqueue(encoder.encode(line)),
+  };
+}
+
 /** A supervisor that stays up: its exit never settles. */
 function liveSupervisor(): Promise<Deno.CommandStatus> {
   return new Promise<Deno.CommandStatus>(() => {});
-}
-
-/** A supervisor that exits after `ms`, as one does when its FUSE child dies. */
-function supervisorExitingAfter(ms: number): Promise<Deno.CommandStatus> {
-  return new Promise<Deno.CommandStatus>((resolve) =>
-    setTimeout(() => resolve({ success: false, code: 1, signal: null }), ms)
-  );
 }
 
 function trackRemoval(removed: string[]): (path: string) => Promise<void> {
@@ -516,7 +528,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([readinessLine("mounted")]),
         isAlive: (pid) => {
           alive.push(pid);
@@ -538,11 +549,39 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: openReadinessStream([readinessLine("mounted")]),
         isAlive: () => true,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("puts no deadline on readiness, however much time passes", async () => {
+    // Nothing about the readiness wait is time-based, so no count of events can
+    // show the absence of a deadline. A wall clock can: an hour of virtual time
+    // passes with the child still starting, and the wait must survive it and
+    // then settle on the report that finally arrives. A reintroduced deadline
+    // would fire during the tick and fail this test.
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const channel = controllableReadinessStream();
+    const time = new FakeTime();
+
+    try {
+      const startup = awaitBackgroundMountStartup(Deno.pid, statePath, {
+        readiness: channel.stream,
+        supervisorExit: liveSupervisor(),
+        isAlive: () => true,
+      });
+      let ended = false;
+      startup.then(() => ended = true, () => ended = true);
+
+      await time.tickAsync(60 * 60 * 1000);
+      expect(ended).toBe(false);
+
+      channel.push(readinessLine("mounted"));
+      await expect(startup).resolves.toBeUndefined();
+    } finally {
+      time.restore();
+    }
   });
 
   it("reads past a starting report to the mounted report", async () => {
@@ -551,7 +590,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([
           readinessLine("starting"),
           readinessLine("mounted"),
@@ -568,7 +606,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([
           line.slice(0, 12),
           line.slice(12, 30),
@@ -599,7 +636,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: new ReadableStream({
           start(controller) {
             for (const chunk of chunks) controller.enqueue(chunk);
@@ -617,7 +653,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream(["{not-json\n", readinessLine("mounted")]),
         isAlive: () => true,
       }),
@@ -633,7 +668,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([]),
         childStatusPath,
         isAlive: () => true,
@@ -659,34 +693,12 @@ describe("mount state operations", () => {
         supervisorExit: Promise.resolve(
           { success: false, code: 1, signal: null } as Deno.CommandStatus,
         ),
-        confirmMs: 5,
         isAlive: () => true,
         removeStateFile: trackRemoval(removed),
       }),
     ).rejects.toThrow(/Background FUSE process exited during startup/i);
 
     expect(removed).toEqual([statePath]);
-  });
-
-  it("rejects background mounts whose child dies just after reporting mounted", async () => {
-    const statePath = await writeMountState(tmpDir, mountStateFixture());
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
-
-    // The child is still running when its report arrives, so a pid probe says it
-    // is alive; the supervisor's exit moments later is what gives it away.
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        readiness: openReadinessStream([readinessLine("mounted")]),
-        supervisorExit: supervisorExitingAfter(10),
-        confirmMs: 500,
-        childStatusPath,
-        isAlive: () => true,
-        removeStateFile: trackRemoval(removed),
-      }),
-    ).rejects.toThrow(/child exited after reporting mounted/i);
-
-    expect(removed).toEqual([statePath, childStatusPath]);
   });
 
   it("rejects background mounts when the child reports startup failure", async () => {
@@ -697,7 +709,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([
           readinessLine("failed", { error: "fuse_session_mount failed" }),
         ]),
@@ -718,7 +729,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([readinessLine("exiting")]),
         isAlive: () => true,
         removeStateFile: trackRemoval(removed),
@@ -737,7 +747,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([readinessLine("mounted")]),
         childStatusPath,
         isAlive: (pid) => pid !== CHILD_PID,
@@ -755,7 +764,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([readinessLine("mounted")]),
         isAlive: (pid) => pid !== Deno.pid,
         removeStateFile: trackRemoval(removed),
@@ -772,7 +780,6 @@ describe("mount state operations", () => {
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
         supervisorExit: liveSupervisor(),
-        confirmMs: 5,
         readiness: readinessStream([
           `${JSON.stringify({ state: "mounted" })}\n`,
         ]),

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -21,6 +21,7 @@ import {
   isAlive,
   isMountStateAlive,
   mountpointHash,
+  type MountStateEntry,
   readAllMountStates,
   readMountState,
   writeMountState,
@@ -29,12 +30,84 @@ import {
   buildFuseChildCommand,
   cleanupFuseChild,
   parseSupervisorArgs,
-  recordFuseChildPid,
+  recordFuseMountState,
   runFuseSupervisor,
   supervisorHelp,
 } from "../lib/fuse-supervisor.ts";
 import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
 import { withEnv } from "./utils.ts";
+
+const CHILD_PID = 321;
+
+function mountStateFixture(
+  overrides: Partial<MountStateEntry> = {},
+): MountStateEntry {
+  return {
+    pid: Deno.pid,
+    childPid: CHILD_PID,
+    mountpoint: "/tmp/test-mount",
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/test-identity.pem",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** One readiness report, in the form the FUSE child writes to its stdout. */
+function readinessLine(
+  state: string,
+  extra: Record<string, unknown> = {},
+): string {
+  return `${
+    JSON.stringify({
+      state,
+      pid: CHILD_PID,
+      mountpoint: "/tmp/test-mount",
+      updatedAt: "2026-03-17T00:00:00.000Z",
+      ...extra,
+    })
+  }\n`;
+}
+
+/** A channel whose writers all exit once the given chunks are through. */
+function readinessStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+/** A channel a live mount keeps open after reporting. */
+function openReadinessStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+    },
+  });
+}
+
+/** A supervisor that stays up: its exit never settles. */
+function liveSupervisor(): Promise<Deno.CommandStatus> {
+  return new Promise<Deno.CommandStatus>(() => {});
+}
+
+/** A supervisor that exits after `ms`, as one does when its FUSE child dies. */
+function supervisorExitingAfter(ms: number): Promise<Deno.CommandStatus> {
+  return new Promise<Deno.CommandStatus>((resolve) =>
+    setTimeout(() => resolve({ success: false, code: 1, signal: null }), ms)
+  );
+}
+
+function trackRemoval(removed: string[]): (path: string) => Promise<void> {
+  return async (path: string) => {
+    removed.push(path);
+    await Deno.remove(path).catch(() => undefined);
+  };
+}
 
 describe("mountpointHash", () => {
   it("returns a 16-char hex string", async () => {
@@ -436,252 +509,279 @@ describe("mount state operations", () => {
     await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
-  it("rejects background mounts that die during startup and removes their state file", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: 1073741824,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-
-    const removed: string[] = [];
-    await expect(
-      awaitBackgroundMountStartup(
-        1073741824,
-        statePath,
-        {
-          attempts: 1,
-          isAlive: () => false,
-          removeStateFile: async (path: string) => {
-            removed.push(path);
-            await Deno.remove(path);
-          },
-          sleep: () => Promise.resolve(),
-        },
-      ),
-    ).rejects.toThrow(/Background FUSE process exited during startup/i);
-
-    expect(removed).toEqual([statePath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
-  });
-
-  it("allows background mounts that stay alive through the startup window", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-
-    let checks = 0;
-    await expect(
-      awaitBackgroundMountStartup(
-        Deno.pid,
-        statePath,
-        {
-          attempts: 3,
-          isAlive: () => {
-            checks++;
-            return true;
-          },
-          sleep: () => Promise.resolve(),
-        },
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(checks).toBe(3);
-    await expect(Deno.stat(statePath)).resolves.toBeDefined();
-  });
-
-  it("waits for explicit child mounted status when available", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    let reads = 0;
+  it("returns once the child reports mounted and both processes are alive", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const alive: number[] = [];
 
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 3,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () => {
-          reads++;
-          return Promise.resolve(JSON.stringify({
-            state: reads === 1 ? "starting" : "mounted",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          }));
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([readinessLine("mounted")]),
+        isAlive: (pid) => {
+          alive.push(pid);
+          return true;
         },
-        sleep: () => Promise.resolve(),
       }),
     ).resolves.toBeUndefined();
 
-    expect(reads).toBe(3);
+    // Both the supervisor and the FUSE child are confirmed, in that order.
+    expect(alive).toEqual([CHILD_PID, Deno.pid]);
     await expect(Deno.stat(statePath)).resolves.toBeDefined();
   });
 
-  it("rejects background mounts when child exits after reporting mounted", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
+  it("returns while the mount still holds the readiness channel open", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+
+    // A live mount never closes the channel, so the wait has to settle on the
+    // readiness line rather than on end of stream.
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: openReadinessStream([readinessLine("mounted")]),
+        isAlive: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reads past a starting report to the mounted report", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([
+          readinessLine("starting"),
+          readinessLine("mounted"),
+        ]),
+        isAlive: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reassembles a readiness report split across reads", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const line = readinessLine("mounted");
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([
+          line.slice(0, 12),
+          line.slice(12, 30),
+          line.slice(30),
+        ]),
+        isAlive: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reassembles a report whose multi-byte characters are split across reads", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    // A mountpoint name can be non-ASCII, and a pipe splits writes wherever it
+    // likes, including through a character.
+    const line = `${
+      JSON.stringify({
+        state: "mounted",
+        pid: CHILD_PID,
+        mountpoint: "/tmp/montaña-café-\u{1F600}",
+      })
+    }\n`;
+    const bytes = new TextEncoder().encode(line);
+    const chunks: Uint8Array[] = [];
+    for (let i = 0; i < bytes.length; i += 3) {
+      chunks.push(bytes.slice(i, i + 3));
+    }
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: new ReadableStream({
+          start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+        isAlive: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores unparseable output and settles on the report that follows", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream(["{not-json\n", readinessLine("mounted")]),
+        isAlive: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects background mounts whose channel ends without a report", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
     const childStatusPath = childStatusPathForStatePath(statePath);
+    await Deno.writeTextFile(childStatusPath, readinessLine("starting"));
     const removed: string[] = [];
 
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 2,
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([]),
         childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: (pid) => pid !== 321,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "mounted",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path).catch(() => undefined);
-        },
-        sleep: () => Promise.resolve(),
+        isAlive: () => true,
+        removeStateFile: trackRemoval(removed),
+      }),
+    ).rejects.toThrow(/Background FUSE process exited during startup/i);
+
+    expect(removed).toEqual([statePath, childStatusPath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
+    await expect(Deno.stat(childStatusPath)).rejects.toThrow();
+  });
+
+  it("rejects background mounts when the supervisor exits before any report", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const removed: string[] = [];
+
+    // An orphaned FUSE child inherits the write end and holds the channel open,
+    // so end of stream never comes and the supervisor's exit is the only signal
+    // that no report is coming.
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        readiness: openReadinessStream([]),
+        supervisorExit: Promise.resolve(
+          { success: false, code: 1, signal: null } as Deno.CommandStatus,
+        ),
+        confirmMs: 5,
+        isAlive: () => true,
+        removeStateFile: trackRemoval(removed),
+      }),
+    ).rejects.toThrow(/Background FUSE process exited during startup/i);
+
+    expect(removed).toEqual([statePath]);
+  });
+
+  it("rejects background mounts whose child dies just after reporting mounted", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    // The child is still running when its report arrives, so a pid probe says it
+    // is alive; the supervisor's exit moments later is what gives it away.
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        readiness: openReadinessStream([readinessLine("mounted")]),
+        supervisorExit: supervisorExitingAfter(10),
+        confirmMs: 500,
+        childStatusPath,
+        isAlive: () => true,
+        removeStateFile: trackRemoval(removed),
       }),
     ).rejects.toThrow(/child exited after reporting mounted/i);
 
     expect(removed).toEqual([statePath, childStatusPath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
-  it("rejects background mounts when mounted status is followed by exiting", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
+  it("rejects background mounts when the child reports startup failure", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
     const childStatusPath = childStatusPathForStatePath(statePath);
     const removed: string[] = [];
-    let reads = 0;
 
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 2,
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([
+          readinessLine("failed", { error: "fuse_session_mount failed" }),
+        ]),
         childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
         isAlive: () => true,
-        readTextFile: () => {
-          reads++;
-          return Promise.resolve(JSON.stringify({
-            state: reads === 1 ? "mounted" : "exiting",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          }));
-        },
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path).catch(() => undefined);
-        },
-        sleep: () => Promise.resolve(),
+        removeStateFile: trackRemoval(removed),
       }),
-    ).rejects.toThrow(/child reported exiting/i);
+    ).rejects.toThrow(/fuse_session_mount failed/);
 
-    expect(reads).toBe(2);
     expect(removed).toEqual([statePath, childStatusPath]);
     await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
-  it("ignores mounted child status from a different startup attempt", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
+  it("rejects background mounts when the child reports exiting during startup", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([readinessLine("exiting")]),
+        isAlive: () => true,
+        removeStateFile: trackRemoval(removed),
+      }),
+    ).rejects.toThrow(/child reported exiting/i);
+
+    expect(removed).toEqual([statePath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
+  });
+
+  it("rejects background mounts when the child dies after reporting mounted", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
     const childStatusPath = childStatusPathForStatePath(statePath);
     const removed: string[] = [];
 
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([readinessLine("mounted")]),
         childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "mounted",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "stale-token",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path);
-        },
-        sleep: () => Promise.resolve(),
+        isAlive: (pid) => pid !== CHILD_PID,
+        removeStateFile: trackRemoval(removed),
       }),
-    ).rejects.toThrow(/did not report mount readiness/i);
+    ).rejects.toThrow(/child exited after reporting mounted/i);
+
+    expect(removed).toEqual([statePath, childStatusPath]);
+  });
+
+  it("rejects background mounts when the supervisor dies after the child reports mounted", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([readinessLine("mounted")]),
+        isAlive: (pid) => pid !== Deno.pid,
+        removeStateFile: trackRemoval(removed),
+      }),
+    ).rejects.toThrow(/Background FUSE process exited during startup/i);
 
     expect(removed).toEqual([statePath]);
   });
 
-  it("cleans up malformed child status sidecars after readiness timeout", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-    const childStatusPath = childStatusPathForStatePath(statePath);
+  it("rejects a mounted report that carries no child pid", async () => {
+    const statePath = await writeMountState(tmpDir, mountStateFixture());
     const removed: string[] = [];
 
     await expect(
       awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
+        supervisorExit: liveSupervisor(),
+        confirmMs: 5,
+        readiness: readinessStream([
+          `${JSON.stringify({ state: "mounted" })}\n`,
+        ]),
         isAlive: () => true,
-        readTextFile: () => Promise.resolve("{not-json"),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path).catch(() => undefined);
-        },
-        sleep: () => Promise.resolve(),
+        removeStateFile: trackRemoval(removed),
       }),
-    ).rejects.toThrow(/did not report mount readiness/i);
+    ).rejects.toThrow(/child exited after reporting mounted/i);
 
-    expect(removed).toEqual([statePath, childStatusPath]);
+    expect(removed).toEqual([statePath]);
   });
 
   it("does not read child status sidecars as mount state entries", async () => {
@@ -778,124 +878,6 @@ describe("mount state operations", () => {
 
     expect(rows).toEqual([]);
     expect(formatMountStatusTable(rows)).toBe("No active FUSE mounts.");
-    expect(removed).toEqual([statePath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
-  });
-
-  it("rejects background mounts when child reports startup failure", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
-
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "failed",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-            error: "fuse_session_mount failed",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/fuse_session_mount failed/);
-
-    expect(removed).toEqual([statePath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
-  });
-
-  it("rejects background mounts when child exits during startup", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
-
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "exiting",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/child reported exiting/);
-
-    expect(removed).toEqual([statePath]);
-    await expect(Deno.stat(statePath)).rejects.toThrow();
-  });
-
-  it("rejects background mounts when child readiness times out", async () => {
-    const statePath = await writeMountState(tmpDir, {
-      pid: Deno.pid,
-      childPid: 321,
-      mountpoint: "/tmp/test-mount",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/test-identity.pem",
-      startedAt: "2026-03-17T00:00:00.000Z",
-    });
-    const childStatusPath = childStatusPathForStatePath(statePath);
-    const removed: string[] = [];
-
-    await expect(
-      awaitBackgroundMountStartup(Deno.pid, statePath, {
-        attempts: 1,
-        childStatusPath,
-        childStatusToken: "token-1",
-        mountpoint: "/tmp/test-mount",
-        isAlive: () => true,
-        readTextFile: () =>
-          Promise.resolve(JSON.stringify({
-            state: "starting",
-            pid: 321,
-            mountpoint: "/tmp/test-mount",
-            token: "token-1",
-            updatedAt: "2026-03-17T00:00:00.000Z",
-          })),
-        removeStateFile: async (path: string) => {
-          removed.push(path);
-          await Deno.remove(path);
-        },
-        sleep: () => Promise.resolve(),
-      }),
-    ).rejects.toThrow(/did not report mount readiness/i);
-
     expect(removed).toEqual([statePath]);
     await expect(Deno.stat(statePath)).rejects.toThrow();
   });
@@ -1110,7 +1092,6 @@ describe("FUSE supervisor command construction", () => {
       spaces: ["home", "work"],
       statePath: "/tmp/cf-state.json",
       supervisorStatusPath: "/tmp/cf-state.json.child-status",
-      supervisorToken: "token-1",
       allowOther: true,
       noattrcache: true,
       cfcMode: "observe",
@@ -1123,8 +1104,10 @@ describe("FUSE supervisor command construction", () => {
     expect(args.slice(0, 2)).toEqual(["run", "--allow-run"]);
     expect(args).not.toContain("--allow-read");
     expect(args).not.toContain("--allow-write");
-    expect(args).toContain("--allow-read=/tmp/cf-state.json");
+    // The supervisor writes the mount state and reads nothing, so it is granted
+    // write access to that one file and no read access at all.
     expect(args).toContain("--allow-write=/tmp/cf-state.json");
+    expect(args.some((arg) => arg.startsWith("--allow-read"))).toBe(false);
     expect(args).not.toContain("--allow-env");
     expect(args).not.toContain("--allow-net");
     expect(args).not.toContain("--unstable-ffi");
@@ -1139,8 +1122,6 @@ describe("FUSE supervisor command construction", () => {
     expect(args).toContain("/tmp/cf-state.json");
     expect(args).toContain("--supervisor-status");
     expect(args).toContain("/tmp/cf-state.json.child-status");
-    expect(args).toContain("--supervisor-token");
-    expect(args).toContain("token-1");
     expect(args).toContain("--noattrcache");
     expect(args.filter((arg) => arg === "--space").length).toBe(2);
   });
@@ -1155,7 +1136,6 @@ describe("FUSE supervisor command construction", () => {
       logFile: "/tmp/cf-fuse-mnt.log",
       spaces: [],
       supervisorStatusPath: "/tmp/cf-status.json",
-      supervisorToken: "token-1",
     });
     const childArgs = buildFuseChildDenoArgs({
       modPath: "/repo/packages/fuse/mod.ts",
@@ -1166,7 +1146,6 @@ describe("FUSE supervisor command construction", () => {
       logFile: "/tmp/cf-fuse-mnt.log",
       spaces: [],
       supervisorStatusPath: "/tmp/cf-status.json",
-      supervisorToken: "token-1",
     });
 
     expect(childArgs).not.toEqual(supervisorArgs);
@@ -1175,8 +1154,6 @@ describe("FUSE supervisor command construction", () => {
     expect(childArgs).toContain("/repo/packages/fuse/mod.ts");
     expect(childArgs).toContain("--supervisor-status");
     expect(childArgs).toContain("/tmp/cf-status.json");
-    expect(childArgs).toContain("--supervisor-token");
-    expect(childArgs).toContain("token-1");
     expect(childArgs).not.toContain(
       "/repo/packages/cli/lib/fuse-supervisor.ts",
     );
@@ -1213,7 +1190,6 @@ describe("FUSE supervisor command construction", () => {
       spaces: ["home"],
       execPath: "/usr/local/bin/cf",
       supervisorStatusPath: "/tmp/cf-status",
-      supervisorToken: "token-1",
       attrcacheTimeout: "2",
     });
 
@@ -1221,8 +1197,6 @@ describe("FUSE supervisor command construction", () => {
     expect(child.args).toContain("fuse-daemon");
     expect(child.args).toContain("--supervisor-status");
     expect(child.args).toContain("/tmp/cf-status");
-    expect(child.args).toContain("--supervisor-token");
-    expect(child.args).toContain("token-1");
     const flagIndex = child.args.indexOf("--attrcache-timeout");
     expect(flagIndex).toBeGreaterThan(-1);
     expect(child.args[flagIndex + 1]).toBe("2");
@@ -1322,63 +1296,41 @@ describe("FUSE supervisor command construction", () => {
     })).toBe(true);
   });
 
-  it("records childPid only into state owned by the supervisor PID", async () => {
-    const statePath = await Deno.makeTempFile({ prefix: "cf-fuse-state-" });
+  it("writes the whole mount state without a pre-existing file", async () => {
+    const dir = await Deno.makeTempDir({ prefix: "cf-fuse-state-" });
+    const statePath = join(dir, "mount.json");
     try {
-      await Deno.writeTextFile(
+      // The mount command no longer writes this file, so the supervisor must
+      // not depend on anything already being there.
+      await recordFuseMountState({
+        mountpoint: "/tmp/test-mount",
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        execCli: "",
+        logFile: "/tmp/cf-fuse-test.log",
+        spaces: [],
         statePath,
-        JSON.stringify({
-          pid: 100,
-          mountpoint: "/tmp/test-mount",
-          apiUrl: "",
-          identity: "",
-          startedAt: "2026-03-17T00:00:00.000Z",
-        }),
-      );
-
-      const staleResult = await recordFuseChildPid({
-        statePath,
-        childPid: 300,
+        supervisorStatusPath: "/tmp/cf-fuse-test.child-status",
         supervisorPid: 200,
-        sleep: () => Promise.resolve(),
-      });
-      const staleState = JSON.parse(await Deno.readTextFile(statePath)) as {
-        childPid?: number;
-      };
+      }, 300);
 
-      expect(staleResult).toBe(false);
-      expect(staleState.childPid).toBeUndefined();
-
-      await Deno.writeTextFile(
-        statePath,
-        JSON.stringify({
-          pid: 200,
-          mountpoint: "/tmp/test-mount",
-          apiUrl: "",
-          identity: "",
-          startedAt: "2026-03-17T00:00:00.000Z",
-        }),
-      );
-
-      const matchingResult = await recordFuseChildPid({
-        statePath,
+      const state = JSON.parse(await Deno.readTextFile(statePath));
+      expect(state).toMatchObject({
+        pid: 200,
         childPid: 300,
-        supervisorPid: 200,
-        sleep: () => Promise.resolve(),
+        mountpoint: "/tmp/test-mount",
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        logFile: "/tmp/cf-fuse-test.log",
+        childStatusPath: "/tmp/cf-fuse-test.child-status",
       });
-      const matchingState = JSON.parse(await Deno.readTextFile(statePath)) as {
-        childPid?: number;
-      };
-
-      expect(matchingResult).toBe(true);
-      expect(matchingState.childPid).toBe(300);
+      expect(typeof state.startedAt).toBe("string");
     } finally {
-      await Deno.remove(statePath).catch(() => undefined);
+      await Deno.remove(dir, { recursive: true }).catch(() => undefined);
     }
   });
 
-  it("fails supervisor startup when childPid cannot be recorded", async () => {
-    const statePath = await Deno.makeTempFile({ prefix: "cf-fuse-state-" });
+  it("fails supervisor startup when the mount state cannot be written", async () => {
     const signals: Deno.Signal[] = [];
     let resolveStatus: (status: Deno.CommandStatus) => void = () => undefined;
 
@@ -1399,41 +1351,63 @@ describe("FUSE supervisor command construction", () => {
       }
     }
 
-    try {
-      await Deno.writeTextFile(
-        statePath,
-        JSON.stringify({
-          pid: 100,
-          mountpoint: "/tmp/test-mount",
-          apiUrl: "",
-          identity: "",
-          startedAt: "2026-03-17T00:00:00.000Z",
-        }),
-      );
+    await expect(runFuseSupervisor({
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      logFile: "",
+      spaces: [],
+      statePath: "/tmp/cf-fuse-unwritable-state.json",
+      supervisorPid: 200,
+      command: FakeCommand,
+      writeMountStateFile: () => Promise.reject(new Error("disk full")),
+      addSignalListener: () => undefined,
+      removeSignalListener: () => undefined,
+    })).rejects.toThrow(/Unable to record FUSE mount state: .*disk full/);
 
-      await expect(runFuseSupervisor({
-        mountpoint: "/tmp/test-mount",
-        apiUrl: "",
-        identity: "",
-        execCli: "",
-        logFile: "",
-        spaces: [],
-        statePath,
-        supervisorPid: 200,
-        command: FakeCommand,
-        sleep: () => Promise.resolve(),
-        addSignalListener: () => undefined,
-        removeSignalListener: () => undefined,
-      })).rejects.toThrow(/Unable to record FUSE child PID/);
-
-      expect(signals).toEqual(["SIGTERM"]);
-    } finally {
-      await Deno.remove(statePath).catch(() => undefined);
-    }
+    // The child must not outlive a supervisor that cannot record it.
+    expect(signals).toEqual(["SIGTERM"]);
   });
 
-  it("installs supervisor signal handlers before recording childPid", async () => {
-    const statePath = await Deno.makeTempFile({ prefix: "cf-fuse-state-" });
+  it("hands the child this process's stdout so readiness reaches the mount command", async () => {
+    let childOptions: Deno.CommandOptions | undefined;
+
+    class FakeCommand {
+      constructor(_command: string | URL, options: Deno.CommandOptions) {
+        childOptions = options;
+      }
+
+      spawn() {
+        return {
+          pid: 300,
+          status: Promise.resolve({ success: true, code: 0, signal: null }),
+          kill: () => undefined,
+        };
+      }
+    }
+
+    await expect(runFuseSupervisor({
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      logFile: "",
+      spaces: [],
+      supervisorPid: 200,
+      command: FakeCommand,
+      addSignalListener: () => undefined,
+      removeSignalListener: () => undefined,
+      exit: () => undefined,
+    })).resolves.toBeUndefined();
+
+    // The FUSE child writes its readiness to the descriptor it inherits here.
+    // Any other setting drops that report on the floor, and the mount command,
+    // which waits on it with no deadline, waits for as long as the mount is up.
+    expect(childOptions?.stdout).toBe("inherit");
+  });
+
+  it("installs supervisor signal handlers before recording mount state", async () => {
     const addedSignals: Deno.Signal[] = [];
     let handlersInstalledBeforeRecord = false;
 
@@ -1449,55 +1423,31 @@ describe("FUSE supervisor command construction", () => {
       }
     }
 
-    try {
-      await Deno.writeTextFile(
-        statePath,
-        JSON.stringify({
-          pid: 100,
-          mountpoint: "/tmp/test-mount",
-          apiUrl: "",
-          identity: "",
-          startedAt: "2026-03-17T00:00:00.000Z",
-        }),
-      );
+    await expect(runFuseSupervisor({
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      logFile: "",
+      spaces: [],
+      statePath: "/tmp/cf-fuse-signal-order-state.json",
+      supervisorPid: 200,
+      command: FakeCommand,
+      writeMountStateFile: () => {
+        handlersInstalledBeforeRecord = addedSignals.includes("SIGTERM") &&
+          addedSignals.includes("SIGINT");
+        return Promise.resolve();
+      },
+      addSignalListener: (signal) => {
+        addedSignals.push(signal);
+      },
+      removeSignalListener: () => undefined,
+      exit: (code: number) => {
+        throw new Error(`exit:${code}`);
+      },
+    })).rejects.toThrow(/exit:0/);
 
-      await expect(runFuseSupervisor({
-        mountpoint: "/tmp/test-mount",
-        apiUrl: "",
-        identity: "",
-        execCli: "",
-        logFile: "",
-        spaces: [],
-        statePath,
-        supervisorPid: 200,
-        command: FakeCommand,
-        sleep: async () => {
-          handlersInstalledBeforeRecord = addedSignals.includes("SIGTERM") &&
-            addedSignals.includes("SIGINT");
-          await Deno.writeTextFile(
-            statePath,
-            JSON.stringify({
-              pid: 200,
-              mountpoint: "/tmp/test-mount",
-              apiUrl: "",
-              identity: "",
-              startedAt: "2026-03-17T00:00:00.000Z",
-            }),
-          );
-        },
-        addSignalListener: (signal) => {
-          addedSignals.push(signal);
-        },
-        removeSignalListener: () => undefined,
-        exit: (code: number) => {
-          throw new Error(`exit:${code}`);
-        },
-      })).rejects.toThrow(/exit:0/);
-
-      expect(handlersInstalledBeforeRecord).toBe(true);
-    } finally {
-      await Deno.remove(statePath).catch(() => undefined);
-    }
+    expect(handlersInstalledBeforeRecord).toBe(true);
   });
 });
 
@@ -1536,7 +1486,6 @@ describe("buildFuseBinaryArgs", () => {
       logFile: "/tmp/cf-fuse.log",
       statePath: "/tmp/state.json",
       supervisorStatusPath: "/tmp/state.json.child-status",
-      supervisorToken: "token-1",
     });
 
     expect(args.slice(0, 2)).toEqual(["fuse-supervisor", "/mnt"]);
@@ -1546,8 +1495,6 @@ describe("buildFuseBinaryArgs", () => {
     expect(args[stateIndex + 1]).toBe("/tmp/state.json");
     const statusIndex = args.indexOf("--supervisor-status");
     expect(args[statusIndex + 1]).toBe("/tmp/state.json.child-status");
-    const tokenIndex = args.indexOf("--supervisor-token");
-    expect(args[tokenIndex + 1]).toBe("token-1");
   });
 
   it("omits every optional flag that was not requested", () => {

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -1,8 +1,9 @@
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
   appendDecodedJsonPath,
   bufferForNoHandleTruncate,
   cfcWritebackXattrResultErrno,
+  createSupervisorStatusWriter,
   decodeFuseNamespaceName,
   DEFAULT_CFC_XATTR_NAMESPACE,
   defaultCfcWritebackStatePath,
@@ -231,6 +232,35 @@ Deno.test("mutating callbacks reject disconnected writes before optimistic mutat
   for (const [label, marker, guard, mutation] of mutationGuards) {
     assertAppearsBeforeAfter(source, marker, guard, mutation, label);
   }
+});
+
+Deno.test("mounted is announced only after the session loop and signal handlers", async () => {
+  // The readiness handshake carries no timed confirmation because the `mounted`
+  // announcement is honest: by the time a caller can read it, the session loop
+  // is dispatched and the signal handlers are installed, so the mount serves
+  // requests and unmounts cleanly on a signal. An announcement moved back ahead
+  // of either would reintroduce the confirmation the caller no longer pays for.
+  const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
+  assertAppearsBefore(
+    source,
+    "const sessionLoop = fuse.symbols.fuse_session_loop(handle.session);",
+    'reportSupervisorState("mounted")',
+    "session loop dispatched before mounted is announced",
+  );
+  assertAppearsBefore(
+    source,
+    'Deno.addSignalListener("SIGTERM"',
+    'reportSupervisorState("mounted")',
+    "signal handlers installed before mounted is announced",
+  );
+  // The announcement must also come before the loop is awaited, or every
+  // background mount would block on the loop before it could report `mounted`.
+  assertAppearsBefore(
+    source,
+    'reportSupervisorState("mounted")',
+    "const result = await sessionLoop;",
+    "mounted is announced before the session loop is awaited",
+  );
 });
 
 Deno.test("namespace write failures use shared outage accounting", async () => {
@@ -577,5 +607,182 @@ Deno.test("platform provider reports the implementation openFuse loaded", () => 
       noattrcache: false,
     }),
     ["fuse_ct"],
+  );
+});
+
+// A fake filesystem for the supervisor status writer, whose write latency the
+// test decides so two writes' ordering is chosen rather than raced.
+//
+// Held writes complete newest first, and a held write applies its content only
+// when released. That is an ordering the real filesystem is free to choose, and
+// it is the one that breaks an unserialized writer: the write issued first is
+// the one that lands last, so it is the one that wins the file. A writer that
+// lets only one write be in flight never has a second held write to reorder
+// against.
+function fakeStatusFilesystem() {
+  const files = new Map<string, string>();
+  const pending: Array<() => void> = [];
+  let holdWrites = false;
+
+  return {
+    holdNextWrites() {
+      holdWrites = true;
+    },
+    releaseHeldWrites() {
+      holdWrites = false;
+      while (pending.length > 0) pending.pop()!();
+    },
+    writeTextFile(path: string, data: string): Promise<void> {
+      if (!holdWrites) {
+        files.set(path, data);
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) =>
+        pending.push(() => {
+          files.set(path, data);
+          resolve();
+        })
+      );
+    },
+    rename(from: string, to: string): Promise<void> {
+      files.set(to, files.get(from)!);
+      files.delete(from);
+      return Promise.resolve();
+    },
+    remove(path: string): Promise<void> {
+      files.delete(path);
+      return Promise.resolve();
+    },
+    published(): string | undefined {
+      return files.get("/state/status");
+    },
+    scratchFilesLeft(): string[] {
+      return [...files.keys()].filter((path) => path.endsWith(".tmp"));
+    },
+  };
+}
+
+function statusWriterOver(fs: ReturnType<typeof fakeStatusFilesystem>) {
+  return createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    now: () => "2026-03-17T00:00:01.000Z",
+    writeTextFile: fs.writeTextFile,
+    rename: fs.rename,
+    remove: fs.remove,
+  });
+}
+
+Deno.test("supervisor status publishes each state through a rename", () => {
+  // The reader must never see a half-written file, so the document lands under a
+  // scratch name and is renamed into place rather than written in place.
+  const renames: Array<[string, string]> = [];
+  const write = createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    writeTextFile: () => Promise.resolve(),
+    rename: (from, to) => {
+      renames.push([from, to]);
+      return Promise.resolve();
+    },
+    remove: () => Promise.resolve(),
+  });
+
+  return write("mounted").then(() => {
+    assertEquals(renames.length, 1);
+    assertEquals(renames[0][1], "/state/status");
+    assert(renames[0][0].startsWith("/state/status."));
+    assert(renames[0][0].endsWith(".tmp"));
+  });
+});
+
+Deno.test("supervisor status does not regress when a slow write is still in flight", async () => {
+  const fs = fakeStatusFilesystem();
+  const write = statusWriterOver(fs);
+
+  // The heartbeat announces `mounted` and its write stalls. The session loop
+  // then ends and announces `exited`. The file must settle on the later call,
+  // not on whichever write the filesystem happens to finish last.
+  fs.holdNextWrites();
+  const heartbeat = write("mounted");
+  const exited = write("exited", { exitCode: 0 });
+  fs.releaseHeldWrites();
+  await Promise.all([heartbeat, exited]);
+
+  assertEquals(JSON.parse(fs.published()!).state, "exited");
+});
+
+Deno.test("supervisor status settles on exiting when it follows a stalled mounted", async () => {
+  const fs = fakeStatusFilesystem();
+  const write = statusWriterOver(fs);
+
+  // The readiness report stalls and a signal arrives while it is in flight.
+  fs.holdNextWrites();
+  const mounted = write("mounted");
+  const exiting = write("exiting");
+  fs.releaseHeldWrites();
+  await Promise.all([mounted, exiting]);
+
+  assertEquals(JSON.parse(fs.published()!).state, "exiting");
+});
+
+Deno.test("supervisor status keeps publishing after a write fails", async () => {
+  const fs = fakeStatusFilesystem();
+  let failNext = true;
+  const write = createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    writeTextFile: (path, data) => {
+      if (failNext) {
+        failNext = false;
+        return Promise.reject(new Error("disk full"));
+      }
+      return fs.writeTextFile(path, data);
+    },
+    rename: fs.rename,
+    remove: fs.remove,
+  });
+
+  // A failed write is reported to its caller and leaves no scratch file, and the
+  // states after it still reach the file.
+  await assertRejects(() => write("mounted"), Error, "disk full");
+  await write("exited", { exitCode: 0 });
+
+  assertEquals(JSON.parse(fs.published()!).state, "exited");
+  assertEquals(fs.scratchFilesLeft(), []);
+});
+
+Deno.test("supervisor status records when a state was reached, not when it drained", async () => {
+  const fs = fakeStatusFilesystem();
+  let clock = "2026-03-17T00:00:01.000Z";
+  const write = createSupervisorStatusWriter({
+    statusPath: "/state/status",
+    pid: 321,
+    mountpoint: "/tmp/m",
+    startedAt: "2026-03-17T00:00:00.000Z",
+    now: () => clock,
+    writeTextFile: fs.writeTextFile,
+    rename: fs.rename,
+    remove: fs.remove,
+  });
+
+  // Serializing writes means a state can reach the file well after it was
+  // reached. The stamp has to come from the call, so time moves on while the
+  // write is stalled.
+  fs.holdNextWrites();
+  const mounted = write("mounted");
+  clock = "2026-03-17T00:00:09.000Z";
+  fs.releaseHeldWrites();
+  await mounted;
+
+  assertEquals(
+    JSON.parse(fs.published()!).updatedAt,
+    "2026-03-17T00:00:01.000Z",
   );
 });

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
+  announceSupervisorState,
   appendDecodedJsonPath,
   bufferForNoHandleTruncate,
   cfcWritebackXattrResultErrno,
@@ -785,4 +786,38 @@ Deno.test("supervisor status records when a state was reached, not when it drain
     JSON.parse(fs.published()!).updatedAt,
     "2026-03-17T00:00:01.000Z",
   );
+});
+
+Deno.test("supervisor state is announced on the pipe even when the file write fails", async () => {
+  // The pipe announcement is the handshake's channel; a failed status-file write
+  // must not stop it, or a parent blocked on the pipe would never wake. The write
+  // error still has to reach the caller.
+  const published: Array<[string, Record<string, unknown>]> = [];
+  const publish = (state: string, extra: Record<string, unknown> = {}) => {
+    published.push([state, extra]);
+    return Promise.resolve();
+  };
+  const write = () => Promise.reject(new Error("disk full"));
+
+  await assertRejects(
+    () => announceSupervisorState(write, publish, "mounted"),
+    Error,
+    "disk full",
+  );
+  assertEquals(published, [["mounted", {}]]);
+});
+
+Deno.test("supervisor state records before it announces on the success path", async () => {
+  const order: string[] = [];
+  const write = (state: string) => {
+    order.push(`write:${state}`);
+    return Promise.resolve();
+  };
+  const publish = (state: string) => {
+    order.push(`publish:${state}`);
+    return Promise.resolve();
+  };
+
+  await announceSupervisorState(write, publish, "failed", { error: "x" });
+  assertEquals(order, ["write:failed", "publish:failed"]);
 });

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -435,13 +435,20 @@ export async function main(argv: string[] = Deno.args) {
     }
   }
   // Record the state, then announce it, so a parent woken by the announcement
-  // finds the status file already carrying the same state.
+  // finds the status file already carrying the same state. The announcement is
+  // the handshake's channel and the file is a record for `cf fuse status`, so
+  // the announcement goes out even when the record fails: publishing in a
+  // `finally` keeps a failed status write from stranding a parent that is
+  // blocked on the pipe, while the write error still reaches the caller.
   async function reportSupervisorState(
     state: SupervisorStatusState,
     extra: Record<string, unknown> = {},
   ): Promise<void> {
-    await writeSupervisorStatus(state, extra);
-    await publishSupervisorState(state, extra);
+    try {
+      await writeSupervisorStatus(state, extra);
+    } finally {
+      await publishSupervisorState(state, extra);
+    }
   }
   try {
     await writeSupervisorStatus("starting");

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -243,6 +243,84 @@ type SupervisorStatusState =
   | "exiting"
   | "exited";
 
+export interface SupervisorStatusWriterOptions {
+  statusPath: string;
+  pid: number;
+  mountpoint: string;
+  startedAt: string;
+  now?: () => string;
+  writeTextFile?: (path: string, data: string) => Promise<void>;
+  rename?: (from: string, to: string) => Promise<void>;
+  remove?: (path: string) => Promise<void>;
+}
+
+export type SupervisorStatusWriter = (
+  state: SupervisorStatusState,
+  extra?: Record<string, unknown>,
+) => Promise<void>;
+
+/**
+ * Build the function that writes the daemon's supervisor state to its status
+ * file, the record `cf fuse status` reads.
+ *
+ * The states form a lifecycle, and the calls announcing them come from places
+ * that do not coordinate: the startup path, the readiness report, the heartbeat
+ * and the signal handler. Two properties keep a concurrent reader from ever
+ * seeing a wrong file. Each write replaces the file by writing a scratch file
+ * and renaming it over the target, so a reader woken mid-write sees a complete
+ * document rather than a truncated one. And the writes are serialized through a
+ * queue, so the file ends on the state of the most recent call: renames issued
+ * concurrently could otherwise complete in either order and let a heartbeat
+ * still in flight replace a terminal state, leaving the file claiming a mount
+ * that has already gone.
+ */
+export function createSupervisorStatusWriter(
+  options: SupervisorStatusWriterOptions,
+): SupervisorStatusWriter {
+  const writeTextFile = options.writeTextFile ?? Deno.writeTextFile;
+  const rename = options.rename ?? Deno.rename;
+  const remove = options.remove ?? Deno.remove;
+  const now = options.now ?? (() => new Date().toISOString());
+  let queue: Promise<void> = Promise.resolve();
+  let writes = 0;
+
+  const publish = async (document: string): Promise<void> => {
+    // The scratch name carries the PID and a counter, so a daemon left over
+    // from an earlier mount at this path cannot share it.
+    const pendingPath = `${options.statusPath}.${options.pid}.${writes++}.tmp`;
+    try {
+      await writeTextFile(pendingPath, document);
+      await rename(pendingPath, options.statusPath);
+    } catch (error) {
+      await remove(pendingPath).catch(() => undefined);
+      throw error;
+    }
+  };
+
+  return (state, extra = {}) => {
+    // Built at call time, so `updatedAt` records when the state was reached
+    // rather than when its turn in the queue came up.
+    const document = JSON.stringify(
+      {
+        state,
+        pid: options.pid,
+        mountpoint: options.mountpoint,
+        startedAt: options.startedAt,
+        updatedAt: now(),
+        ...extra,
+      },
+      null,
+      2,
+    );
+    const write = queue.then(() => publish(document));
+    // A failed write must neither stop later states from being published nor
+    // surface through the queue as an unhandled rejection. The caller still
+    // sees the failure through the promise returned here.
+    queue = write.catch(() => undefined);
+    return write;
+  };
+}
+
 export async function writeFailedSupervisorStartupStatus(
   error: unknown,
   writeSupervisorStatus: (
@@ -389,31 +467,17 @@ export async function main(argv: string[] = Deno.args) {
   }
   const supervisorStatusPath = String(args["supervisor-status"] ?? "");
   const supervisorStatusStartedAt = new Date().toISOString();
-  function supervisorStatusPayload(
-    state: SupervisorStatusState,
-    extra: Record<string, unknown>,
-  ): Record<string, unknown> {
-    return {
-      state,
+  // The status file is the record `cf fuse status` reads later. The heartbeat
+  // refreshes it; readers take a snapshot whenever they ask. The writer keeps
+  // those snapshots whole and in order — see createSupervisorStatusWriter.
+  const writeSupervisorStatus: SupervisorStatusWriter = supervisorStatusPath
+    ? createSupervisorStatusWriter({
+      statusPath: supervisorStatusPath,
       pid: Deno.pid,
       mountpoint,
       startedAt: supervisorStatusStartedAt,
-      updatedAt: new Date().toISOString(),
-      ...extra,
-    };
-  }
-  // The status file is the record `cf fuse status` reads later. The heartbeat
-  // refreshes it; readers take a snapshot whenever they ask.
-  async function writeSupervisorStatus(
-    state: SupervisorStatusState,
-    extra: Record<string, unknown> = {},
-  ): Promise<void> {
-    if (!supervisorStatusPath) return;
-    await Deno.writeTextFile(
-      supervisorStatusPath,
-      JSON.stringify(supervisorStatusPayload(state, extra), null, 2),
-    );
-  }
+    })
+    : () => Promise.resolve();
   // A background mount's parent holds the read end of this process's stdout and
   // blocks on it, so one line here wakes it on the transition itself. Only the
   // states a starting mount can settle on are published; the heartbeat stays out
@@ -424,7 +488,16 @@ export async function main(argv: string[] = Deno.args) {
     extra: Record<string, unknown> = {},
   ): Promise<void> {
     if (!supervisorStatusPath) return;
-    const line = `${JSON.stringify(supervisorStatusPayload(state, extra))}\n`;
+    const line = `${
+      JSON.stringify({
+        state,
+        pid: Deno.pid,
+        mountpoint,
+        startedAt: supervisorStatusStartedAt,
+        updatedAt: new Date().toISOString(),
+        ...extra,
+      })
+    }\n`;
     const bytes = new TextEncoder().encode(line);
     try {
       for (let written = 0; written < bytes.length;) {
@@ -3404,19 +3477,6 @@ export async function main(argv: string[] = Deno.args) {
     };
   }
 
-  await reportSupervisorState("mounted").catch((error) => {
-    console.warn(`[FUSE] Unable to write mounted supervisor status: ${error}`);
-  });
-  const supervisorHeartbeat = supervisorStatusPath
-    ? setInterval(() => {
-      if (unmounting) return;
-      writeSupervisorStatus("mounted").catch(() => undefined);
-    }, 1_000)
-    : undefined;
-
-  console.log(`Mounted at ${mountpoint}`);
-  console.log("Press Ctrl+C to unmount");
-
   // Cleanup on signal
   function unmount() {
     if (unmounting) return;
@@ -3434,7 +3494,34 @@ export async function main(argv: string[] = Deno.args) {
   });
 
   // Run FUSE event loop (nonblocking: true → returns Promise)
-  const result = await fuse.symbols.fuse_session_loop(handle.session);
+  const sessionLoop = fuse.symbols.fuse_session_loop(handle.session);
+
+  // Readiness is reported here rather than earlier: the session loop is
+  // dispatched and the signal handlers are installed, so a caller that has seen
+  // `mounted` has a kernel mount that serves requests and unmounts cleanly on
+  // SIGTERM. Because the announcement carries that, the caller needs no timed
+  // confirmation after it. The guard skips the announcement when a signal has
+  // already begun tearing the mount down; a signal that lands during the
+  // announcement itself still publishes it, but that mount then unmounts
+  // through the handler installed above.
+  if (!unmounting) {
+    await reportSupervisorState("mounted").catch((error) => {
+      console.warn(
+        `[FUSE] Unable to write mounted supervisor status: ${error}`,
+      );
+    });
+  }
+  const supervisorHeartbeat = supervisorStatusPath
+    ? setInterval(() => {
+      if (unmounting) return;
+      writeSupervisorStatus("mounted").catch(() => undefined);
+    }, 1_000)
+    : undefined;
+
+  console.log(`Mounted at ${mountpoint}`);
+  console.log("Press Ctrl+C to unmount");
+
+  const result = await sessionLoop;
   console.log(`FUSE loop exited (code ${result})`);
   if (supervisorHeartbeat !== undefined) clearInterval(supervisorHeartbeat);
   await writeSupervisorStatus("exited", { exitCode: result }).catch(() => {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -265,7 +265,6 @@ export async function main(argv: string[] = Deno.args) {
       "exec-cli",
       "log-file",
       "supervisor-status",
-      "supervisor-token",
       "cfc-xattr-namespace",
       "cfc-mode",
       "cfc-writeback-state",
@@ -286,7 +285,6 @@ export async function main(argv: string[] = Deno.args) {
       "exec-cli": "",
       "log-file": "",
       "supervisor-status": "",
-      "supervisor-token": "",
       "cfc-xattr-namespace": DEFAULT_CFC_XATTR_NAMESPACE,
       "cfc-mode": "",
       "cfc-writeback-state": "",
@@ -390,8 +388,22 @@ export async function main(argv: string[] = Deno.args) {
     Deno.exit(1);
   }
   const supervisorStatusPath = String(args["supervisor-status"] ?? "");
-  const supervisorToken = String(args["supervisor-token"] ?? "");
   const supervisorStatusStartedAt = new Date().toISOString();
+  function supervisorStatusPayload(
+    state: SupervisorStatusState,
+    extra: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      state,
+      pid: Deno.pid,
+      mountpoint,
+      startedAt: supervisorStatusStartedAt,
+      updatedAt: new Date().toISOString(),
+      ...extra,
+    };
+  }
+  // The status file is the record `cf fuse status` reads later. The heartbeat
+  // refreshes it; readers take a snapshot whenever they ask.
   async function writeSupervisorStatus(
     state: SupervisorStatusState,
     extra: Record<string, unknown> = {},
@@ -399,20 +411,37 @@ export async function main(argv: string[] = Deno.args) {
     if (!supervisorStatusPath) return;
     await Deno.writeTextFile(
       supervisorStatusPath,
-      JSON.stringify(
-        {
-          state,
-          pid: Deno.pid,
-          mountpoint,
-          token: supervisorToken || undefined,
-          startedAt: supervisorStatusStartedAt,
-          updatedAt: new Date().toISOString(),
-          ...extra,
-        },
-        null,
-        2,
-      ),
+      JSON.stringify(supervisorStatusPayload(state, extra), null, 2),
     );
+  }
+  // A background mount's parent holds the read end of this process's stdout and
+  // blocks on it, so one line here wakes it on the transition itself. Only the
+  // states a starting mount can settle on are published; the heartbeat stays out
+  // of the channel. A parent that has already exited leaves no reader, which
+  // makes the write fail rather than the mount.
+  async function publishSupervisorState(
+    state: SupervisorStatusState,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    if (!supervisorStatusPath) return;
+    const line = `${JSON.stringify(supervisorStatusPayload(state, extra))}\n`;
+    const bytes = new TextEncoder().encode(line);
+    try {
+      for (let written = 0; written < bytes.length;) {
+        written += await Deno.stdout.write(bytes.subarray(written));
+      }
+    } catch {
+      // No reader: the mount continues unobserved.
+    }
+  }
+  // Record the state, then announce it, so a parent woken by the announcement
+  // finds the status file already carrying the same state.
+  async function reportSupervisorState(
+    state: SupervisorStatusState,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    await writeSupervisorStatus(state, extra);
+    await publishSupervisorState(state, extra);
   }
   try {
     await writeSupervisorStatus("starting");
@@ -446,7 +475,7 @@ export async function main(argv: string[] = Deno.args) {
     platform = await getPlatform();
     fuse = platform.openFuse();
   } catch (e) {
-    await writeFailedSupervisorStartupStatus(e, writeSupervisorStatus);
+    await writeFailedSupervisorStartupStatus(e, reportSupervisorState);
     Deno.exit(1);
   }
   const {
@@ -579,7 +608,7 @@ export async function main(argv: string[] = Deno.args) {
       console.log("Static mode: hello.txt");
     }
   } catch (e) {
-    await writeFailedSupervisorStartupStatus(e, writeSupervisorStatus);
+    await writeFailedSupervisorStartupStatus(e, reportSupervisorState);
     Deno.exit(1);
   }
 
@@ -3239,7 +3268,7 @@ export async function main(argv: string[] = Deno.args) {
     );
   } catch (e) {
     console.error(String(e));
-    await writeSupervisorStatus("failed", { error: String(e) }).catch(() => {
+    await reportSupervisorState("failed", { error: String(e) }).catch(() => {
       // Best effort; mount failure is already being reported by process exit.
     });
     Deno.exit(1);
@@ -3368,7 +3397,7 @@ export async function main(argv: string[] = Deno.args) {
     };
   }
 
-  await writeSupervisorStatus("mounted").catch((error) => {
+  await reportSupervisorState("mounted").catch((error) => {
     console.warn(`[FUSE] Unable to write mounted supervisor status: ${error}`);
   });
   const supervisorHeartbeat = supervisorStatusPath

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -321,6 +321,26 @@ export function createSupervisorStatusWriter(
   };
 }
 
+/**
+ * Report a supervisor state to both sinks. `write` records it in the status file
+ * that `cf fuse status` reads; `publish` announces it on the readiness channel a
+ * background mount's parent blocks on. The announcement goes out in a `finally`,
+ * so a failed status write cannot strand a parent waiting on the channel, and
+ * the write's error still reaches the caller.
+ */
+export async function announceSupervisorState(
+  write: SupervisorStatusWriter,
+  publish: SupervisorStatusWriter,
+  state: SupervisorStatusState,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  try {
+    await write(state, extra);
+  } finally {
+    await publish(state, extra);
+  }
+}
+
 export async function writeFailedSupervisorStartupStatus(
   error: unknown,
   writeSupervisorStatus: (
@@ -507,22 +527,19 @@ export async function main(argv: string[] = Deno.args) {
       // No reader: the mount continues unobserved.
     }
   }
-  // Record the state, then announce it, so a parent woken by the announcement
-  // finds the status file already carrying the same state. The announcement is
-  // the handshake's channel and the file is a record for `cf fuse status`, so
-  // the announcement goes out even when the record fails: publishing in a
-  // `finally` keeps a failed status write from stranding a parent that is
-  // blocked on the pipe, while the write error still reaches the caller.
-  async function reportSupervisorState(
+  // Record the state in the status file, then announce it on the pipe. See
+  // announceSupervisorState for why the announcement runs even when the record
+  // fails.
+  const reportSupervisorState = (
     state: SupervisorStatusState,
     extra: Record<string, unknown> = {},
-  ): Promise<void> {
-    try {
-      await writeSupervisorStatus(state, extra);
-    } finally {
-      await publishSupervisorState(state, extra);
-    }
-  }
+  ): Promise<void> =>
+    announceSupervisorState(
+      writeSupervisorStatus,
+      publishSupervisorState,
+      state,
+      extra,
+    );
   try {
     await writeSupervisorStatus("starting");
   } catch (error) {

--- a/packages/fuse/supervisor-status.test.ts
+++ b/packages/fuse/supervisor-status.test.ts
@@ -1,0 +1,116 @@
+// The daemon's supervisor readiness handshake, exercised through a real process.
+//
+// A background mount's parent holds the read end of the daemon's stdout and
+// blocks on it for a readiness line; `cf fuse status` later reads the status
+// file the daemon keeps beside the mount state. Both are driven by main()'s
+// writeSupervisorStatus / publishSupervisorState, which run only when
+// --supervisor-status names a path. Drive a deterministic startup failure with
+// that path set and assert the daemon both announces "failed" on its stdout
+// channel and records it in the status file.
+
+import { assert, assertEquals } from "@std/assert";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const packageDir = dirname(fromFileUrl(import.meta.url));
+const repoRoot = join(packageDir, "..", "..");
+const modPath = join(packageDir, "mod.ts");
+const decoder = new TextDecoder();
+
+interface SupervisorStatus {
+  state?: string;
+  pid?: number;
+  mountpoint?: string;
+  error?: string;
+}
+
+/** Run the daemon entrypoint and capture stdout, stderr, and exit code. */
+async function runDaemon(
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const output = await runDenoCommandWithTemporaryLock({
+    root: repoRoot,
+    args: (lockPath) => [
+      "run",
+      `--lock=${lockPath}`,
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-net",
+      modPath,
+      ...args,
+    ],
+  });
+  return {
+    code: output.code,
+    stdout: decoder.decode(output.stdout),
+    stderr: decoder.decode(output.stderr),
+  };
+}
+
+/** The last JSON readiness line the daemon announced on its stdout channel. */
+function lastReadinessLine(stdout: string): SupervisorStatus | null {
+  let last: SupervisorStatus | null = null;
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as SupervisorStatus;
+      if (typeof parsed.state === "string") last = parsed;
+    } catch {
+      // Not a readiness line.
+    }
+  }
+  return last;
+}
+
+Deno.test(
+  "daemon announces and records a startup failure through the supervisor status path",
+  async () => {
+    const tmp = Deno.makeTempDirSync({ prefix: "cf-fuse-status-test-" });
+    try {
+      // A regular file stands where the mountpoint's parent directory would be,
+      // so creating the mountpoint under it fails deterministically — before the
+      // daemon opens libfuse or touches the network — and the failure path runs
+      // anywhere the tests do.
+      const blocker = join(tmp, "not-a-dir");
+      Deno.writeTextFileSync(blocker, "x");
+      const mountpoint = join(blocker, "mnt");
+      const statusPath = join(tmp, "status.json");
+
+      const { code, stdout } = await runDaemon([
+        mountpoint,
+        "--supervisor-status",
+        statusPath,
+      ]);
+
+      assertEquals(code, 1);
+
+      // The handshake channel: the daemon announced its terminal state on stdout,
+      // which is the pipe `cf fuse mount --background` blocks on.
+      const announced = lastReadinessLine(stdout);
+      assert(announced, `no readiness line on stdout; got: ${stdout}`);
+      assertEquals(announced.state, "failed");
+      assertEquals(announced.mountpoint, mountpoint);
+      assertEquals(typeof announced.pid, "number");
+      assert(
+        typeof announced.error === "string" && announced.error.length > 0,
+        "announced failure carries an error",
+      );
+
+      // The record `cf fuse status` reads: the same terminal state, persisted to
+      // the status file the daemon writes beside the mount state.
+      const recorded = JSON.parse(
+        Deno.readTextFileSync(statusPath),
+      ) as SupervisorStatus;
+      assertEquals(recorded.state, "failed");
+      assertEquals(recorded.mountpoint, mountpoint);
+      assert(
+        typeof recorded.error === "string" && recorded.error.length > 0,
+        "recorded failure carries an error",
+      );
+    } finally {
+      Deno.removeSync(tmp, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
`cf fuse mount --background` starts a supervisor, which starts the FUSE daemon, and then has to find out whether the daemon came up. The daemon already reported the answer: it writes a readiness state — starting, mounted, failed, exiting, exited — to a status file. But a file cannot wake a reader, so both halves of the handshake stood in for the missing signal with a poll.

The mount command re-read the daemon's status file up to 200 times at 100ms intervals, waiting for `mounted`. The supervisor, separately, re-read the mount state file up to 20 times at 50ms intervals, waiting for the mount command to have written it with a matching pid. Both are now gone.

Readiness travels over a pipe. The mount command spawns the supervisor with a piped stdout and blocks reading it; the supervisor passes that descriptor to the daemon, so the daemon's readiness line reaches the command directly. The read wakes on the daemon's own announcement, so there is no interval under the wait and no attempt ceiling over it — a mount slower than twenty seconds now succeeds instead of being killed. The daemon still writes the status file, which is what `cf fuse status` reads later and what the heartbeat refreshes; only the one-shot startup transitions go to the pipe, so the heartbeat cannot flood it.

Being detached does not rule the pipe out. The descriptor is inherited at spawn, so closing the read end cannot disturb the processes holding the write end, and the mount outlives the command that started it. A daemon whose parent has gone does not die either: Deno ignores SIGPIPE and surfaces a write to a readerless pipe as an ordinary error, so the readiness write fails and the mount continues unobserved. Nothing else reaches that descriptor, because a background daemon redirects its console output into its log file and only tees to stderr when stderr is a terminal, which for a background mount it is not.

Failure is an event too, and there are two of them. End of stream means every process holding the write end has exited. The supervisor's exit means no report is coming from a daemon that cannot send one, and the command already holds it, because the supervisor is the process it spawned. Watching that exit is not redundant: the daemon inherits the write end, so a daemon orphaned by a dead supervisor holds the stream open by itself and end of stream never arrives, which would leave the command waiting forever on a mount that will never report. A daemon that fails during startup publishes its own error first, so the command now reports the cause rather than only that the process went away.

The pipe is private to one invocation, which retires a chunk of machinery. The status file is a shared namespace: a stale file from an earlier mount sits at the same path, so a reader needed a correlation token, a mountpoint check and a cross-check against the state file to tell its own child's report from a leftover. A pipe cannot carry a stale message, so the token is dead and is removed here, along with the plumbing that threaded it through six files.

The supervisor's poll is removed by inverting who owns the mount state file rather than by making the wait faster. The command used to spawn the supervisor and then write the file, so the supervisor started before the file it needed existed and had to wait for it. The supervisor spawns the daemon, so it is the only process that knows both pids; it now writes the file once and completely. The command prepares the directory and the path, because the supervisor is granted write access to that one file and nothing else. It no longer reads the file at all, so that grant is dropped.

Confirming that the mount survived keeps a window, and the reason is worth stating. The daemon reports `mounted` just before entering its FUSE session loop, so a mount that fails in the loop reports mounted and then exits. At the instant the report arrives the daemon is still running and a pid probe says so — the probe is not wrong, it is early — so a liveness check at the moment of readiness passes a dying daemon every time rather than occasionally. What distinguishes the two cases is that a dying daemon takes the supervisor down with it, and that exit is an event. The confirmation waits for it to either arrive or not: it fails the moment the supervisor goes, and otherwise costs a fixed grace period. That grace is a genuine timing bet, because nothing announces that a process intends to keep running. It is not a deadline, so a slow mount is not capped by it, and it reads no file — which matters, because the heartbeat rewrites the status file every second without atomicity, and a torn read in the sleep-and-recheck this replaces was reported as "child did not remain mounted", killing a healthy daemon.

Unreferencing the supervisor is deferred until after the handshake. `unref` stops the child from holding the command's event loop open, which is wanted once the mount is up and outlives the command, but doing it before the read means the readiness read does not hold the loop open either and the command exits mid-handshake, reporting nothing.

Cover the wiring the whole handshake rests on. Handing the daemon the supervisor's stdout is a single line, and setting it any other way leaves every unit test passing while the real command waits forever against a healthy mount, so the stdio the child is spawned with is now asserted. The readiness reader is pinned against a report split across reads, including through a multi-byte character, since a pipe splits writes at arbitrary offsets and a mountpoint name can be non-ASCII.

Record all of this in the waiting-in-tests note, which catalogues where polling legitimately stays and documents the one production loop the repository sanctions as an exception. The FUSE mount handshake is neither, and the two waits in it that are deliberately not events — the survival grace, and the child shutdown escalation, which is a policy rather than a stand-in for a missing signal — are written down with their reasons so neither reads as an oversight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make FUSE mount startup event-driven over a pipe to `cf fuse mount --background`, removing polling and timeouts. The supervisor now owns and atomically writes both the mount state and status.

- **Bug Fixes**
  - Replaced polling with a pipe-driven handshake; CLI waits on daemon output and supervisor exit with no deadline, and returns on “mounted”.
  - Announce `mounted` only after the session loop is dispatched and signal handlers installed; dropped the confirmation window, keeping a point‑in‑time liveness check.
  - Readiness is announced even if the status-file write fails; supervisor passes stdout to the child, and the CLI defers `unref()` until after the handshake.
  - Status file writes are atomic and serialized to avoid torn reads and stop heartbeats from overwriting terminal states.

- **Migration**
  - Removed `--supervisor-token`; delete any usage.
  - If invoking the supervisor/daemon directly, pipe or inherit the supervisor’s stdout so readiness reaches the parent.
  - Ownership change: CLI uses `prepareMountStatePath`; supervisor writes via `writeMountStateFile`/`recordFuseMountState` and needs only `--allow-write` for the state file.

<sup>Written for commit ee4c89f7710e8bc485c8c84af84d6e368359a7ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

