### PR TITLE
chore(deps): roll @db/sqlite to 0.13.0 and pin its native library to …

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -7,7 +7,7 @@
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/table@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cmd-johnson/oauth2-client@2": "2.0.0",
-    "jsr:@db/sqlite@0.12": "0.12.0",
+    "jsr:@db/sqlite@0.13.0": "0.13.0",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
     "jsr:@deno/cache-dir@0.22.2": "0.22.2",
     "jsr:@deno/esbuild-plugin@1.2.1": "1.2.1",
@@ -16,7 +16,6 @@
     "jsr:@deno/loader@~0.3.10": "0.3.11",
     "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@std/assert@*": "1.0.16",
-    "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@1": "1.0.16",
     "jsr:@std/assert@^1.0.14": "1.0.16",
     "jsr:@std/assert@^1.0.15": "1.0.16",
@@ -54,8 +53,8 @@
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.6": "1.0.6",
     "jsr:@std/path@*": "1.1.4",
-    "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@1.0": "1.0.9",
     "jsr:@std/path@^1.0.8": "1.1.4",
     "jsr:@std/path@^1.1.1": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
@@ -182,11 +181,11 @@
         "jsr:@std/encoding@^1.0.5"
       ]
     },
-    "@db/sqlite@0.12.0": {
-      "integrity": "dd1ef7f621ad50fc1e073a1c3609c4470bd51edc0994139c5bf9851de7a6d85f",
+    "@db/sqlite@0.13.0": {
+      "integrity": "4545c635e0b3d4ddfdc0f2240f932f24b8ad0178e9c2e3a0f9403e7b18ae2fb5",
       "dependencies": [
         "jsr:@denosaurs/plug",
-        "jsr:@std/path@0.217"
+        "jsr:@std/path@1.0"
       ]
     },
     "@deno-library/progress@1.5.1": {
@@ -228,9 +227,6 @@
         "jsr:@std/fs@1",
         "jsr:@std/path@1"
       ]
-    },
-    "@std/assert@0.217.0": {
-      "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
@@ -326,11 +322,8 @@
     "@std/net@1.0.6": {
       "integrity": "110735f93e95bb9feb95790a8b1d1bf69ec0dc74f3f97a00a76ea5efea25500c"
     },
-    "@std/path@0.217.0": {
-      "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
-      "dependencies": [
-        "jsr:@std/assert@0.217"
-      ]
+    "@std/path@1.0.9": {
+      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
     },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
@@ -2032,13 +2025,13 @@
       },
       "packages/cf-harness": {
         "dependencies": [
-          "jsr:@db/sqlite@0.12"
+          "jsr:@db/sqlite@0.13.0"
         ]
       },
       "packages/cli": {
         "dependencies": [
           "jsr:@cliffy/table@^1.0.0-rc.8",
-          "jsr:@db/sqlite@0.12",
+          "jsr:@db/sqlite@0.13.0",
           "npm:typescript@6.0.3"
         ]
       },
@@ -2081,7 +2074,7 @@
       "packages/memory": {
         "dependencies": [
           "jsr:@commonfabric/leb128@*",
-          "jsr:@db/sqlite@0.12",
+          "jsr:@db/sqlite@0.13.0",
           "jsr:@denosaurs/plug@1",
           "npm:@opentelemetry/api@^1.9.0"
         ]
@@ -2115,7 +2108,7 @@
       },
       "packages/state-inspector": {
         "dependencies": [
-          "jsr:@db/sqlite@0.12",
+          "jsr:@db/sqlite@0.13.0",
           "jsr:@std/assert@1"
         ]
       },
@@ -2132,7 +2125,7 @@
       "packages/toolshed": {
         "dependencies": [
           "jsr:@cmd-johnson/oauth2-client@2",
-          "jsr:@db/sqlite@0.12",
+          "jsr:@db/sqlite@0.13.0",
           "jsr:@std/cli@^1.0.12",
           "npm:@ai-sdk/anthropic@^2.0.9",
           "npm:@ai-sdk/google-vertex@^3.0.16",

--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -76,11 +76,38 @@ from SQLite column metadata via FFI (`sqlite3_column_origin_name` /
 | JOIN / UNION / CTE / view / subquery | true origin | disambiguated |
 
 This binds the SAME libsqlite3 `@db/sqlite` already loaded (it is compiled with
-`SQLITE_ENABLE_COLUMN_METADATA`; it just doesn't expose those symbols), getting
-its path the way `@db/sqlite` does — plug's `download({ cache: "use" })` (a cache
-hit returns the already-downloaded file; no scan, no network) — with
-`DENO_SQLITE_PATH` as an override. If the symbols can't be bound, a labeled query
-fails loudly rather than mislabeling.
+`SQLITE_ENABLE_COLUMN_METADATA`; it just doesn't expose those symbols), picking
+the file the way `@db/sqlite` picks it and in the same order: `DENO_SQLITE_LOCAL`
+selects the build in its own checkout, `DENO_SQLITE_PATH` names a file, and with
+neither set it takes plug's `download({ cache: "use" })` of the pinned release (a
+cache hit returns the already-downloaded file; no scan, no network). Exactly one
+of those is opened, and a source that cannot be opened is reported rather than
+replaced: substituting another file is what produces a second image. A
+`DENO_SQLITE_PATH` naming a libsqlite3 built without
+`SQLITE_ENABLE_COLUMN_METADATA` therefore reports that its symbols are missing.
+`DENO_SQLITE_LOCAL` is reported the same way, because the checkout's path is not
+derived here. If the symbols can't be bound, a labeled query fails loudly rather
+than mislabeling, and the reason goes to the server log: it names a filesystem
+path, and the error itself reaches the query caller.
+
+What this depends on is that both bindings open the same *file*. `dlopen` keys
+images by resolved path, so opening the same path hands back the image already
+loaded, and the process holds a single libsqlite3 with a single set of SQLite
+globals. Opening any other path — even a byte-identical copy — gives a second,
+independent image. `@db/sqlite` calls `sqlite3_initialize()` only on the image it
+loaded, so the second image's global state stays zeroed, and passing a prepared
+statement into it dispatches through that zeroed state and crashes the process.
+Initializing the second image stops the crash, and is not the repair: two
+initialized images still hold separate allocators and mutexes while sharing
+handles. The invariant is one image, not two agreeing ones.
+
+`@db/sqlite` builds its download URL from its own package version, so the release
+version pinned in `column-origin.ts` is what keeps both on one path, and it has
+to be the version the lockfile resolves `@db/sqlite` to. Plug's cache is keyed by
+the URL, so a pin naming a different version names a different file. Rolling
+`@db/sqlite` means updating the pin in the same change; a test in
+`packages/memory` checks the pin against the lockfile, so a stale pin is reported
+as a test failure rather than a crash.
 
 Provenance is captured **server-side** (where the prepared statement lives); the
 **runner** maps each origin → the column's `ifc` and writes the result rows under

--- a/packages/cf-harness/deno.jsonc
+++ b/packages/cf-harness/deno.jsonc
@@ -40,6 +40,6 @@
     "./skills/registry": "./src/skills/registry.ts"
   },
   "imports": {
-    "@db/sqlite": "jsr:@db/sqlite@^0.12.0"
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0"
   }
 }

--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -13,7 +13,7 @@
   },
   "imports": {
     "@cliffy/table": "jsr:@cliffy/table@^1.0.0-rc.8",
-    "@db/sqlite": "jsr:@db/sqlite@^0.12.0",
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "typescript": "npm:typescript@6.0.3"
   }
 }

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -4,7 +4,7 @@
     "check": "deno check .",
     "just-test": {
       "description": "Run unit tests",
-      "command": "deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env"
+      "command": "deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env --allow-run"
     },
     "test": {
       "description": "Type check & run tests",

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -47,7 +47,7 @@
   },
   "imports": {
     "@commonfabric/leb128": "jsr:@commonfabric/leb128",
-    "@db/sqlite": "jsr:@db/sqlite@^0.12.0",
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "@denosaurs/plug": "jsr:@denosaurs/plug@1",
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0"
   }

--- a/packages/memory/test/support/column-origin-download-probe.ts
+++ b/packages/memory/test/support/column-origin-download-probe.ts
@@ -1,0 +1,6 @@
+// Run with an empty plug cache and NO network: the pinned release can't be
+// resolved, so openSource reports the failure instead of binding. Exercises the
+// download-failure catch in openSource.
+import { openSource } from "../../v2/sqlite/column-origin.ts";
+const result = await openSource({ kind: "release" });
+console.log(JSON.stringify("problem" in result));

--- a/packages/memory/test/support/column-origin-env-probe.ts
+++ b/packages/memory/test/support/column-origin-env-probe.ts
@@ -1,0 +1,5 @@
+// Run with env access DENIED (no --allow-env): readEnv's Deno.env.get throws,
+// its catch swallows the denied read and reports the var unset, so librarySource
+// falls through to the release. Exercises readEnv's catch under real denial.
+import { librarySource } from "../../v2/sqlite/column-origin.ts";
+console.log(JSON.stringify(librarySource()));

--- a/packages/memory/test/support/column-origin-server-probe.ts
+++ b/packages/memory/test/support/column-origin-server-probe.ts
@@ -1,0 +1,42 @@
+// @db/sqlite loads its libsqlite3 at import (env still default). Only then do we
+// point DENO_SQLITE_LOCAL at a build column-origin can't derive, so a labeled
+// read's ensureColumnOriginAvailable() fails while @db/sqlite itself keeps
+// working — the one situation the server's fail-loud branch guards.
+import { Server } from "../../v2/server.ts";
+import { connect, loopback } from "../../v2/client.ts";
+import { table } from "../../v2/sqlite/schema.ts";
+import { dbOwner } from "../../v2/sqlite/row-label.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "../v2-auth-test-helpers.ts";
+
+Deno.env.set("DENO_SQLITE_LOCAL", "1");
+
+const SPACE = "did:key:z6Mk-column-origin-server-probe";
+const server = new Server({
+  ...testSessionOpenServerOptions,
+  store: new URL("memory://column-origin-server-probe"),
+});
+const client = await connect({ transport: loopback(server) });
+const session = await client.mount(SPACE, {}, testSessionOpenAuthFactory);
+
+// A per-row label rule makes the db need column provenance (wantColumns=true).
+const db = {
+  id: `of:probe-${crypto.randomUUID()}`,
+  tables: {
+    notes: table({ id: "integer primary key", body: "text" }, () => ({
+      confidentiality: dbOwner(),
+    })),
+  },
+};
+
+let message = "no throw";
+try {
+  await session.sqliteQuery(db, "SELECT body FROM notes");
+} catch (e) {
+  message = (e as Error).message;
+}
+console.log(message);
+await client.close();
+await server.close();

--- a/packages/memory/test/v2-sqlite-column-origin-subprocess-test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin-subprocess-test.ts
@@ -1,0 +1,111 @@
+// The two column-origin binding failures that can only be reproduced with
+// process-level permissions or cache state a fully-permitted in-process test
+// cannot set up. Each runs a helper under `deno run` and inherits
+// DENO_COVERAGE_DIR, so the helper's coverage of column-origin.ts joins the
+// report.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const support = (name: string) =>
+  fromFileUrl(new URL(`./support/${name}`, import.meta.url));
+
+/** The deno cache dir, resolved the way deno resolves it, so the download probe
+ *  can mirror the module cache while emptying the plug cache. */
+async function denoDir(): Promise<string> {
+  const { stdout } = await new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json"],
+    stdout: "piped",
+    stderr: "null",
+  }).output();
+  return JSON.parse(new TextDecoder().decode(stdout)).denoDir as string;
+}
+
+Deno.test("readEnv swallows a denied env read and falls through to release", async () => {
+  // No --allow-env: Deno.env.get throws, readEnv's catch swallows it, and the
+  // source resolves to the release rather than propagating the denial.
+  const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-ffi",
+      support("column-origin-env-probe.ts"),
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assertEquals(
+    code,
+    0,
+    `env probe failed: ${new TextDecoder().decode(stderr)}`,
+  );
+  assertStringIncludes(new TextDecoder().decode(stdout), '"kind":"release"');
+});
+
+Deno.test("openSource reports when the pinned release can't be downloaded", async () => {
+  // A scratch DENO_DIR that mirrors the real module cache but has an empty plug
+  // cache: modules still resolve offline, but the libsqlite3 download misses the
+  // cache and, with no --allow-net, cannot fetch — exercising the download-
+  // failure branch without touching the network.
+  const real = await denoDir();
+  const scratch = await Deno.makeTempDir({ prefix: "column-origin-denodir-" });
+  try {
+    for await (const entry of Deno.readDir(real)) {
+      if (entry.name === "plug") continue;
+      await Deno.symlink(join(real, entry.name), join(scratch, entry.name));
+    }
+    await Deno.mkdir(join(scratch, "plug"));
+
+    const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-ffi",
+        support("column-origin-download-probe.ts"),
+      ],
+      env: { DENO_DIR: scratch },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assertEquals(
+      code,
+      0,
+      `download probe failed: ${new TextDecoder().decode(stderr)}`,
+    );
+    // The probe prints `true` when openSource returned a problem, not a library.
+    assertStringIncludes(new TextDecoder().decode(stdout), "true");
+  } finally {
+    await Deno.remove(scratch, { recursive: true });
+  }
+});
+
+Deno.test("a labeled query fails loudly when column-origin can't bind", async () => {
+  // The probe loads @db/sqlite (so its own library binds) and only then points
+  // DENO_SQLITE_LOCAL at a build column-origin can't open, then runs a labeled
+  // read through the server. The read must fail with the bind error rather than
+  // return mislabeled rows. Isolated in a subprocess because the env change would
+  // otherwise leak into sibling tests.
+  const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-net",
+      "--allow-ffi",
+      "--allow-env",
+      support("column-origin-server-probe.ts"),
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assertEquals(
+    code,
+    0,
+    `server probe failed: ${new TextDecoder().decode(stderr)}`,
+  );
+  assertStringIncludes(
+    new TextDecoder().decode(stdout),
+    "CFC read labeling needs SQLite column-metadata FFI",
+  );
+});

--- a/packages/memory/test/v2-sqlite-column-origin-test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin-test.ts
@@ -4,18 +4,135 @@
 // a non-null origin is the TRUE source column; anything the engine can't
 // attribute reports null (the caller fails closed).
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes, fail } from "@std/assert";
 import { Database } from "@db/sqlite";
 import {
   columnOriginAvailable,
   columnOrigins,
   ensureColumnOriginAvailable,
+  librarySource,
+  openSource,
+  SQLITE3_RELEASE_VERSION,
 } from "../v2/sqlite/column-origin.ts";
 import { ReadConnectionPool } from "../v2/sqlite/read-pool.ts";
 
 // Bind @db/sqlite's column-origin symbols before the sync columnOrigins() calls
 // (production does this once before a labeled query via the server handler).
 await ensureColumnOriginAvailable();
+
+// The origin symbols are bound by dlopen'ing the same libsqlite3 file
+// `@db/sqlite` loaded, found by rebuilding the release URL `@db/sqlite` derives
+// from its package version. A pin the lockfile no longer resolves to names a
+// different file, which gives the process a second libsqlite3 image whose SQLite
+// globals `@db/sqlite` never initialized; the statement handles below then
+// dispatch through that zeroed state and segfault. The crash takes down the run
+// from that test onwards, so the tests that pass a handle across the boundary
+// run only when the pin matches, and this reports the mismatch instead.
+const resolved: { version?: string; problem?: string } = await (async () => {
+  let text: string;
+  try {
+    text = await Deno.readTextFile(
+      new URL("../../../deno.lock", import.meta.url),
+    );
+  } catch (e) {
+    return { problem: `deno.lock could not be read (${e})` };
+  }
+  let specifiers: Record<string, string>;
+  try {
+    specifiers = JSON.parse(text).specifiers ?? {};
+  } catch (e) {
+    return { problem: `deno.lock could not be parsed (${e})` };
+  }
+  const keys = Object.keys(specifiers).filter((k) =>
+    k.startsWith("jsr:@db/sqlite@")
+  );
+  if (keys.length !== 1) {
+    return {
+      problem: `expected exactly one jsr:@db/sqlite specifier in deno.lock, ` +
+        `found ${keys.length}${keys.length ? `: ${keys.join(", ")}` : ""}. ` +
+        `Every package declaring @db/sqlite has to resolve to one version.`,
+    };
+  }
+  return { version: specifiers[keys[0]] };
+})();
+const pinMatchesLock = resolved.version === SQLITE3_RELEASE_VERSION;
+
+Deno.test("pinned libsqlite3 release matches the resolved @db/sqlite", () => {
+  if (resolved.problem) {
+    fail(
+      `cannot check SQLITE3_RELEASE_VERSION against the lockfile: ` +
+        `${resolved.problem}`,
+    );
+  }
+  assertEquals(
+    resolved.version,
+    SQLITE3_RELEASE_VERSION,
+    `deno.lock resolves @db/sqlite to ${resolved.version}, but ` +
+      `SQLITE3_RELEASE_VERSION in v2/sqlite/column-origin.ts pins the ` +
+      `libsqlite3 release to ${SQLITE3_RELEASE_VERSION}. Set the pin to the ` +
+      `resolved version so both open the same file.`,
+  );
+});
+
+// Provenance has to be read from the same libsqlite3 image that runs the query,
+// so the only acceptable file is the one `@db/sqlite` picks. These cover the
+// picking rule and the refusal to substitute a different file for one that
+// cannot be opened.
+Deno.test("library source follows @db/sqlite's own precedence", () => {
+  const env = (vars: Record<string, string>) => (k: string) => vars[k];
+  // @db/sqlite reads DENO_SQLITE_LOCAL first, so it wins even with a path set.
+  assertEquals(
+    librarySource(
+      env({ DENO_SQLITE_LOCAL: "1", DENO_SQLITE_PATH: "/x.dylib" }),
+    ),
+    { kind: "local" },
+  );
+  // Only "1" selects the local build.
+  assertEquals(
+    librarySource(
+      env({ DENO_SQLITE_LOCAL: "0", DENO_SQLITE_PATH: "/x.dylib" }),
+    ),
+    { kind: "path", path: "/x.dylib" },
+  );
+  assertEquals(librarySource(env({ DENO_SQLITE_PATH: "/x.dylib" })), {
+    kind: "path",
+    path: "/x.dylib",
+  });
+  // @db/sqlite tests the path for truthiness, so an empty one is not a path.
+  assertEquals(librarySource(env({ DENO_SQLITE_PATH: "" })), {
+    kind: "release",
+  });
+  assertEquals(librarySource(env({})), { kind: "release" });
+});
+
+Deno.test("an override that cannot be opened reports, and binds nothing", async () => {
+  // A file that is not a library stands in for the real case: a libsqlite3 built
+  // without SQLITE_ENABLE_COLUMN_METADATA, which @db/sqlite loads happily while
+  // the origin symbols are missing from it.
+  const path = Deno.makeTempFileSync({ suffix: ".dylib" });
+  Deno.writeTextFileSync(path, "not a library");
+  try {
+    const result = await openSource({ kind: "path", path });
+    // Binding the prebuilt release here instead would be a second image.
+    assertEquals("lib" in result, false);
+    assertStringIncludes(
+      (result as { problem: string }).problem,
+      "$DENO_SQLITE_PATH",
+    );
+    assertStringIncludes((result as { problem: string }).problem, path);
+  } finally {
+    Deno.removeSync(path);
+  }
+});
+
+Deno.test("a local @db/sqlite build reports rather than binding another file", async () => {
+  const result = await openSource({ kind: "local" });
+  assertEquals("lib" in result, false);
+  assertStringIncludes(
+    (result as { problem: string }).problem,
+    "DENO_SQLITE_LOCAL",
+  );
+});
 
 function seed(path: string): void {
   const db = new Database(path); // writable for setup
@@ -53,6 +170,7 @@ Deno.test({
 Deno.test({
   name: "column origin is sound through alias / spoof / expression / join",
   sanitizeResources: false,
+  ignore: !pinMatchesLock,
 }, () => {
   const path = Deno.makeTempFileSync({ suffix: ".sqlite" });
   seed(path);
@@ -97,6 +215,7 @@ Deno.test({
   name:
     "pool.queryWithOrigins returns rows + per-column origin (real pool path)",
   sanitizeResources: false,
+  ignore: !pinMatchesLock,
 }, () => {
   const path = Deno.makeTempFileSync({ suffix: ".sqlite" });
   seed(path);
@@ -122,6 +241,7 @@ Deno.test({
   name:
     "compound/CTE/view origins are sound (true source or null, never wrong)",
   sanitizeResources: false,
+  ignore: !pinMatchesLock,
 }, () => {
   const path = Deno.makeTempFileSync({ suffix: ".sqlite" });
   seed(path);

--- a/packages/memory/test/v2-sqlite-column-origin-unbound-test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin-unbound-test.ts
@@ -1,0 +1,57 @@
+// The column-origin binding's failure paths, exercised in a module instance
+// where the FFI is NOT bound. Deno gives each test file its own module state, so
+// `cached` starts undefined here — the state the server sees before the first
+// labeled query, and the state a bind failure leaves behind. The sibling file
+// v2-sqlite-column-origin-test.ts covers the bound, happy path.
+
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import {
+  columnOrigins,
+  columnOriginUnavailableReason,
+  ensureColumnOriginAvailable,
+} from "../v2/sqlite/column-origin.ts";
+
+// Runs first, while nothing has bound the FFI and no reason has been recorded:
+// columnOrigins must refuse rather than read through a null library handle, and
+// the message names the call the caller skipped.
+Deno.test("columnOrigins throws before the FFI is bound", () => {
+  assertThrows(
+    () => columnOrigins(null, 1),
+    Error,
+    "column-origin FFI not bound",
+  );
+  assertThrows(
+    () => columnOrigins(null, 1),
+    Error,
+    "ensureColumnOriginAvailable() must resolve",
+  );
+});
+
+// Point @db/sqlite's own loader at a file that is not a library — the shape of a
+// libsqlite3 built without SQLITE_ENABLE_COLUMN_METADATA, which loads for
+// @db/sqlite but exposes no column-origin symbols. ensureColumnOriginAvailable
+// must resolve false, record why, and make a later labeled read throw the reason.
+Deno.test("a bind failure is recorded and surfaces in the reason and the throw", async () => {
+  const notALibrary = Deno.makeTempFileSync({ suffix: ".dylib" });
+  Deno.writeTextFileSync(notALibrary, "not a library");
+  const previous = Deno.env.get("DENO_SQLITE_PATH");
+  Deno.env.set("DENO_SQLITE_PATH", notALibrary);
+  try {
+    assertEquals(await ensureColumnOriginAvailable(), false);
+
+    const reason = columnOriginUnavailableReason();
+    assertStringIncludes(reason ?? "", "$DENO_SQLITE_PATH");
+    assertStringIncludes(reason ?? "", notALibrary);
+
+    // A labeled read now fails loudly, carrying the recorded reason rather than
+    // the generic "must resolve first" message.
+    assertThrows(() => columnOrigins(null, 1), Error, reason!);
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("DENO_SQLITE_PATH");
+    } else {
+      Deno.env.set("DENO_SQLITE_PATH", previous);
+    }
+    Deno.removeSync(notALibrary);
+  }
+});

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -66,7 +66,10 @@ import { RowLabelCommitError } from "./sqlite/commit-eval.ts";
 import type { TableSchema } from "./sqlite/schema.ts";
 import { DiskSourceRegistry } from "./sqlite/disk-source.ts";
 import { ReadConnectionPool } from "./sqlite/read-pool.ts";
-import { ensureColumnOriginAvailable } from "./sqlite/column-origin.ts";
+import {
+  columnOriginUnavailableReason,
+  ensureColumnOriginAvailable,
+} from "./sqlite/column-origin.ts";
 import {
   cloneTrackedGraphState,
   extendTrackedGraph,
@@ -1657,6 +1660,12 @@ export class Server {
       // Bind @db/sqlite's column-origin symbols before a labeled read; fail
       // loudly if they can't be bound rather than mislabeling the result.
       if (wantColumns && !(await ensureColumnOriginAvailable())) {
+        // The reason names a filesystem path, and this error reaches the query
+        // caller, so it goes to the log and the caller gets the bare fact.
+        console.warn(
+          `[memory-sqlite] column-origin symbols could not be bound: ` +
+            `${columnOriginUnavailableReason()}`,
+        );
         throw new Error(
           "sqlite: CFC read labeling needs SQLite column-metadata FFI, but " +
             "@db/sqlite's column-origin symbols could not be bound",

--- a/packages/memory/v2/sqlite/column-origin.ts
+++ b/packages/memory/v2/sqlite/column-origin.ts
@@ -82,13 +82,16 @@ export type LibrarySource =
   | { kind: "path"; path: string }
   | { kind: "release" };
 
-/** `@db/sqlite` swallows a denied env read and carries on, so this does too. */
+/** `@db/sqlite` reads these vars behind a try/catch so a denied `--allow-env`
+ *  falls through to its default rather than throwing; this does the same. A
+ *  denied read is the only failure `Deno.env.get` raises for these constant key
+ *  names — `NotCapable` on current Deno, `PermissionDenied` on older ones — so
+ *  swallow it and report the var as unset. */
 function readEnv(key: string): string | undefined {
   try {
     return Deno.env.get(key);
-  } catch (e) {
-    if (e instanceof Deno.errors.PermissionDenied) return undefined;
-    throw e;
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/memory/v2/sqlite/column-origin.ts
+++ b/packages/memory/v2/sqlite/column-origin.ts
@@ -13,10 +13,13 @@
 // We are NOT switching SQLite implementations: this binds the SAME libsqlite3
 // `@db/sqlite` already loaded (compiled with SQLITE_ENABLE_COLUMN_METADATA). The
 // origin symbols live in that lib but `@db/sqlite` doesn't expose them, so we
-// `Deno.dlopen` its file to declare them. We get its path the way `@db/sqlite`
-// itself does — plug's `download({ cache: "use" })`, which on a cache hit just
-// RETURNS the already-downloaded path (no network, no scanning) — with
-// `DENO_SQLITE_PATH` as an optional override. Resolution is async, so call
+// `Deno.dlopen` its file to declare them. We pick that file the way `@db/sqlite`
+// picks it, in its order: `DENO_SQLITE_LOCAL`, then `DENO_SQLITE_PATH`, then
+// plug's `download({ cache: "use" })`, which on a cache hit just RETURNS the
+// already-downloaded path (no network, no scanning). Exactly one of those is
+// opened. Opening a file other than the one `@db/sqlite` opened would give the
+// process a second libsqlite3 image, so a source that can't be opened reports
+// why and leaves provenance unavailable. Resolution is async, so call
 // `ensureColumnOriginAvailable()` once before issuing labeled queries;
 // `columnOrigins()` then reads the memoized handle synchronously.
 
@@ -36,7 +39,8 @@ type OriginLib = {
 };
 
 let cached: OriginLib | null | undefined;
-let pending: Promise<OriginLib | null> | undefined;
+let problem: string | undefined;
+let pending: Promise<Resolution> | undefined;
 
 const SYMBOLS = {
   sqlite3_column_origin_name: {
@@ -49,33 +53,98 @@ const SYMBOLS = {
   },
 } as const;
 
-// The `@db/sqlite` prebuilt release. These options MUST match what `@db/sqlite`
-// uses internally (and the version pinned in packages/memory/deno.jsonc) so
-// plug's `download()` returns the SAME cached file `@db/sqlite` dlopen'd.
+// The `@db/sqlite` prebuilt release. `@db/sqlite` builds its own download URL
+// from its package version, so this must be the version the lockfile resolves
+// `@db/sqlite` to. Plug's cache is keyed by URL: a different version here names
+// a different file, and dlopen'ing that gives the process a second libsqlite3
+// image instead of the one `@db/sqlite` loaded. Each image carries its own copy
+// of SQLite's global state, and `@db/sqlite` calls `sqlite3_initialize()` only
+// on the image it loaded, so a statement handle passed into the second image
+// segfaults. Calling `sqlite3_initialize()` on the second image stops the crash
+// and is not the repair: two initialized images still hold separate allocators
+// and mutexes, and would then share handles. The requirement is one image, so
+// both bindings must name one file. `deno test` in this package checks this
+// version against the lockfile.
+export const SQLITE3_RELEASE_VERSION = "0.13.0";
+
 const SQLITE3_RELEASE = {
   name: "sqlite3",
-  url: "https://github.com/denodrivers/sqlite3/releases/download/0.12.0/",
+  url:
+    `https://github.com/denodrivers/sqlite3/releases/download/${SQLITE3_RELEASE_VERSION}/`,
   suffixes: { aarch64: "_aarch64" },
   cache: "use",
 } as const;
 
-async function resolveLib(): Promise<OriginLib | null> {
-  const tryOpen = (path: string): OriginLib | null => {
+/** The libsqlite3 `@db/sqlite` loads. `local` is the build in its own checkout,
+ *  `path` is `$DENO_SQLITE_PATH`, `release` is the pinned prebuilt. */
+export type LibrarySource =
+  | { kind: "local" }
+  | { kind: "path"; path: string }
+  | { kind: "release" };
+
+/** `@db/sqlite` swallows a denied env read and carries on, so this does too. */
+function readEnv(key: string): string | undefined {
+  try {
+    return Deno.env.get(key);
+  } catch (e) {
+    if (e instanceof Deno.errors.PermissionDenied) return undefined;
+    throw e;
+  }
+}
+
+/**
+ * Which libsqlite3 `@db/sqlite` will load, in the branch order its own `ffi.ts`
+ * uses: `DENO_SQLITE_LOCAL` outranks `DENO_SQLITE_PATH`, and with neither set it
+ * takes the release its package version names.
+ */
+export function librarySource(
+  getEnv: (key: string) => string | undefined = readEnv,
+): LibrarySource {
+  if (getEnv("DENO_SQLITE_LOCAL") === "1") return { kind: "local" };
+  const path = getEnv("DENO_SQLITE_PATH");
+  return path ? { kind: "path", path } : { kind: "release" };
+}
+
+type Resolution = { lib: OriginLib } | { problem: string };
+
+const describe = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e);
+
+/**
+ * Open one source, or report why it could not be opened. Only the source
+ * `@db/sqlite` itself uses is ever opened: any other file would give the process
+ * a second libsqlite3 image, so there is nothing to fall back to.
+ */
+export async function openSource(source: LibrarySource): Promise<Resolution> {
+  if (source.kind === "local") {
+    return {
+      problem:
+        "DENO_SQLITE_LOCAL=1 points @db/sqlite at the libsqlite3 built in its " +
+        "own checkout, and that path is not derived here",
+    };
+  }
+  let path: string;
+  let label: string;
+  if (source.kind === "path") {
+    path = source.path;
+    label = "$DENO_SQLITE_PATH";
+  } else {
+    label = `the pinned libsqlite3 release ${SQLITE3_RELEASE_VERSION}`;
     try {
-      return { origin: Deno.dlopen(path, SYMBOLS) };
-    } catch {
-      return null;
+      path = await download(SQLITE3_RELEASE);
+    } catch (e) {
+      return { problem: `${label} could not be resolved (${describe(e)})` };
     }
-  };
-  const override = Deno.env.get("DENO_SQLITE_PATH");
-  if (override) {
-    const opened = tryOpen(override);
-    if (opened) return opened;
   }
   try {
-    return tryOpen(await download(SQLITE3_RELEASE));
-  } catch {
-    return null;
+    return { lib: { origin: Deno.dlopen(path, SYMBOLS) } };
+  } catch (e) {
+    return {
+      problem:
+        `${label} names ${path}, whose column-origin symbols could not ` +
+        `be bound (${describe(e)}). A libsqlite3 built without ` +
+        `SQLITE_ENABLE_COLUMN_METADATA does not export them.`,
+    };
   }
 }
 
@@ -87,8 +156,14 @@ async function resolveLib(): Promise<OriginLib | null> {
  */
 export async function ensureColumnOriginAvailable(): Promise<boolean> {
   if (cached === undefined) {
-    pending ??= resolveLib();
-    cached = await pending;
+    pending ??= openSource(librarySource());
+    const resolution = await pending;
+    if ("lib" in resolution) {
+      cached = resolution.lib;
+    } else {
+      cached = null;
+      problem = resolution.problem;
+    }
   }
   return cached !== null;
 }
@@ -97,6 +172,12 @@ export async function ensureColumnOriginAvailable(): Promise<boolean> {
  *  `ensureColumnOriginAvailable()` has resolved. */
 export function columnOriginAvailable(): boolean {
   return !!cached;
+}
+
+/** Why the symbols could not be bound, once `ensureColumnOriginAvailable()` has
+ *  resolved false. Undefined while they are bound or unresolved. */
+export function columnOriginUnavailableReason(): string | undefined {
+  return cached === null ? problem : undefined;
 }
 
 export interface ColumnOrigin {
@@ -125,8 +206,10 @@ export function columnOrigins(
   const l = cached ?? null;
   if (!l) {
     throw new Error(
-      "sqlite: column-origin FFI not bound — ensureColumnOriginAvailable() must " +
-        "resolve before a labeled query reads column provenance",
+      "sqlite: column-origin FFI not bound — " +
+        (problem ??
+          "ensureColumnOriginAvailable() must resolve before a labeled query " +
+            "reads column provenance"),
     );
   }
   const out: ColumnOrigin[] = [];

--- a/packages/memory/v2/sqlite/column-origin.ts
+++ b/packages/memory/v2/sqlite/column-origin.ts
@@ -83,15 +83,21 @@ export type LibrarySource =
   | { kind: "release" };
 
 /** `@db/sqlite` reads these vars behind a try/catch so a denied `--allow-env`
- *  falls through to its default rather than throwing; this does the same. A
- *  denied read is the only failure `Deno.env.get` raises for these constant key
- *  names — `NotCapable` on current Deno, `PermissionDenied` on older ones — so
- *  swallow it and report the var as unset. */
+ *  falls through to its default rather than throwing; this does the same. Only a
+ *  denied read is swallowed — `NotCapable` on current Deno, `PermissionDenied` on
+ *  older ones — and reported as the var being unset; any other failure is
+ *  unexpected and propagates. */
 function readEnv(key: string): string | undefined {
   try {
     return Deno.env.get(key);
-  } catch {
-    return undefined;
+  } catch (e) {
+    if (
+      e instanceof Deno.errors.NotCapable ||
+      e instanceof Deno.errors.PermissionDenied
+    ) {
+      return undefined;
+    }
+    throw e;
   }
 }
 

--- a/packages/state-inspector/deno.jsonc
+++ b/packages/state-inspector/deno.jsonc
@@ -14,7 +14,7 @@
     }
   },
   "imports": {
-    "@db/sqlite": "jsr:@db/sqlite@^0.12.0",
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "@std/assert": "jsr:@std/assert@^1"
   }
 }

--- a/packages/toolshed/deno.jsonc
+++ b/packages/toolshed/deno.jsonc
@@ -12,7 +12,7 @@
   },
   "imports": {
     "@/": "./",
-    "@db/sqlite": "jsr:@db/sqlite@^0.12.0",
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "ai": "npm:ai@^5.0.27",
     "@cmd-johnson/oauth2-client": "jsr:@cmd-johnson/oauth2-client@^2.0.0",
     "@ai-sdk/anthropic": "npm:@ai-sdk/anthropic@^2.0.9",


### PR DESCRIPTION
…match

`@db/sqlite` is declared by the memory, toolshed, cli, cf-harness and state-inspector packages, which resolve as a single unit, so they roll together.

An earlier attempt at this roll was reverted because the test suite died with a segmentation fault in the memory and runner packages instead of failing a test. The cause was in this repository, not the driver.

The memory package reads each result column's true origin table and column through SQLite's column-metadata symbols, which `@db/sqlite` does not expose. It reaches them by opening `@db/sqlite`'s own prebuilt libsqlite3 a second time. This is sound only because `dlopen` keys images by resolved path: opening the path already open returns the image already loaded, so the process holds one libsqlite3 with one set of SQLite globals, and a prepared-statement handle can pass between the two bindings. Opening any other path, even a byte-identical copy, gives a second independent image whose SQLite globals `@db/sqlite` never initialized, since it calls `sqlite3_initialize()` only on the image it loaded, and reading a statement through that image dispatches through zeroed state and crashes.

That invariant held only while both bindings named the same file. The driver builds its download URL from its own package version, whereas this code carried the native-library version as a hardcoded string that still read 0.12.0. Plug's download cache is keyed by URL, so after the roll the driver loaded 0.13.0 while the origin symbols were bound against a separate copy of 0.12.0, and the first labeled query to pass a handle across that boundary segfaulted. The first column-origin test only checks that the symbols bound at all, so it passed; the second was the first to send a handle across, and the runner reached the same crash through its own labeled query.

Move the pin to 0.13.0 and build the URL from a single exported constant. The resolved version cannot be recovered at runtime, because the import map records only the range and not the version the range resolves to, so a test in the memory package compares the constant against the version the lockfile resolves `@db/sqlite` to. That covers a roll that forgets the constant, and a future patch release the range would adopt on its own. The tests that send a statement handle across the boundary run only when the pin matches, so a mismatch surfaces as a test failure naming the constant and both versions rather than a crash that ends the run before it reports anything.

Resolving which library to open had a related defect that the roll does not fix on its own. Resolution consulted `DENO_SQLITE_PATH` first, and when that file could not be opened it fell through and downloaded the prebuilt release instead, which is a different file and so a second image, with the failure swallowed by a bare catch. The override is not hypothetical to get wrong: `SQLITE_ENABLE_COLUMN_METADATA` is not a default SQLite build flag, so a `DENO_SQLITE_PATH` naming an ordinary libsqlite3 loads for `@db/sqlite`, which needs only core symbols, while the column-origin symbols are absent from it. Resolution now names the single library `@db/sqlite` will use, mirroring the branch order of its own loader, where `DENO_SQLITE_LOCAL` outranks `DENO_SQLITE_PATH` and a denied environment read ignores both, and opens only that one. Choosing the source and opening it are separated, so a failed open has nothing to fall through to. A source that cannot be opened is reported rather than replaced, and the reason goes to the server log, because it names a filesystem path and the query error itself reaches the caller.

Rolling this dependency also drops `jsr:@deno/graph`, a transitive dependency of `@deno/cache-dir`, from the lockfile. A plain `deno install` completes the lock so that the frozen install performed by CI keeps working.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Roll `@db/sqlite` to 0.13.0 and pin the bundled `libsqlite3` to the same version to prevent segfaults in column metadata reads. Match the driver’s library selection and open only that file; fail loudly with clear errors and server logs when symbols can’t be bound.

- **Bug Fixes**
  - Choose and open exactly the file `@db/sqlite` uses via `librarySource()` and `openSource()`; follow `DENO_SQLITE_LOCAL` → `DENO_SQLITE_PATH` → pinned release, with no fallback to a different file.
  - Export `SQLITE3_RELEASE_VERSION = "0.13.0"` and build the URL from it; tests compare the pin to the lockfile and gate cross-image cases; docs explain the one-image rule and selection order.
  - Improve error handling and coverage: denied env reads fall through to the release, `columnOriginUnavailableReason()` reports bind failures, the server logs the reason; add subprocess probes (env denial, offline download miss, local-build misbind) and grant `--allow-run` to tests; narrow `readEnv` to swallow only denied reads (`NotCapable`/`PermissionDenied`) and rethrow anything else.

- **Dependencies**
  - Pin `@db/sqlite` to `0.13.0` exactly across `memory`, `toolshed`, `cli`, `cf-harness`, and `state-inspector`.
  - Update lockfile to `@db/sqlite@0.13.0` and `@std/path@1.0.9`; drop unused `@std/*@0.217` entries.

<sup>Written for commit d91da8c7c22b8a5d2ba47d96376e973c87012bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

