### PR TITLE
test(cli,fuse): assert the FUSE stale-descriptor disarm from the daem…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -399,13 +399,13 @@ converting it churns code that no run covers.
 
 `packages/cli/integration/fuse-exec.sh` drives the FUSE daemon as a separate
 process through a real mount, and observes it from bash. Its poll loops —
-`wait_for_path`, `wait_for_json`, `resolve_entity_dir`, and
-`wait_for_piece_value` — stay polls.
+`wait_for_path`, `wait_for_json`, `resolve_entity_dir`, `wait_for_piece_value`,
+`wait_for_trace_line` and `resolve_traced_write_fh` — stay polls.
 
 There is no event channel to convert them to. The state each loop waits on lives
-in another process: the daemon's tree for the path and JSON loops, and the
-server's cell for the value loop. Bash has no callback to resolve a `defer()`
-from.
+in another process: the daemon's tree for the path and JSON loops, the server's
+cell for the value loop, and the daemon's log file for the two trace loops. Bash
+has no callback to resolve a `defer()` from.
 
 Watching the filesystem does not substitute for one. A mounted path appears
 because the daemon added a node to its own tree, and that is not a filesystem
@@ -439,29 +439,114 @@ existing is not the same as its content being final. Those gaps belong to
 until each converges, each carrying its own timeout. What is left for the script
 directly is one check that the daemon survived the handshake.
 
+#### The stale-descriptor assertion reads the daemon's trace, not the cell
+
 The stale-descriptor assertion — that truncating a path does not let an already
-open descriptor write its old buffer back — waits on `wait_for_piece_value`
-alone. This looks like it needs a delay, because it asserts that something does
-not happen. It does not, because a descriptor that could write late is a
-descriptor that has already written.
+open descriptor write its old buffer back — asserts that something does not
+happen. It needs no delay, but the reason is not the one an earlier version of
+this document gave.
 
 Both truncate paths — `open` with `O_TRUNC` on Linux, and the handle-less
 `setattr` that FUSE-T issues on macOS — reach `handles.truncateByIno`, which
-empties the buffer of every handle on the inode and clears both `dirty` and
-`truncatePending` on the one that is not the truncating handle. `flushHandle`,
-`flushCb` and `releaseCb` all gate on that pair, so the disarmed descriptor is
-inert. A descriptor that stayed armed instead flushes from the callback the
-kernel sends on `close()`, which the flush callback issues in the same tick when
-the handle is dirty. Its write targets the same cell as the truncate's own write
-and is issued after it, so it lands last and the value settles on the stale
-content rather than `""`.
+empties the buffer of every handle on the inode and clears `dirty` on all of
+them, leaving `truncatePending` set only on the truncating handle.
+`flushHandle`, `flushCb` and `releaseCb` all gate on `dirty || truncatePending`,
+so a descriptor with both clear is inert. A descriptor that stayed armed instead
+flushes from the callback the kernel sends on `close()`.
 
-The deferred flush that every write arms, `scheduleFlush(handle, 500)`, is the
-one path that could fire after the wait, and it cannot resurrect anything.
-`truncateByIno` does not cancel it, so it does fire around half a second later —
-into `flushHandle`'s guard, which the disarm has already closed. In the armed
-case it never gets that far, because the flush callback calls
-`clearScheduledFlush` before flushing.
+The cell value cannot carry that assertion, for two separate reasons.
+
+The first is that the value cannot see the likeliest regression at all.
+`truncateByIno` empties the buffer of every handle on the inode unconditionally
+and gates only `truncatePending`, so a descriptor left armed holds an empty
+buffer and flushes `""` — byte-identical to what the truncate wanted. Drop the
+`{ pendingFh }` argument at any of the three call sites in `mod.ts` and every
+handle arms; the descriptor then writes back on `close()`, and a check on the
+settled value passes every single time. That regression also passes every test
+in `handles.test.ts`, which calls `truncateByIno` directly and so never
+exercises a call site — and which blesses the argument-less form besides.
+
+The second applies when the buffer does survive to be written. The armed
+descriptor's write and the truncate's write are then two fire-and-forget
+optimistic transactions racing for the same cell: `PieceController.set` calls
+`runtime.editWithRetry`, which applies the write to a transaction synchronously
+and then commits asynchronously, and a commit that loses a conflict re-runs the
+callback and re-applies its own value. The value settles on whichever write
+reaches the server second, and nothing in the daemon orders that. Issue order
+makes the stale write the likely winner, but "likely" is what a test must not
+rest on.
+
+Waiting for the truncate's `""` to land before closing the descriptor does not
+rescue the value check either: it makes the cell hold `""` at the moment of the
+close, so a poll for `""` succeeds before the stale write could arrive. Any
+"the value stays `""`" check needs a barrier proving the stale write has landed
+if it was going to, and the retry-on-conflict behavior above means no later
+write supplies one — a write issued after the stale write can still commit
+before it.
+
+So the assertion observes the disarm where it happens, in the daemon's
+`[write-trace]` log. `releaseCb` traces the handle's `dirty`, `flushing` and
+`pending` fields before it decides anything, so that one line states whether
+`close()` found the descriptor armed. It says so on either truncate path, and
+whichever callback ends up doing the flushing. The script resolves the handle
+number from the `write` line its own `printf` produced, waits for that handle's
+`release` line, and requires it to report `pending=false` — the gate itself —
+and `flushing=false`, since a flush already in flight carries the buffer it
+copied when it started, which the truncate cannot recall.
+
+The write and the truncate have to reach the descriptor's handle with no flush
+between them, or the buffer never survives to the close the assertion is about.
+That is why the script issues both under one redirect of the descriptor's fd
+rather than writing through a transient `>&9`. On Linux the kernel sends a FUSE
+flush on every `close()`, including the `close()` of the duplicate fd a
+transient redirect makes and then drops when it ends — so `printf … >&9` would
+flush the buffered write before the truncate ran, and the release would report a
+handle that was never armed across a truncate at all. Grouping the write and the
+truncate keeps the buffer on the handle until the group ends, after the truncate
+has disarmed it, so every flush of that handle happens post-disarm. macOS
+does not forward the flush on that duplicate close, so the grouping is a no-op
+there and the write stays buffered until the real close either way.
+
+One case escapes that line: a flush that started and finished before `release`
+arrived clears the same fields the disarm clears. So the script also requires no
+`flush-fire` line for the handle. `flushCb` traces `flush-fire` only for a handle
+that got past the gate, which is exactly the case the release line would have
+lost. Neither check subsumes the other. Between them they catch the descriptors
+`flushCb` flushed and the ones `releaseCb` flushed, which is every descriptor
+this sequence can arm.
+
+Waiting for `release` is what makes this an observation rather than a guess.
+`close()` sends `flush` and blocks on its reply before the kernel queues
+`release`, and the daemon runs its callbacks on one thread through
+`fuse_session_loop`, appending trace lines in that order. A `release` line for a
+handle therefore cannot appear before that handle's flush decision has been
+traced. The release check does not depend on `flush` being delivered; only the
+supplementary `flush-fire` check does, and it is the one whose job the release
+line already covers when `flush` is missing.
+
+Both checks do depend on `release` being delivered, and one platform does not
+deliver it: `scheduleFlush(handle, 500)` exists because Docker Desktop's VirtioFS
+does not forward `flush` or `release` through a FUSE-T mount. Run the suite
+there and it fails on the wait for the release line rather than reporting a
+broken disarm. CI runs it on Linux against libfuse3, which delivers both.
+
+That deferred flush is the one path the trace cannot see at all: the timer calls
+`flushHandle` directly, tracing nothing. It cannot resurrect anything, because
+`truncateByIno` has already closed `flushHandle`'s guard by the time it fires —
+half a second after a write the script follows within three syscalls. The window
+where it could pick up a still-armed buffer is not reachable from this sequence,
+so nothing here observes it; it is out of the assertion's reach rather than
+covered by it.
+
+The `flush-fire` check passes by a line being absent, so a reword in `mod.ts`
+would quietly turn it into a no-op that still passes. The other two lines fail
+loudly if reworded — the script cannot resolve the handle, or times out waiting
+for the release line — but they fail far from the cause. `mod.test.ts` pins the
+shape of all three lines, so a reword fails there, naming what it broke.
+
+The value check stays, after the trace checks, as the end-to-end statement that
+the cell really is empty. It is the weaker of the two instruments and is not what
+makes a broken disarm fail.
 
 #### The daemon's `.status` file is not a wait signal
 

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -238,6 +238,113 @@ wait_for_pattern_identity_change() {
   error "Timed out waiting for the FUSE source update to change pattern identity."
 }
 
+# The daemon writes its `[write-trace]` lines to the log named in the mount
+# output. The lines are emitted from the FUSE callbacks themselves, in the
+# order the single-threaded session loop runs them, so the log records what the
+# daemon decided rather than what the decision eventually did to a cell.
+trace_line_count() {
+  if [ ! -f "$DAEMON_LOG" ]; then
+    printf '0\n'
+    return 0
+  fi
+  wc -l <"$DAEMON_LOG" | tr -d ' '
+}
+
+trace_since() {
+  local mark="$1"
+  tail -n "+$((mark + 1))" "$DAEMON_LOG" 2>/dev/null || true
+}
+
+trace_contains() {
+  local mark="$1"
+  local needle="$2"
+  local trace
+  trace=$(trace_since "$mark")
+
+  [[ "$trace" == *"$needle"* ]]
+}
+
+# Match a whole trace line, so `fh=3` cannot satisfy a search for `fh=33`.
+trace_contains_line() {
+  local mark="$1"
+  local line="$2"
+  local trace
+  trace=$(trace_since "$mark")
+
+  [[ $'\n'"$trace"$'\n' == *$'\n'"$line"$'\n'* ]]
+}
+
+wait_for_trace_line() {
+  local mark="$1"
+  local needle="$2"
+  local timeout_seconds="${3:-20}"
+  local started_at
+  started_at=$(date +%s)
+
+  while true; do
+    if trace_contains "$mark" "$needle"; then
+      return 0
+    fi
+    if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  error "Timed out waiting for daemon trace line: $needle"
+}
+
+assert_trace_line_absent() {
+  local mark="$1"
+  local line="$2"
+  local message="$3"
+
+  if trace_contains_line "$mark" "$line"; then
+    error "$message"
+  fi
+}
+
+# Print the daemon's release trace line for a handle. `releaseCb` traces the
+# handle's dirty/flushing/pending state as it found it, before making its own
+# flush decision, so the line states what close() saw regardless of which
+# callback ends up doing the flushing.
+trace_release_line() {
+  local mark="$1"
+  local fh="$2"
+
+  trace_since "$mark" |
+    sed -n "s/^\(\[write-trace\] release fh=$fh .*\)$/\1/p" |
+    tail -n 1
+}
+
+# Report the handle number the daemon assigned to the descriptor that wrote
+# `size` bytes at offset 0 since `mark`. The write callback traces its line
+# before replying, so the line is in the log once the write() has returned.
+resolve_traced_write_fh() {
+  local mark="$1"
+  local size="$2"
+  local timeout_seconds="${3:-20}"
+  local started_at
+  started_at=$(date +%s)
+  local fh
+
+  while true; do
+    fh=$(trace_since "$mark" |
+      sed -n "s/^\[write-trace\] write fh=\([0-9][0-9]*\) size=$size offset=0$/\1/p" |
+      tail -n 1)
+    if [ -n "$fh" ]; then
+      printf '%s\n' "$fh"
+      return 0
+    fi
+    if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  return 1
+}
+
 read_piece_value_or_default() {
   local path="$1"
   local fallback="$2"
@@ -331,6 +438,11 @@ case "$MOUNT_PID" in
     error "Could not parse fuse daemon PID from mount output."
     ;;
 esac
+
+DAEMON_LOG=$(printf '%s\n' "$MOUNT_OUTPUT" | sed -n 's/^[[:space:]]*log:[[:space:]]*//p')
+if [ -z "$DAEMON_LOG" ]; then
+  error "Could not parse fuse daemon log path from mount output."
+fi
 
 # 'cf fuse mount --background' returns only after the daemon has reported the
 # 'mounted' supervisor state and been confirmed alive. The daemon reports that
@@ -528,16 +640,70 @@ wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE + 1))"
 success "Legacy handler write-through still works"
 
 wait_for_path "$INPUT_LAST_MESSAGE"
+
+# `handles.write` overlays the buffer the open seeded from the file, so the
+# stale value is this content over whatever tail of the old value outlives it.
+# The assertions below read the daemon's trace and do not depend on which.
+STALE_CONTENT="open-stale-descriptor"
+STALE_TRACE_MARK=$(trace_line_count)
+
+# Write and truncate under one sustained redirect of fd 9. On Linux the kernel
+# sends FUSE flush on every close(), and `printf >&9` closes a dup of fd 9 when
+# the redirect ends — which would flush the descriptor's buffered write before
+# the truncate ever runs, defeating the point of the test. Redirecting the whole
+# group keeps fd 9's buffered write on the handle until the group ends, so every
+# flush of it happens after the truncate has disarmed it.
 exec 9<> "$INPUT_LAST_MESSAGE"
-printf 'open-stale' >&9
-: > "$INPUT_LAST_MESSAGE"
+{
+  printf '%s' "$STALE_CONTENT"
+  : > "$INPUT_LAST_MESSAGE"
+} >&9
 exec 9>&-
-# The truncate empties the buffer of every descriptor open on this inode, which
-# disarms the one opened above. A descriptor that stayed armed is left dirty, and
-# a dirty handle flushes in the same tick as the callback the kernel sends on
-# close(), so its write is issued before the close returns. That write reaches the
-# cell after the truncate's own write, so lastMessage settles on 'open-stale' and
-# this wait reports it rather than reaching "".
+
+# The write above leaves fd 9's handle holding the stale content and marked
+# dirty. The truncate empties the buffer of every descriptor open on this inode
+# and clears `dirty` on all of them, and leaves `truncatePending` set only on
+# the truncating handle. `dirty || truncatePending` is what `flushHandle`,
+# `flushCb` and `releaseCb` gate on, so clearing both is what makes fd 9's
+# handle inert.
+#
+# `releaseCb` traces the handle's state before deciding anything, so its line
+# reports whether close() found the descriptor armed, on either truncate path
+# and whichever callback does the flushing. The cell value cannot report that;
+# `docs/development/waiting-in-tests.md` records why.
+STALE_FH=$(resolve_traced_write_fh "$STALE_TRACE_MARK" "${#STALE_CONTENT}") ||
+  error "Could not resolve the handle the daemon assigned to fd 9."
+
+wait_for_trace_line "$STALE_TRACE_MARK" "[write-trace] release fh=$STALE_FH "
+STALE_RELEASE_LINE=$(trace_release_line "$STALE_TRACE_MARK" "$STALE_FH")
+
+if [[ "$STALE_RELEASE_LINE" != *" pending="* ]] ||
+  [[ "$STALE_RELEASE_LINE" != *" flushing="* ]]; then
+  error "Daemon release trace no longer reports flushing/pending: $STALE_RELEASE_LINE"
+fi
+
+# `pending` is `dirty || truncatePending`, the pair every flush path gates on.
+if [[ "$STALE_RELEASE_LINE" != *" pending=false"* ]]; then
+  error "Truncate left the open descriptor armed at close(). Daemon traced: $STALE_RELEASE_LINE"
+fi
+
+# A flush already in flight carries the buffer it copied when it started, which
+# the truncate cannot recall.
+if [[ "$STALE_RELEASE_LINE" != *" flushing=false"* ]]; then
+  error "A flush was already in flight for the descriptor at close(). Daemon traced: $STALE_RELEASE_LINE"
+fi
+
+# The release line alone would miss a descriptor whose flush had already
+# finished by the time release arrived, which clears the same fields the disarm
+# does. `flushCb` traces `flush-fire` only for a handle that got past the gate,
+# so its absence rules that out. close() sends flush before release and the
+# daemon runs its callbacks on one thread, so a traced release means the flush
+# decision is already traced too.
+assert_trace_line_absent "$STALE_TRACE_MARK" \
+  "[write-trace] flush-fire fh=$STALE_FH" \
+  "Truncate left the open descriptor armed: the daemon flushed fh=$STALE_FH on close()"
+success "Path truncate disarms an already-open descriptor's buffered write"
+
 wait_for_piece_value "lastMessage" '""'
 success "Path truncate clears stale open write handles"
 

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -264,6 +264,41 @@ Deno.test("mounted is announced only after the session loop and signal handlers"
   );
 });
 
+Deno.test("write-trace lines the FUSE integration suite reads keep their shape", async () => {
+  const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
+
+  // `packages/cli/integration/fuse-exec.sh` asserts that truncating a path
+  // disarms an already-open descriptor by reading these three lines out of the
+  // daemon log. It resolves the handle from the `write` line, requires the
+  // `release` line to report the handle disarmed, and requires no `flush-fire`
+  // line for that handle. That last check is satisfied by a line being absent,
+  // so rewording it turns the check into a no-op that still passes. Pin the
+  // shapes here, where a reword fails and names what it broke.
+  const tracedLines = [
+    "console.log(`[write-trace] write fh=${fh} size=${sz} offset=${off}`);",
+    "console.log(`[write-trace] flush-fire fh=${fh}`);",
+    "[write-trace] release fh=${fh} dirty=${handle.dirty} flushing=${handle.flushing} pending=${",
+  ];
+
+  for (const line of tracedLines) {
+    assert(
+      source.includes(line),
+      `mod.ts no longer emits the trace line fuse-exec.sh reads: ${line}`,
+    );
+  }
+
+  // The release line is only a verdict because it reports the handle's state as
+  // releaseCb found it. Tracing it after the flush decision would report state
+  // that decision had already changed.
+  assertAppearsBeforeAfter(
+    source,
+    'logOp("release"',
+    "[write-trace] release fh=${fh} dirty=${handle.dirty}",
+    "if (handle && handleHasPendingChanges(handle) && bridge) {",
+    "release trace precedes the flush decision",
+  );
+});
+
 Deno.test("namespace write failures use shared outage accounting", async () => {
   const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
 


### PR DESCRIPTION
…on's trace

The FUSE exec suite guards a write-back hazard: opening a descriptor on a mounted value file, writing through it, truncating the same path, then closing the descriptor must not resurrect the written value. `handles.truncateByIno` prevents that by emptying the buffer of every handle on the inode, clearing `dirty` on all of them, and leaving `truncatePending` set only on the truncating handle. `dirty || truncatePending` is what every flush path gates on, so clearing both is what makes the descriptor inert.

The assertion read only the cell's settled value, and could pass while that disarm was broken. There are two reasons, both reproduced against a real mount.

The first is that the value cannot see the likeliest regression at all. `truncateByIno` empties every handle's buffer whether or not it disarms the handle, so a descriptor left armed flushes an empty buffer and writes back the same "" the truncate wanted. Dropping the `{ pendingFh }` argument at one of the three call sites leaves `truncatePending` set on every handle on the inode, and the suite passed three runs out of three against that daemon. The unit tests pass it too: they call `truncateByIno` directly and so never exercise a call site, and one of them blesses the argument-less form.

The second applies when the buffer does survive to be written. The stale write and the truncate's own write then race for the same cell as two fire-and-forget optimistic transactions, and the one reaching the server second re-applies its value on conflict retry, so the value settles on an arrival order the daemon does not control. Waiting longer does not address this, which is why the delay that once sat here was removed. Waiting for the truncate's "" to land first does not either: it makes the cell hold "" at the moment of the close, so a poll for "" succeeds before a stale write could arrive.

Assert the disarm from the daemon's own write trace instead. `releaseCb` traces the handle's dirty, flushing and pending fields before it decides anything, so that line reports what close() found, on either truncate path and whichever callback ends up doing the flushing. The suite resolves the handle from the `write` line its own printf produced, waits for that handle's `release` line, and requires it to report `pending=false` (the gate) and `flushing=false` (no flush already carrying the buffer it copied when it started). A shape check first rejects a release line that no longer reports those fields, so a trace-format change fails with its own message rather than masquerading as a broken disarm.

The one case the release line misses — a flush that started and finished before release arrived, clearing the same fields the disarm clears — is covered by also requiring no `flush-fire` line for the handle, which `flushCb` traces only for a handle that got past the gate.

Waiting for the release line is what makes these observations rather than guesses. close() sends flush and blocks on its reply before the kernel queues release, and the daemon runs its callbacks on one thread, so a traced release means the flush decision is already traced.

Keep the value check afterwards as the end-to-end statement that the cell really is empty. Pin the three trace lines in `mod.test.ts`, and assert that the release line is traced before the flush decision, since that ordering is what makes it a verdict; the `flush-fire` check passes by a line being absent, so a reword would otherwise turn it into a no-op that still passes.

Both broken daemons now fail every run, and the clean daemon passes. Record the mechanism, and the Docker-Desktop/FUSE-T caveat that the checks depend on release being delivered, in `docs/development/waiting-in-tests.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the FUSE stale-descriptor test by asserting the disarm from the daemon’s `[write-trace]` logs and fixing Linux by issuing write+truncate under a single sustained fd redirect. Keeps the end-to-end value check and adds a temporary watchdog for hydration hangs.

- **Bug Fixes**
  - `packages/cli/integration/fuse-exec.sh`: read daemon log path from mount output; add trace helpers; resolve `fh` from `write`; wait for `release fh=<id>`; require `pending=false` and `flushing=false`; assert no `flush-fire`; group write+truncate under one fd; keep the value check.
  - `packages/cli/integration/fuse-exec.sh` [temporary]: hydration-hang watchdog and failure snapshots at 150s and 300s.
  - `packages/fuse/mod.test.ts`: pin shapes of `write`, `flush-fire`, and `release` trace lines; assert the `release` trace precedes the flush decision.
  - `docs/development/waiting-in-tests.md`: document the trace-based verdict, single-threaded ordering, the Docker Desktop/FUSE-T caveat (no `flush`/`release`), and the Linux fd-redirect requirement.

<sup>Written for commit 1df7c72355a3dfc5d36cf854cb40e35b57f8460e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

