### PR TITLE
fix(fuse): generate the `.status` file, and let a reader see it change

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -548,37 +548,41 @@ The value check stays, after the trace checks, as the end-to-end statement that
 the cell really is empty. It is the weaker of the two instruments and is not what
 makes a broken disarm fail.
 
-#### The daemon's `.status` file is not a wait signal
+#### The daemon's `.status` file is a probe, not a signal
 
 The FUSE daemon keeps write statistics (`writeStats` in `packages/fuse/mod.ts`)
-and publishes them through the `.status` file at the mount root. That file looks
-like a way to wait for the daemon to report a write-path event. It is not. The
-counters it carries lag the events they describe, and reading it around a write
-shows them frozen across the open, the write, the truncate and the release, then
-jumping several counts at once.
+and publishes them through the `.status` file at the mount root. A script can
+read that file to see how many descriptors the daemon has opened, written and
+flushed. The counts it reads are the ones the daemon held when it answered, so a
+loop around `.status` would converge on the write-path event it waits for. The
+`fuse-exec.sh` suite does not use it that way — it reads `.status` once, to
+confirm the generated file is served as one coherent document, and waits on the
+events it already has better signals for. Polling `.status` would be a poll it
+can avoid.
 
-The content is a snapshot rather than a live view. `CellBridge.initStatus` bakes
-JSON into a tree node and the read callback serves that node's stored bytes, so
-the numbers a reader sees are the ones the last `updateStatus` call baked.
+That works because nothing writes `.status`. `CellBridge.initStatus` registers
+it through `FsTree.addGeneratedFile`, which hands the tree a function that
+renders the status JSON from the daemon's current counters. The callbacks that
+report the file's size run that renderer and publish what it returns, and reads
+serve the published bytes. The write path announces nothing: a flush increments
+`writeStats.flushed` and stops there. No refresh has to be ordered after a
+counter, because no refresh exists to be ordered.
 
-Refreshes do reach `.status` from the write path, but never carrying the counter
-a waiter wants. A successful flush calls `markExistingFinalized`, which reaches
-`updateStatus` through `CfcWritebackStore.deletePrepared`, `persist` and the
-store's `onChange` hook. That chain runs before `writeStats.flushed++` on every
-flush branch, so the snapshot a flush triggers always reports the count from
-before that flush. Opening and writing move their own counters with no refresh
-attached at all.
+The kernel caches are set to match. `replyEntry` and the getattr callback treat
+a generated inode as dynamic and reply with a zero entry and attribute timeout,
+so on Linux a lookup and a getattr precede each read. Publishing bumps the
+node's mtime whenever the bytes change, and `.status` reports it, so a client
+that validates its cached copy against the timestamp and the size notices a
+counter going from 9 to 10 even though the document's length did not change.
 
-Attribute caching sits on top. `.status` is a static inode, so `replyEntry` gives
-it a one-second entry and attribute timeout on Linux, and a macOS mount bounds
-staleness through an NFS attribute-cache option instead, because FUSE-T ignores
-the timeouts a reply carries. `updateStatus` assigns `node.content` and changes
-no size or mtime, so nothing invalidates a cached reader either way.
-
-Waiting on `.status` therefore means waiting for a refresh that reports the state
-before the event, through a cache with no invalidation, at a granularity coarser
-than the wait itself. Making it a real signal means ordering the refresh after
-the counters, regenerating on read, and giving a reader something to notice.
+A macOS mount cannot use those timeouts, because FUSE-T ignores the ones a reply
+carries; it bounds staleness through an NFS attribute-cache mount option
+instead, the `attrcache-timeout` default described in
+`packages/fuse/mount-options.ts`. A `.status` poll on macOS is therefore only as
+sharp as that option allows: a reader that has read the file once holds the NFS
+client's cached copy until it expires, so a count arrives a beat after the write
+that caused it. That the counts advance is settled by the `CellBridge.status`
+unit tests, which drive the tree directly and need no mount and no wait.
 
 ## Production reconnect backoff
 

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -480,6 +480,17 @@ if [ -z "$ENTITY_DIR" ]; then
   error "Timed out waiting for entity directory entry for $ENTITY_ID."
 fi
 
+# A single read is enough to prove the generated file is served as one coherent
+# document through a real getattr and read. That the counters it carries are
+# fresh and advance is settled deterministically by the CellBridge.status unit
+# tests; asserting it here would mean polling out the macOS NFS attribute cache,
+# and this suite adds no waits it can avoid.
+STATUS_FILE="$MOUNTPOINT/.status"
+path_exists "$STATUS_FILE" || error ".status was not mounted at the mount root."
+cat "$STATUS_FILE" | jq -e . >/dev/null ||
+  error ".status did not read back as a whole JSON document."
+success ".status reads as a whole JSON document"
+
 HANDLER_FILE="$RESULT_DIR/recordMessage.handler"
 LEGACY_HANDLER_FILE="$RESULT_DIR/legacyWrite.handler"
 TOOL_FILE="$RESULT_DIR/search.tool"

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -389,6 +389,45 @@ Writes are fire-and-forget: the FUSE reply is sent before the cell write
 completes, so subscription rebuilds don't block the callback chain (required to
 avoid FUSE-T crashes from `notify_inval_entry` during callbacks).
 
+### The `.status` file
+
+`.status` at the mount root reports the daemon's API URL, debug flag, connection
+state, per-space piece counts, subtree rebuild metrics, write statistics, and a
+`cfc` section carrying writeback phase counts and recent diagnostics.
+
+The file is generated rather than written. `CellBridge.initStatus` registers it
+with `FsTree.addGeneratedFile`, giving the tree a function that renders the JSON
+from the daemon's current state. Nothing on the write path refreshes it, and no
+counter has to be published before a reader can see it: a flush increments
+`writeStats.flushed` and stops there.
+
+`FsTree.refreshGenerated` runs the renderer and publishes the result as the
+node's content, and the callbacks that report the file's size call it —
+`replyEntry` and `getattr`. Reads serve the bytes that were published, never
+rendered per read. This is what keeps a reader from seeing a partial document: a
+client stops a read at the size it was last given, so bytes from a render that
+grew since then would be cut off at that size, and bytes from one that shrank
+would be padded out to it with NULs. Publishing where the size is reported keeps
+the two halves of that answer from one render.
+
+`open` then fixes those published bytes into the descriptor's handle, and every
+read on the descriptor serves them. A reader that has consumed the whole file
+issues one more read to see EOF, which a newer, longer render would otherwise
+answer with a spliced tail. A getattr carrying a descriptor reports that
+descriptor's snapshot length and its publish time both, so a stat from elsewhere
+cannot move the size or the modification time out from under a read in progress.
+
+Publishing bumps the node's mtime whenever the rendered bytes change, so a
+generated file reports when its content last changed while the rest of the mount
+reports the epoch. A status counter can change without changing the document's
+length, and a client that validates its cached copy against the timestamp and
+the size would otherwise keep serving what it holds — on macOS an NFS client
+returning a frozen `.status`, on Linux a page cache that is never invalidated.
+The moving mtime is what tells both to re-read. macOS still bounds how soon that
+happens by the mount's attribute-cache option, for the same reason rebuilt
+subtrees are; see
+[macOS: NFS client cache tuning](#macos-nfs-client-cache-tuning).
+
 See [RELIABILITY_DESIGN.md](./RELIABILITY_DESIGN.md) for the package-local plan
 to move default mutating operations toward commit-confirmed replies, bounded
 deadlines, explicit backpressure, and watchdog/degraded-mode behavior while

--- a/packages/fuse/RELIABILITY_DESIGN.md
+++ b/packages/fuse/RELIABILITY_DESIGN.md
@@ -19,9 +19,14 @@ The implementation already has several reliability foundations:
 - `handles.ts` owns per-handle write buffers, truncate state, dirty flags,
   versioning, range checks, and per-handle CFC authorization.
 - `mod.ts` schedules safety-net flushes for transports that do not reliably send
-  `flush`/`release`, and records write statistics in `.status`.
-- `cell-bridge.ts` exposes `.status`, marks the mount disconnected/read-only on
-  transport errors, and reconnects with capped exponential backoff.
+  `flush`/`release`, and keeps the write statistics that `.status` reports.
+- `cell-bridge.ts` exposes `.status` as a generated file: the write path leaves
+  it alone, and a lookup or a bare stat renders it from current state and
+  publishes what a following read serves. A getattr that carries an already-open
+  descriptor is the exception — it reports that descriptor's snapshot, size and
+  publish time both, rather than publishing again, so the descriptor's reads
+  stay consistent. It also marks the mount disconnected/read-only on transport
+  errors, and reconnects with capped exponential backoff.
 - `cell-bridge.ts` serializes and coalesces per-piece-property rebuilds, dedupes
   in-flight hydrations, stages rebuilds under pending roots and reconciles them
   onto the live subtree in place so inodes stay stable, and invalidates the

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -145,6 +145,15 @@ function getFileContent(tree: FsTree, parentIno: bigint, name: string): string {
 }
 
 /**
+ * Read `.status` the way the daemon serves it: the getattr that reports the
+ * file's size publishes a render, and the read that follows serves those bytes.
+ */
+function readStatusFile(tree: FsTree): string {
+  tree.refreshGenerated(tree.lookup(tree.rootIno, ".status")!);
+  return getFileContent(tree, tree.rootIno, ".status");
+}
+
+/**
  * Build a minimal SpaceState backed by a fake PiecesController.
  * Registers the state in bridge.spaces and bridge.knownSpaces.
  */
@@ -3032,7 +3041,7 @@ Deno.test({
     const resultIno = tree.lookup(pieceIno, "result")!;
     assertEquals(getFileContent(tree, resultIno, "content"), "Final");
 
-    const status = JSON.parse(getFileContent(tree, tree.rootIno, ".status"));
+    const status = JSON.parse(readStatusFile(tree));
     assertEquals(status.debug, false);
     assertEquals(status.rebuilds.pending, 0);
     assertEquals(status.rebuilds.completed >= 1, true);
@@ -3047,6 +3056,93 @@ Deno.test({
     const subs = state.pieceSubs.get("Status-Piece");
     if (subs) { for (const cancel of subs) cancel(); }
   },
+});
+
+function makeStatusBridge(
+  tree: FsTree,
+  statusProvider: () => Record<string, unknown>,
+): CellBridge {
+  const bridge = new CellBridge(tree, "/tmp/cf-exec", { statusProvider });
+  bridge.init({
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/test-identity.pem",
+  });
+  bridge.initStatus();
+  return bridge;
+}
+
+Deno.test("CellBridge.status reports state that moved since the last read", () => {
+  const tree = new FsTree();
+  const writes = { opened: 0, written: 0, flushed: 0 };
+  const bridge = makeStatusBridge(tree, () => ({ writes: { ...writes } }));
+
+  const readStatus = () => JSON.parse(readStatusFile(tree));
+  assertEquals(readStatus().writes, { opened: 0, written: 0, flushed: 0 });
+
+  // The write path moves these counters and tells the bridge nothing. Each
+  // read still has to see the counts as of that read.
+  writes.opened++;
+  assertEquals(readStatus().writes.opened, 1);
+
+  writes.written += 2;
+  writes.flushed++;
+  assertEquals(readStatus().writes, { opened: 1, written: 2, flushed: 1 });
+
+  bridge.setDebug(true);
+  assertEquals(readStatus().debug, true);
+});
+
+Deno.test("CellBridge.status sizes .status from the bytes a read serves", () => {
+  const tree = new FsTree();
+  let diagnostics: string[] = [];
+  makeStatusBridge(tree, () => ({ cfc: { diagnostics } }));
+
+  const statusIno = tree.lookup(tree.rootIno, ".status")!;
+  const sizeOf = () =>
+    (tree.getNode(statusIno) as { content: Uint8Array }).content.length;
+  const before = sizeOf();
+
+  // State moving on its own must not move the size, which a reader has already
+  // been given and will stop its read at.
+  diagnostics = ["denied write to piece result"];
+  assertEquals(sizeOf(), before);
+
+  // Publishing moves the size and the bytes together.
+  tree.refreshGenerated(statusIno);
+  const after = sizeOf();
+  assertEquals(after > before, true);
+  assertEquals(after, getFileContent(tree, tree.rootIno, ".status").length);
+});
+
+Deno.test("CellBridge.status renders nothing when its state moves", () => {
+  const tree = new FsTree();
+  let renders = 0;
+  const bridge = makeStatusBridge(tree, () => {
+    renders++;
+    return {};
+  });
+
+  // initStatus publishes once so the file has bytes before anyone reads it.
+  assertEquals(renders, 1);
+
+  // Rendering the document walks every space and its piece map. Nothing that
+  // moves the state it reports should pay for that — the reader does.
+  bridge.setDebug(true);
+  bridge.markDisconnected("socket closed");
+  assertEquals(renders, 1);
+});
+
+Deno.test("CellBridge.status renders when .status is read", () => {
+  const tree = new FsTree();
+  let renders = 0;
+  const bridge = makeStatusBridge(tree, () => {
+    renders++;
+    return {};
+  });
+  bridge.setDebug(true);
+
+  assertEquals(JSON.parse(readStatusFile(tree)).debug, true);
+  assertEquals(renders, 2);
 });
 
 Deno.test({

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -317,8 +317,6 @@ export class CellBridge {
   private onCfcProjectionRebuilt: (() => void) | undefined;
 
   private startedAt = new Date().toISOString();
-  /** Inode of the .status file (created by initStatus). */
-  private statusIno: bigint | null = null;
   /**
    * Set to true when a write fails due to a transport/connection error.
    * Once disconnected, all files appear read-only (EACCES on write)
@@ -345,7 +343,6 @@ export class CellBridge {
         `Will attempt reconnection in ${this._reconnectDelayMs()}ms.`,
     );
     this._scheduleReconnect();
-    this.updateStatus();
   }
 
   private _reconnectDelayMs(): number {
@@ -384,7 +381,6 @@ export class CellBridge {
           console.error(
             `[FUSE] Backend connection restored — write access resumed.`,
           );
-          this.updateStatus();
           return;
         } finally {
           await manager.runtime.dispose().catch((e) => {
@@ -430,11 +426,6 @@ export class CellBridge {
 
   setDebug(debug: boolean): void {
     this.debug = debug;
-    this.updateStatus();
-  }
-
-  refreshStatus(): void {
-    this.updateStatus();
   }
 
   private debugLog(message: string): void {
@@ -514,23 +505,19 @@ export class CellBridge {
     }
   }
 
-  /** Create the .status file at the mount root. Call once after init. */
+  /**
+   * Create the .status file at the mount root. Call once after init.
+   *
+   * The file is generated: `getStatusJson` runs when a reader asks the tree for
+   * the file's size, and no caller has to announce that a counter moved.
+   */
   initStatus(): void {
-    this.statusIno = this.tree.addFile(
+    this.tree.addGeneratedFile(
       this.tree.rootIno,
       ".status",
-      this.getStatusJson(),
+      () => this.getStatusJson(),
       "object",
     );
-  }
-
-  /** Update the .status file content in the tree. */
-  private updateStatus(): void {
-    if (this.statusIno === null) return;
-    const node = this.tree.getNode(this.statusIno);
-    if (node?.kind === "file") {
-      node.content = new TextEncoder().encode(this.getStatusJson());
-    }
   }
 
   /** Generate current status as JSON. */
@@ -1141,7 +1128,6 @@ export class CellBridge {
       pending.latestValue = args.newValue;
       pending.pieceName = args.pieceName;
       this.rebuildStats.coalesced++;
-      this.updateStatus();
       return;
     }
 
@@ -1163,7 +1149,6 @@ export class CellBridge {
           this.activePropRebuilds.size +
           this.deferredPropRebuilds.size,
       );
-      this.updateStatus();
       return;
     }
 
@@ -1180,7 +1165,6 @@ export class CellBridge {
       timer: setTimeout(() => {
         this.pendingPropRebuilds.delete(key);
         this.activePropRebuilds.add(key);
-        this.updateStatus();
         void this.enqueuePiecePropRebuild({
           cell: entry.cell,
           newValue: entry.latestValue,
@@ -1192,7 +1176,6 @@ export class CellBridge {
           spaceName: entry.spaceName,
         }).catch((e) => {
           this.rebuildStats.errors++;
-          this.updateStatus();
           console.error(
             `[${entry.spaceName}] Error rebuilding ${entry.pieceName}/${entry.propName}: ${e}`,
           );
@@ -1200,7 +1183,6 @@ export class CellBridge {
           this.activePropRebuilds.delete(key);
           const deferred = this.deferredPropRebuilds.get(key);
           this.deferredPropRebuilds.delete(key);
-          this.updateStatus();
           if (deferred) {
             this.schedulePropRebuild(deferred);
           }
@@ -1214,7 +1196,6 @@ export class CellBridge {
         this.activePropRebuilds.size +
         this.deferredPropRebuilds.size,
     );
-    this.updateStatus();
   }
 
   /**
@@ -1502,7 +1483,6 @@ export class CellBridge {
           this.rebuildStats.completed++;
           this.rebuildStats.lastDurationMs = Date.now() - startedAt;
           this.noteCfcProjectionRebuilt();
-          this.updateStatus();
           return;
         }
       }
@@ -1617,7 +1597,6 @@ export class CellBridge {
     this.rebuildStats.completed++;
     this.rebuildStats.lastDurationMs = Date.now() - startedAt;
     this.noteCfcProjectionRebuilt();
-    this.updateStatus();
     this.debugLog(`[${spaceName}] Updated ${pieceName}/${propName}`);
   }
 
@@ -1770,7 +1749,6 @@ export class CellBridge {
         this.onInvalidateInode(staleIno);
       }
     }
-    this.updateStatus();
     return true;
   }
 
@@ -2146,7 +2124,6 @@ export class CellBridge {
     });
     state.unsubscribes.push(piecesListCancel);
 
-    this.updateStatus();
     return state;
   }
 
@@ -2493,7 +2470,6 @@ export class CellBridge {
     if (this.onInvalidateInode) {
       this.onInvalidateInode(state.piecesIno);
     }
-    this.updateStatus();
   }
 
   /** Update the pieces/pieces.json manifest for a space. */

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -880,11 +880,9 @@ export class CfcWritebackStore {
   private records = new Map<string, CfcWritebackRecoveryRecord>();
   private malformedCounter = 0;
   private storagePath: string | undefined;
-  private onChange: (() => void) | undefined;
 
-  constructor(options: { storagePath?: string; onChange?: () => void } = {}) {
+  constructor(options: { storagePath?: string } = {}) {
     this.storagePath = options.storagePath;
-    this.onChange = options.onChange;
     this.load();
   }
 
@@ -1226,10 +1224,7 @@ export class CfcWritebackStore {
   }
 
   private persist(): void {
-    if (!this.storagePath) {
-      this.onChange?.();
-      return;
-    }
+    if (!this.storagePath) return;
     const slash = this.storagePath.lastIndexOf("/");
     if (slash > 0) {
       Deno.mkdirSync(this.storagePath.slice(0, slash), { recursive: true });
@@ -1241,7 +1236,6 @@ export class CfcWritebackStore {
         records: [...this.records.values()],
       }),
     );
-    this.onChange?.();
   }
 }
 

--- a/packages/fuse/handles.test.ts
+++ b/packages/fuse/handles.test.ts
@@ -6,7 +6,7 @@ import {
   MAX_VIRTUAL_FILE_SIZE,
   validateVirtualFileRange,
 } from "./handles.ts";
-import { O_RDWR } from "./platform.ts";
+import { O_RDONLY, O_RDWR } from "./platform.ts";
 
 const encoder = new TextEncoder();
 
@@ -181,4 +181,44 @@ Deno.test("HandleMap tracks CFC truncate and write authorization separately", ()
 
   assertEquals(handles.hasCfcAuthorization(fh, "truncate"), true);
   assertEquals(handles.hasCfcAuthorization(fh, "write"), true);
+});
+
+Deno.test("HandleMap buffers a read-only handle from a read snapshot", () => {
+  const handles = new HandleMap();
+  const snapshot = encoder.encode("generated once");
+  const fh = handles.open(1n, O_RDONLY, undefined, { readSnapshot: snapshot });
+
+  const handle = handles.get(fh);
+  // A read-only handle is otherwise unbuffered, and reads fall through to the
+  // node — which would render again and could disagree with this descriptor.
+  assertEquals(handleHasBufferedContent(handle), true);
+  assertEquals(handle?.buffer, snapshot);
+  // Copied, so a renderer reusing its array cannot change the served bytes.
+  assertEquals(handle?.buffer === snapshot, false);
+  assertEquals(handleHasPendingChanges(handle), false);
+});
+
+Deno.test("HandleMap leaves a read-only handle unbuffered without a snapshot", () => {
+  const handles = new HandleMap();
+  const fh = handles.open(1n, O_RDONLY, encoder.encode("stored"));
+  assertEquals(handleHasBufferedContent(handles.get(fh)), false);
+});
+
+Deno.test("HandleMap carries a snapshot's publish time on the handle", () => {
+  const handles = new HandleMap();
+  const fh = handles.open(1n, O_RDONLY, undefined, {
+    readSnapshot: encoder.encode("v1"),
+    readSnapshotMtime: 1_700_000_000_500,
+  });
+  // A getattr on this handle reports both the snapshot's size and this time, so
+  // its attributes describe one render.
+  assertEquals(handles.get(fh)?.readSnapshotMtime, 1_700_000_000_500);
+});
+
+Deno.test("HandleMap ignores a snapshot time without a snapshot", () => {
+  const handles = new HandleMap();
+  const fh = handles.open(1n, O_RDONLY, encoder.encode("stored"), {
+    readSnapshotMtime: 1_700_000_000_500,
+  });
+  assertEquals(handles.get(fh)?.readSnapshotMtime, undefined);
 });

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -40,6 +40,12 @@ export interface HandleState {
   writeTarget?: unknown;
   cfcAuthorizedOperations: Set<CfcExistingWritebackOperation>;
   cfcAuthorizationAnnotation?: CfcNodeAnnotation;
+  /**
+   * For a read-only snapshot of a generated file, when its bytes were
+   * published. A getattr on this handle reports it so the size and the
+   * modification time it carries describe the same render.
+   */
+  readSnapshotMtime?: number;
 }
 
 export function handleHasPendingChanges(
@@ -61,7 +67,13 @@ export class HandleMap {
   private nextFh = 1n;
   private handles = new Map<bigint, HandleState>();
 
-  /** Open a file handle. Copies current content into buffer if writable. */
+  /**
+   * Open a file handle. Copies current content into buffer if writable.
+   *
+   * `readSnapshot` buffers a read-only handle as well, fixing the bytes it
+   * serves for its lifetime. It is for generated files, whose published content
+   * changes under a descriptor as readers ask the tree for their size.
+   */
   open(
     ino: bigint,
     flags: number,
@@ -70,22 +82,28 @@ export class HandleMap {
       writeTarget?: unknown;
       cfcAuthorizedOperations?: CfcExistingWritebackOperation[];
       cfcAuthorizationAnnotation?: CfcNodeAnnotation;
+      readSnapshot?: Uint8Array;
+      readSnapshotMtime?: number;
     },
   ): bigint {
     const fh = this.nextFh++;
     const isWritable = (flags & O_WRONLY) !== 0 || (flags & O_RDWR) !== 0;
+    const snapshot = options?.readSnapshot;
     this.handles.set(fh, {
       ino,
       flags,
       dirty: false,
       flushing: false,
-      buffer: isWritable ? new Uint8Array(content ?? []) : new Uint8Array(0),
-      bufferValid: isWritable,
+      buffer: snapshot
+        ? new Uint8Array(snapshot)
+        : (isWritable ? new Uint8Array(content ?? []) : new Uint8Array(0)),
+      bufferValid: snapshot !== undefined || isWritable,
       truncatePending: false,
       version: 0,
       writeTarget: options?.writeTarget,
       cfcAuthorizedOperations: new Set(options?.cfcAuthorizedOperations ?? []),
       cfcAuthorizationAnnotation: options?.cfcAuthorizationAnnotation,
+      readSnapshotMtime: snapshot ? options?.readSnapshotMtime : undefined,
     });
     return fh;
   }

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -559,7 +559,6 @@ export async function main(argv: string[] = Deno.args) {
   let bridge: CellBridge | null = null;
   const cfcWritebacks = new CfcWritebackStore({
     storagePath: cfcWritebackStatePath,
-    onChange: () => bridge?.refreshStatus(),
   });
   const cfcDiagnostics: string[] = [];
 
@@ -744,6 +743,39 @@ export async function main(argv: string[] = Deno.args) {
       ),
       ownership: mountOwnership,
     });
+  }
+
+  /**
+   * The bytes an already-open descriptor serves for the generated file `ino`,
+   * and when they were published, when `fi` names such a descriptor. The kernel
+   * passes the descriptor on a getattr it issues to size a read, and omits it
+   * on a bare `stat`. Reporting both the snapshot's length and its publish time
+   * keeps the size and the modification time describing the same render.
+   */
+  function openGeneratedSnapshot(
+    fi: Deno.PointerValue,
+    ino: bigint,
+  ): { buffer: Uint8Array; mtime: number | undefined } | undefined {
+    if (!fi || !tree.isGenerated(ino)) return undefined;
+    const handle = handles.get(readFileInfo(fi).fh);
+    if (!handle || handle.ino !== ino || !handle.bufferValid) return undefined;
+    return { buffer: handle.buffer, mtime: handle.readSnapshotMtime };
+  }
+
+  /**
+   * Whether `ino` carries content the kernel must not cache: a piece inode the
+   * bridge hydrates on demand, or a generated file, which republishes its bytes
+   * whenever a reader asks for its size.
+   */
+  function isDynamicIno(ino: bigint): boolean {
+    if (tree.isGenerated(ino)) return true;
+    return Boolean(
+      bridge?.shouldPrepareDirectory(ino) ||
+        bridge?.shouldPrepareLookup(
+          tree.parents.get(ino) ?? 0n,
+          tree.getPath(ino).split("/").pop() ?? "",
+        ),
+    );
   }
 
   function recordCfcDiagnostics(messages: string[]): void {
@@ -1062,18 +1094,16 @@ export async function main(argv: string[] = Deno.args) {
     node: ReturnType<typeof tree.getNode>,
   ) {
     // These timeouts govern the Linux kernel's entry and attribute caches.
-    // Piece content inodes (under pieces/ and entities/) use 0 so every read
-    // hits our callbacks. Static inodes (root, space.json, .status) use 1s.
+    // Piece content inodes (under pieces/ and entities/) and generated files
+    // (.status) use 0 so every read hits our callbacks. Static inodes (root,
+    // space.json) use 1s.
     // FUSE-T (macOS NFS translation) ignores the timeouts a reply carries,
     // along with notify_inval_entry and notify_inval_inode. A macOS mount
     // bounds staleness with an NFS attribute-cache mount option instead; see
     // mount-options.ts.
-    const isDynamic = bridge?.shouldPrepareDirectory(ino) ||
-      bridge?.shouldPrepareLookup(
-        tree.parents.get(ino) ?? 0n,
-        tree.getPath(ino).split("/").pop() ?? "",
-      );
-    const timeout = isDynamic ? 0 : 1.0;
+    const timeout = isDynamicIno(ino) ? 0 : 1.0;
+    // This reply carries the file's size, so publish the render it sizes.
+    tree.refreshGenerated(ino);
     const entryBuf = new ArrayBuffer(ENTRY_PARAM_SIZE);
     writeEntryParam(entryBuf, {
       ino,
@@ -1186,7 +1216,7 @@ export async function main(argv: string[] = Deno.args) {
   // getattr(req, ino, fi_ptr)
   const getattrCb = new Deno.UnsafeCallback(
     { parameters: ["pointer", "u64", "pointer"], result: "void" } as const,
-    (req: Deno.PointerValue, ino: number | bigint, _fi: Deno.PointerValue) => {
+    (req: Deno.PointerValue, ino: number | bigint, fi: Deno.PointerValue) => {
       logOp("getattr", ino.toString());
       const inode = BigInt(ino);
       const node = tree.getNode(inode);
@@ -1196,19 +1226,31 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
 
+      // The kernel stops a descriptor's reads at the size this reply gives, and
+      // a descriptor serves the bytes it snapshotted at open for its whole
+      // life, so a getattr carrying one reports that snapshot's length. A
+      // getattr without one — a bare stat, and every getattr FUSE-T makes — is
+      // a reader learning the size before reading the node, so that one
+      // publishes.
+      const snapshot = openGeneratedSnapshot(fi, inode);
+      if (!snapshot) tree.refreshGenerated(inode);
+      const attr = buildStat(node, inode);
+      if (snapshot) {
+        // Report the snapshot's size and publish time together, so both
+        // describe the render this descriptor serves rather than the current
+        // one. A real snapshot always carries a time; a descriptor left empty
+        // by a truncate carries none, and reports the epoch, which matches its
+        // empty size.
+        attr.size = snapshot.buffer.length;
+        attr.mtime = snapshot.mtime;
+      }
       const statBuf = new ArrayBuffer(STAT_SIZE);
-      writeStat(statBuf, buildStat(node, inode));
+      writeStat(statBuf, attr);
 
-      const parentIno = tree.parents.get(inode) ?? 0n;
-      const isDynamic = bridge?.shouldPrepareDirectory(inode) ||
-        bridge?.shouldPrepareLookup(
-          parentIno,
-          tree.getPath(inode).split("/").pop() ?? "",
-        );
       fuse.symbols.fuse_reply_attr(
         req,
         Deno.UnsafePointer.of(new Uint8Array(statBuf)),
-        isDynamic ? 0 : 1.0,
+        isDynamicIno(inode) ? 0 : 1.0,
       );
     },
   );
@@ -1330,6 +1372,15 @@ export async function main(argv: string[] = Deno.args) {
       // Get current content for the handle buffer
       const content = node.kind === "file" ? node.content : new Uint8Array(0);
       const truncate = (flags & O_TRUNC) !== 0;
+      // Fix a generated file's bytes for the life of the descriptor, taking
+      // what the last getattr published so the descriptor serves the bytes
+      // whose size its reader was already given. A reader that has read to the
+      // end issues one more read to see EOF, which this answers too. Record
+      // when those bytes were published so the descriptor's later getattr
+      // carries a size and a modification time from the one render.
+      const snapshotGenerated = tree.isGenerated(inode) && !truncate;
+      const readSnapshot = snapshotGenerated ? content : undefined;
+      const readSnapshotMtime = snapshotGenerated ? node.mtime : undefined;
       if (isWriting && writeTarget?.kind !== "ignored") {
         const operation: CfcExistingWritebackOperation = truncate
           ? "truncate"
@@ -1344,7 +1395,13 @@ export async function main(argv: string[] = Deno.args) {
         inode,
         flags,
         truncate ? new Uint8Array(0) : content,
-        { writeTarget, cfcAuthorizedOperations, cfcAuthorizationAnnotation },
+        {
+          writeTarget,
+          cfcAuthorizedOperations,
+          cfcAuthorizationAnnotation,
+          readSnapshot,
+          readSnapshotMtime,
+        },
       );
       if (isWriting) {
         writeStats.opened++;
@@ -2221,7 +2278,7 @@ export async function main(argv: string[] = Deno.args) {
       fuse.symbols.fuse_reply_attr(
         req,
         Deno.UnsafePointer.of(new Uint8Array(statBuf)),
-        1.0,
+        isDynamicIno(inode) ? 0 : 1.0,
       );
       if (
         metadataAuthorization?.allowed &&
@@ -2455,14 +2512,12 @@ export async function main(argv: string[] = Deno.args) {
       }
       if (!result.ok) {
         console.warn(`[FUSE:CFC] rejected ${name}: ${result.reason}`);
-        bridge?.refreshStatus();
         fuse.symbols.fuse_reply_err(
           req,
           cfcWritebackXattrResultErrno(result, { enotsup: ENOTSUP }),
         );
         return;
       }
-      bridge?.refreshStatus();
       fuse.symbols.fuse_reply_err(req, 0);
     },
   );
@@ -2491,7 +2546,6 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
       cfcWritebacks.deleteAllForIno(BigInt(ino));
-      bridge?.refreshStatus();
       fuse.symbols.fuse_reply_err(req, 0);
     },
   );

--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -1,5 +1,5 @@
 // tree.test.ts — Unit tests for FsTree
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { CfcProjectionAnnotator } from "./annotations.ts";
 import { FsTree } from "./tree.ts";
 import type { JsonType } from "./types.ts";
@@ -579,4 +579,171 @@ Deno.test("clear on a missing inode is a no-op", () => {
   const before = tree.inodes.size;
   tree.clear(9_999n);
   assertEquals(tree.inodes.size, before);
+});
+
+// --- generated files (.status) -------------------------------------------
+
+Deno.test("addGeneratedFile publishes an initial render", () => {
+  const tree = new FsTree();
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    ".status",
+    () => "count=0",
+    "object",
+  );
+
+  assertEquals(tree.lookup(tree.rootIno, ".status"), ino);
+  assertEquals(tree.isGenerated(ino), true);
+
+  const node = tree.getNode(ino)!;
+  if (node.kind !== "file") throw new Error("not a file");
+  assertEquals(decoder.decode(node.content), "count=0");
+});
+
+Deno.test("refreshGenerated publishes the current render", () => {
+  const tree = new FsTree();
+  let count = 0;
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    ".status",
+    () => `count=${count}`,
+    "object",
+  );
+
+  count = 7;
+  assertEquals(decoder.decode(tree.refreshGenerated(ino)!), "count=7");
+
+  const node = tree.getNode(ino)!;
+  if (node.kind !== "file") throw new Error("not a file");
+  assertEquals(decoder.decode(node.content), "count=7");
+});
+
+Deno.test("a generated file holds its published bytes between refreshes", () => {
+  const tree = new FsTree();
+  let count = 0;
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    ".status",
+    () => `count=${count}`,
+    "object",
+  );
+  const node = tree.getNode(ino)!;
+  if (node.kind !== "file") throw new Error("not a file");
+
+  // Reads serve these bytes and stop at the size reported alongside them.
+  // State moving underneath must not change either until a refresh.
+  count = 1234;
+  assertEquals(decoder.decode(node.content), "count=0");
+  assertEquals(node.content.length, "count=0".length);
+});
+
+Deno.test("a generated file's mtime advances only when its bytes change", () => {
+  let clock = 5_000;
+  const tree = new FsTree(() => clock);
+  let count = 0;
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    ".status",
+    () => `count=${count}`,
+    "object",
+  );
+  const mtimeOf = () => (tree.getNode(ino) as { mtime: number }).mtime;
+  assertEquals(mtimeOf(), 5_000);
+
+  // A render equal to the published one is not a modification.
+  clock = 6_000;
+  tree.refreshGenerated(ino);
+  assertEquals(mtimeOf(), 5_000);
+
+  // A counter moving without changing the length still advances the mtime, so
+  // a client revalidating by attribute sees a change it could not see by size.
+  count = 9;
+  clock = 7_000;
+  tree.refreshGenerated(ino);
+  assertEquals(mtimeOf(), 7_000);
+  assertEquals(
+    decoder.decode((tree.getNode(ino) as { content: Uint8Array }).content),
+    "count=9",
+  );
+
+  // Two changes inside one clock tick still get distinct, advancing times.
+  count = 10;
+  tree.refreshGenerated(ino);
+  assertEquals(mtimeOf(), 7_001);
+});
+
+Deno.test("refreshGenerated ignores an inode that is not generated", () => {
+  const tree = new FsTree();
+  const ino = tree.addFile(tree.rootIno, "plain.txt", "hi", "string");
+  assertEquals(tree.refreshGenerated(ino), undefined);
+  assertEquals(tree.refreshGenerated(999n), undefined);
+});
+
+Deno.test("refreshGenerated returns undefined when a tracked node is gone", () => {
+  const tree = new FsTree();
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    ".status",
+    () => "{}",
+    "object",
+  );
+  // The public API keeps the generated map and the inode map in step, so this
+  // reaches past it to drop the node while leaving it tracked. The guard has to
+  // return undefined for the missing node rather than throw.
+  (tree as unknown as { inodes: Map<bigint, unknown> }).inodes.delete(ino);
+  assertEquals(tree.isGenerated(ino), true);
+  assertEquals(tree.refreshGenerated(ino), undefined);
+});
+
+Deno.test("a generated file owns its bytes against a renderer reusing its buffer", () => {
+  const tree = new FsTree();
+  const shared = new Uint8Array([1]);
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    "bytes",
+    () => shared,
+    "array",
+  );
+  const contentOf = () =>
+    (tree.getNode(ino) as { content: Uint8Array }).content;
+
+  // The published content is a copy, not the renderer's buffer.
+  assertEquals(contentOf() === shared, false);
+
+  // Mutating the renderer's own buffer does not change what a reader is served
+  // until a refresh, and the change is then seen rather than lost to an
+  // identity comparison against the same buffer.
+  shared[0] = 2;
+  assertEquals([...contentOf()], [1]);
+
+  const published = tree.refreshGenerated(ino)!;
+  assertEquals([...published], [2]);
+  assertEquals(published === shared, false);
+});
+
+Deno.test("stored files are not generated", () => {
+  const tree = new FsTree();
+  const ino = tree.addFile(tree.rootIno, "plain.txt", "hi", "string");
+  assertEquals(tree.isGenerated(ino), false);
+});
+
+Deno.test("updateFile rejects a generated file", () => {
+  const tree = new FsTree();
+  const ino = tree.addGeneratedFile(
+    tree.rootIno,
+    ".status",
+    () => "{}",
+    "object",
+  );
+  assertThrows(() => tree.updateFile(ino, "{}"), Error, "is a generated file");
+});
+
+Deno.test("removeChild forgets that an inode was generated", () => {
+  const tree = new FsTree();
+  const dir = tree.addDir(tree.rootIno, "d");
+  const ino = tree.addGeneratedFile(dir, ".status", () => "{}", "object");
+  assertEquals(tree.isGenerated(ino), true);
+  tree.removeChild(dir, ".status");
+  assertEquals(tree.isGenerated(ino), false);
+  assertEquals(tree.refreshGenerated(ino), undefined);
 });

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -19,7 +19,7 @@ import {
   cfcDirectoryEntryNameDigest,
   type CfcNodeAnnotation,
 } from "./annotations.ts";
-import type { FsNode } from "./types.ts";
+import type { FsNode, JsonType } from "./types.ts";
 
 const ROOT_INO = 1n;
 const encoder = new TextEncoder();
@@ -48,12 +48,26 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   return true;
 }
 
+/**
+ * Run a generated file's renderer and return bytes the tree owns. A string is
+ * encoded, which already yields a fresh array; a `Uint8Array` is copied, so a
+ * renderer reusing its buffer cannot mutate the published content.
+ */
+function ownedRender(render: () => Uint8Array | string): Uint8Array {
+  const rendered = render();
+  return typeof rendered === "string"
+    ? encoder.encode(rendered)
+    : new Uint8Array(rendered);
+}
+
 export class FsTree {
   inodes: Map<bigint, FsNode> = new Map();
   parents: Map<bigint, bigint> = new Map();
   paths: Map<string, bigint> = new Map();
   /** Reverse map: inode → path string (O(1) lookup). */
   private inoPaths: Map<bigint, string> = new Map();
+  /** Renderers for inodes added by `addGeneratedFile`. */
+  private generated: Map<bigint, () => Uint8Array | string> = new Map();
   private nextIno = 2n;
   private now: () => number;
 
@@ -160,6 +174,54 @@ export class FsTree {
     this.trackPath(ino, parentIno, name);
 
     return ino;
+  }
+
+  /**
+   * Add a file whose bytes are produced by `render` rather than written.
+   *
+   * The node's content is whatever `refreshGenerated` last published, and reads
+   * serve that. A client stops a read at the size it last learned, so the size
+   * a caller reports and the bytes it later serves have to come from one
+   * render: publish where the size is reported. A render returning a
+   * `Uint8Array` is copied, so a renderer reusing its buffer cannot change the
+   * published content out from under a reader.
+   */
+  addGeneratedFile(
+    parentIno: bigint,
+    name: string,
+    render: () => Uint8Array | string,
+    jsonType: JsonType,
+  ): bigint {
+    const ino = this.addFile(parentIno, name, ownedRender(render), jsonType);
+    this.generated.set(ino, render);
+    return ino;
+  }
+
+  /**
+   * Re-render a generated file and publish the result as its content.
+   *
+   * Returns the published bytes, or undefined when `ino` is not a generated
+   * file. Call this where the file's size is about to be reported, so that the
+   * size a client caches and the bytes a following read serves are one render.
+   *
+   * A render equal to the published one leaves the content and the node's mtime
+   * alone, so the mtime moves only when the bytes do, and then always forward.
+   */
+  refreshGenerated(ino: bigint): Uint8Array | undefined {
+    const render = this.generated.get(ino);
+    if (render === undefined) return undefined;
+    const node = this.inodes.get(ino);
+    if (!node || node.kind !== "file") return undefined;
+    const bytes = ownedRender(render);
+    if (bytesEqual(node.content, bytes)) return node.content;
+    this.bumpMtime(node);
+    node.content = bytes;
+    return node.content;
+  }
+
+  /** True when `ino` was added by `addGeneratedFile`. */
+  isGenerated(ino: bigint): boolean {
+    return this.generated.has(ino);
   }
 
   addCallable(
@@ -292,7 +354,13 @@ export class FsTree {
     return this.inoPaths.get(ino) ?? "/";
   }
 
-  /** Update a file node's content and optionally its jsonType. */
+  /**
+   * Update a file node's content and optionally its jsonType.
+   *
+   * Throws if `ino` is not a file, or is a generated file — a generated file's
+   * content comes from its renderer through `refreshGenerated`, so writing it
+   * directly would be overwritten and is rejected.
+   */
   updateFile(
     ino: bigint,
     content: Uint8Array | string,
@@ -301,6 +369,9 @@ export class FsTree {
     const node = this.inodes.get(ino);
     if (!node || node.kind !== "file") {
       throw new Error(`Inode ${ino} is not a file`);
+    }
+    if (this.generated.has(ino)) {
+      throw new Error(`Inode ${ino} is a generated file`);
     }
     const data = typeof content === "string"
       ? encoder.encode(content)
@@ -338,6 +409,7 @@ export class FsTree {
     }
     this.inodes.delete(ino);
     this.parents.delete(ino);
+    this.generated.delete(ino);
     this.untrackPath(ino);
   }
 
@@ -603,6 +675,7 @@ export class FsTree {
     this.unlinkFromParent(ino);
     this.inodes.delete(ino);
     this.parents.delete(ino);
+    this.generated.delete(ino);
     this.untrackPath(ino);
   }
 


### PR DESCRIPTION
The FUSE daemon publishes write statistics through a `.status` file at the mount root. It reported wrong numbers, cost the daemon real work in the middle of every write to produce them, and on macOS could hand a reader a broken document. This rebuilds how the file is served.

`CellBridge.initStatus` baked the status JSON into a tree node, and the read callback served that node's stored bytes. Keeping those bytes current was therefore something the write path had to remember, and it did so in three broken ways. A successful flush reached `updateStatus` through `CfcWritebackStore.deletePrepared`, `persist` and the store's `onChange` hook, all of which ran before `writeStats.flushed++`, so the bytes a flush baked carried the count from before that flush. Opening and writing moved their own counters with nothing baking at all. And the bake was eager and expensive: each `onChange` regenerated the whole document, walking every space and its piece map, from fifteen call sites, several on rebuild hot paths.

Generate the file on read instead. `FsTree.addGeneratedFile` registers a node whose bytes come from a renderer, and `.status` becomes one of those. This takes the work off the write path, because nothing bakes, and removes the ordering problem, because nothing is baked early. The fifteen `updateStatus` calls and the store's `onChange` hook all go away, which leaves `CfcWritebackStore` persisting its recovery records and nothing else.

Rendering on each access would break the file, though: the size a reply carries and the bytes a read serves would come from two different renders, and a client stops a read at the size it last learned, so a render that grew in between is cut off and one that shrank is padded out with NULs. Reading `.status` under write load on a FUSE-T mount returned JSON that `jq` refused, because a counter passing from 8 to 10 lengthens the document. So a generated file publishes rather than renders per access: `FsTree.refreshGenerated` stores the render as the node's content, and the callbacks that report a size — `replyEntry` and `getattr` — are the ones that call it. Reads serve what was published. `open` snapshots the published bytes into the descriptor, so its reads stay on the bytes whose size their reader was given, and the extra read a client issues to find EOF is answered from that same snapshot.

A reader also needs something to notice. `writeStat` never wrote a timestamp on either platform, so every file reported a modification time of the epoch, and a client validating its cached copy against the timestamp and the size sees neither move when a counter goes from 9 to 10. On a FUSE-T mount that froze `.status` at whatever a reader saw first; sixty writes through a real mount left the reported count at zero. So `writeStat` now writes the access, modification and change timespecs on both platforms, and a generated file reports when its content last changed. The change time advances by at least a millisecond each time the bytes differ, so two documents of the same length changing inside one clock tick still report distinct times. The rest of the mount carries no timestamp and reports the epoch.

Generated inodes join piece inodes as dynamic, so lookup, getattr and setattr reply with zero entry and attribute timeouts and each read on Linux reaches the daemon. macOS is bounded in kind as before: FUSE-T ignores the timeouts a reply carries, and the mount's NFS attribute-cache option bounds staleness there as it already does for rebuilt subtrees.

The struct offsets the timestamps are written at had almost no coverage. verify-structs.c checked Linux only and only the mtime offset, and no test called `writeStat`; macOS, the platform FUSE-T runs on, had no struct coverage at all, so pointing the darwin access-time offset at st_size — reporting a roughly 1.7 GB `.status` — left the whole suite green. All three timespec offsets are now exported and checked against the headers, and verify-stat- darwin.c adds a macOS check that needs only the system headers, not a FUSE provider.

`docs/development/waiting-in-tests.md` recorded all of this as the reason the FUSE exec suite could not use `.status` as a wait signal. The file is now an honest probe — still a poll, because the daemon has nothing with which to wake a bash script — so that section says what it is instead of why it isn't. The package README gains a section on the file's contract and one on how the struct offsets are held to the headers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate the `.status` file on read and publish bytes at size-report time so readers get coherent JSON and current counters, while removing work from the write path and fixing stale stats and broken reads on macOS.

- **New Features**
  - Generated files: `FsTree.addGeneratedFile` registers a renderer; `refreshGenerated` publishes bytes; reads serve what was published. Rendered bytes are owned (copied) so later mutations cannot change content.
  - Publishing happens where size is reported: `replyEntry` and `getattr` publish; generated inodes are dynamic via `isDynamicIno` (zero timeouts; used in lookup/getattr/setattr).
  - Descriptors: `open` snapshots published bytes and their publish time; a getattr on that handle reports both. Read-only handles buffer a copied snapshot via `readSnapshot`/`readSnapshotMtime`.
  - Generated file mtime advances only when bytes change.
  - `updateFile` rejects generated files; removing a node clears its generated state.
  - Removed `CfcWritebackStore` refresh hooks; the store only persists recovery records.
  - Docs/CLI: `.status` is a probe, not a signal; the exec suite reads it once to confirm whole-JSON reads.

- **Bug Fixes**
  - Size and mtime come from one render for a descriptor snapshot; no partial or padded reads.
  - macOS readers see whole JSON and notice same-length changes via mtime.

<sup>Written for commit 76b1c3f1f9df1200d70b87af291af401c71241fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 490s
NEW_PERF_BASELINE: step: patterns integration = 456s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 490s
NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 269s
