### PR TITLE
fix(data-model): don't count an untouched NaN leaf as a canonicalization change

### DIFF
--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -134,7 +134,9 @@ function canonicalizeSchemaKeyOrder(value: unknown): unknown {
     let changed = false;
     const mapped = value.map((element) => {
       const canon = canonicalizeSchemaKeyOrder(element);
-      if (canon !== element) changed = true;
+      // `Object.is`, not `===`: an untouched `NaN` leaf comes back as the
+      // same value, and `NaN !== NaN` would falsely count it as a change.
+      if (!Object.is(canon, element)) changed = true;
       return canon;
     });
     return changed ? mapped : value;
@@ -148,7 +150,8 @@ function canonicalizeSchemaKeyOrder(value: unknown): unknown {
     const key = sortedKeys[i];
     if (key !== currentKeys[i]) changed = true;
     const canon = canonicalizeSchemaKeyOrder(obj[key]);
-    if (canon !== obj[key]) changed = true;
+    // `Object.is`, not `===`: see the array case above.
+    if (!Object.is(canon, obj[key])) changed = true;
     out[key] = canon;
   }
   if (!changed) return value;

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -121,6 +121,30 @@ describe("schema-hash", () => {
           expect(result).toBe(schema);
         });
 
+        it("preserves identity for an already-canonical schema holding NaN", () => {
+          // `NaN` never `===`-equals itself, so an identity-change check
+          // spelled `!==` spuriously reports the untouched leaf as changed
+          // and clones (and re-registers) the whole schema.
+          const schema = toDeepFrozenSchema({
+            default: NaN,
+            title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
+            type: "number",
+          }) as JSONSchemaObj;
+          const result = callIntern(schema);
+          expect(result).toBe(schema);
+        });
+
+        it("preserves identity for an already-canonical schema holding NaN in an array", () => {
+          // As above, via the array (`examples`) canonicalization branch.
+          const schema = toDeepFrozenSchema({
+            examples: [NaN],
+            title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
+            type: "number",
+          }) as JSONSchemaObj;
+          const result = callIntern(schema);
+          expect(result).toBe(schema);
+        });
+
         it("uses a never-before-encountered, already-canonical mutable schema by reference", () => {
           // As above: content-unique, with keys already in canonical order, so
           // it is frozen in place and returned by reference.


### PR DESCRIPTION
Part of an audit for `===` used where `Object.is` semantics were intended.

## The bug

`canonicalizeSchemaKeyOrder()` tracks whether a sub-value came back different so an already-canonical schema is returned by reference, preserving `internSchema()`'s same-reference contract. That tracking was spelled `!==`, and `NaN !== NaN`, so any schema carrying a `NaN` leaf (e.g. a `default` or an `examples` entry) was reported as changed on every canonicalization: interning minted a needless deep-frozen clone and registered both objects in the intern table.

The hash itself was never wrong — it is computed before canonicalization and is key-order-insensitive — so the damage was identity churn and contract violation, not cross-runtime divergence. `-0` was never affected: primitives are returned by reference, and `-0 !== -0` is `false`.

## The fix

Both change-tracking comparisons (array branch and object branch) now use `Object.is`.

## Tests

Two guard tests pin the identity contract for NaN-bearing schemas (plain property and array element); both fail against the previous code, across both `wantSchemaAndHash` variants. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schema canonicalization in `packages/data-model` to correctly handle `NaN` leaves, preserving identity in `internSchema()` and preventing unnecessary cloning during interning. Hashing behavior remains unchanged.

- **Bug Fixes**
  - Use `Object.is` for change checks in array and object branches of `canonicalizeSchemaKeyOrder()`, so an untouched `NaN` is not counted as a change.
  - Add tests that pin identity for schemas with `NaN` in a property and within `examples` arrays.

<sup>Written for commit 52784c0318faad652eac28c3c444eedf5e35302d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

