### PR TITLE
fix(html): use `Object.is` in the VDOM prop/child value-change guards

### DIFF
--- a/packages/html/src/render-utils.ts
+++ b/packages/html/src/render-utils.ts
@@ -177,7 +177,9 @@ export const setPropDefault = <T>(target: T, key: string, value: unknown) => {
         target.setAttribute(key, newValue);
       }
     }
-  } else if (target[key as keyof T] !== value) {
+  } else if (!Object.is(target[key as keyof T], value)) {
+    // `Object.is`, not `!==`: a `NaN` prop must not be re-assigned on every
+    // pass (custom elements often re-render on any property set).
     target[key as keyof T] = value as T[keyof T];
   }
 };

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1506,7 +1506,9 @@ export class WorkerReconciler {
     return isPrimitiveValue &&
       existingState !== undefined &&
       existingState.cell === undefined &&
-      existingState.currentValue === value &&
+      // `Object.is`, not `===`: an unchanged `NaN` prop must still be
+      // skippable, and a `0` -> `-0` change is a real change.
+      Object.is(existingState.currentValue, value) &&
       !this.isTextIntegrityProp(state, key) &&
       !DOM_LIVE_PROPS.has(key);
   }
@@ -3466,7 +3468,8 @@ export class WorkerReconciler {
       // value-identity check: the value is unchanged but the render DECISION
       // may have flipped.
       if (
-        !forced && !isInitialRender && resolvedChild === childState.currentValue
+        !forced && !isInitialRender &&
+        Object.is(resolvedChild, childState.currentValue)
       ) {
         return;
       }

--- a/packages/html/test/render-utils.test.ts
+++ b/packages/html/test/render-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { setPropDefault } from "../src/render-utils.ts";
+
+describe("setPropDefault", () => {
+  it("does not re-assign an unchanged NaN property", () => {
+    // The write guard uses `Object.is` semantics: an incoming `NaN` over a
+    // stored `NaN` is unchanged, and must not trigger a property set (custom
+    // elements often re-render on any property assignment).
+    let sets = 0;
+    const target = {
+      _value: NaN,
+      get value(): number {
+        return this._value;
+      },
+      set value(v: number) {
+        sets++;
+        this._value = v;
+      },
+    };
+    setPropDefault(target, "value", NaN);
+    expect(sets).toBe(0);
+  });
+
+  it("assigns `-0` over a `0` property (distinct values)", () => {
+    const target = { value: 0 };
+    setPropDefault(target, "value", -0);
+    expect(Object.is(target.value, -0)).toBe(true);
+  });
+});


### PR DESCRIPTION
Part of an audit for `===` used where `Object.is` semantics were intended.

## Fixed sites

Three dedupe/no-op guards in the render pipeline compared prop and child values with `===`/`!==`, which gets two number cases backwards (`NaN` never `===`-equals itself; `0 === -0` despite the two being distinct stored values):

- **`canSkipUnchangedStaticProp`** (`worker/reconciler.ts`): a `NaN`-valued static prop defeated the CT-1798 op-damping entirely — a set-prop op + transform + postMessage on every parent recompute. A `0` → `-0` change was wrongly skipped.
- **`setPropDefault`** (`render-utils.ts`): the main-thread DOM write guard re-assigned a `NaN` property on every delivered op — re-triggering any custom element that re-renders on property assignment (Lit's default `hasChanged` is `!==`, so the two bugs compounded). `0` → `-0` writes were dropped.
- **`renderCellChild`'s per-emission dedupe** (`worker/reconciler.ts`): a `NaN`-valued cell child re-ran the full child render path on every sink emission; a `0` → `-0` update was swallowed.

Prop values reach these guards intact: in-worker they come straight from pattern JSX, and worker→main crosses via structured clone, which preserves `NaN` and `-0`.

## Tests

New `setPropDefault` guard tests (NaN no-reassign; `-0` over `0` assigns) fail against the previous code. The two reconciler guards share the identical mechanism and are covered by the package suite. `packages/html` runs its tests `--no-check`, so the touched files were `deno check`ed explicitly. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `Object.is` in VDOM prop/child value-change guards in `packages/html` to handle `NaN` and `-0` correctly. This stops unnecessary re-renders and dropped updates; adds unit tests for `setPropDefault`.

- **Bug Fixes**
  - `setPropDefault`: write guard now uses `Object.is`; unchanged `NaN` no longer reassigns; `-0` over `0` writes apply.
  - `canSkipUnchangedStaticProp`: skip guard now uses `Object.is`; unchanged `NaN` is skippable; `0`→`-0` is treated as a real change.
  - `renderCellChild` dedupe: per-emission check now uses `Object.is`; avoids repeat renders on `NaN` and preserves `0`→`-0` updates.

<sup>Written for commit 4c87e79da72fbdecfe5f9251a77f8782eb763fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

