### PR TITLE
refactor(integration): gate the remaining click/fill predicates on is…

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -160,7 +160,10 @@ const fillAndVerify = async (
   await new Promise((resolve) =>
     requestAnimationFrame(() => requestAnimationFrame(resolve))
   );
-  if (!probe.isVisible(input) || input.disabled || input.readOnly) {
+  // Rendered, not on-screen: the fill drives the field through focus and
+  // dispatched events rather than a coordinate click, so its viewport position
+  // never bears on whether the value takes.
+  if (!probe.isRendered(input) || input.disabled || input.readOnly) {
     phase("not-fillable");
     return false;
   }
@@ -238,9 +241,12 @@ const markForClick = async (
 };
 
 // Scroll the `index`-th element matching `selector` into view and tag it once it
-// is visible. Unlike `markForClick`, the selector here already resolves to the
+// is rendered. Unlike `markForClick`, the selector here already resolves to the
 // clickable elements, so the match is tagged directly rather than reached
-// through a host's shadow root.
+// through a host's shadow root. The check is viewport-independent for the same
+// reason as `markForClick`: the click scrolls the element into view itself, so
+// requiring it on-screen at tagging time only invites a wait that never
+// satisfies.
 const markNthForClick = async (
   probe: ProbeApi,
   selector: string,
@@ -254,14 +260,19 @@ const markNthForClick = async (
   await new Promise((resolve) =>
     requestAnimationFrame(() => requestAnimationFrame(resolve))
   );
-  if (!probe.isVisible(target)) return false;
+  if (!target.isConnected || !probe.isRendered(target)) return false;
   target.setAttribute(attr, token);
   return true;
 };
 
-// Tag the first visible, enabled element carrying `data-ui-action="<action>"`
+// Tag the first rendered, enabled element carrying `data-ui-action="<action>"`
 // for a single trusted click, and record the next click's provenance so a
 // failure can show whether the dispatch was trusted and where it landed.
+// Rendered-ness is asked of the resolved click target, which covers the host:
+// hiding the host reaches the inner control either way. It is asked without an
+// on-screen requirement, since the trusted click scrolls the target into view
+// before dispatching. Disabled-ness is asked of both, because a host can carry
+// an `aria-disabled` its inner control does not.
 const markTrustedAction = async (
   probe: ProbeApi,
   action: string,
@@ -282,7 +293,7 @@ const markTrustedAction = async (
       | HTMLElement
       | null) ?? target;
     if (
-      probe.isVisible(target) && probe.isVisible(clickTarget) &&
+      probe.isRendered(clickTarget) &&
       !isDisabled(target) && !isDisabled(clickTarget)
     ) {
       clickTarget.setAttribute(attr, token);


### PR DESCRIPTION
…Rendered

An earlier change moved `markForClick` from `probe.isVisible` to `probe.isRendered` so a control is tagged once it is laid out, without also requiring it to be on-screen. Three sibling predicates in the same file kept `probe.isVisible`, and each has the same reason not to: `markNthForClick` behind `clickNthCfButton`, `markTrustedAction` behind `clickTrustedAction`, and `fillAndVerify` behind `fillCfInput`.

`probe.isVisible` is `probe.isRendered` plus a viewport check. For a control the test is about to click, the viewport check is the wrong question. The click scrolls its own element into view before it dispatches, so where the element sits when the predicate tags it does not decide whether the click lands. The check can only cost time: the shell sets `html { scroll-behavior: smooth }`, so the `scrollIntoView()` each predicate issues animates over several hundred milliseconds, and a viewport read in the same predicate samples a position the scroll has not reached yet, leaving the wait to recover on its coarse backstop.

`fillAndVerify` never clicks by coordinate at all. It focuses the field and dispatches input and change events, so the field's viewport position never bears on whether the typed value takes. It now asks `probe.isRendered`, keeping its disabled and read-only checks, which are what actually decide whether the field accepts input.

`markNthForClick` tags the match directly rather than through a host's shadow root, so it gains the `isConnected` guard `markForClick` already carries: a match the reactive view detaches between collection and tagging is skipped and retried rather than tagged while orphaned.

`markTrustedAction` keeps its structure — it iterates the `data-ui-action` matches and selects the first that is rendered and enabled. It now asks rendered-ness of the resolved click target alone, matching `markForClick`: hiding the host reaches the inner control either way, so the earlier check on both the host and the click target was redundant, and checking the host can wrongly skip a candidate whose host has a zero box while its inner control is laid out. Whether the action is enabled stays a genuine selection criterion, so its disabled checks are untouched, and they stay on both nodes because a host can carry an `aria-disabled` its inner control does not.

The presentation-mode fill predicate `cfInputIsFillable` deliberately keeps `probe.isVisible`. That path moves a real cursor to the element's box coordinates and types with the real keyboard as a visible recording, so there the element being on-screen is exactly the property that must hold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch remaining click/fill predicates to check rendered state instead of visibility. This makes clicks and fills more reliable and faster by removing viewport reads and smooth-scroll waits.

- **Refactors**
  - `fillAndVerify` now uses rendered checks; keeps disabled/readOnly guards.
  - `markNthForClick` drops visibility check, adds `isConnected` guard, tags match directly.
  - `markTrustedAction` checks rendered-ness on the resolved click target only; keeps disabled checks on both nodes.
  - Presentation mode `cfInputIsFillable` stays on visibility (uses real cursor and keyboard).

<sup>Written for commit b994e3b1d6ee921139889fdbe89262c3363569fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

