### PR TITLE
fix(runtime-client): compare cell values with `Object.is` semantics in `valuesEqual`

### DIFF
--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -466,6 +466,65 @@ describe("CellHandle reactive CFC label delivery", () => {
   });
 });
 
+describe("CellHandle update change detection", () => {
+  const makeRuntime = () =>
+    ({
+      [$conn]: () => ({
+        request: () => Promise.resolve({ value: undefined }),
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    }) as unknown as RuntimeClient;
+  const ref: CellRef = {
+    id: "of:change-detection-cell" as CellRef["id"],
+    space: "did:key:test" as CellRef["space"],
+    scope: "space",
+    path: [],
+  };
+
+  it("does not re-notify on an unchanged NaN value", () => {
+    // Value equality is `Object.is`-based: `NaN` equals itself, so a
+    // delivery repeating a NaN-bearing value is not a change.
+    const cell = new CellHandle<number>(makeRuntime(), ref);
+    const calls: Array<number | undefined> = [];
+    cell.subscribe((value) => {
+      calls.push(value);
+    });
+
+    cell[$onCellUpdate](NaN);
+    const after = calls.length;
+    cell[$onCellUpdate](NaN);
+    expect(calls.length).toBe(after);
+  });
+
+  it("does not re-notify on an unchanged NaN-bearing record", () => {
+    const cell = new CellHandle<{ x: number }>(makeRuntime(), ref);
+    const calls: Array<unknown> = [];
+    cell.subscribe((value) => {
+      calls.push(value);
+    });
+
+    cell[$onCellUpdate]({ x: NaN });
+    const after = calls.length;
+    cell[$onCellUpdate]({ x: NaN });
+    expect(calls.length).toBe(after);
+  });
+
+  it("notifies on a 0 -> -0 change", () => {
+    // `0` and `-0` are distinct stored values (the content hash
+    // distinguishes them); the update must not be dropped.
+    const cell = new CellHandle<number>(makeRuntime(), ref);
+    const calls: Array<number | undefined> = [];
+    cell.subscribe((value) => {
+      calls.push(value);
+    });
+
+    cell[$onCellUpdate](0);
+    cell[$onCellUpdate](-0);
+    expect(Object.is(calls.at(-1), -0)).toBe(true);
+  });
+});
+
 describe("CellHandle disposal-raced writes", () => {
   const ref: CellRef = {
     id: "of:write-cell" as CellRef["id"],

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -583,7 +583,10 @@ function cellRefsEqual(a: CellRef, b: CellRef): boolean {
  * Handles primitives, arrays, objects, and CellHandles.
  */
 function valuesEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
+  // `Object.is`, not `===`: an unchanged `NaN` leaf must compare equal (else
+  // every delivery of a NaN-bearing value re-notifies all subscribers), and a
+  // `0` -> `-0` change must compare unequal (else the update is dropped).
+  if (Object.is(a, b)) return true;
   if (a == null || b == null) return a === b;
   if (typeof a !== typeof b) return false;
   if (typeof a !== "object") return false;


### PR DESCRIPTION
Part of an audit for `===` used where `Object.is` semantics were intended.

## The bug

`CellHandle`'s backend-delivery change detection (`valuesEqual`, used by `[$onCellUpdate]`) fast-pathed its leaf comparison with `===`, diverging from the system's value equality in both directions:

- an unchanged `NaN`-bearing value counted as changed on every delivery — `#value` re-assigned and every subscriber re-fired;
- a `0` → `-0` change compared equal, so the update was dropped entirely and the client view diverged from stored state (which the content hash distinguishes).

Values cross the worker boundary via `postMessage` structured clone, which preserves both `NaN` and `-0`, so both cases arrive intact.

## The fix

The leaf comparison is now `Object.is`.

## Tests

Guard tests (repeat-NaN dedupe, bare and nested; `0` → `-0` notification) fail against the previous code. This package's test task runs `--no-check`, so the touched files were `deno check`ed explicitly. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `Object.is` for value comparison in `runtime-client` change detection. This stops repeat `NaN` deliveries from re-notifying and ensures `0` → `-0` updates are emitted, keeping client state in sync with stored values.

<sup>Written for commit 99d6ad5adb25e744de720d8a69ca86c38596d3f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

