### PR TITLE
fix(runner): use `Object.is` semantics where `===` conflated NaN / negative zero

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1735,7 +1735,9 @@ export class CellImpl<T extends FabricValue>
           this.runtime,
         )
       )
-      : array.indexOf(ref as ElemT);
+      // Primitives match by `Object.is` (`NaN` is findable; `0` and `-0` are
+      // distinct), unlike `indexOf`'s `===`.
+      : array.findIndex((item) => Object.is(item, ref));
     if (index === -1) {
       return;
     }
@@ -1767,7 +1769,8 @@ export class CellImpl<T extends FabricValue>
           this.tx,
           this.runtime,
         )
-        : item !== ref
+        // As in `remove()`: primitives match by `Object.is`.
+        : !Object.is(item, ref)
     ) as unknown as T;
     this.set(newArray);
   }

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -519,7 +519,7 @@ const eventEnvelopePayloads = (
   const addPayload = (value: unknown, space?: string) => {
     if (
       !payloads.some((payload) =>
-        payload.value === value && payload.space === space
+        Object.is(payload.value, value) && payload.space === space
       )
     ) {
       payloads.push({ value, ...(space !== undefined ? { space } : {}) });

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -339,7 +339,9 @@ export function findAndInlineDataURILinks(value: any): any {
       const inlined = findAndInlineDataURILinks(current);
       if (next) {
         next[index] = inlined;
-      } else if (inlined !== current) {
+      } else if (!Object.is(inlined, current)) {
+        // `Object.is`: an untouched `NaN` leaf comes back as the same value
+        // and must not force a clone of the whole array.
         next = value.slice();
         next[index] = inlined;
       }
@@ -351,7 +353,8 @@ export function findAndInlineDataURILinks(value: any): any {
       const inlined = findAndInlineDataURILinks(entry);
       if (next) {
         next[key] = inlined;
-      } else if (inlined !== entry) {
+      } else if (!Object.is(inlined, entry)) {
+        // `Object.is`: see the array case above.
         next = { ...value };
         next[key] = inlined;
       }

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -366,7 +366,9 @@ function sendValueToBindingInner<T>(
       }
     }
   } else if (!isRecord(binding) || Object.keys(binding).length !== 0) {
-    if (binding !== value) {
+    // `Object.is`, not `===`: a constant `NaN` binding legitimately matches a
+    // produced `NaN`, and `0` vs `-0` is a genuine mismatch.
+    if (!Object.is(binding, value)) {
       throw new Error(`Got ${value} instead of ${binding}`);
     }
   }

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -70,7 +70,9 @@ const applyWriteToAttestation = (
   // same reference). A root delete retracts (root becomes undefined).
   if (relativePath.length === 0) {
     const nextValue = options?.delete === true ? undefined : value;
-    if (source.value === nextValue) return { ok: source };
+    // `Object.is`, not `===`: a primitive root can change from `0` to `-0`,
+    // which are distinct stored values that `===` conflates.
+    if (Object.is(source.value, nextValue)) return { ok: source };
     return { ok: { ...source, value: nextValue } };
   }
 
@@ -350,8 +352,9 @@ export class Chronicle {
         continue;
       }
 
-      if (merged.value === loaded.is) {
-        // Fast path: reference equality means no change needed.
+      if (Object.is(merged.value, loaded.is)) {
+        // Fast path: identity (`Object.is`, since `===` would conflate a
+        // `0` root loaded as `-0` or vice versa) means no change needed.
         edit.claim(loaded);
       } else {
         // Normalize both values for comparison and potential storage.

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -460,6 +460,44 @@ describe("Cell commit callbacks", () => {
       expect(result).toEqual([1, 3, 4]);
     });
 
+    it("should not remove a stored -0 when asked to remove 0", () => {
+      // `0` and `-0` are distinct stored values.
+      const frame = pushFrame();
+      const cell = runtime.getCell<number[]>(
+        space,
+        "remove-negzero-test",
+        { type: "array", items: { type: "number" } },
+        tx,
+      );
+
+      cell.set([-0, 1]);
+      cell.remove(0);
+      popFrame(frame);
+
+      const result = cell.get();
+      expect(result.length).toBe(2);
+      expect(Object.is(result[0], -0)).toBe(true);
+    });
+
+    it("should keep 0 when removing all -0 elements", () => {
+      const frame = pushFrame();
+      const cell = runtime.getCell<number[]>(
+        space,
+        "removeall-negzero-test",
+        { type: "array", items: { type: "number" } },
+        tx,
+      );
+
+      cell.set([0, -0, 1]);
+      cell.removeAll(-0);
+      popFrame(frame);
+
+      const result = cell.get();
+      expect(result.length).toBe(2);
+      expect(Object.is(result[0], 0)).toBe(true);
+      expect(result[1]).toBe(1);
+    });
+
     it("should remove first matching object from array using link comparison", () => {
       const frame = pushFrame();
       const cell = runtime.getCell<{ name: string }[]>(

--- a/packages/runner/test/chronicle-write-paths.test.ts
+++ b/packages/runner/test/chronicle-write-paths.test.ts
@@ -176,6 +176,30 @@ describe("Chronicle write paths", () => {
     expect(Object.is(fact!.is, -0)).toBe(true);
   });
 
+  it("commits a root re-write of the loaded value as a claim, not an assertion", () => {
+    // Identity fast paths: a root write matching the loaded value is elided
+    // (the working copy is returned as-is), and commit claims the loaded
+    // fact instead of asserting a new one.
+    const id = "test:chronicle-identity-root" as const;
+    const replica = {
+      did: () => space,
+      get: () => ({ the: "application/json", of: id, is: 42 }),
+    } as unknown as ISpaceReplica;
+
+    const chronicle = Chronicle.open(replica);
+    const address = { id, type: "application/json" as const, path: [] };
+    const first = chronicle.write(address, 42);
+    expect(first.error).toBeUndefined();
+    const second = chronicle.write(address, 42);
+    expect(second.error).toBeUndefined();
+    expect(second.ok).toBe(first.ok);
+
+    const commitResult = chronicle.commit();
+    expect(commitResult.error).toBeUndefined();
+    expect(commitResult.ok!.facts.length).toBe(0);
+    expect(commitResult.ok!.claims.length).toBe(1);
+  });
+
   it("treats a write of the same value as a no-op (identity returned)", async () => {
     const storage = StorageManager.emulate({ as: signer });
     try {

--- a/packages/runner/test/chronicle-write-paths.test.ts
+++ b/packages/runner/test/chronicle-write-paths.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { ISpaceReplica } from "../src/storage/interface.ts";
 import * as Chronicle from "../src/storage/transaction/chronicle.ts";
 
 const signer = await Identity.fromPassphrase("chronicle-write-paths");
@@ -125,6 +126,54 @@ describe("Chronicle write paths", () => {
     } finally {
       await storage.close();
     }
+  });
+
+  it("does not elide a root rewrite of `0` with `-0`", async () => {
+    // `0` and `-0` are distinct stored values (`valueEqual` and the content
+    // hash both distinguish them), so a `-0` root write over a `0` working
+    // copy must not be dropped as a no-op.
+    const storage = StorageManager.emulate({ as: signer });
+    try {
+      const id = "test:chronicle-negative-zero-root" as const;
+      const replica = storage.open(space).replica;
+      const address = { id, type: "application/json" as const, path: [] };
+
+      const chronicle = Chronicle.open(replica);
+      expect(chronicle.write(address, 0).error).toBeUndefined();
+      expect(chronicle.write(address, -0).error).toBeUndefined();
+
+      const read = chronicle.read(address);
+      expect(read.error).toBeUndefined();
+      expect(Object.is(read.ok?.value, -0)).toBe(true);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("commits a primitive root change from `0` to `-0` as an assertion, not a no-change claim", () => {
+    // A memory v2 replica only stores explicit full-document (record) roots,
+    // so the primitive-root contract is pinned with a minimal replica stub:
+    // the loaded root is `0`, and the transaction writes `-0` over it. The
+    // distinction matters because `valueEqual` and the content hash both
+    // treat `0` and `-0` as different stored values.
+    const id = "test:chronicle-negative-zero-commit" as const;
+    const replica = {
+      did: () => space,
+      get: () => ({ the: "application/json", of: id, is: 0 }),
+    } as unknown as ISpaceReplica;
+
+    const chronicle = Chronicle.open(replica);
+    const result = chronicle.write(
+      { id, type: "application/json", path: [] },
+      -0,
+    );
+    expect(result.error).toBeUndefined();
+
+    const commitResult = chronicle.commit();
+    expect(commitResult.error).toBeUndefined();
+    const fact = commitResult.ok!.facts.find((f) => f.of === id);
+    expect(fact).toBeDefined();
+    expect(Object.is(fact!.is, -0)).toBe(true);
   });
 
   it("treats a write of the same value as a no-op (identity returned)", async () => {

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -9,6 +9,7 @@ import {
   createSigilLinkFromParsedLink,
   decodeJsonPointer,
   encodeJsonPointer,
+  findAndInlineDataURILinks,
   isCellLink,
   isLegacyAlias,
   isSigilLink,
@@ -405,6 +406,20 @@ describe("link-utils", () => {
       expect(parseLink("string")).toBeUndefined();
       expect(parseLink(123)).toBeUndefined();
       expect(parseLink({ notLink: "value" })).toBeUndefined();
+    });
+  });
+
+  describe("findAndInlineDataURILinks", () => {
+    it("returns a link-free array holding NaN by reference", () => {
+      // The copy-on-write gate must treat an untouched `NaN` leaf as
+      // unchanged (`Object.is` semantics), not clone the container.
+      const value = [NaN, 1];
+      expect(findAndInlineDataURILinks(value)).toBe(value);
+    });
+
+    it("returns a link-free record holding NaN by reference", () => {
+      const value = { x: NaN };
+      expect(findAndInlineDataURILinks(value)).toBe(value);
     });
   });
 

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -161,6 +161,27 @@ describe("pattern-binding", () => {
       });
     });
 
+    it("accepts a matching static primitive binding, including NaN", () => {
+      const testCell = runtime.getCell<{ value: number }>(
+        space,
+        "static primitive binding leaf 1",
+        undefined,
+        tx,
+      );
+      testCell.set({ value: 0 });
+      const argumentCellLink = getMetaCell(testCell, "argument", tx)
+        .getAsNormalizedFullLink();
+
+      // A static primitive binding matches an identical produced value...
+      sendValueToBinding(tx, testCell, argumentCellLink, 42, 42);
+      // ...including `NaN` (`Object.is` semantics; a `!==` check would
+      // spuriously throw `Got NaN instead of NaN` here).
+      sendValueToBinding(tx, testCell, argumentCellLink, NaN, NaN);
+      // A genuine mismatch throws.
+      expect(() => sendValueToBinding(tx, testCell, argumentCellLink, 42, 43))
+        .toThrow("Got 43 instead of 42");
+    });
+
     it("normalizes cell values before writing a narrower scoped binding", () => {
       const output = runtime.getCell<{ value: unknown }>(
         space,


### PR DESCRIPTION
Part of an audit for `===` used where `Object.is` semantics were intended (the system's value-equality contract — `valueEqual`, `deepEqual`, the content hash — treats `NaN` as self-equal and `0`/`-0` as distinct).

## Fixed sites

- **`Cell.remove()` / `Cell.removeAll()`** matched primitive elements with `indexOf` / `item !== ref`: removing `0` removed a stored `-0` (and vice versa), and a `NaN` argument could never match. Both now match with `Object.is`, consistent with the sibling `removeByValue()` (which already used `deepEqual`).
- **Chronicle root-write no-op elision and commit-time no-change fast path** (`storage/transaction/chronicle.ts`) treated a `0` → `-0` primitive-root change as a no-op — dropping the write / claiming no-change where the `valueEqual` slow path four lines down calls it a change. These two guards also elide allocation/normalization work (not just an equality call), so they became `Object.is` rather than being deleted.
- **`findAndInlineDataURILinks()`** copy-on-write gates counted an untouched `NaN` leaf as a change, cloning the container on every call and breaking the same-reference-when-unchanged contract.
- **Static-binding assertion** (`pattern-binding.ts`) threw `Got NaN instead of NaN` for a correct `NaN` match and silently accepted a `0` vs `-0` mismatch.
- **Event-payload dedupe** (`cfc/ui-contract.ts`) duplicated `NaN` payloads and conflated `0` with `-0`.

## Tests

Guard tests fail against the previous code: Cell `remove`/`removeAll` with `-0`, `findAndInlineDataURILinks` NaN identity, and chronicle root `0` → `-0` at both the write and commit level. Memory v2 only stores record roots, so the commit-path test pins the primitive-root contract via a minimal replica stub.

Reachability note: `NaN` currently cannot be *stored* through a schema'd cell write (the runner write path throws or silently drops non-finite numbers — reported separately), so the NaN half of the `remove()`/`removeAll()` fix has no storage-backed seam to pin; the `-0` half does, and is pinned.

Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch equality checks in `runner` to `Object.is` where value identity matters, so `NaN` compares to itself and `0`/`-0` are distinct. Adds focused tests, including Chronicle identity-claim paths and static primitive binding with `NaN`.

- **Bug Fixes**
  - `Cell.remove()` / `removeAll()`: use `Object.is` for primitive matches; `0` no longer removes stored `-0`, and `NaN` is matchable.
  - Chronicle root-write and commit fast paths (`storage/transaction/chronicle.ts`): use `Object.is` so `0` → `-0` is a real change, while same-value rewrites claim no-change by identity.
  - `findAndInlineDataURILinks()`: copy-on-write gate uses `Object.is` to avoid cloning when `NaN` leaves are unchanged.
  - Static-binding assertion (`pattern-binding.ts`): uses `Object.is` to correctly accept `NaN` and reject `0` vs `-0`.
  - Event-payload dedupe (`cfc/ui-contract.ts`): uses `Object.is` to dedupe `NaN` and keep `0` and `-0` separate.

<sup>Written for commit f4471c4399980118313585e4e9b4b8f13630c8e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

