### PR TITLE
fix(runner): project non-finite numbers through schema reads

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -20,7 +20,6 @@ import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   type Immutable,
   isBoolean,
-  isFiniteNumber,
   isObject,
   isRecord,
   isString,
@@ -3437,9 +3436,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
           this.isValidType(schemaObj, "string")
         ? { ok: this.traversePrimitive(doc, schemaObj) }
         : fail(TRAVERSE_FAILURES.invalidType);
-    } else if (
-      typeof doc.value === "number" && isFiniteNumber(doc.value)
-    ) {
+    } else if (typeof doc.value === "number") {
+      // All numbers, including `NaN` and the infinities: they are
+      // first-class stored values, so they project like any other number.
       return isPlainTypeSchema(schemaObj, "number") ||
           this.isValidType(schemaObj, getJsonNumberType(doc.value))
         ? { ok: this.traversePrimitive(doc, schemaObj) }
@@ -4569,14 +4568,19 @@ export function canBranchMatch(
   return true;
 }
 
-/** Map JS typeof to its broad JSON Schema type, or null if unknown. */
+/**
+ * Map JS typeof to its broad JSON Schema type, or null if unknown. Every
+ * number is a `"number"`, including `NaN` and the infinities: they are
+ * first-class stored values in this system (the codec and content hash both
+ * represent them), so the schema projection must not hide them.
+ */
 function getPlainJsonType(
   value: unknown,
 ): JSONSchemaTypes | null {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
   if (isString(value)) return "string";
-  if (typeof value === "number" && isFiniteNumber(value)) return "number";
+  if (typeof value === "number") return "number";
   if (isBoolean(value)) return "boolean";
   if (Array.isArray(value)) return "array";
   if (isObject(value)) return "object";
@@ -4585,7 +4589,7 @@ function getPlainJsonType(
 
 /** Refine the broad JSON Schema type so integer values can be distinguished. */
 function getJsonType(value: unknown): JSONSchemaTypes | null {
-  return (typeof value === "number" && isFiniteNumber(value))
+  return (typeof value === "number")
     ? getJsonNumberType(value)
     : getPlainJsonType(value);
 }

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -1456,6 +1456,61 @@ describe(
       expect(result?.pos).toBe(Infinity);
       expect(result?.neg).toBe(-Infinity);
     });
+
+    it("projects a bare NaN through a number schema", () => {
+      // Non-finite numbers are first-class stored values; the schema read
+      // projection must classify them as numbers rather than hiding them.
+      const c = runtime.getCell<number>(
+        space,
+        "schema'd bare NaN",
+        { type: "number" },
+        tx,
+      );
+      c.set(NaN);
+      expect(Number.isNaN(c.get())).toBe(true);
+    });
+
+    it("projects a NaN property through an object schema", () => {
+      const c = runtime.getCell<{ x: number }>(
+        space,
+        "schema'd NaN property",
+        { type: "object", properties: { x: { type: "number" } } },
+        tx,
+      );
+      c.set({ x: NaN });
+      expect(Number.isNaN(c.get()?.x)).toBe(true);
+    });
+
+    it("projects NaN, infinities, and -0 through an array schema", () => {
+      const c = runtime.getCell<number[]>(
+        space,
+        "schema'd weird-number array",
+        { type: "array", items: { type: "number" } },
+        tx,
+      );
+      c.set([1, NaN, Infinity, -Infinity, -0, 2]);
+      const result = c.get();
+      expect(result?.length).toBe(6);
+      expect(result?.[0]).toBe(1);
+      expect(Number.isNaN(result?.[1])).toBe(true);
+      expect(result?.[2]).toBe(Infinity);
+      expect(result?.[3]).toBe(-Infinity);
+      expect(Object.is(result?.[4], -0)).toBe(true);
+      expect(result?.[5]).toBe(2);
+    });
+
+    it("does not project NaN through an integer schema", () => {
+      // `NaN` is a number but not an integer, so an `integer` schema still
+      // rejects it.
+      const c = runtime.getCell<number>(
+        space,
+        "integer schema vs NaN",
+        { type: "integer" },
+        tx,
+      );
+      c.set(NaN);
+      expect(c.get()).toBe(undefined);
+    });
   },
 );
 

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -4167,10 +4167,9 @@ describe("SchemaObjectTraverser unknown type handling", () => {
 });
 
 describe("canBranchMatch NaN and Infinity type handling", () => {
-  // getJsonType uses isFiniteNumber, so NaN/Infinity are not typed as "number".
-  // A schema requiring type "number" should therefore not exclude NaN/Infinity
-  // (canBranchMatch returns true — let traversal deal with it) rather than
-  // incorrectly filtering them out.
+  // NaN and the infinities are first-class stored numbers, so getJsonType
+  // types them as "number": a "number" branch accepts them and a
+  // non-number branch rejects them, exactly like any other number.
   it("does not reject NaN against a {type: 'number'} branch", () => {
     expect(canBranchMatch({ type: "number" }, NaN)).toBe(true);
   });
@@ -4191,10 +4190,9 @@ describe("canBranchMatch NaN and Infinity type handling", () => {
     expect(canBranchMatch({ type: "number" }, 42)).toBe(true);
   });
 
-  it("does not reject NaN against a {type: 'string'} branch (getJsonType returns null for NaN)", () => {
-    // NaN falls through all isFiniteNumber/isString/etc. checks so getJsonType
-    // returns null, and canBranchMatch conservatively allows the branch.
-    expect(canBranchMatch({ type: "string" }, NaN)).toBe(true);
+  it("rejects NaN against a {type: 'string'} branch", () => {
+    // NaN is a number, so a string-only branch definitively excludes it.
+    expect(canBranchMatch({ type: "string" }, NaN)).toBe(false);
   });
 
   it("rejects a finite number against a {type: 'string'} branch", () => {


### PR DESCRIPTION
Follow-on from today's `Object.is` audit: the reported "NaN write data loss" turned out to be a **read-projection** bug — the write path was innocent all along.

## Diagnosis

Stored values were always intact: `normalizeAndDiff` emits `NaN` correctly and `getRaw()` returns it. Two red herrings unwound:

- The scary `[<3 empty items>]` seen when logging a schemaless array read is a display artifact — `console.log` inspects the lazy query-result proxy's sparse stub target. Indexing or spreading returns the real `[1, NaN, 2]`.
- The actual bug: the schema read projection (`traverse.ts` — `getPlainJsonType`, `getJsonType`, and `traverseValueWithSchema`'s number branch) classified a number as `"number"` only when *finite*, so a stored `NaN`/`±Infinity` projected as absent: bare value → `undefined`, object property → silently omitted, schema'd array → invalid. Those `isFiniteNumber` guards came in with a type-predicate cleanup (#3128) that predates the weird-number support and were never updated.

The formal spec is unambiguous the other way: `1-fabric-values.md` §1.3 and space-model `1-data-model.md` declare all IEEE 754 binary64 values — `-0`, `NaN`, `±Infinity` — first-class, faithfully hashed and wire-encoded. The projection was violating its own spec, and the pre-existing schemaless round-trip tests ("stores NaN", "stores +Infinity and -Infinity") already pinned the intended behavior on the path that happened to work.

## The fix

Every number now classifies as `"number"` (three sites in `traverse.ts`). `integer` schemas still reject `NaN` naturally (`Number.isInteger(NaN)` is `false`) — pinned by a test. The action-result validator (`validateAndCheckReactives`), which rejects non-finite numbers loudly with a hint, is a deliberate separate policy layer and is unchanged.

## Tests

Three new projection round-trip tests (bare number, object property, array — covering `NaN`, `±Infinity`, and `-0`) fail against the previous code; a fourth pins the `integer`-rejects-`NaN` boundary in both worlds. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8t2syQh9b5JHxFXGqt1fQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix schema reads to treat all numbers—including `NaN`, `±Infinity`, and `-0`—as numbers. This prevents values from being dropped or read as undefined and aligns with stored values and our number spec.

- **Bug Fixes**
  - Treat all JS numbers as `"number"` during schema projection; remove finite-only checks in `getPlainJsonType`, `getJsonType`, and the number traversal. This also means `canBranchMatch` now classifies `NaN`/`±Infinity` as numbers, so non-number branches reject them.
  - `integer` schemas still reject `NaN`; validator policy remains unchanged.
  - Add round-trip tests for projecting `NaN`, `±Infinity`, `-0` (bare number, object property, array); update `canBranchMatch` expectations; and pin that `integer` rejects `NaN`.

<sup>Written for commit adcf67501bf1101abc5a7df94aa420b12fb33c6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

