### PR TITLE
fix(ui): use `Object.is` semantics in Cell value change detection and matching

### DIFF
--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -512,9 +512,7 @@ export class CFSelect extends BaseElement {
       const values = (currentValue as unknown[] | undefined) ?? [];
       Array.from(this._select.options).forEach((opt) => {
         const item = this._keyMap.get(opt.value);
-        opt.selected = item
-          ? values.some((v) => Object.is(item.value, v))
-          : false;
+        opt.selected = !!item && values.some((v) => Object.is(item.value, v));
       });
     } else {
       const val = currentValue;

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -512,12 +512,14 @@ export class CFSelect extends BaseElement {
       const values = (currentValue as unknown[] | undefined) ?? [];
       Array.from(this._select.options).forEach((opt) => {
         const item = this._keyMap.get(opt.value);
-        opt.selected = item ? values.some((v) => item.value === v) : false;
+        opt.selected = item
+          ? values.some((v) => Object.is(item.value, v))
+          : false;
       });
     } else {
       const val = currentValue;
       const matchKey = [...this._keyMap.entries()].find(
-        ([, item]) => item.value === val,
+        ([, item]) => Object.is(item.value, val),
       )?.[0];
 
       this._select.value = matchKey ?? "";

--- a/packages/ui/src/v2/core/cell-controller.test.ts
+++ b/packages/ui/src/v2/core/cell-controller.test.ts
@@ -184,6 +184,40 @@ describe("CellController", () => {
     expect(setValueChange!.oldVal).toBe("a");
   });
 
+  it("announces a 0 -> -0 delivery as a change", async () => {
+    // `0` and `-0` are distinct values under the system's equality
+    // (`Object.is` semantics); the subscription gate must not swallow the
+    // update.
+    const host = createMockHost();
+    const changes: Array<{ newVal: number; oldVal: number | undefined }> = [];
+    const ctrl = new CellController<number>(host, {
+      timing: { strategy: "immediate" },
+      onChange: (n, o) => changes.push({ newVal: n, oldVal: o }),
+    });
+    const cell = createMockCellHandle(0);
+    ctrl.bind(cell);
+    changes.length = 0;
+
+    await cell.set(-0);
+    expect(changes.length).toBe(1);
+    expect(Object.is(changes[0].newVal, -0)).toBe(true);
+  });
+
+  it("does not re-announce an unchanged NaN delivery", async () => {
+    const host = createMockHost();
+    const changes: Array<{ newVal: number; oldVal: number | undefined }> = [];
+    const ctrl = new CellController<number>(host, {
+      timing: { strategy: "immediate" },
+      onChange: (n, o) => changes.push({ newVal: n, oldVal: o }),
+    });
+    const cell = createMockCellHandle(NaN);
+    ctrl.bind(cell);
+    changes.length = 0;
+
+    await cell.set(NaN);
+    expect(changes.length).toBe(0);
+  });
+
   it("requestUpdate is called when cell subscription fires", async () => {
     let updateCount = 0;
     const host: ReactiveControllerHost = {
@@ -501,6 +535,34 @@ describe("ArrayCellController", () => {
     ctrl.bind(cell);
     ctrl.removeItem("b");
     expect(cell.get()).toEqual(["a", "c"]);
+  });
+
+  it("removeItem removes a NaN element and keeps -0 distinct from 0", () => {
+    // `Object.is` matching: `NaN` is removable; removing `0` must not take a
+    // stored `-0` with it.
+    const host = createMockHost();
+    const ctrl = new ArrayCellController<number>(host);
+    const cell = createMockCellHandle([NaN, -0, 1]);
+    ctrl.bind(cell);
+
+    ctrl.removeItem(NaN);
+    let result = cell.get() as number[];
+    expect(result.length).toBe(2);
+    expect(Object.is(result[0], -0)).toBe(true);
+
+    ctrl.removeItem(0);
+    result = cell.get() as number[];
+    expect(result.length).toBe(2);
+    expect(Object.is(result[0], -0)).toBe(true);
+  });
+
+  it("updateItem finds a NaN element", () => {
+    const host = createMockHost();
+    const ctrl = new ArrayCellController<number>(host);
+    const cell = createMockCellHandle([1, NaN, 3]);
+    ctrl.bind(cell);
+    ctrl.updateItem(NaN, 2);
+    expect(cell.get()).toEqual([1, 2, 3]);
   });
 
   it("updateItem replaces item via cell.key().set() and propagates to parent", () => {

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -429,7 +429,9 @@ export class CellController<T> implements ReactiveController {
           const typedNewValue = newValue as T | undefined;
           if (!this._subscribeEcho) this._bindingHydrated = true;
           const suppressed = this._classifyDelivery(typedNewValue);
-          if (!suppressed && typedNewValue !== previousValue) {
+          // `Object.is`, not `!==`: an unchanged `NaN` must not re-announce,
+          // and a `0` -> `-0` change is a real change.
+          if (!suppressed && !Object.is(typedNewValue, previousValue)) {
             const oldValue = previousValue;
             previousValue = typedNewValue;
             if (oldValue !== undefined || typedNewValue !== undefined) {
@@ -530,7 +532,7 @@ function sameCellDoc(a: CellRef, b: CellRef): boolean {
  * value (plain JSON-ish data; CellHandles compare by identity only).
  */
 function deepValueEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
+  if (Object.is(a, b)) return true;
   if (a instanceof CellHandle || b instanceof CellHandle) return false;
   if (
     a === null || b === null || typeof a !== "object" || typeof b !== "object"
@@ -642,7 +644,11 @@ export class ArrayCellController<T> extends CellController<T[]> {
    */
   removeItem(itemToRemove: T): void {
     const currentArray = this.getValue();
-    this.setValue(currentArray.filter((item) => item !== itemToRemove));
+    // `Object.is` matching: a `NaN` element is removable, and `0`/`-0` are
+    // distinct.
+    this.setValue(
+      currentArray.filter((item) => !Object.is(item, itemToRemove)),
+    );
   }
 
   /**
@@ -650,7 +656,8 @@ export class ArrayCellController<T> extends CellController<T[]> {
    */
   updateItem(oldItem: T, newItem: T): void {
     const currentArray = this.getValue();
-    const index = currentArray.indexOf(oldItem);
+    // As in `removeItem()`: match by `Object.is`, not `indexOf`'s `===`.
+    const index = currentArray.findIndex((item) => Object.is(item, oldItem));
     if (index !== -1) {
       if (this.hasCell()) {
         const cell = this.getCell()!;

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -312,7 +312,7 @@ export class FormFieldController<T> implements ReactiveController {
    * Simple deep equality check for comparing values
    */
   private _deepEqual(a: unknown, b: unknown): boolean {
-    if (a === b) return true;
+    if (Object.is(a, b)) return true;
     if (a === null || b === null) return false;
     if (typeof a !== typeof b) return false;
     if (typeof a !== "object") return false;


### PR DESCRIPTION
Part of an audit for `===` used where `Object.is` semantics were intended.

## Fixed sites

The v2 core controllers and `cf-select` compared Cell-derived values with `===`/`!==`/`indexOf`, diverging from the system's value equality (`NaN` self-equal; `0`/`-0` distinct):

- **`CellController` subscription gate**: announced an unchanged `NaN` on every delivery (spurious value-changed events; write-back echo risk if a handler writes on change) and swallowed a `0` → `-0` change.
- **`deepValueEqual`** (local-edit confirmation): a `NaN` edit never confirmed (deliveries misclassified as stale until write-settle), and a `-0` edit was falsely confirmed by a `+0` delivery.
- **`FormFieldController._deepEqual`** (`isDirty()`): a field whose stored value is `NaN` read as permanently dirty; a genuine `0` → `-0` change read as clean.
- **`ArrayCellController.removeItem`/`updateItem`**: a `NaN` element could never be removed or updated; `0` and `-0` were conflated.
- **`cf-select` selection matching**: an option whose value is `NaN` never displayed as selected.

## Tests

Guard tests fail against the previous code: subscription-gate NaN dedupe and `0` → `-0` announcement (via the mock CellHandle), and `ArrayCellController` NaN/`-0` matching. `isDirty()` is gated on Lit form context, which the existing harness deliberately does not mock, so `_deepEqual` rides on the same one-word change without a direct seam. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch value comparisons in v2 controllers and `cf-select` to `Object.is` to match system equality. Fixes NaN and ±0 handling to stop noisy change events, bad dirty states, and broken selection.

- **Bug Fixes**
  - `CellController`: no re-announce on unchanged `NaN`; correctly emits `0` → `-0`.
  - Deep equality: `deepValueEqual` and `FormFieldController._deepEqual` now use `Object.is`, fixing `isDirty()` for `NaN` and `0`/`-0`.
  - `ArrayCellController`: `removeItem`/`updateItem` match with `Object.is` so `NaN` items are found and `0`/`-0` stay distinct.
  - `cf-select`: selection matching uses `Object.is`; kept the predicate as a single expression to preserve coverage.

<sup>Written for commit 14e19c4cf3b7b76d84bea737b895c7122ae2a86e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

