### PR TITLE
fix(runtime): make fetch contracts independent of ambient globals

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -605,15 +605,17 @@ Whether its globals reach a given package's type graph is not something
 `deno info` will tell you. They arrive as a type-only injection rather than
 through the module graph, and which packages they reach shifts with the rest of
 the dependency tree and with the Deno version. At 26.1.1 under Deno 2.8.1 they
-reach `cf-harness`, and `typeof fetch` there resolves to a type whose `init`
-parameter is the union `global.RequestInit | RequestInit`. Neither `signal` nor
-`body` is available on that union, so reading either one stops type checking. At
-24.2.0 the same code checks clean, and so does 26.1.1 under Deno 2.8.3.
+reach several package graphs, and `typeof fetch` there resolves to a type whose
+`init` parameter is the union `global.RequestInit | RequestInit`. Fields such as
+`signal` and `body` are not available on that union, so reading them stops type
+checking. At 24.2.0 the same code checks clean, and so does 26.1.1 under Deno
+2.8.3.
 
 The practical trap is that `typeof fetch` is not a dependable way to name a
-fetch-shaped value. Write the signature out instead, as
-`packages/cf-harness/src/contracts/http-fetch.ts` does. That holds whichever
-version resolves and whichever compiler checks it.
+fetch-shaped value. Write the signature out instead. `HarnessFetch` in
+`packages/cf-harness/src/contracts/http-fetch.ts` and `RuntimeFetch` in
+`packages/runner/src/runtime.ts` are the package-level contracts. They hold
+whichever version resolves and whichever compiler checks them.
 
 Two things make this class of breakage easy to miss. `deno task check` does not
 cover every package: `cf-harness` is type checked only by its own test task, so

--- a/packages/cli/lib/fetch-mock.ts
+++ b/packages/cli/lib/fetch-mock.ts
@@ -12,6 +12,8 @@
  * (`@commonfabric/llm`).
  */
 
+import type { RuntimeFetch } from "@commonfabric/runner";
+
 /**
  * One declarative fetch mock. The first entry whose `urlIncludes` is a substring
  * of a request URL wins; `base64Body` takes precedence over `body` (for binary
@@ -91,8 +93,8 @@ export function makeMockResponse(entry: FetchMockEntry): Response {
  */
 export function makeMockFetch(
   getEntries: () => FetchMockEntry[] | undefined,
-  realFetch: typeof globalThis.fetch,
-): typeof globalThis.fetch {
+  realFetch: RuntimeFetch,
+): RuntimeFetch {
   return async (input, init) => {
     const entry = matchFetchMock(getEntries(), input);
     if (!entry) return realFetch(input as RequestInfo | URL, init);

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -124,15 +124,22 @@ describe("makeMockFetch", () => {
 
   it("falls through to realFetch (with init) when nothing matches", async () => {
     let seen: { input: unknown; init: unknown } | undefined;
+    const client = {} as Deno.HttpClient;
     const realFetch = ((input: unknown, init: unknown) => {
       seen = { input, init };
       return Promise.resolve(new Response("real"));
     }) as typeof globalThis.fetch;
     const fetch = makeMockFetch(() => [{ urlIncludes: "/mock" }], realFetch);
-    const res = await fetch("https://x.test/other", { method: "POST" });
+    const res = await fetch("https://x.test/other", {
+      method: "POST",
+      client,
+    });
     expect(await res.text()).toBe("real");
     expect(seen?.input).toBe("https://x.test/other");
     expect((seen?.init as RequestInit).method).toBe("POST");
+    expect(
+      (seen?.init as RequestInit & { client?: Deno.HttpClient }).client,
+    ).toBe(client);
   });
 
   it("reads entries late-bound on each call", async () => {

--- a/packages/patterns/google/core/util/calendar-write-client.test.ts
+++ b/packages/patterns/google/core/util/calendar-write-client.test.ts
@@ -7,16 +7,15 @@ import {
   createCalendarWriteClient,
 } from "./calendar-write-client.ts";
 
-type FetchInput = Parameters<typeof fetch>[0];
-type FetchInit = Parameters<typeof fetch>[1];
+type FetchInput = RequestInfo | URL;
 type FetchResponder = (
   input: FetchInput,
-  init: FetchInit,
+  init?: RequestInit,
 ) => Response | Promise<Response>;
 
 interface CapturedRequest {
   url: string;
-  init: FetchInit;
+  init?: RequestInit;
 }
 
 interface TestAuthCell {
@@ -78,7 +77,10 @@ function mockFetch(responders: FetchResponder[]): {
   const requests: CapturedRequest[] = [];
   let index = 0;
 
-  globalThis.fetch = ((input, init) => {
+  const replacementFetch = (
+    input: FetchInput,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const responder = responders[index++];
     if (!responder) {
       throw new Error(`Unexpected fetch call ${index}`);
@@ -89,7 +91,8 @@ function mockFetch(responders: FetchResponder[]): {
       init,
     });
     return Promise.resolve(responder(input, init));
-  }) as typeof fetch;
+  };
+  globalThis.fetch = replacementFetch as typeof globalThis.fetch;
 
   return {
     requests,

--- a/packages/runner/src/harness/version-gate.ts
+++ b/packages/runner/src/harness/version-gate.ts
@@ -15,6 +15,8 @@
  * build time).
  */
 
+import type { RuntimeFetch } from "../runtime.ts";
+
 /**
  * True only when both build versions are known AND equal. Any unknown
  * (`undefined`) side ⇒ `false` — fail safe: never auto-update against an
@@ -36,7 +38,7 @@ export function buildsMatch(
  * `gitSha`) — the gate treats every `undefined` as "unknown → do not update".
  */
 export async function fetchToolshedGitSha(
-  fetchImpl: typeof globalThis.fetch,
+  fetchImpl: RuntimeFetch,
   host: string | URL,
 ): Promise<string | undefined> {
   try {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -4,6 +4,7 @@ export type {
   ErrorHandler,
   ErrorWithContext as RuntimeErrorWithContext,
   ExperimentalOptions, // Space-model feature flags; see ExperimentalOptions in runtime.ts
+  RuntimeFetch,
   RuntimeOptions,
   SpaceCellContents,
   VersionSkewHandler,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -98,6 +98,7 @@ import type {
   ModuleByteCache,
   NavigateCallback,
   PieceCreatedCallback,
+  RuntimeFetch,
   RuntimeOptions,
   VersionSkewHandler,
 } from "./runtime.ts";
@@ -288,7 +289,7 @@ export interface RemoteClientPresetParams extends CoreParams {
 
 export interface PatternTestPresetParams extends CoreParams {
   /** Mock fetch honoring test-declared `fetchMocks` (CT-1768). */
-  fetch?: typeof globalThis.fetch;
+  fetch?: RuntimeFetch;
   errorHandlers?: ErrorHandler[];
   navigateCallback?: NavigateCallback;
   moduleByteCache?: ModuleByteCache;
@@ -317,7 +318,7 @@ export interface BrowserWorkerPresetParams extends CoreParams {
 export interface UnitTestPresetParams extends Omit<CoreParams, "experimental"> {
   /** Optional here (unlike the first-party presets): unit tests default to no flags. */
   experimental?: ExperimentalOptions;
-  fetch?: typeof globalThis.fetch;
+  fetch?: RuntimeFetch;
   errorHandlers?: ErrorHandler[];
   moduleByteCache?: ModuleByteCache;
   cfcEnforcementMode?: CfcEnforcementMode;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -288,6 +288,11 @@ export interface ModuleByteCache {
   ): void;
 }
 
+export type RuntimeFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit & { client?: Deno.HttpClient },
+) => Promise<Response>;
+
 export interface RuntimeOptions {
   apiUrl: URL;
   /**
@@ -439,7 +444,7 @@ export interface RuntimeOptions {
    * a test harness can inject a deterministic mock without mutating process
    * globals. (LLM calls mock separately, at the `LLMClient` layer.)
    */
-  fetch?: typeof globalThis.fetch;
+  fetch?: RuntimeFetch;
 }
 
 export interface CfcRuntimeStats {
@@ -610,7 +615,7 @@ export class Runtime {
    * the host `globalThis.fetch`; a test harness can inject a mock via
    * `RuntimeOptions.fetch`.
    */
-  readonly fetch: typeof globalThis.fetch;
+  readonly fetch: RuntimeFetch;
   /** Runtime-learned host hints (site table); see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
   readonly userIdentityDID: DID;

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -18,7 +18,7 @@ import {
 } from "./runtime-processor.ts";
 import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
-import { runtimePresets } from "@commonfabric/runner";
+import { type RuntimeFetch, runtimePresets } from "@commonfabric/runner";
 import {
   type CellRef,
   type CfcLabelView,
@@ -1038,7 +1038,7 @@ describe("RuntimeProcessor blob upload IPC", () => {
     const originalFetch = globalThis.fetch;
     let requestedUrl: string | undefined;
     let requestedPayload: unknown;
-    globalThis.fetch = (input, init) => {
+    const blobFetch: RuntimeFetch = (input, init) => {
       requestedUrl = input.toString();
       requestedPayload = decodeMemoryBoundary(init?.body as string);
       return Promise.resolve(
@@ -1054,6 +1054,7 @@ describe("RuntimeProcessor blob upload IPC", () => {
         ),
       );
     };
+    globalThis.fetch = blobFetch as typeof globalThis.fetch;
     // The constructor performs full runtime initialization; this focused unit
     // test calls the handler with the fields it reads directly.
     const hostForSpaceCalls: string[] = [];


### PR DESCRIPTION
Rolling the transitive @types/node dependency to 26 exposed a Deno 2.8.1 type-graph collision. Fetch-shaped values named with typeof fetch acquired a global.RequestInit or RequestInit union, so ordinary signal, body, method, and headers reads stopped type checking in the Check job.

Define and export an explicit RuntimeFetch contract, use it across runtime options, presets, the version gate, and the CLI fetch mock, and annotate the remaining affected test doubles with the stable DOM request types. Preserve Deno's optional HttpClient request option and verify that the CLI mock forwards it unchanged.

Update the development guide to describe the wider package impact and point to both explicit fetch contracts. The contract now stays stable when ambient Node globals enter a package type graph without changing runtime fetch behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce an explicit `RuntimeFetch` contract to decouple runtime fetch typing from ambient Node/Deno globals and restore clean type checking. Adopted across `@commonfabric/runner` options, presets, version gate, CLI fetch mock, and tests; behavior stays the same.

- **Bug Fixes**
  - Avoid the `@types/node@26` + Deno 2.8.1 `typeof fetch` union (`global.RequestInit | RequestInit`) that hid fields like `signal` and `body`.
  - Preserve Deno `HttpClient` in `RequestInit`; verified the CLI fetch mock forwards it unchanged.

- **Migration**
  - If you inject a custom fetch into `@commonfabric/runner` (`RuntimeOptions` or presets), type it as `RuntimeFetch` and accept `RequestInfo | URL` plus `RequestInit` with optional `client?: Deno.HttpClient`.

<sup>Written for commit 17394a9c9f1f7cbaaa186413d44c107ba3c3474d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_COVERAGE_BASELINE