### PR TITLE
fix(cf-harness): name the fetch signature so @types/node can roll to 26

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -115,7 +115,6 @@
     "npm:@types/d3-scale@^4.0.8": "4.0.9",
     "npm:@types/d3-shape@^3.1.6": "3.1.8",
     "npm:@types/leaflet@^1.9.21": "1.9.21",
-    "npm:@types/node@*": "24.2.0",
     "npm:ai@^5.0.27": "5.0.93_zod@3.25.76",
     "npm:ajv@^8.17.1": "8.17.1",
     "npm:d3-array@^3.2.4": "3.2.4",
@@ -1242,8 +1241,8 @@
         "@types/geojson"
       ]
     },
-    "@types/node@24.2.0": {
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+    "@types/node@26.1.1": {
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dependencies": [
         "undici-types"
       ]
@@ -2003,8 +2002,8 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "bin": true
     },
-    "undici-types@7.10.0": {
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+    "undici-types@8.3.0": {
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -593,6 +593,34 @@ Two things keep this off the table today. The fold happens only when minifying,
 and the shell is the only caller that minifies. The shell also lowers `using`,
 and the lowered form is not folded. esbuild fixed the underlying bug in 0.28.1.
 
+### The `@types/node` dependency
+
+Nothing here imports `@types/node`, and no import map names it. It reaches the
+dependency tree only because `protobufjs`, pulled in by the OpenTelemetry proto
+exporters, depends on it with a `>=13.7.0` range. An open-ended range resolves
+to the newest release each time the lockfile is regenerated, so this package's
+version moves on its own rather than when someone decides to roll it.
+
+Whether its globals reach a given package's type graph is not something
+`deno info` will tell you. They arrive as a type-only injection rather than
+through the module graph, and which packages they reach shifts with the rest of
+the dependency tree and with the Deno version. At 26.1.1 under Deno 2.8.1 they
+reach `cf-harness`, and `typeof fetch` there resolves to a type whose `init`
+parameter is the union `global.RequestInit | RequestInit`. Neither `signal` nor
+`body` is available on that union, so reading either one stops type checking. At
+24.2.0 the same code checks clean, and so does 26.1.1 under Deno 2.8.3.
+
+The practical trap is that `typeof fetch` is not a dependable way to name a
+fetch-shaped value. Write the signature out instead, as
+`packages/cf-harness/src/contracts/http-fetch.ts` does. That holds whichever
+version resolves and whichever compiler checks it.
+
+Two things make this class of breakage easy to miss. `deno task check` does not
+cover every package: `cf-harness` is type checked only by its own test task, so
+its type errors surface in a test shard rather than the Check job. And CI pins
+Deno 2.8.1 while `tasks/check.sh` accepts any 2.8.x, so a local check and CI can
+disagree about what type checks.
+
 ### Running Tests
 
 > **Note:** CI enforces that `main` always type-checks and all tests pass, so

--- a/packages/cf-harness/src/contracts/http-fetch.ts
+++ b/packages/cf-harness/src/contracts/http-fetch.ts
@@ -1,0 +1,18 @@
+/**
+ * The fetch implementation the harness calls and that callers can substitute.
+ *
+ * The signature is written out because `typeof fetch` is not stable here: when
+ * `@types/node`'s globals are in the type graph, it resolves to a type whose
+ * `init` parameter has neither `signal` nor `body`.
+ */
+export type HarnessFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * The fetch a caller gets when it supplies none. Delegates to the global
+ * `fetch`, resolved on each call so a replaced global is honored.
+ */
+export const defaultHarnessFetch: HarnessFetch = (input, init) =>
+  fetch(input, init);

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -1,4 +1,8 @@
 import type { LLMNativeModelToolId } from "@commonfabric/llm/types";
+import {
+  defaultHarnessFetch,
+  type HarnessFetch,
+} from "../contracts/http-fetch.ts";
 
 export interface OpenAICompatibleGatewayClientOptions {
   baseUrl: string;
@@ -7,7 +11,7 @@ export interface OpenAICompatibleGatewayClientOptions {
   apiKeySource?: string;
   chatCompletionTransportRetries?: number;
   chatCompletionRetryDelayMs?: number;
-  fetchFn?: typeof fetch;
+  fetchFn?: HarnessFetch;
 }
 
 export type OpenAIChatMessageRole = "system" | "user" | "assistant" | "tool";
@@ -281,7 +285,7 @@ export class OpenAICompatibleGatewayClient {
   readonly authMode: "bearer" | "none";
   readonly apiKey?: string;
   readonly apiKeySource?: string;
-  readonly #fetchFn: typeof fetch;
+  readonly #fetchFn: HarnessFetch;
   readonly #chatCompletionTransportRetries: number;
   readonly #chatCompletionRetryDelayMs: number;
 
@@ -290,7 +294,7 @@ export class OpenAICompatibleGatewayClient {
     this.authMode = options.authMode ?? "bearer";
     this.apiKey = options.apiKey;
     this.apiKeySource = options.apiKeySource;
-    this.#fetchFn = options.fetchFn ?? fetch;
+    this.#fetchFn = options.fetchFn ?? defaultHarnessFetch;
     this.#chatCompletionTransportRetries = nonNegativeIntegerOrDefault(
       options.chatCompletionTransportRetries,
       DEFAULT_CHAT_COMPLETION_TRANSPORT_RETRIES,

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -10,6 +10,7 @@ export * from "./subagent-return.ts";
 export * from "./artifacts.ts";
 export * from "./cli.ts";
 export * from "./gateway/openai-client.ts";
+export * from "./contracts/http-fetch.ts";
 export * from "./contracts/image.ts";
 export * from "./contracts/prompt-slot.ts";
 export * from "./contracts/cfc-invocation-context.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -109,6 +109,7 @@ import {
 import { loadHarnessSkillContext } from "./skills/registry.ts";
 import type { HarnessFailureRecord } from "./diagnostics.ts";
 import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
+import type { HarnessFetch } from "./contracts/http-fetch.ts";
 
 const DEFAULT_MAX_MODEL_TURNS = 8;
 const BASH_CWD_MARKER_PREFIX = "__CF_HARNESS_CWD__";
@@ -119,7 +120,7 @@ export interface CreateHarnessPromptLoopOptions
   gatewayClient?: OpenAICompatibleGatewayClient;
   apiKey?: string;
   apiKeySource?: string;
-  fetchFn?: typeof fetch;
+  fetchFn?: HarnessFetch;
   maxModelTurns?: number;
   allowedToolIds?: readonly BuiltinToolId[];
   allowedSubagentProfiles?: readonly HarnessSubagentProfile[];

--- a/packages/cf-harness/src/tools/web-fetch.ts
+++ b/packages/cf-harness/src/tools/web-fetch.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessToolDefinition } from "./types.ts";
+import type { HarnessFetch } from "../contracts/http-fetch.ts";
 
 export interface WebFetchToolInput {
   url: string;
@@ -73,7 +74,6 @@ export type ResolveHostAddresses = (
   signal?: AbortSignal,
 ) => Promise<readonly string[]>;
 
-type WebFetchHttpFetch = typeof fetch;
 type WebFetchBytes = Uint8Array<ArrayBuffer>;
 
 const DEFAULT_MAX_BYTES = 200_000;
@@ -211,7 +211,7 @@ export const webFetchToolDescriptor: HarnessToolDescriptor = {
 };
 
 export interface CreateWebFetchToolOptions {
-  fetchFn?: WebFetchHttpFetch;
+  fetchFn?: HarnessFetch;
   resolveHostAddresses?: ResolveHostAddresses;
 }
 
@@ -594,7 +594,7 @@ const blockedResolvedAddressReason = (
 
 const createPinnedPublicFetch = (
   resolveHostAddresses: ResolveHostAddresses,
-): WebFetchHttpFetch =>
+): HarnessFetch =>
 async (input, init = {}) => {
   const url = new URL(input instanceof Request ? input.url : String(input));
   const signal = init.signal ?? undefined;
@@ -1324,7 +1324,7 @@ const hasIpv6Prefix = (
 
 interface FetchWithRedirectsOptions {
   url: string;
-  fetchFn: typeof fetch;
+  fetchFn: HarnessFetch;
   resolveHostAddresses: ResolveHostAddresses;
   signal: AbortSignal;
 }

--- a/packages/cf-harness/test/http-fetch.test.ts
+++ b/packages/cf-harness/test/http-fetch.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import {
+  defaultHarnessFetch,
+  OpenAICompatibleGatewayClient,
+} from "../src/index.ts";
+
+// Importing through the package barrel keeps `defaultHarnessFetch` reachable
+// from the public entry point that consumers use, alongside the gateway client
+// that falls back to it.
+Deno.test("barrel re-exports the harness fetch default", () => {
+  assertEquals(typeof defaultHarnessFetch, "function");
+  assertEquals(typeof OpenAICompatibleGatewayClient, "function");
+});
+
+Deno.test("defaultHarnessFetch forwards input and init to the global fetch", async () => {
+  const original = globalThis.fetch;
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const stubResponse = new Response("ok", { status: 200 });
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    return Promise.resolve(stubResponse);
+  }) as typeof globalThis.fetch;
+
+  try {
+    const init: RequestInit = { method: "POST", body: "payload" };
+    const response = await defaultHarnessFetch("https://example.test/", init);
+    assertStrictEquals(response, stubResponse);
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].input, "https://example.test/");
+    assertStrictEquals(calls[0].init, init);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("the gateway client falls back to the global fetch when given none", async () => {
+  const original = globalThis.fetch;
+  const seen: Array<RequestInfo | URL> = [];
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    seen.push(input);
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  }) as typeof globalThis.fetch;
+
+  try {
+    const client = new OpenAICompatibleGatewayClient({
+      baseUrl: "https://llm.example.test/",
+      apiKey: "test-key",
+    });
+    await client.listModels();
+    assertEquals(seen.length, 1);
+    assertEquals(
+      (seen[0] as URL).toString(),
+      "https://llm.example.test/v1/models",
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
Nothing in this repository imports @types/node, and no import map names it. It reaches the dependency tree only because protobufjs, pulled in by the OpenTelemetry proto exporters, depends on it with a `>=13.7.0` range. An open-ended range resolves to the newest release every time the lockfile is regenerated, so the version moves on its own. The lockfile held 24.2.0 only because it had gone stale. This change rolls it to 26.1.1, and undici-types along with it.

cf-harness named its fetch-shaped values with `typeof fetch`. That is not a dependable way to name one. Once @types/node's globals are in this package's type graph, `typeof fetch` resolves to a type whose init parameter is the union `global.RequestInit | RequestInit`, and neither `signal` nor `body` is available on that union, so reading either property stops type checking. At 26.1.1 under the Deno version CI pins, that produced 28 errors across web-fetch.ts and four test files. At 24.2.0 the same code checks clean.

The signature is now written out once, as HarnessFetch in src/contracts/http-fetch.ts, and the five places that said `typeof fetch` use it. This holds whichever version resolves, and regardless of whether the globals reach this package's type graph at all. That last part is worth stating plainly: the globals arrive as a type-only injection rather than through the module graph, so they are invisible to `deno info`, and which packages they reach shifts with the rest of the dependency tree and with the Deno version. Pinning @types/node would only have held one such arrangement still, and the pin would have had to name a package nobody imports.

DEVELOPMENT.md records the trap next to the existing note on the TypeScript compiler dependency, along with two things that make this class of breakage easy to miss: `deno task check` does not cover cf-harness, which is type checked only by its own test task, and CI pins one Deno version while tasks/check.sh accepts any 2.8.x, so a local check and CI can disagree about what type checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes fetch typing in `cf-harness` by adding a named `HarnessFetch` type and a `defaultHarnessFetch` fallback, replacing `typeof fetch` to avoid `@types/node@26` breakage. Rolls the lockfile to `@types/node@26.1.1` and `undici-types@8.3.0`, and adds tests/docs to keep checks reliable across Deno versions.

- **Bug Fixes**
  - Add `HarnessFetch` and `defaultHarnessFetch` in `packages/cf-harness/src/contracts/http-fetch.ts`; switch callers in `gateway/openai-client.ts` (now falls back to `defaultHarnessFetch`), `prompt-loop.ts`, and `tools/web-fetch.ts`; re-export from `index.ts`.
  - Add `packages/cf-harness/test/http-fetch.test.ts` and document the `@types/node` trap in `DEVELOPMENT.md`; resolves `RequestInit` union issues when Node globals are present, restoring clean type checks.

- **Dependencies**
  - Bump `@types/node` to 26.1.1 and `undici-types` to 8.3.0.

<sup>Written for commit 57c43d3dd708ef9eaa8a136f2186d5f2d93706ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

