### PR TITLE
fix(utils): make `toMatchObjectIgnoringSymbols` actually compare values

### DIFF
--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1900,11 +1900,11 @@ describe("setup/start", () => {
       { input: 10 } as any,
       resultCell,
     );
-    // Not started yet; result still aliases internal and shows previous value
+    // Not started yet; the result still aliases the reused pattern's
+    // internals, so the fresh argument value is already visible through the
+    // alias chain on read.
     const rawValue = resultCell.get();
-    expect(rawValue).toMatchObjectIgnoringSymbols({
-      output: { $alias: { partialCause: "output", path: [] } },
-    });
+    expect(rawValue).toMatchObjectIgnoringSymbols({ output: 10 });
 
     // Verify the pattern identity pointer is present after setup without
     // passing the pattern (it was reused from the stored pointer).

--- a/packages/utils/src/equal-ignoring-symbols.ts
+++ b/packages/utils/src/equal-ignoring-symbols.ts
@@ -69,7 +69,7 @@ expect.extend({
 
     // Implement partial matching logic similar to toMatchObject
     const matches = (obj: unknown, subset: unknown): boolean => {
-      if (subset === obj) return true;
+      if (Object.is(subset, obj)) return true;
       if (
         typeof subset !== "object" || subset === null ||
         typeof obj !== "object" || obj === null
@@ -78,9 +78,8 @@ expect.extend({
       }
 
       for (const key in subset) {
-        if (!(key in subset)) return false;
         if (!(key in obj)) return false;
-        const objValue = (subset as Record<string, unknown>)[key] as unknown;
+        const objValue = (obj as Record<string, unknown>)[key] as unknown;
         const subsetValue = (subset as Record<string, unknown>)[key] as unknown;
         if (!context.equal(objValue, subsetValue)) {
           // For nested objects, apply partial matching

--- a/packages/utils/test/equal-ignoring-symbols.test.ts
+++ b/packages/utils/test/equal-ignoring-symbols.test.ts
@@ -212,6 +212,57 @@ describe("toMatchObjectIgnoringSymbols matcher", () => {
     }).toThrow();
   });
 
+  it("should fail when a property value differs", () => {
+    const obj1 = {
+      name: "test1",
+      [testSymbol1]: "ignored",
+    };
+
+    const obj2 = {
+      name: "test2",
+    };
+
+    expect(() => {
+      expect(obj1).toMatchObjectIgnoringSymbols(obj2);
+    }).toThrow();
+  });
+
+  it("should fail when a nested property value differs", () => {
+    const obj1 = {
+      user: {
+        name: "John",
+        [testSymbol1]: "ignored",
+        settings: {
+          theme: "dark",
+        },
+      },
+    };
+
+    const obj2 = {
+      user: {
+        name: "John",
+        settings: {
+          theme: "light",
+        },
+      },
+    };
+
+    expect(() => {
+      expect(obj1).toMatchObjectIgnoringSymbols(obj2);
+    }).toThrow();
+  });
+
+  it("should fail when a number value differs", () => {
+    expect(() => {
+      expect({ value: 1 }).toMatchObjectIgnoringSymbols({ value: 2 });
+    }).toThrow();
+  });
+
+  it("should treat a NaN value as matching NaN", () => {
+    expect({ value: NaN, [testSymbol1]: "ignored" })
+      .toMatchObjectIgnoringSymbols({ value: NaN });
+  });
+
   it("should include custom failure messages for partial matches", () => {
     let message: string | undefined;
     try {


### PR DESCRIPTION
Part of an audit for `===` used where `Object.is` semantics were intended (the system's value-equality contract — `valueEqual`, `deepEqual`, the content hash — treats `NaN` as self-equal and `0`/`-0` as distinct).

## The bug

The partial-match loop in `toMatchObjectIgnoringSymbols` read **both** sides of every property comparison from `subset`, so each leaf comparison was a value against itself: the matcher passed for any two objects sharing keys, regardless of values. The `key in subset` guard inside a `for key in subset` loop was likewise vacuous. (The pre-existing tests only exercised missing-key failures, never a value mismatch, which is how this survived.)

## The fix

- Leaf values now come from the object under test; the vacuous guard is dropped.
- The identity fast path is `Object.is` rather than `===`, matching `valueEqual`/`deepEqual` primitive semantics.

## Fallout repaired

One consumer assertion had rotted invisibly behind the vacuous matcher: `runner.test.ts` "setup without pattern reuses previous pattern" pinned a raw `$alias` structure from before reads resolved alias chains. It now asserts the resolved value — which also demonstrates the reused pattern's wiring is live before `start()` (the fresh argument is visible through the alias chain). The other two `toMatchObjectIgnoringSymbols` call sites pass against the real matcher unchanged.

## Tests

New value-mismatch guard tests (top-level, nested, numeric) plus NaN self-matching; the mismatch tests fail against the old matcher. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `toMatchObjectIgnoringSymbols` matcher to compare real values and use `Object.is`. This removes false positives and honors `NaN` equality and `+0`/`-0` distinction.

- **Bug Fixes**
  - Read property values from the tested object; remove the vacuous key guard.
  - Use `Object.is` for the identity fast path to match `valueEqual`/`deepEqual`.
  - Add mismatch tests (top-level, nested, numeric) and a `NaN` self-match case.
  - Update a `packages/runner` test to assert the resolved alias value before `start()` (`{ output: 10 }`).

<sup>Written for commit 86ce8c4295e11b2ba25565ebd434ea2c15b5ba01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

